### PR TITLE
Change rstrip() to truncation in test function

### DIFF
--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -80,7 +80,7 @@ def test_kernel_theta():
         # Determine kernel parameters that contribute to theta
         init_sign = signature(kernel.__class__.__init__).parameters.values()
         args = [p.name for p in init_sign if p.name != 'self']
-        theta_vars = map(lambda s: s.rstrip("_bounds"),
+        theta_vars = map(lambda s: s[0:-len("_bounds")],
                          filter(lambda s: s.endswith("_bounds"), args))
         assert_equal(
             set(hyperparameter.name


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
In the `test_kernel_theta` function, `s.rstrip('_bounds')` is used to strip "_bounds" from the end of a string. This is almost certainly a misuse of the `rstrip` function, which strips off any number of the characters in the argument from the end, so, for example:

```python
>>> 'some_string_bounds'.rstrip('_bounds')   # This one happens to do what you'd expect
'some_string'
>>> 'noun_unbound_bounds'.rstrip('_bounds')   # All characters from '_bounds' - oh no!
''
>>> 'noun_unbound_bounds'[0:-len('_bounds')] # This is what we expect
'noun_unbound'
```
Normally I would just do `[s if not s.endswith('_bounds') else s[:-len('_bounds')] for s in args]`, but there's already a `filter` on `args` that only takes values that already end with `_bounds`.
