### PR TITLE
[MRG] Add enet path to the API listing

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -738,6 +738,7 @@ Kernels:
    :toctree: generated/
    :template: function.rst
 
+   linear_model.enet_path
    linear_model.lars_path
    linear_model.lasso_path
    linear_model.lasso_stability_path


### PR DESCRIPTION
The `linear_model.coordinate_descent.enet_path` seems to have been left out from `modules/classes.rst`.

@agramfort @MechCoder 