### PR TITLE
Fix typos

### DIFF
--- a/sklearn/datasets/tests/test_svmlight_format.py
+++ b/sklearn/datasets/tests/test_svmlight_format.py
@@ -442,7 +442,7 @@ def test_load_with_offsets():
         mark_2 = 4 * size // 5
         length_1 = mark_2 - mark_1
 
-        # load the original sparse matrix into 3 independant CSR matrices
+        # load the original sparse matrix into 3 independent CSR matrices
         X_0, y_0 = load_svmlight_file(f, n_features=n_features,
                                       offset=mark_0, length=length_0)
         X_1, y_1 = load_svmlight_file(f, n_features=n_features,

--- a/sklearn/feature_selection/base.py
+++ b/sklearn/feature_selection/base.py
@@ -17,7 +17,7 @@ from ..externals import six
 
 class SelectorMixin(six.with_metaclass(ABCMeta, TransformerMixin)):
     """
-    Tranformer mixin that performs feature selection given a support mask
+    Transformer mixin that performs feature selection given a support mask
 
     This mixin provides a feature selector implementation with `transform` and
     `inverse_transform` functionality given an implementation of

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -28,7 +28,7 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
     sample.  The Silhouette Coefficient for a sample is ``(b - a) / max(a,
     b)``.  To clarify, ``b`` is the distance between a sample and the nearest
     cluster that the sample is not a part of.
-    Note that Silhouette Coefficent is only defined if number of labels
+    Note that Silhouette Coefficient is only defined if number of labels
     is 2 <= n_labels <= n_samples - 1.
 
     This function returns the mean Silhouette Coefficient over all samples.
@@ -114,7 +114,7 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
     distance (``a``) and the mean nearest-cluster distance (``b``) for each
     sample.  The Silhouette Coefficient for a sample is ``(b - a) / max(a,
     b)``.
-    Note that Silhouette Coefficent is only defined if number of labels
+    Note that Silhouette Coefficient is only defined if number of labels
     is 2 <= n_labels <= n_samples - 1.
 
     This function returns the Silhouette Coefficient for each sample.

--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -343,7 +343,7 @@ cdef class DistanceMetric:
         """Convert the Reduced distance to the true distance.
 
         The reduced distance, defined for some metrics, is a computationally
-        more efficent measure which preserves the rank of the true distance.
+        more efficient measure which preserves the rank of the true distance.
         For example, in the Euclidean distance metric, the reduced distance
         is the squared-euclidean distance.
         """
@@ -353,7 +353,7 @@ cdef class DistanceMetric:
         """Convert the true distance to the reduced distance.
 
         The reduced distance, defined for some metrics, is a computationally
-        more efficent measure which preserves the rank of the true distance.
+        more efficient measure which preserves the rank of the true distance.
         For example, in the Euclidean distance metric, the reduced distance
         is the squared-euclidean distance.
         """

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -294,5 +294,5 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
                                         self.n_neighbors_ - 1]
         reach_dist_array = np.maximum(distances_X, dist_k)
 
-        #  1e-10 to avoid `nan' when when nb of duplicates > n_neighbors_:
+        #  1e-10 to avoid `nan' when nb of duplicates > n_neighbors_:
         return 1. / (np.mean(reach_dist_array, axis=1) + 1e-10)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -221,7 +221,7 @@ def test_sparse_output_multilabel_binarizer():
     inverse = inputs[0]()
     for sparse_output in [True, False]:
         for inp in inputs:
-            # With fit_tranform
+            # With fit_transform
             mlb = MultiLabelBinarizer(sparse_output=sparse_output)
             got = mlb.fit_transform(inp())
             assert_equal(issparse(got), sparse_output)
@@ -263,7 +263,7 @@ def test_multilabel_binarizer():
                               [1, 1, 0]])
     inverse = inputs[0]()
     for inp in inputs:
-        # With fit_tranform
+        # With fit_transform
         mlb = MultiLabelBinarizer()
         got = mlb.fit_transform(inp())
         assert_array_equal(indicator_mat, got)

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -874,7 +874,7 @@ def test_pipeline_memory():
         # Memoize the transformer at the first fit
         cached_pipe.fit(X, y)
         pipe.fit(X, y)
-        # Get the time stamp of the tranformer in the cached pipeline
+        # Get the time stamp of the transformer in the cached pipeline
         ts = cached_pipe.named_steps['transf'].timestamp_
         # Check that cached_pipe and pipe yield identical results
         assert_array_equal(pipe.predict(X), cached_pipe.predict(X))

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -637,7 +637,7 @@ cdef class Tree:
     def __getstate__(self):
         """Getstate re-implementation, for pickling."""
         d = {}
-        # capacity is infered during the __setstate__ using nodes
+        # capacity is inferred during the __setstate__ using nodes
         d["max_depth"] = self.max_depth
         d["node_count"] = self.node_count
         d["nodes"] = self._get_node_ndarray()


### PR DESCRIPTION
This PR fixes some typos: `independant`, `Tranformer`, `Coefficent`, `efficent`, `when when`, `tranform`, and `infered`.