### PR TITLE
[MRG+1] Fix safe_indexing with read-only indices

### DIFF
--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -142,6 +142,8 @@ def safe_indexing(X, indices):
     not supported.
     """
     if hasattr(X, "iloc"):
+        # Work-around for indexing with read-only indices in pandas
+        indices = indices if indices.flags.writeable else indices.copy()
         # Pandas Dataframes and Series
         try:
             return X.iloc[indices]

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -1,4 +1,4 @@
-from itertools import chain
+from itertools import chain, product
 import warnings
 
 import numpy as np
@@ -200,10 +200,15 @@ def test_safe_indexing_pandas():
     # this happens in joblib memmapping
     X.setflags(write=False)
     X_df_readonly = pd.DataFrame(X)
-    with warnings.catch_warnings(record=True):
-        X_df_ro_indexed = safe_indexing(X_df_readonly, inds)
+    inds_readonly = inds.copy()
+    inds_readonly.setflags(write=False)
 
-    assert_array_equal(np.array(X_df_ro_indexed), X_indexed)
+    for this_df, this_inds in product([X_df, X_df_readonly],
+                                      [inds, inds_readonly]):
+        with warnings.catch_warnings(record=True):
+            X_df_indexed = safe_indexing(this_df, this_inds)
+
+        assert_array_equal(np.array(X_df_indexed), X_indexed)
 
 
 def test_safe_indexing_mock_pandas():


### PR DESCRIPTION
Fix #9483.

`DataFrame.iloc` has problems when read-only arrays are passed into it. 

Here is a simplified snippet (from https://github.com/scikit-learn/scikit-learn/issues/9483#issuecomment-320662377):

```py
import numpy as np
import pandas as pd

df = pd.DataFrame({'first': np.ones(100, dtype='float64')})
indices = np.array([1, 3, 6])
indices.flags.writeable = False
df.iloc[indices]
```

<details>
<summary>Stack-trace</summary>

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-1-a32cbf97fa72> in <module>()
      5 indices = np.array([1, 3, 6])
      6 indices.flags.writeable = False
----> 7 df.iloc[indices]

~/miniconda3/lib/python3.6/site-packages/pandas/core/indexing.py in __getitem__(self, key)
   1326         else:
   1327             key = com._apply_if_callable(key, self.obj)
-> 1328             return self._getitem_axis(key, axis=0)
   1329 
   1330     def _is_scalar_access(self, key):

~/miniconda3/lib/python3.6/site-packages/pandas/core/indexing.py in _getitem_axis(self, key, axis)
   1736         # a list of integers
   1737         elif is_list_like_indexer(key):
-> 1738             return self._get_list_axis(key, axis=axis)
   1739 
   1740         # a single integer

~/miniconda3/lib/python3.6/site-packages/pandas/core/indexing.py in _get_list_axis(self, key, axis)
   1713         """
   1714         try:
-> 1715             return self.obj.take(key, axis=axis, convert=False)
   1716         except IndexError:
   1717             # re-raise with different error message

~/miniconda3/lib/python3.6/site-packages/pandas/core/generic.py in take(self, indices, axis, convert, is_copy, **kwargs)
   1926         new_data = self._data.take(indices,
   1927                                    axis=self._get_block_manager_axis(axis),
-> 1928                                    convert=True, verify=True)
   1929         result = self._constructor(new_data).__finalize__(self)
   1930 

~/miniconda3/lib/python3.6/site-packages/pandas/core/internals.py in take(self, indexer, axis, verify, convert)
   4009         new_labels = self.axes[axis].take(indexer)
   4010         return self.reindex_indexer(new_axis=new_labels, indexer=indexer,
-> 4011                                     axis=axis, allow_dups=True)
   4012 
   4013     def merge(self, other, lsuffix='', rsuffix=''):

~/miniconda3/lib/python3.6/site-packages/pandas/core/internals.py in reindex_indexer(self, new_axis, indexer, axis, fill_value, allow_dups, copy)
   3895             new_blocks = [blk.take_nd(indexer, axis=axis, fill_tuple=(
   3896                 fill_value if fill_value is not None else blk.fill_value,))
-> 3897                 for blk in self.blocks]
   3898 
   3899         new_axes = list(self.axes)

~/miniconda3/lib/python3.6/site-packages/pandas/core/internals.py in <listcomp>(.0)
   3895             new_blocks = [blk.take_nd(indexer, axis=axis, fill_tuple=(
   3896                 fill_value if fill_value is not None else blk.fill_value,))
-> 3897                 for blk in self.blocks]
   3898 
   3899         new_axes = list(self.axes)

~/miniconda3/lib/python3.6/site-packages/pandas/core/internals.py in take_nd(self, indexer, axis, new_mgr_locs, fill_tuple)
   1044             fill_value = fill_tuple[0]
   1045             new_values = algos.take_nd(values, indexer, axis=axis,
-> 1046                                        allow_fill=True, fill_value=fill_value)
   1047 
   1048         if new_mgr_locs is None:

~/miniconda3/lib/python3.6/site-packages/pandas/core/algorithms.py in take_nd(arr, indexer, axis, out, fill_value, mask_info, allow_fill)
   1469     func = _get_take_nd_function(arr.ndim, arr.dtype, out.dtype, axis=axis,
   1470                                  mask_info=mask_info)
-> 1471     func(arr, indexer, out, fill_value)
   1472 
   1473     if flip_order:

pandas/_libs/algos_take_helper.pxi in pandas._libs.algos.take_2d_axis0_float64_float64 (pandas/_libs/algos.c:110417)()

~/miniconda3/lib/python3.6/site-packages/pandas/_libs/algos.cpython-36m-x86_64-linux-gnu.so in View.MemoryView.memoryview_cwrapper (pandas/_libs/algos.c:124730)()

~/miniconda3/lib/python3.6/site-packages/pandas/_libs/algos.cpython-36m-x86_64-linux-gnu.so in View.MemoryView.memoryview.__cinit__ (pandas/_libs/algos.c:120965)()

ValueError: buffer source array is read-only
```

</details>