### PR TITLE
[MRG] Fix decorator called without kwarg that would prevent test from running.

### DIFF
--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -564,7 +564,7 @@ def test_adaptive_learning_rate():
     assert_greater(1e-6, clf._optimizer.learning_rate)
 
 
-@ignore_warnings(RuntimeError)
+@ignore_warnings(category=RuntimeWarning)
 def test_warm_start():
     X = X_iris
     y = y_iris


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

A test was decorated with `@ignore_warnings(RuntimeWarning)`. 

I noticed that nose would not run it locally.

The lack of keyword argument meant that the decorator would not behave as expected.
It would consider `RuntimeWarning` as the callable and *I think* in the end the whole 

```
@ignore_warnings(RuntimeWarning)
def test():
   return 'ok'
```

would turn into a loose `RuntimeWarning` with message <function 'test'>.

Also it was `RuntimeError` instead of `RuntimeWarning`.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
