### PR TITLE
[MRG+2] Fixed memory leak in liblinear

### DIFF
--- a/sklearn/svm/src/liblinear/liblinear_helper.c
+++ b/sklearn/svm/src/liblinear/liblinear_helper.c
@@ -219,6 +219,7 @@ void free_problem(struct problem *problem)
     int i;
     for(i=problem->l-1; i>=0; --i) free(problem->x[i]);
     free(problem->x);
+    free(problem);
 }
 
 void free_parameter(struct parameter *param)

--- a/sklearn/svm/src/liblinear/linear.cpp
+++ b/sklearn/svm/src/liblinear/linear.cpp
@@ -2910,6 +2910,8 @@ void free_model_content(struct model *model_ptr)
 		free(model_ptr->w);
 	if(model_ptr->label != NULL)
 		free(model_ptr->label);
+	if(model_ptr->n_iter != NULL)
+	    free(model_ptr->n_iter);
 }
 
 void free_and_destroy_model(struct model **model_ptr_ptr)


### PR DESCRIPTION
#### Reference Issue

Fixes #8499

#### What does this implement/fix? Explain your changes.

scikit-learn version of liblinear had tow leaks:

- missing free of the problem struct
- missing free of number of iterations

The former was present in the initial version of ``liblinear_helper.c``
while latter appeared after c8c72fd96e13f9a7fd80362311248321949b8de5
which introduced ``n_iter``.

#### Any other comments?

I'm surprised these leaks survived for so long :)