### PR TITLE
[MRG+1] FIX common test failures on Windows

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1378,6 +1378,8 @@ def check_class_weight_classifiers(name, classifier_orig):
         set_random_state(classifier)
         classifier.fit(X_train, y_train)
         y_pred = classifier.predict(X_test)
+        # XXX: Generally can use 0.89 here. On Windows, LinearSVC gets
+        #      0.88 (Issue #9111)
         assert_greater(np.mean(y_pred == 0), 0.87)
 
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1378,7 +1378,7 @@ def check_class_weight_classifiers(name, classifier_orig):
         set_random_state(classifier)
         classifier.fit(X_train, y_train)
         y_pred = classifier.predict(X_test)
-        assert_greater(np.mean(y_pred == 0), 0.89)
+        assert_greater(np.mean(y_pred == 0), 0.87)
 
 
 @ignore_warnings(category=DeprecationWarning)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1142,7 +1142,7 @@ def check_classifiers_train(name, classifier_orig):
             if hasattr(classifier, "predict_log_proba"):
                 # predict_log_proba is a transformation of predict_proba
                 y_log_prob = classifier.predict_log_proba(X)
-                assert_allclose(y_log_prob, np.log(y_prob), 8)
+                assert_allclose(y_log_prob, np.log(y_prob), 8, atol=1e-9)
                 assert_array_equal(np.argsort(y_log_prob), np.argsort(y_prob))
 
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -375,7 +375,7 @@ def assert_raise_message(exceptions, message, function, *args, **kwargs):
                              (names, function.__name__))
 
 
-def assert_allclose_dense_sparse(x, y, rtol=1e-07, atol=1e-13, err_msg=''):
+def assert_allclose_dense_sparse(x, y, rtol=1e-07, atol=1e-9, err_msg=''):
     """Assert allclose for sparse and dense data.
 
     Both x and y need to be either sparse or dense, they
@@ -393,7 +393,9 @@ def assert_allclose_dense_sparse(x, y, rtol=1e-07, atol=1e-13, err_msg=''):
         relative tolerance; see numpy.allclose
 
     atol : float, optional
-        absolute tolerance; see numpy.allclose
+        absolute tolerance; see numpy.allclose. Note that the default here is
+        more tolerant than the default for numpy.testing.assert_allclose, where
+        atol=0.
 
     err_msg : string, default=''
         Error message to raise.

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -375,7 +375,7 @@ def assert_raise_message(exceptions, message, function, *args, **kwargs):
                              (names, function.__name__))
 
 
-def assert_allclose_dense_sparse(x, y, rtol=1e-07, atol=0, err_msg=''):
+def assert_allclose_dense_sparse(x, y, rtol=1e-07, atol=1e-13, err_msg=''):
     """Assert allclose for sparse and dense data.
 
     Both x and y need to be either sparse or dense, they
@@ -388,6 +388,12 @@ def assert_allclose_dense_sparse(x, y, rtol=1e-07, atol=0, err_msg=''):
 
     y : array-like or sparse matrix
         Second array to compare.
+
+    rtol : float, optional
+        relative tolerance; see numpy.allclose
+
+    atol : float, optional
+        absolute tolerance; see numpy.allclose
 
     err_msg : string, default=''
         Error message to raise.


### PR DESCRIPTION
Common tests require some absolute tolerance in array comparison for small numerical imprecisions

Partially fixes #9111.

Is 1e-9 sufficiently small? (Is it sufficiently large for AppVeyor to pass??? We'll see soon.)
