### PR TITLE
[MRG] Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ following rules before submitting:
 
 -  Please include your operating system type and version number, as well
    as your Python, scikit-learn, numpy, and scipy versions. This information
-   can be found by runnning the following code snippet:
+   can be found by running the following code snippet:
 
   ```python
   import platform; print(platform.platform())

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -332,7 +332,7 @@ following rules before submitting:
 
 -  Please include your operating system type and version number, as well
    as your Python, scikit-learn, numpy, and scipy versions. This information
-   can be found by runnning the following code snippet::
+   can be found by running the following code snippet::
 
      import platform; print(platform.platform())
      import sys; print("Python", sys.version)

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -150,7 +150,7 @@ def adjusted_rand_score(labels_true, labels_pred):
     Examples
     --------
 
-    Perfectly maching labelings have a score of 1 even
+    Perfectly matching labelings have a score of 1 even
 
       >>> from sklearn.metrics.cluster import adjusted_rand_score
       >>> adjusted_rand_score([0, 0, 1, 1], [0, 0, 1, 1])

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -772,7 +772,7 @@ def test_normalize_option_binary_classification(n_samples=20):
                             / n_samples, measure)
 
 
-def test_normalize_option_multiclasss_classification():
+def test_normalize_option_multiclass_classification():
     # Test in the multiclass case
     random_state = check_random_state(0)
     y_true = random_state.randint(0, 4, size=(20, ))

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -1077,7 +1077,7 @@ cdef class BinaryTree:
 
         # determine number of levels in the tree, and from this
         # the number of nodes in the tree.  This results in leaf nodes
-        # with numbers of points betweeen leaf_size and 2 * leaf_size
+        # with numbers of points between leaf_size and 2 * leaf_size
         self.n_levels = np.log2(fmax(1, (n_samples - 1) / self.leaf_size)) + 1
         self.n_nodes = (2 ** self.n_levels) - 1
 

--- a/sklearn/utils/graph_shortest_path.pyx
+++ b/sklearn/utils/graph_shortest_path.pyx
@@ -101,7 +101,7 @@ cdef np.ndarray floyd_warshall(np.ndarray[DTYPE_t, ndim=2, mode='c'] graph,
     Parameters
     ----------
     graph : ndarray
-        on input, graph is the matrix of distances betweeen connected points.
+        on input, graph is the matrix of distances between connected points.
         unconnected points have distance=0
         on exit, graph is overwritten with the output
     directed : bool, default = False
@@ -164,14 +164,14 @@ cdef np.ndarray dijkstra(dist_matrix,
     Parameters
     ----------
     graph : array or sparse matrix
-        dist_matrix is the matrix of distances betweeen connected points.
+        dist_matrix is the matrix of distances between connected points.
         unconnected points have distance=0.  It will be converted to
         a csr_matrix internally
     indptr :
         These arrays encode a distance matrix in compressed-sparse-row
         format.
     graph : ndarray
-        on input, graph is the matrix of distances betweeen connected points.
+        on input, graph is the matrix of distances between connected points.
         unconnected points have distance=0
         on exit, graph is overwritten with the output
     directed : bool, default = False


### PR DESCRIPTION
This PR fixes some typos: `runnning`, `maching`, `classs`, and `betweeen`.