### PR TITLE
[MRG] partial_fit for BayesianGaussianMixture

### DIFF
--- a/doc/modules/mixture.rst
+++ b/doc/modules/mixture.rst
@@ -235,6 +235,9 @@ from the two resulting mixtures.
       plotting the confidence ellipsoids for both :class:`GaussianMixture`
       and :class:`BayesianGaussianMixture`.
 
+    * See :ref:`sphx_glr_auto_examples_mixture_plot_partial_fit.py` shows using
+      the `partial_fit` method to fit a large dataset using :class:`BayesianGaussianMixture`
+
     * :ref:`sphx_glr_auto_examples_mixture_plot_gmm_sin.py` shows using
       :class:`GaussianMixture` and :class:`BayesianGaussianMixture` to fit a
       sine wave.
@@ -272,6 +275,9 @@ Pros
    variational solutions have less pathological special cases than
    expectation-maximization solutions.
 
+:Online inference: using the ``partial_fit()`` method, variational Bayesian
+     mixture models streaming data or large datasets split into minibatches.
+
 
 Cons
 .....
@@ -285,7 +291,7 @@ Cons
 :Bias: there are many implicit biases in the inference algorithms (and also in
    the Dirichlet process if used), and whenever there is a mismatch between
    these biases and the data it might be possible to fit better models using a
-   finite mixture.
+   finite mixture.  In particular, variational methods are known to underestimate variance.
 
 
 .. _dirichlet_process:

--- a/doc/modules/mixture.rst
+++ b/doc/modules/mixture.rst
@@ -227,6 +227,16 @@ from the two resulting mixtures.
    :align: center
    :scale: 65%
 
+In the following example, we fit a large dataset using the `partial_fit` method.
+As we can see, it converges to approximately the same posterior in significantly
+less time than fitting on the full set, regardless of the number of initial clusters.
+
+.. figure:: ../auto_examples/mixture/images/sphx_glr_plot_partial_fit_001.png
+   :target: ../auto_examples/mixture/plot_partial_fit.html
+   :align: center
+   :scale: 65%
+
+
 
 
 .. topic:: Examples:
@@ -248,6 +258,9 @@ from the two resulting mixtures.
       ``weight_concentration_prior_type`` for different values of the parameter
       ``weight_concentration_prior``.
 
+    * See :ref:`sphx_glr_auto_examples_mixture_plot_partial_fit.py` for an
+      example of fitting the :class:`BayesianGaussianMixture` with batches using
+      `partial_fit`
 
 Pros and cons of variational inference with :class:`BayesianGaussianMixture`
 ----------------------------------------------------------------------------

--- a/doc/modules/scaling_strategies.rst
+++ b/doc/modules/scaling_strategies.rst
@@ -63,6 +63,7 @@ Here is a list of incremental estimators for different tasks:
       + :class:`sklearn.linear_model.SGDClassifier`
       + :class:`sklearn.linear_model.PassiveAggressiveClassifier`
       + :class:`sklearn.neural_network.MLPClassifier`
+      + :class:'sklearn.mixture.BayesianGaussianMixture'
   - Regression
       + :class:`sklearn.linear_model.SGDRegressor`
       + :class:`sklearn.linear_model.PassiveAggressiveRegressor`
@@ -70,6 +71,7 @@ Here is a list of incremental estimators for different tasks:
   - Clustering
       + :class:`sklearn.cluster.MiniBatchKMeans`
       + :class:`sklearn.cluster.Birch`
+      + :class:'sklearn.mixture.BayesianGaussianMixture'
   - Decomposition / feature Extraction
       + :class:`sklearn.decomposition.MiniBatchDictionaryLearning`
       + :class:`sklearn.decomposition.IncrementalPCA`

--- a/examples/mixture/plot_partial_fit.py
+++ b/examples/mixture/plot_partial_fit.py
@@ -4,12 +4,14 @@ Bayesian Gaussian Mixture Model Ellipsoids
 ===========================================
 
 Plot the confidence ellipsoids of a mixture of two Gaussians
-obtained with Variational Inference (``BayesianGaussianMixture`` class models with
-a Dirichlet process prior), using the ``fit()`` and ``partial_fit()`` methods. 
+obtained with Variational Inference (``BayesianGaussianMixture`` class models
+with a Dirichlet process prior), using the ``fit()`` and ``partial_fit()``
+methods.
 
-The ``fit()`` method uses the entire dataset, while ``partial_fit()`` can be used 
-for either the full dataset or minibatches.  For streaming data or datasets too large
-to fit into memory, ```partial_fit()``` gives a similar or better fit much faster. 
+The ``fit()`` method uses the entire dataset, while ``partial_fit()`` can be
+used for either the full dataset or minibatches.  For streaming data or
+datasets too large to fit into memory, ```partial_fit()``` gives a similar or
+better fit much faster.
 """
 
 import itertools

--- a/examples/mixture/plot_partial_fit.py
+++ b/examples/mixture/plot_partial_fit.py
@@ -93,6 +93,7 @@ f, axarr = plt.subplots(2, 2, figsize=(10, 10))
 n_components = [20, 12]
 
 for i in xrange(len(n_components)):
+    # Fit a Dirichlet process Gaussian Mixture using the full dataset
     dpgmm = BayesianGaussianMixture(n_components=n_components[i],
                                     random_state=1,
                                     max_iter=500)
@@ -105,8 +106,7 @@ for i in xrange(len(n_components)):
                 runtime %.3f s''' % (n_components[i], runtime)
     plot_results(X, dpgmm, title, axarr[0, i])
 
-    # Fit a Dirichlet process Gaussian mixture "online"
-
+    # Fit a Dirichlet process Gaussian mixture using minibatches
     dpgmm_online = BayesianGaussianMixture(n_components=n_components[i],
                                            random_state=1,
                                            max_iter=10)

--- a/examples/mixture/plot_partial_fit.py
+++ b/examples/mixture/plot_partial_fit.py
@@ -1,0 +1,96 @@
+"""
+===========================================
+Bayesian Gaussian Mixture Model Ellipsoids
+===========================================
+
+Plot the confidence ellipsoids of a mixture of two Gaussians
+obtained with Variational Inference (``BayesianGaussianMixture`` class models with
+a Dirichlet process prior), using the ``fit()`` and ``partial_fit()`` methods. 
+
+The ``fit()`` method uses the entire dataset, while ``partial_fit()`` can be used 
+for either the full dataset or minibatches.  For streaming data or datasets too large
+to fit into memory, ```partial_fit()``` gives a similar or better fit much faster. 
+"""
+
+import itertools
+
+import numpy as np
+from scipy import linalg
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+
+from sklearn import mixture
+
+import time
+
+color_iter = itertools.cycle(['navy', 'c', 'cornflowerblue', 'gold',
+                              'darkorange'])
+
+
+def plot_results(X, Y_, means, covariances, index, title):
+    splot = plt.subplot(2, 1, 1 + index)
+    for i, (mean, covar, color) in enumerate(zip(
+            means, covariances, color_iter)):
+        v, w = linalg.eigh(covar)
+        v = 2. * np.sqrt(2.) * np.sqrt(v)
+        u = w[0] / linalg.norm(w[0])
+        # as the DP will not use every component it has access to
+        # unless it needs it, we shouldn't plot the redundant
+        # components.
+        if not np.any(Y_ == i):
+            continue
+        plt.scatter(X[Y_ == i, 0], X[Y_ == i, 1], .8, color=color)
+
+        # Plot an ellipse to show the Gaussian component
+        angle = np.arctan(u[1] / u[0])
+        angle = 180. * angle / np.pi  # convert to degrees
+        ell = mpl.patches.Ellipse(mean, v[0], v[1], 180. + angle, color=color)
+        ell.set_clip_box(splot.bbox)
+        ell.set_alpha(0.5)
+        splot.add_artist(ell)
+
+    plt.xlim(-9., 5.)
+    plt.ylim(-3., 6.)
+    plt.xticks(())
+    plt.yticks(())
+    plt.title(title)
+
+
+# Number of samples per component
+n_samples = 10000
+
+# Generate random sample, two components
+np.random.seed(0)
+C = np.array([[0., -0.1], [1.7, .4]])
+X = np.r_[np.dot(np.random.randn(n_samples, 2), C),
+          .7 * np.random.randn(n_samples, 2) + np.array([-6, 3])]
+
+# Fit a Dirichlet process Gaussian mixture using five components
+dpgmm = mixture.BayesianGaussianMixture(n_components=5,
+                                        covariance_type='full',
+                                        max_iter=200)
+start = time.time()
+dpgmm.fit(X)
+full_runtime = time.time() - start
+
+plot_results(X, dpgmm.predict(X), dpgmm.means_, dpgmm.covariances_, 0,
+             'Fitting using full data')
+
+dpgmm2 = mixture.BayesianGaussianMixture(n_components=5,
+                                         covariance_type='full',
+                                         max_iter=200, warm_start=True)
+n_batches = 10
+minibatches = np.array_split(X, n_batches)
+
+start2 = time.time()
+for batch in minibatches:
+    dpgmm2.partial_fit(batch)
+
+partial_runtime = (time.time() - start2)
+
+plot_results(X, dpgmm2.predict(X), dpgmm2.means_, dpgmm2.covariances_, 1,
+             'Fitting using batches')
+
+print "fit() runtime: ", full_runtime
+print "partial_fit() runtime: ", partial_runtime
+plt.show()

--- a/examples/mixture/plot_partial_fit.py
+++ b/examples/mixture/plot_partial_fit.py
@@ -79,13 +79,13 @@ batch_size = 500
 # Generate random sample, two components
 np.random.seed(0)
 
-point = 5*np.sqrt(2)/2.
+point = 5 * np.sqrt(2) / 2.
 centers = [[-5, 0], [-point, point], [5, 0], [point, point], [0, 0],
            [5, 0], [point, -point], [0, -5], [-point, -point], [0, 5]]
 X, labels = make_blobs(n_samples=n_samples, centers=centers,
                        cluster_std=1.1)
 
-updates = np.array_split(X, np.ceil(n_samples/(batch_size)))
+updates = np.array_split(X, np.ceil(n_samples / (batch_size)))
 
 
 f, axarr = plt.subplots(2, 2, figsize=(10, 10))

--- a/examples/mixture/plot_partial_fit.py
+++ b/examples/mixture/plot_partial_fit.py
@@ -30,6 +30,7 @@ import matplotlib as mpl
 
 from sklearn.datasets import make_blobs
 from sklearn.mixture import BayesianGaussianMixture
+from sklearn.externals.six.moves import xrange
 
 print(__doc__)
 

--- a/examples/mixture/plot_partial_fit.py
+++ b/examples/mixture/plot_partial_fit.py
@@ -1,8 +1,8 @@
 
 """
-===============================================
-Bayesian Gaussian Mixture Model Fitting Methods
-===============================================
+=================================================
+Online Fitting of Bayesian Gaussian Mixture Model
+=================================================
 
 Plot the confidence ellipsoids of a mixture of two Gaussians
 obtained with Variational Inference (``BayesianGaussianMixture`` class models
@@ -11,29 +11,40 @@ methods.
 
 The ``fit()`` method uses the entire dataset, either all at once or in
 minibatches, while ``partial_fit()`` can be used for any number of points
-equal to or greater than the number of componentsIn this case, we use
-partial_fit each update on the minimum number of points necessary for fitting,
-to simulate online learning
+equal to or greater than the number of componentsI.  In this case, we use
+partial_fit on batches of size 500, and restrict each batch to 10 iterations,
+We see that we get nearly identical results in a fraction of the time.
+The effect is more pronounced if we start with a larger number of components.
 """
 # Authors: Joshua Engelman <j.aaron.engelman@gmail.com>
 # License: BSD 3 clause
 
-import itertools
+from itertools import cycle
+from time import time
+
 import numpy as np
 from scipy import linalg
+
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 
+from sklearn.datasets import make_blobs
 from sklearn.mixture import BayesianGaussianMixture
 
 print(__doc__)
 
-color_iter = itertools.cycle(['navy', 'c', 'cornflowerblue', 'gold',
-                              'darkorange'])
+
+color_iter = cycle(['navy', 'c', 'cornflowerblue', 'gold',
+                    'darkorange', 'brown', 'k', 'g', 'r', 'm'])
 
 
-def plot_results(X, Y_, means, covariances, index, title):
-    splot = plt.subplot(3, 1, 1 + index)
+def plot_results(X, estimator, title, subplot):
+
+    means = estimator.means_
+    covariances = estimator.covariances_
+    Y_ = estimator.predict(X)
+    loss = estimator.score(X)
+
     for i, (mean, covar, color) in enumerate(zip(
             means, covariances, color_iter)):
         v, w = linalg.eigh(covar)
@@ -44,78 +55,69 @@ def plot_results(X, Y_, means, covariances, index, title):
         # components.
         if not np.any(Y_ == i):
             continue
-        plt.scatter(X[Y_ == i, 0], X[Y_ == i, 1], .8, color=color)
+        subplot.scatter(X[Y_ == i, 0], X[Y_ == i, 1], .8, color=color)
 
         # Plot an ellipse to show the Gaussian component
         angle = np.arctan(u[1] / u[0])
         angle = 180. * angle / np.pi  # convert to degrees
         ell = mpl.patches.Ellipse(mean, v[0], v[1], 180. + angle, color=color)
-        ell.set_clip_box(splot.bbox)
+        ell.set_clip_box(subplot.bbox)
         ell.set_alpha(0.5)
-        splot.add_artist(ell)
+        subplot.add_artist(ell)
 
-    plt.xlim(-9., 5.)
-    plt.ylim(-3., 6.)
-    plt.xticks(())
-    plt.yticks(())
-    plt.title(title)
+    subplot.set_xticks(())
+    subplot.set_xlabel('Log likelihood: %f' % loss)
+    subplot.set_yticks(())
+    subplot.set_title(title)
 
 
 # Number of samples per component
-n_samples = 5000
-n_components = 5
+n_samples = 10000
+batch_size = 500
 
 # Generate random sample, two components
 np.random.seed(0)
-X = np.zeros((n_samples, 2))
-step = 4. * np.pi / n_samples
 
-np.random.seed(0)
-C = np.array([[0., -0.1], [1.7, .4]])
-X = np.r_[np.dot(np.random.randn(n_samples, 2), C),
-          .7 * np.random.randn(n_samples, 2) + np.array([-6, 3])]
+point = 5*np.sqrt(2)/2.
+centers = [[-5, 0], [-point, point], [5, 0], [point, point], [0, 0],
+           [5, 0], [point, -point], [0, -5], [-point, -point], [0, 5]]
+X, labels = make_blobs(n_samples=n_samples, centers=centers,
+                       cluster_std=1.1)
 
-plt.figure(figsize=(10, 10))
-plt.subplots_adjust(bottom=.04, top=0.95, hspace=.2, wspace=.05,
-                    left=.03, right=.97)
+updates = np.array_split(X, np.ceil(n_samples/(batch_size)))
 
-# Fit a Dirichlet process Gaussian mixture using the whole dataset
-dpgmm = BayesianGaussianMixture(n_components=n_components,
-                                random_state=1)
 
-dpgmm.fit(X)
-plot_results(X, dpgmm.predict(X), dpgmm.means_, dpgmm.covariances_, 0,
-             'Fitting using full data')
+f, axarr = plt.subplots(2, 2, figsize=(10, 10))
 
-# Fit a Dirichlet process Gaussian mixture using the whole dataset
-dpgmm_minibatches = BayesianGaussianMixture(n_components=n_components,
-                                            random_state=1,
-                                            batch_size=100,
-                                            n_jobs=-1)
+n_components = [20, 12]
 
-dpgmm_minibatches.fit(X)
-plot_results(X, dpgmm_minibatches.predict(X), dpgmm_minibatches.means_,
-             dpgmm_minibatches.covariances_, 1,
-             'Fitting using minibatches')
+for i in xrange(len(n_components)):
+    dpgmm = BayesianGaussianMixture(n_components=n_components[i],
+                                    random_state=1,
+                                    max_iter=500)
 
-# Fit a Dirichlet process Gaussian mixture "online"
+    start = time()
+    dpgmm.fit(X)
+    runtime = time() - start
 
-np.random.shuffle(X)
-updates = np.array_split(X, np.floor(n_samples/n_components))
-dpgmm_online = BayesianGaussianMixture(n_components=n_components,
-                                       mean_precision_prior=1e-8,
-                                       covariance_prior=1e1*np.eye(2),
-                                       random_state=1)
+    title = '''fit() with %i components,
+                runtime %.3f s''' % (n_components[i], runtime)
+    plot_results(X, dpgmm, title, axarr[0, i])
 
-scores = []
-timestep = 0
-for update in updates:
-    timestep += 1
-    dpgmm_online.partial_fit(update, lr=1./(timestep*1e-3))
-    scores.append([timestep, dpgmm_online.score(X)])
+    # Fit a Dirichlet process Gaussian mixture "online"
 
-plot_results(X, dpgmm_online.predict(X), dpgmm_online.means_,
-             dpgmm_online.covariances_, 2,
-             'Fitting online using partial_fit')
+    dpgmm_online = BayesianGaussianMixture(n_components=n_components[i],
+                                           random_state=1,
+                                           max_iter=10)
+
+    start2 = time()
+    for update in updates:
+        dpgmm_online.partial_fit(update)
+
+    runtime2 = time() - start2
+
+    title = 'partial_fit() with 20 components, runtime %.3f s' % runtime2
+    plot_results(X, dpgmm_online, title, axarr[1, i])
+
 
 plt.show()

--- a/sklearn/mixture/bayesian_mixture.py
+++ b/sklearn/mixture/bayesian_mixture.py
@@ -430,7 +430,7 @@ class BayesianGaussianMixture(BaseMixture):
         elif self.mean_precision_prior > 0.:
             self.mean_precision_prior_ = self.mean_precision_prior
         else:
-            raise ValueError("The parameter 'mean_precision_prior' should"
+            raise ValueError("The parameter 'mean_precision_prior' should "
                              "be greater than 0., but got %.3f."
                              % self.mean_precision_prior)
 
@@ -933,3 +933,5 @@ class BayesianGaussianMixture(BaseMixture):
                                          for result in results], axis=0)
         else:
             super(BayesianGaussianMixture, self).fit(X)
+
+        return self

--- a/sklearn/mixture/bayesian_mixture.py
+++ b/sklearn/mixture/bayesian_mixture.py
@@ -5,7 +5,6 @@
 # License: BSD 3 clause
 
 import math
-import warnings
 
 import numpy as np
 

--- a/sklearn/mixture/bayesian_mixture.py
+++ b/sklearn/mixture/bayesian_mixture.py
@@ -912,26 +912,3 @@ class BayesianGaussianMixture(BaseMixture):
         self.n_iter_ = best_n_iter
 
         return self
-
-    def fit(self, X, y=None):
-        if self.batch_size:
-            slices = gen_batches(X.shape[0], self.batch_size)
-            batches = [X[s] for s in slices]
-            results = Parallel(n_jobs=self.n_jobs)(
-                delayed(_partial_fit)(self, batch) for batch in batches)
-
-            parameters = ['weight_concentration_', 'mean_precision_',
-                          'means_', 'degrees_of_freedom_',
-                          'covariances_', 'precisions_cholesky_']
-
-            params = [np.mean([getattr(result, param)
-                               for result in results], axis=0)
-                      for param in parameters]
-
-            self._set_parameters(params)
-            self.lower_bound_ = np.mean([result.lower_bound_
-                                         for result in results], axis=0)
-        else:
-            super(BayesianGaussianMixture, self).fit(X)
-
-        return self

--- a/sklearn/mixture/bayesian_mixture.py
+++ b/sklearn/mixture/bayesian_mixture.py
@@ -19,9 +19,8 @@ from .gaussian_mixture import _compute_precision_cholesky
 from .gaussian_mixture import _estimate_gaussian_parameters
 from .gaussian_mixture import _estimate_log_gaussian_prob
 from ..exceptions import ConvergenceWarning
-from ..utils import check_array, check_random_state, gen_batches
+from ..utils import check_array, check_random_state
 from ..utils.validation import check_is_fitted
-from ..externals.joblib import Parallel, delayed
 
 
 def _log_dirichlet_norm(dirichlet_concentration):
@@ -357,7 +356,7 @@ class BayesianGaussianMixture(BaseMixture):
                  mean_precision_prior=None, mean_prior=None,
                  degrees_of_freedom_prior=None, covariance_prior=None,
                  random_state=None, warm_start=False, verbose=0,
-                 verbose_interval=10, n_jobs=1, batch_size=0, learning_rate=1):
+                 verbose_interval=10):
         super(BayesianGaussianMixture, self).__init__(
             n_components=n_components, tol=tol, reg_covar=reg_covar,
             max_iter=max_iter, n_init=n_init, init_params=init_params,
@@ -371,8 +370,6 @@ class BayesianGaussianMixture(BaseMixture):
         self.mean_prior = mean_prior
         self.degrees_of_freedom_prior = degrees_of_freedom_prior
         self.covariance_prior = covariance_prior
-        self.n_jobs = n_jobs
-        self.batch_size = batch_size
 
     def _check_parameters(self, X):
         """Check that the parameters are well defined.

--- a/sklearn/mixture/tests/test_bayesian_mixture.py
+++ b/sklearn/mixture/tests/test_bayesian_mixture.py
@@ -1,5 +1,6 @@
 # Author: Wei Xue <xuewei4d@gmail.com>
 #         Thierry Guillemot <thierry.guillemot.work@gmail.com>
+#         Joshua Engelman <j.aaron.engelman@gmail.com>
 # License: BSD 3 clause
 
 import numpy as np
@@ -81,7 +82,6 @@ def test_bayesian_mixture_weight_concentration_prior_type():
                          " %s 'weight_concentration_prior_type' should be in "
                          "['dirichlet_process', 'dirichlet_distribution']"
                          % bad_prior_type, bgmm.fit, X)
-
 
 def test_bayesian_mixture_weights_prior_initialisation():
     rng = np.random.RandomState(0)
@@ -417,5 +417,28 @@ def test_invariant_translation():
                 tol=1e-3, reg_covar=0).fit(X + 100)
 
             assert_almost_equal(bgmm1.means_, bgmm2.means_ - 100)
+            assert_almost_equal(bgmm1.weights_, bgmm2.weights_)
+            assert_almost_equal(bgmm1.covariances_, bgmm2.covariances_)
+
+@ignore_warnings(category=ConvergenceWarning)
+def test_partial_fit():
+    # Test that calling partial_fit once is equivalent to fit
+    rng = np.random.RandomState(0)
+    rand_data = RandomData(rng, scale=100)
+    n_components = 2 * rand_data.n_components
+
+    for prior_type in PRIOR_TYPE:
+        for covar_type in COVARIANCE_TYPE:
+            X = rand_data.X[covar_type]
+            bgmm1 = BayesianGaussianMixture(
+                weight_concentration_prior_type=prior_type,
+                n_components=n_components, max_iter=100, random_state=0,
+                tol=1e-3, reg_covar=0).fit(X)
+            bgmm2 = BayesianGaussianMixture(
+                weight_concentration_prior_type=prior_type,
+                n_components=n_components, max_iter=100, random_state=0,
+                tol=1e-3, reg_covar=0).partial_fit(X)
+
+            assert_almost_equal(bgmm1.means_, bgmm2.means_)
             assert_almost_equal(bgmm1.weights_, bgmm2.weights_)
             assert_almost_equal(bgmm1.covariances_, bgmm2.covariances_)

--- a/sklearn/mixture/tests/test_bayesian_mixture.py
+++ b/sklearn/mixture/tests/test_bayesian_mixture.py
@@ -420,6 +420,7 @@ def test_invariant_translation():
             assert_almost_equal(bgmm1.weights_, bgmm2.weights_)
             assert_almost_equal(bgmm1.covariances_, bgmm2.covariances_)
 
+
 @ignore_warnings(category=ConvergenceWarning)
 def test_partial_fit():
     # Test that calling partial_fit once is equivalent to fit


### PR DESCRIPTION
#### Reference Issue
Implements #8714 Online Inference for BayesianGaussianMixture

#### What does this implement/fix? Explain your changes.
Implements a partial_fit() method for BayesianGaussianMixture models, which allows for online or minibatch inference.  It simply sets the posterior from the previous fit as the new prior,  a method known as [Streaming Variational Inference](http://proceedings.mlr.press/v45/Huynh15.pdf).  Under very mild conditions, the expectation of the posterior on each batch forms an unbiased estimate of the posterior on the whole data, so after going through all batches the models will be very similar.  Due to the stochastic nature of the fitting process, it often reaches a lower Evidence Lower Bound than fitting the model to the whole dataset, because it is less likely to get stuck in local minima during optimization.

I included an example identical to the one comparing Bayesian and non-Bayesian mixture models, but with many more samples to take advantage of the speed increase.

#### Any other comments?
Was not sure what tests were required/useful, since it just sets a few parameters and then makes use of the existing fit() function which has its own tests.  I also wanted add the image from the example to the mixture docs but couldn't figure out how auto_examples worked.

- [x] main implementation
- [x] example
- [x] documentation
- [x] tests