### PR TITLE
[MRG+2] Clean common tests

### DIFF
--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -68,7 +68,10 @@ def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0,
     if n_samples is not None:
         idx = random_state.permutation(X.shape[0])[:n_samples]
         X = X[idx]
-    nbrs = NearestNeighbors(n_neighbors=int(X.shape[0] * quantile),
+    n_neighbors = int(X.shape[0] * quantile)
+    if n_neighbors < 1:  # cannot fit NearestNeighbors with n_neighbors = 0
+        n_neighbors = 1
+    nbrs = NearestNeighbors(n_neighbors=n_neighbors,
                             n_jobs=n_jobs)
     nbrs.fit(X)
 

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -434,7 +434,7 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
             matrix of shape (n_samples, n_samples)
         """
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'],
-                        dtype=np.float64)
+                        dtype=np.float64, ensure_min_samples=2)
         if X.shape[0] == X.shape[1] and self.affinity != "precomputed":
             warnings.warn("The spectral clustering API has changed. ``fit``"
                           "now constructs an affinity matrix from data. To use"
@@ -442,7 +442,8 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
                           "set ``affinity=precomputed``.")
 
         if self.affinity == 'nearest_neighbors':
-            connectivity = kneighbors_graph(X, n_neighbors=self.n_neighbors, include_self=True,
+            connectivity = kneighbors_graph(X, n_neighbors=self.n_neighbors,
+                                            include_self=True,
                                             n_jobs=self.n_jobs)
             self.affinity_matrix_ = 0.5 * (connectivity + connectivity.T)
         elif self.affinity == 'precomputed':

--- a/sklearn/cluster/tests/test_mean_shift.py
+++ b/sklearn/cluster/tests/test_mean_shift.py
@@ -34,8 +34,8 @@ def test_estimate_bandwidth():
 
 
 def test_estimate_bandwidth_1sample():
-    # Test estimate_bandwidth when n_samples=1 and quantile<1 such that
-    # n_neighors is set to 1.
+    # Test estimate_bandwidth when n_samples=1 and quantile<1, so that
+    # n_neighbors is set to 1.
     bandwidth = estimate_bandwidth(X, n_samples=1, quantile=0.3)
     assert_equal(bandwidth, 0.)
 

--- a/sklearn/cluster/tests/test_mean_shift.py
+++ b/sklearn/cluster/tests/test_mean_shift.py
@@ -33,6 +33,13 @@ def test_estimate_bandwidth():
     assert_true(0.9 <= bandwidth <= 1.5)
 
 
+def test_estimate_bandwidth_1sample():
+    # Test estimate_bandwidth when n_samples=1 and quantile<1 such that
+    # n_neighors is set to 1.
+    bandwidth = estimate_bandwidth(X, n_samples=1, quantile=0.3)
+    assert_equal(bandwidth, 0.)
+
+
 def test_mean_shift():
     # Test MeanShift algorithm
     bandwidth = 1.2

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -786,7 +786,8 @@ class PLSSVD(BaseEstimator, TransformerMixin):
     def fit(self, X, Y):
         # copy since this will contains the centered data
         check_consistent_length(X, Y)
-        X = check_array(X, dtype=np.float64, copy=self.copy)
+        X = check_array(X, dtype=np.float64, copy=self.copy,
+                        ensure_min_samples=2)
         Y = check_array(Y, dtype=np.float64, copy=self.copy, ensure_2d=False)
         if Y.ndim == 1:
             Y = Y.reshape(-1, 1)

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -245,7 +245,8 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
 
         # copy since this will contains the residuals (deflated) matrices
         check_consistent_length(X, Y)
-        X = check_array(X, dtype=np.float64, copy=self.copy)
+        X = check_array(X, dtype=np.float64, copy=self.copy,
+                        ensure_min_samples=2)
         Y = check_array(Y, dtype=np.float64, copy=self.copy, ensure_2d=False)
         if Y.ndim == 1:
             Y = Y.reshape(-1, 1)

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -267,7 +267,8 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
     fun_args = {} if fun_args is None else fun_args
     # make interface compatible with other decompositions
     # a copy is required only for non whitened data
-    X = check_array(X, copy=whiten, dtype=FLOAT_DTYPES).T
+    X = check_array(X, copy=whiten, dtype=FLOAT_DTYPES,
+                    ensure_min_samples=2).T
 
     alpha = fun_args.get('alpha', 1.0)
     if not 1 <= alpha <= 2:

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -638,7 +638,8 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
         n_samples, n_features = X.shape
         n_classes = len(self.classes_)
         if n_classes < 2:
-            raise ValueError('y has less than 2 classes')
+            raise ValueError('The number of classes has to be greater than'
+                             ' one; got %d class' % (n_classes))
         if self.priors is None:
             self.priors_ = np.bincount(y) / float(n_samples)
         else:

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -468,8 +468,8 @@ class BinomialDeviance(ClassificationLossFunction):
     """
     def __init__(self, n_classes):
         if n_classes != 2:
-            raise ValueError("{0:s} requires 2 classes.".format(
-                self.__class__.__name__))
+            raise ValueError("{0:s} requires 2 classes; got {1:d} class(es)"
+                             .format(self.__class__.__name__, n_classes))
         # we only need to fit one tree for binary clf.
         super(BinomialDeviance, self).__init__(1)
 
@@ -601,8 +601,8 @@ class ExponentialLoss(ClassificationLossFunction):
     """
     def __init__(self, n_classes):
         if n_classes != 2:
-            raise ValueError("{0:s} requires 2 classes.".format(
-                self.__class__.__name__))
+            raise ValueError("{0:s} requires 2 classes; got {1:d} class(es)"
+                             .format(self.__class__.__name__, n_classes))
         # we only need to fit one tree for binary clf.
         super(ExponentialLoss, self).__init__(1)
 

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -488,9 +488,9 @@ class SelectKBest(_BaseFilter):
 
     def _check_params(self, X, y):
         if not (self.k == "all" or 0 <= self.k <= X.shape[1]):
-            raise ValueError("k should be >=0, <= n_features; got %r."
+            raise ValueError("k should be >=0, <= n_features = %d; got %r. "
                              "Use k='all' to return all features."
-                             % self.k)
+                             % (X.shape[1], self.k))
 
     def _get_support_mask(self):
         check_is_fitted(self, 'scores_')

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -189,8 +189,9 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
                              "y contains classes %s"
                              % (self.__class__.__name__, self.classes_))
         elif self.classes_.size == 1:
-            raise ValueError("{0:s} requires 2 classes.".format(
-                self.__class__.__name__))
+            raise ValueError("{0:s} requires 2 classes; got {1:d} class"
+                             .format(self.__class__.__name__,
+                                     self.classes_.size))
 
         if self.optimizer is not None and self.kernel_.n_dims > 0:
             # Choose hyperparameters based on maximizing the log-marginal
@@ -595,8 +596,9 @@ class GaussianProcessClassifier(BaseEstimator, ClassifierMixin):
         self.n_classes_ = self.classes_.size
         if self.n_classes_ == 1:
             raise ValueError("GaussianProcessClassifier requires 2 or more "
-                             "distinct classes. Only class %s present."
-                             % self.classes_[0])
+                             "distinct classes; got %d class."
+                             " Only class %s present."
+                             % (self.n_classes_, self.classes_[0]))
         if self.n_classes_ > 2:
             if self.multi_class == "one_vs_rest":
                 self.base_estimator_ = \

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -597,7 +597,6 @@ class GaussianProcessClassifier(BaseEstimator, ClassifierMixin):
         if self.n_classes_ == 1:
             raise ValueError("GaussianProcessClassifier requires 2 or more "
                              "distinct classes; got %d class."
-                             " Only class %s present."
                              % (self.n_classes_, self.classes_[0]))
         if self.n_classes_ > 2:
             if self.multi_class == "one_vs_rest":

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -597,7 +597,7 @@ class GaussianProcessClassifier(BaseEstimator, ClassifierMixin):
         if self.n_classes_ == 1:
             raise ValueError("GaussianProcessClassifier requires 2 or more "
                              "distinct classes; got %d class."
-                             % (self.n_classes_, self.classes_[0]))
+                             % (self.n_classes_))
         if self.n_classes_ > 2:
             if self.multi_class == "one_vs_rest":
                 self.base_estimator_ = \

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -596,8 +596,9 @@ class GaussianProcessClassifier(BaseEstimator, ClassifierMixin):
         self.n_classes_ = self.classes_.size
         if self.n_classes_ == 1:
             raise ValueError("GaussianProcessClassifier requires 2 or more "
-                             "distinct classes; got %d class."
-                             % (self.n_classes_))
+                             "distinct classes; got %d class (only class %s "
+                             "is present)"
+                             % (self.n_classes_, self.classes_[0]))
         if self.n_classes_ > 2:
             if self.multi_class == "one_vs_rest":
                 self.base_estimator_ = \

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -426,7 +426,8 @@ class ARDRegression(LinearModel, RegressorMixin):
         -------
         self : returns an instance of self.
         """
-        X, y = check_X_y(X, y, dtype=np.float64, y_numeric=True)
+        X, y = check_X_y(X, y, dtype=np.float64, y_numeric=True,
+                         ensure_min_samples=2)
 
         n_samples, n_features = X.shape
         coef_ = np.zeros(n_features)

--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -270,7 +270,7 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
                              "positive.")
         if min_samples > X.shape[0]:
             raise ValueError("`min_samples` may not be larger than number "
-                             "of samples ``X.shape[0]``.")
+                             "of samples: n_samples = %d." % (X.shape[0]))
 
         if self.stop_probability < 0 or self.stop_probability > 1:
             raise ValueError("`stop_probability` must be in range [0, 1].")

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -803,6 +803,9 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         -------
         self : returns an instance of self.
         """
+        check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
+                  multi_output=True)
+
         self._label_binarizer = LabelBinarizer(pos_label=1, neg_label=-1)
         Y = self._label_binarizer.fit_transform(y)
         if not self._label_binarizer.y_type_.startswith('multilabel'):
@@ -1347,6 +1350,9 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         self : object
             Returns self.
         """
+        check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
+                  multi_output=True)
+
         self._label_binarizer = LabelBinarizer(pos_label=1, neg_label=-1)
         Y = self._label_binarizer.fit_transform(y)
         if not self._label_binarizer.y_type_.startswith('multilabel'):

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -398,8 +398,9 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
                              sample_weight=sample_weight,
                              max_iter=max_iter)
         else:
-            raise ValueError("The number of class labels must be "
-                             "greater than one.")
+            raise ValueError(
+                "The number of classes has to be greater than one; got %d"
+                % n_classes)
 
         return self
 

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -399,8 +399,8 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
                              max_iter=max_iter)
         else:
             raise ValueError(
-                "The number of classes has to be greater than one; got %d"
-                % n_classes)
+                "The number of classes has to be greater than one;"
+                " got %d class" % n_classes)
 
         return self
 

--- a/sklearn/manifold/locally_linear.py
+++ b/sklearn/manifold/locally_linear.py
@@ -298,7 +298,11 @@ def locally_linear_embedding(
         raise ValueError("output dimension must be less than or equal "
                          "to input dimension")
     if n_neighbors >= N:
-        raise ValueError("n_neighbors must be less than number of points")
+        raise ValueError(
+            "Expected n_neighbors <= n_samples, "
+            " but n_samples = %d, n_neighbors = %d" %
+            (N, n_neighbors)
+        )
 
     if n_neighbors <= 0:
         raise ValueError("n_neighbors must be positive")

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -275,12 +275,6 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
             eigen_solver = "lobpcg"
             # Revert the laplacian to its opposite to have lobpcg work
             laplacian *= -1
-        except ValueError as e:
-            if (laplacian.shape == (1, 1) and
-                    "k must be between 1 and the order of the square "
-                    "input matrix." in repr(e)):
-                msg = 'X might contain only one sample'
-                raise ValueError(msg).with_traceback(e.__traceback__)
 
     if eigen_solver == 'amg':
         # Use AMG to get a preconditioner and speed up the eigenvalue

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -275,6 +275,12 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
             eigen_solver = "lobpcg"
             # Revert the laplacian to its opposite to have lobpcg work
             laplacian *= -1
+        except ValueError as e:
+            if (laplacian.shape == (1, 1) and
+                    "k must be between 1 and the order of the square "
+                    "input matrix." in repr(e)):
+                msg = 'X might contain only one sample'
+                raise ValueError(msg).with_traceback(e.__traceback__)
 
     if eigen_solver == 'amg':
         # Use AMG to get a preconditioner and speed up the eigenvalue

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -707,7 +707,8 @@ class TSNE(BaseEstimator):
                             'memory. Otherwise consider dimensionality '
                             'reduction techniques (e.g. TruncatedSVD)')
         if self.method == 'barnes_hut':
-            X = check_array(X, ensure_min_samples=2, dtype=np.float64)
+            X = check_array(X, ensure_min_samples=2,
+                            dtype=[np.float32, np.float64])
         else:
             X = check_array(X, accept_sparse=['csr', 'csc', 'coo'],
                             dtype=np.float64)

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -706,6 +706,8 @@ class TSNE(BaseEstimator):
                             'the array is small enough for it to fit in '
                             'memory. Otherwise consider dimensionality '
                             'reduction techniques (e.g. TruncatedSVD)')
+        if self.method == 'barnes_hut':
+            X = check_array(X, ensure_min_samples=2, dtype=np.float64)
         else:
             X = check_array(X, accept_sparse=['csr', 'csc', 'coo'],
                             dtype=np.float64)

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -293,14 +293,14 @@ def test_early_exaggeration_too_small():
     # Early exaggeration factor must be >= 1.
     tsne = TSNE(early_exaggeration=0.99)
     assert_raises_regexp(ValueError, "early_exaggeration .*",
-                         tsne.fit_transform, np.array([[0.0]]))
+                         tsne.fit_transform, np.array([[0.0], [0.0]]))
 
 
 def test_too_few_iterations():
     # Number of gradient descent iterations must be at least 200.
     tsne = TSNE(n_iter=199)
     assert_raises_regexp(ValueError, "n_iter .*", tsne.fit_transform,
-                         np.array([[0.0]]))
+                         np.array([[0.0], [0.0]]))
 
 
 def test_non_square_precomputed_distances():

--- a/sklearn/mixture/base.py
+++ b/sklearn/mixture/base.py
@@ -38,7 +38,7 @@ def _check_shape(param, param_shape, name):
                          "but got %s" % (name, param_shape, param.shape))
 
 
-def _check_X(X, n_components=None, n_features=None):
+def _check_X(X, n_components=None, n_features=None, ensure_min_samples=1):
     """Check the input data X.
 
     Parameters
@@ -51,7 +51,8 @@ def _check_X(X, n_components=None, n_features=None):
     -------
     X : array, shape (n_samples, n_features)
     """
-    X = check_array(X, dtype=[np.float64, np.float32])
+    X = check_array(X, dtype=[np.float64, np.float32],
+                    ensure_min_samples=ensure_min_samples)
     if n_components is not None and X.shape[0] < n_components:
         raise ValueError('Expected n_samples >= n_components '
                          'but got n_components = %d, n_samples = %d'
@@ -187,7 +188,7 @@ class BaseMixture(six.with_metaclass(ABCMeta, DensityMixin, BaseEstimator)):
         -------
         self
         """
-        X = _check_X(X, self.n_components)
+        X = _check_X(X, self.n_components, ensure_min_samples=2)
         self._check_initial_parameters(X)
 
         # if we enable warm_start, we will have a unique initialisation

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -314,8 +314,8 @@ class _BaseKFold(with_metaclass(ABCMeta, BaseCrossValidator)):
         if self.n_splits > n_samples:
             raise ValueError(
                 ("Cannot have number of splits n_splits={0} greater"
-                 " than the number of samples: {1}.").format(self.n_splits,
-                                                             n_samples))
+                 " than the number of samples: n_samples={1}.")
+                .format(self.n_splits, n_samples))
 
         for train, test in super(_BaseKFold, self).split(X, y, groups):
             yield train, test

--- a/sklearn/neighbors/nearest_centroid.py
+++ b/sklearn/neighbors/nearest_centroid.py
@@ -115,7 +115,8 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
         self.classes_ = classes = le.classes_
         n_classes = classes.size
         if n_classes < 2:
-            raise ValueError('y has less than 2 classes')
+            raise ValueError('The number of classes has to be greater than'
+                             ' one; got %d class' % (n_classes))
 
         # Mask mapping each class to its members.
         self.centroids_ = np.empty((n_classes, n_features), dtype=np.float64)

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -503,6 +503,7 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
         if len(cls) < 2:
             raise ValueError(
                 "The number of classes has to be greater than one; got %d"
+                " class"
                 % len(cls))
 
         self.classes_ = cls

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -503,8 +503,7 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
         if len(cls) < 2:
             raise ValueError(
                 "The number of classes has to be greater than one; got %d"
-                " class"
-                % len(cls))
+                " class" % len(cls))
 
         self.classes_ = cls
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -222,7 +222,7 @@ def _yield_all_checks(name, estimator):
         for check in _yield_clustering_checks(name, estimator):
             yield check
     yield check_fit2d_predict1d
-    if name != 'GaussianProcess' and name != 'SpectralClustering':  # FIXME
+    if name != 'GaussianProcess':  # FIXME
         # XXX GaussianProcess deprecated in 0.20
         yield check_fit2d_1sample
     yield check_fit2d_1feature
@@ -578,8 +578,9 @@ def check_fit2d_predict1d(name, estimator_orig):
 
 @ignore_warnings
 def check_fit2d_1sample(name, estimator_orig):
-    # check fitting a 2d array with only one sample either works or returns
-    # informative message
+    # Check that fitting a 2d array with only one sample either works or
+    # returns an informative message. The error message should either mention
+    # the number of samples or the number of classes.
     rnd = np.random.RandomState(0)
     X = 3 * rnd.uniform(size=(1, 10))
     y = X[:, 0].astype(np.int)
@@ -593,17 +594,8 @@ def check_fit2d_1sample(name, estimator_orig):
 
     set_random_state(estimator, 1)
 
-    msgs = ["Found array with 1 sample(s)",
-            "number of classes has to be greater than one",
-            "greater than the number of samples: 1",
-            "requires 2 classes",
-            "requires 2 or more distinct classes",
-            "n_samples = 1",
-            "n_samples=1",
-            "one sample",
-            "one class",
-            "less than 2 classes",
-            ]
+    msgs = ["1 sample", "n_samples = 1", "n_samples=1", "one sample",
+            "1 class", "one class"]
 
     try:
         estimator.fit(X, y)
@@ -636,7 +628,7 @@ def check_fit2d_1feature(name, estimator_orig):
     y = multioutput_estimator_convert_y_2d(estimator, y)
     set_random_state(estimator, 1)
 
-    msgs = ["Found array with 1 feature(s)", "n_features = 1"]
+    msgs = ["1 feature(s)", "n_features = 1", "n_features=1"]
 
     try:
         estimator.fit(X, y)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -123,6 +123,7 @@ def _yield_classifier_checks(name, classifier):
             # the column y interface is used by the forests.
 
         yield check_supervised_y_2d
+    yield check_supervised_y_no_nan
     # test if NotFittedError is raised
     yield check_estimators_unfitted
     if 'class_weight' in classifier.get_params().keys():

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1121,9 +1121,6 @@ def check_classifiers_train(name, classifier_orig):
                     assert_equal(decision.shape, (n_samples, n_classes))
                     assert_array_equal(np.argmax(decision, axis=1), y_pred)
 
-                # raises error on malformed input
-                assert_raises(ValueError,
-                              classifier.decision_function, X.T)
                 # raises error on malformed input for decision_function
                 assert_raises(ValueError,
                               classifier.decision_function, X.T)
@@ -1136,8 +1133,6 @@ def check_classifiers_train(name, classifier_orig):
             assert_array_equal(np.argmax(y_prob, axis=1), y_pred)
             # check that probas for all classes sum to one
             assert_allclose(np.sum(y_prob, axis=1), np.ones(n_samples))
-            # raises error on malformed input
-            assert_raises(ValueError, classifier.predict_proba, X.T)
             # raises error on malformed input for predict_proba
             assert_raises(ValueError, classifier.predict_proba, X.T)
             if hasattr(classifier, "predict_log_proba"):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -577,7 +577,7 @@ def check_fit2d_predict1d(name, estimator_orig):
 
 @ignore_warnings
 def check_fit2d_1sample(name, estimator_orig):
-    # check by fitting a 2d array and prediting with a 1d array
+    # check by fitting a 2d array with only one sample
     rnd = np.random.RandomState(0)
     X = 3 * rnd.uniform(size=(1, 10))
     y = X[:, 0].astype(np.int)
@@ -598,7 +598,7 @@ def check_fit2d_1sample(name, estimator_orig):
 
 @ignore_warnings
 def check_fit2d_1feature(name, estimator_orig):
-    # check by fitting a 2d array and prediting with a 1d array
+    # check by fitting a 2d array with only one feature
     rnd = np.random.RandomState(0)
     X = 3 * rnd.uniform(size=(10, 1))
     y = X[:, 0].astype(np.int)
@@ -641,7 +641,7 @@ def check_fit1d_1feature(name, estimator_orig):
 
 @ignore_warnings
 def check_fit1d_1sample(name, estimator_orig):
-    # check fitting 1d array with 1 feature
+    # check fitting 1d array with 1 sample
     rnd = np.random.RandomState(0)
     X = 3 * rnd.uniform(size=(20))
     y = np.array([1])

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -222,7 +222,8 @@ def _yield_all_checks(name, estimator):
         for check in _yield_clustering_checks(name, estimator):
             yield check
     yield check_fit2d_predict1d
-    if name != 'GaussianProcess':  # XXX deprecated in 0.20
+    if name != 'GaussianProcess' and name != 'SpectralClustering':  # FIXME
+        # XXX GaussianProcess deprecated in 0.20
         yield check_fit2d_1sample
     yield check_fit2d_1feature
     yield check_fit1d


### PR DESCRIPTION

#### What does this implement/fix? Explain your changes.
This PR fixes typos and removes dupes in check_estimators.py.

It also adds `check_supervised_y_no_nan` to `yield_classifier_checks`. Maybe there was a good reason for not using it for classifiers. If this is the case I will remove the associated commit.
Note that some tests were then failing for `RidgeClassifier` and `RidgeClassifierCV` because there was no `check_X_y` in their `fit` methods before calling `LabelBinarizer`. However their `fit` methods then call `fit` from `_BaseRidge` and `_BaseRidgeCV` which has a `check_X_y`. The current implementation thus implies two calls of `check_X_y` for `RidgeClassifier` and `RidgeClassifierCV`.


#### Any other comments?
Other questions about common tests that came to me when implementing common tests for outlier detection estimators (PR #9270):
- is there a common test checking that `predict` returns int for classifiers?
- why isn't `check_estimator` used in the common tests?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
