### PR TITLE
[MRG + 1] Fix the cross_val_predict function for method='predict_proba'

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -73,6 +73,10 @@ Enhancements
 Bug fixes
 .........
 
+   - :func:`model_selection.cross_val_predict` now returns output of the
+     correct shape for all values of the argument ``method``.
+     :issue:`7863` by :user:`Aman Dalmia <dalmia>`.
+
    - Fix a bug where :class:`sklearn.feature_selection.SelectFdr` did not
      exactly implement Benjamini-Hochberg procedure. It formerly may have
      selected fewer features than it should.

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -476,17 +476,12 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params,
         estimator.fit(X_train, y_train, **fit_params)
     func = getattr(estimator, method)
     predictions = func(X_test)
-    if method in ['decision_function', 'predict_proba', 'predict_log_proba']:
+    if method in ['predict_proba', 'predict_log_proba']:
         true_classes = np.unique(y)
         train_classes = np.unique(y_train)
         predictions_ = np.zeros((X_test.shape[0], true_classes.shape[0]))
-        if method is 'decision_function' and len(train_classes) == 2:
-            class_predictions = estimator.predict(X_test)
-            for i, j in enumerate(class_predictions):
-                predictions_[i, j] = predictions[i]
-        else:
-            for i, j in enumerate(train_classes):
-                predictions_[:, j] = predictions[:, i]
+        for i, j in enumerate(train_classes):
+            predictions_[:, j] = predictions[:, i]
         predictions = predictions_
     return predictions, test
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -462,6 +462,10 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params,
 
     test : array-like
         This is the value of the test parameter
+
+    classes : array-like
+        Result of calling 'estimator.classes_' for estimators having the
+        `classes_` attribute
     """
     # Adjust length of sample weights
     fit_params = fit_params if fit_params is not None else {}

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -477,18 +477,11 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params,
         estimator.fit(X_train, y_train, **fit_params)
     func = getattr(estimator, method)
     predictions = func(X_test)
-    if method is 'predict_proba' and is callable(getattr(estimator, 'classes_')):
-        class_func = getattr(estimator, 'classes_')
-        classes = class_func(X_test)
+    if method is 'predict_proba' and hasattr(estimator, 'classes_'):
+        classes = getattr(estimator, 'classes_')
         class_map = dict()
         for i in range(len(classes)):
             class_map[i] = classes[i]
-       
-        #pred = np.empty(predictions.shape)
-        #for i,(x,y) in enumerate(sorted(class_map.items(), key=operator.itemgetter(1))):
-        #    pred[i] = predictions[x]
-        #predictions = pred
-        
         sorted_indices=[x for (x,y) in sorted(class_map.items(), key=operator.itemgetter(1))]
         predictions=predictions[sorted_indices]
     return predictions, test

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -484,7 +484,7 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params,
     if method in ['decision_function', 'predict_proba', 'predict_log_proba']:
         true_classes = np.unique(y)
         predictions_ = np.zeros((X_test.shape[0], true_classes.shape[0]))
-        if method is 'decision_function' and len(estimator.classes_) == 2:
+        if method == 'decision_function' and len(estimator.classes_) == 2:
             predictions_[:, estimator.classes_[-1]] = predictions
         else:
             predictions_[:, estimator.classes_] = predictions

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -484,7 +484,7 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params,
             class_map[i] = classes[i]
         sorted_indices = [i for i, j in sorted(class_map.items(),
                                                key=operator.itemgetter(1))]
-        predictions = predictions[sorted_indices]
+        predictions = predictions[:, sorted_indices]
     return predictions, test
 
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -482,8 +482,9 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params,
         class_map = dict()
         for i in range(len(classes)):
             class_map[i] = classes[i]
-        sorted_indices=[x for (x,y) in sorted(class_map.items(), key=operator.itemgetter(1))]
-        predictions=predictions[sorted_indices]
+        sorted_indices = [i for i, j in sorted(class_map.items(),
+                                               key=operator.itemgetter(1))]
+        predictions = predictions[sorted_indices]
     return predictions, test
 
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -15,6 +15,7 @@ from __future__ import division
 import warnings
 import numbers
 import time
+import operator
 
 import numpy as np
 import scipy.sparse as sp
@@ -365,7 +366,9 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv=None, n_jobs=1,
               as in '2*n_jobs'
 
     method : string, optional, default: 'predict'
-        Invokes the passed method name of the passed estimator.
+        Invokes the passed method name of the passed estimator. For
+        method='predict_proba', the columns correspond to the classes
+        in sorted order.
 
     Returns
     -------
@@ -474,6 +477,20 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params,
         estimator.fit(X_train, y_train, **fit_params)
     func = getattr(estimator, method)
     predictions = func(X_test)
+    if method is 'predict_proba' and is callable(getattr(estimator, 'classes_')):
+        class_func = getattr(estimator, 'classes_')
+        classes = class_func(X_test)
+        class_map = dict()
+        for i in range(len(classes)):
+            class_map[i] = classes[i]
+       
+        #pred = np.empty(predictions.shape)
+        #for i,(x,y) in enumerate(sorted(class_map.items(), key=operator.itemgetter(1))):
+        #    pred[i] = predictions[x]
+        #predictions = pred
+        
+        sorted_indices=[x for (x,y) in sorted(class_map.items(), key=operator.itemgetter(1))]
+        predictions=predictions[sorted_indices]
     return predictions, test
 
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -482,8 +482,8 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params,
     func = getattr(estimator, method)
     predictions = func(X_test)
     if method in ['decision_function', 'predict_proba', 'predict_log_proba']:
-        true_classes = np.unique(y)
-        predictions_ = np.zeros((X_test.shape[0], true_classes.shape[0]))
+        n_classes = len(set(y))
+        predictions_ = np.zeros((X_test.shape[0], n_classes))
         if method == 'decision_function' and len(estimator.classes_) == 2:
             predictions_[:, estimator.classes_[-1]] = predictions
         else:

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1006,7 +1006,7 @@ def test_cross_val_predict_different_label_types():
     y_str[50:100] = iris.target_names[1]
     X[:100], y_str[:100] = shuffle(X[:100], y_str[:100], random_state=0)
 
-    kfold = KFold(len(iris.target))
+    kfold = KFold(classes)
 
     le = LabelEncoder()
     est = LogisticRegression()
@@ -1030,7 +1030,14 @@ def test_cross_val_predict_different_label_types():
         # Naive loop (should be same as cross_val_predict):
         for train, test in kfold.split(X, y_):
             est.fit(X[train], y_[train])
-            expected_predictions[test] = func(X[test])
+            expected_predictions_ = func(X[test])
+            # To avoid 2 dimensional indexing
+            exp_pred_test = np.zeros((len(test), classes))
+            if method is 'decision_function' and len(est.classes_) == 2:
+                exp_pred_test[:, est.classes_[-1]] = expected_predictions_
+            else:
+                exp_pred_test[:, est.classes_] = expected_predictions_
+            expected_predictions[test] = exp_pred_test
 
         assert_array_almost_equal(expected_predictions, predictions)
 
@@ -1050,7 +1057,14 @@ def test_cross_val_predict_different_label_types():
         # Naive loop (should be same as cross_val_predict):
         for train, test in kfold.split(X, y_str):
             est.fit(X[train], y_str[train])
-            expected_predictions[test] = func(X[test])
+            expected_predictions_ = func(X[test])
+            # To avoid 2 dimensional indexing
+            exp_pred_test = np.zeros((len(test), classes))
+            if method is 'decision_function' and len(est.classes_) == 2:
+                exp_pred_test[:, est.classes_[-1]] = expected_predictions_
+            else:
+                exp_pred_test[:, est.classes_] = expected_predictions_
+            expected_predictions[test] = exp_pred_test
 
         assert_array_almost_equal(expected_predictions, predictions)
 

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -963,10 +963,14 @@ def test_cross_val_predict_corner_case():
         # Naive loop (should be same as cross_val_predict):
         for train, test in kfold.split(X, y):
             est.fit(X[train], y[train])
-            train_classes = np.unique(y[train])
             expected_predictions_ = func(X[test])
-            for i, j in enumerate(train_classes):
-                expected_predictions[test, j] = expected_predictions_[:, i]
+            # To avoid 2 dimensional indexing
+            exp_pred_test = np.zeros((len(test), classes))
+            if method is 'decision_function' and len(est.classes_) == 2:
+                exp_pred_test[:, est.classes_[-1]] = expected_predictions_
+            else:
+                exp_pred_test[:, est.classes_] = expected_predictions_
+            expected_predictions[test] = exp_pred_test
 
         predictions = cross_val_predict(est, X, y, method=method,
                                         cv=kfold)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -914,10 +914,6 @@ def test_cross_val_predict_with_method():
     X, y = shuffle(X, y, random_state=0)
     classes = len(set(y))
 
-    y[:50] = 0
-    y[50:100] = 1
-    X[:100], y[:100] = shuffle(X[:100], y[:100], random_state=0)
-
     kfold = KFold(len(iris.target))
 
     methods = ['decision_function', 'predict_proba', 'predict_log_proba']
@@ -933,15 +929,44 @@ def test_cross_val_predict_with_method():
         # Naive loop (should be same as cross_val_predict):
         for train, test in kfold.split(X, y):
             est.fit(X[train], y[train])
+            expected_predictions[test] = func(X[test])
+
+        predictions = cross_val_predict(est, X, y, method=method,
+                                        cv=kfold)
+        assert_array_almost_equal(expected_predictions, predictions)
+
+
+def test_cross_val_predict_corner_case():
+    iris = load_iris()
+    X, y = iris.data, iris.target
+    X, y = shuffle(X, y, random_state=0)
+    classes = len(set(y))
+
+    # Modifies the dataset so that in a particular fold, produced by
+    # kfold.split, the training set is composed of only 2 classes instead of 3
+    y[:50] = 0
+    y[50:100] = 1
+    X[:100], y[:100] = shuffle(X[:100], y[:100], random_state=0)
+
+    kfold = KFold(len(iris.target))
+
+    methods = ['predict_proba', 'predict_log_proba']
+    for method in methods:
+        est = LogisticRegression()
+
+        predictions = cross_val_predict(est, X, y, method=method)
+        assert_equal(len(predictions), len(y))
+
+        expected_predictions = np.zeros([len(y), classes])
+        func = getattr(est, method)
+
+        # Naive loop (should be same as cross_val_predict):
+        for train, test in kfold.split(X, y):
+            est.fit(X[train], y[train])
             train_classes = np.unique(y[train])
             expected_predictions_ = func(X[test])
-            if method is 'decision_function' and len(train_classes) == 2:
-                expected_test_predictions = est.predict(X[test])
-                for i, j in enumerate(expected_test_predictions):
-                    expected_predictions[i, j] = expected_predictions_[i]
-            else:
-                for i, j in enumerate(train_classes):
-                    expected_predictions[test, j] = expected_predictions_[:, i]
+            for i, j in enumerate(train_classes):
+                expected_predictions[test, j] = expected_predictions_[:, i]
 
         predictions = cross_val_predict(est, X, y, method=method,
                                         cv=kfold)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -937,7 +937,7 @@ def test_cross_val_predict_with_method():
         assert_array_almost_equal(expected_predictions, predictions)
 
 
-def test_cross_val_predict_corner_case():
+def test_cross_val_predict_class_subset():
     iris = load_iris()
     X, y = iris.data, iris.target
     X, y = shuffle(X, y, random_state=0)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -937,11 +937,11 @@ def test_cross_val_predict_with_method():
         assert_array_almost_equal(expected_predictions, predictions)
 
         # Test alternative representations of y
-        predictions_y1 = cross_val_predict(est, X, y+1, method=method,
+        predictions_y1 = cross_val_predict(est, X, y + 1, method=method,
                                            cv=kfold)
         assert_array_equal(predictions, predictions_y1)
 
-        predictions_y2 = cross_val_predict(est, X, y-2, method=method,
+        predictions_y2 = cross_val_predict(est, X, y - 2, method=method,
                                            cv=kfold)
         assert_array_equal(predictions, predictions_y2)
 

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -945,7 +945,7 @@ def test_cross_val_predict_with_method():
                                            cv=kfold)
         assert_array_equal(predictions, predictions_y2)
 
-        predictions_ystr = cross_val_predict(est, X, y.astype('U'),
+        predictions_ystr = cross_val_predict(est, X, y.astype('str'),
                                              method=method, cv=kfold)
         assert_array_equal(predictions, predictions_ystr)
 


### PR DESCRIPTION
#### Reference Issue
Fixes #7863 

#### What does this implement/fix? Explain your changes.
cross_val_predict() did not specify the order of the classes when method='predict_proba' was passed as the argument. So firstly, the change mentions in the documentation that the columns returned would be sorted. Secondly, for the estimators having a `classes_` attribute, it ensures that the predictions are returned in a sorted manner.

#### Any other comments?
Currently, I haven't yet tested the code. Would be completing that within a day or so.

