### PR TITLE
[MRG+1] Calculate confidence intervall only if we have enough samples

### DIFF
--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -57,7 +57,7 @@ def check_increasing(x, y):
     increasing_bool = rho >= 0
 
     # Run Fisher transform to get the rho CI, but handle rho=+/-1
-    if rho not in [-1.0, 1.0]:
+    if (rho not in [-1.0, 1.0]) and (len(x) > 3):
         F = 0.5 * math.log((1. + rho) / (1. - rho))
         F_se = 1 / math.sqrt(len(x) - 3)
 

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -57,7 +57,7 @@ def check_increasing(x, y):
     increasing_bool = rho >= 0
 
     # Run Fisher transform to get the rho CI, but handle rho=+/-1
-    if (rho not in [-1.0, 1.0]) and (len(x) > 3):
+    if rho not in [-1.0, 1.0] and len(x) > 3:
         F = 0.5 * math.log((1. + rho) / (1. - rho))
         F_se = 1 / math.sqrt(len(x) - 3)
 

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -26,6 +26,12 @@ def test_permutation_invariance():
 
     assert_array_equal(y_transformed, y_transformed_s)
 
+def test_check_increasing_small_number_of_samples():
+    x = [0, 1, 2]
+    y = [1, 1.1, 1.05]
+
+    is_increasing = assert_no_warnings(check_increasing, x, y)
+    assert_true(is_increasing)
 
 def test_check_increasing_up():
     x = [0, 1, 2, 3, 4, 5]

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -26,12 +26,14 @@ def test_permutation_invariance():
 
     assert_array_equal(y_transformed, y_transformed_s)
 
+
 def test_check_increasing_small_number_of_samples():
     x = [0, 1, 2]
     y = [1, 1.1, 1.05]
 
     is_increasing = assert_no_warnings(check_increasing, x, y)
     assert_true(is_increasing)
+
 
 def test_check_increasing_up():
     x = [0, 1, 2, 3, 4, 5]


### PR DESCRIPTION

#### Reference Issue
 Fixes #8620


#### What does this implement/fix? Explain your changes.
To calculate frequentist standard errors we need at least 4 data points.
I checked for this requirement and did not enter the buggy calculation. 
