### PR TITLE
[MRG]np_version version check, compatible with numpy-1.12.0b1, to solve the tuple comparison, (1,12, '0b1')>   (1,12,0) the TypeError

### DIFF
--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -360,7 +360,7 @@ else:
     from scipy.stats import rankdata
 
 
-if np_version[:2] < (1, 12):
+if np_version < (1, 12):
     class MaskedArray(np.ma.MaskedArray):
         # Before numpy 1.12, np.ma.MaskedArray object is not picklable
         # This fix is needed to make our model_selection.GridSearchCV

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -360,7 +360,7 @@ else:
     from scipy.stats import rankdata
 
 
-if np_version < (1, 12, 0):
+if np_version[:2] < (1, 12):
     class MaskedArray(np.ma.MaskedArray):
         # Before numpy 1.12, np.ma.MaskedArray object is not picklable
         # This fix is needed to make our model_selection.GridSearchCV


### PR DESCRIPTION
np_version version check, compatible with numpy-1.12.0b1, to solve the tuple comparison, (1,12, '0b1')> 

(1,12,0) the TypeError