### PR TITLE
[WIP] Fixes #8113 : fix deprecation msg for attribute(property)

### DIFF
--- a/sklearn/utils/deprecation.py
+++ b/sklearn/utils/deprecation.py
@@ -1,3 +1,4 @@
+import inspect
 import warnings
 
 __all__ = ["deprecated", ]
@@ -62,12 +63,25 @@ class deprecated(object):
     def _decorate_fun(self, fun):
         """Decorate function fun"""
 
-        msg = "Function %s is deprecated" % fun.__name__
+        msg = " %s is deprecated" % fun.__name__
         if self.extra:
             msg += "; %s" % self.extra
 
         def wrapped(*args, **kwargs):
-            warnings.warn(msg, category=DeprecationWarning)
+            def ismethod(f):
+                spec = inspect.getfullargspec(f)
+                return 'self' in spec.args
+
+            entity = "Function"
+            if ismethod(fun):
+                properties = inspect.getmembers(
+                    args[0].__class__, lambda x: isinstance(x, property))
+                properties_names = [x[0] for x in properties]
+
+                if fun.__name__ in properties_names:
+                    entity = "Attribute"
+
+            warnings.warn(entity + msg, category=DeprecationWarning)
             return fun(*args, **kwargs)
 
         wrapped.__name__ = fun.__name__


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Fixes #8113  

#### What does this implement/fix? Explain your changes.
If deprecated function is attribute (`@property`) then change message to `"Attribute ... "`

To check if function is an attribute

1. check that it is method (first argument should be `self`)
2. get all properties of class 
3. check if name of function in properties

#### Any other comments?
For now I avoid this https://github.com/scikit-learn/scikit-learn/issues/8113#issuecomment-269136227
because I have not figured out how to wrap property object properly

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
