### PR TITLE
[MRG] Fix help link on about page

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -67,5 +67,5 @@ The following people have been core contributors to scikit-learn's development a
 
 Please do not email the authors directly to ask for assistance or report issues.
 Instead, please see `What's the best way to ask questions about scikit-learn
-<http://scikit-learn.org/stable/faq.html#what-s-the-best-way-to-ask-questions-about-scikit-learn>`_
+<http://scikit-learn.org/stable/faq.html#what-s-the-best-way-to-get-help-on-scikit-learn-usage>`_
 in the FAQ.


### PR DESCRIPTION
#### Reference Issue
None


#### What does this implement/fix? Explain your changes.
In the [About page](http://scikit-learn.org/stable/about.html), the link to "What’s the best way to ask questions about scikit-learn" leads to http://scikit-learn.org/stable/faq.html#what-s-the-best-way-to-ask-questions-about-scikit-learn, which is an invalid anchor in the page. The correct link is http://scikit-learn.org/stable/faq.html#what-s-the-best-way-to-get-help-on-scikit-learn-usage
