### PR TITLE
[MRG] remove depreated "plt.hold" that defaults to "on".

### DIFF
--- a/examples/plot_kernel_ridge_regression.py
+++ b/examples/plot_kernel_ridge_regression.py
@@ -104,7 +104,6 @@ plt.scatter(X[sv_ind], y[sv_ind], c='r', s=50, label='SVR support vectors',
             zorder=2, edgecolors=(0, 0, 0))
 plt.scatter(X[:100], y[:100], c='k', label='data', zorder=1,
             edgecolors=(0, 0, 0))
-plt.hold('on')
 plt.plot(X_plot, y_svr, c='r',
          label='SVR (fit: %.3fs, predict: %.3fs)' % (svr_fit, svr_predict))
 plt.plot(X_plot, y_kr, c='g',

--- a/examples/svm/plot_svm_regression.py
+++ b/examples/svm/plot_svm_regression.py
@@ -34,7 +34,6 @@ y_poly = svr_poly.fit(X, y).predict(X)
 # Look at the results
 lw = 2
 plt.scatter(X, y, color='darkorange', label='data')
-plt.hold('on')
 plt.plot(X, y_rbf, color='navy', lw=lw, label='RBF model')
 plt.plot(X, y_lin, color='c', lw=lw, label='Linear model')
 plt.plot(X, y_poly, color='cornflowerblue', lw=lw, label='Polynomial model')


### PR DESCRIPTION
Deprecated in Matplotlib 2.0:
http://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.hold.html
http://matplotlib.org/api/api_changes.html#api-changes-in-2-0-0