### PR TITLE
[MRG+1] Run sphinxext doctests only on CircleCI

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -107,15 +107,15 @@ then
    wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
    -O miniconda.sh
 fi
-chmod +x miniconda.sh && ./miniconda.sh -b -p $HOME/miniconda
+chmod +x miniconda.sh && ./miniconda.sh -b -p $MINICONDA_PATH
 cd ..
-export PATH="$HOME/miniconda/bin:$PATH"
+export PATH="$MINICONDA_PATH/bin:$PATH"
 conda update --yes --quiet conda
 popd
 
 # Configure the conda environment and put it in the path using the
 # provided versions
-conda create -n testenv --yes --quiet python numpy scipy \
+conda create -n $CONDA_ENV_NAME --yes --quiet python numpy scipy \
   cython nose coverage matplotlib sphinx pillow
 source activate testenv
 

--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -41,7 +41,7 @@ run_tests() {
 
     # Test doc
     cd $OLDPWD
-    make test-doc test-sphinxext
+    make test-doc
 }
 
 if [[ "$RUN_FLAKE8" == "true" ]]; then

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,11 @@ checkout:
   post:
     - ./build_tools/circle/checkout_merge_commit.sh
 
+machine:
+  environment:
+    MINICONDA_PATH: $HOME/miniconda
+    CONDA_ENV_NAME: testenv
+
 dependencies:
   cache_directories:
     - "~/scikit_learn_data"
@@ -12,10 +17,13 @@ dependencies:
   override:
     - ./build_tools/circle/build_doc.sh:
         timeout: 3600 # seconds
+
 test:
   override:
-    # override is needed otherwise nosetests is run by default
-    - echo "Documentation has been built in the 'dependencies' step. No additional test to run"
+    - |
+      export PATH="$MINICONDA_PATH/bin:$PATH"
+      source activate $CONDA_ENV_NAME
+      make test-sphinxext
 deployment:
  push:
    branch: /^master$|^[0-9]+\.[0-9]+\.X$/

--- a/doc/sphinxext/sphinx_issues.py
+++ b/doc/sphinxext/sphinx_issues.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-"""A Sphinx extension for linking to your project's issue tracker."""
-"""
+"""A Sphinx extension for linking to your project's issue tracker.
+
 Copyright 2014 Steven Loria
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,12 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-try:
-    from docutils import nodes, utils
-    from sphinx.util.nodes import split_explicit_title
-except ImportError:
-    # Load lazily so that test-sphinxext does not require docutils dependency
-    pass
+from docutils import nodes, utils
+from sphinx.util.nodes import split_explicit_title
 
 __version__ = '0.2.0'
 __author__ = 'Steven Loria'


### PR DESCRIPTION
~~Building the documentation on CircleCI is a better test. Also doctests are generally not very extensive tests and sphinx extensions in `doc/sphinxext` are third party libraries and we should not be the ones testing it.~~

sphinx extensions may have dependencies, e.g. sphinx.

Discussed in https://github.com/scikit-learn/scikit-learn/pull/8222#issuecomment-274748645. ping @jnothman.