### PR TITLE
[MRG + 1] Set min_impurity_split in gradient boosting models

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -118,6 +118,11 @@ Bug fixes
      when a numpy array is passed in for weights. :issue:`7983` by
      :user:`Vincent Pham <vincentpham1991>`.
 
+   - Fix a bug where :class:`sklearn.ensemble.GradientBoostingClassifier` and
+     :class:`sklearn.ensemble.GradientBoostingRegressor` ignored the
+     ``min_impurity_split`` parameter.
+     :issue:`8006` by :user:`Sebastian Pölsterl <sebp>`.
+
 API changes summary
 -------------------
 
@@ -126,7 +131,6 @@ API changes summary
      ensemble estimators (deriving from :class:`ensemble.BaseEnsemble`)
      now only have ``self.estimators_`` available after ``fit``.
      :issue:`7464` by `Lars Buitinck`_ and `Loic Esteve`_.
-
 
 .. _changes_0_18_1:
 

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -765,6 +765,7 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
                 min_samples_split=self.min_samples_split,
                 min_samples_leaf=self.min_samples_leaf,
                 min_weight_fraction_leaf=self.min_weight_fraction_leaf,
+                min_impurity_split=self.min_impurity_split,
                 max_features=self.max_features,
                 max_leaf_nodes=self.max_leaf_nodes,
                 random_state=random_state,

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -961,6 +961,19 @@ def test_max_leaf_nodes_max_depth():
         assert_equal(tree.max_depth, 1)
 
 
+def test_min_impurity_split():
+    # Test if min_impurity_split of base estimators is set
+    # Regression test for #8006
+    X, y = datasets.make_hastie_10_2(n_samples=100, random_state=1)
+    all_estimators = [GradientBoostingRegressor,
+                      GradientBoostingClassifier]
+
+    for GBEstimator in all_estimators:
+        est = GBEstimator(min_impurity_split=0.1).fit(X, y)
+        for tree in est.estimators_.flat:
+            assert_equal(tree.min_impurity_split, 0.1)
+
+
 def test_warm_start_wo_nestimators_change():
     # Test if warm_start does nothing if n_estimators is not changed.
     # Regression test for #3513.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Fixes #8006

#### What does this implement/fix? Explain your changes.
Pass `self.min_impurity_split` to `DecisionTreeRegressor` in `BaseGradientBoosting._fit_stage`.
