### PR TITLE
[MRG] Fix typo in FAQ

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -17,7 +17,7 @@ sy-kit learn. sci stands for science!
 
 Why scikit?
 ------------
-There are multiple scikits, which are scientific toolboxes build around SciPy.
+There are multiple scikits, which are scientific toolboxes built around SciPy.
 You can find a list at `<https://scikits.appspot.com/scikits>`_.
 Apart from scikit-learn, another popular one is `scikit-image <http://scikit-image.org/>`_.
 


### PR DESCRIPTION
#### Reference Issue
None


#### What does this implement/fix? Explain your changes.
Change from "build around SciPy" to "built around SciPy" in first sentence of "Why scikit?" section in FAQ
