### PR TITLE
[MRG] remove identical assert in test_iforest_sparse

### DIFF
--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -86,7 +86,6 @@ def test_iforest_sparse():
             dense_results = dense_classifier.predict(X_test)
 
             assert_array_equal(sparse_results, dense_results)
-            assert_array_equal(sparse_results, dense_results)
 
 
 def test_iforest_error():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### What does this implement/fix? Explain your changes.
This removes identical lines in test_iforest_sparse function: `assert_array_equal(sparse_results, dense_results)`.

```python
sparse_classifier = IsolationForest(
    n_estimators=10, random_state=1, **params).fit(X_train_sparse)
sparse_results = sparse_classifier.predict(X_test_sparse)

dense_classifier = IsolationForest(
    n_estimators=10, random_state=1, **params).fit(X_train)
dense_results = dense_classifier.predict(X_test)

assert_array_equal(sparse_results, dense_results)
assert_array_equal(sparse_results, dense_results)
```

#### Any other comments?
Given the context of the test I don't think that the removed line was supposed to test something different than the line above. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
