### PR TITLE
[MRG] remove unused X_train in LocalOutlierFactor tests

### DIFF
--- a/sklearn/neighbors/tests/test_lof.py
+++ b/sklearn/neighbors/tests/test_lof.py
@@ -51,7 +51,6 @@ def test_lof_performance():
     # Generate train/test data
     rng = check_random_state(2)
     X = 0.3 * rng.randn(120, 2)
-    X_train = np.r_[X + 2, X - 2]
     X_train = X[:100]
 
     # Generate some abnormal novel observations


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
 Removes unused X_train in LocalOutlierFactor tests (only the second assignment is used).

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
