### PR TITLE
[MRG] ENH: multi-output support for BaggingRegressor

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -959,6 +959,9 @@ Trees and ensembles
      :class:`ensemble.VotingClassifier` to fit underlying estimators in parallel.
      :issue:`5805` by :user:`Ibraim Ganiev <olologin>`.
 
+   - :class:`ensemble.BaggingRegressor` now supports multi-output targets.
+     By :user:`Elvis Dohmatob <dohmatob>`.
+	    
 Linear, kernelized and related models
 
    - In :class:`linear_model.LogisticRegression`, the SAG solver is now

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -280,7 +280,7 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
         random_state = check_random_state(self.random_state)
 
         # Convert data
-        X, y = check_X_y(X, y, ['csr', 'csc'])
+        X, y = check_X_y(X, y, ['csr', 'csc'], multi_output=True)
         if sample_weight is not None:
             sample_weight = check_array(sample_weight, ensure_2d=False)
             check_consistent_length(y, sample_weight)
@@ -390,8 +390,9 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
         """Calculate out of bag predictions and score."""
 
     def _validate_y(self, y):
-        # Default implementation
-        return column_or_1d(y, warn=True)
+        # Default implementation. We skip column_or_1d and similar checks
+        # in order to make the code support multi-output targets.
+        return y
 
     def _get_estimators_indices(self):
         # Get drawn indices along both sample and feature axes

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -66,7 +66,8 @@ MULTI_OUTPUT = ['CCA', 'DecisionTreeRegressor', 'ElasticNet',
                 'MultiTaskElasticNetCV', 'MultiTaskLasso', 'MultiTaskLassoCV',
                 'OrthogonalMatchingPursuit', 'PLSCanonical', 'PLSRegression',
                 'RANSACRegressor', 'RadiusNeighborsRegressor',
-                'RandomForestRegressor', 'Ridge', 'RidgeCV']
+                'RandomForestRegressor', 'Ridge', 'RidgeCV',
+                "BaggingRegressor"]
 
 
 def _yield_non_meta_checks(name, estimator):


### PR DESCRIPTION
Closes #8993, #3449, #4848. This minimalistic patch adds multi-output support to BaggingRegressor.

