### PR TITLE
[MRG+1] Accept keyword parameters to hyperparameter search fit methods

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -222,6 +222,17 @@ API changes summary
      (``n_samples``, ``n_classes``) for that particular output.
      :issue:`8093` by :user:`Peter Bull <pjbull>`.
 
+    - Deprecate the ``fit_params`` constructor input to the
+      :class:`sklearn.model_selection.GridSearchCV` and
+      :class:`sklearn.model_selection.RandomizedSearchCV` in favor
+      of passing keyword parameters to the ``fit`` methods
+      of those classes. Data-dependent parameters needed for model
+      training should be passed as keyword arguments to ``fit``,
+      and conforming to this convention will allow the hyperparameter
+      selection classes to be used with tools such as
+      :func:`sklearn.model_selection.cross_val_predict`.
+      :issue:`2879` by :user:`Stephen Hoover <stephen-hoover>`.
+
 .. _changes_0_18_1:
 
 Version 0.18.1

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -213,7 +213,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.
-        Alpha corresponds to ``C^-1`` in other linear models such as 
+        Alpha corresponds to ``C^-1`` in other linear models such as
         LogisticRegression or LinearSVC. If an array is passed, penalties are
         assumed to be specific to the targets. Hence they must correspond in
         number.
@@ -508,7 +508,7 @@ class Ridge(_BaseRidge, RegressorMixin):
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.
-        Alpha corresponds to ``C^-1`` in other linear models such as 
+        Alpha corresponds to ``C^-1`` in other linear models such as
         LogisticRegression or LinearSVC. If an array is passed, penalties are
         assumed to be specific to the targets. Hence they must correspond in
         number.
@@ -653,7 +653,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.
-        Alpha corresponds to ``C^-1`` in other linear models such as 
+        Alpha corresponds to ``C^-1`` in other linear models such as
         LogisticRegression or LinearSVC.
 
     class_weight : dict or 'balanced', optional
@@ -1090,11 +1090,9 @@ class _BaseRidgeCV(LinearModel):
                 raise ValueError("cv!=None and store_cv_values=True "
                                  " are incompatible")
             parameters = {'alpha': self.alphas}
-            fit_params = {'sample_weight': sample_weight}
             gs = GridSearchCV(Ridge(fit_intercept=self.fit_intercept),
-                              parameters, fit_params=fit_params, cv=self.cv,
-                              scoring=self.scoring)
-            gs.fit(X, y)
+                              parameters, cv=self.cv, scoring=self.scoring)
+            gs.fit(X, y, sample_weight=sample_weight)
             estimator = gs.best_estimator_
             self.alpha_ = gs.best_estimator_.alpha
 
@@ -1119,8 +1117,8 @@ class RidgeCV(_BaseRidgeCV, RegressorMixin):
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.
-        Alpha corresponds to ``C^-1`` in other linear models such as 
-        LogisticRegression or LinearSVC. 
+        Alpha corresponds to ``C^-1`` in other linear models such as
+        LogisticRegression or LinearSVC.
 
     fit_intercept : boolean
         Whether to calculate the intercept for this model. If set
@@ -1152,7 +1150,7 @@ class RidgeCV(_BaseRidgeCV, RegressorMixin):
         - An iterable yielding train/test splits.
 
         For integer/None inputs, if ``y`` is binary or multiclass,
-        :class:`sklearn.model_selection.StratifiedKFold` is used, else, 
+        :class:`sklearn.model_selection.StratifiedKFold` is used, else,
         :class:`sklearn.model_selection.KFold` is used.
 
         Refer :ref:`User Guide <cross_validation>` for the various
@@ -1222,8 +1220,8 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.
-        Alpha corresponds to ``C^-1`` in other linear models such as 
-        LogisticRegression or LinearSVC. 
+        Alpha corresponds to ``C^-1`` in other linear models such as
+        LogisticRegression or LinearSVC.
 
     fit_intercept : boolean
         Whether to calculate the intercept for this model. If set

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -604,10 +604,8 @@ def test_ridgecv_sample_weight():
 
         # Check using GridSearchCV directly
         parameters = {'alpha': alphas}
-        fit_params = {'sample_weight': sample_weight}
-        gs = GridSearchCV(Ridge(), parameters, fit_params=fit_params,
-                          cv=cv)
-        gs.fit(X, y)
+        gs = GridSearchCV(Ridge(), parameters, cv=cv)
+        gs.fit(X, y, sample_weight=sample_weight)
 
         assert_equal(ridgecv.alpha_, gs.best_estimator_.alpha)
         assert_array_almost_equal(ridgecv.coef_, gs.best_estimator_.coef_)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -532,7 +532,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         self._check_is_fitted('inverse_transform')
         return self.best_estimator_.transform(Xt)
 
-    def fit(self, X, y=None, groups=None):
+    def fit(self, X, y=None, groups=None, **fit_params):
         """Run fit with all sets of parameters.
 
         Parameters
@@ -549,7 +549,21 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         groups : array-like, with shape (n_samples,), optional
             Group labels for the samples used while splitting the dataset into
             train/test set.
+
+        **fit_params : dict of string -> object
+            Parameters passed to the ``fit`` method of the estimator
         """
+        if self.fit_params:
+            warnings.warn('"fit_params" as a constructor argument was '
+                          'deprecated in version 0.19 and will be removed '
+                          'in version 0.21. Pass fit parameters to the '
+                          '"fit" method instead.', DeprecationWarning)
+            if fit_params:
+                warnings.warn('Ignoring fit_params passed as a constructor '
+                              'argument in favor of keyword arguments to '
+                              'the "fit" method.', RuntimeWarning)
+            else:
+                fit_params = self.fit_params
         estimator = self.estimator
         cv = check_cv(self.cv, y, classifier=is_classifier(estimator))
         self.scorer_ = check_scoring(self.estimator, scoring=self.scoring)
@@ -572,7 +586,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             pre_dispatch=pre_dispatch
         )(delayed(_fit_and_score)(clone(base_estimator), X, y, self.scorer_,
                                   train, test, self.verbose, parameters,
-                                  fit_params=self.fit_params,
+                                  fit_params=fit_params,
                                   return_train_score=self.return_train_score,
                                   return_n_test_samples=True,
                                   return_times=True, return_parameters=False,
@@ -655,9 +669,9 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             best_estimator = clone(base_estimator).set_params(
                 **best_parameters)
             if y is not None:
-                best_estimator.fit(X, y, **self.fit_params)
+                best_estimator.fit(X, y, **fit_params)
             else:
-                best_estimator.fit(X, **self.fit_params)
+                best_estimator.fit(X, **fit_params)
             self.best_estimator_ = best_estimator
         return self
 
@@ -732,6 +746,7 @@ class GridSearchCV(BaseSearchCV):
 
     fit_params : dict, optional
         Parameters to pass to the fit method.
+        DEPRECATED -- pass parameters directly to the fit method instead.
 
     n_jobs : int, default=1
         Number of jobs to run in parallel.
@@ -992,6 +1007,7 @@ class RandomizedSearchCV(BaseSearchCV):
 
     fit_params : dict, optional
         Parameters to pass to the fit method.
+        DEPRECATED -- pass parameters directly to the fit method instead.
 
     n_jobs : int, default=1
         Number of jobs to run in parallel.

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -744,10 +744,6 @@ class GridSearchCV(BaseSearchCV):
         ``scorer(estimator, X, y)``.
         If ``None``, the ``score`` method of the estimator is used.
 
-    fit_params : dict, optional
-        Parameters to pass to the fit method.
-        DEPRECATED -- pass parameters directly to the fit method instead.
-
     n_jobs : int, default=1
         Number of jobs to run in parallel.
 
@@ -1004,10 +1000,6 @@ class RandomizedSearchCV(BaseSearchCV):
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
         If ``None``, the ``score`` method of the estimator is used.
-
-    fit_params : dict, optional
-        Parameters to pass to the fit method.
-        DEPRECATED -- pass parameters directly to the fit method instead.
 
     n_jobs : int, default=1
         Number of jobs to run in parallel.

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -173,6 +173,28 @@ def test_grid_search():
     assert_raises(ValueError, grid_search.fit, X, y)
 
 
+def test_grid_search_with_fit_params():
+    X = np.arange(100).reshape(10, 10)
+    y = np.array([0] * 5 + [1] * 5)
+    clf = CheckingClassifier(expected_fit_params=['spam', 'eggs'])
+    grid_search = GridSearchCV(clf, {'foo_param': [1, 2, 3]})
+
+    # The CheckingClassifer generates an assertion error if
+    # a parameter is missing or has length != len(X).
+    grid_search.fit(X, y, spam=np.ones(10), eggs=np.zeros(10))
+
+
+def test_random_search_with_fit_params():
+    X = np.arange(100).reshape(10, 10)
+    y = np.array([0] * 5 + [1] * 5)
+    clf = CheckingClassifier(expected_fit_params=['spam', 'eggs'])
+    random_search = RandomizedSearchCV(clf, {'foo_param': [0]}, n_iter=1)
+
+    # The CheckingClassifer generates an assertion error if
+    # a parameter is missing or has length != len(X).
+    random_search.fit(X, y, spam=np.ones(10), eggs=np.zeros(10))
+
+
 @ignore_warnings
 def test_grid_search_no_score():
     # Test grid-search on classifier that has no score function.

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -17,6 +17,7 @@ from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_false, assert_true
 from sklearn.utils.testing import assert_array_equal
@@ -173,26 +174,72 @@ def test_grid_search():
     assert_raises(ValueError, grid_search.fit, X, y)
 
 
-def test_grid_search_with_fit_params():
+def check_hyperparameter_searcher_with_fit_params(klass, **klass_kwargs):
     X = np.arange(100).reshape(10, 10)
     y = np.array([0] * 5 + [1] * 5)
     clf = CheckingClassifier(expected_fit_params=['spam', 'eggs'])
-    grid_search = GridSearchCV(clf, {'foo_param': [1, 2, 3]})
+    searcher = klass(clf, {'foo_param': [1, 2, 3]}, cv=2, **klass_kwargs)
 
     # The CheckingClassifer generates an assertion error if
     # a parameter is missing or has length != len(X).
-    grid_search.fit(X, y, spam=np.ones(10), eggs=np.zeros(10))
+    assert_raise_message(AssertionError,
+                         "Expected fit parameter(s) {'eggs'} not seen.",
+                         searcher.fit, X, y, spam=np.ones(10))
+    assert_raise_message(AssertionError,
+                         "Fit parameter spam has length 1; expected 4.",
+                         searcher.fit, X, y, spam=np.ones(1),
+                         eggs=np.zeros(10))
+    searcher.fit(X, y, spam=np.ones(10), eggs=np.zeros(10))
+
+
+def test_grid_search_with_fit_params():
+    check_hyperparameter_searcher_with_fit_params(GridSearchCV)
 
 
 def test_random_search_with_fit_params():
+    check_hyperparameter_searcher_with_fit_params(RandomizedSearchCV, n_iter=1)
+
+
+def test_grid_search_fit_params_deprecation():
+    # NOTE: Remove this test in v0.21
+
+    # Use of `fit_params` in the class constructor is deprecated,
+    # but will still work until v0.21.
     X = np.arange(100).reshape(10, 10)
     y = np.array([0] * 5 + [1] * 5)
-    clf = CheckingClassifier(expected_fit_params=['spam', 'eggs'])
-    random_search = RandomizedSearchCV(clf, {'foo_param': [0]}, n_iter=1)
+    clf = CheckingClassifier(expected_fit_params=['spam'])
+    grid_search = GridSearchCV(clf, {'foo_param': [1, 2, 3]},
+                               fit_params={'spam': np.ones(10)})
+    assert_warns(DeprecationWarning, grid_search.fit, X, y)
 
-    # The CheckingClassifer generates an assertion error if
-    # a parameter is missing or has length != len(X).
-    random_search.fit(X, y, spam=np.ones(10), eggs=np.zeros(10))
+
+def test_grid_search_fit_params_two_places():
+    # NOTE: Remove this test in v0.21
+
+    # If users try to input fit parameters in both
+    # the constructor (deprecated use) and the `fit`
+    # method, we'll ignore the values passed to the constructor.
+    X = np.arange(100).reshape(10, 10)
+    y = np.array([0] * 5 + [1] * 5)
+    clf = CheckingClassifier(expected_fit_params=['spam'])
+
+    # The "spam" array is too short and will raise an
+    # error in the CheckingClassifier if used.
+    grid_search = GridSearchCV(clf, {'foo_param': [1, 2, 3]},
+                               fit_params={'spam': np.ones(1)})
+
+    expected_warning = ('Ignoring fit_params passed as a constructor '
+                        'argument in favor of keyword arguments to '
+                        'the "fit" method.')
+    assert_warns_message(RuntimeWarning, expected_warning,
+                         grid_search.fit, X, y, spam=np.ones(10))
+
+    # Verify that `fit` prefers its own kwargs by giving valid
+    # kwargs in the constructor and invalid in the method call
+    grid_search = GridSearchCV(clf, {'foo_param': [1, 2, 3]},
+                               fit_params={'spam': np.ones(10)})
+    assert_raise_message(AssertionError, "Fit parameter spam has length 1",
+                         grid_search.fit, X, y, spam=np.ones(1))
 
 
 @ignore_warnings

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -183,7 +183,7 @@ def check_hyperparameter_searcher_with_fit_params(klass, **klass_kwargs):
     # The CheckingClassifer generates an assertion error if
     # a parameter is missing or has length != len(X).
     assert_raise_message(AssertionError,
-                         "Expected fit parameter(s) {'eggs'} not seen.",
+                         "Expected fit parameter(s) ['eggs'] not seen.",
                          searcher.fit, X, y, spam=np.ones(10))
     assert_raise_message(AssertionError,
                          "Fit parameter spam has length 1; expected 4.",

--- a/sklearn/utils/mocking.py
+++ b/sklearn/utils/mocking.py
@@ -44,8 +44,7 @@ class CheckingClassifier(BaseEstimator, ClassifierMixin):
     This allows testing whether pipelines / cross-validation or metaestimators
     changed the input.
     """
-    def __init__(self, check_y=None,
-                 check_X=None, foo_param=0,
+    def __init__(self, check_y=None, check_X=None, foo_param=0,
                  expected_fit_params=None):
         self.check_y = check_y
         self.check_X = check_X
@@ -61,10 +60,9 @@ class CheckingClassifier(BaseEstimator, ClassifierMixin):
         self.classes_ = np.unique(check_array(y, ensure_2d=False,
                                               allow_nd=True))
         if self.expected_fit_params:
-            missing = (set(np.atleast_1d(self.expected_fit_params)) -
-                       set(fit_params))
-            assert_true(len(missing) == 0, 'Expected fit parameters "%s" not '
-                                           'seen.' % self.expected_fit_params)
+            missing = set(self.expected_fit_params) - set(fit_params)
+            assert_true(len(missing) == 0, 'Expected fit parameter(s) %s not '
+                                           'seen.' % missing)
             for key, value in fit_params.items():
                 assert_true(len(value) == len(X),
                             'Fit parameter %s has length %d; '

--- a/sklearn/utils/mocking.py
+++ b/sklearn/utils/mocking.py
@@ -45,12 +45,14 @@ class CheckingClassifier(BaseEstimator, ClassifierMixin):
     changed the input.
     """
     def __init__(self, check_y=None,
-                 check_X=None, foo_param=0):
+                 check_X=None, foo_param=0,
+                 expected_fit_params=None):
         self.check_y = check_y
         self.check_X = check_X
         self.foo_param = foo_param
+        self.expected_fit_params = expected_fit_params
 
-    def fit(self, X, y):
+    def fit(self, X, y, **fit_params):
         assert_true(len(X) == len(y))
         if self.check_X is not None:
             assert_true(self.check_X(X))
@@ -58,6 +60,15 @@ class CheckingClassifier(BaseEstimator, ClassifierMixin):
             assert_true(self.check_y(y))
         self.classes_ = np.unique(check_array(y, ensure_2d=False,
                                               allow_nd=True))
+        if self.expected_fit_params:
+            missing = (set(np.atleast_1d(self.expected_fit_params)) -
+                       set(fit_params))
+            assert_true(len(missing) == 0, 'Expected fit parameters "%s" not '
+                                           'seen.' % self.expected_fit_params)
+            for key, value in fit_params.items():
+                assert_true(len(value) == len(X),
+                            'Fit parameter %s has length %d; '
+                            'expected %d.' % (key, len(value), len(X)))
 
         return self
 

--- a/sklearn/utils/mocking.py
+++ b/sklearn/utils/mocking.py
@@ -62,7 +62,7 @@ class CheckingClassifier(BaseEstimator, ClassifierMixin):
         if self.expected_fit_params:
             missing = set(self.expected_fit_params) - set(fit_params)
             assert_true(len(missing) == 0, 'Expected fit parameter(s) %s not '
-                                           'seen.' % missing)
+                                           'seen.' % list(missing))
             for key, value in fit_params.items():
                 assert_true(len(value) == len(X),
                             'Fit parameter %s has length %d; '


### PR DESCRIPTION
#### Reference Issue

Closes #2879 

#### What does this implement/fix? Explain your changes.

This PR allows the hyperparameter search classes in ``sklearn.model_selection._search`` (i.e. ``GridSearchCV`` and ``RandomizedSearchCV``) to accept keyword parameters and pass them to the wrapped Estimator.  This brings their ``fit`` methods into closer compliance with the Estimator API. This PR does not address issues #8158 or #4632 which deal with passing parameters to the scoring function.

To ease testing of the new parameter, I added an extra argument to the ``sklearn.utils.mocking.CheckingClassifier`` which allows it to enforce the presence of keyword ``fit`` arguments and verify that they have the expected length.

#### Any other comments?

The ultimate fate of fit parameters on these methods will depend on the resolution to #4497, but I think the change in this PR conforms to present usage without establishing any new conventions. Accepting keyword parameters in these ``fit`` methods is something that I (and I think other users) would expect.

One limitation of this PR is that the ``groups`` parameter is still reserved by the ``fit`` method and not passed to the wrapped Estimator. Perhaps a solution to that would wait on #4497, but I think it doesn't need to be solved in this PR.

I also had to choose what to do if users try to provide fit parameters through both the constructor and the ``fit`` method. I chose to emit a warning and ignore parameters passed through the constructor (since that behavior is deprecated), but I don't feel strongly about that decision.

I searched through existing documentation and tests, but I was unable to find any uses of the ``fit_params`` constructor argument for either ``GridSearchCV`` or ``RandomizedSearchCV``.