### PR TITLE
[MRG+1]: Website / fix second carousel entry

### DIFF
--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -142,7 +142,7 @@
 			     style="max-height: 200px; max-width: 629px; margin-left: -21px;"></div></a>
 		  </div>
 		  <div class="item">
-		    <a href="{{pathto('auto_examples/covariance/plot_outlier_detection.html') }}">
+		    <a href="{{pathto('auto_examples/covariance/plot_outlier_detection') }}">
 		      <img src="_images/sphx_glr_plot_outlier_detection_003_carousel.png"></a>
 		  </div>
 		  <div class="item">


### PR DESCRIPTION
#### Reference Issue

#### What does this implement/fix? Explain your changes.

On the main website, link for the second entry in the carousel is broken because of an extra `.html` in the layout template

#### Any other comments?


