### PR TITLE
[RFC] MNT ensure PLS* doesn't transform on y

### DIFF
--- a/sklearn/cross_decomposition/cca_.py
+++ b/sklearn/cross_decomposition/cca_.py
@@ -36,6 +36,8 @@ class CCA(_PLS):
     y_weights_ : array, [q, n_components]
         Y block weights vectors.
 
+        .. deprecated:: 0.19
+
     x_loadings_ : array, [p, n_components]
         X block loadings vectors.
 
@@ -53,6 +55,8 @@ class CCA(_PLS):
 
     y_rotations_ : array, [q, n_components]
         Y block to latents rotations.
+
+        .. deprecated:: 0.19
 
     n_iter_ : array-like
         Number of iterations of the NIPALS inner loop for each
@@ -80,7 +84,7 @@ class CCA(_PLS):
     >>> cca.fit(X, Y)
     ... # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     CCA(copy=True, max_iter=500, n_components=1, scale=True, tol=1e-06)
-    >>> X_c, Y_c = cca.transform(X, Y)
+    >>> X_c = cca.transform(X)
 
     References
     ----------

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -4,6 +4,8 @@ from numpy.testing import assert_approx_equal
 from sklearn.utils.testing import (assert_equal, assert_array_almost_equal,
                                    assert_array_equal, assert_true,
                                    assert_raise_message)
+from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import assert_warns_message
 from sklearn.datasets import load_linnerud
 from sklearn.cross_decomposition import pls_, CCA
 from sklearn.preprocessing import StandardScaler
@@ -41,7 +43,7 @@ def test_pls():
     Wx = plsca.x_weights_
     U = plsca.y_scores_
     Q = plsca.y_loadings_
-    Wy = plsca.y_weights_
+    Wy = assert_warns(DeprecationWarning, getattr, plsca, 'y_weights_')
 
     def check_ortho(M, err_msg):
         K = np.dot(M.T, M)
@@ -70,7 +72,7 @@ def test_pls():
     Xr = plsca.transform(X)
     assert_array_almost_equal(Xr, plsca.x_scores_,
                               err_msg="rotation on X failed")
-    Xr, Yr = plsca.transform(X, Y)
+    Xr, Yr = assert_warns(DeprecationWarning, plsca.transform, X, Y)
     assert_array_almost_equal(Xr, plsca.x_scores_,
                               err_msg="rotation on X failed")
     assert_array_almost_equal(Yr, plsca.y_scores_,
@@ -106,7 +108,11 @@ def test_pls():
         [[+0.58989127,  0.7168115,  0.30665872],
          [+0.77134053, -0.70791757,  0.19786539],
          [-0.23887670, -0.00343595,  0.94162826]])
-    y_rotations_sign_flip = pls_ca.y_rotations_ / y_rotations
+
+    pls_y_rotations = assert_warns_message(DeprecationWarning,
+                                           "y_rotations_ is deprecated",
+                                           getattr, pls_ca, 'y_rotations_')
+    y_rotations_sign_flip = pls_y_rotations / y_rotations
 
     # x_weights = X.dot(x_rotation)
     # Hence R/python sign flip should be the same in x_weight and x_rotation
@@ -299,8 +305,15 @@ def test_predict_transform_copy():
     assert_array_almost_equal(clf.transform(X), clf.transform(X.copy(), copy=False))
 
     # check also if passing Y
-    assert_array_almost_equal(clf.transform(X, Y),
-                              clf.transform(X.copy(), Y.copy(), copy=False))
+    transform = assert_warns_message(DeprecationWarning,
+                                     "parameter Y on transform() is "
+                                     "deprecated", clf.transform, X, Y)
+    transform2 = assert_warns_message(DeprecationWarning,
+                                      "parameter Y on transform() is "
+                                      "deprecated", clf.transform,
+                                      X.copy(), Y.copy())
+    assert_array_almost_equal(transform, transform2)
+
     # check that copy doesn't destroy
     # we do want to check exact equality here
     assert_array_equal(X_copy, X)
@@ -343,14 +356,17 @@ def test_scale_and_stability():
         for clf in [CCA(), pls_.PLSCanonical(), pls_.PLSRegression(),
                     pls_.PLSSVD()]:
             clf.set_params(scale=True)
-            X_score, Y_score = clf.fit_transform(X, Y)
+            X_score, Y_score = assert_warns(DeprecationWarning,
+                                            clf.fit_transform, X, Y)
             clf.set_params(scale=False)
-            X_s_score, Y_s_score = clf.fit_transform(X_s, Y_s)
+            X_s_score, Y_s_score = assert_warns(DeprecationWarning,
+                                                clf.fit_transform, X_s, Y_s)
             assert_array_almost_equal(X_s_score, X_score)
             assert_array_almost_equal(Y_s_score, Y_score)
             # Scaling should be idempotent
             clf.set_params(scale=True)
-            X_score, Y_score = clf.fit_transform(X_s, Y_s)
+            X_score, Y_score = assert_warns(DeprecationWarning,
+                                            clf.fit_transform, X_s, Y_s)
             assert_array_almost_equal(X_s_score, X_score)
             assert_array_almost_equal(Y_s_score, Y_score)
 


### PR DESCRIPTION
This removes support for transforming on `Y`

A few questions -

1. Is this correct? I did this as transforming on y doesn't conform with our API. Also it returns `X, y` which again doesn't conform with our API right?

2. Why are we terming that parameter `Y` in capital letter. Because of multitarget? But even forests support multioutput and still have `fit(X, y)`

**cc**: The PLS authors @naoyak @NelleV and for the API @GaelVaroquaux, @jnothman, @agramfort