### PR TITLE
[MRG + 2] Deprecated comparison to string in GP

### DIFF
--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -283,8 +283,9 @@ def test_set_get_params():
         index = 0
         params = kernel.get_params()
         for hyperparameter in kernel.hyperparameters:
-            if hyperparameter.bounds == "fixed":
-                continue
+            if isinstance("string", type(hyperparameter.bounds)):
+                if hyperparameter.bounds == "fixed":
+                    continue
             size = hyperparameter.n_elements
             if size > 1:  # anisotropic kernels
                 assert_almost_equal(np.exp(kernel.theta[index:index + size]),
@@ -298,8 +299,9 @@ def test_set_get_params():
         index = 0
         value = 10  # arbitrary value
         for hyperparameter in kernel.hyperparameters:
-            if hyperparameter.bounds == "fixed":
-                continue
+            if isinstance("string", type(hyperparameter.bounds)):
+                if hyperparameter.bounds == "fixed":
+                    continue
             size = hyperparameter.n_elements
             if size > 1:  # anisotropic kernels
                 kernel.set_params(**{hyperparameter.name: [value] * size})


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #8503 

#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
