### PR TITLE
[MRG] DOCATHON : LLE and Isomap match doc for sparse input

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -327,7 +327,7 @@ Decomposition and manifold learning
   `Tom Dupre la Tour`_.
 
 - Support sparse input in :meth:`manifold.Isomap.fit`. :issue:`8554` by
-  :user:`lmcinnes`.
+  :user:`Leland McInnes <lmcinnes>`.
 
 Metrics
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -326,6 +326,9 @@ Decomposition and manifold learning
   :class:`manifold.TSNE`. :issue:`10593` and :issue:`10610` by
   `Tom Dupre la Tour`_.
 
+- Support sparse input in :meth:`manifold.Isomap.fit`. :issue:`8554` by
+  :user:`lmcinnes`.
+
 Metrics
 
 - :func:`metrics.roc_auc_score` now supports binary ``y_true`` other than

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -100,7 +100,7 @@ class Isomap(BaseEstimator, TransformerMixin):
         self.n_jobs = n_jobs
 
     def _fit_transform(self, X):
-        X = check_array(X)
+        X = check_array(X, accept_sparse='csr')
         self.nbrs_ = NearestNeighbors(n_neighbors=self.n_neighbors,
                                       algorithm=self.neighbors_algorithm,
                                       n_jobs=self.n_jobs)

--- a/sklearn/manifold/locally_linear.py
+++ b/sklearn/manifold/locally_linear.py
@@ -69,9 +69,9 @@ def barycenter_kneighbors_graph(X, n_neighbors, reg=1e-3, n_jobs=1):
 
     Parameters
     ----------
-    X : {array-like, BallTree, KDTree, NearestNeighbors}
+    X : {array-like, NearestNeighbors}
         Sample data, shape = (n_samples, n_features), in the form of a
-        numpy array.
+        numpy array or a NearestNeighbors object.
 
     n_neighbors : int
         Number of neighbors for each sample.
@@ -193,9 +193,9 @@ def locally_linear_embedding(
 
     Parameters
     ----------
-    X : {array-like, BallTree, KDTree, NearestNeighbors}
+    X : {array-like, NearestNeighbors}
         Sample data, shape = (n_samples, n_features), in the form of a
-        numpy array.
+        numpy array or a NearestNeighbors object.
 
     n_neighbors : integer
         number of neighbors to consider for each point.

--- a/sklearn/manifold/locally_linear.py
+++ b/sklearn/manifold/locally_linear.py
@@ -69,10 +69,9 @@ def barycenter_kneighbors_graph(X, n_neighbors, reg=1e-3, n_jobs=1):
 
     Parameters
     ----------
-    X : {array-like, sparse matrix, BallTree, KDTree, NearestNeighbors}
+    X : array-like
         Sample data, shape = (n_samples, n_features), in the form of a
-        numpy array, sparse array, precomputed tree, or NearestNeighbors
-        object.
+        numpy array.
 
     n_neighbors : int
         Number of neighbors for each sample.
@@ -194,10 +193,9 @@ def locally_linear_embedding(
 
     Parameters
     ----------
-    X : {array-like, sparse matrix, BallTree, KDTree, NearestNeighbors}
+    X : array-like
         Sample data, shape = (n_samples, n_features), in the form of a
-        numpy array, sparse array, precomputed tree, or NearestNeighbors
-        object.
+        numpy array.
 
     n_neighbors : integer
         number of neighbors to consider for each point.

--- a/sklearn/manifold/locally_linear.py
+++ b/sklearn/manifold/locally_linear.py
@@ -69,7 +69,7 @@ def barycenter_kneighbors_graph(X, n_neighbors, reg=1e-3, n_jobs=1):
 
     Parameters
     ----------
-    X : array-like
+    X : {array-like, BallTree, KDTree, NearestNeighbors}
         Sample data, shape = (n_samples, n_features), in the form of a
         numpy array.
 
@@ -193,7 +193,7 @@ def locally_linear_embedding(
 
     Parameters
     ----------
-    X : array-like
+    X : {array-like, BallTree, KDTree, NearestNeighbors}
         Sample data, shape = (n_samples, n_features), in the form of a
         numpy array.
 

--- a/sklearn/manifold/tests/test_isomap.py
+++ b/sklearn/manifold/tests/test_isomap.py
@@ -125,6 +125,7 @@ def test_isomap_clone_bug():
         assert_equal(model.nbrs_.n_neighbors,
                      n_neighbors)
 
+
 def test_sparse_input():
     X = sparse_rand(100, 3, density=0.1, format='csr')
 

--- a/sklearn/manifold/tests/test_isomap.py
+++ b/sklearn/manifold/tests/test_isomap.py
@@ -126,8 +126,7 @@ def test_isomap_clone_bug():
                      n_neighbors)
 
 def test_sparse_input():
-    X = sparse_rand(100, 3, density=0.1, format='csr',
-                    dtype=np.float)
+    X = sparse_rand(100, 3, density=0.1, format='csr')
 
     # Should not error
     for eigen_solver in eigen_solvers:

--- a/sklearn/manifold/tests/test_isomap.py
+++ b/sklearn/manifold/tests/test_isomap.py
@@ -126,9 +126,8 @@ def test_isomap_clone_bug():
                      n_neighbors)
 
 def test_sparse_input():
-    rand = np.random.RandomState(0)
     X = sparse_rand(100, 3, density=0.1, format='csr',
-                    dtype=np.float, random_state=rand)
+                    dtype=np.float)
 
     # Should not error
     for eigen_solver in eigen_solvers:

--- a/sklearn/manifold/tests/test_isomap.py
+++ b/sklearn/manifold/tests/test_isomap.py
@@ -10,6 +10,8 @@ from sklearn import pipeline
 from sklearn import preprocessing
 from sklearn.utils.testing import assert_less
 
+from scipy.sparse import rand as sparse_rand
+
 eigen_solvers = ['auto', 'dense', 'arpack']
 path_methods = ['auto', 'FW', 'D']
 
@@ -122,3 +124,16 @@ def test_isomap_clone_bug():
         model.fit(np.random.rand(50, 2))
         assert_equal(model.nbrs_.n_neighbors,
                      n_neighbors)
+
+def test_sparse_input():
+    rand = np.random.RandomState(0)
+    X = sparse_rand(100, 3, density=0.1, format='csr',
+                    dtype=np.float, random_state=rand)
+
+    # Should not error
+    for eigen_solver in eigen_solvers:
+        for path_method in path_methods:
+            clf = manifold.Isomap(n_components=2,
+                                  eigen_solver=eigen_solver,
+                                  path_method=path_method)
+            clf.fit(X)


### PR DESCRIPTION
Fix #8416 

Isomap does, in fact support sparse input. Code was changed to match the documentation, and a test was added to verify that it doesn't error.

LLE does not support sparse input -- the ``barycenter_kneighbors_graph`` function makes use of fancy indexing which is not supported by sparse matrices. Further the claim of support for KDTree, BallTree and NearestNeighbor objects turned out to be false as well. Docs were updated to reflect this.
