### PR TITLE
[MRG + 1] Fix numerical instability in LassoLars when alpha=0 (#7778)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -97,6 +97,10 @@ Bug fixes
      attribute in `transform()`. :issue:`7553` by :user:`Ekaterina
      Krivich <kiote>`.
 
+   - Fixed a bug where :class:`sklearn.linear_model.LassoLars` does not give
+     the same result as the LassoLars implementation available
+     in R (lars library). :issue:`7849` by `Jair Montoya Martinez`_.
+
 .. _changes_0_18_1:
 
 Version 0.18.1

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -97,10 +97,6 @@ Bug fixes
      attribute in `transform()`. :issue:`7553` by :user:`Ekaterina
      Krivich <kiote>`.
 
-   - Fixed a bug where :class:`sklearn.linear_model.LassoLars` does not give
-     the same result as the LassoLars implementation available
-     in R (lars library). :issue:`7849` by `Jair Montoya Martinez`_.
-
 .. _changes_0_18_1:
 
 Version 0.18.1

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -100,6 +100,9 @@ Bug fixes
    - :class:`sklearn.linear_model.LogisticRegressionCV` now correctly handles
      string labels. :issue:`5874` by `Raghav RV`_.
 
+   - Fixed a bug where :class:`sklearn.linear_model.LassoLars` does not give
+     the same result as the LassoLars implementation available
+     in R (lars library). :issue:`7849` by `Jair Montoya Martinez`_
 
 .. _changes_0_18_1:
 

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -403,8 +403,11 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
                 del coef, alpha, prev_alpha, prev_coef
                 # resize the coefs and alphas array
                 add_features = 2 * max(1, (max_features - n_active))
-                coefs = np.resize(coefs, (n_iter + add_features, n_features))
-                alphas = np.resize(alphas, n_iter + add_features)
+                coefs = np.concatenate((coefs,
+                                       np.zeros((add_features, n_features))),
+                                       axis=0)
+                alphas = np.concatenate((alphas, np.zeros(add_features)),
+                                        axis=0)
             coef = coefs[n_iter]
             prev_coef = coefs[n_iter - 1]
             alpha = alphas[n_iter, np.newaxis]

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -404,7 +404,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
                 # resize the coefs and alphas array
                 add_features = 2 * max(1, (max_features - n_active))
                 coefs = np.concatenate((coefs,
-                                       np.zeros((add_features, n_features))),
+                                        np.zeros((add_features, n_features))),
                                        axis=0)
                 alphas = np.concatenate((alphas, np.zeros(add_features)),
                                         axis=0)

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -403,11 +403,10 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
                 del coef, alpha, prev_alpha, prev_coef
                 # resize the coefs and alphas array
                 add_features = 2 * max(1, (max_features - n_active))
-                coefs = np.concatenate((coefs,
-                                        np.zeros((add_features, n_features))),
-                                       axis=0)
-                alphas = np.concatenate((alphas, np.zeros(add_features)),
-                                        axis=0)
+                coefs = np.resize(coefs, (n_iter + add_features, n_features))
+                coefs[-add_features:] = 0
+                alphas = np.resize(alphas, n_iter + add_features)
+                alphas[-add_features:] = 0
             coef = coefs[n_iter]
             prev_coef = coefs[n_iter - 1]
             alpha = alphas[n_iter, np.newaxis]

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -597,7 +597,7 @@ def test_lasso_lars_vs_R_implementation():
     model_lasso_lars.fit(X, y)
     skl_betas = model_lasso_lars.coef_path_
 
-    assert_array_almost_equal(r, skl_betas, decimal=13)
+    assert_array_almost_equal(r, skl_betas, decimal=12)
     ###########################################################################
 
     ###########################################################################
@@ -636,5 +636,5 @@ def test_lasso_lars_vs_R_implementation():
     normx = np.sqrt(np.sum(temp ** 2, axis=0))
     skl_betas2 /= normx[:, np.newaxis]
 
-    assert_array_almost_equal(r2, skl_betas2, decimal=13)
+    assert_array_almost_equal(r2, skl_betas2, decimal=12)
     ###########################################################################

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -562,10 +562,10 @@ def test_lasso_lars_vs_R_implementation():
 
     X = x.T
 
-    ############################################################################
+    ###########################################################################
     # Scenario 1: Let's compare R vs sklearn when fit_intercept=False and
     # normalize=False
-    ############################################################################
+    ###########################################################################
     #
     # The R result was obtained using the following code:
     #
@@ -587,9 +587,10 @@ def test_lasso_lars_vs_R_implementation():
                    2.811549786389614, 2.813766976061531, 2.817462468949557,
                    2.817368178703816, 2.816221090636795],
                   [0, 0, -1.218422599914637, -3.457726183014808,
-                   -4.021304522060710, -45.827461592423745, -47.776608869312305,
-                   -47.911561610746404, -47.914845922736234, -48.039562334265717
-                   ]])
+                   -4.021304522060710, -45.827461592423745,
+                   -47.776608869312305,
+                   -47.911561610746404, -47.914845922736234,
+                   -48.039562334265717]])
 
     model_lasso_lars = linear_model.LassoLars(alpha=0, fit_intercept=False,
                                               normalize=False)
@@ -597,17 +598,17 @@ def test_lasso_lars_vs_R_implementation():
     skl_betas = model_lasso_lars.coef_path_
 
     assert_array_almost_equal(r, skl_betas, decimal=13)
-    ############################################################################
+    ###########################################################################
 
-    ############################################################################
+    ###########################################################################
     # Scenario 2: Let's compare R vs sklearn when fit_intercept=True and
     # normalize=True
     #
-    # Note: When normalize is equal to True, R returns the coefficients in their
-    # original units, that is, they are rescaled back, whereas sklearn does not
-    # do that, therefore, we need to do this step before comparing their
-    # results.
-    ############################################################################
+    # Note: When normalize is equal to True, R returns the coefficients in
+    # their original units, that is, they are rescaled back, whereas sklearn
+    # does not do that, therefore, we need to do this step before comparing
+    # their results.
+    ###########################################################################
     #
     # The R result was obtained using the following code:
     #
@@ -619,8 +620,8 @@ def test_lasso_lars_vs_R_implementation():
     r2 = np.array([[0, 0, 0, 0, 0],
                    [0, 0, 0, 8.371887668009453, 19.463768371044026],
                    [0, 0, 0, 0, 9.901611055290553],
-                   [0, 7.495923132833733, 9.245133544334507, 17.389369207545062,
-                    26.971656815643499],
+                   [0, 7.495923132833733, 9.245133544334507,
+                    17.389369207545062, 26.971656815643499],
                    [0, 0, -1.569380717440311, -5.924804108067312,
                     -7.996385265061972]])
 
@@ -636,4 +637,4 @@ def test_lasso_lars_vs_R_implementation():
     skl_betas2 /= normx[:, np.newaxis]
 
     assert_array_almost_equal(r2, skl_betas2, decimal=13)
-    ############################################################################
+    ###########################################################################


### PR DESCRIPTION
This pull request fixes issue #7778: sklearn LassoLars implementation does not give the same result that the LassoLars implementation available in R (lars library).

#### What does this implement/fix? Explain your changes.

This mismatch is due to a bug in the file least_angle.py, in lines 406 and 407 (lars_path method).
The bug is related to the way these two lines use the np.resize function.
According to the docs of the np.resize function, If the new array is larger than the original array, then the new array is filled with repeated copies of a, which causes a subtle error, because in the lars_path implementation those new values are used as if they were equal to zero.