### PR TITLE
DOC: fix links to examples

### DIFF
--- a/doc/datasets/labeled_faces.rst
+++ b/doc/datasets/labeled_faces.rst
@@ -115,4 +115,4 @@ an evaluation ``10_folds`` set meant to compute performance metrics using a
 Examples
 --------
 
-:ref:`sphx_glr_auto_examples_applications_face_recognition.py`
+:ref:`sphx_glr_auto_examples_applications_plot_face_recognition.py`

--- a/doc/modules/biclustering.rst
+++ b/doc/modules/biclustering.rst
@@ -154,7 +154,7 @@ and the remaining ``n_columns`` labels provide the column partitioning.
    showing how to generate a data matrix with biclusters and apply
    this method to it.
 
- * :ref:`sphx_glr_auto_examples_bicluster_bicluster_newsgroups.py`: An example of finding
+ * :ref:`sphx_glr_auto_examples_bicluster_plot_bicluster_newsgroups.py`: An example of finding
    biclusters in the twenty newsgroup dataset.
 
 

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -199,7 +199,7 @@ section.
 
     * :ref:`sphx_glr_auto_examples_model_selection_plot_roc_crossval.py`,
     * :ref:`sphx_glr_auto_examples_feature_selection_plot_rfe_with_cross_validation.py`,
-    * :ref:`sphx_glr_auto_examples_model_selection_grid_search_digits.py`,
+    * :ref:`sphx_glr_auto_examples_model_selection_plot_grid_search_digits.py`,
     * :ref:`sphx_glr_auto_examples_model_selection_grid_search_text_feature_extraction.py`,
     * :ref:`sphx_glr_auto_examples_plot_cv_predict.py`,
     * :ref:`sphx_glr_auto_examples_model_selection_plot_nested_cross_validation_iris.py`.

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -160,7 +160,7 @@ Note: the implementation of ``inverse_transform`` in :class:`PCA` with
 
 .. topic:: Examples:
 
-    * :ref:`sphx_glr_auto_examples_applications_face_recognition.py`
+    * :ref:`sphx_glr_auto_examples_applications_plot_face_recognition.py`
     * :ref:`sphx_glr_auto_examples_decomposition_plot_faces_decomposition.py`
 
 .. topic:: References:
@@ -796,7 +796,7 @@ stored components::
 .. topic:: Examples:
 
     * :ref:`sphx_glr_auto_examples_decomposition_plot_faces_decomposition.py`
-    * :ref:`sphx_glr_auto_examples_applications_topics_extraction_with_nmf_lda.py`
+    * :ref:`sphx_glr_auto_examples_applications_plot_topics_extraction_with_nmf_lda.py`
     * :ref:`sphx_glr_auto_examples_decomposition_plot_beta_divergence.py`
 
 .. topic:: References:
@@ -890,7 +890,7 @@ when data can be fetched sequentially.
 
 .. topic:: Examples:
 
-    * :ref:`sphx_glr_auto_examples_applications_topics_extraction_with_nmf_lda.py`
+    * :ref:`sphx_glr_auto_examples_applications_plot_topics_extraction_with_nmf_lda.py`
 
 .. topic:: References:
 

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -669,7 +669,7 @@ Finally it is possible to discover the main topics of a corpus by
 relaxing the hard assignment constraint of clustering, for instance by
 using :ref:`NMF`:
 
-  * :ref:`sphx_glr_auto_examples_applications_topics_extraction_with_nmf_lda.py`
+  * :ref:`sphx_glr_auto_examples_applications_plot_topics_extraction_with_nmf_lda.py`
 
 
 Limitations of the Bag of Words representation

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -70,7 +70,7 @@ evaluated and the best combination is retained.
 
 .. topic:: Examples:
 
-    - See :ref:`sphx_glr_auto_examples_model_selection_grid_search_digits.py` for an example of
+    - See :ref:`sphx_glr_auto_examples_model_selection_plot_grid_search_digits.py` for an example of
       Grid Search computation on the digits dataset.
 
     - See :ref:`sphx_glr_auto_examples_model_selection_grid_search_text_feature_extraction.py` for an example
@@ -131,7 +131,7 @@ increasing ``n_iter`` will always lead to a finer search.
 
 .. topic:: Examples:
 
-    * :ref:`sphx_glr_auto_examples_model_selection_randomized_search.py` compares the usage and efficiency
+    * :ref:`sphx_glr_auto_examples_model_selection_plot_randomized_search.py` compares the usage and efficiency
       of randomized search and grid search.
 
 .. topic:: References:

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -466,7 +466,7 @@ and inferred labels::
     for an example of classification report usage for text
     documents.
 
-  * See :ref:`sphx_glr_auto_examples_model_selection_grid_search_digits.py`
+  * See :ref:`sphx_glr_auto_examples_model_selection_plot_grid_search_digits.py`
     for an example of classification report usage for
     grid search with nested cross-validation.
 
@@ -602,7 +602,7 @@ binary classification and multilabel indicator format.
     for an example of :func:`f1_score` usage to classify  text
     documents.
 
-  * See :ref:`sphx_glr_auto_examples_model_selection_grid_search_digits.py`
+  * See :ref:`sphx_glr_auto_examples_model_selection_plot_grid_search_digits.py`
     for an example of :func:`precision_score` and :func:`recall_score` usage
     to estimate parameters using grid search with nested cross-validation.
 

--- a/doc/modules/outlier_detection.rst
+++ b/doc/modules/outlier_detection.rst
@@ -220,10 +220,10 @@ This strategy is illustrated below.
 
 .. topic:: Examples:
 
-   * See :ref:`sphx_glr_auto_example_neighbors_plot_lof.py` for
+   * See :ref:`sphx_glr_auto_examples_neighbors_plot_lof.py` for
      an illustration of the use of :class:`neighbors.LocalOutlierFactor`.
 
-   * See :ref:`sphx_glr_auto_example_covariance_plot_outlier_detection.py` for a
+   * See :ref:`sphx_glr_auto_examples_covariance_plot_outlier_detection.py` for a
      comparison with other anomaly detection methods.
 
 .. topic:: References:

--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -102,7 +102,7 @@ ignored by setting them to ``None``::
 
 .. topic:: Examples:
 
- * :ref:`sphx_glr_auto_examples_feature_selection_feature_selection_pipeline.py`
+ * :ref:`sphx_glr_auto_examples_feature_selection_plot_feature_selection_pipeline.py`
  * :ref:`sphx_glr_auto_examples_model_selection_grid_search_text_feature_extraction.py`
  * :ref:`sphx_glr_auto_examples_plot_digits_pipe.py`
  * :ref:`sphx_glr_auto_examples_plot_kernel_approximation.py`
@@ -265,5 +265,5 @@ and ignored by setting to ``None``::
 
 .. topic:: Examples:
 
- * :ref:`sphx_glr_auto_examples_feature_stacker.py`
+ * :ref:`sphx_glr_auto_examples_plot_feature_stacker.py`
  * :ref:`sphx_glr_auto_examples_hetero_feature_union.py`

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -549,7 +549,7 @@ in the matrix. This format is thus suitable when there are many more missing
 values than observed values.
 
 :class:`Imputer` can be used in a Pipeline as a way to build a composite
-estimator that supports imputation. See :ref:`sphx_glr_auto_examples_plot_missing_values.py`
+estimator that supports imputation. See :ref:`sphx_glr_auto_examples_plot_missing_values.py`.
 
 .. _polynomial_features:
 

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -549,7 +549,7 @@ in the matrix. This format is thus suitable when there are many more missing
 values than observed values.
 
 :class:`Imputer` can be used in a Pipeline as a way to build a composite
-estimator that supports imputation. See :ref:`sphx_glr_auto_examples_missing_values.py`
+estimator that supports imputation. See :ref:`sphx_glr_auto_examples_plot_missing_values.py`
 
 .. _polynomial_features:
 

--- a/doc/modules/unsupervised_reduction.rst
+++ b/doc/modules/unsupervised_reduction.rst
@@ -26,7 +26,7 @@ capture well the variance of the original features. See :ref:`decompositions`.
 
 .. topic:: **Examples**
 
-   * :ref:`sphx_glr_auto_examples_applications_face_recognition.py`
+   * :ref:`sphx_glr_auto_examples_applications_plot_face_recognition.py`
 
 Random projections
 -------------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -4841,7 +4841,7 @@ Changelog
 
   - Lots of cool new examples and a new section that uses real-world
     datasets was created. These include:
-    :ref:`sphx_glr_auto_examples_applications_face_recognition.py`,
+    :ref:`sphx_glr_auto_examples_applications_plot_face_recognition.py`,
     :ref:`sphx_glr_auto_examples_applications_plot_species_distribution_modeling.py`,
     :ref:`sphx_glr_auto_examples_applications_svm_gui.py`,
     :ref:`sphx_glr_auto_examples_applications_wikipedia_principal_eigenvector.py` and


### PR DESCRIPTION
Fixes a bunch of not working links to examples.