### PR TITLE
Test for class_weights when using a dictionary and referring to an invalid class

### DIFF
--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -117,6 +117,14 @@ def test_compute_class_weight_balanced_unordered():
     assert_almost_equal(np.dot(cw, class_counts), y.shape[0])
     assert_array_almost_equal(cw, [2., 1., 2. / 3])
 
+def test_class_weight_with_string_label():
+    y = np.asarray(["A","A","A","B","B","C"])
+    classes = np.unique(y)
+    class_weights = {c: 1.0 for c in classes}
+    class_weights['D'] = 1.0 # because of this, we should get a proper ValueError
+    cw = assert_raises(ValueError, compute_class_weight, class_weights, 
+                       classes, y)
+    return
 
 def test_compute_sample_weight():
     # Test (and demo) compute_sample_weight.

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -121,7 +121,7 @@ def test_class_weight_with_string_label():
     y = np.asarray(["A","A","A","B","B","C"])
     classes = np.unique(y)
     class_weights = {c: 1.0 for c in classes}
-    class_weights['D'] = 1.0 # because of this, we should get a proper ValueError
+    class_weights['D'] = 1.0  # This should get a proper ValueError
     cw = assert_raises(ValueError, compute_class_weight, class_weights, 
                        classes, y)
     return


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #8312-->


#### What does this implement/fix? Explain your changes.
This adds a test called "test_class_weight_with_string_label" that sees if an illegal non-integer class defined in "class_weights" will raise the ValueError.  When this test is run on the original code, there is an error that occurs but when run on the revised code it passes the test.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
