### PR TITLE
[MRG] make the ransac example slightly more terse, improve range of plot

### DIFF
--- a/examples/linear_model/plot_ransac.py
+++ b/examples/linear_model/plot_ransac.py
@@ -54,4 +54,6 @@ plt.plot(line_X, line_y, color='navy', linewidth=lw, label='Linear regressor')
 plt.plot(line_X, line_y_ransac, color='cornflowerblue', linewidth=lw,
          label='RANSAC regressor')
 plt.legend(loc='lower right')
+plt.xlabel("Input")
+plt.ylabel("Response")
 plt.show()

--- a/examples/linear_model/plot_ransac.py
+++ b/examples/linear_model/plot_ransac.py
@@ -27,32 +27,31 @@ X[:n_outliers] = 3 + 0.5 * np.random.normal(size=(n_outliers, 1))
 y[:n_outliers] = -3 + 10 * np.random.normal(size=n_outliers)
 
 # Fit line using all data
-model = linear_model.LinearRegression()
-model.fit(X, y)
+lr = linear_model.LinearRegression()
+lr.fit(X, y)
 
 # Robustly fit linear model with RANSAC algorithm
-model_ransac = linear_model.RANSACRegressor(linear_model.LinearRegression())
-model_ransac.fit(X, y)
-inlier_mask = model_ransac.inlier_mask_
+ransac = linear_model.RANSACRegressor()
+ransac.fit(X, y)
+inlier_mask = ransac.inlier_mask_
 outlier_mask = np.logical_not(inlier_mask)
 
 # Predict data of estimated models
-line_X = np.arange(-5, 5)
-line_y = model.predict(line_X[:, np.newaxis])
-line_y_ransac = model_ransac.predict(line_X[:, np.newaxis])
+line_X = np.arange(X.min(), X.max())[:, np.newaxis]
+line_y = lr.predict(line_X)
+line_y_ransac = ransac.predict(line_X)
 
 # Compare estimated coefficients
-print("Estimated coefficients (true, normal, RANSAC):")
-print(coef, model.coef_, model_ransac.estimator_.coef_)
+print("Estimated coefficients (true, linear regression, RANSAC):")
+print(coef, lr.coef_, ransac.estimator_.coef_)
 
 lw = 2
 plt.scatter(X[inlier_mask], y[inlier_mask], color='yellowgreen', marker='.',
             label='Inliers')
 plt.scatter(X[outlier_mask], y[outlier_mask], color='gold', marker='.',
             label='Outliers')
-plt.plot(line_X, line_y, color='navy', linestyle='-', linewidth=lw,
-         label='Linear regressor')
-plt.plot(line_X, line_y_ransac, color='cornflowerblue', linestyle='-',
-         linewidth=lw, label='RANSAC regressor')
+plt.plot(line_X, line_y, color='navy', linewidth=lw, label='Linear regressor')
+plt.plot(line_X, line_y_ransac, color='cornflowerblue', linewidth=lw,
+         label='RANSAC regressor')
 plt.legend(loc='lower right')
 plt.show()


### PR DESCRIPTION
This gets rid of some redundant code and is more explicit in the names (and in the print).
before:
![figure_ransac_before](https://cloud.githubusercontent.com/assets/449558/22492505/3035b8c8-e7f8-11e6-8ac7-10ac546593e5.png)
after:
![figure_ransac_after](https://cloud.githubusercontent.com/assets/449558/22492504/2e71bce4-e7f8-11e6-8c03-0564af19c94f.png)


