### PR TITLE
[noWIP] Pytest doctests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PYTHON ?= python
 CYTHON ?= cython
 NOSETESTS ?= nosetests
 CTAGS ?= ctags
+PYTEST ?= pytest
 
 # skip doctests on 32bit python
 BITS := $(shell python -c 'import struct; print(8 * struct.calcsize("P"))')
@@ -37,6 +38,12 @@ ifeq ($(BITS),64)
 	$(NOSETESTS) -s -v doc/*.rst doc/modules/ doc/datasets/ \
 	doc/developers doc/tutorial/basic doc/tutorial/statistical_inference \
 	doc/tutorial/text_analytics
+endif
+
+test-doc-pytest:
+ifeq ($(BITS),64)
+	$(PYTEST) doc/modules/ doc/datasets/ \
+	doc/developers doc/tutorial/basic doc/tutorial/statistical_inference
 endif
 
 test-coverage:

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,8 @@ endif
 test-doc-pytest:
 ifeq ($(BITS),64)
 	$(PYTEST) doc/modules/ doc/datasets/ \
-	doc/developers doc/tutorial/basic doc/tutorial/statistical_inference
+	doc/developers doc/tutorial/basic doc/tutorial/statistical_inference \
+	doc/tutorial/text_analytics
 endif
 
 test-coverage:

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,7 @@ endif
 
 test-doc-pytest:
 ifeq ($(BITS),64)
-	$(PYTEST) doc/modules/ doc/datasets/ \
-	doc/developers doc/tutorial/basic doc/tutorial/statistical_inference \
-	doc/tutorial/text_analytics
+	$(PYTEST) doc/
 endif
 
 test-coverage:

--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -43,11 +43,12 @@ run_tests() {
     fi
     $TEST_CMD sklearn
 
-    # Test doc (only with nose until we switch completely to pytest)
+    # Going back to git checkout folder needed for make test-doc
+    cd $OLDPWD
     if [[ "$USE_PYTEST" != "true" ]]; then
-        # Going back to git checkout folder needed for make test-doc
-        cd $OLDPWD
         make test-doc
+    else
+        make test-doc-pytest
     fi
 }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,11 +23,14 @@ ignore-files=^setup\.py$
 #doctest-options = +ELLIPSIS,+NORMALIZE_WHITESPACE
 
 [tool:pytest]
+# add _build to default norecursedirs
+norecursedirs = .* build dist CVS _darcs {arch} *.egg venv _build
 # disable-pytest-warnings should be removed once we drop nose and we
 # rewrite tests using yield with parametrize
 addopts =
     --doctest-modules
     --disable-pytest-warnings
+    --doctest-glob='*.rst'
 
 [wheelhouse_uploader]
 artifact_indexes=

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ ignore-files=^setup\.py$
 #doctest-options = +ELLIPSIS,+NORMALIZE_WHITESPACE
 
 [tool:pytest]
-# add _build to default norecursedirs
+# add _build to default norecursedirs, as well as text tutorial sub-dirs
 norecursedirs = .* build dist CVS _darcs {arch} *.egg venv _build
 # disable-pytest-warnings should be removed once we drop nose and we
 # rewrite tests using yield with parametrize
@@ -31,6 +31,16 @@ addopts =
     --doctest-modules
     --disable-pytest-warnings
     --doctest-glob='*.rst'
+    --ignore=doc/conf.py
+    --ignore=doc/auto_examples
+    --ignore=doc/sphinxext
+    --ignore=doc/modules/generated
+    --ignore=doc/tutorial/text_analytics/solutions
+    --ignore=doc/tutorial/text_analytics/skeletons
+    --ignore=doc/tutorial/text_analytics/data
+    --ignore=doc/tutorial/machine_learning_map
+    --ignore=doc/conf.py
+
 
 [wheelhouse_uploader]
 artifact_indexes=


### PR DESCRIPTION
Starting on #9445.
Something really weird is happening with the text_analytics docs for me locally. The python files on disk **get changed** by running the tests and then they fail with ``ImportMismatchError``.
Also, it seems pytest just runs all python files, and the exercises have no ``if __name__ == "__main__"`` protection, so they fail.