### PR TITLE
DOC: add bug fix for ``download_if_missing`` behavior to whatsnew.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -95,6 +95,9 @@ Bug fixes
    - Fixed a bug where :class:`sklearn.linear_model.LassoLars` does not give
      the same result as the LassoLars implementation available
      in R (lars library). :issue:`7849` by `Jair Montoya Martinez`_
+   - Some ``fetch_`` functions in `sklearn.datasets` were ignoring the
+     ``download_if_missing`` keyword.  This was fixed in :issue:`7944` by
+     :user:`Ralf Gommers <rgommers>`.
 
 
    - Fix a bug regarding fitting :class:`sklearn.cluster.KMeans` with a


### PR DESCRIPTION
On request of @amueller, see gh-7944