### PR TITLE
[MRG+1] Clarified that DBSCAN is deterministic apart from data ordering

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -757,9 +757,7 @@ by black points below.
     triangular inequality, those two core samples must be more distant than
     ``eps`` from each other, or they would be in the same cluster. The non-core
     sample is assigned to whichever cluster is generated first in a pass
-    through the data, and so the results will depend on the data ordering. 
-    As long as the dataset ordering is constant, the algorithm is deterministic, 
-    making the results stable between runs on the same data.
+    through the data, and so the results will depend on the data ordering.
 
     The current implementation uses ball trees and kd-trees
     to determine the neighborhood of points,

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -746,21 +746,20 @@ by black points below.
 
 .. topic:: Implementation
 
-    The DBSCAN algorithm is deterministic, generating the same clusters when given
-    the same data in the same order.  However, the results can differ when
+    The DBSCAN algorithm is deterministic, always generating the same clusters 
+    when given the same data in the same order.  However, the results can differ when
     data is provided in a different order. First, even though the core samples 
     will always be assigned to the same clusters, the labels of those clusters
     will depend on the order in which those samples are encountered in the data.
-    More importantly, the clusters to which non-core samples are assigned can 
-    differ depending on the data order.  This will happen when a non-core sample
+    Second and more importantly, the clusters to which non-core samples are assigned
+    can differ depending on the data order.  This would happen when a non-core sample
     has a distance lower than ``eps`` to two core samples in different clusters. By the
     triangular inequality, those two core samples must be more distant than
     ``eps`` from each other, or they would be in the same cluster. The non-core
     sample is assigned to whichever cluster is generated first in a pass
-    through the data, and thus data encountered in a different order
-    will result in clusters with different labels. Other than the ordering of
-    the dataset, the algorithm is deterministic, making the results stable
-    between runs on the same data.
+    through the data, and so the results will depend on the data ordering. 
+    As long as the dataset ordering is constant, the algorithm is deterministic, 
+    making the results stable between runs on the same data.
 
     The current implementation uses ball trees and kd-trees
     to determine the neighborhood of points,

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -746,17 +746,21 @@ by black points below.
 
 .. topic:: Implementation
 
-    The algorithm is non-deterministic, but the core samples will
-    always belong to the same clusters (although the labels may be
-    different). The non-determinism comes from deciding to which cluster a
-    non-core sample belongs. A non-core sample can have a distance lower
-    than ``eps`` to two core samples in different clusters. By the
+    The DBSCAN algorithm is deterministic, generating the same clusters when given
+    the same data in the same order.  However, the results can differ when
+    data is provided in a different order. First, even though the core samples 
+    will always be assigned to the same clusters, the labels of those clusters
+    will depend on the order in which those samples are encountered in the data.
+    More importantly, the clusters to which non-core samples are assigned can 
+    differ depending on the data order.  This will happen when a non-core sample
+    has a distance lower than ``eps`` to two core samples in different clusters. By the
     triangular inequality, those two core samples must be more distant than
     ``eps`` from each other, or they would be in the same cluster. The non-core
-    sample is assigned to whichever cluster is generated first, where
-    the order is determined randomly. Other than the ordering of
-    the dataset, the algorithm is deterministic, making the results relatively
-    stable between runs on the same data.
+    sample is assigned to whichever cluster is generated first in a pass
+    through the data, and thus data encountered in a different order
+    will result in clusters with different labels. Other than the ordering of
+    the dataset, the algorithm is deterministic, making the results stable
+    between runs on the same data.
 
     The current implementation uses ball trees and kd-trees
     to determine the neighborhood of points,


### PR DESCRIPTION
Fixes #7848.

The documentation previously stated that DBSCAN was non-deterministic and that order was being randomized, both of which were misleading, as the algorithm is deterministic as long as the order of the inputs is not varied, and the code itself was not randomizing the inputs.  Rewrote the description to make this clear.