### PR TITLE
[MRG+1] makedirs(..., exists_ok) not available in Python 2

### DIFF
--- a/sklearn/datasets/covtype.py
+++ b/sklearn/datasets/covtype.py
@@ -89,7 +89,8 @@ def fetch_covtype(data_home=None, download_if_missing=True,
     available = exists(samples_path)
 
     if download_if_missing and not available:
-        makedirs(covtype_dir, exist_ok=True)
+        if not exists(covtype_dir):
+            makedirs(covtype_dir)
         logger.warning("Downloading %s" % URL)
         f = BytesIO(urlopen(URL).read())
         Xy = np.genfromtxt(GzipFile(fileobj=f), delimiter=',')

--- a/sklearn/datasets/rcv1.py
+++ b/sklearn/datasets/rcv1.py
@@ -114,7 +114,8 @@ def fetch_rcv1(data_home=None, subset='all', download_if_missing=True,
     data_home = get_data_home(data_home=data_home)
     rcv1_dir = join(data_home, "RCV1")
     if download_if_missing:
-        makedirs(rcv1_dir, exist_ok=True)
+        if not exists(rcv1_dir):
+            makedirs(rcv1_dir)
 
     samples_path = _pkl_filepath(rcv1_dir, "samples.pkl")
     sample_id_path = _pkl_filepath(rcv1_dir, "sample_id.pkl")


### PR DESCRIPTION
#### Reference Issue
Fixes #9279 


#### What does this implement/fix? Explain your changes.
exists_ok parameter of os.makedirs() exists upwards of Python 3. This change will support Python 2 also.