### PR TITLE
[MRG+2] Incorrect implementation of explained_variance_ in PCA

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -372,6 +372,12 @@ Bug fixes
    - Add ``shuffle`` parameter to :func:`model_selection.train_test_split`.
      :issue:`#8845` by  :user:`themrmax <themrmax>`
 
+   - Fixed the implementation of explained_variance_
+     in :class:`decomposition.PCA`,
+     :class:`decomposition.RandomizedPCA` and
+     :class:`decomposition.IncrementalPCA`.
+     :issue:`#9105` by `Hanmin Qin <https://github.com/qinhanmin2014>`_. 
+
 API changes summary
 -------------------
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -372,11 +372,11 @@ Bug fixes
    - Add ``shuffle`` parameter to :func:`model_selection.train_test_split`.
      :issue:`#8845` by  :user:`themrmax <themrmax>`
 
-   - Fixed the implementation of explained_variance_
+   - Fixed the implementation of `explained_variance_`
      in :class:`decomposition.PCA`,
      :class:`decomposition.RandomizedPCA` and
      :class:`decomposition.IncrementalPCA`.
-     :issue:`#9105` by `Hanmin Qin <https://github.com/qinhanmin2014>`_. 
+     :issue:`9105` by `Hanmin Qin <https://github.com/qinhanmin2014>`_. 
 
 API changes summary
 -------------------

--- a/sklearn/decomposition/incremental_pca.py
+++ b/sklearn/decomposition/incremental_pca.py
@@ -251,7 +251,7 @@ class IncrementalPCA(_BasePCA):
 
         U, S, V = linalg.svd(X, full_matrices=False)
         U, V = svd_flip(U, V, u_based_decision=False)
-        explained_variance = S ** 2 / n_total_samples
+        explained_variance = S ** 2 / (n_total_samples - 1)
         explained_variance_ratio = S ** 2 / np.sum(col_var * n_total_samples)
 
         self.n_samples_seen_ = n_total_samples

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -285,12 +285,6 @@ class PCA(_BasePCA):
     >>> print(pca.singular_values_)  # doctest: +ELLIPSIS
     [ 6.30061...]
 
-    Notes
-    -----
-    PCA uses the maximum likelihood estimate of the eigenvalues, which does not
-    include the Bessel correction, though in practice this should rarely make a
-    difference in a machine learning context.
-
     See also
     --------
     KernelPCA

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -714,8 +714,8 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
                                  n_iter=self.iterated_power,
                                  random_state=random_state)
 
-        self.explained_variance_ = exp_var = (S ** 2) / n_samples
-        full_var = np.var(X, axis=0).sum()
+        self.explained_variance_ = exp_var = (S ** 2) / (n_samples - 1)
+        full_var = np.var(X, ddof=1, axis=0).sum()
         self.explained_variance_ratio_ = exp_var / full_var
         self.singular_values_ = S  # Store the singular values.
 

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -346,7 +346,7 @@ class PCA(_BasePCA):
 
         if self.whiten:
             # X_new = X * V / S * sqrt(n_samples) = U * sqrt(n_samples)
-            U *= sqrt(X.shape[0])
+            U *= sqrt(X.shape[0] - 1)
         else:
             # X_new = X * V = U * S * V^T * V = U * S
             U *= S[:self.n_components_]

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -416,7 +416,7 @@ class PCA(_BasePCA):
         components_ = V
 
         # Get variance explained by singular values
-        explained_variance_ = (S ** 2) / n_samples
+        explained_variance_ = (S ** 2) / (n_samples - 1)
         total_var = explained_variance_.sum()
         explained_variance_ratio_ = explained_variance_ / total_var
         singular_values_ = S.copy()  # Store the singular values.
@@ -495,8 +495,8 @@ class PCA(_BasePCA):
         self.n_components_ = n_components
 
         # Get variance explained by singular values
-        self.explained_variance_ = (S ** 2) / n_samples
-        total_var = np.var(X, axis=0)
+        self.explained_variance_ = (S ** 2) / (n_samples - 1)
+        total_var = np.var(X, ddof=1, axis=0)
         self.explained_variance_ratio_ = \
             self.explained_variance_ / total_var.sum()
         self.singular_values_ = S.copy()  # Store the singular values.

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -174,7 +174,8 @@ def test_whitening():
         X_whitened2 = pca.transform(X_)
         assert_array_almost_equal(X_whitened, X_whitened2)
 
-        assert_almost_equal(X_whitened.std(axis=0), np.ones(n_components),
+        assert_almost_equal(X_whitened.std(ddof=1, axis=0),
+                            np.ones(n_components),
                             decimal=6)
         assert_almost_equal(X_whitened.mean(axis=0), np.zeros(n_components))
 

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -228,18 +228,17 @@ def test_explained_variance():
                               decimal=1)
 
     # Another way to run this part (according to the original definition)
-    # compare to empirical variances
-    # expected_result = np.linalg.eig(np.cov(X, rowvar=False))[0]
-    # expected_result = sorted(expected_result, reverse=True)[:2]
-    # X_pca = pca.transform(X)
-    # assert_array_almost_equal(pca.explained_variance_, expected_result)
+    expected_result = np.linalg.eig(np.cov(X, rowvar=False))[0]
+    expected_result = sorted(expected_result, reverse=True)[:2]
+    X_pca = pca.transform(X)
+    assert_array_almost_equal(pca.explained_variance_, expected_result)
 
-    # X_pca = apca.transform(X)
-    # assert_array_almost_equal(apca.explained_variance_, expected_result)
+    X_pca = apca.transform(X)
+    assert_array_almost_equal(apca.explained_variance_, expected_result)
 
-    # X_rpca = rpca.transform(X)
-    # assert_array_almost_equal(rpca.explained_variance_,
-    #                           expected_result, decimal=1)
+    X_rpca = rpca.transform(X)
+    assert_array_almost_equal(rpca.explained_variance_,
+                              expected_result, decimal=1)
 
     # Same with correlated data
     X = datasets.make_classification(n_samples, n_features,

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -215,15 +215,30 @@ def test_explained_variance():
     # compare to empirical variances
     X_pca = pca.transform(X)
     assert_array_almost_equal(pca.explained_variance_,
-                              np.var(X_pca, axis=0))
+                              np.var(X_pca, ddof=1, axis=0))
 
     X_pca = apca.transform(X)
     assert_array_almost_equal(apca.explained_variance_,
-                              np.var(X_pca, axis=0))
+                              np.var(X_pca, ddof=1, axis=0))
 
     X_rpca = rpca.transform(X)
-    assert_array_almost_equal(rpca.explained_variance_, np.var(X_rpca, axis=0),
+    assert_array_almost_equal(rpca.explained_variance_,
+                              np.var(X_rpca, ddof=1, axis=0),
                               decimal=1)
+
+    # Another way to run this part (according to the original definition)
+    # compare to empirical variances
+    # expected_result = np.linalg.eig(np.cov(X, rowvar=False))[0]
+    # expected_result = sorted(expected_result, reverse=True)[:2]
+    # X_pca = pca.transform(X)
+    # assert_array_almost_equal(pca.explained_variance_, expected_result)
+
+    # X_pca = apca.transform(X)
+    # assert_array_almost_equal(apca.explained_variance_, expected_result)
+
+    # X_rpca = rpca.transform(X)
+    # assert_array_almost_equal(rpca.explained_variance_,
+    #                           expected_result, decimal=1)
 
     # Same with correlated data
     X = datasets.make_classification(n_samples, n_features,

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -214,29 +214,23 @@ def test_explained_variance():
                               rpca.explained_variance_ratio_, 1)
 
     # compare to empirical variances
+    expected_result = np.linalg.eig(np.cov(X, rowvar=False))[0]
+    expected_result = sorted(expected_result, reverse=True)[:2]
+
     X_pca = pca.transform(X)
     assert_array_almost_equal(pca.explained_variance_,
                               np.var(X_pca, ddof=1, axis=0))
+    assert_array_almost_equal(pca.explained_variance_, expected_result)
 
     X_pca = apca.transform(X)
     assert_array_almost_equal(apca.explained_variance_,
                               np.var(X_pca, ddof=1, axis=0))
+    assert_array_almost_equal(apca.explained_variance_, expected_result)
 
     X_rpca = rpca.transform(X)
     assert_array_almost_equal(rpca.explained_variance_,
                               np.var(X_rpca, ddof=1, axis=0),
                               decimal=1)
-
-    # Another way to run this part (according to the original definition)
-    expected_result = np.linalg.eig(np.cov(X, rowvar=False))[0]
-    expected_result = sorted(expected_result, reverse=True)[:2]
-    X_pca = pca.transform(X)
-    assert_array_almost_equal(pca.explained_variance_, expected_result)
-
-    X_pca = apca.transform(X)
-    assert_array_almost_equal(apca.explained_variance_, expected_result)
-
-    X_rpca = rpca.transform(X)
     assert_array_almost_equal(rpca.explained_variance_,
                               expected_result, decimal=1)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #7699
Mentioned in #8541 (the 5th comment by IainStrachan on 11 May)
Mentioned in #8544 (the 6th comment by IainStrachan on 11 May)

#### What does this implement/fix? Explain your changes.
`PCA.explained_variance_` is incorrectly implemented.  The test is also wrong so that the mistake is not detected.

#### The result of explained_variance_ is wrong.
**result from python:**
![04](https://user-images.githubusercontent.com/12003569/27007678-c9f857bc-4e8d-11e7-9b5e-6a519887319a.jpg)
**result from R:**
![01](https://user-images.githubusercontent.com/12003569/27007656-2877777e-4e8d-11e7-9b6d-f976dd818e26.jpg)
**result according to the definition:**
![02](https://user-images.githubusercontent.com/12003569/27007663-46040d5c-4e8d-11e7-90b3-b6144a4e91cc.jpg)

#### Reason for the incorrect implementation.
(1)In the code, `explained_variance_ = (S ** 2) / n_samples` should be `explained_variance_ = (S ** 2) / (n_samples - 1)`. Because when using SVD to calculate PCA, we get the eigenvalue of `A'A`(A' means the transpose of A), but what we need is the eigenvalue of `A'A/(n_samples - 1)` , which is equivalent to the covariance matrix of A.
(2)In the test, we simply use `np.var` to calculate the variance. That's incorrect. We should use `np.cor` and pick the elements on the diagonal or set `ddof=1` . 

#### Any other comments?
I provide two ways for the new test, one based on current version, another based on the definition.
Please take some time to consider it. Thanks.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
