### PR TITLE
[MRG+2] use manylinux dev wheels for numpy / scipy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ cache:
 addons:
   apt:
     packages:
-      - libatlas3gf-base
-      - libatlas-dev
       # only required by the DISTRIB="ubuntu" build:
       - python-scipy
 
@@ -58,15 +56,8 @@ matrix:
     # This environment tests scikit-learn against numpy and scipy master
     # installed from their CI wheels in a virtualenv with the Python
     # interpreter provided by travis.
-    # Note: libatlas3gf-base is not allowed yet so we need 'sudo':
-    # https://github.com/travis-ci/apt-package-whitelist/issues/2407
-    # Once libatlas3gf-base is on the whitelist it will be possible to replace
-    # the before_install step with and addons/apt/packages declaration.
     -  python: 3.5
        env: DISTRIB="scipy-dev-wheels"
-       sudo: True
-       before_install: sudo apt-get install -yqq libatlas3gf-base libatlas-dev
-
 
 install: source build_tools/travis/install.sh
 script: bash build_tools/travis/test_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ cache:
 addons:
   apt:
     packages:
-      # only required by the DISTRIB="ubuntu" build:
+      # these only required by the DISTRIB="ubuntu" builds:
       - python-scipy
-
+      - libatlas3gf-base
+      - libatlas-dev
 env:
   global:
     # Directory where tests are run from

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -86,11 +86,9 @@ elif [[ "$DISTRIB" == "scipy-dev-wheels" ]]; then
     source ~/testvenv/bin/activate
     pip install --upgrade pip setuptools
 
-    # We use the default Python virtualenv provided by travis
-    echo "Installing numpy master wheel"
-    pip install --pre --upgrade --no-index --timeout=60 \
-        --trusted-host travis-dev-wheels.scipy.org \
-        -f https://travis-dev-wheels.scipy.org/ numpy scipy
+    echo "Installing numpy and scipy master wheels"
+    dev_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
+    pip install --pre --upgrade --timeout=60 -f $dev_url numpy scipy
     pip install nose nose-timer cython
 fi
 


### PR DESCRIPTION
Use daily manylinux wheels for numpy and scipy, instead of
soon-to-be-discontinued per-commit Precise wheels.