### PR TITLE
plot iso-f1 curves in plot_precision_recall

### DIFF
--- a/examples/model_selection/plot_precision_recall.py
+++ b/examples/model_selection/plot_precision_recall.py
@@ -127,6 +127,21 @@ average_precision["micro"] = average_precision_score(y_test, y_score,
                                                      average="micro")
 
 
+# Plot ISO-F1 curve
+plt.clf()
+f_scores = np.linspace(0.1, 0.9, num=9)
+for F in f_scores:
+    x = R = np.linspace(0.01, 1)
+    y = F * R / (2 * R - F)
+    plt.plot(x[y >= 0], y[y >= 0], color='navy')
+    plt.annotate('f1={0:0.1f}'.format(F), xy=(0.9, y[45] + 0.02))
+plt.xlabel('Recall')
+plt.ylabel('Precision')
+plt.xlim([0.0, 1.0])
+plt.ylim([0.0, 1.0])
+plt.title('ISO-F1 curves')
+plt.show()
+
 # Plot Precision-Recall curve
 plt.clf()
 plt.plot(recall[0], precision[0], lw=lw, color='navy',


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Fixes #8313 
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
while plotting PR curves, it separates out the curves with equal f1 values.



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
