### PR TITLE
[MRG] Fixes sklearn.tree pydoc help #8108

### DIFF
--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -62,7 +62,7 @@ def _color_brew(n):
 
 
 class Sentinel(object):
-    def __repr__():
+    def __repr__(self):
         return '"tree.dot"'
 SENTINEL = Sentinel()
 


### PR DESCRIPTION
This PR solves Bug #8108, it's my 2nd PR on this issue, as my 1st PR #8109 had some
issues.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
 Fixes #8108 

#### What does this implement/fix? Explain your changes.
This fixes the broken pydoc of sklearn.tree .Earlier pydoc used to give error. Now the 

> __repr__ function in sklearn/tree/export.py is modified to include the self argument.


#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
