### PR TITLE
[MRG+1] BUG: fix svd_solver validation in PCA.fit

### DIFF
--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -386,6 +386,9 @@ class PCA(_BasePCA):
             return self._fit_full(X, n_components)
         elif svd_solver in ['arpack', 'randomized']:
             return self._fit_truncated(X, n_components, svd_solver)
+        else:
+            raise ValueError("Unrecognized svd_solver='{0}'"
+                             "".format(svd_solver))
 
     def _fit_full(self, X, n_components):
         """Fit the model by computing full SVD on X"""

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -584,3 +584,9 @@ def test_pca_spase_input():
         pca = PCA(n_components=3, svd_solver=svd_solver)
 
         assert_raises(TypeError, pca.fit, X)
+
+
+def test_pca_bad_solver():
+    X = np.random.RandomState(0).rand(5, 4)
+    pca = PCA(n_components=3, svd_solver='bad_argument')
+    assert_raises(ValueError, pca.fit, X)


### PR DESCRIPTION
Minor issue: ``svd_solver`` argument was not being validated. This should fix it.