### PR TITLE
[MRG] DOC: hdbscan is now part of scikit-learn-contrib; update link

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -177,7 +177,7 @@ and tasks.
 - `kmodes <https://github.com/nicodv/kmodes>`_ k-modes clustering algorithm for
   categorical data, and several of its variations.
 
-- `hdbscan <https://github.com/lmcinnes/hdbscan>`_ HDBSCAN and Robust Single
+- `hdbscan <https://github.com/scikit-learn-contrib/hdbscan>`_ HDBSCAN and Robust Single
   Linkage clustering algorithms for robust variable density clustering.
 
 - `spherecluster <https://github.com/clara-labs/spherecluster>`_ Spherical


### PR DESCRIPTION
In related projects the link for hdbscan clustering pointed at a personal repository -- the hdbscan clustering library is no in scikit-learn-contrib, so the link should point there instead.
