### PR TITLE
[MRG+2] Fixing Math domain error on NMF due to numpy.dot

### DIFF
--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -92,7 +92,7 @@ def _beta_divergence(X, W, H, beta, square_root=False):
     if beta == 2:
         # Avoid the creation of the dense np.dot(W, H) if X is sparse.
         if sp.issparse(X):
-            norm_X = pow(np.linalg.norm(X.data), 2)
+            norm_X = np.dot(X.data, X.data)
             norm_WH = trace_dot(np.dot(np.dot(W.T, W), H), H)
             cross_prod = trace_dot((X * H.T), W)
             res = (norm_X + norm_WH - 2. * cross_prod) / 2.
@@ -957,7 +957,7 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
     factorization with the beta-divergence. Neural Computation, 23(9).
     """
 
-    X = check_array(X, accept_sparse=('csr', 'csc'))
+    X = check_array(X, accept_sparse=('csr', 'csc'), dtype=float)
     check_non_negative(X, "NMF (input X)")
     beta_loss = _check_string_param(solver, regularization, beta_loss, init)
 
@@ -1204,7 +1204,7 @@ class NMF(BaseEstimator, TransformerMixin):
         W : array, shape (n_samples, n_components)
             Transformed data.
         """
-        X = check_array(X, accept_sparse=('csr', 'csc'))
+        X = check_array(X, accept_sparse=('csr', 'csc'), dtype=float)
 
         W, H, n_iter_ = non_negative_factorization(
             X=X, W=W, H=H, n_components=self.n_components, init=self.init,

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -92,7 +92,7 @@ def _beta_divergence(X, W, H, beta, square_root=False):
     if beta == 2:
         # Avoid the creation of the dense np.dot(W, H) if X is sparse.
         if sp.issparse(X):
-            norm_X = np.dot(X.data, X.data)
+            norm_X = pow(np.linalg.norm(X.data), 2)
             norm_WH = trace_dot(np.dot(np.dot(W.T, W), H), H)
             cross_prod = trace_dot((X * H.T), W)
             res = (norm_X + norm_WH - 2. * cross_prod) / 2.

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -55,7 +55,8 @@ def squared_norm(x):
     x = _ravel(x)
     if np.issubdtype(x.dtype, np.integer):
         warnings.warn('Array type is integer, np.dot may overflow.'
-                      ' Data should be float type to avoid this issue')
+                      ' Data should be float type to avoid this issue',
+                      UserWarning)
     return np.dot(x, x)
 
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -53,6 +53,9 @@ def squared_norm(x):
     is a matrix (2-d array). Faster than norm(x) ** 2.
     """
     x = _ravel(x)
+    if np.issubdtype(x.dtype, np.integer):
+        warnings.warn('Array type is integer, np.dot may overflow.'
+                      ' Data should be float type to avoid this issue')
     return np.dot(x, x)
 
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -54,8 +54,8 @@ def squared_norm(x):
     """
     x = _ravel(x)
     if np.issubdtype(x.dtype, np.integer):
-        warnings.warn('Array type is integer, np.dot may overflow.'
-                      ' Data should be float type to avoid this issue',
+        warnings.warn('Array type is integer, np.dot may overflow. '
+                      'Data should be float type to avoid this issue',
                       UserWarning)
     return np.dot(x, x)
 

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -150,9 +150,10 @@ def test_norm_squared_norm():
     assert_almost_equal(norm(X) ** 2, squared_norm(X), decimal=6)
     assert_almost_equal(np.linalg.norm(X), np.sqrt(squared_norm(X)), decimal=6)
     # Check the warning with an int array and np.dot potential overflow
-    assert_warns_message(UserWarning, 'Array type is integer, np.dot may '
-                  'overflow. Data should be float type to avoid this issue',
-                  squared_norm, X.astype(int))
+    assert_warns_message(
+                    UserWarning, 'Array type is integer, np.dot may '
+                    'overflow. Data should be float type to avoid this issue',
+                    squared_norm, X.astype(int))
 
 
 def test_row_norms():

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -148,6 +148,8 @@ def test_norm_squared_norm():
     assert_almost_equal(np.linalg.norm(X.ravel()), norm(X))
     assert_almost_equal(norm(X) ** 2, squared_norm(X), decimal=6)
     assert_almost_equal(np.linalg.norm(X), np.sqrt(squared_norm(X)), decimal=6)
+    # Check the warning with an int array and np.dot potential overflow
+    assert_warns(UserWarning, squared_norm, X.astype(int))
 
 
 def test_row_norms():

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -18,6 +18,7 @@ from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import skip_if_32bit
 from sklearn.utils.testing import SkipTest
 from sklearn.utils.fixes import np_version
@@ -149,7 +150,9 @@ def test_norm_squared_norm():
     assert_almost_equal(norm(X) ** 2, squared_norm(X), decimal=6)
     assert_almost_equal(np.linalg.norm(X), np.sqrt(squared_norm(X)), decimal=6)
     # Check the warning with an int array and np.dot potential overflow
-    assert_warns(UserWarning, squared_norm, X.astype(int))
+    assert_warns_message(UserWarning, 'Array type is integer, np.dot may '
+                  'overflow. Data should be float type to avoid this issue',
+                  squared_norm, X.astype(int))
 
 
 def test_row_norms():


### PR DESCRIPTION
Fixes #8764, Fixes #7190
As referenced in this issue https://github.com/scikit-learn/scikit-learn/issues/8764 I tried to fix the Math domain error due to integer overflow with np.dot.

Note: the function squared_norm in utils/extmath.py also uses np.dot, should we change it to np.linalg.norm ?
Sorry in advance if this pull request is wrong in any way