### PR TITLE
[MRG+1] CI gratuitous optimisation of doc pushing

### DIFF
--- a/build_tools/circle/push_doc.sh
+++ b/build_tools/circle/push_doc.sh
@@ -24,9 +24,11 @@ MSG="Pushing the docs to $dir/ for branch: $CIRCLE_BRANCH, commit $CIRCLE_SHA1"
 
 cd $HOME
 if [ ! -d $DOC_REPO ];
-then git clone "git@github.com:scikit-learn/"$DOC_REPO".git";
+then git clone --depth 1 --no-checkout "git@github.com:scikit-learn/"$DOC_REPO".git";
 fi
 cd $DOC_REPO
+git config core.sparseCheckout true
+echo $dir > .git/info/sparse-checkout
 git checkout $CIRCLE_BRANCH
 git reset --hard origin/$CIRCLE_BRANCH
 git rm -rf $dir/ && rm -rf $dir/


### PR DESCRIPTION
This is completely unnecessary, but in cloning scikit-learn.github.io, I realised how much faster that can be done with a couple of flags to git.