### PR TITLE
Make BaseSVC.classes_ sample_weight aware (#8566)

### DIFF
--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -149,7 +149,8 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
         sample_weight = np.asarray([]
                                    if sample_weight is None
                                    else sample_weight, dtype=np.float64)
-        X, y = check_X_y(X, y, dtype=np.float64, order='C', accept_sparse='csr')
+        X, y = check_X_y(X, y, dtype=np.float64, order='C',
+                         accept_sparse='csr')
         y = self._validate_targets(y, sample_weight)
         solver_type = LIBSVM_IMPL.index(self._impl)
 

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -198,7 +198,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
 
         return self
 
-    def _validate_targets(self, y):
+    def _validate_targets(self, y, sample_weight):
         """Validation of y and class_weight.
 
         Default implementation for SVR and one-class; overridden in BaseSVC.

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -146,12 +146,11 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
             raise TypeError("Sparse precomputed kernels are not supported.")
         self._sparse = sparse and not callable(self.kernel)
 
-        X, y = check_X_y(X, y, dtype=np.float64, order='C', accept_sparse='csr')
-        y = self._validate_targets(y)
-
         sample_weight = np.asarray([]
                                    if sample_weight is None
                                    else sample_weight, dtype=np.float64)
+        X, y = check_X_y(X, y, dtype=np.float64, order='C', accept_sparse='csr')
+        y = self._validate_targets(y, sample_weight)
         solver_type = LIBSVM_IMPL.index(self._impl)
 
         # input validation
@@ -495,10 +494,13 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
             class_weight=class_weight, verbose=verbose, max_iter=max_iter,
             random_state=random_state)
 
-    def _validate_targets(self, y):
+    def _validate_targets(self, y, sample_weight):
         y_ = column_or_1d(y, warn=True)
         check_classification_targets(y)
         cls, y = np.unique(y_, return_inverse=True)
+        if sample_weight.shape[0]:
+            y_ = y_[sample_weight > 0]
+            cls = np.unique(y_)
         self.class_weight_ = compute_class_weight(self.class_weight, cls, y_)
         if len(cls) < 2:
             raise ValueError(


### PR DESCRIPTION
of possible classes to the ones that have a weight assigned.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Fixes #8566 


#### What does this implement/fix? Explain your changes.
When sample_weights are such that some classes do not have any assigned weight, libsvm results exclude the missing classes. This causes BaseSVC.classes_ to be out of sync with libsvm results. This commit fixes the issue by limiting BaseSVC.classes_ to the ones that have a sample_weight.
#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
