### PR TITLE
[WIP] fixed bug in _log_reg_scoring_path

### DIFF
--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -919,7 +919,11 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
         check_input=False, max_squared_sum=max_squared_sum,
         sample_weight=sample_weight)
 
-    log_reg = LogisticRegression(fit_intercept=fit_intercept)
+    log_reg = LogisticRegression(
+		fit_intercept=fit_intercept, penalty=penalty, dual=dual, tol=tol,
+		intercept_scaling=intercept_scaling, class_weight=class_weight,
+		random_state=random_state, max_iter=max_iter, multi_class=multi_class,
+		verbose=verbose, solver=solver)
 
     # The score method of Logistic Regression has a classes_ attribute.
     if multi_class == 'ovr':
@@ -1150,7 +1154,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
     """
 
     def __init__(self, penalty='l2', dual=False, tol=1e-4, C=1.0,
-                 fit_intercept=True, intercept_scaling=1, class_weight=None,
+                 fit_intercept=True, intercept_scaling=1., class_weight=None,
                  random_state=None, solver='liblinear', max_iter=100,
                  multi_class='ovr', verbose=0, warm_start=False, n_jobs=1):
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #8720 

#### What does this implement/fix? Explain your changes.
In _log_reg_scoring_path method, constructor of LogisticRegression accepted only fit_intercept as argument, which caused the bug explained in the issue above.
As @njiles suggested, adding multi_class as argument when creating logistic regression object, solves the problem for multi_class case.
After that, it seems like other similar parameters must be passed as arguments to logistic regression constructor.
Also, changed intercept_scaling default value to float

#### Any other comments?
Tested on the code provided in the issue by @njiles with various arguments on linear_model.logistic._log_reg_scoring_path and linear_model.LogisticRegression, seems ok.
Probably needs more testing.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
