### PR TITLE
[MRG] Document `length_scale_bounds="fixed"` in GP kernels #8358

### DIFF
--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1154,7 +1154,7 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 
     length_scale_bounds : pair of floats >= 0 or the string "fixed", default: (1e-5, 1e5)
         The lower and upper bound on length_scale. This should be set to "fixed" 
-        If the length scale is fixed or does not change during training.
+        if the length scale is fixed or does not change during training.
 
     """
     def __init__(self, length_scale=1.0, length_scale_bounds=(1e-5, 1e5)):

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1152,8 +1152,9 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
         used. If an array, an anisotropic kernel is used where each dimension
         of l defines the length-scale of the respective feature dimension.
 
-    length_scale_bounds : pair of floats >= 0, default: (1e-5, 1e5)
-        The lower and upper bound on length_scale
+    length_scale_bounds : pair of floats >= 0 or the string "fixed", default: (1e-5, 1e5)
+        The lower and upper bound on length_scale. This should be set to "fixed" 
+        If the length scale is fixed or does not change during training.
 
     """
     def __init__(self, length_scale=1.0, length_scale_bounds=(1e-5, 1e5)):

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1152,9 +1152,11 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
         used. If an array, an anisotropic kernel is used where each dimension
         of l defines the length-scale of the respective feature dimension.
 
-    length_scale_bounds : pair of floats >= 0 or the string "fixed", default: (1e-5, 1e5)
-        The lower and upper bound on length_scale. This should be set to "fixed" 
-        if the length scale is fixed or does not change during training.
+    length_scale_bounds : pair of floats >= 0 or the string "fixed",
+        default: (1e-5, 1e5)
+        The lower and upper bound on length_scale. This should be
+        set to "fixed" if the length scale is fixed or does not
+        change during training.
 
     """
     def __init__(self, length_scale=1.0, length_scale_bounds=(1e-5, 1e5)):

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1155,7 +1155,7 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
     length_scale_bounds : pair of floats >= 0 or the string "fixed",
         default: (1e-5, 1e5)
         The lower and upper bound on length_scale. This should be
-        set to "fixed" if the length scale is fixed or does not
+        set to "fixed" if the length scale is fixed or should not
         change during training.
 
     """
@@ -1268,8 +1268,11 @@ class Matern(RBF):
         used. If an array, an anisotropic kernel is used where each dimension
         of l defines the length-scale of the respective feature dimension.
 
-    length_scale_bounds : pair of floats >= 0, default: (1e-5, 1e5)
-        The lower and upper bound on length_scale
+    length_scale_bounds : pair of floats >= 0 or the string "fixed",
+        default: (1e-5, 1e5)
+        The lower and upper bound on length_scale. This should be
+        set to "fixed" if the length scale is fixed or should not
+        change during training.
 
     nu: float, default: 1.5
         The parameter nu controlling the smoothness of the learned function.
@@ -1416,8 +1419,11 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
     alpha : float > 0, default: 1.0
         Scale mixture parameter
 
-    length_scale_bounds : pair of floats >= 0, default: (1e-5, 1e5)
-        The lower and upper bound on length_scale
+    length_scale_bounds : pair of floats >= 0 or the string "fixed",
+        default: (1e-5, 1e5)
+        The lower and upper bound on length_scale. This should be
+        set to "fixed" if the length scale is fixed or should not
+        change during training.
 
     alpha_bounds : pair of floats >= 0, default: (1e-5, 1e5)
         The lower and upper bound on alpha
@@ -1527,8 +1533,11 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
     periodicity : float > 0, default: 1.0
         The periodicity of the kernel.
 
-    length_scale_bounds : pair of floats >= 0, default: (1e-5, 1e5)
-        The lower and upper bound on length_scale
+    length_scale_bounds : pair of floats >= 0 or the string "fixed",
+        default: (1e-5, 1e5)
+        The lower and upper bound on length_scale. This should be
+        set to "fixed" if the length scale is fixed or should not
+        change during training.
 
     periodicity_bounds : pair of floats >= 0, default: (1e-5, 1e5)
         The lower and upper bound on periodicity


### PR DESCRIPTION
#### Reference Issue
Fixes #8358 

#### What does this implement/fix? Explain your changes.

Document length_scale_bounds = "fixed" in GP kernels.