### PR TITLE
[MRG + 1] do the warning test as we do it in other places.

### DIFF
--- a/sklearn/feature_selection/tests/test_chi2.py
+++ b/sklearn/feature_selection/tests/test_chi2.py
@@ -77,7 +77,7 @@ def test_chi2_unused_feature():
         warnings.simplefilter('always')
         chi, p = chi2([[1, 0], [0, 0]], [1, 0])
         for w in warned:
-            if 'divide by zero' in w.message:
+            if 'divide by zero' in repr(w):
                 raise AssertionError('Found unexpected warning %s' % w)
     assert_array_equal(chi, [1, np.nan])
     assert_array_equal(p[1], np.nan)


### PR DESCRIPTION
This fixes a test error on 3.3 with the particular version of numpy that we are using on our build servers. This change means we build 3.3 wheels, which currently fail.