### PR TITLE
[MRG+1] FIX out of bounds array access in SAGA

### DIFF
--- a/sklearn/linear_model/sag_fast.pyx
+++ b/sklearn/linear_model/sag_fast.pyx
@@ -614,10 +614,14 @@ cdef void lagged_update(double* weights, double wscale, int xnnz,
                         last_update_ind = sample_itr - 1
                     for lagged_ind in range(sample_itr - 1,
                                    last_update_ind - 1, -1):
-                        grad_step = (cumulative_sums[lagged_ind]
-                           - cumulative_sums[lagged_ind - 1])
-                        prox_step = (cumulative_sums_prox[lagged_ind]
-                           - cumulative_sums_prox[lagged_ind - 1])
+                        if lagged_ind > 1:
+                            grad_step = (cumulative_sums[lagged_ind]
+                               - cumulative_sums[lagged_ind - 1])
+                            prox_step = (cumulative_sums_prox[lagged_ind]
+                               - cumulative_sums_prox[lagged_ind - 1])
+                        else:
+                            grad_step = cumulative_sums[lagged_ind]
+                            prox_step = cumulative_sums_prox[lagged_ind]
                         weights[idx] -= sum_gradient[idx] * grad_step
                         weights[idx] = _soft_thresholding(weights[idx],
                                                           prox_step)

--- a/sklearn/linear_model/sag_fast.pyx
+++ b/sklearn/linear_model/sag_fast.pyx
@@ -614,7 +614,7 @@ cdef void lagged_update(double* weights, double wscale, int xnnz,
                         last_update_ind = sample_itr - 1
                     for lagged_ind in range(sample_itr - 1,
                                    last_update_ind - 1, -1):
-                        if lagged_ind > 1:
+                        if lagged_ind > 0:
                             grad_step = (cumulative_sums[lagged_ind]
                                - cumulative_sums[lagged_ind - 1])
                             prox_step = (cumulative_sums_prox[lagged_ind]


### PR DESCRIPTION
Fixes #9351 (random inconsistencies between SAGA and liblinear LogisticRegression on OS X).

To hedge my bets that this is the right fix, I'll ping @tomdlt, @arthurmensch, @dsullivan7.