### PR TITLE
[MRG + 1] Set a random random_state at init to ensure deterministic randomness when random_state is `None`

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -378,11 +378,11 @@ class KFold(_BaseKFold):
     >>> from sklearn.model_selection import KFold
     >>> X = np.array([[1, 2], [3, 4], [1, 2], [3, 4]])
     >>> y = np.array([1, 2, 3, 4])
-    >>> kf = KFold(n_splits=2)
+    >>> kf = KFold(n_splits=2, random_state=0)
     >>> kf.get_n_splits(X)
     2
     >>> print(kf)  # doctest: +NORMALIZE_WHITESPACE
-    KFold(n_splits=2, random_state=None, shuffle=False)
+    KFold(n_splits=2, random_state=0, shuffle=False)
     >>> for train_index, test_index in kf.split(X):
     ...    print("TRAIN:", train_index, "TEST:", test_index)
     ...    X_train, X_test = X[train_index], X[test_index]
@@ -543,11 +543,11 @@ class StratifiedKFold(_BaseKFold):
     >>> from sklearn.model_selection import StratifiedKFold
     >>> X = np.array([[1, 2], [3, 4], [1, 2], [3, 4]])
     >>> y = np.array([0, 0, 1, 1])
-    >>> skf = StratifiedKFold(n_splits=2)
+    >>> skf = StratifiedKFold(n_splits=2, random_state=0)
     >>> skf.get_n_splits(X, y)
     2
     >>> print(skf)  # doctest: +NORMALIZE_WHITESPACE
-    StratifiedKFold(n_splits=2, random_state=None, shuffle=False)
+    StratifiedKFold(n_splits=2, random_state=0, shuffle=False)
     >>> for train_index, test_index in skf.split(X, y):
     ...    print("TRAIN:", train_index, "TEST:", test_index)
     ...    X_train, X_test = X[train_index], X[test_index]

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -284,14 +284,15 @@ class _BaseKFold(with_metaclass(ABCMeta, BaseCrossValidator)):
 
         self.n_splits = n_splits
         self.shuffle = shuffle
-        if isinstance(random_state, (np.integer, numbers.Integral)):
-            self.random_state = random_state
-        else:
+        if shuffle and not isinstance(random_state,
+                                      (np.integer, numbers.Integral)):
             # This is done to ensure that the multiple calls to split
             # are random for each initialization of splitter but consistent
             # across multiple calls for the same initialization.
             self.random_state = check_random_state(
                 random_state).randint(np.iinfo(np.int32).max)
+        else:
+            self.random_state = random_state
 
     def split(self, X, y=None, groups=None):
         """Generate indices to split data into training and test set.

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -291,7 +291,7 @@ class _BaseKFold(with_metaclass(ABCMeta, BaseCrossValidator)):
             # are random for each initialization of splitter but consistent
             # across multiple calls for the same initialization.
             self._random_state = check_random_state(
-                random_state).randint(99999999)
+                random_state).randint(np.iinfo(np.int32).max)
         else:
             self._random_state = random_state
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -284,7 +284,16 @@ class _BaseKFold(with_metaclass(ABCMeta, BaseCrossValidator)):
 
         self.n_splits = n_splits
         self.shuffle = shuffle
+        # For repr
         self.random_state = random_state
+        if random_state is None:
+            # This is done to ensure that the multiple calls to split
+            # are random for each initialization of splitter but consistent
+            # across multiple calls for the same initialization.
+            self._random_state = check_random_state(
+                random_state).randint(99999999)
+        else:
+            self._random_state = random_state
 
     def split(self, X, y=None, groups=None):
         """Generate indices to split data into training and test set.
@@ -407,7 +416,7 @@ class KFold(_BaseKFold):
         n_samples = _num_samples(X)
         indices = np.arange(n_samples)
         if self.shuffle:
-            check_random_state(self.random_state).shuffle(indices)
+            check_random_state(self._random_state).shuffle(indices)
 
         n_splits = self.n_splits
         fold_sizes = (n_samples // n_splits) * np.ones(n_splits, dtype=np.int)
@@ -560,9 +569,9 @@ class StratifiedKFold(_BaseKFold):
 
     def _make_test_folds(self, X, y=None, groups=None):
         if self.shuffle:
-            rng = check_random_state(self.random_state)
+            rng = check_random_state(self._random_state)
         else:
-            rng = self.random_state
+            rng = self._random_state
         y = np.asarray(y)
         n_samples = y.shape[0]
         unique_y, y_inversed = np.unique(y, return_inverse=True)
@@ -922,7 +931,16 @@ class BaseShuffleSplit(with_metaclass(ABCMeta)):
         self.n_splits = n_splits
         self.test_size = test_size
         self.train_size = train_size
+        # For repr
         self.random_state = random_state
+        if random_state is None:
+            # This is done to ensure that the multiple calls to split
+            # are random for each initialization of splitter but consistent
+            # across multiple calls for the same initialization.
+            self._random_state = check_random_state(
+                random_state).randint(99999999)
+        else:
+            self._random_state = random_state
 
     def split(self, X, y=None, groups=None):
         """Generate indices to split data into training and test set.
@@ -1042,7 +1060,7 @@ class ShuffleSplit(BaseShuffleSplit):
         n_samples = _num_samples(X)
         n_train, n_test = _validate_shuffle_split(n_samples, self.test_size,
                                                   self.train_size)
-        rng = check_random_state(self.random_state)
+        rng = check_random_state(self._random_state)
         for i in range(self.n_splits):
             # random partition
             permutation = rng.permutation(n_samples)
@@ -1269,7 +1287,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
                              'equal to the number of classes = %d' %
                              (n_test, n_classes))
 
-        rng = check_random_state(self.random_state)
+        rng = check_random_state(self._random_state)
 
         for _ in range(self.n_splits):
             # if there are ties in the class-counts, we want

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -284,16 +284,14 @@ class _BaseKFold(with_metaclass(ABCMeta, BaseCrossValidator)):
 
         self.n_splits = n_splits
         self.shuffle = shuffle
-        # For repr
-        self.random_state = random_state
-        if random_state is None:
+        if not isinstance(random_state, (np.integer, numbers.Integral)):
             # This is done to ensure that the multiple calls to split
             # are random for each initialization of splitter but consistent
             # across multiple calls for the same initialization.
-            self._random_state = check_random_state(
+            self.random_state = check_random_state(
                 random_state).randint(np.iinfo(np.int32).max)
         else:
-            self._random_state = random_state
+            self.random_state = random_state
 
     def split(self, X, y=None, groups=None):
         """Generate indices to split data into training and test set.
@@ -416,7 +414,7 @@ class KFold(_BaseKFold):
         n_samples = _num_samples(X)
         indices = np.arange(n_samples)
         if self.shuffle:
-            check_random_state(self._random_state).shuffle(indices)
+            check_random_state(self.random_state).shuffle(indices)
 
         n_splits = self.n_splits
         fold_sizes = (n_samples // n_splits) * np.ones(n_splits, dtype=np.int)
@@ -568,10 +566,7 @@ class StratifiedKFold(_BaseKFold):
         super(StratifiedKFold, self).__init__(n_splits, shuffle, random_state)
 
     def _make_test_folds(self, X, y=None, groups=None):
-        if self.shuffle:
-            rng = check_random_state(self._random_state)
-        else:
-            rng = self._random_state
+        rng = check_random_state(self.random_state)
         y = np.asarray(y)
         n_samples = y.shape[0]
         unique_y, y_inversed = np.unique(y, return_inverse=True)
@@ -931,16 +926,14 @@ class BaseShuffleSplit(with_metaclass(ABCMeta)):
         self.n_splits = n_splits
         self.test_size = test_size
         self.train_size = train_size
-        # For repr
-        self.random_state = random_state
-        if random_state is None:
+        if not isinstance(random_state, (np.integer, numbers.Integral)):
             # This is done to ensure that the multiple calls to split
             # are random for each initialization of splitter but consistent
             # across multiple calls for the same initialization.
-            self._random_state = check_random_state(
+            self.random_state = check_random_state(
                 random_state).randint(np.iinfo(np.int32).max)
         else:
-            self._random_state = random_state
+            self.random_state = random_state
 
     def split(self, X, y=None, groups=None):
         """Generate indices to split data into training and test set.
@@ -1060,7 +1053,7 @@ class ShuffleSplit(BaseShuffleSplit):
         n_samples = _num_samples(X)
         n_train, n_test = _validate_shuffle_split(n_samples, self.test_size,
                                                   self.train_size)
-        rng = check_random_state(self._random_state)
+        rng = check_random_state(self.random_state)
         for i in range(self.n_splits):
             # random partition
             permutation = rng.permutation(n_samples)
@@ -1287,7 +1280,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
                              'equal to the number of classes = %d' %
                              (n_test, n_classes))
 
-        rng = check_random_state(self._random_state)
+        rng = check_random_state(self.random_state)
 
         for _ in range(self.n_splits):
             # if there are ties in the class-counts, we want

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -284,14 +284,14 @@ class _BaseKFold(with_metaclass(ABCMeta, BaseCrossValidator)):
 
         self.n_splits = n_splits
         self.shuffle = shuffle
-        if not isinstance(random_state, (np.integer, numbers.Integral)):
+        if isinstance(random_state, (np.integer, numbers.Integral)):
+            self.random_state = random_state
+        else:
             # This is done to ensure that the multiple calls to split
             # are random for each initialization of splitter but consistent
             # across multiple calls for the same initialization.
             self.random_state = check_random_state(
                 random_state).randint(np.iinfo(np.int32).max)
-        else:
-            self.random_state = random_state
 
     def split(self, X, y=None, groups=None):
         """Generate indices to split data into training and test set.
@@ -926,14 +926,14 @@ class BaseShuffleSplit(with_metaclass(ABCMeta)):
         self.n_splits = n_splits
         self.test_size = test_size
         self.train_size = train_size
-        if not isinstance(random_state, (np.integer, numbers.Integral)):
+        if isinstance(random_state, (np.integer, numbers.Integral)):
+            self.random_state = random_state
+        else:
             # This is done to ensure that the multiple calls to split
             # are random for each initialization of splitter but consistent
             # across multiple calls for the same initialization.
             self.random_state = check_random_state(
                 random_state).randint(np.iinfo(np.int32).max)
-        else:
-            self.random_state = random_state
 
     def split(self, X, y=None, groups=None):
         """Generate indices to split data into training and test set.

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -938,7 +938,7 @@ class BaseShuffleSplit(with_metaclass(ABCMeta)):
             # are random for each initialization of splitter but consistent
             # across multiple calls for the same initialization.
             self._random_state = check_random_state(
-                random_state).randint(99999999)
+                random_state).randint(np.iinfo(np.int32).max)
         else:
             self._random_state = random_state
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -379,11 +379,11 @@ class KFold(_BaseKFold):
     >>> from sklearn.model_selection import KFold
     >>> X = np.array([[1, 2], [3, 4], [1, 2], [3, 4]])
     >>> y = np.array([1, 2, 3, 4])
-    >>> kf = KFold(n_splits=2, random_state=0)
+    >>> kf = KFold(n_splits=2)
     >>> kf.get_n_splits(X)
     2
     >>> print(kf)  # doctest: +NORMALIZE_WHITESPACE
-    KFold(n_splits=2, random_state=0, shuffle=False)
+    KFold(n_splits=2, random_state=None, shuffle=False)
     >>> for train_index, test_index in kf.split(X):
     ...    print("TRAIN:", train_index, "TEST:", test_index)
     ...    X_train, X_test = X[train_index], X[test_index]
@@ -544,11 +544,11 @@ class StratifiedKFold(_BaseKFold):
     >>> from sklearn.model_selection import StratifiedKFold
     >>> X = np.array([[1, 2], [3, 4], [1, 2], [3, 4]])
     >>> y = np.array([0, 0, 1, 1])
-    >>> skf = StratifiedKFold(n_splits=2, random_state=0)
+    >>> skf = StratifiedKFold(n_splits=2)
     >>> skf.get_n_splits(X, y)
     2
     >>> print(skf)  # doctest: +NORMALIZE_WHITESPACE
-    StratifiedKFold(n_splits=2, random_state=0, shuffle=False)
+    StratifiedKFold(n_splits=2, random_state=None, shuffle=False)
     >>> for train_index, test_index in skf.split(X, y):
     ...    print("TRAIN:", train_index, "TEST:", test_index)
     ...    X_train, X_test = X[train_index], X[test_index]

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -147,8 +147,8 @@ def test_cross_validator_with_default_params():
     groups = np.array([1, 2, 3, 4])
     loo = LeaveOneOut()
     lpo = LeavePOut(p)
-    kf = KFold(n_splits)
-    skf = StratifiedKFold(n_splits)
+    kf = KFold(n_splits, random_state=0)
+    skf = StratifiedKFold(n_splits, random_state=0)
     lolo = LeaveOneGroupOut()
     lopo = LeavePGroupsOut(p)
     ss = ShuffleSplit(random_state=0)
@@ -156,8 +156,8 @@ def test_cross_validator_with_default_params():
 
     loo_repr = "LeaveOneOut()"
     lpo_repr = "LeavePOut(p=2)"
-    kf_repr = "KFold(n_splits=2, random_state=None, shuffle=False)"
-    skf_repr = "StratifiedKFold(n_splits=2, random_state=None, shuffle=False)"
+    kf_repr = "KFold(n_splits=2, random_state=0, shuffle=False)"
+    skf_repr = "StratifiedKFold(n_splits=2, random_state=0, shuffle=False)"
     lolo_repr = "LeaveOneGroupOut()"
     lopo_repr = "LeavePGroupsOut(n_groups=2)"
     ss_repr = ("ShuffleSplit(n_splits=10, random_state=0, test_size=0.1, "
@@ -425,8 +425,11 @@ def test_shuffle_kfold_stratifiedkfold_reproducibility():
 
     kf = KFold(3, shuffle=True, random_state=0)
     skf = StratifiedKFold(3, shuffle=True, random_state=0)
+    kf2 = KFold(3, shuffle=True, random_state=np.random.RandomState(0))
+    skf2 = StratifiedKFold(3, shuffle=True,
+                           random_state=np.random.RandomState(0))
 
-    for cv in (kf, skf):
+    for cv in (kf, skf, kf2, skf2):
         np.testing.assert_equal(list(cv.split(X, y)), list(cv.split(X, y)))
         np.testing.assert_equal(list(cv.split(X2, y2)), list(cv.split(X2, y2)))
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -430,19 +430,28 @@ def test_shuffle_kfold_stratifiedkfold_reproducibility():
         np.testing.assert_equal(list(cv.split(X, y)), list(cv.split(X, y)))
         np.testing.assert_equal(list(cv.split(X2, y2)), list(cv.split(X2, y2)))
 
+    # Tests to ensure consistent behaviour even when random_state is not set.
     kf = KFold(3, shuffle=True)
     skf = StratifiedKFold(3, shuffle=True)
-
-    for cv in (kf, skf):
+    kf1 = KFold(3, shuffle=True)
+    kf2 = KFold(3, shuffle=True)
+    skf1 = StratifiedKFold(3, shuffle=True)
+    skf2 = StratifiedKFold(3, shuffle=True)
+    for cvs in ((kf, kf1, kf2), (skf, skf1, skf2)):
         for data in zip((X, X2), (y, y2)):
+            # For the same initialilzation, splits should be same across
+            # multiple split calls, even when random_state is not set.
+            np.testing.assert_equal(list(cvs[0].split(*data)),
+                                    list(cvs[0].split(*data)))
+
             try:
-                np.testing.assert_equal(list(cv.split(*data)),
-                                        list(cv.split(*data)))
+                np.testing.assert_equal(list(cvs[1].split(*data)),
+                                        list(cvs[2].split(*data)))
             except AssertionError:
                 pass
             else:
-                raise AssertionError("The splits for data, %s, are same even "
-                                     "when random state is not set" % data)
+                raise AssertionError("When random_state is not set, the splits"
+                                     " are same for different initializations")
 
 
 def test_shuffle_stratifiedkfold():

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -429,11 +429,13 @@ def test_shuffle_kfold_stratifiedkfold_reproducibility():
     skf2 = StratifiedKFold(3, shuffle=True,
                            random_state=np.random.RandomState(0))
 
+    # 1) Test to ensure consistent behavior when random_state is set explicitly
     for cv in (kf, skf, kf2, skf2):
+        # Check that calling split twice yields the same results
         np.testing.assert_equal(list(cv.split(X, y)), list(cv.split(X, y)))
         np.testing.assert_equal(list(cv.split(X2, y2)), list(cv.split(X2, y2)))
 
-    # Tests to ensure consistent behaviour even when random_state is not set.
+    # 2) Tests to ensure consistent behavior even when random_state is not set
     kf = KFold(3, shuffle=True)
     skf = StratifiedKFold(3, shuffle=True)
     kf1 = KFold(3, shuffle=True)

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -439,11 +439,13 @@ def test_shuffle_kfold_stratifiedkfold_reproducibility():
     skf2 = StratifiedKFold(3, shuffle=True)
     for cvs in ((kf, kf1, kf2), (skf, skf1, skf2)):
         for data in zip((X, X2), (y, y2)):
-            # For the same initialilzation, splits should be same across
+            # For the same initialization, splits should be same across
             # multiple split calls, even when random_state is not set.
             np.testing.assert_equal(list(cvs[0].split(*data)),
                                     list(cvs[0].split(*data)))
 
+            # For different initialisations, splits should not be same when
+            # random_state is not set.
             try:
                 np.testing.assert_equal(list(cvs[1].split(*data)),
                                         list(cvs[2].split(*data)))

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -147,20 +147,20 @@ def test_cross_validator_with_default_params():
     groups = np.array([1, 2, 3, 4])
     loo = LeaveOneOut()
     lpo = LeavePOut(p)
-    kf = KFold(n_splits, random_state=0)
-    skf = StratifiedKFold(n_splits, random_state=0)
+    kf = KFold(n_splits)
+    skf = StratifiedKFold(n_splits)
     lolo = LeaveOneGroupOut()
     lopo = LeavePGroupsOut(p)
-    ss = ShuffleSplit(random_state=0)
+    ss = ShuffleSplit(random_state=42)
     ps = PredefinedSplit([1, 1, 2, 2])  # n_splits = np of unique folds = 2
 
     loo_repr = "LeaveOneOut()"
     lpo_repr = "LeavePOut(p=2)"
-    kf_repr = "KFold(n_splits=2, random_state=0, shuffle=False)"
-    skf_repr = "StratifiedKFold(n_splits=2, random_state=0, shuffle=False)"
+    kf_repr = "KFold(n_splits=2, random_state=None, shuffle=False)"
+    skf_repr = "StratifiedKFold(n_splits=2, random_state=None, shuffle=False)"
     lolo_repr = "LeaveOneGroupOut()"
     lopo_repr = "LeavePGroupsOut(n_groups=2)"
-    ss_repr = ("ShuffleSplit(n_splits=10, random_state=0, test_size=0.1, "
+    ss_repr = ("ShuffleSplit(n_splits=10, random_state=42, test_size=0.1, "
                "train_size=None)")
     ps_repr = "PredefinedSplit(test_fold=array([1, 1, 2, 2]))"
 


### PR DESCRIPTION
This is a better fix for #6726 as opposed to my previous #7660 

Ensures deterministic randomness across multiple calls to `split` even when `random_state` is not set...

This replicates the behaviour of cross-validators in pre 0.18...

#### In master (0.18.1)

```py
>>> from sklearn.model_selection import KFold

# Splits are different for multiple split calls when random_state is not set
>>> kf = KFold(n_splits=2, shuffle=True, random_state=None)
>>> for _ in range(2):
...     print(list(kf.split([1,] * 4)))
[(array([2, 3]), array([0, 1])), (array([0, 1]), array([2, 3]))]
[(array([1, 2]), array([0, 3])), (array([0, 3]), array([1, 2]))]
```

#### In this branch, splits are different for multiple initializations of cross-validators but same across multiple split calls for the same initialization.

```py
>>> from sklearn.model_selection import KFold

# Splits are same for same initialization in successive split calls.
>>> kf = KFold(n_splits=2, shuffle=True, random_state=None)
>>> for _ in range(2):
...     print(list(kf.split([1,] * 4)))
[(array([2, 3]), array([0, 1])), (array([0, 1]), array([2, 3]))]
[(array([2, 3]), array([0, 1])), (array([0, 1]), array([2, 3]))]

# Splits are different for different initializations of cross-validators.
>>> for _ in range(2):
...     print(list(KFold(n_splits=2, shuffle=True, random_state=None).split([1,] * 4)))
[(array([0, 2]), array([1, 3])), (array([1, 3]), array([0, 2]))]
[(array([0, 3]), array([1, 2])), (array([1, 2]), array([0, 3]))]
```

Ping @GaelVaroquaux @jnothman @amueller 

(Sorry for the tongue twisting PR title :p)