### PR TITLE
[MRG+1] reduce decimal restriction in test_singular_values to avoid non-deterministic test failure

### DIFF
--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -263,7 +263,7 @@ def test_singular_values():
     assert_array_almost_equal(np.sum(pca.singular_values_**2.0),
                               np.linalg.norm(X_pca, "fro")**2.0, 12)
     assert_array_almost_equal(np.sum(apca.singular_values_**2.0),
-                              np.linalg.norm(X_apca, "fro")**2.0, 12)
+                              np.linalg.norm(X_apca, "fro")**2.0, 6)
     assert_array_almost_equal(np.sum(rpca.singular_values_**2.0),
                               np.linalg.norm(X_rpca, "fro")**2.0, 0)
 

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -263,7 +263,7 @@ def test_singular_values():
     assert_array_almost_equal(np.sum(pca.singular_values_**2.0),
                               np.linalg.norm(X_pca, "fro")**2.0, 12)
     assert_array_almost_equal(np.sum(apca.singular_values_**2.0),
-                              np.linalg.norm(X_apca, "fro")**2.0, 6)
+                              np.linalg.norm(X_apca, "fro")**2.0, 9)
     assert_array_almost_equal(np.sum(rpca.singular_values_**2.0),
                               np.linalg.norm(X_rpca, "fro")**2.0, 0)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #7893 (temporarily avoid it)

#### What does this implement/fix? Explain your changes.
Please refer to the issue.
`test_singular_values` sometimes fail and it seems unrelated to scikit-learn.
(CI become green after an empty commit)
For example in pull request #9108 :
https://ci.appveyor.com/project/sklearn-ci/scikit-learn/build/1.0.14629/job/t8udw2qky46u5ewm (fail)
https://ci.appveyor.com/project/sklearn-ci/scikit-learn/build/1.0.14695/job/8kovdaea238us3u2 (pass)
Before we find the reason, it may be better to reduce the `decimal` restriction in `assert_array_almost_equal` to avoid unecessary confusion.

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
