### PR TITLE
[MRG] Add MAE formula in the regression criteria docs.

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -486,14 +486,24 @@ Regression criteria
 -------------------
 
 If the target is a continuous value, then for node :math:`m`,
-representing a region :math:`R_m` with :math:`N_m` observations, a common
-criterion to minimise is the Mean Squared Error
+representing a region :math:`R_m` with :math:`N_m` observations, common
+criteria to minimise are
+
+Mean Squared Error:
 
 .. math::
 
     c_m = \frac{1}{N_m} \sum_{i \in N_m} y_i
 
     H(X_m) = \frac{1}{N_m} \sum_{i \in N_m} (y_i - c_m)^2
+
+Mean Absolute Error:
+
+.. math::
+
+    c_m = \frac{1}{N_m} \sum_{i \in N_m} y_i
+
+    H(X_m) = \frac{1}{N_m} \sum_{i \in N_m} |y_i - c_m|
 
 where :math:`X_m` is the training data in node :math:`m`
 

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -501,9 +501,9 @@ Mean Absolute Error:
 
 .. math::
 
-    c_m = \frac{1}{N_m} \sum_{i \in N_m} y_i
+    \bar{y_m} = \frac{1}{N_m} \sum_{i \in N_m} y_i
 
-    H(X_m) = \frac{1}{N_m} \sum_{i \in N_m} |y_i - c_m|
+    H(X_m) = \frac{1}{N_m} \sum_{i \in N_m} |y_i - \bar{y_m}|
 
 where :math:`X_m` is the training data in node :math:`m`
 


### PR DESCRIPTION
Location: doc/modules/tree.rst

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Fixes #8396 

#### What does this implement/fix? Explain your changes.

This PR adds the Mean Absolute Error formula in the regression criteria docs. 
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
