### PR TITLE
[mrg] fix Typo in Supervised learning tutorial #8389

### DIFF
--- a/doc/tutorial/statistical_inference/supervised_learning.rst
+++ b/doc/tutorial/statistical_inference/supervised_learning.rst
@@ -341,7 +341,7 @@ application of Occam's razor: *prefer simpler models*.
     solves the lasso regression problem using a
     `coordinate descent <https://en.wikipedia.org/wiki/Coordinate_descent>`_ method,
     that is efficient on large datasets. However, scikit-learn also
-    provides the :class:`LassoLars` object using the *LARS* algorthm,
+    provides the :class:`LassoLars` object using the *LARS* algorithm,
     which is very efficient for problems in which the weight vector estimated
     is very sparse (i.e. problems with very few observations).
 


### PR DESCRIPTION
#### Reference Issue
Fixes #8389 


#### What does this implement/fix? Explain your changes.

Fix typo on line 344 in statistical_inference/supervised_learning.rst: algorthm -> algorithm