### PR TITLE
[MRG+1] removed precomputed support in nearestcentroid

### DIFF
--- a/sklearn/neighbors/nearest_centroid.py
+++ b/sklearn/neighbors/nearest_centroid.py
@@ -95,6 +95,8 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
         y : array, shape = [n_samples]
             Target values (integers)
         """
+        if self.metric == 'precomputed':
+            raise ValueError("Precomputed is not supported.")
         # If X is sparse and the metric is "manhattan", store it in a csc
         # format is easier to calculate the median.
         if self.metric == 'manhattan':
@@ -133,8 +135,6 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
                     self.centroids_[cur_class] = np.median(X[center_mask], axis=0)
                 else:
                     self.centroids_[cur_class] = csc_median_axis_0(X[center_mask])
-            elif self.metric == 'precomputed':
-                raise ValueError("Ambiguous metric.")
             else:
                 if self.metric != 'euclidean':
                     warnings.warn("Averaging for metrics other than "

--- a/sklearn/neighbors/nearest_centroid.py
+++ b/sklearn/neighbors/nearest_centroid.py
@@ -133,6 +133,8 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
                     self.centroids_[cur_class] = np.median(X[center_mask], axis=0)
                 else:
                     self.centroids_[cur_class] = csc_median_axis_0(X[center_mask])
+            elif self.metric == 'precomputed':
+                raise ValueError("Ambiguous metric.")
             else:
                 if self.metric != 'euclidean':
                     warnings.warn("Averaging for metrics other than "

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -6,10 +6,10 @@ import numpy as np
 from scipy import sparse as sp
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_equal
+from numpy.testing import assert_raises
 
 from sklearn.neighbors import NearestCentroid
 from sklearn import datasets
-from sklearn.metrics.pairwise import pairwise_distances
 
 # toy sample
 X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]
@@ -56,11 +56,10 @@ def test_classification_toy():
 
 
 def test_precomputed():
-    clf = NearestCentroid(metric="precomputed")
-    clf.fit(X, y)
-    S = pairwise_distances(T, clf.centroids_)
-    assert_array_equal(clf.predict(S), true_result)
-
+    clf = NearestCentroid(metric='precomputed')
+    with assert_raises(ValueError) as context:
+        clf.fit(X, y)
+    assert_equal(ValueError, type(context.exception))
 
 def test_iris():
     # Check consistency on dataset iris.

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -55,6 +55,12 @@ def test_classification_toy():
     assert_array_equal(clf.predict(T_csr.tolil()), true_result)
 
 
+def test_precomputed():
+    clf = NearestCentroid(metric="precomputed")
+    clf.fit(X, y)
+    S = pairwise_distances(T, clf.centroids_)
+    assert_array_equal(clf.predict(S), true_result)
+
 
 def test_iris():
     # Check consistency on dataset iris.

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -55,12 +55,6 @@ def test_classification_toy():
     assert_array_equal(clf.predict(T_csr.tolil()), true_result)
 
 
-def test_precomputed():
-    clf = NearestCentroid(metric="precomputed")
-    clf.fit(X, y)
-    S = pairwise_distances(T, clf.centroids_)
-    assert_array_equal(clf.predict(S), true_result)
-
 
 def test_iris():
     # Check consistency on dataset iris.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue #8505

#### What does this implement/fix? Explain your changes.

It is ambiguous what the self.centrodis_ should be when X is already a distance metrics. So, there is no reason to do test for pre-computed matrix.


#### Any other comments?
 This was added in commit cf811d226db0cb4ff3f504bc70fb540a1147f1e4 by @mblondel 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->