### PR TITLE
[MRG+1] Pass sample_weight as kwargs in VotingClassifier

### DIFF
--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -279,8 +279,8 @@ def test_sample_weight_kwargs():
     """Check that VotingClassifier passes sample_weight as kwargs"""
     class MockClassifier(BaseEstimator, ClassifierMixin):
         """Mock Classifier to check that sample_weight is received as kwargs"""
-        def fit(self, X, y, *args, sample_weight=None):
-            assert_true(sample_weight is not None)
+        def fit(self, X, y, *args, **sample_weight):
+            assert_true('sample_weight' in sample_weight)
 
     clf = MockClassifier()
     eclf = VotingClassifier(estimators=[('mock', clf)], voting='soft')

--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -17,6 +17,7 @@ from sklearn.datasets import make_multilabel_classification
 from sklearn.svm import SVC
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.neighbors import KNeighborsClassifier
+from sklearn.base import BaseEstimator, ClassifierMixin
 
 
 # Load the iris dataset and randomly permute it
@@ -272,6 +273,20 @@ def test_sample_weight():
         voting='soft')
     msg = ('Underlying estimator \'knn\' does not support sample weights.')
     assert_raise_message(ValueError, msg, eclf3.fit, X, y, sample_weight)
+
+
+def test_sample_weight_kwargs():
+    """Check that VotingClassifier passes sample_weight as kwargs"""
+    class MockClassifier(BaseEstimator, ClassifierMixin):
+        """Mock Classifier to check that sample_weight is received as kwargs"""
+        def fit(self, X, y, *args, sample_weight=None):
+            assert_true(sample_weight is not None)
+
+    clf = MockClassifier()
+    eclf = VotingClassifier(estimators=[('mock', clf)], voting='soft')
+
+    # Should not raise an error.
+    eclf.fit(X, y, sample_weight=np.ones((len(y),)))
 
 
 def test_set_params():

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -23,10 +23,10 @@ from ..utils.validation import has_fit_parameter, check_is_fitted
 from ..utils.metaestimators import _BaseComposition
 
 
-def _parallel_fit_estimator(estimator, X, y, sample_weight):
+def _parallel_fit_estimator(estimator, X, y, sample_weight=None):
     """Private function used to fit an estimator within a job."""
     if sample_weight is not None:
-        estimator.fit(X, y, sample_weight)
+        estimator.fit(X, y, sample_weight=sample_weight)
     else:
         estimator.fit(X, y)
     return estimator
@@ -185,7 +185,7 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
 
         self.estimators_ = Parallel(n_jobs=self.n_jobs)(
                 delayed(_parallel_fit_estimator)(clone(clf), X, transformed_y,
-                                                 sample_weight)
+                                                 sample_weight=sample_weight)
                 for clf in clfs if clf is not None)
 
         return self


### PR DESCRIPTION
#### Reference Issue
Fixes #9474 

#### What does this implement/fix? Explain your changes.
Modified `VotingClassifier` to pass `sample_weight` as kwargs to estimators.  Current behavior is to pass `sample_weight` as a positional arg, which is inconsistent with the rest of the codebase and could cause problems if a signature of an underlying estimator changes.

#### Any other comments?
First contribution to scikit-learn, let me know if there are any best practices that I'm not following.
