### PR TITLE
[MRG+1] EHN/DOC Make error msg more informative in Pipeline

### DIFF
--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -609,7 +609,8 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
         "manhattan", "cosine", or 'precomputed'.
         If linkage is "ward", only "euclidean" is accepted.
 
-    memory : Instance of joblib.Memory or string (optional)
+    memory : Instance of sklearn.externals.joblib.Memory or string, optional \
+            (default=None)
         Used to cache the output of the computation of the tree.
         By default, no caching is done. If a string is given, it is the
         path to the caching directory.
@@ -690,8 +691,10 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
         elif isinstance(memory, six.string_types):
             memory = Memory(cachedir=memory, verbose=0)
         elif not isinstance(memory, Memory):
-            raise ValueError('`memory` has to be a `str` or a `joblib.Memory`'
-                             ' instance')
+            raise ValueError("'memory' should either be a string or"
+                             " a sklearn.externals.joblib.Memory"
+                             " instance, got 'memory={!r}' instead.".format(
+                                 type(memory)))
 
         if self.n_clusters <= 0:
             raise ValueError("n_clusters should be an integer greater than 0."
@@ -776,7 +779,8 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
         "manhattan", "cosine", or 'precomputed'.
         If linkage is "ward", only "euclidean" is accepted.
 
-    memory : Instance of joblib.Memory or string, optional
+    memory : Instance of sklearn.externals.joblib.Memory or string, optional \
+            (default=None)
         Used to cache the output of the computation of the tree.
         By default, no caching is done. If a string is given, it is the
         path to the caching directory.

--- a/sklearn/linear_model/randomized_l1.py
+++ b/sklearn/linear_model/randomized_l1.py
@@ -99,8 +99,15 @@ class BaseRandomizedLinearModel(six.with_metaclass(ABCMeta, BaseEstimator,
 
         estimator_func, params = self._make_estimator_and_params(X, y)
         memory = self.memory
-        if isinstance(memory, six.string_types):
-            memory = Memory(cachedir=memory)
+        if memory is None:
+            memory = Memory(cachedir=None, verbose=0)
+        elif isinstance(memory, six.string_types):
+            memory = Memory(cachedir=memory, verbose=0)
+        elif not isinstance(memory, Memory):
+            raise ValueError("'memory' should either be a string or"
+                             " a sklearn.externals.joblib.Memory"
+                             " instance, got 'memory={!r}' instead.".format(
+                                 type(memory)))
 
         scores_ = memory.cache(
             _resample_model, ignore=['verbose', 'n_jobs', 'pre_dispatch']
@@ -265,7 +272,8 @@ class RandomizedLasso(BaseRandomizedLinearModel):
             - A string, giving an expression as a function of n_jobs,
               as in '2*n_jobs'
 
-    memory : Instance of joblib.Memory or string
+    memory : Instance of sklearn.externals.joblib.Memory or string, optional \
+            (default=None)
         Used for internal caching. By default, no caching is done.
         If a string is given, it is the path to the caching directory.
 
@@ -456,7 +464,8 @@ class RandomizedLogisticRegression(BaseRandomizedLinearModel):
             - A string, giving an expression as a function of n_jobs,
               as in '2*n_jobs'
 
-    memory : Instance of joblib.Memory or string
+    memory : Instance of sklearn.externals.joblib.Memory or string, optional \
+            (default=None)
         Used for internal caching. By default, no caching is done.
         If a string is given, it is the path to the caching directory.
 
@@ -498,7 +507,7 @@ class RandomizedLogisticRegression(BaseRandomizedLinearModel):
                  normalize=True,
                  random_state=None,
                  n_jobs=1, pre_dispatch='3*n_jobs',
-                 memory=Memory(cachedir=None, verbose=0)):
+                 memory=None):
         self.C = C
         self.scaling = scaling
         self.sample_fraction = sample_fraction

--- a/sklearn/linear_model/randomized_l1.py
+++ b/sklearn/linear_model/randomized_l1.py
@@ -315,7 +315,7 @@ class RandomizedLasso(BaseRandomizedLinearModel):
                  max_iter=500,
                  eps=np.finfo(np.float).eps, random_state=None,
                  n_jobs=1, pre_dispatch='3*n_jobs',
-                 memory=Memory(cachedir=None, verbose=0)):
+                 memory=None):
         self.alpha = alpha
         self.scaling = scaling
         self.sample_fraction = sample_fraction

--- a/sklearn/linear_model/tests/test_randomized_l1.py
+++ b/sklearn/linear_model/tests/test_randomized_l1.py
@@ -1,5 +1,7 @@
 # Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
 # License: BSD 3 clause
+from tempfile import mkdtemp
+import shutil
 
 import numpy as np
 from scipy import sparse
@@ -57,6 +59,17 @@ def test_randomized_lasso():
     feature_scores = clf.fit(X, y).scores_
     assert_equal(clf.all_scores_.shape, (X.shape[1], 2))
     assert_array_equal(np.argsort(F)[-3:], np.argsort(feature_scores)[-3:])
+    # test caching
+    try:
+        tempdir = mkdtemp()
+        clf = RandomizedLasso(verbose=False, alpha=[1, 0.8], random_state=42,
+                              scaling=scaling,
+                              selection_threshold=selection_threshold)
+        feature_scores = clf.fit(X, y).scores_
+        assert_equal(clf.all_scores_.shape, (X.shape[1], 2))
+        assert_array_equal(np.argsort(F)[-3:], np.argsort(feature_scores)[-3:])
+    finally:
+        shutil.rmtree(tempdir)
 
     X_r = clf.transform(X)
     X_full = clf.inverse_transform(X_r)

--- a/sklearn/linear_model/tests/test_randomized_l1.py
+++ b/sklearn/linear_model/tests/test_randomized_l1.py
@@ -9,6 +9,7 @@ from scipy import sparse
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raises_regex
 
 from sklearn.linear_model.randomized_l1 import (lasso_stability_path,
                                                 RandomizedLasso,
@@ -40,6 +41,19 @@ def test_lasso_stability_path():
                        np.argsort(np.sum(scores_path, axis=1))[-3:])
 
 
+def test_randomized_lasso_error_memory():
+    scaling = 0.3
+    selection_threshold = 0.5
+    tempdir = 5
+    clf = RandomizedLasso(verbose=False, alpha=[1, 0.8], random_state=42,
+                          scaling=scaling,
+                          selection_threshold=selection_threshold,
+                          memory=tempdir)
+    assert_raises_regex(ValueError, "'memory' should either be a string or"
+                        " a sklearn.externals.joblib.Memory instance",
+                        clf.fit, X, y)
+
+
 def test_randomized_lasso():
     # Check randomized lasso
     scaling = 0.3
@@ -64,7 +78,8 @@ def test_randomized_lasso():
         tempdir = mkdtemp()
         clf = RandomizedLasso(verbose=False, alpha=[1, 0.8], random_state=42,
                               scaling=scaling,
-                              selection_threshold=selection_threshold)
+                              selection_threshold=selection_threshold,
+                              memory=tempdir)
         feature_scores = clf.fit(X, y).scores_
         assert_equal(clf.all_scores_.shape, (X.shape[1], 2))
         assert_array_equal(np.argsort(F)[-3:], np.argsort(feature_scores)[-3:])

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -52,7 +52,8 @@ class Pipeline(_BaseComposition):
         chained, in the order in which they are chained, with the last object
         an estimator.
 
-    memory : Instance of joblib.Memory or string, optional (default=None)
+    memory : Instance of sklearn.external.joblib.Memory or string, optional \
+            (default=None)
         Used to cache the fitted transformers of the pipeline. By default,
         no caching is performed. If a string is given, it is the path to
         the caching directory. Enabling caching triggers a clone of
@@ -193,8 +194,9 @@ class Pipeline(_BaseComposition):
             memory = Memory(cachedir=memory, verbose=0)
         elif not isinstance(memory, Memory):
             raise ValueError("'memory' should either be a string or"
-                             " a joblib.Memory instance, got"
-                             " 'memory={!r}' instead.".format(memory))
+                             " a sklearn.externals.joblib.Memory"
+                             " instance, got 'memory={!r}' instead.".format(
+                                 type(memory)))
 
         fit_transform_one_cached = memory.cache(_fit_transform_one)
 
@@ -536,7 +538,8 @@ def make_pipeline(*steps, **kwargs):
     ----------
     *steps : list of estimators,
 
-    memory : Instance of joblib.Memory or string, optional (default=None)
+    memory : Instance of sklearn.externals.joblib.Memory or string, optional \
+            (default=None)
         Used to cache the fitted transformers of the pipeline. By default,
         no caching is performed. If a string is given, it is the path to
         the caching directory. Enabling caching triggers a clone of

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -853,7 +853,8 @@ def test_pipeline_wrong_memory():
     cached_pipe = Pipeline([('transf', DummyTransf()), ('svc', SVC())],
                            memory=memory)
     assert_raises_regex(ValueError, "'memory' should either be a string or a"
-                        " joblib.Memory instance, got 'memory=1' instead.",
+                        " sklearn.externals.joblib.Memory instance, got"
+                        " 'memory=<class 'int'>' instead.",
                         cached_pipe.fit, X, y)
 
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -853,8 +853,7 @@ def test_pipeline_wrong_memory():
     cached_pipe = Pipeline([('transf', DummyTransf()), ('svc', SVC())],
                            memory=memory)
     assert_raises_regex(ValueError, "'memory' should either be a string or a"
-                        " sklearn.externals.joblib.Memory instance, got"
-                        " 'memory=<class 'int'>' instead.",
+                        " sklearn.externals.joblib.Memory instance, got",
                         cached_pipe.fit, X, y)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

None

#### What does this implement/fix? Explain your changes.

The message in `Pipeline` can be tricky to understand. If a `joblib.Memory` is passed instead of
`sklearn.externals.joblib.Memory`, the error message mention that we should provide a `joblib.Memory`, we got `memory=Memory(...)` instead.

This PR intends to:

- Make the error more explicit by printing the type of the object passed in the error message;
- Write explicitly in the documentation that `Memory` has to be from `sklearn.externals.joblib`

#### Any other comments?

Another solution is to make some ducktyping: we can remove the `isinstance` by checking that the object has a known `joblib.Memory` method. However, it might open the door to some bugs due to different versions of internal and external joblib.



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
