### PR TITLE
[MRG+1] Catch cases for different class size in MLPClassifier with warm start (#7976) 

### DIFF
--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -955,8 +955,8 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         -------
         self : returns a trained MLP model.
         """
-        num_classes = len(unique_labels(y))
         if getattr(self, 'classes_', None) is not None:
+            num_classes = len(unique_labels(y))
             if num_classes != len(self.classes_):
                 raise ValueError("The current output has %s unique labels. "
                                  " Model expected %s unique labels." %

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -910,7 +910,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
             self.classes_ = self._label_binarizer.classes_
         else:
             classes = unique_labels(y)
-            if np.setdiff1d(classes, self.classes_, assume_unique=True):
+            if np.setdiff1d(classes, self.classes_, assume_unique=True).any():
                 raise ValueError("`y` has classes not in `self.classes_`."
                                  " `self.classes_` has %s. 'y' has %s." %
                                  (self.classes_, classes))
@@ -955,13 +955,11 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         -------
         self : returns a trained MLP model.
         """
-        if getattr(self, 'classes_', None) is not None:
-            num_classes = len(unique_labels(y))
-            if num_classes != len(self.classes_):
-                raise ValueError("The current output has %s unique labels. "
-                                 " Model expected %s unique labels." %
-                                 (num_classes, len(self.classes_)))
-        return self._fit(X, y, incremental=False)
+        if self.warm_start and hasattr(self, "classes_"):
+            incremental = True
+        else:
+            incremental = False
+        return self._fit(X, y, incremental=incremental)
 
     @property
     def partial_fit(self):

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -939,6 +939,30 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
 
         return self._label_binarizer.inverse_transform(y_pred)
 
+    def fit(self, X, y):
+        """Fit the model to data matrix X and target(s) y.
+
+        Parameters
+        ----------
+        X : array-like or sparse matrix, shape (n_samples, n_features)
+            The input data.
+
+        y : array-like, shape (n_samples,) or (n_samples, n_outputs)
+            The target values (class labels in classification, real numbers in
+            regression).
+
+        Returns
+        -------
+        self : returns a trained MLP model.
+        """
+        num_classes = len(unique_labels(y))
+        if getattr(self, 'classes_', None) is not None:
+            if num_classes != len(self.classes_):
+                raise ValueError("The current output has %s unique labels. "
+                                 " Model expected %s unique labels." %
+                                 (num_classes, len(self.classes_)))
+        return self._fit(X, y, incremental=False)
+
     @property
     def partial_fit(self):
         """Fit the model to data matrix X and target y.

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -908,9 +908,15 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
             self._label_binarizer = LabelBinarizer()
             self._label_binarizer.fit(y)
             self.classes_ = self._label_binarizer.classes_
+        elif self.warm_start:
+            classes = unique_labels(y)
+            if set(classes) != set(self.classes_):
+                raise ValueError("`y` has classes not in `self.classes_`."
+                                 " `self.classes_` has %s. 'y' has %s." %
+                                 (self.classes_, classes))
         else:
             classes = unique_labels(y)
-            if np.setdiff1d(classes, self.classes_, assume_unique=True).any():
+            if np.setdiff1d(classes, self.classes_, assume_unique=True):
                 raise ValueError("`y` has classes not in `self.classes_`."
                                  " `self.classes_` has %s. 'y' has %s." %
                                  (self.classes_, classes))

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -911,8 +911,8 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         elif self.warm_start:
             classes = unique_labels(y)
             if set(classes) != set(self.classes_):
-                raise ValueError("`y` has classes not in `self.classes_`."
-                                 " `self.classes_` has %s. 'y' has %s." %
+                raise ValueError("warm_start can only be used where `y` has the same classes as in the previous "
+                                 "call to fit. Previously got %s, `y` has %s" %
                                  (self.classes_, classes))
         else:
             classes = unique_labels(y)

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -911,7 +911,8 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         elif self.warm_start:
             classes = unique_labels(y)
             if set(classes) != set(self.classes_):
-                raise ValueError("warm_start can only be used where `y` has the same classes as in the previous "
+                raise ValueError("warm_start can only be used where `y` has "
+                                 "the same classes as in the previous "
                                  "call to fit. Previously got %s, `y` has %s" %
                                  (self.classes_, classes))
         else:

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -962,11 +962,8 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         -------
         self : returns a trained MLP model.
         """
-        if self.warm_start and hasattr(self, "classes_"):
-            incremental = True
-        else:
-            incremental = False
-        return self._fit(X, y, incremental=incremental)
+        return self._fit(X, y, incremental=(self.warm_start and
+                                            hasattr(self, "classes_")))
 
     @property
     def partial_fit(self):

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -567,41 +567,34 @@ def test_warm_class():
     X = X_iris[:150]
     y = y_iris[:150]
 
-    n = len(y)
-
     y_2classes = np.array([0]*75 + [1]*75)
     y_3classes = np.array([0]*50 + [1]*50 + [2]*50)
     y_4classes = np.array([0]*37 + [1]*37 + [2]*38 + [3]*38)
     y_5classes = np.array([0]*30 + [1]*30 + [2]*30 + [3]*30 + [4]*30)
 
-    # failed in converting 7th argument `g' of _lbfgsb.setulb to C/Fortran array
-    model = MLPClassifier(hidden_layer_sizes=10, solver='lbfgs',
-                          warm_start=True)
+    with ignore_warnings(category=Warning):
+        # failed in converting 7th argument `g' of _lbfgsb.setulb to
+        # C/Fortran array
+        clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
+                              warm_start=True)
+        clf.fit(X, y)
+        assert_raises(ValueError, clf.fit, X, y_2classes)
 
-    model.fit(X, y)
-    model.fit(X, y_2classes)
-    # model.predict(X)
+        # Success
+        clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
+                              warm_start=True)
+        clf.fit(X, y)
+        clf.fit(X, y_3classes)
 
-    # Success
-    model = MLPClassifier(hidden_layer_sizes=10, solver='lbfgs',
-                          warm_start=True)
+        # ValueError: operands could not be broadcast together with shapes
+        # (150,10) (3) (150,10)
+        clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
+                              warm_start=True)
+        clf.fit(X, y)
+        assert_raises(ValueError, clf.fit, X, y_4classes)
 
-    model.fit(X, y)
-    model.fit(X, y_3classes)
-    # model.predict(X)
-
-    # ValueError: operands could not be broadcast together with shapes (150,10) (3) (150,10)
-    model = MLPClassifier(hidden_layer_sizes=10, solver='lbfgs',
-                          warm_start=True)
-
-    model.fit(X, y)
-    model.fit(X, y_4classes)
-    # model.predict(X)
-
-    # ValueError: total size of new array must be unchanged
-    model = MLPClassifier(hidden_layer_sizes=10, solver='lbfgs',
-                          warm_start=True)
-
-    model.fit(X, y)
-    model.fit(X, y_5classes)
-    # model.predict(X)
+        # ValueError: total size of new array must be unchanged
+        clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
+                              warm_start=True)
+        clf.fit(X, y)
+        assert_raises(ValueError, clf.fit, X, y_5classes)

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -576,25 +576,25 @@ def test_warm_class():
         # failed in converting 7th argument `g' of _lbfgsb.setulb to
         # C/Fortran array
         clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
-                              warm_start=True)
+                            warm_start=True)
         clf.fit(X, y)
         assert_raises(ValueError, clf.fit, X, y_2classes)
 
         # Success
         clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
-                              warm_start=True)
+                            warm_start=True)
         clf.fit(X, y)
         clf.fit(X, y_3classes)
 
         # ValueError: operands could not be broadcast together with shapes
         # (150,10) (3) (150,10)
         clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
-                              warm_start=True)
+                            warm_start=True)
         clf.fit(X, y)
         assert_raises(ValueError, clf.fit, X, y_4classes)
 
         # ValueError: total size of new array must be unchanged
         clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
-                              warm_start=True)
+                            warm_start=True)
         clf.fit(X, y)
         assert_raises(ValueError, clf.fit, X, y_5classes)

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -570,6 +570,7 @@ def test_warm_start():
 
     y_2classes = np.array([0] * 75 + [1] * 75)
     y_3classes = np.array([0] * 50 + [1] * 50 + [2] * 50)
+    y_3classes_alt = np.array([0] * 50 + [1] * 50 + [3] * 50)
     y_4classes = np.array([0] * 37 + [1] * 37 + [2] * 38 + [3] * 38)
     y_5classes = np.array([0] * 30 + [1] * 30 + [2] * 30 + [3] * 30 + [4] * 30)
 
@@ -579,28 +580,37 @@ def test_warm_start():
         clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
                             warm_start=True)
         clf.fit(X, y)
-        message = ("`y` has classes not in `self.classes_`. `self.classes_`"
-                   " has [0 1 2]. 'y' has [0 1].")
+        message = ('warm_start can only be used where `y` has the same classes as in the previous call to fit.'
+                   ' Previously got [0 1 2], `y` has [0 1]')
         assert_raise_message(ValueError, message, clf.fit, X, y_2classes)
 
-        # Test with 3 unique labels
+        # Test with 3 unique labels that are the same as original fit.
         clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
                             warm_start=True)
         clf.fit(X, y)
         clf.fit(X, y_3classes)
 
+        # Test with 3 unique labels that are different from original fit.
+
+        clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
+                            warm_start=True)
+        clf.fit(X, y)
+        message = ('warm_start can only be used where `y` has the same classes as in the previous call to fit.'
+                   ' Previously got [0 1 2], `y` has [0 1 3]')
+        assert_raise_message(ValueError, message, clf.fit, X, y_3classes_alt)
+
         # Test with 4 unique labels
         clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
                             warm_start=True)
         clf.fit(X, y)
-        message = ("`y` has classes not in `self.classes_`. `self.classes_`"
-                   " has [0 1 2]. 'y' has [0 1 2 3].")
+        message = ('warm_start can only be used where `y` has the same classes as in the previous call to fit.'
+                   ' Previously got [0 1 2], `y` has [0 1 2 3]')
         assert_raise_message(ValueError, message, clf.fit, X, y_4classes)
 
-        # Test with 5 unique labels
+        # Test with 5 unique labels. This is a non-regression error.
         clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
                             warm_start=True)
         clf.fit(X, y)
-        message = ("`y` has classes not in `self.classes_`. `self.classes_`"
-                   " has [0 1 2]. 'y' has [0 1 2 3 4].")
+        message = ('warm_start can only be used where `y` has the same classes as in the previous call to fit.'
+                   ' Previously got [0 1 2], `y` has [0 1 2 3 4]')
         assert_raise_message(ValueError, message, clf.fit, X, y_5classes)

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -564,6 +564,7 @@ def test_adaptive_learning_rate():
     assert_greater(1e-6, clf._optimizer.learning_rate)
 
 
+@ignore_warnings(RuntimeError)
 def test_warm_start():
     X = X_iris
     y = y_iris
@@ -574,17 +575,16 @@ def test_warm_start():
     y_4classes = np.array([0] * 37 + [1] * 37 + [2] * 38 + [3] * 38)
     y_5classes = np.array([0] * 30 + [1] * 30 + [2] * 30 + [3] * 30 + [4] * 30)
 
-    with ignore_warnings(category=Warning):
-        # No error raised
+    # No error raised
+    clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
+                        warm_start=True).fit(X, y)
+    clf.fit(X, y)
+    clf.fit(X, y_3classes)
+
+    for y_i in (y_2classes, y_3classes_alt, y_4classes, y_5classes):
         clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
                             warm_start=True).fit(X, y)
-        clf.fit(X, y)
-        clf.fit(X, y_3classes)
-
-        for y_i in (y_2classes, y_3classes_alt, y_4classes, y_5classes):
-            clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
-                                warm_start=True).fit(X, y)
-            message = ('warm_start can only be used where `y` has the same '
-                       'classes as in the previous call to fit.'
-                       ' Previously got [0 1 2], `y` has %s' % np.unique(y_i))
-            assert_raise_message(ValueError, message, clf.fit, X, y_i)
+        message = ('warm_start can only be used where `y` has the same '
+                   'classes as in the previous call to fit.'
+                   ' Previously got [0 1 2], `y` has %s' % np.unique(y_i))
+        assert_raise_message(ValueError, message, clf.fit, X, y_i)

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -23,8 +23,8 @@ from sklearn.preprocessing import LabelBinarizer
 from sklearn.preprocessing import StandardScaler, MinMaxScaler
 from scipy.sparse import csr_matrix
 from sklearn.utils.testing import (assert_raises, assert_greater, assert_equal,
-                                   assert_false, ignore_warnings,
-                                   assert_raise_message)
+                                   assert_false, ignore_warnings)
+from sklearn.utils.testing import assert_raise_message
 
 
 np.seterr(all='warn')
@@ -565,55 +565,26 @@ def test_adaptive_learning_rate():
 
 
 def test_warm_start():
-    X = X_iris[:150]
-    y = y_iris[:150]
+    X = X_iris
+    y = y_iris
 
     y_2classes = np.array([0] * 75 + [1] * 75)
-    y_3classes = np.array([0] * 50 + [1] * 50 + [2] * 50)
+    y_3classes = np.array([0] * 40 + [1] * 40 + [2] * 70)
     y_3classes_alt = np.array([0] * 50 + [1] * 50 + [3] * 50)
     y_4classes = np.array([0] * 37 + [1] * 37 + [2] * 38 + [3] * 38)
     y_5classes = np.array([0] * 30 + [1] * 30 + [2] * 30 + [3] * 30 + [4] * 30)
 
     with ignore_warnings(category=Warning):
-
-        # Test with 2 unique labels
+        # No error raised
         clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
-                            warm_start=True)
-        clf.fit(X, y)
-        message = ('warm_start can only be used where `y` has the same '
-                   'classes as in the previous call to fit.'
-                   ' Previously got [0 1 2], `y` has [0 1]')
-        assert_raise_message(ValueError, message, clf.fit, X, y_2classes)
-
-        # Test with 3 unique labels that are the same as original fit.
-        clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
-                            warm_start=True)
+                            warm_start=True).fit(X, y)
         clf.fit(X, y)
         clf.fit(X, y_3classes)
 
-        # Test with 3 unique labels that are different from original fit.
-        clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
-                            warm_start=True)
-        clf.fit(X, y)
-        message = ('warm_start can only be used where `y` has the same '
-                   'classes as in the previous call to fit.'
-                   ' Previously got [0 1 2], `y` has [0 1 3]')
-        assert_raise_message(ValueError, message, clf.fit, X, y_3classes_alt)
-
-        # Test with 4 unique labels
-        clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
-                            warm_start=True)
-        clf.fit(X, y)
-        message = ('warm_start can only be used where `y` has the same '
-                   'classes as in the previous call to fit.'
-                   ' Previously got [0 1 2], `y` has [0 1 2 3]')
-        assert_raise_message(ValueError, message, clf.fit, X, y_4classes)
-
-        # Test with 5 unique labels. This is a non-regression error.
-        clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
-                            warm_start=True)
-        clf.fit(X, y)
-        message = ('warm_start can only be used where `y` has the '
-                   'same classes as in the previous call to fit.'
-                   ' Previously got [0 1 2], `y` has [0 1 2 3 4]')
-        assert_raise_message(ValueError, message, clf.fit, X, y_5classes)
+        for y_i in (y_2classes, y_3classes_alt, y_4classes, y_5classes):
+            clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
+                                warm_start=True).fit(X, y)
+            message = ('warm_start can only be used where `y` has the same '
+                       'classes as in the previous call to fit.'
+                       ' Previously got [0 1 2], `y` has %s' % np.unique(y_i))
+            assert_raise_message(ValueError, message, clf.fit, X, y_i)

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -568,10 +568,10 @@ def test_warm_start():
     X = X_iris[:150]
     y = y_iris[:150]
 
-    y_2classes = np.array([0]*75 + [1]*75)
-    y_3classes = np.array([0]*50 + [1]*50 + [2]*50)
-    y_4classes = np.array([0]*37 + [1]*37 + [2]*38 + [3]*38)
-    y_5classes = np.array([0]*30 + [1]*30 + [2]*30 + [3]*30 + [4]*30)
+    y_2classes = np.array([0] * 75 + [1] * 75)
+    y_3classes = np.array([0] * 50 + [1] * 50 + [2] * 50)
+    y_4classes = np.array([0] * 37 + [1] * 37 + [2] * 38 + [3] * 38)
+    y_5classes = np.array([0] * 30 + [1] * 30 + [2] * 30 + [3] * 30 + [4] * 30)
 
     with ignore_warnings(category=Warning):
 

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -580,7 +580,8 @@ def test_warm_start():
         clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
                             warm_start=True)
         clf.fit(X, y)
-        message = ('warm_start can only be used where `y` has the same classes as in the previous call to fit.'
+        message = ('warm_start can only be used where `y` has the same '
+                   'classes as in the previous call to fit.'
                    ' Previously got [0 1 2], `y` has [0 1]')
         assert_raise_message(ValueError, message, clf.fit, X, y_2classes)
 
@@ -591,11 +592,11 @@ def test_warm_start():
         clf.fit(X, y_3classes)
 
         # Test with 3 unique labels that are different from original fit.
-
         clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
                             warm_start=True)
         clf.fit(X, y)
-        message = ('warm_start can only be used where `y` has the same classes as in the previous call to fit.'
+        message = ('warm_start can only be used where `y` has the same '
+                   'classes as in the previous call to fit.'
                    ' Previously got [0 1 2], `y` has [0 1 3]')
         assert_raise_message(ValueError, message, clf.fit, X, y_3classes_alt)
 
@@ -603,7 +604,8 @@ def test_warm_start():
         clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
                             warm_start=True)
         clf.fit(X, y)
-        message = ('warm_start can only be used where `y` has the same classes as in the previous call to fit.'
+        message = ('warm_start can only be used where `y` has the same '
+                   'classes as in the previous call to fit.'
                    ' Previously got [0 1 2], `y` has [0 1 2 3]')
         assert_raise_message(ValueError, message, clf.fit, X, y_4classes)
 
@@ -611,6 +613,7 @@ def test_warm_start():
         clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
                             warm_start=True)
         clf.fit(X, y)
-        message = ('warm_start can only be used where `y` has the same classes as in the previous call to fit.'
+        message = ('warm_start can only be used where `y` has the '
+                   'same classes as in the previous call to fit.'
                    ' Previously got [0 1 2], `y` has [0 1 2 3 4]')
         assert_raise_message(ValueError, message, clf.fit, X, y_5classes)

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -579,7 +579,9 @@ def test_warm_start():
         clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',
                             warm_start=True)
         clf.fit(X, y)
-        clf.fit(X, y_2classes)
+        message = ("`y` has classes not in `self.classes_`. `self.classes_`"
+                   " has [0 1 2]. 'y' has [0 1].")
+        assert_raise_message(ValueError, message, clf.fit, X, y_2classes)
 
         # Test with 3 unique labels
         clf = MLPClassifier(hidden_layer_sizes=2, solver='lbfgs',


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #7976 

#### What does this implement/fix? Explain your changes.
This provides a test for different cases that throws an error when warm_start = True for MLPClassifier. Currently, vague errors are thrown when class size is different between the current fit and the previous fit. This fix will throw a clearer error message. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

