### PR TITLE
Imputer to maintain missing collumns

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -454,7 +454,7 @@ that contain the missing values::
     >>> imp = Imputer(missing_values='NaN', strategy='mean', axis=0)
     >>> imp.fit([[1, 2], [np.nan, 3], [7, 6]])
     Imputer(axis=0, copy=True, fill_empty=None, missing_values='NaN',
-    strategy='mean', verbose=0)
+        strategy='mean', verbose=0)
     >>> X = [[np.nan, 2], [6, np.nan], [7, 6]]
     >>> print(imp.transform(X))                           # doctest: +ELLIPSIS
     [[ 4.          2.        ]
@@ -468,7 +468,7 @@ The :class:`Imputer` class also supports sparse matrices::
     >>> imp = Imputer(missing_values=0, strategy='mean', axis=0)
     >>> imp.fit(X)
     Imputer(axis=0, copy=True, fill_empty=None, missing_values=0, strategy='mean',
-    verbose=0)
+        verbose=0)
     >>> X_test = sp.csc_matrix([[0, 2], [6, 0], [7, 6]])
     >>> print(imp.transform(X_test))                      # doctest: +ELLIPSIS
     [[ 4.          2.        ]

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -453,7 +453,8 @@ that contain the missing values::
     >>> from sklearn.preprocessing import Imputer
     >>> imp = Imputer(missing_values='NaN', strategy='mean', axis=0)
     >>> imp.fit([[1, 2], [np.nan, 3], [7, 6]])
-    Imputer(axis=0, copy=True, missing_values='NaN', strategy='mean', verbose=0)
+    Imputer(axis=0, copy=True, fill_empty=None, missing_values='NaN',
+    strategy='mean', verbose=0)
     >>> X = [[np.nan, 2], [6, np.nan], [7, 6]]
     >>> print(imp.transform(X))                           # doctest: +ELLIPSIS
     [[ 4.          2.        ]
@@ -466,7 +467,8 @@ The :class:`Imputer` class also supports sparse matrices::
     >>> X = sp.csc_matrix([[1, 2], [0, 3], [7, 6]])
     >>> imp = Imputer(missing_values=0, strategy='mean', axis=0)
     >>> imp.fit(X)
-    Imputer(axis=0, copy=True, missing_values=0, strategy='mean', verbose=0)
+    Imputer(axis=0, copy=True, fill_empty=None, missing_values=0, strategy='mean',
+    verbose=0)
     >>> X_test = sp.csc_matrix([[0, 2], [6, 0], [7, 6]])
     >>> print(imp.transform(X_test))                      # doctest: +ELLIPSIS
     [[ 4.          2.        ]

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -312,7 +312,7 @@ class Imputer(BaseEstimator, TransformerMixin):
             check_is_fitted(self, 'statistics_')
             X = check_array(X, accept_sparse='csc', dtype=FLOAT_DTYPES,
                             force_all_finite=False, copy=self.copy)
-            statistics = self.statistics_
+            statistics = self.statistics_.copy()
             if X.shape[1] != statistics.shape[0]:
                 raise ValueError("X has %d features per sample, expected %d"
                                  % (X.shape[1], self.statistics_.shape[0]))
@@ -336,11 +336,16 @@ class Imputer(BaseEstimator, TransformerMixin):
                                              self.missing_values,
                                              self.axis)
 
-        # impute completelly empty columns with constant, if required
+        # impute completelly empty columns with constant, if
+        # `empty_attribute_constant' parameter was set
         if self.empty_attribute_constant is not None:
             invalid_mask = np.isnan(statistics)
-            X[:, invalid_mask] = self.empty_attribute_constant
-            statistics[invalid_mask] = self.empty_attribute_constant
+            if self.axis == 0:
+                X[:, invalid_mask] = self.empty_attribute_constant
+                statistics[invalid_mask] = self.empty_attribute_constant
+            else:
+                X[invalid_mask, :] = self.empty_attribute_constant
+                statistics[invalid_mask] = self.empty_attribute_constant
 
         # Delete the invalid rows/columns
         invalid_mask = np.isnan(statistics)

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -347,7 +347,8 @@ class Imputer(BaseEstimator, TransformerMixin):
         if self.fill_empty is not None:
             if sparse.issparse(X):
                 X = X.toarray()
-            empty_mask = np.all(_get_mask(X, self.missing_values), axis=self.axis)
+            empty_mask = np.all(_get_mask(X, self.missing_values),
+                                axis=self.axis)
             statistics[empty_mask] = self.fill_empty
 
         # Delete the invalid rows/columns

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -116,12 +116,13 @@ class Imputer(BaseEstimator, TransformerMixin):
       contain missing values).
     """
     def __init__(self, missing_values="NaN", strategy="mean",
-                 axis=0, verbose=0, copy=True):
+                 axis=0, verbose=0, copy=True, empty_attribute_constant=None):
         self.missing_values = missing_values
         self.strategy = strategy
         self.axis = axis
         self.verbose = verbose
         self.copy = copy
+        self.empty_attribute_constant = empty_attribute_constant
 
     def fit(self, X, y=None):
         """Fit the imputer on X.
@@ -334,6 +335,12 @@ class Imputer(BaseEstimator, TransformerMixin):
                                              self.strategy,
                                              self.missing_values,
                                              self.axis)
+
+        # impute completelly empty columns with constant, if required
+        if self.empty_attribute_constant is not None:
+            invalid_mask = np.isnan(statistics)
+            X[:, invalid_mask] = self.empty_attribute_constant
+            statistics[invalid_mask] = self.empty_attribute_constant
 
         # Delete the invalid rows/columns
         invalid_mask = np.isnan(statistics)

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -16,7 +16,7 @@ from sklearn.random_projection import sparse_random_matrix
 
 def _check_statistics(X, X_true,
                       strategy, statistics, missing_values,
-                      empty_attribute_constant=None):
+                      fill_empty=None, avoids_value_error=False):
     """Utility function for testing imputation for a given strategy.
 
     Test:
@@ -31,16 +31,16 @@ def _check_statistics(X, X_true,
               "axis = {0}, sparse = {1}" % (strategy, missing_values)
 
     # Normal matrix, axis = 0
-    imputer = Imputer(missing_values, strategy=strategy, axis=0, empty_attribute_constant=empty_attribute_constant)
+    imputer = Imputer(missing_values, strategy=strategy, axis=0, fill_empty=fill_empty)
     X_trans = imputer.fit(X).transform(X.copy())
     assert_array_equal(imputer.statistics_, statistics,
                        err_msg.format(0, False))
     assert_array_equal(X_trans, X_true, err_msg.format(0, False))
 
     # Normal matrix, axis = 1
-    imputer = Imputer(missing_values, strategy=strategy, axis=1, empty_attribute_constant=empty_attribute_constant)
+    imputer = Imputer(missing_values, strategy=strategy, axis=1, fill_empty=fill_empty)
     imputer.fit(X.transpose())
-    if np.isnan(statistics).any() and empty_attribute_constant is None:
+    if np.isnan(statistics).any() and not avoids_value_error:
         assert_raises(ValueError, imputer.transform, X.copy().transpose())
     else:
         X_trans = imputer.transform(X.copy().transpose())
@@ -48,7 +48,7 @@ def _check_statistics(X, X_true,
                            err_msg.format(1, False))
 
     # Sparse matrix, axis = 0
-    imputer = Imputer(missing_values, strategy=strategy, axis=0, empty_attribute_constant=empty_attribute_constant)
+    imputer = Imputer(missing_values, strategy=strategy, axis=0, fill_empty=fill_empty)
     imputer.fit(sparse.csc_matrix(X))
     X_trans = imputer.transform(sparse.csc_matrix(X.copy()))
 
@@ -60,9 +60,9 @@ def _check_statistics(X, X_true,
     assert_array_equal(X_trans, X_true, err_msg.format(0, True))
 
     # Sparse matrix, axis = 1
-    imputer = Imputer(missing_values, strategy=strategy, axis=1, empty_attribute_constant=empty_attribute_constant)
+    imputer = Imputer(missing_values, strategy=strategy, axis=1, fill_empty=fill_empty)
     imputer.fit(sparse.csc_matrix(X.transpose()))
-    if np.isnan(statistics).any() and empty_attribute_constant is None:
+    if np.isnan(statistics).any() and not avoids_value_error:
         assert_raises(ValueError, imputer.transform,
                       sparse.csc_matrix(X.copy().transpose()))
     else:
@@ -123,6 +123,9 @@ def test_imputation_mean_median_only_zero():
 
 
 def test_imputation_empty_column_missing_zero():
+    # Test imputation using the mean and median strategies, when
+    # missing_values == 0 and empty columns get imputed with
+    # constant -1.
     X = np.array([
         [np.nan, 0, 0, 0, 5],
         [np.nan, 1, 0, np.nan, 3],
@@ -130,58 +133,69 @@ def test_imputation_empty_column_missing_zero():
         [np.nan, 6, 0, 5, 13],
     ])
 
+    # despite the empty column imputation, columns containing "NaN"
+    # are still removed
     X_imputed_mean = np.array([
-        [-1, 3, -1, -1, 5],
-        [-1, 1, -1, -1, 3],
-        [-1, 2, -1, -1, 7],
-        [-1, 6, -1, -1, 13],
+        [3, -1, 5],
+        [1, -1, 3],
+        [2, -1, 7],
+        [6, -1, 13],
     ])
     statistics_mean = [np.nan, 3, np.nan, np.nan, 7]
     _check_statistics(X, X_imputed_mean, "mean",
-                      statistics_mean, 0, empty_attribute_constant=-1)
+                      statistics_mean, 0, fill_empty=-1)
 
     X_for_median = X[:, [0, 1, 2, 4]]
+
+    # despite the empty column imputation, columns containing "NaN"
+    # are still removed. However, original column idx 2 is replaced
+    # by constant -1
     X_imputed_median = np.array([
-        [-1, 2, -1, 5],
-        [-1, 1, -1, 3],
-        [-1, 2, -1, 5],
-        [-1, 6, -1, 13],
+        [2, -1, 5],
+        [1, -1, 3],
+        [2, -1, 5],
+        [6, -1, 13],
     ])
     statistics_median = [np.nan, 2, np.nan, 5]
     _check_statistics(X_for_median, X_imputed_median,
                       "median", statistics_median, 0,
-                      empty_attribute_constant=-1)
+                      fill_empty=-1)
 
 
 def test_imputation_empty_column_missing_nan():
+    # Test imputation using the mean and median strategies, when
+    # missing_values == "NaN" and empty columns get imputed with
+    # constant -1.
     X = np.array([
         [np.nan, 3, 0, 4, np.nan],
         [np.nan, 1, 0, np.nan, 5],
-        [np.nan, 2, 0, 0, 0],
-        [np.nan, 6, 0, 5, 13],
+        [np.nan, 3, 0, 0, 0],
+        [np.nan, 5, 0, 5, 13],
     ])
 
     X_imputed_mean = np.array([
         [-1, 3, 0, 4, 6],
         [-1, 1, 0, 3, 5],
-        [-1, 2, 0, 0, 0],
-        [-1, 6, 0, 5, 13],
+        [-1, 3, 0, 0, 0],
+        [-1, 5, 0, 5, 13],
     ])
     statistics_mean = [np.nan, 3, 0, 3, 6]
     _check_statistics(X, X_imputed_mean, "mean",
                       statistics_mean, "NaN",
-                      empty_attribute_constant=-1)
+                      fill_empty=-1,
+                      avoids_value_error=True)
 
     X_imputed_median = np.array([
         [-1, 3, 0, 4, 5],
         [-1, 1, 0, 4, 5],
-        [-1, 2, 0, 0, 0],
-        [-1, 6, 0, 5, 13],
+        [-1, 3, 0, 0, 0],
+        [-1, 5, 0, 5, 13],
     ])
-    X_imputed_median = [np.nan, 3, 0, 4, 5]
-    _check_statistics(X, X_imputed_mean, "mean",
-                      statistics_mean, "NaN",
-                      empty_attribute_constant=-1)
+    statistics_median = [np.nan, 3, 0, 4, 5]
+    _check_statistics(X, X_imputed_median, "median",
+                      statistics_median, "NaN",
+                      fill_empty=-1,
+                      avoids_value_error=True)
 
 
 def safe_median(arr, *args, **kwargs):

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -31,14 +31,16 @@ def _check_statistics(X, X_true,
               "axis = {0}, sparse = {1}" % (strategy, missing_values)
 
     # Normal matrix, axis = 0
-    imputer = Imputer(missing_values, strategy=strategy, axis=0, fill_empty=fill_empty)
+    imputer = Imputer(missing_values, strategy=strategy, axis=0,
+                      fill_empty=fill_empty)
     X_trans = imputer.fit(X).transform(X.copy())
     assert_array_equal(imputer.statistics_, statistics,
                        err_msg.format(0, False))
     assert_array_equal(X_trans, X_true, err_msg.format(0, False))
 
     # Normal matrix, axis = 1
-    imputer = Imputer(missing_values, strategy=strategy, axis=1, fill_empty=fill_empty)
+    imputer = Imputer(missing_values, strategy=strategy, axis=1,
+                      fill_empty=fill_empty)
     imputer.fit(X.transpose())
     if np.isnan(statistics).any() and not avoids_value_error:
         assert_raises(ValueError, imputer.transform, X.copy().transpose())
@@ -48,7 +50,8 @@ def _check_statistics(X, X_true,
                            err_msg.format(1, False))
 
     # Sparse matrix, axis = 0
-    imputer = Imputer(missing_values, strategy=strategy, axis=0, fill_empty=fill_empty)
+    imputer = Imputer(missing_values, strategy=strategy, axis=0,
+                      fill_empty=fill_empty)
     imputer.fit(sparse.csc_matrix(X))
     X_trans = imputer.transform(sparse.csc_matrix(X.copy()))
 
@@ -60,7 +63,8 @@ def _check_statistics(X, X_true,
     assert_array_equal(X_trans, X_true, err_msg.format(0, True))
 
     # Sparse matrix, axis = 1
-    imputer = Imputer(missing_values, strategy=strategy, axis=1, fill_empty=fill_empty)
+    imputer = Imputer(missing_values, strategy=strategy, axis=1,
+                      fill_empty=fill_empty)
     imputer.fit(sparse.csc_matrix(X.transpose()))
     if np.isnan(statistics).any() and not avoids_value_error:
         assert_raises(ValueError, imputer.transform,


### PR DESCRIPTION
The preprocessing.imputer module removes attributes that are completely empty. While this makes sense in general, when used in a pipeline this is undesirable (see issue #8539)

In consultation with @amueller I wrote an extension that (if desired) replaces these attributes with a constant. This way, in the pipeline we can always rely on a constant feature ordering (and if needed, remove the constant features afterwards)

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
