### PR TITLE
[MRG+2] Ridge linear model dtype consistency (all solvers but sag)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -187,6 +187,10 @@ Enhancements
      :class:`sklearn.linear_model.LogisticRegression` when using newton-cg solver
      by :user:`Joan Massich <massich>`
 
+   - Prevent cast from float32 to float64 in
+     :class:`sklearn.linear_model.Ridge` when using svd, sparse_cg, cholesky or lsqr solvers
+     by :user:`Joan Massich <massich>`, ::user::`Nicolas Cordier <ncordier>`
+
    - Add ``max_train_size`` parameter to :class:`model_selection.TimeSeriesSplit`
      :issue:`8282` by :user:`Aman Dalmia <dalmia>`.
 

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -171,7 +171,7 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
         if sp.issparse(X):
             X_offset, X_var = mean_variance_axis(X, axis=0)
             if not return_mean:
-                X_offset = np.zeros(X.shape[1], dtype=X.dtype)
+                X_offset[:] = 0
 
             if normalize:
 

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -171,7 +171,7 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
         if sp.issparse(X):
             X_offset, X_var = mean_variance_axis(X, axis=0)
             if not return_mean:
-                X_offset = np.zeros(X.shape[1])
+                X_offset = np.zeros(X.shape[1], dtype=X.dtype)
 
             if normalize:
 
@@ -186,7 +186,7 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
                 X_scale[X_scale == 0] = 1
                 inplace_column_scale(X, 1. / X_scale)
             else:
-                X_scale = np.ones(X.shape[1])
+                X_scale = np.ones(X.shape[1], dtype=X.dtype)
 
         else:
             X_offset = np.average(X, axis=0, weights=sample_weight)
@@ -195,12 +195,12 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
                 X, X_scale = f_normalize(X, axis=0, copy=False,
                                          return_norm=True)
             else:
-                X_scale = np.ones(X.shape[1])
+                X_scale = np.ones(X.shape[1], dtype=X.dtype)
         y_offset = np.average(y, axis=0, weights=sample_weight)
         y = y - y_offset
     else:
-        X_offset = np.zeros(X.shape[1])
-        X_scale = np.ones(X.shape[1])
+        X_offset = np.zeros(X.shape[1], dtype=X.dtype)
+        X_scale = np.ones(X.shape[1], dtype=X.dtype)
         y_offset = 0. if y.ndim == 1 else np.zeros(y.shape[1], dtype=X.dtype)
 
     return X, y, X_offset, y_offset, X_scale

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -165,7 +165,7 @@ def _solve_cholesky_kernel(K, y, alpha, sample_weight=None, copy=False):
         return dual_coef
     else:
         # One penalty per target. We need to solve each target separately.
-        dual_coefs = np.empty([n_targets, n_samples])
+        dual_coefs = np.empty([n_targets, n_samples], K.dtype)
 
         for dual_coef, target, current_alpha in zip(dual_coefs, y.T, alpha):
             K.flat[::n_samples + 1] += current_alpha

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -320,6 +320,8 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
                           "automatically changed into 'sag'.")
         solver = 'sag'
 
+    _dtype = [np.float64, np.float32]
+
     # SAG needs X and y columns to be C-contiguous and np.float64
     if solver in ['sag', 'saga']:
         X = check_array(X, accept_sparse=['csr'],
@@ -327,7 +329,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         y = check_array(y, dtype=np.float64, ensure_2d=False, order='F')
     else:
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'],
-                        dtype=np.float64)
+                        dtype=_dtype)
         y = check_array(y, dtype='numeric', ensure_2d=False)
     check_consistent_length(X, y)
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -330,7 +330,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
     else:
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'],
                         dtype=_dtype)
-        y = check_array(y, dtype='numeric', ensure_2d=False)
+        y = check_array(y, dtype=X.dtype, ensure_2d=False)
     check_consistent_length(X, y)
 
     n_samples, n_features = X.shape

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -820,7 +820,10 @@ def test_dtype_match():
         assert_equal(coef_32.dtype, X_32.dtype)
         assert_equal(coef_64.dtype, X_64.dtype)
 
+
 def test_dtype_match_cholesky():
+    # Test different alphas in cholesky solver to ensure full coverage.
+    # This test is separated from test_dtype_match for clarity.
     rng = np.random.RandomState(0)
     alpha = (1.0, 0.5)
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -788,3 +788,30 @@ def test_errors_and_values_svd_helper():
 def test_ridge_classifier_no_support_multilabel():
     X, y = make_multilabel_classification(n_samples=10, random_state=0)
     assert_raises(ValueError, RidgeClassifier().fit, X, y)
+
+
+def test_dtype_match():
+    rng = np.random.RandomState(0)
+    alpha = 1.0
+
+    n_samples, n_features = 6, 5
+    X_64 = rng.randn(n_samples, n_features)
+    y_64 = rng.randn(n_samples)
+    X_32 = X_64.astype(np.float32)
+    y_32 = y_64.astype(np.float32)
+
+    solvers = ["svd", "sparse_cg", "cholesky", "lsqr"]
+    for solver in solvers:
+
+        # Check type consistency 32bits
+        ridge_32 = Ridge(alpha=alpha, solver=solver)
+        ridge_32.fit(X_32, y_32)
+        assert_equal(ridge_32.coef_.dtype, X_32.dtype)
+
+        # Check type consistency 64 bits
+        ridge_64 = Ridge(alpha=alpha, solver=solver)
+        ridge_64.fit(X_64, y_64)
+        assert_equal(ridge_64.coef_.dtype, X_64.dtype)
+
+        # Check accuracy consistency
+        assert_almost_equal(ridge_32.coef_, ridge_64.coef_, decimal=5)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -806,12 +806,41 @@ def test_dtype_match():
         # Check type consistency 32bits
         ridge_32 = Ridge(alpha=alpha, solver=solver)
         ridge_32.fit(X_32, y_32)
-        assert_equal(ridge_32.coef_.dtype, X_32.dtype)
+        coef_32 = ridge_32.coef_
 
         # Check type consistency 64 bits
         ridge_64 = Ridge(alpha=alpha, solver=solver)
         ridge_64.fit(X_64, y_64)
-        assert_equal(ridge_64.coef_.dtype, X_64.dtype)
+        coef_64 = ridge_64.coef_
 
-        # Check accuracy consistency
+        # Do all the checks at once, like this is easier to debug
         assert_almost_equal(ridge_32.coef_, ridge_64.coef_, decimal=5)
+
+        # Do the actual checks at once for easier debug
+        assert_equal(coef_32.dtype, X_32.dtype)
+        assert_equal(coef_64.dtype, X_64.dtype)
+
+def test_dtype_match_cholesky():
+    rng = np.random.RandomState(0)
+    alpha = (1.0, 0.5)
+
+    n_samples, n_features, n_target = 6, 7, 2
+    X_64 = rng.randn(n_samples, n_features)
+    y_64 = rng.randn(n_samples, n_target)
+    X_32 = X_64.astype(np.float32)
+    y_32 = y_64.astype(np.float32)
+
+    # Check type consistency 32bits
+    ridge_32 = Ridge(alpha=alpha, solver='cholesky')
+    ridge_32.fit(X_32, y_32)
+    coef_32 = ridge_32.coef_
+
+    # Check type consistency 64 bits
+    ridge_64 = Ridge(alpha=alpha, solver='cholesky')
+    ridge_64.fit(X_64, y_64)
+    coef_64 = ridge_64.coef_
+
+    # Do all the checks at once, like this is easier to debug
+    assert_equal(coef_32.dtype, X_32.dtype)
+    assert_equal(coef_64.dtype, X_64.dtype)
+    assert_almost_equal(ridge_32.coef_, ridge_64.coef_, decimal=5)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -363,7 +363,7 @@ def check_array(array, accept_sparse=False, dtype="numeric", order=None,
         accept_sparse = False
 
     # store whether originally we wanted numeric dtype
-    dtype_numeric = dtype == "numeric"
+    dtype_numeric = isinstance(dtype, six.string_types) and dtype == "numeric"
 
     dtype_orig = getattr(array, "dtype", None)
     if not hasattr(dtype_orig, 'kind'):


### PR DESCRIPTION
#### Reference Issue
works on #8769 for Ridge case

#### What does this implement/fix? Explain your changes.
Avoids Ridge to aggressively cast the data to `np.float64` when `np.float32` is supplied. 

#### Any other comments?
