### PR TITLE
[MRG+1] Make return_std faster in Gaussian Processes

### DIFF
--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -321,10 +321,11 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
                 return y_mean, y_cov
             elif return_std:
                 # cache result of K_inv computation
-                if not hasattr(self,'_K_inv'):
+                if not hasattr(self, '_K_inv'):
                     # compute inverse K_inv of K based on its Cholesky
                     # decomposition L and its inverse L_inv
-                    L_inv = solve_triangular(self.L_.T,np.eye(self.L_.shape[0]))
+                    L_inv = solve_triangular(self.L_.T,
+                                             np.eye(self.L_.shape[0]))
                     self._K_inv = L_inv.dot(L_inv.T)
 
                 # Compute variance of predictive distribution

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -332,7 +332,8 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
 
                 # Compute variance of predictive distribution
                 y_var = self.kernel_.diag(X)
-                y_var -= np.einsum("ij,ij->i", np.dot(K_trans, self._K_inv), K_trans)
+                y_var -= np.einsum("ij,ij->i",
+                                   np.dot(K_trans, self._K_inv), K_trans)
 
                 # Check if any of the variances is negative because of
                 # numerical issues. If yes: set the variance to 0.

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -321,15 +321,15 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
                 return y_mean, y_cov
             elif return_std:
                 # cache result of K_inv computation
-                if not hasattr(self,'K_inv_'):
+                if not hasattr(self,'_K_inv'):
                     # compute inverse K_inv of K based on its Cholesky
                     # decomposition L and its inverse L_inv
-                    L_inv = solve_triangular(self.L_.T, np.eye(self.L_.shape[0]))
-                    self.K_inv_ = L_inv.dot(L_inv.T)
-                
+                    L_inv = solve_triangular(self.L_.T,np.eye(self.L_.shape[0]))
+                    self._K_inv = L_inv.dot(L_inv.T)
+
                 # Compute variance of predictive distribution
                 y_var = self.kernel_.diag(X)
-                sum1 = np.dot(K_trans, self.K_inv_).T
+                sum1 = np.dot(K_trans, self._K_inv).T
                 y_var -= np.einsum("ki,ik->k", K_trans, sum1)
 
                 # Check if any of the variances is negative because of

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -245,7 +245,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
         K[np.diag_indices_from(K)] += self.alpha
         try:
             self.L_ = cholesky(K, lower=True)  # Line 2
-            # self.L_ changed, delete self._K_inv
+            # self.L_ changed, self._K_inv needs to be recomputed
             self._K_inv = None
         except np.linalg.LinAlgError as exc:
             exc.args = ("The kernel, %s, is not returning a "

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -332,8 +332,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
 
                 # Compute variance of predictive distribution
                 y_var = self.kernel_.diag(X)
-                sum1 = np.dot(K_trans, self._K_inv).T
-                y_var -= np.einsum("ki,ik->k", K_trans, sum1)
+                y_var -= np.einsum("ij,ij->i", np.dot(K_trans, self._K_inv), K_trans)
 
                 # Check if any of the variances is negative because of
                 # numerical issues. If yes: set the variance to 0.

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -245,6 +245,8 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
         K[np.diag_indices_from(K)] += self.alpha
         try:
             self.L_ = cholesky(K, lower=True)  # Line 2
+            # self.L_ changed, delete self._K_inv
+            self._K_inv = None
         except np.linalg.LinAlgError as exc:
             exc.args = ("The kernel, %s, is not returning a "
                         "positive definite matrix. Try gradually "
@@ -321,7 +323,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
                 return y_mean, y_cov
             elif return_std:
                 # cache result of K_inv computation
-                if not hasattr(self, '_K_inv'):
+                if self._K_inv is None:
                     # compute inverse K_inv of K based on its Cholesky
                     # decomposition L and its inverse L_inv
                     L_inv = solve_triangular(self.L_.T,

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -20,6 +20,8 @@ from sklearn.utils.testing \
 
 def f(x):
     return x * np.sin(x)
+
+
 X = np.atleast_2d([1., 3., 5., 6., 7., 8.]).T
 X2 = np.atleast_2d([2., 4., 5.5, 6.5, 7.5]).T
 y = f(X).ravel()
@@ -344,3 +346,11 @@ def test_no_fit_default_predict():
 
     assert_array_almost_equal(y_std1, y_std2)
     assert_array_almost_equal(y_cov1, y_cov2)
+
+
+def test_K_inv_reset():
+    # Test that self._K_inv is reset after a new fit
+    for kernel in kernels:
+        gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
+        assert_true(hasattr(gpr, '_K_inv'))
+        assert_true(gpr._K_inv is None)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -15,7 +15,7 @@ from sklearn.gaussian_process.kernels import DotProduct
 from sklearn.utils.testing \
     import (assert_true, assert_greater, assert_array_less,
             assert_almost_equal, assert_equal, assert_raise_message,
-            assert_array_almost_equal)
+            assert_array_almost_equal, assert_array_equal)
 
 
 def f(x):
@@ -349,8 +349,18 @@ def test_no_fit_default_predict():
 
 
 def test_K_inv_reset():
-    # Test that self._K_inv is reset after a new fit
+    y2 = f(X2).ravel()
     for kernel in kernels:
+        # Test that self._K_inv is reset after a new fit
         gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
         assert_true(hasattr(gpr, '_K_inv'))
         assert_true(gpr._K_inv is None)
+        gpr.predict(X, return_std=True)
+        assert_true(gpr._K_inv is not None)
+        gpr.fit(X2, y2)
+        assert_true(gpr._K_inv is None)
+        gpr.predict(X2, return_std=True)
+        gpr2 = GaussianProcessRegressor(kernel=kernel).fit(X2, y2)
+        gpr2.predict(X2, return_std=True)
+        # the value of K_inv should be independent of the first fit
+        assert_array_equal(gpr._K_inv, gpr2._K_inv)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Issue #9234

#### What does this implement/fix? Explain your changes.
1. Cache result of `K_inv`
```py
if not hasattr(self,'K_inv_'):
        L_inv = solve_triangular(self.L_.T, np.eye(self.L_.shape[0]))
        self.K_inv_ = L_inv.dot(L_inv.T)
```
2. Change line 329 from
```py
    y_var -= np.einsum("ij,ij->i", np.dot(K_trans, K_inv), K_trans)
```
to
```py
    sum1 = np.dot(K_trans, self.K_inv_).T
    y_var -= np.einsum("ki,ik->k", K_trans, sum1)
```
#### Any other comments?
No.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
