### PR TITLE
[MRG+1] Clarify error message for min_samples_split.

### DIFF
--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -185,14 +185,16 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
 
         if isinstance(self.min_samples_split, (numbers.Integral, np.integer)):
             if not 2 <= self.min_samples_split:
-                raise ValueError("min_samples_split must be at least 2 "
-                                 "or in (0, 1.0], got %s"
+                raise ValueError("min_samples_split must be an integer "
+                                 "greater than 1 or a float in (0.0, 1.0]; "
+                                 "got the integer %s"
                                  % self.min_samples_split)
             min_samples_split = self.min_samples_split
         else:  # float
             if not 0. < self.min_samples_split <= 1.:
-                raise ValueError("min_samples_split must be at least 2 "
-                                 "or in (0, 1.0], got %s"
+                raise ValueError("min_samples_split must be an integer "
+                                 "greater than 1 or a float in (0.0, 1.0]; "
+                                 "got the float %s"
                                  % self.min_samples_split)
             min_samples_split = int(ceil(self.min_samples_split * n_samples))
             min_samples_split = max(2, min_samples_split)


### PR DESCRIPTION
I found the error message for a tree when `min_samples_split == 1` (an int) confusing. There was a earlier commit 25 days ago that I think was supposed to resolve this problem, but maybe this change will be still clearer?

Without this commit, we get this:

```
~ $ cat example.py 
from sklearn.tree import DecisionTreeClassifier
dtc = DecisionTreeClassifier(min_samples_split=1)
dtc.fit([[0]], [0])
~ $ python example.py 
Traceback (most recent call last):
  File "example.py", line 3, in <module>
    dtc.fit([[0]], [0])
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/sklearn/tree/tree.py", line 739, in fit
    X_idx_sorted=X_idx_sorted)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/sklearn/tree/tree.py", line 199, in fit
    % self.min_samples_split)
ValueError: min_samples_split must be at least 2 or in (0, 1.0], got 1
```