### PR TITLE
[MRG] Deprecated the rng_ attribute of GaussianProcessRegressor

### DIFF
--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -222,9 +222,10 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
                 for iteration in range(self.n_restarts_optimizer):
                     theta_initial = \
                         self._rng.uniform(bounds[:, 0], bounds[:, 1])
-                        # Deprecation 0.21
-                        # Replace the above line by
-                        # rng.uniform(bounds[:, 0], bounds[:, 1])
+                    # Deprecation 0.21
+                    # Replace the above line by
+                    # theta_initial = \
+                    #     rng.uniform(bounds[:, 0], bounds[:, 1])
                     optima.append(
                         self._constrained_optimization(obj_func, theta_initial,
                                                        bounds))

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -142,8 +142,8 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
         self.random_state = random_state
 
     @property
-    @deprecated("Attribute ``rng_`` is deprecated in version 0.19 and will be"
-                " used only as a variable in version 0.21.")
+    @deprecated("Attribute ``rng`` is deprecated in version 0.19 and will be"
+                " removed in version 0.21.")
     def rng(self):
         return self._rng
 

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -169,6 +169,9 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
             self.kernel_ = clone(self.kernel)
 
         self._rng = check_random_state(self.random_state)
+        # Deprecation 0.21
+        # Replace the above line by
+        # rng = check_random_state(self.random_state)
 
         X, y = check_X_y(X, y, multi_output=True, y_numeric=True)
 
@@ -219,6 +222,9 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
                 for iteration in range(self.n_restarts_optimizer):
                     theta_initial = \
                         self._rng.uniform(bounds[:, 0], bounds[:, 1])
+                        # Deprecation 0.21
+                        # Replace the above line by
+                        # rng.uniform(bounds[:, 0], bounds[:, 1])
                     optima.append(
                         self._constrained_optimization(obj_func, theta_initial,
                                                        bounds))

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -140,6 +140,12 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
         self.copy_X_train = copy_X_train
         self.random_state = random_state
 
+    @property
+    @deprecated("Attribute ``rng_`` is deprecated in version 0.19 and will be"
+                " used only as a variable in version 0.21.")
+    def rng_(self):
+        return self._rng_
+
     def fit(self, X, y):
         """Fit Gaussian process regression model
 
@@ -161,7 +167,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
         else:
             self.kernel_ = clone(self.kernel)
 
-        self.rng = check_random_state(self.random_state)
+        self._rng_ = check_random_state(self.random_state)
 
         X, y = check_X_y(X, y, multi_output=True, y_numeric=True)
 
@@ -211,7 +217,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
                 bounds = self.kernel_.bounds
                 for iteration in range(self.n_restarts_optimizer):
                     theta_initial = \
-                        self.rng.uniform(bounds[:, 0], bounds[:, 1])
+                        self._rng_.uniform(bounds[:, 0], bounds[:, 1])
                     optima.append(
                         self._constrained_optimization(obj_func, theta_initial,
                                                        bounds))

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -15,6 +15,7 @@ from sklearn.base import BaseEstimator, RegressorMixin, clone
 from sklearn.gaussian_process.kernels import RBF, ConstantKernel as C
 from sklearn.utils import check_random_state
 from sklearn.utils.validation import check_X_y, check_array
+from sklearn.utils.deprecation import deprecated
 
 
 class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
@@ -143,8 +144,8 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
     @property
     @deprecated("Attribute ``rng_`` is deprecated in version 0.19 and will be"
                 " used only as a variable in version 0.21.")
-    def rng_(self):
-        return self._rng_
+    def rng(self):
+        return self._rng
 
     def fit(self, X, y):
         """Fit Gaussian process regression model
@@ -167,7 +168,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
         else:
             self.kernel_ = clone(self.kernel)
 
-        self._rng_ = check_random_state(self.random_state)
+        self._rng = check_random_state(self.random_state)
 
         X, y = check_X_y(X, y, multi_output=True, y_numeric=True)
 
@@ -217,7 +218,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
                 bounds = self.kernel_.bounds
                 for iteration in range(self.n_restarts_optimizer):
                     theta_initial = \
-                        self._rng_.uniform(bounds[:, 0], bounds[:, 1])
+                        self._rng.uniform(bounds[:, 0], bounds[:, 1])
                     optima.append(
                         self._constrained_optimization(obj_func, theta_initial,
                                                        bounds))


### PR DESCRIPTION
#### Reference Issue
Fixes #7752 


#### What does this implement/fix? Explain your changes.
Adds the deprecation for  `rng_` to be kept only as a variable for `fit`