### PR TITLE
[MRG] Gradient boosting overflow bug

### DIFF
--- a/examples/preprocessing/count_featurizer_transformer.py
+++ b/examples/preprocessing/count_featurizer_transformer.py
@@ -12,17 +12,24 @@ from sklearn.ensemble import RandomForestClassifier, ExtraTreesClassifier
 
 RANDOM_STATE = 123
 
-n_datapoints = 500 # 500
-n_informative = 15 # 15
-n_features = 25 # 25
+n_datapoints = 500  # 500
+n_informative = 10  # 15
+n_features = 10  # 25
+n_redundant = 0
 
 # Generate a binary classification dataset.
 X, y = make_classification(n_samples=n_datapoints, n_features=n_features,
                            n_clusters_per_class=1, n_informative=n_informative,
-                           random_state=RANDOM_STATE)
+                           n_redundant=n_redundant, random_state=RANDOM_STATE)
+
+X = X * 10
+# only make these selected features "categorical"
+discretized_features = [0, 1]
+for feature in discretized_features:
+    X[:, feature] = (X[:, feature]).astype(int)
 
 # X_count is X with an additional feature column 'count'
-cf = CountFeaturizer()
+cf = CountFeaturizer(inclusion=discretized_features)
 X_count = cf.fit_transform(X)
 
 # NOTE: Setting the `warm_start` construction parameter to `True` disables
@@ -35,17 +42,17 @@ def init_clfs():
     global ensemble_clfs
     ensemble_clfs = [
         ("RandomForestClassifier, max_features='sqrt'",
-            RandomForestClassifier(warm_start=True, oob_score=True,
-                                   max_features="sqrt",
-                                   random_state=RANDOM_STATE)),
+         RandomForestClassifier(warm_start=True, oob_score=True,
+                                max_features="sqrt",
+                                random_state=RANDOM_STATE)),
         ("RandomForestClassifier, max_features='log2'",
-            RandomForestClassifier(warm_start=True, max_features='log2',
-                                   oob_score=True,
-                                   random_state=RANDOM_STATE)),
+         RandomForestClassifier(warm_start=True, max_features='log2',
+                                oob_score=True,
+                                random_state=RANDOM_STATE)),
         ("RandomForestClassifier, max_features=None",
-            RandomForestClassifier(warm_start=True, max_features=None,
-                                   oob_score=True,
-                                   random_state=RANDOM_STATE))
+         RandomForestClassifier(warm_start=True, max_features=None,
+                                oob_score=True,
+                                random_state=RANDOM_STATE))
     ]
 
 classifiers_used = [1]
@@ -66,7 +73,7 @@ error_rate = OrderedDict((label, []) for index, label in
 
 # Range of `n_estimators` values to explore.
 min_estimators = 15
-max_estimators = 175 # 175
+max_estimators = 175  # 175
 
 index = 0
 time_start = time.time()

--- a/examples/preprocessing/count_featurizer_transformer.py
+++ b/examples/preprocessing/count_featurizer_transformer.py
@@ -1,0 +1,112 @@
+from __future__ import print_function
+import matplotlib.pyplot as plt
+import numpy as np
+import time
+from sklearn.preprocessing.data import CountFeaturizer
+from collections import OrderedDict
+from sklearn.datasets import make_classification
+from sklearn.ensemble import RandomForestClassifier, ExtraTreesClassifier
+
+# with reference to auto_examples/ensemble/plot_ensemble_oob
+
+
+RANDOM_STATE = 123
+
+n_datapoints = 500 # 500
+n_informative = 15 # 15
+n_features = 25 # 25
+
+# Generate a binary classification dataset.
+X, y = make_classification(n_samples=n_datapoints, n_features=n_features,
+                           n_clusters_per_class=1, n_informative=n_informative,
+                           random_state=RANDOM_STATE)
+
+# X_count is X with an additional feature column 'count'
+cf = CountFeaturizer()
+X_count = cf.fit_transform(X)
+
+# NOTE: Setting the `warm_start` construction parameter to `True` disables
+# support for parallelized ensembles but is necessary for tracking the OOB
+# error trajectory during training.
+ensemble_clfs = None
+
+
+def init_clfs():
+    global ensemble_clfs
+    ensemble_clfs = [
+        ("RandomForestClassifier, max_features='sqrt'",
+            RandomForestClassifier(warm_start=True, oob_score=True,
+                                   max_features="sqrt",
+                                   random_state=RANDOM_STATE)),
+        ("RandomForestClassifier, max_features='log2'",
+            RandomForestClassifier(warm_start=True, max_features='log2',
+                                   oob_score=True,
+                                   random_state=RANDOM_STATE)),
+        ("RandomForestClassifier, max_features=None",
+            RandomForestClassifier(warm_start=True, max_features=None,
+                                   oob_score=True,
+                                   random_state=RANDOM_STATE))
+    ]
+
+classifiers_used = [1]
+init_clfs()
+
+label_list = ["RandomForestClassifier, max_features='sqrt', with_count",
+              "RandomForestClassifier, max_features='log2', with_count",
+              "RandomForestClassifier, max_features=None, with_count",
+              "RandomForestClassifier, max_features='sqrt', no_count",
+              "RandomForestClassifier, max_features='log2', no_count",
+              "RandomForestClassifier, max_features=None, no_count"]
+
+# Map a classifier name to a list of (<n_estimators>, <error rate>) pairs.
+error_rate = OrderedDict((label, []) for index, label in
+                         enumerate(label_list)
+                         if index in classifiers_used
+                         or (index - 3) in classifiers_used)
+
+# Range of `n_estimators` values to explore.
+min_estimators = 15
+max_estimators = 175 # 175
+
+index = 0
+time_start = time.time()
+
+for label, clf in ensemble_clfs:
+    if index in classifiers_used:
+        for i in range(min_estimators, max_estimators + 1):
+            clf.set_params(n_estimators=i)
+            clf.fit(X_count, y)
+            # Record the OOB error for each `n_estimators=i` setting.
+            oob_error = 1 - clf.oob_score_
+            error_rate[label + ", with_count"].append((i, oob_error))
+    index = index + 1
+
+index = 0
+print("Time taken using CountFeaturizer: ", (time.time() - time_start))
+time_start = time.time()
+
+# reinitialize the clfs for another test run with no counts
+init_clfs()
+
+for label, clf in ensemble_clfs:
+    if index in classifiers_used:
+        for i in range(min_estimators, max_estimators + 1):
+            clf.set_params(n_estimators=i)
+            clf.fit(X, y)
+            # Record the OOB error for each `n_estimators=i` setting.
+            oob_error = 1 - clf.oob_score_
+            error_rate[label + ", no_count"].append((i, oob_error))
+    index = index + 1
+
+print("Time taken without CountFeaturizer: ", (time.time() - time_start))
+
+# Generate the "OOB error rate" vs. "n_estimators" plot.
+for label, clf_err in error_rate.items():
+    xs, ys = zip(*clf_err)
+    plt.plot(xs, ys, label=label)
+
+plt.xlim(min_estimators, max_estimators)
+plt.xlabel("n_estimators")
+plt.ylabel("OOB error rate")
+plt.legend(loc="upper right")
+plt.show()

--- a/examples/preprocessing/count_featurizer_transformer.py
+++ b/examples/preprocessing/count_featurizer_transformer.py
@@ -16,7 +16,7 @@ from sklearn.preprocessing.data import CountFeaturizer
 from sklearn.preprocessing.data import OneHotEncoder
 from collections import OrderedDict
 from sklearn.datasets import make_classification
-from sklearn.ensemble import RandomForestClassifier, ExtraTreesClassifier
+from sklearn.ensemble import RandomForestClassifier
 
 # with reference to auto_examples/ensemble/plot_ensemble_oob
 

--- a/examples/preprocessing/count_featurizer_transformer.py
+++ b/examples/preprocessing/count_featurizer_transformer.py
@@ -1,3 +1,12 @@
+"""
+=========================================================
+Using CountFeaturizer to featurize frequencies
+=========================================================
+
+Shows how to use CountFeaturizer to transform some categorical variables
+into a frequency feature. CountFeaturizer can often be used to reduce
+training time, classification time, and classification error.
+"""
 from __future__ import print_function
 import matplotlib.pyplot as plt
 import numpy as np
@@ -14,29 +23,29 @@ from sklearn.ensemble import RandomForestClassifier, ExtraTreesClassifier
 
 RANDOM_STATE = 123
 
-n_datapoints = 500  # 500
-n_informative = 10  # 15
-n_features = 10  # 25
+n_datapoints = 1000  # 500
+n_informative = 30  # 15
+n_features = 30  # 25
 n_redundant = 0
 
 # Generate a binary classification dataset.
 X, y = make_classification(n_samples=n_datapoints, n_features=n_features,
-						   n_clusters_per_class=1, n_informative=n_informative,
-						   n_redundant=n_redundant, random_state=RANDOM_STATE)
+                           n_clusters_per_class=1, n_informative=n_informative,
+                           n_redundant=n_redundant, random_state=RANDOM_STATE)
 
 
 # only make these selected features "categorical"
 discretized_features = [0, 1]
 non_discretized_features = \
-	list(set(range(n_features)) - set(discretized_features))
+    list(set(range(n_features)) - set(discretized_features))
 
 X_non_discretized = X[:, non_discretized_features]
 
 for feature in discretized_features:
-	X_transform_col = (X[:, feature]).astype(int)
-	# to make all categorical variables non-negative 
-	col_min = min(np.amin(X_transform_col), 0)
-	X[:, feature] = X_transform_col - col_min
+    X_transform_col = (X[:, feature]).astype(int)
+    # to make all categorical variables non-negative
+    col_min = min(np.amin(X_transform_col), 0)
+    X[:, feature] = X_transform_col - col_min
 
 time_start = time.time()
 
@@ -50,59 +59,61 @@ time_start = time.time()
 ohe = OneHotEncoder()
 X_one_hot_part = ohe.fit_transform(X[:, discretized_features])
 
-# build the original matrix with back 
+# build the original matrix with back
 X_one_hot = ssp.hstack([X_one_hot_part, X_non_discretized]).toarray()
 
 ohe_time_preprocessing = time.time() - time_start
 
+
 def get_classifier():
-	return RandomForestClassifier(warm_start=True, max_features='log2', \
-	oob_score=True, random_state=RANDOM_STATE)
+    return RandomForestClassifier(warm_start=True, max_features='log2',
+                                  oob_score=True, random_state=RANDOM_STATE)
 
 
 clf = get_classifier()
-labels = ['CountFeaturizer + RandomForestClassifier', 
-	'OneHotEncoder + RandomForestClassifier', 'Only RandomForestClassifier']
+labels = ['CountFeaturizer + RandomForestClassifier',
+          'OneHotEncoder + RandomForestClassifier',
+          'Only RandomForestClassifier']
 error_rate = OrderedDict((label, []) for label in labels)
 
-min_estimators = 15
-max_estimators = 175
+min_estimators = (15 * n_datapoints // 500)
+max_estimators = (175 * n_datapoints // 500)
 time_start = time.time()
 
 for i in range(min_estimators, max_estimators + 1):
- 	clf.set_params(n_estimators=i)
- 	clf.fit(X_count, y)
- 	oob_error = 1 - clf.oob_score_
- 	error_rate[labels[0]].append((i, oob_error));
+    clf.set_params(n_estimators=i)
+    clf.fit(X_count, y)
+    oob_error = 1 - clf.oob_score_
+    error_rate[labels[0]].append((i, oob_error))
 
-print("Time taken on CountFeaturizer: ", \
-	(time.time() - time_start + cf_time_preprocessing))
+print("Time taken on CountFeaturizer: ",
+      (time.time() - time_start + cf_time_preprocessing))
 clf = get_classifier()
 time_start = time.time()
 
 for i in range(min_estimators, max_estimators + 1):
- 	clf.set_params(n_estimators=i)
- 	clf.fit(X_one_hot, y)
- 	oob_error = 1 - clf.oob_score_
- 	error_rate[labels[1]].append((i, oob_error));
+    clf.set_params(n_estimators=i)
+    clf.fit(X_one_hot, y)
+    oob_error = 1 - clf.oob_score_
+    error_rate[labels[1]].append((i, oob_error))
 
-print("Time taken on OneHotEncoder: ", \
-	(time.time() - time_start + ohe_time_preprocessing))
+print("Time taken on OneHotEncoder: ",
+      (time.time() - time_start + ohe_time_preprocessing))
 clf = get_classifier()
 time_start = time.time()
 
 for i in range(min_estimators, max_estimators + 1):
- 	clf.set_params(n_estimators=i)
- 	clf.fit(X_non_discretized, y)
- 	oob_error = 1 - clf.oob_score_
- 	error_rate[labels[2]].append((i, oob_error));
+    clf.set_params(n_estimators=i)
+    clf.fit(X_non_discretized, y)
+    oob_error = 1 - clf.oob_score_
+    error_rate[labels[2]].append((i, oob_error))
 
 print("Time taken on No Encoding: ", (time.time() - time_start))
 
 # Generate the "OOB error rate" vs. "n_estimators" plot.
 for label, clf_err in error_rate.items():
-	xs, ys = zip(*clf_err)
-	plt.plot(xs, ys, label=label)
+    xs, ys = zip(*clf_err)
+    plt.plot(xs, ys, label=label)
 
 plt.xlim(min_estimators, max_estimators)
 plt.xlabel("n_estimators")

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -511,7 +511,7 @@ class BinomialDeviance(ClassificationLossFunction):
         numerator = np.sum(sample_weight * residual)
         denominator = np.sum(sample_weight * (y - residual) * (1 - y + residual))
 
-        if denominator == 0.0:
+        if np.isclose(denominator, 0.0):
             tree.value[leaf, 0, 0] = 0.0
         else:
             tree.value[leaf, 0, 0] = numerator / denominator

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2080,7 +2080,10 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         transformed[:, :-1] = X 
         for i in xrange(len_data):
             data_i_tuple = self._extract_tuple(X[i])
-            transformed[i, num_features] = self.count_cache[data_i_tuple]
+            if data_i_tuple in self.count_cache:
+                transformed[i, num_features] = self.count_cache[data_i_tuple]
+            else:
+                transformed[i, num_features] = 0
         return transformed 
 
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1999,15 +1999,15 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
     >>> cf = CountFeaturizer()
     >>> cf.fit_transform(data)
     array([[ 1.,  1.,  2.],
-         [ 1.,  1.,  2.],
-         [ 3.,  1.,  1.],
-         [ 0.,  0.,  1.]])
+        [ 1.,  1.,  2.],
+        [ 3.,  1.,  1.],
+        [ 0.,  0.,  1.]])
     >>> cf = CountFeaturizer(inclusion=[0, 1])
     >>> cf.fit_transform(data)
     array([[ 1.,  1.,  3.],
-         [ 1.,  1.,  3.],
-         [ 3.,  1.,  3.],
-         [ 0.,  0.,  1.]])
+        [ 1.,  1.,  3.],
+        [ 3.,  1.,  3.],
+        [ 0.,  0.,  1.]])
     >>> data_2 = [[1, 1]]
     >>> cf = CountFeaturizer()
     >>> cf.fit(data).transform(data_2)

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2000,13 +2000,13 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
     >>> from sklearn.preprocessing.data import CountFeaturizer
     >>> data = [[1, 1], [1, 1], [3, 1], [0, 0]]
     >>> cf = CountFeaturizer()
-    >>> cf.fit_transform(data)
+    >>> cf.fit_transform(data)      # doctest: +NORMALIZE_WHITESPACE
     array([[ 1.,  1.,  2.],
            [ 1.,  1.,  2.],
            [ 3.,  1.,  1.],
            [ 0.,  0.,  1.]])
-    >>> cf = CountFeaturizer(inclusion=[1])
-    >>> cf.fit_transform(data)
+    >>> cf = CountFeaturizer(inclusion=[1]) 
+    >>> cf.fit_transform(data)      # doctest: +NORMALIZE_WHITESPACE
     array([[ 1.,  1.,  3.],
            [ 1.,  1.,  3.],
            [ 3.,  1.,  3.],
@@ -2015,7 +2015,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
     >>> cf = CountFeaturizer()
     >>> cf.fit(data).transform(data_2)
     array([[ 1.,  1.,  2.]])
-    # doctest: +NORMALIZE_WHITESPACE
+
 
     Notice how on the second fit, we set the inclusion to [0, 1]
     which made it only count the number of instances of the second feature 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2069,10 +2069,13 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         The data set returned from the transformation will always be a 
         numpy.ndarray 
         """
+        if not self.count_cache:
+            raise ValueError("Transformer must be fit() before transform()")
 
         X = check_array(X)
         len_data = len(X)
         num_features = len(X[0])
+        
         if self.inclusion != 'all' and \
             len(self.inclusion) != num_features:
             raise ValueError("Inclusion/feature must be 1 to 1")

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1989,9 +1989,9 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         The inclusion criteria for counting
         - 'all' (default): Every feature is taken into consideration when
         counting how many of each row is in the dataset.
-        - collection of indices: A collection of values where if the index v is in
-        'inclusion', then the vth feature will be put into the equality checks when
-        counting how often each row occurs.
+        - collection of indices: A collection of values where if the index v is
+        in 'inclusion', then the vth feature will be put into the equality
+        checks when counting how often each row occurs.
 
     removal_policy: set, list, numpy.ndarray, or None, default=None
         - None (default): No features are removed on transformation.

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2002,15 +2002,15 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
     >>> cf = CountFeaturizer()
     >>> cf.fit_transform(data)
     array([[ 1.,  1.,  2.],
-       [ 1.,  1.,  2.],
-       [ 3.,  1.,  1.],
-       [ 0.,  0.,  1.]])
+    [ 1.,  1.,  2.],
+    [ 3.,  1.,  1.],
+    [ 0.,  0.,  1.]])
     >>> cf = CountFeaturizer(inclusion=[1])
     >>> cf.fit_transform(data)
     array([[ 1.,  1.,  3.],
-       [ 1.,  1.,  3.],
-       [ 3.,  1.,  3.],
-       [ 0.,  0.,  1.]])
+    [ 1.,  1.,  3.],
+    [ 3.,  1.,  3.],
+    [ 0.,  0.,  1.]])
     >>> data_2 = [[1, 1]]
     >>> cf = CountFeaturizer()
     >>> cf.fit(data).transform(data_2)
@@ -2030,9 +2030,11 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
             removal_policy=removal_policy)
         if type(inclusion) == str:
             self.inclusion = inclusion
+        elif inclusion == None:
+            self.inclusion = np.array([]) 
         else:
             self.inclusion = np.array(inclusion) 
-        if type(removal_policy) == str:
+        if removal_policy == None or type(removal_policy) == str:
             self.removal_policy = removal_policy
         else:
             self.removal_policy = np.array(removal_policy)

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2048,7 +2048,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         Sets the value of count_cache which holds the counts of each data point
         """
         
-        X = check_array(X, dtype=None, force_all_finite=False)
+        X = check_array(X)
         num_features = len(X[0])
         if self.inclusion != 'all' and len(self.inclusion) != num_features:
             # there must be one value of inclusion for each feature
@@ -2070,7 +2070,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         numpy.ndarray 
         """
 
-        X = check_array(X, dtype=None, force_all_finite=False)
+        X = check_array(X)
         len_data = len(X)
         num_features = len(X[0])
         if self.inclusion != 'all' and \

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2002,15 +2002,15 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
     >>> cf = CountFeaturizer()
     >>> cf.fit_transform(data)
     array([[ 1.,  1.,  2.],
-    [ 1.,  1.,  2.],
-    [ 3.,  1.,  1.],
-    [ 0.,  0.,  1.]])
+           [ 1.,  1.,  2.],
+           [ 3.,  1.,  1.],
+           [ 0.,  0.,  1.]])
     >>> cf = CountFeaturizer(inclusion=[1])
     >>> cf.fit_transform(data)
     array([[ 1.,  1.,  3.],
-    [ 1.,  1.,  3.],
-    [ 3.,  1.,  3.],
-    [ 0.,  0.,  1.]])
+           [ 1.,  1.,  3.],
+           [ 3.,  1.,  3.],
+           [ 0.,  0.,  1.]])
     >>> data_2 = [[1, 1]]
     >>> cf = CountFeaturizer()
     >>> cf.fit(data).transform(data_2)

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -184,6 +184,7 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
 
 
 class MinMaxScaler(BaseEstimator, TransformerMixin):
+
     """Transforms features by scaling each feature to a given range.
 
     This estimator scales and translates each feature individually such
@@ -447,6 +448,7 @@ def minmax_scale(X, feature_range=(0, 1), axis=0, copy=True):
 
 
 class StandardScaler(BaseEstimator, TransformerMixin):
+
     """Standardize features by removing the mean and scaling to unit variance
 
     Centering and scaling happen independently on each feature by computing
@@ -697,6 +699,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
 
 
 class MaxAbsScaler(BaseEstimator, TransformerMixin):
+
     """Scale each feature by its maximum absolute value.
 
     This estimator scales and translates each feature individually such
@@ -896,6 +899,7 @@ def maxabs_scale(X, axis=0, copy=True):
 
 
 class RobustScaler(BaseEstimator, TransformerMixin):
+
     """Scale features using statistics that are robust to outliers.
 
     This Scaler removes the median and scales the data according to
@@ -1137,6 +1141,7 @@ def robust_scale(X, axis=0, with_centering=True, with_scaling=True,
 
 
 class PolynomialFeatures(BaseEstimator, TransformerMixin):
+
     """Generate polynomial and interaction features.
 
     Generate a new feature matrix consisting of all polynomial combinations
@@ -1199,6 +1204,7 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
     See :ref:`examples/linear_model/plot_polynomial_interpolation.py
     <sphx_glr_auto_examples_linear_model_plot_polynomial_interpolation.py>`
     """
+
     def __init__(self, degree=2, interaction_only=False, include_bias=True):
         self.degree = degree
         self.interaction_only = interaction_only
@@ -1375,6 +1381,7 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
 
 
 class Normalizer(BaseEstimator, TransformerMixin):
+
     """Normalize samples individually to unit norm.
 
     Each sample (i.e. each row of the data matrix) with at least one
@@ -1485,6 +1492,7 @@ def binarize(X, threshold=0.0, copy=True):
 
 
 class Binarizer(BaseEstimator, TransformerMixin):
+
     """Binarize data (set feature values to 0 or 1) according to a threshold
 
     Values greater than the threshold map to 1, while values less than
@@ -1552,6 +1560,7 @@ class Binarizer(BaseEstimator, TransformerMixin):
 
 
 class KernelCenterer(BaseEstimator, TransformerMixin):
+
     """Center a kernel matrix
 
     Let K(x, z) be a kernel defined by phi(x)^T phi(z), where phi is a
@@ -1726,6 +1735,7 @@ def _transform_selected(X, transform, selected="all", copy=True):
 
 
 class OneHotEncoder(BaseEstimator, TransformerMixin):
+
     """Encode categorical integer features using a one-hot aka one-of-K scheme.
 
     The input to this transformer should be a matrix of integers, denoting
@@ -1821,6 +1831,7 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
     sklearn.preprocessing.LabelEncoder : encodes labels with values between 0
       and n_classes-1.
     """
+
     def __init__(self, n_values="auto", categorical_features="all",
                  dtype=np.float64, sparse=True, handle_unknown='error'):
         self.n_values = n_values
@@ -1958,7 +1969,6 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
                                    self.categorical_features, copy=True)
 
 
-
 class CountFeaturizer(BaseEstimator, TransformerMixin):
 
     """
@@ -2024,24 +2034,25 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
     --------
     WIP, I will make the documentation .rst afterwards 
     """
-    def __init__(self, inclusion='all', removal_policy=None):  
+
+    def __init__(self, inclusion='all', removal_policy=None):
         # removal policy currently not implemented, but the method
-        # signatures are set 
-        CountFeaturizer._check_params(inclusion=inclusion, \
-            removal_policy=removal_policy)
+        # signatures are set
+        CountFeaturizer._check_params(inclusion=inclusion,
+                                      removal_policy=removal_policy)
         if type(inclusion) == str:
             self.inclusion = inclusion
         elif inclusion == None:
-            self.inclusion = np.array([]) 
+            self.inclusion = np.array([])
         else:
-            self.inclusion = np.array(inclusion) 
+            self.inclusion = np.array(inclusion)
         if removal_policy == None or type(removal_policy) == str:
             self.removal_policy = removal_policy
         else:
             self.removal_policy = np.array(removal_policy)
         self.count_cache = {}
 
-        # the num_feature variable acts as a way to ensure that the number of 
+        # the num_feature variable acts as a way to ensure that the number of
         # columns of X going into fit() is the same as the number of columns
         # of X going into transform()
         self.num_features = 0
@@ -2054,7 +2065,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
                 raise ValueError("Illegal data type in inclusion")
 
         if removal_policy != None and removal_policy != 'inclusion' and \
-            not CountFeaturizer._valid_data_type(removal_policy):
+                not CountFeaturizer._valid_data_type(removal_policy):
             raise ValueError("Illegal data type in removal_policy")
 
     @staticmethod
@@ -2064,7 +2075,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         Currently, only Python lists and numpy arrays are accepted
         """
         return type(type_check) == np.ndarray or type(type_check) == list \
-            or type(type_check) == set 
+            or type(type_check) == set
 
     @staticmethod
     def _check_well_formed(X):
@@ -2078,7 +2089,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         # This is a temporary method but I am unsure whether there already
         # exists something similar in the utils.validation.py
         # There did not seem to be anything I could use to check well-formed
-        # in utils.validation.check_array() 
+        # in utils.validation.check_array()
 
         num_columns = len(X[0])
         for i in range(1, len(X)):
@@ -2094,8 +2105,9 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
             return tuple(data_row)
         else:
             num_features = len(data_row)
-            return tuple([data_row[i] \
-                for i in range(num_features) if (i in self.inclusion)])
+            return tuple([data_row[i]
+                          for i in range(num_features)
+                          if (i in self.inclusion)])
 
     def _final_num_features(self, cols_X):
         """
@@ -2104,16 +2116,15 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         features in the output of transform()
         """
         if type(self.removal_policy) == str \
-            and self.removal_policy == 'inclusion':
+                and self.removal_policy == 'inclusion':
             if type(self.inclusion) == str and \
-                self.inclusion == 'all':
+                    self.inclusion == 'all':
                 return 1
             else:
-                return num_features - inclusion.size + 1
+                return cols_X - inclusion.size + 1
         elif self.removal_policy != None:
-            return num_features - removal_policy + 1
+            return cols_X - len(self.removal_policy) + 1
         return cols_X + 1
-
 
     def fit(self, X, y=None):
         """
@@ -2125,10 +2136,10 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         if self._final_num_features(cols_X) <= 0:
             # the removal_policy and inclusion were set such that the output
             # array of transform() is expected to have 0 or a negative
-            # number of columns 
+            # number of columns
             raise ValueError("inclusion or removal_policy incompatible")
         self.num_features = cols_X
-        self.count_cache = {} 
+        self.count_cache = {}
         for data_i in X:
             data_i_tuple = self._extract_tuple(data_i)
             if data_i_tuple not in self.count_cache:
@@ -2142,8 +2153,9 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         Transforms the inputted data with the new 'count' feature (column)
         and returns it 
         The data set returned from the transformation will always be a 
-        numpy.ndarray 
+        numpy.ndarray     
         """
+
         if not self.count_cache:
             raise ValueError("Transformer must be fit() before transform()")
         X = check_array(X)
@@ -2151,27 +2163,28 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         len_data = len(X)
         num_features = len(X[0])
         if self.num_features != num_features:
-            raise ValueError("transform() must have same number of" + \
-                " features as it was fitted with")
+            raise ValueError("transform() must have same number of" +
+                             " features as it was fitted with")
         num_features_transform = self._final_num_features(num_features)
+        removal_policy_list = []
         if type(self.removal_policy) == str \
-            and self.removal_policy == 'inclusion':
+                and self.removal_policy == 'inclusion':
             if type(self.inclusion) == str and \
-                self.inclusion == 'all':
+                    self.inclusion == 'all':
                 removal_policy_list = range(num_features)
             else:
                 removal_policy_list = self.inclusion
-        elif self.removal_policy == None:
-            removal_policy_list = []
+        elif not (self.removal_policy is None):
+            removal_policy_list = self.removal_policy
         transformed = np.zeros((len_data, num_features_transform))
         transformed[:, :-1] = \
             X[:, list(set(range(num_features)) - set(removal_policy_list))]
         for i in range(len_data):
             data_i_tuple = self._extract_tuple(X[i])
             if data_i_tuple in self.count_cache:
-                transformed[i, num_features] = self.count_cache[data_i_tuple]
+                transformed[
+                    i, num_features_transform - 1] = \
+                        self.count_cache[data_i_tuple]
             else:
-                transformed[i, num_features] = 0
-        return transformed 
-
-
+                transformed[i, num_features_transform - 1] = 0
+        return transformed

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1960,7 +1960,6 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
 
 
 class CountFeaturizer(BaseEstimator, TransformerMixin):
-
     """
     Adds in a new feature column containing the number of occurences of 
     each row in the given data set.
@@ -2016,9 +2015,6 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
     --------
     WIP, I will make the documentation afterwards 
     """
-    def __init__(self, data=None, inclusion='all'):
-        if data != None:
-            self.fit(data, inclusion=inclusion)
 
     def fit(self, X, y=None, inclusion='all'):
         """

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2031,15 +2031,6 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         """
         return type(type_check) == np.ndarray or type(type_check) == list 
 
-    @staticmethod
-    def _valid_X(X):
-        """
-        Ensures that X is valid and can be processed by CountFeaturizer
-        """
-        if not CountFeaturizer._valid_data_type(X):
-            raise ValueError("X must be of compatible type with CountFeaturizer")
-        return len(X) > 0
-
     def _extract_tuple(self, data_row):
         """
         Extracts the values of the data_row[inclusion] into an ordered tuple
@@ -2057,20 +2048,18 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         Sets the value of count_cache which holds the counts of each data point
         """
         
-        if CountFeaturizer._valid_X(X):
-            num_features = len(X[0])
-            if self.inclusion != 'all' and len(self.inclusion) != num_features:
-                # there must be one value of inclusion for each feature
-                raise ValueError("Inclusion/feature must be 1 to 1")
-            self.count_cache = {} 
-            for data_i in X:
-                data_i_tuple = self._extract_tuple(data_i)
-                if data_i_tuple not in self.count_cache:
-                    self.count_cache[data_i_tuple] = 1
-                else:
-                    self.count_cache[data_i_tuple] += 1
-        else:
-            self.count_cache = {}
+        X = check_array(X, dtype=None, force_all_finite=False)
+        num_features = len(X[0])
+        if self.inclusion != 'all' and len(self.inclusion) != num_features:
+            # there must be one value of inclusion for each feature
+            raise ValueError("Inclusion/feature must be 1 to 1")
+        self.count_cache = {} 
+        for data_i in X:
+            data_i_tuple = self._extract_tuple(data_i)
+            if data_i_tuple not in self.count_cache:
+                self.count_cache[data_i_tuple] = 1
+            else:
+                self.count_cache[data_i_tuple] += 1
         return self
 
     def transform(self, X):
@@ -2080,19 +2069,18 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         The data set returned from the transformation will always be a 
         numpy.ndarray 
         """
-        if CountFeaturizer._valid_X(X):
-            len_data = len(X)
-            num_features = len(X[0])
-            if self.inclusion != 'all' and \
-                len(self.inclusion) != num_features:
-                raise ValueError("Inclusion/feature must be 1 to 1")
-            transformed = np.zeros((len_data, num_features + 1))
-            transformed[:, :-1] = X 
-            for i in xrange(len_data):
-                data_i_tuple = self._extract_tuple(X[i])
-                transformed[i, num_features] = self.count_cache[data_i_tuple]
-            return transformed 
-        else:
-            return numpy.array([])
+
+        X = check_array(X, dtype=None, force_all_finite=False)
+        len_data = len(X)
+        num_features = len(X[0])
+        if self.inclusion != 'all' and \
+            len(self.inclusion) != num_features:
+            raise ValueError("Inclusion/feature must be 1 to 1")
+        transformed = np.zeros((len_data, num_features + 1))
+        transformed[:, :-1] = X 
+        for i in xrange(len_data):
+            data_i_tuple = self._extract_tuple(X[i])
+            transformed[i, num_features] = self.count_cache[data_i_tuple]
+        return transformed 
 
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2015,6 +2015,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
     >>> cf = CountFeaturizer()
     >>> cf.fit(data).transform(data_2)
     array([[ 1.,  1.,  2.]])
+    # doctest: +NORMALIZE_WHITESPACE
 
     Notice how on the second fit, we set the inclusion to [0, 1]
     which made it only count the number of instances of the second feature 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1960,6 +1960,7 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
 
 
 class CountFeaturizer(BaseEstimator, TransformerMixin):
+
     """
     Adds in a new feature column containing the number of occurences of 
     each row in the given data set.
@@ -2013,76 +2014,76 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    WIP, I will make the documentation afterwards 
+    WIP, I will make the documentation .rst afterwards 
     """
+    def __init__(self, inclusion='all'):  
+        if inclusion != 'all' and not _valid_data_type(inclusion):
+            raise ValueError("Only supports lists / numpy arrays (inclusion)")
+        self.inclusion = inclusion 
+        self.count_cache = {}
 
-    def fit(self, X, y=None, inclusion='all'):
+    def _valid_data_type(type_check):
         """
-        Sets the value of data and inclusion for the CountFeaturizer
+        Defines the data types that are compatible with CountFeaturizer
+        Currently, only Python lists and numpy arrays are accepted
         """
-        def valid_data_type(type_check):
-            return type(type_check) == np.ndarray or type(type_check) == list 
+        return type(type_check) == np.ndarray or type(type_check) == list 
 
-        if X == None:
-            raise ValueError("Data is None")
+    def _extract_tuple(data_row):
+        if self.inclusion == 'all':
+            return tuple(data_row)
+        else:
+            num_features = len(data_row)
+            return tuple([data_row[i] \
+                for i in xrange(num_features) if self.inclusion[i]])
 
-        if not valid_data_type(X):
-            raise ValueError("Only supports lists / numpy arrays (data)")
+    def fit(self, X, y=None):
+        """
+        Sets the value of count_cache which holds the counts of each data point
+        """
+            
+        if not _valid_data_type(X):
+            raise ValueError("Only supports lists / numpy arrays (fit)")
+        if len(X) > 0:
+            num_features = len(X[0])
 
-        if len(X) == 0:
-            raise ValueError("Data is empty")
-
-        num_features = len(X[0])
-
-        if inclusion != 'all':
-            if not valid_data_type(inclusion):
-                raise ValueError("Only supports lists / numpy arrays (inclusion)")
-            elif len(inclusion) != num_features:
-                raise ValueError("Inclusion/feature mismatch")
-
-        self.X = np.array(X)
-        self.inclusion = inclusion
+            if self.inclusion != 'all' and len(self.inclusion) != num_features:
+                # there must be one value of inclusion for each feature
+                raise ValueError("Inclusion/feature must be 1 to 1")
+            self.count_cache = {} 
+            for data_i in X:
+                data_i_tuple = _extract_tuple(data_i)
+                if data_i_tuple not in self.count_cache:
+                    self.count_cache[data_i_tuple] = 1
+                else:
+                    self.count_cache[data_i_tuple] += 1
+        else:
+            self.count_cache = {}
         return self
 
-    def transform(self):
+    def transform(self, X):
         """
         Transforms the inputted data with the new 'count' feature (column)
         and returns it 
         The data set returned from the transformation will always be a 
         numpy.ndarray 
         """
-        def extract_tuple(data_row):
-            if self.inclusion == 'all':
-                return tuple(data_row)
-            else:
-                num_features = len(data_row)
-                return tuple([data_row[i] \
-                    for i in xrange(num_features) if self.inclusion[i]])
+        if not _valid_data_type(X):
+            raise ValueError("Only supports lists / numpy arrays (transform)")
+        len_data = len(X)
+        if len_data > 0:
+            num_features = len(X[0])
 
-        # caching is faster but memory intensive
-        cache = {}
-        for data_i in self.X:
-            data_i_tuple = extract_tuple(data_i)
-            if data_i_tuple not in cache:
-                cache[data_i_tuple] = 1
-            else:
-                cache[data_i_tuple] += 1
-        len_data = len(self.X)
-        num_features = len(self.X[0])
-        transformed = np.zeros((len_data, num_features + 1))
-        transformed[:, :-1] = self.X 
-        for i in xrange(len_data):
-            data_i_tuple = extract_tuple(self.X[i])
-            transformed[i, num_features] = cache[data_i_tuple] 
-        self.X = transformed
-        return self.X 
-
-    def fit_transform(self, X, y=None):
-        """Fit CountFeaturizer to X, then transform X.
-
-        Equivalent to self.fit(X).transform(), but more convenient 
-        See fit for the parameters, transform for the return value.
-        """
-        return self.fit(X).transform()
+            if self.inclusion != 'all' and \
+                len(self.inclusion) != num_features:
+                raise ValueError("Inclusion/feature must be 1 to 1")
+            transformed = np.zeros((len_data, num_features + 1))
+            transformed[:, :-1] = X 
+            for i in xrange(len_data):
+                data_i_tuple = _extract_tuple(X[i])
+                transformed[i, num_features] = self.count_cache[data_i_tuple]
+                return transformed 
+        else:
+            return numpy.array([])
 
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1999,15 +1999,15 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
     >>> cf = CountFeaturizer()
     >>> cf.fit_transform(data)
     array([[ 1.,  1.,  2.],
-        [ 1.,  1.,  2.],
-        [ 3.,  1.,  1.],
-        [ 0.,  0.,  1.]])
+       [ 1.,  1.,  2.],
+       [ 3.,  1.,  1.],
+       [ 0.,  0.,  1.]])
     >>> cf = CountFeaturizer(inclusion=[0, 1])
     >>> cf.fit_transform(data)
     array([[ 1.,  1.,  3.],
-        [ 1.,  1.,  3.],
-        [ 3.,  1.,  3.],
-        [ 0.,  0.,  1.]])
+       [ 1.,  1.,  3.],
+       [ 3.,  1.,  3.],
+       [ 0.,  0.,  1.]])
     >>> data_2 = [[1, 1]]
     >>> cf = CountFeaturizer()
     >>> cf.fit(data).transform(data_2)

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2020,23 +2020,23 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         if data != None:
             self.fit(data, inclusion=inclusion)
 
-    def fit(self, data, inclusion='all'):
+    def fit(self, X, y=None, inclusion='all'):
         """
         Sets the value of data and inclusion for the CountFeaturizer
         """
         def valid_data_type(type_check):
             return type(type_check) == np.ndarray or type(type_check) == list 
 
-        if data == None:
+        if X == None:
             raise ValueError("Data is None")
 
-        if not valid_data_type(data):
+        if not valid_data_type(X):
             raise ValueError("Only supports lists / numpy arrays (data)")
 
-        if len(data) == 0:
+        if len(X) == 0:
             raise ValueError("Data is empty")
 
-        num_features = len(data[0])
+        num_features = len(X[0])
 
         if inclusion != 'all':
             if not valid_data_type(inclusion):
@@ -2044,8 +2044,9 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
             elif len(inclusion) != num_features:
                 raise ValueError("Inclusion/feature mismatch")
 
-        self.data = np.array(data)
+        self.X = np.array(X)
         self.inclusion = inclusion
+        return self
 
     def transform(self):
         """
@@ -2064,20 +2065,28 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
 
         # caching is faster but memory intensive
         cache = {}
-        for data_i in self.data:
+        for data_i in self.X:
             data_i_tuple = extract_tuple(data_i)
             if data_i_tuple not in cache:
                 cache[data_i_tuple] = 1
             else:
                 cache[data_i_tuple] += 1
-        len_data = len(self.data)
-        num_features = len(self.data[0])
+        len_data = len(self.X)
+        num_features = len(self.X[0])
         transformed = np.zeros((len_data, num_features + 1))
-        transformed[:, :-1] = self.data 
+        transformed[:, :-1] = self.X 
         for i in xrange(len_data):
-            data_i_tuple = extract_tuple(self.data[i])
+            data_i_tuple = extract_tuple(self.X[i])
             transformed[i, num_features] = cache[data_i_tuple] 
-        self.data = transformed
-        return self.data 
+        self.X = transformed
+        return self.X 
+
+    def fit_transform(self, X, y=None):
+        """Fit CountFeaturizer to X, then transform X.
+
+        Equivalent to self.fit(X).transform(), but more convenient 
+        See fit for the parameters, transform for the return value.
+        """
+        return self.fit(X).transform()
 
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2061,7 +2061,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         # in utils.validation.check_array() 
 
         num_columns = len(X[0])
-        for i in xrange(1, X):
+        for i in xrange(1, len(X)):
             if len(X[i]) != num_columns:
                 raise ValueError("Malformed input array X")
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2066,14 +2066,6 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
             if len(X[i]) != num_columns:
                 raise ValueError("Malformed input array X")
 
-    @staticmethod
-    def _check_array(X):
-        """
-        Gets the allowed types for elements of X 
-        """
-        # return check_array(X, dtype=[int, float, tuple, str])
-        return check_array(X)
-
     def _extract_tuple(self, data_row):
         """
         Extracts the values of the data_row[inclusion] into an ordered tuple
@@ -2092,7 +2084,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         """
         # We do not want to enforce type constraints because we want our input
         # to be able to have categorical variables such as strings 
-        X = CountFeaturizer._check_array(X)
+        X = check_array(X)
         CountFeaturizer._check_well_formed(X)
         self.num_features = len(X[0])
         if self.inclusion != 'all' and \
@@ -2117,7 +2109,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         """
         if not self.count_cache:
             raise ValueError("Transformer must be fit() before transform()")
-        X = CountFeaturizer._check_array(X)
+        X = check_array(X)
         CountFeaturizer._check_well_formed(X)
         len_data = len(X)
         num_features = len(X[0])

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2041,11 +2041,11 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
                                       removal_policy=removal_policy)
         if type(inclusion) == str:
             self.inclusion = inclusion
-        elif inclusion == None:
+        elif inclusion is None:
             self.inclusion = np.array([])
         else:
             self.inclusion = np.array(inclusion)
-        if removal_policy == None or type(removal_policy) == str:
+        if removal_policy is None or type(removal_policy) == str:
             self.removal_policy = removal_policy
         else:
             self.removal_policy = np.array(removal_policy)
@@ -2059,11 +2059,11 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
     @staticmethod
     def _check_params(inclusion=None, removal_policy=None):
 
-        if inclusion != None and inclusion != 'all':
+        if inclusion is not None and inclusion != 'all':
             if not CountFeaturizer._valid_data_type(inclusion):
                 raise ValueError("Illegal data type in inclusion")
 
-        if removal_policy != None and removal_policy != 'inclusion' and \
+        if removal_policy is not None and removal_policy != 'inclusion' and \
                 not CountFeaturizer._valid_data_type(removal_policy):
             raise ValueError("Illegal data type in removal_policy")
 
@@ -2121,7 +2121,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
                 return 1
             else:
                 return cols_X - self.inclusion.size + 1
-        elif self.removal_policy != None:
+        elif self.removal_policy is not None:
             return cols_X - len(self.removal_policy) + 1
         return cols_X + 1
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2062,7 +2062,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         # in utils.validation.check_array() 
 
         num_columns = len(X[0])
-        for i in xrange(1, len(X)):
+        for i in range(1, len(X)):
             if len(X[i]) != num_columns:
                 raise ValueError("Malformed input array X")
 
@@ -2076,7 +2076,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         else:
             num_features = len(data_row)
             return tuple([data_row[i] \
-                for i in xrange(num_features) if self.inclusion[i]])
+                for i in range(num_features) if self.inclusion[i]])
 
     def fit(self, X, y=None):
         """
@@ -2121,7 +2121,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
             raise ValueError("Inclusion/feature must be 1 to 1")
         transformed = np.zeros((len_data, num_features + 1))
         transformed[:, :-1] = X 
-        for i in xrange(len_data):
+        for i in range(len_data):
             data_i_tuple = self._extract_tuple(X[i])
             if data_i_tuple in self.count_cache:
                 transformed[i, num_features] = self.count_cache[data_i_tuple]

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1972,16 +1972,16 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
 class CountFeaturizer(BaseEstimator, TransformerMixin):
 
     """
-    Adds in a new feature column containing the number of occurences of 
+    Adds in a new feature column containing the number of occurences of
     each row in the given data set.
 
-    Formally, for each data point X_i in the dataset X, it will add in 
-    a new feature count_X_i to the end of X_i where count_X_i is the number of 
+    Formally, for each data point X_i in the dataset X, it will add in
+    a new feature count_X_i to the end of X_i where count_X_i is the number of
     occurences of X_i in the dataset X given the equality indicator
     'inclusion'
 
     This preprocessing step is useful when the number of occurences
-    of a particular piece of data is helpful in computing the prediction. 
+    of a particular piece of data is helpful in computing the prediction.
 
     Parameters
     ----------
@@ -1993,19 +1993,19 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         'inclusion', then the vth feature will be put into the equality checks when
         counting how often each row occurs.
 
-    removal_policy: set, list, numpy.ndarray, or None, default=None 
+    removal_policy: set, list, numpy.ndarray, or None, default=None
         - None (default): No features are removed on transformation.
-        - 'inclusion': Every feature counted will be removed and replaced with 
+        - 'inclusion': Every feature counted will be removed and replaced with
         the count feature. This is equivalent to having the 'inclusion' and
         'removal_policy' parameter being set to the exact same collection.
-        - collection of indices: For each index v in 'removal_policy', the vth 
+        - collection of indices: For each index v in 'removal_policy', the vth
         feature will be removed in the transformation (and be replaced with
         the new count feature).
 
     Examples
     --------
     Given a dataset with two features and four samples, we let the transformer
-    find the number of occurences of each data point in the dataset 
+    find the number of occurences of each data point in the dataset
 
     >>> from sklearn.preprocessing.data import CountFeaturizer
     >>> data = [[1, 1], [1, 1], [3, 1], [0, 0]]
@@ -2015,7 +2015,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
            [ 1.,  1.,  2.],
            [ 3.,  1.,  1.],
            [ 0.,  0.,  1.]])
-    >>> cf = CountFeaturizer(inclusion=[1]) 
+    >>> cf = CountFeaturizer(inclusion=[1])
     >>> cf.fit_transform(data)      # doctest: +NORMALIZE_WHITESPACE
     array([[ 1.,  1.,  3.],
            [ 1.,  1.,  3.],
@@ -2026,13 +2026,12 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
     >>> cf.fit(data).transform(data_2)
     array([[ 1.,  1.,  2.]])
 
-
     Notice how on the second fit, we set the inclusion to [0, 1]
-    which made it only count the number of instances of the second feature 
+    which made it only count the number of instances of the second feature
 
     See also
     --------
-    WIP, I will make the documentation .rst afterwards 
+    WIP, I will make the documentation .rst afterwards
     """
 
     def __init__(self, inclusion='all', removal_policy=None):
@@ -2080,11 +2079,11 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
     @staticmethod
     def _check_well_formed(X):
         """
-        Ensures that X is well formed, meaning that every single row of X must 
-        have the same number of elements 
+        Ensures that X is well formed, meaning that every single row of X must
+        have the same number of elements
         [[1, 2], [3, 4]] is "well formed"
         but [[1], [3, 5, 7]] is not "well formed"
-        Assumes that check_array(X) has already been called 
+        Assumes that check_array(X) has already been called
         """
         # This is a temporary method but I am unsure whether there already
         # exists something similar in the utils.validation.py
@@ -2099,7 +2098,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
     def _extract_tuple(self, data_row):
         """
         Extracts the values of the data_row[inclusion] into an ordered tuple
-        for use as a dictionary key 
+        for use as a dictionary key
         """
         if type(self.inclusion) == str and self.inclusion == 'all':
             return tuple(data_row)
@@ -2111,8 +2110,8 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
 
     def _final_num_features(self, cols_X):
         """
-        Given the number of columns of X, uses the number of elements in 
-        'inclusion' and 'removal_policy' to calclulate the number of 
+        Given the number of columns of X, uses the number of elements in
+        'inclusion' and 'removal_policy' to calclulate the number of
         features in the output of transform()
         """
         if type(self.removal_policy) == str \
@@ -2121,7 +2120,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
                     self.inclusion == 'all':
                 return 1
             else:
-                return cols_X - inclusion.size + 1
+                return cols_X - self.inclusion.size + 1
         elif self.removal_policy != None:
             return cols_X - len(self.removal_policy) + 1
         return cols_X + 1
@@ -2151,9 +2150,9 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
     def transform(self, X):
         """
         Transforms the inputted data with the new 'count' feature (column)
-        and returns it 
-        The data set returned from the transformation will always be a 
-        numpy.ndarray     
+        and returns it
+        The data set returned from the transformation will always be a
+        numpy.ndarray
         """
 
         if not self.count_cache:
@@ -2182,9 +2181,8 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         for i in range(len_data):
             data_i_tuple = self._extract_tuple(X[i])
             if data_i_tuple in self.count_cache:
-                transformed[
-                    i, num_features_transform - 1] = \
-                        self.count_cache[data_i_tuple]
+                transformed[i, num_features_transform - 1] = \
+                    self.count_cache[data_i_tuple]
             else:
                 transformed[i, num_features_transform - 1] = 0
         return transformed

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2017,11 +2017,13 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
     WIP, I will make the documentation .rst afterwards 
     """
     def __init__(self, inclusion='all'):  
-        if inclusion != 'all' and not _valid_data_type(inclusion):
+        if inclusion != 'all' and \
+            not CountFeaturizer._valid_data_type(inclusion):
             raise ValueError("Only supports lists / numpy arrays (inclusion)")
         self.inclusion = inclusion 
         self.count_cache = {}
 
+    @staticmethod
     def _valid_data_type(type_check):
         """
         Defines the data types that are compatible with CountFeaturizer
@@ -2029,6 +2031,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         """
         return type(type_check) == np.ndarray or type(type_check) == list 
 
+    @staticmethod
     def _extract_tuple(data_row):
         if self.inclusion == 'all':
             return tuple(data_row)
@@ -2042,17 +2045,16 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         Sets the value of count_cache which holds the counts of each data point
         """
             
-        if not _valid_data_type(X):
+        if not CountFeaturizer._valid_data_type(X):
             raise ValueError("Only supports lists / numpy arrays (fit)")
         if len(X) > 0:
             num_features = len(X[0])
-
             if self.inclusion != 'all' and len(self.inclusion) != num_features:
                 # there must be one value of inclusion for each feature
                 raise ValueError("Inclusion/feature must be 1 to 1")
             self.count_cache = {} 
             for data_i in X:
-                data_i_tuple = _extract_tuple(data_i)
+                data_i_tuple = CountFeaturizer._extract_tuple(data_i)
                 if data_i_tuple not in self.count_cache:
                     self.count_cache[data_i_tuple] = 1
                 else:
@@ -2068,19 +2070,18 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         The data set returned from the transformation will always be a 
         numpy.ndarray 
         """
-        if not _valid_data_type(X):
+        if not CountFeaturizer._valid_data_type(X):
             raise ValueError("Only supports lists / numpy arrays (transform)")
         len_data = len(X)
         if len_data > 0:
             num_features = len(X[0])
-
             if self.inclusion != 'all' and \
                 len(self.inclusion) != num_features:
                 raise ValueError("Inclusion/feature must be 1 to 1")
             transformed = np.zeros((len_data, num_features + 1))
             transformed[:, :-1] = X 
             for i in xrange(len_data):
-                data_i_tuple = _extract_tuple(X[i])
+                data_i_tuple = CountFeaturizer._extract_tuple(X[i])
                 transformed[i, num_features] = self.count_cache[data_i_tuple]
                 return transformed 
         else:

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1994,20 +1994,20 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
     Given a dataset with two features and four samples, we let the transformer
     find the number of occurences of each data point in the dataset 
 
-    >>> from sklearn.preprocessing import CountFeaturizer
+    >>> from sklearn.preprocessing.data import CountFeaturizer
     >>> data = [[1, 1], [1, 1], [3, 1], [0, 0]]
     >>> cf = CountFeaturizer()
     >>> cf.fit_transform(data)
     array([[ 1.,  1.,  2.],
-        [ 1.,  1.,  2.],
-        [ 3.,  1.,  1.],
-        [ 0.,  0.,  1.]])
+         [ 1.,  1.,  2.],
+         [ 3.,  1.,  1.],
+         [ 0.,  0.,  1.]])
     >>> cf = CountFeaturizer(inclusion=[0, 1])
     >>> cf.fit_transform(data)
     array([[ 1.,  1.,  3.],
-        [ 1.,  1.,  3.],
-        [ 3.,  1.,  3.],
-        [ 0.,  0.,  1.]])
+         [ 1.,  1.,  3.],
+         [ 3.,  1.,  3.],
+         [ 0.,  0.,  1.]])
     >>> data_2 = [[1, 1]]
     >>> cf = CountFeaturizer()
     >>> cf.fit(data).transform(data_2)

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2071,7 +2071,8 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         """
         Gets the allowed types for elements of X 
         """
-        return check_array(X, dtype=[int, float, tuple, str])
+        # return check_array(X, dtype=[int, float, tuple, str])
+        return check_array(X)
 
     def _extract_tuple(self, data_row):
         """

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2024,13 +2024,13 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         """
         Sets the value of data and inclusion for the CountFeaturizer
         """
-        def valid_data_type(self, type_check):
+        def valid_data_type(type_check):
             return type(type_check) == np.ndarray or type(type_check) == list 
 
         if data == None:
             raise ValueError("Data is None")
 
-        if not self.valid_data_type(data):
+        if not valid_data_type(data):
             raise ValueError("Only supports lists / numpy arrays (data)")
 
         if len(data) == 0:
@@ -2039,7 +2039,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
         num_features = len(data[0])
 
         if inclusion != 'all':
-            if not self.valid_data_type(inclusion):
+            if not valid_data_type(inclusion):
                 raise ValueError("Only supports lists / numpy arrays (inclusion)")
             elif len(inclusion) != num_features:
                 raise ValueError("Inclusion/feature mismatch")

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2091,7 +2091,7 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
             for i in xrange(len_data):
                 data_i_tuple = self._extract_tuple(X[i])
                 transformed[i, num_features] = self.count_cache[data_i_tuple]
-                return transformed 
+            return transformed 
         else:
             return numpy.array([])
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1996,18 +1996,22 @@ class CountFeaturizer(BaseEstimator, TransformerMixin):
 
     >>> from sklearn.preprocessing import CountFeaturizer
     >>> data = [[1, 1], [1, 1], [3, 1], [0, 0]]
-    >>> cf = CountFeaturizer(data)
-    >>> cf.transform()
+    >>> cf = CountFeaturizer()
+    >>> cf.fit_transform(data)
     array([[ 1.,  1.,  2.],
-       [ 1.,  1.,  2.],
-       [ 3.,  1.,  1.],
-       [ 0.,  0.,  1.]])
-    >>> cf.fit(data, inclusion=[0, 1])
-    >>> cf.transform()
+        [ 1.,  1.,  2.],
+        [ 3.,  1.,  1.],
+        [ 0.,  0.,  1.]])
+    >>> cf = CountFeaturizer(inclusion=[0, 1])
+    >>> cf.fit_transform(data)
     array([[ 1.,  1.,  3.],
-       [ 1.,  1.,  3.],
-       [ 3.,  1.,  3.],
-       [ 0.,  0.,  1.]])
+        [ 1.,  1.,  3.],
+        [ 3.,  1.,  3.],
+        [ 0.,  0.,  1.]])
+    >>> data_2 = [[1, 1]]
+    >>> cf = CountFeaturizer()
+    >>> cf.fit(data).transform(data_2)
+    array([[ 1.,  1.,  2.]])
 
     Notice how on the second fit, we set the inclusion to [0, 1]
     which made it only count the number of instances of the second feature 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1686,3 +1686,10 @@ def test_count_featurizer_ft_standard_inclusion():
     assert_array_equal( \
         cf_inclusion_4.fit_transform(X2), \
         np.array([[0, 2, 1, 2], [0, 2, 3, 2], [1, 0, 5, 1], [1, 1, 5, 1]]))
+
+def test_count_featurizer_string_support():
+    cf_1 = CountFeaturizer()
+    X = np.array([["foo"], ["bar"], ["foo"]])
+    assert_array_equal( \
+        cf_1.fit_transform(X), \
+        np.array([["foo", 2], ["bar", 1], ["foo", 2]]))

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1637,7 +1637,6 @@ def test_one_hot_encoder_unknown_transform():
     oh.fit(X)
     assert_raises(ValueError, oh.transform, y)
 
-
 def test_fit_cold_start():
     X = iris.data
     X_2d = X[:, :2]
@@ -1686,3 +1685,4 @@ def test_count_featurizer_ft_standard_inclusion():
     assert_array_equal( \
         cf_inclusion_4.fit_transform(X2), \
         np.array([[0, 2, 1, 2], [0, 2, 3, 2], [1, 0, 5, 1], [1, 1, 5, 1]]))
+

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -39,6 +39,7 @@ from sklearn.preprocessing.data import KernelCenterer
 from sklearn.preprocessing.data import Normalizer
 from sklearn.preprocessing.data import normalize
 from sklearn.preprocessing.data import OneHotEncoder
+from sklearn.preprocessing.data import CountFeaturizer
 from sklearn.preprocessing.data import StandardScaler
 from sklearn.preprocessing.data import scale
 from sklearn.preprocessing.data import MinMaxScaler

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1651,3 +1651,37 @@ def test_fit_cold_start():
         # with a different shape, this may break the scaler unless the internal
         # state is reset
         scaler.fit_transform(X_2d)
+
+def test_count_featurizer_ft_standard():
+    # test count featurizer fit-transform on a very standard data
+    cf_standard = CountFeaturizer()
+    X = np.array([[0, 2, 1], [1, 0, 3], [1, 0, 2], [1, 0, 2]])
+    assert_array_equal( \
+        cf.fit_transform(X), \
+        np.array([[0, 2, 1, 1], [1, 0, 3, 1], [1, 0, 2, 2], [1, 0, 2, 2]]))
+
+def test_count_featurizer_ft_standard_inclusion():
+    # test count featurizer fit-transform on a very standard data
+    # with different inclusion parameters
+    
+    cf_inclusion_1 = CountFeaturizer(inclusion=[1, 0, 0])
+    cf_inclusion_2 = CountFeaturizer(inclusion=[0, 0, 0])
+    cf_inclusion_3 = CountFeaturizer(inclusion=[1, 1, 1])
+    cf_inclusion_4 = CountFeaturizer(inclusion=[1, 1, 0])
+    X = np.array([[0, 2, 1], [1, 0, 3], [1, 0, 2], [1, 0, 2]])
+    X2 = np.array([[0, 2, 1], [0, 2, 3], [1, 0, 5], [1, 1, 5]])
+    assert_array_equal( \
+        cf_inclusion_1.fit_transform(X), \
+        np.array([[0, 2, 1, 1], [1, 0, 3, 3], [1, 0, 2, 3], [1, 0, 2, 3]]))
+
+    assert_array_equal( \
+        cf_inclusion_2.fit_transform(X), \
+        np.array([[0, 2, 1, 4], [1, 0, 3, 4], [1, 0, 2, 4], [1, 0, 2, 4]]))
+
+    assert_array_equal( \
+        cf_inclusion_3.fit_transform(X), \
+        np.array([[0, 2, 1, 1], [1, 0, 3, 1], [1, 0, 2, 2], [1, 0, 2, 2]]))
+
+    assert_array_equal( \
+        cf_inclusion_4.fit_transform(X2), \
+        np.array([[0, 2, 1, 2], [0, 2, 3, 2], [1, 0, 5, 1], [1, 1, 5, 1]]))

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1655,10 +1655,10 @@ def test_fit_cold_start():
 
 def test_count_featurizer_ft_standard():
     # test count featurizer fit-transform on a very standard data
-    cf_standard = CountFeaturizer()
+    cf_1 = CountFeaturizer()
     X = np.array([[0, 2, 1], [1, 0, 3], [1, 0, 2], [1, 0, 2]])
     assert_array_equal( \
-        cf.fit_transform(X), \
+        cf_1.fit_transform(X), \
         np.array([[0, 2, 1, 1], [1, 0, 3, 1], [1, 0, 2, 2], [1, 0, 2, 2]]))
 
 def test_count_featurizer_ft_standard_inclusion():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1665,10 +1665,10 @@ def test_count_featurizer_ft_standard_inclusion():
     # test count featurizer fit-transform on a very standard data
     # with different inclusion parameters
     
-    cf_inclusion_1 = CountFeaturizer(inclusion=[1, 0, 0])
-    cf_inclusion_2 = CountFeaturizer(inclusion=[0, 0, 0])
-    cf_inclusion_3 = CountFeaturizer(inclusion=[1, 1, 1])
-    cf_inclusion_4 = CountFeaturizer(inclusion=[1, 1, 0])
+    cf_inclusion_1 = CountFeaturizer(inclusion=[0])
+    cf_inclusion_2 = CountFeaturizer(inclusion=[])
+    cf_inclusion_3 = CountFeaturizer(inclusion=[0, 1, 2])
+    cf_inclusion_4 = CountFeaturizer(inclusion=[0, 1])
     X = np.array([[0, 2, 1], [1, 0, 3], [1, 0, 2], [1, 0, 2]])
     X2 = np.array([[0, 2, 1], [0, 2, 3], [1, 0, 5], [1, 1, 5]])
     assert_array_equal( \

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -27,7 +27,6 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_no_warnings
-from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import skip_if_32bit
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -124,7 +124,7 @@ def test_polynomial_features():
     assert_array_almost_equal(X_poly, P2[:, [0, 1, 2, 4]])
 
     assert_equal(interact.powers_.shape, (interact.n_output_features_,
-                 interact.n_input_features_))
+                                          interact.n_input_features_))
 
 
 def test_polynomial_feature_names():
@@ -143,7 +143,8 @@ def test_polynomial_feature_names():
                         'b c^2', 'c^3'], feature_names)
     # test some unicode
     poly = PolynomialFeatures(degree=1, include_bias=True).fit(X)
-    feature_names = poly.get_feature_names([u"\u0001F40D", u"\u262E", u"\u05D0"])
+    feature_names = poly.get_feature_names(
+        [u"\u0001F40D", u"\u262E", u"\u05D0"])
     assert_array_equal([u"1", u"\u0001F40D", u"\u262E", u"\u05D0"],
                        feature_names)
 
@@ -1637,6 +1638,7 @@ def test_one_hot_encoder_unknown_transform():
     oh.fit(X)
     assert_raises(ValueError, oh.transform, y)
 
+
 def test_fit_cold_start():
     X = iris.data
     X_2d = X[:, :2]
@@ -1652,37 +1654,44 @@ def test_fit_cold_start():
         # state is reset
         scaler.fit_transform(X_2d)
 
+
 def test_count_featurizer_ft_standard():
     # test count featurizer fit-transform on a very standard data
     cf_1 = CountFeaturizer()
     X = np.array([[0, 2, 1], [1, 0, 3], [1, 0, 2], [1, 0, 2]])
-    assert_array_equal( \
-        cf_1.fit_transform(X), \
+    assert_array_equal(
+        cf_1.fit_transform(X),
         np.array([[0, 2, 1, 1], [1, 0, 3, 1], [1, 0, 2, 2], [1, 0, 2, 2]]))
+
 
 def test_count_featurizer_ft_standard_inclusion():
     # test count featurizer fit-transform on a very standard data
     # with different inclusion parameters
-    
+
     cf_inclusion_1 = CountFeaturizer(inclusion=[0])
     cf_inclusion_2 = CountFeaturizer(inclusion=[])
     cf_inclusion_3 = CountFeaturizer(inclusion=[0, 1, 2])
     cf_inclusion_4 = CountFeaturizer(inclusion=[0, 1])
     X = np.array([[0, 2, 1], [1, 0, 3], [1, 0, 2], [1, 0, 2]])
     X2 = np.array([[0, 2, 1], [0, 2, 3], [1, 0, 5], [1, 1, 5]])
-    assert_array_equal( \
-        cf_inclusion_1.fit_transform(X), \
+    assert_array_equal(
+        cf_inclusion_1.fit_transform(X),
         np.array([[0, 2, 1, 1], [1, 0, 3, 3], [1, 0, 2, 3], [1, 0, 2, 3]]))
 
-    assert_array_equal( \
-        cf_inclusion_2.fit_transform(X), \
+    assert_array_equal(
+        cf_inclusion_2.fit_transform(X),
         np.array([[0, 2, 1, 4], [1, 0, 3, 4], [1, 0, 2, 4], [1, 0, 2, 4]]))
 
-    assert_array_equal( \
-        cf_inclusion_3.fit_transform(X), \
+    assert_array_equal(
+        cf_inclusion_3.fit_transform(X),
         np.array([[0, 2, 1, 1], [1, 0, 3, 1], [1, 0, 2, 2], [1, 0, 2, 2]]))
 
-    assert_array_equal( \
-        cf_inclusion_4.fit_transform(X2), \
+    assert_array_equal(
+        cf_inclusion_4.fit_transform(X2),
         np.array([[0, 2, 1, 2], [0, 2, 3, 2], [1, 0, 5, 1], [1, 1, 5, 1]]))
 
+
+def test_count_featurizer_standard_removal():
+    cf_removal = CountFeaturizer(removal_policy=[0, 1])
+    X = np.array([[1, 1], [1, 2], [1, 1]])
+    assert_array_equal(cf_removal.fit_transform(X), np.array([[2], [1], [2]]))

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1686,10 +1686,3 @@ def test_count_featurizer_ft_standard_inclusion():
     assert_array_equal( \
         cf_inclusion_4.fit_transform(X2), \
         np.array([[0, 2, 1, 2], [0, 2, 3, 2], [1, 0, 5, 1], [1, 1, 5, 1]]))
-
-def test_count_featurizer_string_support():
-    cf_1 = CountFeaturizer()
-    X = np.array([["foo"], ["bar"], ["foo"]])
-    assert_array_equal( \
-        cf_1.fit_transform(X), \
-        np.array([["foo", 2], ["bar", 1], ["foo", 2]]))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
https://github.com/scikit-learn/scikit-learn/issues/7717

#### What does this implement/fix? Explain your changes.
Before, the code was using == to compare float values and dividing by "zero (~10e-309)" which caused an overflow.

`        if denominator == 0:
            tree.value[leaf, 0, 0] = 0.0
        else:
            tree.value[leaf, 0, 0] = numerator / denominator`

Now I made it so that it's
```
        if np.isclose(denominator, 0.0):
            tree.value[leaf, 0, 0] = 0.0
        else:
            tree.value[leaf, 0, 0] = numerator / denominator

```
