### PR TITLE
DOC fixed OneClassSVM.coef_ documentation

### DIFF
--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -1002,7 +1002,7 @@ class OneClassSVM(BaseLibSVM):
     dual_coef_ : array, shape = [n_classes-1, n_SV]
         Coefficients of the support vectors in the decision function.
 
-    coef_ : array, shape = [n_classes-1, n_features]
+    coef_ : array, shape = [1, n_features]
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -999,7 +999,7 @@ class OneClassSVM(BaseLibSVM):
     support_vectors_ : array-like, shape = [nSV, n_features]
         Support vectors.
 
-    dual_coef_ : array, shape = [n_classes-1, n_SV]
+    dual_coef_ : array, shape = [1, n_SV]
         Coefficients of the support vectors in the decision function.
 
     coef_ : array, shape = [1, n_features]
@@ -1009,8 +1009,8 @@ class OneClassSVM(BaseLibSVM):
         `coef_` is readonly property derived from `dual_coef_` and
         `support_vectors_`
 
-    intercept_ : array, shape = [n_classes-1]
-        Constants in decision function.
+    intercept_ : array, shape = [1,]
+        Constant in the decision function.
 
     """
     def __init__(self, kernel='rbf', degree=3, gamma='auto', coef0=0.0,


### PR DESCRIPTION
OneClassSVM implies there is a single class, so n_class-1 reads like `0`. I've changed docstring to state the `coef_` dimension explicitly.