### PR TITLE
[MRG] Make all version comparison use LooseVersion

### DIFF
--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -13,7 +13,7 @@ from distutils.version import LooseVersion
 from numpy.distutils.system_info import get_info
 
 DEFAULT_ROOT = 'sklearn'
-CYTHON_MIN_VERSION = '0.23'
+CYTHON_MIN_VERSION = LooseVersion('0.23')
 
 
 def get_blas_info():

--- a/sklearn/datasets/tests/test_svmlight_format.py
+++ b/sklearn/datasets/tests/test_svmlight_format.py
@@ -7,6 +7,7 @@ import scipy.sparse as sp
 import os
 import shutil
 from tempfile import NamedTemporaryFile
+from distutils.version import LooseVersion
 
 from sklearn.externals.six import b
 
@@ -487,7 +488,8 @@ def test_load_offset_exhaustive_splits():
     # load the same data in 2 parts with all the possible byte offsets to
     # locate the split so has to test for particular boundary cases
     for mark in range(size):
-        if sp_version < (0, 14) and (mark == 0 or mark > size - 100):
+        if (sp_version < LooseVersion('0.14') and
+                (mark == 0 or mark > size - 100)):
             # old scipy does not support sparse matrices with 0 rows.
             continue
         f.seek(0)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -18,6 +18,7 @@ from functools import partial, reduce
 from itertools import product
 import operator
 import warnings
+from distutils.version import LooseVersion
 
 import numpy as np
 from scipy.stats import rankdata
@@ -258,7 +259,7 @@ class ParameterSampler(object):
                 params = dict()
                 for k, v in items:
                     if hasattr(v, "rvs"):
-                        if sp_version < (0, 16):
+                        if sp_version < LooseVersion('0.16'):
                             params[k] = v.rvs()
                         else:
                             params[k] = v.rvs(random_state=rnd)

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -9,6 +9,7 @@ import pickle
 import sys
 from types import GeneratorType
 import re
+from distutils.version import LooseVersion
 
 import numpy as np
 import scipy.sparse as sp
@@ -712,7 +713,7 @@ def test_param_sampler():
                                n_iter=3, random_state=0)
     assert_equal([x for x in sampler], [x for x in sampler])
 
-    if sp_version >= (0, 16):
+    if sp_version >= LooseVersion('0.16'):
         param_distributions = {"C": uniform(0, 1)}
         sampler = ParameterSampler(param_distributions=param_distributions,
                                    n_iter=10, random_state=0)

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -2,6 +2,7 @@
 # License: BSD 3 clause
 
 import warnings
+from distutils.version import LooseVersion
 
 import numpy as np
 import numpy.ma as ma
@@ -264,7 +265,7 @@ class Imputer(BaseEstimator, TransformerMixin):
 
         # Median
         elif strategy == "median":
-            if tuple(int(v) for v in np.__version__.split('.')[:2]) < (1, 5):
+            if LooseVersion(np.__version__) < LooseVersion('1.5'):
                 # In old versions of numpy, calling a median on an array
                 # containing nans returns nan. This is different is
                 # recent versions of numpy, which we want to mimic

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -13,6 +13,7 @@ Extended math utilities.
 
 from __future__ import division
 import warnings
+from distutils.version import LooseVersion
 
 import numpy as np
 from scipy import linalg
@@ -754,7 +755,7 @@ def stable_cumsum(arr, axis=None, rtol=1e-05, atol=1e-08):
         Absolute tolerance, see ``np.allclose``
     """
     # sum is as unstable as cumsum for numpy < 1.9
-    if np_version < (1, 9):
+    if np_version < LooseVersion('1.9'):
         return np.cumsum(arr, axis=axis, dtype=np.float64)
 
     out = np.cumsum(arr, axis=axis, dtype=np.float64)

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -13,6 +13,7 @@ at which the fixe is no longer needed.
 import warnings
 import os
 import errno
+from distutils.version import LooseVersion
 
 import numpy as np
 import scipy.sparse as sp
@@ -23,23 +24,11 @@ try:
 except ImportError:
     from ..externals.funcsigs import signature
 
-
-def _parse_version(version_string):
-    version = []
-    for x in version_string.split('.'):
-        try:
-            version.append(int(x))
-        except ValueError:
-            # x may be of the form dev-1ea1592
-            version.append(x)
-    return tuple(version)
-
-
 euler_gamma = getattr(np, 'euler_gamma',
                       0.577215664901532860606512090082402431)
 
-np_version = _parse_version(np.__version__)
-sp_version = _parse_version(scipy.__version__)
+np_version = LooseVersion(np.__version__)
+sp_version = LooseVersion(scipy.__version__)
 
 
 # Remove when minimum required NumPy >= 1.10
@@ -137,7 +126,7 @@ else:
                 X.max(axis=axis).toarray().ravel())
 
 
-if sp_version < (0, 15):
+if sp_version < LooseVersion('0.15'):
     # Backport fix for scikit-learn/scikit-learn#2986 / scipy/scipy#4142
     from ._scipy_sparse_lsqr_backport import lsqr as sparse_lsqr
 else:
@@ -177,7 +166,7 @@ else:
                 raise
 
 
-if np_version < (1, 12):
+if np_version < LooseVersion('1.12'):
     class MaskedArray(np.ma.MaskedArray):
         # Before numpy 1.12, np.ma.MaskedArray object is not picklable
         # This fix is needed to make our model_selection.GridSearchCV

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -4,6 +4,8 @@
 #
 # License: BSD 3 clause
 
+from distutils.version import LooseVersion
+
 import numpy as np
 from scipy import sparse
 from scipy import linalg
@@ -613,7 +615,7 @@ def test_softmax():
 
 
 def test_stable_cumsum():
-    if np_version < (1, 9):
+    if np_version < LooseVersion('1.9'):
         raise SkipTest("Sum is as unstable as cumsum for numpy < 1.9")
     assert_array_equal(stable_cumsum([1, 2, 3]), np.cumsum([1, 2, 3]))
     r = np.random.RandomState(0).rand(100000)


### PR DESCRIPTION
Fixes #7980, closes #8301.

Basically this is a more pragmatic approach compared to #8301. Using LooseVersion everywhere fixes most of the problems even if it has the surprising downside of:

```py
from distutils.version import LooseVersion
LooseVersion('1.12b1') < LooseVersion('1.12')  # False
```

May be worth to backport this in 0.19 if people agree with the approach.
