### PR TITLE
DOC update LatentDirichletAllocation `components_` description

### DIFF
--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -228,8 +228,11 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
     Attributes
     ----------
     components_ : array, [n_topics, n_features]
-        Topic word distribution. ``components_[i, j]`` represents word j in
-        topic `i`.
+        Variational parameters for topic word distribution. Since the complete
+        conditional for topic word distribution is a Dirichlet,
+        ``components_[i, j]`` can be viewed as pseudocount that represents the
+        number of times word `j` was assigned to topic `i`.
+        Normalized ``components_`` can be viewed as topic word distribution.
 
     n_batch_iter_ : int
         Number of iterations of the EM step.

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -232,7 +232,9 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         conditional for topic word distribution is a Dirichlet,
         ``components_[i, j]`` can be viewed as pseudocount that represents the
         number of times word `j` was assigned to topic `i`.
-        Normalized ``components_`` can be viewed as topic word distribution.
+        It can also be viewed as distribution over the words for each topic
+        after normalization:
+        ``model.components_ / model.components_.sum(axis=1)[:, np.newaxis]``.
 
     n_batch_iter_ : int
         Number of iterations of the EM step.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
#6353 

#### What does this implement/fix? Explain your changes.
Based on discussion in #6353, users are confused why `components_` in LatentDirichletAllocation is not normalized as current doc describes it as "Topic word distribution".

Therefore I add some explanation for this  and hope it is more clear now.

#### Any other comments?
We also discussed weather we should add a function to return normalized `components_` as "topic word distribution" in #6353. If we need it, I can add it in this PR too.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
