### PR TITLE
[MRG+3] ENH Speed up StratifiedShuffleSplit

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -217,6 +217,9 @@ Enhancements
      :mod:`feature_extraction.text` by binding methods for loops and
      special-casing unigrams. :issue:`7567` by `Jaye Doepke <jtdoepke>`
 
+   - Speed improvements to :class:`model_selection.StratifiedShuffleSplit`.
+     :issue:`5991` by :user:`Arthur Mensch <arthurmensch>` and `Joel Nothman`_.
+
 Bug fixes
 .........
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1521,6 +1521,11 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
                              'equal to the number of classes = %d' %
                              (n_test, n_classes))
 
+        # Find the sorted list of instances for each class:
+        # (np.unique above performs a sort, so code is O(n logn) already
+        class_indices = np.split(np.argsort(y_indices, kind='mergesort'),
+                                 np.cumsum(class_counts)[:-1])
+
         rng = check_random_state(self.random_state)
 
         for _ in range(self.n_splits):
@@ -1533,12 +1538,14 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
             train = []
             test = []
 
-            for i, class_i in enumerate(classes):
+            for i in range(n_classes):
                 permutation = rng.permutation(class_counts[i])
-                perm_indices_class_i = np.where((y == class_i))[0][permutation]
+                perm_indices_class_i = class_indices[i].take(permutation,
+                                                             mode='clip')
 
                 train.extend(perm_indices_class_i[:n_i[i]])
                 test.extend(perm_indices_class_i[n_i[i]:n_i[i] + t_i[i]])
+
             train = rng.permutation(train)
             test = rng.permutation(test)
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1522,7 +1522,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
                              (n_test, n_classes))
 
         # Find the sorted list of instances for each class:
-        # (np.unique above performs a sort, so code is O(n logn) already
+        # (np.unique above performs a sort, so code is O(n logn) already)
         class_indices = np.split(np.argsort(y_indices, kind='mergesort'),
                                  np.cumsum(class_counts)[:-1])
 


### PR DESCRIPTION
Fixes #5991

I decided @arthurmensch's performance enhancement to StratifiedShuffleSplit was simple enough, of obvious benefit, and worth having in the coming release. I have edited it here.

A rough benchmark script:

```python
from sklearn.model_selection import StratifiedShuffleSplit
import time
import numpy as np

print('n_classes', 'n_samples', 'time')
for n_classes in [5, 100, 1000]:
    for n_samples in [10000, 100000, 1000000]:
        y = np.random.randint(n_classes, size=n_samples)
        s = time.time()
        list(StratifiedShuffleSplit(n_splits=200).split(y, y))
        print(n_classes, n_samples, time.time() - s)
```

Results:

|n_classes|n_samples|master|pr|
|--|--|--|--|
|5|10000|0.4|0.4|
|5|100000|4.1|3.5|
|5|1000000|46.8|41.0|
|100|10000|1.0|0.7|
|100|100000|5.9|4.0|
|100|1000000|67.0|41.6|
|1000|10000|5.8|3.8|
|1000|100000|23.8|7.2|
|1000|1000000|275.2|44.7|

The determinism does not change (which is a bit of a pity, because I would have liked to [simplify `_approximate_mode`](https://github.com/scikit-learn/scikit-learn/issues/5991#issuecomment-310046206)), but that would break backwards compatibility.
