### PR TITLE
[MRG+1] Avoid occasional failure of test_kernel_ridge_singular_kernel

### DIFF
--- a/sklearn/tests/test_kernel_ridge.py
+++ b/sklearn/tests/test_kernel_ridge.py
@@ -10,7 +10,7 @@ from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_array_almost_equal
 
 
-X, y = make_regression(n_features=10)
+X, y = make_regression(n_features=10, random_state=0)
 Xcsr = sp.csr_matrix(X)
 Xcsc = sp.csc_matrix(X)
 Y = np.array([y, y]).T


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #9535 

#### What does this implement/fix? Explain your changes.
I'll try to only add a random state to ensure a certain output of the test.
From my perspective, it's enough if CIs are green.
Kindly tell me if we need to reduce the decimal requirement of assert_array_almost_equal.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
