### PR TITLE
[MRG + 1] Replace ConvergenceWarning by RuntimeWarning when cumsum in unstable

### DIFF
--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -25,7 +25,7 @@ from ._logistic_sigmoid import _log_logistic_sigmoid
 from ..externals.six.moves import xrange
 from .sparsefuncs_fast import csr_row_norms
 from .validation import check_array
-from ..exceptions import ConvergenceWarning, NonBLASDotWarning
+from ..exceptions import NonBLASDotWarning
 
 
 def norm(x):
@@ -869,5 +869,5 @@ def stable_cumsum(arr, axis=None, rtol=1e-05, atol=1e-08):
                              atol=atol, equal_nan=True)):
         warnings.warn('cumsum was found to be unstable: '
                       'its last element does not correspond to sum',
-                      ConvergenceWarning)
+                      RuntimeWarning)
     return out

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -36,7 +36,6 @@ from sklearn.utils.extmath import _incremental_mean_and_var
 from sklearn.utils.extmath import _deterministic_vector_sign_flip
 from sklearn.utils.extmath import softmax
 from sklearn.utils.extmath import stable_cumsum
-from sklearn.exceptions import ConvergenceWarning
 from sklearn.datasets.samples_generator import make_low_rank_matrix
 
 
@@ -655,7 +654,7 @@ def test_stable_cumsum():
         raise SkipTest("Sum is as unstable as cumsum for numpy < 1.9")
     assert_array_equal(stable_cumsum([1, 2, 3]), np.cumsum([1, 2, 3]))
     r = np.random.RandomState(0).rand(100000)
-    assert_warns(ConvergenceWarning, stable_cumsum, r, rtol=0, atol=0)
+    assert_warns(RuntimeWarning, stable_cumsum, r, rtol=0, atol=0)
 
     # test axis parameter
     A = np.random.RandomState(36).randint(1000, size=(5, 5, 5))


### PR DESCRIPTION
As per https://github.com/scikit-learn/scikit-learn/pull/7376#issuecomment-254730956.

Note, this is a change compared to 0.18.1 but I feel users should not be affected by a change of warning type. Shout if you feel otherwise.
