### PR TITLE
Pipeline pop

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -7,6 +7,8 @@ estimator, as a chain of transforms and estimators.
 #         Virgile Fritsch
 #         Alexandre Gramfort
 #         Lars Buitinck
+#         Joel Nothman
+#         Guillaume Lemaitre
 # License: BSD
 
 from collections import defaultdict
@@ -232,6 +234,41 @@ class Pipeline(_BasePipeline):
     @property
     def _final_estimator(self):
         return self.steps[-1][1]
+
+    def get_subsequence(self, start=None, stop=None):
+        """Extract a Pipeline consisting of a subsequence of steps
+
+        Parameters
+        ----------
+        start : int or str, optional
+            The index (0-based) or name of the step where the extracted
+            subsequence begins (inclusive bound).  By default, get from the
+            beginning.  Negative integers are intpreted as subtracted from the
+            number of steps in the Pipeline.
+        stop : int or str, optional
+            The index (0-based) or name of the step before which the extracted
+            subsequence ends (exclusive bound).  By default, get until the end.
+            Negative integers are intpreted as subtracted from the number of
+            steps in the Pipeline.
+
+        Returns
+        -------
+        sub_pipeline : Pipeline instance
+            The steps of this pipeline range from the start step to the stop
+            step specified.  The constituent estimators are not copied: if the
+            Pipeline had been fit, so will be the returned Pipeline.
+
+            The return type will be of the same type as self, if a subclass
+            is used and if its constructor is compatible.
+        """
+        if isinstance(start, six.string_types):
+            start = [name for name, _ in self.steps].index(start)
+        if isinstance(stop, six.string_types):
+            stop = [name for name, _ in self.steps].index(stop)
+
+        kwargs = self.get_params(deep=False)
+        kwargs['steps'] = self.steps[start:stop]
+        return type(self)(**kwargs)
 
     # Estimator interface
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -906,43 +906,52 @@ class MyPipelineNoMemory(Pipeline):
         self.other_param = other_param
 
 
-def test_pipeline_get_subsequence():
+def test_pipeline_pop():
     pipe = Pipeline([('transf1', Transf()),
                      ('transf2', Transf()),
                      ('predict', Mult())])
     pipe.fit(np.arange(5)[:, None], np.arange(5))
 
-    for start, stop, expected_slice in [
-        (None, None, slice(None, None)),
-        ('transf2', None, slice(1, None)),
-        (None, 'predict', slice(None, 2)),
-        (1, 'predict', slice(1, 2)),
-        (1, -1, slice(1, -1)),
-        (-1, None, slice(-1, None)),
+    for pos, idx in [
+        (0, 0),
+        (1, 1),
+        (2, 2),
+        (-3, 0),
+        (-2, 1),
+        (-1, 2),
+        ('transf1', 0),
+        ('transf2', 1),
+        ('predict', 2),
     ]:
-        new_pipe = pipe.get_subsequence(start, stop)
-        expected_steps = pipe.steps[expected_slice]
+        print(pos, idx)
+        new_pipe, popped_est = pipe.pop(pos)
+        assert_equal(len(pipe.steps) - 1, len(new_pipe.steps))
+        expected_steps = pipe.steps[:idx] + pipe.steps[idx + 1:]
         assert_equal(new_pipe.steps, expected_steps)
         assert_dict_equal(new_pipe.named_steps, dict(expected_steps))
         for name in new_pipe.named_steps:
             assert_true(new_pipe.named_steps[name] is pipe.named_steps[name])
 
+        assert_true(popped_est is pipe.steps[idx][1])
+
     # invalid step name
     assert_raise_message(ValueError, "'foo' is not in list",
-                         pipe.get_subsequence, 'foo')
+                         pipe.pop, 'foo')
 
-    # test subtype is maintained by get_subsequence
+    # test subtype is maintained by pop
     for memory in [None, '/path/to/somewhere']:
         pipe = MyPipeline([('transf1', Transf()),
                            ('predict', Mult())],
                           memory=memory)
-        new_pipe = pipe.get_subsequence(1)
-        assert_equal(new_pipe.steps, pipe.steps[1:])
+        new_pipe, _ = pipe.pop()
+        assert_equal(type(new_pipe), type(pipe))
+        assert_equal(new_pipe.steps, pipe.steps[:-1])
         assert_equal(pipe.memory, new_pipe.memory)
 
+    # test subtype with different constructor signature
     pipe = MyPipelineNoMemory([('transf1', Transf()),
                                ('predict', Mult())],
                               other_param='blah')
-    new_pipe = pipe.get_subsequence(1)
-    assert_equal(new_pipe.steps, pipe.steps[1:])
+    new_pipe, _ = pipe.pop()
+    assert_equal(new_pipe.steps, pipe.steps[:-1])
     assert_equal(pipe.other_param, new_pipe.other_param)


### PR DESCRIPTION
Conceptually Fixes #8414 and related issues. Alternative to #8431, #2568, #2561, #2562, focusing on extracting one specified estimator.

Designed to assist in model inspection and particularly to replicate the
composite transformer represented by steps of the pipeline with the
exception of the last. I.e. `transformer, predictor = pipe.pop()` is a common
idiom. I feel like this becomes more necessary when considering more
API-consistent clone behaviour as per #8350 as `Pipeline(pipe.steps[:-1]).inverse_transform(Xt)`
is no longer possible.

Note that once #8350 is merged, I intend that the popped estimator reflect the instance in `steps_`. I'm not sure what behaviour should be when the `Pipeline` is not fitted and `pop` is called.

Ping @glemaitre, @GaelVaroquaux 

TODO:
* [ ] wait for #8350 and decide whether pop is only available when fitted.
* [ ] narrative docs
* [ ] use in existing example?