### PR TITLE
[MRG] Modified sklearn.metrics to enable euclidean distance calculation with NaN

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1193,6 +1193,7 @@ See the :ref:`metrics` section of the user guide for further details.
    preprocessing.FunctionTransformer
    preprocessing.Imputer
    preprocessing.KernelCenterer
+   preprocessing.KNNImputer
    preprocessing.LabelBinarizer
    preprocessing.LabelEncoder
    preprocessing.MultiLabelBinarizer

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -323,8 +323,8 @@ def masked_euclidean_distances(X, Y=None, squared=False,
     >>> X = [[0, 1], [1, nan]]
     >>> # distance between rows of X
     >>> masked_euclidean_distances(X, X)
-    array([[ 0.,  1.41421356],
-           [ 1.41421356,  0.]])
+    array([[ 0.        ,  1.41421356],
+           [ 1.41421356,  0.        ]])
 
     >>> # get distance to origin
     >>> masked_euclidean_distances(X, [[0, 0]])

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -307,11 +307,13 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
         # Get Y.T mask and anti-mask and set Y.T's missing to zero
         YT = Y.T
         mask_YT = _get_mask(YT, missing_values)
-        NYT = (~mask_YT).astype("int")
+        NYT = (~mask_YT).astype(np.int8)
+        # NYT = (~mask_YT)
         YT[mask_YT] = 0
 
-        #Get X anti-mask and set X's missing to zero
-        NX = (~mask_X).astype("int")
+        # Get X anti-mask and set X's missing to zero
+        NX = (~mask_X).astype(np.int8)
+        # NX = (~mask_X)
         X[mask_X] = 0
 
         # Matrix formula to calculate pair-wise distance between all vectors in a
@@ -319,9 +321,15 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
         # in either vector in the pair and up-weights the remaining coordinates.
         # Matrix formula derived by: Shreya Bhattarai <shreya.bhattarai@gmail.com>
 
-        distances = (X.shape[1] * 1 / ((np.dot(NX, NYT)))) * \
-                    (np.dot((X * X), NYT) - 2 * (np.dot(X, YT)) +
-                     np.dot(NX, (YT * YT)))
+        # distances = (X.shape[1] * 1 / ((np.dot(NX, NYT)))) * \
+        #             (np.dot((X * X), NYT) - 2 * (np.dot(X, YT)) +
+        #              np.dot(NX, (YT * YT)))
+
+        # Above is faster but following for Python 2.x support
+        distances = np.multiply(np.multiply(X.shape[1], (1.0 / np.dot(NX, NYT))),
+                                (np.dot(np.multiply(X, X), NYT) -
+                                (2.0 * (np.dot(X, YT))) +
+                                np.dot(NX, (np.multiply(YT, YT)))))
 
     if X is Y:
         # Ensure that distances between vectors and themselves are set to 0.0.

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -324,13 +324,6 @@ def masked_euclidean_distances(X, Y=None, squared=False,
     vector in the pair or if there are no common non-missing coordinates then
     NaN is returned for that pair.
 
-    References
-    ----------
-    John K. Dixon, "Pattern Recognition with Partly Missing Data",
-    IEEE Transactions on Systems, Man, and Cybernetics, Volume: 9, Issue:
-    10, pp. 617 - 621, Oct. 1979.
-    http://ieeexplore.ieee.org/abstract/document/4310090/
-
     Read more in the :ref:`User Guide <metrics>`.
 
     Parameters
@@ -366,6 +359,13 @@ def masked_euclidean_distances(X, Y=None, squared=False,
     >>> masked_euclidean_distances(X, [[0, 0]])
     array([[ 1.        ],
            [ 1.41421356]])
+
+    References
+    ----------
+    * John K. Dixon, "Pattern Recognition with Partly Missing Data",
+      IEEE Transactions on Systems, Man, and Cybernetics, Volume: 9, Issue:
+      10, pp. 617 - 621, Oct. 1979.
+      http://ieeexplore.ieee.org/abstract/document/4310090/
 
     See also
     --------
@@ -409,9 +409,9 @@ def masked_euclidean_distances(X, Y=None, squared=False,
 
     # Calculate distances
 
-    distances = (X.shape[1] / ((np.dot(NX, NYT)))) * \
-                (np.dot((X * X), NYT) - 2 * (np.dot(X, YT)) +
-                 np.dot(NX, (YT * YT)))
+    distances = (X.shape[1] / (np.dot(NX, NYT))) * \
+                (np.dot(X * X, NYT) - 2 * (np.dot(X, YT)) +
+                 np.dot(NX, YT * YT))
 
     if X is Y:
         # Ensure that distances between vectors and themselves are set to 0.0.
@@ -1208,11 +1208,6 @@ PAIRWISE_DISTANCE_FUNCTIONS = {
     'masked_euclidean': masked_euclidean_distances,
 }
 
-# Helper functions with missing value support - distance
-# MASKED_PAIRWISE_DISTANCE_FUNCTIONS = {
-#     'euclidean': masked_euclidean_distances,
-# }
-
 
 def distance_metrics():
     """Valid metrics for pairwise_distances.
@@ -1223,9 +1218,9 @@ def distance_metrics():
 
     The valid distance metrics, and the function they map to, are:
 
-    ============            ====================================
+    ===================     ============================================
     metric                  Function
-    ============            ====================================
+    ===================     ============================================
     'cityblock'             metrics.pairwise.manhattan_distances
     'cosine'                metrics.pairwise.cosine_distances
     'euclidean'             metrics.pairwise.euclidean_distances
@@ -1233,7 +1228,7 @@ def distance_metrics():
     'l2'                    metrics.pairwise.euclidean_distances
     'manhattan'             metrics.pairwise.manhattan_distances
     'masked_euclidean'      metrics.pairwise.masked_euclidean_distances
-    ============            ====================================
+    ===================     ============================================
 
     Read more in the :ref:`User Guide <metrics>`.
 
@@ -1393,18 +1388,10 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
                          "Valid metrics are %s, or 'precomputed', or a "
                          "callable" % (metric, _VALID_METRICS))
 
-    # To handle kill_missing = False
-    # kill_missing = kwds.get("kill_missing")
-    # if not kill_missing and kill_missing is not None:
     if metric in _MASKED_SUPPORTED_METRICS:
         missing_values = kwds.get("missing_values") if kwds.get(
             "missing_values") is not None else np.nan
 
-        # if (metric not in _MASKED_SUPPORTED_METRICS):
-        #     raise ValueError(
-        #         "Metric {0} does not have missing value support ".format(
-        #             metric)
-        #     )
         if(np.any(_get_mask(X, missing_values).sum(axis=1) == X.shape[1])):
             raise ValueError(
                 "One or more samples(s) only have missing values.")
@@ -1412,9 +1399,6 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
     if metric == "precomputed":
         X, _ = check_pairwise_arrays(X, Y, precomputed=True)
         return X
-    # elif kill_missing is False and metric in \
-    #         MASKED_PAIRWISE_DISTANCE_FUNCTIONS:
-    #         func = MASKED_PAIRWISE_DISTANCE_FUNCTIONS[metric]
     elif metric in PAIRWISE_DISTANCE_FUNCTIONS:
             func = PAIRWISE_DISTANCE_FUNCTIONS[metric]
     elif callable(metric):

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -400,11 +400,11 @@ def masked_euclidean_distances(X, Y=None, squared=False,
     # Get Y.T mask and anti-mask and set Y.T's missing to zero
     YT = Y.T
     mask_YT = _get_mask(YT, missing_values)
-    NYT = (~mask_YT).astype(np.int8)
+    NYT = (~mask_YT).astype(np.int32)
     YT[mask_YT] = 0
 
     # Get X anti-mask and set X's missing to zero
-    NX = (~mask_X).astype(np.int8)
+    NX = (~mask_X).astype(np.int32)
     X[mask_X] = 0
 
     # Calculate distances

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -197,32 +197,44 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
     """
     Considering the rows of X (and Y=X) as vectors, compute the
     distance matrix between each pair of vectors.
+
     For efficiency reasons, the euclidean distance between a pair of row
     vector x and y is computed as::
+
         dist(x, y) = sqrt(dot(x, x) - 2 * dot(x, y) + dot(y, y))
+
     This formulation has two advantages over other ways of computing distances.
     First, it is computationally efficient when dealing with sparse data.
     Second, if one argument varies but the other remains unchanged, then
     `dot(x, x)` and/or `dot(y, y)` can be pre-computed.
+
     However, this is not the most precise way of doing this computation, and
     the distance matrix returned by this function may not be exactly
     symmetric as required by, e.g., ``scipy.spatial.distance`` functions.
+
     Read more in the :ref:`User Guide <metrics>`.
+
     Parameters
     ----------
     X : {array-like, sparse matrix}, shape (n_samples_1, n_features)
+
     Y : {array-like, sparse matrix}, shape (n_samples_2, n_features)
+
     Y_norm_squared : array-like, shape (n_samples_2, ), optional
         Pre-computed dot-products of vectors in Y (e.g.,
         ``(Y**2).sum(axis=1)``)
+
     squared : boolean, optional
         Return squared Euclidean distances.
+
     X_norm_squared : array-like, shape = [n_samples_1], optional
         Pre-computed dot-products of vectors in X (e.g.,
         ``(X**2).sum(axis=1)``)
+
     Returns
     -------
     distances : {array, sparse matrix}, shape (n_samples_1, n_samples_2)
+
     Examples
     --------
     >>> from sklearn.metrics.pairwise import euclidean_distances
@@ -277,7 +289,6 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
     return distances if squared else np.sqrt(distances, out=distances)
 
 
-# Pairwise distances in the presence of missing values
 def masked_euclidean_distances(X, Y=None, squared=False,
                                missing_values="NaN", copy=True):
     """Calculates euclidean distances in the presence of missing values
@@ -302,27 +313,18 @@ def masked_euclidean_distances(X, Y=None, squared=False,
     Formula in matrix form derived by:
     Shreya Bhattarai <shreya.bhattarai@gmail.com>
 
-    This formulation zero-weights feature coordinates with missing value in
-    either vector in the pair and up-weights the remaining coordinates.
-    For instance, say we have two sample points (x1, y1) and (x2, NaN):
+    When calculating the distance between a pair of samples, this formulation
+    essentially zero-weights feature coordinates with a missing value in either
+    sample and scales up the weight of the remaining coordinates:
 
-    To calculate the euclidean distance between these, first the square
-    "distance" is calculated based only on the first feature coordinate
-    as the second coordinate is missing in one of the samples,
-    i.e., we have (x2-x1)**2. This squared distance is scaled-up by the ratio
-    of total number of coordinates to the number of available coordinates,
-    which in this case is 2/1 = 2. Now, we are left with 2*((x2-x1)**2).
-    Finally, if squared=False then the square root of this is evaluated
-    and returned otherwise the value is returned as is.
-
-    Breakdown of euclidean distance calculation between a vector pair x,y:
-
-        weight = Total # of coordinates / # of non-missing coordinates
         dist(x,y) = sqrt(weight * sq. distance from non-missing coordinates)
+        where,
+        weight = Total # of coordinates / # of non-missing coordinates
 
-    This formulation implies that if all coordinates are missing in either
-    vector in the pair or if there are no common non-missing coordinates then
-    NaN is returned for that pair.
+    For instance, the distance between sample points (x1, y1) and (x2, NaN)
+    would result in sqrt(2*((x2-x1)**2). Note that if all the coordinates are
+    missing or if there are no common non-missing coordinates then NaN is
+    returned for that pair.
 
     Read more in the :ref:`User Guide <metrics>`.
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -28,6 +28,7 @@ from ..externals.joblib import cpu_count
 
 from .pairwise_fast import _chi2_kernel_fast, _sparse_manhattan
 
+
 # Get mask for missing values
 def _get_mask(X, value_to_mask):
     """Compute the boolean mask X == missing_values."""
@@ -35,6 +36,7 @@ def _get_mask(X, value_to_mask):
         return np.isnan(X)
     else:
         return X == value_to_mask
+
 
 # Utility Functions
 def _return_float_dtype(X, Y):
@@ -254,10 +256,12 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
     paired_distances : distances betweens pairs of elements of X and Y.
     """
 
-    #NOTE: force_all_finite=False allows not only NaN but also inf/-inf
-    X, Y = check_pairwise_arrays(X, Y, force_all_finite=kill_missing, copy=copy)
+    # NOTE: force_all_finite=False allows not only NaN but also inf/-inf
+    X, Y = check_pairwise_arrays(X, Y,
+                                 force_all_finite=kill_missing, copy=copy)
     if kill_missing is False and \
-            (np.any(np.isinf(X.data)) or (Y is not None and np.any(np.isinf(Y.data)))):
+            (np.any(np.isinf(X.data)) or
+                (Y is not None and np.any(np.isinf(Y.data)))):
         raise ValueError(
             "+/- Infinite values are not allowed.")
 
@@ -290,10 +294,12 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
         np.maximum(distances, 0, out=distances)
 
     else:
-        if missing_values!="NaN" and \
-                (np.any(_get_mask(X.data, "NaN")) or np.any(_get_mask(Y.data, "NaN"))):
+        if missing_values != "NaN" and \
+                (np.any(_get_mask(X.data, "NaN")) or
+                    np.any(_get_mask(Y.data, "NaN"))):
             raise ValueError(
-                "NaN values present but missing_value = {0}".format(missing_values))
+                "NaN values present but missing_value = {0}".
+                format(missing_values))
 
         # ValueError if X and Y have incompatible dimensions
         # if X.shape[1] != Y.shape[1]:
@@ -316,17 +322,19 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
         # NX = (~mask_X)
         X[mask_X] = 0
 
-        # Matrix formula to calculate pair-wise distance between all vectors in a
-        # matrix X to vectors in matrix Y. It zero-weights coordinates with missing value
-        # in either vector in the pair and up-weights the remaining coordinates.
-        # Matrix formula derived by: Shreya Bhattarai <shreya.bhattarai@gmail.com>
+        # Matrix formula to calculate pair-wise distance between all vectors
+        # in a matrix X to vectors in matrix Y. It zero-weights coordinates
+        # with missing value in either vector in the pair and up-weights the
+        # remaining coordinates.
+        # Formula derived by: Shreya Bhattarai <shreya.bhattarai@gmail.com>
 
         # distances = (X.shape[1] * 1 / ((np.dot(NX, NYT)))) * \
         #             (np.dot((X * X), NYT) - 2 * (np.dot(X, YT)) +
         #              np.dot(NX, (YT * YT)))
 
         # Above is faster but following for Python 2.x support
-        distances = np.multiply(np.multiply(X.shape[1], (1.0 / np.dot(NX, NYT))),
+        distances = np.multiply(np.multiply(X.shape[1],
+                                            (1.0 / np.dot(NX, NYT))),
                                 (np.dot(np.multiply(X, X), NYT) -
                                 (2.0 * (np.dot(X, YT))) +
                                 np.dot(NX, (np.multiply(YT, YT)))))
@@ -1215,6 +1223,7 @@ _VALID_METRICS = ['euclidean', 'l2', 'l1', 'manhattan', 'cityblock',
 
 _MISSING_SUPPORTED_METRICS = ['euclidean']
 
+
 def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
     """ Compute the distance matrix from a vector array X and optional Y.
 
@@ -1311,8 +1320,8 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
                 "Missing value support for sparse matrices not added yet")
         if (kwds.get("missing_values") is None):
             raise ValueError("Missing value is not defined")
-        if(np.any(_get_mask(X.data, kwds.get("missing_values")).
-                   sum(axis=1) == X.data.shape[1])):
+        if(np.any(_get_mask(X.data, kwds.get("missing_values")).sum(
+                axis=1) == X.data.shape[1])):
             raise ValueError(
                 "One or more samples(s) only have missing values.")
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -222,9 +222,10 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
     >>> euclidean_distances(X, [[0, 0]])
     array([[ 1.        ],
            [ 1.41421356]])
+
     See also
     --------
-    paired_distances : distances betweens pairs of elements of X and Y.
+    paired_distances : distances between pairs of elements of X and Y.
     """
     X, Y = check_pairwise_arrays(X, Y)
 
@@ -324,6 +325,7 @@ def masked_euclidean_distances(X, Y=None, squared=False,
     >>> masked_euclidean_distances(X, X)
     array([[ 0.,  1.41421356],
            [ 1.41421356,  0.]])
+
     >>> # get distance to origin
     >>> masked_euclidean_distances(X, [[0, 0]])
     array([[ 1.        ],

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1299,8 +1299,7 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
     Valid values for metric are:
 
     - From scikit-learn: ['cityblock', 'cosine', 'euclidean', 'l1', 'l2',
-      'manhattan']. These metrics support sparse matrix
-      inputs.
+      'manhattan']. These metrics support sparse matrix inputs.
       Also, ['masked_euclidean'] but it does not yet support sparse matrices.
 
     - From scipy.spatial.distance: ['braycurtis', 'canberra', 'chebyshev',
@@ -1381,7 +1380,7 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
         X, _ = check_pairwise_arrays(X, Y, precomputed=True)
         return X
     elif metric in PAIRWISE_DISTANCE_FUNCTIONS:
-            func = PAIRWISE_DISTANCE_FUNCTIONS[metric]
+        func = PAIRWISE_DISTANCE_FUNCTIONS[metric]
     elif callable(metric):
         func = partial(_pairwise_callable, metric=metric, **kwds)
     else:

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -427,13 +427,10 @@ def test_masked_euclidean_distances():
                   [np.nan, np.nan, 5., 4., 7.],
                   [np.nan, np.nan, np.nan, 4., 5.]])
 
-    D1 = np.array([[6.32455532, 6.95221787, 4.74341649],
-                   [5., 5., 6.70820393],
-                   [2.23606798, 13.41640786, 8.94427191]])
+    D1 = masked_euclidean_distances(X, Y,  missing_values="NaN")
+    D2 = masked_euclidean_distances(X, Y, squared=True, missing_values="NaN")
 
-    D2 = masked_euclidean_distances(X, Y,  missing_values="NaN")
-
-    assert_array_almost_equal(D1, D2)
+    assert_array_almost_equal(D1**2, D2)
 
     # check when squared = True
     D3 = np.array(
@@ -444,7 +441,7 @@ def test_masked_euclidean_distances():
 
     assert_array_almost_equal(D3, D4)
 
-    # Check with explicit formula and square=True
+    # Check with explicit formula and squared=True
     assert_array_almost_equal(
         masked_euclidean_distances(X[:1], Y[:1], squared=True),
         [[5.0/2.0 * ((7-3)**2 + (2-2)**2)]])

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -17,6 +17,7 @@ from sklearn.utils.testing import ignore_warnings
 from sklearn.externals.six import iteritems
 
 from sklearn.metrics.pairwise import euclidean_distances
+from sklearn.metrics.pairwise import masked_euclidean_distances
 from sklearn.metrics.pairwise import manhattan_distances
 from sklearn.metrics.pairwise import linear_kernel
 from sklearn.metrics.pairwise import chi2_kernel, additive_chi2_kernel
@@ -55,6 +56,17 @@ def test_pairwise_distances():
     Y = rng.random_sample((2, 4))
     S = pairwise_distances(X, Y, metric="euclidean")
     S2 = euclidean_distances(X, Y)
+    assert_array_almost_equal(S, S2)
+    # Euclidean dist. (masked) should be equivalent to calling the function.
+    X = rng.random_sample((5, 4))
+    S = pairwise_distances(X, metric="euclidean", kill_missing=False)
+    S2 = masked_euclidean_distances(X)
+    assert_array_almost_equal(S, S2)
+    # Euclidean distance, with Y != X.
+    Y = rng.random_sample((2, 4))
+    S = pairwise_distances(X, Y, metric="euclidean",
+                           kill_missing=False)
+    S2 = masked_euclidean_distances(X, Y)
     assert_array_almost_equal(S, S2)
     # Test with tuples as X and Y
     X_tuples = tuple([tuple([v for v in row]) for row in X])
@@ -407,13 +419,13 @@ def test_euclidean_distances():
     assert_greater(np.max(np.abs(wrong_D - D1)), .01)
 
 
-def test_euclidean_distances_with_missing():
+def test_masked_euclidean_distances():
     # first check that we get right answer with missing values for X
     X = np.array([[1.,   5.,   7.,   5.,  10.],
                   [8., 2., 4., np.nan, 8.],
                   [5., np.nan, 5., np.nan, 1.],
                   [8., np.nan, np.nan, np.nan, np.nan]])
-    D1 = euclidean_distances(X, kill_missing=False, missing_values="NaN")
+    D1 = masked_euclidean_distances(X, missing_values="NaN")
 
     D2 = np.array([[0.,   9.42072184,  12.97433364,  15.65247584],
                   [9.42072184,   0.,   9.91631652,   0.],
@@ -435,7 +447,7 @@ def test_euclidean_distances_with_missing():
                    [5., 5., 6.70820393],
                    [2.23606798, 13.41640786, 8.94427191]])
 
-    D4 = euclidean_distances(X, Y, kill_missing=False, missing_values="NaN")
+    D4 = masked_euclidean_distances(X, Y,  missing_values="NaN")
 
     assert_array_almost_equal(D3, D4)
 

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -62,7 +62,8 @@ def test_pairwise_distances():
     Y_masked = rng.random_sample((2, 4))
     X_masked[0, 0] = np.nan
     Y_masked[0, 0] = np.nan
-    S_masked = pairwise_distances(X_masked, Y_masked, metric="masked_euclidean")
+    S_masked = pairwise_distances(X_masked, Y_masked,
+                                  metric="masked_euclidean")
     S2_masked = masked_euclidean_distances(X_masked, Y_masked)
     assert_array_almost_equal(S_masked, S2_masked)
     # Test with tuples as X and Y

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -57,7 +57,7 @@ def test_pairwise_distances():
     S = pairwise_distances(X, Y, metric="euclidean")
     S2 = euclidean_distances(X, Y)
     assert_array_almost_equal(S, S2)
-    # Euclidean dist. (masked) should be equivalent to calling the function.
+    # Check to ensure NaNs work with pairwise_distances.
     X_masked = rng.random_sample((5, 4))
     Y_masked = rng.random_sample((2, 4))
     X_masked[0, 0] = np.nan

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -406,6 +406,37 @@ def test_euclidean_distances():
                                   Y_norm_squared=np.zeros_like(Y_norm_sq))
     assert_greater(np.max(np.abs(wrong_D - D1)), .01)
 
+def test_euclidean_distances_with_missing():
+    # first check that we get right answer with missing values for X
+    X = np.array([[1.,   5.,   7.,   5.,  10.],
+                  [8., 2., 4., np.nan, 8.],
+                  [5., np.nan, 5., np.nan, 1.],
+                  [8., np.nan, np.nan, np.nan, np.nan]])
+    D1 = euclidean_distances(X, kill_missing=False, missing_values="NaN")
+
+    D2 = np.array([[0.,   9.42072184,  12.97433364,  15.65247584],
+                  [9.42072184,   0.,   9.91631652,   0.],
+                  [12.97433364,   9.91631652,   0.,   6.70820393],
+                  [15.65247584,   0.,   6.70820393,   0.]])
+
+    assert_array_almost_equal(D1, D2)
+
+    # check with pairs of matrices with missing values
+    X = np.array([[1., np.nan, 3., 4., 2.],
+                  [np.nan, 4., 6., 1., np.nan],
+                  [3., np.nan, np.nan, np.nan, 1.]])
+
+    Y = np.array([[np.nan, 7., 7., np.nan, 2.],
+                  [np.nan, np.nan, 5., 4., 7.],
+                  [np.nan, np.nan, np.nan, 4., 5.]])
+
+    D3 = np.array([[6.32455532, 6.95221787, 4.74341649],
+                   [5., 5., 6.70820393],
+                   [2.23606798, 13.41640786, 8.94427191]])
+
+    D4 = euclidean_distances(X, Y, kill_missing=False, missing_values="NaN")
+
+    assert_array_almost_equal(D3, D4)
 
 def test_cosine_distances():
     # Check the pairwise Cosine distances computation

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -451,6 +451,37 @@ def test_masked_euclidean_distances():
     D6 = masked_euclidean_distances(X, X, missing_values="NaN")
     assert_array_almost_equal(D5, D6)
 
+    # Check with missing_value = 1 while NaN is present
+    assert_raises(ValueError, masked_euclidean_distances, X, Y,
+                  missing_values=1)
+    # Check with inf present
+    X_inf = np.array([
+        [np.inf, np.nan, 3., 4., 2.],
+        [np.nan, 4., 6., 1., np.nan],
+        [3., np.nan, np.nan, np.nan, 1.]])
+
+    assert_raises(ValueError, masked_euclidean_distances, X_inf, Y)
+
+    # Check with a row containing all NaNs
+    X_nan_row = np.array([
+        [1., np.nan, 3., 4., 2.],
+        [np.nan, 4., 6., 1., np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan]])
+
+    Y_nan_row = np.array([
+        [np.nan, 7., 7., np.nan, 2.],
+        [np.nan, np.nan, 5., 4., 7.],
+        [np.nan, np.nan, np.nan, np.nan, np.nan]])
+
+    assert_raises(ValueError, masked_euclidean_distances, X_nan_row, Y)
+    assert_raises(ValueError, masked_euclidean_distances, X, Y_nan_row)
+
+    # Check copy = True against copy = False
+    # Note: This test will alter X and Y
+    D7 = masked_euclidean_distances(X, Y, copy=True)
+    D8 = masked_euclidean_distances(X, Y, copy=False)
+    assert_array_almost_equal(D7, D8)
+
 
 def test_cosine_distances():
     # Check the pairwise Cosine distances computation

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -406,6 +406,7 @@ def test_euclidean_distances():
                                   Y_norm_squared=np.zeros_like(Y_norm_sq))
     assert_greater(np.max(np.abs(wrong_D - D1)), .01)
 
+
 def test_euclidean_distances_with_missing():
     # first check that we get right answer with missing values for X
     X = np.array([[1.,   5.,   7.,   5.,  10.],
@@ -437,6 +438,7 @@ def test_euclidean_distances_with_missing():
     D4 = euclidean_distances(X, Y, kill_missing=False, missing_values="NaN")
 
     assert_array_almost_equal(D3, D4)
+
 
 def test_cosine_distances():
     # Check the pairwise Cosine distances computation

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -59,13 +59,12 @@ def test_pairwise_distances():
     assert_array_almost_equal(S, S2)
     # Euclidean dist. (masked) should be equivalent to calling the function.
     X = rng.random_sample((5, 4))
-    S = pairwise_distances(X, metric="euclidean", kill_missing=False)
+    S = pairwise_distances(X, metric="masked_euclidean")
     S2 = masked_euclidean_distances(X)
     assert_array_almost_equal(S, S2)
     # Euclidean distance, with Y != X.
     Y = rng.random_sample((2, 4))
-    S = pairwise_distances(X, Y, metric="euclidean",
-                           kill_missing=False)
+    S = pairwise_distances(X, Y, metric="masked_euclidean")
     S2 = masked_euclidean_distances(X, Y)
     assert_array_almost_equal(S, S2)
     # Test with tuples as X and Y

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -418,7 +418,7 @@ def test_euclidean_distances():
 
 
 def test_masked_euclidean_distances():
-    # check with pairs of matrices with missing values
+    # Check with pairs of matrices with missing values
     X = np.array([[1., np.nan, 3., 4., 2.],
                   [np.nan, 4., 6., 1., np.nan],
                   [3., np.nan, np.nan, np.nan, 1.]])
@@ -432,7 +432,7 @@ def test_masked_euclidean_distances():
 
     assert_array_almost_equal(D1**2, D2)
 
-    # check when squared = True
+    # Check when squared = True
     D3 = np.array(
         [[40., 48.33333331, 22.5],
          [25., 25., 45.],

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -502,12 +502,15 @@ class KNeighborsMixin(object):
         NearestNeighbors(algorithm='auto', leaf_size=30,...)
         >>> N = neigh.masked_kneighbors(n_neighbors=2, return_distance=False)
         >>> print(N) # doctest: +ELLIPSIS
-        (array([[3, 1], [3, 2], [3, 1], [2, 1]])...)
+        [[3 1]
+        [3 2]
+        [3 1]
+        [2 1]]
 
         >>> X = [[0, nan, 1]]
         >>> N2 = neigh.masked_kneighbors(X, 2, return_distance=False)
         >>> print(N2) # doctest: +ELLIPSIS
-        (array([[1, 3]])...)
+        [[1 3]]
 
         """
         if self._fit_method is None:

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -345,7 +345,8 @@ class KNeighborsMixin(object):
             query_is_train = False
             # copy=True if missing accepted as they will be replaced by 0
             # copy = True if kill_missing is False else False
-            X = check_array(X, accept_sparse='csr', force_all_finite=kill_missing)
+            X = check_array(X, accept_sparse='csr',
+                            force_all_finite=kill_missing)
         else:
             query_is_train = True
             X = self._fit_X

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -500,14 +500,15 @@ class KNeighborsMixin(object):
         >>> neigh = NearestNeighbors(n_neighbors=2, metric="euclidean")
         >>> neigh.fit(samples, kill_missing=False) # doctest: +ELLIPSIS
         NearestNeighbors(algorithm='auto', leaf_size=30,...)
-        >>> print(neigh.masked_kneighbors(n_neighbors=2,
-        >>>                    return_distance=False)) # doctest: +ELLIPSIS
+        >>> N = neigh.masked_kneighbors(n_neighbors=2, return_distance=False)
+        >>> print(N) # doctest: +ELLIPSIS
         (array([[3, 1], [3, 2], [3, 1], [2, 1]])...)
 
         >>> X = [[0, nan, 1]]
-        >>> neigh.masked_kneighbors([[0, nan, 1]], 2,
-        >>>                return_distance=False)  # doctest: +ELLIPSIS
+        >>> N2 = neigh.masked_kneighbors(X, 2, return_distance=False)
+        >>> print(N2) # doctest: +ELLIPSIS
         (array([[1, 3]])...)
+
         """
         if self._fit_method is None:
             raise NotFittedError("Must fit neighbors before querying.")

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -381,8 +381,7 @@ class KNeighborsMixin(object):
                 sample_range, np.argsort(dist[sample_range, neigh_ind])]
 
             if return_distance:
-                if self.effective_metric_ == 'euclidean' or self.\
-                        effective_metric_ == 'masked_euclidean':
+                if self.effective_metric_ in ['euclidean', 'masked_euclidean']:
                     result = np.sqrt(dist[sample_range, neigh_ind]), neigh_ind
                 else:
                     result = dist[sample_range, neigh_ind], neigh_ind

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -503,9 +503,9 @@ class KNeighborsMixin(object):
         >>> N = neigh.masked_kneighbors(n_neighbors=2, return_distance=False)
         >>> print(N) # doctest: +ELLIPSIS
         [[3 1]
-        [3 2]
-        [3 1]
-        [2 1]]
+         [3 2]
+         [3 1]
+         [2 1]]
 
         >>> X = [[0, nan, 1]]
         >>> N2 = neigh.masked_kneighbors(X, 2, return_distance=False)

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -159,8 +159,7 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
         self._fit_method = None
 
     def _fit(self, X):
-        allow_nans = True if self.\
-                                 metric in _MASKED_SUPPORTED_METRICS else False
+        allow_nans = self.metric in _MASKED_SUPPORTED_METRICS
 
         if self.metric_params is None:
             self.effective_metric_params_ = {}

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -366,8 +366,7 @@ class KNeighborsMixin(object):
         n_jobs = _get_n_jobs(self.n_jobs)
         if self._fit_method == 'brute':
             # for efficiency, use squared euclidean distances
-            if self.effective_metric_ == 'euclidean' or self.\
-                    effective_metric_ == 'masked_euclidean':
+            if self.effective_metric_ in ['euclidean', 'masked_euclidean']:
                 dist = pairwise_distances(X, self._fit_X,
                                           self.effective_metric_,
                                           n_jobs=n_jobs, squared=True)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -145,6 +145,11 @@ def test_masked_unsupervised_kneighbors():
     assert_array_equal(X2_neigh, N3)
     assert_array_equal(XY2_neigh, N4)
 
+    # Test 3: Sparse matrix with NaN
+    neigh_sparse = neighbors.NearestNeighbors(n_neighbors=2,
+                                              metric="masked_euclidean")
+    assert_raises(ValueError, neigh_sparse.fit, csr_matrix(X))
+
 
 def test_unsupervised_inputs():
     # test the types of valid input into NearestNeighbors

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -104,9 +104,8 @@ def test_masked_unsupervised_kneighbors():
 
     neigh = neighbors.NearestNeighbors(2, metric="masked_euclidean")
     neigh.fit(X)
-    X_neigh = neigh.masked_kneighbors(n_neighbors=2, return_distance=False)
-    XY_neigh = neigh.masked_kneighbors(Y, 2, return_distance=False)
-
+    X_neigh = neigh.kneighbors(n_neighbors=2, return_distance=False)
+    XY_neigh = neigh.kneighbors(Y, 2, return_distance=False)
     # Expected outcome
     N1 = np.array(
         [[1, 4],
@@ -130,12 +129,10 @@ def test_masked_unsupervised_kneighbors():
     samples = [[0, 5, 5], [1, 0, nan], [4, 1, 1], [nan, 2, 3]]
     neigh = neighbors.NearestNeighbors(n_neighbors=2,
                                        metric="masked_euclidean")
-
     neigh.fit(samples)
-    X2_neigh = neigh.masked_kneighbors(n_neighbors=2, return_distance=False)
 
-    XY2_neigh = neigh.masked_kneighbors([[0, nan, 1]], 2,
-                                        return_distance=False)
+    X2_neigh = neigh.kneighbors(n_neighbors=2, return_distance=False)
+    XY2_neigh = neigh.kneighbors([[0, nan, 1]], 2, return_distance=False)
 
     # Expected outcome
     N3 = np.array(

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -88,6 +88,66 @@ def test_unsupervised_kneighbors(n_samples=20, n_features=5,
             assert_array_almost_equal(results[i][1], results[i + 1][1])
 
 
+def test_masked_unsupervised_kneighbors():
+    # Test 1
+    X = np.array([[np.nan, 3., 7., np.nan],
+                  [6., 3., 7., 2.],
+                  [7., 3., 4., 4.],
+                  [2., 7., 7., 1.],
+                  [np.nan, 2., np.nan, 4.]], dtype=np.float32)
+
+    Y = np.array([[3., 1., 7., np.nan],
+                  [1., 3., 1., 6.],
+                  [np.nan, 1., np.nan, 5.],
+                  [3., 1., 3., 3.],
+                  [2., 3., 1., 9.]], dtype=np.float32)
+
+    neigh = neighbors.NearestNeighbors(2, metric="euclidean")
+    neigh.fit(X,  kill_missing=False)
+    X_neigh = neigh.masked_kneighbors(n_neighbors=2, return_distance=False)
+    XY_neigh = neigh.masked_kneighbors(Y, 2, return_distance=False)
+
+    # Expected outcome
+    N1 = np.array(
+        [[1, 4],
+            [0, 4],
+            [4, 1],
+            [0, 1],
+            [2, 0]])
+
+    N2 = np.array(
+        [[4, 0],
+            [4, 2],
+            [4, 2],
+            [4, 2],
+            [4, 2]])
+
+    assert_array_equal(X_neigh, N1)
+    assert_array_equal(XY_neigh, N2)
+
+    # Test 2
+    nan = float("nan")
+    samples = [[0, 5, 5], [1, 0, nan], [4, 1, 1], [nan, 2, 3]]
+    neigh = neighbors.NearestNeighbors(n_neighbors=2, metric="euclidean")
+
+    neigh.fit(samples, kill_missing=False)
+    X2_neigh = neigh.masked_kneighbors(n_neighbors=2, return_distance=False)
+
+    XY2_neigh = neigh.masked_kneighbors([[0, nan, 1]], 2,
+                                        return_distance=False)
+
+    # Expected outcome
+    N3 = np.array(
+        [[3, 1],
+         [3, 2],
+         [3, 1],
+         [2, 1]])
+    N4 = np.array([[1, 3]])
+
+    assert_array_equal(X2_neigh, N3)
+    assert_array_equal(XY2_neigh, N4)
+
+
 def test_unsupervised_inputs():
     # test the types of valid input into NearestNeighbors
     X = rng.random_sample((10, 3))

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -102,8 +102,8 @@ def test_masked_unsupervised_kneighbors():
                   [3., 1., 3., 3.],
                   [2., 3., 1., 9.]], dtype=np.float32)
 
-    neigh = neighbors.NearestNeighbors(2, metric="euclidean")
-    neigh.fit(X,  kill_missing=False)
+    neigh = neighbors.NearestNeighbors(2, metric="masked_euclidean")
+    neigh.fit(X)
     X_neigh = neigh.masked_kneighbors(n_neighbors=2, return_distance=False)
     XY_neigh = neigh.masked_kneighbors(Y, 2, return_distance=False)
 
@@ -128,9 +128,10 @@ def test_masked_unsupervised_kneighbors():
     # Test 2
     nan = float("nan")
     samples = [[0, 5, 5], [1, 0, nan], [4, 1, 1], [nan, 2, 3]]
-    neigh = neighbors.NearestNeighbors(n_neighbors=2, metric="euclidean")
+    neigh = neighbors.NearestNeighbors(n_neighbors=2,
+                                       metric="masked_euclidean")
 
-    neigh.fit(samples, kill_missing=False)
+    neigh.fit(samples)
     X2_neigh = neigh.masked_kneighbors(n_neighbors=2, return_distance=False)
 
     XY2_neigh = neigh.masked_kneighbors([[0, nan, 1]], 2,
@@ -1079,6 +1080,9 @@ def test_valid_brute_metric_for_auto_algorithm():
             nb_p.kneighbors(DYX)
 
     for metric in VALID_METRICS_SPARSE['brute']:
+        # TODO: Remove after adding sparse support for masked_euclidean
+        if metric == "masked_euclidean":
+            continue
         if metric != 'precomputed' and metric not in require_params:
             nn = neighbors.NearestNeighbors(n_neighbors=3, algorithm='auto',
                                             metric=metric).fit(Xcsr)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Issue: [4844](https://github.com/scikit-learn/scikit-learn/pull/4844),  [2989](https://github.com/scikit-learn/scikit-learn/issues/2989)
Prelude to: [9212](https://github.com/scikit-learn/scikit-learn/pull/9212)

#### What does this implement/fix? Explain your changes.
This is actually first part of another [PR](https://github.com/scikit-learn/scikit-learn/pull/9212). The referenced PR implements a KNN based imputation strategy using its own k-Nearest Neighbor calculator. But it was suggested [here](https://github.com/scikit-learn/scikit-learn/pull/4844) that it might be a better option to make changes within sklearn.metrics instead so that the existing sklearn.neighbors machinery could be used. Given this context, this PR modifies relevant modules in sklearn.metrics (and sklearn.neighbors to a very minor extent) so the euclidean distance between samples with arbitrary missing coordinates can now be calculated. 



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
