### PR TITLE
[MRG + 1] Return correct ridge parameter alpha_ and lambda_ for Bayesian ridge regression

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -240,6 +240,11 @@ Bug fixes
      multiple inheritance context.
      :issue:`8316` by :user:`Holger Peters <HolgerPeters>`.
 
+   - Fix :func:`sklearn.linear_model.BayesianRidge.fit` to return 
+     ridge parameter `alpha_` and `lambda_` consistent with calculated
+     coefficients `coef_` and `intercept_`.
+     :issue:`8224` by :user:`Peter Gedeck <gedeck>`.
+
 API changes summary
 -------------------
 

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -201,6 +201,11 @@ class BayesianRidge(LinearModel, RegressorMixin):
                     logdet_sigma_[:n_samples] += alpha_ * eigen_vals_
                     logdet_sigma_ = - np.sum(np.log(logdet_sigma_))
 
+            # Preserve the alpha and lambda values that were used to calculate the final
+            # coefficients
+            self.alpha_ = alpha_
+            self.lambda_ = lambda_
+
             # Update alpha and lambda
             rmse_ = np.sum((y - np.dot(X, coef_)) ** 2)
             gamma_ = (np.sum((alpha_ * eigen_vals_) /
@@ -229,8 +234,6 @@ class BayesianRidge(LinearModel, RegressorMixin):
                 break
             coef_old_ = np.copy(coef_)
 
-        self.alpha_ = alpha_
-        self.lambda_ = lambda_
         self.coef_ = coef_
         sigma_ = np.dot(Vh.T,
                         Vh / (eigen_vals_ + lambda_ / alpha_)[:, np.newaxis])

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -201,8 +201,8 @@ class BayesianRidge(LinearModel, RegressorMixin):
                     logdet_sigma_[:n_samples] += alpha_ * eigen_vals_
                     logdet_sigma_ = - np.sum(np.log(logdet_sigma_))
 
-            # Preserve the alpha and lambda values that were used to calculate the final
-            # coefficients
+            # Preserve the alpha and lambda values that were used to
+            # calculate the final coefficients
             self.alpha_ = alpha_
             self.lambda_ = lambda_
 

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -6,12 +6,11 @@
 import numpy as np
 
 from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_array_almost_equal, assert_almost_equal
 from sklearn.utils.testing import SkipTest
 from sklearn.linear_model.bayes import BayesianRidge, ARDRegression
 from sklearn.linear_model import Ridge
 from sklearn import datasets
-
-from sklearn.utils.testing import assert_array_almost_equal, assert_almost_equal
 
 
 def test_bayesian_on_diabetes():

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -34,6 +34,21 @@ def test_bayesian_on_diabetes():
     assert_array_equal(np.diff(clf.scores_) > 0, True)
 
 
+def test_bayesian_ridge_parameter():
+    # Test correctness of lambda_ and alpha_ parameters (Github issue #8224)
+    X = np.array([[1, 1], [3, 4], [5, 7], [4, 1], [2, 6], [3, 10], [3, 2]])
+    y = np.array([1, 2, 3, 2, 0, 4, 5]).T
+
+    # A Ridge regression model using an alpha value equal to the ratio of lambda_ and alpha_ from 
+    # the Bayesian Ridge model must be identical
+    brModel = BayesianRidge(compute_score=True).fit(X, y)
+    rrModel = Ridge(alpha=brModel.lambda_ / brModel.alpha_).fit(X, y)
+    assert_almost_equal(rrModel.intercept_, brModel.intercept_)
+    # Results before fix
+    # ACTUAL: 2.422446078010811
+    # DESIRED: 2.4224997161532529
+
+
 def test_toy_bayesian_ridge_object():
     # Test BayesianRidge on toy
     X = np.array([[1], [2], [6], [8], [10]])

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -6,7 +6,8 @@
 import numpy as np
 
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_array_almost_equal, assert_almost_equal
+from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import SkipTest
 from sklearn.linear_model.bayes import BayesianRidge, ARDRegression
 from sklearn.linear_model import Ridge
@@ -39,8 +40,8 @@ def test_bayesian_ridge_parameter():
     X = np.array([[1, 1], [3, 4], [5, 7], [4, 1], [2, 6], [3, 10], [3, 2]])
     y = np.array([1, 2, 3, 2, 0, 4, 5]).T
 
-    # A Ridge regression model using an alpha value equal to the ratio of lambda_ and alpha_ from 
-    # the Bayesian Ridge model must be identical
+    # A Ridge regression model using an alpha value equal to the ratio of
+    # lambda_ and alpha_ from the Bayesian Ridge model must be identical
     br_model = BayesianRidge(compute_score=True).fit(X, y)
     rr_model = Ridge(alpha=br_model.lambda_ / br_model.alpha_).fit(X, y)
     assert_array_almost_equal(rr_model.coef_, br_model.coef_)
@@ -80,7 +81,7 @@ def test_return_std():
         return np.dot(X, w) + b
 
     def f_noise(X, noise_mult):
-        return f(X) + np.random.randn(X.shape[0])*noise_mult
+        return f(X) + np.random.randn(X.shape[0]) * noise_mult
 
     d = 5
     n_train = 50

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -8,9 +8,10 @@ import numpy as np
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import SkipTest
 from sklearn.linear_model.bayes import BayesianRidge, ARDRegression
+from sklearn.linear_model import Ridge
 from sklearn import datasets
 
-from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_array_almost_equal, assert_almost_equal
 
 
 def test_bayesian_on_diabetes():
@@ -41,9 +42,10 @@ def test_bayesian_ridge_parameter():
 
     # A Ridge regression model using an alpha value equal to the ratio of lambda_ and alpha_ from 
     # the Bayesian Ridge model must be identical
-    brModel = BayesianRidge(compute_score=True).fit(X, y)
-    rrModel = Ridge(alpha=brModel.lambda_ / brModel.alpha_).fit(X, y)
-    assert_almost_equal(rrModel.intercept_, brModel.intercept_)
+    br_model = BayesianRidge(compute_score=True).fit(X, y)
+    rr_model = Ridge(alpha=br_model.lambda_ / br_model.alpha_).fit(X, y)
+    assert_array_almost_equal(rr_model.coef_, br_model.coef_)
+    assert_almost_equal(rr_model.intercept_, br_model.intercept_)
     # Results before fix
     # ACTUAL: 2.422446078010811
     # DESIRED: 2.4224997161532529

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -46,9 +46,6 @@ def test_bayesian_ridge_parameter():
     rr_model = Ridge(alpha=br_model.lambda_ / br_model.alpha_).fit(X, y)
     assert_array_almost_equal(rr_model.coef_, br_model.coef_)
     assert_almost_equal(rr_model.intercept_, br_model.intercept_)
-    # Results before fix
-    # ACTUAL: 2.422446078010811
-    # DESIRED: 2.4224997161532529
 
 
 def test_toy_bayesian_ridge_object():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Fixes #8224


#### What does this implement/fix? Explain your changes.
In the original implementation, the `alpha_` and `lambda_` were modified after calculation of `coef_` and were therefore slightly wrong. The change moves the assignment to the object attributes `self.alpha_` and `self.lambda_` to right after the calculation of `coef_`. 

#### Any other comments?
The test uses a comparison to the standard ridge regression. A ridge regression with a ridge parameter of `self.lambda_ / self.alpha_` must return an identical regression. In the test, we compare the calculated intercept of the Bayesian ridge regression with the standard ridge regression. Before the change, the intercepts were slightly different. 
```
    # ACTUAL: 2.422446078010811
    # DESIRED: 2.4224997161532529
```
