### PR TITLE
[MRG+1] OneClassSVM predict now returns int

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -262,6 +262,9 @@ Bug fixes
    - Fixed a bug in :class:`manifold.TSNE` where it stored the incorrect
      ``kl_divergence_``. :issue:`6507` by :user:`Sebastian Saeger <ssaeger>`.
 
+   - Fixed a bug in :class:`svm.OneClassSVM` where it returned floats instead of
+     integer classes. :issue:`8676` by :user:`Vathsala Achar <VathsalaAchar>`.
+
 API changes summary
 -------------------
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -1049,3 +1049,24 @@ class OneClassSVM(BaseLibSVM):
         """
         dec = self._decision_function(X)
         return dec
+
+    def predict(self, X):
+        """
+        Perform classification on samples in X.
+
+        For an one-class model, +1 or -1 is returned.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+            For kernel="precomputed", the expected shape of X is
+            [n_samples_test, n_samples_train]
+
+        Returns
+        -------
+        y_pred : array, shape (n_samples,)
+            Class labels for samples in X.
+        """
+        y = super(OneClassSVM, self).predict(X)
+        return np.asarray(y, dtype=np.intp)
+

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -241,7 +241,8 @@ def test_oneclass():
     clf.fit(X)
     pred = clf.predict(T)
 
-    assert_array_almost_equal(pred, [-1, -1, -1])
+    assert_array_equal(pred, [-1, -1, -1])
+    assert_array_equal(pred.dtype, 'int')
     assert_array_almost_equal(clf.intercept_, [-1.008], decimal=3)
     assert_array_almost_equal(clf.dual_coef_,
                               [[0.632, 0.233, 0.633, 0.234, 0.632, 0.633]],

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -242,7 +242,7 @@ def test_oneclass():
     pred = clf.predict(T)
 
     assert_array_equal(pred, [-1, -1, -1])
-    assert_array_equal(pred.dtype, 'int')
+    assert_equal(pred.dtype, np.dtype('intp'))
     assert_array_almost_equal(clf.intercept_, [-1.008], decimal=3)
     assert_array_almost_equal(clf.dual_coef_,
                               [[0.632, 0.233, 0.633, 0.234, 0.632, 0.633]],


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
Reference Issue #8676

The changes here fixes the OneClassSVM predict method. The method used to return float and now returns integer types.
Small changes to the test are also included. 

If any further testing or documentation is required please let me know.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
