### PR TITLE
[MRG+1] Deprecate ridge_alpha param on SparsePCA.transform()

### DIFF
--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -132,7 +132,7 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         self.error_ = E
         return self
 
-    def transform(self, X, ridge_alpha=None):
+    def transform(self, X, ridge_alpha='deprecated'):
         """Least Squares projection of the data onto the sparse components.
 
         To avoid instability issues in case the system is under-determined,
@@ -154,7 +154,7 @@ class SparsePCA(BaseEstimator, TransformerMixin):
 
             .. deprecated:: 0.19
                This parameter will be removed in 0.21.
-               Specify `ridge_alpha` in the `SparsePCA` constructor.
+               Specify ``ridge_alpha`` in the ``SparsePCA`` constructor.
 
         Returns
         -------
@@ -164,7 +164,7 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         check_is_fitted(self, 'components_')
 
         X = check_array(X)
-        if ridge_alpha is not None:
+        if ridge_alpha != 'deprecated':
             warnings.warn("The ridge_alpha parameter on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21. "
                           "Specify ridge_alpha in the SparsePCA constructor.",

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -169,6 +169,8 @@ class SparsePCA(BaseEstimator, TransformerMixin):
                           "deprecated since 0.19 and will be removed in 0.21. "
                           "Specify ridge_alpha in the SparsePCA constructor.",
                           DeprecationWarning)
+            if ridge_alpha is None:
+                ridge_alpha = self.ridge_alpha
         else:
             ridge_alpha = self.ridge_alpha
         U = ridge_regression(self.components_.T, X.T, ridge_alpha,

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -2,6 +2,8 @@
 # Author: Vlad Niculae, Gael Varoquaux, Alexandre Gramfort
 # License: BSD 3 clause
 
+import warnings
+
 import numpy as np
 
 from ..utils import check_random_state, check_array
@@ -9,8 +11,6 @@ from ..utils.validation import check_is_fitted
 from ..linear_model import ridge_regression
 from ..base import BaseEstimator, TransformerMixin
 from .dict_learning import dict_learning, dict_learning_online
-
-import warnings
 
 
 class SparsePCA(BaseEstimator, TransformerMixin):
@@ -150,8 +150,11 @@ class SparsePCA(BaseEstimator, TransformerMixin):
 
         ridge_alpha: float, default: 0.01
             Amount of ridge shrinkage to apply in order to improve
-            conditioning. Note that as of 0.19 this parameter is deprecated and
-            should be specified in the constructor.
+            conditioning.
+
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
+               Specify `ridge_alpha` in the `SparsePCA` constructor.
 
         Returns
         -------

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -10,6 +10,8 @@ from ..linear_model import ridge_regression
 from ..base import BaseEstimator, TransformerMixin
 from .dict_learning import dict_learning, dict_learning_online
 
+import warnings
+
 
 class SparsePCA(BaseEstimator, TransformerMixin):
     """Sparse Principal Components Analysis (SparsePCA)
@@ -148,7 +150,8 @@ class SparsePCA(BaseEstimator, TransformerMixin):
 
         ridge_alpha: float, default: 0.01
             Amount of ridge shrinkage to apply in order to improve
-            conditioning.
+            conditioning. Note that as of 0.19 this parameter is deprecated and
+            should be specified in the constructor.
 
         Returns
         -------
@@ -158,7 +161,13 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         check_is_fitted(self, 'components_')
 
         X = check_array(X)
-        ridge_alpha = self.ridge_alpha if ridge_alpha is None else ridge_alpha
+        if ridge_alpha is not None:
+            warnings.warn("The ridge_alpha parameter on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. "
+                          "Specify ridge_alpha in the SparsePCA constructor.",
+                          DeprecationWarning)
+        else:
+            ridge_alpha = self.ridge_alpha
         U = ridge_regression(self.components_.T, X.T, ridge_alpha,
                              solver='cholesky')
         s = np.sqrt((U ** 2).sum(axis=0))

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -71,9 +71,9 @@ def test_fit_transform():
     spca_lasso.fit(Y)
     assert_array_almost_equal(spca_lasso.components_, spca_lars.components_)
 
-    # Test calling tranform with deprecated ridge_alpha parameter
-    ridge_alpha = 0.01
-    assert_warns(DeprecationWarning, spca_lars.transform, Y, ridge_alpha)
+    # Test that deprecated ridge_alpha parameter throws warning
+    assert_warns(DeprecationWarning, spca_lars.transform, Y, ridge_alpha=0.01)
+    assert_warns(DeprecationWarning, spca_lars.transform, Y, ridge_alpha=None)
 
 
 @if_safe_multiprocessing_with_blas

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -11,7 +11,7 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import SkipTest
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
-from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import if_safe_multiprocessing_with_blas
 
 from sklearn.decomposition import SparsePCA, MiniBatchSparsePCA
@@ -72,8 +72,11 @@ def test_fit_transform():
     assert_array_almost_equal(spca_lasso.components_, spca_lars.components_)
 
     # Test that deprecated ridge_alpha parameter throws warning
-    assert_warns(DeprecationWarning, spca_lars.transform, Y, ridge_alpha=0.01)
-    assert_warns(DeprecationWarning, spca_lars.transform, Y, ridge_alpha=None)
+    warning_msg = "The ridge_alpha parameter on transform()"
+    assert_warns_message(DeprecationWarning, warning_msg, spca_lars.transform,
+                         Y, ridge_alpha=0.01)
+    assert_warns_message(DeprecationWarning, warning_msg, spca_lars.transform,
+                         Y, ridge_alpha=None)
 
 
 @if_safe_multiprocessing_with_blas

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -11,6 +11,7 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import SkipTest
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
+from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import if_safe_multiprocessing_with_blas
 
 from sklearn.decomposition import SparsePCA, MiniBatchSparsePCA
@@ -69,6 +70,10 @@ def test_fit_transform():
                            alpha=alpha)
     spca_lasso.fit(Y)
     assert_array_almost_equal(spca_lasso.components_, spca_lars.components_)
+
+    # Test calling tranform with deprecated ridge_alpha parameter
+    ridge_alpha = 0.01
+    assert_warns(DeprecationWarning, spca_lars.transform, Y, ridge_alpha)
 
 
 @if_safe_multiprocessing_with_blas


### PR DESCRIPTION
Fixes #1975

Adds a `DeprecationWarning` if the `ridge_alpha` parameter is passed to `SparsePCA.transform()`.