### PR TITLE
Ignore underflow in LabelPropagation

### DIFF
--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -230,6 +230,10 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
         self.X_ = X
         check_classification_targets(y)
 
+	# ignore expected underflow
+        old_error_settings = np.geterr()
+        np.seterr(invalid='ignore', under='ignore')
+
         # actual graph construction (implementations should override this)
         graph_matrix = self._build_graph()
 
@@ -289,6 +293,9 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
 
         normalizer = np.sum(self.label_distributions_, axis=1)[:, np.newaxis]
         self.label_distributions_ /= normalizer
+
+        # restore error settings
+        np.seterr(**old_error_settings)
 
         # set the transduction item
         transduction = self.classes_[np.argmax(self.label_distributions_,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Fixes #9313 


#### What does this implement/fix? Explain your changes.
This pull request fixes issues of underflow and invalid value errors thrown from LabelPropagation, which are expected in certain data topologies. Error settings are temporarily changed to ignore `invalid` and `under` errors and restored at the end of the function.

#### Any other comments?
It appears that the issue of underflow for RBF and Laplacian kernels may occur for other models as well. I will try to go through SVMs and other models using kernel methods and see if this error appears.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
