### PR TITLE
fix copy-paste error in examples

### DIFF
--- a/examples/gaussian_process/plot_compare_gpr_krr.py
+++ b/examples/gaussian_process/plot_compare_gpr_krr.py
@@ -91,7 +91,7 @@ stime = time.time()
 y_kr = kr.predict(X_plot)
 print("Time for KRR prediction: %.3f" % (time.time() - stime))
 
-# Predict using kernel ridge
+# Predict using gaussian process regressor
 stime = time.time()
 y_gpr = gpr.predict(X_plot, return_std=False)
 print("Time for GPR prediction: %.3f" % (time.time() - stime))


### PR DESCRIPTION
I just find the copy-paste problem and correct the comment in examples.