### PR TITLE
[MRG] Fixed output shape in doc for OrthogonalMatchingPursuit

### DIFF
--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -577,7 +577,7 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
 
     Attributes
     ----------
-    coef_ : array, shape (n_features,) or (n_features, n_targets)
+    coef_ : array, shape (n_features,) or (n_targets, n_features)
         parameter vector (w in the formula)
 
     intercept_ : float or array, shape (n_targets,)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #8070

#### What does this implement/fix? Explain your changes.
`coef_` shape changed in the doc from `(n_features,) or (n_features, n_targets)` to `(n_features,) or (n_targets, n_features)`



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
