### PR TITLE
[MRG+2] algorithm='auto' should always work for nearest neighbors (continuation)

### DIFF
--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -425,9 +425,10 @@ and the ``'effective_metric_'`` is in the ``'VALID_METRICS'`` list of
 ``'effective_metric_'`` is in the ``'VALID_METRICS'`` list of
 ``'ball_tree'``. It selects ``'brute'`` if :math:`k < N/2` and the
 ``'effective_metric_'`` is not in the ``'VALID_METRICS'`` list of
-``'kd_tree'`` or ``'ball_tree'``. It selects ``'brute'`` if :math:`k >= N/2`. This choice is based on the assumption that the number of query points is at least the
-same order as the number of training points, and that ``leaf_size`` is
-close to its default value of ``30``.
+``'kd_tree'`` or ``'ball_tree'``. It selects ``'brute'`` if :math:`k >= N/2`.
+This choice is based on the assumption that the number of query points is at
+least the same order as the number of training points, and that ``leaf_size``
+is close to its default value of ``30``.
 
 Effect of ``leaf_size``
 -----------------------

--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -419,12 +419,14 @@ depends on a number of factors:
   a significant fraction of the total cost.  If very few query points
   will be required, brute force is better than a tree-based method.
 
-Currently, ``algorithm = 'auto'`` selects ``'kd_tree'`` if :math:`k < N/2` 
-and the ``'effective_metric_'`` is in the ``'VALID_METRICS'`` list of 
-``'kd_tree'``. It selects ``'ball_tree'`` if :math:`k < N/2` and the 
-``'effective_metric_'`` is not in the ``'VALID_METRICS'`` list of 
-``'kd_tree'``. It selects ``'brute'`` if :math:`k >= N/2`. This choice is based on the assumption that the number of query points is at least the 
-same order as the number of training points, and that ``leaf_size`` is 
+Currently, ``algorithm = 'auto'`` selects ``'kd_tree'`` if :math:`k < N/2`
+and the ``'effective_metric_'`` is in the ``'VALID_METRICS'`` list of
+``'kd_tree'``. It selects ``'ball_tree'`` if :math:`k < N/2` and the
+``'effective_metric_'`` is in the ``'VALID_METRICS'`` list of
+``'ball_tree'``. It selects ``'brute'`` if :math:`k < N/2` and the
+``'effective_metric_'`` is not in the ``'VALID_METRICS'`` list of
+``'kd_tree'`` or ``'ball_tree'``. It selects ``'brute'`` if :math:`k >= N/2`. This choice is based on the assumption that the number of query points is at least the
+same order as the number of training points, and that ``leaf_size`` is
 close to its default value of ``30``.
 
 Effect of ``leaf_size``

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -127,6 +127,8 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
                 alg_check = 'brute'
             else:
                 alg_check = 'ball_tree'
+                if metric not in VALID_METRICS[alg_check]:
+                    alg_check = 'brute'
         else:
             alg_check = algorithm
 
@@ -228,8 +230,10 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
                     self.metric != 'precomputed'):
                 if self.effective_metric_ in VALID_METRICS['kd_tree']:
                     self._fit_method = 'kd_tree'
-                else:
+                elif self.effective_metric_ in VALID_METRICS['ball_tree']:
                     self._fit_method = 'ball_tree'
+                else:
+                    self._fit_method = 'brute'
             else:
                 self._fit_method = 'brute'
 

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -125,10 +125,10 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
         if algorithm == 'auto':
             if metric == 'precomputed':
                 alg_check = 'brute'
-            else:
+            elif callable(metric) or metric in VALID_METRICS['ball_tree']:
                 alg_check = 'ball_tree'
-                if metric not in VALID_METRICS[alg_check]:
-                    alg_check = 'brute'
+            else:
+                alg_check = 'brute'
         else:
             alg_check = algorithm
 
@@ -230,7 +230,8 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
                     self.metric != 'precomputed'):
                 if self.effective_metric_ in VALID_METRICS['kd_tree']:
                     self._fit_method = 'kd_tree'
-                elif self.effective_metric_ in VALID_METRICS['ball_tree']:
+                elif (callable(self.effective_metric_) or
+                        self.effective_metric_ in VALID_METRICS['ball_tree']):
                     self._fit_method = 'ball_tree'
                 else:
                     self._fit_method = 'brute'

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -15,7 +15,8 @@ from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.validation import check_random_state
-from sklearn.metrics.pairwise import pairwise_distances
+from sklearn.metrics.pairwise import (pairwise_distances,
+                                      PAIRWISE_DISTANCE_FUNCTIONS)
 from sklearn import neighbors, datasets
 from sklearn.exceptions import DataConversionWarning
 
@@ -986,6 +987,22 @@ def test_callable_metric():
     dist2, ind2 = nbrs2.kneighbors(X)
 
     assert_array_almost_equal(dist1, dist2)
+
+
+def test_algo_auto_metrics():
+    X = rng.rand(12, 3)
+    Xcsr = csr_matrix(X)
+    Valid_Metrics = dict(dense = ['precomputed', 'sqeuclidean',
+                             'yule', 'cosine', 'correlation'],
+                         sparse=PAIRWISE_DISTANCE_FUNCTIONS.keys())
+    for metric in Valid_Metrics['dense']:
+        nn = neighbors.NearestNeighbors(n_neighbors=3, algorithm='auto',
+                                        metric=metric).fit(X)
+        assert_true(nn._fit_method, 'brute')
+    for metric in Valid_Metrics['sparse']:
+        nn = neighbors.NearestNeighbors(n_neighbors=3, algorithm='auto',
+                                        metric=metric).fit(Xcsr)
+        assert_true(nn._fit_method, 'brute')
 
 
 def test_metric_params_interface():

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1,25 +1,25 @@
 from itertools import product
+
 import numpy as np
 from scipy.sparse import (bsr_matrix, coo_matrix, csc_matrix, csr_matrix,
                           dok_matrix, lil_matrix)
 
 from sklearn import metrics
-from sklearn.model_selection import train_test_split
+from sklearn import neighbors, datasets
+from sklearn.exceptions import DataConversionWarning
+from sklearn.metrics.pairwise import pairwise_distances
 from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import train_test_split
+from sklearn.neighbors.base import VALID_METRICS_SPARSE, VALID_METRICS
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import ignore_warnings
-from sklearn.utils.testing import assert_greater
 from sklearn.utils.validation import check_random_state
-from sklearn.metrics.pairwise import (pairwise_distances,
-                                      PAIRWISE_DISTANCE_FUNCTIONS)
-from sklearn import neighbors, datasets
-from sklearn.exceptions import DataConversionWarning
-from sklearn.neighbors.base import VALID_METRICS_SPARSE, VALID_METRICS
 
 rng = np.random.RandomState(0)
 # load and shuffle iris dataset

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -990,8 +990,7 @@ def test_callable_metric():
     assert_array_almost_equal(dist1, dist2)
 
 
-def test_unsupported_metric_for_auto():
-    # Test unsupported metric for 'auto' algorithm
+def test_valid_brute_metric_for_auto_algorithm():
     X = rng.rand(12, 12)
     Xcsr = csr_matrix(X)
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -14,7 +14,9 @@ from sklearn.neighbors.base import VALID_METRICS_SPARSE, VALID_METRICS
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import assert_in
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_warns
@@ -994,10 +996,15 @@ def test_valid_brute_metric_for_auto_algorithm():
     X = rng.rand(12, 12)
     Xcsr = csr_matrix(X)
 
+    # check that there is a metric that is valid for brute
+    # but not ball_tree (so we actually test something)
+    assert_in("cosine", VALID_METRICS['brute'])
+    assert_false("cosine" in VALID_METRICS['ball_tree'])
+    
     # Metric which don't required any additional parameter
-    _metrics = ['mahalanobis', 'wminkowski', 'seuclidean']
+    require_params = ['mahalanobis', 'wminkowski', 'seuclidean']
     for metric in VALID_METRICS['brute']:
-        if metric != 'precomputed' and metric not in _metrics:
+        if metric != 'precomputed' and metric not in require_params:
             nn = neighbors.NearestNeighbors(n_neighbors=3, algorithm='auto',
                                             metric=metric).fit(X)
             nn.kneighbors(X)
@@ -1012,7 +1019,7 @@ def test_valid_brute_metric_for_auto_algorithm():
             nb_p.kneighbors(DYX)
 
     for metric in VALID_METRICS_SPARSE['brute']:
-        if metric != 'precomputed' and metric not in _metrics:
+        if metric != 'precomputed' and metric not in require_params:
             nn = neighbors.NearestNeighbors(n_neighbors=3, algorithm='auto',
                                             metric=metric).fit(Xcsr)
             nn.kneighbors(Xcsr)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -995,14 +995,14 @@ def test_algo_auto_metrics():
     Xcsr = csr_matrix(X)
 
     # Metric which don't required any additional parameter
-    unsupported_metric = ['mahalanobis', 'wminkowski', 'seuclidean']
+    _metrics = ['mahalanobis', 'wminkowski', 'seuclidean']
     for metric in VALID_METRICS['brute']:
-        if metric not in unsupported_metric:
+        if metric not in _metrics:
             nn = neighbors.NearestNeighbors(n_neighbors=3, algorithm='auto',
                                             metric=metric).fit(X)
             nn.kneighbors(X)
     for metric in VALID_METRICS_SPARSE['brute']:
-        if metric not in unsupported_metric:
+        if metric not in _metrics:
             nn = neighbors.NearestNeighbors(n_neighbors=3, algorithm='auto',
                                             metric=metric).fit(Xcsr)
             if metric != "precomputed":

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1000,7 +1000,7 @@ def test_valid_brute_metric_for_auto_algorithm():
     # but not ball_tree (so we actually test something)
     assert_in("cosine", VALID_METRICS['brute'])
     assert_false("cosine" in VALID_METRICS['ball_tree'])
-    
+
     # Metric which don't required any additional parameter
     require_params = ['mahalanobis', 'wminkowski', 'seuclidean']
     for metric in VALID_METRICS['brute']:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #4931, continuation of #5596

#### What does this implement/fix? Explain your changes.
Implement test for metric in `['mahalanobis', 'wminkowski', 'seuclidean']`

#### Any other comments?
Should we warn the user when the algorithm is set into `brute`? (instead of `auto`)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
