### PR TITLE
[MRG] Documenting char_wb padding functionality (Issue #8694)

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -159,8 +159,8 @@ class VectorizerMixin(object):
         """Whitespace sensitive char-n-gram tokenization.
 
         Tokenize text_document into a sequence of character n-grams
-        operating only inside word boundaries (padded with space on each
-        side)"""
+        operating only inside word boundaries. n-grams at the edges
+        of words are passed with space."""
         # normalize white spaces
         text_document = self._white_spaces.sub(" ", text_document)
 
@@ -355,7 +355,7 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
     analyzer : string, {'word', 'char', 'char_wb'} or callable
         Whether the feature should be made of word or character n-grams.
         Option 'char_wb' creates character n-grams only from text inside
-        word boundaries (padded with space on each side).
+        word boundaries; n-grams at the edges of words are passed with space.
 
         If a callable is passed it is used to extract the sequence of features
         out of the raw, unprocessed input.
@@ -554,7 +554,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
     analyzer : string, {'word', 'char', 'char_wb'} or callable
         Whether the feature should be made of word or character n-grams.
         Option 'char_wb' creates character n-grams only from text inside
-        word boundaries (padded with space on each side).
+        word boundaries; n-grams at the edges of words are passed with space.
 
         If a callable is passed it is used to extract the sequence of features
         out of the raw, unprocessed input.

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -160,7 +160,7 @@ class VectorizerMixin(object):
 
         Tokenize text_document into a sequence of character n-grams
         operating only inside word boundaries. n-grams at the edges
-        of words are passed with space."""
+        of words are padded with space."""
         # normalize white spaces
         text_document = self._white_spaces.sub(" ", text_document)
 
@@ -355,7 +355,7 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
     analyzer : string, {'word', 'char', 'char_wb'} or callable
         Whether the feature should be made of word or character n-grams.
         Option 'char_wb' creates character n-grams only from text inside
-        word boundaries; n-grams at the edges of words are passed with space.
+        word boundaries; n-grams at the edges of words are padded with space.
 
         If a callable is passed it is used to extract the sequence of features
         out of the raw, unprocessed input.
@@ -554,7 +554,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
     analyzer : string, {'word', 'char', 'char_wb'} or callable
         Whether the feature should be made of word or character n-grams.
         Option 'char_wb' creates character n-grams only from text inside
-        word boundaries; n-grams at the edges of words are passed with space.
+        word boundaries; n-grams at the edges of words are padded with space.
 
         If a callable is passed it is used to extract the sequence of features
         out of the raw, unprocessed input.

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -159,7 +159,8 @@ class VectorizerMixin(object):
         """Whitespace sensitive char-n-gram tokenization.
 
         Tokenize text_document into a sequence of character n-grams
-        excluding any whitespace (operating only inside word boundaries)"""
+        operating only inside word boundaries (padded with space on each
+        side)"""
         # normalize white spaces
         text_document = self._white_spaces.sub(" ", text_document)
 
@@ -354,7 +355,7 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
     analyzer : string, {'word', 'char', 'char_wb'} or callable
         Whether the feature should be made of word or character n-grams.
         Option 'char_wb' creates character n-grams only from text inside
-        word boundaries.
+        word boundaries (padded with space on each side).
 
         If a callable is passed it is used to extract the sequence of features
         out of the raw, unprocessed input.
@@ -553,7 +554,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
     analyzer : string, {'word', 'char', 'char_wb'} or callable
         Whether the feature should be made of word or character n-grams.
         Option 'char_wb' creates character n-grams only from text inside
-        word boundaries.
+        word boundaries (padded with space on each side).
 
         If a callable is passed it is used to extract the sequence of features
         out of the raw, unprocessed input.


### PR DESCRIPTION
Fixes #8694 

#### What does this implement/fix? Explain your changes.

This fix addresses the documentation of `char_wb` as an option for the analyzer of `CountVectorizer` and `HashingVectorizer`. The function itself vectorizes n-grams respecting word-boundaries _after padding with spaces on either side of a word_. These spaces appear as part of the n-grams in the resulting embedding.  

While this is mentioned in the User Guide [here](http://scikit-learn.org/stable/modules/feature_extraction.html#limitations-of-the-bag-of-words-representation), this fix adds a similar mention to the relevant docstrings.

#### Any other comments?

Output from `make` after applying this fix was not significantly changed.  
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
