### PR TITLE
[MRG + 1] Remove error grep on Sphinx build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,10 @@ dependencies:
   override:
     - ./build_tools/circle/build_doc.sh:
         timeout: 3600 # seconds
+test:
+  override:
+    # override is needed otherwise nosetests is run by default
+    - echo "Documentation has been built in the 'dependencies' step. No additional test to run"
 deployment:
  push:
    branch: /^master$|^[0-9]+\.[0-9]+\.X$/

--- a/circle.yml
+++ b/circle.yml
@@ -8,10 +8,6 @@ dependencies:
   override:
     - ./build_tools/circle/build_doc.sh:
         timeout: 3600 # seconds
-test:
-  # Grep error on the documentation
-  override:
-    - cat ~/log.txt && if grep -q "Traceback (most recent call last):" ~/log.txt; then false; else true; fi
 deployment:
  push:
    branch: /^master$|^[0-9]+\.[0-9]+\.X$/


### PR DESCRIPTION
Since Sphinx-Gallery summarizes build errors at the end and exits with
error. There is no need to grep for errors in the build log to fail in
Circle CI.