### PR TITLE
[MRG] Expose samples belonging to a subcluster of Birch hierarchical tree

### DIFF
--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -306,7 +306,7 @@ class _CFSubcluster(object):
         if self.samples_id_ is None or subcluster.samples_id_ is None:
             self.samples_id_ = None
         else:
-            self.samples_id_ += subcluster.samples_id_
+            self.samples_id_.extend(subcluster.samples_id_)
         self.linear_sum_ += subcluster.linear_sum_
         self.squared_sum_ += subcluster.squared_sum_
         self.centroid_ = self.linear_sum_ / self.n_samples_
@@ -330,8 +330,7 @@ class _CFSubcluster(object):
             if self.samples_id_ is None or nominee_cluster.samples_id_ is None:
                 self.samples_id_ = None
             else:
-                self.samples_id_ = self.samples_id_ \
-                                    + nominee_cluster.samples_id_
+                self.samples_id_.extend(nominee_cluster.samples_id_)
             return True
         return False
 
@@ -456,7 +455,8 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
     """
 
     def __init__(self, threshold=0.5, branching_factor=50, n_clusters=3,
-                 compute_labels=True, copy=True, compute_samples_indices=False):
+                 compute_labels=True, copy=True,
+                 compute_samples_indices=False):
         self.threshold = threshold
         self.branching_factor = branching_factor
         self.n_clusters = n_clusters

--- a/sklearn/cluster/tests/test_birch.py
+++ b/sklearn/cluster/tests/test_birch.py
@@ -158,3 +158,46 @@ def test_threshold():
     brc = Birch(threshold=5.0, n_clusters=None)
     brc.fit(X)
     check_threshold(brc, 5.)
+
+
+def test_birch_hierarchy():
+    X, y = make_blobs(random_state=42)
+    brc = Birch(n_clusters=None, branching_factor=5, compute_labels=False)
+    brc.fit(X)
+
+    # make sure that leave nodes contain all the samples
+    n_leaves = 1
+    sample_id = []
+    current_leaf = brc.dummy_leaf_.next_leaf_
+    while current_leaf:
+        subclusters = current_leaf.subclusters_
+        for sc in subclusters:
+            assert sc.n_samples_ == len(sc.samples_id_)
+            sample_id += sc.samples_id_
+        current_leaf = current_leaf.next_leaf_
+        n_leaves += 1
+    assert_array_equal(np.sort(sample_id), np.arange(X.shape[0]))
+
+    # Verify that the resulting hierarchical tree is deeper than 1 level
+    # (i.e. subclusters of the root node are nor tree leaves )
+    assert len(brc.root_.subclusters_) < n_leaves
+
+    # Make sure that subclusters of the root_ node contain all the samples
+    sample_id = []
+    for sc in brc.root_.subclusters_:
+        sample_id += sc.samples_id_
+        assert sc.n_samples_ == len(sc.samples_id_)
+    assert_array_equal(np.sort(sample_id), np.arange(X.shape[0]))
+
+    # Pick a sample at random and make sure that reported samples_id_
+    # matches with the subcluster the sample is closest to
+    document_id = 45
+    document_in_subcluster = []
+    distance_to_centroid = []
+    for sc in brc.root_.subclusters_:
+        centroid = X[sc.samples_id_, :].mean(axis=0)
+        distance_to_centroid.append(((X[[document_id]] - centroid)**2).sum())
+        document_in_subcluster.append(document_id in sc.samples_id_)
+
+    assert np.argmin(distance_to_centroid) == \
+        np.nonzero(document_in_subcluster)[0][0]

--- a/sklearn/cluster/tests/test_birch.py
+++ b/sklearn/cluster/tests/test_birch.py
@@ -209,12 +209,11 @@ def test_birch_hierarchy():
     for current_leaf in brc._get_leaves():
         subclusters = current_leaf.subclusters_
         for sc in subclusters:
-            labels2[sc.samples_id_] = cluster_id
+            labels2[list(sc.samples_id_)] = cluster_id
             cluster_id += 1
 
     assert np.unique(brc.labels_).shape == np.unique(labels2).shape
-    # It's not an exact match, this might suggest an issue
+    # The two methods yield approximately equal labels
     assert v_measure_score(brc.labels_, labels2) > 0.95
-    assert ((brc.labels_ == labels2).sum() / labels2.size) >= 0.95
 
     assert_raises(ValueError, brc.partial_fit, X)


### PR DESCRIPTION
Birch clustering constructs a hierarchical tree, using `_CFNode`, `_CFSubclusters` classes which expose attributes such as squared sum of samples, number of samples, centroid of samples etc. However, none of these allow to determine which samples are actually included in a given subcluster, which prevents exploring or doing additional computation on the constructed tree. 

This PR adds an additional attribute `sample_id_` to `_CFSubclusters` containing a list of row indices of the original `X` data array that belong to the current sub cluster.

#### Benchmarks 

This PR has a small performance and memory overhead  for the construction of the hierarchical tree (obtained after `Birch(n_clusters=None, compute_labels=False).fit(X)`. Since this phase is also faster than in the case when `compute_labels=True`  and  faster than the global clustering step that occurs when `n_clusters=<int>`, the overall performance impact is negligible. 

Here is an example of a benchmark,
```py
import numpy as np
from sklearn.cluster import Birch  # imported as Birch_PR for the code in this PR

np.random.seed(42)

X = np.random.randn(10000, 100)
```
before this PR we get,
```py
%timeit -n 5 Birch(n_clusters=None, compute_labels=False).fit(X)
%timeit -n 5 Birch(n_clusters=None, compute_labels=True).fit(X)
%timeit -n 5 Birch(n_clusters=100, compute_labels=True).fit(X)

1.07 s ± 5.93 ms per loop (mean ± std. dev. of 7 runs, 5 loops each)
1.74 s ± 3.09 ms per loop (mean ± std. dev. of 7 runs, 5 loops each)
8.96 s ± 16.8 ms per loop (mean ± std. dev. of 7 runs, 5 loops each)
```
after this PR we get,
```py
%timeit -n 5 Birch_PR(n_clusters=None, compute_labels=False).fit(X)
%timeit -n 5 Birch_PR(n_clusters=None, compute_labels=True).fit(X)
%timeit -n 5 Birch_PR(n_clusters=100, compute_labels=True).fit(X)
1.09 s ± 1.02 ms per loop (mean ± std. dev. of 7 runs, 5 loops each)
1.76 s ± 2.69 ms per loop (mean ± std. dev. of 7 runs, 5 loops each)
8.97 s ± 5.21 ms per loop (mean ± std. dev. of 7 runs, 5 loops each)
```
with mostly mostly the same run times.

cc. @MechCoder 