### PR TITLE
[MRG] Add sample_weight parameter to cohen_kappa_score (resubmitted from #7569)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -144,6 +144,9 @@ Enhancements
    - Added ability to use sparse matrices in :func:`feature_selection.f_regression`
      with ``center=True``. :issue:`8065` by :user:`Daniel LeJeune <acadiansith>`.
 
+   - Add ``sample_weight`` parameter to :func:`metrics.cohen_kappa_score` by
+     Victor Poughon.
+
 Bug fixes
 .........
 

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -275,7 +275,7 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
     return CM
 
 
-def cohen_kappa_score(y1, y2, labels=None, weights=None):
+def cohen_kappa_score(y1, y2, labels=None, weights=None, sample_weight=None):
     """Cohen's kappa: a statistic that measures inter-annotator agreement.
 
     This function computes Cohen's kappa [1]_, a score that expresses the level
@@ -311,6 +311,9 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None):
         List of weighting type to calculate the score. None means no weighted;
         "linear" means linear weighted; "quadratic" means quadratic weighted.
 
+    sample_weight : array-like of shape = [n_samples], optional
+        Sample weights.
+
     Returns
     -------
     kappa : float
@@ -328,7 +331,8 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None):
     .. [3] `Wikipedia entry for the Cohen's kappa.
             <https://en.wikipedia.org/wiki/Cohen%27s_kappa>`_
     """
-    confusion = confusion_matrix(y1, y2, labels=labels)
+    confusion = confusion_matrix(y1, y2, labels=labels,
+                                 sample_weight=sample_weight)
     n_classes = confusion.shape[0]
     sum0 = np.sum(confusion, axis=0)
     sum1 = np.sum(confusion, axis=1)

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -369,7 +369,6 @@ NOT_SYMMETRIC_METRICS = [
 
 # No Sample weight support
 METRICS_WITHOUT_SAMPLE_WEIGHT = [
-    "cohen_kappa_score",
     "confusion_matrix", # Left this one here because the tests in this file do
                         # not work for confusion_matrix, as its output is a
                         # matrix instead of a number. Testing of


### PR DESCRIPTION
#### Reference Issue
Rebased, squashed and resubmitted from PR #7569 after reviews.

#### What does this implement/fix? Explain your changes.
This adds a sample_weight parameter to sklearn.metrics.cohen_kappa_score. The implementation simply forwards the argument to the underlying confusion_matrix call.

#### Any other comments?
It would be better to add a specific test in test_cohen_kappa() (here), but I don't know how to get reference kappa values for this test. Note that cohen_kappa_score is removed from METRICS_WITHOUT_SAMPLE_WEIGHT in test_common.py, which should provide additional testing, although not specific to this metric.

Finally I couldn't manage to run the full test suite locally so I'm relying on travis-ci here.