### PR TITLE
[MRG] fix for #8986 Add reference for Platt's paper in svm.rst

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -241,7 +241,11 @@ and use ``decision_function`` instead of ``predict_proba``.
    `"Probability estimates for multi-class classification by pairwise coupling"
    <http://www.csie.ntu.edu.tw/~cjlin/papers/svmprob/svmprob.pdf>`_,
    JMLR 5:975-1005, 2004.
-
+ 
+ 
+ * Platt
+   `"Probabilistic outputs for SVMs and comparisons to regularized likelihood methods"
+   <http://www.cs.colorado.edu/~mozer/Teaching/syllabi/6622/papers/Platt1999.pdf>`.
 
 Unbalanced problems
 --------------------


### PR DESCRIPTION
fix #8986 
Added reference for Paper by John C. Platt with title
"Probabilistic Outputs for Support Vector Machines and Comparisons to Regularized Likelihood Methods (1999)"
