### PR TITLE
[MRG+1] Fix float size in as_float_array

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -42,26 +42,28 @@ def test_as_float_array():
     # Test function for as_float_array
     X = np.ones((3, 10), dtype=np.int32)
     X = X + np.arange(10, dtype=np.int32)
-    # Checks that the return type is ok
     X2 = as_float_array(X, copy=False)
-    np.testing.assert_equal(X2.dtype, np.float32)
+    assert_equal(X2.dtype, np.float32)
     # Another test
     X = X.astype(np.int64)
     X2 = as_float_array(X, copy=True)
     # Checking that the array wasn't overwritten
     assert_true(as_float_array(X, False) is not X)
-    # Checking that the new type is ok
-    np.testing.assert_equal(X2.dtype, np.float64)
-    # Checking that smaller ints are properly converted to float32
-    dtypes = [np.int8, np.int16, np.int32,
-              np.uint8, np.uint16, np.uint32,
-              np.bool,
-              ]
-    for intsize in dtypes:
-        X = X.astype(intsize)
+    assert_equal(X2.dtype, np.float64)
+    # Test int dtypes <= 32bit
+    tested_dtypes = [np.bool,
+                     np.int8, np.int16, np.int32,
+                     np.uint8, np.uint16, np.uint32]
+    for dtype in tested_dtypes:
+        X = X.astype(dtype)
         X2 = as_float_array(X)
-        # Checking that the new type is ok
-        np.testing.assert_equal(X2.dtype, np.float32)
+        assert_equal(X2.dtype, np.float32)
+
+    # Test object dtype
+    X = X.astype(object)
+    X2 = as_float_array(X, copy=True)
+    assert_equal(X2.dtype, np.float64)
+
     # Here, X is of the right type, it shouldn't be modified
     X = np.ones((3, 2), dtype=np.float32)
     assert_true(as_float_array(X, copy=False) is X)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -52,6 +52,16 @@ def test_as_float_array():
     assert_true(as_float_array(X, False) is not X)
     # Checking that the new type is ok
     np.testing.assert_equal(X2.dtype, np.float64)
+    # Checking that smaller ints are properly converted to float32
+    dtypes = [np.int8, np.int16, np.int32,
+              np.uint8, np.uint16, np.uint32,
+              np.bool,
+              ]
+    for intsize in dtypes:
+        X = X.astype(intsize)
+        X2 = as_float_array(X)
+        # Checking that the new type is ok
+        np.testing.assert_equal(X2.dtype, np.float32)
     # Here, X is of the right type, it shouldn't be modified
     X = np.ones((3, 2), dtype=np.float32)
     assert_true(as_float_array(X, copy=False) is X)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -80,8 +80,7 @@ def as_float_array(X, copy=True, force_all_finite=True):
     elif X.dtype in [np.float32, np.float64]:  # is numpy array
         return X.copy('F' if X.flags['F_CONTIGUOUS'] else 'C') if copy else X
     else:
-        if X.dtype.kind in 'uib' and \
-           X.dtype.itemsize <= 4:  # size of an int32
+        if X.dtype.kind in 'uib' and X.dtype.itemsize <= 4:
             return_dtype = np.float32
         else:
             return_dtype = np.float64

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -80,7 +80,12 @@ def as_float_array(X, copy=True, force_all_finite=True):
     elif X.dtype in [np.float32, np.float64]:  # is numpy array
         return X.copy('F' if X.flags['F_CONTIGUOUS'] else 'C') if copy else X
     else:
-        return X.astype(np.float32 if X.dtype == np.int32 else np.float64)
+        if X.dtype.kind in 'uib' and \
+           X.dtype.itemsize <= 4:  # size of an int32
+            return_dtype = np.float32
+        else:
+            return_dtype = np.float64
+        return X.astype(return_dtype)
 
 
 def _is_arraylike(x):


### PR DESCRIPTION
#### Reference Issue

Fixes #8597 

#### What does this implement/fix? Explain your changes.

This adds a check so that all ints smaller than `int32` are converted to `float32` instead of `float64`. Previously only `int32` was converted to `float32`.

#### Any other comments?

This handles ints and uints, but does not handle the standard python `int`, which will be converted to `float64`. Is this ok, or should it be converted to `float`?

Initially, I tried getting the explicit size of each int/uint and compared it to the size of int32, but getting the size for a standard python `int` is tricky, so I went with the approach of explicitly listing types to be converted to `float32`.