### PR TITLE
[MRG+1] DOC adding a warning on the relation between C and alpha

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -1,4 +1,4 @@
-.. _linear_model:
+f.. _linear_model:
 
 =========================
 Generalized Linear Models
@@ -266,6 +266,11 @@ They also tend to break when the problem is badly conditioned
 
   * :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_model_selection.py`
 
+.. note:: **Comparison with the regularization parameter of SVM**
+
+      The equivalence between ``alpha`` and the regularization parameter of SVM,
+      ``C``, varies with different estimators and depends on the exact objective
+      function optimized by the model.
 
 .. _multi_task_lasso:
 

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -1,4 +1,4 @@
-f.. _linear_model:
+.. _linear_model:
 
 =========================
 Generalized Linear Models

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -266,11 +266,13 @@ They also tend to break when the problem is badly conditioned
 
   * :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_model_selection.py`
 
-.. note:: **Comparison with the regularization parameter of SVM**
+Comparison with the regularization parameter of SVM
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-      The equivalence between ``alpha`` and the regularization parameter of SVM,
-      ``C``, varies with different estimators and depends on the exact objective
-      function optimized by the model.
+The equivalence between ``alpha`` and the regularization parameter of SVM,
+``C`` is given by ``alpha = 1 / C`` or ``alpha = 1 / (n_samples * C)``, 
+depending on the estimator and the exact objective function optimized by the
+model.
 
 .. _multi_task_lasso:
 

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -603,8 +603,8 @@ The decision function is:
     regularization parameter, most other estimators use ``alpha``. The exact
     equivalence between the amount of regularization of two models depends on
     the exact objective function optimized by the model. For example, when the
-    estimator used is :class:`sklearn.linear_model.Ridge <ridge>` regression, the relation between them is given as
-    :math:`C = \frac{1}{alpha}`.
+    estimator used is :class:`sklearn.linear_model.Ridge <ridge>` regression,
+    the relation between them is given as :math:`C = \frac{1}{alpha}`.
 
 .. TODO multiclass case ?/
 

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -603,8 +603,8 @@ The decision function is:
     regularization parameter, most other estimators use ``alpha``. The exact
     equivalence between the amount of regularization of two models depends on
     the exact objective function optimized by the model. For example, when the
-    estimator used is ``Ridge Regression``, the relation between both is given as
-    :math:`C = \frac{n\_samples}{alpha}`.
+    estimator used is :class:`Ridge` regression``, the relation between them is given as
+    :math:`C = \frac{1}{alpha}`.
 
 .. TODO multiclass case ?/
 

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -600,8 +600,11 @@ The decision function is:
 .. note::
 
     While SVM models derived from `libsvm`_ and `liblinear`_ use ``C`` as
-    regularization parameter, most other estimators use ``alpha``. The relation
-    between both is :math:`C = \frac{n\_samples}{alpha}`.
+    regularization parameter, most other estimators use ``alpha``. The exact
+    equivalence between the amount of regularization of two models depends on
+    the exact objective function optimized by the model. For example, when the
+    estimator used is ``Ridge Regression``, the relation between both is given as
+    :math:`C = \frac{n\_samples}{alpha}`.
 
 .. TODO multiclass case ?/
 

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -603,7 +603,7 @@ The decision function is:
     regularization parameter, most other estimators use ``alpha``. The exact
     equivalence between the amount of regularization of two models depends on
     the exact objective function optimized by the model. For example, when the
-    estimator used is :class:`Ridge` regression``, the relation between them is given as
+    estimator used is :class:`Ridge` regression, the relation between them is given as
     :math:`C = \frac{1}{alpha}`.
 
 .. TODO multiclass case ?/

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -603,7 +603,7 @@ The decision function is:
     regularization parameter, most other estimators use ``alpha``. The exact
     equivalence between the amount of regularization of two models depends on
     the exact objective function optimized by the model. For example, when the
-    estimator used is :class:`sklearn.linear_model.Ridge` regression, the relation between them is given as
+    estimator used is :class:`sklearn.linear_model.Ridge <ridge>` regression, the relation between them is given as
     :math:`C = \frac{1}{alpha}`.
 
 .. TODO multiclass case ?/

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -603,7 +603,7 @@ The decision function is:
     regularization parameter, most other estimators use ``alpha``. The exact
     equivalence between the amount of regularization of two models depends on
     the exact objective function optimized by the model. For example, when the
-    estimator used is :class:`Ridge` regression, the relation between them is given as
+    estimator used is :class:`sklearn.linear_model.Ridge` regression, the relation between them is given as
     :math:`C = \frac{1}{alpha}`.
 
 .. TODO multiclass case ?/


### PR DESCRIPTION
#### Reference Issue
Fixes #6919 

#### What does this implement/fix? Explain your changes.
Added the note on varying equivalence between C and alpha depending on the estimator. Also, made a note in the linear models module warning about this dependence.