### PR TITLE
Fix#7898  bug fixes.py line 406 error

### DIFF
--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -404,9 +404,6 @@ else:
 
 
 if np_version < (1, 12):
-    # tuple(1,12,'0b1') ,cannot compare with (1, 12, 0)
-    # it occured error> unorderable types: str() < int().
-    # delete the tuple third index, become (1,12)
     class MaskedArray(np.ma.MaskedArray):
         # Before numpy 1.12, np.ma.MaskedArray object is not picklable
         # This fix is needed to make our model_selection.GridSearchCV

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -403,7 +403,10 @@ else:
     from scipy.stats import rankdata
 
 
-if np_version < (1, 12, 0):
+if np_version < (1, 12):
+    # tuple(1,12,'0b1') ,cannot compare with (1, 12, 0)
+    # it occured error> unorderable types: str() < int().
+    # delete the tuple third index, become (1,12)
     class MaskedArray(np.ma.MaskedArray):
         # Before numpy 1.12, np.ma.MaskedArray object is not picklable
         # This fix is needed to make our model_selection.GridSearchCV


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #7898. 


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
There is a new bug in master brunch, scikit-learn/sklearn/utils/fixes.py
in line 406: if np_version < (1, 12, 0): , an error occured, TypeError: unorderable types: str() < int().
It's because in the function :

def _parse_version(version_string):
    version = []
    for x in version_string.split('.'):
        try:
            version.append(int(x))
        except ValueError:
            # x may be of the form dev-1ea1592
            version.append(x)
    return tuple(version)

I filing the bug by change line 406.
I changed `if np_version < (1, 12, 0):` to `if np_version < (1, 12):`
Also can we don't compare the third index value in the tuple, because numpy version is not sure ,such as '1,12,1b1' etc,  the ` _parse_version` just return (1,12,'1b1'). So we just compare the first two of the numpy version.
So in fixes.py, line 318 also should change to `if np_version < (1, 6):`
and line 356 should change to `if np_version < (1, 8):`