### PR TITLE
[WIP] Pytest test suite completely independent  of nose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ benchmarks/bench_covertype_data/
 !*/src/*.cpp
 *.sln
 *.pyproj
+.cache
+.eggs

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,14 @@
 
 PYTHON ?= python
 CYTHON ?= cython
-NOSETESTS ?= nosetests
+PYTEST ?= py.test
 CTAGS ?= ctags
 
 # skip doctests on 32bit python
 BITS := $(shell python -c 'import struct; print(8 * struct.calcsize("P"))')
 
 ifeq ($(BITS),32)
-  NOSETESTS:=$(NOSETESTS) -c setup32.cfg
+  PYTEST:=$(PYTEST) -c setup32.cfg
 endif
 
 
@@ -29,21 +29,19 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code: in
-	$(NOSETESTS) -s -v sklearn
+	$(PYTEST) -s -v sklearn
 test-sphinxext:
-	$(NOSETESTS) -s -v doc/sphinxext/
+	$(PYTEST) -s -v doc/sphinxext/
 test-doc:
 ifeq ($(BITS),64)
-	$(NOSETESTS) -s -v doc/*.rst doc/modules/ doc/datasets/ \
-	doc/developers doc/tutorial/basic doc/tutorial/statistical_inference \
-	doc/tutorial/text_analytics
+	$(PYTEST) -s -v --doctest-glob='*.rst'
 endif
 
 test-coverage:
 	rm -rf coverage .coverage
-	$(NOSETESTS) -s -v --with-coverage sklearn
+	$(PYTEST) -s -v --cov=sklearn
 
-test: test-code test-sphinxext test-doc
+test: test-code test-doc
 
 trailing-spaces:
 	find sklearn -name "*.py" -exec perl -pi -e 's/[ \t]*$$//' {} \;

--- a/build_tools/appveyor/requirements.txt
+++ b/build_tools/appveyor/requirements.txt
@@ -10,7 +10,7 @@
 numpy==1.9.3
 scipy==0.16.0
 cython
-nose
-nose-timer
+pytest
+pytest-cov
 wheel
 wheelhouse_uploader

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -51,21 +51,21 @@ if [[ "$DISTRIB" == "conda" ]]; then
     # Configure the conda environment and put it in the path using the
     # provided versions
     if [[ "$INSTALL_MKL" == "true" ]]; then
-        conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
+        conda create -n testenv --yes python=$PYTHON_VERSION pip pytest \
             numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
             mkl cython=$CYTHON_VERSION \
             ${PANDAS_VERSION+pandas=$PANDAS_VERSION}
-            
+
     else
-        conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
+        conda create -n testenv --yes python=$PYTHON_VERSION pip pytest \
             numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
             nomkl cython=$CYTHON_VERSION \
             ${PANDAS_VERSION+pandas=$PANDAS_VERSION}
     fi
     source activate testenv
 
-    # Install nose-timer via pip
-    pip install nose-timer
+    # Install pytest-cov via pip
+    pip install pytest-cov
 
 elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # At the time of writing numpy 1.9.1 is included in the travis
@@ -76,7 +76,7 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # and scipy
     virtualenv --system-site-packages testvenv
     source testvenv/bin/activate
-    pip install nose nose-timer cython
+    pip install pytest pytest-cov cython
 
 elif [[ "$DISTRIB" == "scipy-dev-wheels" ]]; then
     # Set up our own virtualenv environment to avoid travis' numpy.
@@ -91,11 +91,11 @@ elif [[ "$DISTRIB" == "scipy-dev-wheels" ]]; then
     pip install --pre --upgrade --no-index --timeout=60 \
         --trusted-host travis-dev-wheels.scipy.org \
         -f https://travis-dev-wheels.scipy.org/ numpy scipy
-    pip install nose nose-timer cython
+    pip install pytest cython
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then
-    pip install coverage codecov
+    pip install pytest-cov coverage codecov
 fi
 
 if [[ "$SKIP_TESTS" == "true" ]]; then

--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -34,9 +34,9 @@ run_tests() {
     export SKLEARN_SKIP_NETWORK_TESTS=1
 
     if [[ "$COVERAGE" == "true" ]]; then
-        nosetests -s --with-coverage --with-timer --timer-top-n 20 sklearn
+        py.test -s --cov=sklearn --durations=20  $OLDPWD/sklearn
     else
-        nosetests -s --with-timer --timer-top-n 20 sklearn
+        py.test -s --durations=20 $OLDPWD/sklearn
     fi
 
     # Test doc

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [aliases]
 # python2.7 has upgraded unittest and it is no longer compatible with some
 # of our tests, so we run all through nose
-test = nosetests
+test = pytest
 
 [nosetests]
 # nosetests skips test files with the executable bit by default

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -6,6 +6,8 @@ import numpy
 from pickle import loads
 from pickle import dumps
 
+import pytest
+
 from sklearn.datasets import get_data_home
 from sklearn.datasets import clear_data_home
 from sklearn.datasets import load_files
@@ -26,13 +28,24 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import with_setup
 
 
-DATA_HOME = tempfile.mkdtemp(prefix="scikit_learn_data_home_test_")
-LOAD_FILES_ROOT = tempfile.mkdtemp(prefix="scikit_learn_load_files_test_")
-TEST_CATEGORY_DIR1 = ""
-TEST_CATEGORY_DIR2 = ""
+@pytest.fixture(scope="module")
+def data_home():
+    try:
+        path = tempfile.mkdtemp(prefix="scikit_learn_data_home_test_")
+        yield path
+    finally:
+        _remove_dir(path)
+
+
+@pytest.fixture(scope="module")
+def load_files_root():
+    try:
+        path = tempfile.mkdtemp(prefix="scikit_learn_load_files_test_")
+        yield path
+    finally:
+        _remove_dir(path)
 
 
 def _remove_dir(path):
@@ -42,30 +55,34 @@ def _remove_dir(path):
 
 def teardown_module():
     """Test fixture (clean up) run once after all tests of this module"""
-    for path in [DATA_HOME, LOAD_FILES_ROOT]:
-        _remove_dir(path)
 
 
-def setup_load_files():
-    global TEST_CATEGORY_DIR1
-    global TEST_CATEGORY_DIR2
-    TEST_CATEGORY_DIR1 = tempfile.mkdtemp(dir=LOAD_FILES_ROOT)
-    TEST_CATEGORY_DIR2 = tempfile.mkdtemp(dir=LOAD_FILES_ROOT)
-    sample_file = tempfile.NamedTemporaryFile(dir=TEST_CATEGORY_DIR1,
-                                              delete=False)
-    sample_file.write(b("Hello World!\n"))
-    sample_file.close()
+@pytest.fixture
+def test_category_dir_1(load_files_root):
+    try:
+        TEST_CATEGORY_DIR1 = tempfile.mkdtemp(dir=load_files_root)
+        sample_file = tempfile.NamedTemporaryFile(dir=TEST_CATEGORY_DIR1,
+                                                  delete=False)
+        sample_file.write(b("Hello World!\n"))
+        sample_file.close()
+        yield TEST_CATEGORY_DIR1
+    finally:
+        _remove_dir(TEST_CATEGORY_DIR1)
 
 
-def teardown_load_files():
-    _remove_dir(TEST_CATEGORY_DIR1)
-    _remove_dir(TEST_CATEGORY_DIR2)
+@pytest.fixture
+def test_category_dir_2(load_files_root):
+    try:
+        TEST_CATEGORY_DIR2 = tempfile.mkdtemp(dir=load_files_root)
+        yield TEST_CATEGORY_DIR2
+    finally:
+        _remove_dir(TEST_CATEGORY_DIR2)
 
 
-def test_data_home():
+def test_data_home(data_home):
     # get_data_home will point to a pre-existing folder
-    data_home = get_data_home(data_home=DATA_HOME)
-    assert_equal(data_home, DATA_HOME)
+    data_home = get_data_home(data_home=data_home)
+    assert_equal(data_home, data_home)
     assert_true(os.path.exists(data_home))
 
     # clear_data_home will delete both the content and the folder it-self
@@ -73,30 +90,28 @@ def test_data_home():
     assert_false(os.path.exists(data_home))
 
     # if the folder is missing it will be created again
-    data_home = get_data_home(data_home=DATA_HOME)
+    data_home = get_data_home(data_home=data_home)
     assert_true(os.path.exists(data_home))
 
 
-def test_default_empty_load_files():
-    res = load_files(LOAD_FILES_ROOT)
+def test_default_empty_load_files(load_files_root):
+    res = load_files(load_files_root)
     assert_equal(len(res.filenames), 0)
     assert_equal(len(res.target_names), 0)
     assert_equal(res.DESCR, None)
 
 
-@with_setup(setup_load_files, teardown_load_files)
-def test_default_load_files():
-    res = load_files(LOAD_FILES_ROOT)
+def test_default_load_files(test_category_dir_1, test_category_dir_2, load_files_root):
+    res = load_files(load_files_root)
     assert_equal(len(res.filenames), 1)
     assert_equal(len(res.target_names), 2)
     assert_equal(res.DESCR, None)
     assert_equal(res.data, [b("Hello World!\n")])
 
 
-@with_setup(setup_load_files, teardown_load_files)
-def test_load_files_w_categories_desc_and_encoding():
-    category = os.path.abspath(TEST_CATEGORY_DIR1).split('/').pop()
-    res = load_files(LOAD_FILES_ROOT, description="test",
+def test_load_files_w_categories_desc_and_encoding(test_category_dir_1, test_category_dir_2, load_files_root):
+    category = os.path.abspath(test_category_dir_1).split('/').pop()
+    res = load_files(load_files_root, description="test",
                      categories=category, encoding="utf-8")
     assert_equal(len(res.filenames), 1)
     assert_equal(len(res.target_names), 1)
@@ -104,9 +119,8 @@ def test_load_files_w_categories_desc_and_encoding():
     assert_equal(res.data, [u("Hello World!\n")])
 
 
-@with_setup(setup_load_files, teardown_load_files)
-def test_load_files_wo_load_content():
-    res = load_files(LOAD_FILES_ROOT, load_content=False)
+def test_load_files_wo_load_content(test_category_dir_1, test_category_dir_2, load_files_root):
+    res = load_files(load_files_root, load_content=False)
     assert_equal(len(res.filenames), 1)
     assert_equal(len(res.target_names), 2)
     assert_equal(res.DESCR, None)

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -6,7 +6,7 @@ import numpy as np
 import scipy as sp
 from scipy import ndimage
 
-from numpy.testing import assert_raises
+from sklearn.utils.testing import assert_raises
 
 from sklearn.feature_extraction.image import (
     img_to_graph, grid_to_graph, extract_patches_2d,

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -23,7 +23,7 @@ from sklearn.base import clone
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
-from numpy.testing import assert_raises
+from sklearn.utils.testing import assert_raises
 from sklearn.utils.random import choice
 from sklearn.utils.testing import (assert_equal, assert_false, assert_true,
                                    assert_not_equal, assert_almost_equal,

--- a/sklearn/linear_model/tests/test_ransac.py
+++ b/sklearn/linear_model/tests/test_ransac.py
@@ -3,7 +3,8 @@ from scipy import sparse
 import numpy as np
 from scipy import sparse
 
-from numpy.testing import assert_equal, assert_raises
+from numpy.testing import assert_equal
+from sklearn.utils.testing import assert_raises
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
 

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -8,9 +8,10 @@ import unittest
 import copy
 import sys
 
+import pytest
+
 import numpy as np
-from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_raises)
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 from scipy import stats
 from sklearn import mixture
 from sklearn.datasets.samples_generator import make_spd_matrix
@@ -157,12 +158,12 @@ def test_GMM_attributes():
     covars = (0.1 + 2 * rng.rand(n_components, n_features)) ** 2
     g.covars_ = covars
     assert_array_almost_equal(g.covars_, covars)
-    assert_raises(ValueError, g._set_covars, [])
-    assert_raises(ValueError, g._set_covars,
-                  np.zeros((n_components - 2, n_features)))
-
-    assert_raises(ValueError, mixture.GMM, n_components=20,
-                  covariance_type='badcovariance_type')
+    with pytest.raises(ValueError):
+        g._set_covars([])
+    with pytest.raises(ValueError):
+        g._set_covars( np.zeros((n_components - 2, n_features)))
+    with pytest.raises(ValueError):
+        mixture.GMM( n_components=20, covariance_type='badcovariance_type')
 
 
 class GMMTester():

--- a/sklearn/neighbors/tests/test_kd_tree.py
+++ b/sklearn/neighbors/tests/test_kd_tree.py
@@ -128,8 +128,8 @@ def test_kd_tree_kde(n_samples=100, n_features=3):
             for rtol in [0, 1E-5]:
                 for atol in [1E-6, 1E-2]:
                     for breadth_first in (True, False):
-                        yield (check_results, kernel, h, atol, rtol,
-                               breadth_first)
+                        check_results(kernel, h, atol, rtol,
+                                      breadth_first)
 
 
 def test_gaussian_kde(n_samples=1000):

--- a/sklearn/neighbors/tests/test_kde.py
+++ b/sklearn/neighbors/tests/test_kde.py
@@ -52,7 +52,7 @@ def test_kernel_density(n_samples=100, n_features=3):
             for rtol in [0, 1E-5]:
                 for atol in [1E-6, 1E-2]:
                     for breadth_first in (True, False):
-                        yield (check_results, kernel, bandwidth, atol, rtol)
+                        check_results(kernel, bandwidth, atol, rtol)
 
 
 def test_kernel_density_sampling(n_samples=100, n_features=3):

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -35,7 +35,7 @@ def test_l1_min_c():
                     check.description = ('Test l1_min_c loss=%r %s %s %s' %
                                          (loss, X_label, Y_label,
                                           intercept_label))
-                    yield check
+                    check()
 
     # loss='l2' should raise ValueError
     assert_raise_message(ValueError, "loss type not in",

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -2,6 +2,7 @@ import pickle
 from io import BytesIO
 import numpy as np
 import scipy.sparse
+import pytest
 
 from sklearn.datasets import load_digits, load_iris
 
@@ -223,9 +224,9 @@ def check_partial_fit(cls):
     assert_array_equal(clf1.feature_count_, clf3.feature_count_)
 
 
-def test_discretenb_partial_fit():
-    for cls in [MultinomialNB, BernoulliNB]:
-        yield check_partial_fit, cls
+@pytest.mark.parametrize("cls", [MultinomialNB, BernoulliNB])
+def test_discretenb_partial_fit(cls):
+    check_partial_fit(cls)
 
 
 def test_gnb_partial_fit():

--- a/sklearn/tests/test_random_projection.py
+++ b/sklearn/tests/test_random_projection.py
@@ -2,6 +2,7 @@ from __future__ import division
 
 import numpy as np
 import scipy.sparse as sp
+import pytest
 
 from sklearn.metrics import euclidean_distances
 
@@ -113,21 +114,22 @@ def check_input_with_sparse_random_matrix(random_matrix):
                       random_matrix, n_components, n_features, density=density)
 
 
-def test_basic_property_of_random_matrix():
+@pytest.mark.parametrize("random_matrix", all_random_matrix)
+def test_basic_property_of_random_matrix(random_matrix):
     # Check basic properties of random matrix generation
-    for random_matrix in all_random_matrix:
-        yield check_input_size_random_matrix, random_matrix
-        yield check_size_generated, random_matrix
-        yield check_zero_mean_and_unit_norm, random_matrix
+    check_input_size_random_matrix(random_matrix)
+    check_size_generated(random_matrix)
+    check_zero_mean_and_unit_norm(random_matrix)
 
-    for random_matrix in all_sparse_random_matrix:
-        yield check_input_with_sparse_random_matrix, random_matrix
 
-        random_matrix_dense = \
-            lambda n_components, n_features, random_state: random_matrix(
-                n_components, n_features, random_state=random_state,
-                density=1.0)
-        yield check_zero_mean_and_unit_norm, random_matrix_dense
+@pytest.mark.parametrize("random_matrix", all_sparse_random_matrix)
+def test_basic_property_of_random_matrix(random_matrix):
+    check_input_with_sparse_random_matrix(random_matrix)
+
+    def random_matrix_dense(n_components, n_features, random_state):
+        return random_matrix(n_components, n_features, random_state=random_state, density=1.0)
+
+    check_zero_mean_and_unit_norm(random_matrix_dense)
 
 
 def test_gaussian_random_matrix():

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -7,6 +7,7 @@ from functools import partial
 from itertools import product
 import struct
 
+import pytest
 import numpy as np
 from scipy.sparse import csc_matrix
 from scipy.sparse import csr_matrix
@@ -695,14 +696,14 @@ def check_min_weight_fraction_leaf(name, datasets, sparse=False):
                 name, est.min_weight_fraction_leaf))
 
 
-def test_min_weight_fraction_leaf():
-    # Check on dense input
-    for name in ALL_TREES:
-        yield check_min_weight_fraction_leaf, name, "iris"
+@pytest.mark.parametrize("name", ALL_TREES)
+def test_min_weight_fraction_leaf_on_dense_input(name):
+    check_min_weight_fraction_leaf(name, "iris")
 
-    # Check on sparse input
-    for name in SPARSE_TREES:
-        yield check_min_weight_fraction_leaf, name, "multilabel", True
+
+@pytest.mark.parametrize("name", SPARSE_TREES)
+def test_min_weight_fraction_leaf_on_sparse_input(name):
+    check_min_weight_fraction_leaf(name, "multilabel", True)
 
 
 def check_min_weight_fraction_leaf_with_min_samples_leaf(name, datasets,
@@ -769,16 +770,14 @@ def check_min_weight_fraction_leaf_with_min_samples_leaf(name, datasets,
                                           est.min_samples_leaf))
 
 
-def test_min_weight_fraction_leaf_with_min_samples_leaf():
-    # Check on dense input
-    for name in ALL_TREES:
-        yield (check_min_weight_fraction_leaf_with_min_samples_leaf,
-               name, "iris")
+@pytest.mark.parametrize("name", ALL_TREES)
+def test_min_weight_fraction_leaf_with_min_samples_leaf_on_dense_input(name):
+    check_min_weight_fraction_leaf_with_min_samples_leaf(name, "iris")
 
-    # Check on sparse input
-    for name in SPARSE_TREES:
-        yield (check_min_weight_fraction_leaf_with_min_samples_leaf,
-               name, "multilabel", True)
+
+@pytest.mark.parametrize("name", SPARSE_TREES)
+def test_min_weight_fraction_leaf_with_min_samples_leaf_on_sparse_input(name):
+    check_min_weight_fraction_leaf_with_min_samples_leaf(name, "multilabel", True)
 
 
 def test_min_impurity_split():
@@ -1107,9 +1106,9 @@ def check_class_weights(name):
     assert_almost_equal(clf1.feature_importances_, clf2.feature_importances_)
 
 
-def test_class_weights():
-    for name in CLF_TREES:
-        yield check_class_weights, name
+@pytest.mark.parametrize("name", CLF_TREES)
+def test_class_weights(name):
+    check_class_weights(name)
 
 
 def check_class_weight_errors(name):
@@ -1131,9 +1130,9 @@ def check_class_weight_errors(name):
     assert_raises(ValueError, clf.fit, X, _y)
 
 
-def test_class_weight_errors():
-    for name in CLF_TREES:
-        yield check_class_weight_errors, name
+@pytest.mark.parametrize("name", CLF_TREES)
+def test_class_weight_errors(name):
+    check_class_weight_errors(name)
 
 
 def test_max_leaf_nodes():
@@ -1278,21 +1277,23 @@ def check_sparse_input(tree, dataset, max_depth=None):
                 assert_array_almost_equal(s.predict_log_proba(X_sparse_test),
                                           y_log_proba)
 
-
-def test_sparse_input():
-    for tree_type, dataset in product(SPARSE_TREES, ("clf_small", "toy",
+tree_type_dataset_combination = product(SPARSE_TREES, ("clf_small", "toy",
                                                      "digits", "multilabel",
                                                      "sparse-pos",
                                                      "sparse-neg",
-                                                     "sparse-mix", "zeros")):
-        max_depth = 3 if dataset == "digits" else None
-        yield (check_sparse_input, tree_type, dataset, max_depth)
+                                                     "sparse-mix", "zeros"))
+@pytest.mark.parametrize("tree_type, dataset", tree_type_dataset_combination)
+def test_sparse_input(tree_type, dataset):
+    max_depth = 3 if dataset == "digits" else None
+    check_sparse_input(tree_type, dataset, max_depth)
 
+
+@pytest.mark.parametrize("tree_type, dataset", product(SPARSE_TREES, ["boston", "reg_small"]))
+def test_sparse_input(tree_type, dataset):
     # Due to numerical instability of MSE and too strict test, we limit the
     # maximal depth
-    for tree_type, dataset in product(SPARSE_TREES, ["boston", "reg_small"]):
-        if tree_type in REG_TREES:
-            yield (check_sparse_input, tree_type, dataset, 2)
+    if tree_type in REG_TREES:
+        check_sparse_input(tree_type, dataset, 2)
 
 
 def check_sparse_parameters(tree, dataset):
@@ -1339,11 +1340,12 @@ def check_sparse_parameters(tree, dataset):
     assert_array_almost_equal(s.predict(X), d.predict(X))
 
 
-def test_sparse_parameters():
-    for tree_type, dataset in product(SPARSE_TREES, ["sparse-pos",
-                                                     "sparse-neg",
-                                                     "sparse-mix", "zeros"]):
-        yield (check_sparse_parameters, tree_type, dataset)
+tree_type_dataset_combinations = product(SPARSE_TREES, ["sparse-pos", "sparse-neg", "sparse-mix", "zeros"])
+
+
+@pytest.mark.parametrize("tree_type, dataset", tree_type_dataset_combinations)
+def test_sparse_parameters(tree_type, dataset):
+    check_sparse_parameters(tree_type, dataset)
 
 
 def check_sparse_criterion(tree, dataset):
@@ -1366,11 +1368,9 @@ def check_sparse_criterion(tree, dataset):
         assert_array_almost_equal(s.predict(X), d.predict(X))
 
 
-def test_sparse_criterion():
-    for tree_type, dataset in product(SPARSE_TREES, ["sparse-pos",
-                                                     "sparse-neg",
-                                                     "sparse-mix", "zeros"]):
-        yield (check_sparse_criterion, tree_type, dataset)
+@pytest.mark.parametrize("tree_type, dataset", tree_type_dataset_combinations)
+def test_sparse_criterion(tree_type, dataset):
+    check_sparse_criterion(tree_type, dataset)
 
 
 def check_explicit_sparse_zeros(tree, max_depth=3,
@@ -1442,9 +1442,9 @@ def check_explicit_sparse_zeros(tree, max_depth=3,
                                       d.predict_proba(X2))
 
 
-def test_explicit_sparse_zeros():
-    for tree_type in SPARSE_TREES:
-        yield (check_explicit_sparse_zeros, tree_type)
+@pytest.mark.parametrize("tree_type", SPARSE_TREES)
+def test_explicit_sparse_zeros(tree_type):
+    check_explicit_sparse_zeros(tree_type)
 
 
 @ignore_warnings
@@ -1462,10 +1462,11 @@ def check_raise_error_on_1d_input(name):
     assert_raises(ValueError, est.predict, [X])
 
 
-@ignore_warnings
-def test_1d_input():
-    for name in ALL_TREES:
-        yield check_raise_error_on_1d_input, name
+# XXX
+# @ignore_warnings
+@pytest.mark.parametrize("name", ALL_TREES)
+def test_1d_input(name):
+    check_raise_error_on_1d_input(name)
 
 
 def _check_min_weight_leaf_split_level(TreeEstimator, X, y, sample_weight):
@@ -1492,9 +1493,9 @@ def check_min_weight_leaf_split_level(name):
                                            sample_weight)
 
 
-def test_min_weight_leaf_split_level():
-    for name in ALL_TREES:
-        yield check_min_weight_leaf_split_level, name
+@pytest.mark.parametrize("name", ALL_TREES)
+def test_min_weight_leaf_split_level(name):
+    check_min_weight_leaf_split_level(name)
 
 
 def check_public_apply(name):
@@ -1515,12 +1516,14 @@ def check_public_apply_sparse(name):
                        est.tree_.apply(X_small32))
 
 
-def test_public_apply():
-    for name in ALL_TREES:
-        yield (check_public_apply, name)
+@pytest.mark.parametrize("name", ALL_TREES)
+def test_public_apply_all_trees(name):
+    check_public_apply(name)
 
-    for name in SPARSE_TREES:
-        yield (check_public_apply_sparse, name)
+
+@pytest.mark.parametrize("name", SPARSE_TREES)
+def test_public_apply_all_trees(name):
+    check_public_apply_sparse(name)
 
 
 def check_presort_sparse(est, X, y):
@@ -1539,7 +1542,7 @@ def test_presort_sparse():
     y = y[:, 0]
 
     for est, sparse_matrix in product(ests, sparse_matrices):
-        yield check_presort_sparse, est, sparse_matrix(X), y
+        check_presort_sparse(est, sparse_matrix(X), y)
 
 
 def test_decision_path_hardcoded():
@@ -1578,9 +1581,9 @@ def check_decision_path(name):
     assert_less_equal(est.tree_.max_depth, max_depth)
 
 
-def test_decision_path():
-    for name in ALL_TREES:
-        yield (check_decision_path, name)
+@pytest.mark.parametrize("name", ALL_TREES)
+def test_decision_path(name):
+    check_decision_path(name)
 
 
 def check_no_sparse_y_support(name):
@@ -1589,10 +1592,10 @@ def check_no_sparse_y_support(name):
     assert_raises(TypeError, TreeEstimator(random_state=0).fit, X, y)
 
 
-def test_no_sparse_y_support():
+@pytest.mark.parametrize("name", ALL_TREES)
+def test_no_sparse_y_support(name):
     # Currently we don't support sparse y
-    for name in ALL_TREES:
-        yield (check_no_sparse_y_support, name)
+    check_no_sparse_y_support(name)
 
 
 def test_mae():

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -46,8 +46,13 @@ import sklearn
 from sklearn.base import BaseEstimator
 from sklearn.externals import joblib
 
-from nose.tools import raises
-from nose import with_setup
+import pytest
+
+
+def raises(exception):
+    return pytest.mark.xfail(raises=exception)
+
+
 
 from numpy.testing import assert_almost_equal
 from numpy.testing import assert_array_equal
@@ -61,7 +66,7 @@ from sklearn.base import (ClassifierMixin, RegressorMixin, TransformerMixin,
 from sklearn.cluster import DBSCAN
 
 __all__ = ["assert_equal", "assert_not_equal", "assert_raises",
-           "assert_raises_regexp", "raises", "with_setup", "assert_true",
+           "assert_raises_regexp", "raises", "assert_true",
            "assert_false", "assert_almost_equal", "assert_array_equal",
            "assert_array_almost_equal", "assert_array_less",
            "assert_less", "assert_less_equal",
@@ -74,7 +79,13 @@ assert_equal = _dummy.assertEqual
 assert_not_equal = _dummy.assertNotEqual
 assert_true = _dummy.assertTrue
 assert_false = _dummy.assertFalse
-assert_raises = _dummy.assertRaises
+
+
+def assert_raises(exception, fct, *args, **kwargs):
+    with pytest.raises(exception):
+        return fct(*args, **kwargs)
+
+
 SkipTest = unittest.case.SkipTest
 assert_dict_equal = _dummy.assertDictEqual
 assert_in = _dummy.assertIn
@@ -673,15 +684,15 @@ def clean_warning_registry():
             getattr(mod, reg).clear()
 
 
-def check_skip_network():
-    if int(os.environ.get('SKLEARN_SKIP_NETWORK_TESTS', 0)):
-        raise SkipTest("Text tutorial requires large dataset download")
+# def check_skip_network():
+    # if int(os.environ.get('SKLEARN_SKIP_NETWORK_TESTS', 0)):
+        # raise SkipTest("Text tutorial requires large dataset download")
 
 
-def check_skip_travis():
-    """Skip test if being run on Travis."""
-    if os.environ.get('TRAVIS') == "true":
-        raise SkipTest("This test needs to be skipped on Travis")
+# def check_skip_travis():
+    # """Skip test if being run on Travis."""
+    # if os.environ.get('TRAVIS') == "true":
+        # raise SkipTest("This test needs to be skipped on Travis")
 
 
 def _delete_folder(folder_path, warn=False):
@@ -716,8 +727,8 @@ class TempMemmap(object):
         _delete_folder(self.temp_folder)
 
 
-with_network = with_setup(check_skip_network)
-with_travis = with_setup(check_skip_travis)
+with_network = pytest.mark.skipif(int(os.environ.get('SKLEARN_SKIP_NETWORK_TESTS', 0)), reason="skip_network tests")
+with_travis = pytest.mark.skipif(os.environ.get('TRAVIS') == 'true', reason='skip on travis')
 
 
 class _named_check(object):

--- a/sklearn/utils/tests/test_stats.py
+++ b/sklearn/utils/tests/test_stats.py
@@ -1,3 +1,4 @@
+import pytest
 from sklearn.utils.testing import assert_array_equal
 
 from sklearn.utils.stats import rankdata
@@ -13,11 +14,7 @@ _cases = (
 )
 
 
-def test_cases():
-
-    def check_case(values, method, expected):
-        r = rankdata(values, method=method)
-        assert_array_equal(r, expected)
-
-    for values, method, expected in _cases:
-        yield check_case, values, method, expected
+@pytest.mark.parametrize("values, method, expected", _cases)
+def test_cases_rankdata(values, method, expected):
+    r = rankdata(values, method=method)
+    assert_array_equal(r, expected)


### PR DESCRIPTION

#### Reference Issue
Addresses issue #7319 


#### What does this implement/fix? Explain your changes.

With this PR I replace nosetest by py.test. Surprised how easy the port was in general.

* replaced a few setup and teardown function with pytest style fixtures.
* used `pytest.mark.parametrize` in many places that featured `yield`-style tests.
* a lot of yield-style tests remain that should be fixed probably, due to the pytest deprecation warning.
* I did not replace `assert_true` and `assert_false`, etc.

This PR is not as polished as I would normally prepare a PR to be, maybe with some feedback & help , especially with regards to the CI infrastructure, we can get it into a mergeable state.

PS: As far as I can tell, flake8 is used for style checks, I would suggest moving to https://pypi.python.org/pypi/pytest-flake8 which integrates nicely with flake8.