### PR TITLE
[MRG+1] Spelling mistake in Feature Extraction documentation

### DIFF
--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -1,4 +1,4 @@
-.. _feature_extraction:
+﻿.. _feature_extraction:
 
 ==================
 Feature extraction
@@ -42,7 +42,7 @@ is a traditional numerical feature::
   >>> measurements = [
   ...     {'city': 'Dubai', 'temperature': 33.},
   ...     {'city': 'London', 'temperature': 12.},
-  ...     {'city': 'San Fransisco', 'temperature': 18.},
+  ...     {'city': 'San Francisco', 'temperature': 18.},
   ... ]
 
   >>> from sklearn.feature_extraction import DictVectorizer
@@ -54,7 +54,7 @@ is a traditional numerical feature::
          [  0.,   0.,   1.,  18.]])
 
   >>> vec.get_feature_names()
-  ['city=Dubai', 'city=London', 'city=San Fransisco', 'temperature']
+  ['city=Dubai', 'city=London', 'city=San Francisco', 'temperature']
 
 :class:`DictVectorizer` is also a useful representation transformation
 for training sequence classifiers in Natural Language Processing models

--- a/examples/model_selection/plot_nested_cross_validation_iris.py
+++ b/examples/model_selection/plot_nested_cross_validation_iris.py
@@ -64,7 +64,7 @@ p_grid = {"C": [1, 10, 100],
           "gamma": [.01, .1]}
 
 # We will use a Support Vector Classifier with "rbf" kernel
-svr = SVC(kernel="rbf")
+svm = SVC(kernel="rbf")
 
 # Arrays to store scores
 non_nested_scores = np.zeros(NUM_TRIALS)
@@ -80,7 +80,7 @@ for i in range(NUM_TRIALS):
     outer_cv = KFold(n_splits=4, shuffle=True, random_state=i)
 
     # Non_nested parameter search and scoring
-    clf = GridSearchCV(estimator=svr, param_grid=p_grid, cv=inner_cv)
+    clf = GridSearchCV(estimator=svm, param_grid=p_grid, cv=inner_cv)
     clf.fit(X_iris, y_iris)
     non_nested_scores[i] = clf.best_score_
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

Fixes Issue #8761 


#### What does this implement/fix? Explain your changes.
Changed measurements = [
... {'city': 'Dubai', 'temperature': 33.},
... {'city': 'London', 'temperature': 12.},
... {'city': 'San Fransisco', 'temperature': 18.},
... ]
"San Fransisco" to "San Francisco"
in both the instances.
#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
