### PR TITLE
[MRG+1] `MLPRegressor` quits fitting too soon due to `self._no_improvement_count`

### DIFF
--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -94,7 +94,7 @@ training samples::
                   beta_1=0.9, beta_2=0.999, early_stopping=False,
                   epsilon=1e-08, hidden_layer_sizes=(5, 2),
                   learning_rate='constant', learning_rate_init=0.001,
-                  max_iter=200, momentum=0.9, n_iter_no_change=2,
+                  max_iter=200, momentum=0.9, n_iter_no_change=10,
                   nesterovs_momentum=True, power_t=0.5, random_state=1,
                   shuffle=True, solver='lbfgs', tol=0.0001,
                   validation_fraction=0.1, verbose=False, warm_start=False)
@@ -143,7 +143,7 @@ indices where the value is `1` represents the assigned classes of that sample::
                   beta_1=0.9, beta_2=0.999, early_stopping=False,
                   epsilon=1e-08, hidden_layer_sizes=(15,),
                   learning_rate='constant', learning_rate_init=0.001,
-                  max_iter=200, momentum=0.9, n_iter_no_change=2,
+                  max_iter=200, momentum=0.9, n_iter_no_change=10,
                   nesterovs_momentum=True, power_t=0.5,  random_state=1,
                   shuffle=True, solver='lbfgs', tol=0.0001,
                   validation_fraction=0.1, verbose=False, warm_start=False)

--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -94,7 +94,7 @@ training samples::
                   beta_1=0.9, beta_2=0.999, early_stopping=False,
                   epsilon=1e-08, hidden_layer_sizes=(5, 2),
                   learning_rate='constant', learning_rate_init=0.001,
-                  max_iter=200, momentum=0.9, n_iter_no_change=10,
+                  max_iter=200, momentum=0.9, n_iter_no_change=2,
                   nesterovs_momentum=True, power_t=0.5, random_state=1,
                   shuffle=True, solver='lbfgs', tol=0.0001,
                   validation_fraction=0.1, verbose=False, warm_start=False)
@@ -143,7 +143,7 @@ indices where the value is `1` represents the assigned classes of that sample::
                   beta_1=0.9, beta_2=0.999, early_stopping=False,
                   epsilon=1e-08, hidden_layer_sizes=(15,),
                   learning_rate='constant', learning_rate_init=0.001,
-                  max_iter=200, momentum=0.9, n_iter_no_change=10,
+                  max_iter=200, momentum=0.9, n_iter_no_change=2,
                   nesterovs_momentum=True, power_t=0.5,  random_state=1,
                   shuffle=True, solver='lbfgs', tol=0.0001,
                   validation_fraction=0.1, verbose=False, warm_start=False)

--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -91,12 +91,12 @@ training samples::
     ...
     >>> clf.fit(X, y)                         # doctest: +NORMALIZE_WHITESPACE
     MLPClassifier(activation='relu', alpha=1e-05, batch_size='auto',
-        beta_1=0.9, beta_2=0.999, early_stopping=False, epsilon=1e-08,
-        hidden_layer_sizes=(5, 2), learning_rate='constant',
-        learning_rate_init=0.001, max_iter=200, momentum=0.9,
-        n_iter_no_change=2, nesterovs_momentum=True, power_t=0.5,
-        random_state=1, shuffle=True, solver='lbfgs', tol=0.0001,
-        validation_fraction=0.1, verbose=False, warm_start=False)
+            beta_1=0.9, beta_2=0.999, early_stopping=False, epsilon=1e-08,
+            hidden_layer_sizes=(5, 2), learning_rate='constant',
+            learning_rate_init=0.001, max_iter=200, momentum=0.9,
+            n_iter_no_change=2, nesterovs_momentum=True, power_t=0.5,
+            random_state=1, shuffle=True, solver='lbfgs', tol=0.0001,
+            validation_fraction=0.1, verbose=False, warm_start=False)
 
 After fitting (training), the model can predict labels for new samples::
 
@@ -139,12 +139,12 @@ indices where the value is `1` represents the assigned classes of that sample::
     ...
     >>> clf.fit(X, y)                         # doctest: +NORMALIZE_WHITESPACE
     MLPClassifier(activation='relu', alpha=1e-05, batch_size='auto',
-        beta_1=0.9, beta_2=0.999, early_stopping=False, epsilon=1e-08,
-        hidden_layer_sizes=(15,), learning_rate='constant',
-        learning_rate_init=0.001, max_iter=200, momentum=0.9,
-        n_iter_no_change=2, nesterovs_momentum=True, power_t=0.5,
-        random_state=1, shuffle=True, solver='lbfgs', tol=0.0001,
-        validation_fraction=0.1, verbose=False, warm_start=False)
+            beta_1=0.9, beta_2=0.999, early_stopping=False, epsilon=1e-08,
+            hidden_layer_sizes=(15,), learning_rate='constant',
+            learning_rate_init=0.001, max_iter=200, momentum=0.9,
+            n_iter_no_change=2, nesterovs_momentum=True, power_t=0.5,
+            random_state=1, shuffle=True, solver='lbfgs', tol=0.0001,
+            validation_fraction=0.1, verbose=False, warm_start=False)
     >>> clf.predict([[1., 2.]])
     array([[1, 1]])
     >>> clf.predict([[0., 0.]])

--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -91,12 +91,13 @@ training samples::
     ...
     >>> clf.fit(X, y)                         # doctest: +NORMALIZE_WHITESPACE
     MLPClassifier(activation='relu', alpha=1e-05, batch_size='auto',
-            beta_1=0.9, beta_2=0.999, early_stopping=False, epsilon=1e-08,
-            hidden_layer_sizes=(5, 2), learning_rate='constant',
-            learning_rate_init=0.001, max_iter=200, momentum=0.9,
-            n_iter_no_change=2, nesterovs_momentum=True, power_t=0.5,
-            random_state=1, shuffle=True, solver='lbfgs', tol=0.0001,
-            validation_fraction=0.1, verbose=False, warm_start=False)
+                  beta_1=0.9, beta_2=0.999, early_stopping=False,
+                  epsilon=1e-08, hidden_layer_sizes=(5, 2),
+                  learning_rate='constant', learning_rate_init=0.001,
+                  max_iter=200, momentum=0.9, n_iter_no_change=2,
+                  nesterovs_momentum=True, power_t=0.5, random_state=1,
+                  shuffle=True, solver='lbfgs', tol=0.0001,
+                  validation_fraction=0.1, verbose=False, warm_start=False)
 
 After fitting (training), the model can predict labels for new samples::
 
@@ -139,12 +140,13 @@ indices where the value is `1` represents the assigned classes of that sample::
     ...
     >>> clf.fit(X, y)                         # doctest: +NORMALIZE_WHITESPACE
     MLPClassifier(activation='relu', alpha=1e-05, batch_size='auto',
-            beta_1=0.9, beta_2=0.999, early_stopping=False, epsilon=1e-08,
-            hidden_layer_sizes=(15,), learning_rate='constant',
-            learning_rate_init=0.001, max_iter=200, momentum=0.9,
-            n_iter_no_change=2, nesterovs_momentum=True, power_t=0.5,
-            random_state=1, shuffle=True, solver='lbfgs', tol=0.0001,
-            validation_fraction=0.1, verbose=False, warm_start=False)
+                  beta_1=0.9, beta_2=0.999, early_stopping=False,
+                  epsilon=1e-08, hidden_layer_sizes=(15,),
+                  learning_rate='constant', learning_rate_init=0.001,
+                  max_iter=200, momentum=0.9, n_iter_no_change=2,
+                  nesterovs_momentum=True, power_t=0.5,  random_state=1,
+                  shuffle=True, solver='lbfgs', tol=0.0001,
+                  validation_fraction=0.1, verbose=False, warm_start=False)
     >>> clf.predict([[1., 2.]])
     array([[1, 1]])
     >>> clf.predict([[0., 0.]])

--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -91,12 +91,12 @@ training samples::
     ...
     >>> clf.fit(X, y)                         # doctest: +NORMALIZE_WHITESPACE
     MLPClassifier(activation='relu', alpha=1e-05, batch_size='auto',
-           beta_1=0.9, beta_2=0.999, early_stopping=False,
-           epsilon=1e-08, hidden_layer_sizes=(5, 2), learning_rate='constant',
-           learning_rate_init=0.001, max_iter=200, momentum=0.9,
-           nesterovs_momentum=True, power_t=0.5, random_state=1, shuffle=True,
-           solver='lbfgs', tol=0.0001, validation_fraction=0.1, verbose=False,
-           warm_start=False)
+        beta_1=0.9, beta_2=0.999, early_stopping=False, epsilon=1e-08,
+        hidden_layer_sizes=(5, 2), learning_rate='constant',
+        learning_rate_init=0.001, max_iter=200, momentum=0.9,
+        n_iter_no_change=2, nesterovs_momentum=True, power_t=0.5,
+        random_state=1, shuffle=True, solver='lbfgs', tol=0.0001,
+        validation_fraction=0.1, verbose=False, warm_start=False)
 
 After fitting (training), the model can predict labels for new samples::
 
@@ -139,12 +139,12 @@ indices where the value is `1` represents the assigned classes of that sample::
     ...
     >>> clf.fit(X, y)                         # doctest: +NORMALIZE_WHITESPACE
     MLPClassifier(activation='relu', alpha=1e-05, batch_size='auto',
-           beta_1=0.9, beta_2=0.999, early_stopping=False,
-           epsilon=1e-08, hidden_layer_sizes=(15,), learning_rate='constant',
-           learning_rate_init=0.001, max_iter=200, momentum=0.9,
-           nesterovs_momentum=True, power_t=0.5, random_state=1, shuffle=True,
-           solver='lbfgs', tol=0.0001, validation_fraction=0.1, verbose=False,
-           warm_start=False)
+        beta_1=0.9, beta_2=0.999, early_stopping=False, epsilon=1e-08,
+        hidden_layer_sizes=(15,), learning_rate='constant',
+        learning_rate_init=0.001, max_iter=200, momentum=0.9,
+        n_iter_no_change=2, nesterovs_momentum=True, power_t=0.5,
+        random_state=1, shuffle=True, solver='lbfgs', tol=0.0001,
+        validation_fraction=0.1, verbose=False, warm_start=False)
     >>> clf.predict([[1., 2.]])
     array([[1, 1]])
     >>> clf.predict([[0., 0.]])

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -66,10 +66,10 @@ Classifiers and regressors
   variances calculation. :issue:`9681` by :user:`Dmitry Mottl <Mottl>`.
 
 - Add `n_iter_no_change` parameter in
-  :class:`multilayer_perceptron.BaseMultilayerPerceptron`,
-  :class:`multilayer_perceptron.MLPRegressor`, and
-  :class:`multilayer_perceptron.MLPClassifier` to give control over
-  maximum number of epochs to not meet `tol` improvement.
+  :class:`neural_network.BaseMultilayerPerceptron`,
+  :class:`neural_network.MLPRegressor`, and
+  :class:`neural_network.MLPClassifier` to give control over
+  maximum number of epochs to not meet ``tol`` improvement.
   :issue:`9456` by :user:`Nicholas Nadeau <nnadeau>`.
 
 - A parameter ``check_inverse`` was added to :class:`FunctionTransformer`
@@ -103,13 +103,13 @@ Classifiers and regressors
   identical X values.
   :issue:`9432` by :user:`Dallas Card <dallascard>`
 
-- Fixed a bug in :class:`multilayer_perceptron.BaseMultilayerPerceptron`,
-  :class:`multilayer_perceptron.MLPRegressor`, and
-  :class:`multilayer_perceptron.MLPClassifier` with new `n_iter_no_change`
+- Fixed a bug in :class:`neural_network.BaseMultilayerPerceptron`,
+  :class:`neural_network.MLPRegressor`, and
+  :class:`neural_network.MLPClassifier` with new ``n_iter_no_change``
   parameter now at 10 from previously hardcoded 2.
   :issue:`9456` by :user:`Nicholas Nadeau <nnadeau>`.
   
-- Fixed a bug in :class:`multilayer_perceptron.MLPRegressor` where fitting
+- Fixed a bug in :class:`neural_network.MLPRegressor` where fitting
   quit unexpectedly early due to local minima or fluctuations.
   :issue:`9456` by :user:`Nicholas Nadeau <nnadeau>`
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -18,6 +18,9 @@ random sampling procedures.
 - :class:`decomposition.IncrementalPCA` in Python 2 (bug fix)
 - :class:`isotonic.IsotonicRegression` (bug fix)
 - :class:`metrics.roc_auc_score` (bug fix)
+- :class:`neural_network.BaseMultilayerPerceptron` (bug fix)
+- :class:`neural_network.MLPRegressor` (bug fix)
+- :class:`neural_network.MLPClassifier` (bug fix)
 
 Details are listed in the changelog below.
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -103,6 +103,12 @@ Classifiers and regressors
   identical X values.
   :issue:`9432` by :user:`Dallas Card <dallascard>`
 
+- Fixed a bug in :class:`multilayer_perceptron.BaseMultilayerPerceptron`,
+  :class:`multilayer_perceptron.MLPRegressor`, and
+  :class:`multilayer_perceptron.MLPClassifier` with new `n_iter_no_change`
+  parameter now at 10 from previously hardcoded 2.
+  :issue:`9456` by :user:`Nicholas Nadeau <nnadeau>`.
+  
 - Fixed a bug in :class:`multilayer_perceptron.MLPRegressor` where fitting
   quit unexpectedly early due to local minima or fluctuations.
   :issue:`9456` by :user:`Nicholas Nadeau <nnadeau>`

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -65,6 +65,13 @@ Classifiers and regressors
   :class:`sklearn.naive_bayes.GaussianNB` to give a precise control over
   variances calculation. :issue:`9681` by :user:`Dmitry Mottl <Mottl>`.
 
+- Add `n_iter_no_change` parameter in
+  :class:`multilayer_perceptron.BaseMultilayerPerceptron`,
+  :class:`multilayer_perceptron.MLPRegressor`, and
+  :class:`multilayer_perceptron.MLPClassifier` to give control over
+  maximum number of epochs to not meet `tol` improvement.
+  :issue:`9456` by :user:`Nicholas Nadeau <nnadeau>`.
+
 Model evaluation and meta-estimators
 
 - A scorer based on :func:`metrics.brier_score_loss` is also available.
@@ -90,6 +97,10 @@ Classifiers and regressors
   combined weights when fitting a model to data involving points with
   identical X values.
   :issue:`9432` by :user:`Dallas Card <dallascard>`
+
+- Fixed a bug in :class:`multilayer_perceptron.MLPRegressor` where fitting
+  quit unexpectedly early due to local minima or fluctuations.
+  :issue:`9456` by :user:`Nicholas Nadeau <nnadeau>`
 
 Decomposition, manifold learning and clustering
 

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -835,6 +835,8 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         Maximum number of epochs to not meet `tol` improvement.
         Only effective when solver='sgd' or 'adam'
 
+        .. versionadded:: 0.20
+
     Attributes
     ----------
     classes_ : array or list of array of shape (n_classes,)
@@ -1216,6 +1218,8 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
     n_iter_no_change : int, optional, default 10
         Maximum number of epochs to not meet `tol` improvement.
         Only effective when solver='sgd' or 'adam'
+
+        .. versionadded:: 0.20
 
     Attributes
     ----------

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -828,7 +828,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
     epsilon : float, optional, default 1e-8
         Value for numerical stability in adam. Only used when solver='adam'
 
-    n_iter_no_change : int, optional, default 2
+    n_iter_no_change : int, optional, default 10
         Maximum number of epochs to not meet `tol` improvement.
         Only effective when solver='sgd' or 'adam'
 
@@ -1210,7 +1210,7 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
     epsilon : float, optional, default 1e-8
         Value for numerical stability in adam. Only used when solver='adam'
 
-    n_iter_no_change : int, optional, default 2
+    n_iter_no_change : int, optional, default 10
         Maximum number of epochs to not meet `tol` improvement.
         Only effective when solver='sgd' or 'adam'
 

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -417,6 +417,9 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
                              self.beta_2)
         if self.epsilon <= 0.0:
             raise ValueError("epsilon must be > 0, got %s." % self.epsilon)
+        if self.n_iter_no_change <= 0:
+            raise ValueError("n_iter_no_change must be > 0, got %s."
+                             % self.n_iter_no_change)
 
         # raise ValueError if not registered
         supported_activations = ('identity', 'logistic', 'tanh', 'relu')

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -784,9 +784,9 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
 
     tol : float, optional, default 1e-4
         Tolerance for the optimization. When the loss or score is not improving
-        by at least tol for two consecutive iterations, unless `learning_rate`
-        is set to 'adaptive', convergence is considered to be reached and
-        training stops.
+        by at least tol for `n_iter_no_change` consecutive iterations, unless
+        `learning_rate` is set to 'adaptive', convergence is considered to be
+        reached and training stops.
 
     verbose : bool, optional, default False
         Whether to print progress messages to stdout.
@@ -808,8 +808,8 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         Whether to use early stopping to terminate training when validation
         score is not improving. If set to true, it will automatically set
         aside 10% of training data as validation and terminate training when
-        validation score is not improving by at least tol for two consecutive
-        epochs.
+        validation score is not improving by at least tol for `n_iter_no_change`
+        consecutive epochs.
         Only effective when solver='sgd' or 'adam'
 
     validation_fraction : float, optional, default 0.1
@@ -827,6 +827,10 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
 
     epsilon : float, optional, default 1e-8
         Value for numerical stability in adam. Only used when solver='adam'
+
+    n_iter_no_change : int, optional, default 2
+        Maximum number of epochs to not meet `tol` improvement.
+        Only effective when solver='sgd' or 'adam'
 
     Attributes
     ----------
@@ -1161,9 +1165,9 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
 
     tol : float, optional, default 1e-4
         Tolerance for the optimization. When the loss or score is not improving
-        by at least tol for two consecutive iterations, unless `learning_rate`
-        is set to 'adaptive', convergence is considered to be reached and
-        training stops.
+        by at least tol for `n_iter_no_change` consecutive iterations, unless
+        `learning_rate` is set to 'adaptive', convergence is considered
+        to be reached and training stops.
 
     verbose : bool, optional, default False
         Whether to print progress messages to stdout.
@@ -1185,8 +1189,8 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
         Whether to use early stopping to terminate training when validation
         score is not improving. If set to true, it will automatically set
         aside 10% of training data as validation and terminate training when
-        validation score is not improving by at least tol for two consecutive
-        epochs.
+        validation score is not improving by at least tol for `n_iter_no_change`
+        consecutive epochs.
         Only effective when solver='sgd' or 'adam'
 
     validation_fraction : float, optional, default 0.1
@@ -1204,6 +1208,10 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
 
     epsilon : float, optional, default 1e-8
         Value for numerical stability in adam. Only used when solver='adam'
+
+    n_iter_no_change : int, optional, default 2
+        Maximum number of epochs to not meet `tol` improvement.
+        Only effective when solver='sgd' or 'adam'
 
     Attributes
     ----------

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -543,10 +543,10 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
                     # stop or decrease learning rate
                     if early_stopping:
                         msg = ("Validation score did not improve more than "
-                               "tol=%f for two consecutive epochs." % self.tol)
+                               "tol=%f for %d consecutive epochs." % (self.tol, self.no_improvement_limit))
                     else:
                         msg = ("Training loss did not improve more than tol=%f"
-                               " for two consecutive epochs." % self.tol)
+                               " for %d consecutive epochs." % (self.tol, self.no_improvement_limit))
 
                     is_stopping = self._optimizer.trigger_stopping(
                         msg, self.verbose)

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -51,7 +51,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
                  alpha, batch_size, learning_rate, learning_rate_init, power_t,
                  max_iter, loss, shuffle, random_state, tol, verbose,
                  warm_start, momentum, nesterovs_momentum, early_stopping,
-                 validation_fraction, beta_1, beta_2, epsilon, no_improvement_limit):
+                 validation_fraction, beta_1, beta_2, epsilon, n_iter_no_change):
         self.activation = activation
         self.solver = solver
         self.alpha = alpha
@@ -74,7 +74,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
         self.beta_1 = beta_1
         self.beta_2 = beta_2
         self.epsilon = epsilon
-        self.no_improvement_limit = no_improvement_limit
+        self.n_iter_no_change = n_iter_no_change
 
     def _unpack(self, packed_parameters):
         """Extract the coefficients and intercepts from packed_parameters."""
@@ -538,15 +538,15 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
                 # for learning rate that needs to be updated at iteration end
                 self._optimizer.iteration_ends(self.t_)
 
-                if self._no_improvement_count > self.no_improvement_limit:
+                if self._no_improvement_count > self.n_iter_no_change:
                     # not better than last two iterations by tol.
                     # stop or decrease learning rate
                     if early_stopping:
                         msg = ("Validation score did not improve more than "
-                               "tol=%f for %d consecutive epochs." % (self.tol, self.no_improvement_limit))
+                               "tol=%f for %d consecutive epochs." % (self.tol, self.n_iter_no_change))
                     else:
                         msg = ("Training loss did not improve more than tol=%f"
-                               " for %d consecutive epochs." % (self.tol, self.no_improvement_limit))
+                               " for %d consecutive epochs." % (self.tol, self.n_iter_no_change))
 
                     is_stopping = self._optimizer.trigger_stopping(
                         msg, self.verbose)
@@ -891,7 +891,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
                  verbose=False, warm_start=False, momentum=0.9,
                  nesterovs_momentum=True, early_stopping=False,
                  validation_fraction=0.1, beta_1=0.9, beta_2=0.999,
-                 epsilon=1e-8, no_improvement_limit=2):
+                 epsilon=1e-8, n_iter_no_change=2):
 
         sup = super(MLPClassifier, self)
         sup.__init__(hidden_layer_sizes=hidden_layer_sizes,
@@ -904,7 +904,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
                      nesterovs_momentum=nesterovs_momentum,
                      early_stopping=early_stopping,
                      validation_fraction=validation_fraction,
-                     beta_1=beta_1, beta_2=beta_2, epsilon=epsilon, no_improvement_limit=no_improvement_limit)
+                     beta_1=beta_1, beta_2=beta_2, epsilon=epsilon, n_iter_no_change=n_iter_no_change)
 
     def _validate_input(self, X, y, incremental):
         X, y = check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
@@ -1266,7 +1266,7 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
                  verbose=False, warm_start=False, momentum=0.9,
                  nesterovs_momentum=True, early_stopping=False,
                  validation_fraction=0.1, beta_1=0.9, beta_2=0.999,
-                 epsilon=1e-8, no_improvement_limit=2):
+                 epsilon=1e-8, n_iter_no_change=2):
 
         sup = super(MLPRegressor, self)
         sup.__init__(hidden_layer_sizes=hidden_layer_sizes,
@@ -1279,7 +1279,7 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
                      nesterovs_momentum=nesterovs_momentum,
                      early_stopping=early_stopping,
                      validation_fraction=validation_fraction,
-                     beta_1=beta_1, beta_2=beta_2, epsilon=epsilon, no_improvement_limit=no_improvement_limit)
+                     beta_1=beta_1, beta_2=beta_2, epsilon=epsilon, n_iter_no_change=n_iter_no_change)
 
     def predict(self, X):
         """Predict using the multi-layer perceptron model.

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -808,8 +808,8 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         Whether to use early stopping to terminate training when validation
         score is not improving. If set to true, it will automatically set
         aside 10% of training data as validation and terminate training when
-        validation score is not improving by at least tol for `n_iter_no_change`
-        consecutive epochs.
+        validation score is not improving by at least tol for
+        `n_iter_no_change` consecutive epochs.
         Only effective when solver='sgd' or 'adam'
 
     validation_fraction : float, optional, default 0.1
@@ -1190,8 +1190,8 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
         Whether to use early stopping to terminate training when validation
         score is not improving. If set to true, it will automatically set
         aside 10% of training data as validation and terminate training when
-        validation score is not improving by at least tol for `n_iter_no_change`
-        consecutive epochs.
+        validation score is not improving by at least tol for
+        `n_iter_no_change` consecutive epochs.
         Only effective when solver='sgd' or 'adam'
 
     validation_fraction : float, optional, default 0.1

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -540,7 +540,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
                 self._optimizer.iteration_ends(self.t_)
 
                 if self._no_improvement_count > self.n_iter_no_change:
-                    # not better than last two iterations by tol.
+                    # not better than last `n_iter_no_change` iterations by tol.
                     # stop or decrease learning rate
                     if early_stopping:
                         msg = ("Validation score did not improve more than "

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -911,7 +911,8 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
                      nesterovs_momentum=nesterovs_momentum,
                      early_stopping=early_stopping,
                      validation_fraction=validation_fraction,
-                     beta_1=beta_1, beta_2=beta_2, epsilon=epsilon, n_iter_no_change=n_iter_no_change)
+                     beta_1=beta_1, beta_2=beta_2, epsilon=epsilon,
+                     n_iter_no_change=n_iter_no_change)
 
     def _validate_input(self, X, y, incremental):
         X, y = check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
@@ -1290,7 +1291,8 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
                      nesterovs_momentum=nesterovs_momentum,
                      early_stopping=early_stopping,
                      validation_fraction=validation_fraction,
-                     beta_1=beta_1, beta_2=beta_2, epsilon=epsilon, n_iter_no_change=n_iter_no_change)
+                     beta_1=beta_1, beta_2=beta_2, epsilon=epsilon,
+                     n_iter_no_change=n_iter_no_change)
 
     def predict(self, X):
         """Predict using the multi-layer perceptron model.

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -543,7 +543,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
                 self._optimizer.iteration_ends(self.t_)
 
                 if self._no_improvement_count > self.n_iter_no_change:
-                    # not better than last `n_iter_no_change` iterations by tol.
+                    # not better than last `n_iter_no_change` iterations by tol
                     # stop or decrease learning rate
                     if early_stopping:
                         msg = ("Validation score did not improve more than "

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -51,7 +51,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
                  alpha, batch_size, learning_rate, learning_rate_init, power_t,
                  max_iter, loss, shuffle, random_state, tol, verbose,
                  warm_start, momentum, nesterovs_momentum, early_stopping,
-                 validation_fraction, beta_1, beta_2, epsilon):
+                 validation_fraction, beta_1, beta_2, epsilon, no_improvement_limit):
         self.activation = activation
         self.solver = solver
         self.alpha = alpha
@@ -74,7 +74,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
         self.beta_1 = beta_1
         self.beta_2 = beta_2
         self.epsilon = epsilon
-        self.no_improvement_limit = 2
+        self.no_improvement_limit = no_improvement_limit
 
     def _unpack(self, packed_parameters):
         """Extract the coefficients and intercepts from packed_parameters."""
@@ -891,7 +891,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
                  verbose=False, warm_start=False, momentum=0.9,
                  nesterovs_momentum=True, early_stopping=False,
                  validation_fraction=0.1, beta_1=0.9, beta_2=0.999,
-                 epsilon=1e-8):
+                 epsilon=1e-8, no_improvement_limit=2):
 
         sup = super(MLPClassifier, self)
         sup.__init__(hidden_layer_sizes=hidden_layer_sizes,
@@ -904,7 +904,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
                      nesterovs_momentum=nesterovs_momentum,
                      early_stopping=early_stopping,
                      validation_fraction=validation_fraction,
-                     beta_1=beta_1, beta_2=beta_2, epsilon=epsilon)
+                     beta_1=beta_1, beta_2=beta_2, epsilon=epsilon, no_improvement_limit=no_improvement_limit)
 
     def _validate_input(self, X, y, incremental):
         X, y = check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
@@ -1266,7 +1266,7 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
                  verbose=False, warm_start=False, momentum=0.9,
                  nesterovs_momentum=True, early_stopping=False,
                  validation_fraction=0.1, beta_1=0.9, beta_2=0.999,
-                 epsilon=1e-8):
+                 epsilon=1e-8, no_improvement_limit=2):
 
         sup = super(MLPRegressor, self)
         sup.__init__(hidden_layer_sizes=hidden_layer_sizes,
@@ -1279,7 +1279,7 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
                      nesterovs_momentum=nesterovs_momentum,
                      early_stopping=early_stopping,
                      validation_fraction=validation_fraction,
-                     beta_1=beta_1, beta_2=beta_2, epsilon=epsilon)
+                     beta_1=beta_1, beta_2=beta_2, epsilon=epsilon, no_improvement_limit=no_improvement_limit)
 
     def predict(self, X):
         """Predict using the multi-layer perceptron model.

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -51,7 +51,8 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
                  alpha, batch_size, learning_rate, learning_rate_init, power_t,
                  max_iter, loss, shuffle, random_state, tol, verbose,
                  warm_start, momentum, nesterovs_momentum, early_stopping,
-                 validation_fraction, beta_1, beta_2, epsilon, n_iter_no_change):
+                 validation_fraction, beta_1, beta_2, epsilon,
+                 n_iter_no_change):
         self.activation = activation
         self.solver = solver
         self.alpha = alpha
@@ -543,10 +544,12 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
                     # stop or decrease learning rate
                     if early_stopping:
                         msg = ("Validation score did not improve more than "
-                               "tol=%f for %d consecutive epochs." % (self.tol, self.n_iter_no_change))
+                               "tol=%f for %d consecutive epochs." % (
+                                   self.tol, self.n_iter_no_change))
                     else:
                         msg = ("Training loss did not improve more than tol=%f"
-                               " for %d consecutive epochs." % (self.tol, self.n_iter_no_change))
+                               " for %d consecutive epochs." % (
+                                   self.tol, self.n_iter_no_change))
 
                     is_stopping = self._optimizer.trigger_stopping(
                         msg, self.verbose)

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -898,7 +898,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
                  verbose=False, warm_start=False, momentum=0.9,
                  nesterovs_momentum=True, early_stopping=False,
                  validation_fraction=0.1, beta_1=0.9, beta_2=0.999,
-                 epsilon=1e-8, n_iter_no_change=2):
+                 epsilon=1e-8, n_iter_no_change=10):
 
         sup = super(MLPClassifier, self)
         sup.__init__(hidden_layer_sizes=hidden_layer_sizes,
@@ -1278,7 +1278,7 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
                  verbose=False, warm_start=False, momentum=0.9,
                  nesterovs_momentum=True, early_stopping=False,
                  validation_fraction=0.1, beta_1=0.9, beta_2=0.999,
-                 epsilon=1e-8, n_iter_no_change=2):
+                 epsilon=1e-8, n_iter_no_change=10):
 
         sup = super(MLPRegressor, self)
         sup.__init__(hidden_layer_sizes=hidden_layer_sizes,

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -74,6 +74,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
         self.beta_1 = beta_1
         self.beta_2 = beta_2
         self.epsilon = epsilon
+        self.no_improvement_limit = 2
 
     def _unpack(self, packed_parameters):
         """Extract the coefficients and intercepts from packed_parameters."""
@@ -537,7 +538,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
                 # for learning rate that needs to be updated at iteration end
                 self._optimizer.iteration_ends(self.t_)
 
-                if self._no_improvement_count > 2:
+                if self._no_improvement_count > self.no_improvement_limit:
                     # not better than last two iterations by tol.
                     # stop or decrease learning rate
                     if early_stopping:

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -903,7 +903,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
                  verbose=False, warm_start=False, momentum=0.9,
                  nesterovs_momentum=True, early_stopping=False,
                  validation_fraction=0.1, beta_1=0.9, beta_2=0.999,
-                 epsilon=1e-8, n_iter_no_change=2):
+                 epsilon=1e-8, n_iter_no_change=10):
 
         sup = super(MLPClassifier, self)
         sup.__init__(hidden_layer_sizes=hidden_layer_sizes,
@@ -1285,7 +1285,7 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
                  verbose=False, warm_start=False, momentum=0.9,
                  nesterovs_momentum=True, early_stopping=False,
                  validation_fraction=0.1, beta_1=0.9, beta_2=0.999,
-                 epsilon=1e-8, n_iter_no_change=2):
+                 epsilon=1e-8, n_iter_no_change=10):
 
         sup = super(MLPRegressor, self)
         sup.__init__(hidden_layer_sizes=hidden_layer_sizes,

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -787,9 +787,9 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
 
     tol : float, optional, default 1e-4
         Tolerance for the optimization. When the loss or score is not improving
-        by at least tol for `n_iter_no_change` consecutive iterations, unless
-        `learning_rate` is set to 'adaptive', convergence is considered to be
-        reached and training stops.
+        by at least ``tol`` for ``n_iter_no_change`` consecutive iterations,
+        unless ``learning_rate`` is set to 'adaptive', convergence is
+        considered to be reached and training stops.
 
     verbose : bool, optional, default False
         Whether to print progress messages to stdout.
@@ -812,7 +812,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         score is not improving. If set to true, it will automatically set
         aside 10% of training data as validation and terminate training when
         validation score is not improving by at least tol for
-        `n_iter_no_change` consecutive epochs.
+        ``n_iter_no_change`` consecutive epochs.
         Only effective when solver='sgd' or 'adam'
 
     validation_fraction : float, optional, default 0.1
@@ -832,7 +832,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         Value for numerical stability in adam. Only used when solver='adam'
 
     n_iter_no_change : int, optional, default 10
-        Maximum number of epochs to not meet `tol` improvement.
+        Maximum number of epochs to not meet ``tol`` improvement.
         Only effective when solver='sgd' or 'adam'
 
         .. versionadded:: 0.20
@@ -1171,9 +1171,9 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
 
     tol : float, optional, default 1e-4
         Tolerance for the optimization. When the loss or score is not improving
-        by at least tol for `n_iter_no_change` consecutive iterations, unless
-        `learning_rate` is set to 'adaptive', convergence is considered
-        to be reached and training stops.
+        by at least ``tol`` for ``n_iter_no_change`` consecutive iterations,
+        unless ``learning_rate`` is set to 'adaptive', convergence is
+        considered to be reached and training stops.
 
     verbose : bool, optional, default False
         Whether to print progress messages to stdout.
@@ -1195,8 +1195,8 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
         Whether to use early stopping to terminate training when validation
         score is not improving. If set to true, it will automatically set
         aside 10% of training data as validation and terminate training when
-        validation score is not improving by at least tol for
-        `n_iter_no_change` consecutive epochs.
+        validation score is not improving by at least ``tol`` for
+        ``n_iter_no_change`` consecutive epochs.
         Only effective when solver='sgd' or 'adam'
 
     validation_fraction : float, optional, default 0.1
@@ -1216,7 +1216,7 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
         Value for numerical stability in adam. Only used when solver='adam'
 
     n_iter_no_change : int, optional, default 10
-        Maximum number of epochs to not meet `tol` improvement.
+        Maximum number of epochs to not meet ``tol`` improvement.
         Only effective when solver='sgd' or 'adam'
 
         .. versionadded:: 0.20

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -903,7 +903,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
                  verbose=False, warm_start=False, momentum=0.9,
                  nesterovs_momentum=True, early_stopping=False,
                  validation_fraction=0.1, beta_1=0.9, beta_2=0.999,
-                 epsilon=1e-8, n_iter_no_change=10):
+                 epsilon=1e-8, n_iter_no_change=2):
 
         sup = super(MLPClassifier, self)
         sup.__init__(hidden_layer_sizes=hidden_layer_sizes,
@@ -1285,7 +1285,7 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
                  verbose=False, warm_start=False, momentum=0.9,
                  nesterovs_momentum=True, early_stopping=False,
                  validation_fraction=0.1, beta_1=0.9, beta_2=0.999,
-                 epsilon=1e-8, n_iter_no_change=10):
+                 epsilon=1e-8, n_iter_no_change=2):
 
         sup = super(MLPRegressor, self)
         sup.__init__(hidden_layer_sizes=hidden_layer_sizes,

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -622,6 +622,30 @@ def test_n_iter_no_change():
         assert_equal(clf._no_improvement_count, n_iter_no_change + 1)
 
 
+def test_n_iter_no_change_inf():
+    # test n_iter_no_change using binary data set
+    # the fitting process should go to max_iter iterations
+    X = X_digits_binary[:100]
+    y = y_digits_binary[:100]
+
+    # set a ridiculous tolerance
+    # this should always trigger _update_no_improvement_count()
+    tol = 1e9
+
+    # fit
+    n_iter_no_change = np.inf
+    max_iter = 3000
+    clf = MLPClassifier(tol=tol, max_iter=max_iter, solver='sgd',
+                        n_iter_no_change=n_iter_no_change)
+    clf.fit(X, y)
+
+    # validate n_iter_no_change doesn't cause early stopping
+    assert_equal(clf.n_iter_, max_iter)
+
+    # validate _update_no_improvement_count() was always triggered
+    assert_equal(clf._no_improvement_count, clf.n_iter_ - 1)
+
+
 def test_n_iter_no_change_fluctations():
     # test n_iter_no_change using binary data set
     # the regression fitting process is prone to loss curve fluctuations

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -644,35 +644,3 @@ def test_n_iter_no_change_inf():
 
     # validate _update_no_improvement_count() was always triggered
     assert_equal(clf._no_improvement_count, clf.n_iter_ - 1)
-
-
-def test_n_iter_no_change_fluctations():
-    # test n_iter_no_change using binary data set
-    # the regression fitting process is prone to loss curve fluctuations
-    X = X_digits_binary[:100]
-    y = y_digits_binary[:100]
-    tol = 0.01
-
-    # test multiple n_iter_no_change
-    for n_iter_no_change in [2, 5, 10, 50, 100]:
-        clf = MLPRegressor(tol=tol, max_iter=3000, solver='sgd',
-                           n_iter_no_change=n_iter_no_change)
-        clf.fit(X, y)
-
-        # calculate the loss curve derivative
-        # negative values signify an improvement
-        diff = np.diff(clf.loss_curve_)
-
-        # count iterations which do not meet the tolerance criteria
-        # reset the counter when the tolerance criteria is met
-        no_improvements = diff > -tol
-        no_improvement_count_from_losses = 0
-        for e in no_improvements:
-            if e:
-                no_improvement_count_from_losses += 1
-            else:
-                no_improvement_count_from_losses = 0
-
-        # validate n_iter_no_change
-        assert_equal(no_improvement_count_from_losses, n_iter_no_change + 1)
-        assert_equal(clf._no_improvement_count, n_iter_no_change + 1)

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -610,6 +610,7 @@ def test_n_iter_no_change():
         assert_greater(max_iter, clf.n_iter_)
 
 
+@ignore_warnings(category=ConvergenceWarning)
 def test_n_iter_no_change_inf():
     # test n_iter_no_change using binary data set
     # the fitting process should go to max_iter iterations

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -596,30 +596,17 @@ def test_n_iter_no_change():
     X = X_digits_binary[:100]
     y = y_digits_binary[:100]
     tol = 0.01
+    max_iter = 3000
 
     # test multiple n_iter_no_change
     for n_iter_no_change in [2, 5, 10, 50, 100]:
-        clf = MLPClassifier(tol=tol, max_iter=3000, solver='sgd',
+        clf = MLPClassifier(tol=tol, max_iter=max_iter, solver='sgd',
                             n_iter_no_change=n_iter_no_change)
         clf.fit(X, y)
 
-        # calculate the loss curve derivative
-        # negative values signify an improvement
-        diff = np.diff(clf.loss_curve_)
-
-        # count iterations which do not meet the tolerance criteria
-        # reset the counter when the tolerance criteria is met
-        no_improvements = diff > -tol
-        no_improvement_count_from_losses = 0
-        for e in no_improvements:
-            if e:
-                no_improvement_count_from_losses += 1
-            else:
-                no_improvement_count_from_losses = 0
-
         # validate n_iter_no_change
-        assert_equal(no_improvement_count_from_losses, n_iter_no_change + 1)
         assert_equal(clf._no_improvement_count, n_iter_no_change + 1)
+        assert_greater(max_iter, clf.n_iter_)
 
 
 def test_n_iter_no_change_inf():

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -420,6 +420,7 @@ def test_params_errors():
     assert_raises(ValueError, clf(beta_2=1).fit, X, y)
     assert_raises(ValueError, clf(beta_2=-0.5).fit, X, y)
     assert_raises(ValueError, clf(epsilon=-0.5).fit, X, y)
+    assert_raises(ValueError, clf(n_iter_no_change=-1).fit, X, y)
 
     assert_raises(ValueError, clf(solver='hadoken').fit, X, y)
     assert_raises(ValueError, clf(learning_rate='converge').fit, X, y)


### PR DESCRIPTION
#### Reference Issue
- Fixes #9456 

#### What does this implement/fix? Explain your changes.
- The ability to set/tune the limit of `self._no_improvement_count`.
- The ability to ignore `self._no_improvement_count` by setting `self.no_improvement_limit` to `np.inf`.
- `MLPRegressor` will not quit fitting unexpectedly early due to local minima or fluctuations.


#### Any other comments?
- ~~`self.no_improvement_limit` was not set as an `__init__` argument since this might cause unknown feature breaks.~~
- A magic number was removed from the code.
- Thanks for the awesome package and hard work! :)