### PR TITLE
Fix typos

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -6,7 +6,7 @@
 Model evaluation: quantifying the quality of predictions
 ========================================================
 
-There are 3 different APIs for evaluating the quality of of a model's
+There are 3 different APIs for evaluating the quality of a model's
 predictions:
 
 * **Estimator score method**: Estimators have a ``score`` method providing a
@@ -1121,7 +1121,7 @@ predictions.
    BS = \frac{1}{N} \sum_{t=1}^{N}(f_t - o_t)^2
 
 where : :math:`N` is the total number of predictions, :math:`f_t` is the
-predicted probablity of the actual outcome :math:`o_t`.
+predicted probability of the actual outcome :math:`o_t`.
 
 Here is a small example of usage of this function:::
 

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -251,14 +251,14 @@ def test_fowlkes_mallows_score_properties():
     score_original = fowlkes_mallows_score(labels_a, labels_b)
     assert_almost_equal(score_original, expected)
 
-    # symetric property
-    score_symetric = fowlkes_mallows_score(labels_b, labels_a)
-    assert_almost_equal(score_symetric, expected)
+    # symmetric property
+    score_symmetric = fowlkes_mallows_score(labels_b, labels_a)
+    assert_almost_equal(score_symmetric, expected)
 
     # permutation property
     score_permuted = fowlkes_mallows_score((labels_a + 1) % 3, labels_b)
     assert_almost_equal(score_permuted, expected)
 
-    # symetric and permutation(both together)
+    # symmetric and permutation(both together)
     score_both = fowlkes_mallows_score(labels_b, (labels_a + 2) % 3)
     assert_almost_equal(score_both, expected)


### PR DESCRIPTION
This PR fixes some typos: `of of`, `probablity`, and `symetric`.