### PR TITLE
[MRG] Randomized Search Example: Fix min_samples_split values for RandomizedSearchCV and GridSearchCV

### DIFF
--- a/examples/model_selection/randomized_search.py
+++ b/examples/model_selection/randomized_search.py
@@ -54,7 +54,7 @@ def report(results, n_top=3):
 # specify parameters and distributions to sample from
 param_dist = {"max_depth": [3, None],
               "max_features": sp_randint(1, 11),
-              "min_samples_split": sp_randint(1.0, 11),
+              "min_samples_split": sp_randint(2, 11),
               "min_samples_leaf": sp_randint(1, 11),
               "bootstrap": [True, False],
               "criterion": ["gini", "entropy"]}
@@ -73,7 +73,7 @@ report(random_search.cv_results_)
 # use a full grid over all parameters
 param_grid = {"max_depth": [3, None],
               "max_features": [1, 3, 10],
-              "min_samples_split": [1.0, 3, 10],
+              "min_samples_split": [2, 3, 10],
               "min_samples_leaf": [1, 3, 10],
               "bootstrap": [True, False],
               "criterion": ["gini", "entropy"]}

--- a/examples/model_selection/randomized_search.py
+++ b/examples/model_selection/randomized_search.py
@@ -54,7 +54,7 @@ def report(results, n_top=3):
 # specify parameters and distributions to sample from
 param_dist = {"max_depth": [3, None],
               "max_features": sp_randint(1, 11),
-              "min_samples_split": sp_randint(1, 11),
+              "min_samples_split": sp_randint(1.0, 11),
               "min_samples_leaf": sp_randint(1, 11),
               "bootstrap": [True, False],
               "criterion": ["gini", "entropy"]}
@@ -73,7 +73,7 @@ report(random_search.cv_results_)
 # use a full grid over all parameters
 param_grid = {"max_depth": [3, None],
               "max_features": [1, 3, 10],
-              "min_samples_split": [1, 3, 10],
+              "min_samples_split": [1.0, 3, 10],
               "min_samples_leaf": [1, 3, 10],
               "bootstrap": [True, False],
               "criterion": ["gini", "entropy"]}


### PR DESCRIPTION
Fixes `min_samples_split` values for RandomizedSearchCV and GridSearchCV in the example used in documentation.

#### Reference Issue
None


#### What does this implement/fix? Explain your changes.

Fixes `ValueError: min_samples_split must be at least 2 or in (0, 1], got 1` error in [examples/model_selection/randomized_search.py](https://github.com/scikit-learn/scikit-learn/blob/master/examples/model_selection/randomized_search.py)

#### Any other comments?
None
