### PR TITLE
[MRG] DOC add pre-processing section in related projects

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -184,6 +184,12 @@ and tasks.
   K-means and mixture of von Mises Fisher clustering routines for data on the
   unit hypersphere.
 
+**Dataset resampling**
+
+- `imbalanced-learn
+  <https://github.com/scikit-learn-contrib/imbalanced-learn>`_ Various
+  methods to under- and over-sample datasets.
+
 Statistical learning with Python
 --------------------------------
 Other packages useful for data analysis and machine learning.

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -184,7 +184,11 @@ and tasks.
   K-means and mixture of von Mises Fisher clustering routines for data on the
   unit hypersphere.
 
-**Dataset resampling**
+**Pre-processing**
+
+- `categorical-encoding
+  <https://github.com/scikit-learn-contrib/categorical-encoding>`_ A
+  library of sklearn compatible categorical variable encoders.
 
 - `imbalanced-learn
   <https://github.com/scikit-learn-contrib/imbalanced-learn>`_ Various


### PR DESCRIPTION
Since `imblearn` is part of `scikit-learn-contrib`, I thought that it could be added in the related projects.