### PR TITLE
[MRG+1] Ensure coef_ is an ndarray when fitting LassoLars

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -182,6 +182,10 @@ Bug fixes
      would be raised on trying to stack matrices with different dimensions.
      :issue:`8093` by :user:`Peter Bull <pjbull>`.
 
+   - Fix a bug where :func:`sklearn.linear_model.LassoLars.fit` sometimes
+     left `coef_` as a list, rather than an ndarray.
+     :issue:`8160` by :user:`CJ Carey <perimosocordiae>`.
+
 API changes summary
 -------------------
 

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -665,9 +665,9 @@ class Lars(LinearModel, RegressorMixin):
 
         self.alphas_ = []
         self.n_iter_ = []
+        self.coef_ = np.empty((n_targets, n_features))
 
         if self.fit_path:
-            self.coef_ = []
             self.active_ = []
             self.coef_path_ = []
             for k in xrange(n_targets):
@@ -682,17 +682,14 @@ class Lars(LinearModel, RegressorMixin):
                 self.active_.append(active)
                 self.n_iter_.append(n_iter_)
                 self.coef_path_.append(coef_path)
-                self.coef_.append(coef_path[:, -1])
+                self.coef_[k] = coef_path[:, -1]
 
             if n_targets == 1:
                 self.alphas_, self.active_, self.coef_path_, self.coef_ = [
                     a[0] for a in (self.alphas_, self.active_, self.coef_path_,
                                    self.coef_)]
                 self.n_iter_ = self.n_iter_[0]
-            else:
-                self.coef_ = np.array(self.coef_)
         else:
-            self.coef_ = np.empty((n_targets, n_features))
             for k in xrange(n_targets):
                 this_Xy = None if Xy is None else Xy[:, k]
                 alphas, _, self.coef_[k], n_iter_ = lars_path(

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -689,6 +689,8 @@ class Lars(LinearModel, RegressorMixin):
                     a[0] for a in (self.alphas_, self.active_, self.coef_path_,
                                    self.coef_)]
                 self.n_iter_ = self.n_iter_[0]
+            else:
+                self.coef_ = np.array(self.coef_)
         else:
             self.coef_ = np.empty((n_targets, n_features))
             for k in xrange(n_targets):

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -366,8 +366,15 @@ def test_multitarget():
     X = diabetes.data
     Y = np.vstack([diabetes.target, diabetes.target ** 2]).T
     n_targets = Y.shape[1]
+    estimators = [
+        linear_model.LassoLars(),
+        linear_model.Lars(),
+        # regression test for gh-1615
+        linear_model.LassoLars(fit_intercept=False),
+        linear_model.Lars(fit_intercept=False),
+    ]
 
-    for estimator in (linear_model.LassoLars(), linear_model.Lars()):
+    for estimator in estimators:
         estimator.fit(X, Y)
         Y_pred = estimator.predict(X)
         alphas, active, coef, path = (estimator.alphas_, estimator.active_,


### PR DESCRIPTION
This PR fixes #1615, an issue related to fitting a `LassoLars` model with the specific combination of `fit_path=True`, `fit_intercept=False`, and >1 targets.

The bug was masked in the `fit_intercept=True` case because of [this line](https://github.com/scikit-learn/scikit-learn/blob/8695ff5969d84429e4a84ee8fea835e52e6d230d/sklearn/linear_model/base.py#L260),
in which the coefficient list is promoted to an ndarray by division with another ndarray.