### PR TITLE
[MRG + 2] EHN additional test for trees regarding fitting behaviour with constant features

### DIFF
--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1189,13 +1189,7 @@ def test_only_constant_features():
 def test_behaviour_constant_feature_after_splits():
     X = np.transpose([[0, 0, 0, 0, 0, 1, 2, 4, 5, 6, 7]])
     y = [0, 0, 0, 1, 1, 2, 2, 2, 3, 3, 3]
-    for name, TreeEstimator in CLF_TREES.items():
-        est = TreeEstimator(random_state=0, max_features=1)
-        est.fit(X, y)
-        assert_equal(est.tree_.max_depth, 2)
-        assert_equal(est.tree_.node_count, 5)
-
-    for name, TreeEstimator in REG_TREES.items():
+    for name, TreeEstimator in ALL_TREES.items():
         est = TreeEstimator(random_state=0, max_features=1)
         est.fit(X, y)
         assert_equal(est.tree_.max_depth, 2)

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1191,10 +1191,12 @@ def test_behaviour_constant_feature_after_splits():
                                np.zeros((4, 11)))))
     y = [0, 0, 0, 1, 1, 2, 2, 2, 3, 3, 3]
     for name, TreeEstimator in ALL_TREES.items():
-        est = TreeEstimator(random_state=0, max_features=1)
-        est.fit(X, y)
-        assert_equal(est.tree_.max_depth, 2)
-        assert_equal(est.tree_.node_count, 5)
+        # do not check extra random trees
+        if "ExtraTree" not in name:
+            est = TreeEstimator(random_state=0, max_features=1)
+            est.fit(X, y)
+            assert_equal(est.tree_.max_depth, 2)
+            assert_equal(est.tree_.node_count, 5)
 
 
 def test_with_only_one_non_constant_features():

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1187,7 +1187,8 @@ def test_only_constant_features():
 
 
 def test_behaviour_constant_feature_after_splits():
-    X = np.transpose([[0, 0, 0, 0, 0, 1, 2, 4, 5, 6, 7]])
+    X = np.transpose(np.vstack(([[0, 0, 0, 0, 0, 1, 2, 4, 5, 6, 7]],
+                               np.zeros((4, 11)))))
     y = [0, 0, 0, 1, 1, 2, 2, 2, 3, 3, 3]
     for name, TreeEstimator in ALL_TREES.items():
         est = TreeEstimator(random_state=0, max_features=1)

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1186,6 +1186,22 @@ def test_only_constant_features():
         assert_equal(est.tree_.max_depth, 0)
 
 
+def test_behaviour_constant_feature_after_splits():
+    X = np.transpose([[0, 0, 0, 0, 0, 1, 2, 4, 5, 6, 7]])
+    y = [0, 0, 0, 1, 1, 2, 2, 2, 3, 3, 3]
+    for name, TreeEstimator in CLF_TREES.items():
+        est = TreeEstimator(random_state=0, max_features=1)
+        est.fit(X, y)
+        assert_equal(est.tree_.max_depth, 2)
+        assert_equal(est.tree_.node_count, 5)
+
+    for name, TreeEstimator in REG_TREES.items():
+        est = TreeEstimator(random_state=0, max_features=1)
+        est.fit(X, y)
+        assert_equal(est.tree_.max_depth, 2)
+        assert_equal(est.tree_.node_count, 5)
+
+
 def test_with_only_one_non_constant_features():
     X = np.hstack([np.array([[1.], [1.], [0.], [0.]]),
                    np.zeros((4, 1000))])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Related to #8231


#### What does this implement/fix? Explain your changes.

In #8231, the following error in the implementation did not trigger any failing in the tests of the trees:
When a feature was found to be constant at a given splitter, this feature was declared constant for the remaining of the fitting. However, this is a wrong behaviour since this feature is potentially non-constant for the other splitter.

This additional test, check that the number of nodes and the tree depth are correct with a feature which would be declared constant at the first split as described previously.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
