### PR TITLE
[MRG] Feature: wrapper for opencv models

### DIFF
--- a/sklearn/opencv_sklearn_wrapper.py
+++ b/sklearn/opencv_sklearn_wrapper.py
@@ -1,0 +1,169 @@
+'''\
+A thin wrapper for OpenCV classifiers to sklearn.
+The complete list of supported OpenCV models is below:
+* Boosted random forest (created by cv2.ml.Boost_create function)
+
+== EXAMPLE ==
+    import opencv_sklearn_wrapper
+    from sklearn.metrics import classification_report
+    from sklearn.model_selection import class_val_predict
+
+    model = cv2.ml.Boost_create()
+    classifier = make_sklearn_wrapper(model)
+    ...
+    predictions = cross_val_predict(classifier, dataset, labels, cv=5)
+    print(classification_report(labels, predictions))
+
+== TESTING ==
+* Use command one-liner below to run the unit tests:
+    python opencv_sklearn_wrapper.py -v
+
+* [07/14/2017] Tested for sklearn 0.18.1 + both of Python 2.7.12 and Python 3.5.2.
+'''
+
+import cv2
+import math
+import numpy as np
+
+import unittest
+import warnings
+
+from sklearn.base import BaseEstimator
+
+
+class Opencv_sklearn_wrapper__base(BaseEstimator):
+    '''Base class for all Opencv wrapper to scikit-learn.
+    Any wrapper implementations for Opencv models must be derived.
+
+    Technical Notes
+    ---------------
+    * Member classes_ and method predict_proba are required by sklearn.calibration.CalibratedClassifierCV.
+    * This __init__ is required by sklearn.base.clone function to reconstruct the estimator by its parameters passed as
+      explicit keyword arguments. As well, it has to store the input model parameters (including model_class) because
+      the sklearn.base.clone checks not for parameter equivalence but for object exactness.
+    '''
+
+    __slots__ = ['opencv_model', 'classes_']
+    _estimator_type = 'classifier'  # To pass sklearn.base.is_classifier check.
+
+
+    def __init__(self, trained_model=None, model_class=None, **kwargs):
+        if not model_class and not trained_model:
+            raise RuntimeError('Cannot create a wrapper for null model.')
+
+        self.__params = kwargs
+        self.__class_of_opencv_model = trained_model.__class__.__name__ if not model_class else model_class
+        self.opencv_model = trained_model
+
+        if not self.opencv_model:
+            _, name = model_class.split('ml_', 1)
+            self.opencv_model = getattr(cv2.ml, name + '_create')()
+        for k, v in self.__params.items():
+            if k != 'model_class':
+                getattr(self.opencv_model, 'set' + k)(v)
+        return
+
+
+    def fit(self, features, labels, sample_weight=None):
+        _, dim = features.shape
+        var_types = np.array([cv2.ml.VAR_NUMERICAL] * dim + [cv2.ml.VAR_CATEGORICAL],
+                             np.uint8)
+        td = cv2.ml.TrainData_create(np.array(features, np.float32),
+                                     cv2.ml.ROW_SAMPLE, labels,
+                                     sampleWeights=sample_weight,
+                                     varType=var_types)
+        self.opencv_model.train(td)
+        self.classes_ =  np.unique(labels)
+        return self
+
+
+    def get_params(self, deep=True):
+        params = {'model_class': self.__class_of_opencv_model}
+        if not self.__params:
+            self.__params = {}
+
+            attributes = dir(self.opencv_model)
+            getter_names = [k[3:] for k in attributes if k.startswith('get')]
+            setter_names = [k[3:] for k in attributes if k.startswith('set')]
+            model_parameters = set(getter_names).intersection(setter_names)
+
+            for name in model_parameters:
+                self.__params.update({name: getattr(self.opencv_model, 'get' + name)()})
+
+        params.update(self.__params)
+        return params
+
+
+    def predict(self, features):
+        raise Exception('No base predict method is defined to work for all Opencv models. Define yours own.')
+
+
+    def predict_proba(self, features):
+        raise Exception('No base predict_proba method is defined to work for all Opencv models. Define yours own.')
+    pass
+
+
+class Opencv_sklearn_wrapper__boost(Opencv_sklearn_wrapper__base):
+    '''Opencv-to-sklearn wrapper for Boosted random forest.'''
+    def _output_to_posteriors(self, sum):
+        p = 1.0 / (1.0 + math.exp(-2.0 * sum))
+        return [1.0 - p, p]
+
+
+    def predict(self, features):
+        _, predictions = self.opencv_model.predict(features, flags=cv2.ml.DTREES_PREDICT_MAX_VOTE)
+        return np.squeeze(np.array(predictions, np.uint32))
+
+
+    def predict_proba(self, features):
+        _, predictions = self.opencv_model.predict(features, flags=cv2.ml.DTREES_PREDICT_SUM)
+        predictions = np.array(map(self._output_to_posteriors, predictions), np.float32)
+        return predictions
+    pass
+
+
+def make_sklearn_wrapper(model):
+    '''Constructs the wrapper for the Opencv's binary classifiers.
+    Technically, this implements a simple dispatcher over the Opencv's entire classifier set.
+
+    Parameters
+    ----------
+    model: the instance of any Opencv's binary classifier.
+    '''
+    model_class = model.__class__.__name__
+    if model_class == 'ml_Boost':
+        wrapper = Opencv_sklearn_wrapper__boost(model_class=model_class)
+
+    wrapper.opencv_model = model
+    return wrapper
+
+
+
+class _Opencv_sklearn_wrapper__tests(unittest.TestCase):
+    _supported_models = ['ml_Boost']
+
+
+    def test__sklearn_base(self):
+        from sklearn.base import clone, is_classifier
+
+        for model in self._supported_models:
+            wrapper = Opencv_sklearn_wrapper__base(model_class=model)
+
+            self.assertTrue(issubclass(wrapper.__class__, BaseEstimator))
+            self.assertTrue(is_classifier(wrapper))
+            with warnings.catch_warnings(record=True) as raised_warnings:
+                warnings.simplefilter('always')
+
+                try:
+                    clone(wrapper)
+                except RuntimeError:
+                    self.fail('Opencv_sklearn_wrapper does not meet the sklearn.base.* requirements')
+
+                self.assertFalse(any([issubclass(w.category, DeprecationWarning) for w in raised_warnings]),
+                                 msg='sklearn.base.* raises the DeprecationWarnings')
+        return
+    pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sklearn/opencv_sklearn_wrapper.py
+++ b/sklearn/opencv_sklearn_wrapper.py
@@ -5,7 +5,8 @@ The complete list of supported OpenCV models is below:
 * Random Forest model created by cv2.ml.RTrees_create()
 * SVM model created by cv2.ml.SVM_create()
 * KNN model created by cv2.ml.KNearest_create()
-* Normal Bayesian Classifer created by cv2.ml.NormalBayesClassifier_create()
+Unfortunately, neither of Opencv's ANN MLP and Normal Bayesian Classifier works.
+That returns Nan or Inf as the predicted values permanently, so no support.
 
 Note, no prior assumptions about classifier's algorithm behind is made.
 
@@ -34,7 +35,7 @@ option due the reasons listed below:
 * Use command one-liner below to run the unit tests:
     python opencv_sklearn_wrapper.py -v
 
-* [07/14/2017] Tested for sklearn 0.18.1 + Opencv 3.1.0 + both of Python 2.7.12 and Python 3.5.2.
+* [07/14/2016] Tested for sklearn 0.18.1 + Opencv 3.1.0 + both of Python 2.7.12 and Python 3.5.2.
 '''
 
 import cv2
@@ -82,12 +83,8 @@ class Opencv_binary_predictor:
          Technically, it must utilizy the classifier's "raw" output like listed below:
          * Random Forest: votes portion casted for the positive category.
          * SVM: oriented distance to the separating hyperplane.
-           See http://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html#sklearn.svm.SVC.decision_function.
          * Boosted: the weighted sum of the weak decisions (-1 for negative category, +1 for positive one).
          * KNN: neighbour's votes portion casted for the positive category.
-         * Logistic Regression: the approximated posterior.
-           See http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html#sklearn.linear_model.LogisticRegression.decision_function.
-         * Normal Bayes:
 
         Parameters
         ----------
@@ -204,26 +201,6 @@ class Opencv_sklearn_wrapper__knn(Opencv_sklearn_wrapper):
     pass
 
 
-class Opencv_sklearn_wrapper__nbc(Opencv_sklearn_wrapper):
-    '''Opencv-to-sklearn wrapper for Normal Bayesian classifier.'''
-    _force_hard_decision__flags = True
-    _force_soft_decision__flags = False
-
-    def __init__(self, model_class='ml_NormalBayesClassifier', **kwargs):
-        super(Opencv_sklearn_wrapper__nbc, self).__init__(model_class=model_class, **kwargs)
-        return
-
-
-    def _estimate(self, features, flags=None):
-        if flags:
-            _, outputs = self.opencv_model.predict(features)
-        else:
-            _, _, outputs = self.opencv_model.predictProb(features)
-            outputs = outputs[:, self._positive_class_idx]
-        return outputs.ravel()
-    pass
-
-
 def make_sklearn_wrapper(model=None, class_name=None):
     '''Constructs the wrapper for the Opencv's binary classifiers.
     Technically, this implements a simple dispatcher over the Opencv's entire classifier set.
@@ -240,8 +217,6 @@ def make_sklearn_wrapper(model=None, class_name=None):
         wrapper = Opencv_sklearn_wrapper__svm(model_class=name)
     elif name == 'ml_KNearest':
         wrapper = Opencv_sklearn_wrapper__knn()
-    elif name == 'ml_NormalBayesClassifier':
-        wrapper = Opencv_sklearn_wrapper__nbc()
     else:
         raise RuntimeError('For make_sklearn_wrapper, both of keyword arguments "model" and "class_name" are None or \
 the model is unsupported')

--- a/sklearn/opencv_sklearn_wrapper.py
+++ b/sklearn/opencv_sklearn_wrapper.py
@@ -162,22 +162,88 @@ class Opencv_sklearn_wrapper(BaseEstimator, Opencv_binary_predictor):
 
 
 class Opencv_sklearn_wrapper__dtree(Opencv_sklearn_wrapper):
-    '''Opencv-to-sklearn wrapper for Random Forest/Boosted decision trees.'''
-    _predict__flags = cv2.ml.DTREES_PREDICT_MAX_VOTE
-    _predict_proba__flags = cv2.ml.DTREES_PREDICT_SUM
+    '''Wraps the Random Forest/Boosted decision trees.'''
+    _force_hard_decision__flags = cv2.ml.DTREES_PREDICT_MAX_VOTE
+    _force_soft_decision__flags = cv2.ml.DTREES_PREDICT_SUM
+    pass
+
+
+class Opencv_sklearn_wrapper__svm(Opencv_sklearn_wrapper):
+    '''Wraps the SVM.'''
+    _force_hard_decision__flags = False
+    _force_soft_decision__flags = True
+
+
+    def __init__(self, model_class='ml_SVM', **kwargs):
+        super(Opencv_sklearn_wrapper__svm, self).__init__(model_class=model_class, **kwargs)
+        return
     pass
 
 
 class Opencv_sklearn_wrapper__knn(Opencv_sklearn_wrapper):
     '''Opencv-to-sklearn wrapper for KNN.'''
+    _force_hard_decision__flags = True
+    _force_soft_decision__flags = False
+
     def __init__(self, model_class='ml_KNearest', **kwargs):
         super(Opencv_sklearn_wrapper__knn, self).__init__(model_class=model_class, **kwargs)
         return
 
 
-    def predict(self, features):
-        _, results, _, _ = self.opencv_model.findNearest(features, k=self.opencv_model.getDefaultK())
-        return results.ravel()
+    def _estimate(self, features, flags=None):
+        if flags:
+            _, outputs = self.opencv_model.predict(features)
+        else:
+            _, _, neighbour_responses, _ = self.opencv_model.findNearest(features,
+                                                                         k=self.opencv_model.getDefaultK())
+            outputs = np.apply_along_axis(lambda rs: len(rs[rs == self._positive_class_idx]) / np.float32(len(rs)),
+                                          1,
+                                          neighbour_responses.astype(np.uint32))
+        return outputs.ravel()
+    pass
+
+
+class Opencv_sklearn_wrapper__ann(Opencv_sklearn_wrapper):
+    '''Opencv-to-sklearn wrapper for the neural networks.'''
+    _force_hard_decision__flags = True
+    _force_soft_decision__flags = False
+
+    def __init__(self, model_class='ml_ANN_MLP', **kwargs):
+        super(Opencv_sklearn_wrapper__ann, self).__init__(model_class=model_class, **kwargs)
+        return
+
+
+    def fit(self, features, labels, sample_weight=None):
+        n = len(labels)
+        m = np.zeros(n * 2, np.float32)
+        index_set = np.uint(labels + np.arange(n) * 2)
+        m[index_set] = 1.0
+        self.opencv_model.train(features,
+                                cv2.ml.ROW_SAMPLE,
+                                m.reshape(-1, 2))
+        return self
+#        return super(Opencv_sklearn_wrapper__ann, self).fit(features,
+#                                                            labels.reshape(-1, 1).astype(np.float32),
+#                                                            sample_weight)
+
+    def _estimate(self, features, flags=None):
+        _, outputs = self.opencv_model.predict(features)
+        print(outputs)
+        # if flags:
+        #     outputs = np.apply_along_axis(lambda rs: rs.argmax(-1),
+        #                                   1,
+        #                                   outputs)
+        # else:
+        #     outputs = outputs[:, self._positive_class_idx]
+        # return outputs.ravel()
+    pass
+
+
+class Opencv_sklearn_wrapper_nbc(Opencv_sklearn_wrapper):
+    '''Opencv-to-sklearn wrapper for Normal Bayesian classifier.'''
+    _force_hard_decision__flags = True
+    _force_soft_decision__flags = False
+    pass
 
 
     def predict_proba(self, features):
@@ -202,6 +268,8 @@ def make_sklearn_wrapper(model=None, class_name=None):
         wrapper = Opencv_sklearn_wrapper__svm(model_class=name)
     elif name == 'ml_KNearest':
         wrapper = Opencv_sklearn_wrapper__knn()
+    elif name == 'ml_ANN_MLP':
+        wrapper = Opencv_sklearn_wrapper__ann()
     else:
         raise RuntimeError('For make_sklearn_wrapper, both of keyword arguments "model" and "class_name" are None or \
 the model is unsupported')

--- a/sklearn/opencv_wrapper.py
+++ b/sklearn/opencv_wrapper.py
@@ -33,7 +33,7 @@ class _Opencv_predictor_base:
         return self._estimate(features, flags=self._force_hard_decision)
 
     def decision_function(self, features):
-        """Returns the soft decision."""
+        """Returns the unnormalized soft decision."""
 
         return self._estimate(features, flags=self._force_soft_decision)
 

--- a/sklearn/opencv_wrapper.py
+++ b/sklearn/opencv_wrapper.py
@@ -1,42 +1,14 @@
-'''\
-A thin wrapper for Opencv classifiers to scikit-learn.
-The complete list of supported OpenCV models is below:
-* Boosted Random Forest model created by cv2.ml.Boost_create()
-* Random Forest model created by cv2.ml.RTrees_create()
-* SVM model created by cv2.ml.SVM_create()
-* KNN model created by cv2.ml.KNearest_create()
-Unfortunately, neither of Opencv's ANN MLP and Normal Bayesian Classifier works.
-That returns Nan or Inf as the predicted values permanently, so no support.
+# -*- coding: utf-8 -*-
 
-Note, no prior assumptions about classifier's algorithm behind is made.
+"""
+The :mod:`sklearn.opencv_wrapper` module implements a thin wrapper for OpenCV classifiers listed below:
+* (Boosted) random forest model
+* SVM
+* KNN
+"""
 
-== MOTIVATION ==
-Want to get the mix of scikit-learn framework power (e.g. cross-validation, posterior calibration) and
-the efortless deploy to C++ for the trained Opencv models.
-
-Unfortunately, the inheritance from scikit-learn models (like KNeighborsClassifier) is not an
-option due the reasons listed below:
-* A huge number of methods to override.
-* Method-set to override distinguishes from a model to a model.
-
-
-== EXAMPLE ==
-    import opencv_sklearn_wrapper
-    from sklearn.metrics import classification_report
-    from sklearn.model_selection import class_val_predict
-
-    model = cv2.ml.Boost_create()
-    classifier = make_sklearn_wrapper(model)
-    ...
-    predictions = cross_val_predict(classifier, dataset, labels, cv=5)
-    print(classification_report(labels, predictions))
-
-== TESTING ==
-* Use command one-liner below to run the unit tests:
-    python opencv_sklearn_wrapper.py -v
-
-* [07/14/2016] Tested for sklearn 0.18.1 + Opencv 3.1.0 + both of Python 2.7.12 and Python 3.5.2.
-'''
+# Author: Piotr Semenov <piotr@dropoutlabs.com>
+# License: BSD 3 clause
 
 import cv2
 import numpy as np
@@ -47,20 +19,20 @@ import warnings
 from sklearn.base import BaseEstimator
 
 
-class Opencv_binary_predictor:
-    '''Provides the hard/soft decisions from the Opencv's binary classifiers.
+__all__ = ['wrap']
 
-    Technical Notes
+class Opencv_binary_predictor:
+    """Hard/soft decisions of opencv binary classifiers.
+
+    Notes
     ---------------
-    * Scikit-learn assumption: positive category is assumed to be at index 1 among the probabilities
-    delivered from predictor for the input sample.
-    Proof: https://github.com/scikit-learn/scikit-learn/blob/8570622a4450fe1ee3c683601454a7189dcccc14/sklearn/calibration.py#L293.
-    '''
+    Positive category is assumed to be at index 1.
+    """
+
     _positive_class_idx = 1
 
 
     def _estimate(self, features, flags=None):
-        '''Provides the basic prediction logics (valid for Opencv's (Boosted) Random Forest/SVM).'''
         if flags is None:
             raise RuntimeError('No flags provided to distinguish the hard/soft decision mode.')
 
@@ -218,7 +190,7 @@ def make_sklearn_wrapper(model=None, class_name=None):
     elif name == 'ml_KNearest':
         wrapper = Opencv_sklearn_wrapper__knn()
     else:
-        raise RuntimeError('For make_sklearn_wrapper, both of keyword arguments "model" and "class_name" are None or \
+        raise RuntimeError('Both of keyword arguments "model" and "class_name" are None or \
 the model is unsupported')
 
     wrapper.opencv_model = model
@@ -274,3 +246,34 @@ class _Opencv_sklearn_wrapper__tests(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+"""
+Note, no prior assumptions about classifier's algorithm behind is made.
+
+== MOTIVATION ==
+Want to get the mix of scikit-learn framework power (e.g. cross-validation, posterior calibration) and
+the efortless deploy to C++ for the trained Opencv models.
+
+Unfortunately, the inheritance from scikit-learn models (like KNeighborsClassifier) is not an
+option due the reasons listed below:
+* A huge number of methods to override.
+* Method-set to override distinguishes from a model to a model.
+
+
+== EXAMPLE ==
+    import opencv_sklearn_wrapper
+    from sklearn.metrics import classification_report
+    from sklearn.model_selection import class_val_predict
+
+    model = cv2.ml.Boost_create()
+    classifier = wrap(model)
+    ...
+    predictions = cross_val_predict(classifier, dataset, labels, cv=5)
+    print(classification_report(labels, predictions))
+
+== TESTING ==
+* Use command one-liner below to run the unit tests:
+    python opencv_sklearn_wrapper.py -v
+
+* [07/14/2017] Tested for sklearn 0.18.1 + Opencv 3.1.0 + both of Python 2.7.12 and Python 3.5.2.
+"""

--- a/sklearn/opencv_wrapper.py
+++ b/sklearn/opencv_wrapper.py
@@ -61,6 +61,8 @@ class _Opencv_predictor(BaseEstimator, _Opencv_predictor_base):
         _, dim = features.shape
         var_types = np.array([cv2.ml.VAR_NUMERICAL] * dim + [cv2.ml.VAR_CATEGORICAL],
                              np.uint8)
+        if not sample_weight is None:
+            sample_weight = np.array(sample_weight, np.float32)
         td = cv2.ml.TrainData_create(np.array(features, np.float32),
                                      cv2.ml.ROW_SAMPLE, labels,
                                      sampleWeights=sample_weight,

--- a/sklearn/opencv_wrapper.py
+++ b/sklearn/opencv_wrapper.py
@@ -13,9 +13,6 @@ The :mod:`sklearn.opencv_wrapper` module implements a thin wrapper for OpenCV cl
 import cv2
 import numpy as np
 
-import unittest
-import warnings
-
 from sklearn.base import BaseEstimator
 
 
@@ -136,54 +133,3 @@ def wrap(model=None, class_name=None):
 
     wrapper.opencv_model = model
     return wrapper
-
-
-
-class _Opencv_predictor_tests(unittest.TestCase):
-    _supported_models = ['ml_Boost', 'ml_RTrees', 'ml_SVM', 'ml_KNearest']
-
-
-    def test_sklearn_base_functions(self):
-        from sklearn.base import clone, is_classifier
-
-        for model in self._supported_models:
-            wrapper = wrap(class_name=model)
-
-            self.assertTrue(issubclass(wrapper.__class__, BaseEstimator))
-            self.assertTrue(is_classifier(wrapper))
-            with warnings.catch_warnings(record=True) as raised_warnings:
-                warnings.simplefilter('always')
-
-                try:
-                    clone(wrapper)
-                except RuntimeError:
-                    self.fail('Opencv_sklearn_wrapper does not meet the sklearn.base.* requirements')
-
-                self.assertFalse(any([issubclass(w.category, DeprecationWarning) for w in raised_warnings]),
-                                 msg='sklearn.base.* raises the DeprecationWarnings')
-        return
-
-
-    def test_sklearn_model_selection(self):
-        from sklearn import datasets
-        from sklearn.metrics import classification_report
-        from sklearn.model_selection import cross_val_predict
-
-        iris = datasets.load_iris()
-        samples, labels = np.array(iris.data[:, :2], np.float32), iris.target
-
-        warnings.filterwarnings('ignore')
-        try:
-            for model in self._supported_models:
-                wrapper = wrap(class_name=model)
-
-                predictions = cross_val_predict(wrapper, samples, labels)
-                report = classification_report(labels, predictions)
-        except RuntimeError:
-            self.fail('Opencv_sklearn_wrapper crashes for sklearn.metrics.* and sklearn.model_selection.*')
-
-    pass
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/sklearn/opencv_wrapper.py
+++ b/sklearn/opencv_wrapper.py
@@ -47,7 +47,7 @@ class Opencv_binary_predictor:
         ----------
         features: the samples to classify. Type: numpy.ndarray of shape (n, m).
         '''
-        return self._estimate(features, self._force_hard_decision__flags)
+        return self._estimate(features, flags=self._force_hard_decision__flags)
 
 
     def decision_function(self, features):
@@ -173,7 +173,7 @@ class Opencv_sklearn_wrapper__knn(Opencv_sklearn_wrapper):
     pass
 
 
-def make_sklearn_wrapper(model=None, class_name=None):
+def wrap(model=None, class_name=None):
     '''Constructs the wrapper for the Opencv's binary classifiers.
     Technically, this implements a simple dispatcher over the Opencv's entire classifier set.
 
@@ -234,7 +234,7 @@ class _Opencv_sklearn_wrapper__tests(unittest.TestCase):
         warnings.filterwarnings('ignore')
         try:
             for model in self._supported_models:
-                wrapper = Opencv_sklearn_wrapper(model_class=model)
+                wrapper = wrap(class_name=model)
 
                 predictions = cross_val_predict(wrapper, samples, labels)
                 report = classification_report(labels, predictions)

--- a/sklearn/opencv_wrapper.py
+++ b/sklearn/opencv_wrapper.py
@@ -133,5 +133,4 @@ def wrap(model=None, class_name=None):
     else:
         raise AssertionError('{} is not supported.'.format(name))
 
-    wrapper.opencv_model = model
     return wrapper

--- a/sklearn/tests/test_opencv.py
+++ b/sklearn/tests/test_opencv.py
@@ -19,6 +19,7 @@ from sklearn.utils.testing import assert_true, assert_false
 
 _supported_models = ['ml_Boost', 'ml_RTrees', 'ml_SVM', 'ml_KNearest']
 
+
 def test_sklearn_base_functions():
     for model in _supported_models:
         wrapper = wrap(class_name=model)
@@ -30,15 +31,20 @@ def test_sklearn_base_functions():
             try:
                 clone(wrapper)
             except RuntimeError:
-                assert_true(False, msg="sklearn.opencv_wrapper does not meet the sklearn.base.clone requirements.")
+                assert_true(False,
+                            msg="sklearn.base.clone is failed.")
 
-                assert_false(any([issubclass(w.category, DeprecationWarning) for w in raised_warnings]),
-                             msg="sklearn.base.* raises the DeprecationWarnings")
+                assert_false(
+                    any([issubclass(w.category, DeprecationWarning)
+                        for w in raised_warnings]),
+                    msg="sklearn.base.clone raises the DeprecationWarnings")
+
 
 def test_sklearn_adaptors():
     iris = datasets.load_iris()
     samples, labels = np.array(iris.data[:, :2], np.float32), iris.target
-    X_train, X_test, y_train, y_test = train_test_split(samples, labels, test_size=0.2)
+    X_train, X_test, y_train, y_test = train_test_split(samples, labels,
+                                                        test_size=0.2)
 
     try:
         for model in _supported_models:
@@ -54,12 +60,15 @@ def test_sklearn_adaptors():
             predictions = clf.predict(X_test)
 
     except RuntimeError:
-        assert_true(False, msg="Opencv_sklearn_wrapper crashes for sklearn.ensemble.*.")
+        assert_true(False,
+                    msg="sklearn.ensemble.* is failed.")
+
 
 def test_sklearn_cv():
     iris = datasets.load_iris()
     samples, labels = np.array(iris.data[:, :2], np.float32), iris.target
-    X_train, X_test, y_train, y_test = train_test_split(samples, labels, test_size=0.2)
+    X_train, X_test, y_train, y_test = train_test_split(samples, labels,
+                                                        test_size=0.2)
 
     try:
         for model in _supported_models:
@@ -70,4 +79,5 @@ def test_sklearn_cv():
             report = classification_report(y_train, predictions)
 
     except RuntimeError:
-        assert_true(False, msg="Opencv_sklearn_wrapper crashes for sklearn.model_selection.*.")
+        assert_true(False,
+                    msg="sklearn.model_selection.cross_val_predict is failed.")

--- a/sklearn/tests/test_opencv.py
+++ b/sklearn/tests/test_opencv.py
@@ -5,8 +5,14 @@ Test the opencv_wrapper module.
 import warnings
 import numpy as np
 
-from sklearn.base import BaseEstimator
 from sklearn.opencv_wrapper import wrap
+
+from sklearn.base import BaseEstimator, clone, is_classifier
+from sklearn import datasets
+from sklearn.metrics import classification_report
+from sklearn.ensemble import AdaBoostClassifier
+from sklearn.calibration import CalibratedClassifierCV
+from sklearn.model_selection import cross_val_predict, train_test_split
 
 from sklearn.utils.testing import assert_true, assert_false
 
@@ -14,8 +20,6 @@ from sklearn.utils.testing import assert_true, assert_false
 _supported_models = ['ml_Boost', 'ml_RTrees', 'ml_SVM', 'ml_KNearest']
 
 def test_sklearn_base_functions():
-    from sklearn.base import clone, is_classifier
-
     for model in _supported_models:
         wrapper = wrap(class_name=model)
 
@@ -31,19 +35,39 @@ def test_sklearn_base_functions():
                 assert_false(any([issubclass(w.category, DeprecationWarning) for w in raised_warnings]),
                              msg="sklearn.base.* raises the DeprecationWarnings")
 
-def test_sklearn_model_selection():
-    from sklearn import datasets
-    from sklearn.metrics import classification_report
-    from sklearn.model_selection import cross_val_predict
-
+def test_sklearn_adaptors():
     iris = datasets.load_iris()
     samples, labels = np.array(iris.data[:, :2], np.float32), iris.target
+    X_train, X_test, y_train, y_test = train_test_split(samples, labels, test_size=0.2)
 
     try:
         for model in _supported_models:
             wrapper = wrap(class_name=model)
+            wrapper.fit(X_train, y_train)
 
-            predictions = cross_val_predict(wrapper, samples, labels)
-            report = classification_report(labels, predictions)
+            clf = CalibratedClassifierCV(wrapper)
+            clf.fit(X_train, y_train)
+            predictions = clf.predict(X_test)
+
+            clf = AdaBoostClassifier(wrapper, algorithm="SAMME")
+            clf.fit(X_train, y_train)
+            predictions = clf.predict(X_test)
+
     except RuntimeError:
-        assert_true(False, msg="Opencv_sklearn_wrapper crashes for sklearn.metrics.* and sklearn.model_selection.*")
+        assert_true(False, msg="Opencv_sklearn_wrapper crashes for sklearn.ensemble.*.")
+
+def test_sklearn_cv():
+    iris = datasets.load_iris()
+    samples, labels = np.array(iris.data[:, :2], np.float32), iris.target
+    X_train, X_test, y_train, y_test = train_test_split(samples, labels, test_size=0.2)
+
+    try:
+        for model in _supported_models:
+            wrapper = wrap(class_name=model)
+            wrapper.fit(X_train, y_train)
+
+            predictions = cross_val_predict(wrapper, X_train, y_train, cv=5)
+            report = classification_report(y_train, predictions)
+
+    except RuntimeError:
+        assert_true(False, msg="Opencv_sklearn_wrapper crashes for sklearn.model_selection.*.")

--- a/sklearn/tests/test_opencv.py
+++ b/sklearn/tests/test_opencv.py
@@ -1,0 +1,49 @@
+"""
+Test the opencv_wrapper module.
+"""
+
+import warnings
+import numpy as np
+
+from sklearn.base import BaseEstimator
+from sklearn.opencv_wrapper import wrap
+
+from sklearn.utils.testing import assert_true, assert_false
+
+
+_supported_models = ['ml_Boost', 'ml_RTrees', 'ml_SVM', 'ml_KNearest']
+
+def test_sklearn_base_functions():
+    from sklearn.base import clone, is_classifier
+
+    for model in _supported_models:
+        wrapper = wrap(class_name=model)
+
+        assert_true(issubclass(wrapper.__class__, BaseEstimator))
+        assert_true(is_classifier(wrapper))
+        with warnings.catch_warnings(record=True) as raised_warnings:
+            warnings.simplefilter("always")
+            try:
+                clone(wrapper)
+            except RuntimeError:
+                assert_true(False, msg="sklearn.opencv_wrapper does not meet the sklearn.base.clone requirements.")
+
+                assert_false(any([issubclass(w.category, DeprecationWarning) for w in raised_warnings]),
+                             msg="sklearn.base.* raises the DeprecationWarnings")
+
+def test_sklearn_model_selection():
+    from sklearn import datasets
+    from sklearn.metrics import classification_report
+    from sklearn.model_selection import cross_val_predict
+
+    iris = datasets.load_iris()
+    samples, labels = np.array(iris.data[:, :2], np.float32), iris.target
+
+    try:
+        for model in _supported_models:
+            wrapper = wrap(class_name=model)
+
+            predictions = cross_val_predict(wrapper, samples, labels)
+            report = classification_report(labels, predictions)
+    except RuntimeError:
+        assert_true(False, msg="Opencv_sklearn_wrapper crashes for sklearn.metrics.* and sklearn.model_selection.*")


### PR DESCRIPTION
Motivation: want to use scikit-learn (like cross-validation, calibration) for opencv models.
Minimum working example:
```py
from sklearn.opencv_wrapper import wrap
from sklearn import datasets
from sklearn.metrics import classification_report
from sklearn.model_selection import cross_val_predict
import cv2
import numpy as np

model = cv2.ml.RTrees_create()
classifier = wrap(model)
iris = datasets.load_iris()
samples, labels = np.array(iris.data[:, :2], np.float32), iris.target
predictions = cross_val_predict(classifier, samples, labels, cv=3)
print(classification_report(labels, predictions))
```