### PR TITLE
[MRG] ENH make rng seed thread safe everywhere it is possible

### DIFF
--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -7,6 +7,7 @@ from sklearn.utils.testing import (assert_equal, assert_array_almost_equal,
 from sklearn.datasets import load_linnerud
 from sklearn.cross_decomposition import pls_, CCA
 from sklearn.preprocessing import StandardScaler
+from sklearn.utils import check_random_state
 
 
 def test_pls():
@@ -167,17 +168,17 @@ def test_pls():
     p_noise = 10
     q_noise = 5
     # 2 latents vars:
-    np.random.seed(11)
-    l1 = np.random.normal(size=n)
-    l2 = np.random.normal(size=n)
+    rng = check_random_state(11)
+    l1 = rng.normal(size=n)
+    l2 = rng.normal(size=n)
     latents = np.array([l1, l1, l2, l2]).T
-    X = latents + np.random.normal(size=4 * n).reshape((n, 4))
-    Y = latents + np.random.normal(size=4 * n).reshape((n, 4))
+    X = latents + rng.normal(size=4 * n).reshape((n, 4))
+    Y = latents + rng.normal(size=4 * n).reshape((n, 4))
     X = np.concatenate(
-        (X, np.random.normal(size=p_noise * n).reshape(n, p_noise)), axis=1)
+        (X, rng.normal(size=p_noise * n).reshape(n, p_noise)), axis=1)
     Y = np.concatenate(
-        (Y, np.random.normal(size=q_noise * n).reshape(n, q_noise)), axis=1)
-    np.random.seed(None)
+        (Y, rng.normal(size=q_noise * n).reshape(n, q_noise)), axis=1)
+
     pls_ca = pls_.PLSCanonical(n_components=3)
     pls_ca.fit(X, Y)
 
@@ -372,7 +373,7 @@ def test_pls_scaling():
     n_targets = 5
     n_features = 10
 
-    rng = np.random.RandomState(0)
+    rng = check_random_state(0)
 
     Q = rng.randn(n_targets, n_features)
     Y = rng.randn(n_samples, n_targets)

--- a/sklearn/feature_selection/tests/test_mutual_info.py
+++ b/sklearn/feature_selection/tests/test_mutual_info.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import run_module_suite
 from scipy.sparse import csr_matrix
 
+from sklearn.utils import check_random_state
 from sklearn.utils.testing import (assert_array_equal, assert_almost_equal,
                                    assert_false, assert_raises, assert_equal,
                                    assert_allclose, assert_greater)
@@ -44,8 +45,8 @@ def test_compute_mi_cc():
     I_theory = (np.log(sigma_1) + np.log(sigma_2) -
                 0.5 * np.log(np.linalg.det(cov)))
 
-    np.random.seed(0)
-    Z = np.random.multivariate_normal(mean, cov, size=1000)
+    rng = check_random_state(0)
+    Z = rng.multivariate_normal(mean, cov, size=1000)
 
     x, y = Z[:, 0], Z[:, 1]
 
@@ -73,15 +74,15 @@ def test_compute_mi_cd():
     # done easily using conditional distribution logic.
 
     n_samples = 1000
-    np.random.seed(0)
+    rng = check_random_state(0)
 
     for p in [0.3, 0.5, 0.7]:
-        x = np.random.uniform(size=n_samples) > p
+        x = rng.uniform(size=n_samples) > p
 
         y = np.empty(n_samples)
         mask = x == 0
-        y[mask] = np.random.uniform(-1, 1, size=np.sum(mask))
-        y[~mask] = np.random.uniform(0, 2, size=np.sum(~mask))
+        y[mask] = rng.uniform(-1, 1, size=np.sum(mask))
+        y[~mask] = rng.uniform(0, 2, size=np.sum(~mask))
 
         I_theory = -0.5 * ((1 - p) * np.log(0.5 * (1 - p)) +
                            p * np.log(0.5 * p) + np.log(0.5)) - np.log(2)
@@ -141,8 +142,8 @@ def test_mutual_info_regression():
     cov = T.dot(T.T)
     mean = np.zeros(4)
 
-    np.random.seed(0)
-    Z = np.random.multivariate_normal(mean, cov, size=1000)
+    rng = check_random_state(0)
+    Z = rng.multivariate_normal(mean, cov, size=1000)
     X = Z[:, 1:]
     y = Z[:, 0]
 
@@ -153,8 +154,8 @@ def test_mutual_info_regression():
 def test_mutual_info_classif_mixed():
     # Here the target is discrete and there are two continuous and one
     # discrete feature. The idea of this test is clear from the code.
-    np.random.seed(0)
-    X = np.random.rand(1000, 3)
+    rng = check_random_state(0)
+    X = rng.rand(1000, 3)
     X[:, 1] += X[:, 0]
     y = ((0.5 * X[:, 0] + X[:, 2]) > 0.5).astype(int)
     X[:, 2] = X[:, 2] > 0.5

--- a/sklearn/gaussian_process/tests/test_gaussian_process.py
+++ b/sklearn/gaussian_process/tests/test_gaussian_process.py
@@ -144,7 +144,6 @@ def test_random_starts():
     # Test that an increasing number of random-starts of GP fitting only
     # increases the reduced likelihood function of the optimal theta.
     n_samples, n_features = 50, 3
-    np.random.seed(0)
     rng = np.random.RandomState(0)
     X = rng.randn(n_samples, n_features) * 2 - 1
     y = np.sin(X).sum(axis=1) + np.sin(3 * X).sum(axis=1)

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -93,7 +93,6 @@ def test_random_starts():
     # Test that an increasing number of random-starts of GP fitting only
     # increases the log marginal likelihood of the chosen theta.
     n_samples, n_features = 25, 2
-    np.random.seed(0)
     rng = np.random.RandomState(0)
     X = rng.randn(n_samples, n_features) * 2 - 1
     y = (np.sin(X).sum(axis=1) + np.sin(3 * X).sum(axis=1)) > 0

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -175,7 +175,6 @@ def test_random_starts():
     # Test that an increasing number of random-starts of GP fitting only
     # increases the log marginal likelihood of the chosen theta.
     n_samples, n_features = 25, 2
-    np.random.seed(0)
     rng = np.random.RandomState(0)
     X = rng.randn(n_samples, n_features) * 2 - 1
     y = np.sin(X).sum(axis=1) + np.sin(3 * X).sum(axis=1) \

--- a/sklearn/neighbors/tests/test_ball_tree.py
+++ b/sklearn/neighbors/tests/test_ball_tree.py
@@ -5,11 +5,12 @@ from sklearn.neighbors.ball_tree import (BallTree, NeighborsHeap,
                                          simultaneous_sort, kernel_norm,
                                          nodeheap_sort, DTYPE, ITYPE)
 from sklearn.neighbors.dist_metrics import DistanceMetric
+from sklearn.utils import check_random_state
 from sklearn.utils.testing import SkipTest, assert_allclose
 
 rng = np.random.RandomState(10)
-V = rng.rand(3, 3)
-V = np.dot(V, V.T)
+V_mahalanobis = rng.rand(3, 3)
+V_mahalanobis = np.dot(V_mahalanobis, V_mahalanobis.T)
 
 DIMENSION = 3
 
@@ -17,9 +18,9 @@ METRICS = {'euclidean': {},
            'manhattan': {},
            'minkowski': dict(p=3),
            'chebyshev': {},
-           'seuclidean': dict(V=np.random.random(DIMENSION)),
-           'wminkowski': dict(p=3, w=np.random.random(DIMENSION)),
-           'mahalanobis': dict(V=V)}
+           'seuclidean': dict(V=rng.random_sample(DIMENSION)),
+           'wminkowski': dict(p=3, w=rng.random_sample(DIMENSION)),
+           'mahalanobis': dict(V=V_mahalanobis)}
 
 DISCRETE_METRICS = ['hamming',
                     'canberra',
@@ -42,9 +43,9 @@ def brute_force_neighbors(X, Y, k, metric, **kwargs):
 
 
 def test_ball_tree_query():
-    np.random.seed(0)
-    X = np.random.random((40, DIMENSION))
-    Y = np.random.random((10, DIMENSION))
+    rng = check_random_state(0)
+    X = rng.random_sample((40, DIMENSION))
+    Y = rng.random_sample((10, DIMENSION))
 
     def check_neighbors(dualtree, breadth_first, k, metric, kwargs):
         bt = BallTree(X, leaf_size=1, metric=metric, **kwargs)
@@ -66,9 +67,9 @@ def test_ball_tree_query():
 
 
 def test_ball_tree_query_boolean_metrics():
-    np.random.seed(0)
-    X = np.random.random((40, 10)).round(0)
-    Y = np.random.random((10, 10)).round(0)
+    rng = check_random_state(0)
+    X = rng.random_sample((40, 10)).round(0)
+    Y = rng.random_sample((10, 10)).round(0)
     k = 5
 
     def check_neighbors(metric):
@@ -82,9 +83,9 @@ def test_ball_tree_query_boolean_metrics():
 
 
 def test_ball_tree_query_discrete_metrics():
-    np.random.seed(0)
-    X = (4 * np.random.random((40, 10))).round(0)
-    Y = (4 * np.random.random((10, 10))).round(0)
+    rng = check_random_state(0)
+    X = (4 * rng.random_sample((40, 10))).round(0)
+    Y = (4 * rng.random_sample((10, 10))).round(0)
     k = 5
 
     def check_neighbors(metric):
@@ -98,8 +99,8 @@ def test_ball_tree_query_discrete_metrics():
 
 
 def test_ball_tree_query_radius(n_samples=100, n_features=10):
-    np.random.seed(0)
-    X = 2 * np.random.random(size=(n_samples, n_features)) - 1
+    rng = check_random_state(0)
+    X = 2 * rng.random_sample(size=(n_samples, n_features)) - 1
     query_pt = np.zeros(n_features, dtype=float)
 
     eps = 1E-15  # roundoff error can cause test to fail
@@ -117,8 +118,8 @@ def test_ball_tree_query_radius(n_samples=100, n_features=10):
 
 
 def test_ball_tree_query_radius_distance(n_samples=100, n_features=10):
-    np.random.seed(0)
-    X = 2 * np.random.random(size=(n_samples, n_features)) - 1
+    rng = check_random_state(0)
+    X = 2 * rng.random_sample(size=(n_samples, n_features)) - 1
     query_pt = np.zeros(n_features, dtype=float)
 
     eps = 1E-15  # roundoff error can cause test to fail
@@ -165,9 +166,9 @@ def check_results(kernel, h, atol, rtol, breadth_first, bt, Y, dens_true):
 
 
 def test_ball_tree_kde(n_samples=100, n_features=3):
-    np.random.seed(0)
-    X = np.random.random((n_samples, n_features))
-    Y = np.random.random((n_samples, n_features))
+    rng = check_random_state(0)
+    X = rng.random_sample((n_samples, n_features))
+    Y = rng.random_sample((n_samples, n_features))
     bt = BallTree(X, leaf_size=10)
 
     for kernel in ['gaussian', 'tophat', 'epanechnikov',
@@ -185,8 +186,8 @@ def test_ball_tree_kde(n_samples=100, n_features=3):
 def test_gaussian_kde(n_samples=1000):
     # Compare gaussian KDE results to scipy.stats.gaussian_kde
     from scipy.stats import gaussian_kde
-    np.random.seed(0)
-    x_in = np.random.normal(0, 1, n_samples)
+    rng = check_random_state(0)
+    x_in = rng.normal(0, 1, n_samples)
     x_out = np.linspace(-5, 5, 30)
 
     for h in [0.01, 0.1, 1]:
@@ -204,9 +205,9 @@ def test_gaussian_kde(n_samples=1000):
 
 
 def test_ball_tree_two_point(n_samples=100, n_features=3):
-    np.random.seed(0)
-    X = np.random.random((n_samples, n_features))
-    Y = np.random.random((n_samples, n_features))
+    rng = check_random_state(0)
+    X = rng.random_sample((n_samples, n_features))
+    Y = rng.random_sample((n_samples, n_features))
     r = np.linspace(0, 1, 10)
     bt = BallTree(X, leaf_size=10)
 
@@ -222,8 +223,8 @@ def test_ball_tree_two_point(n_samples=100, n_features=3):
 
 
 def test_ball_tree_pickle():
-    np.random.seed(0)
-    X = np.random.random((10, 3))
+    rng = check_random_state(0)
+    X = rng.random_sample((10, 3))
 
     bt1 = BallTree(X, leaf_size=1)
     # Test if BallTree with callable metric is picklable
@@ -256,7 +257,7 @@ def test_neighbors_heap(n_pts=5, n_nbrs=10):
     heap = NeighborsHeap(n_pts, n_nbrs)
 
     for row in range(n_pts):
-        d_in = np.random.random(2 * n_nbrs).astype(DTYPE)
+        d_in = rng.random_sample(2 * n_nbrs).astype(DTYPE)
         i_in = np.arange(2 * n_nbrs, dtype=ITYPE)
         for d, i in zip(d_in, i_in):
             heap.push(row, d, i)
@@ -272,7 +273,7 @@ def test_neighbors_heap(n_pts=5, n_nbrs=10):
 
 
 def test_node_heap(n_nodes=50):
-    vals = np.random.random(n_nodes).astype(DTYPE)
+    vals = rng.random_sample(n_nodes).astype(DTYPE)
 
     i1 = np.argsort(vals)
     vals2, i2 = nodeheap_sort(vals)
@@ -282,7 +283,7 @@ def test_node_heap(n_nodes=50):
 
 
 def test_simultaneous_sort(n_rows=10, n_pts=201):
-    dist = np.random.random((n_rows, n_pts)).astype(DTYPE)
+    dist = rng.random_sample((n_rows, n_pts)).astype(DTYPE)
     ind = (np.arange(n_pts) + np.zeros((n_rows, 1))).astype(ITYPE)
 
     dist2 = dist.copy()
@@ -302,8 +303,8 @@ def test_simultaneous_sort(n_rows=10, n_pts=201):
 
 
 def test_query_haversine():
-    np.random.seed(0)
-    X = 2 * np.pi * np.random.random((40, 2))
+    rng = check_random_state(0)
+    X = 2 * np.pi * rng.random_sample((40, 2))
     bt = BallTree(X, leaf_size=1, metric='haversine')
     dist1, ind1 = bt.query(X, k=5)
     dist2, ind2 = brute_force_neighbors(X, X, k=5, metric='haversine')

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_array_almost_equal
 from scipy.spatial.distance import cdist
 from sklearn.neighbors.dist_metrics import DistanceMetric
 from sklearn.neighbors import BallTree
+from sklearn.utils import check_random_state
 from sklearn.utils.testing import assert_raises_regex
 
 
@@ -17,24 +18,24 @@ def dist_func(x1, x2, p):
 class TestMetrics:
     def __init__(self, n1=20, n2=25, d=4, zero_frac=0.5,
                  rseed=0, dtype=np.float64):
-        np.random.seed(rseed)
-        self.X1 = np.random.random((n1, d)).astype(dtype)
-        self.X2 = np.random.random((n2, d)).astype(dtype)
+        rng = check_random_state(rseed)
+        self.X1 = rng.random_sample((n1, d)).astype(dtype)
+        self.X2 = rng.random_sample((n2, d)).astype(dtype)
 
         # make boolean arrays: ones and zeros
         self.X1_bool = self.X1.round(0)
         self.X2_bool = self.X2.round(0)
 
-        V = np.random.random((d, d))
+        V = rng.random_sample((d, d))
         VI = np.dot(V, V.T)
 
         self.metrics = {'euclidean': {},
                         'cityblock': {},
                         'minkowski': dict(p=(1, 1.5, 2, 3)),
                         'chebyshev': {},
-                        'seuclidean': dict(V=(np.random.random(d),)),
+                        'seuclidean': dict(V=(rng.random_sample(d),)),
                         'wminkowski': dict(p=(1, 1.5, 3),
-                                           w=(np.random.random(d),)),
+                                           w=(rng.random_sample(d),)),
                         'mahalanobis': dict(VI=(VI,)),
                         'hamming': {},
                         'canberra': {},
@@ -172,7 +173,7 @@ def test_input_data_size():
         assert x.shape[0] == 3
         return np.sum((x - y) ** 2)
 
-    rng = np.random.RandomState(0)
+    rng = check_random_state(0)
     X = rng.rand(10, 3)
 
     pyfunc = DistanceMetric.get_metric("pyfunc", func=dist_func, p=2)

--- a/sklearn/neighbors/tests/test_kd_tree.py
+++ b/sklearn/neighbors/tests/test_kd_tree.py
@@ -4,9 +4,11 @@ from sklearn.neighbors.kd_tree import (KDTree, NeighborsHeap,
                                        simultaneous_sort, kernel_norm,
                                        nodeheap_sort, DTYPE, ITYPE)
 from sklearn.neighbors.dist_metrics import DistanceMetric
+from sklearn.utils import check_random_state
 from sklearn.utils.testing import SkipTest, assert_allclose
 
-V = np.random.random((3, 3))
+rng = np.random.RandomState(42)
+V = rng.random_sample((3, 3))
 V = np.dot(V, V.T)
 
 DIMENSION = 3
@@ -36,9 +38,9 @@ def check_neighbors(dualtree, breadth_first, k, metric, X, Y, kwargs):
 
 
 def test_kd_tree_query():
-    np.random.seed(0)
-    X = np.random.random((40, DIMENSION))
-    Y = np.random.random((10, DIMENSION))
+    rng = check_random_state(0)
+    X = rng.random_sample((40, DIMENSION))
+    Y = rng.random_sample((10, DIMENSION))
 
     for (metric, kwargs) in METRICS.items():
         for k in (1, 3, 5):
@@ -50,8 +52,8 @@ def test_kd_tree_query():
 
 
 def test_kd_tree_query_radius(n_samples=100, n_features=10):
-    np.random.seed(0)
-    X = 2 * np.random.random(size=(n_samples, n_features)) - 1
+    rng = check_random_state(0)
+    X = 2 * rng.random_sample(size=(n_samples, n_features)) - 1
     query_pt = np.zeros(n_features, dtype=float)
 
     eps = 1E-15  # roundoff error can cause test to fail
@@ -69,8 +71,8 @@ def test_kd_tree_query_radius(n_samples=100, n_features=10):
 
 
 def test_kd_tree_query_radius_distance(n_samples=100, n_features=10):
-    np.random.seed(0)
-    X = 2 * np.random.random(size=(n_samples, n_features)) - 1
+    rng = check_random_state(0)
+    X = 2 * rng.random_sample(size=(n_samples, n_features)) - 1
     query_pt = np.zeros(n_features, dtype=float)
 
     eps = 1E-15  # roundoff error can cause test to fail
@@ -117,9 +119,9 @@ def check_results(kernel, h, atol, rtol, breadth_first, Y, kdt, dens_true):
 
 
 def test_kd_tree_kde(n_samples=100, n_features=3):
-    np.random.seed(0)
-    X = np.random.random((n_samples, n_features))
-    Y = np.random.random((n_samples, n_features))
+    rng = check_random_state(0)
+    X = rng.random_sample((n_samples, n_features))
+    Y = rng.random_sample((n_samples, n_features))
     kdt = KDTree(X, leaf_size=10)
 
     for kernel in ['gaussian', 'tophat', 'epanechnikov',
@@ -137,8 +139,8 @@ def test_kd_tree_kde(n_samples=100, n_features=3):
 def test_gaussian_kde(n_samples=1000):
     # Compare gaussian KDE results to scipy.stats.gaussian_kde
     from scipy.stats import gaussian_kde
-    np.random.seed(0)
-    x_in = np.random.normal(0, 1, n_samples)
+    rng = check_random_state(0)
+    x_in = rng.normal(0, 1, n_samples)
     x_out = np.linspace(-5, 5, 30)
 
     for h in [0.01, 0.1, 1]:
@@ -155,9 +157,9 @@ def test_gaussian_kde(n_samples=1000):
 
 
 def test_kd_tree_two_point(n_samples=100, n_features=3):
-    np.random.seed(0)
-    X = np.random.random((n_samples, n_features))
-    Y = np.random.random((n_samples, n_features))
+    rng = check_random_state(0)
+    X = rng.random_sample((n_samples, n_features))
+    Y = rng.random_sample((n_samples, n_features))
     r = np.linspace(0, 1, 10)
     kdt = KDTree(X, leaf_size=10)
 
@@ -174,8 +176,8 @@ def test_kd_tree_two_point(n_samples=100, n_features=3):
 
 def test_kd_tree_pickle():
     import pickle
-    np.random.seed(0)
-    X = np.random.random((10, 3))
+    rng = check_random_state(0)
+    X = rng.random_sample((10, 3))
     kdt1 = KDTree(X, leaf_size=1)
     ind1, dist1 = kdt1.query(X)
 
@@ -194,7 +196,7 @@ def test_neighbors_heap(n_pts=5, n_nbrs=10):
     heap = NeighborsHeap(n_pts, n_nbrs)
 
     for row in range(n_pts):
-        d_in = np.random.random(2 * n_nbrs).astype(DTYPE)
+        d_in = rng.random_sample(2 * n_nbrs).astype(DTYPE)
         i_in = np.arange(2 * n_nbrs, dtype=ITYPE)
         for d, i in zip(d_in, i_in):
             heap.push(row, d, i)
@@ -210,7 +212,7 @@ def test_neighbors_heap(n_pts=5, n_nbrs=10):
 
 
 def test_node_heap(n_nodes=50):
-    vals = np.random.random(n_nodes).astype(DTYPE)
+    vals = rng.random_sample(n_nodes).astype(DTYPE)
 
     i1 = np.argsort(vals)
     vals2, i2 = nodeheap_sort(vals)
@@ -220,7 +222,7 @@ def test_node_heap(n_nodes=50):
 
 
 def test_simultaneous_sort(n_rows=10, n_pts=201):
-    dist = np.random.random((n_rows, n_pts)).astype(DTYPE)
+    dist = rng.random_sample((n_rows, n_pts)).astype(DTYPE)
     ind = (np.arange(n_pts) + np.zeros((n_rows, 1))).astype(ITYPE)
 
     dist2 = dist.copy()

--- a/sklearn/neighbors/tests/test_kde.py
+++ b/sklearn/neighbors/tests/test_kde.py
@@ -112,10 +112,10 @@ def test_kde_algorithm_metric_choice():
 
 def test_kde_score(n_samples=100, n_features=3):
     pass
-    #FIXME
-    #np.random.seed(0)
-    #X = np.random.random((n_samples, n_features))
-    #Y = np.random.random((n_samples, n_features))
+    # FIXME
+    # rng = np.random.RandomState(0)
+    # X = rng.random_sample((n_samples, n_features))
+    # Y = rng.random_sample((n_samples, n_features))
 
 
 def test_kde_badargs():


### PR DESCRIPTION
Intend to fix usage of `np.random.seed` in testing suit as it is not thread safe.
Fix #9178 

It is not possible to not use `np.random.seed` in:
- `sklearn/decomposition/tests/test_fastica.py`: scipy.stats uses the global RNG

I am not sure about:
- `sklearn/gaussian_process/tests/test_gaussian_process.py:test_random_starts`
- `sklearn/gaussian_process/tests/test_gpc.py:test_random_starts`
- `sklearn/gaussian_process/tests/test_gpr.py:test_random_starts`

For these three tests, I do not know if it is safe to remove the `np.random.seed(0)`.