### PR TITLE
[MRG] Adding LinearKernel to GaussianProcesses

### DIFF
--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1616,6 +1616,132 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
             self.__class__.__name__, self.length_scale, self.periodicity)
 
 
+class LinearKernel(Kernel):
+    """Linear kernel.
+
+    The Linear kernel is non-stationary and can be obtained from Bayesiann
+    linear regression by putting N(0, \sigma_v^2) priors on the coefficients of
+    x_d (d = 1, . . . , D) and a prior of N(0, \sigma_b^2) on the bias. It is
+    parameterized by parameters sigma_v and sigma_0. The parameters of the
+    Linear kernel are about specifying the origin. The kernel is given by:
+
+    k(x_i, x_j) = sigma_b ^ 2 + sigma_v ^ 2 * (x_i \cdot x_j)
+
+    The Linear kernel can be combined with other kernels, more commonly with
+    periodic kernels.
+
+    Parameters
+    ----------
+    sigma_b : float >= 0, default: 1.0
+        Parameter adding an uncertainty offset to the kernel.
+
+    sigma_v : float >= 0, default: 1.0
+        Parameter adding an uncertainty offset to the kernel.
+
+    sigma_b_bounds : pair of floats >= 0, default: (1e-5, 1e5)
+        The lower and upper bound on sigma_b
+
+    sigma_v_bounds : pair of floats >= 0, default: (1e-5, 1e5)
+        The lower and upper bound on sigma_v
+
+    """
+
+    def __init__(self, sigma_b=1.0, sigma_v=1.0, sigma_b_bounds=(1e-5, 1e5),
+                 sigma_v_bounds=(1e-5, 1e5)):
+        self.sigma_b = sigma_b
+        self.sigma_v = sigma_v
+        self.sigma_b_bounds = sigma_b_bounds
+        self.sigma_v_bounds = sigma_v_bounds
+
+    @property
+    def hyperparameter_sigma_b(self):
+        return Hyperparameter("sigma_b", "numeric", self.sigma_b_bounds)
+
+    @property
+    def hyperparameter_sigma_v(self):
+        return Hyperparameter("sigma_v", "numeric", self.sigma_v_bounds)
+
+    def __call__(self, X, Y=None, eval_gradient=False):
+        """Return the kernel k(X, Y) and optionally its gradient.
+
+        Parameters
+        ----------
+        X : array, shape (n_samples_X, n_features)
+            Left argument of the returned kernel k(X, Y)
+
+        Y : array, shape (n_samples_Y, n_features), (optional, default=None)
+            Right argument of the returned kernel k(X, Y). If None, k(X, X)
+            if evaluated instead.
+
+        eval_gradient : bool (optional, default=False)
+            Determines whether the gradient with respect to the kernel
+            hyperparameter is determined. Only supported when Y is None.
+
+        Returns
+        -------
+        K : array, shape (n_samples_X, n_samples_Y)
+            Kernel k(X, Y)
+
+        K_gradient : array (opt.), shape (n_samples_X, n_samples_X, n_dims)
+            The gradient of the kernel k(X, X) with respect to the
+            hyperparameter of the kernel. Only returned when eval_gradient
+            is True.
+        """
+        X = np.atleast_2d(X)
+        if Y is None:
+            K = (self.sigma_v ** 2) * np.inner(X, X) + (self.sigma_b ** 2)
+        else:
+            if eval_gradient:
+                raise ValueError(
+                    "Gradient can only be evaluated when Y is None.")
+            K = (self.sigma_v ** 2) * np.inner(X, Y) + (self.sigma_b ** 2)
+
+        if eval_gradient:
+            # gradient with respect to sigma_b
+            if not self.hyperparameter_sigma_b.fixed:
+                sigma_b_gradient = np.empty((K.shape[0], K.shape[1], 1))
+                sigma_b_gradient[..., 0] = 2 * self.sigma_b ** 2
+            else:
+                sigma_b_gradient = np.empty((X.shape[0], X.shape[0], 0))
+            # gradient with respect to sigma_v
+            if not self.hyperparameter_sigma_v.fixed:
+                sigma_v_gradient = 2 * self.sigma_v ** 2 * np.inner(X, X)
+                sigma_v_gradient = sigma_v_gradient[:, :, np.newaxis]
+            else:
+                sigma_v_gradient = np.empty((X.shape[0], X.shape[0], 0))
+            return K, np.dstack((sigma_b_gradient, sigma_v_gradient))
+        else:
+            return K
+
+    def diag(self, X):
+        """Returns the diagonal of the kernel k(X, X).
+
+        The result of this method is identical to np.diag(self(X)); however,
+        it can be evaluated more efficiently since only the diagonal is
+        evaluated.
+
+        Parameters
+        ----------
+        X : array, shape (n_samples_X, n_features)
+            Left argument of the returned kernel k(X, Y)
+
+        Returns
+        -------
+        K_diag : array, shape (n_samples_X,)
+            Diagonal of kernel k(X, X)
+        """
+        return (self.sigma_v ** 2) * np.einsum('ij,ij->i', X, X) + \
+            self.sigma_b ** 2
+
+    def is_stationary(self):
+        """Returns whether the kernel is stationary."""
+        return False
+
+    def __repr__(self):
+        return "{0}(sigma_b={1:.3g}, sigma_v={2:.3g})".format(
+            self.__class__.__name__, self.sigma_b, self.sigma_v)
+
+
 class DotProduct(Kernel):
     """Dot-Product kernel.
 

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1619,7 +1619,7 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 class LinearKernel(Kernel):
     """Linear kernel.
 
-    The Linear kernel is non-stationary and can be obtained from Bayesiann
+    The Linear kernel is non-stationary and can be obtained from Bayesian
     linear regression by putting N(0, \sigma_v^2) priors on the coefficients of
     x_d (d = 1, . . . , D) and a prior of N(0, \sigma_b^2) on the bias. It is
     parameterized by parameters sigma_v and sigma_0. The parameters of the

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1752,15 +1752,18 @@ class LinearKernel(Kernel):
                 c_gradient = np.empty((X.shape[0], X.shape[0], 0))
             else:
                 if not self.non_uniform_offset:
+                    gradient_mat = np.inner(np.ones(X.shape), X - self.c)
                     c_gradient = - self.c * self.sigma_v ** 2 * \
-                        (np.inner(np.ones(X.shape), X - self.c) +
-                         np.inner(X - self.c, np.ones(X.shape)))
+                        (gradient_mat + gradient_mat.T)
+                    c_gradient = c_gradient[:, :, np.newaxis]
                 else:
-                    print(self.c)
-                    c_gradient = - self.c * self.sigma_v ** 2 * \
-                        (np.inner(np.ones(X.shape), X - self.c) +
-                         np.inner(X - self.c, np.ones(X.shape)))
-                c_gradient = c_gradient[:, :, np.newaxis]
+                    c_gradient = []
+                    for i, c in enumerate(self.c):
+                        gradient_mat = np.vstack(
+                            [(X - self.c)[:, i]] * X.shape[0])
+                        c_gradient.append(c * (gradient_mat + gradient_mat.T))
+                    c_gradient = - (self.sigma_v ** 2) * np.array(c_gradient)
+                    c_gradient = np.rollaxis(c_gradient, 0, 3)
             return K, np.dstack((c_gradient, sigma_b_gradient,
                                  sigma_v_gradient))
         else:
@@ -1791,8 +1794,14 @@ class LinearKernel(Kernel):
         return False
 
     def __repr__(self):
-        return "{0}(sigma_b={1:.3g}, sigma_v={2:.3g}, c={3:.3g})".format(
-            self.__class__.__name__, self.sigma_b, self.sigma_v, self.c)
+        if self.non_uniform_offset:
+            return "{0}(sigma_b={1:.3g}, sigma_v={2:.3g}, c=[{3}])".format(
+                self.__class__.__name__, self.sigma_b, self.sigma_v,
+                ", ".join(map("{0:.3g}".format, self.c)))
+        else:
+            return "{0}(sigma_b={1:.3g}, sigma_v={2:.3g}, c={3:.3g})".format(
+                self.__class__.__name__, self.sigma_b, self.sigma_v,
+                np.ravel(self.c)[0])
 
 
 class DotProduct(Kernel):

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -42,7 +42,8 @@ kernels = [RBF(length_scale=2.0), RBF(length_scale_bounds=(0.5, 2.0)),
            ExpSineSquared(length_scale=0.5, periodicity=1.5),
            DotProduct(sigma_0=2.0), DotProduct(sigma_0=2.0) ** 2,
            RBF(length_scale=[2.0]), Matern(length_scale=[2.0]),
-           LinearKernel(sigma_b=2.0, sigma_v=3.0, c=1.0)]
+           LinearKernel(sigma_b=2.0, sigma_v=3.0, c=1.0),
+           LinearKernel(sigma_b=2.0, sigma_v=2.0, c=[2.0, 3.0])]
 for metric in PAIRWISE_KERNEL_FUNCTIONS:
     if metric in ["additive_chi2", "chi2"]:
         continue
@@ -107,7 +108,7 @@ def test_kernel_theta():
             assert_equal(theta.shape[0], new_kernel.theta.shape[0] + 1)
             assert_equal(K_gradient.shape[2], K_gradient_new.shape[2] + 1)
             if i > 0:
-                assert_equal(theta[:i], new_kernel.theta[:i])
+                assert_array_equal(theta[:i], new_kernel.theta[:i])
                 assert_array_equal(K_gradient[..., :i],
                                    K_gradient_new[..., :i])
             if i + 1 < len(kernel.hyperparameters):

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -14,7 +14,7 @@ from sklearn.metrics.pairwise \
 from sklearn.gaussian_process.kernels \
     import (RBF, Matern, RationalQuadratic, ExpSineSquared, DotProduct,
             ConstantKernel, WhiteKernel, PairwiseKernel, KernelOperator,
-            Exponentiation)
+            Exponentiation, LinearKernel)
 from sklearn.base import clone
 
 from sklearn.utils.testing import (assert_equal, assert_almost_equal,
@@ -41,7 +41,8 @@ kernels = [RBF(length_scale=2.0), RBF(length_scale_bounds=(0.5, 2.0)),
            RationalQuadratic(length_scale=0.5, alpha=1.5),
            ExpSineSquared(length_scale=0.5, periodicity=1.5),
            DotProduct(sigma_0=2.0), DotProduct(sigma_0=2.0) ** 2,
-           RBF(length_scale=[2.0]), Matern(length_scale=[2.0])]
+           RBF(length_scale=[2.0]), Matern(length_scale=[2.0]),
+           LinearKernel(sigma_b=2.0, sigma_v=3.0)]
 for metric in PAIRWISE_KERNEL_FUNCTIONS:
     if metric in ["additive_chi2", "chi2"]:
         continue

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -42,7 +42,7 @@ kernels = [RBF(length_scale=2.0), RBF(length_scale_bounds=(0.5, 2.0)),
            ExpSineSquared(length_scale=0.5, periodicity=1.5),
            DotProduct(sigma_0=2.0), DotProduct(sigma_0=2.0) ** 2,
            RBF(length_scale=[2.0]), Matern(length_scale=[2.0]),
-           LinearKernel(sigma_b=2.0, sigma_v=3.0)]
+           LinearKernel(sigma_b=2.0, sigma_v=3.0, c=1.0)]
 for metric in PAIRWISE_KERNEL_FUNCTIONS:
     if metric in ["additive_chi2", "chi2"]:
         continue
@@ -111,7 +111,7 @@ def test_kernel_theta():
                 assert_array_equal(K_gradient[..., :i],
                                    K_gradient_new[..., :i])
             if i + 1 < len(kernel.hyperparameters):
-                assert_equal(theta[i + 1:], new_kernel.theta[i:])
+                assert_array_equal(theta[i + 1:], new_kernel.theta[i:])
                 assert_array_equal(K_gradient[..., i + 1:],
                                    K_gradient_new[..., i:])
 

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -19,7 +19,7 @@ from sklearn.base import clone
 
 from sklearn.utils.testing import (assert_equal, assert_almost_equal,
                                    assert_not_equal, assert_array_equal,
-                                   assert_array_almost_equal)
+                                   assert_array_almost_equal, assert_true)
 
 
 X = np.random.RandomState(0).normal(0, 1, (5, 2))
@@ -42,8 +42,8 @@ kernels = [RBF(length_scale=2.0), RBF(length_scale_bounds=(0.5, 2.0)),
            ExpSineSquared(length_scale=0.5, periodicity=1.5),
            DotProduct(sigma_0=2.0), DotProduct(sigma_0=2.0) ** 2,
            RBF(length_scale=[2.0]), Matern(length_scale=[2.0]),
-           LinearKernel(sigma_b=2.0, sigma_v=3.0, c=1.0),
-           LinearKernel(sigma_b=2.0, sigma_v=2.0, c=[2.0, 3.0])]
+           LinearKernel(sigma_b=2.0, sigma_v=2.0, c=2.0),
+           LinearKernel(sigma_b=3.0, sigma_v=4.0, c=[2.0, 3.0])]
 for metric in PAIRWISE_KERNEL_FUNCTIONS:
     if metric in ["additive_chi2", "chi2"]:
         continue
@@ -67,7 +67,7 @@ def test_kernel_gradient():
         K_gradient_approx = \
             _approx_fprime(kernel.theta, eval_kernel_for_theta, 1e-10)
 
-        assert_almost_equal(K_gradient, K_gradient_approx, 4)
+        assert_almost_equal(K_gradient, K_gradient_approx, 3)
 
 
 def test_kernel_theta():
@@ -91,13 +91,23 @@ def test_kernel_theta():
 
         # Check that values returned in theta are consistent with
         # hyperparameter values (being their logarithms)
-        for i, hyperparameter in enumerate(kernel.hyperparameters):
-            assert_equal(theta[i],
-                         np.log(getattr(kernel, hyperparameter.name)))
+        i = 0
+        for hyperparameter in kernel.hyperparameters:
+            if hyperparameter.n_elements > 1:
+                assert_array_equal(theta[i:i + hyperparameter.n_elements],
+                                   np.log(getattr(kernel,
+                                                  hyperparameter.name)))
+            else:
+                assert_array_equal(theta[i],
+                                   np.log(getattr(kernel,
+                                                  hyperparameter.name)))
+            i += hyperparameter.n_elements
 
         # Fixed kernel parameters must be excluded from theta and gradient.
-        for i, hyperparameter in enumerate(kernel.hyperparameters):
+        i = 0
+        for hyperparameter in kernel.hyperparameters:
             # create copy with certain hyperparameter fixed
+            n_elements = hyperparameter.n_elements
             params = kernel.get_params()
             params[hyperparameter.name + "_bounds"] = "fixed"
             kernel_class = kernel.__class__
@@ -105,25 +115,44 @@ def test_kernel_theta():
             # Check that theta and K_gradient are identical with the fixed
             # dimension left out
             _, K_gradient_new = new_kernel(X, eval_gradient=True)
-            assert_equal(theta.shape[0], new_kernel.theta.shape[0] + 1)
-            assert_equal(K_gradient.shape[2], K_gradient_new.shape[2] + 1)
+            assert_equal(theta.shape[0],
+                         new_kernel.theta.shape[0] + n_elements)
+            assert_equal(K_gradient.shape[2],
+                         K_gradient_new.shape[2] + n_elements)
             if i > 0:
                 assert_array_equal(theta[:i], new_kernel.theta[:i])
                 assert_array_equal(K_gradient[..., :i],
                                    K_gradient_new[..., :i])
-            if i + 1 < len(kernel.hyperparameters):
-                assert_array_equal(theta[i + 1:], new_kernel.theta[i:])
-                assert_array_equal(K_gradient[..., i + 1:],
+            if i + n_elements < len(kernel.hyperparameters):
+                assert_array_equal(theta[i + n_elements:],
+                                   new_kernel.theta[i:])
+                assert_array_equal(K_gradient[..., i + n_elements:],
                                    K_gradient_new[..., i:])
+            i += n_elements
 
         # Check that values of theta are modified correctly
-        for i, hyperparameter in enumerate(kernel.hyperparameters):
-            theta[i] = np.log(42)
-            kernel.theta = theta
-            assert_almost_equal(getattr(kernel, hyperparameter.name), 42)
+        i = 0
+        for hyperparameter in kernel.hyperparameters:
+            n_elements = hyperparameter.n_elements
+            if n_elements > 1:
+                theta[i:i + hyperparameter.n_elements] = \
+                     [np.log(42)] * hyperparameter.n_elements
+                kernel.theta = theta
+                assert_almost_equal(getattr(kernel, hyperparameter.name),
+                                    [42] * hyperparameter.n_elements)
 
-            setattr(kernel, hyperparameter.name, 43)
-            assert_almost_equal(kernel.theta[i], np.log(43))
+                setattr(kernel, hyperparameter.name,
+                        [43] * hyperparameter.n_elements)
+                assert_almost_equal(kernel.theta[i],
+                                    [np.log(43)] * hyperparameter.n_elements)
+            else:
+                theta[i] = np.log(42)
+                kernel.theta = theta
+                assert_almost_equal(getattr(kernel, hyperparameter.name), 42)
+
+                setattr(kernel, hyperparameter.name, 43)
+                assert_almost_equal(kernel.theta[i], np.log(43))
+            i += n_elements
 
 
 def test_auto_vs_cross():
@@ -206,7 +235,13 @@ def test_kernel_clone():
         assert_not_equal(id(kernel), id(kernel_cloned))
 
         # Check that all constructor parameters are equal.
-        assert_equal(kernel.get_params(), kernel_cloned.get_params())
+        # Need to iterate as some parameters may have more than one element
+        kernel_params = kernel.get_params()
+        kernel_cloned_params = kernel_cloned.get_params()
+        assert_true(kernel_params.keys() == kernel_cloned_params.keys() and
+                    all(np.array(
+                        kernel_params[key] == kernel_cloned_params[key]).all()
+                    for key in kernel_params))
 
         # Check that all hyperparameters are equal.
         yield check_hyperparameters_equal, kernel, kernel_cloned


### PR DESCRIPTION
#### Reference Issue
Fixes #8359


#### What does this implement/fix? Explain your changes.
This adds `LinearKernel` to GaussianProcesses as per the link mentioned in the issue thread.

#### Any other comments?

- [x] Implementation of `sigma_v` and `sigma_b`
- [x] Add `diag(X)`
- [x] Add documentation
- [x] Implementation of `c`