### PR TITLE
Update setup.py DOWNLOAD_URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ MAINTAINER = 'Andreas Mueller'
 MAINTAINER_EMAIL = 'amueller@ais.uni-bonn.de'
 URL = 'http://scikit-learn.org'
 LICENSE = 'new BSD'
-DOWNLOAD_URL = 'http://sourceforge.net/projects/scikit-learn/files/'
+DOWNLOAD_URL = 'https://github.com/scikit-learn/scikit-learn/releases'
 
 # We can actually import a restricted version of sklearn that
 # does not need the compiled code


### PR DESCRIPTION
Changed the DOWNLOAD_URL string from the out of date SourceForge link to the current GitHub link. Fix https://github.com/scikit-learn/scikit-learn/issues/8184.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
setup.py DOWNLOAD_URL is currently set to the out-of-date sourceforge link. This PR is updating that to the current GitHub link.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
