### PR TITLE
Increase the max_iter for LabelPropagation.

### DIFF
--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -380,7 +380,7 @@ class LabelPropagation(BaseLabelPropagation):
     _variant = 'propagation'
 
     def __init__(self, kernel='rbf', gamma=20, n_neighbors=7,
-                 alpha=None, max_iter=30, tol=1e-3, n_jobs=1):
+                 alpha=None, max_iter=1000, tol=1e-3, n_jobs=1):
         super(LabelPropagation, self).__init__(
             kernel=kernel, gamma=gamma, n_neighbors=n_neighbors, alpha=alpha,
             max_iter=max_iter, tol=tol, n_jobs=n_jobs)


### PR DESCRIPTION
In practice, `LabelPropagation` converges much slower than `LabelSpreading`. The default
of `max_iter=30` works well for `LabelSpreading` but not for `LabelPropagation`. This PR changes `max_iter` for `LabelPropagation` to 1000.

This was extracted from #5893.