### PR TITLE
[MRG+1] Ledoit-Wolf behavior explanation

### DIFF
--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -170,13 +170,13 @@ object to the same sample.
      an example on how to fit an :class:`OAS` object
      to data.
 
-   * See :ref:`sphx_glr_auto_examples_covariance_plot_Ledoit-Wolf_vs_oas.py` to visualize the
+   * See :ref:`sphx_glr_auto_examples_covariance_plot_lw_vs_oas.py` to visualize the
      Mean Squared Error difference between a :class:`LedoitWolf` and
      an :class:`OAS` estimator of the covariance.
 
 
-.. figure:: ../auto_examples/covariance/images/sphx_glr_plot_Ledoit-Wolf_vs_oas_001.png
-   :target: ../auto_examples/covariance/plot_Ledoit-Wolf_vs_oas.html
+.. figure:: ../auto_examples/covariance/images/sphx_glr_plot_lw_vs_oas_001.png
+   :target: ../auto_examples/covariance/plot_lw_vs_oas.html
    :align: center
    :scale: 75%
 

--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -109,18 +109,16 @@ It is important to note that when the number of samples is much larger than
 the number of features, one would expect that no shrinkage would be necessary.
 The intuition behind this is that if the population covariance is full rank,
 when the number of sample grows, the sample covariance will also become
-positive definite.  As a result, no shrinkage would necessary
+positive definite. As a result, no shrinkage would necessary
 and the method should automatically do this.
 
-However, this is not the case in the LW procedure when the
-population covariance is a multiple of the identity matrix.  While at
-first this might sound like an issue, it easy to see why this is not
-the case.  When the population covariance is a multiple of the
-identity, the LW shrinkage estimate becomes close or equal to 1.
-This indicates that the optimal estimate of the covariance matrix in
-the LW sense of the is multiple of the identity.  Since the population
-covariance was a multiple of the identity matrix, the LW solution is
-in deed a very good and reasonable.
+This, however, is not the case in the Ledoit-Wolf procedure when the population
+covariance happens to be a multiple of the identity matrix. In this case,
+the Ledoit-Wolf shrinkage estimate approaches 1 as the number of samples
+increases. This indicates that the optimal estimate of the covariance matrix
+in the Ledoit-Wolf sense is multiple of the identity. Since the population
+covariance is already a multiple of the identity matrix, the Ledoit-Wolf
+solution is indeed a reasonable estimate.
 
 .. topic:: Examples:
 
@@ -170,13 +168,13 @@ object to the same sample.
      an example on how to fit an :class:`OAS` object
      to data.
 
-   * See :ref:`sphx_glr_auto_examples_covariance_plot_lw_vs_oas.py` to visualize the
+   * See :ref:`sphx_glr_auto_examples_covariance_plot_Ledoit-Wolf_vs_oas.py` to visualize the
      Mean Squared Error difference between a :class:`LedoitWolf` and
      an :class:`OAS` estimator of the covariance.
 
 
-.. figure:: ../auto_examples/covariance/images/sphx_glr_plot_lw_vs_oas_001.png
-   :target: ../auto_examples/covariance/plot_lw_vs_oas.html
+.. figure:: ../auto_examples/covariance/images/sphx_glr_plot_Ledoit-Wolf_vs_oas_001.png
+   :target: ../auto_examples/covariance/plot_Ledoit-Wolf_vs_oas.html
    :align: center
    :scale: 75%
 

--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -38,7 +38,7 @@ The empirical covariance matrix of a sample can be computed using the
 whether the data are centered or not, the result will be different, so
 one may want to use the ``assume_centered`` parameter accurately. More precisely
 if one uses ``assume_centered=False``, then the test set is supposed to have the
-same mean vector as the training set. If not so, both should be centered by the 
+same mean vector as the training set. If not so, both should be centered by the
 user, and ``assume_centered=True`` should be used.
 
 .. topic:: Examples:
@@ -104,6 +104,23 @@ The Ledoit-Wolf estimator of the covariance matrix can be computed on
 a sample with the :meth:`ledoit_wolf` function of the
 `sklearn.covariance` package, or it can be otherwise obtained by
 fitting a :class:`LedoitWolf` object to the same sample.
+
+It is important to note that when the number of samples is much larger than
+the number of features, one would expect that no shrinkage would be necessary.
+The intuition behind this is that if the population covariance is full rank,
+when the number of sample grows, the sample covariance will also become
+positive definite.  As a result, no shrinkage would necessary
+and the method should automatically do this.
+
+However, this is not the case in the LW procedure when the
+population covariance is a multiple of the identity matrix.  While at
+first this might sound like an issue, it easy to see why this is not
+the case.  When the population covariance is a multiple of the
+identity, the LW shrinkage estimate becomes close or equal to 1.
+This indicates that the optimal estimate of the covariance matrix in
+the LW sense of the is multiple of the identity.  Since the population
+covariance was a multiple of the identity matrix, the LW solution is
+in deed a very good and reasonable.
 
 .. topic:: Examples:
 
@@ -334,4 +351,3 @@ ____
 
     * - |robust_vs_emp|
       - |mahalanobis|
-

--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -105,20 +105,22 @@ a sample with the :meth:`ledoit_wolf` function of the
 `sklearn.covariance` package, or it can be otherwise obtained by
 fitting a :class:`LedoitWolf` object to the same sample.
 
-It is important to note that when the number of samples is much larger than
-the number of features, one would expect that no shrinkage would be necessary.
-The intuition behind this is that if the population covariance is full rank,
-when the number of sample grows, the sample covariance will also become
-positive definite. As a result, no shrinkage would necessary
-and the method should automatically do this.
+.. note:: **Case when population covariance matrix is isotropic**
 
-This, however, is not the case in the Ledoit-Wolf procedure when the population
-covariance happens to be a multiple of the identity matrix. In this case,
-the Ledoit-Wolf shrinkage estimate approaches 1 as the number of samples
-increases. This indicates that the optimal estimate of the covariance matrix
-in the Ledoit-Wolf sense is multiple of the identity. Since the population
-covariance is already a multiple of the identity matrix, the Ledoit-Wolf
-solution is indeed a reasonable estimate.
+    It is important to note that when the number of samples is much larger than
+    the number of features, one would expect that no shrinkage would be
+    necessary. The intuition behind this is that if the population covariance
+    is full rank, when the number of sample grows, the sample covariance will
+    also become positive definite. As a result, no shrinkage would necessary
+    and the method should automatically do this.
+
+    This, however, is not the case in the Ledoit-Wolf procedure when the
+    population covariance happens to be a multiple of the identity matrix. In
+    this case, the Ledoit-Wolf shrinkage estimate approaches 1 as the number of
+    samples increases. This indicates that the optimal estimate of the
+    covariance matrix in the Ledoit-Wolf sense is multiple of the identity.
+    Since the population covariance is already a multiple of the identity
+    matrix, the Ledoit-Wolf solution is indeed a reasonable estimate.
 
 .. topic:: Examples:
 

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -179,6 +179,13 @@ def ledoit_wolf_shrinkage(X, assume_centered=False, block_size=1000):
     (1 - shrinkage)*cov
       + shrinkage * mu * np.identity(n_features)
 
+    Note that if the population covariance is a multiple of the identity
+    matrix, the Ledoit-Wolf shrinkage will tend towards 1 as n/p increases.
+    This seems counter-intuitive, as we would expect shrinkage to go to 0.
+    Because Ledoit-Wolf shrinks the covariance towards mu * np.identity,
+    this will not affect the resulting shrunken covariance matrix. Refer to
+    :ref:`User Guide <shrunk_covariance>` for further explanation.
+
     where mu = trace(cov) / n_features
 
     """
@@ -279,6 +286,13 @@ def ledoit_wolf(X, assume_centered=False, block_size=1000):
     (1 - shrinkage)*cov
       + shrinkage * mu * np.identity(n_features)
 
+    Note that if the population covariance is a multiple of the identity
+    matrix, the Ledoit-Wolf shrinkage will tend towards 1 as n/p increases.
+    This seems counter-intuitive, as we would expect shrinkage to go to 0.
+    Because Ledoit-Wolf shrinks the covariance towards mu * np.identity,
+    this will not affect the resulting shrunken covariance matrix. Refer to
+    :ref:`User Guide <shrunk_covariance>` for further explanation.
+
     where mu = trace(cov) / n_features
 
     """
@@ -357,6 +371,13 @@ class LedoitWolf(EmpiricalCovariance):
 
     where mu = trace(cov) / n_features
     and shrinkage is given by the Ledoit and Wolf formula (see References)
+
+    Note that if the population covariance is a multiple of the identity
+    matrix, the Ledoit-Wolf shrinkage will tend towards 1 as n/p increases.
+    This seems counter-intuitive, as we would expect shrinkage to go to 0.
+    Because Ledoit-Wolf shrinks the covariance towards mu * np.identity,
+    this will not affect the resulting shrunken covariance matrix. Refer to
+    :ref:`User Guide <shrunk_covariance>` for further explanation.
 
     References
     ----------
@@ -486,10 +507,10 @@ class OAS(EmpiricalCovariance):
     The formula used here does not correspond to the one given in the
     article. It has been taken from the Matlab program available from the
     authors' webpage (http://tbayes.eecs.umich.edu/yilun/covestimation).
-    In the original article, formula (23) states that 2/p is multiplied by 
+    In the original article, formula (23) states that 2/p is multiplied by
     Trace(cov*cov) in both the numerator and denominator, this operation is omitted
-    in the author's MATLAB program because for a large p, the value of 2/p is so 
-    small that it doesn't affect the value of the estimator. 
+    in the author's MATLAB program because for a large p, the value of 2/p is so
+    small that it doesn't affect the value of the estimator.
 
     Parameters
     ----------

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -179,13 +179,6 @@ def ledoit_wolf_shrinkage(X, assume_centered=False, block_size=1000):
     (1 - shrinkage)*cov
       + shrinkage * mu * np.identity(n_features)
 
-    Note that if the population covariance is a multiple of the identity
-    matrix, the Ledoit-Wolf shrinkage will tend towards 1 as n/p increases.
-    This seems counter-intuitive, as we would expect shrinkage to go to 0.
-    Because Ledoit-Wolf shrinks the covariance towards mu * np.identity,
-    this will not affect the resulting shrunken covariance matrix. Refer to
-    :ref:`User Guide <shrunk_covariance>` for further explanation.
-
     where mu = trace(cov) / n_features
 
     """
@@ -286,13 +279,6 @@ def ledoit_wolf(X, assume_centered=False, block_size=1000):
     (1 - shrinkage)*cov
       + shrinkage * mu * np.identity(n_features)
 
-    Note that if the population covariance is a multiple of the identity
-    matrix, the Ledoit-Wolf shrinkage will tend towards 1 as n/p increases.
-    This seems counter-intuitive, as we would expect shrinkage to go to 0.
-    Because Ledoit-Wolf shrinks the covariance towards mu * np.identity,
-    this will not affect the resulting shrunken covariance matrix. Refer to
-    :ref:`User Guide <shrunk_covariance>` for further explanation.
-
     where mu = trace(cov) / n_features
 
     """
@@ -371,13 +357,6 @@ class LedoitWolf(EmpiricalCovariance):
 
     where mu = trace(cov) / n_features
     and shrinkage is given by the Ledoit and Wolf formula (see References)
-
-    Note that if the population covariance is a multiple of the identity
-    matrix, the Ledoit-Wolf shrinkage will tend towards 1 as n/p increases.
-    This seems counter-intuitive, as we would expect shrinkage to go to 0.
-    Because Ledoit-Wolf shrinks the covariance towards mu * np.identity,
-    this will not affect the resulting shrunken covariance matrix. Refer to
-    :ref:`User Guide <shrunk_covariance>` for further explanation.
 
     References
     ----------

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -508,9 +508,9 @@ class OAS(EmpiricalCovariance):
     article. It has been taken from the Matlab program available from the
     authors' webpage (http://tbayes.eecs.umich.edu/yilun/covestimation).
     In the original article, formula (23) states that 2/p is multiplied by
-    Trace(cov*cov) in both the numerator and denominator, this operation is omitted
-    in the author's MATLAB program because for a large p, the value of 2/p is so
-    small that it doesn't affect the value of the estimator.
+    Trace(cov*cov) in both the numerator and denominator, this operation is
+    omitted in the author's MATLAB program because for a large p, the value
+    of 2/p is so small that it doesn't affect the value of the estimator.
 
     Parameters
     ----------


### PR DESCRIPTION

#### Reference Issue
Fixes Issue [#6482](https://github.com/scikit-learn/scikit-learn/issues/6482): Explanation of unexpected but correct behavior of Ledoit-Wolf covariance estimate. Originally raised by @clamus.


#### What does this implement/fix? Explain your changes.
The fix adds a brief explanation of some unexpected (but correct) behavior in implementations of the Ledoit-Wolf covariance estimator. The changes are to docstrings and a section of the module documenation—no implementation changes.

The estimator determines the optimal amount of shrinkage towards some multiple identity matrix for a given dataset. If the empirical covariance matrix is _already_ a multiple of the covariance matrix, the estimator will interpret the result as having a high degree of shrinkage. This behavior has no effect on the resulting matrix.

#### Any other comments?
Sorry for the typo in the branch name. Looking forward to working with you in the Fall Professor @amueller!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
