### PR TITLE
DOC more explicit guidelines for WIP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,8 @@ following rules before you submit a pull request:
 
 -  Please prefix the title of your pull request with `[MRG]` (Ready for
    Merge), if the contribution is complete and ready for a detailed review.
-   Incomplete contributions should be prefixed `[WIP]` (to indicate a work
+   An incomplete contribution -- where you expect to do more work before
+   receiving a full review -- should be prefixed `[WIP]` (to indicate a work
    in progress) and changed to `[MRG]` when it matures. WIPs may be useful
    to: indicate you are working on something to avoid duplicated work,
    request broad review of functionality or API, or seek collaborators.

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -187,8 +187,9 @@ rules before submitting a pull request:
       contribution is complete and should be subjected to a detailed review.
       Two core developers will review your code and change the prefix of the pull
       request to ``[MRG + 1]`` and ``[MRG + 2]`` on approval, making it eligible
-      for merging. Incomplete contributions should be prefixed ``[WIP]`` to
-      indicate a work in progress (and changed to ``[MRG]`` when it matures).
+      for merging. An incomplete contribution -- where you expect to do more
+      work before receiving a full review -- should be prefixed ``[WIP]`` (to
+      indicate a work in progress) and changed to ``[MRG]`` when it matures.
       WIPs may be useful to: indicate you are working on something to avoid
       duplicated work, request broad review of functionality or API, or seek
       collaborators. WIPs often benefit from the inclusion of a


### PR DESCRIPTION
I've seen some overuse of [WIP] lately and I thought it could be made more explicit.