### PR TITLE
[MRG+1] Better error message for GPR

### DIFF
--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -250,7 +250,6 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
                              "increasing the 'alpha' parameter of your "
                              "GaussianProcessRegressor estimator."
                              % self.kernel_)
-
         self.alpha_ = cho_solve((self.L_, True), self.y_train_)  # Line 3
         return self
 

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -244,12 +244,13 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
         K[np.diag_indices_from(K)] += self.alpha
         try:
             self.L_ = cholesky(K, lower=True)  # Line 2
-        except np.linalg.LinAlgError:
-            raise ValueError("The kernel, %s, isn't returning a "
-                             "positive definite matrix. Try gradually "
-                             "increasing the 'alpha' parameter of your "
-                             "GaussianProcessRegressor estimator."
-                             % self.kernel_)
+        except np.linalg.LinAlgError as exc:
+            exc.args = ("The kernel, %s, is not returning a "
+                        "positive definite matrix. Try gradually "
+                        "increasing the 'alpha' parameter of your "
+                        "GaussianProcessRegressor estimator."
+                        % self.kernel_,) + exc.args
+            raise
         self.alpha_ = cho_solve((self.L_, True), self.y_train_)  # Line 3
         return self
 

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -241,8 +241,13 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
         # of actual query points
         K = self.kernel_(self.X_train_)
         K[np.diag_indices_from(K)] += self.alpha
-        self.L_ = cholesky(K, lower=True)  # Line 2
-        self.alpha_ = cho_solve((self.L_, True), self.y_train_)  # Line 3
+        try:
+            self.L_ = cholesky(K, lower=True)  # Line 2
+            self.alpha_ = cho_solve((self.L_, True), self.y_train_)  # Line 3
+        except np.linalg.LinAlgError:
+            raise ValueError("The DotProduct kernel isn't returning a "
+                             "positive definite matrix. Try increasing alpha "
+                             "gradually.")
 
         return self
 

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -243,12 +243,12 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
         K[np.diag_indices_from(K)] += self.alpha
         try:
             self.L_ = cholesky(K, lower=True)  # Line 2
-            self.alpha_ = cho_solve((self.L_, True), self.y_train_)  # Line 3
         except np.linalg.LinAlgError:
             raise ValueError("The DotProduct kernel isn't returning a "
                              "positive definite matrix. Try increasing alpha "
                              "gradually.")
 
+        self.alpha_ = cho_solve((self.L_, True), self.y_train_)  # Line 3
         return self
 
     def predict(self, X, return_std=False, return_cov=False):

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -47,13 +47,14 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
 
     alpha : float or array-like, optional (default: 1e-10)
         Value added to the diagonal of the kernel matrix during fitting.
-        Larger values correspond to increased noise level in the observations
-        and reduce potential numerical issue during fitting. If an array is
-        passed, it must have the same number of entries as the data used for
-        fitting and is used as datapoint-dependent noise level. Note that this
-        is equivalent to adding a WhiteKernel with c=alpha. Allowing to specify
-        the noise level directly as a parameter is mainly for convenience and
-        for consistency with Ridge.
+        Larger values correspond to increased noise level in the observations.
+        This can also prevent a potential numerical issue during fitting, by
+        ensuring that the calculated values form a positive definite matrix.
+        If an array is passed, it must have the same number of entries as the
+        data used for fitting and is used as datapoint-dependent noise level.
+        Note that this is equivalent to adding a WhiteKernel with c=alpha.
+        Allowing to specify the noise level directly as a parameter is mainly
+        for convenience and for consistency with Ridge.
 
     optimizer : string or callable, optional (default: "fmin_l_bfgs_b")
         Can either be one of the internally supported optimizers for optimizing

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -244,9 +244,11 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
         try:
             self.L_ = cholesky(K, lower=True)  # Line 2
         except np.linalg.LinAlgError:
-            raise ValueError("The DotProduct kernel isn't returning a "
-                             "positive definite matrix. Try increasing alpha "
-                             "gradually.")
+            raise ValueError("The kernel, %s, isn't returning a "
+                             "positive definite matrix. Try gradually "
+                             "increasing the 'alpha' parameter of your "
+                             "GaussianProcessRegressor estimator."
+                             % self.kernel_)
 
         self.alpha_ = cho_solve((self.L_, True), self.y_train_)  # Line 3
         return self

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -10,10 +10,11 @@ from scipy.optimize import approx_fprime
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels \
     import RBF, ConstantKernel as C, WhiteKernel
+from sklearn.gaussian_process.kernels import DotProduct
 
 from sklearn.utils.testing \
     import (assert_true, assert_greater, assert_array_less,
-            assert_almost_equal, assert_equal)
+            assert_almost_equal, assert_equal, assert_raise_message)
 
 
 def f(x):
@@ -288,6 +289,22 @@ def test_custom_optimizer():
         # Checks that optimizer improved marginal likelihood
         assert_greater(gpr.log_marginal_likelihood(gpr.kernel_.theta),
                        gpr.log_marginal_likelihood(gpr.kernel.theta))
+
+
+def test_gpr_correct_error_message():
+    import urllib2
+    import csv
+    f = urllib2.urlopen('http://pims.structuralbiology.eu/X.csv')
+    X = [[float(i) for i in row] for row in csv.reader(f, delimiter=',')]
+    y = [0.0] * len(X)
+    f.close()
+    gpr = GaussianProcessRegressor(kernel=DotProduct(),
+                                   optimizer='fmin_l_bfgs_b',
+                                   random_state=None,
+                                   alpha=0)
+    assert_raise_message(ValueError, "The DotProduct kernel isn't "
+                         "returning a positive definite matrix. Try "
+                         "increasing alpha gradually.", gpr.fit, X, y)
 
 
 def test_duplicate_input():

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -292,19 +292,15 @@ def test_custom_optimizer():
 
 
 def test_gpr_correct_error_message():
-    import urllib2
-    import csv
-    f = urllib2.urlopen('http://pims.structuralbiology.eu/X.csv')
-    X = [[float(i) for i in row] for row in csv.reader(f, delimiter=',')]
-    y = [0.0] * len(X)
-    f.close()
-    gpr = GaussianProcessRegressor(kernel=DotProduct(),
-                                   optimizer='fmin_l_bfgs_b',
-                                   random_state=None,
-                                   alpha=0)
-    assert_raise_message(ValueError, "The DotProduct kernel isn't "
-                         "returning a positive definite matrix. Try "
-                         "increasing alpha gradually.", gpr.fit, X, y)
+    X = np.arange(12).reshape(6, -1)
+    y = np.ones(6)
+    kernel = DotProduct()
+    gpr = GaussianProcessRegressor(kernel=kernel, alpha=0)
+    assert_raise_message(ValueError, "The kernel, %s, isn't returning a "
+                         "positive definite matrix. Try gradually increasing "
+                         "the 'alpha' parameter of your "
+                         "GaussianProcessRegressor estimator."
+                         % kernel, gpr.fit, X, y)
 
 
 def test_duplicate_input():

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -295,7 +295,7 @@ def test_gpr_correct_error_message():
     X = np.arange(12).reshape(6, -1)
     y = np.ones(6)
     kernel = DotProduct()
-    gpr = GaussianProcessRegressor(kernel=kernel, alpha=0)
+    gpr = GaussianProcessRegressor(kernel=kernel, alpha=0.0)
     assert_raise_message(ValueError, "The kernel, %s, isn't returning a "
                          "positive definite matrix. Try gradually increasing "
                          "the 'alpha' parameter of your "

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -296,7 +296,8 @@ def test_gpr_correct_error_message():
     y = np.ones(6)
     kernel = DotProduct()
     gpr = GaussianProcessRegressor(kernel=kernel, alpha=0.0)
-    assert_raise_message(ValueError, "The kernel, %s, isn't returning a "
+    assert_raise_message(np.linalg.LinAlgError,
+                         "The kernel, %s, is not returning a "
                          "positive definite matrix. Try gradually increasing "
                          "the 'alpha' parameter of your "
                          "GaussianProcessRegressor estimator."


### PR DESCRIPTION
#### Reference Issue
Fixes #8384


#### What does this implement/fix? Explain your changes.
This improves the error message when cholesky is called on a non-positive definite matrix. It's possible to resolve the error by increasing the value of `alpha` in `GaussianProcessRegressor`, so it's best to make the user aware of the same.
