### PR TITLE
[MRG] Replaced float with int in examples

### DIFF
--- a/examples/applications/plot_tomography_l1_reconstruction.py
+++ b/examples/applications/plot_tomography_l1_reconstruction.py
@@ -99,7 +99,7 @@ def build_projection_operator(l_x, n_dir):
 def generate_synthetic_data():
     """ Synthetic binary data """
     rs = np.random.RandomState(0)
-    n_pts = 36.
+    n_pts = 36
     x, y = np.ogrid[0:l, 0:l]
     mask_outer = (x - l / 2) ** 2 + (y - l / 2) ** 2 < (l / 2) ** 2
     mask = np.zeros((l, l))

--- a/examples/classification/plot_digits_classification.py
+++ b/examples/classification/plot_digits_classification.py
@@ -46,17 +46,17 @@ data = digits.images.reshape((n_samples, -1))
 classifier = svm.SVC(gamma=0.001)
 
 # We learn the digits on the first half of the digits
-classifier.fit(data[:n_samples / 2], digits.target[:n_samples / 2])
+classifier.fit(data[:n_samples // 2], digits.target[:n_samples // 2])
 
 # Now predict the value of the digit on the second half:
-expected = digits.target[n_samples / 2:]
-predicted = classifier.predict(data[n_samples / 2:])
+expected = digits.target[n_samples // 2:]
+predicted = classifier.predict(data[n_samples // 2:])
 
 print("Classification report for classifier %s:\n%s\n"
       % (classifier, metrics.classification_report(expected, predicted)))
 print("Confusion matrix:\n%s" % metrics.confusion_matrix(expected, predicted))
 
-images_and_predictions = list(zip(digits.images[n_samples / 2:], predicted))
+images_and_predictions = list(zip(digits.images[n_samples // 2:], predicted))
 for index, (image, prediction) in enumerate(images_and_predictions[:4]):
     plt.subplot(2, 4, index + 5)
     plt.axis('off')

--- a/examples/covariance/plot_robust_vs_empirical_covariance.py
+++ b/examples/covariance/plot_robust_vs_empirical_covariance.py
@@ -68,6 +68,7 @@ repeat = 10
 range_n_outliers = np.concatenate(
     (np.linspace(0, n_samples / 8, 5),
      np.linspace(n_samples / 8, n_samples / 2, 5)[1:-1]))
+range_n_outliers = np.array(range_n_outliers, dtype=np.int)
 
 # definition of arrays to store results
 err_loc_mcd = np.zeros((range_n_outliers.size, repeat))
@@ -135,13 +136,13 @@ x_size = range_n_outliers.size
 plt.errorbar(range_n_outliers, err_cov_mcd.mean(1),
              yerr=err_cov_mcd.std(1),
              label="Robust covariance (mcd)", color='m')
-plt.errorbar(range_n_outliers[:(x_size / 5 + 1)],
-             err_cov_emp_full.mean(1)[:(x_size / 5 + 1)],
-             yerr=err_cov_emp_full.std(1)[:(x_size / 5 + 1)],
+plt.errorbar(range_n_outliers[:(x_size // 5 + 1)],
+             err_cov_emp_full.mean(1)[:(x_size // 5 + 1)],
+             yerr=err_cov_emp_full.std(1)[:(x_size // 5 + 1)],
              label="Full data set empirical covariance", color='green')
-plt.plot(range_n_outliers[(x_size / 5):(x_size / 2 - 1)],
-         err_cov_emp_full.mean(1)[(x_size / 5):(x_size / 2 - 1)], color='green',
-         ls='--')
+plt.plot(range_n_outliers[(x_size // 5):(x_size // 2 - 1)],
+         err_cov_emp_full.mean(1)[(x_size // 5):(x_size // 2 - 1)],
+         color='green', ls='--')
 plt.errorbar(range_n_outliers, err_cov_emp_pure.mean(1),
              yerr=err_cov_emp_pure.std(1),
              label="Pure data set empirical covariance", color='black')

--- a/examples/covariance/plot_robust_vs_empirical_covariance.py
+++ b/examples/covariance/plot_robust_vs_empirical_covariance.py
@@ -67,8 +67,7 @@ repeat = 10
 
 range_n_outliers = np.concatenate(
     (np.linspace(0, n_samples / 8, 5),
-     np.linspace(n_samples / 8, n_samples / 2, 5)[1:-1]))
-range_n_outliers = np.array(range_n_outliers, dtype=np.int)
+     np.linspace(n_samples / 8, n_samples / 2, 5)[1:-1])).astype(np.int)
 
 # definition of arrays to store results
 err_loc_mcd = np.zeros((range_n_outliers.size, repeat))

--- a/examples/cross_decomposition/plot_compare_cross_decomposition.py
+++ b/examples/cross_decomposition/plot_compare_cross_decomposition.py
@@ -36,10 +36,10 @@ latents = np.array([l1, l1, l2, l2]).T
 X = latents + np.random.normal(size=4 * n).reshape((n, 4))
 Y = latents + np.random.normal(size=4 * n).reshape((n, 4))
 
-X_train = X[:n / 2]
-Y_train = Y[:n / 2]
-X_test = X[n / 2:]
-Y_test = Y[n / 2:]
+X_train = X[:n // 2]
+Y_train = Y[:n // 2]
+X_test = X[n // 2:]
+Y_test = Y[n // 2:]
 
 print("Corr(X)")
 print(np.round(np.corrcoef(X.T), 2))

--- a/examples/decomposition/plot_sparse_coding.py
+++ b/examples/decomposition/plot_sparse_coding.py
@@ -50,7 +50,7 @@ n_components = resolution // subsampling
 D_fixed = ricker_matrix(width=width, resolution=resolution,
                         n_components=n_components)
 D_multi = np.r_[tuple(ricker_matrix(width=w, resolution=resolution,
-                      n_components=np.int(np.floor(n_components / 5)))
+                      n_components=n_components // 5)
                 for w in (10, 50, 100, 500, 1000))]
 
 # Generate a signal

--- a/examples/decomposition/plot_sparse_coding.py
+++ b/examples/decomposition/plot_sparse_coding.py
@@ -44,13 +44,13 @@ def ricker_matrix(width, resolution, n_components):
 resolution = 1024
 subsampling = 3  # subsampling factor
 width = 100
-n_components = resolution / subsampling
+n_components = resolution // subsampling
 
 # Compute a wavelet dictionary
 D_fixed = ricker_matrix(width=width, resolution=resolution,
                         n_components=n_components)
 D_multi = np.r_[tuple(ricker_matrix(width=w, resolution=resolution,
-                                    n_components=np.floor(n_components / 5))
+                      n_components=np.int(np.floor(n_components / 5)))
                 for w in (10, 50, 100, 500, 1000))]
 
 # Generate a signal

--- a/examples/exercises/plot_iris_exercise.py
+++ b/examples/exercises/plot_iris_exercise.py
@@ -29,10 +29,10 @@ order = np.random.permutation(n_sample)
 X = X[order]
 y = y[order].astype(np.float)
 
-X_train = X[:.9 * n_sample]
-y_train = y[:.9 * n_sample]
-X_test = X[.9 * n_sample:]
-y_test = y[.9 * n_sample:]
+X_train = X[:int(.9 * n_sample)]
+y_train = y[:int(.9 * n_sample)]
+X_test = X[int(.9 * n_sample):]
+y_test = y[int(.9 * n_sample):]
 
 # fit the model
 for fig_num, kernel in enumerate(('linear', 'rbf', 'poly')):
@@ -58,8 +58,8 @@ for fig_num, kernel in enumerate(('linear', 'rbf', 'poly')):
     # Put the result into a color plot
     Z = Z.reshape(XX.shape)
     plt.pcolormesh(XX, YY, Z > 0, cmap=plt.cm.Paired)
-    plt.contour(XX, YY, Z, colors=['k', 'k', 'k'], linestyles=['--', '-', '--'],
-                levels=[-.5, 0, .5])
+    plt.contour(XX, YY, Z, colors=['k', 'k', 'k'],
+                linestyles=['--', '-', '--'], levels=[-.5, 0, .5])
 
     plt.title(kernel)
 plt.show()

--- a/examples/linear_model/plot_lasso_and_elasticnet.py
+++ b/examples/linear_model/plot_lasso_and_elasticnet.py
@@ -32,8 +32,8 @@ y += 0.01 * np.random.normal((n_samples,))
 
 # Split data in train set and test set
 n_samples = X.shape[0]
-X_train, y_train = X[:n_samples / 2], y[:n_samples / 2]
-X_test, y_test = X[n_samples / 2:], y[n_samples / 2:]
+X_train, y_train = X[:n_samples // 2], y[:n_samples // 2]
+X_test, y_test = X[n_samples // 2:], y[n_samples // 2:]
 
 ###############################################################################
 # Lasso

--- a/examples/neighbors/plot_kde_1d.py
+++ b/examples/neighbors/plot_kde_1d.py
@@ -38,8 +38,8 @@ from sklearn.neighbors import KernelDensity
 # Plot the progression of histograms to kernels
 np.random.seed(1)
 N = 20
-X = np.concatenate((np.random.normal(0, 1, 0.3 * N),
-                    np.random.normal(5, 1, 0.7 * N)))[:, np.newaxis]
+X = np.concatenate((np.random.normal(0, 1, int(0.3 * N)),
+                    np.random.normal(5, 1, int(0.7 * N))))[:, np.newaxis]
 X_plot = np.linspace(-5, 10, 1000)[:, np.newaxis]
 bins = np.linspace(-5, 10, 10)
 
@@ -116,8 +116,8 @@ ax[0, 1].set_title('Available Kernels')
 # Plot a 1D density example
 N = 100
 np.random.seed(1)
-X = np.concatenate((np.random.normal(0, 1, 0.3 * N),
-                    np.random.normal(5, 1, 0.7 * N)))[:, np.newaxis]
+X = np.concatenate((np.random.normal(0, 1, int(0.3 * N)),
+                    np.random.normal(5, 1, int(0.7 * N))))[:, np.newaxis]
 
 X_plot = np.linspace(-5, 10, 1000)[:, np.newaxis]
 

--- a/examples/plot_compare_reduction.py
+++ b/examples/plot_compare_reduction.py
@@ -53,7 +53,7 @@ grid = GridSearchCV(pipe, cv=3, n_jobs=2, param_grid=param_grid)
 digits = load_digits()
 grid.fit(digits.data, digits.target)
 
-mean_scores = np.array(grid.cv_results_['mean_test_score'])
+mean_scores = np.array(grid.cv_results_['mean_test_score'], dtype=np.int)
 # scores are in the order of param_grid iteration, which is alphabetical
 mean_scores = mean_scores.reshape(len(C_OPTIONS), -1, len(N_FEATURES_OPTIONS))
 # select score for best C

--- a/examples/plot_compare_reduction.py
+++ b/examples/plot_compare_reduction.py
@@ -53,7 +53,7 @@ grid = GridSearchCV(pipe, cv=3, n_jobs=2, param_grid=param_grid)
 digits = load_digits()
 grid.fit(digits.data, digits.target)
 
-mean_scores = np.array(grid.cv_results_['mean_test_score'], dtype=np.int)
+mean_scores = np.array(grid.cv_results_['mean_test_score'])
 # scores are in the order of param_grid iteration, which is alphabetical
 mean_scores = mean_scores.reshape(len(C_OPTIONS), -1, len(N_FEATURES_OPTIONS))
 # select score for best C

--- a/examples/plot_kernel_approximation.py
+++ b/examples/plot_kernel_approximation.py
@@ -68,12 +68,14 @@ data = digits.data / 16.
 data -= data.mean(axis=0)
 
 # We learn the digits on the first half of the digits
-data_train, targets_train = data[:n_samples / 2], digits.target[:n_samples / 2]
+data_train, targets_train = (data[:n_samples // 2],
+                             digits.target[:n_samples // 2])
 
 
 # Now predict the value of the digit on the second half:
-data_test, targets_test = data[n_samples / 2:], digits.target[n_samples / 2:]
-#data_test = scaler.transform(data_test)
+data_test, targets_test = (data[n_samples // 2:],
+                           digits.target[n_samples // 2:])
+# data_test = scaler.transform(data_test)
 
 # Create a classifier: a support vector classifier
 kernel_svm = svm.SVC(gamma=.2)

--- a/examples/plot_kernel_ridge_regression.py
+++ b/examples/plot_kernel_ridge_regression.py
@@ -54,7 +54,7 @@ X = 5 * rng.rand(10000, 1)
 y = np.sin(X).ravel()
 
 # Add noise to targets
-y[::5] += 3 * (0.5 - rng.rand(X.shape[0]/5))
+y[::5] += 3 * (0.5 - rng.rand(X.shape[0] // 5))
 
 X_plot = np.linspace(0, 5, 100000)[:, None]
 
@@ -119,8 +119,8 @@ plt.figure()
 # Generate sample data
 X = 5 * rng.rand(10000, 1)
 y = np.sin(X).ravel()
-y[::5] += 3 * (0.5 - rng.rand(X.shape[0]/5))
-sizes = np.logspace(1, 4, 7)
+y[::5] += 3 * (0.5 - rng.rand(X.shape[0] // 5))
+sizes = np.logspace(1, 4, 7, dtype=np.int)
 for name, estimator in {"KRR": KernelRidge(kernel='rbf', alpha=0.1,
                                            gamma=10),
                         "SVR": SVR(kernel='rbf', C=1e1, gamma=10)}.items():

--- a/examples/plot_multioutput_face_completion.py
+++ b/examples/plot_multioutput_face_completion.py
@@ -39,10 +39,12 @@ face_ids = rng.randint(test.shape[0], size=(n_faces, ))
 test = test[face_ids, :]
 
 n_pixels = data.shape[1]
-X_train = train[:, :np.ceil(0.5 * n_pixels)]  # Upper half of the faces
-y_train = train[:, np.floor(0.5 * n_pixels):]  # Lower half of the faces
-X_test = test[:, :np.ceil(0.5 * n_pixels)]
-y_test = test[:, np.floor(0.5 * n_pixels):]
+# Upper half of the faces
+X_train = train[:, :np.int64(np.ceil(0.5 * n_pixels))]
+# Lower half of the faces
+y_train = train[:, np.int64(np.floor(0.5 * n_pixels)):]
+X_test = test[:, :np.int64(np.ceil(0.5 * n_pixels))]
+y_test = test[:, np.int64(np.floor(0.5 * n_pixels)):]
 
 # Fit estimators
 ESTIMATORS = {
@@ -73,7 +75,6 @@ for i in range(n_faces):
     else:
         sub = plt.subplot(n_faces, n_cols, i * n_cols + 1,
                           title="true faces")
-
 
     sub.axis("off")
     sub.imshow(true_face.reshape(image_shape),

--- a/examples/plot_multioutput_face_completion.py
+++ b/examples/plot_multioutput_face_completion.py
@@ -40,11 +40,11 @@ test = test[face_ids, :]
 
 n_pixels = data.shape[1]
 # Upper half of the faces
-X_train = train[:, :np.int64(np.ceil(0.5 * n_pixels))]
+X_train = train[:, :(n_pixels + 1) // 2]
 # Lower half of the faces
-y_train = train[:, np.int64(np.floor(0.5 * n_pixels)):]
-X_test = test[:, :np.int64(np.ceil(0.5 * n_pixels))]
-y_test = test[:, np.int64(np.floor(0.5 * n_pixels)):]
+y_train = train[:, n_pixels // 2:]
+X_test = test[:, :(n_pixels + 1) // 2]
+y_test = test[:, n_pixels // 2:]
 
 # Fit estimators
 ESTIMATORS = {

--- a/examples/svm/plot_svm_scale_c.py
+++ b/examples/svm/plot_svm_scale_c.py
@@ -106,8 +106,8 @@ X_1, y_1 = datasets.make_classification(n_samples=n_samples,
 
 # l2 data: non sparse, but less features
 y_2 = np.sign(.5 - rnd.rand(n_samples))
-X_2 = rnd.randn(n_samples, n_features / 5) + y_2[:, np.newaxis]
-X_2 += 5 * rnd.randn(n_samples, n_features / 5)
+X_2 = rnd.randn(n_samples, n_features // 5) + y_2[:, np.newaxis]
+X_2 += 5 * rnd.randn(n_samples, n_features // 5)
 
 clf_sets = [(LinearSVC(penalty='l1', loss='squared_hinge', dual=False,
                        tol=1e-3),

--- a/examples/tree/plot_unveil_tree_structure.py
+++ b/examples/tree/plot_unveil_tree_structure.py
@@ -54,7 +54,7 @@ threshold = estimator.tree_.threshold
 
 # The tree structure can be traversed to compute various properties such
 # as the depth of each node and whether or not it is a leaf.
-node_depth = np.zeros(shape=n_nodes)
+node_depth = np.zeros(shape=n_nodes, dtype=np.int64)
 is_leaves = np.zeros(shape=n_nodes, dtype=bool)
 stack = [(0, -1)]  # seed is the root node id and its parent depth
 while len(stack) > 0:


### PR DESCRIPTION
#### Reference Issue
Fixes #8017 


#### What does this implement/fix? Explain your changes.
This replaces `float` with `int` in the examples to remove the `VisibleDeprecationWarning` encountered due to the indices being of a non-integer type.

#### Any other comments?
As mentioned in the issue thread, I wasn't able to replicate most of the warnings appearing on the build that was linked to. However, I encountered warnings in other examples that were not present in the build and hence, I chose to not modify them. Please give your suggestions in this regard.