### PR TITLE
Fix typos

### DIFF
--- a/examples/cluster/plot_agglomerative_clustering_metrics.py
+++ b/examples/cluster/plot_agglomerative_clustering_metrics.py
@@ -73,7 +73,7 @@ n_clusters = 3
 
 labels = ('Waveform 1', 'Waveform 2', 'Waveform 3')
 
-# Plot the ground-truth labelling
+# Plot the ground-truth labeling
 plt.figure()
 plt.axes([0, 0, 1, 1])
 for l, c, n in zip(range(n_clusters), 'rgb',

--- a/sklearn/cluster/_k_means_elkan.pyx
+++ b/sklearn/cluster/_k_means_elkan.pyx
@@ -5,7 +5,7 @@
 #
 # Author: Andreas Mueller
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 import numpy as np
 cimport numpy as np

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -248,7 +248,7 @@ def test_ward_agglomeration():
     assert_raises(ValueError, agglo.fit, X[:0])
 
 
-def assess_same_labelling(cut1, cut2):
+def assess_same_labeling(cut1, cut2):
     """Util for comparison with scipy"""
     co_clust = []
     for cut in [cut1, cut2]:
@@ -281,7 +281,7 @@ def test_scikit_vs_scipy():
 
             cut = _hc_cut(k, children, n_leaves)
             cut_ = _hc_cut(k, children_, n_leaves)
-            assess_same_labelling(cut, cut_)
+            assess_same_labeling(cut, cut_)
 
     # Test error management in _hc_cut
     assert_raises(ValueError, _hc_cut, n_leaves + 1, children, n_leaves)

--- a/sklearn/linear_model/sag_fast.pyx
+++ b/sklearn/linear_model/sag_fast.pyx
@@ -263,7 +263,7 @@ def sag(SequentialDataset dataset,
     cdef int *x_ind_ptr = NULL
     # the number of non-zero features for current sample
     cdef int xnnz = -1
-    # the label value for curent sample
+    # the label value for current sample
     cdef double y
     # the sample weight
     cdef double sample_weight

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -645,7 +645,7 @@ def adjusted_mutual_info_score(labels_true, labels_pred):
     -------
     ami: float(upperlimited by 1.0)
        The AMI returns a value of 1 when the two partitions are identical
-       (ie perfectly matched). Random partitions (independent labellings) have
+       (ie perfectly matched). Random partitions (independent labelings) have
        an expected AMI around 0 on average hence can be negative.
 
     See also


### PR DESCRIPTION
This PR fixes some typos: `labelling`, `Licence`, and `curent`.