### PR TITLE
[MRG] fixes typos and adds extra values in species_distributions

### DIFF
--- a/sklearn/datasets/species_distributions.py
+++ b/sklearn/datasets/species_distributions.py
@@ -154,23 +154,24 @@ def fetch_species_distributions(data_home=None,
         The latitude/longitude values for the grid are discussed below.
         Missing data is represented by the value -9999.
 
-    train : record array, shape = (1623,)
+    train : record array, shape = (1624,)
         The training points for the data.  Each point has three fields:
 
         - train['species'] is the species name
         - train['dd long'] is the longitude, in degrees
         - train['dd lat'] is the latitude, in degrees
 
-    test : record array, shape = (619,)
+    test : record array, shape = (620,)
         The test points for the data.  Same format as the training data.
 
-    Nx, Ny : integers
+    Nx, Ny : integers, values : Nx = 1212, Ny = 1592
         The number of longitudes (x) and latitudes (y) in the grid
 
     x_left_lower_corner, y_left_lower_corner : floats
+    values : x_left_lower_corner = -94.8, y_left_lower_corner = -56.05
         The (x,y) position of the lower-left corner, in degrees
 
-    grid_size : float
+    grid_size : float, value = 0.05
         The spacing between points of the grid, in degrees
 
     Notes


### PR DESCRIPTION
Fixed typos and added extra values in docstring of fetch_species_distributions function in  sklearn.datasets.species_distributions.py .

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #8110 

#### What does this implement/fix? Explain your changes.
Corrected typos on values and added extra values.
