### PR TITLE
[MRG + 1] Improve the output of example plot_iris.py after matplotlib2.0

### DIFF
--- a/examples/tree/plot_iris.py
+++ b/examples/tree/plot_iris.py
@@ -48,7 +48,7 @@ for pairidx, pair in enumerate([[0, 1], [0, 2], [0, 3],
 
     Z = clf.predict(np.c_[xx.ravel(), yy.ravel()])
     Z = Z.reshape(xx.shape)
-    cs = plt.contourf(xx, yy, Z, cmap=plt.cm.Paired)
+    cs = plt.contourf(xx, yy, Z, cmap=plt.cm.RdYlBu)
 
     plt.xlabel(iris.feature_names[pair[0]])
     plt.ylabel(iris.feature_names[pair[1]])

--- a/examples/tree/plot_iris.py
+++ b/examples/tree/plot_iris.py
@@ -22,7 +22,7 @@ from sklearn.tree import DecisionTreeClassifier
 
 # Parameters
 n_classes = 3
-plot_colors = "bry"
+plot_colors = "ryb"
 plot_step = 0.02
 
 # Load data
@@ -44,6 +44,7 @@ for pairidx, pair in enumerate([[0, 1], [0, 2], [0, 3],
     y_min, y_max = X[:, 1].min() - 1, X[:, 1].max() + 1
     xx, yy = np.meshgrid(np.arange(x_min, x_max, plot_step),
                          np.arange(y_min, y_max, plot_step))
+    plt.tight_layout(h_pad=0.5, w_pad=0.5, pad=2.5)
 
     Z = clf.predict(np.c_[xx.ravel(), yy.ravel()])
     Z = Z.reshape(xx.shape)
@@ -51,16 +52,14 @@ for pairidx, pair in enumerate([[0, 1], [0, 2], [0, 3],
 
     plt.xlabel(iris.feature_names[pair[0]])
     plt.ylabel(iris.feature_names[pair[1]])
-    plt.axis("tight")
 
     # Plot the training points
     for i, color in zip(range(n_classes), plot_colors):
         idx = np.where(y == i)
         plt.scatter(X[idx, 0], X[idx, 1], c=color, label=iris.target_names[i],
-                    cmap=plt.cm.Paired)
-
-    plt.axis("tight")
+                    cmap=plt.cm.RdYlBu, edgecolor='black', s=15)
 
 plt.suptitle("Decision surface of a decision tree using paired features")
-plt.legend()
+plt.legend(loc='lower right', borderpad=0, handletextpad=0)
+plt.axis("tight")
 plt.show()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
part of #8364 
note that the plot in 0.18(before matplotlib2.0) is also not good so I also modify some other things

#### What does this implement/fix? Explain your changes.
Below are the results from Circle CI
new version:
![sphx_glr_plot_iris_0011](https://user-images.githubusercontent.com/12003569/29250469-7639b39a-8075-11e7-886e-e971093a09a7.png)
old version in 0.19/dev:
![sphx_glr_plot_iris_0012](https://user-images.githubusercontent.com/12003569/29250470-80c23a80-8075-11e7-8f35-6392dd1f8a4a.png)
old version in 0.18:
![sphx_glr_plot_iris_0013](https://user-images.githubusercontent.com/12003569/29250473-898e197c-8075-11e7-8301-e31e61b924f5.png)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
