### PR TITLE
[MRG + 1] Correct typo in cross decomposition example (Fixes #8307)

### DIFF
--- a/examples/cross_decomposition/plot_compare_cross_decomposition.py
+++ b/examples/cross_decomposition/plot_compare_cross_decomposition.py
@@ -53,8 +53,8 @@ print(np.round(np.corrcoef(Y.T), 2))
 # ~~~~~~~~~~~~~~
 plsca = PLSCanonical(n_components=2)
 plsca.fit(X_train, Y_train)
-X_train_r, Y_train_r = plsca.transform(X_train, Y_train)
-X_test_r, Y_test_r = plsca.transform(X_test, Y_test)
+X_train_r, Y_train_r = cca.transform(X_train, Y_train)
+X_test_r, Y_test_r = cca.transform(X_test, Y_test)
 
 # Scatter plot of scores
 # ~~~~~~~~~~~~~~~~~~~~~~
@@ -144,5 +144,5 @@ print(np.round(pls1.coef_, 1))
 
 cca = CCA(n_components=2)
 cca.fit(X_train, Y_train)
-X_train_r, Y_train_r = plsca.transform(X_train, Y_train)
-X_test_r, Y_test_r = plsca.transform(X_test, Y_test)
+X_train_r, Y_train_r = cca.transform(X_train, Y_train)
+X_test_r, Y_test_r = cca.transform(X_test, Y_test)

--- a/examples/cross_decomposition/plot_compare_cross_decomposition.py
+++ b/examples/cross_decomposition/plot_compare_cross_decomposition.py
@@ -53,8 +53,8 @@ print(np.round(np.corrcoef(Y.T), 2))
 # ~~~~~~~~~~~~~~
 plsca = PLSCanonical(n_components=2)
 plsca.fit(X_train, Y_train)
-X_train_r, Y_train_r = cca.transform(X_train, Y_train)
-X_test_r, Y_test_r = cca.transform(X_test, Y_test)
+X_train_r, Y_train_r = plsca.transform(X_train, Y_train)
+X_test_r, Y_test_r = plsca.transform(X_test, Y_test)
 
 # Scatter plot of scores
 # ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Reference Issue

Fixes #8307

#### Description

Error in compare cross decomposition method.

What does this implement/fix? Explain your changes.

The variable needs to be cca in lines 147-148. There was a typo which I corrected.

Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
