### PR TITLE
[MRG+1] Added support for sparse multilabel y for Nearest neighbor classifiers

### DIFF
--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -775,14 +775,20 @@ class SupervisedIntegerMixin(object):
         check_classification_targets(y)
 
         self._issparse = issparse(y)
-        if(issparse(y) and self.outputs_2d_):
-            y = y.toarray()
 
         self.classes_ = []
-        self._y = np.empty(y.shape, dtype=np.int)
-        for k in range(self._y.shape[1]):
-            classes, self._y[:, k] = np.unique(y[:, k], return_inverse=True)
-            self.classes_.append(classes)
+        if self._issparse and self.outputs_2d_:
+            self._y = y
+            for k in range(self._y.shape[1]):
+                classes = np.array([0, 1], dtype=np.int)
+                self.classes_.append(classes)
+
+        else:
+            self._y = np.empty(y.shape, dtype=np.int)
+            for k in range(self._y.shape[1]):
+                classes, self._y[:, k] = np.unique(y[:, k],
+                                                   return_inverse=True)
+                self.classes_.append(classes)
 
         if not self.outputs_2d_:
             self.classes_ = self.classes_[0]

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -774,14 +774,12 @@ class SupervisedIntegerMixin(object):
 
         check_classification_targets(y)
 
-        self._issparse = issparse(y)
+        self._issparsemultilabel = issparse(y) and self.outputs_2d_
 
         self.classes_ = []
-        if self._issparse and self.outputs_2d_:
+        if self._issparsemultilabel:
             self._y = y
-            for k in range(self._y.shape[1]):
-                classes = np.array([0, 1], dtype=np.int)
-                self.classes_.append(classes)
+            self.classes_ = [np.array([0, 1], dtype=np.int)] * y.shape[1]
 
         else:
             self._y = np.empty(y.shape, dtype=np.int)

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -773,6 +773,11 @@ class SupervisedIntegerMixin(object):
             self.outputs_2d_ = True
 
         check_classification_targets(y)
+
+        self.issparse_ = issparse(y)
+        if(issparse(y) and self.outputs_2d_):
+            y = y.toarray()
+
         self.classes_ = []
         self._y = np.empty(y.shape, dtype=np.int)
         for k in range(self._y.shape[1]):

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -6,10 +6,12 @@
 #          Multi-output support by Arnaud Joly <a.joly@ulg.ac.be>
 #
 # License: BSD 3 clause (C) INRIA, University of Amsterdam
+from distutils.version import StrictVersion
 import warnings
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
+import scipy
 from scipy.sparse import csr_matrix, issparse
 
 from .ball_tree import BallTree
@@ -777,6 +779,9 @@ class SupervisedIntegerMixin(object):
         self.classes_ = []
 
         if issparse(y) and self.outputs_2d_:
+            if StrictVersion(scipy.__version__) < StrictVersion('0.13.0'):
+                raise EnvironmentError('Sparse multilabel y not supported for'
+                                       'scipy < 0.13')
             self.outputs_2d_ = 'sparse'
             self._y = y
             self.classes_ = [np.array([0, 1], dtype=np.int)] * y.shape[1]

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -774,7 +774,7 @@ class SupervisedIntegerMixin(object):
 
         check_classification_targets(y)
 
-        self.issparse_ = issparse(y)
+        self._issparse = issparse(y)
         if(issparse(y) and self.outputs_2d_):
             y = y.toarray()
 

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -774,10 +774,10 @@ class SupervisedIntegerMixin(object):
 
         check_classification_targets(y)
 
-        self._issparsemultilabel = issparse(y) and self.outputs_2d_
-
         self.classes_ = []
-        if self._issparsemultilabel:
+
+        if issparse(y) and self.outputs_2d_:
+            self.outputs_2d_ = 'sparse'
             self._y = y
             self.classes_ = [np.array([0, 1], dtype=np.int)] * y.shape[1]
 
@@ -788,9 +788,9 @@ class SupervisedIntegerMixin(object):
                                                    return_inverse=True)
                 self.classes_.append(classes)
 
-        if not self.outputs_2d_:
-            self.classes_ = self.classes_[0]
-            self._y = self._y.ravel()
+            if not self.outputs_2d_:
+                self.classes_ = self.classes_[0]
+                self._y = self._y.ravel()
 
         return self._fit(X)
 

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -155,9 +155,7 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         n_samples = X.shape[0]
         weights = _get_weights(neigh_dist, self.weights)
 
-        y_pred = np.empty((n_samples, n_outputs), dtype=classes_[0].dtype)
-
-        if self._issparsemultilabel:
+        if self.outputs_2d_ == 'sparse':
             y_pred_sparse_multilabel = []
 
             for k, classes_k in enumerate(classes_):
@@ -169,10 +167,14 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
                                             weights, axis=1)
 
                 mode = np.asarray(mode.ravel(), dtype=np.intp)
-                y_pred[:, k] = classes_k.take(mode)
-                y_pred_sparse_multilabel.append(csc_matrix(y_pred[:, k]).T)
+                y_pred_sparse_multilabel.append(
+                    csc_matrix(classes_k.take(mode)).T)
+
+            y_pred = hstack(y_pred_sparse_multilabel)
 
         else:
+            y_pred = np.empty((n_samples, n_outputs), dtype=classes_[0].dtype)
+
             for k, classes_k in enumerate(classes_):
 
                 if weights is None:
@@ -183,11 +185,8 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
                 mode = np.asarray(mode.ravel(), dtype=np.intp)
                 y_pred[:, k] = classes_k.take(mode)
 
-        if not self.outputs_2d_:
-            y_pred = y_pred.ravel()
-
-        if self._issparsemultilabel:
-            y_pred = hstack(y_pred_sparse_multilabel)
+            if not self.outputs_2d_:
+                y_pred = y_pred.ravel()
 
         return y_pred
 

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -11,9 +11,7 @@
 import numpy as np
 from scipy.sparse import csc_matrix, hstack
 from scipy import stats
-from scipy import version
 from ..utils.extmath import weighted_mode
-from distutils.version import StrictVersion
 
 from .base import \
     _check_weights, _get_weights, \
@@ -158,10 +156,6 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         weights = _get_weights(neigh_dist, self.weights)
 
         if self.outputs_2d_ == 'sparse':
-            if StrictVersion(version.version) < StrictVersion('0.13.0'):
-                raise EnvironmentError('Sparse multilabel y passed in fit. '
-                                       'Not supported for scipy < 0.13')
-
             y_pred_sparse_multilabel = []
 
             for k, classes_k in enumerate(classes_):

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -390,19 +390,17 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
 
             for k, classes_k in enumerate(classes_):
                 pred_labels = np.array([_y[ind, k].toarray()
-                                        for ind in inliers],
+                                        for ind in neigh_ind[inliers]],
                                        dtype=object)
                 y_pred_k = np.zeros(n_samples)
 
                 if weights is None:
                     mode = np.array([stats.mode(pl)[0]
-                                     for pl in pred_labels[inliers]],
-                                    dtype=np.int)
+                                     for pl in pred_labels], dtype=np.int)
                 else:
                     mode = np.array([weighted_mode(pl, w)[0]
                                      for (pl, w)
-                                     in zip(pred_labels[inliers],
-                                            weights[inliers])],
+                                     in zip(pred_labels, weights[inliers])],
                                     dtype=np.int)
 
                 mode = mode.ravel()

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -390,7 +390,7 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
 
             for k, classes_k in enumerate(classes_):
                 pred_labels = np.array([_y[ind, k].toarray()
-                                        for ind in neigh_ind],
+                                        for ind in inliers],
                                        dtype=object)
                 y_pred_k = np.zeros(n_samples)
 

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -168,7 +168,7 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         if not self.outputs_2d_:
             y_pred = y_pred.ravel()
 
-        if(self.issparse_):
+        if(self._issparse):
             y_pred = csc_matrix(y_pred)
 
         return y_pred

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -10,7 +10,7 @@
 
 import numpy as np
 from scipy import sparse
-from scipy.sparse import csc_matrix, csr_matrix
+from scipy.sparse import csr_matrix
 from scipy import stats
 from ..utils.extmath import weighted_mode
 
@@ -397,7 +397,7 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
 
                 y_pred_sparse_multilabel.append(csr_matrix(y_pred_k).T)
 
-            y_pred = hstack(y_pred_sparse_multilabel)
+            y_pred = sparse.hstack(y_pred_sparse_multilabel)
 
         else:
             y_pred = np.empty((n_samples, n_outputs), dtype=classes_[0].dtype)

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -9,6 +9,7 @@
 # License: BSD 3 clause (C) INRIA, University of Amsterdam
 
 import numpy as np
+from scipy.sparse import csc_matrix
 from scipy import stats
 from ..utils.extmath import weighted_mode
 
@@ -166,6 +167,9 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
 
         if not self.outputs_2d_:
             y_pred = y_pred.ravel()
+
+        if(self.issparse_):
+            y_pred = csc_matrix(y_pred)
 
         return y_pred
 
@@ -374,7 +378,8 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
             else:
                 mode = np.array([weighted_mode(pl, w)[0]
                                  for (pl, w)
-                                 in zip(pred_labels[inliers], weights[inliers])],
+                                 in zip(pred_labels[inliers],
+                                 weights[inliers])],
                                 dtype=np.int)
 
             mode = mode.ravel()

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -379,7 +379,7 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
                 mode = np.array([weighted_mode(pl, w)[0]
                                  for (pl, w)
                                  in zip(pred_labels[inliers],
-                                 weights[inliers])],
+                                        weights[inliers])],
                                 dtype=np.int)
 
             mode = mode.ravel()

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -11,7 +11,9 @@
 import numpy as np
 from scipy.sparse import csc_matrix, hstack
 from scipy import stats
+from scipy import version
 from ..utils.extmath import weighted_mode
+from distutils.version import StrictVersion
 
 from .base import \
     _check_weights, _get_weights, \
@@ -156,6 +158,10 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         weights = _get_weights(neigh_dist, self.weights)
 
         if self.outputs_2d_ == 'sparse':
+            if StrictVersion(version.version) < StrictVersion('0.13.0'):
+                raise EnvironmentError('Sparse multilabel y passed in fit. '
+                                       'Not supported for scipy < 0.13')
+
             y_pred_sparse_multilabel = []
 
             for k, classes_k in enumerate(classes_):

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -9,7 +9,8 @@
 # License: BSD 3 clause (C) INRIA, University of Amsterdam
 
 import numpy as np
-from scipy.sparse import csc_matrix, hstack
+from scipy import sparse
+from scipy.sparse import csc_matrix, csr_matrix
 from scipy import stats
 from ..utils.extmath import weighted_mode
 
@@ -160,10 +161,9 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
 
             for k, classes_k in enumerate(classes_):
                 mode = self._mode(_y[neigh_ind, k].toarray(), weights)
-                y_pred_sparse_multilabel.append(
-                    csc_matrix(classes_k.take(mode)).T)
+                y_pred_sparse_multilabel.append(csr_matrix(mode).T)
 
-            y_pred = hstack(y_pred_sparse_multilabel)
+            y_pred = sparse.hstack(y_pred_sparse_multilabel)
 
         else:
             y_pred = np.empty((n_samples, n_outputs), dtype=classes_[0].dtype)
@@ -388,14 +388,14 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
                 pred_labels = np.array([_y[ind, k].toarray()
                                         for ind in neigh_ind[inliers]],
                                        dtype=object)
-                y_pred_k = np.zeros(n_samples)
+                y_pred_k = np.zeros(n_samples, dtype=np.int)
                 mode = self._mode(pred_labels, weights, inliers)
-                y_pred_k[inliers] = classes_k.take(mode)
+                y_pred_k[inliers] = mode
 
-                if outliers:
+                if outliers and self.outlier_label != 0:
                     y_pred_k[outliers] = self.outlier_label
 
-                y_pred_sparse_multilabel.append(csc_matrix(y_pred_k).T)
+                y_pred_sparse_multilabel.append(csr_matrix(y_pred_k).T)
 
             y_pred = hstack(y_pred_sparse_multilabel)
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -503,12 +503,24 @@ def test_kneighbors_classifier_sparse(n_samples=40,
             y_pred = knn.predict(X_eps)
             assert_array_equal(y_pred, y[:n_test_pts])
 
+CLASSIFIERS = {
+    'KNeighborsClassifier': neighbors.KNeighborsClassifier(n_neighbors=3),
+    'RadiusNeighborsClassifier': neighbors.RadiusNeighborsClassifier(
+        radius=0.1, outlier_label=-1),
+}
 
-def test_kneighbors_classifier_sparse_multilabel_y():
-    X, y = make_multilabel_classification(random_state=0, n_samples=100)
+
+def check_classifier_sparse_multilabel_y(name):
+    rng = check_random_state(0)
+    n_features = 2
+    n_samples = 100
+    n_output = 3
+
+    X = rng.rand(n_samples, n_features)
+    y = rng.randint(0, 2, (n_samples, n_output))
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
-    clf = neighbors.KNeighborsClassifier(n_neighbors=3)
+    clf = CLASSIFIERS[name]
     clf.fit(X_train, y_train)
     y_pred = clf.predict(X_test)
 
@@ -518,6 +530,11 @@ def test_kneighbors_classifier_sparse_multilabel_y():
     clf.fit(X_train, y_train)
     y_sparse_pred = clf.predict(X_test)
     assert_array_almost_equal(y_pred, y_sparse_pred.toarray())
+
+
+def test_classifiers_sparse_multilabel_y():
+    for name in CLASSIFIERS:
+        yield check_classifier_sparse_multilabel_y, name
 
 
 def test_KNeighborsClassifier_multioutput():

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -523,7 +523,7 @@ def check_classifier_sparse_multilabel_y(name):
     clf.fit(X_train, y_train)
     y_pred = clf.predict(X_test)
 
-    y_sparse = csr_matrix(y)
+    y_sparse = csc_matrix(y)
     X_train, X_test, y_train, y_test = train_test_split(X, y_sparse,
                                                         random_state=0)
     clf.fit(X_train, y_train)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1,7 +1,7 @@
 from distutils.version import StrictVersion
 from itertools import product
 import numpy as np
-from scipy import version
+import scipy
 from scipy.sparse import (bsr_matrix, coo_matrix, csc_matrix, csr_matrix,
                           dok_matrix, lil_matrix)
 
@@ -528,12 +528,10 @@ def check_classifier_sparse_multilabel_y(name):
     y_sparse = csc_matrix(y)
     X_train, X_test, y_train, y_test = train_test_split(X, y_sparse,
                                                         random_state=0)
-    clf.fit(X_train, y_train)
-
-    if (name == 'KNeighborsClassifier' and
-            StrictVersion(version.version) < StrictVersion('0.13.0')):
-        assert_raises(EnvironmentError, clf.predict, X_test)
+    if (StrictVersion(scipy.__version__) < StrictVersion('0.13.0')):
+        assert_raises(EnvironmentError, clf.fit, X_train, y_train)
     else:
+        clf.fit(X_train, y_train)
         y_sparse_pred = clf.predict(X_test)
         assert_array_equal(y_pred, y_sparse_pred.toarray())
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -531,7 +531,7 @@ def check_classifier_sparse_multilabel_y(name):
     clf.fit(X_train, y_train)
 
     if (name == 'KNeighborsClassifier' and
-        StrictVersion(version.version) < StrictVersion('0.13.0')):
+            StrictVersion(version.version) < StrictVersion('0.13.0')):
         assert_raises(EnvironmentError, clf.predict, X_test)
     else:
         y_sparse_pred = clf.predict(X_test)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -528,7 +528,7 @@ def check_classifier_sparse_multilabel_y(name):
     y_sparse = csc_matrix(y)
     X_train, X_test, y_train, y_test = train_test_split(X, y_sparse,
                                                         random_state=0)
-    if (StrictVersion(scipy.__version__) < StrictVersion('0.13.0')):
+    if StrictVersion(scipy.__version__) < StrictVersion('0.13.0'):
         assert_raises(EnvironmentError, clf.fit, X_train, y_train)
     else:
         clf.fit(X_train, y_train)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -528,7 +528,7 @@ def check_classifier_sparse_multilabel_y(name):
                                                         random_state=0)
     clf.fit(X_train, y_train)
     y_sparse_pred = clf.predict(X_test)
-    assert_array_almost_equal(y_pred, y_sparse_pred.toarray())
+    assert_array_equal(y_pred, y_sparse_pred.toarray())
 
 
 def test_classifiers_sparse_multilabel_y():

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -18,6 +18,7 @@ from sklearn.utils.validation import check_random_state
 from sklearn.metrics.pairwise import pairwise_distances
 from sklearn import neighbors, datasets
 from sklearn.exceptions import DataConversionWarning
+from sklearn.datasets import make_multilabel_classification
 
 rng = np.random.RandomState(0)
 # load and shuffle iris dataset
@@ -501,6 +502,22 @@ def test_kneighbors_classifier_sparse(n_samples=40,
             X_eps = sparsev(X[:n_test_pts] + epsilon)
             y_pred = knn.predict(X_eps)
             assert_array_equal(y_pred, y[:n_test_pts])
+
+
+def test_kneighbors_classifier_sparse_multilabel_y():
+    X, y = make_multilabel_classification(random_state=0, n_samples=100)
+
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+    clf = neighbors.KNeighborsClassifier(n_neighbors=3)
+    clf.fit(X_train, y_train)
+    y_pred = clf.predict(X_test)
+
+    y_sparse = csr_matrix(y)
+    X_train, X_test, y_train, y_test = train_test_split(X, y_sparse,
+                                                        random_state=0)
+    clf.fit(X_train, y_train)
+    y_sparse_pred = clf.predict(X_test)
+    assert_array_almost_equal(y_pred, y_sparse_pred.toarray())
 
 
 def test_KNeighborsClassifier_multioutput():

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1,5 +1,7 @@
+from distutils.version import StrictVersion
 from itertools import product
 import numpy as np
+from scipy import version
 from scipy.sparse import (bsr_matrix, coo_matrix, csc_matrix, csr_matrix,
                           dok_matrix, lil_matrix)
 
@@ -527,8 +529,13 @@ def check_classifier_sparse_multilabel_y(name):
     X_train, X_test, y_train, y_test = train_test_split(X, y_sparse,
                                                         random_state=0)
     clf.fit(X_train, y_train)
-    y_sparse_pred = clf.predict(X_test)
-    assert_array_equal(y_pred, y_sparse_pred.toarray())
+
+    if (name == 'KNeighborsClassifier' and
+        StrictVersion(version.version) < StrictVersion('0.13.0')):
+        assert_raises(EnvironmentError, clf.predict, X_test)
+    else:
+        y_sparse_pred = clf.predict(X_test)
+        assert_array_equal(y_pred, y_sparse_pred.toarray())
 
 
 def test_classifiers_sparse_multilabel_y():

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -18,7 +18,6 @@ from sklearn.utils.validation import check_random_state
 from sklearn.metrics.pairwise import pairwise_distances
 from sklearn import neighbors, datasets
 from sklearn.exceptions import DataConversionWarning
-from sklearn.datasets import make_multilabel_classification
 
 rng = np.random.RandomState(0)
 # load and shuffle iris dataset


### PR DESCRIPTION
#### Reference Issue
Fixes #8057 


#### What does this implement/fix? Explain your changes.
Added support for sparse multilabel `y` for nearest neighbor classifiers. Firstly, it checks if the input to `fit` is sparse + multilabel and converts it to a dense one for storing. Also, it stores another parameter indicating whether the original input was sparse + multilabel or not. Now, in `predict`, if this stored value is true, then it converts `y_pred` to sparse CSC.
Also, added tests for the same.