### PR TITLE
[MRG + 2] CI Report likely-affected documentation files

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -61,3 +61,26 @@ else
 fi
 # The pipefail is requested to propagate exit code
 set -o pipefail && cd doc && make $MAKE_TARGET 2>&1 | tee ~/log.txt
+
+cd -
+set +o pipefail
+
+affected_doc_paths() {
+	files=$(git diff --name-only origin/master...$CIRCLE_SHA1)
+	echo "$files" | grep ^doc/.*\.rst | sed 's/^doc\/\(.*\)\.rst$/\1.html/'
+	echo "$files" | grep ^examples/.*.py | sed 's/^\(.*\)\.py$/auto_\1.html/'
+	sklearn_files=$(echo "$files" | grep '^sklearn/')
+	grep -hlR -f<(echo "$sklearn_files" | sed 's/^/scikit-learn\/blob\/[a-z0-9]*\//') doc/_build/html/stable/modules/generated | cut -d/ -f5-
+}
+
+if [ -n "$CI_PULL_REQUEST" ]
+then
+	echo "The following documentation files may have been changed by PR #$CI_PULL_REQUEST:"
+	affected=$(affected_doc_paths)
+	echo "$affected" | sed 's|^|* http://scikit-learn.org/circle?'$CIRCLE_BUILD_NUM'/|'
+	(
+	echo '<html><body><ul>'
+	echo "$affected" | sed 's|.*|<li><a href="&">&</a></li>|'
+	echo '</ul></body></html>'
+	) > 'doc/_build/html/stable/_changed.html'
+fi


### PR DESCRIPTION
In an attempt to make the changed documentation from a PR still more accessible as rendered, this reports a list of doc pages that were most likely affected by the PR. It is reported in the build logs and at a page `http://scikit-learn.org/circle?{BUILD_ID}/_changed.html`.

Affected files are presumed to be:
* `doc/...rst` -> `.html`
* `examples/...py` -> `auto_*.html`
* generated API ref that link as source to files modified by the PR

This last may under-generate in cases of class inheritance (not sure?).

It may over-generate where:
* multiple classes or functions are defined in the same file
* the code but not docstring was modified

this over-generation could be fixed by more specific tracking of which source lines correspond to docstrings for which classes/functions... but probably later.