### PR TITLE
[MRG] Retain sample_weight in AdaBoosting

### DIFF
--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -119,6 +119,9 @@ def test_classification_toy_with_sample_weights():
     # show rows sum to 1
     assert_array_almost_equal(wts.sum(axis=1), np.ones(wts.shape[0]))
 
+    # show there are no zeros in the sample weights
+    assert not (wts == 0.).any()
+
 
 def test_regression_toy_with_sample_weights():
     # Check regression on a toy dataset and show we retain the
@@ -132,6 +135,10 @@ def test_regression_toy_with_sample_weights():
 
     # show rows sum to 1
     assert_array_almost_equal(wts.sum(axis=1), np.ones(wts.shape[0]))
+
+    # show there are no zeros in the sample weights
+    assert not (wts == 0.).any()
+
 
 def test_iris():
     # Check consistency on dataset iris.

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -109,33 +109,31 @@ def test_regression_toy():
 def test_classification_toy_with_sample_weights():
     # Check classification on a toy dataset and show we retain the
     # sample weights
-    n_estimators = 5
-    clf = AdaBoostClassifier(random_state=0, retain_sample_weights=True,
-                             n_estimators=n_estimators)
+    clf = AdaBoostClassifier(random_state=0, retain_sample_weights=True)
     clf.fit(X, y_class)
 
-    # assert shape is correct
+    # assert shape is correct (there will be as many rows
+    # as there are estimators)
     wts = clf.sample_weights_
-    assert wts.shape == (n_estimators, X.shape[0])
+    assert wts.shape == (len(clf.estimators_), len(X))
 
     # show rows sum to 1
-    assert_array_almost_equal(wts.sum(axis=1), np.ones(n_estimators))
+    assert_array_almost_equal(wts.sum(axis=1), np.ones(wts.shape[0]))
 
 
 def test_regression_toy_with_sample_weights():
     # Check regression on a toy dataset and show we retain the
     # sample weights
-    n_estimators = 5
-    clf = AdaBoostRegressor(random_state=0, retain_sample_weights=True,
-                            n_estimators=n_estimators)
+    clf = AdaBoostRegressor(random_state=0, retain_sample_weights=True)
     clf.fit(X, y_regr)
 
-    # assert shape is correct
+    # assert shape is correct (there will be as many rows 
+    # as there are estimators)
     wts = clf.sample_weights_
-    assert wts.shape == (n_estimators, X.shape[0])
+    assert wts.shape == (len(clf.estimators_), len(X))
 
     # show rows sum to 1
-    assert_array_almost_equal(wts.sum(axis=1), np.ones(n_estimators))
+    assert_array_almost_equal(wts.sum(axis=1), np.ones(wts.shape[0]))
 
 def test_iris():
     # Check consistency on dataset iris.

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -115,7 +115,7 @@ def test_classification_toy_with_sample_weights():
 
 
 def test_regression_toy_with_sample_weights():
-    # Check classification on a toy dataset and show we retain the
+    # Check regression on a toy dataset and show we retain the
     # sample weights
     clf = AdaBoostRegressor(random_state=0, retain_sample_weights=True)
     clf.fit(X, y_regr)

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -112,8 +112,7 @@ def test_classification_toy_with_sample_weights():
     clf = AdaBoostClassifier(random_state=0, retain_sample_weights=True)
     clf.fit(X, y_class)
 
-    # assert shape is correct (there will be as many rows
-    # as there are estimators)
+    # assert shape is correct (as many rows as there are estimators)
     wts = clf.sample_weights_
     assert wts.shape == (len(clf.estimators_), len(X))
 
@@ -127,8 +126,7 @@ def test_regression_toy_with_sample_weights():
     clf = AdaBoostRegressor(random_state=0, retain_sample_weights=True)
     clf.fit(X, y_regr)
 
-    # assert shape is correct (there will be as many rows 
-    # as there are estimators)
+    # assert shape is correct (as many rows as there are estimators)
     wts = clf.sample_weights_
     assert wts.shape == (len(clf.estimators_), len(X))
 

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -109,17 +109,33 @@ def test_regression_toy():
 def test_classification_toy_with_sample_weights():
     # Check classification on a toy dataset and show we retain the
     # sample weights
-    clf = AdaBoostClassifier(random_state=0, retain_sample_weights=True)
+    n_estimators = 5
+    clf = AdaBoostClassifier(random_state=0, retain_sample_weights=True,
+                             n_estimators=n_estimators)
     clf.fit(X, y_class)
-    assert hasattr(clf, 'sample_weights_')
+
+    # assert shape is correct
+    wts = clf.sample_weights_
+    assert wts.shape == (n_estimators, X.shape[0])
+
+    # show rows sum to 1
+    assert_array_almost_equal(wts.sum(axis=1), np.ones(n_estimators))
 
 
 def test_regression_toy_with_sample_weights():
     # Check regression on a toy dataset and show we retain the
     # sample weights
-    clf = AdaBoostRegressor(random_state=0, retain_sample_weights=True)
+    n_estimators = 5
+    clf = AdaBoostRegressor(random_state=0, retain_sample_weights=True,
+                            n_estimators=n_estimators)
     clf.fit(X, y_regr)
-    assert hasattr(clf, 'sample_weights_')
+
+    # assert shape is correct
+    wts = clf.sample_weights_
+    assert wts.shape == (n_estimators, X.shape[0])
+
+    # show rows sum to 1
+    assert_array_almost_equal(wts.sum(axis=1), np.ones(n_estimators))
 
 def test_iris():
     # Check consistency on dataset iris.

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -93,6 +93,8 @@ def test_classification_toy():
         assert_equal(clf.predict_proba(T).shape, (len(T), 2))
         assert_equal(clf.decision_function(T).shape, (len(T),))
 
+        # by default sample weights are not retained
+        assert not hasattr(clf, 'sample_weights_')
 
 def test_regression_toy():
     # Check classification on a toy dataset.
@@ -100,6 +102,24 @@ def test_regression_toy():
     clf.fit(X, y_regr)
     assert_array_equal(clf.predict(T), y_t_regr)
 
+    # by default sample weights are not retained
+    assert not hasattr(clf, 'sample_weights_')
+
+
+def test_classification_toy_with_sample_weights():
+    # Check classification on a toy dataset and show we retain the
+    # sample weights
+    clf = AdaBoostClassifier(random_state=0, retain_sample_weights=True)
+    clf.fit(X, y_class)
+    assert hasattr(clf, 'sample_weights_')
+
+
+def test_regression_toy_with_sample_weights():
+    # Check classification on a toy dataset and show we retain the
+    # sample weights
+    clf = AdaBoostRegressor(random_state=0, retain_sample_weights=True)
+    clf.fit(X, y_regr)
+    assert hasattr(clf, 'sample_weights_')
 
 def test_iris():
     # Check consistency on dataset iris.

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -172,7 +172,8 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
                 sample_weight /= sample_weight_sum
 
         if self.retain_sample_weights:
-            self.sample_weights_ = np.asarray(sample_weights_, dtype=np.float64)
+            self.sample_weights_ = np.asarray(
+                sample_weights_, dtype=np.float64)
 
         return self
 

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -131,6 +131,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         # Clear any previous fit results
         self.estimators_ = []
+        self.sample_weights_ = []
         self.estimator_weights_ = np.zeros(self.n_estimators, dtype=np.float64)
         self.estimator_errors_ = np.ones(self.n_estimators, dtype=np.float64)
 
@@ -148,6 +149,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             if sample_weight is None:
                 break
 
+            self.sample_weights_.append(sample_weight)
             self.estimator_weights_[iboost] = estimator_weight
             self.estimator_errors_[iboost] = estimator_error
 

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -130,6 +130,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         # Check parameters
         self._validate_estimator()
+        retain_weights = self.retain_sample_weights
 
         # Clear any previous fit results
         sample_weights_ = []
@@ -154,7 +155,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             self.estimator_weights_[iboost] = estimator_weight
             self.estimator_errors_[iboost] = estimator_error
 
-            if self.retain_sample_weights:
+            if retain_weights:
                 sample_weights_.append(sample_weight)
 
             # Stop if error is zero
@@ -171,7 +172,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
                 # Normalize
                 sample_weight /= sample_weight_sum
 
-        if self.retain_sample_weights:
+        if retain_weights:
             self.sample_weights_ = np.asarray(
                 sample_weights_, dtype=np.float64)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #9305 


#### What does this implement/fix? Explain your changes.
This adds an attribute to the `AdaBoostClassifier` and `AdaBoostRegressor` estimators called `sample_weights_`. It also adds a new hyper-parameter to the respective `__init__` constructors (`'retain_sample_weights'`). If `'retain_sample_weights'` is True, at each iteration in the fit procedure, the adjusted `sample_weight` will be stored in an array.

#### Any other comments?
The `sample_weights_` matrix can become quite large, so the default value for `'retain_sample_weights'` is False. The user has to consciously want to analyze the sample weights (in the case of #9305 it was a researcher needing access to the weights for a paper).

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
