### PR TITLE
[MRG] Add trefoil knot to samples

### DIFF
--- a/sklearn/datasets/__init__.py
+++ b/sklearn/datasets/__init__.py
@@ -100,5 +100,5 @@ __all__ = ['clear_data_home',
            'make_sparse_uncorrelated',
            'make_spd_matrix',
            'make_swiss_roll',
-	   'make_trefoil_knot',
+           'make_trefoil_knot',
            'mldata_filename']

--- a/sklearn/datasets/__init__.py
+++ b/sklearn/datasets/__init__.py
@@ -39,6 +39,7 @@ from .samples_generator import make_sparse_uncorrelated
 from .samples_generator import make_spd_matrix
 from .samples_generator import make_swiss_roll
 from .samples_generator import make_s_curve
+from .samples_generator import make_trefoil_knot
 from .samples_generator import make_sparse_spd_matrix
 from .samples_generator import make_gaussian_quantiles
 from .samples_generator import make_biclusters
@@ -99,4 +100,5 @@ __all__ = ['clear_data_home',
            'make_sparse_uncorrelated',
            'make_spd_matrix',
            'make_swiss_roll',
+	   'make_trefoil_knot',
            'mldata_filename']

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -1354,6 +1354,7 @@ def make_s_curve(n_samples=100, noise=0.0, random_state=None):
 
     return X, t
 
+
 def make_trefoil_knot(n_samples=100, noise=0.0, random_state=None):
     """Generate a trefoil knot dataset.
 
@@ -1395,6 +1396,7 @@ def make_trefoil_knot(n_samples=100, noise=0.0, random_state=None):
     t = np.squeeze(t)
 
     return X, t
+
 
 def make_gaussian_quantiles(mean=None, cov=1., n_samples=100,
                             n_features=2, n_classes=3,

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -1354,6 +1354,47 @@ def make_s_curve(n_samples=100, noise=0.0, random_state=None):
 
     return X, t
 
+def make_trefoil_knot(n_samples=100, noise=0.0, random_state=None):
+    """Generate a trefoil knot dataset.
+
+    Read more in the :ref:`User Guide <sample_generators>`.
+
+    Parameters
+    ----------
+    n_samples : int, optional (default=100)
+        The number of sample points on the S curve.
+
+    noise : float, optional (default=0.0)
+        The standard deviation of the gaussian noise.
+
+    random_state : int, RandomState instance or None, optional (default=None)
+        If int, random_state is the seed used by the random number generator;
+        If RandomState instance, random_state is the random number generator;
+        If None, the random number generator is the RandomState instance used
+        by `np.random`.
+
+    Returns
+    -------
+    X : array of shape [n_samples, 3]
+        The points.
+
+    t : array of shape [n_samples]
+        The univariate position of the sample according to the main dimension
+        of the points in the manifold.
+    """
+    generator = check_random_state(random_state)
+
+    t = np.pi * (1 + 2 * generator.rand(1, n_samples))
+    x = np.sin(t) + 2 * np.sin(2 * t)
+    y = np.cos(t) - 2 * np.cos(2 * t)
+    z = -np.sin(3 * t)
+
+    X = np.concatenate((x, y, z))
+    X += noise * generator.randn(3, n_samples)
+    X = X.T
+    t = np.squeeze(t)
+
+    return X, t
 
 def make_gaussian_quantiles(mean=None, cov=1., n_samples=100,
                             n_features=2, n_classes=3,

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -30,6 +30,7 @@ from sklearn.datasets import make_sparse_uncorrelated
 from sklearn.datasets import make_spd_matrix
 from sklearn.datasets import make_swiss_roll
 from sklearn.datasets import make_s_curve
+from sklearn.datasets import make_trefoil_knot
 from sklearn.datasets import make_biclusters
 from sklearn.datasets import make_checkerboard
 
@@ -326,6 +327,13 @@ def test_make_s_curve():
     assert_array_almost_equal(X[:, 0], np.sin(t))
     assert_array_almost_equal(X[:, 2], np.sign(t) * (np.cos(t) - 1))
 
+def test_make_trefoil_knot():
+    X, t = make_trefoil_knot(n_samples=5, noise=0.0, random_state=0)
+
+    assert_equal(X.shape, (5, 3), "X shape mismatch")
+    assert_equal(t.shape, (5,), "t shape mismatch")
+    assert_array_almost_equal(X[:, 0], np.sin(t) + 2 * np.sin(2 * t))
+    assert_array_almost_equal(X[:, 2], -np.sin(3 * t))
 
 def test_make_biclusters():
     X, rows, cols = make_biclusters(

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -327,6 +327,7 @@ def test_make_s_curve():
     assert_array_almost_equal(X[:, 0], np.sin(t))
     assert_array_almost_equal(X[:, 2], np.sign(t) * (np.cos(t) - 1))
 
+
 def test_make_trefoil_knot():
     X, t = make_trefoil_knot(n_samples=5, noise=0.0, random_state=0)
 
@@ -334,6 +335,7 @@ def test_make_trefoil_knot():
     assert_equal(t.shape, (5,), "t shape mismatch")
     assert_array_almost_equal(X[:, 0], np.sin(t) + 2 * np.sin(2 * t))
     assert_array_almost_equal(X[:, 2], -np.sin(3 * t))
+
 
 def test_make_biclusters():
     X, rows, cols = make_biclusters(


### PR DESCRIPTION
Since trefoil is used in some books and articles as an example, I'm adding it to the samples list. We can also use it to visualize t-SNE for different configurations.

[Python Data Visualization Cookbook](https://books.google.com/books?id=2vOoCwAAQBAJ&pg=PA269&lpg=PA269&dq=3D+%22trefoil%22+python&source=bl&ots=q9CpVfbp0t&sig=U0Cc6X4e1dS9z_FHEdbMHtiYHKc&hl=en&sa=X&ved=0ahUKEwiugaaszZDTAhXK44MKHTR_BOkQ6AEIMTAH#v=onepage&q=3D%20%22trefoil%22%20python&f=false)

http://distill.pub/2016/misread-tsne/

3D example of trefoil knot:
![trekot-knot_3d](https://cloud.githubusercontent.com/assets/12010601/24885980/85ff2b88-1e06-11e7-8116-92c1074f4790.png)

2D: projection with t-SNE
![trekot-knot_2d](https://cloud.githubusercontent.com/assets/12010601/24885985/8cbb94f2-1e06-11e7-96db-0180c8ebbc53.png)

Added test cases similar to other samples.
