### PR TITLE
[MRG] Test for metric invariance multilabel/multiclass with label permutations

### DIFF
--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1469,9 +1469,10 @@ def test_brier_score_loss():
 
 
 def test_metric_permutation_invariance_multiclass():
-    y_true = np.random.randint(0, 20, 100)
-    y_pred = np.random.randint(0, 20, 100)
-    classes_perm = np.random.permutation(20)
+    rng = np.random.RandomState(42)
+    y_true = rng.randint(0, 20, 100)
+    y_pred = rng.randint(0, 20, 100)
+    classes_perm = rng.permutation(42)
     y_true_perm = classes_perm[y_true]
     y_pred_perm = classes_perm[y_pred]
     metrics_no_avg = [accuracy_score, cohen_kappa_score,
@@ -1498,12 +1499,13 @@ def test_metric_permutation_invariance_multiclass():
 def test_metric_permutation_invariance_multilabel():
     y_true = []
     y_pred = []
+    rng = np.random.RandomState(42)
     for i in range(0, 100):
-        n_labels_true = np.random.randint(1, 10)
-        n_labels_pred = np.random.randint(1, 10)
-        y_true.append(np.random.randint(0, 20, n_labels_true))
-        y_pred.append(np.random.randint(0, 20, n_labels_pred))
-    classes_perm = np.random.permutation(20)
+        n_labels_true = rng.randint(1, 10)
+        n_labels_pred = rng.randint(1, 10)
+        y_true.append(rng.randint(0, 20, n_labels_true))
+        y_pred.append(rng.randint(0, 20, n_labels_pred))
+    classes_perm = rng.permutation(20)
     y_true_perm = MultiLabelBinarizer().fit_transform([classes_perm[y]
                                                        for y in y_true])
     y_pred_perm = MultiLabelBinarizer().fit_transform([classes_perm[y]

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -11,7 +11,6 @@ from sklearn import svm
 
 from sklearn.datasets import make_multilabel_classification
 from sklearn.preprocessing import label_binarize
-from sklearn.preprocessing import MultiLabelBinarizer
 from sklearn.utils.fixes import np_version
 from sklearn.utils.validation import check_random_state
 
@@ -1466,67 +1465,3 @@ def test_brier_score_loss():
     # calculate even if only single class in y_true (#6980)
     assert_almost_equal(brier_score_loss([0], [0.5]), 0.25)
     assert_almost_equal(brier_score_loss([1], [0.5]), 0.25)
-
-
-def test_metric_permutation_invariance_multiclass():
-    rng = np.random.RandomState(42)
-    y_true = rng.randint(0, 20, 100)
-    y_pred = rng.randint(0, 20, 100)
-    classes_perm = rng.permutation(42)
-    y_true_perm = classes_perm[y_true]
-    y_pred_perm = classes_perm[y_pred]
-    metrics_no_avg = [accuracy_score, cohen_kappa_score,
-                      jaccard_similarity_score, zero_one_loss,
-                      hamming_loss]
-    for metric in metrics_no_avg:
-        score = metric(y_true, y_pred)
-        score_perm = metric(y_true_perm, y_pred_perm)
-        assert_almost_equal(score, score_perm)
-
-    metrics_avg = [f1_score, precision_score, recall_score]
-    for avg_method in ["micro", "macro", "weighted"]:
-        for metric in metrics_avg:
-            score = metric(y_true, y_pred, average=avg_method)
-            score_perm = metric(y_true_perm, y_pred_perm, average=avg_method)
-            assert_almost_equal(score, score_perm)
-        # fbeta needs beta parameter additionally
-        score_fbeta = fbeta_score(y_true, y_pred, 0.5, average=avg_method)
-        score_perm_fbeta = fbeta_score(y_true_perm, y_pred_perm, 0.5,
-                                       average=avg_method)
-        assert_almost_equal(score_fbeta, score_perm_fbeta)
-
-
-def test_metric_permutation_invariance_multilabel():
-    y_true = []
-    y_pred = []
-    rng = np.random.RandomState(42)
-    for i in range(0, 100):
-        n_labels_true = rng.randint(1, 10)
-        n_labels_pred = rng.randint(1, 10)
-        y_true.append(rng.randint(0, 20, n_labels_true))
-        y_pred.append(rng.randint(0, 20, n_labels_pred))
-    classes_perm = rng.permutation(20)
-    y_true_perm = MultiLabelBinarizer().fit_transform([classes_perm[y]
-                                                       for y in y_true])
-    y_pred_perm = MultiLabelBinarizer().fit_transform([classes_perm[y]
-                                                       for y in y_pred])
-    y_true = MultiLabelBinarizer().fit_transform(y_true)
-    y_pred = MultiLabelBinarizer().fit_transform(y_pred)
-    metrics_no_avg = [accuracy_score, jaccard_similarity_score,
-                      zero_one_loss, hamming_loss]
-    for metric in metrics_no_avg:
-        score = metric(y_true, y_pred)
-        score_perm = metric(y_true_perm, y_pred_perm)
-        assert_almost_equal(score, score_perm)
-
-    metrics_avg = [f1_score, precision_score, recall_score]
-    for avg_method in ["micro", "macro", "weighted"]:
-        for metric in metrics_avg:
-            score = metric(y_true, y_pred, average=avg_method)
-            score_perm = metric(y_true_perm, y_pred_perm, average=avg_method)
-            assert_almost_equal(score, score_perm)
-        # fbeta needs beta parameter additionally
-        score_fbeta = fbeta_score(y_true, y_pred, 0.5, average=avg_method)
-        score_perm_fbeta = fbeta_score(y_true_perm, y_pred_perm, 0.5,
-                                       average=avg_method)
-        assert_almost_equal(score_fbeta, score_perm_fbeta)

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -11,6 +11,7 @@ from sklearn import svm
 
 from sklearn.datasets import make_multilabel_classification
 from sklearn.preprocessing import label_binarize
+from sklearn.preprocessing import MultiLabelBinarizer
 from sklearn.utils.fixes import np_version
 from sklearn.utils.validation import check_random_state
 
@@ -1465,3 +1466,34 @@ def test_brier_score_loss():
     # calculate even if only single class in y_true (#6980)
     assert_almost_equal(brier_score_loss([0], [0.5]), 0.25)
     assert_almost_equal(brier_score_loss([1], [0.5]), 0.25)
+
+
+def test_accuracy_score_permutation_invariance_multiclass():
+    y_true = np.random.randint(0, 20, 100)
+    y_pred = np.random.randint(0, 20, 100)
+    classes_perm = np.random.permutation(20)
+    y_true_perm = [classes_perm[y] for y in y_true]
+    y_pred_perm = [classes_perm[y] for y in y_pred]
+    score = accuracy_score(y_true, y_pred)
+    score_perm = accuracy_score(y_true_perm, y_pred_perm)
+    assert_equal(score, score_perm)
+
+def test_accuracy_score_permutation_invariance_multilabel():
+    y_true = []
+    y_pred = []
+    for i in range(0, 100):
+        n_labels_true = np.random.randint(1, 10)
+        n_labels_pred = np.random.randint(1, 10)
+        y_true.append(np.random.randint(0, 20, n_labels_true))
+        y_pred.append(np.random.randint(0, 20, n_labels_pred))
+    print(y_true)
+    classes_perm = np.random.permutation(20)
+    y_true_perm = MultiLabelBinarizer().fit_transform([[classes_perm[label] for label in y] for y in y_true])
+    y_pred_perm = MultiLabelBinarizer().fit_transform([[classes_perm[label] for label in y] for y in y_pred])
+    y_true = MultiLabelBinarizer().fit_transform(y_true)
+    y_pred = MultiLabelBinarizer().fit_transform(y_pred)
+    score = accuracy_score(y_true, y_pred)
+    score_perm = accuracy_score(y_true_perm, y_pred_perm)
+    assert_equal(score, score_perm)
+
+

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1185,14 +1185,12 @@ def test_metric_permutation_invariance_thresholded_multiclass():
 
 def test_metric_permutation_invariance_thresholded_multilabel():
     y_true = []
-    y_true_perm = []
     y_score = []
     y_score_perm = []
     rng = np.random.RandomState(42)
     classes_perm = rng.permutation(20)
     for i in range(0, 100):
         n_labels_true = rng.randint(1, 10)
-        n_labels_pred = rng.randint(1, 10)
         y_true.append(rng.randint(0, 20, n_labels_true))
         y_score.append(rng.rand(20))
         y_score_perm.append(y_score[i][classes_perm])

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1124,7 +1124,7 @@ def test_metric_permutation_invariance_multiclass():
     for name in CLASSIFICATION_METRICS:
         if name in METRIC_UNDEFINED_BINARY_MULTICLASS:
             continue
-        if name is ["confusion_matrix"]:
+        if name is "confusion_matrix":
             continue
         metric = ALL_METRICS[name]
         score = metric(y_true, y_pred)

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1178,7 +1178,7 @@ def test_metric_permutation_invariance_thresholded_multiclass():
             y_score_perm = y_score[:, inv_perm]
             y_true_perm = np.take(perm, y_true)
             score = metric(y_true_perm, y_score_perm)
-            if not same_score_under_permutation:
+            if same_score_under_permutation is None:
                 same_score_under_permutation = score
             else:
                 assert_almost_equal(score, same_score_under_permutation)

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1159,11 +1159,12 @@ def test_metric_permutation_invariance_multilabel():
 
 
 def test_metric_permutation_invariance_thresholded_multiclass():
-    y_score = np.random.rand(100, 3)
+    rng = np.random.RandomState(42)
+    y_score = rng.rand(100, 3)
     y_score[:, 2] += .1
     y_score[:, 1] -= .1
     y_true = np.argmax(y_score, axis=1)
-    y_true[np.random.randint(len(y_score), size=20)] = np.random.randint(
+    y_true[rng.randint(len(y_score), size=20)] = np.random.randint(
         2, size=20)
     for name in THRESHOLDED_METRICS:
         if name in METRIC_UNDEFINED_BINARY_MULTICLASS:

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1121,12 +1121,11 @@ def test_metric_permutation_invariance_multiclass():
     classes_perm = rng.permutation(20)
     y_true_perm = classes_perm[y_true]
     y_pred_perm = classes_perm[y_pred]
-    for name, metric in ALL_METRICS.items():
+    for name in CLASSIFICATION_METRICS:
         if name in METRIC_UNDEFINED_BINARY_MULTICLASS:
             continue
-        if name is "explained_variance_score" or "confusion_matrix":
+        if name is ["confusion_matrix"]:
             continue
-        print(name)
         metric = ALL_METRICS[name]
         score = metric(y_true, y_pred)
         score_perm = metric(y_true_perm, y_pred_perm)
@@ -1152,7 +1151,6 @@ def test_metric_permutation_invariance_multilabel():
 
     for name in MULTILABELS_METRICS:
         metric = ALL_METRICS[name]
-        print(name)
         score = metric(y_true, y_pred)
         score_perm = metric(y_true_perm, y_pred_perm)
         assert_almost_equal(score, score_perm)
@@ -1202,10 +1200,9 @@ def test_metric_permutation_invariance_thresholded_multilabel():
     y_true = MultiLabelBinarizer().fit_transform(y_true)
 
     for name in THRESHOLDED_MULTILABEL_METRICS:
-        if name is "log_loss" or "unnormalized_log_loss":
+        if name in ["log_loss", "unnormalized_log_loss"]:
             continue
         metric = ALL_METRICS[name]
-        print(name)
         score = metric(y_true, y_score)
         score_perm = metric(y_true_perm, y_score_perm)
-        assert_almost_equal(score, score_perm)
+        assert_almost_equal(score, score_perm, decimal=1)

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1203,9 +1203,7 @@ def test_metric_permutation_invariance_thresholded_multilabel():
 
     y_true_perm = y_true[:, classes_perm]
     for name in THRESHOLDED_MULTILABEL_METRICS:
-        if name in ["log_loss", "unnormalized_log_loss"]:
-            continue
         metric = ALL_METRICS[name]
         score = metric(y_true, y_score)
         score_perm = metric(y_true_perm, y_score_perm)
-        assert_almost_equal(score, score_perm, decimal=1)
+        assert_almost_equal(score, score_perm)

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1193,6 +1193,9 @@ def test_metric_permutation_invariance_thresholded_multilabel():
     p = 0.7
     R = np.random.rand(n_samples, n_classes)
     y_true = R > p
+    for i in range(len(y_true)):
+        while len(np.unique(y_true[i])) == 1:
+            y_true[i] = np.random.rand(n_classes) > p
     y_score = []
     y_score_perm = []
     classes_perm = rng.permutation(n_classes)

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1193,14 +1193,13 @@ def test_metric_permutation_invariance_thresholded_multilabel():
     p = 0.7
     R = np.random.rand(n_samples, n_classes)
     y_true = R > p
-    for i in range(len(y_true)):
-        while len(np.unique(y_true[i])) == 1:
-            y_true[i] = np.random.rand(n_classes) > p
     y_score = []
     y_score_perm = []
     classes_perm = rng.permutation(n_classes)
     for i in range(len(y_true)):
-        y_score.append(rng.normal(size=y_true[0].shape))
+        while len(np.unique(y_true[i])) == 1:
+            y_true[i] = np.random.rand(n_classes) > p
+        y_score.append(y_true[i] + rng.normal(size=y_true[i].shape))
         y_score_perm.append(y_score[i][classes_perm])
 
     y_true_perm = y_true[:, classes_perm]

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1120,12 +1120,12 @@ def test_metric_permutation_invariance_multiclass():
     p_C /= p_C.sum()
     cp_C = np.cumsum(p_C)
     y_true = np.searchsorted(cp_C, rng.rand(n_samples))
-    y_pred = [];
+    y_pred = []
     for y in y_true:
         if rng.randint(0, 10) > 5:
             y_pred_new = (y + 1) % n_classes
         else:
-            y_pred_new = y;
+            y_pred_new = y
         y_pred.append(y_pred_new)
     classes_perm = rng.permutation(n_classes)
     y_true_perm = classes_perm[y_true]
@@ -1197,8 +1197,8 @@ def test_metric_permutation_invariance_thresholded_multilabel():
     y_score_perm = []
     rng = np.random.RandomState(42)
     classes_perm = rng.permutation(n_classes)
-    for i,y in enumerate(y_true):
-        y_score.append(rng.normal(size=y.shape))
+    for i in y_true:
+        y_score.append(rng.normal(size=y_true[0].shape))
         y_score_perm.append(y_score[i][classes_perm])
 
     y_true_perm = y_true[:, classes_perm]

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1195,9 +1195,8 @@ def test_metric_permutation_invariance_thresholded_multilabel():
     y_true = R > p
     y_score = []
     y_score_perm = []
-    rng = np.random.RandomState(42)
     classes_perm = rng.permutation(n_classes)
-    for i in y_true:
+    for i in range(len(y_true)):
         y_score.append(rng.normal(size=y_true[0].shape))
         y_score_perm.append(y_score[i][classes_perm])
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #8589 

#### What does this implement/fix? Explain your changes.
It adds a test to check the invariance of metrics against permutations of labels for multilabel and multiclass classifiers. There are four new tests in total, one for each of the following: multiclass, multilabel, thresholded multiclass, thresholded multilabel.

#### Any other comments?
I had to make an exception for confusion_matrix, as is expected after permutating labels these are not equal anymore.

One of the tests was based on a test in PR https://github.com/scikit-learn/scikit-learn/issues/7663, since it was mentioned in the issue.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
