### PR TITLE
minor fix in svm kernel functions docs: rbf equation fixed (#8356)

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -443,7 +443,7 @@ The *kernel function* can be any of the following:
   * polynomial: :math:`(\gamma \langle x, x'\rangle + r)^d`.
     :math:`d` is specified by keyword ``degree``, :math:`r` by ``coef0``.
 
-  * rbf: :math:`\exp(-\gamma |x-x'|^2)`. :math:`\gamma` is
+  * rbf: :math:`\exp(-\gamma \|x-x'\|^2)`. :math:`\gamma` is
     specified by keyword ``gamma``, must be greater than 0.
 
   * sigmoid (:math:`\tanh(\gamma \langle x,x'\rangle + r)`),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Fixes #8356 

#### What does this implement/fix? Explain your changes.
Minor but important change in docs mentioned by @amueller . I've checked also some other equations with Euclidean distance. The rest seems fine.
