### PR TITLE
[MRG] Fix Ridge floating point instability

### DIFF
--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -885,7 +885,7 @@ class _RidgeGCV(LinearModel):
         constant_column = np.var(Q, 0) < 1.e-12
         # detect constant columns
         w[constant_column] = 0  # cancel the regularization for the intercept
-        w[v == 0] = 0
+
         c = np.dot(Q, self._diag_dot(w, QT_y))
         G_diag = self._decomp_diag(w, Q)
         # handle case where y is 2-d


### PR DESCRIPTION
Fix #7921. This fixes the failure on the manylinux wheels reported in #7921. It also fixes the conda-forge error seen in https://github.com/conda-forge/scikit-learn-feedstock/issues/24 which prevented the 0.18.1 release to be available in conda-forge.

See #7921 for the full discussion.

I am still trying to figure out how to best test this on Travis. For the moment, what I saw is that you need to use conda-forge (to have an OpenBLAS built with dynamic architecture support) and set OPENBLAS_CORETYPE to Prescott. Not sure whether we want to add a build entry in the .travis.yml for this.