### PR TITLE
[MRG] Bug fix and new feature: fix implementation of average precision score and add eleven-point interpolated option (7356 rebased)

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -681,7 +681,7 @@ Here are some small examples in binary classification::
   >>> threshold
   array([ 0.35,  0.4 ,  0.8 ])
   >>> average_precision_score(y_true, y_scores)  # doctest: +ELLIPSIS
-  0.79...
+  0.83...
 
 
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -6,7 +6,7 @@ Release history
 ===============
 
 Version 0.19
-============
+==============
 
 **In Development**
 
@@ -192,6 +192,13 @@ Enhancements
 
 Bug fixes
 .........
+
+   - :func:`metrics.ranking.average_precision_score` no longer linearly
+     interpolates between operating points, and instead weighs precisions
+     by the change in recall since the last operating point, as per the
+     `Wikipedia entry <http://en.wikipedia.org/wiki/Average_precision>`_.
+     (`#7356 <https://github.com/scikit-learn/scikit-learn/pull/7356>`_). By
+     `Nick Dingwall`_ and `Gael Varoquaux`_.
 
    - Fixed a bug in :class:`sklearn.covariance.MinCovDet` where inputting data
      that produced a singular covariance matrix would cause the helper method

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -6,7 +6,7 @@ Release history
 ===============
 
 Version 0.19
-==============
+============
 
 **In Development**
 

--- a/examples/model_selection/plot_precision_recall.py
+++ b/examples/model_selection/plot_precision_recall.py
@@ -5,13 +5,18 @@ Precision-Recall
 
 Example of Precision-Recall metric to evaluate classifier output quality.
 
-In information retrieval, precision is a measure of result relevancy, while
-recall is a measure of how many truly relevant results are returned. A high
-area under the curve represents both high recall and high precision, where high
-precision relates to a low false positive rate, and high recall relates to a
-low false negative rate. High scores for both show that the classifier is
-returning accurate results (high precision), as well as returning a majority of
-all positive results (high recall).
+Precision-Recall is a useful measure of success of prediction when the
+classes are very imbalanced. In information retrieval, precision is a
+measure of result relevancy, while recall is a measure of how many truly
+relevant results are returned.
+
+The precision-recall curve shows the tradeoff between precision and
+recall for different threshold. A high area under the curve represents
+both high recall and high precision, where high precision relates to a
+low false positive rate, and high recall relates to a low false negative
+rate. High scores for both show that the classifier is returning accurate
+results (high precision), as well as returning a majority of all positive
+results (high recall).
 
 A system with high recall but low precision returns many results, but most of
 its predicted labels are incorrect when compared to the training labels. A
@@ -37,7 +42,7 @@ as the harmonic mean of precision and recall.
 
 :math:`F1 = 2\\frac{P \\times R}{P+R}`
 
-It is important to note that the precision may not decrease with recall. The
+Note that the precision may not decrease with recall. The
 definition of precision (:math:`\\frac{T_p}{T_p + F_p}`) shows that lowering
 the threshold of a classifier may increase the denominator, by increasing the
 number of results returned. If the threshold was previously set too high, the
@@ -54,11 +59,20 @@ unchanged, while the precision fluctuates.
 The relationship between recall and precision can be observed in the
 stairstep area of the plot - at the edges of these steps a small change
 in the threshold considerably reduces precision, with only a minor gain in
-recall. See the corner at recall = .59, precision = .8 for an example of this
-phenomenon.
+recall.
+
+**Average precision** summarizes such a plot as the weighted mean of precisions
+achieved at each threshold, with the increase in recall from the previous
+threshold used as the weight:
+
+:math:`\\text{AP} = \\sum_n (R_n - R_{n-1}) P_n`
+
+where :math:`P_n` and :math:`R_n` are the precision and recall at the
+nth threshold. A pair :math:`(R_k, P_k)` is referred to as an
+*operating point*.
 
 Precision-recall curves are typically used in binary classification to study
-the output of a classifier. In order to extend Precision-recall curve and
+the output of a classifier. In order to extend the precision-recall curve and
 average precision to multi-class or multi-label classification, it is necessary
 to binarize the output. One curve can be drawn per label, but one can also draw
 a precision-recall curve by considering each element of the label indicator
@@ -71,76 +85,148 @@ matrix as a binary prediction (micro-averaging).
              :func:`sklearn.metrics.precision_score`,
              :func:`sklearn.metrics.f1_score`
 """
-print(__doc__)
+from __future__ import print_function
 
-import matplotlib.pyplot as plt
-import numpy as np
-from itertools import cycle
-
+###############################################################################
+# In binary classification settings
+# --------------------------------------------------------
+#
+# Create simple data
+# ..................
+#
+# Try to differentiate the two first classes of the iris data
 from sklearn import svm, datasets
-from sklearn.metrics import precision_recall_curve
-from sklearn.metrics import average_precision_score
 from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import label_binarize
-from sklearn.multiclass import OneVsRestClassifier
+import numpy as np
 
-# import some data to play with
 iris = datasets.load_iris()
 X = iris.data
 y = iris.target
-
-# setup plot details
-colors = cycle(['navy', 'turquoise', 'darkorange', 'cornflowerblue', 'teal'])
-lw = 2
-
-# Binarize the output
-y = label_binarize(y, classes=[0, 1, 2])
-n_classes = y.shape[1]
 
 # Add noisy features
 random_state = np.random.RandomState(0)
 n_samples, n_features = X.shape
 X = np.c_[X, random_state.randn(n_samples, 200 * n_features)]
 
-# Split into training and test
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=.5,
+# Limit to the two first classes, and split into training and test
+X_train, X_test, y_train, y_test = train_test_split(X[y < 2], y[y < 2],
+                                                    test_size=.5,
                                                     random_state=random_state)
 
-# Run classifier
-classifier = OneVsRestClassifier(svm.SVC(kernel='linear', probability=True,
-                                 random_state=random_state))
-y_score = classifier.fit(X_train, y_train).decision_function(X_test)
+# Create a simple classifier
+classifier = svm.LinearSVC(random_state=random_state)
+classifier.fit(X_train, y_train)
+y_score = classifier.decision_function(X_test)
 
-# Compute Precision-Recall and plot curve
-precision = dict()
-recall = dict()
-average_precision = dict()
-for i in range(n_classes):
-    precision[i], recall[i], _ = precision_recall_curve(y_test[:, i],
-                                                        y_score[:, i])
-    average_precision[i] = average_precision_score(y_test[:, i], y_score[:, i])
+###############################################################################
+# Compute the average precision score
+# ...................................
+from sklearn.metrics import average_precision_score
+average_precision = average_precision_score(y_test, y_score)
 
-# Compute micro-average ROC curve and ROC area
-precision["micro"], recall["micro"], _ = precision_recall_curve(y_test.ravel(),
-    y_score.ravel())
-average_precision["micro"] = average_precision_score(y_test, y_score,
-                                                     average="micro")
+print('Average precision-recall score: {0:0.2f}'.format(
+      average_precision))
 
+###############################################################################
+# Plot the Precision-Recall curve
+# ................................
+from sklearn.metrics import precision_recall_curve
+import matplotlib.pyplot as plt
 
-# Plot Precision-Recall curve
-plt.clf()
-plt.plot(recall[0], precision[0], lw=lw, color='navy',
-         label='Precision-Recall curve')
+precision, recall, _ = precision_recall_curve(y_test, y_score)
+
+plt.step(recall, precision, color='b', alpha=0.2,
+         where='post')
+plt.fill_between(recall, precision, step='post', alpha=0.2,
+                 color='b')
+
 plt.xlabel('Recall')
 plt.ylabel('Precision')
 plt.ylim([0.0, 1.05])
 plt.xlim([0.0, 1.0])
-plt.title('Precision-Recall example: AUC={0:0.2f}'.format(average_precision[0]))
-plt.legend(loc="lower left")
-plt.show()
+plt.title('2-class Precision-Recall curve: AUC={0:0.2f}'.format(
+          average_precision))
 
+###############################################################################
+# In multi-label settings
+# ------------------------
+#
+# Create multi-label data, fit, and predict
+# ...........................................
+#
+# We create a multi-label dataset, to illustrate the precision-recall in
+# multi-label settings
+
+from sklearn.preprocessing import label_binarize
+
+# Use label_binarize to be multi-label like settings
+Y = label_binarize(y, classes=[0, 1, 2])
+n_classes = Y.shape[1]
+
+# Split into training and test
+X_train, X_test, Y_train, Y_test = train_test_split(X, Y, test_size=.5,
+                                                    random_state=random_state)
+
+# We use OneVsRestClassifier for multi-label prediction
+from sklearn.multiclass import OneVsRestClassifier
+
+# Run classifier
+classifier = OneVsRestClassifier(svm.LinearSVC(random_state=random_state))
+classifier.fit(X_train, Y_train)
+y_score = classifier.decision_function(X_test)
+
+
+###############################################################################
+# The average precision score in multi-label settings
+# ....................................................
+from sklearn.metrics import precision_recall_curve
+from sklearn.metrics import average_precision_score
+
+# For each class
+precision = dict()
+recall = dict()
+average_precision = dict()
+for i in range(n_classes):
+    precision[i], recall[i], _ = precision_recall_curve(Y_test[:, i],
+                                                        y_score[:, i])
+    average_precision[i] = average_precision_score(Y_test[:, i], y_score[:, i])
+
+# A "micro-average": quantifying score on all classes jointly
+precision["micro"], recall["micro"], _ = precision_recall_curve(Y_test.ravel(),
+    y_score.ravel())
+average_precision["micro"] = average_precision_score(Y_test, y_score,
+                                                     average="micro")
+print('Average precision score, micro-averaged over all classes: {0:0.2f}'
+      .format(average_precision["micro"]))
+
+###############################################################################
+# Plot the micro-averaged Precision-Recall curve
+# ...............................................
+#
+
+plt.figure()
+plt.step(recall['micro'], precision['micro'], color='b', alpha=0.2,
+         where='post')
+plt.fill_between(recall["micro"], precision["micro"], step='post', alpha=0.2,
+                 color='b')
+
+plt.xlabel('Recall')
+plt.ylabel('Precision')
+plt.ylim([0.0, 1.05])
+plt.xlim([0.0, 1.0])
+plt.title(
+    'Average precision score, micro-averaged over all classes: AUC={0:0.2f}'
+    .format(average_precision["micro"]))
+
+###############################################################################
 # Plot Precision-Recall curve for each class and iso-f1 curves
-plt.clf()
+# .............................................................
+#
+from itertools import cycle
+# setup plot details
+colors = cycle(['navy', 'turquoise', 'darkorange', 'cornflowerblue', 'teal'])
+
+plt.figure(figsize=(7, 8))
 f_scores = np.linspace(0.2, 0.8, num=4)
 lines = []
 labels = []
@@ -152,23 +238,25 @@ for f_score in f_scores:
 
 lines.append(l)
 labels.append('iso-f1 curves')
-l, = plt.plot(recall["micro"], precision["micro"], color='gold', lw=lw)
+l, = plt.plot(recall["micro"], precision["micro"], color='gold', lw=2)
 lines.append(l)
-labels.append('micro-average Precision-recall curve (area = {0:0.2f})'
+labels.append('micro-average Precision-recall (area = {0:0.2f})'
               ''.format(average_precision["micro"]))
+
 for i, color in zip(range(n_classes), colors):
-    l, = plt.plot(recall[i], precision[i], color=color, lw=lw)
+    l, = plt.plot(recall[i], precision[i], color=color, lw=2)
     lines.append(l)
-    labels.append('Precision-recall curve of class {0} (area = {1:0.2f})'
+    labels.append('Precision-recall for class {0} (area = {1:0.2f})'
                   ''.format(i, average_precision[i]))
 
 fig = plt.gcf()
-fig.set_size_inches(7, 7)
 fig.subplots_adjust(bottom=0.25)
 plt.xlim([0.0, 1.0])
 plt.ylim([0.0, 1.05])
 plt.xlabel('Recall')
 plt.ylabel('Precision')
 plt.title('Extension of Precision-Recall curve to multi-class')
-plt.figlegend(lines, labels, loc='lower center')
+plt.legend(lines, labels, loc=(0, -.38), prop=dict(size=14))
+
+
 plt.show()

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -36,8 +36,10 @@ from ..preprocessing import LabelBinarizer
 from .base import _average_binary_score
 
 
-def auc(x, y, reorder=False):
-    """Compute Area Under the Curve (AUC) using the trapezoidal rule
+def auc(x, y, reorder=False, interpolation='linear',
+        interpolation_direction='right'):
+    """Estimate Area Under the Curve (AUC) using finitely many points and an
+    interpolation strategy.
 
     This is a general function, given points on a curve.  For computing the
     area under the ROC-curve, see :func:`roc_auc_score`.
@@ -53,6 +55,24 @@ def auc(x, y, reorder=False):
     reorder : boolean, optional (default=False)
         If True, assume that the curve is ascending in the case of ties, as for
         an ROC curve. If the curve is non-ascending, the result will be wrong.
+
+    interpolation : string ['trapezoid' (default), 'step']
+        This determines the type of interpolation performed on the data.
+
+        ``'linear'``:
+            Use the trapezoidal rule (linearly interpolating between points).
+        ``'step'``:
+            Use a step function where we ascend/descend from each point to the
+            y-value of the subsequent point.
+
+    interpolation_direction : string ['right' (default), 'left']
+        This determines the direction to interpolate from. The value is ignored
+        unless interpolation is 'step'.
+
+        ``'right'``:
+            Intermediate points inherit their y-value from the subsequent point.
+        ``'left'``:
+            Intermediate points inherit their y-value from the previous point.
 
     Returns
     -------
@@ -76,13 +96,6 @@ def auc(x, y, reorder=False):
         Compute precision-recall pairs for different probability thresholds
 
     """
-    check_consistent_length(x, y)
-    x = column_or_1d(x)
-    y = column_or_1d(y)
-
-    if x.shape[0] < 2:
-        raise ValueError('At least 2 points are needed to compute'
-                         ' area under curve, but x.shape = %s' % x.shape)
 
     direction = 1
     if reorder:
@@ -99,20 +112,42 @@ def auc(x, y, reorder=False):
                 raise ValueError("Reordering is not turned on, and "
                                  "the x array is not increasing: %s" % x)
 
-    area = direction * np.trapz(y, x)
-    if isinstance(area, np.memmap):
-        # Reductions such as .sum used internally in np.trapz do not return a
-        # scalar by default for numpy.memmap instances contrary to
-        # regular numpy.ndarray instances.
-        area = area.dtype.type(area)
+    if interpolation == 'linear':
+
+        area = direction * np.trapz(y, x)
+
+    elif interpolation == 'step':
+
+        # we need the data to start in ascending order
+        if direction == -1:
+            x, y = list(reversed(x)), list(reversed(y))
+
+        if interpolation_direction == 'right':
+            # The left-most y-value is not used
+            area = sum(np.diff(x) * np.array(y)[1:])
+
+        elif interpolation_direction == 'left':
+            # The right-most y-value is not used
+            area = sum(np.diff(x) * np.array(y)[:-1])
+
+        else:
+            raise ValueError("interpolation_direction '{}' not recognised."
+                             " Should be one of ['right', 'left']".format(
+                                 interpolation_direction))
+    else:
+        raise ValueError("interpolation value '{}' not recognized. "
+                         "Should be one of ['linear', 'step']".format(
+                             interpolation))
+
     return area
 
 
 def average_precision_score(y_true, y_score, average="macro",
-                            sample_weight=None):
+                            sample_weight=None, interpolation="linear"):
     """Compute average precision (AP) from prediction scores
 
-    This score corresponds to the area under the precision-recall curve.
+    This score corresponds to the area under the precision-recall curve, where
+    points are joined using either linear or step-wise interpolation.
 
     Note: this implementation is restricted to the binary classification task
     or multilabel classification task.
@@ -126,8 +161,7 @@ def average_precision_score(y_true, y_score, average="macro",
 
     y_score : array, shape = [n_samples] or [n_samples, n_classes]
         Target scores, can either be probability estimates of the positive
-        class, confidence values, or non-thresholded measure of decisions
-        (as returned by "decision_function" on some classifiers).
+        class, confidence values, or binary decisions.
 
     average : string, [None, 'micro', 'macro' (default), 'samples', 'weighted']
         If ``None``, the scores for each class are returned. Otherwise,
@@ -148,6 +182,16 @@ def average_precision_score(y_true, y_score, average="macro",
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
 
+    interpolation : string ['linear' (default), 'step']
+        Determines the kind of interpolation used when computed AUC. If there are
+        many repeated scores, 'step' is recommended to avoid under- or over-
+        estimating the AUC. See www.roamanalytics.com/etc for details.
+
+        ``'linear'``:
+            Linearly interpolates between operating points.
+        ``'step'``:
+            Uses a step function to interpolate between operating points.
+
     Returns
     -------
     average_precision : float
@@ -155,7 +199,7 @@ def average_precision_score(y_true, y_score, average="macro",
     References
     ----------
     .. [1] `Wikipedia entry for the Average precision
-           <https://en.wikipedia.org/wiki/Average_precision>`_
+           <http://en.wikipedia.org/wiki/Average_precision>`_
 
     See also
     --------
@@ -177,8 +221,20 @@ def average_precision_score(y_true, y_score, average="macro",
     def _binary_average_precision(y_true, y_score, sample_weight=None):
         precision, recall, thresholds = precision_recall_curve(
             y_true, y_score, sample_weight=sample_weight)
-        return auc(recall, precision)
+        return auc(recall, precision, interpolation=interpolation,
+                   interpolation_direction='right')
 
+    if interpolation == "linear":
+        # Check for number of unique predictions. If this is substantially less
+        # than the number of predictions, linear interpolation is likely to be
+        # biased.
+        n_discrete_predictions = len(np.unique(y_score))
+        if n_discrete_predictions < 0.75 * len(y_score):
+            warnings.warn("Number of unique scores is less than 75% of the "
+                          "number of scores provided. Linear interpolation "
+                          "is likely to be biased in this case. You may wish "
+                          "to use step interpolation instead. See docstring "
+                          "for details.")
     return _average_binary_score(_binary_average_precision, y_true, y_score,
                                  average, sample_weight=sample_weight)
 
@@ -252,7 +308,7 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
 
         fpr, tpr, tresholds = roc_curve(y_true, y_score,
                                         sample_weight=sample_weight)
-        return auc(fpr, tpr, reorder=True)
+        return auc(fpr, tpr, reorder=True, interpolation='linear')
 
     return _average_binary_score(
         _binary_roc_auc_score, y_true, y_score, average,

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -36,10 +36,8 @@ from ..preprocessing import LabelBinarizer
 from .base import _average_binary_score
 
 
-def auc(x, y, reorder=False, interpolation='linear',
-        interpolation_direction='right'):
-    """Estimate Area Under the Curve (AUC) using finitely many points and an
-    interpolation strategy.
+def auc(x, y, reorder=False):
+    """Compute Area Under the Curve (AUC) using the trapezoidal rule
 
     This is a general function, given points on a curve.  For computing the
     area under the ROC-curve, see :func:`roc_auc_score`.
@@ -48,31 +46,11 @@ def auc(x, y, reorder=False, interpolation='linear',
     ----------
     x : array, shape = [n]
         x coordinates.
-
     y : array, shape = [n]
         y coordinates.
-
     reorder : boolean, optional (default=False)
         If True, assume that the curve is ascending in the case of ties, as for
         an ROC curve. If the curve is non-ascending, the result will be wrong.
-
-    interpolation : string ['trapezoid' (default), 'step']
-        This determines the type of interpolation performed on the data.
-
-        ``'linear'``:
-            Use the trapezoidal rule (linearly interpolating between points).
-        ``'step'``:
-            Use a step function where we ascend/descend from each point to the
-            y-value of the subsequent point.
-
-    interpolation_direction : string ['right' (default), 'left']
-        This determines the direction to interpolate from. The value is ignored
-        unless interpolation is 'step'.
-
-        ``'right'``:
-            Intermediate points inherit their y-value from the subsequent point.
-        ``'left'``:
-            Intermediate points inherit their y-value from the previous point.
 
     Returns
     -------
@@ -91,11 +69,16 @@ def auc(x, y, reorder=False, interpolation='linear',
     See also
     --------
     roc_auc_score : Computes the area under the ROC curve
-
     precision_recall_curve :
         Compute precision-recall pairs for different probability thresholds
-
     """
+    check_consistent_length(x, y)
+    x = column_or_1d(x)
+    y = column_or_1d(y)
+
+    if x.shape[0] < 2:
+        raise ValueError('At least 2 points are needed to compute'
+                         ' area under curve, but x.shape = %s' % x.shape)
 
     direction = 1
     if reorder:
@@ -112,42 +95,18 @@ def auc(x, y, reorder=False, interpolation='linear',
                 raise ValueError("Reordering is not turned on, and "
                                  "the x array is not increasing: %s" % x)
 
-    if interpolation == 'linear':
-
-        area = direction * np.trapz(y, x)
-
-    elif interpolation == 'step':
-
-        # we need the data to start in ascending order
-        if direction == -1:
-            x, y = list(reversed(x)), list(reversed(y))
-
-        if interpolation_direction == 'right':
-            # The left-most y-value is not used
-            area = sum(np.diff(x) * np.array(y)[1:])
-
-        elif interpolation_direction == 'left':
-            # The right-most y-value is not used
-            area = sum(np.diff(x) * np.array(y)[:-1])
-
-        else:
-            raise ValueError("interpolation_direction '{}' not recognised."
-                             " Should be one of ['right', 'left']".format(
-                                 interpolation_direction))
-    else:
-        raise ValueError("interpolation value '{}' not recognized. "
-                         "Should be one of ['linear', 'step']".format(
-                             interpolation))
-
+    area = direction * np.trapz(y, x)
+    if isinstance(area, np.memmap):
+        # Reductions such as .sum used internally in np.trapz do not return a
+        # scalar by default for numpy.memmap instances contrary to
+        # regular numpy.ndarray instances.
+        area = area.dtype.type(area)
     return area
 
 
 def average_precision_score(y_true, y_score, average="macro",
-                            sample_weight=None, interpolation="linear"):
+                            sample_weight=None):
     """Compute average precision (AP) from prediction scores
-
-    This score corresponds to the area under the precision-recall curve, where
-    points are joined using either linear or step-wise interpolation.
 
     Note: this implementation is restricted to the binary classification task
     or multilabel classification task.
@@ -161,7 +120,8 @@ def average_precision_score(y_true, y_score, average="macro",
 
     y_score : array, shape = [n_samples] or [n_samples, n_classes]
         Target scores, can either be probability estimates of the positive
-        class, confidence values, or binary decisions.
+        class, confidence values, or non-thresholded measure of decisions
+        (as returned by "decision_function" on some classifiers).
 
     average : string, [None, 'micro', 'macro' (default), 'samples', 'weighted']
         If ``None``, the scores for each class are returned. Otherwise,
@@ -182,16 +142,6 @@ def average_precision_score(y_true, y_score, average="macro",
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
 
-    interpolation : string ['linear' (default), 'step']
-        Determines the kind of interpolation used when computed AUC. If there are
-        many repeated scores, 'step' is recommended to avoid under- or over-
-        estimating the AUC. See www.roamanalytics.com/etc for details.
-
-        ``'linear'``:
-            Linearly interpolates between operating points.
-        ``'step'``:
-            Uses a step function to interpolate between operating points.
-
     Returns
     -------
     average_precision : float
@@ -200,6 +150,12 @@ def average_precision_score(y_true, y_score, average="macro",
     ----------
     .. [1] `Wikipedia entry for the Average precision
            <http://en.wikipedia.org/wiki/Average_precision>`_
+    .. [2] `Stanford Information Retrieval book
+            <http://nlp.stanford.edu/IR-book/html/htmledition/
+            evaluation-of-ranked-retrieval-results-1.html>`_
+    .. [3] `The PASCAL Visual Object Classes (VOC) Challenge
+            <http://citeseerx.ist.psu.edu/viewdoc/
+            download?doi=10.1.1.157.5766&rep=rep1&type=pdf>`_
 
     See also
     --------
@@ -215,28 +171,21 @@ def average_precision_score(y_true, y_score, average="macro",
     >>> y_true = np.array([0, 0, 1, 1])
     >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
     >>> average_precision_score(y_true, y_scores)  # doctest: +ELLIPSIS
-    0.79...
+    0.83...
+
+    >>> yt = np.array([0, 0, 1, 1])
+    >>> ys = np.array([0.1, 0.4, 0.35, 0.8])
+    >>> ap = average_precision_score(yt, ys)
+    >>> ap # doctest: +ELLIPSIS
+    0.84...
 
     """
-    def _binary_average_precision(y_true, y_score, sample_weight=None):
-        precision, recall, thresholds = precision_recall_curve(
-            y_true, y_score, sample_weight=sample_weight)
-        return auc(recall, precision, interpolation=interpolation,
-                   interpolation_direction='right')
-
-    if interpolation == "linear":
-        # Check for number of unique predictions. If this is substantially less
-        # than the number of predictions, linear interpolation is likely to be
-        # biased.
-        n_discrete_predictions = len(np.unique(y_score))
-        if n_discrete_predictions < 0.75 * len(y_score):
-            warnings.warn("Number of unique scores is less than 75% of the "
-                          "number of scores provided. Linear interpolation "
-                          "is likely to be biased in this case. You may wish "
-                          "to use step interpolation instead. See docstring "
-                          "for details.")
-    return _average_binary_score(_binary_average_precision, y_true, y_score,
-                                 average, sample_weight=sample_weight)
+    precision, recall, thresholds = precision_recall_curve(
+        y_true, y_score, sample_weight=sample_weight)
+    # Return the step function integral
+    # The following works because the last entry of precision is
+    # garantee to be 1, as returned by precision_recall_curve
+    return -np.sum(np.diff(recall) * np.array(precision)[:-1])
 
 
 def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
@@ -308,7 +257,7 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
 
         fpr, tpr, tresholds = roc_curve(y_true, y_score,
                                         sample_weight=sample_weight)
-        return auc(fpr, tpr, reorder=True, interpolation='linear')
+        return auc(fpr, tpr, reorder=True)
 
     return _average_binary_score(
         _binary_roc_auc_score, y_true, y_score, average,

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -173,19 +173,20 @@ def average_precision_score(y_true, y_score, average="macro",
     >>> average_precision_score(y_true, y_scores)  # doctest: +ELLIPSIS
     0.83...
 
-    >>> yt = np.array([0, 0, 1, 1])
-    >>> ys = np.array([0.1, 0.4, 0.35, 0.8])
-    >>> ap = average_precision_score(yt, ys)
-    >>> ap # doctest: +ELLIPSIS
-    0.84...
-
     """
-    precision, recall, thresholds = precision_recall_curve(
-        y_true, y_score, sample_weight=sample_weight)
-    # Return the step function integral
-    # The following works because the last entry of precision is
-    # garantee to be 1, as returned by precision_recall_curve
-    return -np.sum(np.diff(recall) * np.array(precision)[:-1])
+    def _binary_uninterpolated_average_precision(
+            y_true, y_score, sample_weight=None):
+        precision, recall, thresholds = precision_recall_curve(
+            y_true, y_score, sample_weight=sample_weight)
+        # Return the step function integral
+        # The following works because the last entry of precision is
+        # garantee to be 1, as returned by precision_recall_curve
+        return -np.sum(np.diff(recall) * np.array(precision)[:-1])
+
+    return _average_binary_score(_binary_uninterpolated_average_precision,
+                                 y_true, y_score, average,
+                                 sample_weight=sample_weight)
+
 
 
 def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -101,7 +101,13 @@ def _auc(y_true, y_score):
 
 def _average_precision(y_true, y_score):
     """Alternative implementation to check for correctness of
-    `average_precision_score`."""
+    `average_precision_score`.
+
+    Note that this implementation fails on some edge cases.
+    For example, for constant predictions e.g. [0.5, 0.5, 0.5],
+    y_true = [1, 0, 0] returns an average precision of 0.33...
+    but y_true = [0, 0, 1] returns 1.0.
+    """
     pos_label = np.unique(y_true)[1]
     n_pos = np.sum(y_true == pos_label)
     order = np.argsort(y_score)[::-1]
@@ -121,6 +127,25 @@ def _average_precision(y_true, y_score):
             score += prec
 
     return score / n_pos
+
+
+def _average_precision_slow(y_true, y_score):
+    """A second alternative implementation of average precision that closely
+    follows the Wikipedia article's definition (see References). This should
+    give identical results as `average_precision_score` for all inputs.
+
+    References
+    ----------
+    .. [1] `Wikipedia entry for the Average precision
+       <http://en.wikipedia.org/wiki/Average_precision>`_
+    """
+    precision, recall, threshold = precision_recall_curve(y_true, y_score)
+    precision = list(reversed(precision))
+    recall = list(reversed(recall))
+    average_precision = 0
+    for i in range(1, len(precision)):
+        average_precision += precision[i] * (recall[i] - recall[i - 1])
+    return average_precision
 
 
 def test_roc_curve():
@@ -471,19 +496,17 @@ def test_precision_recall_curve_pos_label():
 def _test_precision_recall_curve(y_true, probas_pred):
     # Test Precision-Recall and aread under PR curve
     p, r, thresholds = precision_recall_curve(y_true, probas_pred)
-    precision_recall_auc = auc(r, p)
-    assert_array_almost_equal(precision_recall_auc, 0.85, 2)
+    precision_recall_auc = _average_precision_slow(y_true, probas_pred)
+    assert_array_almost_equal(precision_recall_auc, 0.859, 3)
     assert_array_almost_equal(precision_recall_auc,
                               average_precision_score(y_true, probas_pred))
     assert_almost_equal(_average_precision(y_true, probas_pred),
-                        precision_recall_auc, 1)
+                        precision_recall_auc, decimal=3)
     assert_equal(p.size, r.size)
     assert_equal(p.size, thresholds.size + 1)
     # Smoke test in the case of proba having only one value
     p, r, thresholds = precision_recall_curve(y_true,
                                               np.zeros_like(probas_pred))
-    precision_recall_auc = auc(r, p)
-    assert_array_almost_equal(precision_recall_auc, 0.75, 3)
     assert_equal(p.size, r.size)
     assert_equal(p.size, thresholds.size + 1)
 
@@ -511,7 +534,10 @@ def test_precision_recall_curve_toydata():
         auc_prc = average_precision_score(y_true, y_score)
         assert_array_almost_equal(p, [0.5, 0., 1.])
         assert_array_almost_equal(r, [1., 0.,  0.])
-        assert_almost_equal(auc_prc, 0.25)
+        # Here we are doing a terrible prediction: we are always getting
+        # it wrong, hence the average_precision_score is the accuracy at
+        # chance: 50%
+        assert_almost_equal(auc_prc, 0.5)
 
         y_true = [1, 0]
         y_score = [1, 1]
@@ -519,7 +545,7 @@ def test_precision_recall_curve_toydata():
         auc_prc = average_precision_score(y_true, y_score)
         assert_array_almost_equal(p, [0.5, 1])
         assert_array_almost_equal(r, [1., 0])
-        assert_almost_equal(auc_prc, .75)
+        assert_almost_equal(auc_prc, .5)
 
         y_true = [1, 0]
         y_score = [1, 0]
@@ -535,7 +561,7 @@ def test_precision_recall_curve_toydata():
         auc_prc = average_precision_score(y_true, y_score)
         assert_array_almost_equal(p, [0.5, 1])
         assert_array_almost_equal(r, [1, 0.])
-        assert_almost_equal(auc_prc, .75)
+        assert_almost_equal(auc_prc, .5)
 
         y_true = [0, 0]
         y_score = [0.25, 0.75]
@@ -568,31 +594,45 @@ def test_precision_recall_curve_toydata():
         assert_raises(Exception, average_precision_score, y_true, y_score,
                       average="weighted")
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="samples"), 0.625)
+                            average="samples"), 0.75)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="micro"), 0.625)
+                            average="micro"), 0.5)
 
         y_true = np.array([[1, 0], [0, 1]])
         y_score = np.array([[0, 1], [1, 0]])
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="macro"), 0.25)
+                            average="macro"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="weighted"), 0.25)
+                            average="weighted"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="samples"), 0.25)
+                            average="samples"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="micro"), 0.25)
+                            average="micro"), 0.5)
 
         y_true = np.array([[1, 0], [0, 1]])
         y_score = np.array([[0.5, 0.5], [0.5, 0.5]])
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="macro"), 0.75)
+                            average="macro"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="weighted"), 0.75)
+                            average="weighted"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="samples"), 0.75)
+                            average="samples"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="micro"), 0.75)
+                            average="micro"), 0.5)
+
+
+def test_average_precision_constant_values():
+    # Check the average_precision_score of a constant predictor is
+    # the TPR
+
+    # Generate a dataset with 25% of positives
+    y_true = np.zeros(100, dtype=int)
+    y_true[::4] = 1
+    # And a constant score
+    y_score = np.ones(100)
+    # The precision is then the fraction of positive whatever the recall
+    # is, as there is only one threshold:
+    assert_equal(average_precision_score(y_true, y_score), .25)
 
 
 def test_score_scale_invariance():


### PR DESCRIPTION
Rebased version of #7356

Fixes #4577 and #6377

What does this implement/fix? Explain your changes.

This adds an optional interpolation parameter to both average_precision_score. By default, the value is set to None which replicates the existing behavior, but there is also a 'eleven_point' option that implements the strategy described in Stanford's Introduction to Information Retrieval.



<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
