### PR TITLE
[WIP] ENH arbitrary diagnostic_func callback in GridSarchCV

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -858,7 +858,7 @@ class GridSearchCV(BaseSearchCV):
     >>> clf = GridSearchCV(svr, parameters)
     >>> clf.fit(iris.data, iris.target)
     ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    GridSearchCV(cv=None, error_score=...,
+    GridSearchCV(cv=None, diagnostic_func=None, error_score=...,
            estimator=SVC(C=1.0, cache_size=..., class_weight=..., coef0=...,
                          decision_function_shape='ovr', degree=..., gamma=...,
                          kernel='rbf', max_iter=-1, probability=False,
@@ -1111,6 +1111,45 @@ class RandomizedSearchCV(BaseSearchCV):
     return_train_score : boolean, default=True
         If ``'False'``, the ``cv_results_`` attribute will not include training
         scores.
+
+    diagnostic_func : callable(dict) -> object, optional
+        After fitting and scoring, this will be called, and its return value
+        stored in ``cv_results_['split<K>_diagnostic']`` for split index K.
+        The single parameter passed to ``diagnostic_func`` is a dict with the
+        following keys:
+
+            "estimator"
+                The fitted estimator
+            "split_idx"
+                The index of the current split generated from ``cv``,
+                ranging ``0..n_splits``
+            "X_train"
+                The features used to train the estimator
+            "y_train"
+                The targets used to train the estimator
+            "train_score"
+                The score on training data (where ``return_train_score=True``)
+            "X_test"
+                The features used to train the estimator
+            "y_test"
+                The targets used to train the estimator
+            "test_score"
+                The score on test data
+            "fit_time"
+                Time spent fitting in seconds
+            "score_time"
+                Time spent scoring in seconds
+            "parameters"
+                Parameters being set on the estimator for grid search.
+            "fit_params"
+                Parameters passed to ``fit``
+            "exception"
+                The exception raised when ``fit`` was called, or ``None``.
+
+        New keys may be added to this dict in future versions without notice.
+
+        Note that in order to use parallelism or pickling, this callable must
+        be picklable, e.g. a named function imported from a module.
 
     Attributes
     ----------

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -255,7 +255,8 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
                 train_score = error_score
             warnings.warn("Classifier fit failed. The score on this train-test"
                           " partition for these parameters will be set to %f. "
-                          "Details: \n%r" % (error_score, e), FitFailedWarning)
+                          "Details: \n%r" % (error_score, exc),
+                          FitFailedWarning)
         else:
             raise ValueError("error_score must be the string 'raise' or a"
                              " numeric value. (Hint: if using 'raise', please"

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -214,7 +214,7 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         The parameters that have been evaluated.
 
     diagnostic : object, optional
-        The return value of ``diagnostic_func``, or the exception raised by it
+        The return value of ``diagnostic_func``
     """
     if verbose > 1:
         if parameters is None:
@@ -286,26 +286,22 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         ret.append(parameters)
 
     if diagnostic_func is not None:
-        try:
-            dia = diagnostic_func({'estimator': estimator,
-                                   'split_idx': split_idx,
-                                   'X_train': X_train,
-                                   'y_train': y_train,
-                                   'train_score': (train_score
-                                                   if return_train_score
-                                                   else None),
-                                   'X_test': X_test,
-                                   'y_test': y_test,
-                                   'test_score': test_score,
-                                   'fit_time': fit_time,
-                                   'score_time': score_time,
-                                   'parameters': parameters,
-                                   'fit_params': fit_params,
-                                   'exception': exc})
-        except Exception as dia_exc:
-            ret.append(dia_exc)
-        else:
-            ret.append(dia)
+        dia = diagnostic_func({'estimator': estimator,
+                               'split_idx': split_idx,
+                               'X_train': X_train,
+                               'y_train': y_train,
+                               'train_score': (train_score
+                                               if return_train_score
+                                               else None),
+                               'X_test': X_test,
+                               'y_test': y_test,
+                               'test_score': test_score,
+                               'fit_time': fit_time,
+                               'score_time': score_time,
+                               'parameters': parameters,
+                               'fit_params': fit_params,
+                               'exception': exc})
+        ret.append(dia)
     return ret
 
 


### PR DESCRIPTION
This is a proof of concept for having an arbitrary callback function in `GridSearchCV` (and other CVs in the future) to return non-standard metrics, classification reports, coefficients, etc.; or to dump the model to disk, for instance. This gets around some of the limitations, and the complex engineering, of multiple metric support as in #7388; see https://github.com/scikit-learn/scikit-learn/issues/1837#issuecomment-277912593

Note that the modifications to the example here are currently rubbish just to be played with, not a true proposed change to that example.