### PR TITLE
[MRG] Error for cosine affinity when zero vectors present

### DIFF
--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -379,7 +379,7 @@ def linkage_tree(X, connectivity=None, n_components=None,
             'Unknown linkage option, linkage should be one '
             'of %s, but %s was given' % (linkage_choices.keys(), linkage))
 
-    if np.sum(np.sum(np.abs(X), axis=1) == 0) > 0 and affinity == 'cosine':
+    if np.sum(1 - np.any(X, axis=1)) > 0 and affinity == 'cosine':
         raise ValueError(
             'Cosine affinity cannot be used when X contains zero vectors')
 

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -379,7 +379,7 @@ def linkage_tree(X, connectivity=None, n_components=None,
             'Unknown linkage option, linkage should be one '
             'of %s, but %s was given' % (linkage_choices.keys(), linkage))
 
-	if np.sum(np.sum(np.abs(X), axis=1) == 0) > 0 and affinity == 'cosine':
+    if np.sum(np.sum(np.abs(X), axis=1) == 0) > 0 and affinity == 'cosine':
         raise ValueError(
             'Cosine affinity cannot be used when X contains zero vectors')
 

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -379,6 +379,10 @@ def linkage_tree(X, connectivity=None, n_components=None,
             'Unknown linkage option, linkage should be one '
             'of %s, but %s was given' % (linkage_choices.keys(), linkage))
 
+	if np.sum(np.sum(np.abs(X), axis=1) == 0) > 0 and affinity == 'cosine':
+        raise ValueError(
+            'Cosine affinity cannot be used when X contains zero vectors')
+
     if connectivity is None:
         from scipy.cluster import hierarchy     # imports PIL
 

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -379,7 +379,7 @@ def linkage_tree(X, connectivity=None, n_components=None,
             'Unknown linkage option, linkage should be one '
             'of %s, but %s was given' % (linkage_choices.keys(), linkage))
 
-    if np.sum(1 - np.any(X, axis=1)) > 0 and affinity == 'cosine':
+    if affinity == 'cosine' and np.sum(1 - np.any(X, axis=1)) > 0:
         raise ValueError(
             'Cosine affinity cannot be used when X contains zero vectors')
 

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -379,7 +379,7 @@ def linkage_tree(X, connectivity=None, n_components=None,
             'Unknown linkage option, linkage should be one '
             'of %s, but %s was given' % (linkage_choices.keys(), linkage))
 
-    if affinity == 'cosine' and np.sum(1 - np.any(X, axis=1)) > 0:
+    if affinity == 'cosine' and np.any(~np.any(X, axis=1)):
         raise ValueError(
             'Cosine affinity cannot be used when X contains zero vectors')
 

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -115,6 +115,14 @@ def test_height_linkage_tree():
         assert_true(len(children) + n_leaves == n_nodes)
 
 
+def test_zero_cosine_linkage_tree():
+    # Check that zero vectors in X produce an error when
+    # 'cosine' affinity is used
+    X = np.array([[0, 1],
+                  [0, 0]])
+    assert_raises(ValueError, linkage_tree, X, affinity='cosine')
+
+
 def test_agglomerative_clustering():
     # Check that we obtain the correct number of clusters with
     # agglomerative clustering.

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -120,7 +120,8 @@ def test_zero_cosine_linkage_tree():
     # 'cosine' affinity is used
     X = np.array([[0, 1],
                   [0, 0]])
-    assert_raises(ValueError, linkage_tree, X, affinity='cosine')
+    msg = 'Cosine affinity cannot be used when X contains zero vectors'
+    assert_raise_message(ValueError, msg, linkage_tree, X, affinity='cosine')
 
 
 def test_agglomerative_clustering():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Fixes #7689


#### What does this implement/fix? Explain your changes.
Previously, code would hang/create memory leak when trying to agglomerate observations/features when using cosine distance and zero vectors. Now an error is produced in this setting.

Cosine distance is generally undefined when taking distances to zero vectors--and in fact different answers are produced depending on the code used scipy's pdist vs. sklearn's cosine_distances vs. sklearn's paired_cosine_distances.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
