### PR TITLE
[MRG] DOC add plot_stock_market.py to expected failing examples

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -240,8 +240,9 @@ sphinx_gallery_conf = {
         'sklearn': None,
         'matplotlib': 'http://matplotlib.org',
         'numpy': 'http://docs.scipy.org/doc/numpy-1.6.0',
-        'scipy': 'http://docs.scipy.org/doc/scipy-0.11.0/reference',
-        'nibabel': 'http://nipy.org/nibabel'}
+        'scipy': 'http://docs.scipy.org/doc/scipy-0.11.0/reference'},
+    'expected_failing_examples': [
+        '../examples/applications/plot_stock_market.py']
 }
 
 


### PR DESCRIPTION
as a stop gap solution until we figure out a longer-term work-around for https://github.com/scikit-learn/scikit-learn/issues/8899.

Also remove nibabel from conf.py.

This is related to https://github.com/scikit-learn/scikit-learn/pull/8222 and should get the PRs green again on CircleCI.

I'll merge this one once CirceCI comes back green.