### PR TITLE
[MRG+1] Use GitHub's merge refs to test PRs on CircleCI

### DIFF
--- a/build_tools/circle/checkout_merge_commit.sh
+++ b/build_tools/circle/checkout_merge_commit.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+
+# Add `master` branch to the update list.
+# Otherwise CircleCI will give us a cached one.
+FETCH_REFS="+master:master"
+
+# Update PR refs for testing.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    FETCH_REFS="${FETCH_REFS} +refs/pull/${CIRCLE_PR_NUMBER}/head:pr/${CIRCLE_PR_NUMBER}/head"
+    FETCH_REFS="${FETCH_REFS} +refs/pull/${CIRCLE_PR_NUMBER}/merge:pr/${CIRCLE_PR_NUMBER}/merge"
+fi
+
+# Retrieve the refs.
+git fetch -u origin ${FETCH_REFS}
+
+# Checkout the PR merge ref.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    git checkout -qf "pr/${CIRCLE_PR_NUMBER}/merge"
+fi
+
+# Check for merge conflicts.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    git branch --merged | grep master > /dev/null
+    git branch --merged | grep "pr/${CIRCLE_PR_NUMBER}/head" > /dev/null
+fi

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+checkout:
+  post:
+    - ./build_tools/circle/checkout_merge_commit.sh
+
 dependencies:
   cache_directories:
     - "~/scikit_learn_data"


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/8058

Unlike other CIs, CircleCI does not test the merge commit of a PR with its base branch. Instead it tests the PR's head commit. The problem with this is the PR's status could differ when it is merged with the base branch. For instance, if one needs changes in the base branch to get their PR to pass, they must rebase/merge to get them into the history the PR. This normally isn't a problem, but sometimes things do go wrong when doing this merge/rebase, which adds a new unneeded difficulty. Alternatively, a passing PR could turn out to fail when merged into the base branch because some new content in the base branch was not tested against in the PR.

To solve these issues, we checkout the merge ref for a PR (if it is a PR) from GitHub. However, it should be noted that the merge ref can be out-of-date in some cases w.r.t. the base branch. Still this is the commonly used strategy on Travis CI and AppVeyor. If we had enough info, we could ideally terminate a build that has merge conflicts. Unfortunately it doesn't seem that CircleCI gives us this info.

cc @jnothman