### PR TITLE
DOC List more utils in API ref

### DIFF
--- a/doc/developers/utilities.rst
+++ b/doc/developers/utilities.rst
@@ -68,6 +68,15 @@ For example::
     >>> random_state.rand(4)
     array([ 0.5488135 ,  0.71518937,  0.60276338,  0.54488318])
 
+When developing your own scikit-learn compatible estimator, the following
+helpers are available.
+
+- :func:`validation.check_is_fitted`: check that the estimator has been fitted
+  before calling ``transform``, ``predict``, or similar methods. This helper
+  allows to raise a standardized error message across estimator.
+
+- :func:`validation.has_fit_parameter`: check that a given parameter is
+  supported in the ``fit`` method of a given estimator.
 
 Efficient Linear Algebra & Array Operations
 ===========================================

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1353,11 +1353,28 @@ Low-level methods
    :toctree: generated/
    :template: function.rst
 
-   utils.check_random_state
-   utils.estimator_checks.check_estimator
-   utils.resample
-   utils.shuffle
 
+   utils.check_random_state
+   utils.class_weight.compute_class_weight
+   utils.class_weight.compute_sample_weight
+   utils.estimator_checks.check_estimator
+   utils.extmath.safe_sparse_dot
+   utils.resample
+   utils.safe_indexing
+   utils.shuffle
+   utils.sparsefuncs.mean_variance_axis
+   utils.sparsefuncs.incr_mean_variance_axis
+   utils.sparsefuncs.inplace_column_scale
+   utils.sparsefuncs.inplace_row_scale
+   utils.sparsefuncs.inplace_swap_row
+   utils.sparsefuncs.inplace_swap_column
+   utils.validation.check_X_y
+   utils.validation.check_array
+   utils.validation.check_consistent_length
+   utils.validation.check_is_fitted
+   utils.validation.check_random_state
+   utils.validation.check_symmetric
+   utils.validation.column_or_1d
 
 Recently deprecated
 ===================

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1353,8 +1353,13 @@ Low-level methods
    :toctree: generated/
    :template: function.rst
 
-
+   utils.assert_all_finite
+   utils.as_float_array
+   utils.check_X_y
+   utils.check_array
+   utils.check_consistent_length
    utils.check_random_state
+   utils.indexable
    utils.class_weight.compute_class_weight
    utils.class_weight.compute_sample_weight
    utils.estimator_checks.check_estimator
@@ -1368,13 +1373,10 @@ Low-level methods
    utils.sparsefuncs.inplace_row_scale
    utils.sparsefuncs.inplace_swap_row
    utils.sparsefuncs.inplace_swap_column
-   utils.validation.check_X_y
-   utils.validation.check_array
-   utils.validation.check_consistent_length
    utils.validation.check_is_fitted
-   utils.validation.check_random_state
    utils.validation.check_symmetric
    utils.validation.column_or_1d
+   utils.validation.has_fit_parameter
 
 Recently deprecated
 ===================

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -126,11 +126,15 @@ def safe_indexing(X, indices):
 
     Parameters
     ----------
-    X : array-like, sparse-matrix, list.
+    X : array-like, sparse-matrix, list, pandas.DataFrame, pandas.Series.
         Data from which to sample rows or items.
-
-    indices : array-like, list
+    indices : array-like of int
         Indices according to which X will be subsampled.
+
+    Returns
+    -------
+    subset
+        Subset of X on first axis
     """
     if hasattr(X, "iloc"):
         # Pandas Dataframes and Series

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -179,6 +179,19 @@ def safe_sparse_dot(a, b, dense_output=False):
 
     Uses BLAS GEMM as replacement for numpy.dot where possible
     to avoid unnecessary copies.
+
+    Parameters
+    ----------
+    a : array or sparse matrix
+    b : array or sparse matrix
+    dense_output : boolean, default False
+        When False, either a or b being sparse will yield sparse output.
+        When True, output will always be an array.
+
+    Returns
+    -------
+    dot_product : array or sparse matrix
+        sparse if a or b is sparse and dense_output=False.
     """
     if issparse(a) or issparse(b):
         ret = a * b
@@ -402,7 +415,6 @@ def logsumexp(arr, axis=0):
 
     Examples
     --------
-
     >>> import numpy as np
     >>> from sklearn.utils.extmath import logsumexp
     >>> a = np.arange(10)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -185,13 +185,13 @@ def safe_sparse_dot(a, b, dense_output=False):
     a : array or sparse matrix
     b : array or sparse matrix
     dense_output : boolean, default False
-        When False, either a or b being sparse will yield sparse output.
-        When True, output will always be an array.
+        When False, either ``a`` or ``b`` being sparse will yield sparse
+        output. When True, output will always be an array.
 
     Returns
     -------
     dot_product : array or sparse matrix
-        sparse if a or b is sparse and dense_output=False.
+        sparse if ``a`` or ``b`` is sparse and ``dense_output``=False.
     """
     if issparse(a) or issparse(b):
         ret = a * b

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -174,7 +174,16 @@ def check_classification_targets(y):
 
 
 def type_of_target(y):
-    """Determine the type of data indicated by target `y`
+    """Determine the type of data indicated by target ``y``
+
+    Note that this type is the most specific type that can be inferred.
+    For example:
+
+        * ``binary`` is more specific but compatible with ``multiclass``.
+        * ``multiclass`` of integers is more specific but compatible with
+          ``continuous``.
+        * ``multilabel-indicator`` is more specific but compatible with
+          ``multiclass-multioutput``.
 
     Parameters
     ----------
@@ -184,6 +193,7 @@ def type_of_target(y):
     -------
     target_type : string
         One of:
+
         * 'continuous': `y` is an array-like of floats that are not all
           integers, and is 1d or a column vector.
         * 'continuous-multioutput': `y` is a 2d array of floats that are

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -1,4 +1,3 @@
-
 # Author: Arnaud Joly, Joel Nothman, Hamzeh Alsalhi
 #
 # License: BSD 3 clause
@@ -172,9 +171,8 @@ def check_classification_targets(y):
         raise ValueError("Unknown label type: %r" % y_type)
 
 
-
 def type_of_target(y):
-    """Determine the type of data indicated by target ``y``
+    """Determine the type of data indicated by the target.
 
     Note that this type is the most specific type that can be inferred.
     For example:

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -677,6 +677,15 @@ def check_is_fitted(estimator, attributes, msg=None, all_or_any=all):
 
     all_or_any : callable, {all, any}, default all
         Specify whether all or any of the given attributes must exist.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    NotFittedError
+        If the attributes aren not found.
     """
     if msg is None:
         msg = ("This %(name)s instance is not fitted yet. Call 'fit' with "

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -592,17 +592,17 @@ def has_fit_parameter(estimator, parameter):
 
     Parameters
     ----------
-    estimator : object,
-        A scikit-learn estimator to introspect.
+    estimator : object
+        An estimator to inspect.
 
-    parameter: str,
+    parameter: str
         The searched parameter.
 
     Returns
     -------
-    is_parameter: bool,
-        Whether the parameter was found to be a member variable of the
-        estimator.
+    is_parameter: bool
+        Whether the parameter was found to be a a named parameter of the
+        estimator's fit method.
 
     Examples
     --------

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -43,12 +43,16 @@ def _assert_all_finite(X):
 def assert_all_finite(X):
     """Throw a ValueError if X contains NaN or infinity.
 
-    Input MUST be an np.ndarray instance or a scipy.sparse matrix."""
+    Parameters
+    ----------
+    X : np.ndarray, scipy.sparse
+        ``X`` MUST be an np.ndarray instance or a scipy.sparse matrix.
+    """
     _assert_all_finite(X.data if sp.issparse(X) else X)
 
 
 def as_float_array(X, copy=True, force_all_finite=True):
-    """Converts an array-like to an array of floats
+    """Converts an array-like to an array of floats.
 
     The new dtype will be np.float32 or np.float64, depending on the original
     type. The function can create a copy or modify the argument depending
@@ -585,6 +589,20 @@ def check_random_state(seed):
 
 def has_fit_parameter(estimator, parameter):
     """Checks whether the estimator's fit method supports the given parameter.
+
+    Parameters
+    ----------
+    estimator : object,
+        A scikit-learn estimator to introspect.
+
+    parameter: str,
+        The searched parameter.
+
+    Returns
+    -------
+    is_parameter: bool,
+        Whether the parameter was found to be a member variable of the
+        estimator.
 
     Examples
     --------

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -702,7 +702,7 @@ def check_is_fitted(estimator, attributes, msg=None, all_or_any=all):
     Raises
     ------
     NotFittedError
-        If the attributes aren not found.
+        If the attributes are not found.
     """
     if msg is None:
         msg = ("This %(name)s instance is not fitted yet. Call 'fit' with "

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -45,8 +45,7 @@ def assert_all_finite(X):
 
     Parameters
     ----------
-    X : np.ndarray, scipy.sparse
-        ``X`` MUST be an np.ndarray instance or a scipy.sparse matrix.
+    X : array or sparse matrix
     """
     _assert_all_finite(X.data if sp.issparse(X) else X)
 


### PR DESCRIPTION
We've been talking for a while about making the public status of our utils clearer.

This does not intend to fix the problem completely, but at least to generate API docs for some utilities that have decent docstrings and which are used around the place. There are certainly things missing, but I'd like to be able to refer to, at least, `check_array` and its ilk like they are public API.