### PR TITLE
[MRG+1] Reducing t-SNE memory usage

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,4 @@
+/bhtsne
+*.npy
+*.json
+/mnist_tsne_benchmark_data/

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,4 +1,4 @@
 /bhtsne
 *.npy
 *.json
-/mnist_tsne_benchmark_data/
+/mnist_tsne_output/

--- a/benchmarks/bench_tsne_mnist.py
+++ b/benchmarks/bench_tsne_mnist.py
@@ -20,32 +20,6 @@ from sklearn.manifold import TSNE
 from sklearn.utils import check_array
 
 
-try:
-    from memory_profiler import profile
-except ImportError:
-    def profile(f):
-        return f
-
-try:
-    # If you want comparison with the reference implementation, build the
-    # binary from source (https://github.com/lvdmaaten/bhtsne) in the folder
-    # benchmarks/bhtsne and add an empty `__init__.py` file in the floder.
-    #
-    #  $ git clone git@github.com:lvdmaaten/bhtsne.git
-    #  $ cd bhtsne
-    #  $ g++ sptree.cpp tsne.cpp tsne_main.cpp -o bh_tsne -O2
-    #  $ touch __init__.py
-    #  $ cd ..
-    #
-    from bhtsne.bhtsne import run_bh_tsne
-
-    @profile
-    def bhtsne(data, **kwargs):
-        return run_bh_tsne(data, **kwargs)
-except ImportError:
-    bhtsne = None
-
-
 memory = Memory('mnist_tsne_benchmark_data', mmap_mode='r')
 
 
@@ -62,7 +36,6 @@ def load_data(dtype=np.float32, order='C'):
     return X, y
 
 
-@profile
 def tsne_fit_transform(model, data):
     return model.fit_transform(data)
 
@@ -72,38 +45,88 @@ if __name__ == "__main__":
     parser.add_argument('--order', type=str, default='C',
                         help='Order of the input data')
     parser.add_argument('--perplexity', type=float, default=30)
-    parser.add_argument('--log-max-nsamples', type=int, default=5)
-    parser.add_argument('--verbose', type=int, default=2)
+    parser.add_argument('--bhtsne', action='store_true',
+                        help="if set and the reference bhtsne code is "
+                        "correctly installed, run it in the benchmark.")
+    parser.add_argument('--all', action='store_true',
+                        help="if set, run the benchmark with the whole MNIST."
+                        "dataset. Note that it will take up to 1hour.")
+    parser.add_argument('--profile', action='store_true',
+                        help="if set, run the benchmark with a memory "
+                        "profiler.")
+    parser.add_argument('--verbose', type=int, default=0)
+    parser.add_argument('--n_jobs', type=int, nargs="+", default=1,
+                        help="Number of CPU used to fit sklearn.TSNE")
     args = parser.parse_args()
 
     X, y = load_data(order=args.order)
 
+    methods = []
+
+    # Put TSNE in methods
+    if isinstance(args.n_jobs, int):
+        tsne = TSNE(n_components=2, init='pca', perplexity=args.perplexity,
+                    verbose=args.verbose, n_jobs=args.n_jobs)
+        methods += [("sklearn.TSNE", tsne.fit_transform)]
+    elif isinstance(args.n_jobs, list):
+        for n_jobs in args.n_jobs:
+            tsne = TSNE(n_components=2, init='pca', perplexity=args.perplexity,
+                        verbose=args.verbose, n_jobs=n_jobs)
+            methods += [("sklearn.TSNE_n_jobs{}".format(n_jobs),
+                        tsne.fit_transform)]
+
+    if args.bhtsne:
+        try:
+            from bhtsne.bhtsne import run_bh_tsne
+        except ImportError:
+            raise ImportError(
+                """
+        If you want comparison with the reference implementation, build the
+        binary from source (https://github.com/lvdmaaten/bhtsne) in the folder
+        benchmarks/bhtsne and add an empty `__init__.py` file in the folder:
+
+        $ git clone git@github.com:lvdmaaten/bhtsne.git
+        $ cd bhtsne
+        $ g++ sptree.cpp tsne.cpp tsne_main.cpp -o bh_tsne -O2
+        $ touch __init__.py
+        $ cd ..
+                   """
+            )
+
+        def bhtsne(X):
+            """wrapper for LvdM bhtsne implementation."""
+            return run_bh_tsne(X, initial_dims=X.shape[1],
+                               perplexity=args.perplexity, verbose=False)
+        methods += [("LvdM.bhtsne", bhtsne)]
+
+    if args.profile:
+
+        try:
+            from memory_profiler import profile
+        except ImportError:
+            raise ImportError("To run the benchmark with `--profile`, you "
+                              "need to install `memory_profiler`. Please "
+                              "run `pip install memory_profiler`.")
+        methods = [(n, profile(m)) for n, m in methods]
+
+    data_size = [100, 1000, 5000, 10000]
+    if args.all:
+        data_size += [70000]
+
     results = []
     basename, _ = os.path.splitext(__file__)
     log_filename = basename + '.json'
-    for n in [100, 1000, 5000, 10000]:
+    for n in data_size:
         X_train = X[:n]
         n = X_train.shape[0]
-        print("Fitting TSNE on %d samples..." % n)
-        tsne = TSNE(n_components=2, init='pca', perplexity=args.perplexity,
-                    verbose=0)
-        t0 = time()
-        X_embedded = tsne_fit_transform(tsne, X_train)
-        duration = time() - t0
-        print("Fitting T-SNE on %d samples took %0.3fs" % (n, duration))
-        results.append(dict(method="TSNE", duration=duration, n_samples=n))
-        with open(log_filename, 'w', encoding='utf-8') as f:
-            json.dump(results, f)
-        np.save('mnist_tsne_%d.npy' % n, X_embedded)
-
-        if bhtsne is not None:
+        for name, method in methods:
+            print("Fitting {} on {} samples...".format(name, n))
             t0 = time()
-            X_embedded = bhtsne(X_train, initial_dims=X_train.shape[1],
-                                perplexity=args.perplexity, verbose=False)
+            X_embedded = method(X_train)
             duration = time() - t0
-            print("Fitting bhtsne on %d samples took %0.3fs" % (n, duration))
-            results.append(dict(method="bhtsne", duration=duration,
-                                n_samples=n))
+            print("Fitting {} on {} samples took {:.3f}s"
+                  .format(name, n, duration))
+            results.append(dict(method=name, duration=duration, n_samples=n))
             with open(log_filename, 'w', encoding='utf-8') as f:
                 json.dump(results, f)
-            np.save('mnist_bhtsne_%d.npy' % n, X_embedded)
+            np.save('mnist_{}_{}.npy'.format(name, n), X_embedded)

--- a/benchmarks/bench_tsne_mnist.py
+++ b/benchmarks/bench_tsne_mnist.py
@@ -114,7 +114,7 @@ $ cd ..
             # PCA preprocessing is done elsewhere in the benchmark script
             n_iter = -1  # TODO find a way to report the number of iterations
             return run_bh_tsne(X, use_pca=False, perplexity=args.perplexity,
-                               verbose=False), n_iter
+                               verbose=args.verbose > 0), n_iter
         methods += [("lvdmaaten/bhtsne", bhtsne)]
 
     if args.profile:
@@ -127,7 +127,7 @@ $ cd ..
                               "run `pip install memory_profiler`.")
         methods = [(n, profile(m)) for n, m in methods]
 
-    data_size = [100, 1000, 5000, 10000]
+    data_size = [100, 500, 1000, 5000, 10000]
     if args.all:
         data_size += [70000]
 

--- a/benchmarks/bench_tsne_mnist.py
+++ b/benchmarks/bench_tsne_mnist.py
@@ -49,18 +49,12 @@ def load_data(dtype=np.float32, order='C', shuffle=True, seed=0):
     return X, y
 
 
-def precision_at_k(X, X_embedded, k=5):
-    """Compute the precision at k for the dataset.
-    """
-
-    knn = NearestNeighbors(n_neighbors=k, n_jobs=-1)
+def nn_accuracy(X, X_embedded, k=1):
+    """Accuracy of the first nearest neighbor"""
+    knn = NearestNeighbors(n_neighbors=1, n_jobs=-1)
     _, neighbors_X = knn.fit(X).kneighbors()
     _, neighbors_X_embedded = knn.fit(X_embedded).kneighbors()
-
-    precisions = [len(np.intersect1d(X_n, Xe_n)) / k
-                  for X_n, Xe_n in zip(neighbors_X, neighbors_X_embedded)]
-
-    return np.mean(precisions)
+    return np.mean(neighbors_X == neighbors_X_embedded)
 
 
 def tsne_fit_transform(model, data):
@@ -163,9 +157,9 @@ $ cd ..
             np.save("dump_X.npy", X_train)
             X_embedded, n_iter = method(X_train)
             duration = time() - t0
-            precision_5 = precision_at_k(X_train, X_embedded, k=5)
+            precision_5 = nn_accuracy(X_train, X_embedded)
             print("Fitting {} on {} samples took {:.3f}s in {:d} iterations, "
-                  "precision at 5: {:0.3f}".format(
+                  "nn accuracy: {:0.3f}".format(
                       name, n, duration, n_iter, precision_5))
             results.append(dict(method=name, duration=duration, n_samples=n))
             with open(log_filename, 'w', encoding='utf-8') as f:

--- a/benchmarks/bench_tsne_mnist.py
+++ b/benchmarks/bench_tsne_mnist.py
@@ -138,7 +138,6 @@ $ cd ..
         methods = [(n, profile(m)) for n, m in methods]
 
     data_size = [100, 500, 1000, 5000, 10000]
-    data_size = []
     if args.all:
         data_size.append(70000)
 

--- a/benchmarks/bench_tsne_mnist.py
+++ b/benchmarks/bench_tsne_mnist.py
@@ -9,6 +9,7 @@ from __future__ import division, print_function
 # License: BSD 3 clause
 
 import os
+import os.path as op
 from time import time
 import numpy as np
 import json
@@ -60,6 +61,10 @@ def nn_accuracy(X, X_embedded, k=1):
 def tsne_fit_transform(model, data):
     transformed = model.fit_transform(data)
     return transformed, model.n_iter_
+
+
+def sanitize(filename):
+    return filename.replace("/", '-').replace(" ", "_")
 
 
 if __name__ == "__main__":
@@ -150,11 +155,15 @@ $ cd ..
     log_filename = os.path.join(LOG_DIR, basename + '.json')
     for n in data_size:
         X_train = X[:n]
+        y_train = y[:n]
         n = X_train.shape[0]
         for name, method in methods:
             print("Fitting {} on {} samples...".format(name, n))
             t0 = time()
-            np.save("dump_X.npy", X_train)
+            np.save(os.path.join(LOG_DIR, 'mnist_{}_{}.npy'
+                                 .format('original', n)), X_train)
+            np.save(os.path.join(LOG_DIR, 'mnist_{}_{}.npy'
+                                 .format('original_labels', n)), y_train)
             X_embedded, n_iter = method(X_train)
             duration = time() - t0
             precision_5 = nn_accuracy(X_train, X_embedded)
@@ -164,6 +173,6 @@ $ cd ..
             results.append(dict(method=name, duration=duration, n_samples=n))
             with open(log_filename, 'w', encoding='utf-8') as f:
                 json.dump(results, f)
-            np.save(os.path.join(LOG_DIR, 'mnist_{}_{}.npy'
-                                 .format(name.replace("/", '-'), n)),
+            method_name = sanitize(name)
+            np.save(op.join(LOG_DIR, 'mnist_{}_{}.npy'.format(method_name, n)),
                     X_embedded)

--- a/benchmarks/bench_tsne_mnist.py
+++ b/benchmarks/bench_tsne_mnist.py
@@ -103,14 +103,14 @@ if __name__ == "__main__":
     if isinstance(args.n_jobs, int):
         tsne = TSNE(n_components=2, init='pca', perplexity=args.perplexity,
                     verbose=args.verbose, n_jobs=args.n_jobs, n_iter=1000)
-        methods += [("sklearn TSNE",
-                     lambda data: tsne_fit_transform(tsne, data))]
+        methods.append(("sklearn TSNE",
+                        lambda data: tsne_fit_transform(tsne, data)))
     elif isinstance(args.n_jobs, list):
         for n_jobs in args.n_jobs:
             tsne = TSNE(n_components=2, init='pca', perplexity=args.perplexity,
                         verbose=args.verbose, n_jobs=n_jobs)
-            methods += [("sklearn TSNE (n_jobs={})".format(n_jobs),
-                        lambda data: tsne_fit_transform(tsne, data))]
+            methods.append(("sklearn TSNE (n_jobs={})".format(n_jobs),
+                            lambda data: tsne_fit_transform(tsne, data)))
 
     if args.bhtsne:
         try:
@@ -134,7 +134,7 @@ $ cd ..
             n_iter = -1  # TODO find a way to report the number of iterations
             return run_bh_tsne(X, use_pca=False, perplexity=args.perplexity,
                                verbose=args.verbose > 0), n_iter
-        methods += [("lvdmaaten/bhtsne", bhtsne)]
+        methods.append(("lvdmaaten/bhtsne", bhtsne))
 
     if args.profile:
 
@@ -148,7 +148,7 @@ $ cd ..
 
     data_size = [100, 500, 1000, 5000, 10000]
     if args.all:
-        data_size += [70000]
+        data_size.append(70000)
 
     results = []
     basename, _ = os.path.splitext(__file__)

--- a/benchmarks/bench_tsne_mnist.py
+++ b/benchmarks/bench_tsne_mnist.py
@@ -82,8 +82,6 @@ if __name__ == "__main__":
                         help="if set, run the benchmark with a memory "
                              "profiler.")
     parser.add_argument('--verbose', type=int, default=0)
-    parser.add_argument('--n_jobs', type=int, nargs="+", default=2,
-                        help="Number of CPU used to fit sklearn.TSNE")
     parser.add_argument('--pca-components', type=int, default=50,
                         help="Number of principal components for "
                              "preprocessing.")
@@ -100,17 +98,10 @@ if __name__ == "__main__":
     methods = []
 
     # Put TSNE in methods
-    if isinstance(args.n_jobs, int):
-        tsne = TSNE(n_components=2, init='pca', perplexity=args.perplexity,
-                    verbose=args.verbose, n_jobs=args.n_jobs, n_iter=1000)
-        methods.append(("sklearn TSNE",
-                        lambda data: tsne_fit_transform(tsne, data)))
-    elif isinstance(args.n_jobs, list):
-        for n_jobs in args.n_jobs:
-            tsne = TSNE(n_components=2, init='pca', perplexity=args.perplexity,
-                        verbose=args.verbose, n_jobs=n_jobs)
-            methods.append(("sklearn TSNE (n_jobs={})".format(n_jobs),
-                            lambda data: tsne_fit_transform(tsne, data)))
+    tsne = TSNE(n_components=2, init='pca', perplexity=args.perplexity,
+                verbose=args.verbose, n_iter=1000)
+    methods.append(("sklearn TSNE",
+                    lambda data: tsne_fit_transform(tsne, data)))
 
     if args.bhtsne:
         try:

--- a/benchmarks/bench_tsne_mnist.py
+++ b/benchmarks/bench_tsne_mnist.py
@@ -138,6 +138,7 @@ $ cd ..
         methods = [(n, profile(m)) for n, m in methods]
 
     data_size = [100, 500, 1000, 5000, 10000]
+    data_size = []
     if args.all:
         data_size.append(70000)
 

--- a/benchmarks/bench_tsne_mnist.py
+++ b/benchmarks/bench_tsne_mnist.py
@@ -17,6 +17,7 @@ import argparse
 from sklearn.externals.joblib import Memory
 from sklearn.datasets import fetch_mldata
 from sklearn.manifold import TSNE
+from sklearn.decomposition import PCA
 from sklearn.utils import check_array
 
 
@@ -55,11 +56,16 @@ if __name__ == "__main__":
                         help="if set, run the benchmark with a memory "
                         "profiler.")
     parser.add_argument('--verbose', type=int, default=0)
-    parser.add_argument('--n_jobs', type=int, nargs="+", default=1,
+    parser.add_argument('--n_jobs', type=int, nargs="+", default=2,
                         help="Number of CPU used to fit sklearn.TSNE")
+    parser.add_argument('--pca-components', type=int, default=50,
+                        help="Number of principal components for preprocessing.")
     args = parser.parse_args()
 
     X, y = load_data(order=args.order)
+
+    if args.pca_components > 0:
+        X = PCA(n_components=args.pca_components).fit_transform(X)
 
     methods = []
 
@@ -95,7 +101,7 @@ if __name__ == "__main__":
 
         def bhtsne(X):
             """wrapper for LvdM bhtsne implementation."""
-            return run_bh_tsne(X, initial_dims=X.shape[1],
+            return run_bh_tsne(X, use_pca=False,
                                perplexity=args.perplexity, verbose=False)
         methods += [("LvdM.bhtsne", bhtsne)]
 

--- a/benchmarks/bench_tsne_mnist.py
+++ b/benchmarks/bench_tsne_mnist.py
@@ -1,0 +1,109 @@
+"""
+=============================
+MNIST dataset T-SNE benchmark
+=============================
+
+"""
+from __future__ import division, print_function
+
+# License: BSD 3 clause
+
+import os
+from time import time
+import numpy as np
+import json
+import argparse
+
+from sklearn.externals.joblib import Memory
+from sklearn.datasets import fetch_mldata
+from sklearn.manifold import TSNE
+from sklearn.utils import check_array
+
+
+try:
+    from memory_profiler import profile
+except ImportError:
+    def profile(f):
+        return f
+
+try:
+    # If you want comparison with the reference implementation, build the
+    # binary from source (https://github.com/lvdmaaten/bhtsne) in the folder
+    # benchmarks/bhtsne and add an empty `__init__.py` file in the floder.
+    #
+    #  $ git clone git@github.com:lvdmaaten/bhtsne.git
+    #  $ cd bhtsne
+    #  $ g++ sptree.cpp tsne.cpp tsne_main.cpp -o bh_tsne -O2
+    #  $ touch __init__.py
+    #  $ cd ..
+    #
+    from bhtsne.bhtsne import run_bh_tsne
+
+    @profile
+    def bhtsne(data, **kwargs):
+        return run_bh_tsne(data, **kwargs)
+except ImportError:
+    bhtsne = None
+
+
+memory = Memory('mnist_tsne_benchmark_data', mmap_mode='r')
+
+
+@memory.cache
+def load_data(dtype=np.float32, order='C'):
+    """Load the data, then cache and memmap the train/test split"""
+    print("Loading dataset...")
+    data = fetch_mldata('MNIST original')
+    X = check_array(data['data'], dtype=dtype, order=order)
+    y = data["target"]
+
+    # Normalize features
+    X /= 255
+    return X, y
+
+
+@profile
+def tsne_fit_transform(model, data):
+    return model.fit_transform(data)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser('Benchmark for t-SNE')
+    parser.add_argument('--order', type=str, default='C',
+                        help='Order of the input data')
+    parser.add_argument('--perplexity', type=float, default=30)
+    parser.add_argument('--log-max-nsamples', type=int, default=5)
+    parser.add_argument('--verbose', type=int, default=2)
+    args = parser.parse_args()
+
+    X, y = load_data(order=args.order)
+
+    results = []
+    basename, _ = os.path.splitext(__file__)
+    log_filename = basename + '.json'
+    for n in [100, 1000, 5000, 10000]:
+        X_train = X[:n]
+        n = X_train.shape[0]
+        print("Fitting TSNE on %d samples..." % n)
+        tsne = TSNE(n_components=2, init='pca', perplexity=args.perplexity,
+                    verbose=0)
+        t0 = time()
+        X_embedded = tsne_fit_transform(tsne, X_train)
+        duration = time() - t0
+        print("Fitting T-SNE on %d samples took %0.3fs" % (n, duration))
+        results.append(dict(method="TSNE", duration=duration, n_samples=n))
+        with open(log_filename, 'w', encoding='utf-8') as f:
+            json.dump(results, f)
+        np.save('mnist_tsne_%d.npy' % n, X_embedded)
+
+        if bhtsne is not None:
+            t0 = time()
+            X_embedded = bhtsne(X_train, initial_dims=X_train.shape[1],
+                                perplexity=args.perplexity, verbose=False)
+            duration = time() - t0
+            print("Fitting bhtsne on %d samples took %0.3fs" % (n, duration))
+            results.append(dict(method="bhtsne", duration=duration,
+                                n_samples=n))
+            with open(log_filename, 'w', encoding='utf-8') as f:
+                json.dump(results, f)
+            np.save('mnist_bhtsne_%d.npy' % n, X_embedded)

--- a/benchmarks/bench_tsne_mnist.py
+++ b/benchmarks/bench_tsne_mnist.py
@@ -20,18 +20,23 @@ from sklearn.manifold import TSNE
 from sklearn.manifold.t_sne import trustworthiness
 from sklearn.decomposition import PCA
 from sklearn.utils import check_array
+from sklearn.utils import shuffle as _shuffle
 
 
 memory = Memory('mnist_tsne_benchmark_data', mmap_mode='r')
 
 
 @memory.cache
-def load_data(dtype=np.float32, order='C'):
+def load_data(dtype=np.float32, order='C', shuffle=True, seed=0):
     """Load the data, then cache and memmap the train/test split"""
     print("Loading dataset...")
     data = fetch_mldata('MNIST original')
+
     X = check_array(data['data'], dtype=dtype, order=order)
     y = data["target"]
+
+    if shuffle:
+        X, y = _shuffle(X, y, random_state=seed)
 
     # Normalize features
     X /= 255

--- a/benchmarks/plot_tsne_mnist.py
+++ b/benchmarks/plot_tsne_mnist.py
@@ -1,0 +1,30 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import os.path as op
+
+import argparse
+
+
+LOG_DIR = "mnist_tsne_output"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser('Plot benchmark results for t-SNE')
+    parser.add_argument(
+        '--labels', type=str,
+        default=op.join(LOG_DIR, 'mnist_original_labels_10000.npy'),
+        help='1D integer numpy array for labels')
+    parser.add_argument(
+        '--embedding', type=str,
+        default=op.join(LOG_DIR, 'mnist_sklearn_TSNE_10000.npy'),
+        help='2D float numpy array for embedded data')
+    args = parser.parse_args()
+
+    X = np.load(args.embedding)
+    y = np.load(args.labels)
+
+    for i in np.unique(y):
+        mask = y == i
+        plt.scatter(X[mask, 0], X[mask, 1], alpha=0.2, label=int(i))
+    plt.legend(loc='best')
+    plt.show()

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,7 @@ occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
    * :class:`sklearn.ensemble.IsolationForest` (bug fix)
+   * :class:`sklearn.manifold.TSNE` (bug fix)
 
 Details are listed in the changelog below.
 
@@ -244,6 +245,14 @@ Enhancements
 
    - Speed improvements to :class:`model_selection.StratifiedShuffleSplit`.
      :issue:`5991` by :user:`Arthur Mensch <arthurmensch>` and `Joel Nothman`_.
+
+   - Memory improvements to :class:`manifold.TSNE`
+     :issue:`7089` by :user:`Thomas Moreau <tomMoral> and :user:`Olivier Grisel <ogrisel>`.
+
+   - Optimization schedule improvements for so the results are closer to the
+     one from the reference implementation
+     `lvdmaaten/bhtsne<https://github.com/lvdmaaten/bhtsne>`_, by
+     :user:`Thomas Moreau <tomMoral> and :user:`Olivier Grisel <ogrisel>`.
 
 Bug fixes
 .........
@@ -477,6 +486,14 @@ Bug fixes
    - Fix inconsistent results between :class:`linear_model.RidgeCV`
      and :class:`linear_model.Ridge` when using ``normalize=True``
      by `Alexandre Gramfort`_.
+
+   - Fixed the implementation of :class:`manifold.TSNE`:
+      - ``early_exageration`` parameter had no effect and is now used for the
+        first 250 optimization iterations.
+      - Fixed the ``InsersionError`` reported in :issue:`8992`.
+      - Improve the learning schedule to match the one from the reference
+        implementation `lvdmaaten/bhtsne<https://github.com/lvdmaaten/bhtsne>`_.
+     by :user:`Thomas Moreau <tomMoral> and :user:`Olivier Grisel <ogrisel>`.
 
 API changes summary
 -------------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -246,13 +246,13 @@ Enhancements
    - Speed improvements to :class:`model_selection.StratifiedShuffleSplit`.
      :issue:`5991` by :user:`Arthur Mensch <arthurmensch>` and `Joel Nothman`_.
 
-   - Memory improvements to :class:`manifold.TSNE`
-     :issue:`7089` by :user:`Thomas Moreau <tomMoral> and :user:`Olivier Grisel <ogrisel>`.
+   - Memory improvements for method barnes_hut in :class:`manifold.TSNE`
+     :issue:`7089` by :user:`Thomas Moreau <tomMoral>` and `Olivier Grisel`_.
 
    - Optimization schedule improvements for so the results are closer to the
      one from the reference implementation
-     `lvdmaaten/bhtsne<https://github.com/lvdmaaten/bhtsne>`_, by
-     :user:`Thomas Moreau <tomMoral> and :user:`Olivier Grisel <ogrisel>`.
+     `lvdmaaten/bhtsne <https://github.com/lvdmaaten/bhtsne>`_ by
+     :user:`Thomas Moreau <tomMoral>` and `Olivier Grisel`_.
 
 Bug fixes
 .........
@@ -492,8 +492,8 @@ Bug fixes
         first 250 optimization iterations.
       - Fixed the ``InsersionError`` reported in :issue:`8992`.
       - Improve the learning schedule to match the one from the reference
-        implementation `lvdmaaten/bhtsne<https://github.com/lvdmaaten/bhtsne>`_.
-     by :user:`Thomas Moreau <tomMoral> and :user:`Olivier Grisel <ogrisel>`.
+        implementation `lvdmaaten/bhtsne <https://github.com/lvdmaaten/bhtsne>`_.
+     by :user:`Thomas Moreau <tomMoral>` and `Olivier Grisel`_.
 
 API changes summary
 -------------------

--- a/examples/manifold/plot_t_sne_perplexity.py
+++ b/examples/manifold/plot_t_sne_perplexity.py
@@ -28,15 +28,16 @@ those effects.
 
 print(__doc__)
 
+import numpy as np
 import matplotlib.pyplot as plt
 
 from matplotlib.ticker import NullFormatter
 from sklearn import manifold, datasets
 from time import time
 
-n_samples = 500
+n_samples = 300
 n_components = 2
-(fig, subplots) = plt.subplots(2, 5, figsize=(15, 8))
+(fig, subplots) = plt.subplots(3, 5, figsize=(15, 8))
 perplexities = [5, 30, 50, 100]
 
 X, y = datasets.make_circles(n_samples=n_samples, factor=.5, noise=.05)
@@ -71,7 +72,7 @@ for i, perplexity in enumerate(perplexities):
 X, color = datasets.samples_generator.make_s_curve(n_samples, random_state=0)
 
 ax = subplots[1][0]
-ax.scatter(X[:, 0], X[:, 2], c=color, cmap=plt.cm.Spectral)
+ax.scatter(X[:, 0], X[:, 2], c=color, cmap=plt.cm.viridis)
 ax.xaxis.set_major_formatter(NullFormatter())
 ax.yaxis.set_major_formatter(NullFormatter())
 
@@ -86,9 +87,40 @@ for i, perplexity in enumerate(perplexities):
     print("S-curve, perplexity=%d in %.2g sec" % (perplexity, t1 - t0))
 
     ax.set_title("Perplexity=%d" % perplexity)
-    ax.scatter(Y[:, 0], Y[:, 1], c=color, cmap=plt.cm.Spectral)
+    ax.scatter(Y[:, 0], Y[:, 1], c=color, cmap=plt.cm.viridis)
     ax.xaxis.set_major_formatter(NullFormatter())
     ax.yaxis.set_major_formatter(NullFormatter())
     ax.axis('tight')
+
+
+# Another example using a 2D uniform grid
+x = np.linspace(0, 1, int(np.sqrt(n_samples)))
+xx, yy = np.meshgrid(x, x)
+X = np.hstack([
+    xx.ravel().reshape(-1, 1),
+    yy.ravel().reshape(-1, 1),
+])
+color = xx.ravel()
+ax = subplots[2][0]
+ax.scatter(X[:, 0], X[:, 1], c=color, cmap=plt.cm.viridis)
+ax.xaxis.set_major_formatter(NullFormatter())
+ax.yaxis.set_major_formatter(NullFormatter())
+
+for i, perplexity in enumerate(perplexities):
+    ax = subplots[2][i + 1]
+
+    t0 = time()
+    tsne = manifold.TSNE(n_components=n_components, init='random',
+                         random_state=0, perplexity=perplexity)
+    Y = tsne.fit_transform(X)
+    t1 = time()
+    print("uniform grid, perplexity=%d in %.2g sec" % (perplexity, t1 - t0))
+
+    ax.set_title("Perplexity=%d" % perplexity)
+    ax.scatter(Y[:, 0], Y[:, 1], c=color, cmap=plt.cm.viridis)
+    ax.xaxis.set_major_formatter(NullFormatter())
+    ax.yaxis.set_major_formatter(NullFormatter())
+    ax.axis('tight')
+
 
 plt.show()

--- a/examples/manifold/plot_t_sne_perplexity.py
+++ b/examples/manifold/plot_t_sne_perplexity.py
@@ -14,7 +14,7 @@ perplexity values and does not always convey a meaning.
 As shown below, t-SNE for higher perplexities finds meaningful topology of
 two concentric circles, however the size and the distance of the circles varies
 slightly from the original. Contrary to the two circles dataset, the shapes
-visually diverge from S-curve topology on the S-curve dateset even for
+visually diverge from S-curve topology on the S-curve dataset even for
 larger perplexity values.
 
 For further details, "How to Use t-SNE Effectively"
@@ -37,7 +37,7 @@ from time import time
 n_samples = 500
 n_components = 2
 (fig, subplots) = plt.subplots(2, 5, figsize=(15, 8))
-perplexities = [5, 50, 100, 150]
+perplexities = [5, 30, 50, 100]
 
 X, y = datasets.make_circles(n_samples=n_samples, factor=.5, noise=.05)
 

--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -205,7 +205,7 @@ cdef void compute_gradient_negative(float[:, :] pos_reference,
         printf("[t-SNE] Tree: %li clock ticks | ", dta)
         printf("Force computation: %li clock ticks\n", dtb)
 
-    # Put sum_Q to machine EPSILON to avoid 0 divisions
+    # Put sum_Q to machine EPSILON to avoid divisions by 0
     sum_Q[0] = max(sum_Q[0], EPSILON)
     free(summary)
 

--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -180,7 +180,7 @@ cdef void compute_gradient_negative(float[:, :] pos_reference,
         # Find which nodes are summarizing and collect their centers of mass
         # deltas, and sizes, into vectorized arrays
         t1 = clock()
-        idx = qt.summarize(pos, summary, 0, 0, theta*theta)
+        idx = qt.summarize(pos, summary, theta*theta)
         t2 = clock()
         # Compute the t-SNE negative force
         # for the digits dataset, walking the tree

--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -41,10 +41,10 @@ cdef extern from "time.h":
 
 
 cdef float compute_gradient(float[:] val_P,
-                            float[:,:] pos_reference,
+                            float[:, :] pos_reference,
                             np.int64_t[:] neighbors,
                             np.int64_t[:] indptr,
-                            float[:,:] tot_force,
+                            float[:, :] tot_force,
                             quad_tree._QuadTree qt,
                             float theta,
                             float dof,
@@ -93,7 +93,7 @@ cdef float compute_gradient(float[:] val_P,
 
 
 cdef float compute_gradient_positive(float[:] val_P,
-                                     float[:,:] pos_reference,
+                                     float[:, :] pos_reference,
                                      np.int64_t[:] neighbors,
                                      np.int64_t[:] indptr,
                                      float* pos_f,
@@ -144,7 +144,7 @@ cdef float compute_gradient_positive(float[:] val_P,
     return C
 
 
-cdef void compute_gradient_negative(float[:,:] pos_reference,
+cdef void compute_gradient_negative(float[:, :] pos_reference,
                                     float* neg_f,
                                     quad_tree._QuadTree qt,
                                     float* sum_Q,
@@ -226,10 +226,10 @@ def calculate_edge(pos_output):
 
 
 def gradient(float[:] val_P,
-             float[:,:] pos_output,
+             float[:, :] pos_output,
              np.int64_t[:] neighbors,
              np.int64_t[:] indptr,
-             float[:,:] forces,
+             float[:, :] forces,
              float theta,
              int n_dimensions,
              int verbose,

--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -236,7 +236,8 @@ def gradient(float[:] val_P,
     assert n == indptr.shape[0] - 1, m
     if verbose > 10:
         printf("[t-SNE] Initializing tree of n_dimensions %i\n", n_dimensions)
-    cdef quad_tree._QuadTree qt = quad_tree._QuadTree(pos_output.shape[1], 0)
+    cdef quad_tree._QuadTree qt = quad_tree._QuadTree(pos_output.shape[1],
+                                                      verbose)
     if verbose > 10:
         printf("[t-SNE] Inserting %li points\n", pos_output.shape[0])
     qt.build_tree(pos_output)

--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -14,6 +14,9 @@ from libc.math cimport sqrt, log
 import numpy as np
 cimport numpy as np
 
+from sklearn.neighbors import quad_tree
+from sklearn.neighbors cimport quad_tree
+
 cdef char* EMPTY_STRING = ""
 
 cdef extern from "math.h":
@@ -37,415 +40,12 @@ cdef extern from "time.h":
     double CLOCKS_PER_SEC
 
 
-cdef extern from "cblas.h":
-    float snrm2 "cblas_snrm2"(int N, float *X, int incX) nogil
-
-
-cdef struct Node:
-    # Keep track of the center of mass
-    float* barycenter
-    # If this is a leaf, the position of the point within this leaf 
-    float* leaf_point_position
-    # The number of points including all 
-    # nodes below this one
-    long cumulative_size
-    # Number of points at this node
-    long size
-    # Index of the point at this node
-    # Only defined for non-empty leaf nodes
-    long point_index
-    # level = 0 is the root node
-    # And each subdivision adds 1 to the level
-    long level
-    # Left edge of this node
-    float* left_edge
-    # The center of this node, equal to le + w/2.0
-    float* center
-    # The width of this node -- used to calculate the opening
-    # angle. Equal to width = re - le
-    float* width
-    # The value of the maximum width w
-    float max_width
-
-    # Does this node have children?
-    # Default to leaf until we add points
-    int is_leaf
-    # Array of pointers to pointers of children
-    Node **children
-    # Keep a pointer to the parent
-    Node *parent
-    # Pointer to the tree this node belongs too
-    Tree* tree
-
-cdef struct Tree:
-    # Holds a pointer to the root node
-    Node* root_node 
-    # Number of dimensions in the output
-    int n_dimensions
-    # Total number of cells
-    long n_cells
-    # Total number of points
-    long n_points
-    # Spit out diagnostic information?
-    int verbose
-    # How many cells per node? Should go as 2 ** n_dimensionss
-    int n_cell_per_node
-
-cdef Tree* init_tree(float[:] left_edge, float[:] width, int n_dimensions, 
-                     int verbose) nogil:
-    # tree is freed by free_tree
-    cdef Tree* tree = <Tree*> malloc(sizeof(Tree))
-    tree.n_dimensions = n_dimensions
-    tree.n_cells = 0
-    tree.n_points = 0
-    tree.verbose = verbose
-    tree.root_node = create_root(left_edge, width, n_dimensions)
-    tree.root_node.tree = tree
-    tree.n_cells += 1
-    tree.n_cell_per_node = 2 ** n_dimensions
-    if DEBUGFLAG:
-        printf("[t-SNE] Tree initialised. Left_edge = (%1.9e, %1.9e, %1.9e)\n",
-               left_edge[0], left_edge[1], left_edge[2])
-        printf("[t-SNE] Tree initialised. Width = (%1.9e, %1.9e, %1.9e)\n",
-                width[0], width[1], width[2])
-    return tree
-
-cdef Node* create_root(float[:] left_edge, float[:] width, int n_dimensions) nogil:
-    # Create a default root node
-    cdef int ax
-    cdef int n_cell_per_node = 2 ** n_dimensions
-    # root is freed by free_tree
-    root = <Node*> malloc(sizeof(Node))
-    root.is_leaf = 1
-    root.parent = NULL
-    root.level = 0
-    root.cumulative_size = 0
-    root.size = 0
-    root.point_index = -1
-    root.max_width = 0.0
-    root.width = <float*> malloc(sizeof(float) * n_dimensions)
-    root.left_edge = <float*> malloc(sizeof(float) * n_dimensions)
-    root.center = <float*> malloc(sizeof(float) * n_dimensions)
-    root.barycenter = <float*> malloc(sizeof(float) * n_dimensions)
-    root.leaf_point_position= <float*> malloc(sizeof(float) * n_dimensions)
-    root.children = NULL
-    for ax in range(n_dimensions):
-        root.width[ax] = width[ax]
-        root.left_edge[ax] = left_edge[ax]
-        root.center[ax] = 0.0
-        root.barycenter[ax] = 0.
-        root.leaf_point_position[ax] = -1
-    for ax in range(n_dimensions):
-        root.max_width = max(root.max_width, root.width[ax])
-    if DEBUGFLAG:
-        printf("[t-SNE] Created root node %p\n", root)
-    return root
-
-cdef Node* create_child(Node *parent, int[3] offset) nogil:
-    # Create a new child node with default parameters
-    cdef int ax
-    # these children are freed by free_recursive
-    child = <Node *> malloc(sizeof(Node))
-    child.is_leaf = 1
-    child.parent = parent
-    child.level = parent.level + 1
-    child.size = 0
-    child.cumulative_size = 0
-    child.point_index = -1
-    child.tree = parent.tree
-    child.max_width = 0.0
-    child.width = <float*> malloc(sizeof(float) * parent.tree.n_dimensions)
-    child.left_edge = <float*> malloc(sizeof(float) * parent.tree.n_dimensions)
-    child.center = <float*> malloc(sizeof(float) * parent.tree.n_dimensions)
-    child.barycenter = <float*> malloc(sizeof(float) * parent.tree.n_dimensions)
-    child.leaf_point_position = <float*> malloc(sizeof(float) * parent.tree.n_dimensions)
-    child.children = NULL
-    for ax in range(parent.tree.n_dimensions):
-        child.width[ax] = parent.width[ax] / 2.0
-        child.left_edge[ax] = parent.left_edge[ax] + offset[ax] * parent.width[ax] / 2.0
-        child.center[ax] = child.left_edge[ax] + child.width[ax] / 2.0
-        child.barycenter[ax] = 0.
-        child.leaf_point_position[ax] = -1.
-    for ax in range(parent.tree.n_dimensions):
-        child.max_width = max(child.max_width, child.width[ax])
-    child.tree.n_cells += 1
-    return child
-
-cdef Node* select_child(Node *node, float[3] pos, long index) nogil:
-    # Find which sub-node a position should go into
-    # And return the appropriate node
-    cdef int* offset = <int*> malloc(sizeof(int) * node.tree.n_dimensions)
-    cdef int ax, idx
-    cdef Node* child
-    cdef int error
-    for ax in range(node.tree.n_dimensions):
-        offset[ax] = (pos[ax] - (node.left_edge[ax] + node.width[ax] / 2.0)) > 0.
-    idx = offset2index(offset, node.tree.n_dimensions)
-    child = node.children[idx]
-    if DEBUGFLAG:
-        printf("[t-SNE] Offset [%i, %i] with LE [%f, %f]\n",
-               offset[0], offset[1], child.left_edge[0], child.left_edge[1])
-    free(offset)
-    return child
-
-
-cdef inline void index2offset(int* offset, int index, int n_dimensions) nogil:
-    # Convert a 1D index into N-D index; useful for indexing
-    # children of a quadtree, octree, N-tree
-    # Quite likely there's a fancy bitshift way of doing this
-    # since the offset is equivalent to the binary representation
-    # of the integer index
-    # We read the offset array left-to-right
-    # such that the least significat bit is on the right
-    cdef int rem, k, shift
-    for k in range(n_dimensions):
-        shift = n_dimensions -k -1
-        rem = ((index >> shift) << shift)
-        offset[k] = rem > 0
-        if DEBUGFLAG:
-            printf("i2o index %i k %i rem %i offset", index, k, rem)
-            for j in range(n_dimensions):
-                printf(" %i", offset[j])
-            printf(" n_dimensions %i\n", n_dimensions)
-        index -= rem
-
-
-cdef inline int offset2index(int* offset, int n_dimensions) nogil:
-    # Calculate the 1:1 index for a given offset array
-    # We read the offset array right-to-left
-    # such that the least significat bit is on the right
-    cdef int dim
-    cdef int index = 0
-    for dim in range(n_dimensions):
-        index += (2 ** dim) * offset[n_dimensions - dim - 1]
-        if DEBUGFLAG:
-            printf("o2i index %i dim %i offset", index, dim)
-            for j in range(n_dimensions):
-                printf(" %i", offset[j])
-            printf(" n_dimensions %i\n", n_dimensions)
-    return index
-
-
-cdef void subdivide(Node* node) nogil:
-    # This instantiates 2**n_dimensions = n_cell_per_node nodes for the current node
-    cdef int idx = 0
-    cdef int* offset = <int*> malloc(sizeof(int) * node.tree.n_dimensions)
-    node.is_leaf = False
-    node.children = <Node**> malloc(sizeof(Node*) * node.tree.n_cell_per_node)
-    for idx in range(node.tree.n_cell_per_node):
-        index2offset(offset, idx, node.tree.n_dimensions)
-        node.children[idx] = create_child(node, offset)
-    free(offset)
-
-
-cdef int insert(Node *root, float pos[3], long point_index, long depth, long
-        duplicate_count) nogil:
-    # Introduce a new point into the tree
-    # by recursively inserting it and subdividng as necessary
-    # Carefully treat the case of identical points at the same node
-    # by increasing the root.size and tracking duplicate_count
-    cdef Node *child
-    cdef long i
-    cdef int ax
-    cdef int not_identical = 1
-    cdef int n_dimensions = root.tree.n_dimensions
-    if DEBUGFLAG:
-        printf("[t-SNE] [d=%li] Inserting pos %li [%f, %f] duplicate_count=%li"
-                " into child %p\n", depth, point_index, pos[0], pos[1],
-                duplicate_count, root)    
-    # Increment the total number points including this
-    # node and below it
-    root.cumulative_size += duplicate_count
-    # Evaluate the new center of mass, weighting the previous
-    # center of mass against the new point data
-    cdef double frac_seen = <double>(root.cumulative_size - 1) / (<double>
-            root.cumulative_size)
-    cdef double frac_new  = 1.0 / <double> root.cumulative_size
-    # Assert that duplicate_count > 0
-    if duplicate_count < 1:
-        return -1
-    # Assert that the point is inside the left & right edges
-    for ax in range(n_dimensions):
-        root.barycenter[ax] *= frac_seen
-        if (pos[ax] > (root.left_edge[ax] + root.width[ax] + EPSILON)):
-            printf("[t-SNE] Error: point (%1.9e) is above right edge of node "
-                    "(%1.9e)\n", pos[ax], root.left_edge[ax] + root.width[ax])
-            return -1
-        if (pos[ax] < root.left_edge[ax] - EPSILON):
-            printf("[t-SNE] Error: point (%1.9e) is below left edge of node "
-                   "(%1.9e)\n", pos[ax], root.left_edge[ax])
-            return -1
-    for ax in range(n_dimensions):
-        root.barycenter[ax] += pos[ax] * frac_new
-
-    # If this node is unoccupied, fill it.
-    # Otherwise, we need to insert recursively.
-    # Two insertion scenarios: 
-    # 1) Insert into this node if it is a leaf and empty
-    # 2) Subdivide this node if it is currently occupied
-    if (root.size == 0) & root.is_leaf:
-        # Root node is empty and a leaf
-        if DEBUGFLAG:
-            printf("[t-SNE] [d=%li] Inserting [%f, %f] into blank cell\n", depth,
-                   pos[0], pos[1])
-        for ax in range(n_dimensions):
-            root.leaf_point_position[ax] = pos[ax]
-        root.point_index = point_index
-        root.size = duplicate_count
-        return 0
-    else:
-        # Root node is occupied or not a leaf
-        if DEBUGFLAG:
-            printf("[t-SNE] [d=%li] Node %p is occupied or is a leaf.\n", depth,
-                    root)
-            printf("[t-SNE] [d=%li] Node %p leaf = %i. Size %li\n", depth, root,
-                    root.is_leaf, root.size)
-        if root.is_leaf & (root.size > 0):
-            # is a leaf node and is occupied
-            for ax in range(n_dimensions):
-                not_identical &= (fabsf(pos[ax] - root.leaf_point_position[ax]) < EPSILON)
-                not_identical &= (root.point_index != point_index)
-            if not_identical == 1:
-                root.size += duplicate_count
-                if DEBUGFLAG:
-                    printf("[t-SNE] Warning: [d=%li] Detected identical "
-                            "points. Returning. Leaf now has size %li\n",
-                            depth, root.size)
-                return 0
-        # If necessary, subdivide this node before
-        # descending
-        if root.is_leaf:
-            if DEBUGFLAG:
-                printf("[t-SNE] [d=%li] Subdividing this leaf node %p\n", depth,
-                        root)
-            subdivide(root)
-        # We have two points to relocate: the one previously
-        # at this node, and the new one we're attempting
-        # to insert
-        if root.size > 0:
-            child = select_child(root, root.leaf_point_position, root.point_index)
-            if DEBUGFLAG:
-                printf("[t-SNE] [d=%li] Relocating old point to node %p\n",
-                        depth, child)
-            insert(child, root.leaf_point_position, root.point_index, depth + 1, root.size)
-        # Insert the new point
-        if DEBUGFLAG:
-            printf("[t-SNE] [d=%li] Selecting node for new point\n", depth)
-        child = select_child(root, pos, point_index)
-        if root.size > 0:
-            # Remove the point from this node
-            for ax in range(n_dimensions):
-                root.leaf_point_position[ax] = -1            
-            root.size = 0
-            root.point_index = -1            
-        return insert(child, pos, point_index, depth + 1, 1)
-
-cdef int insert_many(Tree* tree, float[:,:] pos_array) nogil:
-    # Insert each data point into the tree one at a time
-    cdef long nrows = pos_array.shape[0]
-    cdef long i
-    cdef int ax
-    cdef float row[3]
-    cdef long err = 0
-    for i in range(nrows):
-        for ax in range(tree.n_dimensions):
-            row[ax] = pos_array[i, ax]
-        if DEBUGFLAG:
-            printf("[t-SNE] inserting point %li: [%f, %f]\n", i, row[0], row[1])
-        err = insert(tree.root_node, row, i, 0, 1)
-        if err != 0:
-            printf("[t-SNE] ERROR\n%s", EMPTY_STRING)
-            return err
-        tree.n_points += 1
-    return err
-
-cdef int free_tree(Tree* tree) nogil:
-    cdef int check
-    cdef long* cnt = <long*> malloc(sizeof(long) * 3)
-    for i in range(3):
-        cnt[i] = 0
-    free_recursive(tree, tree.root_node, cnt)
-    check = cnt[0] == tree.n_cells
-    check &= cnt[2] == tree.n_points
-    free(tree)
-    free(cnt)
-    return check
-
-cdef void free_post_children(Node *node) nogil:
-    free(node.width)
-    free(node.left_edge)
-    free(node.center)
-    free(node.barycenter)
-    free(node.leaf_point_position)
-    free(node)
-
-cdef void free_recursive(Tree* tree, Node *root, long* counts) nogil:
-    # Free up all of the tree nodes recursively
-    # while counting the number of nodes visited
-    # and total number of data points removed
-    cdef int idx
-    cdef Node* child
-    if not root.is_leaf:
-        for idx in range(tree.n_cell_per_node):
-            child = root.children[idx]
-            free_recursive(tree, child, counts)
-            counts[0] += 1
-            if child.is_leaf:
-                counts[1] += 1
-                if child.size > 0:
-                    counts[2] +=1
-            else:
-                free(child.children)
-
-            free_post_children(child)
-
-    if root == tree.root_node:
-        if not root.is_leaf:
-            free(root.children)
-
-        free_post_children(root)
-
-cdef long count_points(Node* root, long count) nogil:
-    # Walk through the whole tree and count the number 
-    # of points at the leaf nodes
-    if DEBUGFLAG:
-        printf("[t-SNE] Counting nodes at root node %p\n", root)
-    cdef Node* child
-    cdef int idx
-    if root.is_leaf:
-        count += root.size
-        if DEBUGFLAG : 
-            printf("[t-SNE] %p is a leaf node, no children\n", root)
-            printf("[t-SNE] %li points in node %p\n", count, root)
-        return count
-    # Otherwise, get the children
-    for idx in range(root.tree.n_cell_per_node):
-        child = root.children[idx]
-        if DEBUGFLAG:
-            printf("[t-SNE] Counting points for child %p\n", child)
-        if child.is_leaf and child.size > 0:
-            if DEBUGFLAG:
-                printf("[t-SNE] Child has size %ld\n", child.size)
-            count += child.size
-        elif not child.is_leaf:
-            if DEBUGFLAG:
-                printf("[t-SNE] Child is not a leaf. Descending\n%s", EMPTY_STRING)
-            count = count_points(child, count)
-        # else case is we have an empty leaf node
-        # which happens when we create a quadtree for
-        # one point, and then the other neighboring cells
-        # don't get filled in
-    if DEBUGFLAG:
-        printf("[t-SNE] %li points in this node\n", count)
-    return count
-
-
 cdef float compute_gradient(float[:] val_P,
                             float[:,:] pos_reference,
                             np.int64_t[:] neighbors,
                             np.int64_t[:] indptr,
                             float[:,:] tot_force,
-                            Node* root_node,
+                            quad_tree.QuadTree qt,
                             float theta,
                             float dof,
                             long start,
@@ -455,8 +55,8 @@ cdef float compute_gradient(float[:] val_P,
     cdef long i, coord
     cdef int ax
     cdef long n_samples = pos_reference.shape[0]
-    cdef int n_dimensions = root_node.tree.n_dimensions
-    if root_node.tree.verbose > 11:
+    cdef int n_dimensions = qt.n_dimensions
+    if qt.verbose > 11:
         printf("[t-SNE] Allocating %li elements in force arrays\n",
                 n_samples * n_dimensions * 2)
     cdef float* sum_Q = <float*> malloc(sizeof(float))
@@ -467,18 +67,18 @@ cdef float compute_gradient(float[:] val_P,
 
     sum_Q[0] = 0.0
     t1 = clock()
-    compute_gradient_negative(pos_reference, neg_f, root_node, sum_Q,
+    compute_gradient_negative(pos_reference, neg_f, qt, sum_Q,
                               dof, theta, start, stop)
     t2 = clock()
-    if root_node.tree.verbose > 15:
+    if qt.verbose > 15:
         printf("[t-SNE] Computing negative gradient: %e ticks\n", ((float) (t2 - t1)))
     sQ = sum_Q[0]
     t1 = clock()
     error = compute_gradient_positive(val_P, pos_reference, neighbors, indptr,
                                       pos_f, n_dimensions, dof, sQ, start,
-                                      root_node.tree.verbose)
+                                      qt.verbose)
     t2 = clock()
-    if root_node.tree.verbose > 15:
+    if qt.verbose > 15:
         printf("[t-SNE] Computing positive gradient: %e ticks\n", ((float) (t2 - t1)))
     for i in range(start, n_samples):
         for ax in range(n_dimensions):
@@ -544,7 +144,7 @@ cdef float compute_gradient_positive(float[:] val_P,
 
 cdef void compute_gradient_negative(float[:,:] pos_reference,
                                     float* neg_f,
-                                    Node *root_node,
+                                    quad_tree.QuadTree qt,
                                     float* sum_Q,
                                     float dof,
                                     float theta, 
@@ -559,25 +159,21 @@ cdef void compute_gradient_negative(float[:,:] pos_reference,
         float* force
         float* iQ 
         float* pos
-        float* dist2s
-        long* sizes
-        float* deltas
+        float size, dist2s
         long* l
-        int n_dimensions = root_node.tree.n_dimensions
+        int n_dimensions = qt.n_dimensions
         float qijZ, mult
         long idx, 
         long dta = 0
         long dtb = 0
         clock_t t1, t2, t3
         float* neg_force
+        long offset = n_dimensions + 2
 
     iQ = <float*> malloc(sizeof(float))
     force = <float*> malloc(sizeof(float) * n_dimensions)
     pos = <float*> malloc(sizeof(float) * n_dimensions)
-    dist2s = <float*> malloc(sizeof(float) * n)
-    sizes = <long*> malloc(sizeof(long) * n)
-    deltas = <float*> malloc(sizeof(float) * n * n_dimensions)
-    l = <long*> malloc(sizeof(long))
+    summary = <float*> malloc(sizeof(float) * n * offset)
     neg_force= <float*> malloc(sizeof(float) * n_dimensions)
 
     for i in range(start, stop):
@@ -587,96 +183,38 @@ cdef void compute_gradient_negative(float[:,:] pos_reference,
             neg_force[ax] = 0.0
             pos[ax] = pos_reference[i, ax]
         iQ[0] = 0.0
-        l[0] = 0
         # Find which nodes are summarizing and collect their centers of mass
         # deltas, and sizes, into vectorized arrays
         t1 = clock()
-        compute_non_edge_forces(root_node, theta, i, pos, force, dist2s,
-                                     sizes, deltas, l)
+        idx = qt.summarize(pos, summary, 0, 0, theta*theta)
         t2 = clock()
         # Compute the t-SNE negative force
         # for the digits dataset, walking the tree
         # is about 10-15x more expensive than the 
         # following for loop
         exponent = (dof + 1.0) / -2.0
-        for j in range(l[0]):
-            qijZ = ((1.0 + dist2s[j]) / dof) ** exponent
-            sum_Q[0] += sizes[j] * qijZ
-            mult = sizes[j] * qijZ * qijZ
+        for j in range(idx // offset):
+            
+            dist2s = summary[j * offset + n_dimensions]
+            size = summary[j * offset + n_dimensions + 1]
+            qijZ = ((1.0 + dist2s) / dof) ** exponent  # 1/(1+dist)
+            sum_Q[0] += size * qijZ   # size of the node * q
+            mult = size * qijZ * qijZ
             for ax in range(n_dimensions):
-                idx = j * n_dimensions + ax
-                neg_force[ax] += mult * deltas[idx]
+                neg_force[ax] += mult * summary[j * offset + ax]
         t3 = clock()
         for ax in range(n_dimensions):
             neg_f[i * n_dimensions + ax] = neg_force[ax]
         dta += t2 - t1
         dtb += t3 - t2
-    if root_node.tree.verbose > 20:
+    if qt.verbose > 20:
         printf("[t-SNE] Tree: %li clock ticks | ", dta)
         printf("Force computation: %li clock ticks\n", dtb)
     free(iQ)
     free(force)
     free(pos)
-    free(dist2s)
-    free(sizes)
-    free(deltas)
-    free(l)
+    free(summary)
     free(neg_force)
-
-
-cdef void compute_non_edge_forces(Node* node, 
-                                  float theta,
-                                  long point_index,
-                                  float* pos,
-                                  float* force,
-                                  float* dist2s,
-                                  long* sizes,
-                                  float* deltas,
-                                  long* l) nogil:
-    # Compute the t-SNE force on the point in pos given by point_index
-    cdef:
-        Node* child
-        int i, j
-        int n_dimensions = node.tree.n_dimensions
-        long idx, idx1
-        float dist_check
-    
-    # There are no points below this node if cumulative_size == 0
-    # so do not bother to calculate any force contributions
-    # Also do not compute self-interactions
-    if node.cumulative_size > 0 and not (node.is_leaf and (node.point_index ==
-        point_index)):
-        # Compute distance between node center of mass and the reference point
-        # I've tried rewriting this in terms of BLAS functions, but it's about
-        # 1.5x worse when we do so, probbaly because the vectors are small
-        idx1 = l[0] * n_dimensions
-        deltas[idx1] = pos[0] - node.barycenter[0]
-        idx = idx1
-        for i in range(1, n_dimensions):
-            idx += 1
-            deltas[idx] = pos[i] - node.barycenter[i] 
-        # do np.sqrt(np.sum(deltas**2.0))
-        dist2s[l[0]] = snrm2(n_dimensions, &deltas[idx1], 1)
-        # Check whether we can use this node as a summary
-        # It's a summary node if the angular size as measured from the point
-        # is relatively small (w.r.t. to theta) or if it is a leaf node.
-        # If it can be summarized, we use the cell center of mass 
-        # Otherwise, we go a higher level of resolution and into the leaves.
-        if node.is_leaf or ((node.max_width / dist2s[l[0]]) < theta):
-            # Compute the t-SNE force between the reference point and the
-            # current node
-            sizes[l[0]] = node.cumulative_size
-            dist2s[l[0]] = dist2s[l[0]] * dist2s[l[0]]
-            l[0] += 1
-        else:
-            # Recursively apply Barnes-Hut to child nodes
-            for idx in range(node.tree.n_cell_per_node):
-                child = node.children[idx]
-                if child.cumulative_size == 0: 
-                    continue
-                compute_non_edge_forces(child, theta,
-                        point_index, pos, force, dist2s, sizes, deltas,
-                        l)
 
 
 def calculate_edge(pos_output):
@@ -687,9 +225,12 @@ def calculate_edge(pos_output):
     center = (right_edge + left_edge) * 0.5
     width = np.maximum(np.subtract(right_edge, left_edge), EPSILON)
     # Exagerate width to avoid boundary edge
+    printf("WIDTH %f, %f\n", float(width[0]), float(width[1]))
     width = width.astype(np.float32) * 1.001
     left_edge = center - width / 2.0
     right_edge = center + width / 2.0
+    printf("ROOT_x %f, %f\n", float(left_edge[0]), float(right_edge[0]))
+    printf("ROOT_y %f, %f\n", float(left_edge[1]), float(right_edge[1]))
     return left_edge, right_edge, width
 
 
@@ -708,8 +249,6 @@ def gradient(float[:] val_P,
     # up in-place
     cdef float C
     n = pos_output.shape[0]
-    left_edge, right_edge, width = calculate_edge(pos_output)
-    assert width.itemsize == 4
     assert val_P.itemsize == 4
     assert pos_output.itemsize == 4
     assert forces.itemsize == 4
@@ -719,89 +258,22 @@ def gradient(float[:] val_P,
     assert n == indptr.shape[0] - 1, m
     if verbose > 10:
         printf("[t-SNE] Initializing tree of n_dimensions %i\n", n_dimensions)
-    cdef Tree* qt = init_tree(left_edge, width, n_dimensions, verbose)
+    cdef quad_tree.QuadTree qt = quad_tree.QuadTree(pos_output.shape[1], 0)
     if verbose > 10:
         printf("[t-SNE] Inserting %li points\n", pos_output.shape[0])
-    err = insert_many(qt, pos_output)
-    assert err == 0, "[t-SNE] Insertion failed"
+    qt.build_tree(pos_output)
     if verbose > 10:
         # XXX: format hack to workaround lack of `const char *` type
         # in the generated C code that triggers error with gcc 4.9
         # and -Werror=format-security
         printf("[t-SNE] Computing gradient\n%s", EMPTY_STRING)
     C = compute_gradient(val_P, pos_output, neighbors, indptr, forces,
-                         qt.root_node, theta, dof, skip_num_points, -1)
+                         qt, theta, dof, skip_num_points, -1)
     if verbose > 10:
         # XXX: format hack to workaround lack of `const char *` type
         # in the generated C code
         # and -Werror=format-security
         printf("[t-SNE] Checking tree consistency\n%s", EMPTY_STRING)
-    cdef long count = count_points(qt.root_node, 0)
-    m = ("Tree consistency failed: unexpected number of points=%li "
-         "at root node=%li" % (count, qt.root_node.cumulative_size))
-    assert count == qt.root_node.cumulative_size, m 
     m = "Tree consistency failed: unexpected number of points on the tree"
-    assert count == qt.n_points, m
-    free_tree(qt)
+    assert qt.cells[0].cumulative_size == qt.n_points, m
     return C
-
-
-# Helper functions
-def check_quadtree(X, np.int64_t[:] counts):
-    """
-    Helper function to access quadtree functions for testing
-    """
-    
-    X = X.astype(np.float32)
-    left_edge, right_edge, width = calculate_edge(X)
-    # Initialise a tree
-    qt = init_tree(left_edge, width, 2, 2)
-    # Insert data into the tree
-    insert_many(qt, X)
-
-    cdef long count = count_points(qt.root_node, 0)
-    counts[0] = count
-    counts[1] = qt.root_node.cumulative_size
-    counts[2] = qt.n_points
-    free_tree(qt)
-    return counts
-
-
-cdef int helper_test_index2offset(int* check, int index, int n_dimensions):
-    cdef int* offset = <int*> malloc(sizeof(int) * n_dimensions)
-    cdef int error_check = 1
-    for i in range(n_dimensions):
-        offset[i] = 0
-    index2offset(offset, index, n_dimensions)
-    for i in range(n_dimensions):
-        error_check &= offset[i] == check[i]
-    free(offset)
-    return error_check
-
-
-def test_index2offset():
-    ret = 1
-    ret &= helper_test_index2offset([1, 0, 1], 5, 3) == 1
-    ret &= helper_test_index2offset([0, 0, 0], 0, 3) == 1
-    ret &= helper_test_index2offset([0, 0, 1], 1, 3) == 1
-    ret &= helper_test_index2offset([0, 1, 0], 2, 3) == 1
-    ret &= helper_test_index2offset([0, 1, 1], 3, 3) == 1
-    ret &= helper_test_index2offset([1, 0, 0], 4, 3) == 1
-    return ret
-
-
-def test_index_offset():
-    cdef int n_dimensions, idx, tidx, k
-    cdef int error_check = 1
-    cdef int* offset 
-    for n_dimensions in range(2, 10):
-        offset = <int*> malloc(sizeof(int) * n_dimensions)
-        for k in range(n_dimensions):
-            offset[k] = 0
-        for idx in range(2 ** n_dimensions):
-            index2offset(offset, idx, n_dimensions)
-            tidx = offset2index(offset, n_dimensions)
-            error_check &= tidx == idx
-            assert error_check == 1
-        free(offset)
-    return error_check

--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -45,7 +45,7 @@ cdef float compute_gradient(float[:] val_P,
                             np.int64_t[:] neighbors,
                             np.int64_t[:] indptr,
                             float[:,:] tot_force,
-                            quad_tree.QuadTree qt,
+                            quad_tree._QuadTree qt,
                             float theta,
                             float dof,
                             long start,
@@ -146,7 +146,7 @@ cdef float compute_gradient_positive(float[:] val_P,
 
 cdef void compute_gradient_negative(float[:,:] pos_reference,
                                     float* neg_f,
-                                    quad_tree.QuadTree qt,
+                                    quad_tree._QuadTree qt,
                                     float* sum_Q,
                                     float dof,
                                     float theta,
@@ -249,7 +249,7 @@ def gradient(float[:] val_P,
     assert n == indptr.shape[0] - 1, m
     if verbose > 10:
         printf("[t-SNE] Initializing tree of n_dimensions %i\n", n_dimensions)
-    cdef quad_tree.QuadTree qt = quad_tree.QuadTree(pos_output.shape[1], 0)
+    cdef quad_tree._QuadTree qt = quad_tree._QuadTree(pos_output.shape[1], 0)
     if verbose > 10:
         printf("[t-SNE] Inserting %li points\n", pos_output.shape[0])
     qt.build_tree(pos_output)

--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -11,8 +11,8 @@
 from libc.stdlib cimport malloc, free
 from libc.stdio cimport printf
 from libc.math cimport sqrt, log
-cimport numpy as np
 import numpy as np
+cimport numpy as np
 
 cdef char* EMPTY_STRING = ""
 
@@ -219,7 +219,7 @@ cdef inline int offset2index(int* offset, int n_dimensions) nogil:
     for dim in range(n_dimensions):
         index += (2 ** dim) * offset[n_dimensions - dim - 1]
         if DEBUGFLAG:
-            printf("o2i index %i dim %i            offset", index, dim)
+            printf("o2i index %i dim %i offset", index, dim)
             for j in range(n_dimensions):
                 printf(" %i", offset[j])
             printf(" n_dimensions %i\n", n_dimensions)
@@ -250,8 +250,8 @@ cdef int insert(Node *root, float pos[3], long point_index, long depth, long
     cdef int not_identical = 1
     cdef int n_dimensions = root.tree.n_dimensions
     if DEBUGFLAG:
-        printf("[t-SNE] [d=%i] Inserting pos %i [%f, %f] duplicate_count=%i "
-                "into child %p\n", depth, point_index, pos[0], pos[1],
+        printf("[t-SNE] [d=%li] Inserting pos %li [%f, %f] duplicate_count=%li"
+                " into child %p\n", depth, point_index, pos[0], pos[1],
                 duplicate_count, root)    
     # Increment the total number points including this
     # node and below it
@@ -286,7 +286,7 @@ cdef int insert(Node *root, float pos[3], long point_index, long depth, long
     if (root.size == 0) & root.is_leaf:
         # Root node is empty and a leaf
         if DEBUGFLAG:
-            printf("[t-SNE] [d=%i] Inserting [%f, %f] into blank cell\n", depth,
+            printf("[t-SNE] [d=%li] Inserting [%f, %f] into blank cell\n", depth,
                    pos[0], pos[1])
         for ax in range(n_dimensions):
             root.leaf_point_position[ax] = pos[ax]
@@ -296,9 +296,9 @@ cdef int insert(Node *root, float pos[3], long point_index, long depth, long
     else:
         # Root node is occupied or not a leaf
         if DEBUGFLAG:
-            printf("[t-SNE] [d=%i] Node %p is occupied or is a leaf.\n", depth,
+            printf("[t-SNE] [d=%li] Node %p is occupied or is a leaf.\n", depth,
                     root)
-            printf("[t-SNE] [d=%i] Node %p leaf = %i. Size %i\n", depth, root,
+            printf("[t-SNE] [d=%li] Node %p leaf = %i. Size %li\n", depth, root,
                     root.is_leaf, root.size)
         if root.is_leaf & (root.size > 0):
             # is a leaf node and is occupied
@@ -308,15 +308,15 @@ cdef int insert(Node *root, float pos[3], long point_index, long depth, long
             if not_identical == 1:
                 root.size += duplicate_count
                 if DEBUGFLAG:
-                    printf("[t-SNE] Warning: [d=%i] Detected identical "
-                            "points. Returning. Leaf now has size %i\n",
+                    printf("[t-SNE] Warning: [d=%li] Detected identical "
+                            "points. Returning. Leaf now has size %li\n",
                             depth, root.size)
                 return 0
         # If necessary, subdivide this node before
         # descending
         if root.is_leaf:
             if DEBUGFLAG:
-                printf("[t-SNE] [d=%i] Subdividing this leaf node %p\n", depth,
+                printf("[t-SNE] [d=%li] Subdividing this leaf node %p\n", depth,
                         root)
             subdivide(root)
         # We have two points to relocate: the one previously
@@ -325,12 +325,12 @@ cdef int insert(Node *root, float pos[3], long point_index, long depth, long
         if root.size > 0:
             child = select_child(root, root.leaf_point_position, root.point_index)
             if DEBUGFLAG:
-                printf("[t-SNE] [d=%i] Relocating old point to node %p\n",
+                printf("[t-SNE] [d=%li] Relocating old point to node %p\n",
                         depth, child)
             insert(child, root.leaf_point_position, root.point_index, depth + 1, root.size)
         # Insert the new point
         if DEBUGFLAG:
-            printf("[t-SNE] [d=%i] Selecting node for new point\n", depth)
+            printf("[t-SNE] [d=%li] Selecting node for new point\n", depth)
         child = select_child(root, pos, point_index)
         if root.size > 0:
             # Remove the point from this node
@@ -351,7 +351,7 @@ cdef int insert_many(Tree* tree, float[:,:] pos_array) nogil:
         for ax in range(tree.n_dimensions):
             row[ax] = pos_array[i, ax]
         if DEBUGFLAG:
-            printf("[t-SNE] inserting point %i: [%f, %f]\n", i, row[0], row[1])
+            printf("[t-SNE] inserting point %li: [%f, %f]\n", i, row[0], row[1])
         err = insert(tree.root_node, row, i, 0, 1)
         if err != 0:
             printf("[t-SNE] ERROR\n%s", EMPTY_STRING)
@@ -416,7 +416,7 @@ cdef long count_points(Node* root, long count) nogil:
         count += root.size
         if DEBUGFLAG : 
             printf("[t-SNE] %p is a leaf node, no children\n", root)
-            printf("[t-SNE] %i points in node %p\n", count, root)
+            printf("[t-SNE] %li points in node %p\n", count, root)
         return count
     # Otherwise, get the children
     for idx in range(root.tree.n_cell_per_node):
@@ -425,7 +425,7 @@ cdef long count_points(Node* root, long count) nogil:
             printf("[t-SNE] Counting points for child %p\n", child)
         if child.is_leaf and child.size > 0:
             if DEBUGFLAG:
-                printf("[t-SNE] Child has size %d\n", child.size)
+                printf("[t-SNE] Child has size %ld\n", child.size)
             count += child.size
         elif not child.is_leaf:
             if DEBUGFLAG:
@@ -436,13 +436,14 @@ cdef long count_points(Node* root, long count) nogil:
         # one point, and then the other neighboring cells
         # don't get filled in
     if DEBUGFLAG:
-        printf("[t-SNE] %i points in this node\n", count)
+        printf("[t-SNE] %li points in this node\n", count)
     return count
 
 
-cdef float compute_gradient(float[:,:] val_P,
+cdef float compute_gradient(float[:] val_P,
                             float[:,:] pos_reference,
-                            np.int64_t[:,:] neighbors,
+                            np.int64_t[:] neighbors,
+                            np.int64_t[:] indptr,
                             float[:,:] tot_force,
                             Node* root_node,
                             float theta,
@@ -453,46 +454,46 @@ cdef float compute_gradient(float[:,:] val_P,
     # in two components, the positive and negative forces
     cdef long i, coord
     cdef int ax
-    cdef long n = pos_reference.shape[0]
+    cdef long n_samples = pos_reference.shape[0]
     cdef int n_dimensions = root_node.tree.n_dimensions
     if root_node.tree.verbose > 11:
-        printf("[t-SNE] Allocating %i elements in force arrays\n",
-                n * n_dimensions * 2)
+        printf("[t-SNE] Allocating %li elements in force arrays\n",
+                n_samples * n_dimensions * 2)
     cdef float* sum_Q = <float*> malloc(sizeof(float))
-    cdef float* neg_f = <float*> malloc(sizeof(float) * n * n_dimensions)
-    cdef float* neg_f_fast = <float*> malloc(sizeof(float) * n * n_dimensions)
-    cdef float* pos_f = <float*> malloc(sizeof(float) * n * n_dimensions)
+    cdef float* neg_f = <float*> malloc(sizeof(float) * n_samples * n_dimensions)
+    cdef float* pos_f = <float*> malloc(sizeof(float) * n_samples * n_dimensions)
     cdef clock_t t1, t2
     cdef float sQ, error
 
     sum_Q[0] = 0.0
     t1 = clock()
-    compute_gradient_negative(val_P, pos_reference, neg_f, root_node, sum_Q,
+    compute_gradient_negative(pos_reference, neg_f, root_node, sum_Q,
                               dof, theta, start, stop)
     t2 = clock()
     if root_node.tree.verbose > 15:
         printf("[t-SNE] Computing negative gradient: %e ticks\n", ((float) (t2 - t1)))
     sQ = sum_Q[0]
     t1 = clock()
-    error = compute_gradient_positive(val_P, pos_reference, neighbors, pos_f,
-                              n_dimensions, dof, sQ, start, root_node.tree.verbose)
+    error = compute_gradient_positive(val_P, pos_reference, neighbors, indptr,
+                                      pos_f, n_dimensions, dof, sQ, start,
+                                      root_node.tree.verbose)
     t2 = clock()
     if root_node.tree.verbose > 15:
         printf("[t-SNE] Computing positive gradient: %e ticks\n", ((float) (t2 - t1)))
-    for i in range(start, n):
+    for i in range(start, n_samples):
         for ax in range(n_dimensions):
             coord = i * n_dimensions + ax
             tot_force[i, ax] = pos_f[coord] - (neg_f[coord] / sum_Q[0])
     free(sum_Q)
     free(neg_f)
-    free(neg_f_fast)
     free(pos_f)
-    return sQ
+    return error
 
 
-cdef float compute_gradient_positive(float[:,:] val_P,
+cdef float compute_gradient_positive(float[:] val_P,
                                      float[:,:] pos_reference,
-                                     np.int64_t[:,:] neighbors,
+                                     np.int64_t[:] neighbors,
+                                     np.int64_t[:] indptr,
                                      float* pos_f,
                                      int n_dimensions,
                                      float dof,
@@ -507,43 +508,41 @@ cdef float compute_gradient_positive(float[:,:] val_P,
     cdef:
         int ax
         long i, j, k
-        long K = neighbors.shape[1]
-        long n = val_P.shape[0]
-        float[3] buff
-        float D, Q, pij
+        long n_samples = indptr.shape[0] - 1
+        float dij, qij, pij
         float C = 0.0
         float exponent = (dof + 1.0) / -2.0
     cdef clock_t t1, t2
+    cdef float* buff = <float*> malloc(sizeof(float) * n_dimensions)
     t1 = clock()
-    for i in range(start, n):
+    for i in range(start, n_samples):
         for ax in range(n_dimensions):
             pos_f[i * n_dimensions + ax] = 0.0
-        for k in range(K):
-            j = neighbors[i, k]
+        for k in range(indptr[i], indptr[i+1]):
+            j = neighbors[k]
             # we don't need to exclude the i==j case since we've 
             # already thrown it out from the list of neighbors
-            D = 0.0
-            Q = 0.0
-            pij = val_P[i, j]
+            dij = 0.0
+            pij = val_P[k]
             for ax in range(n_dimensions):
                 buff[ax] = pos_reference[i, ax] - pos_reference[j, ax]
-                D += buff[ax] ** 2.0  
-            Q = (((1.0 + D) / dof) ** exponent)
-            D = pij * Q
-            Q /= sum_Q
-            C += pij * log((pij + EPSILON) / (Q + EPSILON))
+                dij += buff[ax] * buff[ax]
+            qij = (((1.0 + dij) / dof) ** exponent)
+            dij = pij * qij
+            qij /= sum_Q
+            C += pij * log((pij + EPSILON) / (qij + EPSILON))
             for ax in range(n_dimensions):
-                pos_f[i * n_dimensions + ax] += D * buff[ax]
+                pos_f[i * n_dimensions + ax] += dij * buff[ax]
     t2 = clock()
     dt = ((float) (t2 - t1))
     if verbose > 10:
         printf("[t-SNE] Computed error=%1.4f in %1.1e ticks\n", C, dt)
+
+    free(buff)
     return C
 
 
-
-cdef void compute_gradient_negative(float[:,:] val_P, 
-                                    float[:,:] pos_reference,
+cdef void compute_gradient_negative(float[:,:] pos_reference,
                                     float* neg_f,
                                     Node *root_node,
                                     float* sum_Q,
@@ -613,8 +612,8 @@ cdef void compute_gradient_negative(float[:,:] val_P,
         dta += t2 - t1
         dtb += t3 - t2
     if root_node.tree.verbose > 20:
-        printf("[t-SNE] Tree: %i clock ticks | ", dta)
-        printf("Force computation: %i clock ticks\n", dtb)
+        printf("[t-SNE] Tree: %li clock ticks | ", dta)
+        printf("Force computation: %li clock ticks\n", dtb)
     free(iQ)
     free(force)
     free(pos)
@@ -680,37 +679,6 @@ cdef void compute_non_edge_forces(Node* node,
                         l)
 
 
-cdef float compute_error(float[:, :] val_P,
-                        float[:, :] pos_reference,
-                        np.int64_t[:,:] neighbors,
-                        float sum_Q,
-                        int n_dimensions,
-                        int verbose) nogil:
-    cdef int i, j, ax
-    cdef int I = neighbors.shape[0]
-    cdef int K = neighbors.shape[1]
-    cdef float pij, Q
-    cdef float C = 0.0
-    cdef clock_t t1, t2
-    cdef float dt, delta
-    t1 = clock()
-    for i in range(I):
-        for k in range(K):
-            j = neighbors[i, k]
-            pij = val_P[i, j]
-            Q = 0.0
-            for ax in range(n_dimensions):
-                delta = (pos_reference[i, ax] - pos_reference[j, ax])
-                Q += delta * delta
-            Q = (1.0 / (sum_Q + Q * sum_Q))
-            C += pij * log((pij + EPSILON) / (Q + EPSILON))
-    t2 = clock()
-    dt = ((float) (t2 - t1))
-    if verbose > 10:
-        printf("[t-SNE] Computed error=%1.4f in %1.1e ticks\n", C, dt)
-    return C
-
-
 def calculate_edge(pos_output):
     # Make the boundaries slightly outside of the data
     # to avoid floating point error near the edge
@@ -724,10 +692,12 @@ def calculate_edge(pos_output):
     right_edge = center + width / 2.0
     return left_edge, right_edge, width
 
-def gradient(float[:,:] pij_input, 
-             float[:,:] pos_output, 
-             np.int64_t[:,:] neighbors, 
-             float[:,:] forces, 
+
+def gradient(float[:] val_P,
+             float[:,:] pos_output,
+             np.int64_t[:] neighbors,
+             np.int64_t[:] indptr,
+             float[:,:] forces,
              float theta,
              int n_dimensions,
              int verbose,
@@ -740,24 +710,18 @@ def gradient(float[:,:] pij_input,
     n = pos_output.shape[0]
     left_edge, right_edge, width = calculate_edge(pos_output)
     assert width.itemsize == 4
-    assert pij_input.itemsize == 4
+    assert val_P.itemsize == 4
     assert pos_output.itemsize == 4
     assert forces.itemsize == 4
-    m = "Number of neighbors must be < # of points - 1"
-    assert n - 1 >= neighbors.shape[1], m
-    m = "neighbors array and pos_output shapes are incompatible"
-    assert n == neighbors.shape[0], m
     m = "Forces array and pos_output shapes are incompatible"
     assert n == forces.shape[0], m
     m = "Pij and pos_output shapes are incompatible"
-    assert n == pij_input.shape[0], m
-    m = "Pij and pos_output shapes are incompatible"
-    assert n == pij_input.shape[1], m
+    assert n == indptr.shape[0] - 1, m
     if verbose > 10:
         printf("[t-SNE] Initializing tree of n_dimensions %i\n", n_dimensions)
     cdef Tree* qt = init_tree(left_edge, width, n_dimensions, verbose)
     if verbose > 10:
-        printf("[t-SNE] Inserting %i points\n", pos_output.shape[0])
+        printf("[t-SNE] Inserting %li points\n", pos_output.shape[0])
     err = insert_many(qt, pos_output)
     assert err == 0, "[t-SNE] Insertion failed"
     if verbose > 10:
@@ -765,18 +729,16 @@ def gradient(float[:,:] pij_input,
         # in the generated C code that triggers error with gcc 4.9
         # and -Werror=format-security
         printf("[t-SNE] Computing gradient\n%s", EMPTY_STRING)
-    sum_Q = compute_gradient(pij_input, pos_output, neighbors, forces,
-                             qt.root_node, theta, dof, skip_num_points, -1)
-    C = compute_error(pij_input, pos_output, neighbors, sum_Q, n_dimensions,
-                      verbose)
+    C = compute_gradient(val_P, pos_output, neighbors, indptr, forces,
+                         qt.root_node, theta, dof, skip_num_points, -1)
     if verbose > 10:
         # XXX: format hack to workaround lack of `const char *` type
         # in the generated C code
         # and -Werror=format-security
         printf("[t-SNE] Checking tree consistency\n%s", EMPTY_STRING)
     cdef long count = count_points(qt.root_node, 0)
-    m = ("Tree consistency failed: unexpected number of points=%i "
-         "at root node=%i" % (count, qt.root_node.cumulative_size))
+    m = ("Tree consistency failed: unexpected number of points=%li "
+         "at root node=%li" % (count, qt.root_node.cumulative_size))
     assert count == qt.root_node.cumulative_size, m 
     m = "Tree consistency failed: unexpected number of points on the tree"
     assert count == qt.n_points, m

--- a/sklearn/manifold/setup.py
+++ b/sklearn/manifold/setup.py
@@ -31,6 +31,7 @@ def configuration(parent_package="", top_path=None):
 
     return config
 
+
 if __name__ == "__main__":
     from numpy.distutils.core import setup
     setup(**configuration().todict())

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -254,7 +254,7 @@ def _kl_divergence_bh(params, P, degrees_of_freedom, n_samples, n_components,
 
 
 def _gradient_descent(objective, p0, it, n_iter,
-                      n_iter_check=1, n_iter_without_progress=51,
+                      n_iter_check=1, n_iter_without_progress=300,
                       momentum=0.8, learning_rate=200.0, min_gain=0.01,
                       min_grad_norm=1e-7, min_error_diff=1e-7, verbose=0,
                       args=None, kwargs=None):
@@ -282,7 +282,7 @@ def _gradient_descent(objective, p0, it, n_iter,
         Number of iterations before evaluating the global error. If the error
         is sufficiently low, we abort the optimization.
 
-    n_iter_without_progress : int, optional (default: 51)
+    n_iter_without_progress : int, optional (default: 300)
         Maximum number of iterations without progress before we abort the
         optimization.
 
@@ -506,7 +506,7 @@ class TSNE(BaseEstimator):
         Maximum number of iterations for the optimization. Should be at
         least 250.
 
-    n_iter_without_progress : int, optional (default: 30)
+    n_iter_without_progress : int, optional (default: 300)
         Maximum number of iterations without progress before we abort the
         optimization, used after 250 initial iterations with early
         exaggeration. Note that progress is only checked every 50 iterations so
@@ -612,7 +612,7 @@ class TSNE(BaseEstimator):
 
     def __init__(self, n_components=2, perplexity=30.0,
                  early_exaggeration=12.0, learning_rate=200.0, n_iter=1000,
-                 n_iter_without_progress=30, min_grad_norm=1e-7,
+                 n_iter_without_progress=300, min_grad_norm=1e-7,
                  metric="euclidean", init="random", verbose=0,
                  random_state=None, method='barnes_hut', angle=0.5):
         self.n_components = n_components

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -9,7 +9,6 @@
 #   http://cseweb.ucsd.edu/~lvdmaaten/workshops/nips2010/papers/vandermaaten.pdf
 
 from time import time
-import warnings
 import numpy as np
 from scipy import linalg
 import scipy.sparse as sp
@@ -17,7 +16,6 @@ from scipy.spatial.distance import pdist
 from scipy.spatial.distance import squareform
 from scipy.sparse import csr_matrix
 from ..neighbors import NearestNeighbors
-from ..neighbors.base import NeighborsBase
 from ..base import BaseEstimator
 from ..utils import check_array
 from ..utils import check_random_state

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -588,9 +588,7 @@ class TSNE(BaseEstimator):
     >>> import numpy as np
     >>> from sklearn.manifold import TSNE
     >>> X = np.array([[0, 0, 0], [0, 1, 1], [1, 0, 1], [1, 1, 1]])
-    >>> model = TSNE(n_components=2, random_state=0)
-    >>> np.set_printoptions(suppress=True)
-    >>> X_embedded = model.fit_transform(X)
+    >>> X_embedded = TSNE(n_components=2).fit_transform(X)
     >>> X_embedded.shape
     (4, 2)
 

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -803,6 +803,8 @@ class TSNE(BaseEstimator):
         if self.method == 'barnes_hut':
             obj_func = _kl_divergence_bh
             opt_args['kwargs']['angle'] = self.angle
+            # Repeat verbose argument for _kl_divergence_bh
+            opt_args['kwargs']['verbose'] = self.verbose
         else:
             obj_func = _kl_divergence
 

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -746,6 +746,9 @@ class TSNE(BaseEstimator):
                 print("[t-SNE] Computed neighbors for {} samples in {:.3f}s..."
                       .format(n_samples, duration))
 
+            # Free the memory used by the ball_tree
+            del knn
+
             if self.metric == "euclidean":
                 # knn return the euclidean distance but we need it squared
                 # to be consistent with the 'exact' method. Note that the

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -800,11 +800,13 @@ class TSNE(BaseEstimator):
         # * final optimization with momentum at 0.8
         params = X_embedded.ravel()
 
-        opt_args = {"it": 0, "n_iter_without_progress": EXPLORATION_N_ITER,
+        opt_args = {"it": 0,
+                    "n_iter_check": 50,
+                    "n_iter_without_progress": EXPLORATION_N_ITER,
+                    "min_grad_norm": self.min_grad_norm,
                     "learning_rate": self.learning_rate,
-                    "verbose": self.verbose, "n_iter_check": 50,
-                    "kwargs": dict(skip_num_points=skip_num_points),
-                    "min_grad_norm": self.min_grad_norm}
+                    "verbose": self.verbose,
+                    "kwargs": dict(skip_num_points=skip_num_points)}
         opt_args['args'] = [P, degrees_of_freedom, n_samples,
                             self.n_components]
         if self.method == 'barnes_hut':

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -421,15 +421,15 @@ def test_early_exaggeration_used():
 
 
 def test_n_iter_used():
-    # check that the ``early_exaggeration`` parameter has an effect
+    # check that the ``n_iter`` parameter has an effect
     random_state = check_random_state(0)
     n_components = 2
     methods = ['exact', 'barnes_hut']
     X = random_state.randn(25, n_components).astype(np.float32)
     for method in methods:
-        for n_iter in [251, 500, 1000]:
+        for n_iter in [251, 500]:
             tsne = TSNE(n_components=n_components, perplexity=1,
-                        learning_rate=1.0, init="pca", random_state=0,
+                        learning_rate=0.5, init="random", random_state=0,
                         method=method, early_exaggeration=1.0, n_iter=n_iter)
             tsne.fit_transform(X)
 

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -442,7 +442,7 @@ def test_n_iter_used():
                         method=method, early_exaggeration=1.0, n_iter=n_iter)
             tsne.fit_transform(X)
 
-            assert tsne.n_iter_final == n_iter - 1
+            assert tsne.n_iter_ == n_iter - 1
 
 
 def test_answer_gradient_two_points():
@@ -640,22 +640,23 @@ def test_barnes_hut_angle():
 def test_n_iter_without_progress():
     # Use a dummy negative n_iter_without_progress and check output on stdout
     random_state = check_random_state(0)
-    X = random_state.randn(100, 2)
-    tsne = TSNE(n_iter_without_progress=-1, verbose=2, learning_rate=1e8,
-                random_state=1, method='exact', n_iter=300)
+    X = random_state.randn(100, 10)
+    for method in ["barnes_hut", "exact"]:
+        tsne = TSNE(n_iter_without_progress=-1, verbose=2, learning_rate=1e8,
+                    random_state=1, method='barnes_hut', n_iter=351)
 
-    old_stdout = sys.stdout
-    sys.stdout = StringIO()
-    try:
-        tsne.fit_transform(X)
-    finally:
-        out = sys.stdout.getvalue()
-        sys.stdout.close()
-        sys.stdout = old_stdout
+        old_stdout = sys.stdout
+        sys.stdout = StringIO()
+        try:
+            tsne.fit_transform(X)
+        finally:
+            out = sys.stdout.getvalue()
+            sys.stdout.close()
+            sys.stdout = old_stdout
 
-    # The output needs to contain the value of n_iter_without_progress
-    assert_in("did not make any progress during the "
-              "last -1 episodes. Finished.", out)
+        # The output needs to contain the value of n_iter_without_progress
+        assert_in("did not make any progress during the "
+                "last -1 episodes. Finished.", out)
 
 
 def test_min_grad_norm():

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -149,7 +149,7 @@ def test_binary_search_neighbors():
     assert_array_almost_equal(P_nn, P2, decimal=4)
 
     # Test that the highest P_ij are the same when few neighbors are used
-    for k in np.linspace(80, n_samples, 10):
+    for k in np.linspace(80, n_samples, 5):
         k = int(k)
         topn = k * 10  # check the top 10 *k entries out of k * k entries
         neighbors_nn = np.argsort(distances, axis=1)[:, :k].astype(np.int64)
@@ -247,10 +247,10 @@ def test_preserve_trustworthiness_approximately():
     # perplexity=5, so that the number of neighbors is 5%.
     n_components = 2
     methods = ['exact', 'barnes_hut']
-    X = random_state.randn(100, n_components).astype(np.float32)
+    X = random_state.randn(50, n_components).astype(np.float32)
     for init in ('random', 'pca'):
         for method in methods:
-            tsne = TSNE(n_components=n_components, perplexity=50,
+            tsne = TSNE(n_components=n_components, perplexity=25,
                         learning_rate=100.0, init=init, random_state=0,
                         method=method)
             X_embedded = tsne.fit_transform(X)
@@ -293,7 +293,7 @@ def test_preserve_trustworthiness_approximately_with_precomputed_distances():
         D = squareform(pdist(X), "sqeuclidean")
         tsne = TSNE(n_components=2, perplexity=2, learning_rate=100.0,
                     early_exaggeration=2.0, metric="precomputed",
-                    random_state=i, verbose=0, neighbors_method='brute')
+                    random_state=i, verbose=0)
         X_embedded = tsne.fit_transform(D)
         t = trustworthiness(D, X_embedded, n_neighbors=1,
                             precomputed=True)
@@ -341,16 +341,6 @@ def test_non_positive_computed_distances():
                          tsne.fit_transform, X)
 
 
-def test_not_available_neighbors_method():
-    # Computed distance matrices must be positive.
-    tsne = TSNE(neighbors_method='not available', method='barnes_hut')
-    assert_raises_regexp(ValueError, "unrecognized algorithm: 'not available'",
-                         tsne.fit_transform, np.array([[0.0, 1.0]]))
-    tsne = TSNE(neighbors_method=1, method='barnes_hut')
-    assert_raises_regexp(ValueError, "'neighbors_method' should be .*",
-                         tsne.fit_transform, np.array([[0.0, 1.0]]))
-
-
 def test_init_not_available():
     # 'init' must be 'pca', 'random', or numpy array.
     tsne = TSNE(init="not available")
@@ -369,8 +359,7 @@ def test_init_ndarray():
 def test_init_ndarray_precomputed():
     # Initialize TSNE with ndarray and metric 'precomputed'
     # Make sure no FutureWarning is thrown from _fit
-    tsne = TSNE(init=np.zeros((100, 2)), metric="precomputed",
-                neighbors_method='brute')
+    tsne = TSNE(init=np.zeros((100, 2)), metric="precomputed")
     tsne.fit(np.zeros((100, 100)))
 
 
@@ -557,7 +546,7 @@ def test_64bit():
     methods = ['barnes_hut', 'exact']
     for method in methods:
         for dt in [np.float32, np.float64]:
-            X = random_state.randn(100, 2).astype(dt)
+            X = random_state.randn(50, 2).astype(dt)
             tsne = TSNE(n_components=2, perplexity=2, learning_rate=100.0,
                         random_state=0, method=method, verbose=0)
             X_embedded = tsne.fit_transform(X)

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -741,11 +741,8 @@ def check_uniform_grid(method, seeds=[0, 1, 2], n_iter=1000):
         # Ensure that the resulting embedding leads to approximately
         # uniformly spaced points: the distance to the closest neighbors
         # should be approximately be non-zero and constant.
-        nn = NearestNeighbors(n_neighbors=2).fit(Y)
-        dist_to_nn, _ = nn.kneighbors(Y, return_distance=True)
-
-        # the first neighbor is the query vector it-self
-        dist_to_nn = dist_to_nn[:, 1]
+        nn = NearestNeighbors(n_neighbors=1).fit(Y)
+        dist_to_nn = nn.kneighbors(return_distance=True)[0].ravel()
         assert dist_to_nn.min() > 0.1
 
         smallest_to_mean = dist_to_nn.min() / np.mean(dist_to_nn)

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -263,7 +263,7 @@ def test_optimization_minimizes_kl_divergence():
     random_state = check_random_state(0)
     X, _ = make_blobs(n_features=3, random_state=random_state)
     kl_divergences = []
-    for n_iter in [200, 250, 300]:
+    for n_iter in [250, 300, 350]:
         tsne = TSNE(n_components=2, perplexity=10, learning_rate=100.0,
                     n_iter=n_iter, random_state=0)
         tsne.fit_transform(X)
@@ -550,51 +550,6 @@ def test_barnes_hut_angle():
         P = squareform(P)
         Pbh = Pbh.toarray()
         assert_array_almost_equal(Pbh, P, decimal=5)
-        assert_array_almost_equal(gradex, gradbh, decimal=5)
-
-
-def test_quadtree_similar_point():
-    # Introduce a point into a quad tree where a similar point already exists.
-    # Test will hang if it doesn't complete.
-    Xs = []
-
-    # check the case where points are actually different
-    Xs.append(np.array([[1, 2], [3, 4]], dtype=np.float32))
-    # check the case where points are the same on X axis
-    Xs.append(np.array([[1.0, 2.0], [1.0, 3.0]], dtype=np.float32))
-    # check the case where points are arbitrarily close on X axis
-    Xs.append(np.array([[1.00001, 2.0], [1.00002, 3.0]], dtype=np.float32))
-    # check the case where points are the same on Y axis
-    Xs.append(np.array([[1.0, 2.0], [3.0, 2.0]], dtype=np.float32))
-    # check the case where points are arbitrarily close on Y axis
-    Xs.append(np.array([[1.0, 2.00001], [3.0, 2.00002]], dtype=np.float32))
-    # check the case where points are arbitrarily close on both axes
-    Xs.append(np.array([[1.00001, 2.00001], [1.00002, 2.00002]],
-              dtype=np.float32))
-
-    # check the case where points are arbitrarily close on both axes
-    # close to machine epsilon - x axis
-    Xs.append(np.array([[1, 0.0003817754041], [2, 0.0003817753750]],
-              dtype=np.float32))
-
-    # check the case where points are arbitrarily close on both axes
-    # close to machine epsilon - y axis
-    Xs.append(np.array([[0.0003817754041, 1.0], [0.0003817753750, 2.0]],
-              dtype=np.float32))
-
-    for X in Xs:
-        counts = np.zeros(3, dtype='int64')
-        _barnes_hut_tsne.check_quadtree(X, counts)
-        m = "Tree consistency failed: unexpected number of points at root node"
-        assert_equal(counts[0], counts[1], m)
-        m = "Tree consistency failed: unexpected number of points on the tree"
-        assert_equal(counts[0], counts[2], m)
-
-
-def test_index_offset():
-    # Make sure translating between 1D and N-D indices are preserved
-    assert_equal(_barnes_hut_tsne.test_index2offset(), 1)
-    assert_equal(_barnes_hut_tsne.test_index_offset(), 1)
 
 
 @skip_if_32bit
@@ -602,8 +557,8 @@ def test_n_iter_without_progress():
     # Use a dummy negative n_iter_without_progress and check output on stdout
     random_state = check_random_state(0)
     X = random_state.randn(100, 2)
-    tsne = TSNE(n_iter_without_progress=-1, verbose=2, learning_rate=1e7,
-                random_state=1, method='exact', n_iter=200)
+    tsne = TSNE(n_iter_without_progress=-1, verbose=2, learning_rate=1e8,
+                random_state=1, method='exact', n_iter=300)
 
     old_stdout = sys.stdout
     sys.stdout = StringIO()
@@ -649,7 +604,7 @@ def test_min_grad_norm():
         start_grad_norm = line.find('gradient norm')
         if start_grad_norm >= 0:
             line = line[start_grad_norm:]
-            line = line.replace('gradient norm = ', '')
+            line = line.replace('gradient norm = ', '').split(' ')[0]
             gradient_norm_values.append(float(line))
 
     # Compute how often the gradient norm is smaller than min_grad_norm

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -10,6 +10,7 @@ from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_less
+from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils.testing import assert_in
 from sklearn.utils.testing import skip_if_32bit
@@ -241,10 +242,6 @@ def test_trustworthiness():
 def test_preserve_trustworthiness_approximately():
     # Nearest neighbors should be preserved approximately.
     random_state = check_random_state(0)
-    # The Barnes-Hut approximation uses a different method to estimate
-    # P_ij using only a number of nearest neighbors instead of all
-    # points (so that k = 3 * perplexity). As a result we set the
-    # perplexity=5, so that the number of neighbors is 5%.
     n_components = 2
     methods = ['exact', 'barnes_hut']
     X = random_state.randn(50, n_components).astype(np.float32)
@@ -254,8 +251,8 @@ def test_preserve_trustworthiness_approximately():
                         learning_rate=100.0, init=init, random_state=0,
                         method=method)
             X_embedded = tsne.fit_transform(X)
-            T = trustworthiness(X, X_embedded, n_neighbors=1)
-            assert_almost_equal(T, 1.0, decimal=1)
+            t = trustworthiness(X, X_embedded, n_neighbors=1)
+            assert_greater(t, 0.9)
 
 
 def test_optimization_minimizes_kl_divergence():

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -740,7 +740,7 @@ def check_uniform_grid(method, seeds=[0, 1, 2], n_iter=1000):
 
         # Ensure that the resulting embedding leads to approximately
         # uniformly spaced points: the distance to the closest neighbors
-        # should be approximately be non-zero and constant.
+        # should be non-zero and approximately constant.
         nn = NearestNeighbors(n_neighbors=1).fit(Y)
         dist_to_nn = nn.kneighbors(return_distance=True)[0].ravel()
         assert dist_to_nn.min() > 0.1

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -638,7 +638,6 @@ def test_n_iter_without_progress():
             out = sys.stdout.getvalue()
             sys.stdout.close()
             sys.stdout = old_stdout
-        print(out)
 
         # The output needs to contain the value of n_iter_without_progress
         assert_in("did not make any progress during the "

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -401,6 +401,41 @@ def test_n_components_range():
                          tsne.fit_transform, np.array([[0.0], [1.0]]))
 
 
+def test_early_exaggeration_used():
+    # check that the ``early_exaggeration`` parameter has an effect
+    random_state = check_random_state(0)
+    n_components = 2
+    methods = ['exact', 'barnes_hut']
+    X = random_state.randn(25, n_components).astype(np.float32)
+    for method in methods:
+        tsne = TSNE(n_components=n_components, perplexity=1,
+                    learning_rate=100.0, init="pca", random_state=0,
+                    method=method, early_exaggeration=1.0)
+        X_embedded1 = tsne.fit_transform(X)
+        tsne = TSNE(n_components=n_components, perplexity=1,
+                    learning_rate=100.0, init="pca", random_state=0,
+                    method=method, early_exaggeration=10.0)
+        X_embedded2 = tsne.fit_transform(X)
+
+        assert not np.allclose(X_embedded1, X_embedded2)
+
+
+def test_n_iter_used():
+    # check that the ``early_exaggeration`` parameter has an effect
+    random_state = check_random_state(0)
+    n_components = 2
+    methods = ['exact', 'barnes_hut']
+    X = random_state.randn(25, n_components).astype(np.float32)
+    for method in methods:
+        for n_iter in [251, 500, 1000]:
+            tsne = TSNE(n_components=n_components, perplexity=1,
+                        learning_rate=1.0, init="pca", random_state=0,
+                        method=method, early_exaggeration=1.0, n_iter=n_iter)
+            tsne.fit_transform(X)
+
+            assert tsne.n_iter_final == n_iter - 1
+
+
 def test_answer_gradient_two_points():
     # Test the tree with only a single set of children.
     #

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -595,8 +595,8 @@ def test_barnes_hut_angle():
         np.fill_diagonal(distances, 0.0)
         params = random_state.randn(n_samples, n_components)
         P = _joint_probabilities(distances, perplexity, verbose=0)
-        kl, gradex = _kl_divergence(params, P, degrees_of_freedom, n_samples,
-                                    n_components)
+        kl_exact, grad_exact = _kl_divergence(params, P, degrees_of_freedom,
+                                              n_samples, n_components)
 
         k = n_samples - 1
         bt = BallTree(distances)
@@ -606,15 +606,17 @@ def test_barnes_hut_angle():
                                  for i in range(n_samples)])
         assert np.all(distances[0, neighbors_nn[0]] == distances_nn[0]),\
             abs(distances[0, neighbors_nn[0]] - distances_nn[0])
-        Pbh = _joint_probabilities_nn(distances_nn, neighbors_nn,
-                                      perplexity, verbose=0)
-        kl, gradbh = _kl_divergence_bh(params, Pbh, degrees_of_freedom,
-                                       n_samples, n_components, angle=angle,
-                                       skip_num_points=0, verbose=0)
+        P_bh = _joint_probabilities_nn(distances_nn, neighbors_nn,
+                                       perplexity, verbose=0)
+        kl_bh, grad_bh = _kl_divergence_bh(params, P_bh, degrees_of_freedom,
+                                           n_samples, n_components,
+                                           angle=angle, skip_num_points=0,
+                                           verbose=0)
 
         P = squareform(P)
-        Pbh = Pbh.toarray()
-        assert_array_almost_equal(Pbh, P, decimal=5)
+        P_bh = P_bh.toarray()
+        assert_array_almost_equal(P_bh, P, decimal=5)
+        assert_almost_equal(kl_exact, kl_bh, decimal=3)
 
 
 @skip_if_32bit

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -293,7 +293,7 @@ def test_preserve_trustworthiness_approximately_with_precomputed_distances():
         D = squareform(pdist(X), "sqeuclidean")
         tsne = TSNE(n_components=2, perplexity=2, learning_rate=100.0,
                     early_exaggeration=2.0, metric="precomputed",
-                    random_state=i, verbose=0)
+                    random_state=i, verbose=0, neighbors_method='brute')
         X_embedded = tsne.fit_transform(D)
         t = trustworthiness(D, X_embedded, n_neighbors=1,
                             precomputed=True)
@@ -337,7 +337,8 @@ def test_init_ndarray():
 def test_init_ndarray_precomputed():
     # Initialize TSNE with ndarray and metric 'precomputed'
     # Make sure no FutureWarning is thrown from _fit
-    tsne = TSNE(init=np.zeros((100, 2)), metric="precomputed")
+    tsne = TSNE(init=np.zeros((100, 2)), metric="precomputed",
+                neighbors_method='brute')
     tsne.fit(np.zeros((100, 100)))
 
 

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -531,9 +531,7 @@ def test_verbose():
     assert("nearest neighbors..." in out)
     assert("Computed conditional probabilities" in out)
     assert("Mean sigma" in out)
-    assert("Finished" in out)
     assert("early exaggeration" in out)
-    assert("Finished" in out)
 
 
 def test_chebyshev_metric():

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -732,7 +732,8 @@ def check_uniform_grid(method, seeds=[0, 1, 2], n_iter=1000):
     """Make sure that TSNE can approximately recover a uniform 2D grid"""
     for seed in seeds:
         tsne = TSNE(n_components=2, init='random', random_state=seed,
-                    perplexity=10, n_iter=n_iter)
+                    perplexity=10, n_iter=n_iter, method=method,
+                    n_iter_without_progress=60)
         Y = tsne.fit_transform(X_2d_grid)
 
         # Ensure that the convergence criterion has been triggered

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -60,7 +60,7 @@ def test_gradient_descent_stops():
         _, error, it = _gradient_descent(
             ObjectiveSmallGradient(), np.zeros(1), 0, n_iter=100,
             n_iter_without_progress=100, momentum=0.0, learning_rate=0.0,
-            min_gain=0.0, min_grad_norm=1e-5, min_error_diff=0.0, verbose=2)
+            min_gain=0.0, min_grad_norm=1e-5, verbose=2)
     finally:
         out = sys.stdout.getvalue()
         sys.stdout.close()
@@ -69,22 +69,6 @@ def test_gradient_descent_stops():
     assert_equal(it, 0)
     assert("gradient norm" in out)
 
-    # Error difference
-    old_stdout = sys.stdout
-    sys.stdout = StringIO()
-    try:
-        _, error, it = _gradient_descent(
-            ObjectiveSmallGradient(), np.zeros(1), 0, n_iter=100,
-            n_iter_without_progress=100, momentum=0.0, learning_rate=0.0,
-            min_gain=0.0, min_grad_norm=0.0, min_error_diff=0.2, verbose=2)
-    finally:
-        out = sys.stdout.getvalue()
-        sys.stdout.close()
-        sys.stdout = old_stdout
-    assert_equal(error, 0.9)
-    assert_equal(it, 1)
-    assert("error difference" in out)
-
     # Maximum number of iterations without improvement
     old_stdout = sys.stdout
     sys.stdout = StringIO()
@@ -92,7 +76,7 @@ def test_gradient_descent_stops():
         _, error, it = _gradient_descent(
             flat_function, np.zeros(1), 0, n_iter=100,
             n_iter_without_progress=10, momentum=0.0, learning_rate=0.0,
-            min_gain=0.0, min_grad_norm=0.0, min_error_diff=-1.0, verbose=2)
+            min_gain=0.0, min_grad_norm=0.0, verbose=2)
     finally:
         out = sys.stdout.getvalue()
         sys.stdout.close()
@@ -108,7 +92,7 @@ def test_gradient_descent_stops():
         _, error, it = _gradient_descent(
             ObjectiveSmallGradient(), np.zeros(1), 0, n_iter=11,
             n_iter_without_progress=100, momentum=0.0, learning_rate=0.0,
-            min_gain=0.0, min_grad_norm=0.0, min_error_diff=0.0, verbose=2)
+            min_gain=0.0, min_grad_norm=0.0, verbose=2)
     finally:
         out = sys.stdout.getvalue()
         sys.stdout.close()

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -288,7 +288,7 @@ def test_fit_csr_matrix():
 def test_preserve_trustworthiness_approximately_with_precomputed_distances():
     # Nearest neighbors should be preserved approximately.
     random_state = check_random_state(0)
-    for i in range(5):
+    for i in range(3):
         X = random_state.randn(100, 2)
         D = squareform(pdist(X), "sqeuclidean")
         tsne = TSNE(n_components=2, perplexity=2, learning_rate=100.0,

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -735,8 +735,7 @@ def check_uniform_grid(method, seeds=[0, 1, 2], n_iter=1000):
     """Make sure that TSNE can approximately recover a uniform 2D grid"""
     for seed in seeds:
         tsne = TSNE(n_components=2, init='random', random_state=seed,
-                    perplexity=10, n_iter=n_iter, method=method,
-                    n_iter_without_progress=101, verbose=10)
+                    perplexity=10, n_iter=n_iter, method=method)
         Y = tsne.fit_transform(X_2d_grid)
 
         # Ensure that the convergence criterion has been triggered

--- a/sklearn/mixture/base.py
+++ b/sklearn/mixture/base.py
@@ -340,7 +340,7 @@ class BaseMixture(six.with_metaclass(ABCMeta, DensityMixin, BaseEstimator)):
         return self._estimate_weighted_log_prob(X).argmax(axis=1)
 
     def predict_proba(self, X):
-        """Predict posterior probability of data per each component.
+        """Predict posterior probability of each component given the data.
 
         Parameters
         ----------
@@ -351,8 +351,8 @@ class BaseMixture(six.with_metaclass(ABCMeta, DensityMixin, BaseEstimator)):
         Returns
         -------
         resp : array, shape (n_samples, n_components)
-            Returns the probability of the sample for each Gaussian
-            (state) in the model.
+            Returns the probability each Gaussian (state) in
+            the model given each sample.
         """
         self._check_is_fitted()
         X = _check_X(X, None, self.means_.shape[1])

--- a/sklearn/mixture/base.py
+++ b/sklearn/mixture/base.py
@@ -340,7 +340,7 @@ class BaseMixture(six.with_metaclass(ABCMeta, DensityMixin, BaseEstimator)):
         return self._estimate_weighted_log_prob(X).argmax(axis=1)
 
     def predict_proba(self, X):
-        """Predict posterior probability of each component given the data.
+        """Predict posterior probability of data per each component.
 
         Parameters
         ----------
@@ -351,8 +351,8 @@ class BaseMixture(six.with_metaclass(ABCMeta, DensityMixin, BaseEstimator)):
         Returns
         -------
         resp : array, shape (n_samples, n_components)
-            Returns the probability of each Gaussian (state) in
-            the model given each sample.
+            Returns the probability of the sample for each Gaussian
+            (state) in the model.
         """
         self._check_is_fitted()
         X = _check_X(X, None, self.means_.shape[1])

--- a/sklearn/neighbors/quad_tree.pxd
+++ b/sklearn/neighbors/quad_tree.pxd
@@ -79,7 +79,7 @@ cdef class QuadTree:
 
     cdef SIZE_t insert_point_in_new_child(self, DTYPE_t[3] point, Cell* cell,
                                           SIZE_t point_index, SIZE_t size=*) nogil
-    cdef void init_cell(self, Cell* cell, SIZE_t parent, SIZE_t depth) nogil
+    cdef void _init_cell(self, Cell* cell, SIZE_t parent, SIZE_t depth) nogil
     cdef bint is_duplicate(self, DTYPE_t[3] point1, DTYPE_t[3] point2) nogil
     cdef SIZE_t select_child(self, DTYPE_t[3] point, Cell* cell) nogil
     cdef void _init_root(self, DTYPE_t[3] min_bounds, DTYPE_t[3] max_bounds) nogil

--- a/sklearn/neighbors/quad_tree.pxd
+++ b/sklearn/neighbors/quad_tree.pxd
@@ -18,10 +18,13 @@ ctypedef np.npy_uint32 UINT32_t          # Unsigned 32 bit integer
 # It allows us to write printf debugging lines
 # and remove them at compile time
 cdef enum:
-    DEBUGFLAG = 0
+    DEBUGFLAG = 1
 
 cdef float EPSILON = 1e-6
 
+# XXX: Careful to not change the order of the arguments. It is important to
+# have is_leaf and max_width consecutive as it permits to avoid padding by
+# the compiler and keep the size coherent for both C and numpy data structures.
 cdef struct Cell:
     # Base storage stucture for cells in a QuadTree object
 
@@ -29,21 +32,24 @@ cdef struct Cell:
     SIZE_t parent              # Parent cell of this cell
     SIZE_t[8] children         # Array pointing to childrens of this cell
     
+    # Cell description
+    SIZE_t cell_id             # Id of the cell in the cells array in the Tree
+    SIZE_t point_index         # Index of the point at this cell (only defined
+                               # in non empty leaf)
+    bint is_leaf               # Does this cell have children?
+    DTYPE_t max_width          # The value of the maximum width w
+    SIZE_t depth               # Depth of the cell in the tree
+    SIZE_t cumulative_size     # Number of points included in the subtree with
+                               # this cell as a root.
+
+    # Internal constants
+    DTYPE_t[3] center          # Store the center for quick split of cells
+    DTYPE_t[3] barycenter      # Keep track of the center of mass of the cell
+
     # Cell boundaries
     DTYPE_t[3] min_bounds      # Inferior boundaries of this cell (inclusive)
     DTYPE_t[3] max_bounds      # Superior boundaries of this cell (exclusive)
-    DTYPE_t[3] center          # Store the center for quick split of cells
-    
-    # Cell description
-    SIZE_t cell_id             # Id of the cell in the cells array in the Tree
-    DTYPE_t max_width          # The value of the maximum width w
-    DTYPE_t[3] barycenter      # Keep track of the center of mass of the cell
-    SIZE_t point_index         # Index of the point at this cell (only defined in non empty leaf)
-    bint is_leaf          # Does this cell have children?
-    SIZE_t depth            # Depth of the cell in the tree
-    SIZE_t cumulative_size  # Number of points including all cell below this one
-    # cdef long size             # Number of points at this cell
-   
+
 
 cdef class QuadTree:
     # The QuadTree object is a quad tree structure constructed by inserting

--- a/sklearn/neighbors/quad_tree.pxd
+++ b/sklearn/neighbors/quad_tree.pxd
@@ -51,7 +51,7 @@ cdef struct Cell:
     DTYPE_t[3] max_bounds      # Superior boundaries of this cell (exclusive)
 
 
-cdef class QuadTree:
+cdef class _QuadTree:
     # The QuadTree object is a quad tree structure constructed by inserting
     # recursively points in the tree and splitting cells in 4 so that each
     # leaf cell contains at most one point.
@@ -73,9 +73,6 @@ cdef class QuadTree:
                           SIZE_t cell_id=*) nogil except -1
     cdef int _resize(self, SIZE_t capacity) nogil except -1
     cdef int _resize_c(self, SIZE_t capacity=*) nogil except -1
-
-    # cdef np.ndarray _get_value_ndarray(self)
-    # cdef np.ndarray _get_node_ndarray(self)
 
     cdef SIZE_t insert_point_in_new_child(self, DTYPE_t[3] point, Cell* cell,
                                           SIZE_t point_index, SIZE_t size=*) nogil

--- a/sklearn/neighbors/quad_tree.pxd
+++ b/sklearn/neighbors/quad_tree.pxd
@@ -80,8 +80,9 @@ cdef class _QuadTree:
     cdef bint _is_duplicate(self, DTYPE_t[3] point1, DTYPE_t[3] point2) nogil
 
     # Create a summary of the Tree compare to a query point
-    cdef long summarize(self, DTYPE_t[3] point, DTYPE_t* results, int cell_id=*,
-                        long idx=*, float squared_theta=*) nogil
+    cdef long summarize(self, DTYPE_t[3] point, DTYPE_t* results,
+                        float squared_theta=*, int cell_id=*, long idx=*
+                        ) nogil
 
     # Internal cell initialization methods
     cdef void _init_cell(self, Cell* cell, SIZE_t parent, SIZE_t depth) nogil

--- a/sklearn/neighbors/quad_tree.pxd
+++ b/sklearn/neighbors/quad_tree.pxd
@@ -37,7 +37,7 @@ cdef struct Cell:
     SIZE_t point_index         # Index of the point at this cell (only defined
                                # in non empty leaf)
     bint is_leaf               # Does this cell have children?
-    DTYPE_t max_width          # The value of the maximum width w
+    DTYPE_t squared_max_width  # Squared value of the maximum width w
     SIZE_t depth               # Depth of the cell in the tree
     SIZE_t cumulative_size     # Number of points included in the subtree with
                                # this cell as a root.

--- a/sklearn/neighbors/quad_tree.pxd
+++ b/sklearn/neighbors/quad_tree.pxd
@@ -55,6 +55,8 @@ cdef class _QuadTree:
     # The QuadTree object is a quad tree structure constructed by inserting
     # recursively points in the tree and splitting cells in 4 so that each
     # leaf cell contains at most one point.
+    # This structure also handle 3D data, inserted in trees with 8 children
+    # for each node.
 
     # Parameters of the tree
     cdef public int n_dimensions         # Number of dimensions in X
@@ -68,21 +70,30 @@ cdef class _QuadTree:
     cdef public SIZE_t n_points          # Total number of points
     cdef Cell* cells                     # Array of nodes
 
-    # Methods
+    # Point insertion methods
     cdef int insert_point(self, DTYPE_t[3] point, SIZE_t point_index,
                           SIZE_t cell_id=*) nogil except -1
-    cdef int _resize(self, SIZE_t capacity) nogil except -1
-    cdef int _resize_c(self, SIZE_t capacity=*) nogil except -1
+    cdef SIZE_t _insert_point_in_new_child(self, DTYPE_t[3] point, Cell* cell,
+                                           SIZE_t point_index, SIZE_t size=*
+                                           ) nogil
+    cdef SIZE_t _select_child(self, DTYPE_t[3] point, Cell* cell) nogil
+    cdef bint _is_duplicate(self, DTYPE_t[3] point1, DTYPE_t[3] point2) nogil
 
-    cdef SIZE_t insert_point_in_new_child(self, DTYPE_t[3] point, Cell* cell,
-                                          SIZE_t point_index, SIZE_t size=*) nogil
-    cdef void _init_cell(self, Cell* cell, SIZE_t parent, SIZE_t depth) nogil
-    cdef bint is_duplicate(self, DTYPE_t[3] point1, DTYPE_t[3] point2) nogil
-    cdef SIZE_t select_child(self, DTYPE_t[3] point, Cell* cell) nogil
-    cdef void _init_root(self, DTYPE_t[3] min_bounds, DTYPE_t[3] max_bounds) nogil
-
-    cdef int check_point_in_cell(self, DTYPE_t[3] point, Cell* cell) nogil except -1
+    # Create a summary of the Tree compare to a query point
     cdef long summarize(self, DTYPE_t[3] point, DTYPE_t* results, int cell_id=*,
                         long idx=*, float squared_theta=*) nogil
+
+    # Internal cell initialization methods
+    cdef void _init_cell(self, Cell* cell, SIZE_t parent, SIZE_t depth) nogil
+    cdef void _init_root(self, DTYPE_t[3] min_bounds, DTYPE_t[3] max_bounds
+                         ) nogil
+
+    # Private methods
+    cdef int _check_point_in_cell(self, DTYPE_t[3] point, Cell* cell
+                                  ) nogil except -1
+
+    # Private array manipulation to manage the ``cells`` array
+    cdef int _resize(self, SIZE_t capacity) nogil except -1
+    cdef int _resize_c(self, SIZE_t capacity=*) nogil except -1
     cdef int _get_cell(self, DTYPE_t[3] point, SIZE_t cell_id=*) nogil except -1
     cdef np.ndarray _get_cell_ndarray(self)

--- a/sklearn/neighbors/quad_tree.pxd
+++ b/sklearn/neighbors/quad_tree.pxd
@@ -18,7 +18,7 @@ ctypedef np.npy_uint32 UINT32_t          # Unsigned 32 bit integer
 # It allows us to write printf debugging lines
 # and remove them at compile time
 cdef enum:
-    DEBUGFLAG = 1
+    DEBUGFLAG = 0
 
 cdef float EPSILON = 1e-6
 

--- a/sklearn/neighbors/quad_tree.pxd
+++ b/sklearn/neighbors/quad_tree.pxd
@@ -1,0 +1,85 @@
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: cdivision=True
+# Author: Thomas Moreau <thomas.moreau.2010@gmail.com>
+# Author: Olivier Grisel <olivier.grisel@ensta.fr>
+
+# See quad_tree.pyx for details.
+
+import numpy as np
+cimport numpy as np
+
+ctypedef np.npy_float32 DTYPE_t          # Type of X
+ctypedef np.npy_intp SIZE_t              # Type for indices and counters
+ctypedef np.npy_int32 INT32_t            # Signed 32 bit integer
+ctypedef np.npy_uint32 UINT32_t          # Unsigned 32 bit integer
+
+# This is effectively an ifdef statement in Cython
+# It allows us to write printf debugging lines
+# and remove them at compile time
+cdef enum:
+    DEBUGFLAG = 0
+
+cdef float EPSILON = 1e-6
+
+cdef struct Cell:
+    # Base storage stucture for cells in a QuadTree object
+
+    # Tree structure
+    SIZE_t parent              # Parent cell of this cell
+    SIZE_t[8] children         # Array pointing to childrens of this cell
+    
+    # Cell boundaries
+    DTYPE_t[3] min_bounds      # Inferior boundaries of this cell (inclusive)
+    DTYPE_t[3] max_bounds      # Superior boundaries of this cell (exclusive)
+    DTYPE_t[3] center          # Store the center for quick split of cells
+    
+    # Cell description
+    SIZE_t cell_id             # Id of the cell in the cells array in the Tree
+    DTYPE_t max_width          # The value of the maximum width w
+    DTYPE_t[3] barycenter      # Keep track of the center of mass of the cell
+    SIZE_t point_index         # Index of the point at this cell (only defined in non empty leaf)
+    bint is_leaf          # Does this cell have children?
+    SIZE_t depth            # Depth of the cell in the tree
+    SIZE_t cumulative_size  # Number of points including all cell below this one
+    # cdef long size             # Number of points at this cell
+   
+
+cdef class QuadTree:
+    # The QuadTree object is a quad tree structure constructed by inserting
+    # recursively points in the tree and splitting cells in 4 so that each
+    # leaf cell contains at most one point.
+
+    # Parameters of the tree
+    cdef public int n_dimensions         # Number of dimensions in X
+    cdef public int verbose              # Verbosity of the output
+    cdef SIZE_t n_cells_per_cell         # Number of children per node. (2 ** n_dimension)
+
+    # Tree inner structure
+    cdef public SIZE_t max_depth         # Max depth of the tree
+    cdef public SIZE_t cell_count        # Counter for node IDs
+    cdef public SIZE_t capacity          # Capacity of tree, in terms of nodes
+    cdef public SIZE_t n_points          # Total number of points
+    cdef Cell* cells                     # Array of nodes
+
+    # Methods
+    cdef int insert_point(self, DTYPE_t[3] point, SIZE_t point_index,
+                          SIZE_t cell_id=*) nogil except -1
+    cdef int _resize(self, SIZE_t capacity) nogil except -1
+    cdef int _resize_c(self, SIZE_t capacity=*) nogil except -1
+
+    # cdef np.ndarray _get_value_ndarray(self)
+    # cdef np.ndarray _get_node_ndarray(self)
+
+    cdef SIZE_t insert_point_in_new_child(self, DTYPE_t[3] point, Cell* cell,
+                                          SIZE_t point_index, SIZE_t size=*) nogil
+    cdef void init_cell(self, Cell* cell, SIZE_t parent, SIZE_t depth) nogil
+    cdef bint is_duplicate(self, DTYPE_t[3] point1, DTYPE_t[3] point2) nogil
+    cdef SIZE_t select_child(self, DTYPE_t[3] point, Cell* cell) nogil
+    cdef void _init_root(self, DTYPE_t[3] min_bounds, DTYPE_t[3] max_bounds) nogil
+
+    cdef int check_point_in_cell(self, DTYPE_t[3] point, Cell* cell) nogil except -1
+    cdef long summarize(self, DTYPE_t[3] point, DTYPE_t* results, int cell_id=*,
+                        long idx=*, float squared_theta=*) nogil
+    cdef int _get_cell(self, DTYPE_t[3] point, SIZE_t cell_id=*) nogil except -1
+    cdef np.ndarray _get_cell_ndarray(self)

--- a/sklearn/neighbors/quad_tree.pyx
+++ b/sklearn/neighbors/quad_tree.pyx
@@ -64,7 +64,7 @@ cdef class _QuadTree:
     """Array-based representation of a QuadTree.
 
     This class is currently working for indexing 2D data (regular QuadTree) and
-    for indexing 3D data (OcTree). It is planned to split the 2 implementation
+    for indexing 3D data (OcTree). It is planned to split the 2 implementations
     using `Cython.Tempita` to save some memory for QuadTree.
 
     Note that this code is currently internally used only by the Barnes-Hut
@@ -110,7 +110,8 @@ cdef class _QuadTree:
 
         capacity = 100
         self._resize(capacity)
-        m, M = np.min(X, axis=0) - 1e-3, np.max(X, axis=0) + 1e-3
+        m = np.min(X, axis=0) - 1e-3
+        M = np.max(X, axis=0) + 1e-3
         for i in range(self.n_dimensions):
             min_bounds[i] = m[i]
             max_bounds[i] = M[i]
@@ -311,29 +312,6 @@ cdef class _QuadTree:
         root.cell_id = 0
 
         self.cell_count += 1
-
-    def plot_tree(self):
-        """Plot the tree with cell boundaries and the points inserted in it."""
-        self._check_coherence()
-        import matplotlib.pyplot as plt
-
-        plt.figure()
-        for c in self.cells[:self.cell_count]:
-            if not c.is_leaf:
-                # Plot the cell division if the cell is an inner cell
-                plt.vlines(c.center[0], c.min_bounds[1], c.max_bounds[1])
-                plt.hlines(c.center[1], c.min_bounds[0], c.max_bounds[0])
-            else:
-                # If the cell is a leaf, display the point contained in it.
-                plt.scatter(c.barycenter[0], c.barycenter[1], c='b', marker='.')
-
-        # Print bounding box of the Tree
-        root = self.cells[0]
-        plt.vlines([root.min_bounds[0], root.max_bounds[0]], root.min_bounds[1],
-                    root.max_bounds[1])
-        plt.hlines([root.min_bounds[1], root.max_bounds[1]], root.min_bounds[0],
-                    root.max_bounds[0])
-        plt.show()
 
     cdef int check_point_in_cell(self, DTYPE_t[3] point, Cell* cell
                                   ) nogil except -1:

--- a/sklearn/neighbors/quad_tree.pyx
+++ b/sklearn/neighbors/quad_tree.pyx
@@ -1,0 +1,528 @@
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: cdivision=True
+# Author: Thomas Moreau <thomas.moreau.2010@gmail.com>
+# Author: Olivier Grisel <olivier.grisel@ensta.fr>
+
+
+from cpython cimport Py_INCREF, PyObject
+
+from libc.stdlib cimport malloc, free
+from libc.string cimport memcpy
+from libc.stdio cimport printf
+
+from sklearn.tree._utils cimport safe_realloc, sizet_ptr_to_ndarray
+from ..utils import check_array
+
+import numpy as np
+cimport numpy as np
+
+cdef extern from "math.h":
+    float fabsf(float x) nogil
+
+cdef extern from "numpy/arrayobject.h":
+    object PyArray_NewFromDescr(object subtype, np.dtype descr,
+                                int nd, np.npy_intp* dims,
+                                np.npy_intp* strides,
+                                void* data, int flags, object obj)
+
+
+cdef SIZE_t DEFAULT = <SIZE_t>(-1)
+
+# Repeat struct definition for numpy
+CELL_DTYPE = np.dtype({
+    'names': ['parent', 'children', 'min_bounds', 'max_bounds', 'center',
+              'cell_id', 'max_width', 'barycenter', 'point_index', 'is_leaf',
+              'depth', 'cumulative_size'],
+    'formats': [np.intp, np.intp, np.float64, np.float64, np.float64, np.intp,
+                np.float64, np.float64, np.intp, np.bool, np.intp, np.intp],
+    'offsets': [
+        <Py_ssize_t> &(<Cell*> NULL).parent,
+        <Py_ssize_t> &(<Cell*> NULL).children,
+        <Py_ssize_t> &(<Cell*> NULL).min_bounds,
+        <Py_ssize_t> &(<Cell*> NULL).max_bounds,
+        <Py_ssize_t> &(<Cell*> NULL).center,
+        <Py_ssize_t> &(<Cell*> NULL).cell_id,
+        <Py_ssize_t> &(<Cell*> NULL).max_width,
+        <Py_ssize_t> &(<Cell*> NULL).barycenter,
+        <Py_ssize_t> &(<Cell*> NULL).point_index,
+        <Py_ssize_t> &(<Cell*> NULL).is_leaf,
+        <Py_ssize_t> &(<Cell*> NULL).depth,
+        <Py_ssize_t> &(<Cell*> NULL).cumulative_size
+    ]
+})
+
+
+cdef DTYPE_t[:, ::1] get_memview_DTYPE_2D(
+                               np.ndarray[DTYPE_t, ndim=2, mode='c'] X):
+    return <DTYPE_t[:X.shape[0], :X.shape[1]:1]> (<DTYPE_t*> X.data)
+
+
+
+cdef class QuadTree:
+    """Array-based representation of a QuadTree.
+    """
+    def __cinit__(self, int n_dimensions, int verbose):
+        """Constructor."""
+        # Parameters of the tree
+        self.n_dimensions = n_dimensions
+        self.verbose = verbose
+        self.n_cells_per_cell = 2 ** self.n_dimensions
+
+        # Inner structures
+        self.max_depth = 0
+        self.cell_count = 0
+        self.capacity = 0
+        self.n_points = 0
+        self.cells = NULL
+
+    def __dealloc__(self):
+        """Destructor."""
+        # Free all inner structures
+        free(self.cells)
+
+    cdef int _resize(self, SIZE_t capacity) nogil except -1:
+        """Resize all inner arrays to `capacity`, if `capacity` == -1, then
+           double the size of the inner arrays.
+
+        Returns -1 in case of failure to allocate memory (and raise MemoryError)
+        or 0 otherwise.
+        """
+        if self._resize_c(capacity) != 0:
+            # Acquire gil only if we need to raise
+            with gil:
+                raise MemoryError()
+
+    # XXX using (size_t)(-1) is ugly, but SIZE_MAX is not available in C89
+    # (i.e., older MSVC).
+    cdef int _resize_c(self, SIZE_t capacity=DEFAULT) nogil except -1:
+        """Guts of _resize
+
+        Returns -1 in case of failure to allocate memory (and raise MemoryError)
+        or 0 otherwise.
+        """
+        if capacity == self.capacity and self.cells != NULL:
+            return 0
+
+        if capacity == DEFAULT:
+            if self.capacity == 0:
+                capacity = 9  # default initial value to min
+            else:
+                capacity = 2 * self.capacity
+
+        safe_realloc(&self.cells, capacity)
+
+        # if capacity smaller than cell_count, adjust the counter
+        if capacity < self.cell_count:
+            self.cell_count = capacity
+
+        self.capacity = capacity
+        return 0
+
+    cdef int check_point_in_cell(self, DTYPE_t[3] point, Cell* cell
+                                  ) nogil except -1:
+        if self.verbose >= 10:
+            printf("[QuadTree] Checking point (%f, %f, %f) in cell %i "
+                    "([%f/%f, %f/%f, %f/%f], size %i)\n",
+                    point[0], point[1], point[2], cell.cell_id,
+                    cell.min_bounds[0], cell.max_bounds[0], cell.min_bounds[1],
+                    cell.max_bounds[1], cell.min_bounds[2], cell.max_bounds[2],
+                    cell.cumulative_size)
+                
+        for i in range(self.n_dimensions):
+            if (cell.min_bounds[i] > point[i] or
+                    cell.max_bounds[i] <= point[i]):
+                with gil:
+                    msg = "[QuadTree] InsertionError: point out of cell boundary.\n"
+                    msg += "Axis %i: cell [%f, %f]; point %f\n"
+                    
+                    msg %= i, cell.min_bounds[i],  cell.max_bounds[i], point[i]
+                    raise ValueError(msg)
+        
+
+    cdef int insert_point(self, DTYPE_t[3] point, SIZE_t point_index,
+                          SIZE_t cell_id=0) nogil except -1:
+        """Insert a point in the QuadTree."""
+        cdef int i
+        cdef DTYPE_t n_frac
+        cdef SIZE_t selected_child
+        cdef Cell* cell = &self.cells[cell_id]
+        cdef SIZE_t n_point = cell.cumulative_size
+
+        if self.verbose >= 10:
+            printf("[QuadTree] Inserting depth %i\n", cell.depth)
+
+        # Assert that the point is in the right range
+        if DEBUGFLAG:
+            self.check_point_in_cell(point, cell)
+
+
+        # If the cell is an empty leaf, insert the point in it
+        if cell.cumulative_size == 0:
+            cell.cumulative_size = 1
+            self.n_points += 1
+            for i in range(self.n_dimensions):
+                cell.barycenter[i] = point[i]
+            cell.point_index = point_index
+            if self.verbose >= 10:
+                printf("[QuadTree] inserted point in cell %i\n", cell_id)
+            return cell_id
+
+        # If the cell is not a leaf, update cell internals and
+        # recurse in selected child
+        if not cell.is_leaf:
+            for i in range(self.n_dimensions):
+                # barycenter update using a weighted mean
+                cell.barycenter[i] = (n_point * cell.barycenter[i] + point[i]) / (n_point + 1)
+            
+            # Increase the size of the subtree starting from this cell
+            cell.cumulative_size += 1
+
+            # Insert child in the correct subtree
+            selected_child = self.select_child(point, cell)
+            if self.verbose >= 10:
+                printf("[QuadTree] selected child %i\n", selected_child)
+            if selected_child == -1:
+                self.n_points += 1
+                return self.insert_point_in_new_child(point, cell, point_index)
+            return self.insert_point(point, point_index, selected_child)
+
+        # Finally, if the cell is a leaf with a point already inserted,
+        # split the cell in n_cells_per_cell if the point is not a duplicate.
+        # If it is a duplicate, increase the size of the leaf and return.
+        if self.is_duplicate(point, cell.barycenter):
+            if self.verbose >= 10:
+                printf("[QuadTree] found a duplicate!\n")
+            cell.cumulative_size += 1
+            self.n_points += 1
+            return cell_id
+
+        # In a leaf, the barycenter correspond to the only point included
+        # in it.
+        self.insert_point_in_new_child(cell.barycenter, cell, cell.point_index, cell.cumulative_size)
+        return self.insert_point(point, point_index, cell_id)
+
+    # XXX: This operation is not Thread safe
+    cdef SIZE_t insert_point_in_new_child(self, DTYPE_t[3] point, Cell* cell,
+                                          SIZE_t point_index, SIZE_t size=1) nogil:
+
+        # Local variable definition
+        cdef SIZE_t cell_id, cell_child_id, parent_id
+        cdef DTYPE_t[3] save_point
+        cdef DTYPE_t width
+        cdef Cell* child
+        cdef int i
+
+        # If the maximal capacity of the Tree have been reach, double the capacity
+        # We need to save the current cell id and the current point to retrieve them
+        # in case the reallocation 
+        if self.cell_count + 1 > self.capacity:
+            parent_id = cell.cell_id
+            for i in range(self.n_dimensions):
+                save_point[i] = point[i]
+            self._resize(DEFAULT)
+            cell = &self.cells[parent_id]
+            point = save_point
+
+        # Get an empty cell and initialize it
+        cell_id = self.cell_count
+        self.cell_count += 1
+        child  = &self.cells[cell_id]
+        
+        self.init_cell(child, cell.cell_id, cell.depth + 1)
+        child.cell_id = cell_id
+
+        # Set the cell as an inner cell of the Tree
+        cell.is_leaf = False
+        cell.point_index = -1
+
+        # Set the correct boundary for the cell and store the point in it
+        cell_child_id = 0
+        for i in range(self.n_dimensions):
+            cell_child_id *= 2
+            if point[i] >= cell.center[i]:
+                cell_child_id += 1
+                child.min_bounds[i] = cell.center[i]
+                child.max_bounds[i] = cell.max_bounds[i]
+            else:
+                child.min_bounds[i] = cell.min_bounds[i]
+                child.max_bounds[i] = cell.center[i]
+            child.center[i] = (child.min_bounds[i] + child.max_bounds[i]) / 2.
+            width = child.max_bounds[i] - child.min_bounds[i]
+
+            child.barycenter[i] = point[i]
+            child.max_width = max(child.max_width, width*width)
+            
+            # TODO: max_width
+        child.point_index = point_index
+        child.cumulative_size = size
+
+        # Store the child cell in the correct place in children
+        cell.children[cell_child_id] = child.cell_id
+            
+        if DEBUGFLAG:
+            # Assert that the point is in the right range
+            self.check_point_in_cell(point, child)
+        if self.verbose >= 10:
+            printf("[QuadTree] inserted point %i in new child %i\n", point_index, cell_id)
+
+        return cell_id
+            
+    cdef void init_cell(self, Cell* cell, SIZE_t parent, SIZE_t depth) nogil:
+        cell.parent = parent
+        cell.is_leaf = True
+        cell.depth = depth
+        cell.max_width = 0
+        cell.cumulative_size = 0
+        for i in range(self.n_cells_per_cell):
+            cell.children[i] = DEFAULT
+
+
+    cdef bint is_duplicate(self, DTYPE_t[3] point1, DTYPE_t[3] point2) nogil:
+        cdef int i
+        cdef bint res = True
+        for i in range(self.n_dimensions):
+            res &= fabsf(point1[i] - point2[i]) <= EPSILON
+        return res
+
+
+    cdef SIZE_t select_child(self, DTYPE_t[3] point, Cell* cell) nogil:
+        cdef int i
+        cdef SIZE_t selected_child = 0
+        for i in range(self.n_dimensions):
+            # Select the correct child cell to insert the point by comparing
+            # it to the borders of the cells using precomputed center.
+            selected_child *= 2
+            if point[i] >= cell.center[i]:
+                selected_child += 1
+        return cell.children[selected_child]
+
+    cdef void _init_root(self, DTYPE_t[3] min_bounds, DTYPE_t[3] max_bounds) nogil:
+        cdef int i
+        cdef DTYPE_t width
+        cdef Cell* root = &self.cells[0]
+        self.init_cell(root, -1, 0)
+        for i in range(self.n_dimensions):
+            root.min_bounds[i] = min_bounds[i]
+            root.max_bounds[i] = max_bounds[i]
+            root.center[i] = (max_bounds[i] + min_bounds[i]) / 2.
+            width = max_bounds[i] - min_bounds[i]
+            root.max_width = max(root.max_width, width*width)
+        root.cell_id = 0
+        
+        self.cell_count += 1
+
+    def build_tree(self, X):
+        """Build a tree from the points in X."""
+        cdef DTYPE_t[3] pt
+        cdef DTYPE_t[3] min_bounds, max_bounds
+
+        # validate X and prepare for query
+        # X = check_array(X, dtype=DTYPE_t, order='C')
+        n_samples = X.shape[0]
+
+        capacity = 100
+        self._resize(capacity)
+        m, M = np.min(X, axis=0) - 1e-3, np.max(X, axis=0) + 1e-3
+        for i in range(self.n_dimensions):
+            min_bounds[i] = m[i]
+            max_bounds[i] = M[i]
+
+        # Create the initial node with boundaries from the dataset
+        self._init_root(min_bounds, max_bounds)
+
+        # cdef DTYPE_t[:, ::1] Xarr = get_memview_DTYPE_2D(X)
+        for i in range(n_samples):
+            for j in range(self.n_dimensions):
+                pt[j] = X[i, j]
+            self.insert_point(pt, i)
+
+        self._resize(capacity=self.cell_count)
+
+    def plot_tree(self):
+        """Plot the tree with cell boundaries and the points inserted in it."""
+        self.check_coherence()
+        import matplotlib.pyplot as plt
+
+        plt.figure()
+        for c in self.cells[:self.cell_count]:
+            if not c.is_leaf:
+                # Plot the cell division if the cell is an inner cell
+                plt.vlines(c.center[0], c.min_bounds[1], c.max_bounds[1])
+                plt.hlines(c.center[1], c.min_bounds[0], c.max_bounds[0])
+            else:
+                # If the cell is a leaf, display the point contained in it.
+                plt.scatter(c.barycenter[0], c.barycenter[1], c='b', marker='.')
+            
+        # Print bounding box of the Tree
+        root = self.cells[0]
+        plt.vlines([root.min_bounds[0], root.max_bounds[0]], root.min_bounds[1], root.max_bounds[1])
+        plt.hlines([root.min_bounds[1], root.max_bounds[1]], root.min_bounds[0], root.max_bounds[0])
+        plt.show()
+
+    def check_coherence(self):
+        for c in self.cells[:self.cell_count]:
+            self.check_point_in_cell(c.barycenter, &c)
+            if not c.is_leaf:
+                n_points = 0
+                for idx in range(self.n_cells_per_cell):
+                    if c.children[idx] != -1:
+                        child = self.cells[c.children[idx]]
+                        n_points += child.cumulative_size
+                if n_points != c.cumulative_size:
+                    raise RuntimeError(
+                        "Cell {} is incoherent. Size={} but found {} points "
+                        "in children. ({})"
+                        .format(c.cell_id, c.cumulative_size, n_points, c.children))
+        if self.n_points != self.cells[0].cumulative_size:
+            raise RuntimeError(
+                "QuadTree is incoherent. Size={} but found {} points "
+                "in children."
+                .format(self.n_points, self.cells[0].cumulative_size))
+                    
+    cdef long summarize(self, DTYPE_t[3] point, DTYPE_t* results, SIZE_t cell_id=0,
+                        long idx=0, float squared_theta=.5) nogil:
+        """Summarize the tree compared to a query point.
+        
+        Input arguments
+        ---------------
+        point: array (n_dimensions)
+             query point to construct the summary.
+        cell_id: integer, optional (default: 0)
+            current cell of the tree summarized. This should be set to 0 for
+            external calls.
+        idx: integer, optional (default: 0)
+            current index in the result array. This should be set to 0 for
+            external calls
+
+        Output arguments
+        ----------------
+        result: array (n_samples * (n_dimensions+2))
+            result will contain a summary of the tree information compared to
+            the query point:
+            - results[idx:idx+n_dimensions] contains the delta between a summary
+                node idx and the query point.
+            - result[idx+n_dimensions+1] contains the squared euclidean distance
+                to the summary node idx.
+            - result[idx+n_dimensions+2] contains the size of the summary node idx.
+
+        Return
+        ------
+        idx: integer
+            number of elements in the results array.
+        """
+        cdef:
+            int i, idx_d = idx + self.n_dimensions
+            bint duplicate = True
+            Cell* cell = &self.cells[cell_id]
+
+        idx_d = idx + self.n_dimensions
+        results[idx_d] = 0.
+        for i in range(self.n_dimensions):
+            results[idx + i] = point[i] - cell.barycenter[i]
+            results[idx_d] += results[idx + i] * results[idx + i]
+            duplicate &= fabsf(results[idx + i]) < EPSILON
+
+        # Do not compute self interactions
+        if duplicate and cell.is_leaf:
+            return idx
+
+        # Check whether we can use this node as a summary
+        # It's a summary node if the angular size as measured from the point
+        # is relatively small (w.r.t. to theta) or if it is a leaf node.
+        # If it can be summarized, we use the cell center of mass 
+        # Otherwise, we go a higher level of resolution and into the leaves.
+        if cell.is_leaf or ((cell.max_width / results[idx_d]) < squared_theta):
+            results[idx_d + 1] = <DTYPE_t> cell.cumulative_size
+            return idx + 2 + self.n_dimensions
+
+        else:
+            # Recursively compute the summary in nodes
+            for c in range(self.n_cells_per_cell):
+                child_id = cell.children[c]
+                if child_id != -1:
+                    idx = self.summarize(point, results, child_id, idx)
+
+        return idx
+        
+    def get_cell(self, point):
+        cdef DTYPE_t[3] query_pt
+        cdef int i
+
+        for i in range(self.n_dimensions):
+            query_pt[i] = point[i]
+
+        return self._get_cell(query_pt, 0)
+
+    cdef int _get_cell(self, DTYPE_t[3] point, SIZE_t cell_id=0) nogil except -1:
+        cdef:
+            SIZE_t selected_child
+            Cell* cell = &self.cells[0]
+
+        if cell.is_leaf:
+            if self.is_duplicate(cell.barycenter, point):
+                return cell_id
+            with gil:
+                raise ValueError("Query point not in the Tree.")
+
+        selected_child = self.select_child(point, cell)
+        if selected_child > 0:
+            return self._get_cell(point, selected_child)
+        with gil:
+            raise ValueError("Query point not in the Tree.")
+
+    def __reduce__(self):
+        """Reduce re-implementation, for pickling."""
+        return (QuadTree, (self.n_dimensions, self.verbose,
+                           self.__getstate__()))
+
+    def __getstate__(self):
+        """Getstate re-implementation, for pickling."""
+        d = {}
+        # capacity is infered during the __setstate__ using nodes
+        d["max_depth"] = self.max_depth
+        d["cell_count"] = self.cell_count
+        d["cells"] = self._get_cell_ndarray()
+        return d
+
+    def __setstate__(self, d):
+        """Setstate re-implementation, for unpickling."""
+        self.max_depth = d["max_depth"]
+        self.cell_count = d["cell_count"]
+
+        if 'cells' not in d:
+            raise ValueError('You have loaded Tree version which '
+                             'cannot be imported')
+
+        cell_ndarray = d['cells']
+
+        if (cell_ndarray.ndim != 1 or
+                cell_ndarray.dtype != CELL_DTYPE or
+                not cell_ndarray.flags.c_contiguous):
+            raise ValueError('Did not recognise loaded array layout')
+
+        self.capacity = cell_ndarray.shape[0]
+        if self._resize_c(self.capacity) != 0:
+            raise MemoryError("resizing tree to %d" % self.capacity)
+        cells = memcpy(self.cells, (<np.ndarray> cell_ndarray).data,
+                       self.capacity * sizeof(Cell))
+
+    cdef np.ndarray _get_cell_ndarray(self):
+        """Wraps nodes as a NumPy struct array.
+
+        The array keeps a reference to this Tree, which manages the underlying
+        memory. Individual fields are publicly accessible as properties of the
+        Tree.
+        """
+        cdef np.npy_intp shape[1]
+        shape[0] = <np.npy_intp> self.cell_count
+        cdef np.npy_intp strides[1]
+        strides[0] = sizeof(Cell)
+        cdef np.ndarray arr
+        Py_INCREF(CELL_DTYPE)
+        arr = PyArray_NewFromDescr(np.ndarray, <np.dtype> CELL_DTYPE, 1, shape,
+                                   strides, <void*> self.cells,
+                                   np.NPY_DEFAULT, None)
+        Py_INCREF(self)
+        arr.base = <PyObject*> self
+        return arr

--- a/sklearn/neighbors/quad_tree.pyx
+++ b/sklearn/neighbors/quad_tree.pyx
@@ -112,7 +112,9 @@ cdef class _QuadTree:
         self._resize(capacity)
         m = np.min(X, axis=0)
         M = np.max(X, axis=0)
-        M = np.maximum(M * 1.001, M + 1e-3)
+        # Scale the maximum to get all points strictly in the tree bounding box
+        # The 3 bounds are for positive, negative and small values
+        M = np.maximum(M * (1. + 1e-3 * np.sign(M)), M + 1e-3)
         for i in range(self.n_dimensions):
             min_bounds[i] = m[i]
             max_bounds[i] = M[i]

--- a/sklearn/neighbors/quad_tree.pyx
+++ b/sklearn/neighbors/quad_tree.pyx
@@ -597,3 +597,60 @@ cdef class _QuadTree:
 
         self.capacity = capacity
         return 0
+
+    @staticmethod
+    def test_summarize():
+
+        cdef:
+            DTYPE_t[3] query_pt
+            float* summary
+            int i, n_samples, n_dimensions
+
+        n_dimensions = 2
+        n_samples = 4
+        angle = 0.9
+        offset = n_dimensions + 2
+        X = np.array([[-10., -10.], [9., 10.], [10., 9.], [10., 10.]])
+
+        n_dimensions = X.shape[1]
+        qt = _QuadTree(n_dimensions, verbose=0)
+        qt.build_tree(X)
+
+        summary = <float*> malloc(sizeof(float) * n_samples * 4)
+
+        for i in range(n_dimensions):
+            query_pt[i] = X[0, i]
+
+        # Summary should contain only 1 node with size 3 and distance to
+        # X[1:] barycenter
+        idx = qt.summarize(query_pt, summary, angle * angle)
+
+        node_dist = summary[n_dimensions]
+        node_size = summary[n_dimensions + 1]
+
+        barycenter = X[1:].mean(axis=0)
+        ds2c = ((X[0] - barycenter) ** 2).sum()
+
+        assert idx == offset
+        assert node_size == 3, "summary size = {}".format(node_size)
+        assert np.isclose(node_dist, ds2c)
+
+        # Summary should contain all 3 node with size 1 and distance to
+        # each point in X[1:] for ``angle=0``
+        idx = qt.summarize(query_pt, summary, 0)
+
+        node_dist = summary[n_dimensions]
+        node_size = summary[n_dimensions + 1]
+
+        barycenter = X[1:].mean(axis=0)
+        ds2c = ((X[0] - barycenter) ** 2).sum()
+
+        assert idx == 3 * (offset)
+        for i in range(3):
+            node_dist = summary[i * offset + n_dimensions]
+            node_size = summary[i * offset + n_dimensions + 1]
+
+            ds2c = ((X[0] - X[i + 1]) ** 2).sum()
+
+            assert node_size == 1, "summary size = {}".format(node_size)
+            assert np.isclose(node_dist, ds2c)

--- a/sklearn/neighbors/quad_tree.pyx
+++ b/sklearn/neighbors/quad_tree.pyx
@@ -124,6 +124,7 @@ cdef class _QuadTree:
                 pt[j] = X[i, j]
             self.insert_point(pt, i)
 
+        # Shrink the cells array to reduce memory usage
         self._resize(capacity=self.cell_count)
 
     cdef int insert_point(self, DTYPE_t[3] point, SIZE_t point_index,
@@ -266,6 +267,7 @@ cdef class _QuadTree:
         cdef int i
         cdef bint res = True
         for i in range(self.n_dimensions):
+            # Use EPSILON to avoid numerical error that would overgrow the tree
             res &= fabsf(point1[i] - point2[i]) <= EPSILON
         return res
 
@@ -380,18 +382,18 @@ cdef class _QuadTree:
 
         Input arguments
         ---------------
-        point: array (n_dimensions)
+        point : array (n_dimensions)
              query point to construct the summary.
-        cell_id: integer, optional (default: 0)
+        cell_id : integer, optional (default: 0)
             current cell of the tree summarized. This should be set to 0 for
             external calls.
-        idx: integer, optional (default: 0)
+        idx : integer, optional (default: 0)
             current index in the result array. This should be set to 0 for
             external calls
 
         Output arguments
         ----------------
-        result: array (n_samples * (n_dimensions+2))
+        results : array (n_samples * (n_dimensions+2))
             result will contain a summary of the tree information compared to
             the query point:
             - results[idx:idx+n_dimensions] contains the coordinate-wise
@@ -404,7 +406,7 @@ cdef class _QuadTree:
 
         Return
         ------
-        idx: integer
+        idx : integer
             number of elements in the results array.
         """
         cdef:

--- a/sklearn/neighbors/setup.py
+++ b/sklearn/neighbors/setup.py
@@ -34,8 +34,7 @@ def configuration(parent_package='', top_path=None):
     config.add_extension("quad_tree",
                          sources=["quad_tree.pyx"],
                          include_dirs=[numpy.get_include()],
-                         libraries=libraries,
-                         extra_compile_args=["-O3"])
+                         libraries=libraries)
 
     config.add_subpackage('tests')
 

--- a/sklearn/neighbors/setup.py
+++ b/sklearn/neighbors/setup.py
@@ -31,6 +31,11 @@ def configuration(parent_package='', top_path=None):
                          sources=['typedefs.pyx'],
                          include_dirs=[numpy.get_include()],
                          libraries=libraries)
+    config.add_extension("quad_tree",
+                         sources=["quad_tree.pyx"],
+                         include_dirs=[numpy.get_include()],
+                         libraries=libraries,
+                         extra_compile_args=["-O3"])
 
     config.add_subpackage('tests')
 

--- a/sklearn/neighbors/tests/test_quad_tree.py
+++ b/sklearn/neighbors/tests/test_quad_tree.py
@@ -4,6 +4,25 @@ from sklearn.neighbors.quad_tree import _QuadTree
 from sklearn.utils import check_random_state
 
 
+def test_quadtree_boundary_computation():
+    # Introduce a point into a quad tree with boundaries not easy to compute.
+    Xs = []
+
+    # check a random case
+    Xs.append(np.array([[-1, 1], [-4, -1]], dtype=np.float32))
+    # check the case where only 0 are inserted
+    Xs.append(np.array([[0, 0], [0, 0]], dtype=np.float32))
+    # check the case where only negative are inserted
+    Xs.append(np.array([[-1, -2], [-4, 0]], dtype=np.float32))
+    # check the case where only small numbers are inserted
+    Xs.append(np.array([[-1e-6, 1e-6], [-4e-6, -1e-6]], dtype=np.float32))
+
+    for X in Xs:
+        tree = _QuadTree(n_dimensions=2, verbose=0)
+        tree.build_tree(X)
+        tree._check_coherence()
+
+
 def test_quadtree_similar_point():
     # Introduce a point into a quad tree where a similar point already exists.
     # Test will hang if it doesn't complete.

--- a/sklearn/neighbors/tests/test_quad_tree.py
+++ b/sklearn/neighbors/tests/test_quad_tree.py
@@ -1,6 +1,6 @@
 import pickle
 import numpy as np
-from sklearn.neighbors.quad_tree import QuadTree
+from sklearn.neighbors.quad_tree import _QuadTree
 from sklearn.utils import check_random_state
 
 
@@ -34,9 +34,9 @@ def test_quadtree_similar_point():
               dtype=np.float32))
 
     for X in Xs:
-        tree = QuadTree(n_dimensions=2, verbose=0)
+        tree = _QuadTree(n_dimensions=2, verbose=0)
         tree.build_tree(X)
-        tree.check_coherence()
+        tree._check_coherence()
 
 
 def test_quad_tree_pickle():
@@ -45,7 +45,7 @@ def test_quad_tree_pickle():
     for n_dimensions in (2, 3):
         X = rng.random_sample((10, n_dimensions))
 
-        tree = QuadTree(n_dimensions=n_dimensions, verbose=0)
+        tree = _QuadTree(n_dimensions=n_dimensions, verbose=0)
         tree.build_tree(X)
 
         def check_pickle_protocol(protocol):
@@ -68,7 +68,7 @@ def test_qt_insert_duplicate():
 
         X = rng.random_sample((10, n_dimensions))
         Xd = np.r_[X, X[:5]]
-        tree = QuadTree(n_dimensions=n_dimensions, verbose=0)
+        tree = _QuadTree(n_dimensions=n_dimensions, verbose=0)
         tree.build_tree(Xd)
 
         cumulative_size = tree.cumulative_size

--- a/sklearn/neighbors/tests/test_quad_tree.py
+++ b/sklearn/neighbors/tests/test_quad_tree.py
@@ -1,0 +1,56 @@
+import pickle
+import numpy as np
+from sklearn.neighbors.quad_tree import QuadTree
+
+
+def test_quadtree_similar_point():
+    # Introduce a point into a quad tree where a similar point already exists.
+    # Test will hang if it doesn't complete.
+    Xs = []
+
+    # check the case where points are actually different
+    Xs.append(np.array([[1, 2], [3, 4]], dtype=np.float32))
+    # check the case where points are the same on X axis
+    Xs.append(np.array([[1.0, 2.0], [1.0, 3.0]], dtype=np.float32))
+    # check the case where points are arbitrarily close on X axis
+    Xs.append(np.array([[1.00001, 2.0], [1.00002, 3.0]], dtype=np.float32))
+    # check the case where points are the same on Y axis
+    Xs.append(np.array([[1.0, 2.0], [3.0, 2.0]], dtype=np.float32))
+    # check the case where points are arbitrarily close on Y axis
+    Xs.append(np.array([[1.0, 2.00001], [3.0, 2.00002]], dtype=np.float32))
+    # check the case where points are arbitrarily close on both axes
+    Xs.append(np.array([[1.00001, 2.00001], [1.00002, 2.00002]],
+              dtype=np.float32))
+
+    # check the case where points are arbitrarily close on both axes
+    # close to machine epsilon - x axis
+    Xs.append(np.array([[1, 0.0003817754041], [2, 0.0003817753750]],
+              dtype=np.float32))
+
+    # check the case where points are arbitrarily close on both axes
+    # close to machine epsilon - y axis
+    Xs.append(np.array([[0.0003817754041, 1.0], [0.0003817753750, 2.0]],
+              dtype=np.float32))
+
+    for X in Xs:
+        tree = QuadTree(n_dimensions=2, verbose=0)
+        tree.build_tree(X)
+        tree.check_coherence()
+
+
+def test_quad_tree_pickle():
+    np.random.seed(0)
+    X = np.random.random((10, 3))
+
+    tree = QuadTree(n_dimensions=2, verbose=0)
+    tree.build_tree(X)
+
+    def check_pickle_protocol(protocol):
+        s = pickle.dumps(tree, protocol=protocol)
+        bt2 = pickle.loads(s)
+
+        for x in X:
+            assert tree.get_cell(x) == bt2.get_cell(x)
+
+    for protocol in (0, 1, 2):
+        yield check_pickle_protocol, protocol

--- a/sklearn/neighbors/tests/test_quad_tree.py
+++ b/sklearn/neighbors/tests/test_quad_tree.py
@@ -1,6 +1,7 @@
 import pickle
 import numpy as np
 from sklearn.neighbors.quad_tree import QuadTree
+from sklearn.utils import check_random_state
 
 
 def test_quadtree_similar_point():
@@ -39,10 +40,10 @@ def test_quadtree_similar_point():
 
 
 def test_quad_tree_pickle():
-    np.random.seed(0)
+    rng = check_random_state(0)
 
     for n_dimensions in (2, 3):
-        X = np.random.random((10, n_dimensions))
+        X = rng.random_sample((10, n_dimensions))
 
         tree = QuadTree(n_dimensions=n_dimensions, verbose=0)
         tree.build_tree(X)
@@ -61,11 +62,11 @@ def test_quad_tree_pickle():
 
 
 def test_qt_insert_duplicate():
-    np.random.seed(0)
+    rng = check_random_state(0)
 
     def check_insert_duplicate(n_dimensions=2):
 
-        X = np.random.random((10, n_dimensions))
+        X = rng.random_sample((10, n_dimensions))
         Xd = np.r_[X, X[:5]]
         tree = QuadTree(n_dimensions=n_dimensions, verbose=0)
         tree.build_tree(Xd)

--- a/sklearn/neighbors/tests/test_quad_tree.py
+++ b/sklearn/neighbors/tests/test_quad_tree.py
@@ -83,3 +83,7 @@ def test_qt_insert_duplicate():
 
     for n_dimensions in (2, 3):
         yield check_insert_duplicate, n_dimensions
+
+
+def test_summarize():
+    _QuadTree.test_summarize()

--- a/sklearn/tree/_utils.pxd
+++ b/sklearn/tree/_utils.pxd
@@ -10,7 +10,8 @@
 
 import numpy as np
 cimport numpy as np
-from _tree cimport Node 
+from _tree cimport Node
+from sklearn.neighbors.quad_tree cimport Cell
 
 ctypedef np.npy_float32 DTYPE_t          # Type of X
 ctypedef np.npy_float64 DOUBLE_t         # Type of y, sample_weight
@@ -39,6 +40,7 @@ ctypedef fused realloc_ptr:
     (DOUBLE_t*)
     (DOUBLE_t**)
     (Node*)
+    (Cell*)
     (Node**)
     (StackRecord*)
     (PriorityHeapRecord*)


### PR DESCRIPTION
The barnes-hut algorithm for t-SNE currently have a `O(N^2)` memory complexity, it could use `O(uN)`. This PR intend to improve the memory usage. (see Issue scikit-learn/scikit-learn#7089)

#### Step to proceed

* [x] Only compute the nearest neighbors distances
* [x] Validate `_barnes_hut2` with `_barnes_hut` functions
* [x] Check memory usage
* [x] Set default values of optimizer hyperparams to match the reference implementation and check that the results are qualitatively and quantitatively matching (compute trustworthiness)
* [x] Make TSNE raise a `ValueError` when `n_components > 3` or `n_components < 2` with the BH solver enabled.

#### Related
* Initial PR scikit-learn/scikit-learn#4025
* Some ideas scikit-learn/scikit-learn#8582
