### PR TITLE
MRG: add warning/doc for positive parameter in multi output

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -190,6 +190,7 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
 
     positive : bool, default False
         If set to True, forces coefficients to be positive.
+        (Only applied when ``y.ndim == 1``).
 
     return_n_iter : bool
         whether to return the number of iterations or not.
@@ -342,6 +343,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
 
     positive : bool, default False
         If set to True, forces coefficients to be positive.
+        (Only applied when ``y.ndim == 1``).
 
     check_input : bool, default True
         Skip input validation checks, including the Gram matrix when provided
@@ -394,6 +396,10 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
     if y.ndim != 1:
         multi_output = True
         _, n_outputs = y.shape
+
+    if multi_output and positive:
+        warnings.warn('positive=True is ignored for multi-output'
+                      ' (y.ndim != 1)', UserWarning)
 
     # MultiTaskElasticNet does not support sparse matrices
     if not multi_output and sparse.isspmatrix(X):

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -398,7 +398,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         _, n_outputs = y.shape
 
     if multi_output and positive:
-        raise ValueError('positive=True is not possible for multi-output'
+        raise ValueError('positive=True is not allowed for multi-output'
                          ' (y.ndim != 1)')
 
     # MultiTaskElasticNet does not support sparse matrices

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -190,7 +190,7 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
 
     positive : bool, default False
         If set to True, forces coefficients to be positive.
-        (Only applied when ``y.ndim == 1``).
+        (Only allowed when ``y.ndim == 1``).
 
     return_n_iter : bool
         whether to return the number of iterations or not.
@@ -343,7 +343,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
 
     positive : bool, default False
         If set to True, forces coefficients to be positive.
-        (Only applied when ``y.ndim == 1``).
+        (Only allowed when ``y.ndim == 1``).
 
     check_input : bool, default True
         Skip input validation checks, including the Gram matrix when provided
@@ -398,8 +398,8 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         _, n_outputs = y.shape
 
     if multi_output and positive:
-        warnings.warn('positive=True is ignored for multi-output'
-                      ' (y.ndim != 1)', UserWarning)
+        raise ValueError('positive=True is not possible for multi-output'
+                         ' (y.ndim != 1)')
 
     # MultiTaskElasticNet does not support sparse matrices
     if not multi_output and sparse.isspmatrix(X):

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -610,12 +610,22 @@ def test_random_descent():
 
 
 def test_enet_path_positive():
-    # Test that the coefs returned by positive=True in enet_path are positive
+    # Test positive parameter
 
+    # For mono output
+    # Test that the coefs returned by positive=True in enet_path are positive
     X, y, _, _ = build_dataset(n_samples=50, n_features=50)
     for path in [enet_path, lasso_path]:
         pos_path_coef = path(X, y, positive=True)[1]
         assert_true(np.all(pos_path_coef >= 0))
+
+    # For multi output positive parameter is ignored
+    # Test that a warning is displayed
+    X, Y, _, _ = build_dataset(n_samples=50, n_features=50, n_targets=2)
+    for path in [enet_path, lasso_path]:
+        assert_warns_message(UserWarning,
+                             'positive=True is ignored for multi-output'
+                             ' (y.ndim != 1)', path, X, Y, positive=True)
 
 
 def test_sparse_dense_descent_paths():

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -620,12 +620,10 @@ def test_enet_path_positive():
         assert_true(np.all(pos_path_coef >= 0))
 
     # For multi output positive parameter is ignored
-    # Test that a warning is displayed
+    # Test that an error is raised
     X, Y, _, _ = build_dataset(n_samples=50, n_features=50, n_targets=2)
     for path in [enet_path, lasso_path]:
-        assert_warns_message(UserWarning,
-                             'positive=True is ignored for multi-output'
-                             ' (y.ndim != 1)', path, X, Y, positive=True)
+        assert_raises(ValueError, path, X, Y, positive=True)
 
 
 def test_sparse_dense_descent_paths():

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -612,16 +612,16 @@ def test_random_descent():
 def test_enet_path_positive():
     # Test positive parameter
 
+    X, Y, _, _ = build_dataset(n_samples=50, n_features=50, n_targets=2)
+
     # For mono output
     # Test that the coefs returned by positive=True in enet_path are positive
-    X, y, _, _ = build_dataset(n_samples=50, n_features=50)
     for path in [enet_path, lasso_path]:
-        pos_path_coef = path(X, y, positive=True)[1]
+        pos_path_coef = path(X, Y[:, 0], positive=True)[1]
         assert_true(np.all(pos_path_coef >= 0))
 
-    # For multi output positive parameter is ignored
+    # For multi output, positive parameter is not allowed
     # Test that an error is raised
-    X, Y, _, _ = build_dataset(n_samples=50, n_features=50, n_targets=2)
     for path in [enet_path, lasso_path]:
         assert_raises(ValueError, path, X, Y, positive=True)
 


### PR DESCRIPTION
#### Reference Issue
Fixes #8360 


#### What does this implement/fix? Explain your changes.
This adds a warning when ``enet_path`` is called with the parameter ``positive=True`` in the multi output case to specify that the parameter is ignored. The docs of ``enet_path`` and ``lasso_path`` have been updated accordingly.
**EDIT**: now raising a ValueError instead of a warning

#### Any other comments?
It appears that ``enet_path`` is actually never called in the multi output case as the multi output classes such as ``MultiTaskElasticNet`` call ``cd_fast.enet_coordinate_descent_multi_task`` directly.