### PR TITLE
[MRG+1] DOC improve RFE/RFECV estimator docstring

### DIFF
--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -123,10 +123,11 @@ Given an external estimator that assigns weights to features (e.g., the
 coefficients of a linear model), recursive feature elimination (:class:`RFE`)
 is to select features by recursively considering smaller and smaller sets of
 features.  First, the estimator is trained on the initial set of features and
-weights are assigned to each one of them. Then, features whose absolute weights
-are the smallest are pruned from the current set features. That procedure is
-recursively repeated on the pruned set until the desired number of features to
-select is eventually reached.
+the importance of each feature is obtained either through a `coef_` attribute
+or through a `feature_importances_` attribute. Then, the least important
+features are pruned from current set of features.That procedure is recursively
+repeated on the pruned set until the desired number of features to select is
+eventually reached.
 
 :class:`RFECV` performs RFE in a cross-validation loop to find the optimal
 number of features.

--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -123,8 +123,8 @@ Given an external estimator that assigns weights to features (e.g., the
 coefficients of a linear model), recursive feature elimination (:class:`RFE`)
 is to select features by recursively considering smaller and smaller sets of
 features.  First, the estimator is trained on the initial set of features and
-the importance of each feature is obtained either through a `coef_` attribute
-or through a `feature_importances_` attribute. Then, the least important
+the importance of each feature is obtained either through a ``coef_`` attribute
+or through a ``feature_importances_`` attribute. Then, the least important
 features are pruned from current set of features.That procedure is recursively
 repeated on the pruned set until the desired number of features to select is
 eventually reached.

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -49,16 +49,13 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
     Parameters
     ----------
     estimator : object
-        A supervised learning estimator with a `fit` method
-        that provides information about feature importance
-        either through a `coef_` attribute
-        or through a `feature_importance_` attribute.
-        `coef_` attributes are usually provided by linear models,
-        while `feature_importance_` attributes
-        are usually provided by tree-based models.
-        Important features must correspond to
-        high absolute values in the `coef_` array
-        or `feature_importance_` array.
+        A supervised learning estimator with a `fit` method that provides
+        information about feature importance either through a `coef_`
+        attribute or through a `feature_importance_` attribute. `coef_`
+        attributes are usually provided by linear models, while
+        `feature_importance_` attributes are usually provided by tree-based
+        models. Important features must correspond to high absolute values
+        in the `coef_` array or `feature_importance_` array.
 
     n_features_to_select : int or None (default=None)
         The number of features to select. If `None`, half of the features
@@ -274,16 +271,13 @@ class RFECV(RFE, MetaEstimatorMixin):
     Parameters
     ----------
     estimator : object
-        A supervised learning estimator with a `fit` method
-        that provides information about feature importance
-        either through a `coef_` attribute
-        or through a `feature_importance_` attribute.
-        `coef_` attributes are usually provided by linear models,
-        while `feature_importance_` attributes
-        are usually provided by tree-based models.
-        Important features must correspond to
-        high absolute values in the `coef_` array
-        or `feature_importance_` array.
+        A supervised learning estimator with a `fit` method that provides
+        information about feature importance either through a `coef_`
+        attribute or through a `feature_importance_` attribute. `coef_`
+        attributes are usually provided by linear models, while
+        `feature_importance_` attributes are usually provided by tree-based
+        models. Important features must correspond to high absolute values
+        in the `coef_` array or `feature_importance_` array.
 
     step : int or float, optional (default=1)
         If greater than or equal to 1, then `step` corresponds to the (integer)

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -39,7 +39,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
     (RFE) is to select features by recursively considering smaller and smaller
     sets of features. First, the estimator is trained on the initial set of
     features and the importance of each feature is obtained either through a
-    `coef_` attribute or through a `feature_importance_` attribute.
+    `coef_` attribute or through a `feature_importances_` attribute.
     Then, the least important features are pruned from current set of features.
     That procedure is recursively repeated on the pruned set until the desired
     number of features to select is eventually reached.
@@ -51,11 +51,11 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
     estimator : object
         A supervised learning estimator with a `fit` method that provides
         information about feature importance either through a `coef_`
-        attribute or through a `feature_importance_` attribute. `coef_`
+        attribute or through a `feature_importances_` attribute. `coef_`
         attributes are usually provided by linear models, while
-        `feature_importance_` attributes are usually provided by tree-based
+        `feature_importances_` attributes are usually provided by tree-based
         models. Important features must correspond to high absolute values
-        in the `coef_` array or `feature_importance_` array.
+        in the `coef_` array or `feature_importances_` array.
 
     n_features_to_select : int or None (default=None)
         The number of features to select. If `None`, half of the features
@@ -273,11 +273,11 @@ class RFECV(RFE, MetaEstimatorMixin):
     estimator : object
         A supervised learning estimator with a `fit` method that provides
         information about feature importance either through a `coef_`
-        attribute or through a `feature_importance_` attribute. `coef_`
+        attribute or through a `feature_importances_` attribute. `coef_`
         attributes are usually provided by linear models, while
-        `feature_importance_` attributes are usually provided by tree-based
+        `feature_importances_` attributes are usually provided by tree-based
         models. Important features must correspond to high absolute values
-        in the `coef_` array or `feature_importance_` array.
+        in the `coef_` array or `feature_importances_` array.
 
     step : int or float, optional (default=1)
         If greater than or equal to 1, then `step` corresponds to the (integer)

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -39,7 +39,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
     (RFE) is to select features by recursively considering smaller and smaller
     sets of features. First, the estimator is trained on the initial set of
     features and the importance of each feature is obtained either through a
-    `coef_` attribute or through a `feature_importances_` attribute.
+    ``coef_`` attribute or through a ``feature_importances_`` attribute.
     Then, the least important features are pruned from current set of features.
     That procedure is recursively repeated on the pruned set until the desired
     number of features to select is eventually reached.
@@ -49,9 +49,9 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
     Parameters
     ----------
     estimator : object
-        A supervised learning estimator with a `fit` method that provides
-        information about feature importance either through a `coef_`
-        attribute or through a `feature_importances_` attribute.
+        A supervised learning estimator with a ``fit`` method that provides
+        information about feature importance either through a ``coef_``
+        attribute or through a ``feature_importances_`` attribute.
 
     n_features_to_select : int or None (default=None)
         The number of features to select. If `None`, half of the features
@@ -267,9 +267,9 @@ class RFECV(RFE, MetaEstimatorMixin):
     Parameters
     ----------
     estimator : object
-        A supervised learning estimator with a `fit` method that provides
-        information about feature importance either through a `coef_`
-        attribute or through a `feature_importances_` attribute.
+        A supervised learning estimator with a ``fit`` method that provides
+        information about feature importance either through a ``coef_``
+        attribute or through a ``feature_importances_`` attribute.
 
     step : int or float, optional (default=1)
         If greater than or equal to 1, then `step` corresponds to the (integer)

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -38,8 +38,9 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
     coefficients of a linear model), the goal of recursive feature elimination
     (RFE) is to select features by recursively considering smaller and smaller
     sets of features. First, the estimator is trained on the initial set of
-    features and weights are assigned to each one of them. Then, features whose
-    absolute weights are the smallest are pruned from the current set features.
+    features and the importance of each feature is obtained either through a
+    `coef_` attribute or through a `feature_importance_` attribute.
+    Then, the least important features are pruned from current set of features.
     That procedure is recursively repeated on the pruned set until the desired
     number of features to select is eventually reached.
 
@@ -48,13 +49,16 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
     Parameters
     ----------
     estimator : object
-        A supervised learning estimator with a `fit` method that updates a
-        `coef_` attribute that holds the fitted parameters. Important features
-        must correspond to high absolute values in the `coef_` array.
-
-        For instance, this is the case for most supervised learning
-        algorithms such as Support Vector Classifiers and Generalized
-        Linear Models from the `svm` and `linear_model` modules.
+        A supervised learning estimator with a `fit` method
+        that provides information about feature importance
+        either through a `coef_` attribute
+        or through a `feature_importance_` attribute.
+        `coef_` attributes are usually provided by linear models,
+        while `feature_importance_` attributes
+        are usually provided by tree-based models.
+        Important features must correspond to
+        high absolute values in the `coef_` array
+        or `feature_importance_` array.
 
     n_features_to_select : int or None (default=None)
         The number of features to select. If `None`, half of the features
@@ -270,13 +274,16 @@ class RFECV(RFE, MetaEstimatorMixin):
     Parameters
     ----------
     estimator : object
-        A supervised learning estimator with a `fit` method that updates a
-        `coef_` attribute that holds the fitted parameters. Important features
-        must correspond to high absolute values in the `coef_` array.
-
-        For instance, this is the case for most supervised learning
-        algorithms such as Support Vector Classifiers and Generalized
-        Linear Models from the `svm` and `linear_model` modules.
+        A supervised learning estimator with a `fit` method
+        that provides information about feature importance
+        either through a `coef_` attribute
+        or through a `feature_importance_` attribute.
+        `coef_` attributes are usually provided by linear models,
+        while `feature_importance_` attributes
+        are usually provided by tree-based models.
+        Important features must correspond to
+        high absolute values in the `coef_` array
+        or `feature_importance_` array.
 
     step : int or float, optional (default=1)
         If greater than or equal to 1, then `step` corresponds to the (integer)

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -51,11 +51,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
     estimator : object
         A supervised learning estimator with a `fit` method that provides
         information about feature importance either through a `coef_`
-        attribute or through a `feature_importances_` attribute. `coef_`
-        attributes are usually provided by linear models, while
-        `feature_importances_` attributes are usually provided by tree-based
-        models. Important features must correspond to high absolute values
-        in the `coef_` array or `feature_importances_` array.
+        attribute or through a `feature_importances_` attribute.
 
     n_features_to_select : int or None (default=None)
         The number of features to select. If `None`, half of the features
@@ -273,11 +269,7 @@ class RFECV(RFE, MetaEstimatorMixin):
     estimator : object
         A supervised learning estimator with a `fit` method that provides
         information about feature importance either through a `coef_`
-        attribute or through a `feature_importances_` attribute. `coef_`
-        attributes are usually provided by linear models, while
-        `feature_importances_` attributes are usually provided by tree-based
-        models. Important features must correspond to high absolute values
-        in the `coef_` array or `feature_importances_` array.
+        attribute or through a `feature_importances_` attribute.
 
     step : int or float, optional (default=1)
         If greater than or equal to 1, then `step` corresponds to the (integer)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #5353

#### What does this implement/fix? Explain your changes.
RFE/RFECV.fit not only support estimators with the coef_ attribute,
but also support estimators with the feature_importance_ attribute.
But the docstring is not updated. 

#### Any other comments?
The docstring is based on @amueller 's comment and current docstring.
ping @jnothman @amueller 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
