### PR TITLE
[WIP] Make knn kernel undirected.

### DIFF
--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -136,9 +136,16 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
                 self.nn_fit = NearestNeighbors(self.n_neighbors,
                                                n_jobs=self.n_jobs).fit(X)
             if y is None:
-                return self.nn_fit.kneighbors_graph(self.nn_fit._fit_X,
-                                                    self.n_neighbors,
-                                                    mode='connectivity')
+                # Nearest neighbors returns a directed matrix.
+                dir_graph = self.nn_fit.kneighbors_graph(self.nn_fit._fit_X,
+                                                         self.n_neighbors,
+                                                         mode='connectivity')
+                # Making the matrix symmetric
+                un_graph = dir_graph + dir_graph.T
+                # Since it is a connectivity matrix, all values should be
+                # either 0 or 1
+                un_graph[un_graph > 1] = 1
+                return un_graph
             else:
                 return self.nn_fit.kneighbors(y, return_distance=False)
         elif callable(self.kernel):

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -146,4 +146,5 @@ def test_convergence_speed():
 
         # this should converge quickly:
         assert mdl.n_iter_ < 10
-        assert_array_almost_equal(mdl.predict_proba([[0.5, 0.5]]), [[0.5, 0.5]], decimal=3)
+        assert_array_almost_equal(mdl.predict_proba([[0.5, 0.5]]),
+                                  [[0.5, 0.5]], decimal=3)


### PR DESCRIPTION
This is a very simple way of making the `knn` kernel matrix symmetric. However, this slightly changes the meaning of `n_neighbors`: the _actual_ number of neighbors may vary from `n_neighbors` to `2 * n_neighbors` in the worst case.

 - [ ] Update tests after #5893 is merged.

Fixes #8008.