### PR TITLE
[MRG+1] Common tests for outlier detection estimators

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -526,7 +526,7 @@ class DensityMixin(object):
 
 class OutlierMixin(object):
     """Mixin class for all outlier detection estimators in scikit-learn."""
-    _estimator_type = "OutlierDetector"
+    _estimator_type = "outlier_detector"
 
     def fit_predict(self, X, y=None):
         """Performs outlier detection on X.
@@ -585,3 +585,19 @@ def is_regressor(estimator):
         True if estimator is a regressor and False otherwise.
     """
     return getattr(estimator, "_estimator_type", None) == "regressor"
+
+
+def is_outlier_detector(estimator):
+    """Returns True if the given estimator is (probably) an outlier detector.
+
+    Parameters
+    ----------
+    estimator : object
+        Estimator object to test.
+
+    Returns
+    -------
+    out : bool
+        True if estimator is an outlier detector and False otherwise.
+    """
+    return getattr(estimator, "_estimator_type", None) == "outlier_detector"

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -525,8 +525,8 @@ class DensityMixin(object):
 
 
 class OutlierMixin(object):
-    """Mixin class for all cluster estimators in scikit-learn."""
-    _estimator_type = "detector"
+    """Mixin class for all outlier detection estimators in scikit-learn."""
+    _estimator_type = "OutlierDetector"
 
     def fit_predict(self, X, y=None):
         """Performs outlier detection on X.

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -524,6 +524,29 @@ class DensityMixin(object):
         pass
 
 
+class OutlierMixin(object):
+    """Mixin class for all cluster estimators in scikit-learn."""
+    _estimator_type = "detector"
+
+    def fit_predict(self, X, y=None):
+        """Performs outlier detection on X.
+
+        Returns -1 for outliers and 1 for inliers.
+
+        Parameters
+        ----------
+        X : ndarray, shape (n_samples, n_features)
+            Input data.
+
+        Returns
+        -------
+        y : ndarray, shape (n_samples,)
+            1 for inliers, -1 for outliers.
+        """
+        # override for transductive outlier detectors like LocalOulierFactor
+        return self.fit(X).predict(X)
+
+
 ###############################################################################
 class MetaEstimatorMixin(object):
     """Mixin class for all meta estimators in scikit-learn."""

--- a/sklearn/covariance/elliptic_envelope.py
+++ b/sklearn/covariance/elliptic_envelope.py
@@ -8,9 +8,10 @@ import warnings
 from . import MinCovDet
 from ..utils.validation import check_is_fitted, check_array
 from ..metrics import accuracy_score
+from ..base import OutlierMixin
 
 
-class EllipticEnvelope(MinCovDet):
+class EllipticEnvelope(MinCovDet, OutlierMixin):
     """An object for detecting outliers in a Gaussian distributed dataset.
 
     Read more in the :ref:`User Guide <outlier_detection>`.

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -17,6 +17,7 @@ from ..externals import six
 from ..tree import ExtraTreeRegressor
 from ..utils import check_random_state, check_array
 from ..utils.validation import check_is_fitted
+from ..base import OutlierMixin
 
 from .bagging import BaseBagging
 
@@ -25,7 +26,7 @@ __all__ = ["IsolationForest"]
 INTEGER_TYPES = (numbers.Integral, np.integer)
 
 
-class IsolationForest(BaseBagging):
+class IsolationForest(BaseBagging, OutlierMixin):
     """Isolation Forest Algorithm
 
     Return the anomaly score of each sample using the IsolationForest algorithm

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -9,6 +9,7 @@ from scipy.stats import scoreatpercentile
 from .base import NeighborsBase
 from .base import KNeighborsMixin
 from .base import UnsupervisedMixin
+from ..base import OutlierMixin
 
 from ..utils.validation import check_is_fitted
 from ..utils import check_array
@@ -16,7 +17,8 @@ from ..utils import check_array
 __all__ = ["LocalOutlierFactor"]
 
 
-class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
+class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin,
+                         OutlierMixin):
     """Unsupervised Outlier Detection using Local Outlier Factor (LOF)
 
     The anomaly score of each sample is called Local Outlier Factor.

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -2,7 +2,7 @@ import warnings
 import numpy as np
 
 from .base import _fit_liblinear, BaseSVC, BaseLibSVM
-from ..base import BaseEstimator, RegressorMixin
+from ..base import BaseEstimator, RegressorMixin, OutlierMixin
 from ..linear_model.base import LinearClassifierMixin, SparseCoefMixin, \
     LinearModel
 from ..utils import check_X_y
@@ -975,7 +975,7 @@ class NuSVR(BaseLibSVM, RegressorMixin):
             verbose=verbose, max_iter=max_iter, random_state=None)
 
 
-class OneClassSVM(BaseLibSVM):
+class OneClassSVM(BaseLibSVM, OutlierMixin):
     """Unsupervised Outlier Detection.
 
     Estimate the support of a high-dimensional distribution.

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2142,6 +2142,11 @@ def check_outliers_fit_predict(name, estimator_orig):
     assert_equal(y_pred.dtype, np.dtype('int'))
     assert_array_equal(np.unique(y_pred), np.array([-1, 1]))
 
+    # check fit_predict = fit.predict when possible
+    if name not in NO_TEST_SET_DETECTORS:
+        y_pred_2 = estimator.fit(X).predict(X)
+        assert_array_equal(y_pred, y_pred_2)
+
     if hasattr(estimator, "contamination"):
         # proportion of outliers equal to contamination parameter when not
         # set to 'auto'
@@ -2154,8 +2159,3 @@ def check_outliers_fit_predict(name, estimator_orig):
         for contamination in [-0.5, 2.3]:
             estimator.set_params(contamination=contamination)
             assert_raises(ValueError, estimator.fit_predict, X)
-
-    # check fit_predict = fit.predict when possible
-    if name not in NO_TEST_SET_DETECTORS:
-        y_pred_2 = estimator.fit(X).predict(X)
-        assert_array_equal(y_pred, y_pred_2)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -18,6 +18,7 @@ from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_not_equal
+from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_in
@@ -1431,7 +1432,7 @@ def check_outliers_train(name, estimator_orig):
         estimator.set_params(contamination=contamination)
         estimator.fit(X)
         y_pred = estimator.predict(X)
-        assert np.mean(y_pred != 1) == contamination
+        assert_almost_equal(np.mean(y_pred != 1), contamination)
 
         # raises error when contamination is a scalar and not in [0,1]
         for contamination in [-0.5, 2.3]:
@@ -2104,7 +2105,7 @@ def check_outliers_fit_predict(name, estimator_orig):
         contamination = 0.1
         estimator.set_params(contamination=contamination)
         y_pred = estimator.fit_predict(X)
-        assert np.mean(y_pred != 1) == contamination
+        assert_almost_equal(np.mean(y_pred != 1), contamination)
 
         # raises error when contamination is a scalar and not in [0,1]
         for contamination in [-0.5, 2.3]:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1414,7 +1414,8 @@ def check_outliers_train(name, estimator_orig):
     decision = estimator.decision_function(X)
     assert_equal(decision.shape, (n_samples,))
     dec_pred = (decision >= 0).astype(np.int)
-    assert_array_equal(dec_pred, y_pred == 1)
+    dec_pred[dec_pred == 0] = -1
+    assert_array_equal(dec_pred, y_pred)
 
     # raises error on malformed input for decision_function
     assert_raises(ValueError, estimator.decision_function, X.T)
@@ -2117,6 +2118,7 @@ def check_outliers_output_dtypes(name, estimator_orig):
 
     y_pred = estimator.predict(X)
     assert_equal(y_pred.dtype, np.dtype('int'))
+    assert_array_equal(np.unique(y_pred), np.array([-1, 1]))
 
     decision = estimator.decision_function(X)
     assert_equal(decision.dtype, np.dtype('float'))
@@ -2138,6 +2140,7 @@ def check_outliers_fit_predict(name, estimator_orig):
     y_pred = estimator.fit_predict(X)
     assert_equal(y_pred.shape, (n_samples,))
     assert_equal(y_pred.dtype, np.dtype('int'))
+    assert_array_equal(np.unique(y_pred), np.array([-1, 1]))
 
     if hasattr(estimator, "contamination"):
         # proportion of outliers equal to contamination parameter when not

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2117,7 +2117,7 @@ def check_outliers_output_dtypes(name, estimator_orig):
     estimator.fit(X)
 
     y_pred = estimator.predict(X)
-    assert_equal(y_pred.dtype, np.dtype('int'))
+    assert_in(y_pred.dtype, [np.dtype('int32'), np.dtype('int64')])
     assert_array_equal(np.unique(y_pred), np.array([-1, 1]))
 
     decision = estimator.decision_function(X)
@@ -2139,7 +2139,7 @@ def check_outliers_fit_predict(name, estimator_orig):
 
     y_pred = estimator.fit_predict(X)
     assert_equal(y_pred.shape, (n_samples,))
-    assert_equal(y_pred.dtype, np.dtype('int'))
+    assert_in(y_pred.dtype, [np.dtype('int32'), np.dtype('int64')])
     assert_array_equal(np.unique(y_pred), np.array([-1, 1]))
 
     # check fit_predict = fit.predict when possible

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -525,8 +525,8 @@ META_ESTIMATORS = ["OneVsOneClassifier", "MultiOutputEstimator",
 OTHER = ["Pipeline", "FeatureUnion", "GridSearchCV", "RandomizedSearchCV",
          "SelectFromModel"]
 
-# some trange ones
-DONT_TEST = ['SparseCoder', 'EllipticEnvelope', 'DictVectorizer',
+# some strange ones
+DONT_TEST = ['SparseCoder', 'DictVectorizer',
              'LabelBinarizer', 'LabelEncoder',
              'MultiLabelBinarizer', 'TfidfTransformer',
              'TfidfVectorizer', 'IsotonicRegression',


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Addresses #8677


#### What does this implement/fix? Explain your changes.

This implements common tests for outlier detection estimators: `OneClassSVM`, `EllipticEnvelope`, `LocalOutlierFactor` and `IsolationForest`.


#### Any other comments?
`LocalOutlierFactor` is only meant for outlier detection (and not novelty detection) as it cannot (yet) be applied to unseen data. Therefore common tests for outlier detection estimators are split into two categories:
- tests for outlier detection which consist basically in testing `fit_predict` (to be run on all estimators). Note that all estimators can be applied in the outlier detection context and I therefore created an OutlierMixin implementing a `fit_predict` for all outlier detection estimators.
- tests for novelty detection (to be run on all estimators except `LocalOutlierFactor`)
