### PR TITLE
[MRG+1] Removed warning from BaseSearchCV

### DIFF
--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -30,7 +30,6 @@ from .utils.random import sample_without_replacement
 from .utils.validation import _num_samples, indexable
 from .utils.metaestimators import if_delegate_has_method
 from .metrics.scorer import check_scoring
-from .exceptions import ChangedBehaviorWarning
 
 
 __all__ = ['GridSearchCV', 'ParameterGrid', 'fit_grid_point',
@@ -438,12 +437,6 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             raise ValueError("No score function explicitly defined, "
                              "and the estimator doesn't provide one %s"
                              % self.best_estimator_)
-        if self.scoring is not None and hasattr(self.best_estimator_, 'score'):
-            warnings.warn("The long-standing behavior to use the estimator's "
-                          "score function in {0}.score has changed. The "
-                          "scoring parameter is now used."
-                          "".format(self.__class__.__name__),
-                          ChangedBehaviorWarning)
         return self.scorer_(self.best_estimator_, X, y)
 
     @if_delegate_has_method(delegate=('best_estimator_', 'estimator'))

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -217,8 +217,7 @@ def test_grid_search_score_method():
                                               scoring='roc_auc').fit(X, y)
     search_auc = GridSearchCV(clf, grid, scoring='roc_auc').fit(X, y)
 
-    # Check warning only occurs in situation where behavior changed:
-    # estimator requires score method to compete with scoring parameter
+    # ChangedBehaviourWarning occurred previously (prior to #9005)
     score_no_scoring = assert_no_warnings(search_no_scoring.score, X, y)
     score_accuracy = assert_no_warnings(search_accuracy.score, X, y)
     score_no_score_auc = assert_no_warnings(search_no_score_method_auc.score,

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -220,12 +220,11 @@ def test_grid_search_score_method():
     # Check warning only occurs in situation where behavior changed:
     # estimator requires score method to compete with scoring parameter
     score_no_scoring = assert_no_warnings(search_no_scoring.score, X, y)
-    score_accuracy = assert_warns(ChangedBehaviorWarning,
-                                  search_accuracy.score, X, y)
+    score_accuracy = assert_no_warnings(search_accuracy.score, X, y)
     score_no_score_auc = assert_no_warnings(search_no_score_method_auc.score,
                                             X, y)
-    score_auc = assert_warns(ChangedBehaviorWarning,
-                             search_auc.score, X, y)
+    score_auc = assert_no_warnings(search_auc.score, X, y)
+
     # ensure the test is sane
     assert_true(score_auc < 1.0)
     assert_true(score_accuracy < 1.0)


### PR DESCRIPTION
Removed the `ChangedBehaviorWarning` from score method of `BaseSearchCV`. Fixes #8991.