### PR TITLE
Fixup of linear svm separating hyperplane plot

### DIFF
--- a/examples/svm/plot_separating_hyperplane.py
+++ b/examples/svm/plot_separating_hyperplane.py
@@ -16,7 +16,7 @@ from sklearn.datasets import make_blobs
 
 
 # we create 40 separable points
-X, y = make_blobs(n_samples=40, centers=2, random_state=3)
+X, y = make_blobs(n_samples=40, centers=2, random_state=6)
 
 # fit the model, don't regularize for illustration purposes
 clf = svm.SVC(kernel='linear', C=1000)

--- a/examples/svm/plot_separating_hyperplane.py
+++ b/examples/svm/plot_separating_hyperplane.py
@@ -16,10 +16,10 @@ from sklearn.datasets import make_blobs
 
 
 # we create 40 separable points
-X, y = make_blobs(n_samples=40, centers=2, random_state=12, cluster_std=0.35)
+X, y = make_blobs(n_samples=40, centers=2, random_state=3)
 
-# fit the model
-clf = svm.SVC(kernel='linear')
+# fit the model, don't regularize for illustration purposes
+clf = svm.SVC(kernel='linear', C=1000)
 clf.fit(X, y)
 
 plt.scatter(X[:, 0], X[:, 1], c=y, s=30, cmap=plt.cm.Paired)
@@ -42,3 +42,4 @@ ax.contour(XX, YY, Z, colors='k', levels=[-1, 0, 1], alpha=0.5,
 # plot support vectors
 ax.scatter(clf.support_vectors_[:, 0], clf.support_vectors_[:, 1], s=100,
            linewidth=1, facecolors='none')
+plt.show()


### PR DESCRIPTION
Minor fixup after #8875.
We definitely need to call ``show``. The rest is more aesthetic.

before:
![image](https://user-images.githubusercontent.com/449558/28842710-ad231764-76cc-11e7-937d-9a2d48621bf2.png)
after:
![figure_1](https://user-images.githubusercontent.com/449558/28842725-b428b28a-76cc-11e7-9652-9a2c82bc3b0b.png)
