### PR TITLE
[MRG + 1] Multiclass Documentation update

### DIFF
--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -64,20 +64,60 @@ Below is a summary of the classifiers supported by scikit-learn
 grouped by strategy; you don't need the meta-estimators in this class
 if you're using one of these, unless you want custom multiclass behavior:
 
-  - Inherently multiclass: :ref:`Naive Bayes <naive_bayes>`,
-    :ref:`LDA and QDA <lda_qda>`,
-    :ref:`Decision Trees <tree>`, :ref:`Random Forests <forest>`,
-    :ref:`Nearest Neighbors <neighbors>`,
-    setting ``multi_class='multinomial'`` in
-    :class:`sklearn.linear_model.LogisticRegression`.
-  - Support multilabel: :ref:`Decision Trees <tree>`,
-    :ref:`Random Forests <forest>`, :ref:`Nearest Neighbors <neighbors>`.
-  - One-Vs-One: :class:`sklearn.svm.SVC`.
-  - One-Vs-All: all linear models except :class:`sklearn.svm.SVC`.
+  - Inherently multiclass:
+    * :class: `AdaBoostClassifier`
+    * :class: `BaggingClassifier`
+    * :class: `BernoulliNB`
+    * :class: `CalibratedClassifierCV`
+    * :class: `DecisionTreeClassifier`
+    * :class: `ExtraTreeClassifier`
+    * :class: `ExtraTreesClassifier`
+    * :class: `GaussianNB`
+    * :class: `GaussianProcessClassifier`
+    * :class: `GradientBoostingClassifier`
+    * :class: `KNeighborsClassifier`
+    * :class: `LabelPropagation`
+    * :class: `LabelSpreading`
+    * :class: `LinearDiscriminantAnalysis`
+    * :class: `LinearSVC`
+    * :class: `LogisticRegression`
+    * :class: `LogisticRegressionCV`
+    * :class: `MLPClassifier`
+    * :class: `NearestCentroid`
+    * :class: `NuSVC`
+    * :class: `PassiveAggressiveClassifier`
+    * :class: `Perceptron`
+    * :class: `QuadraticDiscriminantAnalysis`
+    * :class: `RadiusNeighborsClassifier`
+    * :class: `RandomForestClassifier`
+    * :class: `RidgeClassifier`
+    * :class: `RidgeClassifierCV`
+    * :class: `SGDClassifier`
+    * :class: `SVC`
 
-Some estimators also support multioutput-multiclass classification
-tasks :ref:`Decision Trees <tree>`, :ref:`Random Forests <forest>`,
-:ref:`Nearest Neighbors <neighbors>`.
+  - Support multilabel:
+    * :class: `DecisionTreeClassifier`
+    * :class: `ExtraTreeClassifier`
+    * :class: `ExtraTreesClassifier`
+    * :class: `KNeighborsClassifier`
+    * :class: `MLPClassifier`
+    * :class: `RadiusNeighborsClassifier`
+    * :class: `RandomForestClassifier`
+    * :class: `RidgeClassifierCV`
+
+  - Support multiclass-multioutput:
+    * :class: `DecisionTreeClassifier`
+    * :class: `ExtraTreeClassifier`
+    * :class: `ExtraTreesClassifier`
+    * :class: `KNeighborsClassifier`
+    * :class: `RadiusNeighborsClassifier`
+    * :class: `RandomForestClassifier`
+
+  - One-Vs-One:
+    * :class:`sklearn.svm.SVC`.
+
+  - One-Vs-All:
+    * all linear models except :class:`sklearn.svm.SVC`.
 
 .. warning::
 

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -17,42 +17,42 @@ The :mod:`sklearn.multiclass` module implements *meta-estimators* to solve
 by decomposing such problems into binary classification problems. Multitarget
 regression is also supported.
 
-  - **Multiclass classification** means a classification task with more than
-    two classes; e.g., classify a set of images of fruits which may be oranges,
-    apples, or pears. Multiclass classification makes the assumption that each
-    sample is assigned to one and only one label: a fruit can be either an
-    apple or a pear but not both at the same time.
+- **Multiclass classification** means a classification task with more than
+  two classes; e.g., classify a set of images of fruits which may be oranges,
+  apples, or pears. Multiclass classification makes the assumption that each
+  sample is assigned to one and only one label: a fruit can be either an
+  apple or a pear but not both at the same time.
 
-  - **Multilabel classification** assigns to each sample a set of target
-    labels. This can be thought as predicting properties of a data-point
-    that are not mutually exclusive, such as topics that are relevant for a
-    document. A text might be about any of religion, politics, finance or
-    education at the same time or none of these.
+- **Multilabel classification** assigns to each sample a set of target
+  labels. This can be thought as predicting properties of a data-point
+  that are not mutually exclusive, such as topics that are relevant for a
+  document. A text might be about any of religion, politics, finance or
+  education at the same time or none of these.
 
-  - **Multioutput regression** assigns each sample a set of target
-    values.  This can be thought of as predicting several properties
-    for each data-point, such as wind direction and magnitude at a
-    certain location.
+- **Multioutput regression** assigns each sample a set of target
+  values.  This can be thought of as predicting several properties
+  for each data-point, such as wind direction and magnitude at a
+  certain location.
 
-  - **Multioutput-multiclass classification** and **multi-task classification**
-    means that a single estimator has to handle several joint classification
-    tasks. This is both a generalization of the multi-label classification
-    task, which only considers binary classification, as well as a
-    generalization of the multi-class classification task.  *The output format
-    is a 2d numpy array or sparse matrix.*
+- **Multioutput-multiclass classification** and **multi-task classification**
+  means that a single estimator has to handle several joint classification
+  tasks. This is both a generalization of the multi-label classification
+  task, which only considers binary classification, as well as a
+  generalization of the multi-class classification task.  *The output format
+  is a 2d numpy array or sparse matrix.*
 
-    The set of labels can be different for each output variable.
-    For instance, a sample could be assigned "pear" for an output variable that
-    takes possible values in a finite set of species such as "pear", "apple"; 
-    and "blue" or "green" for a second output variable that takes possible values
-    in a finite set of colors such as "green", "red", "blue", "yellow"...
+  The set of labels can be different for each output variable.
+  For instance, a sample could be assigned "pear" for an output variable that
+  takes possible values in a finite set of species such as "pear", "apple"; 
+  and "blue" or "green" for a second output variable that takes possible values
+  in a finite set of colors such as "green", "red", "blue", "yellow"...
 
-    This means that any classifiers handling multi-output
-    multiclass or multi-task classification tasks,
-    support the multi-label classification task as a special case.
-    Multi-task classification is similar to the multi-output
-    classification task with different model formulations. For
-    more information, see the relevant estimator documentation.
+  This means that any classifiers handling multi-output
+  multiclass or multi-task classification tasks,
+  support the multi-label classification task as a special case.
+  Multi-task classification is similar to the multi-output
+  classification task with different model formulations. For
+  more information, see the relevant estimator documentation.
 
 All scikit-learn classifiers are capable of multiclass classification,
 but the meta-estimators offered by :mod:`sklearn.multiclass`
@@ -64,68 +64,68 @@ Below is a summary of the classifiers supported by scikit-learn
 grouped by strategy; you don't need the meta-estimators in this class
 if you're using one of these, unless you want custom multiclass behavior:
 
-  - Inherently multiclass:
+- **Inherently multiclass:**
 
-    - :class:`sklearn.naive_bayes.BernoulliNB`
-    - :class:`sklearn.tree.DecisionTreeClassifier`
-    - :class:`sklearn.tree.ExtraTreeClassifier`
-    - :class:`sklearn.ensemble.ExtraTreesClassifier`
-    - :class:`sklearn.naive_bayes.GaussianNB`
-    - :class:`sklearn.neighbors.KNeighborsClassifier`
-    - :class:`sklearn.semi_supervised.LabelPropagation`
-    - :class:`sklearn.semi_supervised.LabelSpreading`
-    - :class:`sklearn.discriminant_analysis.LinearDiscriminantAnalysis`
-    - :class:`sklearn.svm.LinearSVC` (setting multi_class="crammer_singer")
-    - :class:`sklearn.linear_model.LogisticRegression` (setting multi_class="multinomial")
-    - :class:`sklearn.linear_model.LogisticRegressionCV` (setting multi_class="multinomial")
-    - :class:`sklearn.neural_network.MLPClassifier`
-    - :class:`sklearn.neighbors.NearestCentroid`
-    - :class:`sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`
-    - :class:`sklearn.neighbors.RadiusNeighborsClassifier`
-    - :class:`sklearn.ensemble.RandomForestClassifier`
-    - :class:`sklearn.linear_model.RidgeClassifier`
-    - :class:`sklearn.linear_model.RidgeClassifierCV`
-
-
-  - Multiclass as One-Vs-One:
-
-    - :class:`sklearn.svm.NuSVC`
-    - :class:`sklearn.svm.SVC`.
-    - :class:`sklearn.gaussian_process.GaussianProcessClassifier` (setting multi_class = "one_vs_one")
+  - :class:`sklearn.naive_bayes.BernoulliNB`
+  - :class:`sklearn.tree.DecisionTreeClassifier`
+  - :class:`sklearn.tree.ExtraTreeClassifier`
+  - :class:`sklearn.ensemble.ExtraTreesClassifier`
+  - :class:`sklearn.naive_bayes.GaussianNB`
+  - :class:`sklearn.neighbors.KNeighborsClassifier`
+  - :class:`sklearn.semi_supervised.LabelPropagation`
+  - :class:`sklearn.semi_supervised.LabelSpreading`
+  - :class:`sklearn.discriminant_analysis.LinearDiscriminantAnalysis`
+  - :class:`sklearn.svm.LinearSVC` (setting multi_class="crammer_singer")
+  - :class:`sklearn.linear_model.LogisticRegression` (setting multi_class="multinomial")
+  - :class:`sklearn.linear_model.LogisticRegressionCV` (setting multi_class="multinomial")
+  - :class:`sklearn.neural_network.MLPClassifier`
+  - :class:`sklearn.neighbors.NearestCentroid`
+  - :class:`sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`
+  - :class:`sklearn.neighbors.RadiusNeighborsClassifier`
+  - :class:`sklearn.ensemble.RandomForestClassifier`
+  - :class:`sklearn.linear_model.RidgeClassifier`
+  - :class:`sklearn.linear_model.RidgeClassifierCV`
 
 
-  - Multiclass as One-Vs-All:
+- **Multiclass as One-Vs-One:**
 
-    - :class:`sklearn.ensemble.GradientBoostingClassifier`
-    - :class:`sklearn.gaussian_process.GaussianProcessClassifier` (setting multi_class = "one_vs_rest")
-    - :class:`sklearn.svm.LinearSVC` (setting multi_class="ovr")
-    - :class:`sklearn.linear_model.LogisticRegression` (setting multi_class="ovr")
-    - :class:`sklearn.linear_model.LogisticRegressionCV` (setting multi_class="ovr")
-    - :class:`sklearn.linear_model.SGDClassifier`
-    - :class:`sklearn.linear_model.Perceptron`
-    - :class:`sklearn.linear_model.PassiveAggressiveClassifier`
+  - :class:`sklearn.svm.NuSVC`
+  - :class:`sklearn.svm.SVC`.
+  - :class:`sklearn.gaussian_process.GaussianProcessClassifier` (setting multi_class = "one_vs_one")
 
 
-  - Support multilabel:
+- **Multiclass as One-Vs-All:**
 
-    - :class:`sklearn.tree.DecisionTreeClassifier`
-    - :class:`sklearn.tree.ExtraTreeClassifier`
-    - :class:`sklearn.ensemble.ExtraTreesClassifier`
-    - :class:`sklearn.neighbors.KNeighborsClassifier`
-    - :class:`sklearn.neural_network.MLPClassifier`
-    - :class:`sklearn.neighbors.RadiusNeighborsClassifier`
-    - :class:`sklearn.ensemble.RandomForestClassifier`
-    - :class:`sklearn.linear_model.RidgeClassifierCV`
+  - :class:`sklearn.ensemble.GradientBoostingClassifier`
+  - :class:`sklearn.gaussian_process.GaussianProcessClassifier` (setting multi_class = "one_vs_rest")
+  - :class:`sklearn.svm.LinearSVC` (setting multi_class="ovr")
+  - :class:`sklearn.linear_model.LogisticRegression` (setting multi_class="ovr")
+  - :class:`sklearn.linear_model.LogisticRegressionCV` (setting multi_class="ovr")
+  - :class:`sklearn.linear_model.SGDClassifier`
+  - :class:`sklearn.linear_model.Perceptron`
+  - :class:`sklearn.linear_model.PassiveAggressiveClassifier`
 
 
-  - Support multiclass-multioutput:
+- **Support multilabel:**
 
-    - :class:`sklearn.tree.DecisionTreeClassifier`
-    - :class:`sklearn.tree.ExtraTreeClassifier`
-    - :class:`sklearn.ensemble.ExtraTreesClassifier`
-    - :class:`sklearn.neighbors.KNeighborsClassifier`
-    - :class:`sklearn.neighbors.RadiusNeighborsClassifier`
-    - :class:`sklearn.ensemble.RandomForestClassifier`
+  - :class:`sklearn.tree.DecisionTreeClassifier`
+  - :class:`sklearn.tree.ExtraTreeClassifier`
+  - :class:`sklearn.ensemble.ExtraTreesClassifier`
+  - :class:`sklearn.neighbors.KNeighborsClassifier`
+  - :class:`sklearn.neural_network.MLPClassifier`
+  - :class:`sklearn.neighbors.RadiusNeighborsClassifier`
+  - :class:`sklearn.ensemble.RandomForestClassifier`
+  - :class:`sklearn.linear_model.RidgeClassifierCV`
+
+
+- **Support multiclass-multioutput:**
+
+  - :class:`sklearn.tree.DecisionTreeClassifier`
+  - :class:`sklearn.tree.ExtraTreeClassifier`
+  - :class:`sklearn.ensemble.ExtraTreesClassifier`
+  - :class:`sklearn.neighbors.KNeighborsClassifier`
+  - :class:`sklearn.neighbors.RadiusNeighborsClassifier`
+  - :class:`sklearn.ensemble.RandomForestClassifier`
 
 
 .. warning::

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -65,53 +65,53 @@ grouped by strategy; you don't need the meta-estimators in this class
 if you're using one of these, unless you want custom multiclass behavior:
 
   - Inherently multiclass:
-    * :class: `AdaBoostClassifier`
-    * :class: `BaggingClassifier`
-    * :class: `BernoulliNB`
-    * :class: `CalibratedClassifierCV`
-    * :class: `DecisionTreeClassifier`
-    * :class: `ExtraTreeClassifier`
-    * :class: `ExtraTreesClassifier`
-    * :class: `GaussianNB`
-    * :class: `GaussianProcessClassifier`
-    * :class: `GradientBoostingClassifier`
-    * :class: `KNeighborsClassifier`
-    * :class: `LabelPropagation`
-    * :class: `LabelSpreading`
-    * :class: `LinearDiscriminantAnalysis`
-    * :class: `LinearSVC`
-    * :class: `LogisticRegression`
-    * :class: `LogisticRegressionCV`
-    * :class: `MLPClassifier`
-    * :class: `NearestCentroid`
-    * :class: `NuSVC`
-    * :class: `PassiveAggressiveClassifier`
-    * :class: `Perceptron`
-    * :class: `QuadraticDiscriminantAnalysis`
-    * :class: `RadiusNeighborsClassifier`
-    * :class: `RandomForestClassifier`
-    * :class: `RidgeClassifier`
-    * :class: `RidgeClassifierCV`
-    * :class: `SGDClassifier`
-    * :class: `SVC`
+    - :class: `sklearn.ensemble.weight_boosting.AdaBoostClassifier`
+    - :class: `sklearn.ensemble.bagging.BaggingClassifier`
+    - :class: `sklearn.naive_bayes.BernoulliNB`
+    - :class: `sklearn.calibration.CalibratedClassifierCV`
+    - :class: `sklearn.tree.tree.DecisionTreeClassifier`
+    - :class: `sklearn.tree.tree.ExtraTreeClassifier`
+    - :class: `sklearn.ensemble.forest.ExtraTreesClassifier`
+    - :class: `sklearn.naive_bayes.GaussianNB`
+    - :class: `sklearn.gaussian_process.gpc.GaussianProcessClassifier`
+    - :class: `sklearn.ensemble.gradient_boosting.GradientBoostingClassifier`
+    - :class: `sklearn.neighbors.classification.KNeighborsClassifier`
+    - :class: `sklearn.semi_supervised.label_propagation.LabelPropagation`
+    - :class: `sklearn.semi_supervised.label_propagation.LabelSpreading`
+    - :class: `sklearn.discriminant_analysis.LinearDiscriminantAnalysis`
+    - :class: `sklearn.svm.classes.LinearSVC`
+    - :class: `sklearn.linear_model.logistic.LogisticRegression`
+    - :class: `sklearn.linear_model.logistic.LogisticRegressionCV`
+    - :class: `sklearn.neural_network.multilayer_perceptron.MLPClassifier`
+    - :class: `sklearn.neighbors.nearest_centroid.NearestCentroid`
+    - :class: `sklearn.svm.classes.NuSVC`
+    - :class: `sklearn.linear_model.passive_aggressive.PassiveAggressiveClassifier`
+    - :class: `sklearn.linear_model.perceptron.Perceptron`
+    - :class: `sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`
+    - :class: `sklearn.neighbors.classification.RadiusNeighborsClassifier`
+    - :class: `sklearn.ensemble.forest.RandomForestClassifier`
+    - :class: `sklearn.linear_model.ridge.RidgeClassifier`
+    - :class: `sklearn.linear_model.ridge.RidgeClassifierCV`
+    - :class: `sklearn.linear_model.stochastic_gradient.SGDClassifier`
+    - :class: `sklearn.svm.classes.SVC`
 
   - Support multilabel:
-    * :class: `DecisionTreeClassifier`
-    * :class: `ExtraTreeClassifier`
-    * :class: `ExtraTreesClassifier`
-    * :class: `KNeighborsClassifier`
-    * :class: `MLPClassifier`
-    * :class: `RadiusNeighborsClassifier`
-    * :class: `RandomForestClassifier`
-    * :class: `RidgeClassifierCV`
+    - :class: `sklearn.tree.tree.DecisionTreeClassifier`
+    - :class: `sklearn.tree.tree.ExtraTreeClassifier`
+    - :class: `sklearn.ensemble.forest.ExtraTreesClassifier`
+    - :class: `sklearn.neighbors.classification.KNeighborsClassifier`
+    - :class: `sklearn.neural_network.multilayer_perceptron.MLPClassifier`
+    - :class: `sklearn.neighbors.classification.RadiusNeighborsClassifier`
+    - :class: `sklearn.ensemble.forest.RandomForestClassifier`
+    - :class: `sklearn.linear_model.ridge.RidgeClassifierCV`
 
   - Support multiclass-multioutput:
-    * :class: `DecisionTreeClassifier`
-    * :class: `ExtraTreeClassifier`
-    * :class: `ExtraTreesClassifier`
-    * :class: `KNeighborsClassifier`
-    * :class: `RadiusNeighborsClassifier`
-    * :class: `RandomForestClassifier`
+    - :class: `sklearn.tree.tree.DecisionTreeClassifier`
+    - :class: `sklearn.tree.tree.ExtraTreeClassifier`
+    - :class: `sklearn.ensemble.forest.ExtraTreesClassifier`
+    - :class: `sklearn.neighbors.classification.KNeighborsClassifier`
+    - :class: `sklearn.neighbors.classification.RadiusNeighborsClassifier`
+    - :class: `sklearn.ensemble.forest.RandomForestClassifier`
 
   - One-Vs-One:
     * :class:`sklearn.svm.SVC`.

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -66,55 +66,55 @@ if you're using one of these, unless you want custom multiclass behavior:
 
   - Inherently multiclass:
 
-    - :class:`sklearn.ensemble.weight_boosting.AdaBoostClassifier`
-    - :class:`sklearn.ensemble.bagging.BaggingClassifier`
+    - :class:`sklearn.ensemble.AdaBoostClassifier`
+    - :class:`sklearn.ensemble.BaggingClassifier`
     - :class:`sklearn.naive_bayes.BernoulliNB`
     - :class:`sklearn.calibration.CalibratedClassifierCV`
-    - :class:`sklearn.tree.tree.DecisionTreeClassifier`
-    - :class:`sklearn.tree.tree.ExtraTreeClassifier`
-    - :class:`sklearn.ensemble.forest.ExtraTreesClassifier`
+    - :class:`sklearn.tree.DecisionTreeClassifier`
+    - :class:`sklearn.tree.ExtraTreeClassifier`
+    - :class:`sklearn.ensemble.ExtraTreesClassifier`
     - :class:`sklearn.naive_bayes.GaussianNB`
-    - :class:`sklearn.gaussian_process.gpc.GaussianProcessClassifier`
-    - :class:`sklearn.ensemble.gradient_boosting.GradientBoostingClassifier`
-    - :class:`sklearn.neighbors.classification.KNeighborsClassifier`
-    - :class:`sklearn.semi_supervised.label_propagation.LabelPropagation`
-    - :class:`sklearn.semi_supervised.label_propagation.LabelSpreading`
+    - :class:`sklearn.gaussian_process.GaussianProcessClassifier`
+    - :class:`sklearn.ensemble.GradientBoostingClassifier`
+    - :class:`sklearn.neighbors.KNeighborsClassifier`
+    - :class:`sklearn.semi_supervised.LabelPropagation`
+    - :class:`sklearn.semi_supervised.LabelSpreading`
     - :class:`sklearn.discriminant_analysis.LinearDiscriminantAnalysis`
-    - :class:`sklearn.svm.classes.LinearSVC`
-    - :class:`sklearn.linear_model.logistic.LogisticRegression`
-    - :class:`sklearn.linear_model.logistic.LogisticRegressionCV`
-    - :class:`sklearn.neural_network.multilayer_perceptron.MLPClassifier`
-    - :class:`sklearn.neighbors.nearest_centroid.NearestCentroid`
-    - :class:`sklearn.svm.classes.NuSVC`
+    - :class:`sklearn.svm.LinearSVC`
+    - :class:`sklearn.linear_model.LogisticRegression`
+    - :class:`sklearn.linear_model.LogisticRegressionCV`
+    - :class:`sklearn.neural_network.MLPClassifier`
+    - :class:`sklearn.neighbors.NearestCentroid`
+    - :class:`sklearn.svm.NuSVC`
     - :class:`sklearn.linear_model.passive_aggressive.PassiveAggressiveClassifier`
-    - :class:`sklearn.linear_model.perceptron.Perceptron`
+    - :class:`sklearn.linear_model.Perceptron`
     - :class:`sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`
-    - :class:`sklearn.neighbors.classification.RadiusNeighborsClassifier`
-    - :class:`sklearn.ensemble.forest.RandomForestClassifier`
-    - :class:`sklearn.linear_model.ridge.RidgeClassifier`
-    - :class:`sklearn.linear_model.ridge.RidgeClassifierCV`
-    - :class:`sklearn.linear_model.stochastic_gradient.SGDClassifier`
-    - :class:`sklearn.svm.classes.SVC`
+    - :class:`sklearn.neighbors.RadiusNeighborsClassifier`
+    - :class:`sklearn.ensemble.RandomForestClassifier`
+    - :class:`sklearn.linear_model.RidgeClassifier`
+    - :class:`sklearn.linear_model.RidgeClassifierCV`
+    - :class:`sklearn.linear_model.SGDClassifier`
+    - :class:`sklearn.svm.SVC`
 
   - Support multilabel:
 
-    - :class:`sklearn.tree.tree.DecisionTreeClassifier`
-    - :class:`sklearn.tree.tree.ExtraTreeClassifier`
-    - :class:`sklearn.ensemble.forest.ExtraTreesClassifier`
-    - :class:`sklearn.neighbors.classification.KNeighborsClassifier`
-    - :class:`sklearn.neural_network.multilayer_perceptron.MLPClassifier`
-    - :class:`sklearn.neighbors.classification.RadiusNeighborsClassifier`
-    - :class:`sklearn.ensemble.forest.RandomForestClassifier`
-    - :class:`sklearn.linear_model.ridge.RidgeClassifierCV`
+    - :class:`sklearn.tree.DecisionTreeClassifier`
+    - :class:`sklearn.tree.ExtraTreeClassifier`
+    - :class:`sklearn.ensemble.ExtraTreesClassifier`
+    - :class:`sklearn.neighbors.KNeighborsClassifier`
+    - :class:`sklearn.neural_network.MLPClassifier`
+    - :class:`sklearn.neighbors.RadiusNeighborsClassifier`
+    - :class:`sklearn.ensemble.RandomForestClassifier`
+    - :class:`sklearn.linear_model.RidgeClassifierCV`
 
   - Support multiclass-multioutput:
 
-    - :class:`sklearn.tree.tree.DecisionTreeClassifier`
-    - :class:`sklearn.tree.tree.ExtraTreeClassifier`
-    - :class:`sklearn.ensemble.forest.ExtraTreesClassifier`
-    - :class:`sklearn.neighbors.classification.KNeighborsClassifier`
-    - :class:`sklearn.neighbors.classification.RadiusNeighborsClassifier`
-    - :class:`sklearn.ensemble.forest.RandomForestClassifier`
+    - :class:`sklearn.tree.DecisionTreeClassifier`
+    - :class:`sklearn.tree.ExtraTreeClassifier`
+    - :class:`sklearn.ensemble.ExtraTreesClassifier`
+    - :class:`sklearn.neighbors.KNeighborsClassifier`
+    - :class:`sklearn.neighbors.RadiusNeighborsClassifier`
+    - :class:`sklearn.ensemble.RandomForestClassifier`
 
   - One-Vs-One:
 

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -65,58 +65,63 @@ grouped by strategy; you don't need the meta-estimators in this class
 if you're using one of these, unless you want custom multiclass behavior:
 
   - Inherently multiclass:
-    - :class: `sklearn.ensemble.weight_boosting.AdaBoostClassifier`
-    - :class: `sklearn.ensemble.bagging.BaggingClassifier`
-    - :class: `sklearn.naive_bayes.BernoulliNB`
-    - :class: `sklearn.calibration.CalibratedClassifierCV`
-    - :class: `sklearn.tree.tree.DecisionTreeClassifier`
-    - :class: `sklearn.tree.tree.ExtraTreeClassifier`
-    - :class: `sklearn.ensemble.forest.ExtraTreesClassifier`
-    - :class: `sklearn.naive_bayes.GaussianNB`
-    - :class: `sklearn.gaussian_process.gpc.GaussianProcessClassifier`
-    - :class: `sklearn.ensemble.gradient_boosting.GradientBoostingClassifier`
-    - :class: `sklearn.neighbors.classification.KNeighborsClassifier`
-    - :class: `sklearn.semi_supervised.label_propagation.LabelPropagation`
-    - :class: `sklearn.semi_supervised.label_propagation.LabelSpreading`
-    - :class: `sklearn.discriminant_analysis.LinearDiscriminantAnalysis`
-    - :class: `sklearn.svm.classes.LinearSVC`
-    - :class: `sklearn.linear_model.logistic.LogisticRegression`
-    - :class: `sklearn.linear_model.logistic.LogisticRegressionCV`
-    - :class: `sklearn.neural_network.multilayer_perceptron.MLPClassifier`
-    - :class: `sklearn.neighbors.nearest_centroid.NearestCentroid`
-    - :class: `sklearn.svm.classes.NuSVC`
-    - :class: `sklearn.linear_model.passive_aggressive.PassiveAggressiveClassifier`
-    - :class: `sklearn.linear_model.perceptron.Perceptron`
-    - :class: `sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`
-    - :class: `sklearn.neighbors.classification.RadiusNeighborsClassifier`
-    - :class: `sklearn.ensemble.forest.RandomForestClassifier`
-    - :class: `sklearn.linear_model.ridge.RidgeClassifier`
-    - :class: `sklearn.linear_model.ridge.RidgeClassifierCV`
-    - :class: `sklearn.linear_model.stochastic_gradient.SGDClassifier`
-    - :class: `sklearn.svm.classes.SVC`
+
+    - :class:`sklearn.ensemble.weight_boosting.AdaBoostClassifier`
+    - :class:`sklearn.ensemble.bagging.BaggingClassifier`
+    - :class:`sklearn.naive_bayes.BernoulliNB`
+    - :class:`sklearn.calibration.CalibratedClassifierCV`
+    - :class:`sklearn.tree.tree.DecisionTreeClassifier`
+    - :class:`sklearn.tree.tree.ExtraTreeClassifier`
+    - :class:`sklearn.ensemble.forest.ExtraTreesClassifier`
+    - :class:`sklearn.naive_bayes.GaussianNB`
+    - :class:`sklearn.gaussian_process.gpc.GaussianProcessClassifier`
+    - :class:`sklearn.ensemble.gradient_boosting.GradientBoostingClassifier`
+    - :class:`sklearn.neighbors.classification.KNeighborsClassifier`
+    - :class:`sklearn.semi_supervised.label_propagation.LabelPropagation`
+    - :class:`sklearn.semi_supervised.label_propagation.LabelSpreading`
+    - :class:`sklearn.discriminant_analysis.LinearDiscriminantAnalysis`
+    - :class:`sklearn.svm.classes.LinearSVC`
+    - :class:`sklearn.linear_model.logistic.LogisticRegression`
+    - :class:`sklearn.linear_model.logistic.LogisticRegressionCV`
+    - :class:`sklearn.neural_network.multilayer_perceptron.MLPClassifier`
+    - :class:`sklearn.neighbors.nearest_centroid.NearestCentroid`
+    - :class:`sklearn.svm.classes.NuSVC`
+    - :class:`sklearn.linear_model.passive_aggressive.PassiveAggressiveClassifier`
+    - :class:`sklearn.linear_model.perceptron.Perceptron`
+    - :class:`sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`
+    - :class:`sklearn.neighbors.classification.RadiusNeighborsClassifier`
+    - :class:`sklearn.ensemble.forest.RandomForestClassifier`
+    - :class:`sklearn.linear_model.ridge.RidgeClassifier`
+    - :class:`sklearn.linear_model.ridge.RidgeClassifierCV`
+    - :class:`sklearn.linear_model.stochastic_gradient.SGDClassifier`
+    - :class:`sklearn.svm.classes.SVC`
 
   - Support multilabel:
-    - :class: `sklearn.tree.tree.DecisionTreeClassifier`
-    - :class: `sklearn.tree.tree.ExtraTreeClassifier`
-    - :class: `sklearn.ensemble.forest.ExtraTreesClassifier`
-    - :class: `sklearn.neighbors.classification.KNeighborsClassifier`
-    - :class: `sklearn.neural_network.multilayer_perceptron.MLPClassifier`
-    - :class: `sklearn.neighbors.classification.RadiusNeighborsClassifier`
-    - :class: `sklearn.ensemble.forest.RandomForestClassifier`
-    - :class: `sklearn.linear_model.ridge.RidgeClassifierCV`
+
+    - :class:`sklearn.tree.tree.DecisionTreeClassifier`
+    - :class:`sklearn.tree.tree.ExtraTreeClassifier`
+    - :class:`sklearn.ensemble.forest.ExtraTreesClassifier`
+    - :class:`sklearn.neighbors.classification.KNeighborsClassifier`
+    - :class:`sklearn.neural_network.multilayer_perceptron.MLPClassifier`
+    - :class:`sklearn.neighbors.classification.RadiusNeighborsClassifier`
+    - :class:`sklearn.ensemble.forest.RandomForestClassifier`
+    - :class:`sklearn.linear_model.ridge.RidgeClassifierCV`
 
   - Support multiclass-multioutput:
-    - :class: `sklearn.tree.tree.DecisionTreeClassifier`
-    - :class: `sklearn.tree.tree.ExtraTreeClassifier`
-    - :class: `sklearn.ensemble.forest.ExtraTreesClassifier`
-    - :class: `sklearn.neighbors.classification.KNeighborsClassifier`
-    - :class: `sklearn.neighbors.classification.RadiusNeighborsClassifier`
-    - :class: `sklearn.ensemble.forest.RandomForestClassifier`
+
+    - :class:`sklearn.tree.tree.DecisionTreeClassifier`
+    - :class:`sklearn.tree.tree.ExtraTreeClassifier`
+    - :class:`sklearn.ensemble.forest.ExtraTreesClassifier`
+    - :class:`sklearn.neighbors.classification.KNeighborsClassifier`
+    - :class:`sklearn.neighbors.classification.RadiusNeighborsClassifier`
+    - :class:`sklearn.ensemble.forest.RandomForestClassifier`
 
   - One-Vs-One:
+
     * :class:`sklearn.svm.SVC`.
 
   - One-Vs-All:
+
     * all linear models except :class:`sklearn.svm.SVC`.
 
 .. warning::

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -66,35 +66,45 @@ if you're using one of these, unless you want custom multiclass behavior:
 
   - Inherently multiclass:
 
-    - :class:`sklearn.ensemble.AdaBoostClassifier`
-    - :class:`sklearn.ensemble.BaggingClassifier`
     - :class:`sklearn.naive_bayes.BernoulliNB`
-    - :class:`sklearn.calibration.CalibratedClassifierCV`
     - :class:`sklearn.tree.DecisionTreeClassifier`
     - :class:`sklearn.tree.ExtraTreeClassifier`
     - :class:`sklearn.ensemble.ExtraTreesClassifier`
     - :class:`sklearn.naive_bayes.GaussianNB`
-    - :class:`sklearn.gaussian_process.GaussianProcessClassifier`
-    - :class:`sklearn.ensemble.GradientBoostingClassifier`
     - :class:`sklearn.neighbors.KNeighborsClassifier`
     - :class:`sklearn.semi_supervised.LabelPropagation`
     - :class:`sklearn.semi_supervised.LabelSpreading`
     - :class:`sklearn.discriminant_analysis.LinearDiscriminantAnalysis`
-    - :class:`sklearn.svm.LinearSVC`
-    - :class:`sklearn.linear_model.LogisticRegression`
-    - :class:`sklearn.linear_model.LogisticRegressionCV`
+    - :class:`sklearn.svm.LinearSVC` (setting multi_class="crammer_singer")
+    - :class:`sklearn.linear_model.LogisticRegression` (setting multi_class="multinomial")
+    - :class:`sklearn.linear_model.LogisticRegressionCV` (setting multi_class="multinomial")
     - :class:`sklearn.neural_network.MLPClassifier`
     - :class:`sklearn.neighbors.NearestCentroid`
-    - :class:`sklearn.svm.NuSVC`
-    - :class:`sklearn.linear_model.passive_aggressive.PassiveAggressiveClassifier`
+    - :class:`sklearn.linear_model.PassiveAggressiveClassifier`
     - :class:`sklearn.linear_model.Perceptron`
     - :class:`sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`
     - :class:`sklearn.neighbors.RadiusNeighborsClassifier`
     - :class:`sklearn.ensemble.RandomForestClassifier`
     - :class:`sklearn.linear_model.RidgeClassifier`
     - :class:`sklearn.linear_model.RidgeClassifierCV`
+
+
+  - Multiclass as One-Vs-One:
+
+    - :class:`sklearn.svm.NuSVC`
+    - :class:`sklearn.svm.SVC`.
+    - :class:`sklearn.gaussian_process.GaussianProcessClassifier` (setting multi_class = "one_vs_one")
+
+
+  - Multiclass as One-Vs-All:
+
+    - :class:`sklearn.ensemble.GradientBoostingClassifier`
+    - :class:`sklearn.gaussian_process.GaussianProcessClassifier` (setting multi_class = "one_vs_rest")
+    - :class:`sklearn.svm.LinearSVC` (setting multi_class="ovr")
+    - :class:`sklearn.linear_model.LogisticRegression` (setting multi_class="ovr")
+    - :class:`sklearn.linear_model.LogisticRegressionCV` (setting multi_class="ovr")
     - :class:`sklearn.linear_model.SGDClassifier`
-    - :class:`sklearn.svm.SVC`
+
 
   - Support multilabel:
 
@@ -107,6 +117,7 @@ if you're using one of these, unless you want custom multiclass behavior:
     - :class:`sklearn.ensemble.RandomForestClassifier`
     - :class:`sklearn.linear_model.RidgeClassifierCV`
 
+
   - Support multiclass-multioutput:
 
     - :class:`sklearn.tree.DecisionTreeClassifier`
@@ -116,13 +127,6 @@ if you're using one of these, unless you want custom multiclass behavior:
     - :class:`sklearn.neighbors.RadiusNeighborsClassifier`
     - :class:`sklearn.ensemble.RandomForestClassifier`
 
-  - One-Vs-One:
-
-    * :class:`sklearn.svm.SVC`.
-
-  - One-Vs-All:
-
-    * all linear models except :class:`sklearn.svm.SVC`.
 
 .. warning::
 

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -80,8 +80,6 @@ if you're using one of these, unless you want custom multiclass behavior:
     - :class:`sklearn.linear_model.LogisticRegressionCV` (setting multi_class="multinomial")
     - :class:`sklearn.neural_network.MLPClassifier`
     - :class:`sklearn.neighbors.NearestCentroid`
-    - :class:`sklearn.linear_model.PassiveAggressiveClassifier`
-    - :class:`sklearn.linear_model.Perceptron`
     - :class:`sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`
     - :class:`sklearn.neighbors.RadiusNeighborsClassifier`
     - :class:`sklearn.ensemble.RandomForestClassifier`
@@ -104,6 +102,8 @@ if you're using one of these, unless you want custom multiclass behavior:
     - :class:`sklearn.linear_model.LogisticRegression` (setting multi_class="ovr")
     - :class:`sklearn.linear_model.LogisticRegressionCV` (setting multi_class="ovr")
     - :class:`sklearn.linear_model.SGDClassifier`
+    - :class:`sklearn.linear_model.Perceptron`
+    - :class:`sklearn.linear_model.PassiveAggressiveClassifier`
 
 
   - Support multilabel:


### PR DESCRIPTION
Modified the documentation present at [multiclass page](http://scikit-learn.org/dev/modules/multiclass.html). Updated classifiers which allow multiclass, multilabel and multiclass-multioutput cases.