### PR TITLE
[MRG+1] Fix for 8368 (Addresses nan output from fit_transform() in kernelPCA)

### DIFF
--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -261,11 +261,9 @@ class KernelPCA(BaseEstimator, TransformerMixin):
 
         # All eigenvalues of Covariance matrix are >= 0
         # Ensure root of zero is not evaluated as nan
-        try:
-            err_mgt = np.seterr(all='ignore')
+
+        with np.errstate(all='ignore'):
             X_transformed = self.alphas_ * np.nan_to_num(np.sqrt(self.lambdas_))
-        finally:
-            np.seterr(**err_mgt)
 
         if self.fit_inverse_transform:
             self._fit_inverse_transform(X_transformed, X)

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -263,12 +263,12 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         # Ensure root of zero is not evaluated as nan
 
         with np.errstate(all='ignore'):
-            X_transformed = self.alphas_*np.nan_to_num(np.sqrt(self.lambdas_))
+            X_transform = self.alphas_ * np.nan_to_num(np.sqrt(self.lambdas_))
 
         if self.fit_inverse_transform:
-            self._fit_inverse_transform(X_transformed, X)
+            self._fit_inverse_transform(X_transform, X)
 
-        return X_transformed
+        return X_transform
 
     def transform(self, X):
         """Transform X.

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -259,7 +259,13 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         """
         self.fit(X, **params)
 
-        X_transformed = self.alphas_ * np.sqrt(self.lambdas_)
+        # All eigenvalues of Covariance matrix are >= 0
+        # Ensure root of zero is not evaluated as nan
+        try:
+            err_mgt = np.seterr(all='ignore')
+            X_transformed = self.alphas_ * np.nan_to_num(np.sqrt(self.lambdas_))
+        finally:
+            np.seterr(**err_mgt)
 
         if self.fit_inverse_transform:
             self._fit_inverse_transform(X_transformed, X)

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -263,7 +263,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         # Ensure root of zero is not evaluated as nan
 
         with np.errstate(all='ignore'):
-            X_transformed = self.alphas_ * np.nan_to_num(np.sqrt(self.lambdas_))
+            X_transformed = self.alphas_*np.nan_to_num(np.sqrt(self.lambdas_))
 
         if self.fit_inverse_transform:
             self._fit_inverse_transform(X_transformed, X)

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -225,24 +225,23 @@ def test_nested_circles():
 def test_nan_fit_transform():
 
     data = np.array([[0.766655, 0.682869, 0.390646, 0.760579, 0.420476],
-                 [0.228259, 0.215964, 0.850258, 0.586082, 0.772744],
-                 [0.844907, 0.622898, 0.590107, 0.0109604, 0.368699],
-                 [0.107109, 0.237776, 0.319929, 0.870119, 0.972007],
-                 [0.494486, 0.373545, 0.887394, 0.185106, 0.189797],
-                 [0.391528, 0.80944, 0.100942, 0.981701, 0.169761]])
+                     [0.228259, 0.215964, 0.850258, 0.586082, 0.772744],
+                     [0.844907, 0.622898, 0.590107, 0.0109604, 0.368699],
+                     [0.107109, 0.237776, 0.319929, 0.870119, 0.972007],
+                     [0.494486, 0.373545, 0.887394, 0.185106, 0.189797],
+                     [0.391528, 0.80944, 0.100942, 0.981701, 0.169761]])
 
     kernel_type = 'sigmoid'
     settings_degree = 10
     settings_gamma = 4
     settings_coef0 = 0
-    
+
     kpca = KernelPCA(n_components=data.shape[1],
                      kernel=kernel_type,
                      degree=settings_degree,
                      gamma=settings_gamma,
                      coef0=settings_coef0)
-    
+
     output = assert_no_warnings(kpca.fit_transform, data)
 
     assert_false(np.isnan(output).any())
-

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -242,10 +242,7 @@ def test_nan_fit_transform():
                      gamma=settings_gamma,
                      coef0=settings_coef0)
     
-    # kpca_transform = kpca.fit_transform(data)
-    # print(kpca_transform)
-
-    
     output = assert_no_warnings(kpca.fit_transform, data)
 
     assert_false(np.isnan(output).any())
+

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -1,11 +1,13 @@
 import numpy as np
 import scipy.sparse as sp
 
-from sklearn.utils.testing import (assert_array_almost_equal, assert_less,
-                                   assert_equal, assert_not_equal,
-                                   assert_raises, assert_false,
-                                   assert_no_warnings)
-
+from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_less
+from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_not_equal
+from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_false
+from sklearn.utils.testing import assert_no_warnings
 from sklearn.decomposition import PCA, KernelPCA
 from sklearn.datasets import make_circles
 from sklearn.linear_model import Perceptron
@@ -223,7 +225,6 @@ def test_nested_circles():
 
 
 def test_nan_fit_transform():
-
     data = np.array([[0.766655, 0.682869, 0.390646, 0.760579, 0.420476],
                      [0.228259, 0.215964, 0.850258, 0.586082, 0.772744],
                      [0.844907, 0.622898, 0.590107, 0.0109604, 0.368699],
@@ -231,17 +232,10 @@ def test_nan_fit_transform():
                      [0.494486, 0.373545, 0.887394, 0.185106, 0.189797],
                      [0.391528, 0.80944, 0.100942, 0.981701, 0.169761]])
 
-    kernel_type = 'sigmoid'
-    settings_degree = 10
-    settings_gamma = 4
-    settings_coef0 = 0
-
     kpca = KernelPCA(n_components=data.shape[1],
-                     kernel=kernel_type,
-                     degree=settings_degree,
-                     gamma=settings_gamma,
-                     coef0=settings_coef0)
-
+                     kernel='sigmoid',
+                     degree=10,
+                     gamma=4,
+                     coef0=0)
     output = assert_no_warnings(kpca.fit_transform, data)
-
     assert_false(np.isnan(output).any())

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -3,7 +3,8 @@ import scipy.sparse as sp
 
 from sklearn.utils.testing import (assert_array_almost_equal, assert_less,
                                    assert_equal, assert_not_equal,
-                                   assert_raises)
+                                   assert_raises, assert_false,
+                                   assert_no_warnings)
 
 from sklearn.decomposition import PCA, KernelPCA
 from sklearn.datasets import make_circles
@@ -11,7 +12,6 @@ from sklearn.linear_model import Perceptron
 from sklearn.pipeline import Pipeline
 from sklearn.model_selection import GridSearchCV
 from sklearn.metrics.pairwise import rbf_kernel
-
 
 def test_kernel_pca():
     rng = np.random.RandomState(0)
@@ -220,3 +220,32 @@ def test_nested_circles():
     # The data is perfectly linearly separable in that space
     train_score = Perceptron().fit(X_kpca, y).score(X_kpca, y)
     assert_equal(train_score, 1.0)
+
+
+def test_nan_fit_transform():
+
+    data = np.array([[0.766655, 0.682869, 0.390646, 0.760579, 0.420476],
+                 [0.228259, 0.215964, 0.850258, 0.586082, 0.772744],
+                 [0.844907, 0.622898, 0.590107, 0.0109604, 0.368699],
+                 [0.107109, 0.237776, 0.319929, 0.870119, 0.972007],
+                 [0.494486, 0.373545, 0.887394, 0.185106, 0.189797],
+                 [0.391528, 0.80944, 0.100942, 0.981701, 0.169761]])
+
+    kernel_type = 'sigmoid'
+    settings_degree = 10
+    settings_gamma = 4
+    settings_coef0 = 0
+    
+    kpca = KernelPCA(n_components=data.shape[1],
+                     kernel=kernel_type,
+                     degree=settings_degree,
+                     gamma=settings_gamma,
+                     coef0=settings_coef0)
+    
+    # kpca_transform = kpca.fit_transform(data)
+    # print(kpca_transform)
+
+    
+    output = assert_no_warnings(kpca.fit_transform, data)
+
+    assert_false(np.isnan(output).any())


### PR DESCRIPTION
Fixes #8368
Addresses nan output from fit_transform() function of sklearn/decomposition/kernel_pca.py
Handles nan output when taking square root of zero with nan_to_num function. Suppresses warnings. 

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
