### PR TITLE
[MRG+1] DOC remove repetition in the Pipeline/memory doc

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -109,8 +109,8 @@ class Pipeline(_BasePipeline):
         an estimator.
 
     memory : Instance of joblib.Memory or string, optional (default=None)
-        Used to caching the fitted transformers of the pipeline. By default,
-        no cache is performed. If a string is given, it is the path to
+        Used to cache the fitted transformers of the pipeline. By default,
+        no caching is performed. If a string is given, it is the path to
         the caching directory. Enabling caching triggers a clone of
         the transformers before fitting. Therefore, the transformer
         instance given to the pipeline cannot be inspected

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -109,16 +109,14 @@ class Pipeline(_BasePipeline):
         an estimator.
 
     memory : Instance of joblib.Memory or string, optional (default=None)
-        Used to caching the fitted transformers of the transformer of the
-        pipeline. By default, no cache is performed.
-        If a string is given, it is the path to the caching directory.
-        Enabling caching triggers a clone of the transformers before fitting.
-        Therefore, the transformer instance given to the pipeline cannot be
-        inspected directly. Use the attribute ``named_steps`` or ``steps``
-        to inspect estimators within the pipeline.
-        Caching the transformers is advantageous when fitting is time
-        consuming.
-
+        Used to caching the fitted transformers of the pipeline. By default,
+        no cache is performed. If a string is given, it is the path to
+        the caching directory. Enabling caching triggers a clone of
+        the transformers before fitting. Therefore, the transformer
+        instance given to the pipeline cannot be inspected
+        directly. Use the attribute ``named_steps`` or ``steps`` to
+        inspect estimators within the pipeline. Caching the
+        transformers is advantageous when fitting is time consuming.
 
     Attributes
     ----------


### PR DESCRIPTION
Correct the following repetition in the documentation of `Pipeline`:

`the fitted transformers of the transformer of the pipeline` changed to `the fitted transformers of the pipeline`