### PR TITLE
Fixes #9148: Use tuples for color specification

### DIFF
--- a/examples/cluster/plot_dbscan.py
+++ b/examples/cluster/plot_dbscan.py
@@ -57,16 +57,16 @@ colors = [plt.cm.Spectral(each)
 for k, col in zip(unique_labels, colors):
     if k == -1:
         # Black used for noise.
-        col = 'k'
+        col = [0, 0, 0, 1]
 
     class_member_mask = (labels == k)
 
     xy = X[class_member_mask & core_samples_mask]
-    plt.plot(xy[:, 0], xy[:, 1], 'o', markerfacecolor=col,
+    plt.plot(xy[:, 0], xy[:, 1], 'o', markerfacecolor=tuple(col),
              markeredgecolor='k', markersize=14)
 
     xy = X[class_member_mask & ~core_samples_mask]
-    plt.plot(xy[:, 0], xy[:, 1], 'o', markerfacecolor=col,
+    plt.plot(xy[:, 0], xy[:, 1], 'o', markerfacecolor=tuple(col),
              markeredgecolor='k', markersize=6)
 
 plt.title('Estimated number of clusters: %d' % n_clusters_)


### PR DESCRIPTION
This PR fixes the issue specified in #9148.

In the Matplotlib 'Specifying Colors' section, an array is not a valid color specification type.  When this example is run using Python 3.5, and matplotlib 2.0.2 (latest), it errors with the message: 

"ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()"

This change preserves the semantics of the example while allowing it to successfully run by converting the arrays to tuples for the matplotlib color specification.