### PR TITLE
[MRG] DOC adding reference to NeighborsBase

### DIFF
--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -104,6 +104,7 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
     -----
     See :ref:`Nearest Neighbors <neighbors>` in the online documentation
     for a discussion of the choice of ``algorithm`` and ``leaf_size``.
+    The classifier inherits attributes from `NeighborsBase`.
 
     .. warning::
 
@@ -309,6 +310,7 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
     -----
     See :ref:`Nearest Neighbors <neighbors>` in the online documentation
     for a discussion of the choice of ``algorithm`` and ``leaf_size``.
+    The classifier inherits attributes from `NeighborsBase`.
 
     https://en.wikipedia.org/wiki/K-nearest_neighbor_algorithm
     """

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -104,6 +104,7 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
     -----
     See :ref:`Nearest Neighbors <neighbors>` in the online documentation
     for a discussion of the choice of ``algorithm`` and ``leaf_size``.
+    The regressor inherits attributes from `NeighborsBase`.
 
     .. warning::
 
@@ -249,6 +250,7 @@ class RadiusNeighborsRegressor(NeighborsBase, RadiusNeighborsMixin,
     -----
     See :ref:`Nearest Neighbors <neighbors>` in the online documentation
     for a discussion of the choice of ``algorithm`` and ``leaf_size``.
+    The regressor inherits attributes from `NeighborsBase`.
 
     https://en.wikipedia.org/wiki/K-nearest_neighbor_algorithm
     """

--- a/sklearn/neighbors/unsupervised.py
+++ b/sklearn/neighbors/unsupervised.py
@@ -109,6 +109,7 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
     -----
     See :ref:`Nearest Neighbors <neighbors>` in the online documentation
     for a discussion of the choice of ``algorithm`` and ``leaf_size``.
+    The learner inherits attributes from `NeighborsBase`.
 
     https://en.wikipedia.org/wiki/K-nearest_neighbor_algorithm
     """


### PR DESCRIPTION
#### Reference Issue
Addresses issue #7617 

#### What does this implement/fix? Explain your changes.
Added the reference to NeighborsBase in the docstring of the inheriting classes.

#### Any other comments?
Although the issue states that the classifier inherits it's attributes from NeighborsBase, I observed that the regressor and learner also do the same. Hence, I made changes there too for the sake of consistency.