### PR TITLE
[MRG] TRAVIS fix flake8_diff.sh check_files

### DIFF
--- a/build_tools/travis/flake8_diff.sh
+++ b/build_tools/travis/flake8_diff.sh
@@ -125,10 +125,13 @@ MODIFIED_FILES="$(git diff --name-only $COMMIT_RANGE | grep -v 'sklearn/external
 
 check_files() {
     files="$1"
-    options="$2"
-    # Conservative approach: diff without context (--unified=0) so that code
-    # that was not changed does not create failures
-    git diff --unified=0 $COMMIT_RANGE -- $files | flake8 --diff --show-source $options
+    shift
+    options="$*"
+    if [ -n "$files" ]; then
+        # Conservative approach: diff without context (--unified=0) so that code
+        # that was not changed does not create failures
+        git diff --unified=0 $COMMIT_RANGE -- $files | flake8 --diff --show-source $options
+    fi
 }
 
 if [[ "$MODIFIED_FILES" == "no_match" ]]; then


### PR DESCRIPTION
when $files is empty.

A sphinx-gallery updated introduced flake8 violations which were not
ignored because $files was empty so all the files were checked instead
of only the examples.

The problem was seen in https://github.com/scikit-learn/scikit-learn/pull/8143#issuecomment-270102437.