### PR TITLE
[WIP] Add test for lasso consistency dtype

### DIFF
--- a/sklearn/linear_model/tests/test_randomized_l1.py
+++ b/sklearn/linear_model/tests/test_randomized_l1.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy import sparse
 
 from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raises_regex
@@ -101,6 +102,33 @@ def test_randomized_lasso():
 
     clf = RandomizedLasso(verbose=False, scaling=1.1)
     assert_raises(ValueError, clf.fit, X, y)
+
+
+def test_dtype_match():
+    # Check randomized lasso
+    scaling = 0.3
+    selection_threshold = 0.5
+
+    X_64 = X.astype(np.float64)
+    y_64 = y.astype(np.float64)
+    X_32 = X.astype(np.float32)
+    y_32 = y.astype(np.float32)
+
+    # check type consistency 32 bits
+    lasso_32 = RandomizedLasso(verbose=False, alpha=1, random_state=42,
+                          scaling=scaling,
+                          selection_threshold=selection_threshold)
+    lasso_32.fit(X_32, y_32)
+    assert_equal(lasso_32.coef_.dtype, X_32.dtype)
+
+    # check type consistency 64 bits
+    lasso_64 = RandomizedLasso(verbose=False, alpha=1, random_state=42,
+                          scaling=scaling,
+                          selection_threshold=selection_threshold)
+    lasso_64.fit(X_64, y_64)
+    assert_equal(lasso_64.coef_.dtype, X_64.dtype)
+
+    assert_almost_equal(lasso_32.coef_, lasso_64.coef_.astype(np.float32))
 
 
 def test_randomized_logistic():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Works on #8769 for linear model with lasso.

#### What does this implement/fix? Explain your changes.
Avoids lasso to aggressively cast the data to `np.float64` when `np.float32` is supplied.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
