### PR TITLE
[MRG] Improve the error message of export_graphviz if a not-fitted decision tree is provided

### DIFF
--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -380,9 +380,8 @@ def export_graphviz(decision_tree, out_file=SENTINEL, max_depth=None,
 
     own_file = False
     return_string = False
+    check_is_fitted(decision_tree, 'tree_')
     try:
-        check_is_fitted(decision_tree, 'tree_')
-
         if out_file == SENTINEL:
             warnings.warn("out_file can be set to None starting from 0.18. "
                           "This will be the default in 0.20.",

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -14,6 +14,7 @@ import numpy as np
 import warnings
 
 from ..externals import six
+from ..exceptions import NotFittedError
 
 from . import _criterion
 from . import _tree
@@ -380,6 +381,12 @@ def export_graphviz(decision_tree, out_file=SENTINEL, max_depth=None,
     own_file = False
     return_string = False
     try:
+        if decision_tree.tree_ is None:
+            raise NotFittedError("This %(name)s instance is not fitted yet."
+                                 "Call 'fit' with appropriate arguments"
+                                 "before using this method."
+                                 % {'name': type(decision_tree).__name__})
+
         if out_file == SENTINEL:
             warnings.warn("out_file can be set to None starting from 0.18. "
                           "This will be the default in 0.20.",

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -378,9 +378,9 @@ def export_graphviz(decision_tree, out_file=SENTINEL, max_depth=None,
                 # Add edge to parent
                 out_file.write('%d -> %d ;\n' % (parent, node_id))
 
+    check_is_fitted(decision_tree, 'tree_')
     own_file = False
     return_string = False
-    check_is_fitted(decision_tree, 'tree_')
     try:
         if out_file == SENTINEL:
             warnings.warn("out_file can be set to None starting from 0.18. "

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -14,7 +14,7 @@ import numpy as np
 import warnings
 
 from ..externals import six
-from ..exceptions import NotFittedError
+from ..utils.validation import check_is_fitted
 
 from . import _criterion
 from . import _tree
@@ -381,11 +381,7 @@ def export_graphviz(decision_tree, out_file=SENTINEL, max_depth=None,
     own_file = False
     return_string = False
     try:
-        if decision_tree.tree_ is None:
-            raise NotFittedError("This %(name)s instance is not fitted yet. "
-                                 "Call 'fit' with appropriate arguments "
-                                 "before using this method."
-                                 % {'name': type(decision_tree).__name__})
+        check_is_fitted(decision_tree, 'tree_')
 
         if out_file == SENTINEL:
             warnings.warn("out_file can be set to None starting from 0.18. "

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -382,8 +382,8 @@ def export_graphviz(decision_tree, out_file=SENTINEL, max_depth=None,
     return_string = False
     try:
         if decision_tree.tree_ is None:
-            raise NotFittedError("This %(name)s instance is not fitted yet."
-                                 "Call 'fit' with appropriate arguments"
+            raise NotFittedError("This %(name)s instance is not fitted yet. "
+                                 "Call 'fit' with appropriate arguments "
                                  "before using this method."
                                  % {'name': type(decision_tree).__name__})
 

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -9,6 +9,7 @@ from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.tree import export_graphviz
 from sklearn.externals.six import StringIO
 from sklearn.utils.testing import assert_in, assert_equal, assert_raises
+from sklearn.exceptions import NotFittedError
 
 # toy sample
 X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]
@@ -210,6 +211,11 @@ def test_graphviz_toy():
 def test_graphviz_errors():
     # Check for errors of export_graphviz
     clf = DecisionTreeClassifier(max_depth=3, min_samples_split=2)
+
+    # Check not-fitted decision tree error
+    out = StringIO()
+    assert_raises(NotFittedError, export_graphviz, clf, out)
+
     clf.fit(X, y)
 
     # Check feature_names error


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #8775 

#### What does this implement/fix? Explain your changes.
This pull request aims to improve the error message of export_graphviz if a not-fitted decision tree is provided.
I think for this special case, it is unnecessary to use sklearn.utils.validation.check_is_fitted, so I simply add an 'if' statement at the beginning of the function and output a NotFittedError.

#### Any other comments?
Thanks for your precious time.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
