### PR TITLE
[MRG] MAINT remove verbose flag for appveyor tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,8 +73,7 @@ test_script:
   # installed library.
   - "mkdir empty_folder"
   - "cd empty_folder"
-
-  - "python -c \"import nose; nose.main()\" --with-timer --timer-top-n 20 -s -v sklearn"
+  - "python -c \"import nose; nose.main()\" --with-timer --timer-top-n 20 -s sklearn"
 
   # Move back to the project folder
   - "cd .."


### PR DESCRIPTION
This PR removes the verbose flag on appveyor to avoid having to slowly scroll the appveyor output page to find the interesting error message in case of failure.

I remember we wanted the detailed output in the past because it used to be the case that we had random freeze / timeout or segfaults but this has not happened for a while.

I will merge this PR if CI is green.