### PR TITLE
[MRG] Notes about default params for trees

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -1349,6 +1349,14 @@ class ExtraTreesClassifier(ForestClassifier):
         was never left out during the bootstrap. In this case,
         `oob_decision_function_` might contain NaN.
 
+    Notes
+    -----
+    The default values for the parameters controlling the size of the trees
+    (e.g. ``max_depth``, ``min_samples_leaf``, etc.) lead to fully grown and
+    unpruned trees which can potentially be very large on some data sets. To
+    reduce memory consumption, the complexity and size of the trees should be
+    controlled by setting those parameter values.
+
     References
     ----------
 
@@ -1544,6 +1552,14 @@ class ExtraTreesRegressor(ForestRegressor):
 
     oob_prediction_ : array of shape = [n_samples]
         Prediction computed with out-of-bag estimate on the training set.
+
+    Notes
+    -----
+    The default values for the parameters controlling the size of the trees
+    (e.g. ``max_depth``, ``min_samples_leaf``, etc.) lead to fully grown and
+    unpruned trees which can potentially be very large on some data sets. To
+    reduce memory consumption, the complexity and size of the trees should be
+    controlled by setting those parameter values.
 
     References
     ----------

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -909,10 +909,11 @@ class RandomForestClassifier(ForestClassifier):
 
     Notes
     -----
-    The default values for parameters that control the size of the trees (e.g.
-    ``max_depth``, ``min_samples_leaf``, etc.) can potentially result in large
-    trees on many data sets. To reduce memory consumption the complexity and
-    size of the trees should be controlled with appropriate parameter values.
+    The default values for the parameters controlling the size of the trees
+    (e.g. ``max_depth``, ``min_samples_leaf``, etc.) lead to fully grown and
+    unpruned trees which can potentially be very large on some data sets. To
+    reduce memory consumption, the complexity and size of the trees should be
+    controlled by setting those parameter values.
 
     The features are always randomly permuted at each split. Therefore,
     the best found split may vary, even with the same training data,
@@ -1119,10 +1120,11 @@ class RandomForestRegressor(ForestRegressor):
 
     Notes
     -----
-    The default values for parameters that control the size of the trees (e.g.
-    ``max_depth``, ``min_samples_leaf``, etc.) can potentially result in large
-    trees on many data sets. To reduce memory consumption the complexity and
-    size of the trees should be controlled with appropriate parameter values.
+    The default values for the parameters controlling the size of the trees
+    (e.g. ``max_depth``, ``min_samples_leaf``, etc.) lead to fully grown and
+    unpruned trees which can potentially be very large on some data sets. To
+    reduce memory consumption, the complexity and size of the trees should be
+    controlled by setting those parameter values.
 
     The features are always randomly permuted at each split. Therefore,
     the best found split may vary, even with the same training data,

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -909,12 +909,10 @@ class RandomForestClassifier(ForestClassifier):
 
     Notes
     -----
-    The parameters that control the size of the individual trees (e.g.
-    ``max_depth``, ``min_samples_leaf``, etc.) should be set according to the
-    learning task and the training data. The defaults for these parameters
-    might be inclined towards giving each sample instance a distinct leaf thus
-    overfitting the data. Large trees can also be a problem because of their
-    memory requirements; limiting the size can save RAM.
+    The default values for parameters that control the size of the trees (e.g.
+    ``max_depth``, ``min_samples_leaf``, etc.) can potentially result in large
+    trees on many data sets. To reduce memory consumption the complexity and
+    size of the trees should be controlled with appropriate parameter values.
 
     The features are always randomly permuted at each split. Therefore,
     the best found split may vary, even with the same training data,
@@ -1121,12 +1119,10 @@ class RandomForestRegressor(ForestRegressor):
 
     Notes
     -----
-    The parameters that control the size of the individual trees (e.g.
-    ``max_depth``, ``min_samples_leaf``, etc.) should be set according to the
-    learning task and the training data. The defaults for these parameters
-    might be inclined towards giving each sample instance a distinct leaf thus
-    overfitting the data. Large trees can also be a problem because of their
-    memory requirements; limiting the size can save RAM.
+    The default values for parameters that control the size of the trees (e.g.
+    ``max_depth``, ``min_samples_leaf``, etc.) can potentially result in large
+    trees on many data sets. To reduce memory consumption the complexity and
+    size of the trees should be controlled with appropriate parameter values.
 
     The features are always randomly permuted at each split. Therefore,
     the best found split may vary, even with the same training data,

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -909,6 +909,13 @@ class RandomForestClassifier(ForestClassifier):
 
     Notes
     -----
+    The parameters that control the size of the individual trees (e.g.
+    ``max_depth``, ``min_samples_leaf``, etc.) should be set according to the
+    learning task and the training data. The defaults for these parameters
+    might be inclined towards giving each sample instance a distinct leaf thus
+    overfitting the data. Large trees can also be a problem because of their
+    memory requirements; limiting the size can save RAM.
+
     The features are always randomly permuted at each split. Therefore,
     the best found split may vary, even with the same training data,
     ``max_features=n_features`` and ``bootstrap=False``, if the improvement
@@ -1114,6 +1121,13 @@ class RandomForestRegressor(ForestRegressor):
 
     Notes
     -----
+    The parameters that control the size of the individual trees (e.g.
+    ``max_depth``, ``min_samples_leaf``, etc.) should be set according to the
+    learning task and the training data. The defaults for these parameters
+    might be inclined towards giving each sample instance a distinct leaf thus
+    overfitting the data. Large trees can also be a problem because of their
+    memory requirements; limiting the size can save RAM.
+
     The features are always randomly permuted at each split. Therefore,
     the best found split may vary, even with the same training data,
     ``max_features=n_features`` and ``bootstrap=False``, if the improvement

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -1117,6 +1117,14 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
     --------
     ExtraTreeRegressor, ExtraTreesClassifier, ExtraTreesRegressor
 
+    Notes
+    -----
+    The default values for the parameters controlling the size of the trees
+    (e.g. ``max_depth``, ``min_samples_leaf``, etc.) lead to fully grown and
+    unpruned trees which can potentially be very large on some data sets. To
+    reduce memory consumption, the complexity and size of the trees should be
+    controlled by setting those parameter values.
+
     References
     ----------
 
@@ -1168,6 +1176,14 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
     See also
     --------
     ExtraTreeClassifier, ExtraTreesClassifier, ExtraTreesRegressor
+
+    Notes
+    -----
+    The default values for the parameters controlling the size of the trees
+    (e.g. ``max_depth``, ``min_samples_leaf``, etc.) lead to fully grown and
+    unpruned trees which can potentially be very large on some data sets. To
+    reduce memory consumption, the complexity and size of the trees should be
+    controlled by setting those parameter values.
 
     References
     ----------

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -662,12 +662,10 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
 
     Notes
     -----
-    The parameters that control the size of the tree (e.g. ``max_depth``,
-    ``min_samples_leaf``, etc.) should be set according to the learning task
-    and the training data. The defaults for these parameters might be inclined
-    towards giving each sample instance a distinct leaf thus overfitting the
-    data. Large trees can also be a problem because of their memory
-    requirements; limiting the size can save RAM.
+    The default values for parameters that control the size of the trees (e.g.
+    ``max_depth``, ``min_samples_leaf``, etc.) can potentially result in large
+    trees on many data sets. To reduce memory consumption the complexity and
+    size of the trees should be controlled with appropriate parameter values.
 
     The features are always randomly permuted at each split. Therefore,
     the best found split may vary, even with the same training data and
@@ -985,12 +983,10 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
 
     Notes
     -----
-    The parameters that control the size of the tree (e.g. ``max_depth``,
-    ``min_samples_leaf``, etc.) should be set according to the learning task
-    and the training data. The defaults for these parameters might be inclined
-    towards giving each sample instance a distinct leaf thus overfitting the
-    data. Large trees can also be a problem because of their memory
-    requirements; limiting the size can save RAM.
+    The default values for parameters that control the size of the trees (e.g.
+    ``max_depth``, ``min_samples_leaf``, etc.) can potentially result in large
+    trees on many data sets. To reduce memory consumption the complexity and
+    size of the trees should be controlled with appropriate parameter values.
 
     The features are always randomly permuted at each split. Therefore,
     the best found split may vary, even with the same training data and

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -662,6 +662,13 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
 
     Notes
     -----
+    The parameters that control the size of the tree (e.g. ``max_depth``,
+    ``min_samples_leaf``, etc.) should be set according to the learning task
+    and the training data. The defaults for these parameters might be inclined
+    towards giving each sample instance a distinct leaf thus overfitting the
+    data. Large trees can also be a problem because of their memory
+    requirements; limiting the size can save RAM.
+
     The features are always randomly permuted at each split. Therefore,
     the best found split may vary, even with the same training data and
     ``max_features=n_features``, if the improvement of the criterion is
@@ -978,6 +985,13 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
 
     Notes
     -----
+    The parameters that control the size of the tree (e.g. ``max_depth``,
+    ``min_samples_leaf``, etc.) should be set according to the learning task
+    and the training data. The defaults for these parameters might be inclined
+    towards giving each sample instance a distinct leaf thus overfitting the
+    data. Large trees can also be a problem because of their memory
+    requirements; limiting the size can save RAM.
+
     The features are always randomly permuted at each split. Therefore,
     the best found split may vary, even with the same training data and
     ``max_features=n_features``, if the improvement of the criterion is

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -662,10 +662,11 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
 
     Notes
     -----
-    The default values for parameters that control the size of the trees (e.g.
-    ``max_depth``, ``min_samples_leaf``, etc.) can potentially result in large
-    trees on many data sets. To reduce memory consumption the complexity and
-    size of the trees should be controlled with appropriate parameter values.
+    The default values for the parameters controlling the size of the trees
+    (e.g. ``max_depth``, ``min_samples_leaf``, etc.) lead to fully grown and
+    unpruned trees which can potentially be very large on some data sets. To
+    reduce memory consumption, the complexity and size of the trees should be
+    controlled by setting those parameter values.
 
     The features are always randomly permuted at each split. Therefore,
     the best found split may vary, even with the same training data and
@@ -983,10 +984,11 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
 
     Notes
     -----
-    The default values for parameters that control the size of the trees (e.g.
-    ``max_depth``, ``min_samples_leaf``, etc.) can potentially result in large
-    trees on many data sets. To reduce memory consumption the complexity and
-    size of the trees should be controlled with appropriate parameter values.
+    The default values for the parameters controlling the size of the trees
+    (e.g. ``max_depth``, ``min_samples_leaf``, etc.) lead to fully grown and
+    unpruned trees which can potentially be very large on some data sets. To
+    reduce memory consumption, the complexity and size of the trees should be
+    controlled by setting those parameter values.
 
     The features are always randomly permuted at each split. Therefore,
     the best found split may vary, even with the same training data and


### PR DESCRIPTION
#### Reference Issue
Fixes issue #8594

#### What does this implement/fix? Explain your changes.
This PR adds some notes in the documentation of DecisionTreeClassifier, DecisionTreeRegressor, RandomForestClassifier and RandomForestRegressor about using the default parameters resulting in quite large and overfitting trees.