### PR TITLE
[MRG] grid_search_digits.py: Remove impact-less (and confusing) 'C=1' parameter

### DIFF
--- a/examples/model_selection/grid_search_digits.py
+++ b/examples/model_selection/grid_search_digits.py
@@ -50,7 +50,7 @@ for score in scores:
     print("# Tuning hyper-parameters for %s" % score)
     print()
 
-    clf = GridSearchCV(SVC(C=1), tuned_parameters, cv=5,
+    clf = GridSearchCV(SVC(), tuned_parameters, cv=5,
                        scoring='%s_macro' % score)
     clf.fit(X_train, y_train)
 


### PR DESCRIPTION
#### What does this implement/fix?
This parameter does not modify at all the behavior of GridSearchCV,
and is quite confusing for the user.
Useful values of 'C' are already set in 'tuned_parameters'.