### PR TITLE
DOC make Tree docs public

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1326,6 +1326,7 @@ Low-level methods
    tree.DecisionTreeRegressor
    tree.ExtraTreeClassifier
    tree.ExtraTreeRegressor
+   tree.Tree
 
 .. autosummary::
    :toctree: generated/

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -627,7 +627,7 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
         The number of outputs when ``fit`` is performed.
 
     tree_ : Tree object
-        The underlying Tree object.
+        The underlying :class:`Tree` object.
 
     See also
     --------
@@ -920,7 +920,7 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
         The number of outputs when ``fit`` is performed.
 
     tree_ : Tree object
-        The underlying Tree object.
+        The underlying :class:`Tree` object.
 
     See also
     --------


### PR DESCRIPTION
I feel like the Tree class needs an official public interface. If we wish to be conservative, we can mark some parts private/experimental. I've not tested the rendering; will lazily rely on Circle.