### PR TITLE
clarify logisticregression n_jobs param

### DIFF
--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1056,8 +1056,9 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
            *warm_start* to support *lbfgs*, *newton-cg*, *sag* solvers.
 
     n_jobs : int, default: 1
-        Number of CPU cores used during the cross-validation loop. If given
-        a value of -1, all cores are used.
+        Number of CPU cores used for fitting one classifier per class
+        if multi_class='ovr'.
+        If given a value of -1, all cores are used.
 
     Attributes
     ----------

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1056,8 +1056,8 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
            *warm_start* to support *lbfgs*, *newton-cg*, *sag* solvers.
 
     n_jobs : int, default: 1
-        Number of CPU cores used for fitting one classifier per class
-        if multi_class='ovr'.
+        Number of CPU cores used when parallelizing over classes
+        if multi_class='ovr'".
         If given a value of -1, all cores are used.
 
     Attributes


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

- /

#### What does this implement/fix? Explain your changes.

Clarifies the purpose of the `n_jobs` parameter in the `LogisticRegression` docstring, i.e., that it is used for fitting estimators in parallel as opposed to doing cross-validation.

#### Any other comments?

- /

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
