### PR TITLE
[MRG] Fixing wrapping in named_test.test_common

### DIFF
--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -369,11 +369,11 @@ NOT_SYMMETRIC_METRICS = [
 
 # No Sample weight support
 METRICS_WITHOUT_SAMPLE_WEIGHT = [
-    "confusion_matrix", # Left this one here because the tests in this file do
-                        # not work for confusion_matrix, as its output is a
-                        # matrix instead of a number. Testing of
-                        # confusion_matrix with sample_weight is in
-                        # test_classification.py
+    "confusion_matrix",  # Left this one here because the tests in this file do
+                         # not work for confusion_matrix, as its output is a
+                         # matrix instead of a number. Testing of
+                         # confusion_matrix with sample_weight is in
+                         # test_classification.py
     "median_absolute_error",
 ]
 
@@ -619,9 +619,9 @@ def test_invariance_string_vs_numbers_labels():
 
 
 def test_inf_nan_input():
-    invalids =[([0, 1], [np.inf, np.inf]),
-               ([0, 1], [np.nan, np.nan]),
-               ([0, 1], [np.nan, np.inf])]
+    invalids = [([0, 1], [np.inf, np.inf]),
+                ([0, 1], [np.nan, np.nan]),
+                ([0, 1], [np.nan, np.inf])]
 
     METRICS = dict()
     METRICS.update(THRESHOLDED_METRICS)
@@ -1088,11 +1088,12 @@ def generate_sample_weight_invariance(n_samples=50):
             yield (_named_check(check_sample_weight_invariance, name), name,
                    metric, y_true, y_pred)
 
+
 def test_sample_weight_invariance(n_samples=50):
     # iterate through each metric testing each case
-
     for metrics in generate_sample_weight_invariance(n_samples):
         pass
+
 
 @ignore_warnings
 def test_no_averaging_labels():

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -369,6 +369,7 @@ NOT_SYMMETRIC_METRICS = [
 
 # No Sample weight support
 METRICS_WITHOUT_SAMPLE_WEIGHT = [
+    "cohen_kappa_score",
     "confusion_matrix", # Left this one here because the tests in this file do
                         # not work for confusion_matrix, as its output is a
                         # matrix instead of a number. Testing of
@@ -888,7 +889,7 @@ def test_averaging_multiclass(n_samples=50, n_classes=3):
 
     lb = LabelBinarizer().fit(y_true)
     y_true_binarize = lb.transform(y_true)
-    y_pred_binarize = lb.transform(y_pred)
+    y_pred_binarize = lb.transform(y_pred)   
 
     for name in METRICS_WITH_AVERAGING:
         yield (_named_check(check_averaging, name), name, y_true,
@@ -1011,19 +1012,9 @@ def check_sample_weight_invariance(name, metric, y1, y2):
                   sample_weight=np.hstack([sample_weight, sample_weight]))
 
 
-def test_sample_weight_invariance(n_samples=50):
+def generate_sample_weight_invariance(n_samples=50):
+    #create generator function to go through each relevant metric
     random_state = check_random_state(0)
-    # regression
-    y_true = random_state.random_sample(size=(n_samples,))
-    y_pred = random_state.random_sample(size=(n_samples,))
-    for name in ALL_METRICS:
-        if name not in REGRESSION_METRICS:
-            continue
-        if name in METRICS_WITHOUT_SAMPLE_WEIGHT:
-            continue
-        metric = ALL_METRICS[name]
-        yield _named_check(check_sample_weight_invariance, name), name,\
-            metric, y_true, y_pred
 
     # binary
     random_state = check_random_state(0)
@@ -1031,8 +1022,6 @@ def test_sample_weight_invariance(n_samples=50):
     y_pred = random_state.randint(0, 2, size=(n_samples, ))
     y_score = random_state.random_sample(size=(n_samples,))
     for name in ALL_METRICS:
-        if name in REGRESSION_METRICS:
-            continue
         if (name in METRICS_WITHOUT_SAMPLE_WEIGHT or
                 name in METRIC_UNDEFINED_BINARY):
             continue
@@ -1050,8 +1039,6 @@ def test_sample_weight_invariance(n_samples=50):
     y_pred = random_state.randint(0, 5, size=(n_samples, ))
     y_score = random_state.random_sample(size=(n_samples, 5))
     for name in ALL_METRICS:
-        if name in REGRESSION_METRICS:
-            continue
         if (name in METRICS_WITHOUT_SAMPLE_WEIGHT or
                 name in METRIC_UNDEFINED_BINARY_MULTICLASS):
             continue
@@ -1087,6 +1074,10 @@ def test_sample_weight_invariance(n_samples=50):
             yield (_named_check(check_sample_weight_invariance, name), name,
                    metric, y_true, y_pred)
 
+def test_sample_weight_invariance(n_samples=50):
+    #iterate through each metric in generator function
+    for metrics in generate_sample_weight_invariance(n_samples):
+        pass
 
 @ignore_warnings
 def test_no_averaging_labels():

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -369,7 +369,6 @@ NOT_SYMMETRIC_METRICS = [
 
 # No Sample weight support
 METRICS_WITHOUT_SAMPLE_WEIGHT = [
-    "cohen_kappa_score",
     "confusion_matrix", # Left this one here because the tests in this file do
                         # not work for confusion_matrix, as its output is a
                         # matrix instead of a number. Testing of
@@ -889,7 +888,7 @@ def test_averaging_multiclass(n_samples=50, n_classes=3):
 
     lb = LabelBinarizer().fit(y_true)
     y_true_binarize = lb.transform(y_true)
-    y_pred_binarize = lb.transform(y_pred)   
+    y_pred_binarize = lb.transform(y_pred)
 
     for name in METRICS_WITH_AVERAGING:
         yield (_named_check(check_averaging, name), name, y_true,
@@ -1013,8 +1012,19 @@ def check_sample_weight_invariance(name, metric, y1, y2):
 
 
 def generate_sample_weight_invariance(n_samples=50):
-    #create generator function to go through each relevant metric
+    #create generative function to iterate through each relevant metric 
     random_state = check_random_state(0)
+    # regression
+    y_true = random_state.random_sample(size=(n_samples,))
+    y_pred = random_state.random_sample(size=(n_samples,))
+    for name in ALL_METRICS:
+        if name not in REGRESSION_METRICS:
+            continue
+        if name in METRICS_WITHOUT_SAMPLE_WEIGHT:
+            continue
+        metric = ALL_METRICS[name]
+        yield _named_check(check_sample_weight_invariance, name), name,\
+            metric, y_true, y_pred
 
     # binary
     random_state = check_random_state(0)
@@ -1022,6 +1032,8 @@ def generate_sample_weight_invariance(n_samples=50):
     y_pred = random_state.randint(0, 2, size=(n_samples, ))
     y_score = random_state.random_sample(size=(n_samples,))
     for name in ALL_METRICS:
+        if name in REGRESSION_METRICS:
+            continue
         if (name in METRICS_WITHOUT_SAMPLE_WEIGHT or
                 name in METRIC_UNDEFINED_BINARY):
             continue
@@ -1039,6 +1051,8 @@ def generate_sample_weight_invariance(n_samples=50):
     y_pred = random_state.randint(0, 5, size=(n_samples, ))
     y_score = random_state.random_sample(size=(n_samples, 5))
     for name in ALL_METRICS:
+        if name in REGRESSION_METRICS:
+            continue
         if (name in METRICS_WITHOUT_SAMPLE_WEIGHT or
                 name in METRIC_UNDEFINED_BINARY_MULTICLASS):
             continue
@@ -1075,7 +1089,6 @@ def generate_sample_weight_invariance(n_samples=50):
                    metric, y_true, y_pred)
 
 def test_sample_weight_invariance(n_samples=50):
-    #iterate through each metric in generator function
     for metrics in generate_sample_weight_invariance(n_samples):
         pass
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1012,7 +1012,7 @@ def check_sample_weight_invariance(name, metric, y1, y2):
 
 
 def generate_sample_weight_invariance(n_samples=50):
-    #create generative function to iterate through each relevant metric 
+    # create generative function to iterate through each relevant metric
     random_state = check_random_state(0)
     # regression
     y_true = random_state.random_sample(size=(n_samples,))
@@ -1089,6 +1089,8 @@ def generate_sample_weight_invariance(n_samples=50):
                    metric, y_true, y_pred)
 
 def test_sample_weight_invariance(n_samples=50):
+    # iterate through each metric testing each case
+
     for metrics in generate_sample_weight_invariance(n_samples):
         pass
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue #8507
<!-- Example: Fixes  -->


#### What does this implement/fix? Explain your changes.
The issue is common to five functions. Not only test_sample_weight_invariance. However, this pull request only fixes test_sample_weight_invariance. 

The functions:
```
test_averaging_multiclass
test_averaging_multilabel
test_averaging_multilabel_all_zeroes
test_averaging_multilabel_all_ones
test_sample_weight_invariance
```
are generative functions made to yield a particular output. However, the test simply calls the generator function without iterating through them. This change fixes that, by defining an additional function to iterate through each metric. 

#### Any other comments?

These functions were added in commit #7620. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
