### PR TITLE
ENH: new method to return all intermediate activations in MLP

### DIFF
--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -643,7 +643,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
     def _partial_fit(self, X, y):
         return self._fit(X, y, incremental=True)
 
-    def _predict(self, X):
+    def _predict_all_activations(self, X):
         """Predict using the trained model
 
         Parameters
@@ -675,8 +675,24 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
                                          layer_units[i + 1])))
         # forward propagate
         self._forward_pass(activations)
-        y_pred = activations[-1]
 
+        return activations
+
+    def _predict(self, X):
+        """Predict using the trained model
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+            The input data.
+
+        Returns
+        -------
+        y_pred : array-like, shape (n_samples,) or (n_samples, n_outputs)
+            The decision function of the samples for each class in the model.
+        """
+        activations = self._predict_all_activations(X)
+        y_pred = activations[-1]
         return y_pred
 
 

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -588,3 +588,24 @@ def test_warm_start():
                    'classes as in the previous call to fit.'
                    ' Previously got [0 1 2], `y` has %s' % np.unique(y_i))
         assert_raise_message(ValueError, message, clf.fit, X, y_i)
+
+
+def test_predict_all_activations():
+    X = Xboston
+    y = yboston
+    n_train = len(X) // 2
+    X_train = X[:n_train]
+    y_train = y[:n_train]
+    X_test = X[n_train:]
+    input_dim = X.shape[1]
+    batch_size = n_train // 4
+    hidden_sizes = [20, 10, 2]
+    for solver in ["sgd", "lbfgs"]:
+        for activation in ["relu", "identity"]:
+            mlp = MLPRegressor(solver=solver, activation=activation,
+                               random_state=1, batch_size=batch_size,
+                               hidden_layer_sizes=hidden_sizes)
+            mlp.fit(X_train, y_train)
+            activations = mlp._predict_all_activations(X_test)
+            for h, activation in zip([input_dim] + hidden_sizes, activations):
+                assert_equal(activation.shape, (n_train, h))


### PR DESCRIPTION
#### Description
The `predict` method of  `MLPRegressor` (for example) only returns the activation of the last layer (consistently with the rest of sklearn). It'd be nice to be able to get the activation of all the other (non-input) layers too ---via a new method named something like `_predict_all_activations`-- since these are computed anyways in the `_predict` method invoked by `predict`. This PR implements such a method.

This can be useful for understanding what's happening deep in the network by inspecting the features extracted by the different layers.