### PR TITLE
[MRG] Make BaseSVC.classes_ sample_weight aware (#8566)

### DIFF
--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -151,7 +151,6 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
                                    else sample_weight, dtype=np.float64)
         X, y = check_X_y(X, y, dtype=np.float64, order='C',
                          accept_sparse='csr')
-        y = self._validate_targets(y, sample_weight)
         solver_type = LIBSVM_IMPL.index(self._impl)
 
         # input validation
@@ -169,6 +168,8 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
                              "Note: Sparse matrices cannot be indexed w/"
                              "boolean masks (use `indices=True` in CV)."
                              % (sample_weight.shape, X.shape))
+
+        y = self._validate_targets(y, sample_weight)
 
         if self.gamma == 'auto':
             self._gamma = 1.0 / X.shape[1]

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -432,6 +432,27 @@ def test_sample_weights():
     assert_array_almost_equal(dual_coef_no_weight, clf.dual_coef_)
 
 
+def test_zero_sample_weights():
+    # Test weights on individual samples
+    # TODO: check on NuSVR, OneClass, etc.
+    X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]
+    Y = [1, 1, 2, 2, 3, 3]
+
+    # Test without weights
+    clf = svm.SVC()
+    clf.fit(X, Y)
+    assert_array_equal(clf.predict([X[2]]), [2.])
+    assert_array_equal(clf.class_weight_, [1,1,1])
+    assert_array_equal(clf.classes_, [1,2,3])
+
+    # use sample_weight 0 for class 1
+    sample_weight = [0.] * 2 + [10] * 4
+    clf.fit(X, Y, sample_weight=sample_weight)
+    assert_array_equal(clf.class_weight_, [1,1])
+    assert_array_equal(clf.classes_, [2,3])
+    assert_array_equal(clf.predict([X[2]]), [2.])
+
+
 def test_auto_weight():
     # Test class weights for imbalanced data
     from sklearn.linear_model import LogisticRegression

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -442,14 +442,14 @@ def test_zero_sample_weights():
     clf = svm.SVC()
     clf.fit(X, Y)
     assert_array_equal(clf.predict([X[2]]), [2.])
-    assert_array_equal(clf.class_weight_, [1,1,1])
-    assert_array_equal(clf.classes_, [1,2,3])
+    assert_array_equal(clf.class_weight_, [1, 1, 1])
+    assert_array_equal(clf.classes_, [1, 2, 3])
 
     # use sample_weight 0 for class 1
     sample_weight = [0.] * 2 + [10] * 4
     clf.fit(X, Y, sample_weight=sample_weight)
-    assert_array_equal(clf.class_weight_, [1,1])
-    assert_array_equal(clf.classes_, [2,3])
+    assert_array_equal(clf.class_weight_, [1, 1])
+    assert_array_equal(clf.classes_, [2, 3])
     assert_array_equal(clf.predict([X[2]]), [2.])
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Fixes #8566 


#### What does this implement/fix? Explain your changes.
When sample_weights are such that some classes do not have any assigned weight, libsvm results exclude the missing classes. This causes BaseSVC.classes_ to be out of sync with libsvm results. This commit fixes the issue by limiting BaseSVC.classes_ to the ones that have a sample_weight.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
