### PR TITLE
[MRG+1] DOC: styling of deprecated boxes

### DIFF
--- a/doc/themes/scikit-learn/static/nature.css_t
+++ b/doc/themes/scikit-learn/static/nature.css_t
@@ -559,7 +559,7 @@ div.body p, div.body dd, div.body li {
     line-height: 1.5em;
 }
 
-div.admonition p.admonition-title + p {
+div.admonition p.admonition-title + p, div.deprecated p {
     display: inline;
 }
 
@@ -615,7 +615,7 @@ div.topic {
     -moz-border-radius: 4px;
 }
 
-div.admonition {
+div.admonition, div.deprecated {
     margin-bottom: 10px;
     margin-top: 10px;
     padding: 7px;


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

In the PR of @glemaitre (https://github.com/scikit-learn/scikit-learn/pull/8907), I noticed the deprecation boxes looked a bit wonky:

![screenshot from 2017-05-22 14-27-21](https://cloud.githubusercontent.com/assets/1020496/26308778/d33aecb0-3efa-11e7-8076-f7a2ca2f16fb.png)

Apparently, this is because those deprecated boxes are not "admonition"s in sphinx's css terminology, like "see also" or "warning" boxes are. So now gave them the same styling as those admonition boxes. 

![screenshot from 2017-05-22 15-53-08](https://cloud.githubusercontent.com/assets/1020496/26312084/c85eba2c-3f06-11e7-902c-b67a64b1bfd3.png)

(it's another warning as from the image from the PR, just pasted a random one in there for testing, but you get the idea)


