### PR TITLE
[MRG]  Fallback for safe_sparse_dot w/ dense output larger than 2**31 elements 

### DIFF
--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -20,7 +20,7 @@ from scipy import linalg
 from scipy.sparse import issparse, csr_matrix
 
 from . import check_random_state
-from .fixes import np_version, sp_version
+from .fixes import np_version, sp_version, _csr_to_array_fallback
 from ._logistic_sigmoid import _log_logistic_sigmoid
 from ..externals.six.moves import xrange
 from .sparsefuncs_fast import csr_row_norms
@@ -172,24 +172,6 @@ def density(w, **kwargs):
     else:
         d = 0 if w is None else float((w != 0).sum()) / w.size
     return d
-
-
-def _csr_to_array_fallback(X):
-    """ This provides the equivalent functionality to
-       csr_matrix.toarray()
-    and provides a fix for scipy versions <1.0.0 where
-    the above command fails for arrays with more than 2**31
-    elements.
-    """
-    if X.format != 'csr':
-        raise ValueError('Only CSR sparse arrays are supported')
-    row_indices = np.zeros(len(X.indices), dtype='int32')
-    indptr = X.indptr
-    for idx in range(len(indptr) - 1):
-        row_indices[indptr[idx]:indptr[idx+1]] = idx
-    Y = np.zeros(X.shape, dtype=X.dtype)
-    Y[row_indices, X.indices] = X.data
-    return Y
 
 
 def safe_sparse_dot(a, b, dense_output=False):

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -408,3 +408,19 @@ if 'axis' not in signature(np.linalg.norm).parameters:
 
 else:
     norm = np.linalg.norm
+
+
+def _csr_to_array_fallback(X):
+    """ This provides the equivalent functionality to
+       csr_matrix.toarray()
+    and provides a fix for scipy versions <1.0.0 where
+    the above command fails for arrays with more than 2**31
+    elements.
+    """
+    row_indices = np.zeros(len(X.indices), dtype='int32')
+    indptr = X.indptr
+    for idx in range(len(indptr) - 1):
+        row_indices[indptr[idx]:indptr[idx+1]] = idx
+    Y = np.zeros(X.shape, dtype=X.dtype)
+    Y[row_indices, X.indices] = X.data
+    return Y

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -36,6 +36,7 @@ from sklearn.utils.extmath import _incremental_mean_and_var
 from sklearn.utils.extmath import _deterministic_vector_sign_flip
 from sklearn.utils.extmath import softmax
 from sklearn.utils.extmath import stable_cumsum
+from sklearn.utils.extmath import _csr_to_array_fallback
 from sklearn.datasets.samples_generator import make_low_rank_matrix
 
 
@@ -661,3 +662,15 @@ def test_stable_cumsum():
     assert_array_equal(stable_cumsum(A, axis=0), np.cumsum(A, axis=0))
     assert_array_equal(stable_cumsum(A, axis=1), np.cumsum(A, axis=1))
     assert_array_equal(stable_cumsum(A, axis=2), np.cumsum(A, axis=2))
+
+
+def test_csr_to_array_fallback():
+    X = np.random.rand(100, 10)
+    X_sp = sparse.csr_matrix(X)
+    X_sp_dense = _csr_to_array_fallback(X_sp)
+    assert_array_equal(X, X_sp_dense)
+
+    X_sp = sparse.rand(1000, 1000, random_state=0, format='csr')
+    X = X_sp.toarray()
+    X_2 = _csr_to_array_fallback(X_sp)
+    assert_array_equal(X, X_2)

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -21,7 +21,6 @@ from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import skip_if_32bit
 from sklearn.utils.testing import SkipTest
 from sklearn.utils.fixes import np_version
-from sklearn.utils.fixes import sp_version
 
 from sklearn.utils.extmath import density
 from sklearn.utils.extmath import logsumexp
@@ -37,7 +36,6 @@ from sklearn.utils.extmath import _incremental_mean_and_var
 from sklearn.utils.extmath import _deterministic_vector_sign_flip
 from sklearn.utils.extmath import softmax
 from sklearn.utils.extmath import stable_cumsum
-from sklearn.utils.extmath import _csr_to_array_fallback
 from sklearn.datasets.samples_generator import make_low_rank_matrix
 
 
@@ -663,20 +661,3 @@ def test_stable_cumsum():
     assert_array_equal(stable_cumsum(A, axis=0), np.cumsum(A, axis=0))
     assert_array_equal(stable_cumsum(A, axis=1), np.cumsum(A, axis=1))
     assert_array_equal(stable_cumsum(A, axis=2), np.cumsum(A, axis=2))
-
-
-def test_csr_to_array_fallback():
-    X = np.random.rand(100, 10)
-    X_sp = sparse.csr_matrix(X)
-    X_sp_dense = _csr_to_array_fallback(X_sp)
-    assert_array_equal(X, X_sp_dense)
-    if sp_version > (0, 12, 0):
-        args = {'random_state': 0}
-    else:
-        # random state not supported by scipy.sparse.rand
-        args = {}
-
-    X_sp = sparse.rand(1000, 1000, format='csr', **args)
-    X = X_sp.toarray()
-    X_2 = _csr_to_array_fallback(X_sp)
-    assert_array_equal(X, X_2)

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -21,6 +21,7 @@ from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import skip_if_32bit
 from sklearn.utils.testing import SkipTest
 from sklearn.utils.fixes import np_version
+from sklearn.utils.fixes import sp_version
 
 from sklearn.utils.extmath import density
 from sklearn.utils.extmath import logsumexp
@@ -669,8 +670,13 @@ def test_csr_to_array_fallback():
     X_sp = sparse.csr_matrix(X)
     X_sp_dense = _csr_to_array_fallback(X_sp)
     assert_array_equal(X, X_sp_dense)
+    if sp_version > (0, 12, 0):
+        args = {'random_state': 0}
+    else:
+        # random state not supported by scipy.sparse.rand
+        args = {}
 
-    X_sp = sparse.rand(1000, 1000, random_state=0, format='csr')
+    X_sp = sparse.rand(1000, 1000, format='csr', **args)
     X = X_sp.toarray()
     X_2 = _csr_to_array_fallback(X_sp)
     assert_array_equal(X, X_2)


### PR DESCRIPTION
This partially fixes #8666 by providing a fallback `csr_matrix.toarray()` implementation when  the `safe_sparse_dot(.., dense_output=True)` would return an array with more than 2**31 elements. Only CSR arrays are supported.

Performance wise this fallback implementation is between 35% faster (for large sparse arrays) to 40 % slower (for dense arrays converted to the CSR sparse format) than the reference `toarray()` method.
```py
In [1]: import numpy as np
   ...: import scipy.sparse
   ...:
   ...: X = scipy.sparse.rand(5000, 100000, format='csr')
   ...:
   ...: %timeit X.toarray()
   ...: %timeit _csr_to_array_fallback(X)
1 loop, best of 3: 1.88 s per loop
1 loop, best of 3: 1.24 s per loop

In [2]: X = scipy.sparse.csr_matrix(np.random.rand(1000, 5000))
   ...:
   ...: %timeit X.toarray()
   ...: %timeit _csr_to_array_fallback(X)
   ...:
10 loops, best of 3: 33.5 ms per loop
10 loops, best of 3: 45.6 ms per loop
```

**PS:** codecov is unhappy, again.. sigh 
-0.01% patch coverage: I'm sure it deserves a failed CI status when you look at the list of PRs...