### PR TITLE
[MRG+2] change module from pydotplus to graphviz

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -126,7 +126,7 @@ Using the Iris dataset, we can construct a tree as follows::
 
 Once trained, we can export the tree in `Graphviz
 <http://www.graphviz.org/>`_ format using the :func:`export_graphviz`
-exporter. If you use the `conda<http://conda.io>`_ package manager, the graphviz binaries  
+exporter. If you use the `conda <http://conda.io>`_ package manager, the graphviz binaries  
 and the python package can be installed with 
 
     conda install python-graphviz

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -126,17 +126,17 @@ Using the Iris dataset, we can construct a tree as follows::
 
 Once trained, we can export the tree in `Graphviz
 <http://www.graphviz.org/>`_ format using the :func:`export_graphviz`
-exporter. Below is an example export of a tree trained on the entire
-iris dataset::
+exporter. If you use the `conda<http://conda.io>`_ the graphviz binaries together 
+with the python library can be installed with 
 
-    >>> with open("iris.dot", 'w') as f:
-    ...     f = tree.export_graphviz(clf, out_file=f)
+    conda install graphviz
+    pip install graphviz 
+   
+Alternatively binaries for graphviz can be downloaded from the graphviz project homepage. 
 
-Then we can use Graphviz's ``dot`` tool to create a PDF file (or any other
-supported file type): ``dot -Tpdf iris.dot -o iris.pdf``.
+Below is an example graphviz export of the above tree trained on the entire
+iris dataset; the results are saved in an output file `iris.pdf`::
 
-Alternatively, if we have Python module ``graphviz`` installed, we can generate
-a PDF file directly in Python::
 
     >>> import graphviz # doctest: +SKIP
     >>> dot_data = tree.export_graphviz(clf, out_file=None) # doctest: +SKIP

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -129,10 +129,10 @@ Once trained, we can export the tree in `Graphviz
 exporter. If you use the `conda<http://conda.io>`_ package manager, the graphviz binaries  
 and the python package can be installed with 
 
-    conda install graphviz
-    pip install graphviz 
+    conda install python-graphviz
    
-Alternatively binaries for graphviz can be downloaded from the graphviz project homepage. 
+Alternatively binaries for graphviz can be downloaded from the graphviz project homepage,
+and the Python wrapper installed from pypi with `pip install graphviz`. 
 
 Below is an example graphviz export of the above tree trained on the entire
 iris dataset; the results are saved in an output file `iris.pdf`::

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -126,8 +126,8 @@ Using the Iris dataset, we can construct a tree as follows::
 
 Once trained, we can export the tree in `Graphviz
 <http://www.graphviz.org/>`_ format using the :func:`export_graphviz`
-exporter. If you use the `conda<http://conda.io>`_ the graphviz binaries together 
-with the python library can be installed with 
+exporter. If you use the `conda<http://conda.io>`_ package manager, the graphviz binaries  
+and the python package can be installed with 
 
     conda install graphviz
     pip install graphviz 

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -135,32 +135,26 @@ iris dataset::
 Then we can use Graphviz's ``dot`` tool to create a PDF file (or any other
 supported file type): ``dot -Tpdf iris.dot -o iris.pdf``.
 
-::
+Alternatively, if we have Python module ``graphviz`` installed, we can generate
+a PDF file directly in Python::
 
-    >>> import os
-    >>> os.unlink('iris.dot')
-
-Alternatively, if we have Python module ``pydotplus`` installed, we can generate
-a PDF file (or any other supported file type) directly in Python::
-
-    >>> import pydotplus # doctest: +SKIP
+    >>> import graphviz # doctest: +SKIP
     >>> dot_data = tree.export_graphviz(clf, out_file=None) # doctest: +SKIP
-    >>> graph = pydotplus.graph_from_dot_data(dot_data) # doctest: +SKIP
-    >>> graph.write_pdf("iris.pdf") # doctest: +SKIP
+    >>> graph = graphviz.Source(dot_data) # doctest: +SKIP
+    >>> graph.render("iris") # doctest: +SKIP
 
 The :func:`export_graphviz` exporter also supports a variety of aesthetic
 options, including coloring nodes by their class (or value for regression) and
-using explicit variable and class names if desired. IPython notebooks can also
-render these plots inline using the `Image()` function::
+using explicit variable and class names if desired. Jupyter notebooks also
+render these plots inline automatically::
 
-    >>> from IPython.display import Image  # doctest: +SKIP
     >>> dot_data = tree.export_graphviz(clf, out_file=None, # doctest: +SKIP
                              feature_names=iris.feature_names,  # doctest: +SKIP
                              class_names=iris.target_names,  # doctest: +SKIP
                              filled=True, rounded=True,  # doctest: +SKIP
                              special_characters=True)  # doctest: +SKIP
-    >>> graph = pydotplus.graph_from_dot_data(dot_data)  # doctest: +SKIP
-    >>> Image(graph.create_png())  # doctest: +SKIP
+    >>> graph = graphviz.Source(dot_data)  # doctest: +SKIP
+    >>> graph # doctest: +SKIP
 
 .. only:: html
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Further to #6261 it now seems that the pypy package "graphviz " is a better way of rendering dot data in Jupyter notebooks etc.

#### What does this implement/fix? Explain your changes.
In particular you no longer need to import/call `Ipython.Display.Image`  to render the graph in a notebook. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
