### PR TITLE
[MRG] DOC fix markdown-style link and some wording

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -224,16 +224,15 @@ rules before submitting a pull request:
       practice and, if possible, compare it to other methods available in
       scikit-learn.
 
-    * Documentation and high-coverage tests are necessary for enhancements
-      to be accepted.
-      Bug-fixes or new features should be provided with
-      [non-regression tests](https://en.wikipedia.org/wiki/Non-regression_testing).
-      These tests verify the correct behavior of the fix or feature. In this
-      manner, further modifications on the code base are granted to be consistent
-      with the desired behavior.
-      For the Bug-fixes case, at the time of the PR, this tests should fail for
-      the code base in master and pass for the PR code.
-
+    * Documentation and high-coverage tests are necessary for enhancements to be
+      accepted. Bug-fixes or new features should be provided with
+      `non-regression tests
+      <https://en.wikipedia.org/wiki/Non-regression_testing>`_. These tests
+      verify the correct behavior of the fix or feature. In this manner, further
+      modifications on the code base are granted to be consistent with the
+      desired behavior. For the case of bug fixes, at the time of the PR, the
+      non-regression tests should fail for the code base in the master branch
+      and pass for the PR code.
 
     * At least one paragraph of narrative documentation with links to
       references in the literature (with PDF links when possible) and


### PR DESCRIPTION
Quick and simple PR: fixes a wrongly-formatted link in the contributor guidelines, as well as some minor wording around that area.