### PR TITLE
[MRG+2] Outlier detection algorithms API consistency

### DIFF
--- a/doc/modules/outlier_detection.rst
+++ b/doc/modules/outlier_detection.rst
@@ -31,7 +31,17 @@ new observations can then be sorted as inliers or outliers with a
 
     estimator.predict(X_test)
 
-Inliers are labeled 1, while outliers are labeled -1.
+Inliers are labeled 1, while outliers are labeled -1. The predict method
+makes use of a threshold on the raw scoring function computed by the
+estimator. This scoring function is accessible through the `score_samples`
+method, while the threshold can be controlled by the `contamination`
+parameter.
+
+The `decision_function` method is also defined from the scoring function,
+in such a way that negative values are outliers and non-negative ones are
+inliers::
+
+    estimator.decision_function(X_test)
 
 Overview of outlier detection methods
 =====================================

--- a/doc/modules/outlier_detection.rst
+++ b/doc/modules/outlier_detection.rst
@@ -27,21 +27,25 @@ implemented with objects learning in an unsupervised way from the data::
     estimator.fit(X_train)
 
 new observations can then be sorted as inliers or outliers with a
-`predict` method::
+``predict`` method::
 
     estimator.predict(X_test)
 
 Inliers are labeled 1, while outliers are labeled -1. The predict method
 makes use of a threshold on the raw scoring function computed by the
-estimator. This scoring function is accessible through the `score_samples`
-method, while the threshold can be controlled by the `contamination`
+estimator. This scoring function is accessible through the ``score_samples``
+method, while the threshold can be controlled by the ``contamination``
 parameter.
 
-The `decision_function` method is also defined from the scoring function,
+The ``decision_function`` method is also defined from the scoring function,
 in such a way that negative values are outliers and non-negative ones are
 inliers::
 
     estimator.decision_function(X_test)
+
+Note that :class:`neighbors.LocalOutlierFactor` does not support
+``predict`` and ``decision_function`` methods, as this algorithm is
+purely transductive and is thus not designed to deal with new data.
 
 Overview of outlier detection methods
 =====================================

--- a/doc/whats_new/_contributors.rst
+++ b/doc/whats_new/_contributors.rst
@@ -106,7 +106,7 @@
 
 .. _Eric Martin: http://www.ericmart.in
 
-.. _Nicolas Goix: https://perso.telecom-paristech.fr/~goix/
+.. _Nicolas Goix: http://ngoix.github.io
 
 .. _Sebastian Raschka: http://sebastianraschka.com
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -293,6 +293,24 @@ Cluster
   :class:`cluster.AgglomerativeClustering`. :issue:`9875` by :user:`Kumar Ashutosh
   <thechargedneutron>`.
 
+Outlier Detection models
+
+- More consistent outlier detection API:
+  Add a ``score_samples`` method in :class:`svm.OneClassSVM`,
+  :class:`ensemble.IsolationForest`, :class:`neighbors.LocalOutlierFactor`,
+  :class:`covariance.EllipticEnvelope`. It allows to access raw score
+  functions from original papers. A new ``offset_`` parameter allows to link
+  ``score_samples`` and ``decision_function`` methods.
+  The ``contamination`` parameter of :class:`ensemble.IsolationForest` and
+  :class:`neighbors.LocalOutlierFactor` ``decision_function`` methods is used
+  to define this ``offset_`` such that outliers (resp. inliers) have negative (resp.
+  positive) ``decision_function`` values. By default, ``contamination`` is
+  now set to "auto", thus using method-specific score offsets.
+  In :class:`covariance.EllipticEnvelope` ``decision_function`` method, the
+  ``raw_values`` parameter is deprecated as the shifted Mahalanobis distance
+  will be always returned in 0.22. :issue:`9015` by `Nicolas Goix`_.
+
+
 Changes to estimator checks
 ---------------------------
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -24,8 +24,6 @@ random sampling procedures.
 - :class:`neural_network.BaseMultilayerPerceptron` (bug fix)
 - :class:`neural_network.MLPRegressor` (bug fix)
 - :class:`neural_network.MLPClassifier` (bug fix)
-- :class:`ensemble.IsolationForest` (API change)
-- :class:`neighbors.LocalOutlierFactor` (API change)
   
 Details are listed in the changelog below.
 
@@ -307,8 +305,8 @@ Outlier Detection models
   :class:`neighbors.LocalOutlierFactor` ``decision_function`` methods is used
   to define this ``offset_`` such that outliers (resp. inliers) have negative (resp.
   positive) ``decision_function`` values. By default, ``contamination`` is
-  now set to "auto", thus using method-specific score offsets: this can change the
-  behavior of predict methods.
+  kept unchanged to 0.1 for a deprecation period. In 0.22, it will be set to "auto",
+  thus using method-specific score offsets.
   In :class:`covariance.EllipticEnvelope` ``decision_function`` method, the
   ``raw_values`` parameter is deprecated as the shifted Mahalanobis distance
   will be always returned in 0.22. :issue:`9015` by `Nicolas Goix`_.

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -24,7 +24,9 @@ random sampling procedures.
 - :class:`neural_network.BaseMultilayerPerceptron` (bug fix)
 - :class:`neural_network.MLPRegressor` (bug fix)
 - :class:`neural_network.MLPClassifier` (bug fix)
-
+- :class:`ensemble.IsolationForest` (API change)
+- :class:`neighbors.LocalOutlierFactor` (API change)
+  
 Details are listed in the changelog below.
 
 (While we are trying to better inform users by providing this information, we
@@ -305,7 +307,8 @@ Outlier Detection models
   :class:`neighbors.LocalOutlierFactor` ``decision_function`` methods is used
   to define this ``offset_`` such that outliers (resp. inliers) have negative (resp.
   positive) ``decision_function`` values. By default, ``contamination`` is
-  now set to "auto", thus using method-specific score offsets.
+  now set to "auto", thus using method-specific score offsets: this can change the
+  behavior of predict methods.
   In :class:`covariance.EllipticEnvelope` ``decision_function`` method, the
   ``raw_values`` parameter is deprecated as the shifted Mahalanobis distance
   will be always returned in 0.22. :issue:`9015` by `Nicolas Goix`_.

--- a/examples/applications/plot_species_distribution_modeling.py
+++ b/examples/applications/plot_species_distribution_modeling.py
@@ -168,7 +168,7 @@ def plot_species_distribution(species=("bradypus_variegatus_0",
         idx = np.where(land_reference > -9999)
         coverages_land = data.coverages[:, idx[0], idx[1]].T
 
-        pred = clf.decision_function((coverages_land - mean) / std)[:, 0]
+        pred = clf.decision_function((coverages_land - mean) / std)
         Z *= pred.min()
         Z[idx[0], idx[1]] = pred
 
@@ -192,8 +192,7 @@ def plot_species_distribution(species=("bradypus_variegatus_0",
 
         # Compute AUC with regards to background points
         pred_background = Z[background_points[0], background_points[1]]
-        pred_test = clf.decision_function((species.cov_test - mean)
-                                          / std)[:, 0]
+        pred_test = clf.decision_function((species.cov_test - mean) / std)
         scores = np.r_[pred_test, pred_background]
         y = np.r_[np.ones(pred_test.shape), np.zeros(pred_background.shape)]
         fpr, tpr, thresholds = metrics.roc_curve(y, scores)

--- a/examples/covariance/plot_outlier_detection.py
+++ b/examples/covariance/plot_outlier_detection.py
@@ -95,8 +95,6 @@ for _, offset in enumerate(clusters_separation):
             clf.fit(X)
             scores_pred = clf.decision_function(X)
             y_pred = clf.predict(X)
-        threshold = stats.scoreatpercentile(scores_pred,
-                                            100 * outliers_fraction)
         n_errors = (y_pred != ground_truth).sum()
         # plot the levels lines and the points
         if clf_name == "Local Outlier Factor":
@@ -106,11 +104,11 @@ for _, offset in enumerate(clusters_separation):
             Z = clf.decision_function(np.c_[xx.ravel(), yy.ravel()])
         Z = Z.reshape(xx.shape)
         subplot = plt.subplot(2, 2, i + 1)
-        subplot.contourf(xx, yy, Z, levels=np.linspace(Z.min(), threshold, 7),
+        subplot.contourf(xx, yy, Z, levels=np.linspace(Z.min(), 0, 7),
                          cmap=plt.cm.Blues_r)
-        a = subplot.contour(xx, yy, Z, levels=[threshold],
+        a = subplot.contour(xx, yy, Z, levels=[0],
                             linewidths=2, colors='red')
-        subplot.contourf(xx, yy, Z, levels=[threshold, Z.max()],
+        subplot.contourf(xx, yy, Z, levels=[0, Z.max()],
                          colors='orange')
         b = subplot.scatter(X[:-n_outliers, 0], X[:-n_outliers, 1], c='white',
                             s=20, edgecolor='k')

--- a/sklearn/covariance/__init__.py
+++ b/sklearn/covariance/__init__.py
@@ -13,7 +13,7 @@ from .shrunk_covariance_ import shrunk_covariance, ShrunkCovariance, \
     LedoitWolf, oas, OAS
 from .robust_covariance import fast_mcd, MinCovDet
 from .graph_lasso_ import graph_lasso, GraphLasso, GraphLassoCV
-from .outlier_detection import EllipticEnvelope
+from .elliptic_envelope import EllipticEnvelope
 
 
 __all__ = ['EllipticEnvelope',

--- a/sklearn/covariance/elliptic_envelope.py
+++ b/sklearn/covariance/elliptic_envelope.py
@@ -1,19 +1,10 @@
-"""
-Class for outlier detection.
-
-This class provides a framework for outlier detection. It consists in
-several methods that can be added to a covariance estimator in order to
-assess the outlying-ness of the observations of a data set.
-Such a "outlier detector" object is proposed constructed from a robust
-covariance estimator (the Minimum Covariance Determinant).
-
-"""
 # Author: Virgile Fritsch <virgile.fritsch@inria.fr>
 #
 # License: BSD 3 clause
 
 import numpy as np
 import scipy as sp
+import warnings
 from . import MinCovDet
 from ..utils.validation import check_is_fitted, check_array
 from ..metrics import accuracy_score
@@ -70,6 +61,13 @@ class EllipticEnvelope(MinCovDet):
         A mask of the observations that have been used to compute the
         robust estimates of location and shape.
 
+    offset_ : float
+        Offset used to define the decision function from the raw scores.
+        We have the relation: decision_function = score_samples - offset_.
+        The offset depends on the contamination parameter and is defined in
+        such a way we obtain the expected number of outliers (samples with
+        decision function < 0) in training.
+
     See Also
     --------
     EmpiricalCovariance, MinCovDet
@@ -97,79 +95,92 @@ class EllipticEnvelope(MinCovDet):
         self.contamination = contamination
 
     def fit(self, X, y=None):
-        """Fit the EllipticEnvelope model with X.
+        """Fit the EllipticEnvelope model.
 
         Parameters
         ----------
-        X : numpy array or sparse matrix of shape [n_samples, n_features]
+        X : numpy array or sparse matrix, shape (n_samples, n_features).
             Training data
         y : (ignored)
         """
         super(EllipticEnvelope, self).fit(X)
-        self.threshold_ = sp.stats.scoreatpercentile(
-            self.dist_, 100. * (1. - self.contamination))
+        self.offset_ = sp.stats.scoreatpercentile(
+            -self.dist_, 100. * self.contamination)
         return self
 
-    def decision_function(self, X, raw_values=False):
+    def decision_function(self, X, raw_values=None):
         """Compute the decision function of the given observations.
 
         Parameters
         ----------
         X : array-like, shape (n_samples, n_features)
 
-        raw_values : bool
+        raw_values : bool, optional
             Whether or not to consider raw Mahalanobis distances as the
             decision function. Must be False (default) for compatibility
             with the others outlier detection tools.
 
+        .. deprecated:: 0.20
+            ``raw_values`` has been deprecated in 0.20 and will be removed
+            in 0.22.
+
         Returns
         -------
+
         decision : array-like, shape (n_samples, )
             Decision function of the samples.
-            It is equal to the Mahalanobis distances if `raw_values`
-            is True. By default (``raw_values=False``), it is equal
-            to the cubic root of the shifted Mahalanobis distances.
-            In that case, the threshold for being an outlier is 0, which
-            ensures a compatibility with other outlier detection tools
-            such as the One-Class SVM.
+            It is equal to the shifted Mahalanobis distances.
+            The threshold for being an outlier is 0, which ensures a
+            compatibility with other outlier detection algorithms.
 
         """
-        check_is_fitted(self, 'threshold_')
-        X = check_array(X)
-        mahal_dist = self.mahalanobis(X)
-        if raw_values:
-            decision = mahal_dist
-        else:
-            transformed_mahal_dist = mahal_dist ** 0.33
-            decision = self.threshold_ ** 0.33 - transformed_mahal_dist
+        check_is_fitted(self, 'offset_')
+        negative_mahal_dist = self.score_samples(X)
 
-        return decision
+        # raw_values deprecation:
+        if raw_values is not None:
+            warnings.warn("raw_values parameter is deprecated in 0.20 and will"
+                          " be removed in 0.22.", DeprecationWarning)
 
-    def predict(self, X):
-        """Outlyingness of observations in X according to the fitted model.
+            if not raw_values:
+                return (-self.offset_) ** 0.33 - (-negative_mahal_dist) ** 0.33
+
+        return negative_mahal_dist - self.offset_
+
+    def score_samples(self, X):
+        """Compute the negative Mahalanobis distances.
 
         Parameters
         ----------
-        X : array-like, shape = (n_samples, n_features)
+        X : array-like, shape (n_samples, n_features)
 
         Returns
         -------
-        is_outliers : array, shape = (n_samples, ), dtype = bool
-            For each observation, tells whether or not it should be considered
-            as an outlier according to the fitted model.
-
-        threshold : float,
-            The values of the less outlying point's decision function.
-
+        negative_mahal_distances : array-like, shape (n_samples, )
+            Opposite of the Mahalanobis distances.
         """
-        check_is_fitted(self, 'threshold_')
+        check_is_fitted(self, 'offset_')
+        X = check_array(X)
+        return -self.mahalanobis(X)
+
+    def predict(self, X):
+        """
+        Predict the labels (1 inlier, -1 outlier) of X according to the
+        fitted model.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+
+        Returns
+        -------
+        is_inlier : array, shape (n_samples,)
+            Returns -1 for anomalies/outliers and +1 for inliers.
+        """
         X = check_array(X)
         is_inlier = -np.ones(X.shape[0], dtype=int)
-        if self.contamination is not None:
-            values = self.decision_function(X, raw_values=True)
-            is_inlier[values <= self.threshold_] = 1
-        else:
-            raise NotImplementedError("You must provide a contamination rate.")
+        values = self.decision_function(X)
+        is_inlier[values >= 0] = 1
 
         return is_inlier
 
@@ -182,13 +193,13 @@ class EllipticEnvelope(MinCovDet):
 
         Parameters
         ----------
-        X : array-like, shape = (n_samples, n_features)
+        X : array-like, shape (n_samples, n_features)
             Test samples.
 
-        y : array-like, shape = (n_samples,) or (n_samples, n_outputs)
+        y : array-like, shape (n_samples,) or (n_samples, n_outputs)
             True labels for X.
 
-        sample_weight : array-like, shape = (n_samples,), optional
+        sample_weight : array-like, shape (n_samples,), optional
             Sample weights.
 
         Returns
@@ -198,3 +209,9 @@ class EllipticEnvelope(MinCovDet):
 
         """
         return accuracy_score(y, self.predict(X), sample_weight=sample_weight)
+
+    @property
+    def threshold_(self):
+        warnings.warn("threshold_ attribute is deprecated in 0.20 and will"
+                      " be removed in 0.22.", DeprecationWarning)
+        return self.offset_

--- a/sklearn/covariance/tests/test_elliptic_envelope.py
+++ b/sklearn/covariance/tests/test_elliptic_envelope.py
@@ -1,0 +1,60 @@
+"""
+Testing for Elliptic Envelope algorithm (sklearn.covariance.elliptic_envelope).
+"""
+
+import numpy as np
+from sklearn.covariance import EllipticEnvelope
+from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_array_equal, assert_warns_message
+from sklearn.exceptions import NotFittedError
+
+
+def test_elliptic_envelope():
+    rnd = np.random.RandomState(0)
+    X = rnd.randn(100, 10)
+    clf = EllipticEnvelope(contamination=0.1)
+    assert_raises(NotFittedError, clf.predict, X)
+    assert_raises(NotFittedError, clf.decision_function, X)
+    clf.fit(X)
+    y_pred = clf.predict(X)
+    scores = clf.score_samples(X)
+    decisions = clf.decision_function(X)
+
+    assert_array_almost_equal(
+        scores, -clf.mahalanobis(X))
+    assert_array_almost_equal(clf.mahalanobis(X), clf.dist_)
+    assert_almost_equal(clf.score(X, np.ones(100)),
+                        (100 - y_pred[y_pred == -1].size) / 100.)
+    assert(sum(y_pred == -1) == sum(decisions < 0))
+
+
+def test_score_samples():
+    X_train = [[1, 1], [1, 2], [2, 1]]
+    clf1 = EllipticEnvelope(contamination=0.2).fit(X_train)
+    clf2 = EllipticEnvelope().fit(X_train)
+    assert_array_equal(clf1.score_samples([[2., 2.]]),
+                       clf1.decision_function([[2., 2.]]) + clf1.offset_)
+    assert_array_equal(clf2.score_samples([[2., 2.]]),
+                       clf2.decision_function([[2., 2.]]) + clf2.offset_)
+    assert_array_equal(clf1.score_samples([[2., 2.]]),
+                       clf2.score_samples([[2., 2.]]))
+
+
+def test_raw_values_deprecation():
+    X = [[0.0], [1.0]]
+    clf = EllipticEnvelope().fit(X)
+    assert_warns_message(DeprecationWarning,
+                         "raw_values parameter is deprecated in 0.20 and will"
+                         " be removed in 0.22.",
+                         clf.decision_function, X, raw_values=True)
+
+
+def test_threshold_deprecation():
+    X = [[0.0], [1.0]]
+    clf = EllipticEnvelope().fit(X)
+    assert_warns_message(DeprecationWarning,
+                         "threshold_ attribute is deprecated in 0.20 and will"
+                         " be removed in 0.22.",
+                         getattr, clf, "threshold_")

--- a/sklearn/covariance/tests/test_robust_covariance.py
+++ b/sklearn/covariance/tests/test_robust_covariance.py
@@ -8,15 +8,11 @@ import itertools
 
 import numpy as np
 
-from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raise_message
-from sklearn.exceptions import NotFittedError
 
 from sklearn import datasets
-from sklearn.covariance import empirical_covariance, MinCovDet, \
-    EllipticEnvelope
+from sklearn.covariance import empirical_covariance, MinCovDet
 from sklearn.covariance import fast_mcd
 
 X = datasets.load_iris().data
@@ -137,22 +133,3 @@ def test_mcd_support_covariance_is_zero():
            'increase support_fraction')
     for X in [X_1, X_2]:
         assert_raise_message(ValueError, msg, MinCovDet().fit, X)
-
-
-def test_outlier_detection():
-    rnd = np.random.RandomState(0)
-    X = rnd.randn(100, 10)
-    clf = EllipticEnvelope(contamination=0.1)
-    assert_raises(NotFittedError, clf.predict, X)
-    assert_raises(NotFittedError, clf.decision_function, X)
-    clf.fit(X)
-    y_pred = clf.predict(X)
-    decision = clf.decision_function(X, raw_values=True)
-    decision_transformed = clf.decision_function(X, raw_values=False)
-
-    assert_array_almost_equal(
-        decision, clf.mahalanobis(X))
-    assert_array_almost_equal(clf.mahalanobis(X), clf.dist_)
-    assert_almost_equal(clf.score(X, np.ones(100)),
-                        (100 - y_pred[y_pred == -1].size) / 100.)
-    assert(sum(y_pred == -1) == sum(decision_transformed < 0))

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -150,10 +150,9 @@ class IsolationForest(BaseBagging):
 
         if contamination == "legacy":
             warnings.warn('default contamination parameter 0.1 will change '
-                          'in 0.22 to "auto". This will change the predict '
-                          'method behavior.',
+                          'in version 0.22 to "auto". This will change the '
+                          'predict method behavior.',
                           DeprecationWarning)
-            contamination = 0.1
         self.contamination = contamination
 
     def _set_oob_score(self, X, y):
@@ -224,6 +223,9 @@ class IsolationForest(BaseBagging):
             self.offset_ = -0.5
             # need to save (depreciated) threshold_ in this case:
             self._threshold_ = sp.stats.scoreatpercentile(
+                self.score_samples(X), 100. * 0.1)
+        elif self.contamination == "legacy":  # to be rm in 0.22
+            self.offset_ = sp.stats.scoreatpercentile(
                 self.score_samples(X), 100. * 0.1)
         else:
             self.offset_ = sp.stats.scoreatpercentile(

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -63,7 +63,7 @@ class IsolationForest(BaseBagging):
         If max_samples is larger than the number of samples provided,
         all samples will be used for all trees (no sampling).
 
-    contamination : float in (0., 0.5), optional (default="auto")
+    contamination : float in (0., 0.5), optional (default=0.1)
         The amount of contamination of the data set, i.e. the proportion
         of outliers in the data set. Used when fitting to define the threshold
         on the decision function. If 'auto', the decision function threshold is
@@ -127,7 +127,7 @@ class IsolationForest(BaseBagging):
     def __init__(self,
                  n_estimators=100,
                  max_samples="auto",
-                 contamination="auto",
+                 contamination="legacy",
                  max_features=1.,
                  bootstrap=False,
                  n_jobs=1,
@@ -147,6 +147,13 @@ class IsolationForest(BaseBagging):
             n_jobs=n_jobs,
             random_state=random_state,
             verbose=verbose)
+
+        if contamination == "legacy":
+            warnings.warn('default contamination parameter 0.1 will change '
+                          'in 0.22 to "auto". This will change the predict '
+                          'method behavior.',
+                          DeprecationWarning)
+            contamination = 0.1
         self.contamination = contamination
 
     def _set_oob_score(self, X, y):

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -6,6 +6,7 @@ from __future__ import division
 
 import numpy as np
 import scipy as sp
+import warnings
 from warnings import warn
 from sklearn.utils.fixes import euler_gamma
 
@@ -15,6 +16,7 @@ import numbers
 from ..externals import six
 from ..tree import ExtraTreeRegressor
 from ..utils import check_random_state, check_array
+from ..utils.validation import check_is_fitted
 
 from .bagging import BaseBagging
 
@@ -61,10 +63,11 @@ class IsolationForest(BaseBagging):
         If max_samples is larger than the number of samples provided,
         all samples will be used for all trees (no sampling).
 
-    contamination : float in (0., 0.5), optional (default=0.1)
+    contamination : float in (0., 0.5), optional (default="auto")
         The amount of contamination of the data set, i.e. the proportion
         of outliers in the data set. Used when fitting to define the threshold
-        on the decision function.
+        on the decision function. If 'auto', the decision function threshold is
+        determined as in the original paper.
 
     max_features : int or float, optional (default=1.0)
         The number of features to draw from X to train each base estimator.
@@ -103,6 +106,14 @@ class IsolationForest(BaseBagging):
     max_samples_ : integer
         The actual number of samples
 
+    offset_ : float
+        Offset used to define the decision function from the raw scores.
+        We have the relation: decision_function = score_samples - offset_.
+        The offset is set to 0.5 as in the original paper, except when a
+        contamination parameter different than "auto" is provided. In that
+        case, the offset is defined in such a way we obtain the expected
+        number of outliers (samples with decision function < 0) in training.
+
     References
     ----------
     .. [1] Liu, Fei Tony, Ting, Kai Ming and Zhou, Zhi-Hua. "Isolation forest."
@@ -116,7 +127,7 @@ class IsolationForest(BaseBagging):
     def __init__(self,
                  n_estimators=100,
                  max_samples="auto",
-                 contamination=0.1,
+                 contamination="auto",
                  max_features=1.,
                  bootstrap=False,
                  n_jobs=1,
@@ -200,8 +211,16 @@ class IsolationForest(BaseBagging):
                                           max_depth=max_depth,
                                           sample_weight=sample_weight)
 
-        self.threshold_ = -sp.stats.scoreatpercentile(
-            -self.decision_function(X), 100. * (1. - self.contamination))
+        if self.contamination == "auto":
+            # 0.5 plays a special role as described in the original paper.
+            # we take the opposite as we consider the opposite of their score.
+            self.offset_ = -0.5
+            # need to save (depreciated) threshold_ in this case:
+            self._threshold_ = sp.stats.scoreatpercentile(
+                self.score_samples(X), 100. * 0.1)
+        else:
+            self.offset_ = sp.stats.scoreatpercentile(
+                self.score_samples(X), 100. * self.contamination)
 
         return self
 
@@ -218,12 +237,13 @@ class IsolationForest(BaseBagging):
         Returns
         -------
         is_inlier : array, shape (n_samples,)
-            For each observations, tells whether or not (+1 or -1) it should
+            For each observation, tells whether or not (+1 or -1) it should
             be considered as an inlier according to the fitted model.
         """
+        check_is_fitted(self, ["offset_"])
         X = check_array(X, accept_sparse='csr')
         is_inlier = np.ones(X.shape[0], dtype=int)
-        is_inlier[self.decision_function(X) <= self.threshold_] = -1
+        is_inlier[self.decision_function(X) < 0] = -1
         return is_inlier
 
     def decision_function(self, X):
@@ -246,14 +266,51 @@ class IsolationForest(BaseBagging):
 
         Returns
         -------
-        scores : array of shape (n_samples,)
+        scores : array, shape (n_samples,)
             The anomaly score of the input samples.
-            The lower, the more abnormal.
+            The lower, the more abnormal. Negative scores represent outliers,
+            positive scores represent inliers.
 
         """
+        # We substract self.offset_ to make 0 be the threshold value for being
+        # an outlier:
+
+        return self.score_samples(X) - self.offset_
+
+    def score_samples(self, X):
+        """Opposite of the anomaly score defined in the original paper.
+
+        The anomaly score of an input sample is computed as
+        the mean anomaly score of the trees in the forest.
+
+        The measure of normality of an observation given a tree is the depth
+        of the leaf containing this observation, which is equivalent to
+        the number of splittings required to isolate this point. In case of
+        several observations n_left in the leaf, the average path length of
+        a n_left samples isolation tree is added.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+            The training input samples. Sparse matrices are accepted only if
+            they are supported by the base estimator.
+
+        Returns
+        -------
+        scores : array, shape (n_samples,)
+            The anomaly score of the input samples.
+            The lower, the more abnormal.
+        """
         # code structure from ForestClassifier/predict_proba
+        check_is_fitted(self, ["estimators_"])
+
         # Check data
         X = check_array(X, accept_sparse='csr')
+        if self.n_features_ != X.shape[1]:
+            raise ValueError("Number of features of the model must "
+                             "match the input. Model n_features is {0} and "
+                             "input n_features is {1}."
+                             "".format(self.n_features_, X.shape[1]))
         n_samples = X.shape[0]
 
         n_samples_leaf = np.zeros((n_samples, self.n_estimators), order="f")
@@ -278,12 +335,20 @@ class IsolationForest(BaseBagging):
 
         depths += _average_path_length(n_samples_leaf)
 
-        scores = 2 ** (-depths.mean(axis=1) / _average_path_length(self.max_samples_))
+        scores = 2 ** (-depths.mean(axis=1) / _average_path_length(
+            self.max_samples_))
 
         # Take the opposite of the scores as bigger is better (here less
-        # abnormal) and add 0.5 (this value plays a special role as described
-        # in the original paper) to give a sense to scores = 0:
-        return 0.5 - scores
+        # abnormal)
+        return -scores
+
+    @property
+    def threshold_(self):
+        warnings.warn("threshold_ attribute is deprecated in 0.20 and will"
+                      " be removed in 0.22.", DeprecationWarning)
+        if self.contamination == 'auto':
+            return self._threshold_
+        return self.offset_
 
 
 def _average_path_length(n_samples_leaf):
@@ -292,7 +357,7 @@ def _average_path_length(n_samples_leaf):
     latter has the same structure as an isolation tree.
     Parameters
     ----------
-    n_samples_leaf : array-like of shape (n_samples, n_estimators), or int.
+    n_samples_leaf : array-like, shape (n_samples, n_estimators), or int.
         The number of training samples in each test sample leaf, for
         each estimators.
 

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -246,7 +246,7 @@ def test_score_samples():
 def test_deprecation():
     assert_warns_message(DeprecationWarning,
                          'default contamination parameter 0.1 will change '
-                         'in 0.22 to "auto"',
+                         'in version 0.22 to "auto"',
                          IsolationForest, )
     X = [[0.0], [1.0]]
     clf = IsolationForest().fit(X)

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -243,7 +243,11 @@ def test_score_samples():
                        clf2.score_samples([[2., 2.]]))
 
 
-def test_threshold_deprecation():
+def test_deprecation():
+    assert_warns_message(DeprecationWarning,
+                         'default contamination parameter 0.1 will change '
+                         'in 0.22 to "auto"',
+                         IsolationForest, )
     X = [[0.0], [1.0]]
     clf = IsolationForest().fit(X)
     assert_warns_message(DeprecationWarning,

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -110,6 +110,9 @@ def test_iforest_error():
     assert_raises(ValueError, IsolationForest(max_samples='foobar').fit, X)
     assert_raises(ValueError, IsolationForest(max_samples=1.5).fit, X)
 
+    # test X_test n_features match X_train one:
+    assert_raises(ValueError, IsolationForest().fit(X).predict, X[:, 1:])
+
 
 def test_recalculate_max_depth():
     """Check max_depth recalculation when max_samples is reset to n_samples"""
@@ -186,15 +189,15 @@ def test_iforest_works():
     # toy sample (the last two samples are outliers)
     X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [6, 3], [-4, 7]]
 
-    # Test LOF
-    clf = IsolationForest(random_state=rng, contamination=0.25)
-    clf.fit(X)
-    decision_func = - clf.decision_function(X)
-    pred = clf.predict(X)
-
-    # assert detect outliers:
-    assert_greater(np.min(decision_func[-2:]), np.max(decision_func[:-2]))
-    assert_array_equal(pred, 6 * [1] + 2 * [-1])
+    # Test IsolationForest
+    for contamination in [0.25, "auto"]:
+        clf = IsolationForest(random_state=rng, contamination=contamination)
+        clf.fit(X)
+        decision_func = - clf.decision_function(X)
+        pred = clf.predict(X)
+        # assert detect outliers:
+        assert_greater(np.min(decision_func[-2:]), np.max(decision_func[:-2]))
+        assert_array_equal(pred, 6 * [1] + 2 * [-1])
 
 
 def test_max_samples_consistency():
@@ -226,3 +229,24 @@ def test_iforest_average_path_length():
     assert_almost_equal(_average_path_length(999), result_two, decimal=10)
     assert_array_almost_equal(_average_path_length(np.array([1, 5, 999])),
                               [1., result_one, result_two], decimal=10)
+
+
+def test_score_samples():
+    X_train = [[1, 1], [1, 2], [2, 1]]
+    clf1 = IsolationForest(contamination=0.1).fit(X_train)
+    clf2 = IsolationForest().fit(X_train)
+    assert_array_equal(clf1.score_samples([[2., 2.]]),
+                       clf1.decision_function([[2., 2.]]) + clf1.offset_)
+    assert_array_equal(clf2.score_samples([[2., 2.]]),
+                       clf2.decision_function([[2., 2.]]) + clf2.offset_)
+    assert_array_equal(clf1.score_samples([[2., 2.]]),
+                       clf2.score_samples([[2., 2.]]))
+
+
+def test_threshold_deprecation():
+    X = [[0.0], [1.0]]
+    clf = IsolationForest().fit(X)
+    assert_warns_message(DeprecationWarning,
+                         "threshold_ attribute is deprecated in 0.20 and will"
+                         " be removed in 0.22.",
+                         getattr, clf, "threshold_")

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -3,7 +3,7 @@
 # License: BSD 3 clause
 
 import numpy as np
-from warnings import warn
+import warnings
 from scipy.stats import scoreatpercentile
 
 from .base import NeighborsBase
@@ -92,7 +92,7 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
     metric_params : dict, optional (default=None)
         Additional keyword arguments for the metric function.
 
-    contamination : float in (0., 0.5), optional (default="auto")
+    contamination : float in (0., 0.5), optional (default=0.1)
         The amount of contamination of the data set, i.e. the proportion
         of outliers in the data set. When fitting this is used to define the
         threshold on the decision function. If "auto", the decision function
@@ -135,13 +135,19 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
     """
     def __init__(self, n_neighbors=20, algorithm='auto', leaf_size=30,
                  metric='minkowski', p=2, metric_params=None,
-                 contamination="auto", n_jobs=1):
+                 contamination="legacy", n_jobs=1):
         super(LocalOutlierFactor, self).__init__(
               n_neighbors=n_neighbors,
               algorithm=algorithm,
               leaf_size=leaf_size, metric=metric, p=p,
               metric_params=metric_params, n_jobs=n_jobs)
 
+        if contamination == "legacy":
+            warnings.warn('default contamination parameter 0.1 will change '
+                          'in 0.22 to "auto". This will change the predict '
+                          'method behavior.',
+                          DeprecationWarning)
+            contamination = 0.1
         self.contamination = contamination
 
     def fit_predict(self, X, y=None):
@@ -187,7 +193,7 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
 
         n_samples = self._fit_X.shape[0]
         if self.n_neighbors > n_samples:
-            warn("n_neighbors (%s) is greater than the "
+            warnings.warn("n_neighbors (%s) is greater than the "
                  "total number of samples (%s). n_neighbors "
                  "will be set to (n_samples - 1) for estimation."
                  % (self.n_neighbors, n_samples))

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -144,10 +144,9 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
 
         if contamination == "legacy":
             warnings.warn('default contamination parameter 0.1 will change '
-                          'in 0.22 to "auto". This will change the predict '
-                          'method behavior.',
+                          'in version 0.22 to "auto". This will change the '
+                          'predict method behavior.',
                           DeprecationWarning)
-            contamination = 0.1
         self.contamination = contamination
 
     def fit_predict(self, X, y=None):
@@ -184,7 +183,7 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         self : object
             Returns self.
         """
-        if self.contamination != "auto":
+        if self.contamination not in ["auto", "legacy"]:  # rm legacy in 0.22
             if not(0. < self.contamination <= .5):
                 raise ValueError("contamination must be in (0, 0.5], "
                                  "got: %f" % self.contamination)
@@ -194,9 +193,9 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         n_samples = self._fit_X.shape[0]
         if self.n_neighbors > n_samples:
             warnings.warn("n_neighbors (%s) is greater than the "
-                 "total number of samples (%s). n_neighbors "
-                 "will be set to (n_samples - 1) for estimation."
-                 % (self.n_neighbors, n_samples))
+                          "total number of samples (%s). n_neighbors "
+                          "will be set to (n_samples - 1) for estimation."
+                          % (self.n_neighbors, n_samples))
         self.n_neighbors_ = max(1, min(self.n_neighbors, n_samples - 1))
 
         self._distances_fit_X_, _neighbors_indices_fit_X_ = (
@@ -214,6 +213,9 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         if self.contamination == "auto":
             # inliers score around -1 (the higher, the less abnormal).
             self.offset_ = -1.5
+        elif self.contamination == "legacy":  # to rm in 0.22
+            self.offset_ = scoreatpercentile(
+                self.negative_outlier_factor_, 100. * 0.1)
         else:
             self.offset_ = scoreatpercentile(
                 self.negative_outlier_factor_, 100. * self.contamination)

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -92,10 +92,11 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
     metric_params : dict, optional (default=None)
         Additional keyword arguments for the metric function.
 
-    contamination : float in (0., 0.5), optional (default=0.1)
+    contamination : float in (0., 0.5), optional (default="auto")
         The amount of contamination of the data set, i.e. the proportion
         of outliers in the data set. When fitting this is used to define the
-        threshold on the decision function.
+        threshold on the decision function. If "auto", the decision function
+        threshold is determined as in the original paper.
 
     n_jobs : int, optional (default=1)
         The number of parallel jobs to run for neighbors search.
@@ -106,9 +107,9 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
     Attributes
     ----------
     negative_outlier_factor_ : numpy array, shape (n_samples,)
-        The opposite LOF of the training samples. The lower, the more abnormal.
-        Inliers tend to have a LOF score close to 1, while outliers tend
-        to have a larger LOF score.
+        The opposite LOF of the training samples. The higher, the more normal.
+        Inliers tend to have a LOF score close to 1 (negative_outlier_factor_
+        close to -1), while outliers tend to have a larger LOF score.
 
         The local outlier factor (LOF) of a sample captures its
         supposed 'degree of abnormality'.
@@ -118,6 +119,15 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
     n_neighbors_ : integer
         The actual number of neighbors used for :meth:`kneighbors` queries.
 
+    offset_ : float
+        Offset used to obtain binary labels from the raw scores.
+        Observations having a negative_outlier_factor smaller than offset_ are
+        detected as abnormal.
+        The offset is set to -1.5 (inliers score around -1), except when a
+        contamination parameter different than "auto" is provided. In that
+        case, the offset is defined in such a way we obtain the expected
+        number of outliers in training.
+
     References
     ----------
     .. [1] Breunig, M. M., Kriegel, H. P., Ng, R. T., & Sander, J. (2000, May).
@@ -125,7 +135,7 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
     """
     def __init__(self, n_neighbors=20, algorithm='auto', leaf_size=30,
                  metric='minkowski', p=2, metric_params=None,
-                 contamination=0.1, n_jobs=1):
+                 contamination="auto", n_jobs=1):
         super(LocalOutlierFactor, self).__init__(
               n_neighbors=n_neighbors,
               algorithm=algorithm,
@@ -168,8 +178,10 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         self : object
             Returns self.
         """
-        if not (0. < self.contamination <= .5):
-            raise ValueError("contamination must be in (0, 0.5]")
+        if self.contamination != "auto":
+            if not(0. < self.contamination <= .5):
+                raise ValueError("contamination must be in (0, 0.5], "
+                                 "got: %f" % self.contamination)
 
         super(LocalOutlierFactor, self).fit(X)
 
@@ -187,14 +199,18 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         self._lrd = self._local_reachability_density(
             self._distances_fit_X_, _neighbors_indices_fit_X_)
 
-        # Compute lof score over training samples to define threshold_:
+        # Compute lof score over training samples to define offset_:
         lrd_ratios_array = (self._lrd[_neighbors_indices_fit_X_] /
                             self._lrd[:, np.newaxis])
 
         self.negative_outlier_factor_ = -np.mean(lrd_ratios_array, axis=1)
 
-        self.threshold_ = -scoreatpercentile(
-            -self.negative_outlier_factor_, 100. * (1. - self.contamination))
+        if self.contamination == "auto":
+            # inliers score around -1 (the higher, the less abnormal).
+            self.offset_ = -1.5
+        else:
+            self.offset_ = scoreatpercentile(
+                self.negative_outlier_factor_, 100. * self.contamination)
 
         return self
 
@@ -204,7 +220,8 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         If X is None, returns the same as fit_predict(X_train).
         This method allows to generalize prediction to new observations (not
         in the training set). As LOF originally does not deal with new data,
-        this method is kept private.
+        this method is kept private. In particular, fit(X)._predict(X) is not
+        the same as fit_predict(X).
 
         Parameters
         ----------
@@ -218,29 +235,57 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
         is_inlier : array, shape (n_samples,)
             Returns -1 for anomalies/outliers and +1 for inliers.
         """
-        check_is_fitted(self, ["threshold_", "negative_outlier_factor_",
+        check_is_fitted(self, ["offset_", "negative_outlier_factor_",
                                "n_neighbors_", "_distances_fit_X_"])
 
         if X is not None:
             X = check_array(X, accept_sparse='csr')
             is_inlier = np.ones(X.shape[0], dtype=int)
-            is_inlier[self._decision_function(X) <= self.threshold_] = -1
+            is_inlier[self._decision_function(X) < 0] = -1
         else:
             is_inlier = np.ones(self._fit_X.shape[0], dtype=int)
-            is_inlier[self.negative_outlier_factor_ <= self.threshold_] = -1
+            is_inlier[self.negative_outlier_factor_ < self.offset_] = -1
 
         return is_inlier
 
     def _decision_function(self, X):
-        """Opposite of the Local Outlier Factor of X (as bigger is better,
-        i.e. large values correspond to inliers).
+        """Shifted opposite of the Local Outlier Factor of X
+
+        Bigger is better, i.e. large values correspond to inliers.
+
+        The shift offset allows a zero threshold for being an outlier.
+        The argument X is supposed to contain *new data*: if X contains a
+        point from training, it consider the later in its own neighborhood.
+        Also, the samples in X are not considered in the neighborhood of any
+        point.
+        This method is kept private as the predict method is.
+        The decision function on training data is available by considering the
+        the negative_outlier_factor_ attribute.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+            The query sample or samples to compute the Local Outlier Factor
+            w.r.t. the training samples.
+
+        Returns
+        -------
+        shifted_opposite_lof_scores : array, shape (n_samples,)
+            The shifted opposite of the Local Outlier Factor of each input
+            samples. The lower, the more abnormal. Negative scores represent
+            outliers, positive scores represent inliers.
+        """
+        return self._score_samples(X) - self.offset_
+
+    def _score_samples(self, X):
+        """Opposite of the Local Outlier Factor of X (as bigger is
+        better, i.e. large values correspond to inliers).
 
         The argument X is supposed to contain *new data*: if X contains a
         point from training, it consider the later in its own neighborhood.
         Also, the samples in X are not considered in the neighborhood of any
         point.
-        The decision function on training data is available by considering the
-        opposite of the negative_outlier_factor_ attribute.
+        This method is kept private as the predict method is.
 
         Parameters
         ----------
@@ -254,9 +299,8 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
             The opposite of the Local Outlier Factor of each input samples.
             The lower, the more abnormal.
         """
-        check_is_fitted(self, ["threshold_", "negative_outlier_factor_",
+        check_is_fitted(self, ["offset_", "negative_outlier_factor_",
                                "_distances_fit_X_"])
-
         X = check_array(X, accept_sparse='csr')
 
         distances_X, neighbors_indices_X = (

--- a/sklearn/neighbors/tests/test_lof.py
+++ b/sklearn/neighbors/tests/test_lof.py
@@ -141,3 +141,11 @@ def test_contamination():
     X = [[1, 1], [1, 0]]
     clf = neighbors.LocalOutlierFactor(contamination=0.6)
     assert_raises(ValueError, clf.fit, X)
+
+
+def test_deprecation():
+    assert_warns_message(DeprecationWarning,
+                         'default contamination parameter 0.1 will change '
+                         'in 0.22 to "auto"',
+                         neighbors.LocalOutlierFactor, )
+

--- a/sklearn/neighbors/tests/test_lof.py
+++ b/sklearn/neighbors/tests/test_lof.py
@@ -146,6 +146,5 @@ def test_contamination():
 def test_deprecation():
     assert_warns_message(DeprecationWarning,
                          'default contamination parameter 0.1 will change '
-                         'in 0.22 to "auto"',
+                         'in version 0.22 to "auto"',
                          neighbors.LocalOutlierFactor, )
-

--- a/sklearn/neighbors/tests/test_lof.py
+++ b/sklearn/neighbors/tests/test_lof.py
@@ -15,7 +15,7 @@ from sklearn.utils import check_random_state
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_warns_message
+from sklearn.utils.testing import assert_warns_message, assert_raises
 
 from sklearn.datasets import load_iris
 
@@ -71,15 +71,20 @@ def test_lof_performance():
 def test_lof_values():
     # toy samples:
     X_train = [[1, 1], [1, 2], [2, 1]]
-    clf = neighbors.LocalOutlierFactor(n_neighbors=2).fit(X_train)
+    clf1 = neighbors.LocalOutlierFactor(n_neighbors=2,
+                                        contamination=0.1).fit(X_train)
+    clf2 = neighbors.LocalOutlierFactor(n_neighbors=2).fit(X_train)
     s_0 = 2. * sqrt(2.) / (1. + sqrt(2.))
     s_1 = (1. + sqrt(2)) * (1. / (4. * sqrt(2.)) + 1. / (2. + 2. * sqrt(2)))
     # check predict()
-    assert_array_almost_equal(-clf.negative_outlier_factor_, [s_0, s_1, s_1])
+    assert_array_almost_equal(-clf1.negative_outlier_factor_, [s_0, s_1, s_1])
+    assert_array_almost_equal(-clf2.negative_outlier_factor_, [s_0, s_1, s_1])
     # check predict(one sample not in train)
-    assert_array_almost_equal(-clf._decision_function([[2., 2.]]), [s_0])
-    # # check predict(one sample already in train)
-    assert_array_almost_equal(-clf._decision_function([[1., 1.]]), [s_1])
+    assert_array_almost_equal(-clf1._score_samples([[2., 2.]]), [s_0])
+    assert_array_almost_equal(-clf2._score_samples([[2., 2.]]), [s_0])
+    # check predict(one sample already in train)
+    assert_array_almost_equal(-clf1._score_samples([[1., 1.]]), [s_1])
+    assert_array_almost_equal(-clf2._score_samples([[1., 1.]]), [s_1])
 
 
 def test_lof_precomputed(random_state=42):
@@ -117,3 +122,22 @@ def test_n_neighbors_attribute():
                          "n_neighbors will be set to (n_samples - 1)",
                          clf.fit, X)
     assert_equal(clf.n_neighbors_, X.shape[0] - 1)
+
+
+def test_score_samples():
+    X_train = [[1, 1], [1, 2], [2, 1]]
+    clf1 = neighbors.LocalOutlierFactor(n_neighbors=2,
+                                        contamination=0.1).fit(X_train)
+    clf2 = neighbors.LocalOutlierFactor(n_neighbors=2).fit(X_train)
+    assert_array_equal(clf1._score_samples([[2., 2.]]),
+                       clf1._decision_function([[2., 2.]]) + clf1.offset_)
+    assert_array_equal(clf2._score_samples([[2., 2.]]),
+                       clf2._decision_function([[2., 2.]]) + clf2.offset_)
+    assert_array_equal(clf1._score_samples([[2., 2.]]),
+                       clf2._score_samples([[2., 2.]]))
+
+
+def test_contamination():
+    X = [[1, 1], [1, 0]]
+    clf = neighbors.LocalOutlierFactor(contamination=0.6)
+    assert_raises(ValueError, clf.fit, X)

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -1058,6 +1058,12 @@ class OneClassSVM(BaseLibSVM):
     intercept_ : array, shape = [1,]
         Constant in the decision function.
 
+    offset_ : float
+        Offset used to define the decision function from the raw scores.
+        We have the relation: decision_function = score_samples - offset_.
+        The offset is the opposite of intercept_ and is provided for
+        consistency with other outlier detection algorithms.
+
     """
 
     _impl = 'one_class'
@@ -1102,6 +1108,7 @@ class OneClassSVM(BaseLibSVM):
 
         super(OneClassSVM, self).fit(X, np.ones(_num_samples(X)),
                                      sample_weight=sample_weight, **params)
+        self.offset_ = -self._intercept_
         return self
 
     def decision_function(self, X):
@@ -1115,11 +1122,25 @@ class OneClassSVM(BaseLibSVM):
 
         Returns
         -------
-        X : array-like, shape (n_samples,)
+        dec : array-like, shape (n_samples,)
             Returns the decision function of the samples.
         """
-        dec = self._decision_function(X)
+        dec = self._decision_function(X).ravel()
         return dec
+
+    def score_samples(self, X):
+        """Raw scoring function of the samples.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+
+        Returns
+        -------
+        score_samples : array-like, shape (n_samples,)
+            Returns the (unshifted) scoring function of the samples.
+        """
+        return self.decision_function(X) + self.offset_
 
     def predict(self, X):
         """

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -280,6 +280,13 @@ def test_oneclass_decision_function():
     assert_array_equal((dec_func_outliers > 0).ravel(), y_pred_outliers == 1)
 
 
+def test_oneclass_score_samples():
+    X_train = [[1, 1], [1, 2], [2, 1]]
+    clf = svm.OneClassSVM().fit(X_train)
+    assert_array_equal(clf.score_samples([[2., 2.]]),
+                       clf.decision_function([[2., 2.]]) + clf.offset_)
+
+
 def test_tweak_params():
     # Make sure some tweaking of parameters works.
     # We change clf.dual_coef_ at run time and expect .predict() to change


### PR DESCRIPTION
Resolves #8693
Resolves #8707 

Following up discussion in issue #8693

- Make `IsolationForest` and `LocalOutlierFactor` decision functions use `contamination` as `EllipticEnvelope` does. It is used to define a drift such that the threshold on the decision function for being an outlier is 0 (positive value = inlier, negative value = outlier).

- Add a `score_samples` method to OCSVM, iForest, LOF, EllipticEnvelope, enabling the user to access   raw score functions from original papers. A new `offset_` parameter allows to link this new method to  `decision_function` through "decision_function = score_samples - offset_".

- clean `EllipticEnvelope`, fix docs, deprecate `raw_values` parameter. 

- Add why lof decision_function is private (mentioned in #8707)

- ravel the decision function of OCSVM so that it is indeed of shape (n_samples,)