### PR TITLE
[MRG] Add scikit-surprise as a related project

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -179,6 +179,8 @@ Domain specific packages
 - `MSMBuilder <http://msmbuilder.org/>`_  Machine learning for protein
   conformational dynamics time series.
 
+- `scikit-surprise <http://surpriselib.com>`_ A scikit for recommender systems.
+
 Snippets and tidbits
 ---------------------
 

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -179,7 +179,8 @@ Domain specific packages
 - `MSMBuilder <http://msmbuilder.org/>`_  Machine learning for protein
   conformational dynamics time series.
 
-- `scikit-surprise <http://surpriselib.com>`_ A scikit for recommender systems.
+- `scikit-surprise <http://surpriselib.com>`_ A scikit for building and
+  evaluating recommender systems.
 
 Snippets and tidbits
 ---------------------


### PR DESCRIPTION
Hi, 

(This is a bit of a shameless plug)

I developed [surprise](http://surpriselib.com/), a scikit for recommender systems. I know people often wonder how to use `scikit-learn` for RS purposes, so I thought it could be useful to add a link in the *related project* section of the doc.

Thanks!
Nicolas