### PR TITLE
[MRG+2] ENH : SAGA support for LogisticRegression (+ L1 support), Ridge

### DIFF
--- a/benchmarks/bench_mnist.py
+++ b/benchmarks/bench_mnist.py
@@ -91,7 +91,10 @@ ESTIMATORS = {
         Nystroem(gamma=0.015, n_components=1000), LinearSVC(C=100)),
     'SampledRBF-SVM': make_pipeline(
         RBFSampler(gamma=0.015, n_components=1000), LinearSVC(C=100)),
-    'LinearRegression-SAG': LogisticRegression(solver='sag', tol=1e-1, C=1e4),
+    'LogisticRegression-SAG': LogisticRegression(solver='sag', tol=1e-1,
+                                                 C=1e4),
+    'LogisticRegression-SAGA': LogisticRegression(solver='saga', tol=1e-1,
+                                                  C=1e4),
     'MultilayerPerceptron': MLPClassifier(
         hidden_layer_sizes=(100, 100), max_iter=400, alpha=1e-4,
         solver='sgd', learning_rate_init=0.2, momentum=0.9, verbose=1,

--- a/benchmarks/bench_saga.py
+++ b/benchmarks/bench_saga.py
@@ -1,0 +1,244 @@
+"""Author: Arthur Mensch
+
+Benchmarks of sklearn SAGA vs lightning SAGA vs Liblinear. Shows the gain
+in using multinomial logistic regression in term of learning time.
+"""
+import json
+import time
+from os.path import expanduser
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from sklearn.datasets import fetch_rcv1, load_iris, load_digits, \
+    fetch_20newsgroups_vectorized
+from sklearn.externals.joblib import delayed, Parallel, Memory
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import log_loss
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import LabelBinarizer, LabelEncoder
+from sklearn.utils.extmath import safe_sparse_dot, softmax
+
+
+def fit_single(solver, X, y, penalty='l2', single_target=True, C=1,
+               max_iter=10, skip_slow=False):
+    if skip_slow and solver == 'lightning' and penalty == 'l1':
+        print('skip_slowping l1 logistic regression with solver lightning.')
+        return
+
+    print('Solving %s logistic regression with penalty %s, solver %s.'
+          % ('binary' if single_target else 'multinomial',
+             penalty, solver))
+
+    if solver == 'lightning':
+        from lightning.classification import SAGAClassifier
+
+    if single_target or solver not in ['sag', 'saga']:
+        multi_class = 'ovr'
+    else:
+        multi_class = 'multinomial'
+
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42,
+                                                        stratify=y)
+    n_samples = X_train.shape[0]
+    n_classes = np.unique(y_train).shape[0]
+    test_scores = [1]
+    train_scores = [1]
+    accuracies = [1 / n_classes]
+    times = [0]
+
+    if penalty == 'l2':
+        alpha = 1. / (C * n_samples)
+        beta = 0
+        lightning_penalty = None
+    else:
+        alpha = 0.
+        beta = 1. / (C * n_samples)
+        lightning_penalty = 'l1'
+
+    for this_max_iter in range(1, max_iter + 1, 2):
+        print('[%s, %s, %s] Max iter: %s' %
+              ('binary' if single_target else 'multinomial',
+               penalty, solver, this_max_iter))
+        if solver == 'lightning':
+            lr = SAGAClassifier(loss='log', alpha=alpha, beta=beta,
+                                penalty=lightning_penalty,
+                                tol=-1, max_iter=this_max_iter)
+        else:
+            lr = LogisticRegression(solver=solver,
+                                    multi_class=multi_class,
+                                    C=C,
+                                    penalty=penalty,
+                                    fit_intercept=False, tol=1e-24,
+                                    max_iter=this_max_iter,
+                                    random_state=42,
+                                    )
+        t0 = time.clock()
+        lr.fit(X_train, y_train)
+        train_time = time.clock() - t0
+
+        scores = []
+        for (X, y) in [(X_train, y_train), (X_test, y_test)]:
+            try:
+                y_pred = lr.predict_proba(X)
+            except NotImplementedError:
+                # Lightning predict_proba is not implemented for n_classes > 2
+                y_pred = _predict_proba(lr, X)
+            score = log_loss(y, y_pred, normalize=False) / n_samples
+            score += (0.5 * alpha * np.sum(lr.coef_ ** 2) +
+                      beta * np.sum(np.abs(lr.coef_)))
+            scores.append(score)
+        train_score, test_score = tuple(scores)
+
+        y_pred = lr.predict(X_test)
+        accuracy = np.sum(y_pred == y_test) / y_test.shape[0]
+        test_scores.append(test_score)
+        train_scores.append(train_score)
+        accuracies.append(accuracy)
+        times.append(train_time)
+    return lr, times, train_scores, test_scores, accuracies
+
+
+def _predict_proba(lr, X):
+    pred = safe_sparse_dot(X, lr.coef_.T)
+    if hasattr(lr, "intercept_"):
+        pred += lr.intercept_
+    return softmax(pred)
+
+
+def exp(solvers, penalties, single_target, n_samples=30000, max_iter=20,
+        dataset='rcv1', n_jobs=1, skip_slow=False):
+    mem = Memory(cachedir=expanduser('~/cache'), verbose=0)
+
+    if dataset == 'rcv1':
+        rcv1 = fetch_rcv1()
+
+        lbin = LabelBinarizer()
+        lbin.fit(rcv1.target_names)
+
+        X = rcv1.data
+        y = rcv1.target
+        y = lbin.inverse_transform(y)
+        le = LabelEncoder()
+        y = le.fit_transform(y)
+        if single_target:
+            y_n = y.copy()
+            y_n[y > 16] = 1
+            y_n[y <= 16] = 0
+            y = y_n
+
+    elif dataset == 'digits':
+        digits = load_digits()
+        X, y = digits.data, digits.target
+        if single_target:
+            y_n = y.copy()
+            y_n[y < 5] = 1
+            y_n[y >= 5] = 0
+            y = y_n
+    elif dataset == 'iris':
+        iris = load_iris()
+        X, y = iris.data, iris.target
+    elif dataset == '20newspaper':
+        ng = fetch_20newsgroups_vectorized()
+        X = ng.data
+        y = ng.target
+        if single_target:
+            y_n = y.copy()
+            y_n[y > 4] = 1
+            y_n[y <= 16] = 0
+            y = y_n
+
+    X = X[:n_samples]
+    y = y[:n_samples]
+
+    cached_fit = mem.cache(fit_single)
+    out = Parallel(n_jobs=n_jobs, mmap_mode=None)(
+        delayed(cached_fit)(solver, X, y,
+                            penalty=penalty, single_target=single_target,
+                            C=1, max_iter=max_iter, skip_slow=skip_slow)
+        for solver in solvers
+        for penalty in penalties)
+
+    res = []
+    idx = 0
+    for solver in solvers:
+        for penalty in penalties:
+            if not (skip_slow and solver == 'lightning' and penalty == 'l1'):
+                lr, times, train_scores, test_scores, accuracies = out[idx]
+                this_res = dict(solver=solver, penalty=penalty,
+                                single_target=single_target,
+                                times=times, train_scores=train_scores,
+                                test_scores=test_scores,
+                                accuracies=accuracies)
+                res.append(this_res)
+            idx += 1
+
+    with open('bench_saga.json', 'w+') as f:
+        json.dump(res, f)
+
+
+def plot():
+    import pandas as pd
+    with open('bench_saga.json', 'r') as f:
+        f = json.load(f)
+    res = pd.DataFrame(f)
+    res.set_index(['single_target', 'penalty'], inplace=True)
+
+    grouped = res.groupby(level=['single_target', 'penalty'])
+
+    colors = {'saga': 'blue', 'liblinear': 'orange', 'lightning': 'green'}
+
+    for idx, group in grouped:
+        single_target, penalty = idx
+        fig = plt.figure(figsize=(12, 4))
+        ax = fig.add_subplot(131)
+
+        train_scores = group['train_scores'].values
+        ref = np.min(np.concatenate(train_scores)) * 0.999
+
+        for scores, times, solver in zip(group['train_scores'], group['times'],
+                                         group['solver']):
+            scores = scores / ref - 1
+            ax.plot(times, scores, label=solver, color=colors[solver])
+        ax.set_xlabel('Time (s)')
+        ax.set_ylabel('Training objective (relative to min)')
+        ax.set_yscale('log')
+
+        ax = fig.add_subplot(132)
+
+        test_scores = group['test_scores'].values
+        ref = np.min(np.concatenate(test_scores)) * 0.999
+
+        for scores, times, solver in zip(group['test_scores'], group['times'],
+                                         group['solver']):
+            scores = scores / ref - 1
+            ax.plot(times, scores, label=solver, color=colors[solver])
+        ax.set_xlabel('Time (s)')
+        ax.set_ylabel('Test objective (relative to min)')
+        ax.set_yscale('log')
+
+        ax = fig.add_subplot(133)
+
+        for accuracy, times, solver in zip(group['accuracies'], group['times'],
+                                           group['solver']):
+            ax.plot(times, accuracy, label=solver, color=colors[solver])
+        ax.set_xlabel('Time (s)')
+        ax.set_ylabel('Test accuracy')
+        ax.legend()
+        name = 'single_target' if single_target else 'multi_target'
+        name += '_%s' % penalty
+        plt.suptitle(name)
+        name += '.png'
+        fig.tight_layout()
+        fig.subplots_adjust(top=0.9)
+        plt.savefig(name)
+        plt.close(fig)
+
+
+if __name__ == '__main__':
+    solvers = ['saga', 'liblinear', 'lightning']
+    penalties = ['l1', 'l2']
+    single_target = True
+    exp(solvers, penalties, single_target, n_samples=None, n_jobs=1,
+        dataset='20newspaper', max_iter=20)
+    plot()

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -721,7 +721,7 @@ optimization problem
 .. math:: \underset{w, c}{min\,} \|w\|_1 + C \sum_{i=1}^n \log(\exp(- y_i (X_i^T w + c)) + 1) .
 
 The solvers implemented in the class :class:`LogisticRegression`
-are "liblinear", "newton-cg", "lbfgs" and "sag":
+are "liblinear", "newton-cg", "lbfgs", "sag" and "saga":
 
 The solver "liblinear" uses a coordinate descent (CD) algorithm, and relies
 on the excellent C++ `LIBLINEAR library
@@ -739,25 +739,31 @@ The "lbfgs", "sag" and "newton-cg" solvers only support L2 penalization and
 are found to converge faster for some high dimensional data. Setting
 `multi_class` to "multinomial" with these solvers learns a true multinomial
 logistic regression model [5]_, which means that its probability estimates
-should be better calibrated than the default "one-vs-rest" setting. The
-"lbfgs", "sag" and "newton-cg"" solvers cannot optimize L1-penalized models,
-therefore the "multinomial" setting does not learn sparse models.
+should be better calibrated than the default "one-vs-rest" setting.
 
-The solver "sag" uses a Stochastic Average Gradient descent [6]_. It is faster
+The "sag" solver uses a Stochastic Average Gradient descent [6]_. It is faster
 than other solvers for large datasets, when both the number of samples and the
 number of features are large.
 
+The "saga" solver [7]_ is a variant of "sag" that also supports the
+non-smooth `penalty="l1"` option. This is therefore the solver of choice
+for sparse multinomial logistic regression.
+
 In a nutshell, one may choose the solver with the following rules:
 
-=================================  =============================
+=================================  =====================================
 Case                               Solver
-=================================  =============================
-Small dataset or L1 penalty        "liblinear"
-Multinomial loss or large dataset  "lbfgs", "sag" or "newton-cg"
-Very Large dataset                 "sag"
-=================================  =============================
+=================================  =====================================
+L1 penalty                         "liblinear" or "saga"
+Multinomial loss                   "lbfgs", "sag", "saga" or "newton-cg"
+Very Large dataset (`n_samples`)   "sag" or "saga"
+=================================  =====================================
 
-For large dataset, you may also consider using :class:`SGDClassifier` with 'log' loss.
+The "saga" solver is often the best choice. The "liblinear" solver is
+used by default for historical reasons.
+
+For large dataset, you may also consider using :class:`SGDClassifier`
+with 'log' loss.
 
 .. topic:: Examples:
 
@@ -766,6 +772,10 @@ For large dataset, you may also consider using :class:`SGDClassifier` with 'log'
   * :ref:`sphx_glr_auto_examples_linear_model_plot_logistic_path.py`
 
   * :ref:`sphx_glr_auto_examples_linear_model_plot_logistic_multinomial.py`
+
+  * :ref:`sphx_glr_auto_examples_linear_model_plot_sparse_logistic_regression_20newsgroups.py`
+
+  * :ref:`sphx_glr_auto_examples_linear_model_plot_sparse_logistic_regression_mnist.py`
 
 .. _liblinear_differences:
 
@@ -788,19 +798,22 @@ For large dataset, you may also consider using :class:`SGDClassifier` with 'log'
    thus be used to perform feature selection, as detailed in
    :ref:`l1_feature_selection`.
 
-:class:`LogisticRegressionCV` implements Logistic Regression with builtin
-cross-validation to find out the optimal C parameter. "newton-cg", "sag" and
-"lbfgs" solvers are found to be faster for high-dimensional dense data, due to
-warm-starting. For the multiclass case, if `multi_class` option is set to
-"ovr", an optimal C is obtained for each class and if the `multi_class` option
-is set to "multinomial", an optimal C is obtained by minimizing the cross-
-entropy loss.
+:class:`LogisticRegressionCV` implements Logistic Regression with
+builtin cross-validation to find out the optimal C parameter.
+"newton-cg", "sag", "saga" and "lbfgs" solvers are found to be faster
+for high-dimensional dense data, due to warm-starting. For the
+multiclass case, if `multi_class` option is set to "ovr", an optimal C
+is obtained for each class and if the `multi_class` option is set to
+"multinomial", an optimal C is obtained by minimizing the cross-entropy
+loss.
 
 .. topic:: References:
 
     .. [5] Christopher M. Bishop: Pattern Recognition and Machine Learning, Chapter 4.3.4
 
     .. [6] Mark Schmidt, Nicolas Le Roux, and Francis Bach: `Minimizing Finite Sums with the Stochastic Average Gradient. <https://hal.inria.fr/hal-00860051/document>`_
+
+    .. [7] Aaron Defazio, Francis Bach, Simon Lacoste-Julien: `SAGA: A Fast Incremental Gradient Method With Support for Non-Strongly Convex Composite Objectives. <https://arxiv.org/abs/1407.0202>`_
 
 Stochastic Gradient Descent - SGD
 =================================

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -50,6 +50,13 @@ New features
      particularly useful for targets with an exponential trend.
      :issue:`7655` by :user:`Karan Desai <karandesai-96>`.
 
+   - Added solver ``saga`` that implements the improved version of Stochastic
+     Average Gradient, in :class:`linear_model.LogisticRegression` and
+     :class:`linear_model.Ridge`. It allows the use of L1 penalty with
+     multinomial logistic loss, and behaves marginally better than 'sag'
+     during the first epochs of ridge and logistic regression.
+     By `Arthur Mensch`_.
+
 Enhancements
 ............
 
@@ -5037,3 +5044,4 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Anish Shah: https://github.com/AnishShah
 
 .. _Neeraj Gangwar: http://neerajgangwar.in
+.. _Arthur Mensch: https://amensch.fr

--- a/examples/linear_model/plot_sparse_logistic_regression_20newsgroups.py
+++ b/examples/linear_model/plot_sparse_logistic_regression_20newsgroups.py
@@ -1,0 +1,118 @@
+"""
+=====================================================
+Multiclass sparse logisitic regression on newgroups20
+=====================================================
+
+Comparison of multinomial logistic L1 vs one-versus-rest L1 logistic regression
+to classify documents from the newgroups20 dataset. Multinomial logistic
+regression yields more accurate results and is faster to train on the larger
+scale dataset.
+
+Here we use the l1 sparsity that trims the weights of not informative
+features to zero. This is good if the goal is to extract the strongly
+discriminative vocabulary of each class. If the goal is to get the best
+predictive accuracy, it is better to use the non sparsity-inducing l2 penalty
+instead.
+
+A more traditional (and possibly better) way to predict on a sparse subset of
+input features would be to use univariate feature selection followed by a
+traditional (l2-penalised) logistic regression model.
+"""
+import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from sklearn.datasets import fetch_20newsgroups_vectorized
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
+
+print(__doc__)
+# Author: Arthur Mensch
+
+t0 = time.clock()
+
+# We use SAGA solver
+solver = 'saga'
+
+# Turn down for faster run time
+n_samples = 10000
+
+# Memorized fetch_rcv1 for faster access
+dataset = fetch_20newsgroups_vectorized('all')
+X = dataset.data
+y = dataset.target
+X = X[:n_samples]
+y = y[:n_samples]
+
+X_train, X_test, y_train, y_test = train_test_split(X, y,
+                                                    random_state=42,
+                                                    stratify=y,
+                                                    test_size=0.1)
+train_samples, n_features = X_train.shape
+n_classes = np.unique(y).shape[0]
+
+print('Dataset 20newsgroup, train_samples=%i, n_features=%i, n_classes=%i'
+      % (train_samples, n_features, n_classes))
+
+models = {'ovr': {'name': 'One versus Rest', 'iters': [1, 3]},
+          'multinomial': {'name': 'Multinomial', 'iters': [1, 3, 7]}}
+
+for model in models:
+    # Add initial chance-level values for plotting purpose
+    accuracies = [1 / n_classes]
+    times = [0]
+    densities = [1]
+
+    model_params = models[model]
+
+    # Small number of epochs for fast runtime
+    for this_max_iter in model_params['iters']:
+        print('[model=%s, solver=%s] Number of epochs: %s' %
+              (model_params['name'], solver, this_max_iter))
+        lr = LogisticRegression(solver=solver,
+                                multi_class=model,
+                                C=1,
+                                penalty='l1',
+                                fit_intercept=True,
+                                max_iter=this_max_iter,
+                                random_state=42,
+                                )
+        t1 = time.clock()
+        lr.fit(X_train, y_train)
+        train_time = time.clock() - t1
+
+        y_pred = lr.predict(X_test)
+        accuracy = np.sum(y_pred == y_test) / y_test.shape[0]
+        density = np.mean(lr.coef_ != 0, axis=1) * 100
+        accuracies.append(accuracy)
+        densities.append(density)
+        times.append(train_time)
+    models[model]['times'] = times
+    models[model]['densities'] = densities
+    models[model]['accuracies'] = accuracies
+    print('Test accuracy for model %s: %.4f' % (model, accuracies[-1]))
+    print('%% non-zero coefficients for model %s, '
+          'per class:\n %s' % (model, densities[-1]))
+    print('Run time (%i epochs) for model %s:'
+          '%.2f' % (model_params['iters'][-1], model, times[-1]))
+
+fig = plt.figure()
+ax = fig.add_subplot(111)
+
+for model in models:
+    name = models[model]['name']
+    times = models[model]['times']
+    accuracies = models[model]['accuracies']
+    ax.plot(times, accuracies, marker='o',
+            label='Model: %s' % name)
+    ax.set_xlabel('Train time (s)')
+    ax.set_ylabel('Test accuracy')
+ax.legend()
+fig.suptitle('Multinomial vs One-vs-Rest Logistic L1\n'
+             'Dataset %s' % '20newsgroups')
+fig.tight_layout()
+fig.subplots_adjust(top=0.85)
+run_time = time.clock() - t0
+print('Example run in %.3f s' % run_time)
+plt.show()

--- a/examples/linear_model/plot_sparse_logistic_regression_mnist.py
+++ b/examples/linear_model/plot_sparse_logistic_regression_mnist.py
@@ -1,0 +1,79 @@
+"""
+=====================================================
+MNIST classfification using multinomial logistic + L1
+=====================================================
+
+Here we fit a multinomial logistic regression with L1 penalty on a subset of
+the MNIST digits classification task. We use the SAGA algorithm for this
+purpose: this a solver that is fast when the number of samples is significantly
+larger than the number of features and is able to finely optimize non-smooth
+objective functions which is the case with the l1-penalty. Test accuracy
+reaches > 0.8, while weight vectors remains *sparse* and therefore more easily
+*interpretable*.
+
+Note that this accuracy of this l1-penalized linear model is significantly
+below what can be reached by an l2-penalized linear model or a non-linear
+multi-layer perceptron model on this dataset.
+
+"""
+import time
+import matplotlib.pyplot as plt
+import numpy as np
+
+from sklearn.datasets import fetch_mldata
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+from sklearn.utils import check_random_state
+
+print(__doc__)
+
+# Author: Arthur Mensch <arthur.mensch@m4x.org>
+# License: BSD 3 clause
+
+# Turn down for faster convergence
+t0 = time.time()
+train_samples = 5000
+
+mnist = fetch_mldata('MNIST original')
+X = mnist.data.astype('float64')
+y = mnist.target
+random_state = check_random_state(0)
+permutation = random_state.permutation(X.shape[0])
+X = X[permutation]
+y = y[permutation]
+X = X.reshape((X.shape[0], -1))
+
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, train_size=train_samples, test_size=10000)
+
+scaler = StandardScaler()
+X_train = scaler.fit_transform(X_train)
+X_test = scaler.transform(X_test)
+
+# Turn up tolerance for faster convergence
+clf = LogisticRegression(C=50 / train_samples,
+                         multi_class='multinomial',
+                         penalty='l1', solver='saga', tol=0.1)
+clf.fit(X_train, y_train)
+sparsity = np.mean(clf.coef_ == 0) * 100
+score = clf.score(X_test, y_test)
+# print('Best C % .4f' % clf.C_)
+print("Sparsity with L1 penalty: %.2f%%" % sparsity)
+print("Test score with L1 penalty: %.4f" % score)
+
+coef = clf.coef_.copy()
+plt.figure(figsize=(10, 5))
+scale = np.abs(coef).max()
+for i in range(10):
+    l1_plot = plt.subplot(2, 5, i + 1)
+    l1_plot.imshow(coef[i].reshape(28, 28), interpolation='nearest',
+                   cmap=plt.cm.RdBu, vmin=-scale, vmax=scale)
+    l1_plot.set_xticks(())
+    l1_plot.set_yticks(())
+    l1_plot.set_xlabel('Class %i' % i)
+plt.suptitle('Classification vector for...')
+
+run_time = time.time() - t0
+print('Example run in %.3f s' % run_time)
+plt.show()

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -8,6 +8,7 @@ Logistic Regression
 #         Manoj Kumar <manojkumarsivaraj334@gmail.com>
 #         Lars Buitinck
 #         Simon Wu <s8wu@uwaterloo.ca>
+#         Arthur Mensch <arthur.mensch@m4x.org
 
 import numbers
 import warnings
@@ -421,7 +422,7 @@ def _multinomial_grad_hess(w, X, Y, alpha, sample_weight):
 
 
 def _check_solver_option(solver, multi_class, penalty, dual):
-    if solver not in ['liblinear', 'newton-cg', 'lbfgs', 'sag']:
+    if solver not in ['liblinear', 'newton-cg', 'lbfgs', 'sag', 'saga']:
         raise ValueError("Logistic Regression supports only liblinear,"
                          " newton-cg, lbfgs and sag solvers, got %s" % solver)
 
@@ -433,10 +434,11 @@ def _check_solver_option(solver, multi_class, penalty, dual):
         raise ValueError("Solver %s does not support "
                          "a multinomial backend." % solver)
 
-    if solver != 'liblinear':
+    if solver not in ['liblinear', 'saga']:
         if penalty != 'l2':
             raise ValueError("Solver %s supports only l2 penalties, "
                              "got %s penalty." % (solver, penalty))
+    if solver != 'liblinear':
         if dual:
             raise ValueError("Solver %s supports only "
                              "dual=False, got dual=%s" % (solver, dual))
@@ -494,7 +496,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
         For the liblinear and lbfgs solvers set verbose to any positive
         number for verbosity.
 
-    solver : {'lbfgs', 'newton-cg', 'liblinear', 'sag'}
+    solver : {'lbfgs', 'newton-cg', 'liblinear', 'sag', 'saga'}
         Numerical solver to use.
 
     coef : array-like, shape (n_features,), default None
@@ -631,7 +633,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
             sample_weight *= class_weight_[le.fit_transform(y_bin)]
 
     else:
-        if solver != 'sag':
+        if solver not in ['sag', 'saga']:
             lbin = LabelBinarizer()
             Y_multi = lbin.fit_transform(y)
             if Y_multi.shape[1] == 1:
@@ -726,16 +728,23 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
             else:
                 w0 = coef_.ravel()
 
-        elif solver == 'sag':
+        elif solver in ['sag', 'saga']:
             if multi_class == 'multinomial':
                 target = target.astype(np.float64)
                 loss = 'multinomial'
             else:
                 loss = 'log'
-
+            if penalty == 'l1':
+                alpha = 0.
+                beta = 1. / C
+            else:
+                alpha = 1. / C
+                beta = 0.
             w0, n_iter_i, warm_start_sag = sag_solver(
-                X, target, sample_weight, loss, 1. / C, max_iter, tol,
-                verbose, random_state, False, max_squared_sum, warm_start_sag)
+                X, target, sample_weight, loss, alpha,
+                beta, max_iter, tol,
+                verbose, random_state, False, max_squared_sum, warm_start_sag,
+                is_saga=(solver == 'saga'))
 
         else:
             raise ValueError("solver must be one of {'liblinear', 'lbfgs', "
@@ -820,7 +829,7 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
         For the liblinear and lbfgs solvers set verbose to any positive
         number for verbosity.
 
-    solver : {'lbfgs', 'newton-cg', 'liblinear', 'sag'}
+    solver : {'lbfgs', 'newton-cg', 'liblinear', 'sag', 'saga'}
         Decides which solver to use.
 
     penalty : str, 'l1' or 'l2'
@@ -848,8 +857,8 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
         Multiclass option can be either 'ovr' or 'multinomial'. If the option
         chosen is 'ovr', then a binary problem is fit for each label. Else
         the loss minimised is the multinomial loss fit across
-        the entire probability distribution. Works only for the 'lbfgs' and
-        'newton-cg' solver.
+        the entire probability distribution. Does not work for
+        liblinear solver.
 
     random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use when
@@ -967,6 +976,9 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         Used to specify the norm used in the penalization. The 'newton-cg',
         'sag' and 'lbfgs' solvers support only l2 penalties.
 
+        .. versionadded:: 0.19
+           l1 penalty with SAGA solver (allowing 'multinomial' + L1)
+
     dual : bool, default: False
         Dual or primal formulation. Dual formulation is only implemented for
         l2 penalty with liblinear solver. Prefer dual=False when
@@ -1016,22 +1028,26 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         The seed of the pseudo random number generator to use when
         shuffling the data. Used only in solvers 'sag' and 'liblinear'.
 
-    solver : {'newton-cg', 'lbfgs', 'liblinear', 'sag'}, default: 'liblinear'
+    solver : {'newton-cg', 'lbfgs', 'liblinear', 'sag', 'saga'},
+        default: 'liblinear'
         Algorithm to use in the optimization problem.
 
-        - For small datasets, 'liblinear' is a good choice, whereas 'sag' is
-            faster for large ones.
-        - For multiclass problems, only 'newton-cg', 'sag' and 'lbfgs' handle
-            multinomial loss; 'liblinear' is limited to one-versus-rest
+        - For small datasets, 'liblinear' is a good choice, whereas 'sag' and
+            'saga' are faster for large ones.
+        - For multiclass problems, only 'newton-cg', 'sag', 'saga' and 'lbfgs'
+            handle multinomial loss; 'liblinear' is limited to one-versus-rest
             schemes.
-        - 'newton-cg', 'lbfgs' and 'sag' only handle L2 penalty.
+        - 'newton-cg', 'lbfgs' and 'sag' only handle L2 penalty, whereas
+            'liblinear' and 'saga' handle L1 penalty.
 
-        Note that 'sag' fast convergence is only guaranteed on features with
-        approximately the same scale. You can preprocess the data with a
-        scaler from sklearn.preprocessing.
+        Note that 'sag' and 'saga' fast convergence is only guaranteed on
+        features with approximately the same scale. You can
+        preprocess the data with a scaler from sklearn.preprocessing.
 
         .. versionadded:: 0.17
            Stochastic Average Gradient descent solver.
+        .. versionadded:: 0.19
+           SAGA solver.
 
     tol : float, default: 1e-4
         Tolerance for stopping criteria.
@@ -1040,8 +1056,8 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         Multiclass option can be either 'ovr' or 'multinomial'. If the option
         chosen is 'ovr', then a binary problem is fit for each label. Else
         the loss minimised is the multinomial loss fit across
-        the entire probability distribution. Works only for the 'newton-cg',
-        'sag' and 'lbfgs' solver.
+        the entire probability distribution. Does not work for liblinear
+        solver.
 
         .. versionadded:: 0.18
            Stochastic Average Gradient descent solver for 'multinomial' case.
@@ -1056,7 +1072,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         Useless for liblinear solver.
 
         .. versionadded:: 0.17
-           *warm_start* to support *lbfgs*, *newton-cg*, *sag* solvers.
+           *warm_start* to support *lbfgs*, *newton-cg*, *sag*, *saga* solvers.
 
     n_jobs : int, default: 1
         Number of CPU cores used when parallelizing over classes
@@ -1109,6 +1125,11 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
     SAG -- Mark Schmidt, Nicolas Le Roux, and Francis Bach
         Minimizing Finite Sums with the Stochastic Average Gradient
         https://hal.inria.fr/hal-00860051/document
+
+    SAGA -- Defazio, A., Bach F. & Lacoste-Julien S. (2014).
+        SAGA: A Fast Incremental Gradient Method With Support
+        for Non-Strongly Convex Composite Objectives
+        https://arxiv.org/abs/1407.0202
 
     Hsiang-Fu Yu, Fang-Lan Huang, Chih-Jen Lin (2011). Dual coordinate descent
         methods for logistic regression and maximum entropy models.
@@ -1188,7 +1209,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
             self.n_iter_ = np.array([n_iter_])
             return self
 
-        if self.solver == 'sag':
+        if self.solver in ['sag', 'saga']:
             max_squared_sum = row_norms(X, squared=True).max()
         else:
             max_squared_sum = None
@@ -1220,7 +1241,6 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         if self.multi_class == 'multinomial':
             classes_ = [None]
             warm_start_coef = [warm_start_coef]
-
         if warm_start_coef is None:
             warm_start_coef = [None] * n_classes
 
@@ -1228,7 +1248,10 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
 
         # The SAG solver releases the GIL so it's more efficient to use
         # threads for this solver.
-        backend = 'threading' if self.solver == 'sag' else 'multiprocessing'
+        if self.solver in ['sag', 'saga']:
+            backend = 'threading'
+        else:
+            backend = 'multiprocessing'
         fold_coefs_ = Parallel(n_jobs=self.n_jobs, verbose=self.verbose,
                                backend=backend)(
             path_func(X, y, pos_class=class_, Cs=[self.C],
@@ -1237,9 +1260,10 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
                       multi_class=self.multi_class, max_iter=self.max_iter,
                       class_weight=self.class_weight, check_input=False,
                       random_state=self.random_state, coef=warm_start_coef_,
+                      penalty=self.penalty,
                       max_squared_sum=max_squared_sum,
                       sample_weight=sample_weight)
-            for (class_, warm_start_coef_) in zip(classes_, warm_start_coef))
+            for class_, warm_start_coef_ in zip(classes_, warm_start_coef))
 
         fold_coefs_, _, n_iter_ = zip(*fold_coefs_)
         self.n_iter_ = np.asarray(n_iter_, dtype=np.int32)[:, 0]
@@ -1379,25 +1403,28 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         that can be used, look at :mod:`sklearn.metrics`. The
         default scoring option used is 'accuracy'.
 
-
-    solver : {'newton-cg', 'lbfgs', 'liblinear', 'sag'}
+    solver : {'newton-cg', 'lbfgs', 'liblinear', 'sag', 'saga'},
+        default: 'liblinear'
         Algorithm to use in the optimization problem.
 
-        - For small datasets, 'liblinear' is a good choice, whereas 'sag' is
-            faster for large ones.
-        - For multiclass problems, only 'newton-cg', 'sag' and 'lbfgs' handle
-            multinomial loss; 'liblinear' is limited to one-versus-rest
+        - For small datasets, 'liblinear' is a good choice, whereas 'sag' and
+            'saga' are faster for large ones.
+        - For multiclass problems, only 'newton-cg', 'sag', 'saga' and 'lbfgs'
+            handle multinomial loss; 'liblinear' is limited to one-versus-rest
             schemes.
-        - 'newton-cg', 'lbfgs' and 'sag' only handle L2 penalty.
+        - 'newton-cg', 'lbfgs' and 'sag' only handle L2 penalty, whereas
+            'liblinear' and 'saga' handle L1 penalty.
         - 'liblinear' might be slower in LogisticRegressionCV because it does
             not handle warm-starting.
 
-        Note that 'sag' fast convergence is only guaranteed on features with
-        approximately the same scale. You can preprocess the data with a
-        scaler from sklearn.preprocessing.
+        Note that 'sag' and 'saga' fast convergence is only guaranteed on
+        features with approximately the same scale. You can preprocess the data
+        with a scaler from sklearn.preprocessing.
 
         .. versionadded:: 0.17
            Stochastic Average Gradient descent solver.
+        .. versionadded:: 0.19
+           SAGA solver.
 
     tol : float, optional
         Tolerance for stopping criteria.
@@ -1569,7 +1596,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         classes = self.classes_ = label_encoder.classes_
         encoded_labels = label_encoder.transform(label_encoder.classes_)
 
-        if self.solver == 'sag':
+        if self.solver in ['sag', 'saga']:
             max_squared_sum = row_norms(X, squared=True).max()
         else:
             max_squared_sum = None
@@ -1612,7 +1639,10 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
 
         # The SAG solver releases the GIL so it's more efficient to use
         # threads for this solver.
-        backend = 'threading' if self.solver == 'sag' else 'multiprocessing'
+        if self.solver in ['sag', 'saga']:
+            backend = 'threading'
+        else:
+            backend = 'multiprocessing'
         fold_coefs_ = Parallel(n_jobs=self.n_jobs, verbose=self.verbose,
                                backend=backend)(
             path_func(X, y, train, test, pos_class=label, Cs=self.Cs,

--- a/sklearn/linear_model/sag.py
+++ b/sklearn/linear_model/sag.py
@@ -4,17 +4,20 @@
 #
 # License: BSD 3 clause
 
-import numpy as np
 import warnings
 
+import numpy as np
+
+from .base import make_dataset
+from .sag_fast import sag
 from ..exceptions import ConvergenceWarning
 from ..utils import check_array
 from ..utils.extmath import row_norms
-from .base import make_dataset
-from .sag_fast import sag
 
 
-def get_auto_step_size(max_squared_sum, alpha_scaled, loss, fit_intercept):
+def get_auto_step_size(max_squared_sum, alpha_scaled, loss, fit_intercept,
+                       n_samples=None,
+                       is_saga=False):
     """Compute automatic step size for SAG solver
 
     The step size is set to 1 / (alpha_scaled + L + fit_intercept) where L is
@@ -36,6 +39,13 @@ def get_auto_step_size(max_squared_sum, alpha_scaled, loss, fit_intercept):
         Specifies if a constant (a.k.a. bias or intercept) will be
         added to the decision function.
 
+    n_samples : int, optional
+        Number of rows in X. Useful if is_saga=True.
+
+    is_saga : boolean, optional
+        Whether to return step size for the SAGA algorithm or the SAG
+        algorithm.
+
     Returns
     -------
     step_size : float
@@ -46,23 +56,38 @@ def get_auto_step_size(max_squared_sum, alpha_scaled, loss, fit_intercept):
     Schmidt, M., Roux, N. L., & Bach, F. (2013).
     Minimizing finite sums with the stochastic average gradient
     https://hal.inria.fr/hal-00860051/document
+
+    Defazio, A., Bach F. & Lacoste-Julien S. (2014).
+    SAGA: A Fast Incremental Gradient Method With Support
+    for Non-Strongly Convex Composite Objectives
+    https://arxiv.org/abs/1407.0202
     """
     if loss in ('log', 'multinomial'):
-        # inverse Lipschitz constant for log loss
-        return 4.0 / (max_squared_sum + int(fit_intercept)
-                      + 4.0 * alpha_scaled)
+        L = (0.25 * (max_squared_sum + int(fit_intercept)) + alpha_scaled)
     elif loss == 'squared':
         # inverse Lipschitz constant for squared loss
-        return 1.0 / (max_squared_sum + int(fit_intercept) + alpha_scaled)
+        L = max_squared_sum + int(fit_intercept) + alpha_scaled
     else:
         raise ValueError("Unknown loss function for SAG solver, got %s "
                          "instead of 'log' or 'squared'" % loss)
+    if is_saga:
+        # SAGA theoretical step size is 1/3L or 1 / (2 * (L + mu n))
+        # See Defazio et al. 2014
+        mun = min(2 * n_samples * alpha_scaled, L)
+        step = 1. / (2 * L + mun)
+    else:
+        # SAG theoretical step size is 1/16L but it is recommended to use 1 / L
+        # see http://www.birs.ca//workshops//2014/14w5003/files/schmidt.pdf,
+        # slide 65
+        step = 1. / L
+    return step
 
 
-def sag_solver(X, y, sample_weight=None, loss='log', alpha=1.,
+def sag_solver(X, y, sample_weight=None, loss='log', alpha=1., beta=0.,
                max_iter=1000, tol=0.001, verbose=0, random_state=None,
                check_input=True, max_squared_sum=None,
-               warm_start_mem=None):
+               warm_start_mem=None,
+               is_saga=False):
     """SAG solver for Ridge and LogisticRegression
 
     SAG stands for Stochastic Average Gradient: the gradient of the loss is
@@ -145,6 +170,10 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1.,
             - 'seen': array of boolean describing the seen samples.
             - 'num_seen': the number of seen samples.
 
+    is_saga : boolean, optional
+        Whether to use the SAGA algorithm or the SAG algorithm. SAGA behaves
+        better in the first epochs, and allow for l1 regularisation.
+
     Returns
     -------
     coef_ : array, shape (n_features)
@@ -188,6 +217,11 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1.,
     Minimizing finite sums with the stochastic average gradient
     https://hal.inria.fr/hal-00860051/document
 
+    Defazio, A., Bach F. & Lacoste-Julien S. (2014).
+    SAGA: A Fast Incremental Gradient Method With Support
+    for Non-Strongly Convex Composite Objectives
+    https://arxiv.org/abs/1407.0202
+
     See also
     --------
     Ridge, SGDRegressor, ElasticNet, Lasso, SVR, and
@@ -206,6 +240,7 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1.,
     n_samples, n_features = X.shape[0], X.shape[1]
     # As in SGD, the alpha is scaled by n_samples.
     alpha_scaled = float(alpha) / n_samples
+    beta_scaled = float(beta) / n_samples
 
     # if loss == 'multinomial', y should be label encoded.
     n_classes = int(y.max()) + 1 if loss == 'multinomial' else 1
@@ -261,8 +296,8 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1.,
     if max_squared_sum is None:
         max_squared_sum = row_norms(X, squared=True).max()
     step_size = get_auto_step_size(max_squared_sum, alpha_scaled, loss,
-                                   fit_intercept)
-
+                                   fit_intercept, n_samples=n_samples,
+                                   is_saga=is_saga)
     if step_size * alpha_scaled == 1:
         raise ZeroDivisionError("Current sag implementation does not handle "
                                 "the case step_size * alpha_scaled == 1")
@@ -273,6 +308,7 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1.,
                             max_iter,
                             loss,
                             step_size, alpha_scaled,
+                            beta_scaled,
                             sum_gradient_init,
                             gradient_memory_init,
                             seen_init,
@@ -280,6 +316,7 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1.,
                             fit_intercept,
                             intercept_sum_gradient,
                             intercept_decay,
+                            is_saga,
                             verbose)
     if n_iter_ == max_iter:
         warnings.warn("The max_iter was reached which means "

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1,32 +1,31 @@
 import numpy as np
 import scipy.sparse as sp
 from scipy import linalg, optimize, sparse
-
+from sklearn.datasets import load_iris, make_classification
+from sklearn.metrics import log_loss
+from sklearn.model_selection import StratifiedKFold
+from sklearn.preprocessing import LabelEncoder
+from sklearn.utils import compute_class_weight
+from sklearn.utils.fixes import sp_version
 from sklearn.utils.testing import assert_almost_equal
-from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_warns
-from sklearn.utils.testing import raises
 from sklearn.utils.testing import ignore_warnings
-from sklearn.utils.testing import assert_raise_message
-from sklearn.exceptions import ConvergenceWarning
-from sklearn.utils import compute_class_weight
-from sklearn.utils.fixes import sp_version
+from sklearn.utils.testing import raises
 
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model.logistic import (
     LogisticRegression,
     logistic_regression_path, LogisticRegressionCV,
     _logistic_loss_and_grad, _logistic_grad_hess,
     _multinomial_grad_hess, _logistic_loss,
-    )
-from sklearn.model_selection import StratifiedKFold
-from sklearn.datasets import load_iris, make_classification
-from sklearn.metrics import log_loss
-from sklearn.preprocessing import LabelEncoder
+)
 
 X = [[-1, 0], [0, 1], [1, 1]]
 X_sp = sp.csr_matrix(X)
@@ -106,7 +105,10 @@ def test_predict_iris():
                 LogisticRegression(C=len(iris.data), solver='newton-cg',
                                    multi_class='multinomial'),
                 LogisticRegression(C=len(iris.data), solver='sag', tol=1e-2,
-                                   multi_class='ovr', random_state=42)]:
+                                   multi_class='ovr', random_state=42),
+                LogisticRegression(C=len(iris.data), solver='saga', tol=1e-2,
+                                   multi_class='ovr', random_state=42)
+                ]:
         clf.fit(iris.data, target)
         assert_array_equal(np.unique(target), clf.classes_)
 
@@ -122,7 +124,7 @@ def test_predict_iris():
 
 
 def test_multinomial_validation():
-    for solver in ['lbfgs', 'newton-cg', 'sag']:
+    for solver in ['lbfgs', 'newton-cg', 'sag', 'saga']:
         lr = LogisticRegression(C=-1, solver=solver, multi_class='multinomial')
         assert_raises(ValueError, lr.fit, [[0, 1], [1, 0]], [0, 1])
 
@@ -151,7 +153,7 @@ def test_check_solver_option():
                    solver)
             lr = LR(solver=solver, penalty='l1')
             assert_raise_message(ValueError, msg, lr.fit, X, y)
-
+        for solver in ['newton-cg', 'lbfgs', 'sag', 'saga']:
             msg = ("Solver %s supports only dual=False, got dual=True" %
                    solver)
             lr = LR(solver=solver, dual=True)
@@ -163,7 +165,7 @@ def test_multinomial_binary():
     target = (iris.target > 0).astype(np.intp)
     target = np.array(["setosa", "not-setosa"])[target]
 
-    for solver in ['lbfgs', 'newton-cg', 'sag']:
+    for solver in ['lbfgs', 'newton-cg', 'sag', 'saga']:
         clf = LogisticRegression(solver=solver, multi_class='multinomial',
                                  random_state=42, max_iter=2000)
         clf.fit(iris.data, target)
@@ -249,12 +251,14 @@ def test_consistency_path():
     f = ignore_warnings
     # can't test with fit_intercept=True since LIBLINEAR
     # penalizes the intercept
-    for solver in ('lbfgs', 'newton-cg', 'liblinear', 'sag'):
+    for solver in ['sag', 'saga']:
         coefs, Cs, _ = f(logistic_regression_path)(
             X, y, Cs=Cs, fit_intercept=False, tol=1e-5, solver=solver,
+            max_iter=1000,
             random_state=0)
         for i, C in enumerate(Cs):
             lr = LogisticRegression(C=C, fit_intercept=False, tol=1e-5,
+                                    solver=solver,
                                     random_state=0)
             lr.fit(X, y)
             lr_coef = lr.coef_.ravel()
@@ -262,7 +266,7 @@ def test_consistency_path():
                                       err_msg="with solver = %s" % solver)
 
     # test for fit_intercept=True
-    for solver in ('lbfgs', 'newton-cg', 'liblinear', 'sag'):
+    for solver in ('lbfgs', 'newton-cg', 'liblinear', 'sag', 'saga'):
         Cs = [1e3]
         coefs, Cs, _ = f(logistic_regression_path)(
             X, y, Cs=Cs, fit_intercept=True, tol=1e-6, solver=solver,
@@ -307,19 +311,19 @@ def test_logistic_loss_and_grad():
         loss, grad = _logistic_loss_and_grad(w, X, y, alpha=1.)
         approx_grad = optimize.approx_fprime(
             w, lambda w: _logistic_loss_and_grad(w, X, y, alpha=1.)[0], 1e-3
-            )
+        )
         assert_array_almost_equal(grad, approx_grad, decimal=2)
 
         # Second check that our intercept implementation is good
         w = np.zeros(n_features + 1)
         loss_interp, grad_interp = _logistic_loss_and_grad(
             w, X, y, alpha=1.
-            )
+        )
         assert_array_almost_equal(loss, loss_interp)
 
         approx_grad = optimize.approx_fprime(
             w, lambda w: _logistic_loss_and_grad(w, X, y, alpha=1.)[0], 1e-3
-            )
+        )
         assert_array_almost_equal(grad_interp, approx_grad, decimal=2)
 
 
@@ -356,7 +360,7 @@ def test_logistic_grad_hess():
         d_grad = np.array([
             _logistic_loss_and_grad(w + t * vector, X, y, alpha=1.)[1]
             for t in d_x
-            ])
+        ])
 
         d_grad -= d_grad.mean(axis=0)
         approx_hess_col = linalg.lstsq(d_x[:, np.newaxis], d_grad)[0].ravel()
@@ -393,7 +397,7 @@ def test_logistic_cv():
 
     coefs_paths = np.asarray(list(lr_cv.coefs_paths_.values()))
     assert_array_equal(coefs_paths.shape, (1, 3, 1, n_features))
-    assert_array_equal(lr_cv.Cs_.shape, (1, ))
+    assert_array_equal(lr_cv.Cs_.shape, (1,))
     scores = np.asarray(list(lr_cv.scores_.values()))
     assert_array_equal(scores.shape, (1, 3, 1))
 
@@ -518,16 +522,17 @@ def test_ovr_multinomial_iris():
     assert_array_equal(clf.classes_, [0, 1, 2])
     coefs_paths = np.asarray(list(clf.coefs_paths_.values()))
     assert_array_almost_equal(coefs_paths.shape, (3, n_cv, 10, n_features + 1))
-    assert_equal(clf.Cs_.shape, (10, ))
+    assert_equal(clf.Cs_.shape, (10,))
     scores = np.asarray(list(clf.scores_.values()))
     assert_equal(scores.shape, (3, n_cv, 10))
 
     # Test that for the iris data multinomial gives a better accuracy than OvR
-    for solver in ['lbfgs', 'newton-cg', 'sag']:
-        max_iter = 100 if solver == 'sag' else 15
+    for solver in ['lbfgs', 'newton-cg', 'sag', 'saga']:
+        max_iter = 2000 if solver in ['sag', 'saga'] else 15
         clf_multi = LogisticRegressionCV(
             solver=solver, multi_class='multinomial', max_iter=max_iter,
-            random_state=42, tol=1e-2, cv=2)
+            random_state=42, tol=1e-5 if solver in ['sag', 'saga'] else 1e-2,
+            cv=2)
         clf_multi.fit(train, target)
         multi_score = clf_multi.score(train, target)
         ovr_score = clf.score(train, target)
@@ -539,7 +544,7 @@ def test_ovr_multinomial_iris():
         coefs_paths = np.asarray(list(clf_multi.coefs_paths_.values()))
         assert_array_almost_equal(coefs_paths.shape, (3, n_cv, 10,
                                                       n_features + 1))
-        assert_equal(clf_multi.Cs_.shape, (10, ))
+        assert_equal(clf_multi.Cs_.shape, (10,))
         scores = np.asarray(list(clf_multi.scores_.values()))
         assert_equal(scores.shape, (3, n_cv, 10))
 
@@ -552,9 +557,12 @@ def test_logistic_regression_solvers():
     lib = LogisticRegression(fit_intercept=False)
     sag = LogisticRegression(solver='sag', fit_intercept=False,
                              random_state=42)
+    saga = LogisticRegression(solver='saga', fit_intercept=False,
+                              random_state=42)
     ncg.fit(X, y)
     lbf.fit(X, y)
     sag.fit(X, y)
+    saga.fit(X, y)
     lib.fit(X, y)
     assert_array_almost_equal(ncg.coef_, lib.coef_, decimal=3)
     assert_array_almost_equal(lib.coef_, lbf.coef_, decimal=3)
@@ -562,20 +570,27 @@ def test_logistic_regression_solvers():
     assert_array_almost_equal(sag.coef_, lib.coef_, decimal=3)
     assert_array_almost_equal(sag.coef_, ncg.coef_, decimal=3)
     assert_array_almost_equal(sag.coef_, lbf.coef_, decimal=3)
+    assert_array_almost_equal(saga.coef_, sag.coef_, decimal=3)
+    assert_array_almost_equal(saga.coef_, lbf.coef_, decimal=3)
+    assert_array_almost_equal(saga.coef_, ncg.coef_, decimal=3)
+    assert_array_almost_equal(saga.coef_, lib.coef_, decimal=3)
 
 
 def test_logistic_regression_solvers_multiclass():
     X, y = make_classification(n_samples=20, n_features=20, n_informative=10,
                                n_classes=3, random_state=0)
-    tol = 1e-6
+    tol = 1e-7
     ncg = LogisticRegression(solver='newton-cg', fit_intercept=False, tol=tol)
     lbf = LogisticRegression(solver='lbfgs', fit_intercept=False, tol=tol)
     lib = LogisticRegression(fit_intercept=False, tol=tol)
     sag = LogisticRegression(solver='sag', fit_intercept=False, tol=tol,
                              max_iter=1000, random_state=42)
+    saga = LogisticRegression(solver='saga', fit_intercept=False, tol=tol,
+                              max_iter=10000, random_state=42)
     ncg.fit(X, y)
     lbf.fit(X, y)
     sag.fit(X, y)
+    saga.fit(X, y)
     lib.fit(X, y)
     assert_array_almost_equal(ncg.coef_, lib.coef_, decimal=4)
     assert_array_almost_equal(lib.coef_, lbf.coef_, decimal=4)
@@ -583,6 +598,10 @@ def test_logistic_regression_solvers_multiclass():
     assert_array_almost_equal(sag.coef_, lib.coef_, decimal=4)
     assert_array_almost_equal(sag.coef_, ncg.coef_, decimal=4)
     assert_array_almost_equal(sag.coef_, lbf.coef_, decimal=4)
+    assert_array_almost_equal(saga.coef_, sag.coef_, decimal=4)
+    assert_array_almost_equal(saga.coef_, lbf.coef_, decimal=4)
+    assert_array_almost_equal(saga.coef_, ncg.coef_, decimal=4)
+    assert_array_almost_equal(saga.coef_, lib.coef_, decimal=4)
 
 
 def test_logistic_regressioncv_class_weights():
@@ -608,13 +627,20 @@ def test_logistic_regressioncv_class_weights():
                                            class_weight=class_weight,
                                            tol=1e-5, max_iter=10000,
                                            random_state=0)
+            clf_saga = LogisticRegressionCV(solver='saga', Cs=1,
+                                            fit_intercept=False,
+                                            class_weight=class_weight,
+                                            tol=1e-5, max_iter=10000,
+                                            random_state=0)
             clf_lbf.fit(X, y)
             clf_ncg.fit(X, y)
             clf_lib.fit(X, y)
             clf_sag.fit(X, y)
+            clf_saga.fit(X, y)
             assert_array_almost_equal(clf_lib.coef_, clf_lbf.coef_, decimal=4)
             assert_array_almost_equal(clf_ncg.coef_, clf_lbf.coef_, decimal=4)
             assert_array_almost_equal(clf_sag.coef_, clf_lbf.coef_, decimal=4)
+            assert_array_almost_equal(clf_saga.coef_, clf_lbf.coef_, decimal=4)
 
 
 def test_logistic_regression_sample_weights():
@@ -760,11 +786,12 @@ def test_logistic_regression_multinomial():
     ref_w.fit(X, y)
     assert_array_equal(ref_i.coef_.shape, (n_classes, n_features))
     assert_array_equal(ref_w.coef_.shape, (n_classes, n_features))
-    for solver in ['sag', 'newton-cg']:
+    for solver in ['sag', 'saga', 'newton-cg']:
         clf_i = LogisticRegression(solver=solver, multi_class='multinomial',
-                                   random_state=42, max_iter=1000, tol=1e-6)
+                                   random_state=42, max_iter=2000, tol=1e-7,
+                                   )
         clf_w = LogisticRegression(solver=solver, multi_class='multinomial',
-                                   random_state=42, max_iter=1000, tol=1e-6,
+                                   random_state=42, max_iter=2000, tol=1e-7,
                                    fit_intercept=False)
         clf_i.fit(X, y)
         clf_w.fit(X, y)
@@ -779,7 +806,7 @@ def test_logistic_regression_multinomial():
     # Test that the path give almost the same results. However since in this
     # case we take the average of the coefs after fitting across all the
     # folds, it need not be exactly the same.
-    for solver in ['lbfgs', 'newton-cg', 'sag']:
+    for solver in ['lbfgs', 'newton-cg', 'sag', 'saga']:
         clf_path = LogisticRegressionCV(solver=solver, max_iter=2000, tol=1e-6,
                                         multi_class='multinomial', Cs=[1.])
         clf_path.fit(X, y)
@@ -812,7 +839,7 @@ def test_multinomial_grad_hess():
         _multinomial_grad_hess(w + t * vec, X, Y, alpha=1.,
                                sample_weight=sample_weights)[0]
         for t in d_x
-        ])
+    ])
     d_grad -= d_grad.mean(axis=0)
     approx_hess_col = linalg.lstsq(d_x[:, np.newaxis], d_grad)[0].ravel()
     assert_array_almost_equal(hess_col, approx_hess_col)
@@ -841,6 +868,14 @@ def test_liblinear_logregcv_sparse():
     clf.fit(sparse.csr_matrix(X), y)
 
 
+def test_saga_sparse():
+    # Test LogRegCV with solver='liblinear' works for sparse matrices
+
+    X, y = make_classification(n_samples=10, n_features=5, random_state=0)
+    clf = LogisticRegressionCV(solver='saga')
+    clf.fit(sparse.csr_matrix(X), y)
+
+
 def test_logreg_intercept_scaling():
     # Test that the right error message is thrown when intercept_scaling <= 0
 
@@ -858,6 +893,71 @@ def test_logreg_intercept_scaling_zero():
     clf = LogisticRegression(fit_intercept=False)
     clf.fit(X, Y1)
     assert_equal(clf.intercept_, 0.)
+
+
+def test_logreg_l1():
+    # Because liblinear penalizes the intercept and saga does not, we do not
+    # fit the intercept to make it possible to compare the coefficients of
+    # the two models at convergence.
+    rng = np.random.RandomState(42)
+    n_samples = 50
+    X, y = make_classification(n_samples=n_samples, n_features=20,
+                               random_state=0)
+    X_noise = rng.normal(size=(n_samples, 3))
+    X_constant = np.ones(shape=(n_samples, 2))
+    X = np.concatenate((X, X_noise, X_constant), axis=1)
+    lr_liblinear = LogisticRegression(penalty="l1", C=1.0, solver='liblinear',
+                                      fit_intercept=False,
+                                      tol=1e-10)
+    lr_liblinear.fit(X, y)
+
+    lr_saga = LogisticRegression(penalty="l1", C=1.0, solver='saga',
+                                 fit_intercept=False,
+                                 max_iter=1000, tol=1e-10)
+    lr_saga.fit(X, y)
+    assert_array_almost_equal(lr_saga.coef_, lr_liblinear.coef_)
+
+    # Noise and constant features should be regularized to zero by the l1
+    # penalty
+    assert_array_almost_equal(lr_liblinear.coef_[0, -5:], np.zeros(5))
+    assert_array_almost_equal(lr_saga.coef_[0, -5:], np.zeros(5))
+
+
+def test_logreg_l1_sparse_data():
+    # Because liblinear penalizes the intercept and saga does not, we do not
+    # fit the intercept to make it possible to compare the coefficients of
+    # the two models at convergence.
+    rng = np.random.RandomState(42)
+    n_samples = 50
+    X, y = make_classification(n_samples=n_samples, n_features=20,
+                               random_state=0)
+    X_noise = rng.normal(scale=0.1, size=(n_samples, 3))
+    X_constant = np.zeros(shape=(n_samples, 2))
+    X = np.concatenate((X, X_noise, X_constant), axis=1)
+    X[X < 1] = 0
+    X = sparse.csr_matrix(X)
+
+    lr_liblinear = LogisticRegression(penalty="l1", C=1.0, solver='liblinear',
+                                      fit_intercept=False,
+                                      tol=1e-10)
+    lr_liblinear.fit(X, y)
+
+    lr_saga = LogisticRegression(penalty="l1", C=1.0, solver='saga',
+                                 fit_intercept=False,
+                                 max_iter=1000, tol=1e-10)
+    lr_saga.fit(X, y)
+    assert_array_almost_equal(lr_saga.coef_, lr_liblinear.coef_)
+    # Noise and constant features should be regularized to zero by the l1
+    # penalty
+    assert_array_almost_equal(lr_liblinear.coef_[0, -5:], np.zeros(5))
+    assert_array_almost_equal(lr_saga.coef_[0, -5:], np.zeros(5))
+
+    # Check that solving on the sparse and dense data yield the same results
+    lr_saga_dense = LogisticRegression(penalty="l1", C=1.0, solver='saga',
+                                       fit_intercept=False,
+                                       max_iter=1000, tol=1e-10)
+    lr_saga_dense.fit(X.toarray(), y)
+    assert_array_almost_equal(lr_saga.coef_, lr_saga_dense.coef_)
 
 
 def test_logreg_cv_penalty():
@@ -897,7 +997,7 @@ def test_max_iter():
     X, y_bin = iris.data, iris.target.copy()
     y_bin[y_bin == 2] = 0
 
-    solvers = ['newton-cg', 'liblinear', 'sag']
+    solvers = ['newton-cg', 'liblinear', 'sag', 'saga']
     # old scipy doesn't have maxiter
     if sp_version >= (0, 12):
         solvers.append('lbfgs')
@@ -923,7 +1023,7 @@ def test_n_iter():
     n_Cs = 4
     n_cv_fold = 2
 
-    for solver in ['newton-cg', 'liblinear', 'sag', 'lbfgs']:
+    for solver in ['newton-cg', 'liblinear', 'sag', 'saga', 'lbfgs']:
         # OvR case
         n_classes = 1 if solver == 'liblinear' else np.unique(y).shape[0]
         clf = LogisticRegression(tol=1e-2, multi_class='ovr',
@@ -943,7 +1043,7 @@ def test_n_iter():
 
         # multinomial case
         n_classes = 1
-        if solver in ('liblinear', 'sag'):
+        if solver in ('liblinear', 'sag', 'saga'):
             break
 
         clf = LogisticRegression(tol=1e-2, multi_class='multinomial',
@@ -967,7 +1067,7 @@ def test_warm_start():
     # Warm starting does not work with liblinear solver.
     X, y = iris.data, iris.target
 
-    solvers = ['newton-cg', 'sag']
+    solvers = ['newton-cg', 'sag', 'saga']
     # old scipy doesn't have maxiter
     if sp_version >= (0, 12):
         solvers.append('lbfgs')
@@ -996,3 +1096,43 @@ def test_warm_start():
                         assert_greater(2.0, cum_diff, msg)
                     else:
                         assert_greater(cum_diff, 2.0, msg)
+
+
+def test_saga_vs_liblinear():
+    iris = load_iris()
+    X, y = iris.data, iris.target
+    X = np.concatenate([X] * 10)
+    y = np.concatenate([y] * 10)
+
+    X_bin = X[y <= 1]
+    y_bin = y[y <= 1] * 2 - 1
+
+    X_sparse, y_sparse = make_classification(n_samples=50, n_features=20,
+                                             random_state=0)
+    X_sparse = sparse.csr_matrix(X_sparse)
+
+    for (X, y) in ((X_bin, y_bin), (X_sparse, y_sparse)):
+        for penalty in ['l1', 'l2']:
+            n_samples = X.shape[0]
+            # alpha=1e-3 is time consuming
+            for alpha in np.logspace(-1, 1, 3):
+                saga = LogisticRegression(
+                    C=1. / (n_samples * alpha),
+                    solver='saga',
+                    multi_class='ovr',
+                    max_iter=200,
+                    fit_intercept=False,
+                    penalty=penalty, random_state=0, tol=1e-24)
+
+                liblinear = LogisticRegression(
+                    C=1. / (n_samples * alpha),
+                    solver='liblinear',
+                    multi_class='ovr',
+                    max_iter=200,
+                    fit_intercept=False,
+                    penalty=penalty, random_state=0, tol=1e-24)
+
+                saga.fit(X, y)
+                liblinear.fit(X, y)
+                # Convergence for alpha=1e-3 is very slow
+                assert_array_almost_equal(saga.coef_, liblinear.coef_, 3)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -282,7 +282,7 @@ def test_ridge_individual_penalties():
 
     coefs_indiv_pen = [
         Ridge(alpha=penalties, solver=solver, tol=1e-8).fit(X, y).coef_
-        for solver in ['svd', 'sparse_cg', 'lsqr', 'cholesky', 'sag']]
+        for solver in ['svd', 'sparse_cg', 'lsqr', 'cholesky', 'sag', 'saga']]
     for coef_indiv_pen in coefs_indiv_pen:
         assert_array_almost_equal(coef_cholesky, coef_indiv_pen)
 
@@ -712,7 +712,7 @@ def test_n_iter():
     y_n = np.tile(y, (n_targets, 1)).T
 
     for max_iter in range(1, 4):
-        for solver in ('sag', 'lsqr'):
+        for solver in ('sag', 'saga', 'lsqr'):
             reg = Ridge(solver=solver, max_iter=max_iter, tol=1e-12)
             reg.fit(X, y_n)
             assert_array_equal(reg.n_iter_, np.tile(max_iter, n_targets))
@@ -728,12 +728,13 @@ def test_ridge_fit_intercept_sparse():
                            bias=10., random_state=42)
     X_csr = sp.csr_matrix(X)
 
-    dense = Ridge(alpha=1., tol=1.e-15, solver='sag', fit_intercept=True)
-    sparse = Ridge(alpha=1., tol=1.e-15, solver='sag', fit_intercept=True)
-    dense.fit(X, y)
-    sparse.fit(X_csr, y)
-    assert_almost_equal(dense.intercept_, sparse.intercept_)
-    assert_array_almost_equal(dense.coef_, sparse.coef_)
+    for solver in ['saga', 'sag']:
+        dense = Ridge(alpha=1., tol=1.e-15, solver=solver, fit_intercept=True)
+        sparse = Ridge(alpha=1., tol=1.e-15, solver=solver, fit_intercept=True)
+        dense.fit(X, y)
+        sparse.fit(X_csr, y)
+        assert_almost_equal(dense.intercept_, sparse.intercept_)
+        assert_array_almost_equal(dense.coef_, sparse.coef_)
 
     # test the solver switch and the corresponding warning
     sparse = Ridge(alpha=1., tol=1.e-15, solver='lsqr', fit_intercept=True)

--- a/sklearn/linear_model/tests/test_sag.py
+++ b/sklearn/linear_model/tests/test_sag.py
@@ -63,7 +63,7 @@ def get_pobj(w, alpha, myX, myy, loss):
 
 
 def sag(X, y, step_size, alpha, n_iter=1, dloss=None, sparse=False,
-        sample_weight=None, fit_intercept=True):
+        sample_weight=None, fit_intercept=True, saga=False):
     n_samples, n_features = X.shape[0], X.shape[1]
 
     weights = np.zeros(X.shape[1])
@@ -93,15 +93,25 @@ def sag(X, y, step_size, alpha, n_iter=1, dloss=None, sparse=False,
             if sample_weight is not None:
                 gradient *= sample_weight[idx]
             update = entry * gradient + alpha * weights
-            sum_gradient += update - gradient_memory[idx]
+            gradient_correction = update - gradient_memory[idx]
+            sum_gradient += gradient_correction
             gradient_memory[idx] = update
+            if saga:
+                weights -= (gradient_correction *
+                            step_size * (1 - 1. / len(seen)))
 
             if fit_intercept:
-                intercept_sum_gradient += (gradient -
-                                           intercept_gradient_memory[idx])
+                gradient_correction = (gradient -
+                                       intercept_gradient_memory[idx])
                 intercept_gradient_memory[idx] = gradient
-                intercept -= (step_size * intercept_sum_gradient
-                              / len(seen) * decay)
+                intercept_sum_gradient += gradient_correction
+                gradient_correction *= step_size * (1. - 1. / len(seen))
+                if saga:
+                    intercept -= (step_size * intercept_sum_gradient /
+                                  len(seen) * decay) + gradient_correction
+                else:
+                    intercept -= (step_size * intercept_sum_gradient /
+                                  len(seen) * decay)
 
             weights -= step_size * sum_gradient / len(seen)
 
@@ -110,7 +120,7 @@ def sag(X, y, step_size, alpha, n_iter=1, dloss=None, sparse=False,
 
 def sag_sparse(X, y, step_size, alpha, n_iter=1,
                dloss=None, sample_weight=None, sparse=False,
-               fit_intercept=True):
+               fit_intercept=True, saga=False):
     if step_size * alpha == 1.:
         raise ZeroDivisionError("Sparse sag does not handle the case "
                                 "step_size * alpha == 1")
@@ -158,12 +168,24 @@ def sag_sparse(X, y, step_size, alpha, n_iter=1,
                 gradient *= sample_weight[idx]
 
             update = entry * gradient
-            sum_gradient += update - (gradient_memory[idx] * entry)
+            gradient_correction = update - (gradient_memory[idx] * entry)
+            sum_gradient += gradient_correction
+            if saga:
+                for j in range(n_features):
+                    weights[j] -= (gradient_correction[j] * step_size *
+                                   (1 - 1. / len(seen)) / wscale)
 
             if fit_intercept:
-                intercept_sum_gradient += gradient - gradient_memory[idx]
-                intercept -= (step_size * intercept_sum_gradient
-                              / len(seen) * decay)
+                gradient_correction = gradient - gradient_memory[idx]
+                intercept_sum_gradient += gradient_correction
+                gradient_correction *= step_size * (1. - 1. / len(seen))
+                if saga:
+                    intercept -= ((step_size * intercept_sum_gradient /
+                                   len(seen) * decay) +
+                                  gradient_correction)
+                else:
+                    intercept -= (step_size * intercept_sum_gradient /
+                                  len(seen) * decay)
 
             gradient_memory[idx] = gradient
 
@@ -202,8 +224,8 @@ def sag_sparse(X, y, step_size, alpha, n_iter=1,
 
 def get_step_size(X, alpha, fit_intercept, classification=True):
     if classification:
-        return (4.0 / (np.max(np.sum(X * X, axis=1))
-                + fit_intercept + 4.0 * alpha))
+        return (4.0 / (np.max(np.sum(X * X, axis=1)) +
+                       fit_intercept + 4.0 * alpha))
     else:
         return 1.0 / (np.max(np.sum(X * X, axis=1)) + fit_intercept + alpha)
 
@@ -215,29 +237,36 @@ def test_classifier_matching():
                       cluster_std=0.1)
     y[y == 0] = -1
     alpha = 1.1
-    n_iter = 80
     fit_intercept = True
     step_size = get_step_size(X, alpha, fit_intercept)
-    clf = LogisticRegression(solver="sag", fit_intercept=fit_intercept,
-                             tol=1e-11, C=1. / alpha / n_samples,
-                             max_iter=n_iter, random_state=10)
-    clf.fit(X, y)
+    for solver in ['sag', 'saga']:
+        if solver == 'sag':
+            n_iter = 80
+        else:
+            # SAGA variance w.r.t. stream order is higher
+            n_iter = 300
+        clf = LogisticRegression(solver=solver, fit_intercept=fit_intercept,
+                                 tol=1e-11, C=1. / alpha / n_samples,
+                                 max_iter=n_iter, random_state=10)
+        clf.fit(X, y)
 
-    weights, intercept = sag_sparse(X, y, step_size, alpha, n_iter=n_iter,
-                                    dloss=log_dloss,
-                                    fit_intercept=fit_intercept)
-    weights2, intercept2 = sag(X, y, step_size, alpha, n_iter=n_iter,
-                               dloss=log_dloss,
-                               fit_intercept=fit_intercept)
-    weights = np.atleast_2d(weights)
-    intercept = np.atleast_1d(intercept)
-    weights2 = np.atleast_2d(weights2)
-    intercept2 = np.atleast_1d(intercept2)
+        weights, intercept = sag_sparse(X, y, step_size, alpha, n_iter=n_iter,
+                                        dloss=log_dloss,
+                                        fit_intercept=fit_intercept,
+                                        saga=solver == 'saga')
+        weights2, intercept2 = sag(X, y, step_size, alpha, n_iter=n_iter,
+                                   dloss=log_dloss,
+                                   fit_intercept=fit_intercept,
+                                   saga=solver == 'saga')
+        weights = np.atleast_2d(weights)
+        intercept = np.atleast_1d(intercept)
+        weights2 = np.atleast_2d(weights2)
+        intercept2 = np.atleast_1d(intercept2)
 
-    assert_array_almost_equal(weights, clf.coef_, decimal=10)
-    assert_array_almost_equal(intercept, clf.intercept_, decimal=10)
-    assert_array_almost_equal(weights2, clf.coef_, decimal=10)
-    assert_array_almost_equal(intercept2, clf.intercept_, decimal=10)
+        assert_array_almost_equal(weights, clf.coef_, decimal=9)
+        assert_array_almost_equal(intercept, clf.intercept_, decimal=9)
+        assert_array_almost_equal(weights2, clf.coef_, decimal=9)
+        assert_array_almost_equal(intercept2, clf.intercept_, decimal=9)
 
 
 @ignore_warnings
@@ -372,10 +401,10 @@ def test_sag_regressor_computed_correctly():
     assert_almost_equal(clf1.intercept_, spintercept1, decimal=1)
 
     # TODO: uncomment when sparse Ridge with intercept will be fixed (#4710)
-    #assert_array_almost_equal(clf2.coef_.ravel(),
+    # assert_array_almost_equal(clf2.coef_.ravel(),
     #                          spweights2.ravel(),
     #                          decimal=3)
-    #assert_almost_equal(clf2.intercept_, spintercept2, decimal=1)'''
+    # assert_almost_equal(clf2.intercept_, spintercept2, decimal=1)'''
 
 
 @ignore_warnings
@@ -386,20 +415,37 @@ def test_get_auto_step_size():
     # sum the squares of the second sample because that's the largest
     max_squared_sum = 4 + 9 + 16
     max_squared_sum_ = row_norms(X, squared=True).max()
+    n_samples = X.shape[0]
     assert_almost_equal(max_squared_sum, max_squared_sum_, decimal=4)
 
-    for fit_intercept in (True, False):
-        step_size_sqr = 1.0 / (max_squared_sum + alpha + int(fit_intercept))
-        step_size_log = 4.0 / (max_squared_sum + 4.0 * alpha +
-                               int(fit_intercept))
+    for saga in [True, False]:
+        for fit_intercept in (True, False):
+            if saga:
+                L_sqr = (max_squared_sum + alpha + int(fit_intercept))
+                L_log = (max_squared_sum + 4.0 * alpha +
+                         int(fit_intercept)) / 4.0
+                mun_sqr = min(2 * n_samples * alpha, L_sqr)
+                mun_log = min(2 * n_samples * alpha, L_log)
+                step_size_sqr = 1 / (2 * L_sqr + mun_sqr)
+                step_size_log = 1 / (2 * L_log + mun_log)
+            else:
+                step_size_sqr = 1.0 / (max_squared_sum +
+                                       alpha + int(fit_intercept))
+                step_size_log = 4.0 / (max_squared_sum + 4.0 * alpha +
+                                       int(fit_intercept))
 
-        step_size_sqr_ = get_auto_step_size(max_squared_sum_, alpha, "squared",
-                                            fit_intercept)
-        step_size_log_ = get_auto_step_size(max_squared_sum_, alpha, "log",
-                                            fit_intercept)
+            step_size_sqr_ = get_auto_step_size(max_squared_sum_, alpha,
+                                                "squared",
+                                                fit_intercept,
+                                                n_samples=n_samples,
+                                                is_saga=saga)
+            step_size_log_ = get_auto_step_size(max_squared_sum_, alpha, "log",
+                                                fit_intercept,
+                                                n_samples=n_samples,
+                                                is_saga=saga)
 
-        assert_almost_equal(step_size_sqr, step_size_sqr_, decimal=4)
-        assert_almost_equal(step_size_log, step_size_log_, decimal=4)
+            assert_almost_equal(step_size_sqr, step_size_sqr_, decimal=4)
+            assert_almost_equal(step_size_log, step_size_log_, decimal=4)
 
     msg = 'Unknown loss function for SAG solver, got wrong instead of'
     assert_raise_message(ValueError, msg, get_auto_step_size,


### PR DESCRIPTION
This PR proposes slight adaptations of the existing `sag_fast.pyx` module to be able to use SAGA in addition to the SAG algorithm. This is the way to go if we want to propose enet/l1 penalty for fast incremental solvers in for ridge and logistic regression.

A SAGA implementation is already available in `lightning`, which is adapted from the original paper. This one is slightly different as it is built around understanding SAGA update as a "corrected" version of SAG.
I believe it would also be possible to slightly adapt the module to have SVRG in addition to SAGA, if this interests people.

I tried to keep the changes made to `sag_fast.pyx` as scarse as possible. I reckon that the `sag_fast.pyx` module could be made a little more readable using 2d memoryviews instead of using strided pointers everywhere. For further work.

For the moment I adapted the `test_logistic.py` file to ensure correctness of the algorithm, but the saga algorithm should be tested within `test_sag.py`.

[SAGA paper](https://www.di.ens.fr/~fbach/Defazio_NIPS2014.pdf)

# TODO

- [x] Documentation
- [x] Reference for step size
- [x] Check optimal step size
- [x] Ridge API + tests
- [x] Test module `sag.py` directly
- [x] Implement l1 penalty (simple projection)
- [x] *Different PR* ~~Use minibatches ? I cannot recall whether this is actually interesting.~~
- [x] Add nice benchmarks.
- [x] Benchmarks against `liblinear` and `lightning`
- [x] *Different PR* ~~Add a SAGA solver for Lasso (which might imply a bit of refactoring...)~~
- [x] Add `rcv1` example with multinomial + L1
- [x] *Different PR* ~~Add elastic net `l1_ratio` in `LogisticRegression`~~
ping @TomDLT @agramfort  you might be interested by this :)