### PR TITLE
[MRG+1] Refactoring plot_iris svm example.

### DIFF
--- a/examples/svm/plot_iris.py
+++ b/examples/svm/plot_iris.py
@@ -74,29 +74,8 @@ def plot_contours(ax, clf, xx, yy, **params):
     Z = clf.predict(np.c_[xx.ravel(), yy.ravel()])
     Z = Z.reshape(xx.shape)
     out = ax.contourf(xx, yy, Z, **params)
-    ax.set_xlim(xx.min(), xx.max())
-    ax.set_ylim(yy.min(), yy.max())
     return out
 
-
-def plot_points_boundary(ax, clf, x, y, xx, yy,
-                         points_params, contour_params):
-    """Plot the decision boundaries and points.
-
-    Parameters
-    ----------
-    ax: matplotlib axes object
-    clf: a fitted classifier
-    x: x-axis of points to plot
-    y: y-axis of points to plot
-    xx: meshgrid ndarray
-    yy: meshgrid ndarray
-    point_params: dictionary of params to pass to `ax.scatter`, optional
-    countour_params: dictionary of params to pass to `plot_contours`, optional
-    """
-    contours = plot_contours(ax, clf, xx, yy, **contour_params)
-    points = ax.scatter(x, y, **points_params)
-    return [contours, points]
 
 # import some data to play with
 iris = datasets.load_iris()
@@ -126,9 +105,11 @@ plt.subplots_adjust(wspace=0.4, hspace=0.4)
 xx, yy = make_meshgrid(X[:, 0], X[:, 1])
 
 for clf, title, ax in zip(models, titles, sub.flatten()):
-    plot_points_boundary(ax, clf, X[:, 0], X[:, 1], xx, yy,
-                         dict(c=y, cmap=plt.cm.coolwarm, s=20, edgecolors='k'),
-                         dict(cmap=plt.cm.coolwarm, alpha=0.8))
+    plot_contours(ax, clf, xx, yy,
+                  cmap=plt.cm.coolwarm, alpha=0.8)
+    ax.scatter(x, y, c=y, cmap=plt.cm.coolwarm, s=20, edgecolors='k')
+    ax.set_xlim(xx.min(), xx.max())
+    ax.set_ylim(yy.min(), yy.max())
     ax.set_xlabel('Sepal length')
     ax.set_ylabel('Sepal width')
     ax.set_xticks(())

--- a/examples/svm/plot_iris.py
+++ b/examples/svm/plot_iris.py
@@ -39,55 +39,69 @@ import numpy as np
 import matplotlib.pyplot as plt
 from sklearn import svm, datasets
 
+
+def make_meshgrid(x, y, h=.02):
+    """Create a mesh of points to plot in
+    """
+    x_min, x_max = x.min() - 1, x.max() + 1
+    y_min, y_max = y.min() - 1, y.max() + 1
+    xx, yy = np.meshgrid(np.arange(x_min, x_max, h),
+                         np.arange(y_min, y_max, h))
+    return xx, yy
+
+def plot_contours(ax, clf, xx, yy, **params):
+    """Plot the decision boundaries for a classifier.
+    """
+    Z = clf.predict(np.c_[xx.ravel(), yy.ravel()])
+    Z = Z.reshape(xx.shape)
+    out = ax.contourf(xx, yy, Z, **params)
+    ax.set_xlim(xx.min(), xx.max())
+    ax.set_ylim(yy.min(), yy.max())
+    return out
+
+def plot_points_boundary(ax, clf, x, y, xx, yy,
+                               points_params, contour_params):
+    """Plot the decision boundaries and points.
+    """
+    contours = plot_contours(ax, clf, xx, yy, **contour_params)
+    points = ax.scatter(x, y, **points_params)
+    return [contours, points]
+
 # import some data to play with
 iris = datasets.load_iris()
 X = iris.data[:, :2]  # we only take the first two features. We could
                       # avoid this ugly slicing by using a two-dim dataset
 y = iris.target
 
-h = .02  # step size in the mesh
-
 # we create an instance of SVM and fit out data. We do not scale our
 # data since we want to plot the support vectors
 C = 1.0  # SVM regularization parameter
-svc = svm.SVC(kernel='linear', C=C).fit(X, y)
-rbf_svc = svm.SVC(kernel='rbf', gamma=0.7, C=C).fit(X, y)
-poly_svc = svm.SVC(kernel='poly', degree=3, C=C).fit(X, y)
-lin_svc = svm.LinearSVC(C=C).fit(X, y)
-
-# create a mesh to plot in
-x_min, x_max = X[:, 0].min() - 1, X[:, 0].max() + 1
-y_min, y_max = X[:, 1].min() - 1, X[:, 1].max() + 1
-xx, yy = np.meshgrid(np.arange(x_min, x_max, h),
-                     np.arange(y_min, y_max, h))
+models = (svm.SVC(kernel='linear', C=C),
+          svm.LinearSVC(C=C),
+          svm.SVC(kernel='rbf', gamma=0.7, C=C),
+          svm.SVC(kernel='poly', degree=3, C=C))
+models = (clf.fit(X, y) for clf in models)
 
 # title for the plots
-titles = ['SVC with linear kernel',
+titles = ('SVC with linear kernel',
           'LinearSVC (linear kernel)',
           'SVC with RBF kernel',
-          'SVC with polynomial (degree 3) kernel']
+          'SVC with polynomial (degree 3) kernel')
 
+#Set-up 2x2 grid for plotting.
+fig, sub = plt.subplots(2,2)
+plt.subplots_adjust(wspace=0.4, hspace=0.4)
 
-for i, clf in enumerate((svc, lin_svc, rbf_svc, poly_svc)):
-    # Plot the decision boundary. For that, we will assign a color to each
-    # point in the mesh [x_min, x_max]x[y_min, y_max].
-    plt.subplot(2, 2, i + 1)
-    plt.subplots_adjust(wspace=0.4, hspace=0.4)
+xx, yy = make_meshgrid(X[:, 0], X[:, 1])
 
-    Z = clf.predict(np.c_[xx.ravel(), yy.ravel()])
-
-    # Put the result into a color plot
-    Z = Z.reshape(xx.shape)
-    plt.contourf(xx, yy, Z, cmap=plt.cm.coolwarm, alpha=0.8)
-
-    # Plot also the training points
-    plt.scatter(X[:, 0], X[:, 1], c=y, cmap=plt.cm.coolwarm)
-    plt.xlabel('Sepal length')
-    plt.ylabel('Sepal width')
-    plt.xlim(xx.min(), xx.max())
-    plt.ylim(yy.min(), yy.max())
-    plt.xticks(())
-    plt.yticks(())
-    plt.title(titles[i])
+for clf, title, ax in zip(models, titles, sub.flatten()):
+    plot_points_boundary(ax, clf, X[:, 0], X[:, 1], xx, yy,
+                               dict(c=y, cmap=plt.cm.coolwarm),
+                               dict(cmap=plt.cm.coolwarm, alpha=0.8))
+    ax.set_xlabel('Sepal length')
+    ax.set_ylabel('Sepal width')
+    ax.set_xticks(())
+    ax.set_yticks(())
+    ax.set_title(title)
 
 plt.show()

--- a/examples/svm/plot_iris.py
+++ b/examples/svm/plot_iris.py
@@ -86,7 +86,7 @@ def plot_points_boundary(ax, clf, x, y, xx, yy,
     Parameters
     ----------
     ax: matplotlib axes object
-    clf: a classifier
+    clf: a fitted classifier
     x: x-axis of points to plot
     y: y-axis of points to plot
     xx: meshgrid ndarray

--- a/examples/svm/plot_iris.py
+++ b/examples/svm/plot_iris.py
@@ -42,6 +42,16 @@ from sklearn import svm, datasets
 
 def make_meshgrid(x, y, h=.02):
     """Create a mesh of points to plot in
+
+    Parameters
+    ----------
+    x: data to base x-axis meshgrid on
+    y: data to base y-axis meshgrid on
+    h: stepsize for meshgrid, optional
+
+    Returns
+    -------
+    xx, yy : ndarray
     """
     x_min, x_max = x.min() - 1, x.max() + 1
     y_min, y_max = y.min() - 1, y.max() + 1
@@ -49,8 +59,17 @@ def make_meshgrid(x, y, h=.02):
                          np.arange(y_min, y_max, h))
     return xx, yy
 
+
 def plot_contours(ax, clf, xx, yy, **params):
     """Plot the decision boundaries for a classifier.
+
+    Parameters
+    ----------
+    ax: matplotlib axes object
+    clf: a classifier
+    xx: meshgrid ndarray
+    yy: meshgrid ndarray
+    params: dictionary of params to pass to contourf, optional
     """
     Z = clf.predict(np.c_[xx.ravel(), yy.ravel()])
     Z = Z.reshape(xx.shape)
@@ -59,9 +78,21 @@ def plot_contours(ax, clf, xx, yy, **params):
     ax.set_ylim(yy.min(), yy.max())
     return out
 
+
 def plot_points_boundary(ax, clf, x, y, xx, yy,
-                               points_params, contour_params):
+                         points_params, contour_params):
     """Plot the decision boundaries and points.
+
+    Parameters
+    ----------
+    ax: matplotlib axes object
+    clf: a classifier
+    x: x-axis of points to plot
+    y: y-axis of points to plot
+    xx: meshgrid ndarray
+    yy: meshgrid ndarray
+    point_params: dictionary of params to pass to `ax.scatter`, optional
+    countour_params: dictionary of params to pass to `plot_contours`, optional
     """
     contours = plot_contours(ax, clf, xx, yy, **contour_params)
     points = ax.scatter(x, y, **points_params)
@@ -69,8 +100,8 @@ def plot_points_boundary(ax, clf, x, y, xx, yy,
 
 # import some data to play with
 iris = datasets.load_iris()
-X = iris.data[:, :2]  # we only take the first two features. We could
-                      # avoid this ugly slicing by using a two-dim dataset
+# Take the first two features. We could avoid this by using a two-dim dataset
+X = iris.data[:, :2]
 y = iris.target
 
 # we create an instance of SVM and fit out data. We do not scale our
@@ -88,16 +119,16 @@ titles = ('SVC with linear kernel',
           'SVC with RBF kernel',
           'SVC with polynomial (degree 3) kernel')
 
-#Set-up 2x2 grid for plotting.
-fig, sub = plt.subplots(2,2)
+# Set-up 2x2 grid for plotting.
+fig, sub = plt.subplots(2, 2)
 plt.subplots_adjust(wspace=0.4, hspace=0.4)
 
 xx, yy = make_meshgrid(X[:, 0], X[:, 1])
 
 for clf, title, ax in zip(models, titles, sub.flatten()):
     plot_points_boundary(ax, clf, X[:, 0], X[:, 1], xx, yy,
-                               dict(c=y, cmap=plt.cm.coolwarm),
-                               dict(cmap=plt.cm.coolwarm, alpha=0.8))
+                         dict(c=y, cmap=plt.cm.coolwarm),
+                         dict(cmap=plt.cm.coolwarm, alpha=0.8))
     ax.set_xlabel('Sepal length')
     ax.set_ylabel('Sepal width')
     ax.set_xticks(())

--- a/examples/svm/plot_iris.py
+++ b/examples/svm/plot_iris.py
@@ -102,7 +102,7 @@ titles = ('SVC with linear kernel',
 fig, sub = plt.subplots(2, 2)
 plt.subplots_adjust(wspace=0.4, hspace=0.4)
 
-X0, X1 = X[:,0], X[:,1]
+X0, X1 = X[:, 0], X[:, 1]
 xx, yy = make_meshgrid(X0, X1)
 
 for clf, title, ax in zip(models, titles, sub.flatten()):

--- a/examples/svm/plot_iris.py
+++ b/examples/svm/plot_iris.py
@@ -127,7 +127,7 @@ xx, yy = make_meshgrid(X[:, 0], X[:, 1])
 
 for clf, title, ax in zip(models, titles, sub.flatten()):
     plot_points_boundary(ax, clf, X[:, 0], X[:, 1], xx, yy,
-                         dict(c=y, cmap=plt.cm.coolwarm),
+                         dict(c=y, cmap=plt.cm.coolwarm, s=20, edgecolors='k'),
                          dict(cmap=plt.cm.coolwarm, alpha=0.8))
     ax.set_xlabel('Sepal length')
     ax.set_ylabel('Sepal width')

--- a/examples/svm/plot_iris.py
+++ b/examples/svm/plot_iris.py
@@ -102,12 +102,13 @@ titles = ('SVC with linear kernel',
 fig, sub = plt.subplots(2, 2)
 plt.subplots_adjust(wspace=0.4, hspace=0.4)
 
-xx, yy = make_meshgrid(X[:, 0], X[:, 1])
+X0, X1 = X[:,0], X[:,1]
+xx, yy = make_meshgrid(X0, X1)
 
 for clf, title, ax in zip(models, titles, sub.flatten()):
     plot_contours(ax, clf, xx, yy,
                   cmap=plt.cm.coolwarm, alpha=0.8)
-    ax.scatter(x, y, c=y, cmap=plt.cm.coolwarm, s=20, edgecolors='k')
+    ax.scatter(X0, X1, c=y, cmap=plt.cm.coolwarm, s=20, edgecolors='k')
     ax.set_xlim(xx.min(), xx.max())
     ax.set_ylim(yy.min(), yy.max())
     ax.set_xlabel('Sepal length')


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This refactors without in any way changing the outcome of the code in the "Plot different SVM classifiers in the iris dataset" example.

A couple of  features of the current state of affairs that are motivating:
1. It mixes the concerns of model fitting, predicting and plot making, which in my experience makes it both hard to comprehend, and difficult to reuse in other applications.
2. It demonstrates a couple of less-than-best practices, such as:
  * Using `enumerate` where `zip` would be more appropriate.
  * Some repeated code, such as slicing columns of `X`, fitting, restating names of models.
3. It uses the `matplotlib` state machine interface rather than the object-oriented interface and stretches that interface about as far as it ought to be stretched, making the code unsuitable to serve as the basis for extension or reuse.

I've addressed the concerns by switching to OO interface for matplotlib and by trying to follow some best practices, most notably by using the [function signature](http://matplotlib.org/faq/usage_faq.html) recommended by matplotlib.

#### Any other comments?

I think this is important, because it's one of the chief ways people learn about both `sklearn` and `matplotlib`, so demonstrating best practices can have a positive effect for people with limited exposure to both packages--those who are most likely to be cribbing from examples.

If this is considered to be an improvement, would love to give more of the examples the same treatment.