### PR TITLE
[MRG] DOC: shift projects missing in related_projects from the wiki page

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -29,6 +29,9 @@ enhance the functionality of scikit-learn's estimators.
   preprocessors as well as the estimators. Works as a drop-in replacement for a
   scikit-learn estimator.
 
+- `pyensemble <https://github.com/dclambert/pyensemble>`_ An implementation of
+  Caruana et al's Ensemble Selection algorithm in Python, based on scikit-learn
+
 **Experimentation frameworks**
 
 - `PyMC <http://pymc-devs.github.io/pymc/>`_ Bayesian statistical models and
@@ -161,14 +164,14 @@ and tasks.
 
 - `libOPF <https://github.com/LibOPF/LibOPF>`_ Optimal path forest classifier
 
-- `pyensemble <https://github.com/dclambert/pyensemble>`_ An implementation of
-  Caruana et al's Ensemble Selection algorithm in Python, based on scikit-learn
-
 - `random-output-trees <https://github.com/arjoly/random-output-trees>`_
-  Multi-output random forest on randomised output space
+  Randomized output tree for multilabel / multi-output regression tasks
 
 - `fastFM <https://github.com/ibayer/fastFM>`_ Fast factorization machine
   implementation compatible with scikit-learn
+
+- `glm-sklearn <https://github.com/jcrudy/glm-sklearn>`_ scikit-learn
+  compatible wrapper around the GLM module in statsmodel.
 
 **Decomposition and clustering**
 
@@ -197,6 +200,9 @@ and tasks.
 - `pyIPCA <https://github.com/pickle27/pyIPCA>`_ Incremental Principal
   Component Analysis
 
+- `scikit-protopy <https://github.com/dvro/scikit-protopy>`_ scikit-learn
+  compatible prototype selection and generation algorithms.
+
 Statistical learning with Python
 --------------------------------
 Other packages useful for data analysis and machine learning.
@@ -222,9 +228,6 @@ Other packages useful for data analysis and machine learning.
 
 - `Deep Learning <http://deeplearning.net/software_links/>`_ A curated list of deep learning
   software libraries.
-
-- `glm-sklearn <https://github.com/jcrudy/glm-sklearn>`_ scikit-learn
-  compatible wrapper around the GLM module in statsmodel.
 
 Domain specific packages
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -278,6 +281,3 @@ Code snippets that do not follow the fit / predict / transform API.
 
 - Generating data with `non-parametric Gaussian mixture models <https://gist.github.com/2011426>`_
   Useful if you need "random" data that should have non-trivial structure.
-
-- `scikit-protopy <https://github.com/dvro/scikit-protopy>`_ scikit-learn
-  compatible prototype selection and generation algorithms.

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -48,6 +48,9 @@ enhance the functionality of scikit-learn's estimators.
   wrapper around scikit-learn that makes it easy to run machine learning
   experiments with multiple learners and large feature sets.
 
+- `sklearn-deap <https://github.com/rsteca/sklearn-deap>`_ Use evolutionary
+  algorithms instead of gridsearch in scikit-learn.
+
 **Model inspection and visualisation**
 
 - `eli5 <https://github.com/TeamHG-Memex/eli5/>`_ A library for
@@ -57,6 +60,8 @@ enhance the functionality of scikit-learn's estimators.
 - `mlxtend <https://github.com/rasbt/mlxtend>`_ Includes model visualization
   utilities.
 
+- `Fast svmlight / libsvm file loader <https://github.com/mblondel/svmlight-loader>`_
+  Fast and memory-efficient svmlight / libsvm file loader for Python.
 
 **Model export for production**
 
@@ -121,6 +126,10 @@ and tasks.
 - `lasagne <https://github.com/Lasagne/Lasagne>`_ A lightweight library to
   build and train neural networks in Theano.
 
+- `Extreme Learning Machines <https://github.com/dclambert/Python-ELM>`_
+  Implementation of ELM (random layer + ridge) with a scikit-learn compatible
+  interface.
+
 **Broad scope**
 
 - `mlxtend <https://github.com/rasbt/mlxtend>`_ Includes a number of additional
@@ -150,6 +159,17 @@ and tasks.
 - `multiisotonic <https://github.com/alexfields/multiisotonic>`_ Isotonic
   regression on multidimensional features.
 
+- `libOPF <https://github.com/LibOPF/LibOPF>`_ Optimal path forest classifier
+
+- `pyensemble <https://github.com/dclambert/pyensemble>`_ An implementation of
+  Caruana et al's Ensemble Selection algorithm in Python, based on scikit-learn
+
+- `random-output-trees <https://github.com/arjoly/random-output-trees>`_
+  Multi-output random forest on randomised output space
+
+- `fastFM <https://github.com/ibayer/fastFM>`_ Fast factorization machine
+  implementation compatible with scikit-learn
+
 **Decomposition and clustering**
 
 - `lda <https://github.com/ariddell/lda/>`_: Fast implementation of latent
@@ -173,6 +193,9 @@ and tasks.
 - `spherecluster <https://github.com/clara-labs/spherecluster>`_ Spherical
   K-means and mixture of von Mises Fisher clustering routines for data on the
   unit hypersphere.
+
+- `pyIPCA <https://github.com/pickle27/pyIPCA>`_ Incremental Principal
+  Component Analysis
 
 Statistical learning with Python
 --------------------------------
@@ -199,6 +222,9 @@ Other packages useful for data analysis and machine learning.
 
 - `Deep Learning <http://deeplearning.net/software_links/>`_ A curated list of deep learning
   software libraries.
+
+- `glm-sklearn <https://github.com/jcrudy/glm-sklearn>`_ scikit-learn
+  compatible wrapper around the GLM module in statsmodel.
 
 Domain specific packages
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -51,9 +51,6 @@ enhance the functionality of scikit-learn's estimators.
   wrapper around scikit-learn that makes it easy to run machine learning
   experiments with multiple learners and large feature sets.
 
-- `sklearn-deap <https://github.com/rsteca/sklearn-deap>`_ Use evolutionary
-  algorithms instead of gridsearch in scikit-learn.
-
 **Model inspection and visualisation**
 
 - `eli5 <https://github.com/TeamHG-Memex/eli5/>`_ A library for
@@ -229,6 +226,9 @@ Other packages useful for data analysis and machine learning.
 - `Deep Learning <http://deeplearning.net/software_links/>`_ A curated list of deep learning
   software libraries.
 
+- `sklearn-deap <https://github.com/rsteca/sklearn-deap>`_ Use evolutionary
+   algorithms instead of gridsearch in scikit-learn.
+
 Domain specific packages
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -247,33 +247,6 @@ Domain specific packages
 
 Snippets and tidbits
 ---------------------
-
-**Gists**
-
-- `Multi-Layer-Perceptron <https://gist.github.com/2061456>`_ neural network
-  classifier trained by SGD
-
-- `Non-Negative Garotte <https://gist.github.com/2351057>`_
-
-- `Kernel SGD <https://gist.github.com/2573392>`_
-
-- `Fuzzy K-means and K-medians <https://gist.github.com/1451300>`_
-
-- `Kernel k-means <https://gist.github.com/mblondel/6230787>`_
-
-- `Non-negative Least-Squares <https://gist.github.com/mblondel/4421380>`_
-
-- `Non-negative Matrix Factorization for I-divergence <https://gist.github.com/omangin/8801846>`_
-
-- `K-means + RBF transformation <https://gist.github.com/larsmans/5996074>`_
-  inspired by `The secret of the big guys <http://fastml.com/the-secret-of-the-big-guys>`_
-
-- `Multiclass SVMs <https://gist.github.com/mblondel/97cffbea574a5890f0d7>`_
-
-- `Coordinate descent solver for NMF <https://gist.github.com/mblondel/09648344984565f9477a>`_
-  designed for sparse data without missing values
-
-**Other**
 
 Code snippets that do not follow the fit / predict / transform API.
 

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -245,4 +245,39 @@ Domain specific packages
 Snippets and tidbits
 ---------------------
 
-The `wiki <https://github.com/scikit-learn/scikit-learn/wiki/Third-party-projects-and-code-snippets>`_ has more!
+**Gists**
+
+- `Multi-Layer-Perceptron <https://gist.github.com/2061456>`_ neural network
+  classifier trained by SGD
+
+- `Non-Negative Garotte <https://gist.github.com/2351057>`_
+
+- `Kernel SGD <https://gist.github.com/2573392>`_
+
+- `Fuzzy K-means and K-medians <https://gist.github.com/1451300>`_
+
+- `Kernel k-means <https://gist.github.com/mblondel/6230787>`_
+
+- `Non-negative Least-Squares <https://gist.github.com/mblondel/4421380>`_
+
+- `Non-negative Matrix Factorization for I-divergence <https://gist.github.com/omangin/8801846>`_
+
+- `K-means + RBF transformation <https://gist.github.com/larsmans/5996074>`_
+  inspired by `The secret of the big guys <http://fastml.com/the-secret-of-the-big-guys>`_
+
+- `Multiclass SVMs <https://gist.github.com/mblondel/97cffbea574a5890f0d7>`_
+
+- `Coordinate descent solver for NMF <https://gist.github.com/mblondel/09648344984565f9477a>`_
+  designed for sparse data without missing values
+
+**Other**
+
+Code snippets that do not follow the fit / predict / transform API.
+
+- `Adaptive Lasso <https://gist.github.com/1610922>`_
+
+- Generating data with `non-parametric Gaussian mixture models <https://gist.github.com/2011426>`_
+  Useful if you need "random" data that should have non-trivial structure.
+
+- `scikit-protopy <https://github.com/dvro/scikit-protopy>`_ scikit-learn
+  compatible prototype selection and generation algorithms.


### PR DESCRIPTION
#### Reference Issue
Fixes #8266 

#### What does this implement/fix? Explain your changes.
Links the related projects from the wiki page to `related_projects.rst`

#### Any other comments
Am linking everything that is missing as of now. However, in the issue thread it was mentioned that we need include only the important. Please provide feedback as to what all should be included.
