### PR TITLE
[MRG+1] DOC adding info about circleci build artifacts

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -384,13 +384,13 @@ users that are just interested in what the feature will do, as
 opposed to how it works "under the hood".
 
 You may also be asked to show your changes when it's built. When you create
-a pull request or make changes in an existing one modifying the docs, circleci
+a pull request or make changes in an existing one modifying the docs, CircleCI
 automatically builds them. Thus, you can easily view your changes in the built
 artifacts using the following formula:
 
 ``http://scikit-learn.org/circle?{BUILD_NUMBER}``
 
-Note: When you visit the details page of the circleci tests, you can find your
+Note: When you visit the details page of the CircleCI tests, you can find your
 BUILD_NUMBER mentioned as 'build #' which is different from your pull request number
 present as 'pull/#'.
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -383,6 +383,11 @@ documentation with the maths makes it more friendly towards
 users that are just interested in what the feature will do, as
 opposed to how it works "under the hood".
 
+You may also be asked to show your changes when it's built. When you create
+a pull request or make changes in an existing one, circleci automatically
+builds the docs. Thus, you can easily view your changes in the build
+artifacts.
+
 Finally, follow the formatting rules below to make it consistently good:
 
     * Add "See also" in docstrings for related classes/functions.

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -388,7 +388,7 @@ a pull request or make changes in an existing one modifying the docs, circleci
 automatically builds them. Thus, you can easily view your changes in the built
 artifacts using the following formula:
 
-``https://{BUILD_NUMBER}-843222-gh.circle-artifacts.com/0//home/ubuntu/scikit-learn/doc/_build/html/stable/index.html``
+``http://scikit-learn.org/circle?{BUILD_NUMBER}``
 
 Note: When you visit the details page of the circleci tests, you can find your
 BUILD_NUMBER mentioned as 'build #' which is different from your pull request number

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -385,8 +385,10 @@ opposed to how it works "under the hood".
 
 You may also be asked to show your changes when it's built. When you create
 a pull request or make changes in an existing one, circleci automatically
-builds the docs. Thus, you can easily view your changes in the build
-artifacts.
+builds the docs. Thus, you can easily view your changes in the built
+artifacts using the following formula:
+
+``https://{BUILD_NUMBER}-843222-gh.circle-artifacts.com/0//home/ubuntu/scikit-learn/doc/_build/html/stable/index.html``
 
 Finally, follow the formatting rules below to make it consistently good:
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -391,8 +391,8 @@ artifacts using the following formula:
 ``http://scikit-learn.org/circle?{BUILD_NUMBER}``
 
 Note: When you visit the details page of the CircleCI tests, you can find your
-BUILD_NUMBER mentioned as 'build #' which is different from your pull request number
-present as 'pull/#'.
+BUILD_NUMBER mentioned as 'build #' which is different from your pull request
+number, which is presented as 'pull/#'.
 
 Finally, follow the formatting rules below to make it consistently good:
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -384,11 +384,15 @@ users that are just interested in what the feature will do, as
 opposed to how it works "under the hood".
 
 You may also be asked to show your changes when it's built. When you create
-a pull request or make changes in an existing one, circleci automatically
-builds the docs. Thus, you can easily view your changes in the built
+a pull request or make changes in an existing one modifying the docs, circleci
+automatically builds them. Thus, you can easily view your changes in the built
 artifacts using the following formula:
 
 ``https://{BUILD_NUMBER}-843222-gh.circle-artifacts.com/0//home/ubuntu/scikit-learn/doc/_build/html/stable/index.html``
+
+Note: When you visit the details page of the circleci tests, you can find your
+BUILD_NUMBER mentioned as 'build #' which is different from your pull request number
+present as 'pull/#'.
 
 Finally, follow the formatting rules below to make it consistently good:
 


### PR DESCRIPTION
#### Reference Issue
Fixes #7451 

#### What does this implement/fix? Explain your changes.
Added the information about accessing the circleci build artifacts when making doc changes.

#### Any other comments?
Still haven't included as to how the artifacts should be accessed. Should the formula mentioned in the thread be included? If not, then we need some way of letting them know how to access it or else adding this won't make much of a difference.
