### PR TITLE
[MRG] MNT Ignore E731: Use a def instead of lambda

### DIFF
--- a/build_tools/travis/flake8_diff.sh
+++ b/build_tools/travis/flake8_diff.sh
@@ -134,8 +134,8 @@ check_files() {
 if [[ "$MODIFIED_FILES" == "no_match" ]]; then
     echo "No file outside sklearn/externals and doc/sphinxext/sphinx_gallery has been modified"
 else
-    check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)"
+    check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)" --ignore=E731
     # Examples are allowed to not have imports at top of file
-    check_files "$(echo "$MODIFIED_FILES" | grep ^examples)" --ignore=E402
+    check_files "$(echo "$MODIFIED_FILES" | grep ^examples)" --ignore=E402,E731
 fi
 echo -e "No problem detected by flake8\n"


### PR DESCRIPTION
Our flake8 checker in travis raises error for lambdas for one-liners. I don't think we follow that. Most contributors might prefer lambdas actually...

Ref [`lambda check_df = lambda x: isinstance(x, InputFeatureType)`](https://github.com/scikit-learn/scikit-learn/pull/5697/files#diff-d51a9726ff1d2791c05babac47e936d5R984)

@GaelVaroquaux @jnothman @ogrisel Is this fine with you?