### PR TITLE
DOC Remove unnecessary module prefix in example code.

### DIFF
--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -390,7 +390,7 @@ is similarly possible for an instance to be assigned multiple labels::
 
   >> from sklearn.preprocessing import MultiLabelBinarizer
   >> y = [[0, 1], [0, 2], [1, 3], [0, 2, 3], [2, 4]]
-  >> y = preprocessing.MultiLabelBinarizer().fit_transform(y)
+  >> y = MultiLabelBinarizer().fit_transform(y)
   >> classif.fit(X, y).predict(X)
   array([[1, 1, 0, 0, 0],
          [1, 0, 1, 0, 0],


### PR DESCRIPTION

MultiLabelBinarizer is already imported, calling it with the
``preprocessing`` module prefix produces an error.

This commit fixes that problem.