### PR TITLE
[MRG] Update URL for species distribution dataset

### DIFF
--- a/examples/applications/plot_species_distribution_modeling.py
+++ b/examples/applications/plot_species_distribution_modeling.py
@@ -31,7 +31,7 @@ References
 ----------
 
  * `"Maximum entropy modeling of species geographic distributions"
-   <http://www.cs.princeton.edu/~schapire/papers/ecolmod.pdf>`_
+   <http://rob.schapire.net/papers/ecolmod.pdf>`_
    S. J. Phillips, R. P. Anderson, R. E. Schapire - Ecological Modelling,
    190:231-259, 2006.
 """

--- a/examples/neighbors/plot_species_kde.py
+++ b/examples/neighbors/plot_species_kde.py
@@ -31,7 +31,7 @@ References
 ----------
 
  * `"Maximum entropy modeling of species geographic distributions"
-   <http://www.cs.princeton.edu/~schapire/papers/ecolmod.pdf>`_
+   <http://rob.schapire.net/papers/ecolmod.pdf>`_
    S. J. Phillips, R. P. Anderson, R. E. Schapire - Ecological Modelling,
    190:231-259, 2006.
 """

--- a/sklearn/datasets/species_distributions.py
+++ b/sklearn/datasets/species_distributions.py
@@ -20,7 +20,7 @@ The two species are:
 References:
 
  * `"Maximum entropy modeling of species geographic distributions"
-   <http://www.cs.princeton.edu/~schapire/papers/ecolmod.pdf>`_
+   <http://rob.schapire.net/papers/ecolmod.pdf>`_
    S. J. Phillips, R. P. Anderson, R. E. Schapire - Ecological Modelling,
    190:231-259, 2006.
 
@@ -55,7 +55,7 @@ from ..utils import Bunch
 from sklearn.datasets.base import _pkl_filepath
 from sklearn.externals import joblib
 
-DIRECTORY_URL = "http://www.cs.princeton.edu/~schapire/maxent/datasets/"
+DIRECTORY_URL = "http://biodiversityinformatics.amnh.org/open_source/maxent/"
 
 SAMPLES_URL = DIRECTORY_URL + "samples.zip"
 COVERAGES_URL = DIRECTORY_URL + "coverages.zip"
@@ -195,7 +195,7 @@ def fetch_species_distributions(data_home=None,
     ----------
 
     * `"Maximum entropy modeling of species geographic distributions"
-      <http://www.cs.princeton.edu/~schapire/papers/ecolmod.pdf>`_
+      <http://rob.schapire.net/papers/ecolmod.pdf>`_
       S. J. Phillips, R. P. Anderson, R. E. Schapire - Ecological Modelling,
       190:231-259, 2006.
 


### PR DESCRIPTION
The species distribution dataset moved to a new host.

See http://www.cs.princeton.edu/~schapire/maxent/:
> This website has moved to the American Museum of Natural History.