### PR TITLE
[MRG] rename store_covariances to store_covariance

### DIFF
--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -25,6 +25,7 @@ from .utils import check_array, check_X_y
 from .utils.validation import check_is_fitted
 from .utils.fixes import bincount
 from .utils.multiclass import check_classification_targets
+from .utils import deprecated
 from .preprocessing import StandardScaler
 
 
@@ -558,7 +559,7 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
 
     Attributes
     ----------
-    covariances_ : list of array-like, shape = [n_features, n_features]
+    covariance_ : list of array-like, shape = [n_features, n_features]
         Covariance matrices of each class.
 
     means_ : array-like, shape = [n_classes, n_features]
@@ -580,7 +581,7 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
 
     store_covariance : boolean
         If True the covariance matrices are computed and stored in the
-        `self.covariances_` attribute.
+        `self.covariance_` attribute.
 
         .. versionadded:: 0.17
 
@@ -610,17 +611,25 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
     """
 
     def __init__(self, priors=None, reg_param=0., store_covariance=False,
-                 tol=1.0e-4, store_covariances=False):
+                 tol=1.0e-4, store_covariances=None):
         self.priors = np.asarray(priors) if priors is not None else None
         self.reg_param = reg_param
+        self.store_covariances = store_covariances
         self.store_covariance = store_covariance
         self.tol = tol
+
+    @property
+    @deprecated("Attribute 'covariances_' was deprecated in version 0.19 and "
+                "will be removed in 0.21. Use 'covariance_' instead")
+    def covariances_(self):
+        return self.covariance_
 
     def fit(self, X, y):
         """Fit the model according to the given training data and parameters.
 
             .. versionchanged:: 0.19
-               *store_covariance* has been moved to main constructor.
+               *store_covariances* has been moved to main constructor as
+               *store_covariance*.
 
             .. versionchanged:: 0.19
                *tol* has been moved to main constructor.
@@ -647,6 +656,12 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
             self.priors_ = self.priors
 
         cov = None
+        if self.store_covariances is not None:
+            warnings.warn("'store_covariances' was renamed to "
+                          "'store_covariance' in version 0.19 and will be "
+                          "removed in 0.21.",
+                          DeprecationWarning)
+            self.store_covariance = self.store_covariances
         if self.store_covariance:
             cov = []
         means = []
@@ -673,7 +688,7 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
             scalings.append(S2)
             rotations.append(Vt.T)
         if self.store_covariance:
-            self.covariances_ = cov
+            self.covariance_ = cov
         self.means_ = np.asarray(means)
         self.scalings_ = scalings
         self.rotations_ = rotations

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -578,7 +578,7 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
         of the Gaussian distributions along its principal axes, i.e. the
         variance in the rotated coordinate system.
 
-    store_covariances : boolean
+    store_covariance : boolean
         If True the covariance matrices are computed and stored in the
         `self.covariances_` attribute.
 
@@ -599,7 +599,7 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
     >>> clf.fit(X, y)
     ... # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     QuadraticDiscriminantAnalysis(priors=None, reg_param=0.0,
-                                  store_covariances=False, tol=0.0001)
+                                  store_covariance=False, tol=0.0001)
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
 
@@ -609,11 +609,11 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
         Discriminant Analysis
     """
 
-    def __init__(self, priors=None, reg_param=0., store_covariances=False,
-                 tol=1.0e-4):
+    def __init__(self, priors=None, reg_param=0., store_covariance=False,
+                 tol=1.0e-4, store_covariances=False):
         self.priors = np.asarray(priors) if priors is not None else None
         self.reg_param = reg_param
-        self.store_covariances = store_covariances
+        self.store_covariance = store_covariance
         self.tol = tol
 
     def fit(self, X, y):
@@ -647,7 +647,7 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
             self.priors_ = self.priors
 
         cov = None
-        if self.store_covariances:
+        if self.store_covariance:
             cov = []
         means = []
         scalings = []
@@ -667,12 +667,12 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
                 warnings.warn("Variables are collinear")
             S2 = (S ** 2) / (len(Xg) - 1)
             S2 = ((1 - self.reg_param) * S2) + self.reg_param
-            if self.store_covariances:
+            if self.store_covariance:
                 # cov = V * (S^2 / (n-1)) * V.T
                 cov.append(np.dot(S2 * Vt.T, Vt))
             scalings.append(S2)
             rotations.append(Vt.T)
-        if self.store_covariances:
+        if self.store_covariance:
             self.covariances_ = cov
         self.means_ = np.asarray(means)
         self.scalings_ = scalings

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -262,22 +262,22 @@ def test_qda_priors():
     assert_greater(n_pos2, n_pos)
 
 
-def test_qda_store_covariances():
+def test_qda_store_covariance():
     # The default is to not set the covariances_ attribute
     clf = QuadraticDiscriminantAnalysis().fit(X6, y6)
-    assert_true(not hasattr(clf, 'covariances_'))
+    assert_true(not hasattr(clf, 'covariance_'))
 
     # Test the actual attribute:
-    clf = QuadraticDiscriminantAnalysis(store_covariances=True).fit(X6, y6)
-    assert_true(hasattr(clf, 'covariances_'))
+    clf = QuadraticDiscriminantAnalysis(store_covariance=True).fit(X6, y6)
+    assert_true(hasattr(clf, 'covariance_'))
 
     assert_array_almost_equal(
-        clf.covariances_[0],
+        clf.covariance_[0],
         np.array([[0.7, 0.45], [0.45, 0.7]])
     )
 
     assert_array_almost_equal(
-        clf.covariances_[1],
+        clf.covariance_[1],
         np.array([[0.33333333, -0.33333333], [-0.33333333, 0.66666667]])
     )
 


### PR DESCRIPTION
#### Reference Issue
Fixes #7998 
See #8000 


#### What does this implement/fix? Explain your changes.
This renames the `store_covariances` parameter to `store_covariance`. This is continued from the PR linked above since the contributor there did not wish to work on the issue further.