### PR TITLE
Do not normalize sample weights with adaboost

### DIFF
--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -113,7 +113,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         if sample_weight is None:
             # Initialize weights to 0
-            sample_weight = np.zeros(X.shape[0], dtype=np.float64)
+            sample_weight = np.ones(X.shape[0], dtype=np.float64)
         else:
             sample_weight = check_array(sample_weight, ensure_2d=False)
 

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -112,13 +112,10 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
                          y_numeric=is_regressor(self))
 
         if sample_weight is None:
-            # Initialize weights to 1 / n_samples
-            sample_weight = np.empty(X.shape[0], dtype=np.float64)
-            sample_weight[:] = 1. / X.shape[0]
+            # Initialize weights to 0
+            sample_weight = np.zeros(X.shape[0], dtype=np.float64)
         else:
             sample_weight = check_array(sample_weight, ensure_2d=False)
-            # Normalize existing weights
-            sample_weight = sample_weight / sample_weight.sum(dtype=np.float64)
 
             # Check that the sample weights sum is positive
             if sample_weight.sum() <= 0:


### PR DESCRIPTION
Initialize sample weights to 1 and do not normalize.

Setting sample weights to small values in the order of 1 / number_of_samples results in diminished gradients in gradient boosting estimators like XGBoost or LightGBM. Those estimators never learn with sklearn's weight boosting models.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
