### PR TITLE
[MRG+1] plot_stock_market retry on failed download of google data

### DIFF
--- a/examples/applications/plot_stock_market.py
+++ b/examples/applications/plot_stock_market.py
@@ -77,7 +77,34 @@ from sklearn import cluster, covariance, manifold
 # #############################################################################
 # Retrieve the data from Internet
 
+def retry(f, n_retry=3):
+    """Define wrapper function to retry function calls in case of Exceptions
 
+    Parameters
+    -----------
+    f: function
+        Function that will be wrapped
+    n_retry: int
+        Number of retries of function call
+
+    Returns
+    -------
+    f : function
+        Wrapped input function
+
+    """
+    def wrapper(*args, **kwargs):
+        exception = None
+        for i in range(n_retry):
+            try:
+                return f(*args, **kwargs)
+            except Exception as e:
+                exception = e
+        raise exception
+    return wrapper
+
+
+@retry
 def quotes_historical_google(symbol, date1, date2):
     """Get the historical data from Google finance.
 

--- a/examples/applications/plot_stock_market.py
+++ b/examples/applications/plot_stock_market.py
@@ -77,30 +77,15 @@ from sklearn import cluster, covariance, manifold
 # #############################################################################
 # Retrieve the data from Internet
 
-def retry(f, n_retry=3):
-    """Define wrapper function to retry function calls in case of Exceptions
-
-    Parameters
-    -----------
-    f: function
-        Function that will be wrapped
-    n_retry: int
-        Number of retries of function call
-
-    Returns
-    -------
-    f : function
-        Wrapped input function
-
-    """
+def retry(f, n_attempts=3):
+    "Wrapper function to retry function calls in case of exceptions"
     def wrapper(*args, **kwargs):
-        exception = None
-        for i in range(n_retry):
+        for i in range(n_attempts):
             try:
                 return f(*args, **kwargs)
             except Exception as e:
-                exception = e
-        raise exception
+                if i == n_attempts - 1:
+                    raise
     return wrapper
 
 
@@ -205,8 +190,8 @@ symbol_dict = {
 
 symbols, names = np.array(list(symbol_dict.items())).T
 
-# Function for downloading stock data is decorated with retry() because download
-# can temporary fail for various reasons (e.g. empty result from Google API).
+# retry is used because quotes_historical_google can temporarily fail
+# for various reasons (e.g. empty result from Google API).
 quotes = [
     retry(quotes_historical_google)(symbol, d1, d2) for symbol in symbols
 ]

--- a/examples/applications/plot_stock_market.py
+++ b/examples/applications/plot_stock_market.py
@@ -104,7 +104,6 @@ def retry(f, n_retry=3):
     return wrapper
 
 
-@retry
 def quotes_historical_google(symbol, date1, date2):
     """Get the historical data from Google finance.
 
@@ -206,8 +205,10 @@ symbol_dict = {
 
 symbols, names = np.array(list(symbol_dict.items())).T
 
+# Function for downloading stock data is decorated with retry() because download
+# can temporary fail for various reasons (e.g. empty result from Google API).
 quotes = [
-    quotes_historical_google(symbol, d1, d2) for symbol in symbols
+    retry(quotes_historical_google)(symbol, d1, d2) for symbol in symbols
 ]
 
 close_prices = np.vstack([q['close'] for q in quotes])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Fixes #9172

#### What does this implement/fix? Explain your changes.
In case when download of Google data fails or there is something wrong with the response data (e.g. empty response), download will be retried several times before example fails.

#### Any other comments?
I couldn't reproduce exact errors mentioned in #9172  so I created small decorator that retries to download data after any kind of exception 3 times before it finally fails. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
