### PR TITLE
[MRG] clarify max_iter meaning for MLPClassifier/MLPRegressor

### DIFF
--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -753,7 +753,10 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
 
     max_iter : int, optional, default 200
         Maximum number of iterations. The solver iterates until convergence
-        (determined by 'tol') or this number of iterations.
+        (determined by 'tol') or this number of iterations. For stochastic
+        solvers ('sgd', 'adam'), note that this determines the number of epochs
+        (how many times each data point will be used), not the number of
+        gradient steps.
 
     random_state : int, RandomState instance or None, optional, default None
         If int, random_state is the seed used by the random number generator;
@@ -1127,7 +1130,10 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
 
     max_iter : int, optional, default 200
         Maximum number of iterations. The solver iterates until convergence
-        (determined by 'tol') or this number of iterations.
+        (determined by 'tol') or this number of iterations. For stochastic
+        solvers ('sgd', 'adam'), note that this determines the number of epochs
+        (how many times each data point will be used), not the number of
+        gradient steps.
 
     random_state : int, RandomState instance or None, optional, default None
         If int, random_state is the seed used by the random number generator;


### PR DESCRIPTION
The documentation for `max_iter`, in MLPClassifier / MLPRegressor, just says that it sets the max number of "iterations". This is fine for L-BFGS, but when using minibatches (with SGD or ADAM, by default), in the standard terminology it actually sets the number of epochs. This is [confusing](https://stats.stackexchange.com/q/284491/9964), so this PR adds a clarification.