### PR TITLE
[MRG + 1] Replace assert_equal by assert_almost_equal in cosine test

### DIFF
--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -418,7 +418,7 @@ def test_cosine_distances():
     assert_true(np.all(D >= 0.))
     assert_true(np.all(D <= 2.))
     # check that diagonal elements are equal to 0
-    assert_array_equal(D[np.diag_indices_from(D)], [0., 0.])
+    assert_array_almost_equal(D[np.diag_indices_from(D)], [0., 0.])
 
     XB = np.vstack([x, -x])
     D2 = cosine_distances(XB)
@@ -426,7 +426,7 @@ def test_cosine_distances():
     assert_true(np.all(D2 >= 0.))
     assert_true(np.all(D2 <= 2.))
     # check that diagonal elements are equal to 0 and non diagonal to 2
-    assert_array_equal(D2, [[0., 2.], [2., 0.]])
+    assert_array_almost_equal(D2, [[0., 2.], [2., 0.]])
 
     # check large random matrix
     X = np.abs(rng.rand(1000, 5000))


### PR DESCRIPTION
This test fails on the build servers:
https://travis-ci.org/MacPython/scikit-learn-wheels

So this needs a merge and backport asap :-/