### PR TITLE
[MRG] Add transform method in MLPClassifier.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -53,6 +53,10 @@ New features
 Enhancements
 ............
 
+   - :class:`neural_network.MLPClassifier` now has a ``transform`` method to
+     return activations of hidden layers, these are learned features by the
+     network. :issue:`8574` by :user:`Karan Desai <karandesai-96>`
+
    - Update Sphinx-Gallery from 0.1.4 to 0.1.7 for resolving links in
      documentation build with Sphinx>1.5 :issue:`8010`, :issue:`7986`
      :user:`Oscar Najera <Titan-C>`

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -715,7 +715,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
         activations = self._get_empty_activations(X)
         # forward propagate
         self._forward_pass(activations)
-        Xt = activations[:-1]
+        Xt = np.column_stack(activations[:-1])
 
         return Xt
 

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -167,6 +167,29 @@ def test_fit():
     assert_almost_equal(mlp.predict_proba(X)[0, 1], 0.739, decimal=3)
 
 
+def test_transform():
+    # Test that MLPClassifier transforms input data properly.
+    X = np.array([[0.6, 0.8, 0.7]])
+    mlp = MLPClassifier(activation='identity', hidden_layer_sizes=2)
+
+    # set weights
+    mlp.coefs_ = [0] * 2
+    mlp.intercepts_ = [0] * 2
+    mlp.n_outputs_ = 1
+    mlp.coefs_[0] = np.array([[0.1, 0.2], [0.3, 0.1], [0.5, 0]])
+    mlp.coefs_[1] = np.array([[0.1], [0.2]])
+    mlp.intercepts_[0] = np.array([0.1, 0.1])
+    mlp.intercepts_[1] = np.array([1.0])
+
+    # Compute the number of layers
+    mlp.n_layers_ = 3
+    mlp.out_activation_ = 'identity'
+
+    Xt = mlp.transform(X)
+    assert_almost_equal(Xt[0], X, decimal=3)
+    assert_almost_equal(Xt[1], np.array([[0.75, 0.3]]), decimal=3)
+
+
 def test_gradient():
     # Test gradient.
 

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -186,8 +186,7 @@ def test_transform():
     mlp.out_activation_ = 'identity'
 
     Xt = mlp.transform(X)
-    assert_almost_equal(Xt[0], X, decimal=3)
-    assert_almost_equal(Xt[1], np.array([[0.75, 0.3]]), decimal=3)
+    assert_almost_equal(Xt, np.array([[0.6, 0.8, 0.7, 0.75, 0.3]]), decimal=3)
 
 
 def test_gradient():


### PR DESCRIPTION
#### Reference Issue
Fixes #8291

#### What does this implement/fix? Explain your changes.
Adds a new method named `transform` in `sklearn.neural_network.MLPClassifier`. Returns all the activations at hidden layers, whch can be interpreted as the learned features by neural network. PR is complete with docstrings, test and a _CHANGELOG_ entry.

#### Any other comments?
Both methods `predict` and `transform` require validation of input data, alongwith initialization of empty placeholder array for activations to hold, internally (in Base class). So to avoid repetition of code, changes were made in base class.