### PR TITLE
[MRG] MNT Use the default flake8 --ignore options

### DIFF
--- a/build_tools/travis/flake8_diff.sh
+++ b/build_tools/travis/flake8_diff.sh
@@ -137,11 +137,12 @@ check_files() {
 if [[ "$MODIFIED_FILES" == "no_match" ]]; then
     echo "No file outside sklearn/externals and doc/sphinxext/sphinx_gallery has been modified"
 else
-    # Running flake8 with the default --ignore options
+    # Default ignore PEP8 violations are from flake8 3.3.0
+    DEFAULT_IGNORED_PEP8=E121,E123,E126,E226,E24,E704,W503,W504
     check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)" \
-           --ignore=E121,E123,E126,E226,E24,E704,W503,W504
+           --ignore $DEFAULT_IGNORED_PEP8
     # Examples are allowed to not have imports at top of file
     check_files "$(echo "$MODIFIED_FILES" | grep ^examples)" \
-           --ignore=E402,E121,E123,E126,E226,E24,E704,W503,W504
+           --ignore $DEFAULT_IGNORED_PEP8 --ignore E402
 fi
 echo -e "No problem detected by flake8\n"

--- a/build_tools/travis/flake8_diff.sh
+++ b/build_tools/travis/flake8_diff.sh
@@ -137,8 +137,11 @@ check_files() {
 if [[ "$MODIFIED_FILES" == "no_match" ]]; then
     echo "No file outside sklearn/externals and doc/sphinxext/sphinx_gallery has been modified"
 else
-    check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)" --ignore=W503
+    # Running flake8 with the default --ignore options
+    check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)" \
+           --ignore=E121,E123,E126,E226,E24,E704,W503,W504
     # Examples are allowed to not have imports at top of file
-    check_files "$(echo "$MODIFIED_FILES" | grep ^examples)" --ignore=E402,W503
+    check_files "$(echo "$MODIFIED_FILES" | grep ^examples)" \
+           --ignore=E402,E121,E123,E126,E226,E24,E704,W503,W504
 fi
 echo -e "No problem detected by flake8\n"


### PR DESCRIPTION
Fixes #9121

This makes sure that the the TravisCI flake8 build is using the [default flake8 `--ignore` options](https://github.com/PyCQA/flake8/blob/52180995046583cacf9d78a4423b82448a47fef1/docs/source/manpage.rst#L59), for smoother contribution workflow..   Also checked that these are defaults in the flake8 [master branch](https://github.com/PyCQA/flake8/blob/master/src/flake8/defaults.py#L15).   

As [suggested by](https://github.com/scikit-learn/scikit-learn/issues/9121#issuecomment-308415440) @lesteve  this specifies the ignored errors/warnings explicitly, while keeping one extra ignored error for examples. Unless you think it's better to simply remove the `--ignore` flag for non-examples?

cc @jnothman 

