### PR TITLE
[MRG] add iterable values support for dictvectorizer

### DIFF
--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -3,10 +3,9 @@
 # License: BSD 3 clause
 
 from array import array
-from collections import Mapping
+from collections import Mapping, Iterable
 from operator import itemgetter
 from numbers import Number
-import types
 
 import numpy as np
 import scipy.sparse as sp
@@ -133,14 +132,14 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         return self
 
     def add_element(self, f, v, feature_names, vocab, fitting=True, transforming=False, indices=None, values=None):
-        if hasattr(v, '__iter__'):
-            for vv in v.__iter__():
+        if not isinstance(v, six.string_types) and isinstance(v, Iterable):
+            for vv in v:
                 self.add_element(f, vv, feature_names, vocab, fitting, transforming, indices, values)
         else:
-            if isinstance(v, basestring):
+            if isinstance(v, six.string_types):
                 feature_name = "%s%s%s" % (f, self.separator, v)
                 v = 1
-            elif isinstance(v, (Number, types.BooleanType, types.NoneType)):
+            elif isinstance(v, Number) or (v is True) or (v is False) or (v is None):
                 feature_name = f
             else:
                 raise Exception('Unsupported Type %s for {%s: %s}' % (type(v), f, v))
@@ -298,26 +297,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         Xa : {array, sparse matrix}
             Feature vectors; always 2-d.
         """
-        if self.sparse:
-            return self._transform(X, fitting=False)
-
-        else:
-            dtype = self.dtype
-            vocab = self.vocabulary_
-            X = _tosequence(X)
-            Xa = np.zeros((len(X), len(vocab)), dtype=dtype)
-
-            for i, x in enumerate(X):
-                for f, v in six.iteritems(x):
-                    if isinstance(v, six.string_types):
-                        f = "%s%s%s" % (f, self.separator, v)
-                        v = 1
-                    try:
-                        Xa[i, vocab[f]] = dtype(v)
-                    except KeyError:
-                        pass
-
-            return Xa
+        return self._transform(X, fitting=False)
 
     def get_feature_names(self):
         """Returns a list of feature names, ordered by their indices.

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -88,18 +88,18 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         [{'bar': 2.0, 'foo': 1.0}, {'baz': 1.0, 'foo': 3.0}]
     True
     >>> v.transform({'foo': 4, 'unseen_feature': 3})
-    array([[ 0.,  0.,  4.]])
+    array([[0., 0., 4.]])
     >>> D2 = [{'foo': '1', 'bar': '2'}, {'foo': '3', 'baz': '1'}, {'foo': ['1', '3']}]
-    >>> X = v.fit_transform(D)
+    >>> X = v.fit_transform(D2)
     >>> X
-    array([[ 1.,  0.,  1., 0.],
-           [ 0.,  1.,  0., 1.],
-           [ 0.,  0.,  1., 1.])
+    array([[ 1.,  0.,  1.,  0.],
+           [ 0.,  1.,  0.,  1.],
+           [ 0.,  0.,  1.,  1.]])
     >>> v.inverse_transform(X) == \
-    [{'foo=1': 1.0, 'bar=2': 1.0}, {'foo=3': 1.0, 'baz=1': 1.0}, {'foo=3': 1.0, 'foo=1': 1.0}]
+    ... [{'foo=1': 1.0, 'bar=2': 1.0}, {'foo=3': 1.0, 'baz=1': 1.0}, {'foo=3': 1.0, 'foo=1': 1.0}]
     True
     >>> v.transform({'foo': '1', 'unseen_feature': [3]})
-    array([[ 1.,  0.,  0., 0.]])
+    array([[ 0.,  0.,  1.,  0.]])
 
     See also
     --------

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -133,29 +133,29 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
 
     def add_element(self, f, v, feature_names, vocab, fitting=True,
                     transforming=False, indices=None, values=None):
-        if not isinstance(v, six.string_types) and isinstance(v, Iterable):
+        if isinstance(v, six.string_types):
+            feature_name = "%s%s%s" % (f, self.separator, v)
+            v = 1
+        elif isinstance(v, Number) or (v is None):
+            feature_name = f
+        elif isinstance(v, Iterable):
             for vv in v:
                 self.add_element(f, vv, feature_names, vocab,
                                  fitting, transforming, indices, values)
+            return
         else:
-            if isinstance(v, six.string_types):
-                feature_name = "%s%s%s" % (f, self.separator, v)
-                v = 1
-            elif isinstance(v, Number) or (v is True) or\
-                    (v is False) or (v is None):
-                feature_name = f
-            else:
-                raise Exception(
-                    'Unsupported Type %s for {%s: %s}' % (type(v), f, v))
-            if fitting:
-                if feature_name not in vocab:
-                    vocab[feature_name] = len(feature_names)
-                    feature_names.append(feature_name)
+            raise Exception(
+                'Unsupported Type %s for {%s: %s}' % (type(v), f, v))
 
-            if transforming:
-                if feature_name in vocab:
-                    indices.append(vocab[feature_name])
-                    values.append(self.dtype(v))
+        if fitting:
+            if feature_name not in vocab:
+                vocab[feature_name] = len(feature_names)
+                feature_names.append(feature_name)
+
+        if transforming:
+            if feature_name in vocab:
+                indices.append(vocab[feature_name])
+                values.append(self.dtype(v))
 
     def _transform(self, X, fitting):
         # Sanity check: Python's array has no way of explicitly requesting the

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -60,8 +60,8 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         Whether transform should produce scipy.sparse matrices.
         True by default.
     sort : boolean, optional.
-        Whether ``feature_names_`` and ``vocabulary_`` should be sorted when fitting.
-        True by default.
+        Whether ``feature_names_`` and ``vocabulary_`` should be sorted
+        when fitting. True by default.
 
     Attributes
     ----------
@@ -131,18 +131,22 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
 
         return self
 
-    def add_element(self, f, v, feature_names, vocab, fitting=True, transforming=False, indices=None, values=None):
+    def add_element(self, f, v, feature_names, vocab, fitting=True,
+                    transforming=False, indices=None, values=None):
         if not isinstance(v, six.string_types) and isinstance(v, Iterable):
             for vv in v:
-                self.add_element(f, vv, feature_names, vocab, fitting, transforming, indices, values)
+                self.add_element(f, vv, feature_names, vocab,
+                                 fitting, transforming, indices, values)
         else:
             if isinstance(v, six.string_types):
                 feature_name = "%s%s%s" % (f, self.separator, v)
                 v = 1
-            elif isinstance(v, Number) or (v is True) or (v is False) or (v is None):
+            elif isinstance(v, Number) or (v is True) or\
+                    (v is False) or (v is None):
                 feature_name = f
             else:
-                raise Exception('Unsupported Type %s for {%s: %s}' % (type(v), f, v))
+                raise Exception(
+                    'Unsupported Type %s for {%s: %s}' % (type(v), f, v))
             if fitting:
                 if feature_name not in vocab:
                     vocab[feature_name] = len(feature_names)
@@ -186,7 +190,8 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         # same time
         for x in X:
             for f, v in six.iteritems(x):
-                self.add_element(f, v, feature_names, vocab, fitting, transforming, indices, values)
+                self.add_element(f, v, feature_names, vocab,
+                                 fitting, transforming, indices, values)
             indptr.append(len(indices))
 
         if len(indptr) == 1:

--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -99,30 +99,29 @@ def test_iterable_value_with_generator():
             {"version=3": True, "spam": -1}]
     v = DictVectorizer(sparse=False)
     X = v.fit_transform(D_in)
-    assert_equal(X.shape, (3, 5))
+    assert X.shape == (3, 5)
 
     D_out = v.inverse_transform(X)
-    assert_equal(D_out[0], {"version=1": 1, "version=2": 1, "ham": 2})
+    assert D_out[0] == {"version=1": 1, "version=2": 1, "ham": 2}
 
     actual_x0 = v.transform({"version": map(str, range(1, 3)), "ham": 2})
     assert_array_equal(actual_x0, X[0:1])
 
     names = v.get_feature_names()
-    assert_true("version=2" in names)
-    assert_true("version=1" in names)
-    assert_true("version=3" in names)
-    assert_false("version" in names)
+    assert "version=2" in names
+    assert "version=1" in names
+    assert "version=3" in names
+    assert "version" not in names
 
 
 def test_iterable_value_fail_with_mapping():
-    D_in = [{"version": dict((i, str(i)) for i in xrange(1, 3)), "ham": 2},
+    D_in = [{"version": dict((i, str(i)) for i in range(1, 3)), "ham": 2},
             {"version": "2", "spam": .3},
             {"version=3": True, "spam": -1}]
     v = DictVectorizer()
-    try:
+    with pytest.raises(ValueError) as e:
         v.fit(D_in)
-    except ValueError as e:
-        assert_in("Unsupported Value Type", str(e))
+    assert "Unsupported Value Type" in str(e)
 
 
 def test_unseen_or_no_features():

--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -77,6 +77,23 @@ def test_one_of_k():
     assert_false("version" in names)
 
 
+def test_iterable_value():
+    D_in = [{"version": ["1", "2"], "ham": 2},
+            {"version": "2", "spam": .3},
+            {"version=3": True, "spam": -1}]
+    v = DictVectorizer()
+    X = v.fit_transform(D_in)
+    assert_equal(X.shape, (3, 5))
+
+    D_out = v.inverse_transform(X)
+    assert_equal(D_out[0], {"version=1": 1, "version=2": 1, "ham": 2})
+
+    names = v.get_feature_names()
+    assert_true("version=2" in names)
+    assert_true("version=1" in names)
+    assert_false("version" in names)
+
+
 def test_unseen_or_no_features():
     D = [{"camelot": 0, "spamalot": 1}]
     for sparse in [True, False]:

--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -2,7 +2,6 @@
 #          Dan Blanchard <dblanchard@ets.org>
 # License: BSD 3 clause
 
-from itertools import imap
 from random import Random
 import numpy as np
 import scipy.sparse as sp
@@ -97,7 +96,7 @@ def test_iterable_value():
 
 
 def test_iterable_value_with_generator():
-    D_in = [{"version": imap(str, xrange(1, 3)), "ham": 2},
+    D_in = [{"version": map(str, range(1, 3)), "ham": 2},
             {"version": "2", "spam": .3},
             {"version=3": True, "spam": -1}]
     v = DictVectorizer(sparse=False)
@@ -107,7 +106,7 @@ def test_iterable_value_with_generator():
     D_out = v.inverse_transform(X)
     assert_equal(D_out[0], {"version=1": 1, "version=2": 1, "ham": 2})
 
-    actual_x0 = v.transform({"version": imap(str, xrange(1, 3)), "ham": 2})
+    actual_x0 = v.transform({"version": map(str, range(1, 3)), "ham": 2})
     assert_array_equal(actual_x0, X[0:1])
 
     names = v.get_feature_names()

--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -4,11 +4,10 @@
 
 from random import Random
 import numpy as np
+import pytest
 import scipy.sparse as sp
 
 from numpy.testing import assert_array_equal
-from sklearn.utils.testing import (assert_equal, assert_in,
-                                   assert_false, assert_true)
 
 from sklearn.feature_extraction import DictVectorizer
 from sklearn.feature_selection import SelectKBest, chi2
@@ -26,10 +25,10 @@ def test_dictvectorizer():
                     v = DictVectorizer(sparse=sparse, dtype=dtype, sort=sort)
                     X = v.fit_transform(iter(D) if iterable else D)
 
-                    assert_equal(sp.issparse(X), sparse)
-                    assert_equal(X.shape, (3, 5))
-                    assert_equal(X.sum(), 14)
-                    assert_equal(v.inverse_transform(X), D)
+                    assert sp.issparse(X) == sparse
+                    assert X.shape == (3, 5)
+                    assert X.sum() == 14
+                    assert v.inverse_transform(X) == D
 
                     if sparse:
                         # CSR matrices can't be compared for equality
@@ -40,8 +39,8 @@ def test_dictvectorizer():
                                                           else D))
 
                     if sort:
-                        assert_equal(v.feature_names_,
-                                     sorted(v.feature_names_))
+                        assert v.feature_names_ == \
+                                     sorted(v.feature_names_)
 
 
 def test_feature_selection():
@@ -58,7 +57,7 @@ def test_feature_selection():
         sel = SelectKBest(chi2, k=2).fit(X, [0, 1])
 
         v.restrict(sel.get_support(indices=indices), indices=indices)
-        assert_equal(v.get_feature_names(), ["useful1", "useful2"])
+        assert v.get_feature_names() == ["useful1", "useful2"]
 
 
 def test_one_of_k():
@@ -67,14 +66,14 @@ def test_one_of_k():
             {"version=3": True, "spam": -1}]
     v = DictVectorizer()
     X = v.fit_transform(D_in)
-    assert_equal(X.shape, (3, 5))
+    assert X.shape == (3, 5)
 
     D_out = v.inverse_transform(X)
-    assert_equal(D_out[0], {"version=1": 1, "ham": 2})
+    assert D_out[0] == {"version=1": 1, "ham": 2}
 
     names = v.get_feature_names()
-    assert_true("version=2" in names)
-    assert_false("version" in names)
+    assert "version=2" in names
+    assert "version" not in names
 
 
 def test_iterable_value():
@@ -83,16 +82,15 @@ def test_iterable_value():
             {"version=3": True, "spam": -1}]
     v = DictVectorizer()
     X = v.fit_transform(D_in)
-    assert_equal(X.shape, (3, 5))
+    assert X.shape == (3, 5)
 
     D_out = v.inverse_transform(X)
-    assert_equal(D_out[0], {"version=1": 1, "version=2": 1, "ham": 2})
+    assert D_out[0] == {"version=1": 1, "version=2": 1, "ham": 2}
 
     names = v.get_feature_names()
-    assert_true("version=2" in names)
-    assert_true("version=1" in names)
-    assert_true("version=3" in names)
-    assert_false("version" in names)
+    assert "version=2" in names
+    assert "version=1" in names
+    assert "version" not in names
 
 
 def test_iterable_value_with_generator():
@@ -141,11 +139,9 @@ def test_unseen_or_no_features():
         if sparse:
             X = X.toarray()
         assert_array_equal(X, np.zeros((1, 2)))
-
-        try:
+        with pytest.raises(ValueError) as e:
             v.transform([])
-        except ValueError as e:
-            assert_in("empty", str(e))
+        assert "empty" in str(e)
 
 
 def test_deterministic_vocabulary():
@@ -160,4 +156,4 @@ def test_deterministic_vocabulary():
     v_1 = DictVectorizer().fit([d_sorted])
     v_2 = DictVectorizer().fit([d_shuffled])
 
-    assert_equal(v_1.vocabulary_, v_2.vocabulary_)
+    assert v_1.vocabulary_ == v_2.vocabulary_

--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -2,6 +2,7 @@
 #          Dan Blanchard <dblanchard@ets.org>
 # License: BSD 3 clause
 
+from itertools import imap
 from random import Random
 import numpy as np
 import scipy.sparse as sp
@@ -91,7 +92,40 @@ def test_iterable_value():
     names = v.get_feature_names()
     assert_true("version=2" in names)
     assert_true("version=1" in names)
+    assert_true("version=3" in names)
     assert_false("version" in names)
+
+
+def test_iterable_value_with_generator():
+    D_in = [{"version": imap(str, xrange(1, 3)), "ham": 2},
+            {"version": "2", "spam": .3},
+            {"version=3": True, "spam": -1}]
+    v = DictVectorizer(sparse=False)
+    X = v.fit_transform(D_in)
+    assert_equal(X.shape, (3, 5))
+
+    D_out = v.inverse_transform(X)
+    assert_equal(D_out[0], {"version=1": 1, "version=2": 1, "ham": 2})
+
+    actual_x0 = v.transform({"version": imap(str, xrange(1, 3)), "ham": 2})
+    assert_array_equal(actual_x0, X[0:1])
+
+    names = v.get_feature_names()
+    assert_true("version=2" in names)
+    assert_true("version=1" in names)
+    assert_true("version=3" in names)
+    assert_false("version" in names)
+
+
+def test_iterable_value_fail_with_mapping():
+    D_in = [{"version": dict((i, str(i)) for i in xrange(1, 3)), "ham": 2},
+            {"version": "2", "spam": .3},
+            {"version=3": True, "spam": -1}]
+    v = DictVectorizer()
+    try:
+        v.fit(D_in)
+    except ValueError as e:
+        assert_in("Unsupported Value Type", str(e))
 
 
 def test_unseen_or_no_features():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
fixes #6045
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

add iterable support for value types in dictvectorizer

#### Any other comments?
It would be helpful if we add a `feature_dimension_` property for `DictVectorizer` to make the dictvectorizer support aggregation over list/array of numbers or vectors

```
data = [{'a': [1, 2, 3],  'b': {1: 'fail', 2: 'fail'}}] 
```
^ this type of input would fail

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
