### PR TITLE
[MRG] Fix plot_unveil_tree_structure.py: incorrect indexing for X_test

### DIFF
--- a/examples/tree/plot_unveil_tree_structure.py
+++ b/examples/tree/plot_unveil_tree_structure.py
@@ -114,7 +114,7 @@ for node_id in node_index:
     else:
         threshold_sign = ">"
 
-    print("decision id node %s : (X[%s, %s] (= %s) %s %s)"
+    print("decision id node %s : (X_test[%s, %s] (= %s) %s %s)"
           % (node_id,
              sample_id,
              feature[node_id],

--- a/examples/tree/plot_unveil_tree_structure.py
+++ b/examples/tree/plot_unveil_tree_structure.py
@@ -118,7 +118,7 @@ for node_id in node_index:
           % (node_id,
              sample_id,
              feature[node_id],
-             X_test[i, feature[node_id]],
+             X_test[sample_id, feature[node_id]],
              threshold_sign,
              threshold[node_id]))
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
Fix index of `X_test` when printing output for tree structure example.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
