### PR TITLE
[MRG+1] BUILD Give clear error message when there are merge conflicts

### DIFF
--- a/build_tools/circle/checkout_merge_commit.sh
+++ b/build_tools/circle/checkout_merge_commit.sh
@@ -18,7 +18,10 @@ git fetch -u origin ${FETCH_REFS}
 # Checkout the PR merge ref.
 if [[ -n "${CIRCLE_PR_NUMBER}" ]]
 then
-    git checkout -qf "pr/${CIRCLE_PR_NUMBER}/merge"
+    git checkout -qf "pr/${CIRCLE_PR_NUMBER}/merge" || (
+        echo Could not fetch merge commit. >&2
+        echo There may be conflicts in merging PR \#${CIRCLE_PR_NUMBER} with master. >&2;
+        exit 1)
 fi
 
 # Check for merge conflicts.


### PR DESCRIPTION
I had a PR with merge conflicts. I did not realise. Circle CI output was:
```
fatal: Couldn't find remote ref refs/pull/8944/merge
error: pathspec 'pr/8944/merge' did not match any file(s) known to git.

./build_tools/circle/checkout_merge_commit.sh returned exit code 1
```

This PR should make that error clearer.