### PR TITLE
 [MRG+1] NMF speed-up for beta_loss = 0

### DIFF
--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -546,6 +546,7 @@ def _multiplicative_update_w(X, W, H, beta_loss, l1_reg_W, l2_reg_W, gamma,
         if beta_loss == 1:
             np.divide(X_data, WH_safe_X_data, out=WH_safe_X_data)
         elif beta_loss == 0:
+            # using numpy's reciprocal function for exponent -1
             WH_safe_X_data **= -1
             WH_safe_X_data **= 2
             # element-wise multiplication
@@ -625,6 +626,7 @@ def _multiplicative_update_h(X, W, H, beta_loss, l1_reg_H, l2_reg_H, gamma):
         if beta_loss == 1:
             np.divide(X_data, WH_safe_X_data, out=WH_safe_X_data)
         elif beta_loss == 0:
+            # using numpy's reciprocal function for exponent -1
             WH_safe_X_data **= -1
             WH_safe_X_data **= 2
             # element-wise multiplication

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -546,8 +546,8 @@ def _multiplicative_update_w(X, W, H, beta_loss, l1_reg_W, l2_reg_W, gamma,
         if beta_loss == 1:
             np.divide(X_data, WH_safe_X_data, out=WH_safe_X_data)
         elif beta_loss == 0:
-            WH_safe_X_data *= WH_safe_X_data
-            WH_safe_X_data = 1 / WH_safe_X_data
+            WH_safe_X_data **= -1
+            WH_safe_X_data **= 2
             # element-wise multiplication
             WH_safe_X_data *= X_data
         else:
@@ -625,8 +625,8 @@ def _multiplicative_update_h(X, W, H, beta_loss, l1_reg_H, l2_reg_H, gamma):
         if beta_loss == 1:
             np.divide(X_data, WH_safe_X_data, out=WH_safe_X_data)
         elif beta_loss == 0:
-            WH_safe_X_data *= WH_safe_X_data
-            WH_safe_X_data = 1 / WH_safe_X_data
+            WH_safe_X_data **= -1
+            WH_safe_X_data **= 2
             # element-wise multiplication
             WH_safe_X_data *= X_data
         else:

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -546,8 +546,8 @@ def _multiplicative_update_w(X, W, H, beta_loss, l1_reg_W, l2_reg_W, gamma,
         if beta_loss == 1:
             np.divide(X_data, WH_safe_X_data, out=WH_safe_X_data)
         elif beta_loss == 0:
-            WH_safe_X_data **= 2
-            WH_safe_X_data **= -1
+            WH_safe_X_data *= WH_safe_X_data
+            WH_safe_X_data = 1 / WH_safe_X_data
             # element-wise multiplication
             WH_safe_X_data *= X_data
         else:
@@ -625,8 +625,8 @@ def _multiplicative_update_h(X, W, H, beta_loss, l1_reg_H, l2_reg_H, gamma):
         if beta_loss == 1:
             np.divide(X_data, WH_safe_X_data, out=WH_safe_X_data)
         elif beta_loss == 0:
-            WH_safe_X_data **= 2
-            WH_safe_X_data **= -1
+            WH_safe_X_data *= WH_safe_X_data
+            WH_safe_X_data *= 1 / WH_safe_X_data
             # element-wise multiplication
             WH_safe_X_data *= X_data
         else:

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -546,7 +546,8 @@ def _multiplicative_update_w(X, W, H, beta_loss, l1_reg_W, l2_reg_W, gamma,
         if beta_loss == 1:
             np.divide(X_data, WH_safe_X_data, out=WH_safe_X_data)
         elif beta_loss == 0:
-            # using numpy's reciprocal function for exponent -1
+            # speeds up computation time
+            # refer to /numpy/numpy/issues/9363
             WH_safe_X_data **= -1
             WH_safe_X_data **= 2
             # element-wise multiplication
@@ -626,7 +627,8 @@ def _multiplicative_update_h(X, W, H, beta_loss, l1_reg_H, l2_reg_H, gamma):
         if beta_loss == 1:
             np.divide(X_data, WH_safe_X_data, out=WH_safe_X_data)
         elif beta_loss == 0:
-            # using numpy's reciprocal function for exponent -1
+            # speeds up computation time
+            # refer to /numpy/numpy/issues/9363
             WH_safe_X_data **= -1
             WH_safe_X_data **= 2
             # element-wise multiplication

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -545,6 +545,11 @@ def _multiplicative_update_w(X, W, H, beta_loss, l1_reg_W, l2_reg_W, gamma,
 
         if beta_loss == 1:
             np.divide(X_data, WH_safe_X_data, out=WH_safe_X_data)
+        elif beta_loss == 0:
+            WH_safe_X_data **= 2
+            WH_safe_X_data **= -1
+            # element-wise multiplication
+            WH_safe_X_data *= X_data
         else:
             WH_safe_X_data **= beta_loss - 2
             # element-wise multiplication
@@ -619,6 +624,11 @@ def _multiplicative_update_h(X, W, H, beta_loss, l1_reg_H, l2_reg_H, gamma):
 
         if beta_loss == 1:
             np.divide(X_data, WH_safe_X_data, out=WH_safe_X_data)
+        elif beta_loss == 0:
+            WH_safe_X_data **= 2
+            WH_safe_X_data **= -1
+            # element-wise multiplication
+            WH_safe_X_data *= X_data
         else:
             WH_safe_X_data **= beta_loss - 2
             # element-wise multiplication
@@ -1167,6 +1177,7 @@ class NMF(BaseEstimator, TransformerMixin):
     Fevotte, C., & Idier, J. (2011). Algorithms for nonnegative matrix
     factorization with the beta-divergence. Neural Computation, 23(9).
     """
+
     def __init__(self, n_components=None, init=None, solver='cd',
                  beta_loss='frobenius', tol=1e-4, max_iter=200,
                  random_state=None, alpha=0., l1_ratio=0., verbose=0,

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -626,7 +626,7 @@ def _multiplicative_update_h(X, W, H, beta_loss, l1_reg_H, l2_reg_H, gamma):
             np.divide(X_data, WH_safe_X_data, out=WH_safe_X_data)
         elif beta_loss == 0:
             WH_safe_X_data *= WH_safe_X_data
-            WH_safe_X_data *= 1 / WH_safe_X_data
+            WH_safe_X_data = 1 / WH_safe_X_data
             # element-wise multiplication
             WH_safe_X_data *= X_data
         else:


### PR DESCRIPTION
Suggestion for speeding up IS divergence in NMF mu update:

```py
WH_safe_X_data **= -1
WH_safe_X_data **= 2
```
is much faster than

```py
 WH_safe_X_data **= beta_loss - 2
```
Using line_profiler on ipython to time the lines,


```
seconds
4363077           WH_safe_X_data **= beta_loss - 2

vs

219524            WH_safe_X_data **= -1
33966             WH_safe_X_data **= 2
```


test code below:

```py
from sklearn.decomposition.nmf import non_negative_factorization
from sklearn.decomposition.nmf import _multiplicative_update_w
from sklearn.datasets import make_classification
import time
from IPython import get_ipython
import numpy as np

ipython = get_ipython()
np.random.seed(10)
t0 = time.time()
all_samples, all_targets = make_classification(n_samples=1000, n_features=513, n_informative=511,
                                               n_redundant=2, n_repeated=0, n_classes=2,
                                               n_clusters_per_class=1, random_state=0)
all_samples += 5000
ipython.magic(
    "lprun -f _multiplicative_update_w non_negative_factorization(all_samples, n_components=16, solver='mu', beta_loss='itakura-saito', max_iter=100)")
```
