### PR TITLE
[MRG] doc: Fix default value in RandomizedLasso

### DIFF
--- a/sklearn/linear_model/randomized_l1.py
+++ b/sklearn/linear_model/randomized_l1.py
@@ -213,7 +213,7 @@ class RandomizedLasso(BaseRandomizedLinearModel):
     verbose : boolean or integer, optional
         Sets the verbosity amount
 
-    normalize : boolean, optional, default False
+    normalize : boolean, optional, default True
         If True, the regressors X will be normalized before regression.
         This parameter is ignored when `fit_intercept` is set to False.
         When the regressors are normalized, note that this makes the


### PR DESCRIPTION
The signature of the constructor shows a default of `normalize=True`, so the doc should reflect that, too.

http://scikit-learn.org/circle?9122/_changed.html