### PR TITLE
[MRG+1] Fixing a bug where entropy included labeled items

### DIFF
--- a/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
+++ b/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
@@ -9,7 +9,10 @@ using label propagation.
 We start by training a label propagation model with only 10 labeled points,
 then we select the top five most uncertain points to label. Next, we train
 with 15 labeled points (original 10 + 5 new ones). We repeat this process
-four times to have a model trained with 30 labeled examples.
+four times to have a model trained with 30 labeled examples. Note you can
+increase this to label more than 30 by changing `max_iterations`. Labeling
+more than 30 can be useful to get a sense for the speed of convergence of
+this active learning technique.
 
 A plot will appear showing the top 5 most uncertain digits for each iteration
 of training. These may or may not contain mistakes, but we will train the next
@@ -39,11 +42,12 @@ images = digits.images[indices[:330]]
 
 n_total_samples = len(y)
 n_labeled_points = 10
+max_iterations = 5
 
 unlabeled_indices = np.arange(n_total_samples)[n_labeled_points:]
 f = plt.figure()
 
-for i in range(5):
+for i in range(max_iterations):
     if len(unlabeled_indices) == 0:
         print("No unlabeled items left to label.")
         break

--- a/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
+++ b/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
@@ -80,14 +80,14 @@ for i in range(5):
     # keep track of indices that we get labels for
     delete_indices = np.array([])
     
-    # if running for more than 5 iterations,  visualize the gain on only the first 5
+    # if running for more than 5 iterations, visualize the gain on only the first 5
     if i < 5:
         f.text(.05, (1 - (i + 1) * .183),
                "model %d\n\nfit with\n%d labels" % ((i + 1), i * 5 + 10), size=10)
     for index, image_index in enumerate(uncertainty_index):
         image = images[image_index]
 
-        # if running for more than 5 iterations,  visualize the gain on only the first 5
+        # if running for more than 5 iterations, visualize the gain on only the first 5
         if i < 5:
             sub = f.add_subplot(5, 5, index + 1 + (5 * i))
             sub.imshow(image, cmap=plt.cm.gray_r)

--- a/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
+++ b/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
@@ -72,7 +72,7 @@ for i in range(5):
     pred_entropies = stats.distributions.entropy(
         lp_model.label_distributions_.T)
 
-    # select up to five digit examples that the classifier is most uncertain about
+    # select up to 5 digit examples that the classifier is most uncertain about
     uncertainty_index = np.argsort(pred_entropies)[::-1]
     uncertainty_index = uncertainty_index[
         np.in1d(uncertainty_index, unlabeled_indices)][:5]
@@ -80,14 +80,15 @@ for i in range(5):
     # keep track of indices that we get labels for
     delete_indices = np.array([])
 
-    # if running for more than 5 iterations, visualize the gain on only the first 5
+    # for more than 5 iterations, visualize the gain only on the first 5
     if i < 5:
         f.text(.05, (1 - (i + 1) * .183),
-               "model %d\n\nfit with\n%d labels" % ((i + 1), i * 5 + 10), size=10)
+               "model %d\n\nfit with\n%d labels" %
+               ((i + 1), i * 5 + 10), size=10)
     for index, image_index in enumerate(uncertainty_index):
         image = images[image_index]
 
-        # if running for more than 5 iterations, visualize the gain on only the first 5
+        # for more than 5 iterations, visualize the gain only on the first 5
         if i < 5:
             sub = f.add_subplot(5, 5, index + 1 + (5 * i))
             sub.imshow(image, cmap=plt.cm.gray_r)

--- a/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
+++ b/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
@@ -79,24 +79,28 @@ for i in range(5):
 
     # keep track of indices that we get labels for
     delete_indices = np.array([])
-
-    f.text(.05, (1 - (i + 1) * .183),
-           "model %d\n\nfit with\n%d labels" % ((i + 1), i * 5 + 10), size=10)
+    
+    # if running for more than 5 iterations visualiaze the gain only on the first 5.
+    if i < 5:
+        f.text(.05, (1 - (i + 1) * .183),
+               "model %d\n\nfit with\n%d labels" % ((i + 1), i * 5 + 10), size=10)
     for index, image_index in enumerate(uncertainty_index):
         image = images[image_index]
 
-        sub = f.add_subplot(5, 5, index + 1 + (5 * i))
-        sub.imshow(image, cmap=plt.cm.gray_r)
-        sub.set_title("predict: %i\ntrue: %i" % (
-            lp_model.transduction_[image_index], y[image_index]), size=10)
-        sub.axis('off')
+        # if running for more than 5 iterations visualiaze the gain only on the first 5.
+        if i < 5:
+            sub = f.add_subplot(5, 5, index + 1 + (5 * i))
+            sub.imshow(image, cmap=plt.cm.gray_r)
+            sub.set_title("predict: %i\ntrue: %i" % (
+                lp_model.transduction_[image_index], y[image_index]), size=10)
+            sub.axis('off')
 
         # labeling 5 points, remote from labeled set
         delete_index, = np.where(unlabeled_indices == image_index)
         delete_indices = np.concatenate((delete_indices, delete_index))
 
     unlabeled_indices = np.delete(unlabeled_indices, delete_indices)
-    n_labeled_points += len(unlabeled_indices)
+    n_labeled_points += len(uncertainty_index)
 
 f.suptitle("Active learning with Label Propagation.\nRows show 5 most "
            "uncertain labels to learn with the next model.")

--- a/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
+++ b/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
@@ -80,14 +80,14 @@ for i in range(5):
     # keep track of indices that we get labels for
     delete_indices = np.array([])
     
-    # if running for more than 5 iterations visualiaze the gain only on the first 5.
+    # if running for more than 5 iterations,  visualize the gain on only the first 5
     if i < 5:
         f.text(.05, (1 - (i + 1) * .183),
                "model %d\n\nfit with\n%d labels" % ((i + 1), i * 5 + 10), size=10)
     for index, image_index in enumerate(uncertainty_index):
         image = images[image_index]
 
-        # if running for more than 5 iterations visualiaze the gain only on the first 5.
+        # if running for more than 5 iterations,  visualize the gain on only the first 5
         if i < 5:
             sub = f.add_subplot(5, 5, index + 1 + (5 * i))
             sub.imshow(image, cmap=plt.cm.gray_r)

--- a/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
+++ b/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
@@ -79,7 +79,7 @@ for i in range(5):
 
     # keep track of indices that we get labels for
     delete_indices = np.array([])
-    
+
     # if running for more than 5 iterations, visualize the gain on only the first 5
     if i < 5:
         f.text(.05, (1 - (i + 1) * .183),

--- a/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
+++ b/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
@@ -44,6 +44,9 @@ unlabeled_indices = np.arange(n_total_samples)[n_labeled_points:]
 f = plt.figure()
 
 for i in range(5):
+    if len(unlabeled_indices) == 0:
+        print("No unlabeled items left to label.")
+        break
     y_train = np.copy(y)
     y_train[unlabeled_indices] = -1
 
@@ -56,7 +59,7 @@ for i in range(5):
     cm = confusion_matrix(true_labels, predicted_labels,
                           labels=lp_model.classes_)
 
-    print('Iteration %i %s' % (i, 70 * '_'))
+    print("Iteration %i %s" % (i, 70 * "_"))
     print("Label Spreading model: %d labeled & %d unlabeled (%d total)"
           % (n_labeled_points, n_total_samples - n_labeled_points, n_total_samples))
 
@@ -69,7 +72,7 @@ for i in range(5):
     pred_entropies = stats.distributions.entropy(
         lp_model.label_distributions_.T)
 
-    # select five digit examples that the classifier is most uncertain about
+    # select up to five digit examples that the classifier is most uncertain about
     uncertainty_index = np.argsort(pred_entropies)[::-1]
     uncertainty_index = uncertainty_index[
         np.in1d(uncertainty_index, unlabeled_indices)][:5]
@@ -84,7 +87,7 @@ for i in range(5):
 
         sub = f.add_subplot(5, 5, index + 1 + (5 * i))
         sub.imshow(image, cmap=plt.cm.gray_r)
-        sub.set_title('predict: %i\ntrue: %i' % (
+        sub.set_title("predict: %i\ntrue: %i" % (
             lp_model.transduction_[image_index], y[image_index]), size=10)
         sub.axis('off')
 
@@ -93,7 +96,7 @@ for i in range(5):
         delete_indices = np.concatenate((delete_indices, delete_index))
 
     unlabeled_indices = np.delete(unlabeled_indices, delete_indices)
-    n_labeled_points += 5
+    n_labeled_points += len(unlabeled_indices)
 
 f.suptitle("Active learning with Label Propagation.\nRows show 5 most "
            "uncertain labels to learn with the next model.")

--- a/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
+++ b/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
@@ -70,7 +70,9 @@ for i in range(5):
         lp_model.label_distributions_.T)
 
     # select five digit examples that the classifier is most uncertain about
-    uncertainty_index = uncertainty_index = np.argsort(pred_entropies)[-5:]
+    uncertainty_index = np.argsort(pred_entropies)[::-1]
+    uncertainty_index = uncertainty_index[
+        np.in1d(uncertainty_index, unlabeled_indices)][:5]
 
     # keep track of indices that we get labels for
     delete_indices = np.array([])


### PR DESCRIPTION
This bug leads the loop to never converge no matter how high the iteration count since it includes already labeled items in the bucket of items it'll label in the next iteration.

This can readily be seen by adding a "print unlabeled_indices.shape" statement and noticing it stops shrinking after only 1/3 of the data is labeled.

Note I'm not sure how to rebuild the documentation and the .py and .ipynb files linked to [here](http://scikit-learn.org/0.18/auto_examples/semi_supervised/plot_label_propagation_digits_active_learning.html#sphx-glr-auto-examples-semi-supervised-plot-label-propagation-digits-active-learning-py), is that done automatically?