### PR TITLE
[MRG] FIX Modify the API of Pipeline and FeatureUnion to match common scikit-learn estimators conventions

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -1222,7 +1222,7 @@ polynomial regression can be created and used as follows::
     >>> x = np.arange(5)
     >>> y = 3 - 2 * x + x ** 2 - x ** 3
     >>> model = model.fit(x[:, np.newaxis], y)
-    >>> model.named_steps['linear'].coef_
+    >>> model.named_steps_['linear'].coef_
     array([ 3., -2.,  1., -1.])
 
 The linear model trained on polynomial features is able to exactly recover

--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -65,9 +65,9 @@ The estimators of a pipeline are stored as a list in the ``steps`` attribute::
     ('reduce_dim', PCA(copy=True, iterated_power='auto', n_components=None, random_state=None,
       svd_solver='auto', tol=0.0, whiten=False))
 
-and as a ``dict`` in ``named_steps``::
+and as a ``dict`` in ``named_steps_``::
 
-    >>> pipe.named_steps['reduce_dim']
+    >>> pipe.named_steps_['reduce_dim']
     PCA(copy=True, iterated_power='auto', n_components=None, random_state=None,
       svd_solver='auto', tol=0.0, whiten=False)
 
@@ -176,7 +176,7 @@ object::
    In following example, accessing the :class:`PCA` instance ``pca2``
    will raise an ``AttributeError`` since ``pca2`` will be an unfitted
    transformer.
-   Instead, use the attribute ``named_steps`` to inspect estimators within
+   Instead, use the attribute ``named_steps_`` to inspect estimators within
    the pipeline::
 
      >>> cachedir = mkdtemp()
@@ -188,7 +188,7 @@ object::
      ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
       Pipeline(memory=...,
                steps=[('reduce_dim', PCA(...)), ('clf', SVC(...))])
-     >>> print(cached_pipe.named_steps['reduce_dim'].components_)
+     >>> print(cached_pipe.named_steps_['reduce_dim'].components_)
      ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
          [[ -1.77484909e-19  ... 4.07058917e-18]]
      >>> # Remove the cache directory

--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -166,48 +166,6 @@ object::
     >>> # Clear the cache directory when you don't need it anymore
     >>> rmtree(cachedir)
 
-.. warning:: **Side effect of caching transfomers**
-
-   Using a :class:`Pipeline` without cache enabled, it is possible to
-   inspect the original instance such as::
-
-     >>> from sklearn.datasets import load_digits
-     >>> digits = load_digits()
-     >>> pca1 = PCA()
-     >>> svm1 = SVC()
-     >>> pipe = Pipeline([('reduce_dim', pca1), ('clf', svm1)])
-     >>> pipe.fit(digits.data, digits.target)
-     ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
-     Pipeline(memory=None,
-              steps=[('reduce_dim', PCA(...)), ('clf', SVC(...))])
-     >>> # The pca instance can be inspected directly
-     >>> print(pca1.components_) # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
-         [[ -1.77484909e-19  ... 4.07058917e-18]]
-
-   Enabling caching triggers a clone of the transformers before fitting.
-   Therefore, the transformer instance given to the pipeline cannot be
-   inspected directly.
-   In following example, accessing the :class:`PCA` instance ``pca2``
-   will raise an ``AttributeError`` since ``pca2`` will be an unfitted
-   transformer.
-   Instead, use the attribute ``named_steps_`` to inspect estimators within
-   the pipeline::
-
-     >>> cachedir = mkdtemp()
-     >>> pca2 = PCA()
-     >>> svm2 = SVC()
-     >>> cached_pipe = Pipeline([('reduce_dim', pca2), ('clf', svm2)],
-     ...                        memory=cachedir)
-     >>> cached_pipe.fit(digits.data, digits.target)
-     ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
-      Pipeline(memory=...,
-               steps=[('reduce_dim', PCA(...)), ('clf', SVC(...))])
-     >>> print(cached_pipe.named_steps_['reduce_dim'].components_)
-     ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
-         [[ -1.77484909e-19  ... 4.07058917e-18]]
-     >>> # Remove the cache directory
-     >>> rmtree(cachedir)
-
 .. topic:: Examples:
 
  * :ref:`sphx_glr_auto_examples_plot_compare_reduction.py`

--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -50,26 +50,40 @@ it takes a variable number of estimators and returns a pipeline,
 filling in the names automatically::
 
     >>> from sklearn.pipeline import make_pipeline
-    >>> from sklearn.naive_bayes import MultinomialNB
-    >>> from sklearn.preprocessing import Binarizer
-    >>> make_pipeline(Binarizer(), MultinomialNB()) # doctest: +NORMALIZE_WHITESPACE
+    >>> make_pipeline(PCA(), SVC()) # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
     Pipeline(memory=None,
-             steps=[('binarizer', Binarizer(copy=True, threshold=0.0)),
-                    ('multinomialnb', MultinomialNB(alpha=1.0,
-                                                    class_prior=None,
-                                                    fit_prior=True))])
+             steps=[('pca', PCA(copy=True,...)),
+                    ('svc', SVC(C=1.0,...))])
 
-The estimators of a pipeline are stored as a list in the ``steps`` attribute::
+The original estimators of a pipeline are stored as a list in the ``steps``
+attribute::
 
     >>> pipe.steps[0]
     ('reduce_dim', PCA(copy=True, iterated_power='auto', n_components=None, random_state=None,
       svd_solver='auto', tol=0.0, whiten=False))
 
-and as a ``dict`` in ``named_steps_``::
+and as a ``dict`` in ``named_steps``::
 
-    >>> pipe.named_steps_['reduce_dim']
+    >>> pipe.named_steps['reduce_dim']
     PCA(copy=True, iterated_power='auto', n_components=None, random_state=None,
       svd_solver='auto', tol=0.0, whiten=False)
+
+Once the pipeline has been fitted, ``steps_`` and ``named_steps_`` have to be
+used.
+
+    >>> from sklearn.datasets import load_iris
+    >>> iris = load_iris()
+    >>> pipe.fit(iris.data, iris.target)
+    ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
+    Pipeline(memory=None,
+             steps=[('reduce_dim', PCA(copy=True,...)),
+                    ('clf', SVC(C=1.0,...))])
+    >>> pipe.named_steps_['reduce_dim']  # doctest: +NORMALIZE_WHITESPACE
+    PCA(copy=True, iterated_power='auto', n_components=None, random_state=None,
+        svd_solver='auto', tol=0.0, whiten=False)
+    >>> pipe.steps_[0]  # doctest: +NORMALIZE_WHITESPACE
+    ('reduce_dim', PCA(copy=True, iterated_power='auto', n_components=None,
+     random_state=None, svd_solver='auto', tol=0.0, whiten=False))
 
 Parameters of the estimators in the pipeline can be accessed using the
 ``<estimator>__<parameter>`` syntax::

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -255,7 +255,8 @@ API changes summary
     - In the future, the estimators in the ``steps`` and ``named_steps``
       attributes will no longer have their ``fit()`` methods called directly.
       Users will have to access fitted Pipeline steps in ``steps_``
-      and ``named_steps_``.
+      and ``named_steps_`. The warning was introduced in 0.19 and will take
+      effect in 0.22.
       :issue:`8350` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 .. _changes_0_18_1:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -56,6 +56,7 @@ Enhancements
    - :class:`multioutput.MultiOutputRegressor` and :class:`multioutput.MultiOutputClassifier`
      now support online learning using `partial_fit`.
      issue: `8053` by :user:`Peng Yu <yupbank>`.
+
    - :class:`pipeline.Pipeline` allows to cache transformers
      within a pipeline by using the ``memory`` constructor parameter.
      By :issue:`7990` by :user:`Guillaume Lemaitre <glemaitre>`.
@@ -250,6 +251,12 @@ API changes summary
       selection classes to be used with tools such as
       :func:`sklearn.model_selection.cross_val_predict`.
       :issue:`2879` by :user:`Stephen Hoover <stephen-hoover>`.
+
+    - In :class:`pipeline.Pipeline`, ``steps`` has been changed by ``steps`` and
+     ``steps_`` to not mutate the argument given by the users. Additionally,
+     ``named_step`` and ``named_steps_`` have to be used to access ``steps``
+      and ``steps_``, respectively.
+      :issue:`8350` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 .. _changes_0_18_1:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -252,10 +252,10 @@ API changes summary
       :func:`sklearn.model_selection.cross_val_predict`.
       :issue:`2879` by :user:`Stephen Hoover <stephen-hoover>`.
 
-    - In :class:`pipeline.Pipeline`, ``steps`` has been changed by ``steps`` and
-     ``steps_`` to not mutate the argument given by the users. Additionally,
-     ``named_step`` and ``named_steps_`` have to be used to access ``steps``
-      and ``steps_``, respectively.
+    - In the future, the estimators in the ``steps`` and ``named_steps``
+      attributes will no longer have their ``fit()`` methods called directly.
+      Users will have to access fitted Pipeline steps in ``steps_``
+      and ``named_steps_``.
       :issue:`8350` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 .. _changes_0_18_1:

--- a/examples/neural_networks/plot_rbm_logistic_classification.py
+++ b/examples/neural_networks/plot_rbm_logistic_classification.py
@@ -129,7 +129,7 @@ print("Logistic regression using raw pixel features:\n%s\n" % (
 # Plotting
 
 plt.figure(figsize=(4.2, 4))
-for i, comp in enumerate(rbm.components_):
+for i, comp in enumerate(classifier.named_steps_['rbm'].components_):
     plt.subplot(10, 10, i + 1)
     plt.imshow(comp.reshape((8, 8)), cmap=plt.cm.gray_r,
                interpolation='nearest')

--- a/examples/plot_digits_pipe.py
+++ b/examples/plot_digits_pipe.py
@@ -57,7 +57,7 @@ estimator = GridSearchCV(pipe,
                               logistic__C=Cs))
 estimator.fit(X_digits, y_digits)
 
-plt.axvline(estimator.best_estimator_.named_steps['pca'].n_components,
+plt.axvline(estimator.best_estimator_.named_steps_['pca'].n_components,
             linestyle=':', label='n_components chosen')
 plt.legend(prop=dict(size=12))
 plt.show()

--- a/examples/preprocessing/plot_scaling_importance.py
+++ b/examples/preprocessing/plot_scaling_importance.py
@@ -86,15 +86,15 @@ print('\nPrediction accuracy for the standardized test dataset with PCA')
 print('{:.2%}\n'.format(metrics.accuracy_score(y_test, pred_test_std)))
 
 # Extract PCA from pipeline
-pca = unscaled_clf.named_steps['pca']
-pca_std = std_clf.named_steps['pca']
+pca = unscaled_clf.named_steps_['pca']
+pca_std = std_clf.named_steps_['pca']
 
 # Show first principal componenets
 print('\nPC 1 without scaling:\n', pca.components_[0])
 print('\nPC 1 with scaling:\n', pca_std.components_[0])
 
 # Scale and use PCA on X_train data for visualization.
-scaler = std_clf.named_steps['standardscaler']
+scaler = std_clf.named_steps_['standardscaler']
 X_train_std = pca_std.transform(scaler.transform(X_train))
 
 # visualize standardized vs. untouched dataset with PCA performed

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -246,7 +246,7 @@ def test_countvectorizer_custom_vocabulary_pipeline():
         ('count', CountVectorizer(vocabulary=what_we_like)),
         ('tfidf', TfidfTransformer())])
     X = pipe.fit_transform(ALL_FOOD_DOCS)
-    assert_equal(set(pipe.named_steps['count'].vocabulary_),
+    assert_equal(set(pipe.named_steps_['count'].vocabulary_),
                  set(what_we_like))
     assert_equal(X.shape[1], len(what_we_like))
 
@@ -728,7 +728,7 @@ def test_count_vectorizer_pipeline_grid_selection():
     # the grid_search is considered the best estimator since they all converge
     # to 100% accuracy models
     assert_equal(grid_search.best_score_, 1.0)
-    best_vectorizer = grid_search.best_estimator_.named_steps['vect']
+    best_vectorizer = grid_search.best_estimator_.named_steps_['vect']
     assert_equal(best_vectorizer.ngram_range, (1, 1))
 
 
@@ -765,7 +765,7 @@ def test_vectorizer_pipeline_grid_selection():
     # the grid_search is considered the best estimator since they all converge
     # to 100% accuracy models
     assert_equal(grid_search.best_score_, 1.0)
-    best_vectorizer = grid_search.best_estimator_.named_steps['vect']
+    best_vectorizer = grid_search.best_estimator_.named_steps_['vect']
     assert_equal(best_vectorizer.ngram_range, (1, 1))
     assert_equal(best_vectorizer.norm, 'l2')
     assert_false(best_vectorizer.fixed_vocabulary_)

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -231,7 +231,7 @@ class Pipeline(_BasePipeline):
 
     @property
     def _estimator_type(self):
-        return self.steps_[-1][1]._estimator_type
+        return self._steps[-1][1]._estimator_type
 
     @property
     def steps(self):

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -243,7 +243,9 @@ class Pipeline(_BasePipeline):
         if hasattr(self, 'steps_'):
             warnings.warn("In the future, 'steps' will contain the estimator"
                           " used to instantiate the pipeline. To get the"
-                          " fitted steps, use 'steps_' instead.",
+                          " fitted steps, use 'steps_' instead. The warning"
+                          " was introduced in 0.19 and will take effect in "
+                          " 0.22.",
                           FutureWarning)
             return self.steps_
         else:
@@ -255,7 +257,10 @@ class Pipeline(_BasePipeline):
         if hasattr(self, 'steps_'):
             warnings.warn("In the future, 'steps' will be the steps used to"
                           " instantiate the pipeline. To set the fitted"
-                          " steps, use 'steps_' instead.", FutureWarning)
+                          " steps, use 'steps_' instead. The warning"
+                          " was introduced in 0.19 and will take effect in "
+                          " 0.22.",
+                          FutureWarning)
             self.steps_ = val
         # set the user argument
         self._steps = val
@@ -265,7 +270,10 @@ class Pipeline(_BasePipeline):
         if hasattr(self, 'steps_'):
             warnings.warn("In the future, 'named_steps' will return the"
                           " unfitted estimator. To get the fitted estimator,"
-                          " use 'name_steps_' instead.", FutureWarning)
+                          " use 'name_steps_' instead. The warning"
+                          " was introduced in 0.19 and will take effect in "
+                          " 0.22.",
+                          FutureWarning)
             return dict(self.steps_)
         else:
             return dict(self._steps)

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -13,7 +13,6 @@ import warnings
 
 from collections import defaultdict
 from abc import ABCMeta, abstractmethod
-from copy import deepcopy
 
 import numpy as np
 from scipy import sparse

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -126,7 +126,7 @@ class Pipeline(_BasePipeline):
     Attributes
     ----------
     named_steps : dict
-        Read-only attribute to access any unfitted step parameter by user
+        Read-only attribute to access any unfitted step parameter by its
         given name. Keys are step names and values are steps parameters.
 
     named_steps_ : dict
@@ -227,7 +227,13 @@ class Pipeline(_BasePipeline):
                             "'%s' (type %s) doesn't"
                             % (estimator, type(estimator)))
 
-        return deepcopy(self._steps)
+        # in version 0.21, we need to return:
+        # [(name, clone(est)) if est is not None else (name, None)
+        #  for name, est in self._steps]
+        # instead of:
+        # self._steps
+        # return self._steps
+        return self._steps
 
     @property
     def _estimator_type(self):
@@ -236,9 +242,10 @@ class Pipeline(_BasePipeline):
     @property
     def steps(self):
         if hasattr(self, 'steps_'):
-            warnings.warn("In the future, 'steps' will be the steps used to"
-                          " instantiate the pipeline. To get the fitted"
-                          " steps, use 'steps_' instead.", FutureWarning)
+            warnings.warn("In the future, 'steps' will contain the estimator"
+                          " used to instantiate the pipeline. To get the"
+                          " fitted steps, use 'steps_' instead.",
+                          FutureWarning)
             return self.steps_
         else:
             return self._steps
@@ -257,7 +264,7 @@ class Pipeline(_BasePipeline):
     @property
     def named_steps(self):
         if hasattr(self, 'steps_'):
-            warnings.warn("In the future, 'named_steps' will returned the"
+            warnings.warn("In the future, 'named_steps' will return the"
                           " unfitted estimator. To get the fitted estimator,"
                           " use 'name_steps_' instead.", FutureWarning)
             return dict(self.steps_)

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -172,6 +172,8 @@ class Pipeline(_BasePipeline):
         # shallow copy of steps
         self._steps = tosequence(steps)
         self.memory = memory
+        # to be removed in 0.22 - allows back-compatibility
+        self.steps_ = self._validate_steps()
 
     def get_params(self, deep=True):
         """Get parameters for this estimator.

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -381,7 +381,11 @@ class Pipeline(_BasePipeline):
         """
         last_step = self._final_estimator
         Xt, fit_params = self._fit(X, y, **fit_params)
-        if last_step is None:
+        if hasattr(last_step, 'fit_transform'):
+            Xt = last_step.fit_transform(Xt, y, **fit_params)
+            self.steps_[-1] = (self.steps_[-1][0], last_step)
+            return Xt
+        elif last_step is None:
             return Xt
         else:
             fitted_transformer = last_step.fit(Xt, y, **fit_params)

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -22,7 +22,6 @@ from .externals.joblib import Parallel, delayed, Memory
 from .externals import six
 from .utils import tosequence
 from .utils.metaestimators import if_delegate_has_method
-from .utils.validation import check_is_fitted
 
 __all__ = ['Pipeline', 'FeatureUnion']
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -173,7 +173,7 @@ class Pipeline(_BasePipeline):
         self._steps = tosequence(steps)
         self.memory = memory
         # to be removed in 0.22 - allows back-compatibility
-        self.steps_ = self._validate_steps()
+        # self.steps_ = self._validate_steps()
 
     def get_params(self, deep=True):
         """Get parameters for this estimator.
@@ -422,7 +422,16 @@ class Pipeline(_BasePipeline):
         -------
         y_pred : array-like
         """
-        check_is_fitted(self, 'steps_')
+        # to ensure back-compatibility
+        if not hasattr(self, 'steps_'):
+            warnings.warn("In the future, 'steps_' will need to be set instead"
+                          " of 'steps' to 'predict' without calling 'fit'. The"
+                          " warning was introduced in 0.19 and will take"
+                          " effect in 0.22",
+                          FutureWarning)
+            self.steps_ = self._validate_steps()
+        # to replaced the code above
+        # check_is_fitted(self, 'steps_')
         Xt = X
         for name, transform in self.steps_[:-1]:
             if transform is not None:
@@ -473,7 +482,16 @@ class Pipeline(_BasePipeline):
         -------
         y_proba : array-like, shape = [n_samples, n_classes]
         """
-        check_is_fitted(self, 'steps_')
+        # to ensure back-compatibility
+        if not hasattr(self, 'steps_'):
+            warnings.warn("In the future, 'steps_' will need to be set instead"
+                          " of 'steps' to 'predict_proba' without calling"
+                          " 'fit'. The warning was introduced in 0.19 and will"
+                          " take effect in 0.22",
+                          FutureWarning)
+            self.steps_ = self._validate_steps()
+        # to replaced the code above
+        # check_is_fitted(self, 'steps_')
         Xt = X
         for name, transform in self.steps_[:-1]:
             if transform is not None:
@@ -494,7 +512,16 @@ class Pipeline(_BasePipeline):
         -------
         y_score : array-like, shape = [n_samples, n_classes]
         """
-        check_is_fitted(self, 'steps_')
+        # to ensure back-compatibility
+        if not hasattr(self, 'steps_'):
+            warnings.warn("In the future, 'steps_' will need to be set instead"
+                          " of 'steps' to 'decision_function' without calling"
+                          " 'fit'. The warning was introduced in 0.19 and will"
+                          " take effect in 0.22",
+                          FutureWarning)
+            self.steps_ = self._validate_steps()
+        # to replaced the code above
+        # check_is_fitted(self, 'steps_')
         Xt = X
         for name, transform in self.steps_[:-1]:
             if transform is not None:
@@ -515,7 +542,16 @@ class Pipeline(_BasePipeline):
         -------
         y_score : array-like, shape = [n_samples, n_classes]
         """
-        check_is_fitted(self, 'steps_')
+        # to ensure back-compatibility
+        if not hasattr(self, 'steps_'):
+            warnings.warn("In the future, 'steps_' will need to be set instead"
+                          " of 'steps' to 'predict_log_proba' without calling"
+                          " 'fit'. The warning was introduced in 0.19 and will"
+                          " take effect in 0.22",
+                          FutureWarning)
+            self.steps_ = self._validate_steps()
+        # to replaced the code above
+        # check_is_fitted(self, 'steps_')
         Xt = X
         for name, transform in self.steps_[:-1]:
             if transform is not None:
@@ -545,7 +581,16 @@ class Pipeline(_BasePipeline):
         return self._transform
 
     def _transform(self, X):
-        check_is_fitted(self, 'steps_')
+        # to ensure back-compatibility
+        if not hasattr(self, 'steps_'):
+            warnings.warn("In the future, 'steps_' will need to be set instead"
+                          " of 'steps' to 'transform' without calling"
+                          " 'fit'. The warning was introduced in 0.19 and will"
+                          " take effect in 0.22",
+                          FutureWarning)
+            self.steps_ = self._validate_steps()
+        # to replaced the code above
+        # check_is_fitted(self, 'steps_')
         Xt = X
         for name, transform in self.steps_:
             if transform is not None:
@@ -577,7 +622,16 @@ class Pipeline(_BasePipeline):
         return self._inverse_transform
 
     def _inverse_transform(self, X):
-        check_is_fitted(self, 'steps_')
+        # to ensure back-compatibility
+        if not hasattr(self, 'steps_'):
+            warnings.warn("In the future, 'steps_' will need to be set instead"
+                          " of 'steps' to 'inverse_transform' without calling"
+                          " 'fit'. The warning was introduced in 0.19 and will"
+                          " take effect in 0.22",
+                          FutureWarning)
+            self.steps_ = self._validate_steps()
+        # to replaced the code above
+        # check_is_fitted(self, 'steps_')
         Xt = X
         for name, transform in self.steps_[::-1]:
             if transform is not None:
@@ -606,7 +660,16 @@ class Pipeline(_BasePipeline):
         -------
         score : float
         """
-        check_is_fitted(self, 'steps_')
+        # to ensure back-compatibility
+        if not hasattr(self, 'steps_'):
+            warnings.warn("In the future, 'steps_' will need to be set instead"
+                          " of 'steps' to 'score' without calling"
+                          " 'fit'. The warning was introduced in 0.19 and will"
+                          " take effect in 0.22",
+                          FutureWarning)
+            self.steps_ = self._validate_steps()
+        # to replaced the code above
+        # check_is_fitted(self, 'steps_')
         Xt = X
         for name, transform in self.steps_[:-1]:
             if transform is not None:

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -147,9 +147,10 @@ class DummyTransf(Transf):
 def test_pipeline_init():
     # Test the various init parameters of the pipeline.
     assert_raises(TypeError, Pipeline)
-    iris = load_iris()
-    X = iris.data
-    y = iris.target
+    # data required for later test in 0.22
+    # iris = load_iris()
+    # X = iris.data
+    # y = iris.target
     # Check that we can't instantiate pipelines with objects without fit
     # method
     assert_raises_regex(TypeError,
@@ -669,6 +670,7 @@ def test_pipeline_deprecation_warnings():
     assert_warns(FutureWarning, getattr, pipeline, 'steps')
     assert_warns(FutureWarning, getattr, pipeline, 'named_steps')
 
+
 def test_make_pipeline():
     t1 = Transf()
     t2 = Transf()
@@ -850,9 +852,10 @@ def test_set_feature_union_step_none():
 
 
 def test_step_name_validation_pipeline():
-    iris = load_iris()
-    X = iris.data
-    y = iris.target
+    # data required for 0.22
+    # iris = load_iris()
+    # X = iris.data
+    # y = iris.target
 
     bad_steps1 = [('a__q', Mult(2)), ('b', Mult(3))]
     bad_steps2 = [('a', Mult(2)), ('a', Mult(3))]

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -152,11 +152,16 @@ def test_pipeline_init():
     y = iris.target
     # Check that we can't instantiate pipelines with objects without fit
     # method
-    pipe = Pipeline([('clf', NoFit())])
     assert_raises_regex(TypeError,
                         'Last step of Pipeline should implement fit. '
                         '.*NoFit.*',
-                        pipe.fit, X, y)
+                        Pipeline, [('clf', NoFit())])
+    # test which will replace the previous one from 0.22
+    # pipe = Pipeline([('clf', NoFit())])
+    # assert_raises_regex(TypeError,
+    #                     'Last step of Pipeline should implement fit. '
+    #                     '.*NoFit.*',
+    #                     pipe.fit, X, y)
     # Smoke test with only an estimator
     clf = NoTrans()
     pipe = Pipeline([('svc', clf)])
@@ -178,11 +183,16 @@ def test_pipeline_init():
 
     # Check that we can't instantiate with non-transformers on the way
     # Note that NoTrans implements fit, but not transform
-    pipe_no_transf = Pipeline([('t', NoTrans()), ('svc', clf)])
     assert_raises_regex(TypeError,
                         'All intermediate steps should be transformers'
                         '.*\\bNoTrans\\b.*',
-                        pipe_no_transf.fit, X, y)
+                        Pipeline, [('t', NoTrans()), ('svc', clf)])
+    # test which will replace the previous one from 0.22
+    # pipe_no_transf = Pipeline([('t', NoTrans()), ('svc', clf)])
+    # assert_raises_regex(TypeError,
+    #                     'All intermediate steps should be transformers'
+    #                     '.*\\bNoTrans\\b.*',
+    #                     pipe_no_transf.fit, X, y)
 
     # Check that params are set
     pipe.set_params(svc__C=0.1)
@@ -857,8 +867,11 @@ def test_step_name_validation_pipeline():
     ]:
         # three ways to make invalid:
         # - construction
-        pipe = cls(bad_steps)
-        assert_raise_message(ValueError, message, pipe.fit, X, y)
+        assert_raise_message(ValueError, message, cls,
+                             **{param: bad_steps})
+        # test which will replace the previous one from 0.22
+        # pipe = cls(bad_steps)
+        # assert_raise_message(ValueError, message, pipe.fit, X, y)
 
         # - setattr
         est = cls(**{param: [('a', Mult(1))]})

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -18,6 +18,7 @@ from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_warns
 
 from sklearn.base import clone, BaseEstimator
 from sklearn.pipeline import Pipeline, FeatureUnion, make_pipeline, make_union
@@ -646,6 +647,17 @@ def test_pipeline_steps():
     # check that the estimators have been fitted in steps_
     check_is_fitted(pipe.named_steps_['pca'], 'n_components_')
     check_is_fitted(pipe.named_steps_['svc'], 'support_vectors_')
+
+
+def test_pipeline_deprecation_warnings():
+    # TODO remove in 0.22
+    iris = load_iris()
+    X = iris.data
+    pca = PCA(n_components=2, svd_solver='full')
+    pipeline = Pipeline([('pca', pca)])
+    pipeline.fit(X)
+    assert_warns(FutureWarning, getattr, pipeline, 'steps')
+    assert_warns(FutureWarning, getattr, pipeline, 'named_steps')
 
 def test_make_pipeline():
     t1 = Transf()

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -307,6 +307,10 @@ def test_pipeline_methods_pca_svm():
     pipe.predict_proba(X)
     pipe.predict_log_proba(X)
     pipe.score(X, y)
+    # in version 0.21, we need to change assert_true by assert_false
+    # for the moment _steps and steps_ are the same object for back-
+    # compatibility
+    assert_true(pipe._steps is pipe.steps_)
 
 
 def test_pipeline_methods_preprocessing_svm():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -537,15 +537,17 @@ def test_set_pipeline_step_none():
     assert_array_equal([[exp]], pipeline.fit_transform(X, y))
     assert_array_equal([exp], pipeline.fit(X).predict(X))
     assert_array_equal(X, pipeline.inverse_transform([[exp]]))
+    print(pipeline.get_params(deep=True))
     assert_dict_equal(pipeline.get_params(deep=True),
-                      {'steps': pipeline.steps,
-                       'm2': mult2,
-                       'm3': None,
-                       'last': mult5,
+                      {'last': Mult(mult=5),
                        'memory': None,
-                       'm2__mult': 2,
                        'last__mult': 5,
-                       })
+                       'steps': [('m2', Mult(mult=2)),
+                                 ('m3', None),
+                                 ('last', Mult(mult=5))],
+                       'm2__mult': 2,
+                       'm3': None,
+                       'm2': Mult(mult=2)})
 
     pipeline.set_params(m2=None)
     exp = 5


### PR DESCRIPTION
#### Reference Issue

#8157 

#### What does this implement/fix? Explain your changes.

Modify the Pipeline API such that `steps` given by the user at initialization is not modified.

#### Any other comments?

* `steps` is replaced by `steps_` at fit time to follow scikit-learn API.
* `named_steps` has the same behaviour as before with a `FutureWarning`. It will return unfitted estimators from `steps`.
* `named_steps_` returns fitted estimators from `steps_` .
* `steps` becomes `_steps` in order to create property and setter `steps`.

Update: `FeatureUnion` has a nearly identical design issue.