### PR TITLE
[MRG + 1] DOC add sklearn-crfsuite to related projects

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -73,6 +73,11 @@ and tasks.
 - `pomegranate <https://github.com/jmschrei/pomegranate>`_ Probabilistic modelling
   for Python, with an emphasis on hidden Markov models.
 
+- `sklearn-crfsuite <https://github.com/TeamHG-Memex/sklearn-crfsuite>`_
+  Linear-chain conditional random fields
+  (`CRFsuite <http://www.chokkan.org/software/crfsuite/>`_ wrapper with
+  sklearn-like API).
+
 - `py-earth <https://github.com/scikit-learn-contrib/py-earth>`_ Multivariate adaptive
   regression splines
 


### PR DESCRIPTION
What do you think about adding [sklearn-crfsuite](https://github.com/TeamHG-Memex/sklearn-crfsuite) to related projects? 

It is a https://github.com/chokkan/crfsuite wrapper which provides a CRF estimator with API similar to scikit-learn (compatible with e.g. sklearn model selection utilities). There are also some sklearn-compatible metrics and scorers for sequence classification tasks (though not many).

Another simiilar package is https://github.com/jakevdp/pyCRFsuite, but it is unmaintained.