### PR TITLE
[MRG] Make tests runnable with pytest without error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,11 @@ env:
     - DISTRIB="conda" PYTHON_VERSION="3.6" INSTALL_MKL="true"
       NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" PANDAS_VERSION="0.19.1"
       CYTHON_VERSION="0.25.2"
+    # This environment use pytest to run the tests. It uses the newest
+    # supported anaconda env. It also runs tests requiring Pandas.
+    - USE_PYTEST="true" DISTRIB="conda" PYTHON_VERSION="3.6" INSTALL_MKL="true"
+      NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" PANDAS_VERSION="0.19.1"
+      CYTHON_VERSION="0.25.2"
     # flake8 linting on diff wrt common ancestor with upstream/master
     - RUN_FLAKE8="true" SKIP_TESTS="true"
       DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="true"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -51,13 +51,13 @@ if [[ "$DISTRIB" == "conda" ]]; then
     # Configure the conda environment and put it in the path using the
     # provided versions
     if [[ "$INSTALL_MKL" == "true" ]]; then
-        conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
+        conda create -n testenv --yes python=$PYTHON_VERSION pip nose pytest \
             numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
             mkl cython=$CYTHON_VERSION \
             ${PANDAS_VERSION+pandas=$PANDAS_VERSION}
             
     else
-        conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
+        conda create -n testenv --yes python=$PYTHON_VERSION pip nose pytest \
             numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
             nomkl cython=$CYTHON_VERSION \
             ${PANDAS_VERSION+pandas=$PANDAS_VERSION}

--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -21,6 +21,11 @@ except ImportError:
 python -c "import multiprocessing as mp; print('%d CPUs' % mp.cpu_count())"
 
 run_tests() {
+    if [[ "$USE_PYTEST" == "true" ]]; then
+        TEST_CMD="pytest --showlocals --pyargs"
+    else
+        TEST_CMD="nosetests --with-coverage" # --with-timer --timer-top-n 20"
+    fi
     # Get into a temp directory to run test from the installed scikit learn and
     # check if we do not leave artifacts
     mkdir -p $TEST_DIR
@@ -34,10 +39,9 @@ run_tests() {
     export SKLEARN_SKIP_NETWORK_TESTS=1
 
     if [[ "$COVERAGE" == "true" ]]; then
-        nosetests -s --with-coverage --with-timer --timer-top-n 20 sklearn
-    else
-        nosetests -s --with-timer --timer-top-n 20 sklearn
+        TEST_CMD="$TEST_CMD --with-coverage"
     fi
+    $TEST_CMD sklearn
 
     # Test doc
     cd $OLDPWD

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,13 @@ doctest-fixtures = _fixture
 ignore-files=^setup\.py$
 #doctest-options = +ELLIPSIS,+NORMALIZE_WHITESPACE
 
+[tool:pytest]
+# disable-pytest-warnings should be removed once we drop nose and we
+# replace yield test by parametrize
+addopts =
+    --doctest-modules
+    --disable-pytest-warnings
+
 [wheelhouse_uploader]
 artifact_indexes=
     # OSX wheels built by travis (only for specific tags):

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ ignore-files=^setup\.py$
 
 [tool:pytest]
 # disable-pytest-warnings should be removed once we drop nose and we
-# replace yield test by parametrize
+# rewrite tests using yield with parametrize
 addopts =
     --doctest-modules
     --disable-pytest-warnings

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -194,7 +194,6 @@ def check_hyperparameters_equal(kernel1, kernel2):
 
 def test_kernel_clone():
     # Test that sklearn's clone works correctly on kernels.
-    bounds = (1e-5, 1e5)
     for kernel in kernels:
         kernel_cloned = clone(kernel)
 
@@ -209,12 +208,17 @@ def test_kernel_clone():
         # Check that all hyperparameters are equal.
         yield check_hyperparameters_equal, kernel, kernel_cloned
 
-        # This test is to verify that using set_params does not
-        # break clone on kernels.
-        # This used to break because in kernels such as the RBF, non-trivial
-        # logic that modified the length scale used to be in the constructor
-        # See https://github.com/scikit-learn/scikit-learn/issues/6961
-        # for more details.
+
+def test_kernel_clone_after_set_params():
+    # This test is to verify that using set_params does not
+    # break clone on kernels.
+    # This used to break because in kernels such as the RBF, non-trivial
+    # logic that modified the length scale used to be in the constructor
+    # See https://github.com/scikit-learn/scikit-learn/issues/6961
+    # for more details.
+    bounds = (1e-5, 1e5)
+    for kernel in kernels:
+        kernel_cloned = clone(kernel)
         params = kernel.get_params()
         # RationalQuadratic kernel is isotropic.
         isotropic_kernels = (ExpSineSquared, RationalQuadratic)

--- a/sklearn/neighbors/tests/test_ball_tree.py
+++ b/sklearn/neighbors/tests/test_ball_tree.py
@@ -156,6 +156,14 @@ def compute_kernel_slow(Y, X, kernel, h):
         raise ValueError('kernel not recognized')
 
 
+def check_results(kernel, h, atol, rtol, breadth_first, bt, Y, dens_true):
+    dens = bt.kernel_density(Y, h, atol=atol, rtol=rtol,
+                             kernel=kernel,
+                             breadth_first=breadth_first)
+    assert_allclose(dens, dens_true,
+                    atol=atol, rtol=max(rtol, 1e-7))
+
+
 def test_ball_tree_kde(n_samples=100, n_features=3):
     np.random.seed(0)
     X = np.random.random((n_samples, n_features))
@@ -167,18 +175,11 @@ def test_ball_tree_kde(n_samples=100, n_features=3):
         for h in [0.01, 0.1, 1]:
             dens_true = compute_kernel_slow(Y, X, kernel, h)
 
-            def check_results(kernel, h, atol, rtol, breadth_first):
-                dens = bt.kernel_density(Y, h, atol=atol, rtol=rtol,
-                                         kernel=kernel,
-                                         breadth_first=breadth_first)
-                assert_allclose(dens, dens_true,
-                                atol=atol, rtol=max(rtol, 1e-7))
-
             for rtol in [0, 1E-5]:
                 for atol in [1E-6, 1E-2]:
                     for breadth_first in (True, False):
                         yield (check_results, kernel, h, atol, rtol,
-                               breadth_first)
+                               breadth_first, bt, Y, dens_true)
 
 
 def test_gaussian_kde(n_samples=1000):


### PR DESCRIPTION
Related to #7319. This is the minimal set of changes to make the tests runnable with pytest. All in all it amounts to:
* splitting a test function in two functions. I made sure that this was still testing correctly the fix in c31ad7a.
* moving `check_` functions using closures to module-level

Errors were due to pytest quirks with (deprecated) yield support. AFAICT the underlying reason is that pytest first collects the tests (collecting the test function and the arguments) and then runs them. It is somewhat easy to modify the arguments at collection time which creates suprises during the test run.

See below for an example test highlighting the quirk:

```python
class A(object):
    def __init__(self, a):
        self.a = a

args = [A(i) for i in [0]]


def check(x, y):
    print('\nin check:', 'x.a:', x.a, 'y.a:', y.a)
    assert x.a == y.a


def test():
    for arg in args:
        arg_copy = A(arg.a)

        print('\nin test: arg.a:', arg.a, 'arg_copy.a:', arg_copy.a)
        yield check, arg, arg_copy

        arg_copy.a = -100
        assert arg_copy.a == -100
```

Output:
```
❯ pytest -s test_pytest.py
======================================================== test session starts =========================================================
platform linux -- Python 3.5.2, pytest-3.0.5, py-1.4.31, pluggy-0.4.0
rootdir: /tmp, inifile: 
plugins: cov-2.3.1
collecting 0 items
in test: arg.a: 0 arg_copy.a: 0
collected 1 items 

test_pytest.py 
in check: x.a: 0 y.a: -100
F

============================================================== FAILURES ==============================================================
______________________________________________________________ test[0] _______________________________________________________________

x = <test_pytest.A object at 0x7efcd0c6ab38>, y = <test_pytest.A object at 0x7efcd0716048>

    def check(x, y):
        print('\nin check:', 'x.a:', x.a, 'y.a:', y.a)
>       assert x.a == y.a
E       assert 0 == -100
E        +  where 0 = <test_pytest.A object at 0x7efcd0c6ab38>.a
E        +  and   -100 = <test_pytest.A object at 0x7efcd0716048>.a

test_pytest.py:10: AssertionError
======================================================= pytest-warning summary =======================================================
WC1 /tmp/test_pytest.py yield tests are deprecated, and scheduled to be removed in pytest 4.0
============================================ 1 failed, 1 pytest-warnings in 0.05 seconds =============================================
```