### PR TITLE
[MRG+1] DOC clarify OneClassSVM decision_function docstring

### DIFF
--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -1051,7 +1051,8 @@ class OneClassSVM(BaseLibSVM):
         return self
 
     def decision_function(self, X):
-        """Distance of the samples X to the separating hyperplane.
+        """Signed distance to the separating hyperplane: positive if inlier,
+        negative if outlier.
 
         Parameters
         ----------

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -1051,8 +1051,9 @@ class OneClassSVM(BaseLibSVM):
         return self
 
     def decision_function(self, X):
-        """Signed distance to the separating hyperplane: positive if inlier,
-        negative if outlier.
+        """Signed distance to the separating hyperplane.
+
+        Signed distance is positive for an inlier and negative for an outlier.
 
         Parameters
         ----------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
This finishes PR #7788 and addresses issue #7713.


#### What does this implement/fix? Explain your changes.

Clarifies the docstring of the decision function of the `OneClassSVM` saying that positive means inlier and negative means outlier.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
