### PR TITLE
[MRG] Fix LassoCV cross validation split() call

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1150,7 +1150,7 @@ class LinearModelCV(six.with_metaclass(ABCMeta, LinearModel)):
         cv = check_cv(self.cv)
 
         # Compute path for all folds and compute MSE to get the best alpha
-        folds = list(cv.split(X))
+        folds = list(cv.split(X, y))
         best_mse = np.inf
 
         # We do a double for loop folded in one, in order to be able to

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -175,6 +175,24 @@ def test_lasso_cv():
     assert_greater(clf.score(X_test, y_test), 0.99)
 
 
+def test_lasso_cv_with_some_model_selection():
+    from sklearn.pipeline import make_pipeline
+    from sklearn.preprocessing import StandardScaler
+    from sklearn.model_selection import KFold
+    from sklearn import datasets
+    from sklearn.linear_model import LassoCV
+
+    diabetes = datasets.load_diabetes()
+    X = diabetes.data
+    y = diabetes.target
+
+    pipe = make_pipeline(
+        StandardScaler(),
+        LassoCV(cv=KFold(n_splits=5))
+    )
+    pipe.fit(X, y)
+
+
 def test_lasso_cv_positive_constraint():
     X, y, X_test, y_test = build_dataset()
     max_iter = 500

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -178,7 +178,7 @@ def test_lasso_cv():
 def test_lasso_cv_with_some_model_selection():
     from sklearn.pipeline import make_pipeline
     from sklearn.preprocessing import StandardScaler
-    from sklearn.model_selection import KFold
+    from sklearn.model_selection import StratifiedKFold
     from sklearn import datasets
     from sklearn.linear_model import LassoCV
 
@@ -188,7 +188,7 @@ def test_lasso_cv_with_some_model_selection():
 
     pipe = make_pipeline(
         StandardScaler(),
-        LassoCV(cv=KFold(n_splits=5))
+        LassoCV(cv=StratifiedKFold(n_splits=5))
     )
     pipe.fit(X, y)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Fixes #1234 -->
Fixes https://github.com/scikit-learn/scikit-learn/issues/8426

#### What does this implement/fix? Explain your changes.

Added the missing `y` parameter that was causing the error `TypeError: split() missing 1 required positional argument: 'y'`, and its non-regression test.

#### Any other comments?

Will be positively influenced by issue https://github.com/scikit-learn/scikit-learn/issues/8971.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
