### PR TITLE
[MRG+2] Add named_estimator_ for votingClassifier

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -50,6 +50,10 @@ Classifiers and regressors
   several times in a row. :issue:`9234` by :user:`andrewww <andrewww>`
   and :user:`Minghui Liu <minghui-liu>`.
 
+- Add `named_estimators_` parameter in
+  :class:`sklearn.ensemble.voting_classifier` to access fitted
+  estimators. :issue:`9157` by :user:`Herilalaina Rakotoarison <herilalaina>`.
+
 
 Model evaluation and meta-estimators
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -236,10 +236,6 @@ Trees and ensembles
   removed by setting it to ``None``.
   :issue:`7674` by :user:`Yichuan Liu <yl565>`.
 
-- Add `named_estimators_` parameter in
-  :class:`sklearn.ensemble.voting_classifier` to access fitted 
-  estimators. :issue:`9157` by :user:`Herilalaina Rakotoarison <herilalaina>`.
-
 - :func:`tree.export_graphviz` now shows configurable number of decimal
   places. :issue:`8698` by :user:`Guillaume Lemaitre <glemaitre>`.
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -739,6 +739,133 @@ API changes summary
 -------------------
 
 Trees and ensembles
+   - Ensure that estimators' attributes ending with ``_`` are not set
+     in the constructor but only in the ``fit`` method. Most notably,
+     ensemble estimators (deriving from :class:`ensemble.BaseEnsemble`)
+     now only have ``self.estimators_`` available after ``fit``.
+     :issue:`7464` by `Lars Buitinck`_ and `Loic Esteve`_.
+
+   - All checks in ``utils.estimator_checks``, in particular
+     :func:`utils.estimator_checks.check_estimator` now accept estimator
+     instances. Most other checks do not accept
+     estimator classes any more. :issue:`9019` by `Andreas Müller`_.
+
+   - Deprecate the ``doc_topic_distr`` argument of the ``perplexity`` method
+     in :class:`decomposition.LatentDirichletAllocation` because the
+     user no longer has access to the unnormalized document topic distribution
+     needed for the perplexity calculation. :issue:`7954` by
+     :user:`Gary Foreman <garyForeman>`.
+
+   - Replace attribute ``named_steps`` ``dict`` to :class:`utils.Bunch`
+     in :class:`pipeline.Pipeline` to enable tab completion in interactive
+     environment. In the case conflict value on ``named_steps`` and ``dict``
+     attribute, ``dict`` behavior will be prioritized.
+     :issue:`8481` by :user:`Herilalaina Rakotoarison <herilalaina>`.
+
+   - The :func:`multioutput.MultiOutputClassifier.predict_proba`
+     function used to return a 3d array (``n_samples``, ``n_classes``,
+     ``n_outputs``). In the case where different target columns had different
+     numbers of classes, a `ValueError` would be raised on trying to stack
+     matrices with different dimensions. This function now returns a list of
+     arrays where the length of the list is ``n_outputs``, and each array is
+     (``n_samples``, ``n_classes``) for that particular output.
+     :issue:`8093` by :user:`Peter Bull <pjbull>`.
+     
+   - Add `named_estimators_` parameter in
+   	 :class:`sklearn.ensemble.voting_classifier` to access fitted 
+   	 estimators. :issue:`9157` by
+   	 :user:`Herilalaina Rakotoarison <herilalaina>`.
+
+   - Deprecate the ``fit_params`` constructor input to the
+     :class:`model_selection.GridSearchCV` and
+     :class:`model_selection.RandomizedSearchCV` in favor
+     of passing keyword parameters to the ``fit`` methods
+     of those classes. Data-dependent parameters needed for model
+     training should be passed as keyword arguments to ``fit``,
+     and conforming to this convention will allow the hyperparameter
+     selection classes to be used with tools such as
+     :func:`model_selection.cross_val_predict`.
+     :issue:`2879` by :user:`Stephen Hoover <stephen-hoover>`.
+
+   - The ``decision_function`` output shape for binary classification in
+     :class:`multiclass.OneVsRestClassifier` and
+     :class:`multiclass.OneVsOneClassifier` is now ``(n_samples,)`` to conform
+     to scikit-learn conventions. :issue:`9100` by `Andreas Müller`_.
+
+   - Gradient boosting base models are no longer estimators. By `Andreas Müller`_.
+
+   - :class:`feature_selection.SelectFromModel` now validates the ``threshold``
+     parameter and sets the ``threshold_`` attribute during the call to
+     ``fit``, and no longer during the call to ``transform```, by `Andreas
+     Müller`_.
+
+   - :class:`feature_selection.SelectFromModel` now has a ``partial_fit``
+     method only if the underlying estimator does. By `Andreas Müller`_.
+
+   - :class:`multiclass.OneVsRestClassifier` now has a ``partial_fit`` method
+     only if the underlying estimator does.  By `Andreas Müller`_.
+
+   - Estimators with both methods ``decision_function`` and ``predict_proba``
+     are now required to have a monotonic relation between them. The
+     method ``check_decision_proba_consistency`` has been added in
+     **sklearn.utils.estimator_checks** to check their consistency.
+     :issue:`7578` by :user:`Shubham Bhardwaj <shubham0704>`
+
+   - In version 0.21, the default behavior of splitters that use the
+     ``test_size`` and ``train_size`` parameter will change, such that
+     specifying ``train_size`` alone will cause ``test_size`` to be the
+     remainder. :issue:`7459` by :user:`Nelson Liu <nelson-liu>`.
+
+   - All tree based estimators now accept a ``min_impurity_decrease``
+     parameter in lieu of the ``min_impurity_split``, which is now deprecated.
+     The ``min_impurity_decrease`` helps stop splitting the nodes in which
+     the weighted impurity decrease from splitting is no longer alteast
+     ``min_impurity_decrease``.  :issue:`8449` by `Raghav RV`_.
+
+   - The ``n_topics`` parameter of :class:`decomposition.LatentDirichletAllocation`
+     has been renamed to ``n_components`` and will be removed in version 0.21.
+     :issue:`8922` by :user:`Attractadore`
+
+   - :class:`cluster.bicluster.SpectralCoclustering` and
+     :class:`cluster.bicluster.SpectralBiclustering` now accept ``y`` in fit.
+     :issue:`6126` by :user:ldirer
+
+   - :class:`neighbors.LSHForest` has been deprecated and will be
+     removed in 0.21 due to poor performance.
+     :issue:`8996` by `Andreas Müller`_.
+
+   - SciPy >= 0.13.3 and NumPy >= 1.8.2 are now the minimum supported versions
+     for scikit-learn. The following backported functions in
+     :mod:`sklearn.utils` have been removed or deprecated accordingly.
+     :issue:`8854` and :issue:`8874` by :user:`Naoya Kanai <naoyak>`
+
+     Removed in 0.19:
+
+     - ``utils.fixes.argpartition``
+     - ``utils.fixes.array_equal``
+     - ``utils.fixes.astype``
+     - ``utils.fixes.bincount``
+     - ``utils.fixes.expit``
+     - ``utils.fixes.frombuffer_empty``
+     - ``utils.fixes.in1d``
+     - ``utils.fixes.norm``
+     - ``utils.fixes.rankdata``
+     - ``utils.fixes.safe_copy``
+
+     Deprecated in 0.19, to be removed in 0.21:
+
+     - ``utils.arpack.eigs``
+     - ``utils.arpack.eigsh``
+     - ``utils.arpack.svds``
+     - ``utils.extmath.fast_dot``
+     - ``utils.extmath.logsumexp``
+     - ``utils.extmath.norm``
+     - ``utils.extmath.pinvh``
+     - ``utils.graph.graph_laplacian``
+     - ``utils.random.choice``
+     - ``utils.sparsetools.connected_components``
+     - ``utils.stats.rankdata``
+     - ``neighbors.approximate.LSHForest``
 
 - Gradient boosting base models are no longer estimators. By `Andreas Müller`_.
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -236,6 +236,10 @@ Trees and ensembles
   removed by setting it to ``None``.
   :issue:`7674` by :user:`Yichuan Liu <yl565>`.
 
+- Add `named_estimators_` parameter in
+  :class:`sklearn.ensemble.voting_classifier` to access fitted 
+  estimators. :issue:`9157` by :user:`Herilalaina Rakotoarison <herilalaina>`.
+
 - :func:`tree.export_graphviz` now shows configurable number of decimal
   places. :issue:`8698` by :user:`Guillaume Lemaitre <glemaitre>`.
 
@@ -739,133 +743,6 @@ API changes summary
 -------------------
 
 Trees and ensembles
-   - Ensure that estimators' attributes ending with ``_`` are not set
-     in the constructor but only in the ``fit`` method. Most notably,
-     ensemble estimators (deriving from :class:`ensemble.BaseEnsemble`)
-     now only have ``self.estimators_`` available after ``fit``.
-     :issue:`7464` by `Lars Buitinck`_ and `Loic Esteve`_.
-
-   - All checks in ``utils.estimator_checks``, in particular
-     :func:`utils.estimator_checks.check_estimator` now accept estimator
-     instances. Most other checks do not accept
-     estimator classes any more. :issue:`9019` by `Andreas Müller`_.
-
-   - Deprecate the ``doc_topic_distr`` argument of the ``perplexity`` method
-     in :class:`decomposition.LatentDirichletAllocation` because the
-     user no longer has access to the unnormalized document topic distribution
-     needed for the perplexity calculation. :issue:`7954` by
-     :user:`Gary Foreman <garyForeman>`.
-
-   - Replace attribute ``named_steps`` ``dict`` to :class:`utils.Bunch`
-     in :class:`pipeline.Pipeline` to enable tab completion in interactive
-     environment. In the case conflict value on ``named_steps`` and ``dict``
-     attribute, ``dict`` behavior will be prioritized.
-     :issue:`8481` by :user:`Herilalaina Rakotoarison <herilalaina>`.
-
-   - The :func:`multioutput.MultiOutputClassifier.predict_proba`
-     function used to return a 3d array (``n_samples``, ``n_classes``,
-     ``n_outputs``). In the case where different target columns had different
-     numbers of classes, a `ValueError` would be raised on trying to stack
-     matrices with different dimensions. This function now returns a list of
-     arrays where the length of the list is ``n_outputs``, and each array is
-     (``n_samples``, ``n_classes``) for that particular output.
-     :issue:`8093` by :user:`Peter Bull <pjbull>`.
-     
-   - Add `named_estimators_` parameter in
-   	 :class:`sklearn.ensemble.voting_classifier` to access fitted 
-   	 estimators. :issue:`9157` by
-   	 :user:`Herilalaina Rakotoarison <herilalaina>`.
-
-   - Deprecate the ``fit_params`` constructor input to the
-     :class:`model_selection.GridSearchCV` and
-     :class:`model_selection.RandomizedSearchCV` in favor
-     of passing keyword parameters to the ``fit`` methods
-     of those classes. Data-dependent parameters needed for model
-     training should be passed as keyword arguments to ``fit``,
-     and conforming to this convention will allow the hyperparameter
-     selection classes to be used with tools such as
-     :func:`model_selection.cross_val_predict`.
-     :issue:`2879` by :user:`Stephen Hoover <stephen-hoover>`.
-
-   - The ``decision_function`` output shape for binary classification in
-     :class:`multiclass.OneVsRestClassifier` and
-     :class:`multiclass.OneVsOneClassifier` is now ``(n_samples,)`` to conform
-     to scikit-learn conventions. :issue:`9100` by `Andreas Müller`_.
-
-   - Gradient boosting base models are no longer estimators. By `Andreas Müller`_.
-
-   - :class:`feature_selection.SelectFromModel` now validates the ``threshold``
-     parameter and sets the ``threshold_`` attribute during the call to
-     ``fit``, and no longer during the call to ``transform```, by `Andreas
-     Müller`_.
-
-   - :class:`feature_selection.SelectFromModel` now has a ``partial_fit``
-     method only if the underlying estimator does. By `Andreas Müller`_.
-
-   - :class:`multiclass.OneVsRestClassifier` now has a ``partial_fit`` method
-     only if the underlying estimator does.  By `Andreas Müller`_.
-
-   - Estimators with both methods ``decision_function`` and ``predict_proba``
-     are now required to have a monotonic relation between them. The
-     method ``check_decision_proba_consistency`` has been added in
-     **sklearn.utils.estimator_checks** to check their consistency.
-     :issue:`7578` by :user:`Shubham Bhardwaj <shubham0704>`
-
-   - In version 0.21, the default behavior of splitters that use the
-     ``test_size`` and ``train_size`` parameter will change, such that
-     specifying ``train_size`` alone will cause ``test_size`` to be the
-     remainder. :issue:`7459` by :user:`Nelson Liu <nelson-liu>`.
-
-   - All tree based estimators now accept a ``min_impurity_decrease``
-     parameter in lieu of the ``min_impurity_split``, which is now deprecated.
-     The ``min_impurity_decrease`` helps stop splitting the nodes in which
-     the weighted impurity decrease from splitting is no longer alteast
-     ``min_impurity_decrease``.  :issue:`8449` by `Raghav RV`_.
-
-   - The ``n_topics`` parameter of :class:`decomposition.LatentDirichletAllocation`
-     has been renamed to ``n_components`` and will be removed in version 0.21.
-     :issue:`8922` by :user:`Attractadore`
-
-   - :class:`cluster.bicluster.SpectralCoclustering` and
-     :class:`cluster.bicluster.SpectralBiclustering` now accept ``y`` in fit.
-     :issue:`6126` by :user:ldirer
-
-   - :class:`neighbors.LSHForest` has been deprecated and will be
-     removed in 0.21 due to poor performance.
-     :issue:`8996` by `Andreas Müller`_.
-
-   - SciPy >= 0.13.3 and NumPy >= 1.8.2 are now the minimum supported versions
-     for scikit-learn. The following backported functions in
-     :mod:`sklearn.utils` have been removed or deprecated accordingly.
-     :issue:`8854` and :issue:`8874` by :user:`Naoya Kanai <naoyak>`
-
-     Removed in 0.19:
-
-     - ``utils.fixes.argpartition``
-     - ``utils.fixes.array_equal``
-     - ``utils.fixes.astype``
-     - ``utils.fixes.bincount``
-     - ``utils.fixes.expit``
-     - ``utils.fixes.frombuffer_empty``
-     - ``utils.fixes.in1d``
-     - ``utils.fixes.norm``
-     - ``utils.fixes.rankdata``
-     - ``utils.fixes.safe_copy``
-
-     Deprecated in 0.19, to be removed in 0.21:
-
-     - ``utils.arpack.eigs``
-     - ``utils.arpack.eigsh``
-     - ``utils.arpack.svds``
-     - ``utils.extmath.fast_dot``
-     - ``utils.extmath.logsumexp``
-     - ``utils.extmath.norm``
-     - ``utils.extmath.pinvh``
-     - ``utils.graph.graph_laplacian``
-     - ``utils.random.choice``
-     - ``utils.sparsetools.connected_components``
-     - ``utils.stats.rankdata``
-     - ``neighbors.approximate.LSHForest``
 
 - Gradient boosting base models are no longer estimators. By `Andreas Müller`_.
 

--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -299,6 +299,8 @@ def test_set_params():
     eclf1.fit(X, y)
     assert_true('lr' in eclf1.named_estimators_)
     assert_true(eclf1.named_estimators_.lr is eclf1.estimators_[0])
+    assert_array_equal(eclf1.named_estimators_.lr.predict(X),
+                       eclf1.named_estimators_['lr'].predict(X))
 
     eclf2 = VotingClassifier([('lr', clf1), ('nb', clf3)], voting='soft',
                              weights=[1, 2])

--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -297,6 +297,9 @@ def test_set_params():
     eclf1 = VotingClassifier([('lr', clf1), ('rf', clf2)], voting='soft',
                              weights=[1, 2])
     eclf1.fit(X, y)
+    assert_true('lr' in eclf1.named_estimators_)
+    assert_true(eclf1.named_estimators_.lr is eclf1.estimators_[0])
+
     eclf2 = VotingClassifier([('lr', clf1), ('nb', clf3)], voting='soft',
                              weights=[1, 2])
     eclf2.set_params(nb=clf2).fit(X, y)

--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -299,7 +299,7 @@ def test_set_params():
     eclf1.fit(X, y)
     assert_true('lr' in eclf1.named_estimators_)
     assert_true(eclf1.named_estimators_.lr is eclf1.estimators_[0])
-    assert_true(eclf1.named_estimators_.lr is eclf1.estimators_['lr'])
+    assert_true(eclf1.named_estimators_.lr is eclf1.named_estimators_['lr'])
 
     eclf2 = VotingClassifier([('lr', clf1), ('nb', clf3)], voting='soft',
                              weights=[1, 2])

--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -296,6 +296,9 @@ def test_set_params():
     clf3 = GaussianNB()
     eclf1 = VotingClassifier([('lr', clf1), ('rf', clf2)], voting='soft',
                              weights=[1, 2])
+    assert_true('lr' in eclf1.named_estimators)
+    assert_true(eclf1.named_estimators.lr is eclf1.estimators[0][1])
+    assert_true(eclf1.named_estimators.lr is eclf1.named_estimators['lr'])
     eclf1.fit(X, y)
     assert_true('lr' in eclf1.named_estimators_)
     assert_true(eclf1.named_estimators_.lr is eclf1.estimators_[0])

--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -299,8 +299,7 @@ def test_set_params():
     eclf1.fit(X, y)
     assert_true('lr' in eclf1.named_estimators_)
     assert_true(eclf1.named_estimators_.lr is eclf1.estimators_[0])
-    assert_array_equal(eclf1.named_estimators_.lr.predict(X),
-                       eclf1.named_estimators_['lr'].predict(X))
+    assert_true(eclf1.named_estimators_.lr is eclf1.estimators_['lr'])
 
     eclf2 = VotingClassifier([('lr', clf1), ('nb', clf3)], voting='soft',
                              weights=[1, 2])

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -131,7 +131,7 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
 
     @property
     def named_estimators(self):
-        return dict(self.estimators)
+        return Bunch(**dict(self.estimators))
 
     def fit(self, X, y, sample_weight=None):
         """ Fit the estimators.

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -79,6 +79,8 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
     named_estimators_ : Bunch object, a dictionary with attribute access
         Attribute to access any fitted sub-estimators by name.
 
+        .. versionadded:: 0.19
+
     classes_ : array-like, shape = [n_predictions]
         The classes labels.
 

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -76,7 +76,7 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
         The collection of fitted sub-estimators as defined in ``estimators``
         that are not `None`.
 
-    named_estimators_ : bunch object, a dictionary with attribute access
+    named_estimators_ : Bunch object, a dictionary with attribute access
         Attribute to access any fitted sub-estimators by name.
 
     classes_ : array-like, shape = [n_predictions]
@@ -99,7 +99,7 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
     >>> print(eclf1.predict(X))
     [1 1 1 2 2 2]
     >>> np.array_equal(eclf1.named_estimators_.lr.predict(X),
-    ...         eclf1.named_estimators_['lr'].predict(X))
+    ...                eclf1.named_estimators_['lr'].predict(X))
     True
     >>> eclf2 = VotingClassifier(estimators=[
     ...         ('lr', clf1), ('rf', clf2), ('gnb', clf3)],

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -79,7 +79,7 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
     named_estimators_ : Bunch object, a dictionary with attribute access
         Attribute to access any fitted sub-estimators by name.
 
-        .. versionadded:: 0.19
+        .. versionadded:: 0.20
 
     classes_ : array-like, shape = [n_predictions]
         The classes labels.

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -98,8 +98,8 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
     >>> eclf1 = eclf1.fit(X, y)
     >>> print(eclf1.predict(X))
     [1 1 1 2 2 2]
-    >>> eclf1.named_estimators_.lr.predict(X) == eclf1
-    ...         .named_estimators_['lr'].predict(X)
+    >>> np.array_equal(eclf1.named_estimators_.lr.predict(X),
+    ...         eclf1.named_estimators_['lr'].predict(X))
     True
     >>> eclf2 = VotingClassifier(estimators=[
     ...         ('lr', clf1), ('rf', clf2), ('gnb', clf3)],

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -77,7 +77,7 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
         that are not `None`.
 
     named_estimators_ : bunch object, a dictionary with attribute access
-        Attribute to access any fitted sub-estimators by user given name.
+        Attribute to access any fitted sub-estimators by name.
 
     classes_ : array-like, shape = [n_predictions]
         The classes labels.
@@ -98,7 +98,8 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
     >>> eclf1 = eclf1.fit(X, y)
     >>> print(eclf1.predict(X))
     [1 1 1 2 2 2]
-    >>> eclf1.named_estimators_.lr == eclf1.named_estimators_['lr']
+    >>> eclf1.named_estimators_.lr.predict(X) == eclf1
+    ...         .named_estimators_['lr'].predict(X)
     True
     >>> eclf2 = VotingClassifier(estimators=[
     ...         ('lr', clf1), ('rf', clf2), ('gnb', clf3)],

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -21,6 +21,7 @@ from ..preprocessing import LabelEncoder
 from ..externals.joblib import Parallel, delayed
 from ..utils.validation import has_fit_parameter, check_is_fitted
 from ..utils.metaestimators import _BaseComposition
+from ..utils import Bunch
 
 
 def _parallel_fit_estimator(estimator, X, y, sample_weight=None):
@@ -187,7 +188,9 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
                 delayed(_parallel_fit_estimator)(clone(clf), X, transformed_y,
                                                  sample_weight=sample_weight)
                 for clf in clfs if clf is not None)
-
+        self.named_estimators_ = Bunch(**dict())
+        for k, e in zip(self.estimators, self.estimators_):
+            self.named_estimators_[k[0]] = e
         return self
 
     @property

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -76,6 +76,9 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
         The collection of fitted sub-estimators as defined in ``estimators``
         that are not `None`.
 
+    named_estimators_ : bunch object, a dictionary with attribute access
+        Attribute to access any fitted sub-estimators by user given name.
+
     classes_ : array-like, shape = [n_predictions]
         The classes labels.
 
@@ -95,6 +98,8 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
     >>> eclf1 = eclf1.fit(X, y)
     >>> print(eclf1.predict(X))
     [1 1 1 2 2 2]
+    >>> eclf1.named_estimators_.lr == eclf1.named_estimators_['lr']
+    True
     >>> eclf2 = VotingClassifier(estimators=[
     ...         ('lr', clf1), ('rf', clf2), ('gnb', clf3)],
     ...         voting='soft')
@@ -188,6 +193,7 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
                 delayed(_parallel_fit_estimator)(clone(clf), X, transformed_y,
                                                  sample_weight=sample_weight)
                 for clf in clfs if clf is not None)
+
         self.named_estimators_ = Bunch(**dict())
         for k, e in zip(self.estimators, self.estimators_):
             self.named_estimators_[k[0]] = e


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes  #9157

#### What does this implement/fix? Explain your changes.
Add new `bunch` like property `named_estimators_` in voting classifier class to access fitted estimator.

#### Any other comments?
Should we also change `named_estimator` into bunch?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
