### PR TITLE
[MRG+1] Added examples to docstrings of ElasticNet and ElasticNetCV

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -614,6 +614,24 @@ class ElasticNet(LinearModel, RegressorMixin):
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance.
 
+    Examples
+    --------
+    >>> from sklearn.linear_model import ElasticNet
+    >>> from sklearn.datasets import make_regression
+    >>>
+    >>> X, y = make_regression(n_features=2, random_state=0)
+    >>> regr = ElasticNet(random_state=0)
+    >>> regr.fit(X, y)
+    ElasticNet(alpha=1.0, copy_X=True, fit_intercept=True, l1_ratio=0.5,
+          max_iter=1000, normalize=False, positive=False, precompute=False,
+          random_state=0, selection='cyclic', tol=0.0001, warm_start=False)
+    >>> regr.coef_
+    array([ 18.83816048,  64.55968825])
+    >>> regr.intercept_
+    1.4512607561654027
+    >>> regr.predict([[0,0]])
+    array([ 1.45126076])
+
     Notes
     -----
     To avoid unnecessary memory duplication the X argument of the fit method
@@ -1485,6 +1503,25 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
     n_iter_ : int
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance for the optimal alpha.
+
+    Examples
+    --------
+    >>> from sklearn.linear_model import ElasticNetCV
+    >>> from sklearn.datasets import make_regression
+    >>>
+    >>> X, y = make_regression(n_features=2, random_state=0)
+    >>> regr = ElasticNetCV(cv=5, random_state=0)
+    >>> regr.fit(X, y)
+    ElasticNetCV(alphas=None, copy_X=True, cv=5, eps=0.001, fit_intercept=True,
+           l1_ratio=0.5, max_iter=1000, n_alphas=100, n_jobs=1,
+           normalize=False, positive=False, precompute='auto', random_state=0,
+           selection='cyclic', tol=0.0001, verbose=0)
+    >>> regr.alpha_
+    0.1994727942696716
+    >>> regr.intercept_
+    0.39888296542767998
+    >>> regr.predict([[0,0]])
+    array([ 0.39888297])
 
     Notes
     -----

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -625,12 +625,13 @@ class ElasticNet(LinearModel, RegressorMixin):
     ElasticNet(alpha=1.0, copy_X=True, fit_intercept=True, l1_ratio=0.5,
           max_iter=1000, normalize=False, positive=False, precompute=False,
           random_state=0, selection='cyclic', tol=0.0001, warm_start=False)
-    >>> regr.coef_.round(3)
-    array([ 18.838,  64.56 ])
-    >>> regr.intercept_.round(3)
-    1.4510000000000001
-    >>> regr.predict([[0, 0]]).round(3)
-    array([ 1.451])
+    >>> print(regr.coef_) # doctest: +ELLIPSIS
+    [ 18.83816048  64.55968825]
+    >>> print(regr.intercept_) # doctest: +ELLIPSIS
+    1.45126075617
+    >>> print(regr.predict([[0, 0]])) # doctest: +ELLIPSIS
+    [ 1.45126076]
+
 
     Notes
     -----
@@ -1516,12 +1517,13 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
            l1_ratio=0.5, max_iter=1000, n_alphas=100, n_jobs=1,
            normalize=False, positive=False, precompute='auto', random_state=0,
            selection='cyclic', tol=0.0001, verbose=0)
-    >>> regr.alpha_.round(3)
-    0.19900000000000001
-    >>> regr.intercept_.round(3)
-    0.39900000000000002
-    >>> regr.predict([[0, 0]]).round(3)
-    array([ 0.399])
+    >>> print(regr.alpha_) # doctest: +ELLIPSIS
+    0.19947279427
+    >>> print(regr.intercept_) # doctest: +ELLIPSIS
+    0.398882965428
+    >>> print(regr.predict([[0, 0]])) # doctest: +ELLIPSIS
+    [ 0.39888297]
+
 
     Notes
     -----

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -625,12 +625,12 @@ class ElasticNet(LinearModel, RegressorMixin):
     ElasticNet(alpha=1.0, copy_X=True, fit_intercept=True, l1_ratio=0.5,
           max_iter=1000, normalize=False, positive=False, precompute=False,
           random_state=0, selection='cyclic', tol=0.0001, warm_start=False)
-    >>> regr.coef_
-    array([ 18.83816048,  64.55968825])
-    >>> regr.intercept_
-    1.4512607561654027
-    >>> regr.predict([[0,0]])
-    array([ 1.45126076])
+    >>> regr.coef_.round(3)
+    array([ 18.838,  64.56 ])
+    >>> regr.intercept_.round(3)
+    1.4510000000000001
+    >>> regr.predict([[0, 0]]).round(3)
+    array([ 1.451])
 
     Notes
     -----
@@ -1516,12 +1516,12 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
            l1_ratio=0.5, max_iter=1000, n_alphas=100, n_jobs=1,
            normalize=False, positive=False, precompute='auto', random_state=0,
            selection='cyclic', tol=0.0001, verbose=0)
-    >>> regr.alpha_
-    0.1994727942696716
-    >>> regr.intercept_
-    0.39888296542767998
-    >>> regr.predict([[0,0]])
-    array([ 0.39888297])
+    >>> regr.alpha_.round(3)
+    0.19900000000000001
+    >>> regr.intercept_.round(3)
+    0.39900000000000002
+    >>> regr.predict([[0, 0]]).round(3)
+    array([ 0.399])
 
     Notes
     -----


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Addresses #3846 

#### What does this implement/fix? Explain your changes.
Adds examples to docstrings of ElasticNet and ElasticNetCV.

#### Any other comments?
I used make regression with fixed random states and if something will change in make_regression outputs for users may not be compatible. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
