### PR TITLE
Fix a typo for "k-means++" usage, in clustering module documentation

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -191,7 +191,7 @@ minimum. This is highly dependent on the initialization of the centroids.
 As a result, the computation is often done several times, with different
 initializations of the centroids. One method to help address this issue is the
 k-means++ initialization scheme, which has been implemented in scikit-learn
-(use the ``init='kmeans++'`` parameter). This initializes the centroids to be
+(use the ``init='k-means++'`` parameter). This initializes the centroids to be
 (generally) distant from each other, leading to provably better results than
 random initialization, as shown in the reference.
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The documentation explained how to use "k-means++" algorithm.
There was a mistake passing a value to `init`.
This value is not `kmeans++` but `k-means++`.