### PR TITLE
[MRG] Use base.is_classifier instead of isinstance

### DIFF
--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -29,7 +29,7 @@ import numpy as np
 from numpy.core.umath_tests import inner1d
 
 from .base import BaseEnsemble
-from ..base import ClassifierMixin, RegressorMixin, is_regressor
+from ..base import ClassifierMixin, RegressorMixin, is_regressor, is_classifier
 from ..externals import six
 from ..externals.six.moves import zip
 from ..externals.six.moves import xrange as range
@@ -231,7 +231,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
         z : float
         """
         for y_pred in self.staged_predict(X):
-            if isinstance(self, ClassifierMixin):
+            if is_classifier(self):
                 yield accuracy_score(y, y_pred, sample_weight=sample_weight)
             else:
                 yield r2_score(y, y_pred, sample_weight=sample_weight)

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -18,7 +18,7 @@ import numpy as np
 import scipy.sparse as sp
 from abc import ABCMeta, abstractmethod
 from .base import BaseEstimator, clone, MetaEstimatorMixin
-from .base import RegressorMixin, ClassifierMixin
+from .base import RegressorMixin, ClassifierMixin, is_classifier
 from .model_selection import cross_val_predict
 from .utils import check_array, check_X_y, check_random_state
 from .utils.fixes import parallel_helper
@@ -152,7 +152,7 @@ class MultiOutputEstimator(six.with_metaclass(ABCMeta, BaseEstimator,
                          multi_output=True,
                          accept_sparse=True)
 
-        if isinstance(self, ClassifierMixin):
+        if is_classifier(self):
             check_classification_targets(y)
 
         if y.ndim == 1:

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -13,6 +13,7 @@ from scipy.optimize import fmin_l_bfgs_b
 import warnings
 
 from ..base import BaseEstimator, ClassifierMixin, RegressorMixin
+from ..base import is_classifier
 from ._base import ACTIVATIONS, DERIVATIVES, LOSS_FUNCTIONS
 from ._stochastic_optimizers import SGDOptimizer, AdamOptimizer
 from ..model_selection import train_test_split
@@ -268,7 +269,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
         self.n_layers_ = len(layer_units)
 
         # Output for regression
-        if not isinstance(self, ClassifierMixin):
+        if not is_classifier(self):
             self.out_activation_ = 'identity'
         # Output for multi class
         elif self._label_binarizer.y_type_ == 'multiclass':
@@ -491,7 +492,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
             X, X_val, y, y_val = train_test_split(
                 X, y, random_state=self._random_state,
                 test_size=self.validation_fraction)
-            if isinstance(self, ClassifierMixin):
+            if is_classifier(self):
                 y_val = self._label_binarizer.inverse_transform(y_val)
         else:
             X_val = None

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -6,7 +6,7 @@ from re import finditer, search
 
 from numpy.random import RandomState
 
-from sklearn.base import ClassifierMixin
+from sklearn.base import is_classifier
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.tree import export_graphviz
@@ -292,7 +292,7 @@ def test_precision():
                     len(search("\.\d+", finding.group()).group()),
                     precision + 1)
             # check impurity
-            if isinstance(clf, ClassifierMixin):
+            if is_classifier(clf):
                 pattern = "gini = \d+\.\d+"
             else:
                 pattern = "friedman_mse = \d+\.\d+"

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -29,6 +29,7 @@ from scipy.sparse import issparse
 from ..base import BaseEstimator
 from ..base import ClassifierMixin
 from ..base import RegressorMixin
+from ..base import is_classifier
 from ..externals import six
 from ..utils import check_array
 from ..utils import check_random_state
@@ -123,7 +124,7 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
 
         # Determine output settings
         n_samples, self.n_features_ = X.shape
-        is_classification = isinstance(self, ClassifierMixin)
+        is_classification = is_classifier(self)
 
         y = np.atleast_1d(y)
         expanded_class_weight = None
@@ -413,7 +414,7 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
         n_samples = X.shape[0]
 
         # Classification
-        if isinstance(self, ClassifierMixin):
+        if is_classifier(self):
             if self.n_outputs_ == 1:
                 return self.classes_.take(np.argmax(proba, axis=1), axis=0)
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -35,8 +35,8 @@ from sklearn.utils.testing import assert_dict_equal
 from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
 
 
-from sklearn.base import (clone, ClassifierMixin, RegressorMixin,
-                          TransformerMixin, ClusterMixin, BaseEstimator)
+from sklearn.base import (clone, TransformerMixin, ClusterMixin,
+                          BaseEstimator, is_classifier, is_regressor)
 from sklearn.metrics import accuracy_score, adjusted_rand_score, f1_score
 
 from sklearn.random_projection import BaseRandomProjection
@@ -208,10 +208,10 @@ def _yield_clustering_checks(name, clusterer):
 def _yield_all_checks(name, estimator):
     for check in _yield_non_meta_checks(name, estimator):
         yield check
-    if isinstance(estimator, ClassifierMixin):
+    if is_classifier(estimator):
         for check in _yield_classifier_checks(name, estimator):
             yield check
-    if isinstance(estimator, RegressorMixin):
+    if is_regressor(estimator):
         for check in _yield_regressor_checks(name, estimator):
             yield check
     if isinstance(estimator, TransformerMixin):
@@ -980,7 +980,7 @@ def check_estimators_partial_fit_n_features(name, estimator_orig):
     X -= X.min()
 
     try:
-        if isinstance(estimator, ClassifierMixin):
+        if is_classifier(estimator):
             classes = np.unique(y)
             estimator.partial_fit(X, y, classes=classes)
         else:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #9475

#### What does this implement/fix? Explain your changes.
change `isinstance(estimator, ClassifierMixin)` to use `base.is_classifier()` and `isinstance(estimator, RegressorMixin)` to use `base.is_regressor()`

#### Any other comments?
There are also occurrences of `isinstance(estimator, TransformerMixin)` and `isinstance(estimator, ClusterMixin)`. I would like to add `base.is_transformer()` and `base.is_cluster()` methods and use them instead.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
