### PR TITLE
[WIP] Allow SGDClassifier to support np.float32 without upcasting to float64

### DIFF
--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -335,7 +335,13 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
                      loss, learning_rate, n_iter,
                      classes, sample_weight,
                      coef_init, intercept_init):
-        X, y = check_X_y(X, y, 'csr', dtype=np.float64, order="C")
+
+        if loss in ['hinge']:
+            _dtype = [np.float64, np.float32]
+        else:
+            _dtype = np.float64
+
+        X, y = check_X_y(X, y, 'csr', dtype=_dtype, order="C")
 
         n_samples, n_features = X.shape
 

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -380,7 +380,12 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
         if hasattr(self, "classes_"):
             self.classes_ = None
 
-        X, y = check_X_y(X, y, 'csr', dtype=np.float64, order="C")
+        if loss in ['hinge']:
+            _dtype = [np.float64, np.float32]
+        else:
+            _dtype = np.float64
+
+        X, y = check_X_y(X, y, 'csr', dtype=_dtype, order="C")
         n_samples, n_features = X.shape
 
         # labels can be encoded as float, int, or string literals

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -824,6 +824,30 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
         y = [["ham", "spam"][i] for i in LabelEncoder().fit_transform(Y)]
         clf.fit(X[:, :-1], y)
 
+    def test_dtype_match(self):
+
+        X_64 = X.astype(np.float64);
+        Y_64 = Y.astype(np.float64);
+        X_32 = X.astype(np.float32);
+        Y_32 = Y.astype(np.float32);
+
+        # loss in ("hinge", "squared_hinge", "log", "modified_huber")
+        for loss in ("hinge"):
+
+            # check type consistency 32 bits
+            sgd_32 = self.factory(penalty='l2', alpha=0.01, fit_intercept=True,
+                               loss=loss, n_iter=10, shuffle=True)
+            sgd_32.fit(X_32, Y_32)
+            assert_equal(sgd_32.coef_.dtype, X_32.dtype)
+
+            # check type consistency 64 bits
+            sgd_64 = self.factory(penalty='l2', alpha=0.01, fit_intercept=True,
+                               loss=loss, n_iter=10, shuffle=True)
+            sgd_64.fit(X_64, Y_64)
+            assert_equal(sgd_64.coef_.dtype, X_64.dtype)
+
+            assert_almost_equal(sgd_32.coef_, sgd_64.coef_, decimal=5)
+
 
 class SparseSGDClassifierTestCase(DenseSGDClassifierTestCase):
     """Run exactly the same tests using the sparse representation variant"""

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -827,9 +827,7 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
     def test_dtype_match(self):
 
         X_64 = X.astype(np.float64);
-        Y_64 = Y.astype(np.float64);
         X_32 = X.astype(np.float32);
-        Y_32 = Y.astype(np.float32);
 
         # loss in ("hinge", "squared_hinge", "log", "modified_huber")
         for loss in ("hinge"):
@@ -837,13 +835,13 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
             # check type consistency 32 bits
             sgd_32 = self.factory(penalty='l2', alpha=0.01, fit_intercept=True,
                                loss=loss, n_iter=10, shuffle=True)
-            sgd_32.fit(X_32, Y_32)
+            sgd_32.fit(X_32, Y)
             assert_equal(sgd_32.coef_.dtype, X_32.dtype)
 
             # check type consistency 64 bits
             sgd_64 = self.factory(penalty='l2', alpha=0.01, fit_intercept=True,
                                loss=loss, n_iter=10, shuffle=True)
-            sgd_64.fit(X_64, Y_64)
+            sgd_64.fit(X_64, Y)
             assert_equal(sgd_64.coef_.dtype, X_64.dtype)
 
             assert_almost_equal(sgd_32.coef_, sgd_64.coef_, decimal=5)

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -830,7 +830,7 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
         X_32 = X.astype(np.float32);
 
         # loss in ("hinge", "squared_hinge", "log", "modified_huber")
-        for loss in ("hinge"):
+        for loss in ["hinge"]:
 
             # check type consistency 32 bits
             sgd_32 = self.factory(penalty='l2', alpha=0.01, fit_intercept=True,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

Works on #8769 for Stochastic Gradient Descent.

#### What does this implement/fix? Explain your changes.
The goal is to avoid aggressively casting input data to `np.float64` when `np.float32` is supplied to the `fit()` method of `SGDClassifier`. A unit test is added to `DenseSGDClassifierTestCase` to check whether the dtype of the output of `fit()` is consistent with the input.

#### Any other comments?
