### PR TITLE
[MRG + 1] Fix sklearn.model_selection.tests.test_split:test_cv_iterable_wrapper on numpy master

### DIFF
--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1028,16 +1028,23 @@ def test_cv_iterable_wrapper():
     # Since the wrapped iterable is enlisted and stored,
     # split can be called any number of times to produce
     # consistent results.
-    assert_array_equal(list(kf_iter_wrapped.split(X, y)),
-                       list(kf_iter_wrapped.split(X, y)))
+    np.testing.assert_equal(list(kf_iter_wrapped.split(X, y)),
+                            list(kf_iter_wrapped.split(X, y)))
     # If the splits are randomized, successive calls to split yields different
     # results
     kf_randomized_iter = KFold(n_splits=5, shuffle=True).split(X, y)
     kf_randomized_iter_wrapped = check_cv(kf_randomized_iter)
-    assert_array_equal(list(kf_randomized_iter_wrapped.split(X, y)),
-                       list(kf_randomized_iter_wrapped.split(X, y)))
-    assert_true(np.any(np.array(list(kf_iter_wrapped.split(X, y))) !=
-                       np.array(list(kf_randomized_iter_wrapped.split(X, y)))))
+    np.testing.assert_equal(list(kf_randomized_iter_wrapped.split(X, y)),
+                            list(kf_randomized_iter_wrapped.split(X, y)))
+
+    try:
+        np.testing.assert_equal(list(kf_iter_wrapped.split(X, y)),
+                                list(kf_randomized_iter_wrapped.split(X, y)))
+        splits_are_equal = True
+    except AssertionError:
+        splits_are_equal = False
+    assert_false(splits_are_equal, "If the splits are randomized, "
+                 "successive calls to split should yield different results")
 
 
 def test_group_kfold():


### PR DESCRIPTION
As mentioned in https://github.com/scikit-learn/scikit-learn/pull/7910#issuecomment-263117496 the tests started failing with numpy master one day or so ago.

#### What does this implement/fix? Explain your changes.
It looks like we were in a edge case of assert_array_equal. See https://github.com/numpy/numpy/issues/8323#issuecomment-263147507 for more details.

I am using `numpy.testing.assert_equal` which seems better at dealing with nested structures containing arrays.