### PR TITLE
[MRG+2] MAINT: no longer backport graph_laplacian, use scipy one

### DIFF
--- a/doc/developers/utilities.rst
+++ b/doc/developers/utilities.rst
@@ -159,11 +159,6 @@ Graph Routines
   If this is ever needed again, it would be far faster to use a single
   iteration of Dijkstra's algorithm from ``graph_shortest_path``.
 
-- :func:`graph.graph_laplacian`:
-  (used in :func:`sklearn.cluster.spectral.spectral_embedding`)
-  Return the Laplacian of a given graph.  There is specialized code for
-  both dense and sparse connectivity matrices.
-
 - :func:`graph_shortest_path.graph_shortest_path`:
   (used in :class:`sklearn.manifold.Isomap`)
   Return the shortest path between all pairs of connected points on a directed

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -431,9 +431,9 @@ API changes summary
      for scikit-learn. The following backported functions in ``sklearn.utils``
      have been removed or deprecated accordingly.
      :issue:`8854` and :issue:`8874` by :user:`Naoya Kanai <naoyak>`
-     
+
      Removed in 0.19:
-     
+
      - ``utils.fixes.argpartition``
      - ``utils.fixes.array_equal``
      - ``utils.fixes.astype``
@@ -444,9 +444,9 @@ API changes summary
      - ``utils.fixes.norm``
      - ``utils.fixes.rankdata``
      - ``utils.fixes.safe_copy``
-     
+
      Deprecated in 0.19, to be removed in 0.21:
-     
+
      - ``utils.arpack.eigs``
      - ``utils.arpack.eigsh``
      - ``utils.arpack.svds``
@@ -454,6 +454,7 @@ API changes summary
      - ``utils.extmath.logsumexp``
      - ``utils.extmath.norm``
      - ``utils.extmath.pinvh``
+     - ``utils.graph.graph_laplacian``
      - ``utils.random.choice``
      - ``utils.sparsetools.connected_components``
      - ``utils.stats.rankdata``

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -16,7 +16,6 @@ from ..base import BaseEstimator
 from ..externals import six
 from ..utils import check_random_state, check_array, check_symmetric
 from ..utils.extmath import _deterministic_vector_sign_flip
-from ..utils.graph import graph_laplacian
 from ..metrics.pairwise import rbf_kernel
 from ..neighbors import kneighbors_graph
 
@@ -235,8 +234,8 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
         warnings.warn("Graph is not fully connected, spectral embedding"
                       " may not work as expected.")
 
-    laplacian, dd = graph_laplacian(adjacency,
-                                    normed=norm_laplacian, return_diag=True)
+    laplacian, dd = sparse.csgraph.laplacian(adjacency, normed=norm_laplacian,
+                                             return_diag=True)
     if (eigen_solver == 'arpack' or eigen_solver != 'lobpcg' and
        (not sparse.isspmatrix(laplacian) or n_nodes < 5 * n_components)):
         # lobpcg used with eigen_solver='amg' has bugs for low number of nodes

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -1,10 +1,9 @@
-from scipy.sparse import csr_matrix
-from scipy.sparse import csc_matrix
-from scipy.sparse import coo_matrix
-from scipy.linalg import eigh
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
+
+from scipy import sparse
+from scipy.linalg import eigh
 
 from sklearn.manifold.spectral_embedding_ import SpectralEmbedding
 from sklearn.manifold.spectral_embedding_ import _graph_is_connected
@@ -14,7 +13,6 @@ from sklearn.metrics.pairwise import rbf_kernel
 from sklearn.metrics import normalized_mutual_info_score
 from sklearn.cluster import KMeans
 from sklearn.datasets.samples_generator import make_blobs
-from sklearn.utils.graph import graph_laplacian
 from sklearn.utils.extmath import _deterministic_vector_sign_flip
 from sklearn.utils.testing import assert_true, assert_equal, assert_raises
 from sklearn.utils.testing import SkipTest
@@ -70,7 +68,7 @@ def test_sparse_graph_connected_component():
     # Build a symmetric affinity matrix
     row_idx, column_idx = tuple(np.array(connections).T)
     data = rng.uniform(.1, 42, size=len(connections))
-    affinity = coo_matrix((data, (row_idx, column_idx)))
+    affinity = sparse.coo_matrix((data, (row_idx, column_idx)))
     affinity = 0.5 * (affinity + affinity.T)
 
     for start, stop in zip(boundaries[:-1], boundaries[1:]):
@@ -221,16 +219,16 @@ def test_connectivity(seed=36):
                       [0, 0, 1, 1, 1],
                       [0, 0, 0, 1, 1]])
     assert_equal(_graph_is_connected(graph), False)
-    assert_equal(_graph_is_connected(csr_matrix(graph)), False)
-    assert_equal(_graph_is_connected(csc_matrix(graph)), False)
+    assert_equal(_graph_is_connected(sparse.csr_matrix(graph)), False)
+    assert_equal(_graph_is_connected(sparse.csc_matrix(graph)), False)
     graph = np.array([[1, 1, 0, 0, 0],
                       [1, 1, 1, 0, 0],
                       [0, 1, 1, 1, 0],
                       [0, 0, 1, 1, 1],
                       [0, 0, 0, 1, 1]])
     assert_equal(_graph_is_connected(graph), True)
-    assert_equal(_graph_is_connected(csr_matrix(graph)), True)
-    assert_equal(_graph_is_connected(csc_matrix(graph)), True)
+    assert_equal(_graph_is_connected(sparse.csr_matrix(graph)), True)
+    assert_equal(_graph_is_connected(sparse.csc_matrix(graph)), True)
 
 
 def test_spectral_embedding_deterministic():
@@ -256,7 +254,8 @@ def test_spectral_embedding_unnormalized():
                                      drop_first=False)
 
     # Verify using manual computation with dense eigh
-    laplacian, dd = graph_laplacian(sims, normed=False, return_diag=True)
+    laplacian, dd = sparse.csgraph.laplacian(sims, normed=False,
+                                             return_diag=True)
     _, diffusion_map = eigh(laplacian)
     embedding_2 = diffusion_map.T[:n_components] * dd
     embedding_2 = _deterministic_vector_sign_flip(embedding_2).T

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -63,7 +63,6 @@ from ..externals import six
 from ..metrics.pairwise import rbf_kernel
 from ..neighbors.unsupervised import NearestNeighbors
 from ..utils.extmath import safe_sparse_dot
-from ..utils.graph import graph_laplacian
 from ..utils.multiclass import check_classification_targets
 from ..utils.validation import check_X_y, check_is_fitted, check_array
 
@@ -464,7 +463,7 @@ class LabelSpreading(BaseLabelPropagation):
             self.nn_fit = None
         n_samples = self.X_.shape[0]
         affinity_matrix = self._get_kernel(self.X_)
-        laplacian = graph_laplacian(affinity_matrix, normed=True)
+        laplacian = sparse.csgraph.laplacian(affinity_matrix, normed=True)
         laplacian = -laplacian
         if sparse.isspmatrix(laplacian):
             diag_mask = (laplacian.row == laplacian.col)

--- a/sklearn/utils/graph.py
+++ b/sklearn/utils/graph.py
@@ -12,7 +12,6 @@ sparse matrices.
 
 import numpy as np
 from scipy import sparse
-from scipy.sparse.csgraph import laplacian as graph_laplacian
 
 from .validation import check_array
 from .graph_shortest_path import graph_shortest_path
@@ -72,8 +71,15 @@ def single_source_shortest_path_length(graph, source, cutoff=None):
     return seen  # return all path lengths as dictionary
 
 
-@deprecated("sklearn.utils.graph.connected_components was deprecated in"
-            "version 0.19 and will be removed in 0.21. Use"
+@deprecated("sklearn.utils.graph.connected_components was deprecated in "
+            "version 0.19 and will be removed in 0.21. Use "
             "scipy.sparse.csgraph.connected_components instead.")
 def connected_components(*args, **kwargs):
     return sparse.csgraph.connected_components(*args, **kwargs)
+
+
+@deprecated("sklearn.utils.graph.graph_laplacian was deprecated in version "
+            "0.19 and will be removed in 0.21. Use "
+            "scipy.sparse.csgraph.laplacian instead.")
+def graph_laplacian(*args, **kwargs):
+    return sparse.csgraph.laplacian(*args, **kwargs)

--- a/sklearn/utils/graph.py
+++ b/sklearn/utils/graph.py
@@ -12,6 +12,7 @@ sparse matrices.
 
 import numpy as np
 from scipy import sparse
+from scipy.sparse.csgraph import laplacian as graph_laplacian
 
 from .validation import check_array
 from .graph_shortest_path import graph_shortest_path
@@ -76,111 +77,3 @@ def single_source_shortest_path_length(graph, source, cutoff=None):
             "scipy.sparse.csgraph.connected_components instead.")
 def connected_components(*args, **kwargs):
     return sparse.csgraph.connected_components(*args, **kwargs)
-
-
-###############################################################################
-# Graph laplacian
-def graph_laplacian(csgraph, normed=False, return_diag=False):
-    """ Return the Laplacian matrix of a directed graph.
-
-    For non-symmetric graphs the out-degree is used in the computation.
-
-    Parameters
-    ----------
-    csgraph : array_like or sparse matrix, 2 dimensions
-        compressed-sparse graph, with shape (N, N).
-    normed : bool, optional
-        If True, then compute normalized Laplacian.
-    return_diag : bool, optional
-        If True, then return diagonal as well as laplacian.
-
-    Returns
-    -------
-    lap : ndarray
-        The N x N laplacian matrix of graph.
-    diag : ndarray
-        The length-N diagonal of the laplacian matrix.
-        diag is returned only if return_diag is True.
-
-    Notes
-    -----
-    The Laplacian matrix of a graph is sometimes referred to as the
-    "Kirchoff matrix" or the "admittance matrix", and is useful in many
-    parts of spectral graph theory.  In particular, the eigen-decomposition
-    of the laplacian matrix can give insight into many properties of the graph.
-
-    For non-symmetric directed graphs, the laplacian is computed using the
-    out-degree of each node.
-    """
-    if csgraph.ndim != 2 or csgraph.shape[0] != csgraph.shape[1]:
-        raise ValueError('csgraph must be a square matrix or array')
-
-    if normed and (np.issubdtype(csgraph.dtype, np.int)
-                   or np.issubdtype(csgraph.dtype, np.uint)):
-        csgraph = check_array(csgraph, dtype=np.float64, accept_sparse=True)
-
-    if sparse.isspmatrix(csgraph):
-        return _laplacian_sparse(csgraph, normed=normed,
-                                 return_diag=return_diag)
-    else:
-        return _laplacian_dense(csgraph, normed=normed,
-                                return_diag=return_diag)
-
-
-def _laplacian_sparse(graph, normed=False, return_diag=False):
-    n_nodes = graph.shape[0]
-    if not graph.format == 'coo':
-        lap = (-graph).tocoo()
-    else:
-        lap = -graph.copy()
-    diag_mask = (lap.row == lap.col)
-    if not diag_mask.sum() == n_nodes:
-        # The sparsity pattern of the matrix has holes on the diagonal,
-        # we need to fix that
-        diag_idx = lap.row[diag_mask]
-        diagonal_holes = list(set(range(n_nodes)).difference(diag_idx))
-        new_data = np.concatenate([lap.data, np.ones(len(diagonal_holes))])
-        new_row = np.concatenate([lap.row, diagonal_holes])
-        new_col = np.concatenate([lap.col, diagonal_holes])
-        lap = sparse.coo_matrix((new_data, (new_row, new_col)),
-                                shape=lap.shape)
-        diag_mask = (lap.row == lap.col)
-
-    lap.data[diag_mask] = 0
-    w = -np.asarray(lap.sum(axis=1)).squeeze()
-    if normed:
-        w = np.sqrt(w)
-        w_zeros = (w == 0)
-        w[w_zeros] = 1
-        lap.data /= w[lap.row]
-        lap.data /= w[lap.col]
-        lap.data[diag_mask] = (1 - w_zeros[lap.row[diag_mask]]).astype(
-            lap.data.dtype)
-    else:
-        lap.data[diag_mask] = w[lap.row[diag_mask]]
-
-    if return_diag:
-        return lap, w
-    return lap
-
-
-def _laplacian_dense(graph, normed=False, return_diag=False):
-    n_nodes = graph.shape[0]
-    lap = -np.asarray(graph)  # minus sign leads to a copy
-
-    # set diagonal to zero
-    lap.flat[::n_nodes + 1] = 0
-    w = -lap.sum(axis=0)
-    if normed:
-        w = np.sqrt(w)
-        w_zeros = (w == 0)
-        w[w_zeros] = 1
-        lap /= w
-        lap /= w[:, np.newaxis]
-        lap.flat[::n_nodes + 1] = (1 - w_zeros).astype(lap.dtype)
-    else:
-        lap.flat[::n_nodes + 1] = w.astype(lap.dtype)
-
-    if return_diag:
-        return lap, w
-    return lap

--- a/sklearn/utils/tests/test_graph.py
+++ b/sklearn/utils/tests/test_graph.py
@@ -5,8 +5,10 @@ import numpy as np
 from scipy import sparse
 
 from sklearn.utils.graph import graph_laplacian
+from sklearn.utils.testing import ignore_warnings
 
 
+@ignore_warnings(category=DeprecationWarning)
 def test_graph_laplacian():
     for mat in (np.arange(10) * np.arange(10)[:, np.newaxis],
                 np.ones((7, 7)),

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -4,6 +4,7 @@ import warnings
 import numpy as np
 import scipy.sparse as sp
 from scipy.linalg import pinv2
+from scipy.sparse.csgraph import laplacian
 
 from sklearn.utils.testing import (assert_equal, assert_raises, assert_true,
                                    assert_almost_equal, assert_array_equal,
@@ -20,7 +21,6 @@ from sklearn.utils import gen_even_slices
 from sklearn.utils.extmath import pinvh
 from sklearn.utils.arpack import eigsh
 from sklearn.utils.mocking import MockDataFrame
-from sklearn.utils.graph import graph_laplacian
 
 
 def test_make_rng():
@@ -140,7 +140,7 @@ def test_arpack_eigsh_initialization():
 
     A = random_state.rand(50, 50)
     A = np.dot(A.T, A)  # create s.p.d. matrix
-    A = graph_laplacian(A) + 1e-7 * np.identity(A.shape[0])
+    A = laplacian(A) + 1e-7 * np.identity(A.shape[0])
     k = 5
 
     # Test if eigsh is working correctly


### PR DESCRIPTION
#### Reference Issue: None


#### What does this implement/fix? Explain your changes.

Clean-up: our minimum supported scipy (0.13) has a compatible implementation of graph laplacian, so we no longer need to keep a copy in our repo.

#### Any other comments?

The upstream implementation might have a couple of optimizations compared to ours, but nothing breaking. I kept our test in utils, to have it run *once* on CI; then I will remove it. I ran the full test suite with scipy 0.13.3 on my machine. 

Ping @glemaitre, @jmargeta; helps the debugging scope of #9062 
