### PR TITLE
[MRG] add stratify and shuffle variants for GroupKFold

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -532,12 +532,12 @@ parameter.
 Group k-fold
 ------------
 
-:class:`GroupKFold` is a variation of k-fold which ensures that the same group is
-not represented in both testing and training sets. For example if the data is
-obtained from different subjects with several samples per-subject and if the
+:class:`GroupKFold` is a variation of k-fold which ensures that the same group
+is not represented in both testing and training sets. For example if the data
+is obtained from different subjects with several samples per-subject and if the
 model is flexible enough to learn from highly person specific features it
 could fail to generalize to new subjects. :class:`GroupKFold` makes it possible
-to detect this kind of overfitting situations.
+to avoid these kind of overfitting situations.
 
 Imagine you have three subjects, each with an associated number from 1 to 3::
 
@@ -560,18 +560,26 @@ size due to the imbalance in the data.
 
 The same group will not appear in two different folds;
 this is a hard constraint. After this constraint is enforced,
-there are still multiple ways to divide groups across folds.
+there are still multiple ways to divide groups across folds. A greedy strategy
+is used to create folds of approximately the same size: at each step, the fold
+with the least number of items is assigned a new group. The order in which
+groups are assigned can be used to tweak the distribution of the resulting
+folds.
 
-The default, ``method='balance'``, will balance the sizes of the folds,
-such that each has approximately the same amount of items, as far as possible.
-With ``method='stratify'``, items are spread across the folds by stratifying on
-the ``y`` variable, as far as possible. Since this is done by sorting, it works
-for continuous variables as well.
-Finally, ``method='shuffle'`` distributes groups across folds randomly.
+The default, ``method='balance'``, will try to balance the sizes of the folds,
+by assigning the largest groups first. With ``method='stratify_median'`` or
+``method='stratify_mode``, items are spread across the folds by stratifying on
+the ``y`` variable, as far as possible. Median should be used for continuous
+variables, and mode for discrete variables. Stratification may be important
+when the ``y`` variable has a skewed distribution; stratification can help
+ensure that rare ``y`` values are represented in each fold.
+Finally, ``method='shuffle'`` adds randomness by shuffling the groups. This
+strategy is useful when you want to generate multiple sets of folds; repeated
+use of the other methods would deterministically result in the same folds.
 
 The latter two options work best when groups are relatively small (i.e., there
 are many groups), to avoid folds of uneven sizes. The stratification relies on
-the median ``y``-value of each group being representative of its group.
+picking ``y``-values of each group that are representative of its group.
 
 .. topic:: Examples
 

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -569,9 +569,9 @@ the ``y`` variable, as far as possible. Since this is done by sorting, it works
 for continuous variables as well.
 Finally, ``method='shuffle'`` distributes groups across folds randomly.
 
-The latter two options work best when groups are relatively small, to avoid
-folds of uneven sizes. The stratification relies on the ``y``-value of the
-first item of a group being representative of its group.
+The latter two options work best when groups are relatively small (i.e., there
+are many groups), to avoid folds of uneven sizes. The stratification relies on
+the median ``y``-value of each group being representative of its group.
 
 .. topic:: Examples
 

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -573,6 +573,10 @@ The latter two options work best when groups are relatively small, to avoid
 folds of uneven sizes. The stratification relies on the ``y``-value of the
 first item of a group being representative of its group.
 
+.. topic:: Examples
+
+    * :ref:`sphx_glr_auto_examples_model_selection_plot_groupkfold.py`,
+
 
 Leave One Group Out
 -------------------

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -532,11 +532,11 @@ parameter.
 Group k-fold
 ------------
 
-class:GroupKFold is a variation of k-fold which ensures that the same group is
+:class:`GroupKFold` is a variation of k-fold which ensures that the same group is
 not represented in both testing and training sets. For example if the data is
 obtained from different subjects with several samples per-subject and if the
 model is flexible enough to learn from highly person specific features it
-could fail to generalize to new subjects. class:GroupKFold makes it possible
+could fail to generalize to new subjects. :class:`GroupKFold` makes it possible
 to detect this kind of overfitting situations.
 
 Imagine you have three subjects, each with an associated number from 1 to 3::
@@ -557,6 +557,21 @@ Imagine you have three subjects, each with an associated number from 1 to 3::
 Each subject is in a different testing fold, and the same subject is never in
 both testing and training. Notice that the folds do not have exactly the same
 size due to the imbalance in the data.
+
+The same group will not appear in two different folds;
+this is a hard constraint. After this constraint is enforced,
+there are still multiple ways to divide groups across folds.
+
+The default, ``method='balance'``, will balance the sizes of the folds,
+such that each has approximately the same amount of items, as far as possible.
+With ``method='stratify'``, items are spread across the folds by stratifying on
+the ``y`` variable, as far as possible. Since this is done by sorting, it works
+for continuous variables as well.
+Finally, ``method='shuffle'`` distributes groups across folds randomly.
+
+The latter two options work best when groups are relatively small, to avoid
+folds of uneven sizes. The stratification relies on the ``y``-value of the
+first item of a group being representative of its group.
 
 
 Leave One Group Out

--- a/examples/model_selection/plot_groupkfold.py
+++ b/examples/model_selection/plot_groupkfold.py
@@ -15,16 +15,19 @@ print(__doc__)
 rng = np.random.RandomState(0)
 n_samples = 1000
 n_groups = 100
+n_folds = 2
 X = np.arange(n_samples)
+# Sort data points to highlight the effect of stratification
 y = np.sort(rng.normal(size=n_samples))
 groups = np.sort(rng.randint(0, n_groups, n_samples))
 
 fig, axes = plt.subplots(1, 3, figsize=(18, 4), sharex=True, sharey=True)
-for n, method in enumerate(('balance', 'stratify', 'shuffle')):
-    cv = GroupKFold(2, method=method)
+for n, method in enumerate(('balance', 'stratify_median', 'shuffle')):
+    cv = GroupKFold(n_folds, method=method)
     for m, (train, test) in enumerate(cv.split(X, y, groups)):
-        axes[n].hist(y[test], bins=20, histtype='step')
+        axes[n].hist(y[test], bins=20, histtype='step',
+                     label='fold %d' % (m + 1))
         print('%s fold %d: %d items' % (method, m + 1, len(test)))
     axes[n].set_xlabel(method)
-
+    axes[n].legend(loc='upper right')
 plt.show()

--- a/examples/model_selection/plot_groupkfold.py
+++ b/examples/model_selection/plot_groupkfold.py
@@ -1,0 +1,30 @@
+"""
+====================
+Group K-Fold methods
+====================
+
+This example demonstrates when the stratify option of GroupKFold has an
+advantage.
+"""
+from matplotlib import pyplot as plt
+import numpy as np
+from sklearn.model_selection import GroupKFold
+
+print(__doc__)
+
+rng = np.random.RandomState(0)
+n_samples = 1000
+n_groups = 100
+X = np.arange(n_samples)
+y = np.sort(rng.normal(size=n_samples))
+groups = np.sort(rng.randint(0, n_groups, n_samples))
+
+fig, axes = plt.subplots(1, 3, figsize=(18, 4), sharex=True, sharey=True)
+for n, method in enumerate(('balance', 'stratify', 'shuffle')):
+    cv = GroupKFold(2, method=method)
+    for m, (train, test) in enumerate(cv.split(X, y, groups)):
+        axes[n].hist(y[test], bins=20, histtype='step')
+        print('%s fold %d: %d items' % (method, m + 1, len(test)))
+    axes[n].set_xlabel(method)
+
+plt.show()

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -458,11 +458,11 @@ class GroupKFold(_BaseKFold):
     >>> X = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
     >>> y = np.array([1, 2, 3, 4])
     >>> groups = np.array([0, 0, 2, 2])
-    >>> group_kfold = GroupKFold(n_splits=2)
+    >>> group_kfold = GroupKFold(method='balance', n_splits=2)
     >>> group_kfold.get_n_splits(X, y, groups)
     2
     >>> print(group_kfold)
-    GroupKFold(n_splits=2)
+    GroupKFold(method='balance', n_splits=2)
     >>> for train_index, test_index in group_kfold.split(X, y, groups):
     ...     print("TRAIN:", train_index, "TEST:", test_index)
     ...     X_train, X_test = X[train_index], X[test_index]

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -487,7 +487,7 @@ class GroupKFold(_BaseKFold):
     def __init__(self, n_splits=3, method='balance'):
         if method not in ('balance', 'stratify', 'shuffle'):
             raise ValueError("The 'method' parameter should be in "
-                    "('balance', 'stratify', 'shuffle')")
+                             "('balance', 'stratify', 'shuffle')")
         self.method = method
         super(GroupKFold, self).__init__(n_splits, shuffle=False,
                                          random_state=None)

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1220,7 +1220,7 @@ def test_group_kfold():
 
     ideal_n_groups_per_fold = n_samples // n_splits
 
-    for method in ('balance', 'stratify', 'shuffle'):
+    for method in ('balance', 'stratify_median', 'stratify_mode', 'shuffle'):
         # Get the test fold indices from the test set indices of each fold
         folds = np.zeros(n_samples)
         lkf = GroupKFold(n_splits=n_splits, method=method)

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1220,28 +1220,30 @@ def test_group_kfold():
 
     ideal_n_groups_per_fold = n_samples // n_splits
 
-    len(np.unique(groups))
-    # Get the test fold indices from the test set indices of each fold
-    folds = np.zeros(n_samples)
-    lkf = GroupKFold(n_splits=n_splits)
-    for i, (_, test) in enumerate(lkf.split(X, y, groups)):
-        folds[test] = i
+    for method in ('balance', 'stratify', 'shuffle'):
+        # Get the test fold indices from the test set indices of each fold
+        folds = np.zeros(n_samples)
+        lkf = GroupKFold(n_splits=n_splits, method=method)
+        for i, (_, test) in enumerate(lkf.split(X, y, groups)):
+            folds[test] = i
 
-    # Check that folds have approximately the same size
-    assert_equal(len(folds), len(groups))
-    for i in np.unique(folds):
-        assert_greater_equal(tolerance,
-                             abs(sum(folds == i) - ideal_n_groups_per_fold))
+        # Check that folds have approximately the same size
+        if method == 'balance':
+            assert_equal(len(folds), len(groups))
+            for i in np.unique(folds):
+                assert_greater_equal(tolerance,
+                        abs(sum(folds == i) - ideal_n_groups_per_fold))
 
-    # Check that each group appears only in 1 fold
-    for group in np.unique(groups):
-        assert_equal(len(np.unique(folds[groups == group])), 1)
+        # Check that each group appears only in 1 fold
+        for group in np.unique(groups):
+            assert_equal(len(np.unique(folds[groups == group])), 1)
 
-    # Check that no group is on both sides of the split
-    groups = np.asarray(groups, dtype=object)
-    for train, test in lkf.split(X, y, groups):
-        assert_equal(len(np.intersect1d(groups[train], groups[test])), 0)
+        # Check that no group is on both sides of the split
+        groups = np.asarray(groups, dtype=object)
+        for train, test in lkf.split(X, y, groups):
+            assert_equal(len(np.intersect1d(groups[train], groups[test])), 0)
 
+    lkf = GroupKFold(n_splits=n_splits, method='balance')
     # Construct the test data
     groups = np.array(['Albert', 'Jean', 'Bertrand', 'Michel', 'Jean',
                        'Francis', 'Robert', 'Michel', 'Rachel', 'Lois',

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1231,7 +1231,8 @@ def test_group_kfold():
         if method == 'balance':
             assert_equal(len(folds), len(groups))
             for i in np.unique(folds):
-                assert_greater_equal(tolerance,
+                assert_greater_equal(
+                        tolerance,
                         abs(sum(folds == i) - ideal_n_groups_per_fold))
 
         # Check that each group appears only in 1 fold


### PR DESCRIPTION
Supersedes  #5396

Adds an option "method" to GroupKFold to change the way groups are distributed over folds. Current default is to balance the sizes of the folds. This adds the alternative of stratifying on the y variable, or shuffling the groups to randomize the folds they end up in.