### PR TITLE
[WIP] Add prediction strength method to determine number of clusters

### DIFF
--- a/examples/cluster/plot_prediction_strength_cv.py
+++ b/examples/cluster/plot_prediction_strength_cv.py
@@ -1,0 +1,92 @@
+"""
+=====================================================================
+Selecting the number of clusters with prediction strength grid search
+=====================================================================
+
+Prediction strength is a metric that measures the stability of a clustering
+algorithm and can be used to determine an optimal number of clusters without
+knowing the true cluster assignments.
+
+First, one splits the data into two parts (A) and (B).
+One obtains two cluster assignments, the first one using the centroids
+derived from the subset (A), and the second one using the centroids
+from the subset (B). Prediction strength measures the proportion of observation
+pairs that are assigned to the same clusters according to both clusterings.
+The overall prediction strength is the minimum of this quantity over all
+predicted clusters.
+
+By varying the desired number of clusters from low to high, we can choose the
+highest number of clusters for which the prediction strength exceeds some
+threshold. This is precisely how
+:class:`sklearn.model_selection.PredictionStrengthGridSearchCV` operates,
+as illustrated in the example below. We evaluate ``n_clusters`` in the range
+2 to 8 via 5-fold cross-validation. While the average prediction strength
+is high for 2, 3, and 4, it sharply drops below the threshold of 0.8 if
+``n_clusters`` is 5 or higher. Therefore, we can conclude that the optimal
+number of clusters is 4.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.stats import sem
+
+from sklearn.datasets import make_blobs
+from sklearn.cluster import KMeans
+from sklearn.model_selection import PredictionStrengthGridSearchCV
+from sklearn.model_selection import KFold
+
+# Generating the sample data from make_blobs
+# This particular setting has one distinct cluster and 3 clusters placed close
+# together.
+X, y = make_blobs(n_samples=500,
+                  n_features=2,
+                  centers=4,
+                  cluster_std=1,
+                  center_box=(-10.0, 10.0),
+                  shuffle=True,
+                  random_state=1)  # For reproducibility
+
+# Define list of values for n_clusters we want to explore
+range_n_clusters = [2, 3, 4, 5, 6, 7, 8]
+param_grid = {'n_clusters': range_n_clusters}
+
+# Determine optimal choice of n_clusters using 5-fold cross-validation.
+# The optimal number of clusters k is the largest k such that the
+# corresponding prediction strength is above some threshold.
+# Tibshirani and Guenther suggest a threshold in the range 0.8 to 0.9
+# for well separated clusters.
+clusterer = KMeans(random_state=10)
+n_splits = 5
+grid_search = PredictionStrengthGridSearchCV(clusterer, threshold=0.8,
+                                             param_grid=param_grid,
+                                             cv=KFold(n_splits))
+grid_search.fit(X)
+
+# Retrieve the best configuration
+print(grid_search.best_params_, grid_search.best_score_)
+
+# Retrieve the results stored in the cv_results_ attribute
+n_parameters = len(range_n_clusters)
+param_n_clusters = grid_search.cv_results_["param_n_clusters"]
+mean_test_score = grid_search.cv_results_["mean_test_score"]
+
+# plot average prediction strength for each value for n_clusters
+points = np.empty((n_parameters, 2), dtype=np.float_)
+for i, values in enumerate(zip(param_n_clusters, mean_test_score)):
+    points[i, :] = values
+plt.plot(points[:, 0], points[:, 1], marker='o', markerfacecolor='none')
+plt.xlabel("n_clusters")
+plt.ylabel("average prediction strength")
+
+# plot the standard error of the prediction strength as error bars
+test_score_keys = ["split%d_test_score" % split_i
+                   for split_i in range(n_splits)]
+test_scores = [grid_search.cv_results_[key] for key in test_score_keys]
+se = np.fromiter((sem(values) for values in zip(*test_scores)),
+                 dtype=np.float_)
+plt.errorbar(points[:, 0], points[:, 1], se)
+
+plt.hlines(grid_search.threshold, min(range_n_clusters), max(range_n_clusters),
+           linestyles='dashed')
+
+plt.show()

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -53,6 +53,7 @@ from .cluster import silhouette_score
 from .cluster import calinski_harabasz_score
 from .cluster import v_measure_score
 from .cluster import davies_bouldin_score
+from .cluster import prediction_strength_score
 
 from .pairwise import euclidean_distances
 from .pairwise import nan_euclidean_distances
@@ -156,6 +157,7 @@ __all__ = [
     'precision_recall_curve',
     'precision_recall_fscore_support',
     'precision_score',
+    'prediction_strength_score',
     'r2_score',
     'rand_score',
     'recall_score',

--- a/sklearn/metrics/cluster/__init__.py
+++ b/sklearn/metrics/cluster/__init__.py
@@ -23,6 +23,7 @@ from ._unsupervised import silhouette_samples
 from ._unsupervised import silhouette_score
 from ._unsupervised import calinski_harabasz_score
 from ._unsupervised import davies_bouldin_score
+from ._unsupervised import prediction_strength_score
 from ._bicluster import consensus_score
 
 __all__ = ["adjusted_mutual_info_score", "normalized_mutual_info_score",
@@ -32,4 +33,5 @@ __all__ = ["adjusted_mutual_info_score", "normalized_mutual_info_score",
            "homogeneity_score", "mutual_info_score", "v_measure_score",
            "fowlkes_mallows_score", "entropy", "silhouette_samples",
            "silhouette_score", "calinski_harabasz_score",
-           "davies_bouldin_score", "consensus_score"]
+           "davies_bouldin_score", "consensus_score",
+           "prediction_strength_score"]

--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -365,6 +365,13 @@ def davies_bouldin_score(X, labels):
     return np.mean(scores)
 
 
+def _non_zero_add(sparse_matrix, value):
+    """Add value to non-zero entries of a sparse matrix"""
+    M = sparse_matrix.copy()
+    M.data += value
+    return M
+
+
 def prediction_strength_score(labels_train, labels_test):
     """Compute the prediction strength score.
 
@@ -409,9 +416,10 @@ def prediction_strength_score(labels_train, labels_test):
     if n_clusters == 1:
         return 1.0  # by definition
 
-    C = contingency_matrix(labels_train, labels_test)
-    pairs_matching = (C * (C - 1) / 2).sum(axis=0)
-    M = C.sum(axis=0)
+    C = contingency_matrix(labels_train, labels_test, sparse=True)
+    Cp = C.multiply(_non_zero_add(C, -1)) / 2
+    pairs_matching = np.asarray(Cp.sum(axis=0)).ravel()
+    M = np.asarray(C.sum(axis=0)).ravel()
     pairs_total = (M * (M - 1) / 2)
     nz = pairs_total.nonzero()[0]
 

--- a/sklearn/model_selection/__init__.py
+++ b/sklearn/model_selection/__init__.py
@@ -29,6 +29,7 @@ from ._search import GridSearchCV
 from ._search import RandomizedSearchCV
 from ._search import ParameterGrid
 from ._search import ParameterSampler
+from ._search import PredictionStrengthGridSearchCV
 from ._search import fit_grid_point
 
 if typing.TYPE_CHECKING:
@@ -54,6 +55,7 @@ __all__ = ['BaseCrossValidator',
            'ParameterGrid',
            'ParameterSampler',
            'PredefinedSplit',
+           'PredictionStrengthGridSearchCV',
            'RandomizedSearchCV',
            'ShuffleSplit',
            'StratifiedKFold',

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -28,6 +28,7 @@ from ..utils.validation import _deprecate_positional_args
 from ..utils.fixes import delayed
 from ..utils.metaestimators import _safe_split
 from ..metrics import check_scoring
+from ..metrics import prediction_strength_score
 from ..metrics._scorer import _check_multimetric_scoring, _MultimetricScorer
 from ..exceptions import FitFailedWarning, NotFittedError
 from ._split import check_cv
@@ -451,7 +452,7 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
                    return_parameters=False, return_n_test_samples=False,
                    return_times=False, return_estimator=False,
                    split_progress=None, candidate_progress=None,
-                   error_score=np.nan):
+                   error_score=np.nan, use_prediction_strength=False):
 
     """Fit estimator and compute scores for a given dataset split.
 
@@ -580,49 +581,22 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
 
         estimator = estimator.set_params(**cloned_parameters)
 
-    start_time = time.time()
-
     X_train, y_train = _safe_split(estimator, X, y, train)
     X_test, y_test = _safe_split(estimator, X, y, test, train)
 
-    result = {}
-    try:
-        if y_train is None:
-            estimator.fit(X_train, **fit_params)
-        else:
-            estimator.fit(X_train, y_train, **fit_params)
-
-    except Exception as e:
-        # Note fit time as time until error
-        fit_time = time.time() - start_time
-        score_time = 0.0
-        if error_score == 'raise':
-            raise
-        elif isinstance(error_score, numbers.Number):
-            if isinstance(scorer, dict):
-                test_scores = {name: error_score for name in scorer}
-                if return_train_score:
-                    train_scores = test_scores.copy()
-            else:
-                test_scores = error_score
-                if return_train_score:
-                    train_scores = error_score
-            warnings.warn("Estimator fit failed. The score on this train-test"
-                          " partition for these parameters will be set to %f. "
-                          "Details: \n%s" %
-                          (error_score, format_exc()),
-                          FitFailedWarning)
-        result["fit_failed"] = True
+    if use_prediction_strength:
+        (fit_failed, test_scores,
+         score_time, fit_time) = _prediction_strength_fit_and_score(
+            estimator, X_train, X_test, y_train, y_test,
+            fit_params, error_score
+        )
     else:
-        result["fit_failed"] = False
-
-        fit_time = time.time() - start_time
-        test_scores = _score(estimator, X_test, y_test, scorer, error_score)
-        score_time = time.time() - start_time - fit_time
-        if return_train_score:
-            train_scores = _score(
-                estimator, X_train, y_train, scorer, error_score
-            )
+        (fit_failed, test_scores, train_scores,
+         score_time, fit_time) = _default_fit_and_score(
+            estimator, X_train, X_test, y_train, y_test, scorer,
+            fit_params, return_train_score, error_score
+        )
+    result = {"fit_failed": fit_failed, "test_scores": test_scores}
 
     if verbose > 1:
         total_time = score_time + fit_time
@@ -642,7 +616,6 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         end_msg += result_msg
         print(end_msg)
 
-    result["test_scores"] = test_scores
     if return_train_score:
         result["train_scores"] = train_scores
     if return_n_test_samples:
@@ -655,6 +628,96 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     if return_estimator:
         result["estimator"] = estimator
     return result
+
+
+def _default_fit_and_score(estimator, X_train, X_test, y_train, y_test,
+                           scorer, fit_params, return_train_score,
+                           error_score):
+    start_time = time.time()
+    train_scores = None
+
+    try:
+        if y_train is None:
+            estimator.fit(X_train, **fit_params)
+        else:
+            estimator.fit(X_train, y_train, **fit_params)
+
+    except Exception:
+        # Note fit time as time until error
+        fit_time = time.time() - start_time
+        score_time = 0.0
+        if error_score == 'raise':
+            raise
+        elif isinstance(error_score, numbers.Number):
+            if isinstance(scorer, dict):
+                test_scores = {name: error_score for name in scorer}
+                if return_train_score:
+                    train_scores = test_scores.copy()
+            else:
+                test_scores = error_score
+                if return_train_score:
+                    train_scores = error_score
+            warnings.warn("Estimator fit failed. The score on this train-test"
+                          " partition for these parameters will be set to %f. "
+                          "Details: \n%s" %
+                          (error_score, format_exc()),
+                          FitFailedWarning)
+        fit_failed = True
+    else:
+        fit_failed = False
+
+        fit_time = time.time() - start_time
+        test_scores = _score(estimator, X_test, y_test, scorer, error_score)
+        score_time = time.time() - start_time - fit_time
+        if return_train_score:
+            train_scores = _score(
+                estimator, X_train, y_train, scorer, error_score
+            )
+
+    return fit_failed, test_scores, train_scores, score_time, fit_time
+
+
+def _prediction_strength_fit_and_score(estimator, X_train, X_test,
+                                       y_train, y_test, fit_params,
+                                       error_score):
+    start_time = time.time()
+
+    try:
+        if y_train is None:
+            estimator.fit(X_train, **fit_params)
+            predict_train = estimator.predict(X_train)
+
+            estimator.fit(X_test, **fit_params)
+            predict_test = estimator.predict(X_train)
+        else:
+            estimator.fit(X_train, y_train, **fit_params)
+            predict_train = estimator.predict(X_train, y_train)
+
+            estimator.fit(X_test, y_test, **fit_params)
+            predict_test = estimator.predict(X_train)
+
+    except Exception:
+        # Note fit time as time until error
+        fit_time = time.time() - start_time
+        score_time = 0.0
+        if error_score == 'raise':
+            raise
+        elif isinstance(error_score, numbers.Number):
+            test_scores = error_score
+            warnings.warn("Estimator fit failed. The score on this train-test"
+                          " partition for these parameters will be set to %f. "
+                          "Details: \n%s" %
+                          (error_score, format_exc()),
+                          FitFailedWarning)
+        fit_failed = True
+    else:
+        fit_failed = False
+
+        fit_time = time.time() - start_time
+        test_scores = prediction_strength_score(predict_test, predict_train)
+        score_time = time.time() - start_time - fit_time
+
+    return fit_failed, test_scores, score_time, fit_time
 
 
 def _score(estimator, X_test, y_test, scorer, error_score="raise"):

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -51,6 +51,7 @@ from sklearn.model_selection import GridSearchCV
 from sklearn.model_selection import RandomizedSearchCV
 from sklearn.model_selection import ParameterGrid
 from sklearn.model_selection import ParameterSampler
+from sklearn.model_selection import PredictionStrengthGridSearchCV
 from sklearn.model_selection._search import BaseSearchCV
 
 from sklearn.model_selection._validation import FitFailedWarning
@@ -2117,3 +2118,138 @@ def test_search_cv_using_minimal_compatible_estimator(SearchCV, Predictor):
     else:
         assert_allclose(y_pred, y.mean())
         assert search.score(X, y) == pytest.approx(r2_score(y, y_pred))
+
+
+def test_prediction_strength_fit_easy():
+    X, y = make_blobs(600, 10, centers=4, random_state=1)
+
+    pscv = PredictionStrengthGridSearchCV(
+        estimator=KMeans(random_state=1),
+        param_grid={'n_clusters': [2, 3, 4, 5, 6, 7, 8]},
+        threshold=0.9,
+        cv=2)
+    pscv.fit(X)
+
+    assert pscv.best_params_ == {'n_clusters': 4}
+    assert pscv.best_estimator_.get_params()['n_clusters'] == 4
+    assert pscv.best_score_ > 0.9
+    assert pscv.n_splits_ == 2
+
+    pscv_rev = PredictionStrengthGridSearchCV(
+        estimator=KMeans(random_state=1),
+        param_grid={'n_clusters': [8, 7, 6, 5, 4, 3, 2]},
+        threshold=0.9,
+        cv=2)
+    pscv_rev.fit(X)
+    assert pscv_rev.best_params_ == pscv.best_params_
+    assert_almost_equal(pscv_rev.best_score_, pscv.best_score_)
+
+
+def test_prediction_strength_fit_hard():
+    X, y = make_blobs(600, 10, centers=3, cluster_std=10.,
+                      center_box=(-5., 5.), random_state=1)
+
+    pscv = PredictionStrengthGridSearchCV(
+        estimator=KMeans(random_state=1),
+        param_grid={'n_clusters': [2, 3, 4, 5, 6, 7, 8]},
+        threshold=0.7,
+        cv=5)
+
+    with pytest.warns(UserWarning):
+        pscv.fit(X)
+    assert pscv.best_params_ == {'n_clusters': 2}
+    assert pscv.best_estimator_.get_params()['n_clusters'] == 2
+    assert 0.6 > pscv.best_score_
+
+
+def test_prediction_strength_fit_verbose():
+    X, y = make_blobs()
+    pscv = PredictionStrengthGridSearchCV(
+        estimator=KMeans(random_state=1),
+        param_grid={'n_clusters': [2, 3, 4, 5, 6, 7, 8]},
+        verbose=10, error_score='raise')
+
+    pscv.fit(X)
+
+
+class FailingClusterer(BaseEstimator):
+    """Classifier that raises a ValueError on fit()"""
+
+    FAILING_PARAMETER = 2
+
+    def __init__(self, n_clusters=None):
+        self.n_clusters = n_clusters
+
+    def fit(self, X):
+        if self.n_clusters == FailingClusterer.FAILING_PARAMETER:
+            raise ValueError("Failing clusterer failed as required")
+
+    def predict(self, X):
+        return np.zeros(X.shape[0])
+
+    def score(self, X):
+        return np.nan
+
+
+def test_prediction_strength_fit_failing_clusterer():
+    X, y = make_blobs()
+    pscv = PredictionStrengthGridSearchCV(
+        estimator=FailingClusterer(5),
+        param_grid={'n_clusters': [2, 3, 4, 5, 6, 7, 8]},
+        refit=False, error_score='raise')
+
+    # FailingClusterer issues a ValueError so this is what we look for.
+    with pytest.raises(ValueError,
+                       match="Failing clusterer failed as required"):
+        pscv.fit(X)
+
+
+def test_prediction_strength_threshold_range():
+    X, y = make_blobs()
+    pscv = PredictionStrengthGridSearchCV(
+        estimator=KMeans(random_state=1),
+        param_grid={'n_clusters': [2, 3, 4, 5, 6, 7, 8]},
+        threshold=0.0,
+        cv=5)
+    with pytest.raises(ValueError,
+                       match=r"threshold must be in the interval \(0, 1\], "
+                             r"but was"):
+        pscv.fit(X)
+
+    pscv.set_params(threshold=-0.1)
+    with pytest.raises(ValueError,
+                       match=r"threshold must be in the interval \(0, 1\], "
+                             r"but was"):
+        pscv.fit(X)
+
+    pscv.set_params(threshold=10)
+    with pytest.raises(ValueError,
+                       match=r"threshold must be in the interval \(0, 1\], "
+                             r"but was"):
+        pscv.fit(X)
+
+    pscv.set_params(threshold=float('nan'))
+    with pytest.raises(ValueError,
+                       match="threshold must be finite"):
+        pscv.fit(X)
+
+    pscv.set_params(threshold=float('-inf'))
+    with pytest.raises(ValueError,
+                       match="threshold must be finite"):
+        pscv.fit(X)
+
+    pscv.set_params(threshold=float('inf'))
+    with pytest.raises(ValueError,
+                       match="threshold must be finite"):
+        pscv.fit(X)
+
+
+def test_prediction_strength_param_grid():
+    X, y = make_blobs()
+    pscv = PredictionStrengthGridSearchCV(
+        estimator=KMeans(random_state=1),
+        param_grid={'n_init': [2, 5, 10]},
+        cv=5)
+    with pytest.raises(ValueError,
+                       match="param_grid must contain n_clusters"):
+        pscv.fit(X)


### PR DESCRIPTION
### Description
Prediction strength is a metric that measures the stability of a clustering algorithm and can be used to determine an optimal number of clusters without knowing the true cluster assignments. It has been introduced by [Tibshirani and Guenther (2005)](http://doi.org/10.1198/106186005X59243).

First, one splits the data into two parts (A) and (B). One obtains two cluster assignments, the first one using the centroids derived from the subset (A), and the second one using the centroids from the subset (B). Prediction strength measures the proportion of observation pairs that are assigned to the same clusters  according to both clusterings. The overall prediction strength is the minimum of this quantity over all predicted clusters.

The definition of prediction strength makes it difficult to integrate it into the existing GridSearchCV and metrics API, because a clusterer needs to trained twice, each time on a different subset of the data, and evaluated on a single subset.

### Implementation
Given two lists of cluster assignments, the function `prediction_strength_score` computes the actual score.
The class `PredictionStrengthGridSearchCV`extends `GridSearchCV` and modifies the way `_fit_and_score` operates. Instead of fitting an estimator on a training set and evaluating it on a test set (`_default_fit_and_score` function),  we need to fit and predict twice and compute the prediction score based on the two predictions (`_prediction_strength_fit_and_score` function). In addition, `PredictionStrengthGridSearchCV` uses the cross-validation generator twice, where the roles of training and test set are reversed the second time around. The final prediction strength for a given *k* and fold are the averages from both runs.

Moreover, `PredictionStrengthGridSearchCV` overrides how the best estimator is selected. The optimal number of clusters *k* is the largest *k* such that the corresponding prediction strength is above some threshold. Tibshirani and Guenther suggest a threshold in the range 0.8 to 0.9 for well separated clusters. If no configuration exceeds the threshold, a warning is displayed and the configuration with the highest prediction strength is selected.

`PredictionStrengthGridSearchCV` assumes that the `param_grid` parameter contains a key "n_clusters". 

### Open questions
1. The user could define additional parameters beside "n_clusters" in the parameter grid. For a given number of clusters, one would first need to choose the configuration that maximizes the prediction strength, and then choose the maximum *k* such that the maximum prediction strength is above a threshold.

2. Alternatively, one could remove "param_grid" and only offer the option to define a list of parameters for "n_clusters".

3. Finally, I had to add a flag `use_prediction_strength` to `_fit_and_score` to allow deviating from the common case: fit once and predict once. I welcome any suggestions on how this could be improved without duplicating too much code.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
