### PR TITLE
[WIP] Fuzzy c-means clustering

### DIFF
--- a/sklearn/cluster/__init__.py
+++ b/sklearn/cluster/__init__.py
@@ -10,7 +10,7 @@ from .affinity_propagation_ import affinity_propagation, AffinityPropagation
 from .hierarchical import (ward_tree, AgglomerativeClustering, linkage_tree,
                            FeatureAgglomeration)
 from .k_means_ import k_means, KMeans, MiniBatchKMeans
-from .c_means_ import c_means, ProbabilisticCMeans, PossibilisticCMeans
+from .c_means_ import c_means, CMeans
 from .dbscan_ import dbscan, DBSCAN
 from .bicluster import SpectralBiclustering, SpectralCoclustering
 from .birch import Birch
@@ -20,8 +20,7 @@ __all__ = ['AffinityPropagation',
            'Birch',
            'DBSCAN',
            'KMeans',
-           'ProbabilisticCMeans',
-           'PossibilisticCMeans',
+           'CMeans',
            'FeatureAgglomeration',
            'MeanShift',
            'MiniBatchKMeans',

--- a/sklearn/cluster/__init__.py
+++ b/sklearn/cluster/__init__.py
@@ -10,7 +10,7 @@ from .affinity_propagation_ import affinity_propagation, AffinityPropagation
 from .hierarchical import (ward_tree, AgglomerativeClustering, linkage_tree,
                            FeatureAgglomeration)
 from .k_means_ import k_means, KMeans, MiniBatchKMeans
-from .c_means import c_means, CMeans
+from .c_means_ import c_means, CMeans
 from .dbscan_ import dbscan, DBSCAN
 from .bicluster import SpectralBiclustering, SpectralCoclustering
 from .birch import Birch

--- a/sklearn/cluster/__init__.py
+++ b/sklearn/cluster/__init__.py
@@ -10,7 +10,7 @@ from .affinity_propagation_ import affinity_propagation, AffinityPropagation
 from .hierarchical import (ward_tree, AgglomerativeClustering, linkage_tree,
                            FeatureAgglomeration)
 from .k_means_ import k_means, KMeans, MiniBatchKMeans
-from .c_means_ import c_means, CMeans
+from .c_means_ import c_means, ProbabilisticCMeans, PossibilisticCMeans
 from .dbscan_ import dbscan, DBSCAN
 from .bicluster import SpectralBiclustering, SpectralCoclustering
 from .birch import Birch
@@ -20,7 +20,8 @@ __all__ = ['AffinityPropagation',
            'Birch',
            'DBSCAN',
            'KMeans',
-           'CMeans',
+           'ProbabilisticCMeans',
+           'PossibilisticCMeans',
            'FeatureAgglomeration',
            'MeanShift',
            'MiniBatchKMeans',

--- a/sklearn/cluster/__init__.py
+++ b/sklearn/cluster/__init__.py
@@ -10,6 +10,7 @@ from .affinity_propagation_ import affinity_propagation, AffinityPropagation
 from .hierarchical import (ward_tree, AgglomerativeClustering, linkage_tree,
                            FeatureAgglomeration)
 from .k_means_ import k_means, KMeans, MiniBatchKMeans
+from .c_means import c_means, CMeans
 from .dbscan_ import dbscan, DBSCAN
 from .bicluster import SpectralBiclustering, SpectralCoclustering
 from .birch import Birch
@@ -19,6 +20,7 @@ __all__ = ['AffinityPropagation',
            'Birch',
            'DBSCAN',
            'KMeans',
+           'CMeans',
            'FeatureAgglomeration',
            'MeanShift',
            'MiniBatchKMeans',
@@ -28,6 +30,7 @@ __all__ = ['AffinityPropagation',
            'estimate_bandwidth',
            'get_bin_seeds',
            'k_means',
+           'c_means',
            'linkage_tree',
            'mean_shift',
            'spectral_clustering',

--- a/sklearn/cluster/_c_means.py
+++ b/sklearn/cluster/_c_means.py
@@ -1,12 +1,12 @@
 import numpy as np
-from sklearn.metrics.pairwise import euclidean_distances, check_pairwise_arrays
+from scipy.spatial.distance import cdist
 
 
 class Probabilistic:
 
     @staticmethod
     def distances(X, Y=None,  **kwargs):
-        return euclidean_distances(X, Y, **kwargs)
+        return cdist(X, Y, **kwargs)
 
     @staticmethod
     def memberships(distances, m=2.):
@@ -63,7 +63,7 @@ class Possibilistic:
 
     @staticmethod
     def distances(X, Y=None, **kwargs):
-        return euclidean_distances(X, Y, **kwargs)
+        return cdist(X, Y, **kwargs)
 
     def memberships(self, distances, m=2.):
         """Calculate possibilistic memberships based on distances.

--- a/sklearn/cluster/_c_means.py
+++ b/sklearn/cluster/_c_means.py
@@ -38,8 +38,54 @@ def _centers_probabilistic(X, memberships, m=2.):
 
     Returns
     -------
+    centers : float ndarray, shape (n_clusters, n_features)
+        The positions of the cluster centers.
 
     """
     centers = np.dot(memberships.T ** m, X) / \
               np.sum(memberships.T ** m, axis=1)[..., np.newaxis]
     return centers
+
+
+def _memberships_possibilistic(distances, weights, m=2.):
+    """Calculate possibilistic memberships based on distances.
+
+    Parameters
+    ----------
+    distances : array-like, shape (n_samples, n_samples)
+        The distances from each point to every other.
+    weights : array-like, shape (n_clusters, )
+        The relative weighting of the clusters.
+    m : float, optional, default 2.0
+        The fuzziness factor. Larger values dilute membership.
+
+    Returns
+    -------
+    memberships : float ndarray, shape (n_samples, n_clusters)
+        Updated memberships
+
+    """
+    memberships = (1. + (distances / weights) ** (1. / (m - 1))) ** -1.
+    return memberships
+
+
+def _centers_possibilistic(X, memberships, m=2.):
+    """Calculate possibilistic centers based on memberships.
+
+    Parameters
+    ----------
+    X : array-like, shape (n_samples, n_features)
+        The data points to cluster.
+    memberships : float ndarray, shape (n_samples, n_clusters)
+        Membership of each data point to the cluster centers.
+    m : float, optional, default 2.0
+        The fuzziness factor. Larger values dilute membership.
+
+    Returns
+    -------
+    centers : float ndarray, shape (n_clusters, n_features)
+        The positions of the cluster centers.
+
+    """
+    return np.divide(np.dot((memberships ** m).T, X),
+                     np.sum(memberships ** m, axis=0)[..., np.newaxis])

--- a/sklearn/cluster/_c_means.py
+++ b/sklearn/cluster/_c_means.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+
+def _calculate_memberships(distances, m):
+    distance_ratio = np.divide(distances[:, :, np.newaxis], distances[:, np.newaxis, :])
+    distance_ratio[np.isnan(distance_ratio)] = 1.
+    memberships = np.sum(np.power(distance_ratio, 2 / (m - 1)), axis=2) ** -1
+    return memberships
+
+
+def _calculate_centers(X, memberships, m):
+    centers = np.dot(memberships.T ** m, X) / \
+              np.sum(memberships.T ** m, axis=1)[..., np.newaxis]
+    return centers

--- a/sklearn/cluster/_c_means.py
+++ b/sklearn/cluster/_c_means.py
@@ -1,91 +1,99 @@
 import numpy as np
 
 
-def _memberships_probabilistic(distances, m=2.):
-    """Calculate probabilistic memberships based on distances.
+class Probabilistic:
 
-    Parameters
-    ----------
-    distances : array-like, shape (n_samples, n_samples)
-        The distances from each point to every other.
-    m : float, optional, default 2.0
-        The fuzziness factor. Larger values dilute membership.
+    @staticmethod
+    def memberships(distances, m=2.):
+        """Calculate probabilistic memberships based on distances.
 
-    Returns
-    -------
-    memberships : float ndarray, shape (n_samples, n_clusters)
-        Updated memberships
+        Parameters
+        ----------
+        distances : array-like, shape (n_samples, n_samples)
+            The distances from each point to every other.
+        m : float, optional, default 2.0
+            The fuzziness factor. Larger values dilute membership.
 
-    """
-    distance_ratio = np.divide(distances[:, :, np.newaxis],
-                               distances[:, np.newaxis, :])
-    distance_ratio[np.isnan(distance_ratio)] = 1.
-    memberships = np.sum(np.power(distance_ratio, 2 / (m - 1)), axis=2) ** -1
-    return memberships
+        Returns
+        -------
+        memberships : float ndarray, shape (n_samples, n_clusters)
+            Updated memberships
 
+        """
+        distance_ratio = np.divide(distances[:, :, np.newaxis],
+                                   distances[:, np.newaxis, :])
+        distance_ratio[np.isnan(distance_ratio)] = 1.
+        memberships = np.sum(np.power(distance_ratio, 2 / (m - 1)), axis=2) ** -1
+        return memberships
 
-def _centers_probabilistic(X, memberships, m=2.):
-    """Calculate probabilistic centers based on memberships.
+    @staticmethod
+    def centers(X, memberships, m=2.):
+        """Calculate probabilistic centers based on memberships.
 
-    Parameters
-    ----------
-    X : array-like, shape (n_samples, n_features)
-        The data points to cluster.
-    memberships : float ndarray, shape (n_samples, n_clusters)
-        Membership of each data point to the cluster centers.
-    m : float, optional, default 2.0
-        The fuzziness factor. Larger values dilute membership.
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+            The data points to cluster.
+        memberships : float ndarray, shape (n_samples, n_clusters)
+            Membership of each data point to the cluster centers.
+        m : float, optional, default 2.0
+            The fuzziness factor. Larger values dilute membership.
 
-    Returns
-    -------
-    centers : float ndarray, shape (n_clusters, n_features)
-        The positions of the cluster centers.
+        Returns
+        -------
+        centers : float ndarray, shape (n_clusters, n_features)
+            The positions of the cluster centers.
 
-    """
-    centers = np.dot(memberships.T ** m, X) / \
-              np.sum(memberships.T ** m, axis=1)[..., np.newaxis]
-    return centers
-
-
-def _memberships_possibilistic(distances, weights, m=2.):
-    """Calculate possibilistic memberships based on distances.
-
-    Parameters
-    ----------
-    distances : array-like, shape (n_samples, n_samples)
-        The distances from each point to every other.
-    weights : array-like, shape (n_clusters, )
-        The relative weighting of the clusters.
-    m : float, optional, default 2.0
-        The fuzziness factor. Larger values dilute membership.
-
-    Returns
-    -------
-    memberships : float ndarray, shape (n_samples, n_clusters)
-        Updated memberships
-
-    """
-    memberships = (1. + (distances / weights) ** (1. / (m - 1))) ** -1.
-    return memberships
+        """
+        centers = np.dot(memberships.T ** m, X) / \
+                  np.sum(memberships.T ** m, axis=1)[..., np.newaxis]
+        return centers
 
 
-def _centers_possibilistic(X, memberships, m=2.):
-    """Calculate possibilistic centers based on memberships.
+class Possibilistic:
 
-    Parameters
-    ----------
-    X : array-like, shape (n_samples, n_features)
-        The data points to cluster.
-    memberships : float ndarray, shape (n_samples, n_clusters)
-        Membership of each data point to the cluster centers.
-    m : float, optional, default 2.0
-        The fuzziness factor. Larger values dilute membership.
+    @staticmethod
+    def memberships(distances, weights, m=2.):
+        """Calculate possibilistic memberships based on distances.
 
-    Returns
-    -------
-    centers : float ndarray, shape (n_clusters, n_features)
-        The positions of the cluster centers.
+        Parameters
+        ----------
+        distances : array-like, shape (n_samples, n_samples)
+            The distances from each point to every other.
+        weights : array-like, shape (n_clusters, )
+            The relative weighting of the clusters.
+        m : float, optional, default 2.0
+            The fuzziness factor. Larger values dilute membership.
 
-    """
-    return np.divide(np.dot((memberships ** m).T, X),
-                     np.sum(memberships ** m, axis=0)[..., np.newaxis])
+        Returns
+        -------
+        memberships : float ndarray, shape (n_samples, n_clusters)
+            Updated memberships
+
+        """
+        memberships = (1. + (distances / weights) ** (1. / (m - 1))) ** -1.
+        return memberships
+
+    @staticmethod
+    def centers(X, memberships, m=2.):
+        """Calculate possibilistic centers based on memberships.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+            The data points to cluster.
+        memberships : float ndarray, shape (n_samples, n_clusters)
+            Membership of each data point to the cluster centers.
+        m : float, optional, default 2.0
+            The fuzziness factor. Larger values dilute membership.
+
+        Returns
+        -------
+        centers : float ndarray, shape (n_clusters, n_features)
+            The positions of the cluster centers.
+
+        """
+        return np.divide(np.dot((memberships ** m).T, X),
+                         np.sum(memberships ** m, axis=0)[..., np.newaxis])
+
+

--- a/sklearn/cluster/_c_means.py
+++ b/sklearn/cluster/_c_means.py
@@ -2,7 +2,6 @@ import numpy as np
 
 
 class Probabilistic:
-
     @staticmethod
     def memberships(distances, m=2.):
         """Calculate probabilistic memberships based on distances.
@@ -23,7 +22,8 @@ class Probabilistic:
         distance_ratio = np.divide(distances[:, :, np.newaxis],
                                    distances[:, np.newaxis, :])
         distance_ratio[np.isnan(distance_ratio)] = 1.
-        memberships = np.sum(np.power(distance_ratio, 2 / (m - 1)), axis=2) ** -1
+        memberships = np.sum(np.power(distance_ratio, 2 / (m - 1)),
+                             axis=2) ** -1
         return memberships
 
     @staticmethod
@@ -46,12 +46,11 @@ class Probabilistic:
 
         """
         centers = np.dot(memberships.T ** m, X) / \
-                  np.sum(memberships.T ** m, axis=1)[..., np.newaxis]
+            np.sum(memberships.T ** m, axis=1)[..., np.newaxis]
         return centers
 
 
 class Possibilistic:
-
     @staticmethod
     def memberships(distances, weights, m=2.):
         """Calculate possibilistic memberships based on distances.
@@ -95,5 +94,3 @@ class Possibilistic:
         """
         return np.divide(np.dot((memberships ** m).T, X),
                          np.sum(memberships ** m, axis=0)[..., np.newaxis])
-
-

--- a/sklearn/cluster/_c_means.py
+++ b/sklearn/cluster/_c_means.py
@@ -1,14 +1,45 @@
 import numpy as np
 
 
-def _calculate_memberships(distances, m):
-    distance_ratio = np.divide(distances[:, :, np.newaxis], distances[:, np.newaxis, :])
+def _memberships_probabilistic(distances, m=2.):
+    """Calculate probabilistic memberships based on distances.
+
+    Parameters
+    ----------
+    distances : array-like, shape (n_samples, n_samples)
+        The distances from each point to every other.
+    m : float, optional, default 2.0
+        The fuzziness factor. Larger values dilute membership.
+
+    Returns
+    -------
+    memberships : float ndarray, shape (n_samples, n_clusters)
+        Updated memberships
+
+    """
+    distance_ratio = np.divide(distances[:, :, np.newaxis],
+                               distances[:, np.newaxis, :])
     distance_ratio[np.isnan(distance_ratio)] = 1.
     memberships = np.sum(np.power(distance_ratio, 2 / (m - 1)), axis=2) ** -1
     return memberships
 
 
-def _calculate_centers(X, memberships, m):
+def _centers_probabilistic(X, memberships, m=2.):
+    """Calculate probabilistic centers based on memberships.
+
+    Parameters
+    ----------
+    X : array-like, shape (n_samples, n_features)
+        The data points to cluster.
+    memberships : float ndarray, shape (n_samples, n_clusters)
+        Membership of each data point to the cluster centers.
+    m : float, optional, default 2.0
+        The fuzziness factor. Larger values dilute membership.
+
+    Returns
+    -------
+
+    """
     centers = np.dot(memberships.T ** m, X) / \
               np.sum(memberships.T ** m, axis=1)[..., np.newaxis]
     return centers

--- a/sklearn/cluster/c_means.py
+++ b/sklearn/cluster/c_means.py
@@ -4,18 +4,78 @@ import numpy as np
 
 from ..base import BaseEstimator, ClusterMixin, TransformerMixin
 from ..utils import check_array
+from ..utils import check_random_state
+from ..utils import as_float_array
+from ..externals.six import string_types
+
+
+def _validate_center_shape(X, n_centers, centers):
+    """Check if centers is compatible with X and n_centers"""
+    if len(centers) != n_centers:
+        raise ValueError('The shape of the initial centers (%s) '
+                         'does not match the number of clusters %i'
+                         % (centers.shape, n_centers))
+    if centers.shape[1] != X.shape[1]:
+        raise ValueError(
+            "The number of features of the initial centers %s "
+            "does not match the number of features of the data %s."
+            % (centers.shape[1], X.shape[1]))
+
 
 def c_means(X, n_clusters, n_init=10, max_iter=300, verbose=False, tol=1e-4,
-            random_state=None, algorithm="auto", return_n_iter=False):
+            random_state=None, algorithm="auto", return_n_iter=False,
+            copy_x=True):
     if n_init <= 0:
-        raise ValueError("Invalid number of initializations."
-                         " n_init={:d}")
+        raise ValueError('Number of initializations should be a positive'
+                         ' number, got {:d} instead.'.format(n_init))
+
+    random_state = check_random_state(random_state)
+
+    if max_iter <= 0:
+        raise ValueError('Number of iterations should be a positive number,'
+                         ' got {:d} instead.'.format(max_iter))
+
+    X = as_float_array(X, copy=copy_x)
+
+    X_mean = X.mean(axis=0)
+    X -= X_mean
+
+    if not copy_x:
+        X += X_mean
+
+def _cmeans_single_probabilistic(X, n_clusters, max_iter=300, random_state=None,
+                                 tol=1e-4):
+    random_state = check_random_state(random_state)
+
+    memberships_best, intertia_best, centers_best = None, None, None
+
+
+def _init_centroids(X, k, init, random_state=None):
+    random_state = check_random_state(random_state)
+    n_samples = X.shape[0]
+
+    if n_samples < k:
+        raise ValueError(
+            "`n_samples={:d} should be larger than n_clusters={:d}".format(
+                n_samples, k
+            )
+        )
+
+    if isinstance(init, string_types) and init == 'random':
+        seeds = random_state.permutation(n_samples)[:k]
+        centers = X[seeds]
+    else:
+        raise ValueError("`init` should be 'random'. '{}' (type '{}') "
+                         "was passed.".format(init, type(init)))
+
+    _validate_center_shape(X, k, centers)
+    return centers
 
 
 class CMeans(BaseEstimator, ClusterMixin, TransformerMixin):
 
     def __init__(self, n_clusters=8, n_init=10, max_iter=300, tol=1e-4,
-                 random_state=None, algorithm='auto'):
+                 random_state=None, algorithm='auto', copy_x=True):
 
         self.n_clusters = n_clusters
         self.max_iter = max_iter
@@ -23,10 +83,12 @@ class CMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         self.n_init = n_init
         self.random_state = random_state
         self.algorithm = algorithm
+        self.copy_x = copy_x
 
     def fit(self, X, y=None):
         c_means(
             X, n_clusters=self.n_clusters, n_init=self.n_init,
             max_iter=self.max_iter, tol=self.tol,
-            random_state=self.random_state, algorithm=self.algorithm)
+            random_state=self.random_state, algorithm=self.algorithm,
+            copy_x=self.copy_x)
         return self

--- a/sklearn/cluster/c_means.py
+++ b/sklearn/cluster/c_means.py
@@ -1,0 +1,32 @@
+"""C-means clustering"""
+
+import numpy as np
+
+from ..base import BaseEstimator, ClusterMixin, TransformerMixin
+from ..utils import check_array
+
+def c_means(X, n_clusters, n_init=10, max_iter=300, verbose=False, tol=1e-4,
+            random_state=None, algorithm="auto", return_n_iter=False):
+    if n_init <= 0:
+        raise ValueError("Invalid number of initializations."
+                         " n_init={:d}")
+
+
+class CMeans(BaseEstimator, ClusterMixin, TransformerMixin):
+
+    def __init__(self, n_clusters=8, n_init=10, max_iter=300, tol=1e-4,
+                 random_state=None, algorithm='auto'):
+
+        self.n_clusters = n_clusters
+        self.max_iter = max_iter
+        self.tol = tol
+        self.n_init = n_init
+        self.random_state = random_state
+        self.algorithm = algorithm
+
+    def fit(self, X, y=None):
+        c_means(
+            X, n_clusters=self.n_clusters, n_init=self.n_init,
+            max_iter=self.max_iter, tol=self.tol,
+            random_state=self.random_state, algorithm=self.algorithm)
+        return self

--- a/sklearn/cluster/c_means_.py
+++ b/sklearn/cluster/c_means_.py
@@ -197,6 +197,7 @@ class CMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         return X
 
     def _check_test_data(self, X):
+        """Verify that the number of features in the data is appropriate"""
         X = check_array(X, accept_sparse='csr', dtype=FLOAT_DTYPES)
         n_samples, n_features = X.shape
         expected_n_features = self.centers_.shape[1]
@@ -214,6 +215,14 @@ class CMeans(BaseEstimator, ClusterMixin, TransformerMixin):
 class ProbabilisticCMeans(CMeans):
 
     def fit(self, X, y=None):
+        """Compute c-means clustering.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+            Training samples to cluster.
+
+        """
         random_state = check_random_state(self.random_state)
         X = self._check_fit_data(X)
 

--- a/sklearn/cluster/c_means_.py
+++ b/sklearn/cluster/c_means_.py
@@ -122,12 +122,14 @@ def possibilistic_single(X, n_clusters, m=2., max_iter=300,
     weights = np.sum(memberships ** m * distances,
                      axis=0) / np.sum(memberships ** m, axis=0)
 
+    possibilistic = Possibilistic(weights=weights)
+
     for i in range(max_iter):
         inertia_old = inertia
-        distances = Possibilistic.distances(X, centers)
-        memberships = Possibilistic.memberships(distances, m)
+        distances = possibilistic.distances(X, centers)
+        memberships = possibilistic.memberships(distances, m)
         inertia = np.sum(memberships ** m * distances)
-        centers = Possibilistic.centers(X, memberships, m)
+        centers = possibilistic.centers(X, memberships, m)
 
         if abs(inertia - inertia_old) < tol:
             break
@@ -138,7 +140,7 @@ def possibilistic_single(X, n_clusters, m=2., max_iter=300,
         'centers': centers,
         'weights': weights,
         'n_iter': i + 1,
-        'algorithm': Possibilistic
+        'algorithm': possibilistic
     }
 
     return results

--- a/sklearn/cluster/c_means_.py
+++ b/sklearn/cluster/c_means_.py
@@ -42,11 +42,30 @@ def c_means(X, n_clusters, m=2, n_init=10, max_iter=300, init='random',
     X_mean = X.mean(axis=0)
     X -= X_mean
 
+    membership_best, inertia_best, centers_best, n_iter_best = (
+        None, None, None, None
+    )
+
+    cmeans_single = _cmeans_single_probabilistic
+
+    for it in range(n_init):
+        membership, inertia, centers, n_iter_ = cmeans_single(
+            X, n_clusters, max_iter=max_iter, init=init, tol=tol,
+            random_state=random_state)
+        if inertia_best is None or inertia < inertia_best:
+            membership_best = membership
+            centers_best = centers
+            inertia_best = inertia
+            n_iter_best = n_iter_
+
     if not copy_x:
         X += X_mean
 
+    return membership_best, centers_best, inertia_best, n_iter_best
 
-def _cmeans_single_probabilistic(X, n_clusters, m=2, max_iter=300, init='random', random_state=None, tol=1e-4):
+
+def _cmeans_single_probabilistic(X, n_clusters, m=2, max_iter=300,
+                                 init='random', random_state=None, tol=1e-4):
     random_state = check_random_state(random_state)
 
     memberships_best, inertia_best, centers_best = None, None, None

--- a/sklearn/cluster/tests/test_c_means.py
+++ b/sklearn/cluster/tests/test_c_means.py
@@ -2,16 +2,51 @@
 
 import numpy as np
 
-from sklearn.utils.testing import assert_raises_regex
+from sklearn.utils.testing import assert_raise_message
+from sklearn.utils.testing import assert_array_almost_equal
 
 from sklearn.cluster import CMeans, c_means
+from sklearn.datasets.samples_generator import make_blobs
 
 
-def test_c_means_n_init():
-    rnd = np.random.RandomState(0)
-    X = rnd.normal(size=(40, 2))
+centers = np.array([
+    [0.0, 5.0, 0.0, 0.0, 0.0],
+    [1.0, 1.0, 4.0, 0.0, 0.0],
+    [1.0, 0.0, 0.0, 5.0, 1.0],
+])
+n_samples = 100
+n_clusters, n_features = centers.shape
+X, true_labels = make_blobs(n_samples=n_samples, centers=centers,
+                            cluster_std=1., random_state=42)
 
-    # two regression tests on bad n_init argument
-    # previous bug: n_init <= 0 threw non-informative TypeError (#3858)
-    assert_raises_regex(ValueError, "n_init", CMeans(n_init=0).fit, X)
-    assert_raises_regex(ValueError, "n_init", CMeans(n_init=-1).fit, X)
+
+def test_n_init_error():
+    cm = CMeans(n_init=0)
+    assert_raise_message(ValueError,
+                         'Number of initializations should be a positive number,'
+                         ' got 0 instead.',
+                         cm.fit, X)
+    cm = CMeans(n_init=-1)
+    assert_raise_message(ValueError,
+                         'Number of initializations should be a positive number, got -1 instead.',
+                         cm.fit, X)
+
+def test_max_iter_error():
+    cm = CMeans(max_iter=0)
+    assert_raise_message(ValueError,
+                         'Number of iterations should be a positive number,'
+                         ' got 0 instead.',
+                         cm.fit, X)
+    cm = CMeans(max_iter=-1)
+    assert_raise_message(ValueError,
+                         'Number of iterations should be a positive number, got -1 instead.',
+                         cm.fit, X)
+
+
+def test_copyx():
+    # Check if copy_x=False returns nearly equal X after de-centering.
+    my_X = X.copy()
+    cm = CMeans(copy_x=False, n_clusters=n_clusters, random_state=42).fit(my_X)
+
+    # check if my_X is centered
+    assert_array_almost_equal(my_X, X)

--- a/sklearn/cluster/tests/test_c_means.py
+++ b/sklearn/cluster/tests/test_c_means.py
@@ -11,9 +11,12 @@ from sklearn.utils.testing import (assert_array_almost_equal,
 
 from sklearn.cluster import CMeans
 from sklearn.cluster.c_means_ import (_cmeans_single_probabilistic,
+                                      _cmeans_single_possibilistic,
                                       _init_centroids)
 from sklearn.cluster._c_means import (_memberships_probabilistic,
-                                      _centers_probabilistic)
+                                      _centers_probabilistic,
+                                      _memberships_possibilistic,
+                                      _centers_possibilistic,)
 
 from sklearn.datasets.samples_generator import make_blobs
 from sklearn.metrics.pairwise import euclidean_distances
@@ -72,14 +75,14 @@ def test_init_centroids_bounds():
     assert_array_almost_equal(c, np.nan_to_num(c))
 
 
-def test_calculate_memberships_shape():
+def test_probabilistic_update_memberships_shape():
     c = _init_centroids(X, n_clusters, 'random', random_state=42)
     distances = euclidean_distances(X, c)
     m = _memberships_probabilistic(distances, 2)
     assert_equal(m.shape, (n_samples, n_clusters))
 
 
-def test_calculate_memberships_bounds():
+def test_probabilistic_update_memberships_bounds():
     c = _init_centroids(X, n_clusters, 'random', random_state=42)
     distances = euclidean_distances(X, c)
     m = _memberships_probabilistic(distances, 2)
@@ -87,7 +90,7 @@ def test_calculate_memberships_bounds():
     assert_array_less(np.zeros_like(m) - 1e-6, m)
 
 
-def test_calculate_centers_shape():
+def test_probabilistic_update_centers_shape():
     distances = euclidean_distances(X, centers)
     m = _memberships_probabilistic(distances, 2)
     c = _centers_probabilistic(X, m, 2)
@@ -103,6 +106,38 @@ def test_probabilistic_center_shape():
     m, i, c, _ = _cmeans_single_probabilistic(X, n_clusters)
     assert_equal(c.shape, (n_clusters, n_features))
 
+
+def test_possibilistic_update_memberships_shape():
+    c = _init_centroids(X, n_clusters, 'random', random_state=42)
+    distances = euclidean_distances(X, c)
+    m = _memberships_possibilistic(distances, 2)
+    assert_equal(m.shape, (n_samples, n_clusters))
+
+
+def test_possibilistic_update_memberships_bounds():
+    c = _init_centroids(X, n_clusters, 'random', random_state=42)
+    distances = euclidean_distances(X, c)
+    m = _memberships_possibilistic(distances, 2)
+    assert_array_less(m, 1e-6 + np.ones_like(m))
+    assert_array_less(np.zeros_like(m) - 1e-6, m)
+
+
+def test_possibilistic_update_centers_shape():
+    distances = euclidean_distances(X, centers)
+    m = _memberships_possibilistic(distances, 2)
+    c = _centers_possibilistic(X, m, 2)
+    assert_equal(c.shape, (n_clusters, n_features))
+
+
+def test_possibilistic_membership_shape():
+    m, i, c, _ = _cmeans_single_possibilistic(X, n_clusters)
+    assert_equal(m.shape, (n_samples, n_clusters))
+
+
+def test_possibilistic_center_shape():
+    m, i, c, _ = _cmeans_single_possibilistic(X, n_clusters)
+    assert_equal(c.shape, (n_clusters, n_features))
+    
 
 def test_labels():
     cm = CMeans()
@@ -123,7 +158,13 @@ def _check_fitted_model(cm):
 
 
 def test_probabilistic_results():
-    cm = CMeans(n_clusters=3, random_state=4)
+    cm = CMeans(n_clusters=3, algorithm="probabilistic", random_state=4)
+    cm.fit(X)
+    _check_fitted_model(cm)
+
+
+def test_possibilistic_results():
+    cm = CMeans(n_clusters=3, algorithm="possibilistic", random_state=4)
     cm.fit(X)
     _check_fitted_model(cm)
 

--- a/sklearn/cluster/tests/test_c_means.py
+++ b/sklearn/cluster/tests/test_c_means.py
@@ -167,19 +167,3 @@ def test_possibilistic_results():
     _check_fitted_model(cm)
 
 
-def test_probabilistic_predict():
-    cm = ProbabilisticCMeans(n_clusters=3, algorithm="probabilistic", random_state=4)
-    cm.fit(X)
-    pred = cm.predict(centers)
-    assert_equal(pred.shape, (n_clusters, n_clusters))
-    assert_equal(v_measure_score(np.arange(n_clusters), np.argmax(pred, axis=1)), 1.0)
-
-
-def test_possibilistic_predict():
-    cm = PossibilisticCMeans(n_clusters=3, algorithm="possibilistic", random_state=4)
-    cm.fit(X)
-    pred = cm.predict(centers)
-    assert_equal(pred.shape, (n_clusters, n_clusters))
-    assert_equal(v_measure_score(np.arange(n_clusters), np.argmax(pred, axis=1)), 1.0)
-
-

--- a/sklearn/cluster/tests/test_c_means.py
+++ b/sklearn/cluster/tests/test_c_means.py
@@ -1,0 +1,17 @@
+"""Testing for C-means"""
+
+import numpy as np
+
+from sklearn.utils.testing import assert_raises_regex
+
+from sklearn.cluster import CMeans, c_means
+
+
+def test_c_means_n_init():
+    rnd = np.random.RandomState(0)
+    X = rnd.normal(size=(40, 2))
+
+    # two regression tests on bad n_init argument
+    # previous bug: n_init <= 0 threw non-informative TypeError (#3858)
+    assert_raises_regex(ValueError, "n_init", CMeans(n_init=0).fit, X)
+    assert_raises_regex(ValueError, "n_init", CMeans(n_init=-1).fit, X)

--- a/sklearn/cluster/tests/test_c_means.py
+++ b/sklearn/cluster/tests/test_c_means.py
@@ -11,8 +11,7 @@ from sklearn.utils.testing import (assert_array_almost_equal,
 
 from sklearn.cluster.c_means_ import (probabilistic_single,
                                       possibilistic_single,
-                                      ProbabilisticCMeans,
-                                      PossibilisticCMeans,
+                                      CMeans,
                                       _init_centroids)
 from sklearn.cluster._c_means import Probabilistic, Possibilistic
 
@@ -34,12 +33,12 @@ X, true_labels = make_blobs(n_samples=n_samples, centers=centers,
 
 
 def test_n_init_error():
-    cm = ProbabilisticCMeans(n_init=0)
+    cm = CMeans(n_init=0)
     assert_raise_message(ValueError,
                          'Number of initializations should be a positive '
                          'number, got 0 instead.',
                          cm.fit, X)
-    cm = ProbabilisticCMeans(n_init=-1)
+    cm = CMeans(n_init=-1)
     assert_raise_message(ValueError,
                          'Number of initializations should be a positive '
                          'number, got -1 instead.',
@@ -47,12 +46,12 @@ def test_n_init_error():
 
 
 def test_max_iter_error():
-    cm = ProbabilisticCMeans(max_iter=0)
+    cm = CMeans(max_iter=0)
     assert_raise_message(ValueError,
                          'Number of iterations should be a positive number,'
                          ' got 0 instead.',
                          cm.fit, X)
-    cm = ProbabilisticCMeans(max_iter=-1)
+    cm = CMeans(max_iter=-1)
     assert_raise_message(ValueError,
                          'Number of iterations should be a positive number, '
                          'got -1 instead.',
@@ -62,7 +61,7 @@ def test_max_iter_error():
 def test_copyx():
     # Check if copy_x=False returns nearly equal X after de-centering.
     my_X = X.copy()
-    ProbabilisticCMeans(copy_x=False, n_clusters=n_clusters, random_state=42).fit(my_X)
+    CMeans(copy_x=False, n_clusters=n_clusters, random_state=42).fit(my_X)
 
     # check if my_X is centered
     assert_array_almost_equal(my_X, X)
@@ -108,22 +107,28 @@ def test_probabilistic_center_shape():
 def test_possibilistic_update_memberships_shape():
     c = _init_centroids(X, n_clusters, 'random', random_state=42)
     distances = euclidean_distances(X, c)
-    m = Possibilistic.memberships(distances, 2)
+    weights = np.array([1., 1., 1.,])
+    possibilistic = Possibilistic(weights)
+    m = possibilistic.memberships(distances, 2)
     assert_equal(m.shape, (n_samples, n_clusters))
 
 
 def test_possibilistic_update_memberships_bounds():
     c = _init_centroids(X, n_clusters, 'random', random_state=42)
     distances = euclidean_distances(X, c)
-    m = Possibilistic.memberships(distances, 2)
+    weights = np.array([1., 1., 1.,])
+    possibilistic = Possibilistic(weights)
+    m = possibilistic.memberships(distances, 2)
     assert_array_less(m, 1e-6 + np.ones_like(m))
     assert_array_less(np.zeros_like(m) - 1e-6, m)
 
 
 def test_possibilistic_update_centers_shape():
     distances = euclidean_distances(X, centers)
-    m = Possibilistic.memberships(distances, 2)
-    c = Possibilistic.centers(X, m, 2)
+    weights = np.array([1., 1., 1.,])
+    possibilistic = Possibilistic(weights)
+    m = possibilistic.memberships(distances, 2)
+    c = possibilistic.centers(X, m, 2)
     assert_equal(c.shape, (n_clusters, n_features))
 
 
@@ -138,7 +143,7 @@ def test_possibilistic_center_shape():
     
 
 def test_labels():
-    cm = ProbabilisticCMeans()
+    cm = CMeans()
     cm.memberships_ = np.array([
         [1.0, 0.0],
         [0.7, 0.3],
@@ -156,14 +161,14 @@ def _check_fitted_model(cm):
 
 
 def test_probabilistic_results():
-    cm = ProbabilisticCMeans(n_clusters=3, algorithm="probabilistic", random_state=4)
+    cm = CMeans(n_clusters=3, algorithm="probabilistic", random_state=4)
     cm.fit(X)
     _check_fitted_model(cm)
 
-
-def test_possibilistic_results():
-    cm = PossibilisticCMeans(n_clusters=3, algorithm="possibilistic", random_state=4)
-    cm.fit(X)
-    _check_fitted_model(cm)
+# Possibilistic results are known to be poor, included here for completeness
+# def test_possibilistic_results():
+#     cm = CMeans(n_clusters=3, algorithm="possibilistic", random_state=4)
+#     cm.fit(X)
+#     _check_fitted_model(cm)
 
 

--- a/sklearn/cluster/tests/test_c_means.py
+++ b/sklearn/cluster/tests/test_c_means.py
@@ -1,13 +1,23 @@
 """Testing for C-means"""
+import warnings
 
 import numpy as np
 
+from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raise_message
-from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import (assert_array_almost_equal,
+                                   assert_array_less)
 
-from sklearn.cluster import CMeans, c_means
+from sklearn.cluster import CMeans
+from sklearn.cluster.c_means_ import (_cmeans_single_probabilistic,
+                                      _init_centroids)
+from sklearn.cluster._c_means import (_calculate_memberships,
+                                      _calculate_centers)
+
 from sklearn.datasets.samples_generator import make_blobs
+from sklearn.metrics.pairwise import euclidean_distances
 
+warnings.filterwarnings('ignore', category=RuntimeWarning)
 
 centers = np.array([
     [0.0, 5.0, 0.0, 0.0, 0.0],
@@ -23,13 +33,15 @@ X, true_labels = make_blobs(n_samples=n_samples, centers=centers,
 def test_n_init_error():
     cm = CMeans(n_init=0)
     assert_raise_message(ValueError,
-                         'Number of initializations should be a positive number,'
-                         ' got 0 instead.',
+                         'Number of initializations should be a positive '
+                         'number, got 0 instead.',
                          cm.fit, X)
     cm = CMeans(n_init=-1)
     assert_raise_message(ValueError,
-                         'Number of initializations should be a positive number, got -1 instead.',
+                         'Number of initializations should be a positive '
+                         'number, got -1 instead.',
                          cm.fit, X)
+
 
 def test_max_iter_error():
     cm = CMeans(max_iter=0)
@@ -39,14 +51,52 @@ def test_max_iter_error():
                          cm.fit, X)
     cm = CMeans(max_iter=-1)
     assert_raise_message(ValueError,
-                         'Number of iterations should be a positive number, got -1 instead.',
+                         'Number of iterations should be a positive number, '
+                         'got -1 instead.',
                          cm.fit, X)
 
 
 def test_copyx():
     # Check if copy_x=False returns nearly equal X after de-centering.
     my_X = X.copy()
-    cm = CMeans(copy_x=False, n_clusters=n_clusters, random_state=42).fit(my_X)
+    CMeans(copy_x=False, n_clusters=n_clusters, random_state=42).fit(my_X)
 
     # check if my_X is centered
     assert_array_almost_equal(my_X, X)
+
+
+def test_init_centroids_bounds():
+    c = _init_centroids(X, n_clusters, 'random', random_state=42)
+    assert_array_almost_equal(c, np.nan_to_num(c))
+
+
+def test_calculate_memberships_shape():
+    c = _init_centroids(X, n_clusters, 'random', random_state=42)
+    distances = euclidean_distances(X, c)
+    m = _calculate_memberships(distances, 2)
+    assert_equal(m.shape, (n_samples, n_clusters))
+
+
+def test_calculate_memberships_bounds():
+    c = _init_centroids(X, n_clusters, 'random', random_state=42)
+    distances = euclidean_distances(X, c)
+    m = _calculate_memberships(distances, 2)
+    assert_array_less(m, 1e-6 + np.ones_like(m))
+    assert_array_less(np.zeros_like(m) - 1e-6, m)
+
+
+def test_calculate_centers_shape():
+    distances = euclidean_distances(X, centers)
+    m = _calculate_memberships(distances, 2)
+    c = _calculate_centers(X, m, 2)
+    assert_equal(c.shape, (n_clusters, n_features))
+
+
+def test_probabilistic_membership_shape():
+    m, i, c, _ = _cmeans_single_probabilistic(X, n_clusters)
+    assert_equal(m.shape, (n_samples, n_clusters))
+
+
+def test_probabilistic_center_shape():
+    m, i, c, _ = _cmeans_single_probabilistic(X, n_clusters)
+    assert_equal(c.shape, (n_clusters, n_features))

--- a/sklearn/cluster/tests/test_c_means.py
+++ b/sklearn/cluster/tests/test_c_means.py
@@ -9,14 +9,12 @@ from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import (assert_array_almost_equal,
                                    assert_array_less)
 
-from sklearn.cluster import CMeans
-from sklearn.cluster.c_means_ import (_cmeans_single_probabilistic,
-                                      _cmeans_single_possibilistic,
+from sklearn.cluster.c_means_ import (probabilistic_single,
+                                      possibilistic_single,
+                                      ProbabilisticCMeans,
+                                      PossibilisticCMeans,
                                       _init_centroids)
-from sklearn.cluster._c_means import (_memberships_probabilistic,
-                                      _centers_probabilistic,
-                                      _memberships_possibilistic,
-                                      _centers_possibilistic,)
+from sklearn.cluster._c_means import Probabilistic, Possibilistic
 
 from sklearn.datasets.samples_generator import make_blobs
 from sklearn.metrics.pairwise import euclidean_distances
@@ -36,12 +34,12 @@ X, true_labels = make_blobs(n_samples=n_samples, centers=centers,
 
 
 def test_n_init_error():
-    cm = CMeans(n_init=0)
+    cm = ProbabilisticCMeans(n_init=0)
     assert_raise_message(ValueError,
                          'Number of initializations should be a positive '
                          'number, got 0 instead.',
                          cm.fit, X)
-    cm = CMeans(n_init=-1)
+    cm = ProbabilisticCMeans(n_init=-1)
     assert_raise_message(ValueError,
                          'Number of initializations should be a positive '
                          'number, got -1 instead.',
@@ -49,12 +47,12 @@ def test_n_init_error():
 
 
 def test_max_iter_error():
-    cm = CMeans(max_iter=0)
+    cm = ProbabilisticCMeans(max_iter=0)
     assert_raise_message(ValueError,
                          'Number of iterations should be a positive number,'
                          ' got 0 instead.',
                          cm.fit, X)
-    cm = CMeans(max_iter=-1)
+    cm = ProbabilisticCMeans(max_iter=-1)
     assert_raise_message(ValueError,
                          'Number of iterations should be a positive number, '
                          'got -1 instead.',
@@ -64,7 +62,7 @@ def test_max_iter_error():
 def test_copyx():
     # Check if copy_x=False returns nearly equal X after de-centering.
     my_X = X.copy()
-    CMeans(copy_x=False, n_clusters=n_clusters, random_state=42).fit(my_X)
+    ProbabilisticCMeans(copy_x=False, n_clusters=n_clusters, random_state=42).fit(my_X)
 
     # check if my_X is centered
     assert_array_almost_equal(my_X, X)
@@ -78,69 +76,69 @@ def test_init_centroids_bounds():
 def test_probabilistic_update_memberships_shape():
     c = _init_centroids(X, n_clusters, 'random', random_state=42)
     distances = euclidean_distances(X, c)
-    m = _memberships_probabilistic(distances, 2)
+    m = Probabilistic.memberships(distances, 2)
     assert_equal(m.shape, (n_samples, n_clusters))
 
 
 def test_probabilistic_update_memberships_bounds():
     c = _init_centroids(X, n_clusters, 'random', random_state=42)
     distances = euclidean_distances(X, c)
-    m = _memberships_probabilistic(distances, 2)
+    m = Probabilistic.memberships(distances, 2)
     assert_array_less(m, 1e-6 + np.ones_like(m))
     assert_array_less(np.zeros_like(m) - 1e-6, m)
 
 
 def test_probabilistic_update_centers_shape():
     distances = euclidean_distances(X, centers)
-    m = _memberships_probabilistic(distances, 2)
-    c = _centers_probabilistic(X, m, 2)
+    m = Probabilistic.memberships(distances, 2)
+    c = Probabilistic.centers(X, m, 2)
     assert_equal(c.shape, (n_clusters, n_features))
 
 
 def test_probabilistic_membership_shape():
-    m, i, c, _ = _cmeans_single_probabilistic(X, n_clusters)
+    m = probabilistic_single(X, n_clusters)['memberships']
     assert_equal(m.shape, (n_samples, n_clusters))
 
 
 def test_probabilistic_center_shape():
-    m, i, c, _ = _cmeans_single_probabilistic(X, n_clusters)
+    c = probabilistic_single(X, n_clusters)['centers']
     assert_equal(c.shape, (n_clusters, n_features))
 
 
 def test_possibilistic_update_memberships_shape():
     c = _init_centroids(X, n_clusters, 'random', random_state=42)
     distances = euclidean_distances(X, c)
-    m = _memberships_possibilistic(distances, 2)
+    m = Possibilistic.memberships(distances, 2)
     assert_equal(m.shape, (n_samples, n_clusters))
 
 
 def test_possibilistic_update_memberships_bounds():
     c = _init_centroids(X, n_clusters, 'random', random_state=42)
     distances = euclidean_distances(X, c)
-    m = _memberships_possibilistic(distances, 2)
+    m = Possibilistic.memberships(distances, 2)
     assert_array_less(m, 1e-6 + np.ones_like(m))
     assert_array_less(np.zeros_like(m) - 1e-6, m)
 
 
 def test_possibilistic_update_centers_shape():
     distances = euclidean_distances(X, centers)
-    m = _memberships_possibilistic(distances, 2)
-    c = _centers_possibilistic(X, m, 2)
+    m = Possibilistic.memberships(distances, 2)
+    c = Possibilistic.centers(X, m, 2)
     assert_equal(c.shape, (n_clusters, n_features))
 
 
 def test_possibilistic_membership_shape():
-    m, i, c, _ = _cmeans_single_possibilistic(X, n_clusters)
+    m = possibilistic_single(X, n_clusters)['memberships']
     assert_equal(m.shape, (n_samples, n_clusters))
 
 
 def test_possibilistic_center_shape():
-    m, i, c, _ = _cmeans_single_possibilistic(X, n_clusters)
+    c = possibilistic_single(X, n_clusters)['centers']
     assert_equal(c.shape, (n_clusters, n_features))
     
 
 def test_labels():
-    cm = CMeans()
+    cm = ProbabilisticCMeans()
     cm.memberships_ = np.array([
         [1.0, 0.0],
         [0.7, 0.3],
@@ -158,13 +156,30 @@ def _check_fitted_model(cm):
 
 
 def test_probabilistic_results():
-    cm = CMeans(n_clusters=3, algorithm="probabilistic", random_state=4)
+    cm = ProbabilisticCMeans(n_clusters=3, algorithm="probabilistic", random_state=4)
     cm.fit(X)
     _check_fitted_model(cm)
 
 
 def test_possibilistic_results():
-    cm = CMeans(n_clusters=3, algorithm="possibilistic", random_state=4)
+    cm = PossibilisticCMeans(n_clusters=3, algorithm="possibilistic", random_state=4)
     cm.fit(X)
     _check_fitted_model(cm)
+
+
+def test_probabilistic_predict():
+    cm = ProbabilisticCMeans(n_clusters=3, algorithm="probabilistic", random_state=4)
+    cm.fit(X)
+    pred = cm.predict(centers)
+    assert_equal(pred.shape, (n_clusters, n_clusters))
+    assert_equal(v_measure_score(np.arange(n_clusters), np.argmax(pred, axis=1)), 1.0)
+
+
+def test_possibilistic_predict():
+    cm = PossibilisticCMeans(n_clusters=3, algorithm="possibilistic", random_state=4)
+    cm.fit(X)
+    pred = cm.predict(centers)
+    assert_equal(pred.shape, (n_clusters, n_clusters))
+    assert_equal(v_measure_score(np.arange(n_clusters), np.argmax(pred, axis=1)), 1.0)
+
 


### PR DESCRIPTION
## _c_-means clustering

_c_-means clustering is a generalisation of _k_-means clustering that solves the problem of ambiguous data points. Rather than being assigned complete membership to a cluster, each data point has a membership to *all* clusters that varies between 0 and 1. The exact behaviour of this is algorithm-dependent. Although this changes the update rules for calculation of the centres, the basic algorithm (update centres, update labels, repeat) is the same as _k_-means [1].

![comparison](https://user-images.githubusercontent.com/15631502/28077191-f49ec946-6658-11e7-971a-af9f82226b9a.png)

#### To Do:
- [x] Implement probabilistic algorithm
- [x] Implement possibilistic algorithm
- [x] Take advantage of k++ initialization
- [x] Include the Gustafson-Kessel extension for non-circular clusters [2]
- [ ] Examples
- [ ] Descriptive documentation
- [ ] Full test coverage
- [ ] Optimisation using Cython (help would be appreciated on this as I've got very limited experience with Cython)

#### References
[1] Bezdek, James C., Robert Ehrlich, and William Full. "FCM: The fuzzy c-means clustering algorithm." Computers & Geosciences 10.2-3 (1984): 191-203.
[2] Gustafson, Donald E., and William C. Kessel. "Fuzzy clustering with a fuzzy covariance matrix." Decision and Control including the 17th Symposium on Adaptive Processes, 1978 IEEE Conference on. IEEE, 1979.