### PR TITLE
[MRG+2] Adding return_std options for models in linear_model/bayes.py

### DIFF
--- a/examples/linear_model/plot_ard.py
+++ b/examples/linear_model/plot_ard.py
@@ -88,6 +88,7 @@ def f(x, noise_amount):
     noise = np.random.normal(0, 1, len(x))
     return y + noise_amount * noise
 
+
 degree = 10
 X = np.linspace(0, 10, 100)
 y = f(X, noise_amount=1)

--- a/examples/linear_model/plot_ard.py
+++ b/examples/linear_model/plot_ard.py
@@ -89,10 +89,10 @@ def f(x, noise_amount):
     noise = np.random.normal(0, 1, len(x))
     return y + noise_amount * noise
 
-degree = 30
+degree = 10
 X = np.linspace(0, 10, 100)
 y = f(X, noise_amount=1)
-clf_poly = ARDRegression()
+clf_poly = ARDRegression(threshold_lambda=1e5)
 clf_poly.fit(np.vander(X, degree), y)
 
 X_plot = np.linspace(0, 11, 25)
@@ -100,7 +100,7 @@ y_plot = f(X_plot, noise_amount=0)
 y_mean, y_std = clf_poly.predict(np.vander(X_plot, degree), return_std=True)
 plt.figure(figsize=(6, 5))
 plt.errorbar(X_plot, y_mean, y_std, color='navy',
-        label="Polynomial Bayesian Ridge Regression", linewidth=2)
+        label="Polynomial ARD", linewidth=2)
 plt.plot(X_plot, y_plot, color='gold', linewidth=2, 
          label="Ground Truth")
 plt.ylabel("Output y")

--- a/examples/linear_model/plot_ard.py
+++ b/examples/linear_model/plot_ard.py
@@ -99,7 +99,7 @@ clf_1d.fit(X, y)
 
 X_range = np.arange(-30, 30, 1)[:, np.newaxis]
 y_range = np.dot(X_range, w)
-y_mean, y_std = clf_1d.predict(X_range, predict_std=True)
+y_mean, y_std = clf_1d.predict(X_range, return_std=True)
 plt.figure(figsize=(6, 5))
 plt.title("Test predictions and standard deviations")
 plt.plot(X_range, y_range, color='gold', linewidth=2, label='Ground truth')

--- a/examples/linear_model/plot_ard.py
+++ b/examples/linear_model/plot_ard.py
@@ -97,7 +97,7 @@ y = np.dot(X, w) + noise
 clf_1d = ARDRegression(compute_score=True)
 clf_1d.fit(X, y)
 
-X_range = np.arange(-3, 3, 0.1)[:, np.newaxis]
+X_range = np.arange(-30, 30, 1)[:, np.newaxis]
 y_range = np.dot(X_range, w)
 y_mean, y_std = clf_1d.predict(X_range, predict_std=True)
 plt.figure(figsize=(6, 5))

--- a/examples/linear_model/plot_ard.py
+++ b/examples/linear_model/plot_ard.py
@@ -84,7 +84,6 @@ plt.xlabel("Iterations")
 
 # Plotting some predictions for polynomial regression
 def f(x, noise_amount):
-    """ function to approximate by polynomial interpolation"""
     y = np.sqrt(x) * np.sin(x)
     noise = np.random.normal(0, 1, len(x))
     return y + noise_amount * noise
@@ -100,8 +99,8 @@ y_plot = f(X_plot, noise_amount=0)
 y_mean, y_std = clf_poly.predict(np.vander(X_plot, degree), return_std=True)
 plt.figure(figsize=(6, 5))
 plt.errorbar(X_plot, y_mean, y_std, color='navy',
-        label="Polynomial ARD", linewidth=2)
-plt.plot(X_plot, y_plot, color='gold', linewidth=2, 
+             label="Polynomial ARD", linewidth=2)
+plt.plot(X_plot, y_plot, color='gold', linewidth=2,
          label="Ground Truth")
 plt.ylabel("Output y")
 plt.xlabel("Feature X")

--- a/examples/linear_model/plot_ard.py
+++ b/examples/linear_model/plot_ard.py
@@ -15,6 +15,11 @@ prior is implied on the weights.
 
 The estimation of the model is done by iteratively maximizing the
 marginal log-likelihood of the observations.
+
+We also plot predictions and uncertainties for polynomial ARD.
+Note the uncertainty starts going up on the right side of the plot.
+This is because these test samples are outside of the range of the training
+samples.
 """
 print(__doc__)
 

--- a/examples/linear_model/plot_ard.py
+++ b/examples/linear_model/plot_ard.py
@@ -54,8 +54,8 @@ ols = LinearRegression()
 ols.fit(X, y)
 
 ###############################################################################
-# Plot the true weights, the estimated weights and the histogram of the
-# weights
+# Plot the true weights, the estimated weights, the histogram of the
+# weights, and predictions with standard deviations
 plt.figure(figsize=(6, 5))
 plt.title("Weights of the model")
 plt.plot(clf.coef_, color='darkblue', linestyle='-', linewidth=2,
@@ -81,31 +81,29 @@ plt.title("Marginal log-likelihood")
 plt.plot(clf.scores_, color='navy', linewidth=2)
 plt.ylabel("Score")
 plt.xlabel("Iterations")
-plt.show()
 
-###############################################################################
-# Plot predictions with standard deviation
-n_samples, n_features = 50, 1
-X = np.random.randn(n_samples, n_features)  # Create Gaussian data
-w = [-1]
-# Create noise with a precision alpha of 50.
-alpha_ = 50.
-noise = stats.norm.rvs(loc=0, scale=1. / np.sqrt(alpha_), size=n_samples)
-# Create the target
-y = np.dot(X, w) + noise
-# fit model
-clf_1d = ARDRegression(compute_score=True)
-clf_1d.fit(X, y)
+# Plotting some predictions for polynomial regression
+def f(x, noise_amount):
+    """ function to approximate by polynomial interpolation"""
+    y = np.sqrt(x) * np.sin(x)
+    noise = np.random.normal(0, 1, len(x))
+    return y + noise_amount * noise
 
-X_range = np.arange(-30, 30, 1)[:, np.newaxis]
-y_range = np.dot(X_range, w)
-y_mean, y_std = clf_1d.predict(X_range, return_std=True)
+degree = 30
+X = np.linspace(0, 10, 100)
+y = f(X, noise_amount=1)
+clf_poly = ARDRegression()
+clf_poly.fit(np.vander(X, degree), y)
+
+X_plot = np.linspace(0, 11, 25)
+y_plot = f(X_plot, noise_amount=0)
+y_mean, y_std = clf_poly.predict(np.vander(X_plot, degree), return_std=True)
 plt.figure(figsize=(6, 5))
-plt.title("Test predictions and standard deviations")
-plt.plot(X_range, y_range, color='gold', linewidth=2, label='Ground truth')
-plt.errorbar(X_range, y_mean, y_std, color='navy',
-             label='Predictions and Uncertainties')
-plt.ylabel("Feature")
-plt.xlabel("Output")
-plt.legend(loc="upper right")
+plt.errorbar(X_plot, y_mean, y_std, color='navy',
+        label="Polynomial Bayesian Ridge Regression", linewidth=2)
+plt.plot(X_plot, y_plot, color='gold', linewidth=2, 
+         label="Ground Truth")
+plt.ylabel("Output y")
+plt.xlabel("Feature X")
+plt.legend(loc="lower left")
 plt.show()

--- a/examples/linear_model/plot_ard.py
+++ b/examples/linear_model/plot_ard.py
@@ -82,3 +82,30 @@ plt.plot(clf.scores_, color='navy', linewidth=2)
 plt.ylabel("Score")
 plt.xlabel("Iterations")
 plt.show()
+
+###############################################################################
+# Plot predictions with standard deviation
+n_samples, n_features = 50, 1
+X = np.random.randn(n_samples, n_features)  # Create Gaussian data
+w = [-1]
+# Create noise with a precision alpha of 50.
+alpha_ = 50.
+noise = stats.norm.rvs(loc=0, scale=1. / np.sqrt(alpha_), size=n_samples)
+# Create the target
+y = np.dot(X, w) + noise
+# fit model
+clf_1d = ARDRegression(compute_score=True)
+clf_1d.fit(X, y)
+
+X_range = np.arange(-3, 3, 0.1)[:, np.newaxis]
+y_range = np.dot(X_range, w)
+y_mean, y_std = clf_1d.predict(X_range, predict_std=True)
+plt.figure(figsize=(6, 5))
+plt.title("Test predictions and standard deviations")
+plt.plot(X_range, y_range, color='gold', linewidth=2, label='Ground truth')
+plt.errorbar(X_range, y_mean, y_std, color='navy',
+             label='Predictions and Uncertainties')
+plt.ylabel("Feature")
+plt.xlabel("Output")
+plt.legend(loc="upper right")
+plt.show()

--- a/examples/linear_model/plot_ard.py
+++ b/examples/linear_model/plot_ard.py
@@ -16,7 +16,8 @@ prior is implied on the weights.
 The estimation of the model is done by iteratively maximizing the
 marginal log-likelihood of the observations.
 
-We also plot predictions and uncertainties for polynomial ARD.
+We also plot predictions and uncertainties for ARD
+for one dimensional regression using polynomial feature expansion.
 Note the uncertainty starts going up on the right side of the plot.
 This is because these test samples are outside of the range of the training
 samples.

--- a/examples/linear_model/plot_ard.py
+++ b/examples/linear_model/plot_ard.py
@@ -82,6 +82,7 @@ plt.plot(clf.scores_, color='navy', linewidth=2)
 plt.ylabel("Score")
 plt.xlabel("Iterations")
 
+
 # Plotting some predictions for polynomial regression
 def f(x, noise_amount):
     y = np.sqrt(x) * np.sin(x)

--- a/examples/linear_model/plot_bayesian_ridge.py
+++ b/examples/linear_model/plot_bayesian_ridge.py
@@ -78,3 +78,30 @@ plt.plot(clf.scores_, color='navy', linewidth=lw)
 plt.ylabel("Score")
 plt.xlabel("Iterations")
 plt.show()
+
+###############################################################################
+# Plot predictions with standard deviation
+n_samples, n_features = 50, 1
+X = np.random.randn(n_samples, n_features)  # Create Gaussian data
+w = [-1]
+# Create noise with a precision alpha of 50.
+alpha_ = 50.
+noise = stats.norm.rvs(loc=0, scale=1. / np.sqrt(alpha_), size=n_samples)
+# Create the target
+y = np.dot(X, w) + noise
+# fit model
+clf_1d = BayesianRidge(compute_score=True)
+clf_1d.fit(X, y)
+
+X_range = np.arange(-3, 3, 0.1)[:, np.newaxis]
+y_range = np.dot(X_range, w)
+y_mean, y_std = clf_1d.predict(X_range, predict_std=True)
+plt.figure(figsize=(6, 5))
+plt.title("Test predictions and standard deviations")
+plt.plot(X_range, y_range, color='gold', linewidth=lw, label='Ground truth')
+plt.errorbar(X_range, y_mean, y_std, color='navy',
+             label='Predictions and Uncertainties')
+plt.ylabel("Feature")
+plt.xlabel("Output")
+plt.legend(loc="upper right")
+plt.show()

--- a/examples/linear_model/plot_bayesian_ridge.py
+++ b/examples/linear_model/plot_bayesian_ridge.py
@@ -51,7 +51,7 @@ ols = LinearRegression()
 ols.fit(X, y)
 
 ###############################################################################
-# Plot true weights, estimated weights, histogram of the weights, and 
+# Plot true weights, estimated weights, histogram of the weights, and
 # predictions with standard deviations
 lw = 2
 plt.figure(figsize=(6, 5))
@@ -81,7 +81,6 @@ plt.xlabel("Iterations")
 
 # Plotting some predictions for polynomial regression
 def f(x, noise_amount):
-    """ function to approximate by polynomial interpolation"""
     y = np.sqrt(x) * np.sin(x)
     noise = np.random.normal(0, 1, len(x))
     return y + noise_amount * noise
@@ -97,8 +96,8 @@ y_plot = f(X_plot, noise_amount=0)
 y_mean, y_std = clf_poly.predict(np.vander(X_plot, degree), return_std=True)
 plt.figure(figsize=(6, 5))
 plt.errorbar(X_plot, y_mean, y_std, color='navy',
-        label="Polynomial Bayesian Ridge Regression", linewidth=lw)
-plt.plot(X_plot, y_plot, color='gold', linewidth=lw, 
+             label="Polynomial Bayesian Ridge Regression", linewidth=lw)
+plt.plot(X_plot, y_plot, color='gold', linewidth=lw,
          label="Ground Truth")
 plt.ylabel("Output y")
 plt.xlabel("Feature X")

--- a/examples/linear_model/plot_bayesian_ridge.py
+++ b/examples/linear_model/plot_bayesian_ridge.py
@@ -93,7 +93,7 @@ y = np.dot(X, w) + noise
 clf_1d = BayesianRidge(compute_score=True)
 clf_1d.fit(X, y)
 
-X_range = np.arange(-3, 3, 0.1)[:, np.newaxis]
+X_range = np.arange(-30, 30, 1)[:, np.newaxis]
 y_range = np.dot(X_range, w)
 y_mean, y_std = clf_1d.predict(X_range, predict_std=True)
 plt.figure(figsize=(6, 5))

--- a/examples/linear_model/plot_bayesian_ridge.py
+++ b/examples/linear_model/plot_bayesian_ridge.py
@@ -95,7 +95,7 @@ clf_1d.fit(X, y)
 
 X_range = np.arange(-30, 30, 1)[:, np.newaxis]
 y_range = np.dot(X_range, w)
-y_mean, y_std = clf_1d.predict(X_range, predict_std=True)
+y_mean, y_std = clf_1d.predict(X_range, return_std=True)
 plt.figure(figsize=(6, 5))
 plt.title("Test predictions and standard deviations")
 plt.plot(X_range, y_range, color='gold', linewidth=lw, label='Ground truth')

--- a/examples/linear_model/plot_bayesian_ridge.py
+++ b/examples/linear_model/plot_bayesian_ridge.py
@@ -16,7 +16,8 @@ estimated weights is Gaussian.
 The estimation of the model is done by iteratively maximizing the
 marginal log-likelihood of the observations.
 
-We also plot predictions and uncertainties for polynomial Bayesian Ridge.
+We also plot predictions and uncertainties for Bayesian Ridge Regression
+for one dimensional regression using polynomial feature expansion.
 Note the uncertainty starts going up on the right side of the plot.
 This is because these test samples are outside of the range of the training
 samples.

--- a/examples/linear_model/plot_bayesian_ridge.py
+++ b/examples/linear_model/plot_bayesian_ridge.py
@@ -79,6 +79,7 @@ plt.plot(clf.scores_, color='navy', linewidth=lw)
 plt.ylabel("Score")
 plt.xlabel("Iterations")
 
+
 # Plotting some predictions for polynomial regression
 def f(x, noise_amount):
     y = np.sqrt(x) * np.sin(x)

--- a/examples/linear_model/plot_bayesian_ridge.py
+++ b/examples/linear_model/plot_bayesian_ridge.py
@@ -15,6 +15,11 @@ estimated weights is Gaussian.
 
 The estimation of the model is done by iteratively maximizing the
 marginal log-likelihood of the observations.
+
+We also plot predictions and uncertainties for polynomial Bayesian Ridge.
+Note the uncertainty starts going up on the right side of the plot.
+This is because these test samples are outside of the range of the training
+samples.
 """
 print(__doc__)
 

--- a/examples/linear_model/plot_bayesian_ridge.py
+++ b/examples/linear_model/plot_bayesian_ridge.py
@@ -85,6 +85,7 @@ def f(x, noise_amount):
     noise = np.random.normal(0, 1, len(x))
     return y + noise_amount * noise
 
+
 degree = 10
 X = np.linspace(0, 10, 100)
 y = f(X, noise_amount=0.1)

--- a/examples/linear_model/plot_bayesian_ridge.py
+++ b/examples/linear_model/plot_bayesian_ridge.py
@@ -51,7 +51,8 @@ ols = LinearRegression()
 ols.fit(X, y)
 
 ###############################################################################
-# Plot true weights, estimated weights and histogram of the weights
+# Plot true weights, estimated weights, histogram of the weights, and 
+# predictions with standard deviations
 lw = 2
 plt.figure(figsize=(6, 5))
 plt.title("Weights of the model")
@@ -77,31 +78,29 @@ plt.title("Marginal log-likelihood")
 plt.plot(clf.scores_, color='navy', linewidth=lw)
 plt.ylabel("Score")
 plt.xlabel("Iterations")
-plt.show()
 
-###############################################################################
-# Plot predictions with standard deviation
-n_samples, n_features = 50, 1
-X = np.random.randn(n_samples, n_features)  # Create Gaussian data
-w = [-1]
-# Create noise with a precision alpha of 50.
-alpha_ = 50.
-noise = stats.norm.rvs(loc=0, scale=1. / np.sqrt(alpha_), size=n_samples)
-# Create the target
-y = np.dot(X, w) + noise
-# fit model
-clf_1d = BayesianRidge(compute_score=True)
-clf_1d.fit(X, y)
+# Plotting some predictions for polynomial regression
+def f(x, noise_amount):
+    """ function to approximate by polynomial interpolation"""
+    y = np.sqrt(x) * np.sin(x)
+    noise = np.random.normal(0, 1, len(x))
+    return y + noise_amount * noise
 
-X_range = np.arange(-30, 30, 1)[:, np.newaxis]
-y_range = np.dot(X_range, w)
-y_mean, y_std = clf_1d.predict(X_range, return_std=True)
+degree = 10
+X = np.linspace(0, 10, 100)
+y = f(X, noise_amount=0.1)
+clf_poly = BayesianRidge()
+clf_poly.fit(np.vander(X, degree), y)
+
+X_plot = np.linspace(0, 11, 25)
+y_plot = f(X_plot, noise_amount=0)
+y_mean, y_std = clf_poly.predict(np.vander(X_plot, degree), return_std=True)
 plt.figure(figsize=(6, 5))
-plt.title("Test predictions and standard deviations")
-plt.plot(X_range, y_range, color='gold', linewidth=lw, label='Ground truth')
-plt.errorbar(X_range, y_mean, y_std, color='navy',
-             label='Predictions and Uncertainties')
-plt.ylabel("Feature")
-plt.xlabel("Output")
-plt.legend(loc="upper right")
+plt.errorbar(X_plot, y_mean, y_std, color='navy',
+        label="Polynomial Bayesian Ridge Regression", linewidth=lw)
+plt.plot(X_plot, y_plot, color='gold', linewidth=lw, 
+         label="Ground Truth")
+plt.ylabel("Output y")
+plt.xlabel("Feature X")
+plt.legend(loc="lower left")
 plt.show()

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -186,8 +186,8 @@ class BayesianRidge(LinearModel, RegressorMixin):
             # coef_ = sigma_^-1 * XT * y
             if n_samples > n_features:
                 coef_ = np.dot(Vh.T,
-                               Vh / (eigen_vals_ + lambda_ / alpha_)[:,
-                                    np.newaxis])
+                               Vh / (eigen_vals_ +
+                                     lambda_ / alpha_)[:, np.newaxis])
                 coef_ = np.dot(coef_, XT_y)
                 if self.compute_score:
                     logdet_sigma_ = - np.sum(

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -186,7 +186,8 @@ class BayesianRidge(LinearModel, RegressorMixin):
             # coef_ = sigma_^-1 * XT * y
             if n_samples > n_features:
                 coef_ = np.dot(Vh.T,
-                               Vh / (eigen_vals_ + lambda_ / alpha_)[:, np.newaxis])
+                               Vh / (eigen_vals_ + lambda_ / alpha_)[:,
+                                    np.newaxis])
                 coef_ = np.dot(coef_, XT_y)
                 if self.compute_score:
                     logdet_sigma_ = - np.sum(

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -244,7 +244,7 @@ class BayesianRidge(LinearModel, RegressorMixin):
         y_mean : array, shape = (n_samples,)
             Mean of predictive distribution of query points.
             
-        y_std : array, shaoe = (n_samples,)
+        y_std : array, shape = (n_samples,)
             Standard deviation of predictive distribution of query points.
         """
         y_mean = self._decision_function(X)

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -112,6 +112,16 @@ class BayesianRidge(LinearModel, RegressorMixin):
     Notes
     -----
     See examples/linear_model/plot_bayesian_ridge.py for an example.
+    
+    References
+    -------
+    D. J. C. MacKay, Bayesian Interpolation, Computation and Neural Systems,
+    Vol. 4, No. 3, 1992.
+
+    See also: http://www.utstat.toronto.edu/~rsalakhu/sta4273/notes/Lecture2.pdf
+    Slide 15, titled "Predictive Distribution"
+    Their beta is our self.beta_
+    Their alpha is our self.lambda_
     """
 
     def __init__(self, n_iter=300, tol=1.e-3, alpha_1=1.e-6, alpha_2=1.e-6,
@@ -231,11 +241,6 @@ class BayesianRidge(LinearModel, RegressorMixin):
     def predict(self, X, return_std=False):
         """Predict using the linear model. In addition to the mean of the
         predictive distribution, also its standard deviation can be returned.
-
-        See: http://www.utstat.toronto.edu/~rsalakhu/sta4273/notes/Lecture2.pdf
-        Slide 15, titled "Predictive Distribution"
-        Russ's beta is our self.beta_
-        Russ's alpha is our self.lambda_
 
         Parameters
         ----------
@@ -366,6 +371,18 @@ class ARDRegression(LinearModel, RegressorMixin):
     Notes
     --------
     See examples/linear_model/plot_ard.py for an example.
+
+    References
+    -------
+    D. J. C. MacKay, Bayesian nonlinear modeling for the prediction competition,
+    ASHRAE Transactions, 1994.
+
+    See also: http://www.utstat.toronto.edu/~rsalakhu/sta4273/notes/Lecture2.pdf
+    Slide 15, titled "Predictive Distribution"
+    Their beta is our self.beta_
+    Their alpha is our self.lambda_
+    ARD is a little different than the slide: only dimensions/features for which
+    self.lambda_ < self.threshold_lambda are kept and the rest are discarded.
     """
 
     def __init__(self, n_iter=300, tol=1.e-3, alpha_1=1.e-6, alpha_2=1.e-6,
@@ -481,14 +498,6 @@ class ARDRegression(LinearModel, RegressorMixin):
     def predict(self, X, return_std=False):
         """Predict using the linear model. In addition to the mean of the
         predictive distribution, also its standard deviation can be returned.
-
-        See: http://www.utstat.toronto.edu/~rsalakhu/sta4273/notes/Lecture2.pdf
-        Slide 15, titled "Predictive Distribution"
-        Russ's beta is our self.beta_
-        Russ's alpha is our self.lambda_
-        ARD is only a little different: only dimensions/features for which
-        self.lambda_ < self.threshold_lambda are kept and the rest are
-        discarded.
 
         Parameters
         ----------

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -233,6 +233,9 @@ class BayesianRidge(LinearModel, RegressorMixin):
         predictive distribution, also its standard deviation can be returned.
 
         See: http://www.utstat.toronto.edu/~rsalakhu/sta4273/notes/Lecture2.pdf
+        Slide 15, titled "Predictive Distribution"
+        Russ's beta is our self.beta_
+        Russ's alpha is our self.lambda_
 
         Parameters
         ----------
@@ -478,6 +481,14 @@ class ARDRegression(LinearModel, RegressorMixin):
     def predict(self, X, predict_std=False):
         """Predict using the linear model. In addition to the mean of the
         predictive distribution, also its standard deviation can be returned.
+
+        See: http://www.utstat.toronto.edu/~rsalakhu/sta4273/notes/Lecture2.pdf
+        Slide 15, titled "Predictive Distribution"
+        Russ's beta is our self.beta_
+        Russ's alpha is our self.lambda_
+        ARD is only a little different: only dimensions/features for which
+        self.lambda_ < self.threshold_lambda are kept and the rest are 
+        discarded.
 
         Parameters
         ----------

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -112,7 +112,7 @@ class BayesianRidge(LinearModel, RegressorMixin):
     Notes
     -----
     See examples/linear_model/plot_bayesian_ridge.py for an example.
-    
+
     References
     ----------
     D. J. C. MacKay, Bayesian Interpolation, Computation and Neural Systems,
@@ -374,15 +374,16 @@ class ARDRegression(LinearModel, RegressorMixin):
 
     References
     ----------
-    D. J. C. MacKay, Bayesian nonlinear modeling for the prediction competition,
-    ASHRAE Transactions, 1994.
+    D. J. C. MacKay, Bayesian nonlinear modeling for the prediction
+    competition, ASHRAE Transactions, 1994.
 
     R. Salakhutdinov, Lecture notes on Statistical Machine Learning,
     http://www.utstat.toronto.edu/~rsalakhu/sta4273/notes/Lecture2.pdf#page=15
     Their beta is our self.beta_
     Their alpha is our self.lambda_
-    ARD is a little different than the slide: only dimensions/features for which
-    self.lambda_ < self.threshold_lambda are kept and the rest are discarded.
+    ARD is a little different than the slide: only dimensions/features for 
+    which self.lambda_ < self.threshold_lambda are kept and the rest are 
+    discarded.
     """
 
     def __init__(self, n_iter=300, tol=1.e-3, alpha_1=1.e-6, alpha_2=1.e-6,

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -228,7 +228,7 @@ class BayesianRidge(LinearModel, RegressorMixin):
         self._set_intercept(X_offset, y_offset, X_scale)
         return self
 
-    def predict(self, X, predict_std=False):
+    def predict(self, X, return_std=False):
         """Predict using the linear model. In addition to the mean of the
         predictive distribution, also its standard deviation can be returned.
 
@@ -242,7 +242,7 @@ class BayesianRidge(LinearModel, RegressorMixin):
         X : {array-like, sparse matrix}, shape = (n_samples, n_features)
             Samples.
 
-        predict_std : boolean, optional
+        return_std : boolean, optional
             Whether to return the standard deviation of posterior prediction.
 
         Returns
@@ -254,7 +254,7 @@ class BayesianRidge(LinearModel, RegressorMixin):
             Standard deviation of predictive distribution of query points.
         """
         y_mean = self._decision_function(X)
-        if predict_std is False:
+        if return_std is False:
             return y_mean
         else:
             if self.normalize:
@@ -478,7 +478,7 @@ class ARDRegression(LinearModel, RegressorMixin):
         self._set_intercept(X_offset, y_offset, X_scale)
         return self
 
-    def predict(self, X, predict_std=False):
+    def predict(self, X, return_std=False):
         """Predict using the linear model. In addition to the mean of the
         predictive distribution, also its standard deviation can be returned.
 
@@ -495,7 +495,7 @@ class ARDRegression(LinearModel, RegressorMixin):
         X : {array-like, sparse matrix}, shape = (n_samples, n_features)
             Samples.
 
-        predict_std : boolean, optional
+        return_std : boolean, optional
             Whether to return the standard deviation of posterior prediction.
 
         Returns
@@ -507,7 +507,7 @@ class ARDRegression(LinearModel, RegressorMixin):
             Standard deviation of predictive distribution of query points.
         """
         y_mean = self._decision_function(X)
-        if predict_std is False:
+        if return_std is False:
             return y_mean
         else:
             if self.normalize:

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -120,7 +120,7 @@ class BayesianRidge(LinearModel, RegressorMixin):
 
     R. Salakhutdinov, Lecture notes on Statistical Machine Learning,
     http://www.utstat.toronto.edu/~rsalakhu/sta4273/notes/Lecture2.pdf#page=15
-    Their beta is our self.beta_
+    Their beta is our self.alpha_
     Their alpha is our self.lambda_
     """
 
@@ -382,7 +382,7 @@ class ARDRegression(LinearModel, RegressorMixin):
 
     R. Salakhutdinov, Lecture notes on Statistical Machine Learning,
     http://www.utstat.toronto.edu/~rsalakhu/sta4273/notes/Lecture2.pdf#page=15
-    Their beta is our self.beta_
+    Their beta is our self.alpha_
     Their alpha is our self.lambda_
     ARD is a little different than the slide: only dimensions/features for
     which self.lambda_ < self.threshold_lambda are kept and the rest are

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -487,7 +487,7 @@ class ARDRegression(LinearModel, RegressorMixin):
         Russ's beta is our self.beta_
         Russ's alpha is our self.lambda_
         ARD is only a little different: only dimensions/features for which
-        self.lambda_ < self.threshold_lambda are kept and the rest are 
+        self.lambda_ < self.threshold_lambda are kept and the rest are
         discarded.
 
         Parameters

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -381,8 +381,8 @@ class ARDRegression(LinearModel, RegressorMixin):
     http://www.utstat.toronto.edu/~rsalakhu/sta4273/notes/Lecture2.pdf#page=15
     Their beta is our self.beta_
     Their alpha is our self.lambda_
-    ARD is a little different than the slide: only dimensions/features for 
-    which self.lambda_ < self.threshold_lambda are kept and the rest are 
+    ARD is a little different than the slide: only dimensions/features for
+    which self.lambda_ < self.threshold_lambda are kept and the rest are
     discarded.
     """
 

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -114,12 +114,12 @@ class BayesianRidge(LinearModel, RegressorMixin):
     See examples/linear_model/plot_bayesian_ridge.py for an example.
     
     References
-    -------
+    ----------
     D. J. C. MacKay, Bayesian Interpolation, Computation and Neural Systems,
     Vol. 4, No. 3, 1992.
 
-    See also: http://www.utstat.toronto.edu/~rsalakhu/sta4273/notes/Lecture2.pdf
-    Slide 15, titled "Predictive Distribution"
+    R. Salakhutdinov, Lecture notes on Statistical Machine Learning,
+    http://www.utstat.toronto.edu/~rsalakhu/sta4273/notes/Lecture2.pdf#page=15
     Their beta is our self.beta_
     Their alpha is our self.lambda_
     """
@@ -373,12 +373,12 @@ class ARDRegression(LinearModel, RegressorMixin):
     See examples/linear_model/plot_ard.py for an example.
 
     References
-    -------
+    ----------
     D. J. C. MacKay, Bayesian nonlinear modeling for the prediction competition,
     ASHRAE Transactions, 1994.
 
-    See also: http://www.utstat.toronto.edu/~rsalakhu/sta4273/notes/Lecture2.pdf
-    Slide 15, titled "Predictive Distribution"
+    R. Salakhutdinov, Lecture notes on Statistical Machine Learning,
+    http://www.utstat.toronto.edu/~rsalakhu/sta4273/notes/Lecture2.pdf#page=15
     Their beta is our self.beta_
     Their alpha is our self.lambda_
     ARD is a little different than the slide: only dimensions/features for which

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -62,7 +62,7 @@ def test_return_std_bayesian():
     def f(X):
         return np.dot(X, w) + b
 
-    def f_noise(X):
+    def f_noise(X, noise_mult):
         return f(X) + np.random.randn(X.shape[0])*noise_mult
 
     d = 5
@@ -75,20 +75,20 @@ def test_return_std_bayesian():
 
     X = np.random.random((n_train, d))
     X_test = np.random.random((n_test, d))
-    y = f_noise(X)
+    y = f_noise(X, noise_mult)
 
     m1 = BayesianRidge()
     m1.fit(X, y)
     X_test = np.random.random((n_test, d))
     y_mean, y_std = m1.predict(X_test, return_std=True)
-    assert_array_almost_equal(y_std, 0.1, decimal=1)
+    assert_array_almost_equal(y_std, noise_mult, decimal=1)
 
 
 def test_return_std_ard():
     def f(X):
         return np.dot(X, w) + b
 
-    def f_noise(X):
+    def f_noise(X, noise_mult):
         return f(X) + np.random.randn(X.shape[0])*noise_mult
 
     d = 5
@@ -101,10 +101,10 @@ def test_return_std_ard():
 
     X = np.random.random((n_train, d))
     X_test = np.random.random((n_test, d))
-    y = f_noise(X)
+    y = f_noise(X, noise_mult)
 
     m1 = ARDRegression()
     m1.fit(X, y)
     X_test = np.random.random((n_test, d))
     y_mean, y_std = m1.predict(X_test, return_std=True)
-    assert_array_almost_equal(y_std, 0.1, decimal=1)
+    assert_array_almost_equal(y_std, noise_mult, decimal=1)

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -86,5 +86,5 @@ def test_return_std():
 
         m2 = ARDRegression()
         m2.fit(X, y)
-        y_mean2, y_std2 = m1.predict(X_test, return_std=True)
+        y_mean2, y_std2 = m2.predict(X_test, return_std=True)
         assert_array_almost_equal(y_std2, noise_mult, decimal=decimal)

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -58,7 +58,8 @@ def test_toy_ard_object():
     assert_array_almost_equal(clf.predict(test), [1, 3, 4], 2)
 
 
-def test_return_std_bayesian():
+def test_return_std():
+    # Test return_std option for both Bayesian regressors
     def f(X):
         return np.dot(X, w) + b
 
@@ -69,42 +70,21 @@ def test_return_std_bayesian():
     n_train = 50
     n_test = 10
 
-    noise_mult = 0.1
     w = np.array([1.0, 0.0, 1.0, -1.0, 0.0])
     b = 1.0
 
     X = np.random.random((n_train, d))
     X_test = np.random.random((n_test, d))
-    y = f_noise(X, noise_mult)
 
-    m1 = BayesianRidge()
-    m1.fit(X, y)
-    X_test = np.random.random((n_test, d))
-    y_mean, y_std = m1.predict(X_test, return_std=True)
-    assert_array_almost_equal(y_std, noise_mult, decimal=1)
+    for decimal, noise_mult in enumerate([1, 0.1, 0.01]):
+        y = f_noise(X, noise_mult)
 
+        m1 = BayesianRidge()
+        m1.fit(X, y)
+        y_mean1, y_std1 = m1.predict(X_test, return_std=True)
+        assert_array_almost_equal(y_std1, noise_mult, decimal=decimal)
 
-def test_return_std_ard():
-    def f(X):
-        return np.dot(X, w) + b
-
-    def f_noise(X, noise_mult):
-        return f(X) + np.random.randn(X.shape[0])*noise_mult
-
-    d = 5
-    n_train = 50
-    n_test = 10
-
-    noise_mult = 0.1
-    w = np.array([1.0, 0.0, 1.0, -1.0, 0.0])
-    b = 1.0
-
-    X = np.random.random((n_train, d))
-    X_test = np.random.random((n_test, d))
-    y = f_noise(X, noise_mult)
-
-    m1 = ARDRegression()
-    m1.fit(X, y)
-    X_test = np.random.random((n_test, d))
-    y_mean, y_std = m1.predict(X_test, return_std=True)
-    assert_array_almost_equal(y_std, noise_mult, decimal=1)
+        m2 = ARDRegression()
+        m2.fit(X, y)
+        y_mean2, y_std2 = m1.predict(X_test, return_std=True)
+        assert_array_almost_equal(y_std2, noise_mult, decimal=decimal)

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -59,10 +59,10 @@ def test_toy_ard_object():
 
 
 def test_return_std_bayesian():
-    def f(X): 
+    def f(X):
         return np.dot(X, w) + b
 
-    def f_noise(X): 
+    def f_noise(X):
         return f(X) + np.random.randn(X.shape[0])*noise_mult
 
     d = 5
@@ -85,10 +85,10 @@ def test_return_std_bayesian():
 
 
 def test_return_std_ard():
-    def f(X): 
+    def f(X):
         return np.dot(X, w) + b
 
-    def f_noise(X): 
+    def f_noise(X):
         return f(X) + np.random.randn(X.shape[0])*noise_mult
 
     d = 5

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -67,20 +67,20 @@ def test_predict_std_bayesian():
     noise_mult = 0.1
     w = np.array([1.0, 0.0, 1.0, -1.0, 0.0])
     b = 1.0
-    f = lambda X: (np.dot(X, w) + b)
-    f_noise = lambda X: f(X) + np.random.randn(X.shape[0])*noise_mult
-    
+    def f(X): return np.dot(X, w) + b
+    def f_noise(X): return f(X) + np.random.randn(X.shape[0])*noise_mult
+
     X = np.random.random((n_train, d))
     X_test = np.random.random((n_test, d))
     y = f_noise(X)
-    
+
     m1 = BayesianRidge()
     m1.fit(X, y)
-    X_test = np.random.random((n_test,d))
+    X_test = np.random.random((n_test, d))
     y_mean, y_std = m1.predict(X_test, predict_std=True)
     assert_array_almost_equal(y_std, 0.1, decimal=1)
-    
-    
+
+
 def test_predict_std_ard():
     # generate some 1-d data with noise
     d = 5
@@ -90,15 +90,15 @@ def test_predict_std_ard():
     noise_mult = 0.1
     w = np.array([1.0, 0.0, 1.0, -1.0, 0.0])
     b = 1.0
-    f = lambda X: (np.dot(X, w) + b)
-    f_noise = lambda X: f(X) + np.random.randn(X.shape[0])*noise_mult
-    
+    def f(X): return np.dot(X, w) + b
+    def f_noise(X): return f(X) + np.random.randn(X.shape[0])*noise_mult
+
     X = np.random.random((n_train, d))
     X_test = np.random.random((n_test, d))
     y = f_noise(X)
-    
+
     m1 = ARDRegression()
     m1.fit(X, y)
-    X_test = np.random.random((n_test,d))
+    X_test = np.random.random((n_test, d))
     y_mean, y_std = m1.predict(X_test, predict_std=True)
     assert_array_almost_equal(y_std, 0.1, decimal=1)

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -59,7 +59,12 @@ def test_toy_ard_object():
 
 
 def test_return_std_bayesian():
-    # generate some 1-d data with noise
+    def f(X): 
+        return np.dot(X, w) + b
+
+    def f_noise(X): 
+        return f(X) + np.random.randn(X.shape[0])*noise_mult
+
     d = 5
     n_train = 50
     n_test = 10
@@ -67,9 +72,6 @@ def test_return_std_bayesian():
     noise_mult = 0.1
     w = np.array([1.0, 0.0, 1.0, -1.0, 0.0])
     b = 1.0
-    def f(X): return np.dot(X, w) + b
-
-    def f_noise(X): return f(X) + np.random.randn(X.shape[0])*noise_mult
 
     X = np.random.random((n_train, d))
     X_test = np.random.random((n_test, d))
@@ -83,7 +85,12 @@ def test_return_std_bayesian():
 
 
 def test_return_std_ard():
-    # generate some 1-d data with noise
+    def f(X): 
+        return np.dot(X, w) + b
+
+    def f_noise(X): 
+        return f(X) + np.random.randn(X.shape[0])*noise_mult
+
     d = 5
     n_train = 50
     n_test = 10
@@ -91,9 +98,6 @@ def test_return_std_ard():
     noise_mult = 0.1
     w = np.array([1.0, 0.0, 1.0, -1.0, 0.0])
     b = 1.0
-    def f(X): return np.dot(X, w) + b
-
-    def f_noise(X): return f(X) + np.random.randn(X.shape[0])*noise_mult
 
     X = np.random.random((n_train, d))
     X_test = np.random.random((n_test, d))

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -56,3 +56,49 @@ def test_toy_ard_object():
     # Check that the model could approximately learn the identity function
     test = [[1], [3], [4]]
     assert_array_almost_equal(clf.predict(test), [1, 3, 4], 2)
+
+
+def test_predict_std_bayesian():
+    # generate some 1-d data with noise
+    d = 5
+    n_train = 50
+    n_test = 10
+
+    noise_mult = 0.1
+    w = np.array([1.0, 0.0, 1.0, -1.0, 0.0])
+    b = 1.0
+    f = lambda X: (np.dot(X, w) + b)
+    f_noise = lambda X: f(X) + np.random.randn(X.shape[0])*noise_mult
+    
+    X = np.random.random((n_train, d))
+    X_test = np.random.random((n_test, d))
+    y = f_noise(X)
+    
+    m1 = BayesianRidge()
+    m1.fit(X, y)
+    X_test = np.random.random((n_test,d))
+    y_mean, y_std = m1.predict(X_test, predict_std=True)
+    assert_array_almost_equal(y_std, 0.1, decimal=1)
+    
+    
+def test_predict_std_ard():
+    # generate some 1-d data with noise
+    d = 5
+    n_train = 50
+    n_test = 10
+
+    noise_mult = 0.1
+    w = np.array([1.0, 0.0, 1.0, -1.0, 0.0])
+    b = 1.0
+    f = lambda X: (np.dot(X, w) + b)
+    f_noise = lambda X: f(X) + np.random.randn(X.shape[0])*noise_mult
+    
+    X = np.random.random((n_train, d))
+    X_test = np.random.random((n_test, d))
+    y = f_noise(X)
+    
+    m1 = ARDRegression()
+    m1.fit(X, y)
+    X_test = np.random.random((n_test,d))
+    y_mean, y_std = m1.predict(X_test, predict_std=True)
+    assert_array_almost_equal(y_std, 0.1, decimal=1)

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -58,7 +58,7 @@ def test_toy_ard_object():
     assert_array_almost_equal(clf.predict(test), [1, 3, 4], 2)
 
 
-def test_predict_std_bayesian():
+def test_return_std_bayesian():
     # generate some 1-d data with noise
     d = 5
     n_train = 50
@@ -68,6 +68,7 @@ def test_predict_std_bayesian():
     w = np.array([1.0, 0.0, 1.0, -1.0, 0.0])
     b = 1.0
     def f(X): return np.dot(X, w) + b
+
     def f_noise(X): return f(X) + np.random.randn(X.shape[0])*noise_mult
 
     X = np.random.random((n_train, d))
@@ -77,11 +78,11 @@ def test_predict_std_bayesian():
     m1 = BayesianRidge()
     m1.fit(X, y)
     X_test = np.random.random((n_test, d))
-    y_mean, y_std = m1.predict(X_test, predict_std=True)
+    y_mean, y_std = m1.predict(X_test, return_std=True)
     assert_array_almost_equal(y_std, 0.1, decimal=1)
 
 
-def test_predict_std_ard():
+def test_return_std_ard():
     # generate some 1-d data with noise
     d = 5
     n_train = 50
@@ -91,6 +92,7 @@ def test_predict_std_ard():
     w = np.array([1.0, 0.0, 1.0, -1.0, 0.0])
     b = 1.0
     def f(X): return np.dot(X, w) + b
+
     def f_noise(X): return f(X) + np.random.randn(X.shape[0])*noise_mult
 
     X = np.random.random((n_train, d))
@@ -100,5 +102,5 @@ def test_predict_std_ard():
     m1 = ARDRegression()
     m1.fit(X, y)
     X_test = np.random.random((n_test, d))
-    y_mean, y_std = m1.predict(X_test, predict_std=True)
+    y_mean, y_std = m1.predict(X_test, return_std=True)
     assert_array_almost_equal(y_std, 0.1, decimal=1)


### PR DESCRIPTION
#### Reference Issue
The reason for this pull request appears in a conversation for #4844


#### What does this implement/fix? Explain your changes.
This is the first of two pull requests. The ultimate goal is to add the MICE imputation algorithm to scikit-learn. To do so, we need sklearn's Bayesian regression algorithms to be able to return standard deviations as well as predictions. 

This pull requests adds the option `return_std` to the `predict` methods of both `BayesianRidge` and `ARDRegression`. 

#### Any other comments?
Once this is accepted, I will make a pull request that implements MICE using `BayesianRidge` by default (which seems more robust to small sample sizes than ARD in my limited experience). 
