### PR TITLE
[MRG+1] Fixes incorrect output when input is precomputed sparse matrix in DBSCAN.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -150,8 +150,8 @@ Enhancements
 Bug fixes
 .........
    - Fixed a bug where :class:`sklearn.cluster.DBSCAN` gives incorrect 
-     result when input is precomputed sparse matrix with initial rows
-     all zero.
+     result when input is a precomputed sparse matrix with initial
+     rows all zero.
      :issue:`8306` by :user:`Akshay Gupta <Akshay0724>`
 
    - Fixed a bug where :func:`sklearn.datasets.make_moons` gives an

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -149,6 +149,10 @@ Enhancements
 
 Bug fixes
 .........
+   - Fixed a bug where :class:`sklearn.cluster.DBSCAN` gives incorrect 
+     result when input is precomputed sparse matrix with initial rows
+     all zero.
+     :issue:`8306` by :user:`Akshay Gupta <Akshay0724>`
 
    - Fixed a bug where :func:`sklearn.datasets.make_moons` gives an
      incorrect result when ``n_samples`` is odd.

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -125,6 +125,10 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski', metric_params=None,
         X_mask = X.data <= eps
         masked_indices = astype(X.indices, np.intp, copy=False)[X_mask]
         masked_indptr = np.cumsum(X_mask)[X.indptr[1:] - 1]
+
+        if X.indptr[0] == X.indptr[1] == 0:  # check if first row is all zero
+            masked_indptr[0] = 0
+
         # insert the diagonal: a point is its own neighbor, but 0 distance
         # means absence from sparse matrix data
         masked_indices = np.insert(masked_indices, masked_indptr,

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -124,8 +124,7 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski', metric_params=None,
         X.sum_duplicates()  # XXX: modifies X's internals in-place
         X_mask = X.data <= eps
         masked_indices = astype(X.indices, np.intp, copy=False)[X_mask]
-        masked_indptr = np.concatenate(([0], np.cumsum(X_mask)),
-                                       axis=0)[X.indptr[1:]]
+        masked_indptr = np.concatenate(([0], np.cumsum(X_mask)))[X.indptr[1:]]
 
         # insert the diagonal: a point is its own neighbor, but 0 distance
         # means absence from sparse matrix data

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -124,10 +124,8 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski', metric_params=None,
         X.sum_duplicates()  # XXX: modifies X's internals in-place
         X_mask = X.data <= eps
         masked_indices = astype(X.indices, np.intp, copy=False)[X_mask]
-        masked_indptr = np.cumsum(X_mask)[X.indptr[1:] - 1]
-
-        if X.indptr[0] == X.indptr[1] == 0:  # check if first row is all zero
-            masked_indptr[0] = 0
+        masked_indptr = np.concatenate(([0], np.cumsum(X_mask)),
+                                       axis=0)[X.indptr[1:]]
 
         # insert the diagonal: a point is its own neighbor, but 0 distance
         # means absence from sparse matrix data

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -350,3 +350,20 @@ def test_dbscan_precomputed_metric_with_degenerate_input_arrays():
     X = np.zeros((10, 10))
     labels = DBSCAN(eps=0.5, metric='precomputed').fit(X).labels_
     assert_equal(len(set(labels)), 1)
+
+
+def test_dbscan_precomputed_metric_with_initial_rows_zero():
+    # sample matrix with initial two row all zero
+    ar = np.array([
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0],
+        [0.0, 0.0, 0.1, 0.1, 0.0, 0.0, 0.3],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1],
+        [0.0, 0.0, 0.0, 0.0, 0.3, 0.1, 0.0]
+    ])
+    matrix = sparse.csr_matrix(ar)
+    labels = DBSCAN(eps=0.2, metric='precomputed',
+                    min_samples=2).fit(matrix).labels_
+    assert_array_equal(labels, [-1, -1,  0,  0,  0,  1,  1])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #8306 

#### What does this implement/fix? Explain your changes.

This implementation fixes the incorrect output case when first row of precomputed sparse matrix is all zero.
Issue was due to this line-

`masked_indptr = np.cumsum(X_mask)[X.indptr[1:] - 1]`

with such input `X.indptr` is of form [0, 0, ....] and first element of index `[X.indptr[1:] - 1]` become -1 which in python means the last element.
So it would be better to avoid the case when `X.indptr` become [0, 0, ...] for this I have changed the value of first element of first row to eps+1. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
