### PR TITLE
[MRG+1] Chassifier chain example fix

### DIFF
--- a/examples/multioutput/plot_classifier_chain_yeast.py
+++ b/examples/multioutput/plot_classifier_chain_yeast.py
@@ -18,7 +18,7 @@ chain are ordered randomly. In addition to the 103 features in the dataset,
 each model gets the predictions of the preceding models in the chain as
 features (note that by default at training time each model gets the true
 labels as features). These additional features allow each chain to exploit
-correlations among the classes. The Jaccard similarity score for each chain 
+correlations among the classes. The Jaccard similarity score for each chain
 tends to be greater than that of the set independent logistic models.
 
 Because the models in each chain are arranged randomly there is significant
@@ -109,7 +109,7 @@ ax.set_xticklabels(model_names, rotation='vertical')
 ax.set_ylabel('Jaccard Similarity Score')
 ax.set_ylim([min(model_scores) * .9, max(model_scores) * 1.1])
 width = .8
-ax.set_xlim([-width, x_pos[-1]+width])
+ax.set_xlim([-width, x_pos[-1] + width])
 colors = ['r'] + ['b'] * len(chain_jaccard_scores) + ['g']
 ax.bar(x_pos, model_scores, width=width, alpha=0.5, color=colors)
 ax.plot([-width, x_pos[-1] + width],

--- a/examples/multioutput/plot_classifier_chain_yeast.py
+++ b/examples/multioutput/plot_classifier_chain_yeast.py
@@ -5,11 +5,11 @@ Classifier Chain
 Example of using classifier chain on a multilabel dataset.
 
 For this example we will use the `yeast
-<http://mldata.org/repository/data/viewslug/yeast>`_ dataset which
-contains 2417 datapoints each with 103 features and 14 possible labels. Each
-datapoint has at least one label. As a baseline we first train a logistic
-regression classifier for each of the 14 labels. To evaluate the performance
-of these classifiers we predict on a held-out test set and calculate the
+<http://mldata.org/repository/data/viewslug/yeast>`_ dataset which contains
+2417 datapoints each with 103 features and 14 possible labels. Each
+data point has at least one label. As a baseline we first train a logistic
+regression classifier for each of the 14 labels. To evaluate the performance of
+these classifiers we predict on a held-out test set and calculate the
 :ref:`jaccard similarity score <jaccard_similarity_score>`.
 
 Next we create 10 classifier chains. Each classifier chain contains a
@@ -18,7 +18,7 @@ chain are ordered randomly. In addition to the 103 features in the dataset,
 each model gets the predictions of the preceding models in the chain as
 features (note that by default at training time each model gets the true
 labels as features). These additional features allow each chain to exploit
-correlations among the classes. The Jaccard similarity score for each chain
+correlations among the classes. The Jaccard similarity score for each chain 
 tends to be greater than that of the set independent logistic models.
 
 Because the models in each chain are arranged randomly there is significant
@@ -112,6 +112,7 @@ width = .8
 ax.set_xlim([-width, x_pos[-1]+width])
 colors = ['r'] + ['b'] * len(chain_jaccard_scores) + ['g']
 ax.bar(x_pos, model_scores, width=width, alpha=0.5, color=colors)
-ax.plot([-width, x_pos[-1] + width], [model_scores[-1], model_scores[-1]], "k--")
+ax.plot([-width, x_pos[-1] + width],
+        [model_scores[-1], model_scores[-1]], "k--")
 plt.tight_layout()
 plt.show()

--- a/examples/multioutput/plot_classifier_chain_yeast.py
+++ b/examples/multioutput/plot_classifier_chain_yeast.py
@@ -10,7 +10,7 @@ contains 2417 datapoints each with 103 features and 14 possible labels. Each
 datapoint has at least one label. As a baseline we first train a logistic
 regression classifier for each of the 14 labels. To evaluate the performance
 of these classifiers we predict on a held-out test set and calculate the
-:ref:`User Guide <jaccard_similarity_score>`.
+:ref:`jaccard similarity score <jaccard_similarity_score>`.
 
 Next we create 10 classifier chains. Each classifier chain contains a
 logistic regression model for each of the 14 labels. The models in each

--- a/examples/multioutput/plot_classifier_chain_yeast.py
+++ b/examples/multioutput/plot_classifier_chain_yeast.py
@@ -92,19 +92,26 @@ model_names = ('Independent Models',
                'Chain 10',
                'Ensemble Average')
 
-y_pos = np.arange(len(model_names))
-y_pos[1:] += 1
-y_pos[-1] += 1
+x_pos = np.arange(len(model_names))
+x_pos[1:] += 1
+x_pos[-1] += 1
 
 # Plot the Jaccard similarity scores for the independent model, each of the
 # chains, and the ensemble (note that the vertical axis on this plot does
 # not begin at 0).
 
-fig = plt.figure(figsize=(7, 4))
-plt.title('Classifier Chain Ensemble')
-plt.xticks(y_pos, model_names, rotation='vertical')
-plt.ylabel('Jaccard Similarity Score')
-plt.ylim([min(model_scores) * .9, max(model_scores) * 1.1])
+fig, ax = plt.subplots()
+fig.set_figheight(7)
+fig.set_figwidth(7)
+ax.set_title('Classifier Chain Ensemble')
+ax.set_xticks(x_pos)
+ax.set_xticklabels(model_names, rotation='vertical')
+ax.set_ylabel('Jaccard Similarity Score')
+ax.set_ylim([min(model_scores) * .9, max(model_scores) * 1.1])
+width = .8
+ax.set_xlim([-width, x_pos[-1]+width])
 colors = ['r'] + ['b'] * len(chain_jaccard_scores) + ['g']
-plt.bar(y_pos, model_scores, align='center', alpha=0.5, color=colors)
+ax.bar(x_pos, model_scores, width=width, alpha=0.5, color=colors)
+ax.plot([-width, x_pos[-1] + width], [model_scores[-1], model_scores[-1]], "k--")
+plt.tight_layout()
 plt.show()

--- a/examples/multioutput/plot_classifier_chain_yeast.py
+++ b/examples/multioutput/plot_classifier_chain_yeast.py
@@ -79,7 +79,7 @@ ensemble_jaccard_score = jaccard_similarity_score(Y_test,
 model_scores = [ovr_jaccard_score] + chain_jaccard_scores
 model_scores.append(ensemble_jaccard_score)
 
-model_names = ('Independent Models',
+model_names = ('Independent',
                'Chain 1',
                'Chain 2',
                'Chain 3',
@@ -90,29 +90,21 @@ model_names = ('Independent Models',
                'Chain 8',
                'Chain 9',
                'Chain 10',
-               'Ensemble Average')
+               'Ensemble')
 
 x_pos = np.arange(len(model_names))
-x_pos[1:] += 1
-x_pos[-1] += 1
 
 # Plot the Jaccard similarity scores for the independent model, each of the
 # chains, and the ensemble (note that the vertical axis on this plot does
 # not begin at 0).
 
-fig, ax = plt.subplots()
-fig.set_figheight(7)
-fig.set_figwidth(7)
-ax.set_title('Classifier Chain Ensemble')
+fig, ax = plt.subplots(figsize=(7, 4))
+ax.set_title('Classifier Chain Ensemble Performance Comparison')
 ax.set_xticks(x_pos)
 ax.set_xticklabels(model_names, rotation='vertical')
 ax.set_ylabel('Jaccard Similarity Score')
 ax.set_ylim([min(model_scores) * .9, max(model_scores) * 1.1])
-width = .8
-ax.set_xlim([-width, x_pos[-1] + width])
 colors = ['r'] + ['b'] * len(chain_jaccard_scores) + ['g']
-ax.bar(x_pos, model_scores, width=width, alpha=0.5, color=colors)
-ax.plot([-width, x_pos[-1] + width],
-        [model_scores[-1], model_scores[-1]], "k--")
+ax.bar(x_pos, model_scores, alpha=0.5, color=colors)
 plt.tight_layout()
 plt.show()

--- a/examples/multioutput/plot_classifier_chain_yeast.py
+++ b/examples/multioutput/plot_classifier_chain_yeast.py
@@ -99,6 +99,7 @@ x_pos = np.arange(len(model_names))
 # not begin at 0).
 
 fig, ax = plt.subplots(figsize=(7, 4))
+ax.grid(True)
 ax.set_title('Classifier Chain Ensemble Performance Comparison')
 ax.set_xticks(x_pos)
 ax.set_xticklabels(model_names, rotation='vertical')


### PR DESCRIPTION
Minor improvements to and fixes in `plot_classifier_chain_yeast.py`

One of the links in the text was not correctly formatted.

I added a dotted line to the bar chart that makes it easier to compare the jaccard similarity score of the independent models and the individual chains to the ensemble average..

The x labels were getting cutoff. I added `tight_layout` to try to correct this.