### PR TITLE
[MRG+1] DOC: complete list of online learners

### DIFF
--- a/doc/modules/scaling_strategies.rst
+++ b/doc/modules/scaling_strategies.rst
@@ -75,8 +75,9 @@ Here is a list of incremental estimators for different tasks:
       + :class:`sklearn.decomposition.IncrementalPCA`
       + :class:`sklearn.decomposition.LatentDirichletAllocation`
   - Preprocessing
-      + :class:`sklearn.preprocessing.MinMaxScaler`
       + :class:`sklearn.preprocessing.StandardScaler`
+      + :class:`sklearn.preprocessing.MinMaxScaler`
+      + :class:`sklearn.preprocessing.MaxAbsScaler`
 
 For classification, a somewhat important thing to note is that although a
 stateless feature extraction routine may be able to cope with new/unseen

--- a/doc/modules/scaling_strategies.rst
+++ b/doc/modules/scaling_strategies.rst
@@ -62,16 +62,21 @@ Here is a list of incremental estimators for different tasks:
       + :class:`sklearn.linear_model.Perceptron`
       + :class:`sklearn.linear_model.SGDClassifier`
       + :class:`sklearn.linear_model.PassiveAggressiveClassifier`
+      + :class:`sklearn.neural_network.MLPClassifier`
   - Regression
       + :class:`sklearn.linear_model.SGDRegressor`
       + :class:`sklearn.linear_model.PassiveAggressiveRegressor`
+      + :class:`sklearn.neural_network.MLPRegressor`
   - Clustering
       + :class:`sklearn.cluster.MiniBatchKMeans`
+      + :class:`sklearn.cluster.Birch`
   - Decomposition / feature Extraction
       + :class:`sklearn.decomposition.MiniBatchDictionaryLearning`
       + :class:`sklearn.decomposition.IncrementalPCA`
       + :class:`sklearn.decomposition.LatentDirichletAllocation`
-      + :class:`sklearn.cluster.MiniBatchKMeans`
+  - Preprocessing
+      + :class:`sklearn.preprocessing.MinMaxScaler`
+      + :class:`sklearn.preprocessing.StandardScaler`
 
 For classification, a somewhat important thing to note is that although a
 stateless feature extraction routine may be able to cope with new/unseen


### PR DESCRIPTION
Trivial doc fix to complete the list of learners with partial_fit.

I have purposely left out the RBM, because it is a model that has fallen out of fashion and should probably not be used. I also left out LSHForest because it implements neither predict nor transform and isn't very useful currently.
