### PR TITLE
[MRG] Fix tests on numpy master

### DIFF
--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1852,7 +1852,7 @@ class PairwiseKernel(Kernel):
             Diagonal of kernel k(X, X)
         """
         # We have to fall back to slow way of computing diagonal
-        return np.apply_along_axis(self, 1, X)[:, 0]
+        return np.apply_along_axis(self, 1, X).ravel()
 
     def is_stationary(self):
         """Returns whether the kernel is stationary. """


### PR DESCRIPTION
`numpy.apply_along_axis` has changed behaviour when the function passed
in returns a 2d array. Very likely related to https://github.com/numpy/numpy/pull/8441.

The first build in master I could find with the failure on numpy dev (from 2 days ago):
https://travis-ci.org/scikit-learn/scikit-learn/builds/200889357

```py
import numpy as np
result = np.apply_along_axis(lambda X: np.array([[X[0]]]), 1, np.arange(6).reshape(3, -1))
print(result.shape)
```

outputs `(3, 1, 1)` on numpy master and `(3, 1)` on numpy 1.12.

A scikit-learn snippet closely related to the test failure:
```py
from sklearn.gaussian_process import kernels
kernel = kernels.PairwiseKernel()
print(kernel.diag(np.arange(6).reshape(3, -1)).shape)
```

outputs `(3, 1)` on numpy master and `(3,)` on numpy 1.12.