### PR TITLE
[MRG] MAINT tweak sklearn/metrics/cluster/setup.py

### DIFF
--- a/sklearn/metrics/cluster/setup.py
+++ b/sklearn/metrics/cluster/setup.py
@@ -5,7 +5,7 @@ from numpy.distutils.misc_util import Configuration
 
 
 def configuration(parent_package="", top_path=None):
-    config = Configuration("metrics/cluster", parent_package, top_path)
+    config = Configuration("cluster", parent_package, top_path)
     libraries = []
     if os.name == 'posix':
         libraries.append('m')


### PR DESCRIPTION
Hint from a warning when doing python setup.py sdist.

```
Warning: Extension name 'sklearn.metrics/cluster.expected_mutual_info_fast' does not match fully qualified name 'sklearn.metrics.cluster.expected_mutual_info_fast' of 'sklearn/metrics/cluster/expected_mutual_info_fast.pyx'
```

I'll merge this one when the CIs come back green.