### PR TITLE
[MRG] Always download latest Miniconda for Travis jobs

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -34,13 +34,9 @@ if [[ "$DISTRIB" == "conda" ]]; then
     cd
     mkdir -p download
     cd download
-    echo "Cached in $HOME/download :"
-    ls -l
     echo
-    if [[ ! -f miniconda.sh ]]; then
-        wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-            -O miniconda.sh
-    fi
+    wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+        -O miniconda.sh
     chmod +x miniconda.sh && ./miniconda.sh -b -p /home/travis/miniconda
     cd ..
     export PATH=/home/travis/miniconda/bin:$PATH

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -37,7 +37,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
     echo "Cached in $HOME/download :"
     ls -l
     echo
-    wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
         -O miniconda.sh
     chmod +x miniconda.sh && ./miniconda.sh -b -p /home/travis/miniconda
     cd ..

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -34,6 +34,8 @@ if [[ "$DISTRIB" == "conda" ]]; then
     cd
     mkdir -p download
     cd download
+    echo "Cached in $HOME/download :"
+    ls -l
     echo
     wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
         -O miniconda.sh

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -37,12 +37,11 @@ if [[ "$DISTRIB" == "conda" ]]; then
     echo "Cached in $HOME/download :"
     ls -l
     echo
-    if [[ ! -f miniconda.sh ]]
-        then
-        wget http://repo.continuum.io/miniconda/Miniconda-3.6.0-Linux-x86_64.sh \
+    if [[ ! -f miniconda.sh ]]; then
+        wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
             -O miniconda.sh
-        fi
-    chmod +x miniconda.sh && ./miniconda.sh -b
+    fi
+    chmod +x miniconda.sh && ./miniconda.sh -b -p /home/travis/miniconda
     cd ..
     export PATH=/home/travis/miniconda/bin:$PATH
     conda update --yes conda


### PR DESCRIPTION
Ref: https://github.com/scikit-learn/scikit-learn/pull/8855#issuecomment-300705621

Travis builds using `conda` have been downloading a version of Miniconda from 2014 before running `conda update conda`. This change makes sure that it instead downloads the Miniconda version corresponding to the latest Anaconda release and overwrites any cached `miniconda.sh`.

ping @lesteve