### PR TITLE
[MRG] FIX lasso/elasticnet example did not add noise to simulated data.

### DIFF
--- a/examples/linear_model/plot_lasso_and_elasticnet.py
+++ b/examples/linear_model/plot_lasso_and_elasticnet.py
@@ -28,7 +28,7 @@ coef[inds[10:]] = 0  # sparsify coef
 y = np.dot(X, coef)
 
 # add noise
-y += 0.01 * np.random.normal(size=(n_samples,))
+y += 0.01 * np.random.normal(size=n_samples)
 
 # Split data in train set and test set
 n_samples = X.shape[0]

--- a/examples/linear_model/plot_lasso_and_elasticnet.py
+++ b/examples/linear_model/plot_lasso_and_elasticnet.py
@@ -28,7 +28,7 @@ coef[inds[10:]] = 0  # sparsify coef
 y = np.dot(X, coef)
 
 # add noise
-y += 0.01 * np.random.normal((n_samples,))
+y += 0.01 * np.random.normal(size=(n_samples,))
 
 # Split data in train set and test set
 n_samples = X.shape[0]


### PR DESCRIPTION
The first argument of np.random.normal is the mean of the distribution, and
not the output shape. The example thus did not add noise but only an intercept
to the model.

Considering the comment, I assume this is a mistake.
