### PR TITLE
[MRG] MAINT Python 3.6 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ env:
       NUMPY_VERSION="1.6.2" SCIPY_VERSION="0.11.0" CYTHON_VERSION="0.23"
     # This environment tests the newest supported anaconda env
     # It also runs tests requiring Pandas.
-    - DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="true"
-      NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.17.0" PANDAS_VERSION="0.18.0"
-      CYTHON_VERSION="0.23.4"
+    - DISTRIB="conda" PYTHON_VERSION="3.6" INSTALL_MKL="true"
+      NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" PANDAS_VERSION="0.19.1"
+      CYTHON_VERSION="0.25.2"
     # flake8 linting on diff wrt common ancestor with upstream/master
     - RUN_FLAKE8="true" SKIP_TESTS="true"
       DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="true"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -52,8 +52,8 @@ if [[ "$DISTRIB" == "conda" ]]; then
     # provided versions
     if [[ "$INSTALL_MKL" == "true" ]]; then
         conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
-            numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION numpy scipy \
-            mkl flake8 cython=$CYTHON_VERSION \
+            numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
+            mkl cython=$CYTHON_VERSION \
             ${PANDAS_VERSION+pandas=$PANDAS_VERSION}
             
     else
@@ -118,5 +118,5 @@ except ImportError:
 fi
 
 if [[ "$RUN_FLAKE8" == "true" ]]; then
-    conda install flake8
+    conda install --yes flake8
 fi

--- a/sklearn/utils/graph.py
+++ b/sklearn/utils/graph.py
@@ -44,10 +44,11 @@ def single_source_shortest_path_length(graph, source, cutoff=None):
     ...                   [ 1, 0, 1, 0],
     ...                   [ 0, 1, 0, 1],
     ...                   [ 0, 0, 1, 0]])
-    >>> single_source_shortest_path_length(graph, 0)
-    {0: 0, 1: 1, 2: 2, 3: 3}
-    >>> single_source_shortest_path_length(np.ones((6, 6)), 2)
-    {0: 1, 1: 1, 2: 0, 3: 1, 4: 1, 5: 1}
+    >>> list(sorted(single_source_shortest_path_length(graph, 0).items()))
+    [(0, 0), (1, 1), (2, 2), (3, 3)]
+    >>> graph = np.ones((6, 6))
+    >>> list(sorted(single_source_shortest_path_length(graph, 2).items()))
+    [(0, 1), (1, 1), (2, 0), (3, 1), (4, 1), (5, 1)]
     """
     if sparse.isspmatrix(graph):
         graph = graph.tolil()

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -345,8 +345,7 @@ def test_check_array_accept_sparse_type_exception():
     assert_raise_message(ValueError, msg.format(()),
                          check_array, X_csr, accept_sparse=())
 
-    msg = "'SVR' object"
-    assert_raise_message(TypeError, msg,
+    assert_raise_message(TypeError, "SVR",
                          check_array, X_csr, accept_sparse=[invalid_type])
 
     # Test deprecation of 'None'


### PR DESCRIPTION
Two cosmetic fixes to get the tests to pass under Python 3.6 as well as a bump up in the version of the conda deps of the newest entry of the travis configuration.