### PR TITLE
[MRG+1] Deprecate Y parameter on transform() 

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -259,7 +259,7 @@ API changes summary
    - Deprecate the ``Y`` parameter from ``transform`` method signature in 
       :class:`sklearn.cluster.birch` :class:`sklearn.cluster.k_means_` :class:`sklearn.decomposition.base` :class:`sklearn.decomposition.dict_learning` :class:`sklearn.decomposition.fastica_` :class:`sklearn.decomposition.pca` :class:`sklearn.feature_extraction.dict_vectorizer` :class:`sklearn.feature_extraction.hashing` :class:`sklearn.feature_extraction.text` :class:`sklearn.kernel_approximation` :class:`sklearn.neighbors.approximate` :class:`sklearn.preprocessing._function_transformer` :class:`sklearn.preprocessing.data` :class:`sklearn.random_projection`
       The method  should not accept y, as ``transform`` is used at predict time. ``Y`` parameter is deprecated on this version and will be removed in 0.21.
-      :issue:`8174` by :user:`Tahar <https://github.com/tzano>`.
+      :issue:`8174` by :user:`Tahar <https://github.com/tzano>`_.
 
 
 .. _changes_0_18_1:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -245,7 +245,7 @@ API changes summary
      (``n_samples``, ``n_classes``) for that particular output.
      :issue:`8093` by :user:`Peter Bull <pjbull>`.
 
-   - Deprecate the ``fit_params`` constructor input to the
+    - Deprecate the ``fit_params`` constructor input to the
       :class:`sklearn.model_selection.GridSearchCV` and
       :class:`sklearn.model_selection.RandomizedSearchCV` in favor
       of passing keyword parameters to the ``fit`` methods
@@ -255,10 +255,9 @@ API changes summary
       selection classes to be used with tools such as
       :func:`sklearn.model_selection.cross_val_predict`.
       :issue:`2879` by :user:`Stephen Hoover <stephen-hoover>`.
-      
-   - Deprecate the ``Y`` parameter from ``transform`` method signature in 
-      :class:`sklearn.cluster.birch` :class:`sklearn.cluster.k_means_` :class:`sklearn.decomposition.base` :class:`sklearn.decomposition.dict_learning` :class:`sklearn.decomposition.fastica_` :class:`sklearn.decomposition.pca` :class:`sklearn.feature_extraction.dict_vectorizer` :class:`sklearn.feature_extraction.hashing` :class:`sklearn.feature_extraction.text` :class:`sklearn.kernel_approximation` :class:`sklearn.neighbors.approximate` :class:`sklearn.preprocessing._function_transformer` :class:`sklearn.preprocessing.data` :class:`sklearn.random_projection`
-      The method  should not accept ``Y`` parameter, as ``transform()`` is used at the prediction time. ``Y`` parameter is deprecated on this version and will be removed in 0.21.
+
+    - Deprecate the ``y`` parameter in :meth:`transform`.
+      The method  should not accept ``y`` parameter, as it's used at the prediction time.
       :issue:`8174` by :user:`Tahar Zanouda <tzano>`.
 
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -245,7 +245,7 @@ API changes summary
      (``n_samples``, ``n_classes``) for that particular output.
      :issue:`8093` by :user:`Peter Bull <pjbull>`.
 
-    - Deprecate the ``fit_params`` constructor input to the
+   - Deprecate the ``fit_params`` constructor input to the
       :class:`sklearn.model_selection.GridSearchCV` and
       :class:`sklearn.model_selection.RandomizedSearchCV` in favor
       of passing keyword parameters to the ``fit`` methods
@@ -255,6 +255,12 @@ API changes summary
       selection classes to be used with tools such as
       :func:`sklearn.model_selection.cross_val_predict`.
       :issue:`2879` by :user:`Stephen Hoover <stephen-hoover>`.
+
+   - Deprecate the ``Y`` parameter from ``transform`` method signature in 
+      :class:`sklearn.cluster.birch` :class:`sklearn.cluster.k_means_` :class:`sklearn.decomposition.base` :class:`sklearn.decomposition.dict_learning` :class:`sklearn.decomposition.fastica_` :class:`sklearn.decomposition.pca` :class:`sklearn.feature_extraction.dict_vectorizer` :class:`sklearn.feature_extraction.hashing` :class:`sklearn.feature_extraction.text` :class:`sklearn.kernel_approximation` :class:`sklearn.neighbors.approximate` :class:`sklearn.preprocessing._function_transformer` :class:`sklearn.preprocessing.data` :class:`sklearn.random_projection`
+      The method  should not accept y, as ``transform`` is used at predict time. ``Y`` parameter is deprecated on this version and will be removed in 0.21.
+      :issue:`8174` by :user:`Tahar <https://github.com/tzano>`.
+
 
 .. _changes_0_18_1:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -255,11 +255,11 @@ API changes summary
       selection classes to be used with tools such as
       :func:`sklearn.model_selection.cross_val_predict`.
       :issue:`2879` by :user:`Stephen Hoover <stephen-hoover>`.
-
+      
    - Deprecate the ``Y`` parameter from ``transform`` method signature in 
       :class:`sklearn.cluster.birch` :class:`sklearn.cluster.k_means_` :class:`sklearn.decomposition.base` :class:`sklearn.decomposition.dict_learning` :class:`sklearn.decomposition.fastica_` :class:`sklearn.decomposition.pca` :class:`sklearn.feature_extraction.dict_vectorizer` :class:`sklearn.feature_extraction.hashing` :class:`sklearn.feature_extraction.text` :class:`sklearn.kernel_approximation` :class:`sklearn.neighbors.approximate` :class:`sklearn.preprocessing._function_transformer` :class:`sklearn.preprocessing.data` :class:`sklearn.random_projection`
-      The method  should not accept y, as ``transform`` is used at predict time. ``Y`` parameter is deprecated on this version and will be removed in 0.21.
-      :issue:`8174` by :user:`Tahar <https://github.com/tzano>`_.
+      The method  should not accept ``Y`` parameter, as ``transform()`` is used at the prediction time. ``Y`` parameter is deprecated on this version and will be removed in 0.21.
+      :issue:`8174` by :user:`Tahar Zanouda <tzano>`.
 
 
 .. _changes_0_18_1:

--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -12,6 +12,7 @@ from math import sqrt
 from ..metrics.pairwise import euclidean_distances
 from ..base import TransformerMixin, ClusterMixin, BaseEstimator
 from ..externals.six.moves import xrange
+from ..externals.six import string_types
 from ..utils import check_array
 from ..utils.extmath import row_norms, safe_sparse_dot
 from ..utils.validation import check_is_fitted
@@ -580,16 +581,20 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
         ----------
         X : {array-like, sparse matrix}, shape (n_samples, n_features)
             Input data.
+        y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
 
         Returns
         -------
         X_trans : {array-like, sparse matrix}, shape (n_samples, n_clusters)
             Transformed data.
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
+
         check_is_fitted(self, 'subcluster_centers_')
         return euclidean_distances(X, self.subcluster_centers_)
 

--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -569,7 +569,7 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
         reduced_distance += self._subcluster_norms
         return self.subcluster_labels_[np.argmin(reduced_distance, axis=1)]
 
-    def transform(self, X, y=None):
+    def transform(self, X, y='deprecated'):
         """
         Transform X into subcluster centroids dimension.
 
@@ -586,6 +586,10 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
         X_trans : {array-like, sparse matrix}, shape (n_samples, n_clusters)
             Transformed data.
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
         check_is_fitted(self, 'subcluster_centers_')
         return euclidean_distances(X, self.subcluster_centers_)
 

--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -588,7 +588,7 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
         check_is_fitted(self, 'subcluster_centers_')
         return euclidean_distances(X, self.subcluster_centers_)

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -911,7 +911,7 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         X = self._check_fit_data(X)
         return self.fit(X)._transform(X)
 
-    def transform(self, X, y=None):
+    def transform(self, X, y='deprecated'):
         """Transform X to a cluster-distance space.
 
         In the new space, each dimension is the distance to the cluster
@@ -928,6 +928,11 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         X_new : array, shape [n_samples, k]
             X transformed in the new space.
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         check_is_fitted(self, 'cluster_centers_')
 
         X = self._check_test_data(X)

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -930,7 +930,7 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         check_is_fitted(self, 'cluster_centers_')

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -922,13 +922,16 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         ----------
         X : {array-like, sparse matrix}, shape = [n_samples, n_features]
             New data to transform.
+        y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
 
         Returns
         -------
         X_new : array, shape [n_samples, k]
             X transformed in the new space.
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)

--- a/sklearn/decomposition/base.py
+++ b/sklearn/decomposition/base.py
@@ -98,7 +98,6 @@ class _BasePCA(six.with_metaclass(ABCMeta, BaseEstimator, TransformerMixin)):
             Returns the instance itself.
         """
 
-
     def transform(self, X, y='deprecated'):
         """Apply dimensionality reduction to X.
 

--- a/sklearn/decomposition/base.py
+++ b/sklearn/decomposition/base.py
@@ -109,6 +109,9 @@ class _BasePCA(six.with_metaclass(ABCMeta, BaseEstimator, TransformerMixin)):
         X : array-like, shape (n_samples, n_features)
             New data, where n_samples is the number of samples
             and n_features is the number of features.
+        y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
 
         Returns
         -------
@@ -125,7 +128,7 @@ class _BasePCA(six.with_metaclass(ABCMeta, BaseEstimator, TransformerMixin)):
         IncrementalPCA(batch_size=3, copy=True, n_components=2, whiten=False)
         >>> ipca.transform(X) # doctest: +SKIP
         """
-        if y != 'deprecated':
+        if isinstance(y, np.ndarray) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)

--- a/sklearn/decomposition/base.py
+++ b/sklearn/decomposition/base.py
@@ -17,6 +17,7 @@ from ..utils import check_array
 from ..utils.extmath import fast_dot
 from ..utils.validation import check_is_fitted
 from ..externals import six
+from ..externals.six import string_types
 from abc import ABCMeta, abstractmethod
 
 
@@ -128,7 +129,7 @@ class _BasePCA(six.with_metaclass(ABCMeta, BaseEstimator, TransformerMixin)):
         IncrementalPCA(batch_size=3, copy=True, n_components=2, whiten=False)
         >>> ipca.transform(X) # doctest: +SKIP
         """
-        if isinstance(y, np.ndarray) or y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)

--- a/sklearn/decomposition/base.py
+++ b/sklearn/decomposition/base.py
@@ -8,6 +8,7 @@
 #
 # License: BSD 3 clause
 
+import warnings
 import numpy as np
 from scipy import linalg
 
@@ -98,7 +99,7 @@ class _BasePCA(six.with_metaclass(ABCMeta, BaseEstimator, TransformerMixin)):
         """
 
 
-    def transform(self, X, y=None):
+    def transform(self, X, y='deprecated'):
         """Apply dimensionality reduction to X.
 
         X is projected on the first principal components previously extracted
@@ -125,6 +126,11 @@ class _BasePCA(six.with_metaclass(ABCMeta, BaseEstimator, TransformerMixin)):
         IncrementalPCA(batch_size=3, copy=True, n_components=2, whiten=False)
         >>> ipca.transform(X) # doctest: +SKIP
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         check_is_fitted(self, ['mean_', 'components_'], all_or_any=all)
 
         X = check_array(X)

--- a/sklearn/decomposition/base.py
+++ b/sklearn/decomposition/base.py
@@ -128,7 +128,7 @@ class _BasePCA(six.with_metaclass(ABCMeta, BaseEstimator, TransformerMixin)):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         check_is_fitted(self, ['mean_', 'components_'], all_or_any=all)

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -18,6 +18,7 @@ from numpy.lib.stride_tricks import as_strided
 from ..base import BaseEstimator, TransformerMixin
 from ..externals.joblib import Parallel, delayed, cpu_count
 from ..externals.six.moves import zip
+from ..externals.six import string_types
 from ..utils import (check_array, check_random_state, gen_even_slices,
                      gen_batches, _get_n_jobs)
 from ..utils.extmath import randomized_svd, row_norms
@@ -803,6 +804,9 @@ class SparseCodingMixin(TransformerMixin):
         X : array of shape (n_samples, n_features)
             Test data to be transformed, must have the same number of
             features as the data used to train the model.
+        y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
 
         Returns
         -------
@@ -810,7 +814,7 @@ class SparseCodingMixin(TransformerMixin):
             Transformed data
 
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import time
 import sys
 import itertools
-import warnings
+import wa
 
 from math import sqrt, ceil
 

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import time
 import sys
 import itertools
+import warnings
 
 from math import sqrt, ceil
 
@@ -791,7 +792,7 @@ class SparseCodingMixin(TransformerMixin):
         self.split_sign = split_sign
         self.n_jobs = n_jobs
 
-    def transform(self, X, y=None):
+    def transform(self, X, y='deprecated'):
         """Encode the data as a sparse combination of the dictionary atoms.
 
         Coding method is determined by the object parameter
@@ -809,6 +810,11 @@ class SparseCodingMixin(TransformerMixin):
             Transformed data
 
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         check_is_fitted(self, 'components_')
 
         # XXX : kwargs is not documented

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import time
 import sys
 import itertools
-import warnings
+import war
 
 from math import sqrt, ceil
 
@@ -812,7 +812,7 @@ class SparseCodingMixin(TransformerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         check_is_fitted(self, 'components_')

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import time
 import sys
 import itertools
-import war
+import warnings
 
 from math import sqrt, ceil
 

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import time
 import sys
 import itertools
-import wa
+import warnings
 
 from math import sqrt, ceil
 

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -543,7 +543,7 @@ class FastICA(BaseEstimator, TransformerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         check_is_fitted(self, 'mixing_')

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -17,6 +17,7 @@ from scipy import linalg
 from ..base import BaseEstimator, TransformerMixin
 from ..externals import six
 from ..externals.six import moves
+from ..externals.six import string_types
 from ..utils import check_array, as_float_array, check_random_state
 from ..utils.extmath import fast_dot
 from ..utils.validation import check_is_fitted
@@ -533,15 +534,17 @@ class FastICA(BaseEstimator, TransformerMixin):
         X : array-like, shape (n_samples, n_features)
             Data to transform, where n_samples is the number of samples
             and n_features is the number of features.
-
         copy : bool (optional)
             If False, data passed to fit are overwritten. Defaults to True.
+        y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
 
         Returns
         -------
         X_new : array-like, shape (n_samples, n_components)
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -8,7 +8,9 @@ Independent Component Analysis, by  Hyvarinen et al.
 # Authors: Pierre Lafaye de Micheaux, Stefan van der Walt, Gael Varoquaux,
 #          Bertrand Thirion, Alexandre Gramfort, Denis A. Engemann
 # License: BSD 3 clause
+
 import warnings
+
 import numpy as np
 from scipy import linalg
 
@@ -523,7 +525,7 @@ class FastICA(BaseEstimator, TransformerMixin):
         self._fit(X, compute_sources=False)
         return self
 
-    def transform(self, X, y=None, copy=True):
+    def transform(self, X, y='deprecated', copy=True):
         """Recover the sources from X (apply the unmixing matrix).
 
         Parameters
@@ -539,6 +541,11 @@ class FastICA(BaseEstimator, TransformerMixin):
         -------
         X_new : array-like, shape (n_samples, n_components)
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         check_is_fitted(self, 'mixing_')
 
         X = check_array(X, copy=copy, dtype=FLOAT_DTYPES)

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -12,6 +12,8 @@
 
 from math import log, sqrt
 
+import warnings
+
 import numpy as np
 from scipy import linalg
 from scipy.special import gammaln
@@ -719,7 +721,7 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
 
         return X
 
-    def transform(self, X, y=None):
+    def transform(self, X, y='deprecated'):
         """Apply dimensionality reduction on X.
 
         X is projected on the first principal components previous extracted
@@ -736,6 +738,11 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         X_new : array-like, shape (n_samples, n_components)
 
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         check_is_fitted(self, 'mean_')
 
         X = check_array(X)

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -30,6 +30,7 @@ from ..utils.extmath import fast_dot, fast_logdet, randomized_svd, svd_flip
 from ..utils.extmath import stable_cumsum
 from ..utils.validation import check_is_fitted
 from ..utils.arpack import svds
+from ..externals.six import string_types
 
 
 def _assess_dimension_(spectrum, rank, n_samples, n_features):
@@ -732,13 +733,16 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         X : array-like, shape (n_samples, n_features)
             New data, where n_samples in the number of samples
             and n_features is the number of features.
+        y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
 
         Returns
         -------
         X_new : array-like, shape (n_samples, n_components)
 
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -740,7 +740,7 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         check_is_fitted(self, 'mean_')

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -573,6 +573,22 @@ def test_deprecation_randomized_pca():
     Y_pca = PCA(svd_solver='randomized', random_state=0).fit_transform(X)
     assert_array_almost_equal(Y, Y_pca)
 
+def test_deprecation_transform():
+    depr_message = "The parameter y on transform() is deprecated"
+
+    # PCA on iris data
+    X = iris.data
+
+    pca = PCA(n_components=2)
+    X_r = pca.fit(X)
+
+    # Tests that deprecated Y parameter throws warning
+    assert_warns_message(DeprecationWarning, depr_message, X_r.transform,
+                         X, y=1)
+    assert_warns_message(DeprecationWarning, depr_message, X_r.transform,
+                         X, y=[1])
+    assert_warns_message(DeprecationWarning, depr_message, X_r.transform,
+                         X, y=None)
 
 def test_pca_spase_input():
 

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -573,6 +573,7 @@ def test_deprecation_randomized_pca():
     Y_pca = PCA(svd_solver='randomized', random_state=0).fit_transform(X)
     assert_array_almost_equal(Y, Y_pca)
 
+
 def test_deprecation_transform():
     depr_message = "The parameter y on transform() is deprecated"
 
@@ -589,6 +590,7 @@ def test_deprecation_transform():
                          X, y=[1])
     assert_warns_message(DeprecationWarning, depr_message, X_r.transform,
                          X, y=None)
+
 
 def test_pca_spase_input():
 

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -285,13 +285,15 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
             Dict(s) or Mapping(s) from feature names (arbitrary Python
             objects) to feature values (strings or convertible to dtype).
         y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
 
         Returns
         -------
         Xa : {array, sparse matrix}
             Feature vectors; always 2-d.
         """
-        if y != 'deprecated':
+        if isinstance(y, np.ndarray) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -6,6 +6,8 @@ from array import array
 from collections import Mapping
 from operator import itemgetter
 
+import warnings
+
 import numpy as np
 import scipy.sparse as sp
 
@@ -271,7 +273,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
 
         return dicts
 
-    def transform(self, X, y=None):
+    def transform(self, X, y='deprecated'):
         """Transform feature->value dicts to array or sparse matrix.
 
         Named features not encountered during fit or fit_transform will be
@@ -289,6 +291,10 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         Xa : {array, sparse matrix}
             Feature vectors; always 2-d.
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
         if self.sparse:
             return self._transform(X, fitting=False)
 

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -14,6 +14,7 @@ import scipy.sparse as sp
 from ..base import BaseEstimator, TransformerMixin
 from ..externals import six
 from ..externals.six.moves import xrange
+from ..externals.six import string_types
 from ..utils import check_array, tosequence
 from ..utils.fixes import frombuffer_empty
 
@@ -293,7 +294,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         Xa : {array, sparse matrix}
             Feature vectors; always 2-d.
         """
-        if isinstance(y, np.ndarray) or y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -293,7 +293,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
         if self.sparse:
             return self._transform(X, fitting=False)

--- a/sklearn/feature_extraction/hashing.py
+++ b/sklearn/feature_extraction/hashing.py
@@ -10,6 +10,7 @@ import scipy.sparse as sp
 
 from . import _hashing
 from ..base import BaseEstimator, TransformerMixin
+from ..externals.six import string_types
 
 
 def _iteritems(d):
@@ -128,14 +129,15 @@ class FeatureHasher(BaseEstimator, TransformerMixin):
             raw_X need not support the len function, so it can be the result
             of a generator; n_samples is determined on the fly.
         y : (ignored)
-
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
         Returns
         -------
         X : scipy.sparse matrix, shape = (n_samples, self.n_features)
             Feature matrix, for use with estimators or further transformers.
 
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)

--- a/sklearn/feature_extraction/hashing.py
+++ b/sklearn/feature_extraction/hashing.py
@@ -137,7 +137,7 @@ class FeatureHasher(BaseEstimator, TransformerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         raw_X = iter(raw_X)

--- a/sklearn/feature_extraction/hashing.py
+++ b/sklearn/feature_extraction/hashing.py
@@ -1,6 +1,8 @@
 # Author: Lars Buitinck
 # License: BSD 3 clause
 
+import warnings
+
 import numbers
 
 import numpy as np
@@ -114,7 +116,7 @@ class FeatureHasher(BaseEstimator, TransformerMixin):
         self._validate_params(self.n_features, self.input_type)
         return self
 
-    def transform(self, raw_X, y=None):
+    def transform(self, raw_X, y='deprecated'):
         """Transform a sequence of instances to a scipy.sparse matrix.
 
         Parameters
@@ -133,6 +135,11 @@ class FeatureHasher(BaseEstimator, TransformerMixin):
             Feature matrix, for use with estimators or further transformers.
 
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         raw_X = iter(raw_X)
         if self.input_type == "dict":
             raw_X = (_iteritems(d) for d in raw_X)

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -27,6 +27,7 @@ import scipy.sparse as sp
 from ..base import BaseEstimator, TransformerMixin
 from ..externals import six
 from ..externals.six.moves import xrange
+from ..externals.six import string_types
 from ..preprocessing import normalize
 from .hashing import FeatureHasher
 from .stop_words import ENGLISH_STOP_WORDS
@@ -470,8 +471,9 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
             Samples. Each sample must be a text document (either bytes or
             unicode strings, file name or file object depending on the
             constructor argument) which will be tokenized and hashed.
-
         y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
 
         Returns
         -------
@@ -479,7 +481,7 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
             Document-term matrix.
 
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -13,6 +13,7 @@ build feature vectors from text documents.
 """
 from __future__ import unicode_literals
 
+import warnings
 import array
 from collections import Mapping, defaultdict
 import numbers
@@ -460,7 +461,7 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
         self._get_hasher().fit(X, y=y)
         return self
 
-    def transform(self, X, y=None):
+    def transform(self, X, y='deprecated'):
         """Transform a sequence of documents to a document-term matrix.
 
         Parameters
@@ -478,6 +479,11 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
             Document-term matrix.
 
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         if isinstance(X, six.string_types):
             raise ValueError(
                 "Iterable over raw text documents expected, "

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -481,7 +481,7 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         if isinstance(X, six.string_types):

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -86,7 +86,7 @@ class RBFSampler(BaseEstimator, TransformerMixin):
                                                    size=self.n_components)
         return self
 
-    def transform(self, X, y=None):
+    def transform(self, X, y='deprecated'):
         """Apply the approximate feature map to X.
 
         Parameters
@@ -99,6 +99,11 @@ class RBFSampler(BaseEstimator, TransformerMixin):
         -------
         X_new : array-like, shape (n_samples, n_components)
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         check_is_fitted(self, 'random_weights_')
 
         X = check_array(X, accept_sparse='csr')
@@ -174,7 +179,7 @@ class SkewedChi2Sampler(BaseEstimator, TransformerMixin):
                                                    size=self.n_components)
         return self
 
-    def transform(self, X, y=None):
+    def transform(self, X, y='deprecated'):
         """Apply the approximate feature map to X.
 
         Parameters
@@ -187,6 +192,11 @@ class SkewedChi2Sampler(BaseEstimator, TransformerMixin):
         -------
         X_new : array-like, shape (n_samples, n_components)
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         check_is_fitted(self, 'random_weights_')
 
         X = as_float_array(X, copy=True)
@@ -272,7 +282,7 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
             self.sample_interval_ = self.sample_interval
         return self
 
-    def transform(self, X, y=None):
+    def transform(self, X, y='deprecated'):
         """Apply approximate feature map to X.
 
         Parameters
@@ -286,6 +296,11 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
             Whether the return value is an array of sparse matrix depends on
             the type of the input X.
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         msg = ("%(name)s is not fitted. Call fit to set the parameters before"
                " calling transform")
         check_is_fitted(self, "sample_interval_", msg=msg)

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -101,7 +101,7 @@ class RBFSampler(BaseEstimator, TransformerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         check_is_fitted(self, 'random_weights_')
@@ -194,7 +194,7 @@ class SkewedChi2Sampler(BaseEstimator, TransformerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         check_is_fitted(self, 'random_weights_')
@@ -298,7 +298,7 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         msg = ("%(name)s is not fitted. Call fit to set the parameters before"

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -19,7 +19,7 @@ from .utils import check_array, check_random_state, as_float_array
 from .utils.extmath import safe_sparse_dot
 from .utils.validation import check_is_fitted
 from .metrics.pairwise import pairwise_kernels
-
+from .externals.six import string_types
 
 class RBFSampler(BaseEstimator, TransformerMixin):
     """Approximates feature map of an RBF kernel by Monte Carlo approximation
@@ -94,12 +94,14 @@ class RBFSampler(BaseEstimator, TransformerMixin):
         X : {array-like, sparse matrix}, shape (n_samples, n_features)
             New data, where n_samples in the number of samples
             and n_features is the number of features.
-
+        y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
         Returns
         -------
         X_new : array-like, shape (n_samples, n_components)
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
@@ -187,12 +189,14 @@ class SkewedChi2Sampler(BaseEstimator, TransformerMixin):
         X : array-like, shape (n_samples, n_features)
             New data, where n_samples in the number of samples
             and n_features is the number of features.
-
+        y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
         Returns
         -------
         X_new : array-like, shape (n_samples, n_components)
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
@@ -295,8 +299,11 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
                shape = (n_samples, n_features * (2*sample_steps + 1))
             Whether the return value is an array of sparse matrix depends on
             the type of the input X.
+        y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)

--- a/sklearn/neighbors/approximate.py
+++ b/sklearn/neighbors/approximate.py
@@ -88,7 +88,7 @@ class ProjectionToHashMixin(object):
     def transform(self, X, y='deprecated'):
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
         return self._to_hash(super(ProjectionToHashMixin, self).transform(X))
 

--- a/sklearn/neighbors/approximate.py
+++ b/sklearn/neighbors/approximate.py
@@ -11,6 +11,7 @@ from .base import KNeighborsMixin, RadiusNeighborsMixin
 from ..base import BaseEstimator
 from ..utils.validation import check_array
 from ..utils import check_random_state
+from ..externals.six import string_types
 from ..metrics.pairwise import pairwise_distances
 
 from ..random_projection import GaussianRandomProjection
@@ -86,7 +87,7 @@ class ProjectionToHashMixin(object):
         return self.transform(X)
 
     def transform(self, X, y='deprecated'):
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)

--- a/sklearn/neighbors/approximate.py
+++ b/sklearn/neighbors/approximate.py
@@ -85,7 +85,11 @@ class ProjectionToHashMixin(object):
         self.fit(X)
         return self.transform(X)
 
-    def transform(self, X, y=None):
+    def transform(self, X, y='deprecated'):
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
         return self._to_hash(super(ProjectionToHashMixin, self).transform(X))
 
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -16,6 +16,7 @@ from scipy import sparse
 
 from ..base import BaseEstimator, TransformerMixin
 from ..externals import six
+from ..externals.six import string_types
 from ..utils import check_array
 from ..utils.extmath import row_norms
 from ..utils.extmath import _incremental_mean_and_var
@@ -594,8 +595,11 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         ----------
         X : array-like, shape [n_samples, n_features]
             The data used to scale along the features axis.
+        y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
@@ -764,8 +768,11 @@ class MaxAbsScaler(BaseEstimator, TransformerMixin):
         ----------
         X : {array-like, sparse matrix}
             The data that should be scaled.
+        y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
@@ -972,8 +979,11 @@ class RobustScaler(BaseEstimator, TransformerMixin):
         ----------
         X : array-like
             The data used to scale along the specified axis.
+        y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
@@ -1216,14 +1226,16 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         ----------
         X : array-like, shape [n_samples, n_features]
             The data to transform, row by row.
-
+        y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
         Returns
         -------
         XP : np.ndarray shape [n_samples, NP]
             The matrix of features, where NP is the number of polynomial
             features generated from the combination of inputs.
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
@@ -1399,8 +1411,11 @@ class Normalizer(BaseEstimator, TransformerMixin):
         X : {array-like, sparse matrix}, shape [n_samples, n_features]
             The data to normalize, row by row. scipy.sparse matrices should be
             in CSR format to avoid an un-necessary copy.
+        y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
@@ -1516,8 +1531,11 @@ class Binarizer(BaseEstimator, TransformerMixin):
             The data to binarize, element by element.
             scipy.sparse matrices should be in CSR format to avoid an
             un-necessary copy.
+        y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
@@ -1563,7 +1581,9 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
         ----------
         K : numpy array of shape [n_samples1, n_samples2]
             Kernel matrix.
-
+        y : (ignored)
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
         copy : boolean, optional, default True
             Set to False to perform inplace computation.
 
@@ -1571,7 +1591,7 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
         -------
         K_new : numpy array of shape [n_samples1, n_samples2]
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -597,7 +597,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         check_is_fitted(self, 'scale_')
@@ -767,7 +767,7 @@ class MaxAbsScaler(BaseEstimator, TransformerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         check_is_fitted(self, 'scale_')
@@ -975,7 +975,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         if self.with_centering:
@@ -1225,7 +1225,7 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         check_is_fitted(self, ['n_input_features_', 'n_output_features_'])
@@ -1402,7 +1402,7 @@ class Normalizer(BaseEstimator, TransformerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         copy = copy if copy is not None else self.copy
@@ -1519,7 +1519,7 @@ class Binarizer(BaseEstimator, TransformerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         copy = copy if copy is not None else self.copy
@@ -1573,7 +1573,7 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         check_is_fitted(self, 'K_fit_all_')

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -587,7 +587,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
 
         return self
 
-    def transform(self, X, y=None, copy=None):
+    def transform(self, X, y='deprecated', copy=None):
         """Perform standardization by centering and scaling
 
         Parameters
@@ -595,6 +595,11 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         X : array-like, shape [n_samples, n_features]
             The data used to scale along the features axis.
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         check_is_fitted(self, 'scale_')
 
         copy = copy if copy is not None else self.copy
@@ -752,7 +757,7 @@ class MaxAbsScaler(BaseEstimator, TransformerMixin):
         self.scale_ = _handle_zeros_in_scale(max_abs)
         return self
 
-    def transform(self, X, y=None):
+    def transform(self, X, y='deprecated'):
         """Scale the data
 
         Parameters
@@ -760,6 +765,11 @@ class MaxAbsScaler(BaseEstimator, TransformerMixin):
         X : {array-like, sparse matrix}
             The data that should be scaled.
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         check_is_fitted(self, 'scale_')
         X = check_array(X, accept_sparse=('csr', 'csc'), copy=self.copy,
                         estimator=self, dtype=FLOAT_DTYPES)
@@ -955,7 +965,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
             self.scale_ = _handle_zeros_in_scale(self.scale_, copy=False)
         return self
 
-    def transform(self, X, y=None):
+    def transform(self, X, y='deprecated'):
         """Center and scale the data
 
         Parameters
@@ -963,6 +973,11 @@ class RobustScaler(BaseEstimator, TransformerMixin):
         X : array-like
             The data used to scale along the specified axis.
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         if self.with_centering:
             check_is_fitted(self, 'center_')
         if self.with_scaling:
@@ -1194,7 +1209,7 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         self.n_output_features_ = sum(1 for _ in combinations)
         return self
 
-    def transform(self, X, y=None):
+    def transform(self, X, y='deprecated'):
         """Transform data to polynomial features
 
         Parameters
@@ -1208,6 +1223,11 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
             The matrix of features, where NP is the number of polynomial
             features generated from the combination of inputs.
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         check_is_fitted(self, ['n_input_features_', 'n_output_features_'])
 
         X = check_array(X, dtype=FLOAT_DTYPES)
@@ -1371,7 +1391,7 @@ class Normalizer(BaseEstimator, TransformerMixin):
         X = check_array(X, accept_sparse='csr')
         return self
 
-    def transform(self, X, y=None, copy=None):
+    def transform(self, X, y='deprecated', copy=None):
         """Scale each non zero row of X to unit norm
 
         Parameters
@@ -1380,6 +1400,11 @@ class Normalizer(BaseEstimator, TransformerMixin):
             The data to normalize, row by row. scipy.sparse matrices should be
             in CSR format to avoid an un-necessary copy.
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         copy = copy if copy is not None else self.copy
         X = check_array(X, accept_sparse='csr')
         return normalize(X, norm=self.norm, axis=1, copy=copy)
@@ -1482,7 +1507,7 @@ class Binarizer(BaseEstimator, TransformerMixin):
         check_array(X, accept_sparse='csr')
         return self
 
-    def transform(self, X, y=None, copy=None):
+    def transform(self, X, y='deprecated', copy=None):
         """Binarize each element of X
 
         Parameters
@@ -1492,6 +1517,11 @@ class Binarizer(BaseEstimator, TransformerMixin):
             scipy.sparse matrices should be in CSR format to avoid an
             un-necessary copy.
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         copy = copy if copy is not None else self.copy
         return binarize(X, threshold=self.threshold, copy=copy)
 
@@ -1526,7 +1556,7 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
         self.K_fit_all_ = self.K_fit_rows_.sum() / n_samples
         return self
 
-    def transform(self, K, y=None, copy=True):
+    def transform(self, K, y='deprecated', copy=True):
         """Center kernel matrix.
 
         Parameters
@@ -1541,6 +1571,11 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
         -------
         K_new : numpy array of shape [n_samples1, n_samples2]
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         check_is_fitted(self, 'K_fit_all_')
 
         K = check_array(K, copy=copy, dtype=FLOAT_DTYPES)

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -386,7 +386,7 @@ class BaseRandomProjection(six.with_metaclass(ABCMeta, BaseEstimator,
 
         return self
 
-    def transform(self, X, y=None):
+    def transform(self, X, y='deprecated'):
         """Project the data by using matrix product with the random matrix
 
         Parameters
@@ -402,6 +402,11 @@ class BaseRandomProjection(six.with_metaclass(ABCMeta, BaseEstimator,
             Projected array.
 
         """
+        if y != 'deprecated':
+            warnings.warn("The parameter y on transform() is "
+                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          DeprecationWarning)
+
         X = check_array(X, accept_sparse=['csr', 'csc'])
 
         check_is_fitted(self, 'components_')

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -404,7 +404,7 @@ class BaseRandomProjection(six.with_metaclass(ABCMeta, BaseEstimator,
         """
         if y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
-                          "deprecated since 0.19 and will be removed in 0.21. ",
+                          "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
         X = check_array(X, accept_sparse=['csr', 'csc'])

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -37,6 +37,7 @@ import scipy.sparse as sp
 
 from .base import BaseEstimator, TransformerMixin
 from .externals import six
+from .externals.six import string_types
 from .externals.six.moves import xrange
 from .utils import check_random_state
 from .utils.extmath import safe_sparse_dot
@@ -395,6 +396,8 @@ class BaseRandomProjection(six.with_metaclass(ABCMeta, BaseEstimator,
             The input data to project into a smaller dimensional space.
 
         y : is not used: placeholder to allow for usage in a Pipeline.
+            .. deprecated:: 0.19
+               This parameter will be removed in 0.21.
 
         Returns
         -------
@@ -402,7 +405,7 @@ class BaseRandomProjection(six.with_metaclass(ABCMeta, BaseEstimator,
             Projected array.
 
         """
-        if y != 'deprecated':
+        if not isinstance(y, string_types) or y != 'deprecated':
             warnings.warn("The parameter y on transform() is "
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -300,7 +300,7 @@ def test_clone_pandas_dataframe():
         def fit(self, X, y=None):
             pass
 
-        def transform(self, X, y=None):
+        def transform(self, X):
             pass
 
     # build and clone estimator

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -300,7 +300,7 @@ def test_clone_pandas_dataframe():
         def fit(self, X, y=None):
             pass
 
-        def transform(self, X):
+        def transform(self, X, y='deprecated'):
             pass
 
     # build and clone estimator

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -300,7 +300,7 @@ def test_clone_pandas_dataframe():
         def fit(self, X, y=None):
             pass
 
-        def transform(self, X, y='deprecated'):
+        def transform(self, X):
             pass
 
     # build and clone estimator

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -67,12 +67,12 @@ class NoTrans(NoFit):
 
 
 class NoInvTransf(NoTrans):
-    def transform(self, X, y=None):
+    def transform(self, X):
         return X
 
 
 class Transf(NoInvTransf):
-    def transform(self, X, y=None):
+    def transform(self, X):
         return X
 
     def inverse_transform(self, X):

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -67,12 +67,12 @@ class NoTrans(NoFit):
 
 
 class NoInvTransf(NoTrans):
-    def transform(self, X, y='deprecated'):
+    def transform(self, X):
         return X
 
 
 class Transf(NoInvTransf):
-    def transform(self, X, y='deprecated'):
+    def transform(self, X):
         return X
 
     def inverse_transform(self, X):

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -67,12 +67,12 @@ class NoTrans(NoFit):
 
 
 class NoInvTransf(NoTrans):
-    def transform(self, X):
+    def transform(self, X, y='deprecated'):
         return X
 
 
 class Transf(NoInvTransf):
-    def transform(self, X):
+    def transform(self, X, y='deprecated'):
         return X
 
     def inverse_transform(self, X):


### PR DESCRIPTION
As further discussed on thread  #8174,  the parameter `Y` in method `transform()` will be deprecated and eventually removed in a future version . 

The method `transform()` has been used in the following: 

```
sklearn/cluster/birch.py:    def transform(self, X, y=None):
sklearn/cluster/k_means_.py:    def transform(self, X, y=None):
sklearn/decomposition/base.py:    def transform(self, X, y=None):
sklearn/decomposition/dict_learning.py:    def transform(self, X, y=None):
sklearn/decomposition/fastica_.py:    def transform(self, X, y=None, copy=True):
sklearn/decomposition/pca.py:    def transform(self, X, y=None):
sklearn/feature_extraction/dict_vectorizer.py:    def transform(self, X, y=None):
sklearn/feature_extraction/hashing.py:    def transform(self, raw_X, y=None):
sklearn/feature_extraction/text.py:    def transform(self, X, y=None):
sklearn/kernel_approximation.py:    def transform(self, X, y=None):
sklearn/kernel_approximation.py:    def transform(self, X, y=None):
sklearn/kernel_approximation.py:    def transform(self, X, y=None):
sklearn/neighbors/approximate.py:    def transform(self, X, y=None):
sklearn/preprocessing/data.py:    def transform(self, X, y=None, copy=None):
sklearn/preprocessing/data.py:    def transform(self, X, y=None):
sklearn/preprocessing/data.py:    def transform(self, X, y=None):
sklearn/preprocessing/data.py:    def transform(self, X, y=None):
sklearn/preprocessing/data.py:    def transform(self, X, y=None, copy=None):
sklearn/preprocessing/data.py:    def transform(self, X, y=None, copy=None):
sklearn/preprocessing/data.py:    def transform(self, K, y=None, copy=True):
sklearn/preprocessing/data.py:    def transform(self, X, y=None):
sklearn/random_projection.py:    def transform(self, X, y=None):
```

I didn't change this one, as Y is used.

```
sklearn/preprocessing/_function_transformer.py:    def transform(self, X, y=None):
```
I have added deprecation message 
```
        if y != 'deprecated':
            warnings.warn("The parameter y on transform() is "
                          "deprecated since 0.19 and will be removed in 0.21. ",
                          DeprecationWarning)
```