### PR TITLE
[MRG+2] Fix excessive memory usage in random forest prediction

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -581,28 +581,28 @@ class ForestClassifier(six.with_metaclass(ABCMeta, BaseForest,
 
         # avoid storing the output of every estimator by summing them in `out`
         if self.n_outputs_ == 1:
-            out = np.zeros((X.shape[0], self.n_classes_), dtype=np.float64)
+            proba = np.zeros((X.shape[0], self.n_classes_), dtype=np.float64)
 
             # Parallel loop
             Parallel(n_jobs=n_jobs, verbose=self.verbose, backend="threading")(
-                delayed(_run_estimator)(e.predict_proba, X, out)
+                delayed(_run_estimator)(e.predict_proba, X, proba)
                 for e in self.estimators_)
 
-            out /= len(self.estimators_)
-            return out
+            proba /= len(self.estimators_)
+            return proba
 
         else:
-            out = [np.zeros((X.shape[0], j), dtype=np.float64)
-                   for j in self.n_classes_]
+            all_proba = [np.zeros((X.shape[0], j), dtype=np.float64)
+                         for j in self.n_classes_]
 
             # Parallel loop
             Parallel(n_jobs=n_jobs, verbose=self.verbose, backend="threading")(
-                delayed(_run_estimator2)(e.predict_proba, X, out)
+                delayed(_run_estimator2)(e.predict_proba, X, all_proba)
                 for e in self.estimators_)
 
-            for out_ in out:
-                out_ /= len(self.estimators_)
-            return out
+            for proba in all_proba:
+                proba /= len(self.estimators_)
+            return all_proba
 
     def predict_log_proba(self, X):
         """Predict class log-probabilities for X.
@@ -693,18 +693,18 @@ class ForestRegressor(six.with_metaclass(ABCMeta, BaseForest, RegressorMixin)):
 
         # avoid storing the output of every estimator by summing them in `out`
         if self.n_outputs_ > 1:
-            out = np.zeros((X.shape[0], self.n_outputs_), dtype=np.float64)
+            y_hat = np.zeros((X.shape[0], self.n_outputs_), dtype=np.float64)
         else:
-            out = np.zeros((X.shape[0]), dtype=np.float64)
+            y_hat = np.zeros((X.shape[0]), dtype=np.float64)
 
         # Parallel loop
         Parallel(n_jobs=n_jobs, verbose=self.verbose, backend="threading")(
-            delayed(_run_estimator)(e.predict, X, out)
+            delayed(_run_estimator)(e.predict, X, y_hat)
             for e in self.estimators_)
 
-        out /= len(self.estimators_)
+        y_hat /= len(self.estimators_)
 
-        return out
+        return y_hat
 
     def _set_oob_score(self, X, y):
         """Compute out-of-bag scores"""

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -536,6 +536,8 @@ class ForestClassifier(six.with_metaclass(ABCMeta, BaseForest,
 
             return predictions
 
+    import memory_profiler
+    @memory_profiler.profile
     def predict_proba(self, X):
         """Predict class probabilities for X.
 
@@ -653,6 +655,8 @@ class ForestRegressor(six.with_metaclass(ABCMeta, BaseForest, RegressorMixin)):
             verbose=verbose,
             warm_start=warm_start)
 
+    import memory_profiler
+    @memory_profiler.profile
     def predict(self, X):
         """Predict regression target for X.
 


### PR DESCRIPTION
Fix #8244. 

That issue was about random forests using excessive memory in predicting. The problem was that the forest held onto each prediction from each estimator, only to combine them at the end. It was suggested in the thread to solve this by parallelizing over the instances instead of the estimators. Instead, I still parallelize over the trees, but keep an array `out` into which I immediately sum each output. Python's GIL makes this thread safe. 

My testing indicates runtime performance is the same, but memory usage is substantially decreased. See [this gist](https://gist.github.com/mikebenfield/934657ccc4eafeba130cacd515ef4106#file-prob_classification-py-L18). Running `python prob_classification.py n` gives a memory increment (around line 587 of forest.py) in MiB of

| n        | master | fix2-forest-memory                                |
|-----|----------|------------------------------------|
| 100   | 13.3 | 1.6 |
| 200 | 25.5 | 2.0 |
| 300 | 38.1 | 2.2 |
| 400 | 50.1 | 2.3 |
| 500 | 62.6 | 2.4 |
| 600 | 75.7 | 2.2 |


I wasn't sure where you'd like the functions `_run_estimator_` and `_run_estimator2`. Let me know if I should move them.