### PR TITLE
[MRG] Add deprecation warning for iid in BaseSearchCV

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -450,6 +450,12 @@ API changes summary
      :class:`multiclass.OneVsOneClassifier` is now ``(n_samples,)`` to conform
      to scikit-learn conventions. :issue:`9100` by `Andreas Müller`_.
 
+   - The ``iid`` parameter of :class:`model_selection.GridSearchCV` and
+     :class:`model_selection.RandomizedSearchCV` has been deprecated and will
+     be removed in version 0.21. Future behavior will be the current default
+     behavior (equivalent to ``iid=True``).
+     :issue:`#9085` by :user:`Laurent Direr<ldirer>`.
+
    - Gradient boosting base models are no longer estimators. By `Andreas Müller`_.
 
    - :class:`feature_selection.SelectFromModel` now validates the ``threshold``

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -398,6 +398,11 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         self.pre_dispatch = pre_dispatch
         self.error_score = error_score
 
+        if not self.iid:
+            warnings.warn("The `iid` parameter has been deprecated "
+                          "in version 0.19 and will be removed in 0.21.",
+                          DeprecationWarning)
+
     @property
     def _estimator_type(self):
         return self.estimator._estimator_type

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -398,11 +398,6 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         self.pre_dispatch = pre_dispatch
         self.error_score = error_score
 
-        if not self.iid:
-            warnings.warn("The `iid` parameter has been deprecated "
-                          "in version 0.19 and will be removed in 0.21.",
-                          DeprecationWarning)
-
     @property
     def _estimator_type(self):
         return self.estimator._estimator_type

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -379,7 +379,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
 
     @abstractmethod
     def __init__(self, estimator, scoring=None,
-                 fit_params=None, n_jobs=1, iid=True,
+                 fit_params=None, n_jobs=1, iid=None,
                  refit=True, cv=None, verbose=0, pre_dispatch='2*n_jobs',
                  error_score='raise', return_train_score=True):
 
@@ -394,6 +394,11 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         self.pre_dispatch = pre_dispatch
         self.error_score = error_score
         self.return_train_score = return_train_score
+
+        if self.iid is not None:
+            warnings.warn("The `iid` parameter has been deprecated "
+                          "in version 0.19 and will be removed in 0.21.",
+                          DeprecationWarning)
 
     @property
     def _estimator_type(self):
@@ -640,7 +645,8 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                                       dtype=np.int)
 
         _store('test_score', test_scores, splits=True, rank=True,
-               weights=test_sample_counts if self.iid else None)
+               weights=test_sample_counts if (self.iid or self.iid is None)
+               else None)
         if self.return_train_score:
             _store('train_score', train_scores, splits=True)
         _store('fit_time', fit_time)
@@ -781,10 +787,15 @@ class GridSearchCV(BaseSearchCV):
             - A string, giving an expression as a function of n_jobs,
               as in '2*n_jobs'
 
-    iid : boolean, default=True
+    iid : boolean, default=None
         If True, the data is assumed to be identically distributed across
         the folds, and the loss minimized is the total loss per sample,
         and not the mean loss across the folds.
+
+        ..deprecated:: 0.19
+            Parameter ``iid`` has been deprecated in version 0.19 and
+            will be removed in 0.21.
+            Future (and default) behavior is equivalent to `iid=true`.
 
     cv : int, cross-validation generator or an iterable, optional
         Determines the cross-validation splitting strategy.
@@ -954,7 +965,7 @@ class GridSearchCV(BaseSearchCV):
     """
 
     def __init__(self, estimator, param_grid, scoring=None, fit_params=None,
-                 n_jobs=1, iid=True, refit=True, cv=None, verbose=0,
+                 n_jobs=1, iid=None, refit=True, cv=None, verbose=0,
                  pre_dispatch='2*n_jobs', error_score='raise',
                  return_train_score=True):
         super(GridSearchCV, self).__init__(
@@ -1046,10 +1057,15 @@ class RandomizedSearchCV(BaseSearchCV):
             - A string, giving an expression as a function of n_jobs,
               as in '2*n_jobs'
 
-    iid : boolean, default=True
+    iid : boolean, default=None
         If True, the data is assumed to be identically distributed across
         the folds, and the loss minimized is the total loss per sample,
         and not the mean loss across the folds.
+
+        ..deprecated:: 0.19
+            Parameter ``iid`` has been deprecated in version 0.19 and
+            will be removed in 0.21.
+            Future (and default) behavior is equivalent to `iid=true`.
 
     cv : int, cross-validation generator or an iterable, optional
         Determines the cross-validation splitting strategy.
@@ -1189,7 +1205,7 @@ class RandomizedSearchCV(BaseSearchCV):
     """
 
     def __init__(self, estimator, param_distributions, n_iter=10, scoring=None,
-                 fit_params=None, n_jobs=1, iid=True, refit=True, cv=None,
+                 fit_params=None, n_jobs=1, iid=None, refit=True, cv=None,
                  verbose=0, pre_dispatch='2*n_jobs', random_state=None,
                  error_score='raise', return_train_score=True):
         self.param_distributions = param_distributions

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -834,6 +834,7 @@ def test_random_search_cv_results():
         check_cv_results_grid_scores_consistency(search)
 
 
+@ignore_warnings(category=DeprecationWarning)
 def test_search_iid_param():
     # Test the IID parameter
     # noise-free simple 2d-data
@@ -855,7 +856,7 @@ def test_search_iid_param():
                                        cv=cv)
     for search in (grid_search, random_search):
         search.fit(X, y)
-        assert_true(search.iid)
+        assert_true(search.iid or search.iid is None)
 
         test_cv_scores = np.array(list(search.cv_results_['split%d_test_score'
                                                           % s_i][0]
@@ -1319,7 +1320,6 @@ def test_transform_inverse_transform_round_trip():
     assert_array_equal(X, X_round_trip)
 
 
-@ignore_warnings(category=DeprecationWarning)
 def test_deprecated_grid_search_idd():
     depr_message = ("The `iid` parameter has been deprecated in version 0.19 "
                     "and will be removed in 0.21.")

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1317,3 +1317,11 @@ def test_transform_inverse_transform_round_trip():
     grid_search.fit(X, y)
     X_round_trip = grid_search.inverse_transform(grid_search.transform(X))
     assert_array_equal(X, X_round_trip)
+
+
+@ignore_warnings(category=DeprecationWarning)
+def test_deprecated_grid_search_idd():
+    depr_message = ("The `iid` parameter has been deprecated in version 0.19 "
+                    "and will be removed in 0.21.")
+    assert_warns_message(DeprecationWarning, depr_message, GridSearchCV,
+                         SVC(), [], iid=False)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
#9085 
#### What does this implement/fix? Explain your changes.

Deprecate iid param.

#### Any other comments?

* I did not find references to iid in the doc/benchmark/examples.
* This will emit a couple additional DeprecationWarnings when running the tests. I'm not sure it's worth removing them.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
