### PR TITLE
[MRG+1] Update class_weight.py

### DIFF
--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -66,7 +66,7 @@ def compute_class_weight(class_weight, classes, y):
         for c in class_weight:
             i = np.searchsorted(classes, c)
             if i >= len(classes) or classes[i] != c:
-                raise ValueError("Class label %d not present." % c)
+                raise ValueError("Class label {} not present.".format(c))
             else:
                 weight[i] = class_weight[c]
 

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -117,6 +117,15 @@ def test_compute_class_weight_balanced_unordered():
     assert_almost_equal(np.dot(cw, class_counts), y.shape[0])
     assert_array_almost_equal(cw, [2., 1., 2. / 3])
 
+def test_class_weight_with_string_label():
+    y = np.asarray(["A","A","A","B","B","C"])
+    classes = np.unique(y)
+    class_weights = {c: 1.0 for c in classes}
+    class_weights['D'] = 1.0  # This should get a proper ValueError
+    cw = assert_raises(ValueError, compute_class_weight, class_weights, 
+                       classes, y)
+    return
+
 
 def test_compute_sample_weight():
     # Test (and demo) compute_sample_weight.

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -117,13 +117,18 @@ def test_compute_class_weight_balanced_unordered():
     assert_almost_equal(np.dot(cw, class_counts), y.shape[0])
     assert_array_almost_equal(cw, [2., 1., 2. / 3])
 
+
 def test_class_weight_with_string_label():
-    y = np.asarray(["A","A","A","B","B","C"])
+    # Fix exception in error message formatting when missing label is a string
+    # https://github.com/scikit-learn/scikit-learn/issues/8312
+    y = np.asarray(["A", "A", "A", "B", "B", "C"])
     classes = np.unique(y)
     class_weights = {c: 1.0 for c in classes}
-    class_weights['D'] = 1.0  # This should get a proper ValueError
-    cw = assert_raises(ValueError, compute_class_weight, class_weights, 
-                       classes, y)
+    class_weights['D'] = 1.0  # This should produce a ValueError
+    assert_raise_message(ValueError,
+                         'Class label D not present',
+                         compute_class_weight,
+                         class_weights, classes, y)
     return
 
 

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -31,6 +31,12 @@ def test_compute_class_weight_not_present():
     classes = np.arange(4)
     y = np.asarray([0, 0, 0, 1, 1, 2])
     assert_raises(ValueError, compute_class_weight, "balanced", classes, y)
+    # Fix exception in error message formatting when missing label is a string
+    # https://github.com/scikit-learn/scikit-learn/issues/8312
+    assert_raise_message(ValueError,
+                         'Class label label_not_present not present',
+                         compute_class_weight,
+                         {'label_not_present': 1.}, classes, y)
     # Raise error when y has items not in classes
     classes = np.arange(2)
     assert_raises(ValueError, compute_class_weight, "balanced", classes, y)
@@ -116,20 +122,6 @@ def test_compute_class_weight_balanced_unordered():
     class_counts = np.bincount(y)[classes]
     assert_almost_equal(np.dot(cw, class_counts), y.shape[0])
     assert_array_almost_equal(cw, [2., 1., 2. / 3])
-
-
-def test_class_weight_with_string_label():
-    # Fix exception in error message formatting when missing label is a string
-    # https://github.com/scikit-learn/scikit-learn/issues/8312
-    y = np.asarray(["A", "A", "A", "B", "B", "C"])
-    classes = np.unique(y)
-    class_weights = {c: 1.0 for c in classes}
-    class_weights['D'] = 1.0  # This should produce a ValueError
-    assert_raise_message(ValueError,
-                         'Class label D not present',
-                         compute_class_weight,
-                         class_weights, classes, y)
-    return
 
 
 def test_compute_sample_weight():


### PR DESCRIPTION
closes #8312 
Changed ValueError message to reflect that a class label may be non-integer

#### Reference Issue #8312 

#### What does this implement/fix? Explain your changes.
The original line `ValueError("Class label %d not present." %c)` implicitly assumed the class label `c` was an integer.  The fix `ValueError("Class label {} not present.".format(c))` allows the class label to be a more general type, such as a string

#### Any other comments?
This is my first ever attempt to fix anything in "open source" using github.  Let me know if I goofed in the process.
