### PR TITLE
[MRG] Travis add coverage to Python 3 build and oldest version build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,12 @@ env:
     # This environment tests the oldest supported anaconda env
     - DISTRIB="conda" PYTHON_VERSION="2.7" INSTALL_MKL="false"
       NUMPY_VERSION="1.6.2" SCIPY_VERSION="0.11.0" CYTHON_VERSION="0.23"
+      COVERAGE=true
     # This environment tests the newest supported anaconda env
     # It also runs tests requiring Pandas.
     - DISTRIB="conda" PYTHON_VERSION="3.6" INSTALL_MKL="true"
       NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" PANDAS_VERSION="0.19.1"
-      CYTHON_VERSION="0.25.2"
+      CYTHON_VERSION="0.25.2" COVERAGE=true
     # This environment use pytest to run the tests. It uses the newest
     # supported anaconda env. It also runs tests requiring Pandas.
     - USE_PYTEST="true" DISTRIB="conda" PYTHON_VERSION="3.6" INSTALL_MKL="true"


### PR DESCRIPTION
Just making sure that the CIs pass and that the codecov looks fine, before I merge it.

codecov can combine the information from multiple builds.

The reason for adding Python 3 to the coverage is obvious. While I was at it I enabled coverage in the "oldest versions" build, there may be some coverage information that does not overlap with the other builds, e.g. in sklearn.utils.fixes.