### PR TITLE
fixed confusing f1_score docs about multi-class

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -611,9 +611,6 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
 
         F1 = 2 * (precision * recall) / (precision + recall)
 
-    In the multi-class and multi-label case, this is the weighted average of
-    the F1 score of each class.
-
     Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
 
     Parameters


### PR DESCRIPTION
Updated documentation to reflect actual behaviour for f1_score multi-class

Fixes #8738 

removed comment "In the multi-class and multi-label case, this is the weighted average of the F1 score of each class." from the documentation. 

The rest of the documentation accurately reflects what f1_score does in the multi-class so I didn't feel the need to add anything. 

