### PR TITLE
[MRG] Fix invalid input of ngram_range in vectorizers

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -975,3 +975,12 @@ def test_vectorizer_string_object_as_input():
             ValueError, message, vec.fit, "hello world!")
         assert_raise_message(
             ValueError, message, vec.transform, "hello world!")
+
+
+def test_vectorizer_ngram_range_validation():
+    invalid_ngram_range = (3, 2)
+    message = "min_n must not be greater than max_n."
+    exception = ValueError
+    for vec in [CountVectorizer, TfidfVectorizer, HashingVectorizer]:
+        assert_raise_message(
+                exception, message, vec, ngram_range=invalid_ngram_range)

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -978,9 +978,12 @@ def test_vectorizer_string_object_as_input():
 
 
 def test_vectorizer_ngram_range_validation():
-    invalid_ngram_range = (3, 2)
-    message = "min_n must not be greater than max_n."
+    invalid_range = (3, 2)
+    min_n, max_n = invalid_range
+    message = ('Invalid value for "ngram_range": {0},'
+               ' min_n must not be greater than max_n.'
+               .format(invalid_range))
     exception = ValueError
     for vec in [CountVectorizer, TfidfVectorizer, HashingVectorizer]:
         assert_raise_message(
-                exception, message, vec, ngram_range=invalid_ngram_range)
+                exception, message, vec, ngram_range=invalid_range)

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -102,18 +102,6 @@ class VectorizerMixin(object):
 
     _white_spaces = re.compile(r"\s\s+")
 
-    @property
-    def ngram_range(self):
-        return self._ngram_range
-
-    @ngram_range.setter
-    def ngram_range(self, value):
-        if isinstance(value, tuple):
-            # raise 'ValueError' if min_n > max_n.
-            if value[0] > value[1]:
-                raise ValueError("min_n must not be greater than max_n.")
-        self._ngram_range = value
-
     def decode(self, doc):
         """Decode the input into a string of unicode symbols
 
@@ -447,6 +435,8 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
         self.stop_words = stop_words
         self.n_features = n_features
         self.ngram_range = ngram_range
+        if ngram_range[0] > ngram_range[1]:
+            raise ValueError("min_n must not be greater than max_n.")
         self.binary = binary
         self.norm = norm
         self.non_negative = non_negative
@@ -695,6 +685,8 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                     "max_features=%r, neither a positive integer nor None"
                     % max_features)
         self.ngram_range = ngram_range
+        if ngram_range[0] > ngram_range[1]:
+            raise ValueError("min_n must not be greater than max_n.")
         self.vocabulary = vocabulary
         self.binary = binary
         self.dtype = dtype

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -435,8 +435,12 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
         self.stop_words = stop_words
         self.n_features = n_features
         self.ngram_range = ngram_range
-        if ngram_range[0] > ngram_range[1]:
-            raise ValueError("min_n must not be greater than max_n.")
+        min_n, max_n = ngram_range
+        if min_n > max_n:
+            raise ValueError(
+                    ('Invalid value for "ngram_range": {0},'
+                     ' min_n must not be greater than max_n.'
+                     .format(ngram_range)))
         self.binary = binary
         self.norm = norm
         self.non_negative = non_negative
@@ -685,8 +689,12 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                     "max_features=%r, neither a positive integer nor None"
                     % max_features)
         self.ngram_range = ngram_range
-        if ngram_range[0] > ngram_range[1]:
-            raise ValueError("min_n must not be greater than max_n.")
+        min_n, max_n = ngram_range
+        if min_n > max_n:
+            raise ValueError(
+                    ('Invalid value for "ngram_range": {0},'
+                     ' min_n must not be greater than max_n.'
+                     .format(ngram_range)))
         self.vocabulary = vocabulary
         self.binary = binary
         self.dtype = dtype

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -102,6 +102,18 @@ class VectorizerMixin(object):
 
     _white_spaces = re.compile(r"\s\s+")
 
+    @property
+    def ngram_range(self):
+        return self._ngram_range
+
+    @ngram_range.setter
+    def ngram_range(self, value):
+        if isinstance(value, tuple):
+            # raise 'ValueError' if min_n > max_n.
+            if value[0] > value[1]:
+                raise ValueError("min_n must not be greater than max_n.")
+        self._ngram_range = value
+
     def decode(self, doc):
         """Decode the input into a string of unicode symbols
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Fixes #8688


#### What does this implement/fix? Explain your changes.
Add 'ngram_range' property in `VectorizerMixin` to check the validation of input parameter 'ngram_range', if `min_n` is greater than `max_n`, throw a `ValueError` with a message "min_n must not be greater than max_n."  

#### Any other comments?
Any suggestions are more than welcome. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
