### PR TITLE
[MRG+1] Ensures that partial_fit for sklearn.decomposition.IncrementalPCA uses float division

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,6 +11,18 @@ Version 0.20 (under development)
 Changed models
 --------------
 
+The following estimators and functions, when fit with the same data and
+parameters, may produce different models from the previous version. This often
+occurs due to changes in the modelling logic (bug fixes or enhancements), or in
+random sampling procedures.
+
+- :class:`decomposition.IncrementalPCA` (bug fix)
+
+Details are listed in the changelog below.
+
+(While we are trying to better inform users by providing this information, we
+cannot assure that this list is complete.)
+
 Changelog
 ---------
 
@@ -23,6 +35,16 @@ Classifiers and regressors
   :class:`ensemble.GradientBoostingRegressor` now support early stopping
   via ``n_iter_no_change``, ``validation_fraction`` and ``tol``. :issue:`7071`
   by `Raghav RV`_
+
+Bug fixes
+.........
+
+Decomposition, manifold learning and clustering
+
+- Fixed a bug where the ``partial_fit`` method of
+  :class:`decomposition.IncrementalPCA` used integer division instead of float
+  division on Python 2 versions. :issue:`9492` by
+  :user:`James Bourbeau <jrbourbeau>`.
 
 
 Version 0.19
@@ -160,7 +182,7 @@ Model selection and evaluation
   :issue:`8120` by `Neeraj Gangwar`_.
 
 - Added a scorer based on :class:`metrics.explained_variance_score`.
-  :issue:`9259` by `Hanmin Qin <https://github.com/qinhanmin2014>`_. 
+  :issue:`9259` by `Hanmin Qin <https://github.com/qinhanmin2014>`_.
 
 Miscellaneous
 
@@ -197,7 +219,7 @@ Trees and ensembles
   places. :issue:`8698` by :user:`Guillaume Lemaitre <glemaitre>`.
    - :func:`tree.export_graphviz` now shows configurable number of decimal
      places. :issue:`8698` by :user:`Guillaume Lemaitre <glemaitre>`.
-     
+
    - Added ``flatten_transform`` parameter to :class:`ensemble.VotingClassifier`
      to change output shape of `transform` method to 2 dimensional.
      :issue:`7794` by :user:`Ibraim Ganiev <olologin>` and
@@ -524,7 +546,7 @@ Decomposition, manifold learning and clustering
   in :class:`decomposition.PCA`,
   :class:`decomposition.RandomizedPCA` and
   :class:`decomposition.IncrementalPCA`.
-  :issue:`9105` by `Hanmin Qin <https://github.com/qinhanmin2014>`_. 
+  :issue:`9105` by `Hanmin Qin <https://github.com/qinhanmin2014>`_.
 
 - Fixed the implementation of noise_variance_ in :class:`decomposition.PCA`.
   :issue:`9108` by `Hanmin Qin <https://github.com/qinhanmin2014>`_.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -16,7 +16,7 @@ parameters, may produce different models from the previous version. This often
 occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
-- :class:`decomposition.IncrementalPCA` (bug fix)
+- :class:`decomposition.IncrementalPCA` in Python 2 (bug fix)
 
 Details are listed in the changelog below.
 

--- a/sklearn/decomposition/incremental_pca.py
+++ b/sklearn/decomposition/incremental_pca.py
@@ -4,6 +4,7 @@
 #         Giorgio Patrini
 # License: BSD 3 clause
 
+from __future__ import division
 import numpy as np
 from scipy import linalg
 
@@ -246,7 +247,7 @@ class IncrementalPCA(_BasePCA):
             X -= col_batch_mean
             # Build matrix of combined previous basis and new data
             mean_correction = \
-                np.sqrt(float(self.n_samples_seen_ * n_samples) /
+                np.sqrt((self.n_samples_seen_ * n_samples) /
                         n_total_samples) * (self.mean_ - col_batch_mean)
             X = np.vstack((self.singular_values_.reshape((-1, 1)) *
                           self.components_, X, mean_correction))

--- a/sklearn/decomposition/incremental_pca.py
+++ b/sklearn/decomposition/incremental_pca.py
@@ -246,7 +246,7 @@ class IncrementalPCA(_BasePCA):
             X -= col_batch_mean
             # Build matrix of combined previous basis and new data
             mean_correction = \
-                np.sqrt((self.n_samples_seen_ * n_samples) /
+                np.sqrt(float(self.n_samples_seen_ * n_samples) /
                         n_total_samples) * (self.mean_ - col_batch_mean)
             X = np.vstack((self.singular_values_.reshape((-1, 1)) *
                           self.components_, X, mean_correction))

--- a/sklearn/decomposition/tests/test_incremental_pca.py
+++ b/sklearn/decomposition/tests/test_incremental_pca.py
@@ -273,3 +273,17 @@ def test_whitening():
         assert_almost_equal(X, Xinv_ipca, decimal=prec)
         assert_almost_equal(X, Xinv_pca, decimal=prec)
         assert_almost_equal(Xinv_pca, Xinv_ipca, decimal=prec)
+
+
+def test_partial_fit_correct_answer():
+    # Non-regression test for issue #9489
+
+    A = np.array([[6, 7, 3], [5, 2, 1], [3, 5, 6]])
+    B = np.array([[1, 2, 4], [5, 3, 6]])
+    C = np.array([[3, 2, 1]])
+
+    ipca = IncrementalPCA(n_components=2)
+    ipca.partial_fit(A)
+    ipca.partial_fit(B)
+    # Know answer is [[-1.48864923, -3.15618645]], want to ensure
+    np.testing.assert_allclose(ipca.transform(C), [[-1.48864923, -3.15618645]])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Fixes #9489

#### What does this implement/fix? Explain your changes.

Currently the `partial_fit` method for `sklearn.decomposition.IncrementalPCA` will use integer division for Python 2 version and float division for Python 3 (see https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/decomposition/incremental_pca.py#L249). This PR ensures that float division is used for all Python versions by casting the relevant numerator to a floating-point number. 

#### Any other comments?

While casting the numerator to a float fixes issue #9489. I'm not sure if this is the preferred style, or if adding `from __future__ import division` is a better option. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
