### PR TITLE
[MRG] DOC change rebase to merge policy

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -155,12 +155,23 @@ If any of the above seems like magic to you, then look up the `Git documentation
 <http://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html>`_ on the
 web.
 
-In particular, if some conflicts arise between your branch and the master
-branch, you will need to `rebase your branch on master
-<http://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#rebasing-on-master>`_.
-Please avoid merging master branch into yours. If you did it anyway, you can fix
-it following `this example
-<https://github.com/scikit-learn/scikit-learn/pull/7111#issuecomment-249175383>`_.
+If some conflicts arise between your branch and the ``master`` branch, you need
+to merge ``master`` into your branch with the explicit ``--no-ff`` flag. The
+command will be::
+
+  $ git merge --no-ff master
+
+with ``master`` being synchronized with the ``upstream``.
+
+Subsequently, you need to solve the conflicts. You can refer to the `Git
+documentation related to resolving merge conflict using the command line
+<https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line/>`_.
+
+.. note::
+
+   In the past, the policy to resolve conflicts was to rebase your branch on
+   ``master``. GitHub interface deals with merging ``master`` better than in
+   the past.
 
 
 Contributing pull requests

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -156,10 +156,9 @@ If any of the above seems like magic to you, then look up the `Git documentation
 web.
 
 If some conflicts arise between your branch and the ``master`` branch, you need
-to merge ``master`` into your branch with the explicit ``--no-ff`` flag. The
-command will be::
+to merge ``master``. The command will be::
 
-  $ git merge --no-ff master
+  $ git merge master
 
 with ``master`` being synchronized with the ``upstream``.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Follow a discussion in #8568 

#### What does this implement/fix? Explain your changes.

The current policies to solve conflicts between `master` and a development branch is based on `git rebase`. Following the [discussion](https://github.com/scikit-learn/scikit-learn/pull/8568#issuecomment-293554962) in #8568 , @jnothman proposes to use a `git merge` policy instead.

#### Any other comments?

I personally like the [following discussion](https://www.atlassian.com/git/articles/git-team-workflows-merge-or-rebase) regarding the two policies.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
