### PR TITLE
[MRG] Use ccache on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
   apt: true
   directories:
   - $HOME/.cache/pip
+  - $HOME/.ccache
 
 dist: trusty
 

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -13,15 +13,15 @@
 
 set -e
 
-# Fix the compilers to workaround avoid having the Python 3.4 build
-# lookup for g++44 unexpectedly.
-export CC=gcc
-export CXX=g++
-
 echo 'List files from cached directories'
 echo 'pip:'
 ls $HOME/.cache/pip
 
+export CC=/usr/lib/ccache/gcc
+# Useful for debugging how ccache is used
+# export CCACHE_LOGFILE=/tmp/ccache.log
+# ~60M is used by .ccache when compiling from scratch at the time of writing
+export CCACHE_MAXSIZE=100M
 
 if [[ "$DISTRIB" == "conda" ]]; then
     # Deactivate the travis-provided virtual environment and setup a
@@ -99,8 +99,10 @@ try:
 except ImportError:
     pass
 "
-
     python setup.py develop
+    ccache --show-stats
+    # Useful for debugging how ccache is used
+    # cat $CCACHE_LOGFILE
 fi
 
 if [[ "$RUN_FLAKE8" == "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -18,6 +18,7 @@ echo 'pip:'
 ls $HOME/.cache/pip
 
 export CC=/usr/lib/ccache/gcc
+export CXX=/usr/lib/ccache/g++
 # Useful for debugging how ccache is used
 # export CCACHE_LOGFILE=/tmp/ccache.log
 # ~60M is used by .ccache when compiling from scratch at the time of writing

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -21,7 +21,7 @@ export CC=/usr/lib/ccache/gcc
 # Useful for debugging how ccache is used
 # export CCACHE_LOGFILE=/tmp/ccache.log
 # ~60M is used by .ccache when compiling from scratch at the time of writing
-export CCACHE_MAXSIZE=100M
+ccache --max-size 100M --show-stats
 
 if [[ "$DISTRIB" == "conda" ]]; then
     # Deactivate the travis-provided virtual environment and setup a


### PR DESCRIPTION
Use ccache and add .ccache to the Travis cache. This should save 2-4 minutes of compilation on each build that builds scikit-learn.

In some tests on Travis there seems to be some variability but here is what I found (I used `time python setup.py develop` to have a better idea about the timings):
* when ccache is working `python setup.py develop` takes 45s-1min (cython compilation)
* without ccache it is about 3-5 min (cython compilation + compilation of generated .c and .cpp files

I tried many different things but for some reason just using "export PATH=/usr/lib/ccache:$PATH" as I do locally does not seem to be enough ...