### PR TITLE
[WIP] support sparse y in GridSearchCV

### DIFF
--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -18,6 +18,7 @@ import operator
 import warnings
 
 import numpy as np
+from scipy.sparse import issparse
 
 from .base import BaseEstimator, is_classifier, clone
 from .base import MetaEstimatorMixin
@@ -27,7 +28,7 @@ from .externals.joblib import Parallel, delayed
 from .externals import six
 from .utils import check_random_state
 from .utils.random import sample_without_replacement
-from .utils.validation import _num_samples, indexable
+from .utils.validation import _num_samples, indexable, check_consistent_length
 from .utils.metaestimators import if_delegate_has_method
 from .metrics.scorer import check_scoring
 from .exceptions import ChangedBehaviorWarning
@@ -526,8 +527,8 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
     def inverse_transform(self, Xt):
         """Call inverse_transform on the estimator with the best found parameters.
 
-        Only available if the underlying estimator implements ``inverse_transform`` and
-        ``refit=True``.
+        Only available if the underlying estimator implements
+        ``inverse_transform`` and ``refit=True``.
 
         Parameters
         -----------
@@ -549,10 +550,12 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         X, y = indexable(X, y)
 
         if y is not None:
-            if len(y) != n_samples:
-                raise ValueError('Target variable (y) has a different number '
-                                 'of samples (%i) than data (X: %i samples)'
-                                 % (len(y), n_samples))
+            check_consistent_length(X, y)
+
+        if issparse(y):
+            print(1)
+            raise ValueError("GridSearchCV doesn't support sparse y")
+
         cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
 
         if self.verbose > 0:

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -141,6 +141,16 @@ def test_parameter_grid():
     assert_grid_iter_equals_getitem(has_empty)
 
 
+def test_grid_search_no_sparse_y_support():
+    X, y = make_multilabel_classification(n_samples=200, return_indicator=True,
+                                          random_state=0)
+    y_sparse = sp.csr_matrix(y)
+    clf = DecisionTreeClassifier()
+    cv = GridSearchCV(clf, {"max_depth": [1, 2, 3, 4]})
+    assert_raise_message(ValueError, "GridSearchCV doesn't support sparse y",
+                         cv.fit, X, y_sparse)
+
+
 def test_grid_search():
     # Test that the best estimator contains the right value for foo_param
     clf = MockClassifier()


### PR DESCRIPTION
#### Reference Issue
Fixes #4225


#### What does this implement/fix? Explain your changes.
This PR attempts at the following:

- [x] Add proper error message for sparse `y` in `GridSearchCV`
- [x] Add tests for the same
- [ ]  Examine difference in behavior between sparse 2-class `y` and sparse multilabel `y`
- [ ] Add support for sparse `y` in all estimators or support for sparse multilabel `y` in estimators support multilabel classification.
- [ ] Make `GridSearchCV` support sparse `y`
- [ ] Add tests

#### Any other comments?
Related PR #7996.
I am thinking of starting my work from the above linked PR as it is a subset of what I intend to achieve.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
