### PR TITLE
[MRG+1] FIX AdaBoost ZeroDivisionError in proba #7501

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -154,7 +154,7 @@ Bug fixes
 .........
 
    - Fixed a bug where :class:`sklearn.ensemble.AdaBoostClassifier` throws
-     `ZeroDivisionError` while fitting data with single class labels.
+     ``ZeroDivisionError`` while fitting data with single class labels.
      :issue:`7501` by :user:`Dominik Krzeminski <dokato>`.
 
    - Fixed a bug where :func:`sklearn.model_selection.BaseSearchCV.inverse_transform`

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -153,6 +153,10 @@ Enhancements
 Bug fixes
 .........
 
+   - Fixed a bug where :class:`sklearn.ensemble.AdaBoostClassifier` throws
+     `ZeroDivisionError` while fitting data with single class labels.
+     :issue:`7501` by :user:`Dominik Krzeminski <dokato>`.
+
    - Fixed a bug where :class:`sklearn.linear_model.RandomizedLasso` and
      :class:`sklearn.linear_model.RandomizedLogisticRegression` breaks for
      sparse input.

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -73,11 +73,13 @@ def test_samme_proba():
     assert_array_equal(np.argmin(samme_proba, axis=1), [2, 0, 0, 2])
     assert_array_equal(np.argmax(samme_proba, axis=1), [0, 1, 1, 1])
 
+
 def test_oneclass_proba():
     # Test `predict_proba` robustness for one class label input.
-    y_t = np.ones((X.shape[0],))
+    y_t = np.ones((len(X),))
     clf = AdaBoostClassifier().fit(X, y_t)
-    assert_array_equal(clf.predict_proba(X), np.ones((X.shape[0],1)))
+    assert_array_equal(clf.predict_proba(X), np.ones((X.shape[0], 1)))
+
 
 def test_classification_toy():
     # Check classification on a toy dataset.

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -74,9 +74,11 @@ def test_samme_proba():
     assert_array_equal(np.argmax(samme_proba, axis=1), [0, 1, 1, 1])
 
 
-def test_oneclass_proba():
-    # Test `predict_proba` robustness for one class label input.
-    y_t = np.ones((len(X),))
+def test_oneclass_adaboost_proba():
+    # Test predict_proba robustness for one class label input.
+    # In response to issue #7501
+    # https://github.com/scikit-learn/scikit-learn/issues/7501
+    y_t = np.ones(len(X))
     clf = AdaBoostClassifier().fit(X, y_t)
     assert_array_equal(clf.predict_proba(X), np.ones((len(X), 1)))
 

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -78,7 +78,7 @@ def test_oneclass_proba():
     # Test `predict_proba` robustness for one class label input.
     y_t = np.ones((len(X),))
     clf = AdaBoostClassifier().fit(X, y_t)
-    assert_array_equal(clf.predict_proba(X), np.ones((X.shape[0], 1)))
+    assert_array_equal(clf.predict_proba(X), np.ones((len(X), 1)))
 
 
 def test_classification_toy():

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -73,6 +73,11 @@ def test_samme_proba():
     assert_array_equal(np.argmin(samme_proba, axis=1), [2, 0, 0, 2])
     assert_array_equal(np.argmax(samme_proba, axis=1), [0, 1, 1, 1])
 
+def test_oneclass_proba():
+    # Test `predict_proba` robustness for one class label input.
+    y_t = np.ones((X.shape[0],))
+    clf = AdaBoostClassifier().fit(X, y_t)
+    assert_array_equal(clf.predict_proba(X), np.ones((X.shape[0],1)))
 
 def test_classification_toy():
     # Check classification on a toy dataset.

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -756,6 +756,9 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         n_classes = self.n_classes_
         X = self._validate_X_predict(X)
 
+        if n_classes == 1:
+            return np.ones((X.shape[0], 1))
+
         if self.algorithm == 'SAMME.R':
             # The weights are all 1. for SAMME.R
             proba = sum(_samme_proba(estimator, n_classes, X)
@@ -765,14 +768,11 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
                         for estimator, w in zip(self.estimators_,
                                                 self.estimator_weights_))
 
-        if n_classes > 1:
-            proba /= self.estimator_weights_.sum()
-            proba = np.exp((1. / (n_classes - 1)) * proba)
-            normalizer = proba.sum(axis=1)[:, np.newaxis]
-            normalizer[normalizer == 0.0] = 1.0
-            proba /= normalizer
-        else:
-            proba = np.ones(proba.shape)
+        proba /= self.estimator_weights_.sum()
+        proba = np.exp((1. / (n_classes - 1)) * proba)
+        normalizer = proba.sum(axis=1)[:, np.newaxis]
+        normalizer[normalizer == 0.0] = 1.0
+        proba /= normalizer
         return proba
 
     def staged_predict_proba(self, X):

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -765,12 +765,14 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
                         for estimator, w in zip(self.estimators_,
                                                 self.estimator_weights_))
 
-        proba /= self.estimator_weights_.sum()
-        proba = np.exp((1. / (n_classes - 1)) * proba)
-        normalizer = proba.sum(axis=1)[:, np.newaxis]
-        normalizer[normalizer == 0.0] = 1.0
-        proba /= normalizer
-
+        if n_classes > 1:
+            proba /= self.estimator_weights_.sum()
+            proba = np.exp((1. / (n_classes - 1)) * proba)
+            normalizer = proba.sum(axis=1)[:, np.newaxis]
+            normalizer[normalizer == 0.0] = 1.0
+            proba /= normalizer
+        else:
+            proba = np.ones(proba.shape)
         return proba
 
     def staged_predict_proba(self, X):

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -773,6 +773,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         normalizer = proba.sum(axis=1)[:, np.newaxis]
         normalizer[normalizer == 0.0] = 1.0
         proba /= normalizer
+
         return proba
 
     def staged_predict_proba(self, X):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
Fixes #7501. As suggested returns vector of ones when only one class.

#### Any other comments?
Tests added as well.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
