### PR TITLE
add html-noplot and changed help message to make.bat

### DIFF
--- a/doc/make.bat
+++ b/doc/make.bat
@@ -42,9 +42,9 @@ if "%1" == "html" (
 )
 
 if "%1" == "html-noplot" (
-        %SPHINXBUILD% -D plot_gallery=0 -b html %ALLSPHINXOPTS% %BUILDDIR%/html
-        echo.
-        echo.Build finished. The HTML pages are in %BUILDDIR%/html
+	%SPHINXBUILD% -D plot_gallery=0 -b html %ALLSPHINXOPTS% %BUILDDIR%/html
+	echo.
+	echo.Build finished. The HTML pages are in %BUILDDIR%/html
 )
 
 if "%1" == "dirhtml" (

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -24,6 +24,7 @@ if "%1" == "help" (
 	echo.  changes   to make an overview over all changed/added/deprecated items
 	echo.  linkcheck to check all external links for integrity
 	echo.  doctest   to run all doctests embedded in the documentation if enabled
+        echo.  html-noplot   to make HTML files using Windows
 	goto end
 )
 
@@ -38,6 +39,12 @@ if "%1" == "html" (
 	echo.
 	echo.Build finished. The HTML pages are in %BUILDDIR%/html.
 	goto end
+)
+
+if "%1" == "html-noplot" (
+        %SPHINXBUILD% -D plot_gallery=0 -b html %ALLSPHINXOPTS% %BUILDDIR%/html
+        echo.
+        echo.Build finished. The HTML pages are in %BUILDDIR%/html
 )
 
 if "%1" == "dirhtml" (

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -24,7 +24,7 @@ if "%1" == "help" (
 	echo.  changes   to make an overview over all changed/added/deprecated items
 	echo.  linkcheck to check all external links for integrity
 	echo.  doctest   to run all doctests embedded in the documentation if enabled
-        echo.  html-noplot   to make HTML files using Windows
+	echo.  html-noplot   to make HTML files using Windows
 	goto end
 )
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue


#### What does this implement/fix? Explain your changes.
Windows users who want to make changes to the documentation and check that the html looks correct can now run 'make html-noplot' so that it doesn't go through all of the examples, which would take a long time. The default for make without a target is still to show help (maybe that should change?), but I added a mention of html-noplot to the help message. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
