### PR TITLE
[MRG] fix typo in cs_mse_path_ deprecation

### DIFF
--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -1168,8 +1168,8 @@ class LarsCV(Lars):
         return self.alpha_
 
     @property
-    @deprecated("Attribute mse_path_ is deprecated in 0.18 and "
-                "will be removed in 0.20. Use 'cv_mse_path_' instead")
+    @deprecated("Attribute cv_mse_path_ is deprecated in 0.18 and "
+                "will be removed in 0.20. Use 'mse_path_' instead")
     def cv_mse_path_(self):
         return self.mse_path_
 


### PR DESCRIPTION
I think this was a simple typo, but it made the DeprecationWarning message really confusing.