### PR TITLE
Update StatLib database URL

### DIFF
--- a/sklearn/datasets/california_housing.py
+++ b/sklearn/datasets/california_housing.py
@@ -2,7 +2,7 @@
 
 The original database is available from StatLib
 
-    http://lib.stat.cmu.edu/
+    http://lib.stat.cmu.edu/datasets/
 
 The data contains 20,640 observations on 9 variables.
 


### PR DESCRIPTION
Fixes StatLib database URL; the previous (root) URL responds with: `mysql://��:@localhost/nuke failed to connectAccess denied for user '��'@'localhost' (using password: YES)` 