### PR TITLE
CI limit diff to commit range

### DIFF
--- a/build_tools/travis/flake8_diff.sh
+++ b/build_tools/travis/flake8_diff.sh
@@ -128,7 +128,7 @@ check_files() {
     options="$2"
     # Conservative approach: diff without context (--unified=0) so that code
     # that was not changed does not create failures
-    git diff --unified=0 $COMMIT -- $files | flake8 --diff --show-source $options
+    git diff --unified=0 $COMMIT_RANGE -- $files | flake8 --diff --show-source $options
 }
 
 if [[ "$MODIFIED_FILES" == "no_match" ]]; then


### PR DESCRIPTION
We seem to be getting some spurious flake8 errors in Travis. I think it is because the diff of merge-base is being used relative to HEAD (merged master with PR head?) instead of the commit range from merge-base to PR head.

Example of spurious errors: https://travis-ci.org/scikit-learn/scikit-learn/jobs/185733709