### PR TITLE
[MRG+2] LogisticRegression convert to float64 (newton-cg)

### DIFF
--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -646,7 +646,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
         else:
             # SAG multinomial solver needs LabelEncoder, not LabelBinarizer
             le = LabelEncoder()
-            Y_multi = le.fit_transform(y)
+            Y_multi = le.fit_transform(y).astype(X.dtype, copy=False)
 
         w0 = np.zeros((classes.size, n_features + int(fit_intercept)),
                       order='F', dtype=X.dtype)
@@ -720,7 +720,6 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
             except:
                 n_iter_i = info['funcalls'] - 1
         elif solver == 'newton-cg':
-            target = target.astype(X.dtype)
             args = (X, target, 1. / C, sample_weight)
             w0, n_iter_i = newton_cg(hess, func, grad, w0, args=args,
                                      maxiter=max_iter, tol=tol)

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -624,10 +624,10 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
     # For doing a ovr, we need to mask the labels first. for the
     # multinomial case this is not necessary.
     if multi_class == 'ovr':
-        w0 = np.zeros(n_features + int(fit_intercept))
+        w0 = np.zeros(n_features + int(fit_intercept), dtype=X.dtype)
         mask_classes = np.array([-1, 1])
         mask = (y == pos_class)
-        y_bin = np.ones(y.shape, dtype=np.float64)
+        y_bin = np.ones(y.shape, dtype=X.dtype)
         y_bin[~mask] = -1.
         # for compute_class_weight
 
@@ -1203,11 +1203,10 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
             raise ValueError("Tolerance for stopping criteria must be "
                              "positive; got (tol=%r)" % self.tol)
 
-        # setup the default dtype
-        _dtype = np.float64
-        if self.solver in ['newton-cg'] \
-                and isinstance(X, np.ndarray) and X.dtype in [np.float32]:
-            _dtype = np.float32
+        if self.solver in ['newton-cg']:
+            _dtype = [np.float32, np.float64]
+        else:
+            _dtype = np.float64
 
         X, y = check_X_y(X, y, accept_sparse='csr', dtype=_dtype,
                          order="C")
@@ -1287,9 +1286,9 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         self.n_iter_ = np.asarray(n_iter_, dtype=np.int32)[:, 0]
 
         if self.multi_class == 'multinomial':
-            self.coef_ = fold_coefs_[0][0].astype(_dtype)
+            self.coef_ = fold_coefs_[0][0]
         else:
-            self.coef_ = np.asarray(fold_coefs_, dtype=_dtype)
+            self.coef_ = np.asarray(fold_coefs_)
             self.coef_ = self.coef_.reshape(n_classes, n_features +
                                             int(self.fit_intercept))
 

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1212,6 +1212,9 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
 
         X, y = check_X_y(X, y, accept_sparse='csr', dtype=_dtype,
                          order="C")
+        # Force X and y equal type, this should be moved somewhere else
+        if X.dtype != y.dtype and y.dtype not in ['<U3']:
+            y = y.astype(X.dtype)
         check_classification_targets(y)
         self.classes_ = np.unique(y)
         n_samples, n_features = X.shape

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1203,18 +1203,11 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
             raise ValueError("Tolerance for stopping criteria must be "
                              "positive; got (tol=%r)" % self.tol)
 
+        # setup the default dtype
         _dtype = np.float64
-        a = (self.solver in ['newton-cg'])
-        b = (isinstance(X, np.ndarray))
-        c = (X.dtype in [np.float32])
-        # if self.solver in ['newton-cg']
-        #                and isinstance(X, np.ndarray)
-        #                and X.dtype in [np.float32]:
-        if a and b and c :
+        if self.solver in ['newton-cg'] \
+                and isinstance(X, np.ndarray) and X.dtype in [np.float32]:
             _dtype = np.float32
-
-        # X, y = check_X_y(X, y, accept_sparse='csr', dtype=np.float64,
-        #                  order="C")
 
         X, y = check_X_y(X, y, accept_sparse='csr', dtype=_dtype,
                          order="C")
@@ -1293,10 +1286,11 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         fold_coefs_, _, n_iter_ = zip(*fold_coefs_)
         self.n_iter_ = np.asarray(n_iter_, dtype=np.int32)[:, 0]
 
+        # TODO: keep _dtype for the multinomial case
         if self.multi_class == 'multinomial':
             self.coef_ = fold_coefs_[0][0]
         else:
-            self.coef_ = np.asarray(fold_coefs_)
+            self.coef_ = np.asarray(fold_coefs_, dtype=_dtype)
             self.coef_ = self.coef_.reshape(n_classes, n_features +
                                             int(self.fit_intercept))
 

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -337,10 +337,12 @@ def _multinomial_loss_grad(w, X, Y, alpha, sample_weight):
     n_classes = Y.shape[1]
     n_features = X.shape[1]
     fit_intercept = (w.size == n_classes * (n_features + 1))
-    grad = np.zeros((n_classes, n_features + bool(fit_intercept)))
+    grad = np.zeros((n_classes, n_features + bool(fit_intercept)),
+                    dtype=X.dtype)
     loss, p, w = _multinomial_loss(w, X, Y, alpha, sample_weight)
     sample_weight = sample_weight[:, np.newaxis]
     diff = sample_weight * (p - Y)
+    diff = diff.astype(X.dtype)
     grad[:, :n_features] = safe_sparse_dot(diff.T, X)
     grad[:, :n_features] += alpha * w
     if fit_intercept:
@@ -608,10 +610,10 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
     # and check length
     # Otherwise set them to 1 for all examples
     if sample_weight is not None:
-        sample_weight = np.array(sample_weight, dtype=np.float64, order='C')
+        sample_weight = np.array(sample_weight, dtype=X.dtype, order='C')
         check_consistent_length(y, sample_weight)
     else:
-        sample_weight = np.ones(X.shape[0])
+        sample_weight = np.ones(X.shape[0], dtype=X.dtype)
 
     # If class_weights is a dict (provided by the user), the weights
     # are assigned to the original labels. If it is "balanced", then
@@ -648,7 +650,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
             Y_multi = le.fit_transform(y)
 
         w0 = np.zeros((classes.size, n_features + int(fit_intercept)),
-                      order='F')
+                      order='F', dtype=X.dtype)
 
     if coef is not None:
         # it must work both giving the bias term and not

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1213,8 +1213,8 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         X, y = check_X_y(X, y, accept_sparse='csr', dtype=_dtype,
                          order="C")
         # Force X and y equal type, this should be moved somewhere else
-        if X.dtype != y.dtype and y.dtype not in ['<U3']:
-            y = y.astype(X.dtype)
+        # if X.dtype != y.dtype and y.dtype not in ['<U3']:
+        #     y = y.astype(X.dtype)
         check_classification_targets(y)
         self.classes_ = np.unique(y)
         n_samples, n_features = X.shape

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1287,7 +1287,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         self.n_iter_ = np.asarray(n_iter_, dtype=np.int32)[:, 0]
 
         if self.multi_class == 'multinomial':
-            self.coef_ = fold_coefs_[0][0].astype(np.float32)
+            self.coef_ = fold_coefs_[0][0].astype(_dtype)
         else:
             self.coef_ = np.asarray(fold_coefs_, dtype=_dtype)
             self.coef_ = self.coef_.reshape(n_classes, n_features +

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -342,7 +342,6 @@ def _multinomial_loss_grad(w, X, Y, alpha, sample_weight):
     loss, p, w = _multinomial_loss(w, X, Y, alpha, sample_weight)
     sample_weight = sample_weight[:, np.newaxis]
     diff = sample_weight * (p - Y)
-    diff = diff.astype(X.dtype, copy=False)
     grad[:, :n_features] = safe_sparse_dot(diff.T, X)
     grad[:, :n_features] += alpha * w
     if fit_intercept:
@@ -721,6 +720,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
             except:
                 n_iter_i = info['funcalls'] - 1
         elif solver == 'newton-cg':
+            target = target.astype(X.dtype)
             args = (X, target, 1. / C, sample_weight)
             w0, n_iter_i = newton_cg(hess, func, grad, w0, args=args,
                                      maxiter=max_iter, tol=tol)

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -342,7 +342,7 @@ def _multinomial_loss_grad(w, X, Y, alpha, sample_weight):
     loss, p, w = _multinomial_loss(w, X, Y, alpha, sample_weight)
     sample_weight = sample_weight[:, np.newaxis]
     diff = sample_weight * (p - Y)
-    diff = diff.astype(X.dtype)
+    diff = diff.astype(X.dtype, copy=False)
     grad[:, :n_features] = safe_sparse_dot(diff.T, X)
     grad[:, :n_features] += alpha * w
     if fit_intercept:

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1212,9 +1212,6 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
 
         X, y = check_X_y(X, y, accept_sparse='csr', dtype=_dtype,
                          order="C")
-        # Force X and y equal type, this should be moved somewhere else
-        # if X.dtype != y.dtype and y.dtype not in ['<U3']:
-        #     y = y.astype(X.dtype)
         check_classification_targets(y)
         self.classes_ = np.unique(y)
         n_samples, n_features = X.shape

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1203,7 +1203,20 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
             raise ValueError("Tolerance for stopping criteria must be "
                              "positive; got (tol=%r)" % self.tol)
 
-        X, y = check_X_y(X, y, accept_sparse='csr', dtype=np.float64,
+        _dtype = np.float64
+        a = (self.solver in ['newton-cg'])
+        b = (isinstance(X, np.ndarray))
+        c = (X.dtype in [np.float32])
+        # if self.solver in ['newton-cg']
+        #                and isinstance(X, np.ndarray)
+        #                and X.dtype in [np.float32]:
+        if a and b and c :
+            _dtype = np.float32
+
+        # X, y = check_X_y(X, y, accept_sparse='csr', dtype=np.float64,
+        #                  order="C")
+
+        X, y = check_X_y(X, y, accept_sparse='csr', dtype=_dtype,
                          order="C")
         check_classification_targets(y)
         self.classes_ = np.unique(y)

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1206,7 +1206,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
                              "positive; got (tol=%r)" % self.tol)
 
         if self.solver in ['newton-cg']:
-            _dtype = [np.float32, np.float64]
+            _dtype = [np.float64, np.float32]
         else:
             _dtype = np.float64
 

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1286,9 +1286,8 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         fold_coefs_, _, n_iter_ = zip(*fold_coefs_)
         self.n_iter_ = np.asarray(n_iter_, dtype=np.int32)[:, 0]
 
-        # TODO: keep _dtype for the multinomial case
         if self.multi_class == 'multinomial':
-            self.coef_ = fold_coefs_[0][0]
+            self.coef_ = fold_coefs_[0][0].astype(np.float32)
         else:
             self.coef_ = np.asarray(fold_coefs_, dtype=_dtype)
             self.coef_ = self.coef_.reshape(n_classes, n_features +

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1145,7 +1145,7 @@ def test_dtype_match():
     y_ = np.array(Y1).astype(np.float32)
 
     for solver in ['newton-cg']:
-        for multi_class in ['ovr']:
+        for multi_class in ['ovr', 'multinomial']:
 
             # Check type consistency
             lr_32 = LogisticRegression(solver=solver, multi_class=multi_class)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1136,3 +1136,14 @@ def test_saga_vs_liblinear():
                 liblinear.fit(X, y)
                 # Convergence for alpha=1e-3 is very slow
                 assert_array_almost_equal(saga.coef_, liblinear.coef_, 3)
+
+def test_dtype_match():
+    # Test that np.float32 input data is not cast to np.float64 when possible
+
+    X_ = np.array(X).astype(np.float32)
+    y_ = np.array(Y1).astype(np.float32)
+
+    for solver in ['newton-cg']:
+        lr = LogisticRegression(solver=solver)
+        lr.fit(X_, y_)
+        assert_equal(lr.coef_.dtype, X_.dtype)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1164,4 +1164,5 @@ def test_dtype_match():
             # Check accuracy consistency
             lr_64 = LogisticRegression(solver=solver, multi_class=multi_class)
             lr_64.fit(X_64, y_64)
+            assert_equal(lr_64.coef_.dtype, X_64.dtype)
             assert_almost_equal(lr_32.coef_, lr_64.coef_.astype(np.float32))

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1144,6 +1144,7 @@ def test_dtype_match():
     y_ = np.array(Y1).astype(np.float32)
 
     for solver in ['newton-cg']:
-        lr = LogisticRegression(solver=solver)
-        lr.fit(X_, y_)
-        assert_equal(lr.coef_.dtype, X_.dtype)
+        for multi_class in ['ovr', 'multinomial']:
+            lr = LogisticRegression(solver=solver, multi_class=multi_class)
+            lr.fit(X_, y_)
+            assert_equal(lr.coef_.dtype, X_.dtype)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1141,33 +1141,20 @@ def test_saga_vs_liblinear():
 def test_dtype_match():
     # Test that np.float32 input data is not cast to np.float64 when possible
 
-    X_ = np.array(X).astype(np.float32)
-    y_ = np.array(Y1).astype(np.float32)
+    X_32 = np.array(X).astype(np.float32)
+    y_32 = np.array(Y1).astype(np.float32)
+    X_64 = np.array(X).astype(np.float64)
+    y_64 = np.array(Y1).astype(np.float64)
 
     for solver in ['newton-cg']:
         for multi_class in ['ovr', 'multinomial']:
 
             # Check type consistency
             lr_32 = LogisticRegression(solver=solver, multi_class=multi_class)
-            lr_32.fit(X_, y_)
-            assert_equal(lr_32.coef_.dtype, X_.dtype)
+            lr_32.fit(X_32, y_32)
+            assert_equal(lr_32.coef_.dtype, X_32.dtype)
 
             # Check accuracy consistency
             lr_64 = LogisticRegression(solver=solver, multi_class=multi_class)
-            lr_64.fit(X, Y1)
+            lr_64.fit(X_64, y_64)
             assert_almost_equal(lr_32.coef_, lr_64.coef_.astype(np.float32))
-
-
-def test_dtype_missmatch_to_profile():
-    # Test that np.float32 input data is not cast to np.float64 when possible
-
-    X_ = np.array(X).astype(np.float32)
-    y_ = np.array(Y1).astype(np.float32)
-
-    for solver in ['newton-cg']:
-        for multi_class in ['ovr', 'multinomial']:
-
-            # Check type consistency
-            lr_32 = LogisticRegression(solver=solver, multi_class=multi_class)
-            lr_32.fit(X_, y_)
-            assert_equal(lr_32.coef_.dtype, X_.dtype)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1156,3 +1156,18 @@ def test_dtype_match():
             lr_64 = LogisticRegression(solver=solver, multi_class=multi_class)
             lr_64.fit(X, Y1)
             assert_almost_equal(lr_32.coef_, lr_64.coef_.astype(np.float32))
+
+
+def test_dtype_missmatch_to_profile():
+    # Test that np.float32 input data is not cast to np.float64 when possible
+
+    X_ = np.array(X).astype(np.float32)
+    y_ = np.array(Y1).astype(np.float32)
+
+    for solver in ['newton-cg']:
+        for multi_class in ['ovr', 'multinomial']:
+
+            # Check type consistency
+            lr_32 = LogisticRegression(solver=solver, multi_class=multi_class)
+            lr_32.fit(X_, y_)
+            assert_equal(lr_32.coef_.dtype, X_.dtype)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1146,6 +1146,13 @@ def test_dtype_match():
 
     for solver in ['newton-cg']:
         for multi_class in ['ovr', 'multinomial']:
-            lr = LogisticRegression(solver=solver, multi_class=multi_class)
-            lr.fit(X_, y_)
-            assert_equal(lr.coef_.dtype, X_.dtype)
+
+            # Check type consistency
+            lr_32 = LogisticRegression(solver=solver, multi_class=multi_class)
+            lr_32.fit(X_, y_)
+            assert_equal(lr_32.coef_.dtype, X_.dtype)
+
+            # Check accuracy consistency
+            lr_64 = LogisticRegression(solver=solver, multi_class=multi_class)
+            lr_64.fit(X, Y1)
+            assert_almost_equal(lr_32.coef_, lr_64.coef_.astype(np.float32))

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1145,7 +1145,7 @@ def test_dtype_match():
     y_ = np.array(Y1).astype(np.float32)
 
     for solver in ['newton-cg']:
-        for multi_class in ['ovr', 'multinomial']:
+        for multi_class in ['ovr']:
 
             # Check type consistency
             lr_32 = LogisticRegression(solver=solver, multi_class=multi_class)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1137,6 +1137,7 @@ def test_saga_vs_liblinear():
                 # Convergence for alpha=1e-3 is very slow
                 assert_array_almost_equal(saga.coef_, liblinear.coef_, 3)
 
+
 def test_dtype_match():
     # Test that np.float32 input data is not cast to np.float64 when possible
 

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1145,6 +1145,7 @@ def test_dtype_match():
     y_32 = np.array(Y1).astype(np.float32)
     X_64 = np.array(X).astype(np.float64)
     y_64 = np.array(Y1).astype(np.float64)
+    X_sparse_32 = sp.csr_matrix(X, dtype=np.float32)
 
     for solver in ['newton-cg']:
         for multi_class in ['ovr', 'multinomial']:
@@ -1153,6 +1154,12 @@ def test_dtype_match():
             lr_32 = LogisticRegression(solver=solver, multi_class=multi_class)
             lr_32.fit(X_32, y_32)
             assert_equal(lr_32.coef_.dtype, X_32.dtype)
+
+            # check consistency with sparsity
+            lr_32_sparse = LogisticRegression(solver=solver,
+                                              multi_class=multi_class)
+            lr_32_sparse.fit(X_sparse_32, y_32)
+            assert_equal(lr_32_sparse.coef_.dtype, X_sparse_32.dtype)
 
             # Check accuracy consistency
             lr_64 = LogisticRegression(solver=solver, multi_class=multi_class)

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -46,7 +46,7 @@ def compute_class_weight(class_weight, classes, y):
                          "be in y")
     if class_weight is None or len(class_weight) == 0:
         # uniform class weights
-        weight = np.ones(classes.shape[0], dtype=y.dtype, order='C')
+        weight = np.ones(classes.shape[0], dtype=np.float64, order='C')
     elif class_weight == 'balanced':
         # Find the weight of each class as present in y.
         le = LabelEncoder()
@@ -55,11 +55,11 @@ def compute_class_weight(class_weight, classes, y):
             raise ValueError("classes should have valid labels that are in y")
 
         recip_freq = len(y) / (len(le.classes_) *
-                               bincount(y_ind).astype(y.dtype))
+                               bincount(y_ind).astype(np.float64))
         weight = recip_freq[le.transform(classes)]
     else:
         # user-defined dictionary
-        weight = np.ones(classes.shape[0], dtype=y.dtype, order='C')
+        weight = np.ones(classes.shape[0], dtype=np.float64, order='C')
         if not isinstance(class_weight, dict):
             raise ValueError("class_weight must be dict, 'balanced', or None,"
                              " got: %r" % class_weight)
@@ -176,6 +176,6 @@ def compute_sample_weight(class_weight, y, indices=None):
 
     expanded_class_weight = np.prod(expanded_class_weight,
                                     axis=0,
-                                    dtype=y.dtype)
+                                    dtype=np.float64)
 
     return expanded_class_weight

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -46,7 +46,7 @@ def compute_class_weight(class_weight, classes, y):
                          "be in y")
     if class_weight is None or len(class_weight) == 0:
         # uniform class weights
-        weight = np.ones(classes.shape[0], dtype=np.float64, order='C')
+        weight = np.ones(classes.shape[0], dtype=y.dtype, order='C')
     elif class_weight == 'balanced':
         # Find the weight of each class as present in y.
         le = LabelEncoder()
@@ -55,11 +55,11 @@ def compute_class_weight(class_weight, classes, y):
             raise ValueError("classes should have valid labels that are in y")
 
         recip_freq = len(y) / (len(le.classes_) *
-                               bincount(y_ind).astype(np.float64))
+                               bincount(y_ind).astype(y.dtype))
         weight = recip_freq[le.transform(classes)]
     else:
         # user-defined dictionary
-        weight = np.ones(classes.shape[0], dtype=np.float64, order='C')
+        weight = np.ones(classes.shape[0], dtype=y.dtype, order='C')
         if not isinstance(class_weight, dict):
             raise ValueError("class_weight must be dict, 'balanced', or None,"
                              " got: %r" % class_weight)
@@ -176,6 +176,6 @@ def compute_sample_weight(class_weight, y, indices=None):
 
     expanded_class_weight = np.prod(expanded_class_weight,
                                     axis=0,
-                                    dtype=np.float64)
+                                    dtype=y.dtype)
 
     return expanded_class_weight

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -41,14 +41,12 @@ def compute_class_weight(class_weight, classes, y):
     # Import error caused by circular imports.
     from ..preprocessing import LabelEncoder
 
-    _dtype = y.dtype
-
     if set(y) - set(classes):
         raise ValueError("classes should include all valid labels that can "
                          "be in y")
     if class_weight is None or len(class_weight) == 0:
         # uniform class weights
-        weight = np.ones(classes.shape[0], dtype=_dtype, order='C')
+        weight = np.ones(classes.shape[0], dtype=np.float64, order='C')
     elif class_weight == 'balanced':
         # Find the weight of each class as present in y.
         le = LabelEncoder()
@@ -57,11 +55,11 @@ def compute_class_weight(class_weight, classes, y):
             raise ValueError("classes should have valid labels that are in y")
 
         recip_freq = len(y) / (len(le.classes_) *
-                               bincount(y_ind).astype(_dtype))
+                               bincount(y_ind).astype(np.float64))
         weight = recip_freq[le.transform(classes)]
     else:
         # user-defined dictionary
-        weight = np.ones(classes.shape[0], dtype=_dtype, order='C')
+        weight = np.ones(classes.shape[0], dtype=np.float64, order='C')
         if not isinstance(class_weight, dict):
             raise ValueError("class_weight must be dict, 'balanced', or None,"
                              " got: %r" % class_weight)

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -41,10 +41,7 @@ def compute_class_weight(class_weight, classes, y):
     # Import error caused by circular imports.
     from ..preprocessing import LabelEncoder
 
-    if y.dtype == np.float32:
-        _dtype = np.float32
-    else:
-        _dtype = np.float64
+    _dtype = y.dtype
 
     if set(y) - set(classes):
         raise ValueError("classes should include all valid labels that can "

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -41,12 +41,17 @@ def compute_class_weight(class_weight, classes, y):
     # Import error caused by circular imports.
     from ..preprocessing import LabelEncoder
 
+    if y.dtype == np.float32:
+        _dtype = np.float32
+    else:
+        _dtype = np.float64
+
     if set(y) - set(classes):
         raise ValueError("classes should include all valid labels that can "
                          "be in y")
     if class_weight is None or len(class_weight) == 0:
         # uniform class weights
-        weight = np.ones(classes.shape[0], dtype=np.float64, order='C')
+        weight = np.ones(classes.shape[0], dtype=_dtype, order='C')
     elif class_weight == 'balanced':
         # Find the weight of each class as present in y.
         le = LabelEncoder()
@@ -55,11 +60,11 @@ def compute_class_weight(class_weight, classes, y):
             raise ValueError("classes should have valid labels that are in y")
 
         recip_freq = len(y) / (len(le.classes_) *
-                               bincount(y_ind).astype(np.float64))
+                               bincount(y_ind).astype(_dtype))
         weight = recip_freq[le.transform(classes)]
     else:
         # user-defined dictionary
-        weight = np.ones(classes.shape[0], dtype=np.float64, order='C')
+        weight = np.ones(classes.shape[0], dtype=_dtype, order='C')
         if not isinstance(class_weight, dict):
             raise ValueError("class_weight must be dict, 'balanced', or None,"
                              " got: %r" % class_weight)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Fixes #8769

#### What does this implement/fix? Explain your changes.
Avoids logistic regression to aggressively cast the data to `np.float64` when `np.float32` is supplied. 

#### Any other comments?
(only for the `newton-cg` case)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
