### PR TITLE
[MRG+1] Fix test of SingleInheritanceEstimator to not raise DeprecationWarning

### DIFF
--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -436,6 +436,7 @@ class SingleInheritanceEstimator(BaseEstimator):
 
     def __getstate__(self):
         data = self.__dict__.copy()
+        data["_sklearn_version"] = sklearn.__version__
         data["_attribute_not_pickled"] = None
         return data
 

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -14,6 +14,7 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_dict_equal
+from sklearn.utils.testing import ignore_warnings
 
 from sklearn.base import BaseEstimator, clone, is_classifier
 from sklearn.svm import SVC
@@ -436,11 +437,11 @@ class SingleInheritanceEstimator(BaseEstimator):
 
     def __getstate__(self):
         data = self.__dict__.copy()
-        data["_sklearn_version"] = sklearn.__version__
         data["_attribute_not_pickled"] = None
         return data
 
 
+@ignore_warnings(category=(DeprecationWarning, UserWarning))
 def test_pickling_works_when_getstate_is_overwritten_in_the_child_class():
     estimator = SingleInheritanceEstimator()
     estimator._attribute_not_pickled = "this attribute should not be pickled"

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -441,7 +441,7 @@ class SingleInheritanceEstimator(BaseEstimator):
         return data
 
 
-@ignore_warnings(category=(DeprecationWarning, UserWarning))
+@ignore_warnings(category=(UserWarning))
 def test_pickling_works_when_getstate_is_overwritten_in_the_child_class():
     estimator = SingleInheritanceEstimator()
     estimator._attribute_not_pickled = "this attribute should not be pickled"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #8506 


#### What does this implement/fix? Explain your changes.
Fix test of SingleInheritanceEstimator to not raise DeprecationWarning. 
Set `sklearn.__version__` to the current version.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
