### PR TITLE
[MRG] TRAVIS:  only install apt packages when needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,62 +3,60 @@ sudo: false
 
 language: python
 
-# Pre-install packages for the ubuntu distribution
 cache:
   apt: true
   directories:
   - $HOME/.cache/pip
-addons:
-  apt:
-    packages:
-      # these only required by the DISTRIB="ubuntu" builds:
-      - python-scipy
-      - libatlas3gf-base
-      - libatlas-dev
+
 dist: trusty
+
 env:
   global:
     # Directory where tests are run from
     - TEST_DIR=/tmp/sklearn
     - OMP_NUM_THREADS=4
     - OPENBLAS_NUM_THREADS=4
-  matrix:
-    # This environment tests that scikit-learn can be built against
-    # versions of numpy, scipy with ATLAS that comes with Ubuntu Trusty 14.04
-    - DISTRIB="ubuntu" PYTHON_VERSION="2.7" CYTHON_VERSION="0.23.4"
-      COVERAGE=true
-    # This environment tests the oldest supported anaconda env
-    - DISTRIB="conda" PYTHON_VERSION="2.7" INSTALL_MKL="false"
-      NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.13.3" CYTHON_VERSION="0.23.4"
-      COVERAGE=true
-    # This environment tests the newest supported Anaconda release (4.3.1)
-    # It also runs tests requiring Pandas.
-    - DISTRIB="conda" PYTHON_VERSION="3.6" INSTALL_MKL="true"
-      NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" PANDAS_VERSION="0.19.2"
-      CYTHON_VERSION="0.25.2" COVERAGE=true
-    # This environment use pytest to run the tests. It uses the newest
-    # supported Anaconda release (4.3.1). It also runs tests requiring Pandas.
-    - USE_PYTEST="true" DISTRIB="conda" PYTHON_VERSION="3.6" INSTALL_MKL="true"
-      NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" PANDAS_VERSION="0.19.2"
-      CYTHON_VERSION="0.25.2"
-    # flake8 linting on diff wrt common ancestor with upstream/master
-    - RUN_FLAKE8="true" SKIP_TESTS="true"
-      DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="true"
-      NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.17.0" CYTHON_VERSION="0.23.4"
-
 
 matrix:
-  allow_failures:
-    # allow_failures seems to be keyed on the python version
-    # We are using this to allow failures for DISTRIB=scipy-dev-wheels
-    - python: 3.5
-
   include:
+    # This environment tests that scikit-learn can be built against
+    # versions of numpy, scipy with ATLAS that comes with Ubuntu Trusty 14.04
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" CYTHON_VERSION="0.23.4"
+           COVERAGE=true
+      addons:
+        apt:
+          packages:
+            # these only required by the DISTRIB="ubuntu" builds:
+            - python-scipy
+            - libatlas3gf-base
+            - libatlas-dev
+    # This environment tests the oldest supported anaconda env
+    - env: DISTRIB="conda" PYTHON_VERSION="2.7" INSTALL_MKL="false"
+           NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.13.3" CYTHON_VERSION="0.23.4"
+           COVERAGE=true
+    # This environment tests the newest supported Anaconda release (4.3.1)
+    # It also runs tests requiring Pandas.
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" INSTALL_MKL="true"
+           NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" PANDAS_VERSION="0.19.2"
+           CYTHON_VERSION="0.25.2" COVERAGE=true
+    # This environment use pytest to run the tests. It uses the newest
+    # supported Anaconda release (4.3.1). It also runs tests requiring Pandas.
+    - env: USE_PYTEST="true" DISTRIB="conda" PYTHON_VERSION="3.6"
+           INSTALL_MKL="true" NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1"
+           PANDAS_VERSION="0.19.2" CYTHON_VERSION="0.25.2"
+    # flake8 linting on diff wrt common ancestor with upstream/master
+    - env: RUN_FLAKE8="true" SKIP_TESTS="true"
+           DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="true"
+           NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.17.0" CYTHON_VERSION="0.23.4"
     # This environment tests scikit-learn against numpy and scipy master
     # installed from their CI wheels in a virtualenv with the Python
     # interpreter provided by travis.
     -  python: 3.5
        env: DISTRIB="scipy-dev-wheels"
+  allow_failures:
+    # allow_failures seems to be keyed on the python version
+    # We are using this to allow failures for DISTRIB=scipy-dev-wheels
+    - python: 3.5
 
 install: source build_tools/travis/install.sh
 script: bash build_tools/travis/test_script.sh


### PR DESCRIPTION
Also revamped .travis.yml to use the matrix/include for all build entries.

This should save 20-30s on all builds, except the Ubuntu one. This is not such a big deal but it also tidies up the .travis.yml a bit.