### PR TITLE
[WIP] ENH allow extraction of subsequence pipeline

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -7,6 +7,8 @@ estimator, as a chain of transforms and estimators.
 #         Virgile Fritsch
 #         Alexandre Gramfort
 #         Lars Buitinck
+#         Joel Nothman
+#         Guillaume Lemaitre
 # License: BSD
 
 from collections import defaultdict
@@ -232,6 +234,41 @@ class Pipeline(_BasePipeline):
     @property
     def _final_estimator(self):
         return self.steps[-1][1]
+
+    def get_subsequence(self, start=None, stop=None):
+        """Extract a Pipeline consisting of a subsequence of steps
+
+        Parameters
+        ----------
+        start : int or str, optional
+            The index (0-based) or name of the step where the extracted
+            subsequence begins (inclusive bound).  By default, get from the
+            beginning.  Negative integers are intpreted as subtracted from the
+            number of steps in the Pipeline.
+        stop : int or str, optional
+            The index (0-based) or name of the step before which the extracted
+            subsequence ends (exclusive bound).  By default, get until the end.
+            Negative integers are intpreted as subtracted from the number of
+            steps in the Pipeline.
+
+        Returns
+        -------
+        sub_pipeline : Pipeline instance
+            The steps of this pipeline range from the start step to the stop
+            step specified.  The constituent estimators are not copied: if the
+            Pipeline had been fit, so will be the returned Pipeline.
+
+            The return type will be of the same type as self, if a subclass
+            is used and if its constructor is compatible.
+        """
+        if isinstance(start, six.string_types):
+            start = [name for name, _ in self.steps].index(start)
+        if isinstance(stop, six.string_types):
+            stop = [name for name, _ in self.steps].index(stop)
+
+        kwargs = self.get_params(deep=False)
+        kwargs['steps'] = self.steps[start:stop]
+        return type(self)(**kwargs)
 
     # Estimator interface
 


### PR DESCRIPTION
Conceptually Fixes #8414 and related issues. Alternative to #2568, #2561, #2562.
without `__getitem__` and the different return types for different arguments.

Designed to assist in model inspection and particularly to replicate the
composite transformer represented by steps of the pipeline with the
exception of the last. I.e. `pipe.get_subsequence(0, -1)` is a common
idiom. I feel like this becomes more necessary when considering more
API-consistent clone behaviour as per #8350 as `Pipeline(pipe.steps[:-1])`
is no longer possible. I still find `pipe[:-1]` of #2568 more readable than `.get_subsequence(0, -1)`

I'm happy to forego the handling of subtypes if seen as too magical, though I thought `imblearn` would appreciate it.

Ping @glemaitre, @GaelVaroquaux 

TODO:
* [ ] narrative docs
* [ ] use in existing example?