### PR TITLE
Determine precisions_cholesky_ in GaussianMixture if not set

### DIFF
--- a/sklearn/mixture/gaussian_mixture.py
+++ b/sklearn/mixture/gaussian_mixture.py
@@ -694,6 +694,10 @@ class GaussianMixture(BaseMixture):
         # Attributes computation
         _, n_features = self.means_.shape
 
+        if self.precisions_cholesky_ is None:
+            self.precisions_cholesky_ = _compute_precision_cholesky(
+                self.covariances_, self.covariance_type)
+
         if self.covariance_type == 'full':
             self.precisions_ = np.empty(self.precisions_cholesky_.shape)
             for k, prec_chol in enumerate(self.precisions_cholesky_):


### PR DESCRIPTION
A small change so a GaussianMixture can be set using means, weights and covariances (and not precisions_cholesky_). This is useful if a model is calculated in another tool, in my case OpenCV, and I want to set GaussianMixture to contain this model.