### PR TITLE
[MRG+1] MAINT Bump Python, scipy and numpy versions for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,12 +25,12 @@ environment:
       PYTHON_VERSION: "2.7.8"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.0"
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.1"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.0"
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.1"
       PYTHON_ARCH: "64"
 
 

--- a/build_tools/appveyor/requirements.txt
+++ b/build_tools/appveyor/requirements.txt
@@ -7,8 +7,8 @@
 # fix the versions of numpy to force the use of numpy and scipy to use the whl
 # of the rackspace folder instead of trying to install from more recent
 # source tarball published on PyPI
-numpy==1.9.3
-scipy==0.16.0
+numpy==1.13.0
+scipy==0.19.0
 cython
 nose
 nose-timer


### PR DESCRIPTION
I have uploaded the matching versions of numpy / scipy to the rackspace object container.