### PR TITLE
[MRG+2] ENH add memory to make_pipeline

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -11,12 +11,10 @@ estimator, as a chain of transforms and estimators.
 
 from collections import defaultdict
 
-from abc import ABCMeta, abstractmethod
-
 import numpy as np
 from scipy import sparse
 
-from .base import clone, BaseEstimator, TransformerMixin
+from .base import clone, TransformerMixin
 from .externals.joblib import Parallel, delayed, Memory
 from .externals import six
 from .utils import tosequence
@@ -35,7 +33,7 @@ class Pipeline(_BaseComposition):
     Intermediate steps of the pipeline must be 'transforms', that is, they
     must implement fit and transform methods.
     The final estimator only needs to implement fit.
-    The transformers in the pipeline can be cached using ```memory`` argument.
+    The transformers in the pipeline can be cached using ``memory`` argument.
 
     The purpose of the pipeline is to assemble several steps that can be
     cross-validated together while setting different parameters.
@@ -527,12 +525,26 @@ def _name_estimators(estimators):
     return list(zip(names, estimators))
 
 
-def make_pipeline(*steps):
+def make_pipeline(*steps, **kwargs):
     """Construct a Pipeline from the given estimators.
 
     This is a shorthand for the Pipeline constructor; it does not require, and
     does not permit, naming the estimators. Instead, their names will be set
     to the lowercase of their types automatically.
+
+    Parameters
+    ----------
+    *steps : list of estimators,
+
+    memory : Instance of joblib.Memory or string, optional (default=None)
+        Used to cache the fitted transformers of the pipeline. By default,
+        no caching is performed. If a string is given, it is the path to
+        the caching directory. Enabling caching triggers a clone of
+        the transformers before fitting. Therefore, the transformer
+        instance given to the pipeline cannot be inspected
+        directly. Use the attribute ``named_steps`` or ``steps`` to
+        inspect estimators within the pipeline. Caching the
+        transformers is advantageous when fitting is time consuming.
 
     Examples
     --------
@@ -549,7 +561,8 @@ def make_pipeline(*steps):
     -------
     p : Pipeline
     """
-    return Pipeline(_name_estimators(steps))
+    memory = kwargs.pop('memory', None)
+    return Pipeline(_name_estimators(steps), memory=memory)
 
 
 def _fit_one_transformer(transformer, X, y):

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -562,6 +562,9 @@ def make_pipeline(*steps, **kwargs):
     p : Pipeline
     """
     memory = kwargs.pop('memory', None)
+    if kwargs:
+        raise TypeError('Unknown keyword arguments: "{}"'
+                        .format(list(kwargs.keys())[0]))
     return Pipeline(_name_estimators(steps), memory=memory)
 
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -637,6 +637,12 @@ def test_make_pipeline():
     assert_equal(pipe.steps[1][0], "transf-2")
     assert_equal(pipe.steps[2][0], "fitparamt")
 
+    assert_raise_message(
+        TypeError,
+        'Unknown keyword arguments: "random_parameter"',
+        make_pipeline, t1, t2, random_parameter='rnd'
+    )
+
 
 def test_feature_union_weights():
     # test feature union with transformer weights
@@ -920,4 +926,5 @@ def test_make_pipeline_memory():
     assert_true(pipeline.memory is memory)
     pipeline = make_pipeline(DummyTransf(), SVC())
     assert_true(pipeline.memory is None)
+
     shutil.rmtree(cachedir)

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -911,3 +911,13 @@ def test_pipeline_memory():
         assert_equal(ts, cached_pipe_2.named_steps['transf_2'].timestamp_)
     finally:
         shutil.rmtree(cachedir)
+
+
+def test_make_pipeline_memory():
+    cachedir = mkdtemp()
+    memory = Memory(cachedir=cachedir)
+    pipeline = make_pipeline(DummyTransf(), SVC(), memory=memory)
+    assert_true(pipeline.memory is memory)
+    pipeline = make_pipeline(DummyTransf(), SVC())
+    assert_true(pipeline.memory is None)
+    shutil.rmtree(cachedir)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
No issue

#### What does this implement/fix? Explain your changes.

- `make_pipeline` can now build `Pipeline` with cache memory;
- remove some unnecessary import due to #7674

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
