### PR TITLE
[MRG + 1] Documentation: Adds yellowbrick to related projects

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -68,8 +68,8 @@ enhance the functionality of scikit-learn's estimators.
   for quick and easy generation of common plots in data analysis and machine learning.
 
 - `yellowbrick <https://github.com/DistrictDataLabs/yellowbrick>`_ A suite of
-  custom matplotlib visualizers for scikit-learn estimators to support visual
-  model selection, evaluation, and diagnostics.
+  custom matplotlib visualizers for scikit-learn estimators to support visual feature
+  analysis, model selection, evaluation, and diagnostics.
 
 
 **Model export for production**

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -67,6 +67,10 @@ enhance the functionality of scikit-learn's estimators.
 - `scikit-plot <https://github.com/reiinakano/scikit-plot>`_ A visualization library
   for quick and easy generation of common plots in data analysis and machine learning.
 
+- `yellowbrick <https://github.com/DistrictDataLabs/yellowbrick>`_ A suite of
+  custom matplotlib visualizers for scikit-learn estimators to support visual
+  model selection, evaluation, and diagnostics.
+
 
 **Model export for production**
 


### PR DESCRIPTION
#### Reference Issue
In response to @amueller's [request](https://github.com/DistrictDataLabs/yellowbrick/issues/193).

#### What does this implement/fix? Explain your changes.
I've added the [Yellowbrick library](https://github.com/DistrictDataLabs/yellowbrick) to the list of related projects for the Scikit-Learn documentation. Yellowbrick ([http://www.scikit-yb.org/](http://www.scikit-yb.org/)) is a suite of visual analysis and diagnostic tools to facilitate feature selection, model selection, and parameter tuning for machine learning with Scikit-Learn. All visualizations are generated in Matplotlib, and the library features a consistent sklearn-like API.
