### PR TITLE
[MRG+1] Fixes bugs in t-SNE argument passing, and a bug with running using n dfs

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -121,7 +121,8 @@ Enhancements
 Bug fixes
 .........
 
-   - Fixed a bug where :class:`sklearn.manifold.t_sne` behaved incorrectly with degrees of freedom other than 1 (default). by :user:`Arthur Goldberg <artcg>`.
+   - Fixed a bug where :class:`sklearn.manifold.t_sne` behaved incorrectly when running
+     with n_components > 2. by :user:`Arthur Goldberg <artcg>`.
 
    - Fixed a bug where :class:`sklearn.linear_model.LassoLars` does not give
      the same result as the LassoLars implementation available

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -121,13 +121,14 @@ Enhancements
 Bug fixes
 .........
 
+   - Fixed a bug where :class:`sklearn.manifold.t_sne` behaved incorrectly with degrees of freedom other than 1 (default). by :user:`Arthur Goldberg <artcg>`.
+
    - Fixed a bug where :class:`sklearn.linear_model.LassoLars` does not give
      the same result as the LassoLars implementation available
      in R (lars library). :issue:`7849` by :user:`Jair Montoya Martinez <jmontoyam>`
    - Some ``fetch_`` functions in `sklearn.datasets` were ignoring the
      ``download_if_missing`` keyword.  This was fixed in :issue:`7944` by
      :user:`Ralf Gommers <rgommers>`.
-
 
    - Fix a bug regarding fitting :class:`sklearn.cluster.KMeans` with a
      sparse array X and initial centroids, where X's means were unnecessarily

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -1351,42 +1351,6 @@ def make_s_curve(n_samples=100, noise=0.0, random_state=None):
 
     return X, t
 
-def make_trefoil_knot(n_samples=100, noise=0.0, random_state=None):
-    """Generate an Uniform Trefoil Knot 
-
-    Read more in the :ref:`User Guide <sample_generators>`.
-
-    Parameters
-    ----------
-    n_samples : int, optional (default=100)
-        The number of sample points on the Trefoil Knot.
-
-    noise : float, optional (default=0.0)
-        The standard deviation of the gaussian noise.
-
-    Returns
-    -------
-    X : array of shape [n_samples, 3]
-        The points.
-
-    t : array of shape [n_samples]
-        The univariate position of the sample according to the main dimension
-        of the points in the manifold.
-    """
-    generator = check_random_state(random_state)
-    
-    t = np.array([np.arange(0,2*np.pi,(2*np.pi)/n_samples)])
-
-    x = np.sin(t) + 2 * np.sin(2*t)
-    y = np.cos(t) - 2 * np.cos(2*t)
-    z = -3 * np.sin(3*t)
-
-    X = np.concatenate((x, y, z))
-    X += noise * generator.randn(3, n_samples)
-    X = X.T
-    t = np.squeeze(t)
-
-    return X, t
 
 def make_gaussian_quantiles(mean=None, cov=1., n_samples=100,
                             n_features=2, n_classes=3,

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -1351,6 +1351,42 @@ def make_s_curve(n_samples=100, noise=0.0, random_state=None):
 
     return X, t
 
+def make_trefoil_knot(n_samples=100, noise=0.0, random_state=None):
+    """Generate an Uniform Trefoil Knot 
+
+    Read more in the :ref:`User Guide <sample_generators>`.
+
+    Parameters
+    ----------
+    n_samples : int, optional (default=100)
+        The number of sample points on the Trefoil Knot.
+
+    noise : float, optional (default=0.0)
+        The standard deviation of the gaussian noise.
+
+    Returns
+    -------
+    X : array of shape [n_samples, 3]
+        The points.
+
+    t : array of shape [n_samples]
+        The univariate position of the sample according to the main dimension
+        of the points in the manifold.
+    """
+    generator = check_random_state(random_state)
+    
+    t = np.array([np.arange(0,2*np.pi,(2*np.pi)/n_samples)])
+
+    x = np.sin(t) + 2 * np.sin(2*t)
+    y = np.cos(t) - 2 * np.cos(2*t)
+    z = -3 * np.sin(3*t)
+
+    X = np.concatenate((x, y, z))
+    X += noise * generator.randn(3, n_samples)
+    X = X.T
+    t = np.squeeze(t)
+
+    return X, t
 
 def make_gaussian_quantiles(mean=None, cov=1., n_samples=100,
                             n_features=2, n_classes=3,
@@ -1640,3 +1676,4 @@ def make_checkerboard(shape, n_clusters, noise=0.0, minval=10,
                      for label in range(n_col_clusters))
 
     return result, rows, cols
+

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -1640,4 +1640,3 @@ def make_checkerboard(shape, n_clusters, noise=0.0, minval=10,
                      for label in range(n_col_clusters))
 
     return result, rows, cols
-

--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -512,7 +512,7 @@ cdef float compute_gradient_positive(float[:,:] val_P,
         float[3] buff
         float D, Q, pij
         float C = 0.0
-        float exponent = (dof + 1.0) / -2.0
+        float exponent = (dof + 1.0) / 2.0
     cdef clock_t t1, t2
     t1 = clock()
     for i in range(start, n):
@@ -528,8 +528,9 @@ cdef float compute_gradient_positive(float[:,:] val_P,
             for ax in range(n_dimensions):
                 buff[ax] = pos_reference[i, ax] - pos_reference[j, ax]
                 D += buff[ax] ** 2.0  
-            Q = ((1.0 + (D / dof)) ** exponent)
+            Q = ((((D) / dof) + 1.0) ** -1)
             D = pij * Q
+            Q = Q ** exponent
             Q /= sum_Q
             C += pij * log((pij + EPSILON) / (Q + EPSILON))
             for ax in range(n_dimensions):
@@ -565,7 +566,7 @@ cdef void compute_gradient_negative(float[:,:] val_P,
         float* deltas
         long* l
         int n_dimensions = root_node.tree.n_dimensions
-        float qijZ, mult
+        float qijZ, mult, oijZ
         long idx, 
         long dta = 0
         long dtb = 0
@@ -599,11 +600,12 @@ cdef void compute_gradient_negative(float[:,:] val_P,
         # for the digits dataset, walking the tree
         # is about 10-15x more expensive than the 
         # following for loop
-        exponent = (dof + 1.0) / -2.0
+        exponent = (dof + 1.0) / 2.0
         for j in range(l[0]):
-            qijZ = (1.0 + (dist2s[j] / dof)) ** exponent
+            oijZ = ((1.0 + (dist2s[j]) / dof)) ** -1
+            qijZ = oijZ ** exponent
             sum_Q[0] += sizes[j] * qijZ
-            mult = sizes[j] * qijZ * qijZ
+            mult = sizes[j] * oijZ * qijZ
             for ax in range(n_dimensions):
                 idx = j * n_dimensions + ax
                 neg_force[ax] += mult * deltas[idx]

--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -528,7 +528,7 @@ cdef float compute_gradient_positive(float[:,:] val_P,
             for ax in range(n_dimensions):
                 buff[ax] = pos_reference[i, ax] - pos_reference[j, ax]
                 D += buff[ax] ** 2.0  
-            Q = (((1.0 + D) / dof) ** exponent)
+            Q = ((1.0 + (D / dof)) ** exponent)
             D = pij * Q
             Q /= sum_Q
             C += pij * log((pij + EPSILON) / (Q + EPSILON))
@@ -601,7 +601,7 @@ cdef void compute_gradient_negative(float[:,:] val_P,
         # following for loop
         exponent = (dof + 1.0) / -2.0
         for j in range(l[0]):
-            qijZ = ((1.0 + dist2s[j]) / dof) ** exponent
+            qijZ = (1.0 + (dist2s[j] / dof)) ** exponent
             sum_Q[0] += sizes[j] * qijZ
             mult = sizes[j] * qijZ * qijZ
             for ax in range(n_dimensions):

--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -528,7 +528,7 @@ cdef float compute_gradient_positive(float[:,:] val_P,
             for ax in range(n_dimensions):
                 buff[ax] = pos_reference[i, ax] - pos_reference[j, ax]
                 D += buff[ax] ** 2.0  
-            Q = ((((D) / dof) + 1.0) ** -1)
+            Q = ((D / dof + 1.0) ** -1)
             D = pij * Q
             Q = Q ** exponent
             Q /= sum_Q
@@ -602,7 +602,7 @@ cdef void compute_gradient_negative(float[:,:] val_P,
         # following for loop
         exponent = (dof + 1.0) / 2.0
         for j in range(l[0]):
-            oijZ = ((1.0 + (dist2s[j]) / dof)) ** -1
+            oijZ = (1.0 + dist2s[j] / dof) ** -1
             qijZ = oijZ ** exponent
             sum_Q[0] += sizes[j] * qijZ
             mult = sizes[j] * oijZ * qijZ

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -297,7 +297,7 @@ def _kl_divergence_bh(params, P, neighbors, degrees_of_freedom, n_samples,
 
 def _gradient_descent(objective, p0, it, n_iter, objective_error=None,
                       n_iter_check=1, n_iter_without_progress=30,
-                      momentum=0.5, learning_rate=200.0, min_gain=0.01,
+                      momentum=0.5, learning_rate=1000.0, min_gain=0.01,
                       min_grad_norm=1e-7, min_error_diff=1e-7, verbose=0,
                       args=None, kwargs=None):
     """Batch gradient descent with momentum and individual gains.
@@ -336,7 +336,7 @@ def _gradient_descent(objective, p0, it, n_iter, objective_error=None,
         The momentum generates a weight for previous gradients that decays
         exponentially.
 
-    learning_rate : float, optional (default: 200.0)
+    learning_rate : float, optional (default: 1000.0)
         The learning rate should be extremely high for t-SNE! Values in the
         range [100.0, 1000.0] are common.
 
@@ -534,14 +534,14 @@ class TSNE(BaseEstimator):
         optimization, the early exaggeration factor or the learning rate
         might be too high.
 
-    learning_rate : float, optional (default: 200)
+    learning_rate : float, optional (default: 1000)
         The learning rate can be a critical parameter. It should be
         between 100 and 1000. If the cost function increases during initial
         optimization, the early exaggeration factor or the learning rate
         might be too high. If the cost function gets stuck in a bad local
         minimum increasing the learning rate helps sometimes.
 
-    n_iter : int, optional (default: 2000)
+    n_iter : int, optional (default: 1000)
         Maximum number of iterations for the optimization. Should be at
         least 200.
 
@@ -645,10 +645,11 @@ class TSNE(BaseEstimator):
     """
 
     def __init__(self, n_components=2, perplexity=30.0,
-                 early_exaggeration=4.0, learning_rate=200.0, n_iter=2000,
+                 early_exaggeration=4.0, learning_rate=1000.0, n_iter=1000,
                  n_iter_without_progress=30, min_grad_norm=1e-7,
                  metric="euclidean", init="random", verbose=0,
-                 random_state=None, method='barnes_hut', angle=0.5, degrees_of_freedom=1, min_error_diff=1e-7):
+                 random_state=None, method='barnes_hut', angle=0.5,
+                 degrees_of_freedom=1, min_error_diff=1e-7):
         if not ((isinstance(init, string_types) and
                 init in ["pca", "random"]) or
                 isinstance(init, np.ndarray)):
@@ -667,7 +668,10 @@ class TSNE(BaseEstimator):
         self.random_state = random_state
         self.method = method
         self.angle = angle
-        self.degrees_of_freedom = degrees_of_freedom
+        if degrees_of_freedom is None:
+            self.degrees_of_freedom = max(self.n_components - 1.0, 1)
+        else:
+            self.degrees_of_freedom = degrees_of_freedom
         self.embedding_ = None
         self.min_error_diff = min_error_diff
 
@@ -737,9 +741,7 @@ class TSNE(BaseEstimator):
             raise ValueError("All distances should be positive, either "
                              "the metric or precomputed distances given "
                              "as X are not correct")
-
-        # Degrees of freedom of the Student's t-distribution. 
-
+        # Degrees of freedom of the Student's t-distribution.
         degrees_of_freedom = self.degrees_of_freedom
         n_samples = X.shape[0]
         # the number of nearest neighbors to find

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -296,7 +296,7 @@ def _kl_divergence_bh(params, P, neighbors, degrees_of_freedom, n_samples,
 
 
 def _gradient_descent(objective, p0, it, n_iter, objective_error=None,
-                      n_iter_check=1, n_iter_without_progress=50,
+                      n_iter_check=1, n_iter_without_progress=30,
                       momentum=0.5, learning_rate=1000.0, min_gain=0.01,
                       min_grad_norm=1e-7, min_error_diff=1e-7, verbose=0,
                       args=None, kwargs=None):
@@ -648,7 +648,7 @@ class TSNE(BaseEstimator):
                  early_exaggeration=4.0, learning_rate=1000.0, n_iter=1000,
                  n_iter_without_progress=30, min_grad_norm=1e-7,
                  metric="euclidean", init="random", verbose=0,
-                 random_state=None, method='barnes_hut', angle=0.5, degrees_of_freedom=1):
+                 random_state=None, method='barnes_hut', angle=0.5, degrees_of_freedom=1, min_error_diff=1e-7):
         if not ((isinstance(init, string_types) and
                 init in ["pca", "random"]) or
                 isinstance(init, np.ndarray)):
@@ -669,6 +669,7 @@ class TSNE(BaseEstimator):
         self.angle = angle
         self.degrees_of_freedom = degrees_of_freedom
         self.embedding_ = None
+        self.min_error_diff = min_error_diff
 
     def _fit(self, X, skip_num_points=0):
         """Fit the model using X as training data.
@@ -821,7 +822,7 @@ class TSNE(BaseEstimator):
                     self.n_components]
             opt_args['args'] = args
             opt_args['min_grad_norm'] = 1e-3
-            opt_args['n_iter_without_progress'] = 30
+            opt_args['n_iter_without_progress'] = self.n_iter_without_progress
             # Don't always calculate the cost since that calculation
             # can be nearly as expensive as the gradient
             opt_args['objective_error'] = objective_error
@@ -831,7 +832,7 @@ class TSNE(BaseEstimator):
             obj_func = _kl_divergence
             opt_args['args'] = [P, degrees_of_freedom, n_samples,
                                 self.n_components]
-            opt_args['min_error_diff'] = 0.0
+            opt_args['min_error_diff'] = self.min_error_diff
             opt_args['min_grad_norm'] = self.min_grad_norm
 
         # Early exaggeration

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -289,8 +289,9 @@ def _kl_divergence_bh(params, P, neighbors, degrees_of_freedom, n_samples,
     error = _barnes_hut_tsne.gradient(sP, X_embedded, neighbors,
                                       grad, angle, n_components, verbose,
                                       dof=degrees_of_freedom)
+    c = 2 * (degrees_of_freedom + 1) / degrees_of_freedom
     grad = grad.ravel()
-    grad *= 2
+    grad *= c
 
     return error, grad
 

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -673,7 +673,6 @@ class TSNE(BaseEstimator):
             self.degrees_of_freedom = max(self.n_components - 1.0, 1)
         else:
             self.degrees_of_freedom = degrees_of_freedom
-        self.embedding_ = None
         self.min_error_diff = min_error_diff
 
     def _fit(self, X, skip_num_points=0):

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -161,7 +161,8 @@ def _kl_divergence(params, P, degrees_of_freedom, n_samples, n_components,
     for i in range(skip_num_points, n_samples):
         np.dot(_ravel(PQd[i]), X_embedded[i] - X_embedded, out=grad[i])
     grad = grad.ravel()
-
+    grad *= 2
+    
     return kl_divergence, grad
 
 

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -162,7 +162,7 @@ def _kl_divergence(params, P, degrees_of_freedom, n_samples, n_components,
         np.dot(_ravel(PQd[i]), X_embedded[i] - X_embedded, out=grad[i])
     grad = grad.ravel()
     grad *= 2
-    
+
     return kl_divergence, grad
 
 
@@ -289,9 +289,8 @@ def _kl_divergence_bh(params, P, neighbors, degrees_of_freedom, n_samples,
     error = _barnes_hut_tsne.gradient(sP, X_embedded, neighbors,
                                       grad, angle, n_components, verbose,
                                       dof=degrees_of_freedom)
-    c = 2.0 * (degrees_of_freedom + 1.0) / degrees_of_freedom
     grad = grad.ravel()
-    grad *= c
+    grad *= 2
 
     return error, grad
 

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -297,7 +297,7 @@ def _kl_divergence_bh(params, P, neighbors, degrees_of_freedom, n_samples,
 
 def _gradient_descent(objective, p0, it, n_iter, objective_error=None,
                       n_iter_check=1, n_iter_without_progress=30,
-                      momentum=0.5, learning_rate=1000.0, min_gain=0.01,
+                      momentum=0.5, learning_rate=200.0, min_gain=0.01,
                       min_grad_norm=1e-7, min_error_diff=1e-7, verbose=0,
                       args=None, kwargs=None):
     """Batch gradient descent with momentum and individual gains.
@@ -336,7 +336,7 @@ def _gradient_descent(objective, p0, it, n_iter, objective_error=None,
         The momentum generates a weight for previous gradients that decays
         exponentially.
 
-    learning_rate : float, optional (default: 1000.0)
+    learning_rate : float, optional (default: 200.0)
         The learning rate should be extremely high for t-SNE! Values in the
         range [100.0, 1000.0] are common.
 
@@ -534,14 +534,14 @@ class TSNE(BaseEstimator):
         optimization, the early exaggeration factor or the learning rate
         might be too high.
 
-    learning_rate : float, optional (default: 1000)
+    learning_rate : float, optional (default: 200)
         The learning rate can be a critical parameter. It should be
         between 100 and 1000. If the cost function increases during initial
         optimization, the early exaggeration factor or the learning rate
         might be too high. If the cost function gets stuck in a bad local
         minimum increasing the learning rate helps sometimes.
 
-    n_iter : int, optional (default: 1000)
+    n_iter : int, optional (default: 2000)
         Maximum number of iterations for the optimization. Should be at
         least 200.
 
@@ -645,7 +645,7 @@ class TSNE(BaseEstimator):
     """
 
     def __init__(self, n_components=2, perplexity=30.0,
-                 early_exaggeration=4.0, learning_rate=1000.0, n_iter=1000,
+                 early_exaggeration=4.0, learning_rate=200.0, n_iter=2000,
                  n_iter_without_progress=30, min_grad_norm=1e-7,
                  metric="euclidean", init="random", verbose=0,
                  random_state=None, method='barnes_hut', angle=0.5, degrees_of_freedom=1, min_error_diff=1e-7):

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -189,24 +189,24 @@ def test_gradient():
     n_samples = 50
     n_features = 2
     n_components = 2
-    alpha = 1.0
+    for alpha in [1.0, 2.5]:
+        distances = random_state.randn(n_samples,
+                                       n_features).astype(np.float32)
+        distances = distances.dot(distances.T)
+        np.fill_diagonal(distances, 0.0)
+        X_embedded = random_state.randn(n_samples, n_components)
 
-    distances = random_state.randn(n_samples, n_features).astype(np.float32)
-    distances = distances.dot(distances.T)
-    np.fill_diagonal(distances, 0.0)
-    X_embedded = random_state.randn(n_samples, n_components)
+        P = _joint_probabilities(distances, desired_perplexity=25.0,
+                                 verbose=0)
 
-    P = _joint_probabilities(distances, desired_perplexity=25.0,
-                             verbose=0)
+        def fun(params):
+            return _kl_divergence(params, P, alpha, n_samples, n_components)[0]
 
-    def fun(params):
-        return _kl_divergence(params, P, alpha, n_samples, n_components)[0]
+        def grad(params):
+            return _kl_divergence(params, P, alpha, n_samples, n_components)[1]
 
-    def grad(params):
-        return _kl_divergence(params, P, alpha, n_samples, n_components)[1]
-
-    assert_almost_equal(check_grad(fun, grad, X_embedded.ravel()), 0.0,
-                        decimal=5)
+        assert_almost_equal(check_grad(fun, grad, X_embedded.ravel()), 0.0,
+                            decimal=5)
 
 
 def test_trustworthiness():

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -188,8 +188,8 @@ def test_gradient():
 
     n_samples = 50
     n_features = 2
-    n_components = 2
-    for alpha in [1.0, 2.5]:
+    for n_components in [2, 4]:
+        alpha = n_components - 1
         distances = random_state.randn(n_samples,
                                        n_features).astype(np.float32)
         distances = distances.dot(distances.T)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
1. There was a bug in the implementation of t-SNE with n degrees of freedom for the 'exact' method.

2. There was a bug where some arguments were not being passed in t-SNE

3. I added support for a trefoil knot generator

4. I changed a couple default arguments for t-SNE
(Details given in the commit message)


#### Any other comments?

Please let me know if you have any questions about the changes!
