### PR TITLE
changed default value rtol in docstring to reflect source code

### DIFF
--- a/sklearn/neighbors/kde.py
+++ b/sklearn/neighbors/kde.py
@@ -54,7 +54,7 @@ class KernelDensity(BaseEstimator):
 
     rtol : float
         The desired relative tolerance of the result.  A larger tolerance will
-        generally lead to faster execution.  Default is 1E-8.
+        generally lead to faster execution.  Default is 0.
 
     breadth_first : boolean
         If true (default), use a breadth-first approach to the problem.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Related to issue #3270... 

#### What does this implement/fix? Explain your changes.
In researching the background for the Jake's question "One thing I'd thought of here: the default parameter value asks for exact results, which is basically the slowest possible algorithm. Most users will not likely dig into the doc strings to figure this out... perhaps we should change it to use some reasonable error threshold as the default?" .... I discovered a typo in the docs. The default value for rtol was stated as a very small number (1E-8). This is true in the underlying code, but is overwritten when called with rtol=0 as default in the source code, as shown at the top of the docstring page in the example default function call. Basically this is a clarifying commit.  

#### Any other comments?
I think Jake makes a good point though that the default shouldn't be the slowest option. The question becomes then, what is reasonable? 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
