### PR TITLE
[MRG+1] fused types in isotonic_regression

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -315,6 +315,13 @@ Support for Python 3.4 and below has been officially dropped.
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 
+:mod:`sklearn.isotonic`
+.......................
+
+- |Feature| Allow different dtypes (such as float32) in
+  :class:`isotonic.IsotonicRegression` :issue:`8769` by :user:`Vlad Niculae <vene>`
+
+
 Multiple modules
 ................
 

--- a/sklearn/_isotonic.pyx
+++ b/sklearn/_isotonic.pyx
@@ -81,9 +81,11 @@ def _make_unique(np.ndarray[dtype=floating] X,
     unique_values = len(np.unique(X))
     if unique_values == len(X):
         return X, y, sample_weights
-    cdef np.ndarray[dtype=floating] y_out = np.empty(unique_values)
-    cdef np.ndarray[dtype=floating] x_out = np.empty(unique_values)
-    cdef np.ndarray[dtype=floating] weights_out = np.empty(unique_values)
+
+    cdef np.ndarray[dtype=floating] y_out = np.empty(unique_values,
+                                                     dtype=X.dtype)
+    cdef np.ndarray[dtype=floating] x_out = np.empty_like(y_out)
+    cdef np.ndarray[dtype=floating] weights_out = np.empty_like(y_out)
 
     cdef floating current_x = X[0]
     cdef floating current_y = 0

--- a/sklearn/_isotonic.pyx
+++ b/sklearn/_isotonic.pyx
@@ -7,17 +7,16 @@
 import numpy as np
 cimport numpy as np
 cimport cython
-
-ctypedef np.float64_t DOUBLE
+from cython cimport floating
 
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-def _inplace_contiguous_isotonic_regression(DOUBLE[::1] y, DOUBLE[::1] w):
+def _inplace_contiguous_isotonic_regression(floating[::1] y, floating[::1] w):
     cdef:
         Py_ssize_t n = y.shape[0], i, k
-        DOUBLE prev_y, sum_wy, sum_w
+        floating prev_y, sum_wy, sum_w
         Py_ssize_t[::1] target = np.arange(n, dtype=np.intp)
 
     # target describes a list of blocks.  At any time, if [i..j] (inclusive) is
@@ -68,9 +67,9 @@ def _inplace_contiguous_isotonic_regression(DOUBLE[::1] y, DOUBLE[::1] w):
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-def _make_unique(np.ndarray[dtype=np.float64_t] X,
-                 np.ndarray[dtype=np.float64_t] y,
-                 np.ndarray[dtype=np.float64_t] sample_weights):
+def _make_unique(np.ndarray[dtype=floating] X,
+                 np.ndarray[dtype=floating] y,
+                 np.ndarray[dtype=floating] sample_weights):
     """Average targets for duplicate X, drop duplicates.
 
     Aggregates duplicate X values into a single X value where
@@ -82,18 +81,18 @@ def _make_unique(np.ndarray[dtype=np.float64_t] X,
     unique_values = len(np.unique(X))
     if unique_values == len(X):
         return X, y, sample_weights
-    cdef np.ndarray[dtype=np.float64_t] y_out = np.empty(unique_values)
-    cdef np.ndarray[dtype=np.float64_t] x_out = np.empty(unique_values)
-    cdef np.ndarray[dtype=np.float64_t] weights_out = np.empty(unique_values)
+    cdef np.ndarray[dtype=floating] y_out = np.empty(unique_values)
+    cdef np.ndarray[dtype=floating] x_out = np.empty(unique_values)
+    cdef np.ndarray[dtype=floating] weights_out = np.empty(unique_values)
 
-    cdef np.float64_t current_x = X[0]
-    cdef np.float64_t current_y = 0
-    cdef np.float64_t current_weight = 0
-    cdef np.float64_t y_old = 0
+    cdef floating current_x = X[0]
+    cdef floating current_y = 0
+    cdef floating current_weight = 0
+    cdef floating y_old = 0
     cdef int i = 0
     cdef int current_count = 0
     cdef int j
-    cdef np.float64_t x
+    cdef floating x
     cdef int n_samples = len(X)
     for j in range(n_samples):
         x = X[j]

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -346,6 +346,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
             The transformed data
         """
 
+
         if hasattr(self, '_necessary_X_'):
             dtype = self._necessary_X_.dtype
         else:
@@ -365,7 +366,12 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         if self.out_of_bounds == "clip":
             T = np.clip(T, self.X_min_, self.X_max_)
 
-        return self.f_(T)
+        res = self.f_(T)
+
+        # on scipy 0.17, interp1d up-casts to float64, so we cast back
+        res = res.astype(T.dtype)
+
+        return res
 
     def predict(self, T):
         """Predict new data by linear interpolation.

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -259,7 +259,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
             mask = sample_weight > 0
             X, y, sample_weight = X[mask], y[mask], sample_weight[mask]
         else:
-            sample_weight = np.ones(len(y)).astype(X.dtype, copy=False)
+            sample_weight = np.ones(len(y), dtype=X.dtype)
 
         order = np.lexsort((y, X))
         X, y, sample_weight = [array[order] for array in [X, y, sample_weight]]

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -240,7 +240,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
 
     def _build_y(self, X, y, sample_weight, trim_duplicates=True):
         """Build the y_ IsotonicRegression."""
-        X = check_array(X, dtype=[np.float64, np.float32], ensure_2d=False)
+        X = as_float_array(X)
         y = check_array(y, dtype=X.dtype, ensure_2d=False)
         check_consistent_length(X, y, sample_weight)
         self._check_fit_data(X, y, sample_weight)

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -243,6 +243,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         check_consistent_length(X, y, sample_weight)
         X, y = [check_array(x, ensure_2d=False) for x in [X, y]]
 
+        X = as_float_array(X)
         y = as_float_array(y)
         self._check_fit_data(X, y, sample_weight)
 
@@ -262,7 +263,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
             sample_weight = np.ones(len(y))
 
         order = np.lexsort((y, X))
-        X, y, sample_weight = [array[order].astype(np.float64, copy=False)
+        X, y, sample_weight = [array[order].astype(X.dtype, copy=False)
                                for array in [X, y, sample_weight]]
         unique_X, unique_y, unique_sample_weight = _make_unique(
             X, y, sample_weight)
@@ -347,6 +348,8 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
             The transformed data
         """
         T = as_float_array(T)
+        T = T.astype(self._necessary_X_.dtype, copy=False)
+
         if len(T.shape) != 1:
             raise ValueError("Isotonic regression input should be a 1d array")
 

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -329,6 +329,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         # the pickle module as the object built by scipy.interp1d is not
         # picklable directly.
         self._necessary_X_, self._necessary_y_ = X, y
+        self._dtype = X.dtype
 
         # Build the interpolation function
         self._build_f(X, y)
@@ -348,7 +349,8 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
             The transformed data
         """
         T = as_float_array(T)
-        T = T.astype(self._necessary_X_.dtype, copy=False)
+        if hasattr(self, '_dtype'):
+            T = T.astype(self._dtype, copy=False)
 
         if len(T.shape) != 1:
             raise ValueError("Isotonic regression input should be a 1d array")

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -346,7 +346,6 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
             The transformed data
         """
 
-
         if hasattr(self, '_necessary_X_'):
             dtype = self._necessary_X_.dtype
         else:

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -119,11 +119,12 @@ def isotonic_regression(y, sample_weight=None, y_min=None, y_max=None,
     by Michael J. Best and Nilotpal Chakravarti, section 3.
     """
     order = np.s_[:] if increasing else np.s_[::-1]
-    y = np.array(y[order], dtype=np.float64)
+    y = as_float_array(y)
+    y = np.array(y[order], dtype=y.dtype)
     if sample_weight is None:
-        sample_weight = np.ones(len(y), dtype=np.float64)
+        sample_weight = np.ones(len(y), dtype=y.dtype)
     else:
-        sample_weight = np.array(sample_weight[order], dtype=np.float64)
+        sample_weight = np.array(sample_weight[order])
 
     _inplace_contiguous_isotonic_regression(y, sample_weight)
     if y_min is not None or y_max is not None:

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -6,6 +6,7 @@ import copy
 from sklearn.isotonic import (check_increasing, isotonic_regression,
                               IsotonicRegression)
 
+from sklearn.utils.validation import as_float_array
 from sklearn.utils.testing import (assert_raises, assert_array_equal,
                                    assert_equal,
                                    assert_array_almost_equal,
@@ -459,3 +460,11 @@ def test_isotonic_copy_before_fit():
     # https://github.com/scikit-learn/scikit-learn/issues/6628
     ir = IsotonicRegression()
     copy.copy(ir)
+
+
+def test_isotonic_dtype():
+    x = [2, 1, 4, 3, 5]
+    for dtype in (np.int32, np.int64, np.float32, np.float64):
+        x_np = np.array(x, dtype=np.int32)
+        y = isotonic_regression(x_np)
+        assert_equal(y.dtype, as_float_array(x_np).dtype)

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -4,7 +4,7 @@ import pickle
 import copy
 
 from sklearn.isotonic import (check_increasing, isotonic_regression,
-                              IsotonicRegression)
+                              IsotonicRegression, _make_unique)
 
 from sklearn.utils.validation import as_float_array
 from sklearn.utils.testing import (assert_raises, assert_array_equal,
@@ -479,3 +479,14 @@ def test_isotonic_dtype():
             reg.fit(X, y_np, sample_weight=sample_weight)
             res = reg.predict(X)
             assert_equal(res.dtype, expected_dtype)
+
+
+def test_make_unique_dtype():
+    x_list = [2, 2, 2, 3, 5]
+    for dtype in (np.float32, np.float64):
+        x = np.array(x_list, dtype=dtype)
+        y = x.copy()
+        w = np.ones_like(x)
+        x, y, w = _make_unique(x, y, w)
+        assert_array_equal(x, [2, 3, 5])
+

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -463,8 +463,12 @@ def test_isotonic_copy_before_fit():
 
 
 def test_isotonic_dtype():
-    x = [2, 1, 4, 3, 5]
+    y = [2, 1, 4, 3, 5]
     for dtype in (np.int32, np.int64, np.float32, np.float64):
-        x_np = np.array(x, dtype=np.int32)
-        y = isotonic_regression(x_np)
-        assert_equal(y.dtype, as_float_array(x_np).dtype)
+        y_np = np.array(y, dtype=np.int32)
+        res = isotonic_regression(y_np)
+        assert_equal(res.dtype, as_float_array(res).dtype)
+
+        X = np.arange(len(y)).astype(dtype)
+        res = IsotonicRegression().fit(X, y_np).predict(X)
+        assert_equal(res.dtype, as_float_array(res).dtype)

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -489,4 +489,3 @@ def test_make_unique_dtype():
         w = np.ones_like(x)
         x, y, w = _make_unique(x, y, w)
         assert_array_equal(x, [2, 3, 5])
-

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -464,11 +464,16 @@ def test_isotonic_copy_before_fit():
 
 def test_isotonic_dtype():
     y = [2, 1, 4, 3, 5]
-    for dtype in (np.int32, np.int64, np.float32, np.float64):
-        y_np = np.array(y, dtype=np.int32)
-        res = isotonic_regression(y_np)
-        assert_equal(res.dtype, as_float_array(res).dtype)
+    weights = np.array([.9, .9, .9, .9, .9], dtype=np.float64)
+    reg = IsotonicRegression()
 
-        X = np.arange(len(y)).astype(dtype)
-        res = IsotonicRegression().fit(X, y_np).predict(X)
-        assert_equal(res.dtype, as_float_array(res).dtype)
+    for dtype in (np.int32, np.int64, np.float32, np.float64):
+        for sample_weight in (None, weights.astype(np.float32), weights):
+            y_np = np.array(y, dtype=dtype)
+            res = isotonic_regression(y_np, sample_weight=sample_weight)
+            assert_equal(res.dtype, as_float_array(res).dtype)
+
+            X = np.arange(len(y)).astype(dtype)
+            reg.fit(X, y_np, sample_weight=sample_weight)
+            reg.predict(X)
+            assert_equal(res.dtype, as_float_array(res).dtype)

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -470,10 +470,12 @@ def test_isotonic_dtype():
     for dtype in (np.int32, np.int64, np.float32, np.float64):
         for sample_weight in (None, weights.astype(np.float32), weights):
             y_np = np.array(y, dtype=dtype)
+            expected_dtype = as_float_array(y_np).dtype
+
             res = isotonic_regression(y_np, sample_weight=sample_weight)
-            assert_equal(res.dtype, as_float_array(res).dtype)
+            assert_equal(res.dtype, expected_dtype)
 
             X = np.arange(len(y)).astype(dtype)
             reg.fit(X, y_np, sample_weight=sample_weight)
-            reg.predict(X)
-            assert_equal(res.dtype, as_float_array(res).dtype)
+            res = reg.predict(X)
+            assert_equal(res.dtype, expected_dtype)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue #8769 -ish?
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
isotonic regression should preserve 32bit dtypes when possible.

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
