### PR TITLE
[WIP] Speed up calculation of MAE when updating tree splits #9553

### DIFF
--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1282,25 +1282,11 @@ cdef class MAE(RegressionCriterion):
         impurity_right[0] = 0.0
 
         for k in range(self.n_outputs):
-            median = (<WeightedMedianCalculator> left_child[k]).get_median()
-            for p in range(start, pos):
-                i = samples[p]
-
-                y_ik = y[i * self.y_stride + k]
-
-                impurity_left[0] += <double>fabs((<double> y_ik) -
-                                                 <double> median)
+            impurity_left[0] += (<WeightedMedianCalculator> left_child[k]).mae
         impurity_left[0] /= <double>((self.weighted_n_left) * self.n_outputs)
 
         for k in range(self.n_outputs):
-            median = (<WeightedMedianCalculator> right_child[k]).get_median()
-            for p in range(pos, end):
-                i = samples[p]
-
-                y_ik = y[i * self.y_stride + k]
-
-                impurity_right[0] += <double>fabs((<double> y_ik) -
-                                                  <double> median)
+            impurity_right[0] += (<WeightedMedianCalculator> left_child[k]).mae
         impurity_right[0] /= <double>((self.weighted_n_right) *
                                       self.n_outputs)
 

--- a/sklearn/tree/_utils.pxd
+++ b/sklearn/tree/_utils.pxd
@@ -154,6 +154,7 @@ cdef class WeightedMedianCalculator:
     cdef SIZE_t k
     cdef DOUBLE_t sum_w_0_k            # represents sum(weights[0:k])
                                        # = w[0] + w[1] + ... + w[k-1]
+    cdef DOUBLE_t mae  # mean absolute error of median
 
     cdef SIZE_t size(self) nogil
     cdef int push(self, DOUBLE_t data, DOUBLE_t weight) nogil except -1
@@ -161,9 +162,18 @@ cdef class WeightedMedianCalculator:
     cdef int update_median_parameters_post_push(
         self, DOUBLE_t data, DOUBLE_t weight,
         DOUBLE_t original_median) nogil
+    cdef int update_mae_post_push(
+        self, DOUBLE_t data, DOUBLE_t weight,
+        DOUBLE_t original_median, int original_k) nogil
     cdef int remove(self, DOUBLE_t data, DOUBLE_t weight) nogil
     cdef int pop(self, DOUBLE_t* data, DOUBLE_t* weight) nogil
     cdef int update_median_parameters_post_remove(
         self, DOUBLE_t data, DOUBLE_t weight,
         DOUBLE_t original_median) nogil
+    cdef int update_mae_post_remove(
+        self, DOUBLE_t data, DOUBLE_t weight,
+        DOUBLE_t original_median, int original_k) nogil
+    cdef int update_mae_post_change(
+        self, DOUBLE_t data, DOUBLE_t weight, DOUBLE_t original_median,
+        int original_k, int shift_from_change) nogil
     cdef DOUBLE_t get_median(self) nogil


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #9553

#### What does this implement/fix? Explain your changes.
Modifies the MAE criterion and the WeightedMedianCalculator so that the median is updated in basically constant time each time a push or remove occurs, rather than re-computing the median from scratch every time the split is updated.

#### Any other comments?
This is a work in progress. Right now everything *should* be implemented and isn't crashing, but the code is scaling the same as it was before the change, for unknown reasons.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
