### PR TITLE
[MRG+1] Improved docstring for permutation_test_score (#8379 and #8564)

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1905,11 +1905,14 @@ def permutation_test_score(estimator, X, y, cv=None,
         The scores obtained for each permutations.
 
     pvalue : float
-        The returned value equals p-value if `scoring` returns bigger
-        numbers for better scores (e.g., accuracy_score). If `scoring` is
-        rather a loss function (i.e. when lower is better such as with
-        `mean_squared_error`) then this is actually the complement of the
-        p-value:  1 - p-value.
+        The p-value, which approximates the probability the score would be
+        obtained by chance. This is calculated as:
+
+        `(C + 1) / (n_permutations + 1)`
+
+        Where C is the number of permutations whose score >= the true score.
+
+        The best possible p-value is 1/(n_permutations + 1), the worst is 1.0.
 
     Notes
     -----

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1905,8 +1905,8 @@ def permutation_test_score(estimator, X, y, cv=None,
         The scores obtained for each permutations.
 
     pvalue : float
-        The p-value, which approximates the probability the score would be
-        obtained by chance. This is calculated as:
+        The p-value, which approximates the probability that the score would
+        be obtained by chance. This is calculated as:
 
         `(C + 1) / (n_permutations + 1)`
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -596,11 +596,14 @@ def permutation_test_score(estimator, X, y, groups=None, cv=None,
         The scores obtained for each permutations.
 
     pvalue : float
-        The returned value equals p-value if `scoring` returns bigger
-        numbers for better scores (e.g., accuracy_score). If `scoring` is
-        rather a loss function (i.e. when lower is better such as with
-        `mean_squared_error`) then this is actually the complement of the
-        p-value:  1 - p-value.
+        The p-value, which approximates the probability the score would be
+        obtained by chance. This is calculated as:
+
+        `(C + 1) / (n_permutations + 1)`
+
+        Where C is the number of permutations whose score >= the true score.
+
+        The best possible p-value is 1/(n_permutations + 1), the worst is 1.0.
 
     Notes
     -----

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -596,8 +596,8 @@ def permutation_test_score(estimator, X, y, groups=None, cv=None,
         The scores obtained for each permutations.
 
     pvalue : float
-        The p-value, which approximates the probability the score would be
-        obtained by chance. This is calculated as:
+        The p-value, which approximates the probability that the score would
+        be obtained by chance. This is calculated as:
 
         `(C + 1) / (n_permutations + 1)`
 


### PR DESCRIPTION
Updated docstring for permutation_test_score (pvalue section) to remove an outdated reference to loss functions (#8564) and explain why the p-value is never zero (#8379) in a way that is hopefully accessible to non machine-learning experts.

Changed in two files because I changed both the deprecated and new locations of the function.