### PR TITLE
[MRG] DOC recommend editable install using pip in contributing

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -67,16 +67,20 @@ extension in place::
     python setup.py build_ext --inplace
 
 
-Another option is to use the ``develop`` option if you change your code a lot
-and do not want to have to reinstall every time. This basically builds the
-extension in place and creates a link to the development directory (see
-`the setuptool docs <http://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode>`_)::
+Another option is to install the package in editable mode if you change your
+code a lot and do not want to have to reinstall every time. This basically
+builds the extension in place and creates a link to the development directory
+(see `the pip docs <https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs>`_)::
 
-    python setup.py develop
+    pip install --editable .
 
 .. note::
 
-    if you decide to do that you have to rerun::
+    This is fundamentally similar to using the command ``python setup.py develop`` (see `the setuptool docs <http://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode>`_). It is however preferred to use pip.
+
+.. note::
+
+    If you decide to do an editable install you have to rerun::
 
         python setup.py build_ext --inplace
 


### PR DESCRIPTION
#### Reference Issue
None

#### What does this implement/fix? Explain your changes.
This recommends using `pip install --editable .` instead of `python setup.py develop` in the Contributing section of the documentation.

It also makes the documentation more consistent as `pip install --editable .` is the command given at the end of the Advanced installation instructions.

#### Any other comments?
I also made the following note about having to build the extension in place more explicit.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
