### PR TITLE
[MRG + 1] Too few arguments in formatting call

### DIFF
--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -773,8 +773,8 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
 
         if self.n_features_ != X.shape[1]:
             raise ValueError("Number of features of the model must "
-                             "match the input. Model n_features is {1} and "
-                             "input n_features is {2} "
+                             "match the input. Model n_features is {0} and "
+                             "input n_features is {1} "
                              "".format(self.n_features_, X.shape[1]))
 
         # Parallel loop

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -19,6 +19,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
+from sklearn.utils.testing import assert_raise_message
 
 from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.model_selection import GridSearchCV, ParameterGrid
@@ -448,14 +449,13 @@ def test_parallel_classification():
     ensemble.set_params(n_jobs=2)
     decisions2 = ensemble.decision_function(X_test)
     assert_array_almost_equal(decisions1, decisions2)
-    try:
-      X_err = np.hstack((X_test, np.zeros((X_test.shape[0], 1))))
-      decisionerr = ensemble.decision_function(X_err)
-    except ValueError:
-      print('ok')
-    except:
-      print("Unexpected error")
-      raise
+
+    X_err = np.hstack((X_test, np.zeros((X_test.shape[0], 1))))
+    assert_raise_message(ValueError, "Number of features of the model "
+                         "must match the input. Model n_features is {0} "
+                         "and input n_features is {1} "
+                         "".format(X_test.shape[1], X_err.shape[1]),
+                         ensemble.decision_function, X_err)
 
     ensemble = BaggingClassifier(SVC(decision_function_shape='ovr'),
                                  n_jobs=1,

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -448,6 +448,14 @@ def test_parallel_classification():
     ensemble.set_params(n_jobs=2)
     decisions2 = ensemble.decision_function(X_test)
     assert_array_almost_equal(decisions1, decisions2)
+    try:
+      X_err = np.hstack((X_test, np.zeros((X_test.shape[0], 1))))
+      decisionerr = ensemble.decision_function(X_err)
+    except ValueError:
+      print('ok')
+    except:
+      print("Unexpected error")
+      raise
 
     ensemble = BaggingClassifier(SVC(decision_function_shape='ovr'),
                                  n_jobs=1,

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -721,7 +721,7 @@ class OutputCodeClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         """
         X, y = check_X_y(X, y)
         if self.code_size <= 0:
-            raise ValueError("code_size should be greater than 0, got {1}"
+            raise ValueError("code_size should be greater than 0, got {0}"
                              "".format(self.code_size))
 
         _check_estimator(self.estimator)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -704,6 +704,9 @@ def test_ecoc_float_y():
 
     ovo = OutputCodeClassifier(LinearSVC())
     assert_raise_message(ValueError, "Unknown label type", ovo.fit, X, y)
+    ovo = OutputCodeClassifier(LinearSVC(), code_size=-1)
+    assert_raise_message(ValueError, "code_size should be greater than 0,"
+                         " got -1", ovo.fit, X, y)
 
 
 def test_pairwise_indices():


### PR DESCRIPTION
#### Reference Issue
Fixes #9280

#### What does this implement/fix? Explain your changes.
Some placeholders for .format() weren't 0 indexed.
