### PR TITLE
DOC adds auto_ml to related projects

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -26,6 +26,12 @@ enhance the functionality of scikit-learn's estimators.
 
 **Auto-ML**
 
+- `auto_ml <https://github.com/ClimbsRocks/auto_ml/>`_
+  Automated machine learning for production and analytics, built on scikit-learn
+  and popular projects with scikit-learn interfaces. Trains a pipeline wth all the
+  standard machine learning steps- just give it a dataset. Tuned for prediction
+  speed and ease of transfer to production, along with verbose analytics. 
+
 - `auto-sklearn <https://github.com/automl/auto-sklearn/>`_
   An automated machine learning toolkit and a drop-in replacement for a
   scikit-learn estimator

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -28,9 +28,8 @@ enhance the functionality of scikit-learn's estimators.
 
 - `auto_ml <https://github.com/ClimbsRocks/auto_ml/>`_
   Automated machine learning for production and analytics, built on scikit-learn
-  and popular projects with scikit-learn interfaces. Trains a pipeline wth all the
-  standard machine learning steps- just give it a dataset. Tuned for prediction
-  speed and ease of transfer to production, along with verbose analytics. 
+  and related projects. Trains a pipeline wth all the standard machine learning 
+  steps. Tuned for prediction speed and ease of transfer to production environments. 
 
 - `auto-sklearn <https://github.com/automl/auto-sklearn/>`_
   An automated machine learning toolkit and a drop-in replacement for a


### PR DESCRIPTION
[auto_ml](https://github.com/ClimbsRocks/auto_ml) is a project built on top of many scikit-learn data processing tools, models, and evaluation methods. We use it in production at our company. 

It's awesome that the community has centered on the scikit-learn interface; it's easy to add in many major advances in the field (several of these related projects are already being used in auto_ml).