### PR TITLE
Fix typos

### DIFF
--- a/examples/calibration/plot_compare_calibration.py
+++ b/examples/calibration/plot_compare_calibration.py
@@ -33,9 +33,9 @@ with different biases per method:
   moving the average prediction of the bagged ensemble away from 0. We observe
   this effect most strongly with random forests because the base-level trees
   trained with random forests have relatively high variance due to feature
-  subseting." As a result, the calibration curve shows a characteristic sigmoid
-  shape, indicating that the classifier could trust its "intuition" more and
-  return probabilities closer to 0 or 1 typically.
+  subsetting." As a result, the calibration curve shows a characteristic
+  sigmoid shape, indicating that the classifier could trust its "intuition"
+  more and return probabilities closer to 0 or 1 typically.
 
 * Support Vector Classification (SVC) shows an even more sigmoid curve as
   the  RandomForestClassifier, which is typical for maximum-margin methods

--- a/sklearn/externals/joblib/_parallel_backends.py
+++ b/sklearn/externals/joblib/_parallel_backends.py
@@ -88,7 +88,7 @@ class ParallelBackendBase(with_metaclass(ABCMeta)):
         managed by the backend it-self: if we expect no new tasks, there is no
         point in re-creating a new working pool.
         """
-        # Does nothing by default: to be overriden in subclasses when canceling
+        # Does nothing by default: to be overridden in subclasses when canceling
         # tasks is possible.
         pass
 

--- a/sklearn/externals/joblib/parallel.py
+++ b/sklearn/externals/joblib/parallel.py
@@ -48,7 +48,7 @@ BACKENDS = {
 DEFAULT_BACKEND = 'multiprocessing'
 DEFAULT_N_JOBS = 1
 
-# Thread local value that can be overriden by the ``parallel_backend`` context
+# Thread local value that can be overridden by the ``parallel_backend`` context
 # manager
 _backend = threading.local()
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -268,7 +268,7 @@ class _IgnoreWarnings(object):
 
     Parameters
     ----------
-    category : tuple of warning class, defaut to Warning
+    category : tuple of warning class, default to Warning
         The category to filter. By default, all the categories will be muted.
 
     """

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -615,7 +615,7 @@ def has_fit_parameter(estimator, parameter):
     Returns
     -------
     is_parameter: bool
-        Whether the parameter was found to be a a named parameter of the
+        Whether the parameter was found to be a named parameter of the
         estimator's fit method.
 
     Examples


### PR DESCRIPTION
This PR fixes some typos: `seting`, `overriden`, and `a a`.