### PR TITLE
[MRG] enable appveyor fast_finish mode

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,13 @@ environment:
       PYTHON_ARCH: "64"
 
 
+# Because we only have a single worker, we don't want to waste precious
+# appveyor CI time and make other PRs wait for repeated failures in a failing
+# PR. The following option cancels pending jobs in a given PR after the first
+# job failure in that specific PR.
+matrix:
+    fast_finish: true
+
 
 install:
   # If there is a newer build queued for the same PR, cancel this one.


### PR DESCRIPTION
Because we only have a single worker, we don't want to waste precious appveyor CI time and make other PRs wait for repeated failures in a failing PR. The following option cancels pending jobs in a given PR after the first job failure in that specific PR.

Note that once we switch the appveyor tests to pytest we could also enable the `-x=5` flag to fail the job as soon as we get 5 failed tests in a given job and furthermore enable the `pytest-timeout` plugin to `--timeout=30` to fail any indiviual test that takes more than 30 second to execute.