### PR TITLE
[WIP] gamma=auto in SVC #8361

### DIFF
--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -68,7 +68,7 @@ def test_classification():
                            Perceptron(),
                            DecisionTreeClassifier(),
                            KNeighborsClassifier(),
-                           SVC()]:
+                           SVC(gamma="scale")]:
         for params in grid:
             BaggingClassifier(base_estimator=base_estimator,
                               random_state=rng,
@@ -309,7 +309,7 @@ def test_oob_score_classification():
                                                         iris.target,
                                                         random_state=rng)
 
-    for base_estimator in [DecisionTreeClassifier(), SVC()]:
+    for base_estimator in [DecisionTreeClassifier(), SVC(gamma="scale")]:
         clf = BaggingClassifier(base_estimator=base_estimator,
                                 n_estimators=100,
                                 bootstrap=True,
@@ -493,7 +493,7 @@ def test_gridsearch():
     parameters = {'n_estimators': (1, 2),
                   'base_estimator__C': (1, 2)}
 
-    GridSearchCV(BaggingClassifier(SVC()),
+    GridSearchCV(BaggingClassifier(SVC(gamma="scale")),
                  parameters,
                  scoring="roc_auc").fit(X, y)
 

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -287,7 +287,7 @@ def test_base_estimator():
     clf = AdaBoostClassifier(RandomForestClassifier())
     clf.fit(X, y_regr)
 
-    clf = AdaBoostClassifier(SVC(), algorithm="SAMME")
+    clf = AdaBoostClassifier(SVC(gamma="scale"), algorithm="SAMME")
     clf.fit(X, y_class)
 
     from sklearn.ensemble import RandomForestRegressor
@@ -302,7 +302,7 @@ def test_base_estimator():
     # Check that an empty discrete ensemble fails in fit, not predict.
     X_fail = [[1, 1], [1, 1], [1, 1], [1, 1]]
     y_fail = ["foo", "bar", 1, 2]
-    clf = AdaBoostClassifier(SVC(), algorithm="SAMME")
+    clf = AdaBoostClassifier(SVC(gamma="scale"), algorithm="SAMME")
     assert_raises_regexp(ValueError, "worse than random",
                          clf.fit, X_fail, y_fail)
 

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -743,7 +743,7 @@ class GridSearchCV(BaseSearchCV):
     >>> from sklearn import svm, grid_search, datasets
     >>> iris = datasets.load_iris()
     >>> parameters = {'kernel':('linear', 'rbf'), 'C':[1, 10]}
-    >>> svr = svm.SVC()
+    >>> svr = svm.SVC(gamma="scale")
     >>> clf = grid_search.GridSearchCV(svr, parameters)
     >>> clf.fit(iris.data, iris.target)
     ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -180,11 +180,11 @@ def test_check_scoring_gridsearchcv():
     # test that check_scoring works on GridSearchCV and pipeline.
     # slightly redundant non-regression test.
 
-    grid = GridSearchCV(LinearSVC(), param_grid={'C': [.1, 1]})
+    grid = GridSearchCV(LinearSVC(gamma="scale"), param_grid={'C': [.1, 1]})
     scorer = check_scoring(grid, "f1")
     assert_true(isinstance(scorer, _PredictScorer))
 
-    pipe = make_pipeline(LinearSVC())
+    pipe = make_pipeline(LinearSVC(gamma="scale"))
     scorer = check_scoring(pipe, "f1")
     assert_true(isinstance(scorer, _PredictScorer))
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -814,7 +814,7 @@ class GridSearchCV(BaseSearchCV):
     >>> from sklearn.model_selection import GridSearchCV
     >>> iris = datasets.load_iris()
     >>> parameters = {'kernel':('linear', 'rbf'), 'C':[1, 10]}
-    >>> svr = svm.SVC()
+    >>> svr = svm.SVC(gamma="scale")
     >>> clf = GridSearchCV(svr, parameters)
     >>> clf.fit(iris.data, iris.target)
     ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -399,7 +399,7 @@ def test_grid_search_one_grid_point():
     X_, y_ = make_classification(n_samples=200, n_features=100, random_state=0)
     param_dict = {"C": [1.0], "kernel": ["rbf"], "gamma": [0.1]}
 
-    clf = SVC()
+    clf = SVC(gamma="scale")
     cv = GridSearchCV(clf, param_dict)
     cv.fit(X_, y_)
 
@@ -423,7 +423,7 @@ def test_grid_search_when_param_grid_includes_range():
 
 def test_grid_search_bad_param_grid():
     param_dict = {"C": 1.0}
-    clf = SVC()
+    clf = SVC(gamma="scale")
     assert_raise_message(
         ValueError,
         "Parameter values for parameter (C) need to be a sequence"
@@ -431,14 +431,14 @@ def test_grid_search_bad_param_grid():
         GridSearchCV, clf, param_dict)
 
     param_dict = {"C": []}
-    clf = SVC()
+    clf = SVC(gamma="scale")
     assert_raise_message(
         ValueError,
         "Parameter values for parameter (C) need to be a non-empty sequence.",
         GridSearchCV, clf, param_dict)
 
     param_dict = {"C": "1,2,3"}
-    clf = SVC()
+    clf = SVC(gamma="scale")
     assert_raise_message(
         ValueError,
         "Parameter values for parameter (C) need to be a sequence"
@@ -446,7 +446,7 @@ def test_grid_search_bad_param_grid():
         GridSearchCV, clf, param_dict)
 
     param_dict = {"C": np.ones(6).reshape(3, 2)}
-    clf = SVC()
+    clf = SVC(gamma="scale")
     assert_raises(ValueError, GridSearchCV, clf, param_dict)
 
 
@@ -742,10 +742,10 @@ def test_grid_search_cv_results():
     n_grid_points = 6
     params = [dict(kernel=['rbf', ], C=[1, 10], gamma=[0.1, 1]),
               dict(kernel=['poly', ], degree=[1, 2])]
-    grid_search = GridSearchCV(SVC(), cv=n_splits, iid=False,
+    grid_search = GridSearchCV(SVC(gamma="scale"), cv=n_splits, iid=False,
                                param_grid=params)
     grid_search.fit(X, y)
-    grid_search_iid = GridSearchCV(SVC(), cv=n_splits, iid=True,
+    grid_search_iid = GridSearchCV(SVC(gamma="scale"), cv=n_splits, iid=True,
                                    param_grid=params)
     grid_search_iid.fit(X, y)
 
@@ -802,11 +802,11 @@ def test_random_search_cv_results():
     n_splits = 3
     n_search_iter = 30
     params = dict(C=expon(scale=10), gamma=expon(scale=0.1))
-    random_search = RandomizedSearchCV(SVC(), n_iter=n_search_iter,
+    random_search = RandomizedSearchCV(SVC(gamma="scale"), n_iter=n_search_iter,
                                        cv=n_splits, iid=False,
                                        param_distributions=params)
     random_search.fit(X, y)
-    random_search_iid = RandomizedSearchCV(SVC(), n_iter=n_search_iter,
+    random_search_iid = RandomizedSearchCV(SVC(gamma="scale"), n_iter=n_search_iter,
                                            cv=n_splits, iid=True,
                                            param_distributions=params)
     random_search_iid.fit(X, y)
@@ -850,8 +850,8 @@ def test_search_iid_param():
     # create "cv" for splits
     cv = [[mask, ~mask], [~mask, mask]]
     # once with iid=True (default)
-    grid_search = GridSearchCV(SVC(), param_grid={'C': [1, 10]}, cv=cv)
-    random_search = RandomizedSearchCV(SVC(), n_iter=2,
+    grid_search = GridSearchCV(SVC(gamma="scale"), param_grid={'C': [1, 10]}, cv=cv)
+    random_search = RandomizedSearchCV(SVC(gamma="scale"), n_iter=2,
                                        param_distributions={'C': [1, 10]},
                                        cv=cv)
     for search in (grid_search, random_search):
@@ -893,10 +893,10 @@ def test_search_iid_param():
         assert_almost_equal(train_std, 0)
 
     # once with iid=False
-    grid_search = GridSearchCV(SVC(),
+    grid_search = GridSearchCV(SVC(gamma="scale"),
                                param_grid={'C': [1, 10]},
                                cv=cv, iid=False)
-    random_search = RandomizedSearchCV(SVC(), n_iter=2,
+    random_search = RandomizedSearchCV(SVC(gamma="scale"), n_iter=2,
                                        param_distributions={'C': [1, 10]},
                                        cv=cv, iid=False)
 
@@ -936,8 +936,8 @@ def test_search_cv_results_rank_tie_breaking():
     # which would result in a tie of their mean cv-scores
     param_grid = {'C': [1, 1.001, 0.001]}
 
-    grid_search = GridSearchCV(SVC(), param_grid=param_grid)
-    random_search = RandomizedSearchCV(SVC(), n_iter=3,
+    grid_search = GridSearchCV(SVC(gamma="scale"), param_grid=param_grid)
+    random_search = RandomizedSearchCV(SVC(gamma="scale"), n_iter=3,
                                        param_distributions=param_grid)
 
     for search in (grid_search, random_search):

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -168,9 +168,14 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
                              "%r vs %r\n"
                              "Note: Sparse matrices cannot be indexed w/"
                              "boolean masks (use `indices=True` in CV)."
-                             % (sample_weight.shape, X.shape))
+                             % (sample_weight.shape, X.shape))        
 
-        if self.gamma == 'auto':
+        if self.gamma == 'scale':
+            self._gamma = 1.0 / (X.shape[1] * X.std())
+        elif self.gamma == 'auto':
+            warnings.warn("The default gamma parameter value 'auto', calculated as 1 / n_features,"
+                " is depreciated in version 0.19 and will be replaced by 'scale'," 
+                " calculated as 1 / (n_features * X.std()) in version 0.21.", DeprecationWarning)
             self._gamma = 1.0 / X.shape[1]
         else:
             self._gamma = self.gamma

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -418,7 +418,14 @@ class SVC(BaseSVC):
 
     gamma : float, optional (default='auto')
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
-        If gamma is 'auto' then 1/n_features will be used instead.
+        If gamma is 'auto' then 1/n_features will be used.
+        If gamma is 'scale' then 1/(n_features * X.std()) will be used.
+        The current default 'auto' is deprecated in version 0.19 and will 
+        be replaced by 'scale' in version 0.21.
+
+        .. versionchanged:: 0.19
+            Default parameter value 'auto' is deprecated and will be replaced by 
+            'scale' in version 0.21
 
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
@@ -572,7 +579,14 @@ class NuSVC(BaseSVC):
 
     gamma : float, optional (default='auto')
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
-        If gamma is 'auto' then 1/n_features will be used instead.
+        If gamma is 'auto' then 1/n_features will be used.
+        If gamma is 'scale' then 1/(n_features * X.std()) will be used.
+        The current default 'auto' is deprecated in version 0.19 and will 
+        be replaced by 'scale' in version 0.21.
+
+        .. versionchanged:: 0.19
+            Default parameter value 'auto' is deprecated and will be replaced by 
+            'scale' in version 0.21
 
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
@@ -725,7 +739,14 @@ class SVR(BaseLibSVM, RegressorMixin):
 
     gamma : float, optional (default='auto')
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
-        If gamma is 'auto' then 1/n_features will be used instead.
+        If gamma is 'auto' then 1/n_features will be used.
+        If gamma is 'scale' then 1/(n_features * X.std()) will be used.
+        The current default 'auto' is deprecated in version 0.19 and will 
+        be replaced by 'scale' in version 0.21.
+
+        .. versionchanged:: 0.19
+            Default parameter value 'auto' is deprecated and will be replaced by 
+            'scale' in version 0.21
 
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
@@ -840,7 +861,14 @@ class NuSVR(BaseLibSVM, RegressorMixin):
 
     gamma : float, optional (default='auto')
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
-        If gamma is 'auto' then 1/n_features will be used instead.
+        If gamma is 'auto' then 1/n_features will be used.
+        If gamma is 'scale' then 1/(n_features * X.std()) will be used.
+        The current default 'auto' is deprecated in version 0.19 and will 
+        be replaced by 'scale' in version 0.21.
+
+        .. versionchanged:: 0.19
+            Default parameter value 'auto' is deprecated and will be replaced by 
+            'scale' in version 0.21
 
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
@@ -949,7 +977,14 @@ class OneClassSVM(BaseLibSVM):
 
     gamma : float, optional (default='auto')
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
-        If gamma is 'auto' then 1/n_features will be used instead.
+        If gamma is 'auto' then 1/n_features will be used.
+        If gamma is 'scale' then 1/(n_features * X.std()) will be used.
+        The current default 'auto' is deprecated in version 0.19 and will 
+        be replaced by 'scale' in version 0.21.
+
+        .. versionchanged:: 0.19
+            Default parameter value 'auto' is deprecated and will be replaced by 
+            'scale' in version 0.21
 
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -181,7 +181,7 @@ def test_error():
     Y2 = Y[:-1]  # wrong dimensions for labels
     assert_raises(ValueError, clf.fit, X_sp, Y2)
 
-    clf = svm.SVC()
+    clf = svm.SVC(gamma="scale")
     clf.fit(X_sp, Y)
     assert_array_equal(clf.predict(T), true_result)
 
@@ -238,7 +238,7 @@ def test_weight():
     X_ = sparse.csr_matrix(X_)
     for clf in (linear_model.LogisticRegression(),
                 svm.LinearSVC(random_state=0),
-                svm.SVC()):
+                svm.SVC(gamma="scale")):
         clf.set_params(class_weight={0: 5})
         clf.fit(X_[:180], y_[:180])
         y_pred = clf.predict(X_[180:])
@@ -247,7 +247,7 @@ def test_weight():
 
 def test_sample_weights():
     # Test weights on individual samples
-    clf = svm.SVC()
+    clf = svm.SVC(gamma="scale")
     clf.fit(X_sp, Y)
     assert_array_equal(clf.predict([X[2]]), [1.])
 

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -232,7 +232,7 @@ def test_get_params_deprecated():
 
 
 def test_is_classifier():
-    svc = SVC()
+    svc = SVC(gamma="scale")
     assert_true(is_classifier(svc))
     assert_true(is_classifier(GridSearchCV(svc, {'C': [0.1, 1]})))
     assert_true(is_classifier(Pipeline([('svc', svc)])))
@@ -242,7 +242,7 @@ def test_is_classifier():
 
 def test_set_params():
     # test nested estimator parameter setting
-    clf = Pipeline([("svc", SVC())])
+    clf = Pipeline([("svc", SVC(gamma="scale"))])
     # non-existing parameter in svc
     assert_raises(ValueError, clf.set_params, svc__stupid_param=True)
     # non-existing parameter of pipeline

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1036,7 +1036,7 @@ def test_shufflesplit_reproducible():
 
 
 def test_safe_split_with_precomputed_kernel():
-    clf = SVC()
+    clf = SVC(gamma="scale")
     clfp = SVC(kernel="precomputed")
 
     iris = load_iris()

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -296,7 +296,7 @@ def test_grid_search_one_grid_point():
     X_, y_ = make_classification(n_samples=200, n_features=100, random_state=0)
     param_dict = {"C": [1.0], "kernel": ["rbf"], "gamma": [0.1]}
 
-    clf = SVC()
+    clf = SVC(gamma="scale")
     cv = GridSearchCV(clf, param_dict)
     cv.fit(X_, y_)
 
@@ -568,7 +568,7 @@ def test_randomized_search_grid_scores():
                   gamma=expon(scale=0.1))
     n_cv_iter = 3
     n_search_iter = 30
-    search = RandomizedSearchCV(SVC(), n_iter=n_search_iter, cv=n_cv_iter,
+    search = RandomizedSearchCV(SVC(gamma="scale"), n_iter=n_search_iter, cv=n_cv_iter,
                                 param_distributions=params, iid=False)
     search.fit(X, y)
     assert_equal(len(search.grid_scores_), n_search_iter)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -171,7 +171,7 @@ def test_ovr_fit_predict_sparse():
         assert_array_equal(pred, Y_pred_sprs.toarray())
 
         # Test decision_function
-        clf_sprs = OneVsRestClassifier(svm.SVC()).fit(X_train, sparse(Y_train))
+        clf_sprs = OneVsRestClassifier(svm.SVC(gamma="scale")).fit(X_train, sparse(Y_train))
         dec_pred = (clf_sprs.decision_function(X_test) > 0).astype(int)
         assert_array_equal(dec_pred, clf_sprs.predict(X_test).toarray())
 
@@ -287,7 +287,7 @@ def test_ovr_multilabel():
 
 
 def test_ovr_fit_predict_svc():
-    ovr = OneVsRestClassifier(svm.SVC())
+    ovr = OneVsRestClassifier(svm.SVC(gamma="scale"))
     ovr.fit(iris.data, iris.target)
     assert_equal(len(ovr.estimators_), 3)
     assert_greater(ovr.score(iris.data, iris.target), .9)
@@ -390,7 +390,7 @@ def test_ovr_multilabel_decision_function():
                                                    random_state=0)
     X_train, Y_train = X[:80], Y[:80]
     X_test = X[80:]
-    clf = OneVsRestClassifier(svm.SVC()).fit(X_train, Y_train)
+    clf = OneVsRestClassifier(svm.SVC(gamma="scale")).fit(X_train, Y_train)
     assert_array_equal((clf.decision_function(X_test) > 0).astype(int),
                        clf.predict(X_test))
 
@@ -401,7 +401,7 @@ def test_ovr_single_label_decision_function():
                                         random_state=0)
     X_train, Y_train = X[:80], Y[:80]
     X_test = X[80:]
-    clf = OneVsRestClassifier(svm.SVC()).fit(X_train, Y_train)
+    clf = OneVsRestClassifier(svm.SVC(gamma="scale")).fit(X_train, Y_train)
     assert_array_equal(clf.decision_function(X_test).ravel() > 0,
                        clf.predict(X_test))
 
@@ -652,7 +652,7 @@ def test_pairwise_indices():
 
 def test_pairwise_attribute():
     clf_precomputed = svm.SVC(kernel='precomputed')
-    clf_notprecomputed = svm.SVC()
+    clf_notprecomputed = svm.SVC(gamma="scale")
 
     for MultiClassClassifier in [OneVsRestClassifier, OneVsOneClassifier]:
         ovr_false = MultiClassClassifier(clf_notprecomputed)

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -166,7 +166,7 @@ def test_pipeline_init():
     repr(pipe)
 
     # Test with two objects
-    clf = SVC()
+    clf = SVC(gamma="scale")
     filter1 = SelectKBest(f_classif)
     pipe = Pipeline([('anova', filter1), ('svc', clf)])
 
@@ -827,7 +827,7 @@ def test_pipeline_wrong_memory():
     y = iris.target
     # Define memory as an integer
     memory = 1
-    cached_pipe = Pipeline([('transf', DummyTransf()), ('svc', SVC())],
+    cached_pipe = Pipeline([('transf', DummyTransf()), ('svc', SVC(gamma="scale"))],
                            memory=memory)
     assert_raises_regex(ValueError, "'memory' should either be a string or a"
                         " joblib.Memory instance, got 'memory=1' instead.",

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -353,7 +353,7 @@ def test_class_distribution():
 
 
 def test_safe_split_with_precomputed_kernel():
-    clf = SVC()
+    clf = SVC(gamma="scale")
     clfp = SVC(kernel="precomputed")
 
     iris = datasets.load_iris()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Addresses #8361 

#### What does this implement/fix? Explain your changes.
Deprecates the default SVC gamma parameter value of "auto", which is calculated as 1 / n_features, and introduces "scale", which is calculated as 1 / (n_features * X.std()).

#### Any other comments?
Could not run nosetests due to problems with Conda environent. There are potentially other occurrences of SVC() that need to be updated to SVC(gamma="scale") to avoid Deprecation Warnings associated with SVC(gamma = "auto"). Submitting pull request to locate errors.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
