### PR TITLE
[MRG] ENH: add support for dropping first level of categorical feature

### DIFF
--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -111,3 +111,23 @@ def test_deterministic_vocabulary():
     v_2 = DictVectorizer().fit([d_shuffled])
 
     assert_equal(v_1.vocabulary_, v_2.vocabulary_)
+
+
+def test_drop_first_level_categorical_feature():
+    raw_data = [{"name": "luca", "country": "italy", "age": 30},
+                {"name": "davide", "country": "italy"},
+                {"name": "yeray", "country": "spain"},
+                {"name": "karol", "country": "poland"}]
+
+    v = DictVectorizer(drop_first_category=True, sparse=False)
+    X = v.fit_transform(raw_data)
+
+    assert_equal(v.feature_names_, ["age", "country=poland", "country=spain",
+                                    "name=davide", "name=karol", "name=yeray"])
+
+    assert_array_equal(
+        X, np.array([[30, 0, 0, 0, 0, 0],
+                     [0, 0, 0, 1, 0, 0],
+                     [0, 0, 1, 0, 0, 1],
+                     [0, 1, 0, 0, 1, 0]])
+    )


### PR DESCRIPTION
#### Reference Issues

Fixes #6053
Fixes #9073

#### What does this implement/fix? Explain your changes.
This Pull Request adds an extra argument to `DictVectorizer` that, if set to `True`, drops the first level of each categorical variable. This is extremely useful in a regression model that to not use regularisation, as it avoids multicollinearity.

#### Any other comments
Even though multicollinearity doesn't affect the predictions, it hugely affects the regression coefficients, which makes troublesome both model inspection and further usage of such coefficients.