### PR TITLE
[MRG + 1] FIX Avoid unintentionally converting numeric data to dtype=object

### DIFF
--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -366,8 +366,8 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
 
         y_pred = np.empty((n_samples, n_outputs), dtype=classes_[0].dtype)
         for k, classes_k in enumerate(classes_):
-            pred_labels = np.array([_y[ind, k] for ind in neigh_ind],
-                                   dtype=object)
+            pred_labels = np.zeros(len(neigh_ind), dtype=object)
+            pred_labels[:] = [_y[ind, k] for ind in neigh_ind]
             if weights is None:
                 mode = np.array([stats.mode(pl)[0]
                                  for pl in pred_labels[inliers]], dtype=np.int)


### PR DESCRIPTION
Minor change.

While reviewing #8096 I note that there is a small bug in `RadiusNeighborsClassifier` where calling `array(..., dtype=object)` on a list of arrays will convert those array values to objects if all arrays are the same length.

