### PR TITLE
[MRG+1] Fixes #8198 - error in datasets.make_moons

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -140,6 +140,10 @@ Enhancements
 Bug fixes
 .........
 
+   - Fixed a bug where :class:`sklearn.datasets.make_moons` gives an
+     incorrect result when ``n_samples`` is odd.
+     :issue:`8198` by :user:`Josh Levy <levy5674>`.
+
    - Fixed a bug where :class:`sklearn.linear_model.LassoLars` does not give
      the same result as the LassoLars implementation available
      in R (lars library). :issue:`7849` by :user:`Jair Montoya Martinez <jmontoyam>`

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -140,7 +140,7 @@ Enhancements
 Bug fixes
 .........
 
-   - Fixed a bug where :class:`sklearn.datasets.make_moons` gives an
+   - Fixed a bug where :func:`sklearn.datasets.make_moons` gives an
      incorrect result when ``n_samples`` is odd.
      :issue:`8198` by :user:`Josh Levy <levy5674>`.
 

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -665,8 +665,8 @@ def make_moons(n_samples=100, shuffle=True, noise=None, random_state=None):
 
     X = np.vstack((np.append(outer_circ_x, inner_circ_x),
                    np.append(outer_circ_y, inner_circ_y))).T
-    y = np.hstack([np.zeros(n_samples_in, dtype=np.intp),
-                   np.ones(n_samples_out, dtype=np.intp)])
+    y = np.hstack([np.zeros(n_samples_out, dtype=np.intp),
+                   np.ones(n_samples_in, dtype=np.intp)])
 
     if shuffle:
         X, y = util_shuffle(X, y, random_state=generator)

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -369,4 +369,4 @@ def test_make_moons():
         center = [0.0, 0.0] if label == 0 else [1.0, 0.5]
         dist_sqr = ((x - center) ** 2).sum()
         assert_almost_equal(dist_sqr, 1.0,
-            		    err_msg="Point is not on expected unit circle")
+                            err_msg="Point is not on expected unit circle")

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -367,5 +367,5 @@ def test_make_moons():
     for x, label in zip(X, y):
         center = [0.0, 0.0] if label == 0 else [1.0, 0.5]
         dist_sqr = ((x - center) ** 2).sum()
-        assert_almost_equal(dist_sqr, 1.0, 
-		    err_msg="Point is not on expected unit circle")
+        assert_almost_equal(dist_sqr, 1.0,
+            err_msg="Point is not on expected unit circle")

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -365,7 +365,7 @@ def test_make_checkerboard():
 def test_make_moons():
     X, y = make_moons(3, shuffle=False)
     for x, label in zip(X, y):
-        if label == 0:
-            assert_almost_equal((x ** 2).sum(), 1.0, err_msg="Point is labeled outside but isn't on unit circle centered at (0,0)")
-        else:
-            assert_almost_equal(((x - [1, 0.5]) ** 2).sum(), 1.0, err_msg="Point is labeled inside but isn't on unit circle centered at (1,0.5)")
+        center = [0.0, 0.0] if label == 0 else [1.0, 0.5]
+        dist_sqr = ((x - center) ** 2).sum()
+        assert_almost_equal(dist_sqr, 1.0, 
+		    err_msg="Point is not on expected unit circle")

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -24,6 +24,7 @@ from sklearn.datasets import make_friedman1
 from sklearn.datasets import make_friedman2
 from sklearn.datasets import make_friedman3
 from sklearn.datasets import make_low_rank_matrix
+from sklearn.datasets import make_moons
 from sklearn.datasets import make_sparse_coded_signal
 from sklearn.datasets import make_sparse_uncorrelated
 from sklearn.datasets import make_spd_matrix
@@ -360,3 +361,11 @@ def test_make_checkerboard():
     X2, _, _ = make_checkerboard(shape=(100, 100), n_clusters=2,
                                  shuffle=True, random_state=0)
     assert_array_equal(X1, X2)
+
+def test_make_moons():
+    X, y = make_moons(3, shuffle=False)
+    for x, label in zip(X, y):
+        if label == 0:
+            assert_almost_equal((x ** 2).sum(), 1.0, err_msg="Point is labeled outside but isn't on unit circle centered at (0,0)")
+        else:
+            assert_almost_equal(((x - [1, 0.5]) ** 2).sum(), 1.0, err_msg="Point is labeled inside but isn't on unit circle centered at (1,0.5)")

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -362,10 +362,11 @@ def test_make_checkerboard():
                                  shuffle=True, random_state=0)
     assert_array_equal(X1, X2)
 
+
 def test_make_moons():
     X, y = make_moons(3, shuffle=False)
     for x, label in zip(X, y):
         center = [0.0, 0.0] if label == 0 else [1.0, 0.5]
         dist_sqr = ((x - center) ** 2).sum()
         assert_almost_equal(dist_sqr, 1.0,
-            err_msg="Point is not on expected unit circle")
+            		    err_msg="Point is not on expected unit circle")


### PR DESCRIPTION
#### Reference Issue
Fixes #8198

#### What does this implement/fix? Explain your changes.
Inside `make_moons`,  `n_samples_out` elements go into `outer_circle_x` and `outer_circle_y` but `n_samples_in` elements of `y` get set to 1

#### Any other comments?
```
%pylab inline
from sklearn.datasets import make_moons

XL, YL = make_moons(5)
XU, YU = make_moons(495)
scatter(XL[:,0], XL[:,1], c=YL, s=200)
scatter(XU[:,0], XU[:,1], c=YU)
```

Before:
![sklearn_8198_broken](https://cloud.githubusercontent.com/assets/10403760/21949806/c887acc2-d9ba-11e6-9347-7602c87513b9.png)

After
![sklearn_8198_fixed](https://cloud.githubusercontent.com/assets/10403760/21949812/d83cd5e8-d9ba-11e6-9a4b-83f829593ac6.png)
