### PR TITLE
[MRG+1] DOC use a chart to explain linnerud dataset in load_linnerud

### DIFF
--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -588,11 +588,12 @@ def load_diabetes(return_X_y=False):
 def load_linnerud(return_X_y=False):
     """Load and return the linnerud dataset (multivariate regression).
 
-    Samples total: 20
-    Dimensionality: 3 for both data and targets
-    Features: integer
-    Targets: integer
-
+    ===============   ============================
+    Dimensionality    3(for both data and target)
+    Features          integer
+    Targets           integer
+    ===============   ============================
+	
     Parameters
     ----------
     return_X_y : boolean, default=False.

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -588,12 +588,12 @@ def load_diabetes(return_X_y=False):
 def load_linnerud(return_X_y=False):
     """Load and return the linnerud dataset (multivariate regression).
 
-    ===============   ============================
+    ==============    ============================
     Samples total     20
-    Dimensionality    3(for both data and target)
+    Dimensionality    3 (for both data and target)
     Features          integer
     Targets           integer
-    ===============   ============================
+    ==============    ============================
 
     Parameters
     ----------

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -589,6 +589,7 @@ def load_linnerud(return_X_y=False):
     """Load and return the linnerud dataset (multivariate regression).
 
     ===============   ============================
+    Samples total     20
     Dimensionality    3(for both data and target)
     Features          integer
     Targets           integer

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -594,7 +594,7 @@ def load_linnerud(return_X_y=False):
     Features          integer
     Targets           integer
     ===============   ============================
-	
+
     Parameters
     ----------
     return_X_y : boolean, default=False.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
`load_linnerud` use plain text to explain the dataset, while other similar functions(like `load_iris`) use a chart. So I convert the plain text to a chart.

#### Any other comments?
Please refer to https://10493-843222-gh.circle-artifacts.com/0/home/ubuntu/scikit-learn/doc/_build/html/stable/modules/generated/sklearn.datasets.load_linnerud.html
Before the modification:
![02](https://cloud.githubusercontent.com/assets/12003569/26663883/5ec7ad50-46c0-11e7-8e61-ae84824a7d35.jpg)

After the modification:
![01](https://cloud.githubusercontent.com/assets/12003569/26663850/287c566a-46c0-11e7-9e21-cb54d4c4c521.jpg)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
