### PR TITLE
Fix typos

### DIFF
--- a/benchmarks/bench_isolation_forest.py
+++ b/benchmarks/bench_isolation_forest.py
@@ -26,7 +26,7 @@ def print_outlier_ratio(y):
     uniq, cnt = np.unique(y, return_counts=True)
     print("----- Target count values: ")
     for u, c in zip(uniq, cnt):
-        print("------ %s -> %d occurences" % (str(u), c))
+        print("------ %s -> %d occurrences" % (str(u), c))
     print("----- Outlier ratio: %.5f" % (np.min(cnt) / len(y)))
 
 

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -668,7 +668,7 @@ affinities), in particular Euclidean distance (*l2*), Manhattan distance
 matrix.
 
 * *l1* distance is often good for sparse features, or sparse noise: ie
-  many of the features are zero, as in text mining using occurences of
+  many of the features are zero, as in text mining using occurrences of
   rare words.
 
 * *cosine* distance is interesting because it is invariant to global

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -412,7 +412,7 @@ Bug fixes
    - Fixed a bug in :class:`linear_model.RandomizedLasso`,
      :class:`linear_model.Lars`, :class:`linear_model.LassoLars`,
      :class:`linear_model.LarsCV` and :class:`linear_model.LassoLarsCV`,
-     where the parameter ``precompute`` were not used consistently accross
+     where the parameter ``precompute`` were not used consistently across
      classes, and some values proposed in the docstring could raise errors.
      :issue:`5359` by `Tom Dupre la Tour`_.
 
@@ -1025,7 +1025,7 @@ Model evaluation and meta-estimators
 
 Metrics
 
-   - Added ``labels`` flag to :class:`metrics.log_loss` to to explicitly provide
+   - Added ``labels`` flag to :class:`metrics.log_loss` to explicitly provide
      the labels when the number of classes in ``y_true`` and ``y_pred`` differ.
      :issue:`7239` by :user:`Hong Guangguo <hongguangguo>` with help from
      :user:`Mads Jensen <indianajensen>` and :user:`Nelson Liu <nelson-liu>`.

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -411,7 +411,7 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
         """The subset of drawn samples for each base estimator.
 
         Returns a dynamically generated list of boolean masks identifying
-        the samples used for for fitting each member of the ensemble, i.e.,
+        the samples used for fitting each member of the ensemble, i.e.,
         the in-bag samples.
 
         Note: the list is re-created at each call to the property in order

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1199,7 +1199,7 @@ def test_prf_warnings():
     my_assert(w, msg, f, np.array([[0, 0], [0, 0]]),
               np.array([[1, 1], [1, 1]]), average='micro')
 
-    # single postive label
+    # single positive label
     msg = ('Precision and F-score are ill-defined and '
            'being set to 0.0 due to no predicted samples.')
     my_assert(w, msg, f, [1, 1], [-1, -1], average='binary')

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -473,7 +473,7 @@ def _naive_lmvnpdf_diag(X, means, covars):
 def test_gaussian_mixture_log_probabilities():
     from sklearn.mixture.gaussian_mixture import _estimate_log_gaussian_prob
 
-    # test aginst with _naive_lmvnpdf_diag
+    # test against with _naive_lmvnpdf_diag
     rng = np.random.RandomState(0)
     rand_data = RandomData(rng)
     n_samples = 500


### PR DESCRIPTION
This PR fixes some typos: `occurences`, `accross`, `for for`, `postive`, and `aginst`.