### PR TITLE
[MRG+1] fowlkes_mallows_score: unit tests (Fixes #8101)

### DIFF
--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -256,9 +256,9 @@ def test_fowlkes_mallows_score_properties():
     assert_almost_equal(score_symetric, expected)
 
     # permutation property
-    score_permuted = fowlkes_mallows_score((labels_a+1) % 3, labels_b)
+    score_permuted = fowlkes_mallows_score((labels_a + 1) % 3, labels_b)
     assert_almost_equal(score_permuted, expected)
 
     # symetric and permutation(both together)
-    score_both = fowlkes_mallows_score(labels_b, (labels_a+2) % 3)
+    score_both = fowlkes_mallows_score(labels_b, (labels_a + 2) % 3)
     assert_almost_equal(score_both, expected)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -239,3 +239,26 @@ def test_fowlkes_mallows_score():
     worst_score = fowlkes_mallows_score([0, 0, 0, 0, 0, 0],
                                         [0, 1, 2, 3, 4, 5])
     assert_almost_equal(worst_score, 0.)
+
+
+def test_fowlkes_mallows_score_properties():
+    # handcrafted example
+    labels_a = np.array([0, 0, 0, 1, 1, 2])
+    labels_b = np.array([1, 1, 2, 2, 0, 0])
+    expected = 1. / np.sqrt((1. + 3.) * (1. + 2.))
+    # FMI = TP / sqrt((TP + FP) * (TP + FN))
+
+    score_original = fowlkes_mallows_score(labels_a, labels_b)
+    assert_almost_equal(score_original, expected)
+
+    # symetric property
+    score_symetric = fowlkes_mallows_score(labels_b, labels_a)
+    assert_almost_equal(score_symetric, expected)
+
+    # permutation property
+    score_permuted = fowlkes_mallows_score((labels_a+1) % 3, labels_b)
+    assert_almost_equal(score_permuted, expected)
+
+    # symetric and permutation(both together)
+    score_both = fowlkes_mallows_score(labels_b, (labels_a+2) % 3)
+    assert_almost_equal(score_both, expected)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Fixes #8101
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
Added one more unit test for fowlkes_mallows_score() in ``sklearn.metrics.cluster`` module as discussed in the issue [#8101](https://github.com/scikit-learn/scikit-learn/issues/8101#issuecomment-269864613)




<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
