### PR TITLE
fix for PR # 7902, #7898 and  # 8115

### DIFF
--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -15,6 +15,7 @@ import sys
 import functools
 import os
 import errno
+import re
 
 import numpy as np
 import scipy.sparse as sp
@@ -33,7 +34,14 @@ def _parse_version(version_string):
             version.append(int(x))
         except ValueError:
             # x may be of the form dev-1ea1592
-            version.append(x)
+            # version.append(x)
+            # x may be of the form dev-1ea1592
+            digits=re.match(r'^(\d)+\D',x)
+            if digits:
+                version.append(int(digits.group(1)))
+            else:
+                # use 0 if no leading digits found
+                version.append(0)
     return tuple(version)
 
 euler_gamma = getattr(np, 'euler_gamma',


### PR DESCRIPTION
when you add "x" into list "version"(change to tuple) at return statement if x is NOT digits, this will cause type error later when you compare tuple (1,12,'1rc1) to tuple (1,12,0). Two possible solution.

    Use tuple of string.
    Change version.append(int(x))
    to version.append(x)
    Comparison using tuple of strings.
    Change tuple (1,12,0) to ('1', '12', '0') etc.
    A lot of changes.
    Simple fix. Extract numeric portion of x if x contains letters using regular expression. Comparison keeps the same.

Hope somebody will merge my fix into next release because I'm NOT a contributor.
...
import re
...
def _parse_version(version_string):
version = []
for x in version_string.split('.'):
try:
version.append(int(x))
except ValueError:
# x may be of the form dev-1ea1592
# version.append(x)
digits=re.match(r'^(\d)+\D',x)
if digits:
version.append(int(digits.group(1)))
else:
# use 0 if no leading digits found
version.append(0)
return tuple(version)

Test environment:
Python 3.4
Numpy 1.12.1rc1
sklearn 0.18.1

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
