### PR TITLE
[MRG] Updated dbscan(): added documentation

### DIFF
--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -74,7 +74,7 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
     n_jobs : int, optional (default = 1)
         The number of parallel jobs to run for neighbors search.
         If ``-1``, then the number of jobs is set to the number of CPU cores.
-        Currently may not work as expected; might not use multiple processors. 
+        Currently may not work as expected; might not use multiple processors.
         See notes below.
 
     Returns

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -74,8 +74,8 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
     n_jobs : int, optional (default = 1)
         The number of parallel jobs to run for neighbors search.
         If ``-1``, then the number of jobs is set to the number of CPU cores.
-        Currently may not work as expected; does not seem to use multiple 
-        processors. See notes below.
+        Currently may not work as expected; might not use multiple processors. 
+        See notes below.
 
     Returns
     -------

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -74,12 +74,12 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
     n_jobs : int, optional (default = 1)
         The number of parallel jobs to run for neighbors search.
         If ``-1``, then the number of jobs is set to the number of CPU cores.
-        Currently may not work as expected. When ``algorithm="brute"``, the 
-        ``n_jobs`` parameter is used to compute a brute force, multiple 
-        processors approach which can cause a slow down. For faster 
+        Parrallelism currently only used when ``algorithm="brute"``, where
+        the ``n_jobs`` parameter is used to compute a brute force, multiple
+        processors approach which can cause a slow down. For faster
         computation, we recommend using other NearestNeighbors algorithms by
         choosing another value for the parameter ``algorithm``. However,
-        these NearestNeighbors methods are not parrellelized in 
+        these NearestNeighbors methods are not parrellelized in
         scikit-learn and will not use the ``n_jobs`` parameter.
 
     Returns

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -100,7 +100,8 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
 
     Note about n_jobs: this does not seem to use multiple processors. Calls
     NearestNeighbour, passing the n_jobs parameter to it, but NearestNeighbour
-    has not yet been parrallelized.
+    has not yet been parrallelized. Setting algorithm="brute" uses multiple
+    cores, but may cause a slow down instead.
 
     References
     ----------

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -74,6 +74,8 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
     n_jobs : int, optional (default = 1)
         The number of parallel jobs to run for neighbors search.
         If ``-1``, then the number of jobs is set to the number of CPU cores.
+        Currently may not work as expected; does not seem to use multiple 
+        processors. See notes below.
 
     Returns
     -------
@@ -95,6 +97,10 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
     :func:`NearestNeighbors.radius_neighbors_graph
     <sklearn.neighbors.NearestNeighbors.radius_neighbors_graph>`
     with ``mode='distance'``.
+    
+    Note about n_jobs: this does not seem to use multiple processors. Calls
+    NearestNeighbour, passing the n_jobs parameter to it, but NearestNeighbour
+    has not yet been parrallelized.
 
     References
     ----------

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -100,8 +100,8 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
 
     Note about n_jobs: this does not seem to use multiple processors. Calls
     NearestNeighbour, passing the n_jobs parameter to it, but NearestNeighbour
-    has not yet been parrallelized. Setting algorithm="brute" uses multiple
-    cores, but may cause a slow down instead.
+    has not been parrallelized. Setting algorithm="brute" uses multiple
+    cores, but will cause a slow down.
 
     References
     ----------

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -74,8 +74,13 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
     n_jobs : int, optional (default = 1)
         The number of parallel jobs to run for neighbors search.
         If ``-1``, then the number of jobs is set to the number of CPU cores.
-        Currently may not work as expected; might not use multiple processors.
-        See notes below.
+        Currently may not work as expected. When ``algorithm="brute"``, the 
+        ``n_jobs`` parameter is used to compute a brute force, multiple 
+        processors approach which can cause a slow down. For faster 
+        computation, we recommend using other NearestNeighbors algorithms by
+        choosing another value for the parameter ``algorithm``. However,
+        these NearestNeighbors methods are not parrellelized in 
+        scikit-learn and will not use the ``n_jobs`` parameter.
 
     Returns
     -------
@@ -97,11 +102,6 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
     :func:`NearestNeighbors.radius_neighbors_graph
     <sklearn.neighbors.NearestNeighbors.radius_neighbors_graph>`
     with ``mode='distance'``.
-
-    Note about n_jobs: this does not seem to use multiple processors. Calls
-    NearestNeighbour, passing the n_jobs parameter to it, but NearestNeighbour
-    has not been parrallelized. Setting algorithm="brute" uses multiple
-    cores, but will cause a slow down.
 
     References
     ----------

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -97,7 +97,7 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
     :func:`NearestNeighbors.radius_neighbors_graph
     <sklearn.neighbors.NearestNeighbors.radius_neighbors_graph>`
     with ``mode='distance'``.
-    
+
     Note about n_jobs: this does not seem to use multiple processors. Calls
     NearestNeighbour, passing the n_jobs parameter to it, but NearestNeighbour
     has not yet been parrallelized.

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -148,7 +148,7 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         Returns
         -------
         is_inlier : array, shape (n_samples,)
-            Returns 1 for inliers and -1 for anomalies/outliers.
+            Returns 1 for anomalies/outliers and -1 for inliers.
         """
 
         return self.fit(X)._predict()

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -148,7 +148,7 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         Returns
         -------
         is_inlier : array, shape (n_samples,)
-            Returns 1 for anomalies/outliers and -1 for inliers.
+            Returns 1 for inliers and -1 for anomalies/outliers.
         """
 
         return self.fit(X)._predict()


### PR DESCRIPTION
Issue #8003 DBSCAN seems not to use multiple processors (n_jobs argument ignored).
Added documentation in dbscan() to alert users to missing functionality, and some information about why this functionality isn't always there.

Updated dbscan() documentation about missing functionality in n_jobs parameter.