### PR TITLE
A doc fix of the description of Criterion.impurity_improvement()

### DIFF
--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -172,11 +172,10 @@ cdef class Criterion:
                 - self.weighted_n_left * impurity_left)
 
     cdef double impurity_improvement(self, double impurity) nogil:
-        """Placeholder for improvement in impurity after a split.
+        """Computes the improvement in impurity
 
-        Placeholder for a method which computes the improvement
-        in impurity when a split occurs. The weighted impurity improvement
-        equation is the following:
+        This methods computes the improvement in impurity when a split occurs.
+        The weighted impurity improvement equation is the following:
 
             N_t / N * (impurity - N_t_R / N_t * right_impurity
                                 - N_t_L / N_t * left_impurity)

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -172,9 +172,9 @@ cdef class Criterion:
                 - self.weighted_n_left * impurity_left)
 
     cdef double impurity_improvement(self, double impurity) nogil:
-        """Computes the improvement in impurity
+        """Compute the improvement in impurity
 
-        This methods computes the improvement in impurity when a split occurs.
+        This method computes the improvement in impurity when a split occurs.
         The weighted impurity improvement equation is the following:
 
             N_t / N * (impurity - N_t_R / N_t * right_impurity


### PR DESCRIPTION
#### Reference Issue
None.


#### What does this implement/fix? Explain your changes.
This is a doc fix.

The Criterion.impurity_improvement() defined in sklearn.tree._criterion.pyx is marked as a "Placeholder method", but I think it is not, since it has its own implementation. Alhough class FriedmanMSE does overrides it later, but still it is not simply a placeholder method.

#### Any other comments?
None


