### PR TITLE
[MRG] Add decision_function api to LocalOutlierFactor

### DIFF
--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -237,7 +237,8 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         The argument X is supposed to contain *new data*: if X contains a
         point from training, it consider the later in its own neighborhood.
         Also, the samples in X are not considered in the neighborhood of any
-        point.
+        point. To avoid training and testing on the different dataset, this
+        method is kept private as well as _predict().
         The decision function on training data is available by considering the
         opposite of the negative_outlier_factor_ attribute.
 

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -198,9 +198,8 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         return self
 
     def score(self, X=None):
-        """Predict the outlier level of X according to LOF.
+        """Predict the outlier score of X according to LOF.
 
-        If X is None, returns the same as fit_predict(X_train).
         This method allows to generalize prediction to new observations (not
         in the training set). As LOF originally does not deal with new data,
         this method is kept private.
@@ -214,8 +213,7 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
 
         Returns
         -------
-        is_inlier : array, shape (n_samples,)
-            Returns -1 for anomalies/outliers and +1 for inliers.
+        score : outlier score as local outlier factor
         """
         check_is_fitted(self, ["threshold_", "negative_outlier_factor_",
                                "n_neighbors_", "_distances_fit_X_"])

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -245,6 +245,7 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         """
         check_is_fitted(self, ["threshold_", "negative_outlier_factor_",
                                "n_neighbors_", "_distances_fit_X_"])
+
         if X is not None:
             X = check_array(X, accept_sparse='csr')
             is_inlier = np.ones(X.shape[0], dtype=int)

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -197,7 +197,7 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
 
         return self
 
-    def score(self, X=None, y=None):
+    def decision_function(self, X=None):
         """Predict the outlier score of X according to LOF.
 
         This method allows to generalize prediction to new observations (not
@@ -217,11 +217,11 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         """
         if X is not None:
             X = check_array(X, accept_sparse='csr')
-            _score = self._decision_function(X)
+            score = self._decision_function(X)
         else:
-            _score = self.negative_outlier_factor_
+            score = self.negative_outlier_factor_
 
-        return _score
+        return score
 
     def _predict(self, X=None):
         """Predict the labels (1 inlier, -1 outlier) of X according to LOF.

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -197,7 +197,7 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
 
         return self
 
-    def predict_proba(self, X=None):
+    def score(self, X=None, y=None):
         """Predict the outlier score of X according to LOF.
 
         This method allows to generalize prediction to new observations (not
@@ -215,7 +215,6 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         -------
         score : outlier score as local outlier factor
         """
-        self.fit(X)
         if X is not None:
             X = check_array(X, accept_sparse='csr')
             _score = self._decision_function(X)

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -197,32 +197,6 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
 
         return self
 
-    def decision_function(self, X=None):
-        """Predict the outlier score of X according to LOF.
-
-        This method allows to generalize prediction to new observations (not
-        in the training set). As LOF originally does not deal with new data,
-        this method is kept private.
-
-        Parameters
-        ----------
-        X : array-like, shape (n_samples, n_features), default=None
-            The query sample or samples to compute the Local Outlier Factor
-            w.r.t. to the training samples. If None, makes prediction on the
-            training data without considering them as their own neighbors.
-
-        Returns
-        -------
-        score : outlier score as local outlier factor
-        """
-        if X is not None:
-            X = check_array(X, accept_sparse='csr')
-            score = self._decision_function(X)
-        else:
-            score = self.negative_outlier_factor_
-
-        return score
-
     def _predict(self, X=None):
         """Predict the labels (1 inlier, -1 outlier) of X according to LOF.
 

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -197,7 +197,7 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
 
         return self
 
-    def score(self, X=None):
+    def predict_proba(self, X=None):
         """Predict the outlier score of X according to LOF.
 
         This method allows to generalize prediction to new observations (not
@@ -215,8 +215,7 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         -------
         score : outlier score as local outlier factor
         """
-        check_is_fitted(self, ["threshold_", "negative_outlier_factor_",
-                               "n_neighbors_", "_distances_fit_X_"])
+        self.fit(X)
         if X is not None:
             X = check_array(X, accept_sparse='csr')
             _score = self._decision_function(X)

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -197,6 +197,35 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
 
         return self
 
+    def score(self, X=None):
+        """Predict the labels (1 inlier, -1 outlier) of X according to LOF.
+
+        If X is None, returns the same as fit_predict(X_train).
+        This method allows to generalize prediction to new observations (not
+        in the training set). As LOF originally does not deal with new data,
+        this method is kept private.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features), default=None
+            The query sample or samples to compute the Local Outlier Factor
+            w.r.t. to the training samples. If None, makes prediction on the
+            training data without considering them as their own neighbors.
+
+        Returns
+        -------
+        is_inlier : array, shape (n_samples,)
+            Returns -1 for anomalies/outliers and +1 for inliers.
+        """
+        check_is_fitted(self, ["threshold_", "negative_outlier_factor_",
+                               "n_neighbors_", "_distances_fit_X_"])
+        if X is not None:
+            _score = self._decision_function(X)
+        else:
+            _score = self.negative_outlier_factor_
+
+        return _score
+
     def _predict(self, X=None):
         """Predict the labels (1 inlier, -1 outlier) of X according to LOF.
 
@@ -219,7 +248,6 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         """
         check_is_fitted(self, ["threshold_", "negative_outlier_factor_",
                                "n_neighbors_", "_distances_fit_X_"])
-
         if X is not None:
             X = check_array(X, accept_sparse='csr')
             is_inlier = np.ones(X.shape[0], dtype=int)

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -198,7 +198,7 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         return self
 
     def score(self, X=None):
-        """Predict the labels (1 inlier, -1 outlier) of X according to LOF.
+        """Predict the outlier level of X according to LOF.
 
         If X is None, returns the same as fit_predict(X_train).
         This method allows to generalize prediction to new observations (not
@@ -220,6 +220,7 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         check_is_fitted(self, ["threshold_", "negative_outlier_factor_",
                                "n_neighbors_", "_distances_fit_X_"])
         if X is not None:
+            X = check_array(X, accept_sparse='csr')
             _score = self._decision_function(X)
         else:
             _score = self.negative_outlier_factor_

--- a/sklearn/neighbors/tests/test_lof.py
+++ b/sklearn/neighbors/tests/test_lof.py
@@ -77,6 +77,7 @@ def test_lof_values():
     s_1 = (1. + sqrt(2)) * (1. / (4. * sqrt(2.)) + 1. / (2. + 2. * sqrt(2)))
     # check predict()
     assert_array_almost_equal(-clf.negative_outlier_factor_, [s_0, s_1, s_1])
+    assert_array_almost_equal(-clf.decision_function(), [s_0, s_1, s_1])
     # check predict(one sample not in train)
     assert_array_almost_equal(-clf._decision_function([[2., 2.]]), [s_0])
     # # check predict(one sample already in train)

--- a/sklearn/neighbors/tests/test_lof.py
+++ b/sklearn/neighbors/tests/test_lof.py
@@ -77,7 +77,6 @@ def test_lof_values():
     s_1 = (1. + sqrt(2)) * (1. / (4. * sqrt(2.)) + 1. / (2. + 2. * sqrt(2)))
     # check predict()
     assert_array_almost_equal(-clf.negative_outlier_factor_, [s_0, s_1, s_1])
-    assert_array_almost_equal(-clf.decision_function(), [s_0, s_1, s_1])
     # check predict(one sample not in train)
     assert_array_almost_equal(-clf._decision_function([[2., 2.]]), [s_0])
     # # check predict(one sample already in train)


### PR DESCRIPTION
sklearn.neighbors.LocalOutlierFactor has an ability to judge the outliers and return as bool, but we cannot get the level of outlier for each data, indicates inlier closed or obvious outlier. So in this pull request, decision_function() api is added to provide the outlier level as Local Outlier Factor.
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
add decision_function api into sklearn.neighbors.LocalOutlierFactor

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
