### PR TITLE
[MRG] Gradient boosting external presort

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -114,9 +114,13 @@ Enhancements
      and :func:`model_selection.cross_val_score` now allow estimators with callable
      kernels which were previously prohibited. :issue:`8005` by `Andreas Müller`_ .
 
-
    - Added ability to use sparse matrices in :func:`feature_selection.f_regression`
      with ``center=True``. :issue:`8065` by :user:`Daniel LeJeune <acadiansith>`.
+
+   - Added ability to pass a presorted training set to
+     :class:`ensemble.GradientBoostingClassifier` and
+     :class:`ensemble.GradientBoostingRegressor`. :issue:`8125` by
+     `Olivier Grisel`_.
 
 Bug fixes
 .........

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -924,7 +924,7 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
         """Check that the estimator is initialized, raising an error if not."""
         check_is_fitted(self, 'estimators_')
 
-    def fit(self, X, y, sample_weight=None, monitor=None):
+    def fit(self, X, y, sample_weight=None, X_idx_sorted=None, monitor=None):
         """Fit the gradient boosting model.
 
         Parameters
@@ -944,6 +944,11 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             ignored while searching for a split in each node. In the case of
             classification, splits are also ignored if they would result in any
             single class carrying a negative weight in either child node.
+
+        X_idx_sorted : array-like, shape = [n_samples, n_features], optional
+            The indexes of the sorted training input samples. If many tree
+            are grown on the same dataset, this allows the ordering to be
+            cached between trees. If None, the data will be sorted here.
 
         monitor : callable, optional
             The monitor is called after each iteration with the current
@@ -1001,7 +1006,6 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             y_pred = self._decision_function(X)
             self._resize_state()
 
-        X_idx_sorted = None
         presort = self.presort
         # Allow presort to be 'auto', which means True if the dataset is dense,
         # otherwise it will be False.
@@ -1010,10 +1014,10 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
         elif presort == 'auto':
             presort = True
 
-        if presort == True:
+        if presort:
             if issparse(X):
                 raise ValueError("Presorting is not supported for sparse matrices.")
-            else:
+            elif X_idx_sorted is None:
                 X_idx_sorted = np.asfortranarray(np.argsort(X, axis=0),
                                                  dtype=np.int32)
 

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -256,12 +256,21 @@ def test_regression_synthetic():
                                    noise=1.0)
     X_train, y_train = X[:200], y[:200]
     X_test, y_test = X[200:], y[200:]
+    X_idx_sorted_train = np.asfortranarray(np.argsort(X_train, axis=0),
+                                           dtype=np.int32)
 
     for presort in True, False:
-        clf = GradientBoostingRegressor(presort=presort)
+        clf = GradientBoostingRegressor(presort=presort, random_state=0)
         clf.fit(X_train, y_train)
         mse = mean_squared_error(y_test, clf.predict(X_test))
         assert_less(mse, 5.0)
+        if presort:
+            # Check that presorting can be done manually ahead of time
+            # and yield the same output
+            clf2 = GradientBoostingRegressor(presort=presort, random_state=0)
+            clf2.fit(X_train, y_train, X_idx_sorted=X_idx_sorted_train)
+            assert_array_almost_equal(clf.predict(X_test),
+                                      clf2.predict(X_test))
 
     # Friedman2
     X, y = datasets.make_friedman2(n_samples=1200, random_state=random_state)


### PR DESCRIPTION
Make it possible to pass externally presorted data to gradient boosting models as is already possible for individual decision trees. This is useful for benchmarking purposes.