### PR TITLE
[MRG] Fix typo in PCA test

### DIFF
--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -574,8 +574,7 @@ def test_deprecation_randomized_pca():
     assert_array_almost_equal(Y, Y_pca)
 
 
-def test_pca_spase_input():
-
+def test_pca_sparse_input():
     X = np.random.RandomState(0).rand(5, 4)
     X = sp.sparse.csr_matrix(X)
     assert(sp.sparse.issparse(X))


### PR DESCRIPTION
Fix a typo of PCA test method and remove empty line.

