### PR TITLE
[MRG+1] enable to use get_n_splits of LeaveOneGroupOut and LeavePGroupsOut with dummy parameters

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -902,11 +902,9 @@ class LeavePGroupsOut(BaseCrossValidator):
         ----------
         X : object
             Always ignored, exists for compatibility.
-            ``np.zeros(n_samples)`` may be used as a placeholder.
 
         y : object
             Always ignored, exists for compatibility.
-            ``np.zeros(n_samples)`` may be used as a placeholder.
 
         groups : array-like, with shape (n_samples,), optional
             Group labels for the samples used while splitting the dataset into
@@ -920,7 +918,6 @@ class LeavePGroupsOut(BaseCrossValidator):
         if groups is None:
             raise ValueError("The groups parameter should not be None")
         groups = check_array(groups, ensure_2d=False, dtype=None)
-        X, y, groups = indexable(X, y, groups)
         return int(comb(len(np.unique(groups)), self.n_groups, exact=True))
 
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -188,7 +188,7 @@ class LeaveOneOut(BaseCrossValidator):
             Returns the number of splitting iterations in the cross-validator.
         """
         if X is None:
-            raise ValueError("The X parameter should not be None")
+            raise ValueError("The 'X' parameter should not be None")
         return _num_samples(X)
 
 
@@ -259,7 +259,7 @@ class LeavePOut(BaseCrossValidator):
             Always ignored, exists for compatibility.
         """
         if X is None:
-            raise ValueError("The X parameter should not be None")
+            raise ValueError("The 'X' parameter should not be None")
         return int(comb(_num_samples(X), self.p, exact=True))
 
 
@@ -477,7 +477,7 @@ class GroupKFold(_BaseKFold):
 
     def _iter_test_indices(self, X, y, groups):
         if groups is None:
-            raise ValueError("The groups parameter should not be None")
+            raise ValueError("The 'groups' parameter should not be None")
         groups = check_array(groups, ensure_2d=False, dtype=None)
 
         unique_groups, groups = np.unique(groups, return_inverse=True)
@@ -787,7 +787,7 @@ class LeaveOneGroupOut(BaseCrossValidator):
 
     def _iter_test_masks(self, X, y, groups):
         if groups is None:
-            raise ValueError("The groups parameter should not be None")
+            raise ValueError("The 'groups' parameter should not be None")
         # We make a copy of groups to avoid side-effects during iteration
         groups = check_array(groups, copy=True, ensure_2d=False, dtype=None)
         unique_groups = np.unique(groups)
@@ -886,7 +886,7 @@ class LeavePGroupsOut(BaseCrossValidator):
 
     def _iter_test_masks(self, X, y, groups):
         if groups is None:
-            raise ValueError("The groups parameter should not be None")
+            raise ValueError("The 'groups' parameter should not be None")
         groups = check_array(groups, copy=True, ensure_2d=False, dtype=None)
         unique_groups = np.unique(groups)
         if self.n_groups >= len(unique_groups):
@@ -1297,7 +1297,7 @@ class GroupShuffleSplit(ShuffleSplit):
 
     def _iter_indices(self, X, y, groups):
         if groups is None:
-            raise ValueError("The groups parameter should not be None")
+            raise ValueError("The 'groups' parameter should not be None")
         groups = check_array(groups, ensure_2d=False, dtype=None)
         classes, group_indices = np.unique(groups, return_inverse=True)
         for group_train, group_test in super(

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -821,7 +821,7 @@ class LeaveOneGroupOut(BaseCrossValidator):
             Returns the number of splitting iterations in the cross-validator.
         """
         if groups is None:
-            raise ValueError("The groups parameter should not be None")
+            raise ValueError("The 'groups' parameter should not be None")
         groups = check_array(groups, ensure_2d=False, dtype=None)
         return len(np.unique(groups))
 
@@ -925,7 +925,7 @@ class LeavePGroupsOut(BaseCrossValidator):
             Returns the number of splitting iterations in the cross-validator.
         """
         if groups is None:
-            raise ValueError("The groups parameter should not be None")
+            raise ValueError("The 'groups' parameter should not be None")
         groups = check_array(groups, ensure_2d=False, dtype=None)
         return int(comb(len(np.unique(groups)), self.n_groups, exact=True))
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -811,8 +811,8 @@ class LeaveOneGroupOut(BaseCrossValidator):
 
         groups : array-like, with shape (n_samples,), optional
             Group labels for the samples used while splitting the dataset into
-            train/test set.   This 'group' parameter must always be specified 
-            to calculate the number of splits, though the other parameters can 
+            train/test set.   This 'group' parameter must always be specified
+            to calculate the number of splits, though the other parameters can
             be omitted.
 
         Returns
@@ -915,7 +915,7 @@ class LeavePGroupsOut(BaseCrossValidator):
 
         groups : array-like, with shape (n_samples,), optional
             Group labels for the samples used while splitting the dataset into
-            train/test set. This 'group' parameter must always be specified to 
+            train/test set. This 'group' parameter must always be specified to
             calculate the number of splits, though the other parameters can be
             omitted.
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -811,9 +811,9 @@ class LeaveOneGroupOut(BaseCrossValidator):
 
         groups : array-like, with shape (n_samples,), optional
             Group labels for the samples used while splitting the dataset into
-            train/test set.   This 'group' parameter must always be specified
-            to calculate the number of splits, though the other parameters can
-            be omitted.
+            train/test set. This 'groups' parameter must always be specified to
+            calculate the number of splits, though the other parameters can be
+            omitted.
 
         Returns
         -------
@@ -915,7 +915,7 @@ class LeavePGroupsOut(BaseCrossValidator):
 
         groups : array-like, with shape (n_samples,), optional
             Group labels for the samples used while splitting the dataset into
-            train/test set. This 'group' parameter must always be specified to
+            train/test set. This 'groups' parameter must always be specified to
             calculate the number of splits, though the other parameters can be
             omitted.
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -188,7 +188,7 @@ class LeaveOneOut(BaseCrossValidator):
             Returns the number of splitting iterations in the cross-validator.
         """
         if X is None:
-            raise ValueError("The 'X' parameter should not be None")
+            raise ValueError("The 'X' parameter should not be None.")
         return _num_samples(X)
 
 
@@ -259,7 +259,7 @@ class LeavePOut(BaseCrossValidator):
             Always ignored, exists for compatibility.
         """
         if X is None:
-            raise ValueError("The 'X' parameter should not be None")
+            raise ValueError("The 'X' parameter should not be None.")
         return int(comb(_num_samples(X), self.p, exact=True))
 
 
@@ -477,7 +477,7 @@ class GroupKFold(_BaseKFold):
 
     def _iter_test_indices(self, X, y, groups):
         if groups is None:
-            raise ValueError("The 'groups' parameter should not be None")
+            raise ValueError("The 'groups' parameter should not be None.")
         groups = check_array(groups, ensure_2d=False, dtype=None)
 
         unique_groups, groups = np.unique(groups, return_inverse=True)
@@ -787,7 +787,7 @@ class LeaveOneGroupOut(BaseCrossValidator):
 
     def _iter_test_masks(self, X, y, groups):
         if groups is None:
-            raise ValueError("The 'groups' parameter should not be None")
+            raise ValueError("The 'groups' parameter should not be None.")
         # We make a copy of groups to avoid side-effects during iteration
         groups = check_array(groups, copy=True, ensure_2d=False, dtype=None)
         unique_groups = np.unique(groups)
@@ -821,7 +821,7 @@ class LeaveOneGroupOut(BaseCrossValidator):
             Returns the number of splitting iterations in the cross-validator.
         """
         if groups is None:
-            raise ValueError("The 'groups' parameter should not be None")
+            raise ValueError("The 'groups' parameter should not be None.")
         groups = check_array(groups, ensure_2d=False, dtype=None)
         return len(np.unique(groups))
 
@@ -886,7 +886,7 @@ class LeavePGroupsOut(BaseCrossValidator):
 
     def _iter_test_masks(self, X, y, groups):
         if groups is None:
-            raise ValueError("The 'groups' parameter should not be None")
+            raise ValueError("The 'groups' parameter should not be None.")
         groups = check_array(groups, copy=True, ensure_2d=False, dtype=None)
         unique_groups = np.unique(groups)
         if self.n_groups >= len(unique_groups):
@@ -925,7 +925,7 @@ class LeavePGroupsOut(BaseCrossValidator):
             Returns the number of splitting iterations in the cross-validator.
         """
         if groups is None:
-            raise ValueError("The 'groups' parameter should not be None")
+            raise ValueError("The 'groups' parameter should not be None.")
         groups = check_array(groups, ensure_2d=False, dtype=None)
         return int(comb(len(np.unique(groups)), self.n_groups, exact=True))
 
@@ -1297,7 +1297,7 @@ class GroupShuffleSplit(ShuffleSplit):
 
     def _iter_indices(self, X, y, groups):
         if groups is None:
-            raise ValueError("The 'groups' parameter should not be None")
+            raise ValueError("The 'groups' parameter should not be None.")
         groups = check_array(groups, ensure_2d=False, dtype=None)
         classes, group_indices = np.unique(groups, return_inverse=True)
         for group_train, group_test in super(

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -765,7 +765,7 @@ class LeaveOneGroupOut(BaseCrossValidator):
     >>> logo = LeaveOneGroupOut()
     >>> logo.get_n_splits(X, y, groups)
     2
-    >>> logo.get_n_splits(None, None, groups) # X, y are always ignored.
+    >>> logo.get_n_splits(groups=groups) # 'groups' is always required
     2
     >>> print(logo)
     LeaveOneGroupOut()
@@ -857,7 +857,7 @@ class LeavePGroupsOut(BaseCrossValidator):
     >>> lpgo = LeavePGroupsOut(n_groups=2)
     >>> lpgo.get_n_splits(X, y, groups)
     3
-    >>> lpgo.get_n_splits(None, None, groups) # X, y are always ignored.
+    >>> lpgo.get_n_splits(groups=groups)  # 'groups' is always required
     3
     >>> print(lpgo)
     LeavePGroupsOut(n_groups=2)

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -765,6 +765,8 @@ class LeaveOneGroupOut(BaseCrossValidator):
     >>> logo = LeaveOneGroupOut()
     >>> logo.get_n_splits(X, y, groups)
     2
+    >>> logo.get_n_splits(None, None, groups) # X, y are always ignored.
+    2
     >>> print(logo)
     LeaveOneGroupOut()
     >>> for train_index, test_index in logo.split(X, y, groups):
@@ -852,6 +854,8 @@ class LeavePGroupsOut(BaseCrossValidator):
     >>> groups = np.array([1, 2, 3])
     >>> lpgo = LeavePGroupsOut(n_groups=2)
     >>> lpgo.get_n_splits(X, y, groups)
+    3
+    >>> lpgo.get_n_splits(None, None, groups) # X, y are always ignored.
     3
     >>> print(lpgo)
     LeavePGroupsOut(n_groups=2)

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -818,6 +818,7 @@ class LeaveOneGroupOut(BaseCrossValidator):
         """
         if groups is None:
             raise ValueError("The groups parameter should not be None")
+        groups = check_array(groups, ensure_2d=False, dtype=None)
         return len(np.unique(groups))
 
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -798,20 +798,22 @@ class LeaveOneGroupOut(BaseCrossValidator):
         for i in unique_groups:
             yield groups == i
 
-    def get_n_splits(self, X, y, groups):
+    def get_n_splits(self, X=None, y=None, groups=None):
         """Returns the number of splitting iterations in the cross-validator
 
         Parameters
         ----------
-        X : object
+        X : object, optional
             Always ignored, exists for compatibility.
 
-        y : object
+        y : object, optional
             Always ignored, exists for compatibility.
 
         groups : array-like, with shape (n_samples,), optional
             Group labels for the samples used while splitting the dataset into
-            train/test set.
+            train/test set.   This 'group' parameter must always be specified 
+            to calculate the number of splits, though the other parameters can 
+            be omitted.
 
         Returns
         -------
@@ -900,20 +902,22 @@ class LeavePGroupsOut(BaseCrossValidator):
                 test_index[groups == l] = True
             yield test_index
 
-    def get_n_splits(self, X, y, groups):
+    def get_n_splits(self, X=None, y=None, groups=None):
         """Returns the number of splitting iterations in the cross-validator
 
         Parameters
         ----------
-        X : object
+        X : object, optional
             Always ignored, exists for compatibility.
 
-        y : object
+        y : object, optional
             Always ignored, exists for compatibility.
 
         groups : array-like, with shape (n_samples,), optional
             Group labels for the samples used while splitting the dataset into
-            train/test set.
+            train/test set. This 'group' parameter must always be specified to 
+            calculate the number of splits, though the other parameters can be
+            omitted.
 
         Returns
         -------

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -317,7 +317,7 @@ def test_grid_search_groups():
     for cv in group_cvs:
         gs = GridSearchCV(clf, grid, cv=cv)
         assert_raise_message(ValueError,
-                             "The groups parameter should not be None",
+                             "The 'groups' parameter should not be None",
                              gs.fit, X, y)
         gs.fit(X, y, groups=groups)
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -317,7 +317,7 @@ def test_grid_search_groups():
     for cv in group_cvs:
         gs = GridSearchCV(clf, grid, cv=cv)
         assert_raise_message(ValueError,
-                             "The 'groups' parameter should not be None",
+                             "The 'groups' parameter should not be None.",
                              gs.fit, X, y)
         gs.fit(X, y, groups=groups)
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -317,7 +317,7 @@ def test_grid_search_groups():
     for cv in group_cvs:
         gs = GridSearchCV(clf, grid, cv=cv)
         assert_raise_message(ValueError,
-                             "The 'groups' parameter should not be None",
+                             "The groups parameter should not be None",
                              gs.fit, X, y)
         gs.fit(X, y, groups=groups)
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -769,7 +769,7 @@ def test_leave_one_p_group_out():
     with assert_raises(ValueError):
         lpgo_2.get_n_splits(None, None, [0.0, np.inf, 0.0])
 
-    msg = "The groups parameter should not be None"
+    msg = "The 'groups' parameter should not be None"
     assert_raise_message(ValueError, msg,
                          logo.get_n_splits, None, None, None)
     assert_raise_message(ValueError, msg,

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -189,6 +189,13 @@ def test_cross_validator_with_default_params():
         # Test if the repr works without any errors
         assert_equal(cv_repr, repr(cv))
 
+    # ValueError for get_n_splits methods
+    msg = "The 'X' parameter should not be None."
+    assert_raise_message(ValueError, msg,
+                         loo.get_n_splits, None, y, groups)
+    assert_raise_message(ValueError, msg,
+                         lpo.get_n_splits, None, y, groups)
+
 
 def check_valid_split(train, test, n_samples=None):
     # Use python sets to get more informative assertion failure messages

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -757,6 +757,24 @@ def test_leave_one_p_group_out():
                 # The number of groups in test must be equal to p_groups_out
                 assert_true(np.unique(groups_arr[test]).shape[0], p_groups_out)
 
+    # check get_n_splits() with dummy parameters
+    assert_equal(
+        logo.get_n_splits(None, None, groups=['a', 'b', 'c', 'b', 'c']),
+        3)
+    assert_equal(lpgo_2.get_n_splits(None, None, groups=np.arange(4)), 6)
+
+    # raise ValueError if a `groups` parameter is illegal
+    with assert_raises(ValueError):
+        logo.get_n_splits(None, None, [0.0, np.nan, 0.0])
+    with assert_raises(ValueError):
+        lpgo_2.get_n_splits(None, None, [0.0, np.inf, 0.0])
+
+    msg = "The groups parameter should not be None"
+    assert_raise_message(ValueError, msg,
+                         logo.get_n_splits, None, None, None)
+    assert_raise_message(ValueError, msg,
+                         lpgo_1.get_n_splits, None, None, None)
+
 
 def test_leave_group_out_changing_groups():
     # Check that LeaveOneGroupOut and LeavePGroupsOut work normally if

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -769,7 +769,7 @@ def test_leave_one_p_group_out():
     with assert_raises(ValueError):
         lpgo_2.get_n_splits(None, None, [0.0, np.inf, 0.0])
 
-    msg = "The 'groups' parameter should not be None"
+    msg = "The 'groups' parameter should not be None."
     assert_raise_message(ValueError, msg,
                          logo.get_n_splits, None, None, None)
     assert_raise_message(ValueError, msg,

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -758,10 +758,10 @@ def test_leave_one_p_group_out():
                 assert_true(np.unique(groups_arr[test]).shape[0], p_groups_out)
 
     # check get_n_splits() with dummy parameters
-    assert_equal(
-        logo.get_n_splits(None, None, groups=['a', 'b', 'c', 'b', 'c']),
-        3)
-    assert_equal(lpgo_2.get_n_splits(None, None, groups=np.arange(4)), 6)
+    assert_equal(logo.get_n_splits(None, None, ['a', 'b', 'c', 'b', 'c']), 3)
+    assert_equal(logo.get_n_splits(groups=[1.0, 1.1, 1.0, 1.2]), 3)
+    assert_equal(lpgo_2.get_n_splits(None, None, np.arange(4)), 6)
+    assert_equal(lpgo_1.get_n_splits(groups=np.arange(4)), 4)
 
     # raise ValueError if a `groups` parameter is illegal
     with assert_raises(ValueError):

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -259,10 +259,10 @@ def test_cross_val_score_predict_groups():
                  GroupShuffleSplit()]
     for cv in group_cvs:
         assert_raise_message(ValueError,
-                             "The 'groups' parameter should not be None",
+                             "The 'groups' parameter should not be None.",
                              cross_val_score, estimator=clf, X=X, y=y, cv=cv)
         assert_raise_message(ValueError,
-                             "The 'groups' parameter should not be None",
+                             "The 'groups' parameter should not be None.",
                              cross_val_predict, estimator=clf, X=X, y=y, cv=cv)
 
 

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -259,10 +259,10 @@ def test_cross_val_score_predict_groups():
                  GroupShuffleSplit()]
     for cv in group_cvs:
         assert_raise_message(ValueError,
-                             "The groups parameter should not be None",
+                             "The 'groups' parameter should not be None",
                              cross_val_score, estimator=clf, X=X, y=y, cv=cv)
         assert_raise_message(ValueError,
-                             "The groups parameter should not be None",
+                             "The 'groups' parameter should not be None",
                              cross_val_predict, estimator=clf, X=X, y=y, cv=cv)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

The number of splits depends only on the `groups` in `model_selection.LeaveOneGroupOut` or `model_selection.LeavePGroupsOut` .

However, due to needless parameter checking, dummy arrays must created.  This is clearly redundant.

#### What does this implement/fix? Explain your changes.

- remove needless parameter checking from `LeaveOneGroupOut`
- add parameter check for the argument `groups` to  `LeaveOneGroupOut` so as to be compatible with the `LeavePGroupsOut`.
- add examples with dummy parameters

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
