### PR TITLE
[MRG+2] modify disadvantage

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -28,7 +28,8 @@ The advantages of support vector machines are:
 The disadvantages of support vector machines include:
 
     - If the number of features is much greater than the number of
-      samples, the method is likely to give poor performances.
+      samples, avoid over-fitting in choosing :ref:`svm_kernels` and regularization
+      term is crucial.
 
     - SVMs do not directly provide probability estimates, these are
       calculated using an expensive five-fold cross-validation


### PR DESCRIPTION
svm can work effectively when feature number is >> number of samples.
But to avoid over-fitting usually happens in such situation by choosing
appropriate kernel (model selection) is important

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<-- Fixes #8450  -->


#### What does this implement/fix? Explain your changes.
In case of high dimensionality, SVM can still work effectively, but the over-fitting issue still need to be considered, cause the vc dimension might be close to infinite in such case, thus choose of kernel or control the regularization factor "C" is essential.

#### Any other comments?
 To test for over-fitting, use cross validation or larger hold-out can be useful. Check some discussions regarding dimensionality [here](http://stats.stackexchange.com/questions/35276/svm-overfitting-curse-of-dimensionality/35311#35311)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
