### PR TITLE
[MRG+1] Add text vectorizers benchmarks

### DIFF
--- a/benchmarks/bench_text_vectorizers.py
+++ b/benchmarks/bench_text_vectorizers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 
 To run this benchmark, you will need,
@@ -22,6 +21,8 @@ from memory_profiler import memory_usage
 from sklearn.datasets import fetch_20newsgroups
 from sklearn.feature_extraction.text import (CountVectorizer, TfidfVectorizer,
                                              HashingVectorizer)
+
+n_repeat = 3
 
 
 def run_vectorizer(Vectorizer, X, **params):
@@ -54,8 +55,8 @@ for Vectorizer, (analyzer, ngram_range) in itertools.product(
     bench.update(params)
     dt = timeit.repeat(run_vectorizer(Vectorizer, text, **params),
                        number=1,
-                       repeat=3)
-    bench['time'] = "{:.2f} (±{:.2f})".format(np.mean(dt), np.std(dt))
+                       repeat=n_repeat)
+    bench['time'] = "{:.2f} (+-{:.2f})".format(np.mean(dt), np.std(dt))
 
     mem_usage = memory_usage(run_vectorizer(Vectorizer, text, **params))
 
@@ -67,6 +68,8 @@ for Vectorizer, (analyzer, ngram_range) in itertools.product(
 df = pd.DataFrame(res).set_index(['analyzer', 'ngram_range', 'vectorizer'])
 
 print('\n========== Run time performance (sec) ===========\n')
+print('Computing the mean and the standard deviation '
+      'of the run time over {} runs...\n'.format(n_repeat))
 print(df['time'].unstack(level=-1))
 
 print('\n=============== Memory usage (MB) ===============\n')

--- a/benchmarks/bench_text_vectorizers.py
+++ b/benchmarks/bench_text_vectorizers.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 
 To run this benchmark, you will need,
@@ -39,7 +40,6 @@ print("This benchmarks runs in ~20 min ...")
 
 res = []
 
-# Wrap the result of iteritools.product with tqdm to get a progress bar
 for Vectorizer, (analyzer, ngram_range) in itertools.product(
             [CountVectorizer, TfidfVectorizer, HashingVectorizer],
             [('word', (1, 1)),

--- a/benchmarks/bench_text_vectorizers.py
+++ b/benchmarks/bench_text_vectorizers.py
@@ -1,0 +1,73 @@
+"""
+
+To run this benchmark, you will need,
+
+ * scikit-learn
+ * pandas
+ * memory_profiler
+ * psutil (optional, but recommended)
+
+"""
+
+from __future__ import print_function
+
+import timeit
+import itertools
+
+import numpy as np
+import pandas as pd
+from memory_profiler import memory_usage
+
+from sklearn.datasets import fetch_20newsgroups
+from sklearn.feature_extraction.text import (CountVectorizer, TfidfVectorizer,
+                                             HashingVectorizer)
+
+
+def run_vectorizer(Vectorizer, X, **params):
+    def f():
+        vect = Vectorizer(**params)
+        vect.fit_transform(X)
+    return f
+
+
+text = fetch_20newsgroups(subset='train').data
+
+print("="*80 + '\n#' + "    Text vectorizers benchmark" + '\n' + '='*80 + '\n')
+print("Using a subset of the 20 newsrgoups dataset ({} documents)."
+      .format(len(text)))
+print("This benchmarks runs in ~20 min ...")
+
+res = []
+
+# Wrap the result of iteritools.product with tqdm to get a progress bar
+for Vectorizer, (analyzer, ngram_range) in itertools.product(
+            [CountVectorizer, TfidfVectorizer, HashingVectorizer],
+            [('word', (1, 1)),
+             ('word', (1, 2)),
+             ('word', (1, 4)),
+             ('char', (4, 4)),
+             ('char_wb', (4, 4))
+             ]):
+
+    bench = {'vectorizer': Vectorizer.__name__}
+    params = {'analyzer': analyzer, 'ngram_range': ngram_range}
+    bench.update(params)
+    dt = timeit.repeat(run_vectorizer(Vectorizer, text, **params),
+                       number=1,
+                       repeat=3)
+    bench['time'] = "{:.2f} (±{:.2f})".format(np.mean(dt), np.std(dt))
+
+    mem_usage = memory_usage(run_vectorizer(Vectorizer, text, **params))
+
+    bench['memory'] = "{:.1f}".format(np.max(mem_usage))
+
+    res.append(bench)
+
+
+df = pd.DataFrame(res).set_index(['analyzer', 'ngram_range', 'vectorizer'])
+
+print('\n========== Run time performance (sec) ===========\n')
+print(df['time'].unstack(level=-1))
+
+print('\n=============== Memory usage (MB) ===============\n')
+print(df['memory'].unstack(level=-1))


### PR DESCRIPTION
In text processing, vectorization usually has large run times compared to `.fit` and `.predict` times of  models further in the processing pipeline (cf. last two figures in [this example](http://scikit-learn.org/stable/auto_examples/applications/plot_out_of_core_classification.html)). As a result, new PRs are recurrently submitted aiming improve the  run time performance  of text vectrization (e.g. #7567, #7272, #7470)

This PR adds standard run time and memory benchmarks for `CountVectorizer`, `TfidfVectorizer` and `HashingVectorizer` and a combination of common values for `ngram_range` and `analyzer`, so that such benchmarks wouldn't need to be implemented anew for each new PR.   cc @lesteve

The output of this benchmark can be found below,
```
$ python benchmarks/bench_text_vectorizers.py
================================================================================
#    Text vectorizers benchmark
================================================================================

Using a subset of the 20 newsrgoups dataset (11314 documents).
This benchmarks runs in ~20 min ...

========== Run time performance (sec) ===========

vectorizer           CountVectorizer HashingVectorizer TfidfVectorizer
analyzer ngram_range
char     (4, 4)        19.18 (±0.07)     18.40 (±0.02)   20.94 (±0.03)
char_wb  (4, 4)        16.87 (±0.06)     16.95 (±0.10)   17.73 (±0.03)
word     (1, 1)         3.23 (±0.02)      3.63 (±0.02)    3.29 (±0.02)
         (1, 2)        12.99 (±0.02)      8.13 (±0.00)   14.10 (±0.02)
         (1, 4)        41.93 (±0.02)     15.18 (±0.06)   45.08 (±0.11)

=============== Memory usage (MB) ===============

vectorizer           CountVectorizer HashingVectorizer TfidfVectorizer
analyzer ngram_range
char     (4, 4)                785.5             611.1           821.8
char_wb  (4, 4)                570.5             380.7           593.9
word     (1, 1)                205.9             205.4           246.9
         (1, 2)                840.9             238.0           828.5
         (1, 4)               3286.7             370.5          3329.5
```
