### PR TITLE
[MRG+1] Fix "cite us" link in sidebar

### DIFF
--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -275,7 +275,7 @@
       <p class="doc-version"><b>{{project}} v{{ release|e }}</b><br/>
       <a href="http://scikit-learn.org/stable/support.html#documentation-resources">Other versions</a></p>
     {%- endif %}
-    <p class="citing">Please <b><a href="about.html#citing-scikit-learn" style="font-size: 110%;">cite us </a></b>if you use the software.</p>
+    <p class="citing">Please <b><a href="{{ '{}#citing-scikit-learn'.format(pathto('about')).replace('##', '#') }}" style="font-size: 110%;">cite us </a></b>if you use the software.</p>
     {{ toc }}
     </div>
 </div>

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -275,7 +275,7 @@
       <p class="doc-version"><b>{{project}} v{{ release|e }}</b><br/>
       <a href="http://scikit-learn.org/stable/support.html#documentation-resources">Other versions</a></p>
     {%- endif %}
-    <p class="citing">Please <b><a href="{{ '{}#citing-scikit-learn'.format(pathto('about')).replace('##', '#') }}" style="font-size: 110%;">cite us </a></b>if you use the software.</p>
+    <p class="citing">Please <b><a href="{{ pathto('about').replace('#', '') }}#citing-scikit-learn" style="font-size: 110%;">cite us </a></b>if you use the software.</p>
     {{ toc }}
     </div>
 </div>


### PR DESCRIPTION
The ["please cite us" link on the dev website](http://scikit-learn.org/dev/tutorial/basic/tutorial.html) was broken by #8072 when it changed to a [non-existent static link](http://scikit-learn.org/dev/tutorial/basic/about.html#citing-scikit-learn). This PR reverts the change.

Incidentally, when struggling to build the docs locally I found that Sphinx 1.5 works if you also use the sphinx-gallery v1.7.1 files. I can send in a separate PR for that if appropriate.