### PR TITLE
[MRG + 1] MAINT disable codecov status failures on PR

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,22 @@
 comment: off
+
+coverage:
+  status:
+    project:
+      default:
+        # Commits pushed to master should not make the overall
+        # project coverage decrease by more than 1%:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        # Be tolerant on slight code coverage diff on PRs to limit
+        # noisy red coverage status on github PRs.
+        # Note The coverage stats are still uploaded
+        # to codecov so that PR reviewers can see uncovered lines
+        # in the github diff if they install the codecov browser
+        # extension:
+        # https://github.com/codecov/browser-extension
+        target: auto
+        threshold: 1%
+ 


### PR DESCRIPTION
Several reviewers complained that the way the change of coverage is computed in PRs cannot be understood and sometimes results in noisy "red" status badge on the PR.

The following should make codecov always output a green coverage status on PRs.

The coverage statistics are still uploaded to the codecov server so that PR reviewers can you the great browser extension to manually checks that all lines in the github diff are green (when doing the code rview):

https://github.com/codecov/browser-extension