### PR TITLE
[MRG+2-1] Add floating point option to max_feature option in CountVectorizer and TfidfVectorizer to use a percentage of the features.

### DIFF
--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -293,7 +293,7 @@ reasonable (please see  the :ref:`reference documentation
   >>> vectorizer                     # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
   CountVectorizer(analyzer=...'word', binary=False, decode_error=...'strict',
           dtype=<... 'numpy.int64'>, encoding=...'utf-8', input=...'content',
-          lowercase=True, max_df=1.0, max_features=None, min_df=1,
+          lowercase=True, max_df=1.0, max_features=1.0, min_df=1,
           ngram_range=(1, 1), preprocessor=None, stop_words=None,
           strip_accents=None, token_pattern=...'(?u)\\b\\w\\w+\\b',
           tokenizer=None, vocabulary=None)

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -564,16 +564,19 @@ def test_count_vectorizer_max_features():
     cv_3 = CountVectorizer(max_features=3)
     cv_all = CountVectorizer(max_features=1.0)
     cv_half = CountVectorizer(max_features=0.5)
+    cv_None = CountVectorizer(max_features=None)
 
     counts_1 = cv_1.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
     counts_3 = cv_3.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
     counts_all = cv_all.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
     counts_half = cv_half.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
+    counts_None = cv_None.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
 
     features_1 = cv_1.get_feature_names()
     features_3 = cv_3.get_feature_names()
     features_all = cv_all.get_feature_names()
     features_half = cv_half.get_feature_names()
+    features_None = cv_None.get_feature_names()
 
     # The most common feature is "the", with frequency 7.
     assert_equal(7, counts_1.max())
@@ -588,6 +591,9 @@ def test_count_vectorizer_max_features():
 
     # The features for a maximum of 50% or a value of 3 should be the same
     assert_equal(features_3, features_half)
+
+    # The previous default None should be equal to the new default 1.0
+    assert_equal(features_all, features_None)
 
 
 def test_vectorizer_max_df():

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -562,25 +562,32 @@ def test_count_vectorizer_max_features():
 
     cv_1 = CountVectorizer(max_features=1)
     cv_3 = CountVectorizer(max_features=3)
-    cv_None = CountVectorizer(max_features=None)
+    cv_all = CountVectorizer(max_features=1.0)
+    cv_half = CountVectorizer(max_features=0.5)
 
     counts_1 = cv_1.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
     counts_3 = cv_3.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
-    counts_None = cv_None.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
+    counts_all = cv_all.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
+    counts_half = cv_half.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
 
     features_1 = cv_1.get_feature_names()
     features_3 = cv_3.get_feature_names()
-    features_None = cv_None.get_feature_names()
+    features_all = cv_all.get_feature_names()
+    features_half = cv_half.get_feature_names()
 
     # The most common feature is "the", with frequency 7.
     assert_equal(7, counts_1.max())
     assert_equal(7, counts_3.max())
-    assert_equal(7, counts_None.max())
+    assert_equal(7, counts_all.max())
+    assert_equal(7, counts_half.max())
 
     # The most common feature should be the same
     assert_equal("the", features_1[np.argmax(counts_1)])
     assert_equal("the", features_3[np.argmax(counts_3)])
-    assert_equal("the", features_None[np.argmax(counts_None)])
+    assert_equal("the", features_all[np.argmax(counts_all)])
+
+    # The features for a maximum of 50% or a value of 3 should be the same
+    assert_equal(features_3, features_half)
 
 
 def test_vectorizer_max_df():

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -589,6 +589,11 @@ def test_count_vectorizer_max_features():
     assert_equal("the", features_3[np.argmax(counts_3)])
     assert_equal("the", features_all[np.argmax(counts_all)])
 
+    # Check if top 1 feature is a subset of top 50% features which should
+    # be a subset of all the features.
+    assert_less(set(features_1), set(features_half))
+    assert_less(set(features_3), set(features_None))
+
     # The features for a maximum of 50% or a value of 3 should be the same
     assert_equal(features_3, features_half)
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -19,6 +19,7 @@ import numbers
 from operator import itemgetter
 import re
 import unicodedata
+import warnings
 
 import numpy as np
 import scipy.sparse as sp
@@ -684,6 +685,9 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         self.max_features = max_features
         if max_features is not None and max_features < 0:
             raise ValueError("negative value for max_features")
+        if max_features is None:
+            warnings.warn("None was replaced by 1.0 in version 0.19.",
+                          DeprecationWarning)
         self.ngram_range = ngram_range
         self.vocabulary = vocabulary
         self.binary = binary

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -608,9 +608,11 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         absolute counts.
         This parameter is ignored if vocabulary is not None.
 
-    max_features : int or None, default=None
-        If not None, build a vocabulary that only consider the top
-        max_features ordered by term frequency across the corpus.
+    max_features : float in range [0.0, 1.0] or int, default=1.0
+        Build a vocabulary that only consider the top max_features ordered
+        by term frequency across the corpus.
+        If float the parameter represents a proportion of the features, integer
+        absolute counts.
 
         This parameter is ignored if vocabulary is not None.
 
@@ -659,7 +661,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                  lowercase=True, preprocessor=None, tokenizer=None,
                  stop_words=None, token_pattern=r"(?u)\b\w\w+\b",
                  ngram_range=(1, 1), analyzer='word',
-                 max_df=1.0, min_df=1, max_features=None,
+                 max_df=1.0, min_df=1, max_features=1.0,
                  vocabulary=None, binary=False, dtype=np.int64):
         self.input = input
         self.encoding = encoding
@@ -676,12 +678,8 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         if max_df < 0 or min_df < 0:
             raise ValueError("negative value for max_df or min_df")
         self.max_features = max_features
-        if max_features is not None:
-            if (not isinstance(max_features, numbers.Integral) or
-                    max_features <= 0):
-                raise ValueError(
-                    "max_features=%r, neither a positive integer nor None"
-                    % max_features)
+        if max_features < 0:
+            raise ValueError("negative value for max_features")
         self.ngram_range = ngram_range
         self.vocabulary = vocabulary
         self.binary = binary
@@ -844,7 +842,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         if not self.fixed_vocabulary_:
             X = self._sort_features(X, vocabulary)
 
-            n_doc = X.shape[0]
+            n_doc, n_features = X.shape
             max_doc_count = (max_df
                              if isinstance(max_df, numbers.Integral)
                              else max_df * n_doc)
@@ -854,10 +852,13 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             if max_doc_count < min_doc_count:
                 raise ValueError(
                     "max_df corresponds to < documents than min_df")
+            max_features_count = (max_features
+                                  if isinstance(max_features, numbers.Integral)
+                                  else max_features * n_features)
             X, self.stop_words_ = self._limit_features(X, vocabulary,
                                                        max_doc_count,
                                                        min_doc_count,
-                                                       max_features)
+                                                       max_features_count)
 
             self.vocabulary_ = vocabulary
 
@@ -1188,9 +1189,11 @@ class TfidfVectorizer(CountVectorizer):
         absolute counts.
         This parameter is ignored if vocabulary is not None.
 
-    max_features : int or None, default=None
-        If not None, build a vocabulary that only consider the top
-        max_features ordered by term frequency across the corpus.
+    max_features : float in range [0.0, 1.0] or int, default=1.0
+        Build a vocabulary that only consider the top max_features ordered
+        by term frequency across the corpus.
+        If float the parameter represents a proportion of the features, integer
+        absolute counts.
 
         This parameter is ignored if vocabulary is not None.
 
@@ -1261,7 +1264,7 @@ class TfidfVectorizer(CountVectorizer):
                  preprocessor=None, tokenizer=None, analyzer='word',
                  stop_words=None, token_pattern=r"(?u)\b\w\w+\b",
                  ngram_range=(1, 1), max_df=1.0, min_df=1,
-                 max_features=None, vocabulary=None, binary=False,
+                 max_features=1.0, vocabulary=None, binary=False,
                  dtype=np.int64, norm='l2', use_idf=True, smooth_idf=True,
                  sublinear_tf=False):
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -852,8 +852,8 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             if max_doc_count < min_doc_count:
                 raise ValueError(
                     "max_df corresponds to < documents than min_df")
-            if (not isinstance(max_features, numbers.Integral)
-                    and max_features is not None):
+            if (not isinstance(max_features, numbers.Integral) and
+                    max_features is not None):
                 max_features = int(max_features * n_features)
             X, self.stop_words_ = self._limit_features(X, vocabulary,
                                                        max_doc_count,

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -612,7 +612,8 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         Build a vocabulary that only considers the top max_features ordered
         by term frequency across the corpus.
         If float, the parameter represents a proportion of the features after
-        stop words removal, integer absolute counts.
+        stop words removal.
+        If integer, it represents absolute counts.
 
         This parameter is ignored if vocabulary is not None.
 
@@ -1196,7 +1197,8 @@ class TfidfVectorizer(CountVectorizer):
         Build a vocabulary that only considers the top max_features ordered
         by term frequency across the corpus.
         If float, the parameter represents a proportion of the features after
-        stop words removal, integer absolute counts.
+        stop words removal.
+        If integer, it represents absolute counts.
 
         This parameter is ignored if vocabulary is not None.
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -678,7 +678,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         if max_df < 0 or min_df < 0:
             raise ValueError("negative value for max_df or min_df")
         self.max_features = max_features
-        if max_features < 0:
+        if max_features is not None and max_features < 0:
             raise ValueError("negative value for max_features")
         self.ngram_range = ngram_range
         self.vocabulary = vocabulary
@@ -852,13 +852,14 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             if max_doc_count < min_doc_count:
                 raise ValueError(
                     "max_df corresponds to < documents than min_df")
-            max_features_count = (max_features
-                                  if isinstance(max_features, numbers.Integral)
-                                  else int(max_features * n_features))
+            max_features = (max_features
+                            if (isinstance(max_features, numbers.Integral)
+                                or max_features is None)
+                            else int(max_features * n_features))
             X, self.stop_words_ = self._limit_features(X, vocabulary,
                                                        max_doc_count,
                                                        min_doc_count,
-                                                       max_features_count)
+                                                       max_features)
 
             self.vocabulary_ = vocabulary
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -611,8 +611,8 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
     max_features : float in range [0.0, 1.0] or int, default=1.0
         Build a vocabulary that only considers the top max_features ordered
         by term frequency across the corpus.
-        If float the parameter represents a proportion of the features, integer
-        absolute counts.
+        If float, the parameter represents a proportion of the features after
+        stop words removal, integer absolute counts.
 
         This parameter is ignored if vocabulary is not None.
 
@@ -1195,8 +1195,8 @@ class TfidfVectorizer(CountVectorizer):
     max_features : float in range [0.0, 1.0] or int, default=1.0
         Build a vocabulary that only considers the top max_features ordered
         by term frequency across the corpus.
-        If float the parameter represents a proportion of the features, integer
-        absolute counts.
+        If float, the parameter represents a proportion of the features after
+        stop words removal, integer absolute counts.
 
         This parameter is ignored if vocabulary is not None.
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -854,7 +854,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                     "max_df corresponds to < documents than min_df")
             max_features_count = (max_features
                                   if isinstance(max_features, numbers.Integral)
-                                  else max_features * n_features)
+                                  else int(max_features * n_features))
             X, self.stop_words_ = self._limit_features(X, vocabulary,
                                                        max_doc_count,
                                                        min_doc_count,

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -852,10 +852,9 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             if max_doc_count < min_doc_count:
                 raise ValueError(
                     "max_df corresponds to < documents than min_df")
-            max_features = (max_features
-                            if (isinstance(max_features, numbers.Integral) or
-                                max_features is None)
-                            else int(max_features * n_features))
+            if (not isinstance(max_features, numbers.Integral)
+                    and max_features is not None):
+                max_features = int(max_features * n_features)
             X, self.stop_words_ = self._limit_features(X, vocabulary,
                                                        max_doc_count,
                                                        min_doc_count,

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -853,8 +853,8 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                 raise ValueError(
                     "max_df corresponds to < documents than min_df")
             max_features = (max_features
-                            if (isinstance(max_features, numbers.Integral)
-                                or max_features is None)
+                            if (isinstance(max_features, numbers.Integral) or
+                                max_features is None)
                             else int(max_features * n_features))
             X, self.stop_words_ = self._limit_features(X, vocabulary,
                                                        max_doc_count,

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -609,12 +609,15 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         This parameter is ignored if vocabulary is not None.
 
     max_features : float in range [0.0, 1.0] or int, default=1.0
-        Build a vocabulary that only consider the top max_features ordered
+        Build a vocabulary that only considers the top max_features ordered
         by term frequency across the corpus.
         If float the parameter represents a proportion of the features, integer
         absolute counts.
 
         This parameter is ignored if vocabulary is not None.
+
+        .. versionchanged:: 0.19
+           Added percentage option.
 
     vocabulary : Mapping or iterable, optional
         Either a Mapping (e.g., a dict) where keys are terms and values are
@@ -1190,12 +1193,15 @@ class TfidfVectorizer(CountVectorizer):
         This parameter is ignored if vocabulary is not None.
 
     max_features : float in range [0.0, 1.0] or int, default=1.0
-        Build a vocabulary that only consider the top max_features ordered
+        Build a vocabulary that only considers the top max_features ordered
         by term frequency across the corpus.
         If float the parameter represents a proportion of the features, integer
         absolute counts.
 
         This parameter is ignored if vocabulary is not None.
+
+        .. versionchanged:: 0.19
+           Added percentage option.
 
     vocabulary : Mapping or iterable, optional
         Either a Mapping (e.g., a dict) where keys are terms and values are


### PR DESCRIPTION
I added an option to CountVectorizer and TfidfVectorizer to use a floating point value for the max_features parameter to express a percentage of the features instead of an absolute value.

I also changed the default from None to 1.0 and added tests.

This is my first contribution to this project so let me know if I did anything wrong :).