### PR TITLE
[MRG+1] Fix pickling bug  due to multiple inheritance & __getstate__

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -220,9 +220,9 @@ Bug fixes
    - Fix a bug in cases where `numpy.cumsum` may be numerically unstable,
      raising an exception if instability is identified.  :issue:`7376` and
      :issue:`7331` by `Joel Nothman`_ and :user:`yangarbiter`.
-   - Fix a bug where :meth:`sklearn.base.BaseEstimator.__getstate__` blocked
+   - Fix a bug where :meth:`sklearn.base.BaseEstimator.__getstate__`
      obstructed pickling customizations of child-classes, when used in a
-     multiple inheritence context.
+     multiple inheritance context.
      :issue:`8316` by :user:`Holger Peters <HolgerPeters>`.
 
 API changes summary

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -220,6 +220,10 @@ Bug fixes
    - Fix a bug in cases where `numpy.cumsum` may be numerically unstable,
      raising an exception if instability is identified.  :issue:`7376` and
      :issue:`7331` by `Joel Nothman`_ and :user:`yangarbiter`.
+   - Fix a bug where :meth:`sklearn.base.BaseEstimator.__getstate__` blocked
+     obstructed pickling customizations of child-classes, when used in a
+     multiple inheritence context.
+     :issue:`8316` by :user:`Holger Peters <HolgerPeters>`.
 
 API changes summary
 -------------------

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -290,10 +290,15 @@ class BaseEstimator(object):
                                                offset=len(class_name),),)
 
     def __getstate__(self):
+        try:
+            state = super(BaseEstimator, self).__getstate__()
+        except AttributeError:
+            state = self.__dict__
+
         if type(self).__module__.startswith('sklearn.'):
-            return dict(self.__dict__.items(), _sklearn_version=__version__)
+            return dict(state.items(), _sklearn_version=__version__)
         else:
-            return dict(self.__dict__.items())
+            return state.copy()
 
     def __setstate__(self, state):
         if type(self).__module__.startswith('sklearn.'):
@@ -305,7 +310,11 @@ class BaseEstimator(object):
                     "invalid results. Use at your own risk.".format(
                         self.__class__.__name__, pickle_version, __version__),
                     UserWarning)
-        self.__dict__.update(state)
+        try:
+            super(BaseEstimator, self).__setstate__(state)
+        except AttributeError:
+            self.__dict__.update(state)
+
 
 
 ###############################################################################

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -293,12 +293,12 @@ class BaseEstimator(object):
         try:
             state = super(BaseEstimator, self).__getstate__()
         except AttributeError:
-            state = self.__dict__
+            state = self.__dict__.copy()
 
         if type(self).__module__.startswith('sklearn.'):
             return dict(state.items(), _sklearn_version=__version__)
         else:
-            return state.copy()
+            return state
 
     def __setstate__(self, state):
         if type(self).__module__.startswith('sklearn.'):

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -13,6 +13,7 @@ from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import assert_warns_message
+from sklearn.utils.testing import assert_dict_equal
 
 from sklearn.base import BaseEstimator, clone, is_classifier
 from sklearn.svm import SVC
@@ -399,9 +400,9 @@ def test_pickling_when_getstate_is_overwritten_by_mixin():
 
     serialized = pickle.dumps(estimator, protocol=2)
     estimator_restored = pickle.loads(serialized)
-    assert estimator_restored.b == 5
-    assert estimator_restored._cache is None
-    assert estimator_restored._restored
+    assert_equal(estimator_restored.b, 5)
+    assert_equal(estimator_restored._cache, None)
+    assert_true(estimator_restored._restored)
 
 
 def test_pickling_when_getstate_is_overwritten_by_mixin_outside_of_sklearn():
@@ -412,12 +413,12 @@ def test_pickling_when_getstate_is_overwritten_by_mixin_outside_of_sklearn():
         type(estimator).__module__ = "notsklearn"
 
         serialized = estimator.__getstate__()
-        assert serialized == {'_cache': None, 'b': 5}
+        assert_dict_equal(serialized, {'_cache': None, 'b': 5})
 
         serialized['b'] = 4
         estimator.__setstate__(serialized)
-        assert estimator.b == 4
-        assert estimator._restored
+        assert_equal(estimator.b, 4)
+        assert_true(estimator._restored)
     finally:
         type(estimator).__module__ = old_mod
 
@@ -439,5 +440,5 @@ def test_pickling_works_when_getstate_is_overwritten_in_the_child_class():
 
     serialized = pickle.dumps(estimator, protocol=2)
     estimator_restored = pickle.loads(serialized)
-    assert estimator_restored.b == 5
-    assert estimator_restored._cache is None
+    assert_equal(estimator_restored.b, 5)
+    assert_equal(estimator_restored._cache, None)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -382,16 +382,10 @@ class MultiInheritanceEstimator(BaseEstimator, DontPickleCacheMixin):
         self.b = b
         self._cache = None
 
-    @property
-    def cache(self):
-        if not self._cache:
-            self._cache = "some value"
-        return self._cache
-
 
 def test_pickling_when_getstate_is_overwritten_by_mixin():
     estimator = MultiInheritanceEstimator()
-    assert estimator.cache
+    estimator._cache = "this attribute should not be pickled"
 
     serialized = pickle.dumps(estimator, protocol=2)
     estimator_restored = pickle.loads(serialized)
@@ -402,6 +396,7 @@ def test_pickling_when_getstate_is_overwritten_by_mixin():
 def test_pickling_when_getstate_is_overwritten_by_mixin_outside_of_sklearn():
     try:
         estimator = MultiInheritanceEstimator()
+        estimator._cache = "this attribute should not be pickled"
         old_mod = type(estimator).__module__
         type(estimator).__module__ = "notsklearn"
 
@@ -434,7 +429,7 @@ class SingleInheritanceEstimator(BaseEstimator):
 
 def test_pickling_works_when_getstate_is_overwritten_in_the_child_class():
     estimator = SingleInheritanceEstimator()
-    assert estimator.cache
+    estimator._cache = "this attribute should not be pickled"
 
     serialized = pickle.dumps(estimator, protocol=2)
     estimator_restored = pickle.loads(serialized)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -335,10 +335,9 @@ def test_pickle_version_warning_is_issued_upon_different_version():
     tree = TreeBadVersion().fit(iris.data, iris.target)
     tree_pickle_other = pickle.dumps(tree)
     message = ("Trying to unpickle estimator TreeBadVersion from "
-               "version {0} when using version {1}. This might lead to "
+               "version something when using version {version}. This might lead to "
                "breaking code or invalid results. "
-               "Use at your own risk.".format("something",
-                                              sklearn.__version__))
+               "Use at your own risk.".format(version=sklearn.__version__))
     assert_warns_message(UserWarning, message, pickle.loads, tree_pickle_other)
 
 
@@ -355,10 +354,9 @@ def test_pickle_version_warning_is_issued_when_no_version_info_in_pickle():
     tree_pickle_noversion = pickle.dumps(tree)
     assert_false(b"version" in tree_pickle_noversion)
     message = ("Trying to unpickle estimator TreeNoVersion from "
-               "version {0} when using version {1}. This might lead to "
+               "version pre-0.18 when using version {version}. This might lead to "
                "breaking code or invalid results. "
-               "Use at your own risk.".format("pre-0.18",
-                                              sklearn.__version__))
+               "Use at your own risk.".format(version=sklearn.__version__))
     # check we got the warning about using pre-0.18 pickle
     assert_warns_message(UserWarning, message, pickle.loads,
                          tree_pickle_noversion)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -398,7 +398,7 @@ def test_pickling_when_getstate_is_overwritten_by_mixin():
     estimator = MultiInheritanceEstimator()
     estimator._cache = "this attribute should not be pickled"
 
-    serialized = pickle.dumps(estimator, protocol=2)
+    serialized = pickle.dumps(estimator)
     estimator_restored = pickle.loads(serialized)
     assert_equal(estimator_restored.b, 5)
     assert_equal(estimator_restored._cache, None)
@@ -438,7 +438,7 @@ def test_pickling_works_when_getstate_is_overwritten_in_the_child_class():
     estimator = SingleInheritanceEstimator()
     estimator._cache = "this attribute should not be pickled"
 
-    serialized = pickle.dumps(estimator, protocol=2)
+    serialized = pickle.dumps(estimator)
     estimator_restored = pickle.loads(serialized)
     assert_equal(estimator_restored.b, 5)
     assert_equal(estimator_restored._cache, None)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -412,12 +412,14 @@ def test_pickling_when_getstate_is_overwritten_by_mixin():
 def test_pickling_when_getstate_is_overwritten_by_mixin_outside_of_sklearn():
     try:
         estimator = MultiInheritanceEstimator()
-        estimator._attribute_not_pickled = "this attribute should not be pickled"
+        text = "this attribute should not be pickled"
+        estimator._attribute_not_pickled = text
         old_mod = type(estimator).__module__
         type(estimator).__module__ = "notsklearn"
 
         serialized = estimator.__getstate__()
-        assert_dict_equal(serialized, {'_attribute_not_pickled': None, 'attribute_pickled': 5})
+        assert_dict_equal(serialized, {'_attribute_not_pickled': None,
+                                       'attribute_pickled': 5})
 
         serialized['attribute_pickled'] = 4
         estimator.__setstate__(serialized)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -382,6 +382,10 @@ class DontPickleCacheMixin(object):
         data["_cache"] = None
         return data
 
+    def __setstate__(self, state):
+        state["_restored"] = True
+        self.__dict__.update(state)
+
 
 class MultiInheritanceEstimator(BaseEstimator, DontPickleCacheMixin):
     def __init__(self, b=5):
@@ -397,6 +401,7 @@ def test_pickling_when_getstate_is_overwritten_by_mixin():
     estimator_restored = pickle.loads(serialized)
     assert estimator_restored.b == 5
     assert estimator_restored._cache is None
+    assert estimator_restored._restored
 
 
 def test_pickling_when_getstate_is_overwritten_by_mixin_outside_of_sklearn():
@@ -412,6 +417,7 @@ def test_pickling_when_getstate_is_overwritten_by_mixin_outside_of_sklearn():
         serialized['b'] = 4
         estimator.__setstate__(serialized)
         assert estimator.b == 4
+        assert estimator._restored
     finally:
         type(estimator).__module__ = old_mod
 

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -330,14 +330,21 @@ class TreeBadVersion(DecisionTreeClassifier):
         return dict(self.__dict__.items(), _sklearn_version="something")
 
 
+pickle_error_message = (
+    "Trying to unpickle estimator {estimator} from "
+    "version {old_version} when using version "
+    "{current_version}. This might "
+    "lead to breaking code or invalid results. "
+    "Use at your own risk.")
+
+
 def test_pickle_version_warning_is_issued_upon_different_version():
     iris = datasets.load_iris()
     tree = TreeBadVersion().fit(iris.data, iris.target)
     tree_pickle_other = pickle.dumps(tree)
-    message = ("Trying to unpickle estimator TreeBadVersion from "
-               "version something when using version {version}. This might "
-               "lead to breaking code or invalid results. "
-               "Use at your own risk.".format(version=sklearn.__version__))
+    message = pickle_error_message.format(estimator="TreeBadVersion",
+                                          old_version="something",
+                                          current_version=sklearn.__version__)
     assert_warns_message(UserWarning, message, pickle.loads, tree_pickle_other)
 
 
@@ -353,10 +360,9 @@ def test_pickle_version_warning_is_issued_when_no_version_info_in_pickle():
 
     tree_pickle_noversion = pickle.dumps(tree)
     assert_false(b"version" in tree_pickle_noversion)
-    message = ("Trying to unpickle estimator TreeNoVersion from "
-               "version pre-0.18 when using version {version}. This might "
-               "lead to breaking code or invalid results. "
-               "Use at your own risk.".format(version=sklearn.__version__))
+    message = pickle_error_message.format(estimator="TreeNoVersion",
+                                          old_version="pre-0.18",
+                                          current_version=sklearn.__version__)
     # check we got the warning about using pre-0.18 pickle
     assert_warns_message(UserWarning, message, pickle.loads,
                          tree_pickle_noversion)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -335,8 +335,8 @@ def test_pickle_version_warning_is_issued_upon_different_version():
     tree = TreeBadVersion().fit(iris.data, iris.target)
     tree_pickle_other = pickle.dumps(tree)
     message = ("Trying to unpickle estimator TreeBadVersion from "
-               "version something when using version {version}. This might lead to "
-               "breaking code or invalid results. "
+               "version something when using version {version}. This might "
+               "lead to breaking code or invalid results. "
                "Use at your own risk.".format(version=sklearn.__version__))
     assert_warns_message(UserWarning, message, pickle.loads, tree_pickle_other)
 
@@ -354,8 +354,8 @@ def test_pickle_version_warning_is_issued_when_no_version_info_in_pickle():
     tree_pickle_noversion = pickle.dumps(tree)
     assert_false(b"version" in tree_pickle_noversion)
     message = ("Trying to unpickle estimator TreeNoVersion from "
-               "version pre-0.18 when using version {version}. This might lead to "
-               "breaking code or invalid results. "
+               "version pre-0.18 when using version {version}. This might "
+               "lead to breaking code or invalid results. "
                "Use at your own risk.".format(version=sklearn.__version__))
     # check we got the warning about using pre-0.18 pickle
     assert_warns_message(UserWarning, message, pickle.loads,

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -432,12 +432,6 @@ class SingleInheritanceEstimator(BaseEstimator):
         data["_cache"] = None
         return data
 
-    @property
-    def cache(self):
-        if not self._cache:
-            self._cache = "some value"
-        return self._cache
-
 
 def test_pickling_works_when_getstate_is_overwritten_in_the_child_class():
     estimator = SingleInheritanceEstimator()

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -373,8 +373,12 @@ def test_pickle_version_no_warning_is_issued_with_non_sklearn_estimator():
     iris = datasets.load_iris()
     tree = TreeNoVersion().fit(iris.data, iris.target)
     tree_pickle_noversion = pickle.dumps(tree)
-    TreeNoVersion.__module__ = "notsklearn"
-    assert_no_warnings(pickle.loads, tree_pickle_noversion)
+    try:
+        module_backup = TreeNoVersion.__module__
+        TreeNoVersion.__module__ = "notsklearn"
+        assert_no_warnings(pickle.loads, tree_pickle_noversion)
+    finally:
+        TreeNoVersion.__module__ = module_backup
 
 
 class DontPickleAttributeMixin(object):

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -317,7 +317,12 @@ def test_pickle_version_warning_is_not_raised_with_matching_version():
     tree = DecisionTreeClassifier().fit(iris.data, iris.target)
     tree_pickle = pickle.dumps(tree)
     assert_true(b"version" in tree_pickle)
-    assert_no_warnings(pickle.loads, tree_pickle)
+    tree_restored = assert_no_warnings(pickle.loads, tree_pickle)
+
+    # test that we can predict with the restored decision tree classifier
+    score_of_original = tree.score(iris.data, iris.target)
+    score_of_restored = tree_restored.score(iris.data, iris.target)
+    assert_equal(score_of_original, score_of_restored)
 
 
 class TreeBadVersion(DecisionTreeClassifier):


### PR DESCRIPTION
Includes a reproducing test case.

sklearn.base.BaseEstimator now tries to use other `__getstate__` methods of the class hierarchy first, before defaulting to the `__dict__` attribute

#### Reference Issue
Fix issue #8316