### PR TITLE
[MRG+3] fix multioutput partial_fit delegation

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -220,6 +220,7 @@ class MultiOutputRegressor(MultiOutputEstimator, RegressorMixin):
     def __init__(self, estimator, n_jobs=1):
         super(MultiOutputRegressor, self).__init__(estimator, n_jobs)
 
+    @if_delegate_has_method('estimator')
     def partial_fit(self, X, y, sample_weight=None):
         """Incrementally fit the model to data.
         Fit a separate model for each output variable.

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -62,12 +62,12 @@ def test_multi_target_regression_partial_fit():
 
     y_pred = sgr.predict(X_test)
     assert_almost_equal(references, y_pred)
+    assert_false(hasattr(MultiOutputRegressor(Lasso), 'partial_fit'))
 
 
 def test_multi_target_regression_one_target():
     # Test multi target regression raises
     X, y = datasets.make_regression(n_targets=1)
-
     rgr = MultiOutputRegressor(GradientBoostingRegressor(random_state=0))
     assert_raises(ValueError, rgr.fit, X, y)
 


### PR DESCRIPTION
Another port from #8022: MultiOutputRegressor should only have ``partial_fit`` if ``estimator`` does.