### PR TITLE
[MRG + 1] CI some improvements to the flake8 CI

### DIFF
--- a/build_tools/travis/flake8_diff.sh
+++ b/build_tools/travis/flake8_diff.sh
@@ -126,19 +126,16 @@ MODIFIED_FILES="$(git diff --name-only $COMMIT_RANGE | grep -v 'sklearn/external
 check_files() {
 	files="$1"
 	options="$2"
-	echo "$files"
-	echo $options
+	# Conservative approach: diff without context (--unified=0) so that code
+    # that was not changed does not create failures
 	git diff --unified=0 $COMMIT -- $files | flake8 --diff --show-source $options
 }
 
 if [[ "$MODIFIED_FILES" == "no_match" ]]; then
     echo "No file outside sklearn/externals and doc/sphinxext/sphinx_gallery has been modified"
 else
-    # Conservative approach: diff without context so that code that
-    # was not changed does not create failures
 	check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)"
-    # Examples are allowed to not have imports at top of file due to print(__doc__)
+    # Examples are allowed to not have imports at top of file
     check_files "$(echo "$MODIFIED_FILES" | grep ^examples)" --ignore=E402
-    check_files "$MODIFIED_FILES"
 fi
 echo -e "No problem detected by flake8\n"

--- a/build_tools/travis/flake8_diff.sh
+++ b/build_tools/travis/flake8_diff.sh
@@ -124,17 +124,17 @@ MODIFIED_FILES="$(git diff --name-only $COMMIT_RANGE | grep -v 'sklearn/external
                      grep -v 'doc/sphinxext/sphinx_gallery' || echo "no_match")"
 
 check_files() {
-	files="$1"
-	options="$2"
-	# Conservative approach: diff without context (--unified=0) so that code
+    files="$1"
+    options="$2"
+    # Conservative approach: diff without context (--unified=0) so that code
     # that was not changed does not create failures
-	git diff --unified=0 $COMMIT -- $files | flake8 --diff --show-source $options
+    git diff --unified=0 $COMMIT -- $files | flake8 --diff --show-source $options
 }
 
 if [[ "$MODIFIED_FILES" == "no_match" ]]; then
     echo "No file outside sklearn/externals and doc/sphinxext/sphinx_gallery has been modified"
 else
-	check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)"
+    check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)"
     # Examples are allowed to not have imports at top of file
     check_files "$(echo "$MODIFIED_FILES" | grep ^examples)" --ignore=E402
 fi

--- a/build_tools/travis/flake8_diff.sh
+++ b/build_tools/travis/flake8_diff.sh
@@ -120,14 +120,25 @@ echo '--------------------------------------------------------------------------
 # uses git 1.8.
 # We need the following command to exit with 0 hence the echo in case
 # there is no match
-MODIFIED_FILES=$(git diff --name-only $COMMIT_RANGE | grep -v 'sklearn/externals' | \
-                     grep -v 'doc/sphinxext/sphinx_gallery' || echo "no_match")
+MODIFIED_FILES="$(git diff --name-only $COMMIT_RANGE | grep -v 'sklearn/externals' | \
+                     grep -v 'doc/sphinxext/sphinx_gallery' || echo "no_match")"
+
+check_files() {
+	files="$1"
+	options="$2"
+	echo "$files"
+	echo $options
+	git diff --unified=0 $COMMIT -- $files | flake8 --diff --show-source $options
+}
 
 if [[ "$MODIFIED_FILES" == "no_match" ]]; then
     echo "No file outside sklearn/externals and doc/sphinxext/sphinx_gallery has been modified"
 else
     # Conservative approach: diff without context so that code that
     # was not changed does not create failures
-    git diff --unified=0 $COMMIT -- $MODIFIED_FILES | flake8 --diff --show-source
+	check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)"
+    # Examples are allowed to not have imports at top of file due to print(__doc__)
+    check_files "$(echo "$MODIFIED_FILES" | grep ^examples)" --ignore=E402
+    check_files "$MODIFIED_FILES"
 fi
 echo -e "No problem detected by flake8\n"


### PR DESCRIPTION
* Examples now cannot fail due to 'E402 module level import not at top of file'
* Changed files are checked for unused imports regardless of diff

In general, I find `flake8 --diff` somewhat deficient: it's not able to check for things like unused names. I think we therefore rely on it excessively.

Ideally we would:
* flake8 over the old version
* flake8 over the new version
* use the diff to find corresponding line numbers between errors in old version and new version
* report any error that does not correspond to an error in the old version

If anyone wants to implement that, they're welcome!