### PR TITLE
[MRG] Improving default print statements when verbose in LatentDirichletAllocation

### DIFF
--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -537,12 +537,15 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
                     bound = self._perplexity_precomp_distr(X, doc_topics_distr,
                                                            sub_sampling=False)
                     if self.verbose:
-                        print('iteration: %d, perplexity: %.4f'
-                              % (i + 1, bound))
+                        print('iteration: %d of max_iters: %d, perplexity: %.4f'
+                              % (i + 1, max_iter, bound))
 
                     if last_bound and abs(last_bound - bound) < self.perp_tol:
                         break
                     last_bound = bound
+
+                elif self.verbose:
+                    print('iteration: %d of max_iter: %d' % (i + 1, max_iter))
                 self.n_iter_ += 1
 
         # calculate final perplexity value on train set

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -537,7 +537,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
                     bound = self._perplexity_precomp_distr(X, doc_topics_distr,
                                                            sub_sampling=False)
                     if self.verbose:
-                        print('iteration: %d of max_iters: %d, perplexity: %.4f'
+                        print('iteration: %d of max_iter: %d, perplexity: %.4f'
                               % (i + 1, max_iter, bound))
 
                     if last_bound and abs(last_bound - bound) < self.perp_tol:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #8705 
By default even if verbose there was no information about fit displayed.

#### What does this implement/fix? Explain your changes.
Added print statement for when verbose but evaluate_every is 0. Also printing max_iter in both cases.

#### Any other comments?
Another person had asked to work on this but since it had been many days and it seemed very small, I am submitting this PR.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
