### PR TITLE
[WIP] affinity passed to _fix_connectivity in linkage_tree

### DIFF
--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -415,7 +415,7 @@ def linkage_tree(X, connectivity=None, n_components=None,
             return children_, 1, n_samples, None, distances
         return children_, 1, n_samples, None
 
-    connectivity, n_components = _fix_connectivity(X, connectivity)
+    connectivity, n_components = _fix_connectivity(X, connectivity, affinity=affinity)
 
     connectivity = connectivity.tocoo()
     # Put the diagonal to zero


### PR DESCRIPTION
#### Reference Issue
Fixes #9308 


#### What does this implement/fix? Explain your changes.
`_fix_connectivity` in sklearn/cluster/hierarchical.py accepts `affinity`, but is not passed it by `linkage_tree`. 

#### Any other comments?
This also needs to be covered with tests.