### PR TITLE
[MRG] DOC add non support of COO safe indexing

### DIFF
--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -135,6 +135,11 @@ def safe_indexing(X, indices):
     -------
     subset
         Subset of X on first axis
+
+    Notes
+    -----
+    CSR, CSC, and LIL sparse matrices are supported. COO sparse matrices are
+    not supported.
     """
     if hasattr(X, "iloc"):
         # Pandas Dataframes and Series


### PR DESCRIPTION
COO matrices are not supported by `sklearn.utils.safe_indexing`. A note is added in the docstring to mention this behaviour.