### PR TITLE
Sample-dependent alpha parameter moved to fit() in GaussianProcessRegressor

### DIFF
--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -178,9 +178,9 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
             self.y_train_mean = np.zeros(1)
 
         if np.iterable(self.alpha):
-            warnings.warn("Non scalar alpha will give error "
-                          "in 0.20. Use sample_alpha in fit()"
-                          " for sample-dependent noise "
+            warnings.warn("Non scalar alpha is deprecated and "
+                          "will be removed in 0.21. Use sample_alpha"
+                          " in fit() for sample-dependent noise "
                           "estimates.", DeprecationWarning)
             if self.alpha.shape[0] != y.shape[0]:
                 if self.alpha.shape[0] == 1:

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -204,7 +204,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
                                      " entries as y.(%d != %d)"
                                      % (sample_alpha.shape[0], y.shape[0]))
             add_alpha = sample_alpha
- 
+
         self.X_train_ = np.copy(X) if self.copy_X_train else X
         self.y_train_ = np.copy(y) if self.copy_X_train else y
 

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -178,9 +178,9 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
             self.y_train_mean = np.zeros(1)
 
         if np.iterable(self.alpha):
-            print("Deprecation warning: Alpha must be scalar."
-                  "Use sample_alpha in fit() for sample dependent"
-                  "noise estimates.")
+            warnings.warn("Non scalar alpha will give error in 0.20."
+                  "Use sample_alpha in fit() for sample-dependent "
+                  "noise estimates.", DeprecationWarning)
             if self.alpha.shape[0] != y.shape[0]:
                 if self.alpha.shape[0] == 1:
                     self.alpha = self.alpha[0]

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -192,7 +192,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
 
         # Add sample-dependent noise-estimates
         if sample_alpha is None:
-            add_alpha = 0.0
+            self.sample_alpha = 0.0
         else:
             if np.iterable(sample_alpha) \
                and sample_alpha.shape[0] != y.shape[0]:
@@ -203,7 +203,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
                                      " or an array with same number of"
                                      " entries as y.(%d != %d)"
                                      % (sample_alpha.shape[0], y.shape[0]))
-            add_alpha = sample_alpha
+            self.sample_alpha = sample_alpha
 
         self.X_train_ = np.copy(X) if self.copy_X_train else X
         self.y_train_ = np.copy(y) if self.copy_X_train else y
@@ -250,7 +250,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
         # Precompute quantities required for predictions which are independent
         # of actual query points
         K = self.kernel_(self.X_train_)
-        K[np.diag_indices_from(K)] += self.alpha+add_alpha
+        K[np.diag_indices_from(K)] += self.alpha+self.sample_alpha
         self.L_ = cholesky(K, lower=True)  # Line 2
         self.alpha_ = cho_solve((self.L_, True), self.y_train_)  # Line 3
 
@@ -407,6 +407,8 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
             K = kernel(self.X_train_)
 
         K[np.diag_indices_from(K)] += self.alpha
+        K[np.diag_indices_from(K)] += self.sample_alpha 
+
         try:
             L = cholesky(K, lower=True)  # Line 2
         except np.linalg.LinAlgError:

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -407,7 +407,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
             K = kernel(self.X_train_)
 
         K[np.diag_indices_from(K)] += self.alpha
-        K[np.diag_indices_from(K)] += self.sample_alpha 
+        K[np.diag_indices_from(K)] += self.sample_alpha
 
         try:
             L = cholesky(K, lower=True)  # Line 2

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -178,9 +178,10 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
             self.y_train_mean = np.zeros(1)
 
         if np.iterable(self.alpha):
-            warnings.warn("Non scalar alpha will give error in 0.20."
-                  "Use sample_alpha in fit() for sample-dependent "
-                  "noise estimates.", DeprecationWarning)
+            warnings.warn("Non scalar alpha will give error "
+                          "in 0.20. Use sample_alpha in fit()"
+                          " for sample-dependent noise "
+                          "estimates.", DeprecationWarning)
             if self.alpha.shape[0] != y.shape[0]:
                 if self.alpha.shape[0] == 1:
                     self.alpha = self.alpha[0]

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -177,8 +177,29 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
             self.y_train_mean = np.zeros(1)
 
         if np.iterable(self.alpha):
-            raise ValueError("alpha must be a scalar. Use sample_alpha in fit() for sample-dependent noise")
-
+            print "Deprecation warning: Alpha must be scalar. Used sample_alpha in fit() for sample dependent noise estimates."
+            if self.alpha.shape[0] != y.shape[0]:
+                if self.alpha.shape[0] == 1:
+                    self.alpha = self.alpha[0]
+                else:
+                    raise ValueError("alpha must be a scalar or an array"
+                                     " with same number of entries as y.(%d != %d)"
+    % (self.alpha.shape[0], y.shape[0]))
+            
+        #Add sample-dependent noise-estimates      
+        if sample_alpha is None:
+            add_alpha=0.0
+        else:
+            if np.iterable(sample_alpha) \
+               and sample_alpha.shape[0] != y.shape[0]:
+                if sample_alpha.shape[0] == 1:
+                    sample_alpha = sample_alpha[0]
+                else:
+                    raise ValueError("sample_alpha must be a scalar or an array"
+                                     " with same number of entries as y.(%d != %d)"
+                                     % (sample_alpha.shape[0], y.shape[0]))
+            add_alpha=sample_alpha
+            
         self.X_train_ = np.copy(X) if self.copy_X_train else X
         self.y_train_ = np.copy(y) if self.copy_X_train else y
 
@@ -221,19 +242,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
             self.log_marginal_likelihood_value_ = \
                 self.log_marginal_likelihood(self.kernel_.theta)
                 
-        #Add sample-dependent noise-estimates      
-        if sample_alpha is None:
-            add_alpha=0.0
-        else:
-            if np.iterable(sample_alpha) \
-               and sample_alpha.shape[0] != y.shape[0]:
-                if sample_alpha.shape[0] == 1:
-                    sample_alpha = sample_alpha[0]
-                else:
-                    raise ValueError("sample_alpha must be a scalar or an array"
-                                     " with same number of entries as y.(%d != %d)"
-                                     % (sample_alpha.shape[0], y.shape[0]))
-            add_alpha=sample_alpha
+        
             
         # Precompute quantities required for predictions which are independent
         # of actual query points

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -138,7 +138,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
         self.copy_X_train = copy_X_train
         self.random_state = random_state
 
-    def fit(self, X, y,sample_alpha=None):
+    def fit(self, X, y, sample_alpha=None):
         """Fit Gaussian process regression model
 
         Parameters
@@ -148,12 +148,13 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
 
         y : array-like, shape = (n_samples, [n_output_dims])
             Target values
-            
+
         sample_alpha : float or array like, shape = (n_samples,), optional
-            Sample dependent noise estimates.
-            Added, in addition to alpha, to the diagonal of the kernel matrix during fitting.
-            Larger values correspond to increased noise level in the observations.
-            
+            Sample dependent noise estimates.Added, in addition to alpha,
+            to the diagonal of the kernel matrix during fitting.
+            Larger values correspond to increased noise level in the
+            observations.
+
         Returns
         -------
         self : returns an instance of self.
@@ -177,29 +178,33 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
             self.y_train_mean = np.zeros(1)
 
         if np.iterable(self.alpha):
-            print("Deprecation warning: Alpha must be scalar. Used sample_alpha in fit() for sample dependent noise estimates.")
+            print("Deprecation warning: Alpha must be scalar."
+                  "Use sample_alpha in fit() for sample dependent"
+                  "noise estimates.")
             if self.alpha.shape[0] != y.shape[0]:
                 if self.alpha.shape[0] == 1:
                     self.alpha = self.alpha[0]
                 else:
-                    raise ValueError("alpha must be a scalar or an array"
-                                     " with same number of entries as y.(%d != %d)"
-    % (self.alpha.shape[0], y.shape[0]))
-            
-        #Add sample-dependent noise-estimates      
+                    raise ValueError("alpha must be a scalar"
+                                     "or an array with same number"
+                                     " of entries as y.(%d != %d)"
+                                     % (self.alpha.shape[0], y.shape[0]))
+
+        # Add sample-dependent noise-estimates
         if sample_alpha is None:
-            add_alpha=0.0
+            add_alpha = 0.0
         else:
             if np.iterable(sample_alpha) \
                and sample_alpha.shape[0] != y.shape[0]:
                 if sample_alpha.shape[0] == 1:
                     sample_alpha = sample_alpha[0]
                 else:
-                    raise ValueError("sample_alpha must be a scalar or an array"
-                                     " with same number of entries as y.(%d != %d)"
+                    raise ValueError("sample_alpha must be a scalar"
+                                     " or an array with same number of"
+                                     " entries as y.(%d != %d)"
                                      % (sample_alpha.shape[0], y.shape[0]))
-            add_alpha=sample_alpha
-            
+            add_alpha = sample_alpha
+ 
         self.X_train_ = np.copy(X) if self.copy_X_train else X
         self.y_train_ = np.copy(y) if self.copy_X_train else y
 
@@ -241,9 +246,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
         else:
             self.log_marginal_likelihood_value_ = \
                 self.log_marginal_likelihood(self.kernel_.theta)
-                
-        
-            
+
         # Precompute quantities required for predictions which are independent
         # of actual query points
         K = self.kernel_(self.X_train_)

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -177,7 +177,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
             self.y_train_mean = np.zeros(1)
 
         if np.iterable(self.alpha):
-            print "Deprecation warning: Alpha must be scalar. Used sample_alpha in fit() for sample dependent noise estimates."
+            print("Deprecation warning: Alpha must be scalar. Used sample_alpha in fit() for sample dependent noise estimates.")
             if self.alpha.shape[0] != y.shape[0]:
                 if self.alpha.shape[0] == 1:
                     self.alpha = self.alpha[0]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #7975 
Fixes #7821 
(Duplicate issues)

#### What does this implement/fix? Explain your changes.
If different samples have different noise-levels(Should be weighted differently), these noise levels should be added in the fit() method. Not in constructor, as it is currently.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

-Alpha passed to constructor of GaussianProcessRegressor now must be scalar.
-In addition to alpha, sample_alpha argument in fit() is added  to the kernel matrix diagonal.  None(default),float or array, shape(num_samples,)

Quick test:
![figure_2](https://cloud.githubusercontent.com/assets/24376889/20905019/693da956-bb42-11e6-97e2-56d85c0479b5.png)
![figure_1](https://cloud.githubusercontent.com/assets/24376889/20905025/6b5a05ae-bb42-11e6-8a2a-ec63a34d93b1.png)
[sample_alpha.zip](https://github.com/scikit-learn/scikit-learn/files/632457/sample_alpha.zip)