### PR TITLE
[MRG] Makes roc_auc_score and average_precision_score docstrings more explicit

### DIFF
--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -440,8 +440,8 @@ def roc_curve(y_true, y_score, pos_label=None, sample_weight=None,
     ----------
 
     y_true : array, shape = [n_samples]
-        True binary labels (either {0, 1} or {-1, 1}). If labels are not
-        binary, pos_label should be explicitly given.
+        True binary labels. If labels are not either {-1, 1} or {0, 1}, then
+        pos_label should be explicitly given.
 
     y_score : array, shape = [n_samples]
         Target scores, can either be probability estimates of the positive

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -440,7 +440,7 @@ def roc_curve(y_true, y_score, pos_label=None, sample_weight=None,
     ----------
 
     y_true : array, shape = [n_samples]
-        True binary labels in range {0, 1} or {-1, 1}.  If labels are not
+        True binary labels (either {0, 1} or {-1, 1}). If labels are not
         binary, pos_label should be explicitly given.
 
     y_score : array, shape = [n_samples]

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -116,7 +116,8 @@ def average_precision_score(y_true, y_score, average="macro",
     Parameters
     ----------
     y_true : array, shape = [n_samples] or [n_samples, n_classes]
-        True binary labels in binary label indicators.
+        True binary labels (either {0, 1} or {-1, 1}) or binary label
+        indicators.
 
     y_score : array, shape = [n_samples] or [n_samples, n_classes]
         Target scores, can either be probability estimates of the positive
@@ -200,7 +201,8 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
     Parameters
     ----------
     y_true : array, shape = [n_samples] or [n_samples, n_classes]
-        True binary labels in binary label indicators.
+        True binary labels (either {0, 1} or {-1, 1}) or binary label
+        indicators.
 
     y_score : array, shape = [n_samples] or [n_samples, n_classes]
         Target scores, can either be probability estimates of the positive

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -116,8 +116,7 @@ def average_precision_score(y_true, y_score, average="macro",
     Parameters
     ----------
     y_true : array, shape = [n_samples] or [n_samples, n_classes]
-        True binary labels (either {0, 1} or {-1, 1}) or binary label
-        indicators.
+        True binary labels (either {0, 1} or {-1, 1}).
 
     y_score : array, shape = [n_samples] or [n_samples, n_classes]
         Target scores, can either be probability estimates of the positive
@@ -201,8 +200,7 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
     Parameters
     ----------
     y_true : array, shape = [n_samples] or [n_samples, n_classes]
-        True binary labels (either {0, 1} or {-1, 1}) or binary label
-        indicators.
+        True binary labels (either {0, 1} or {-1, 1}).
 
     y_score : array, shape = [n_samples] or [n_samples, n_classes]
         Target scores, can either be probability estimates of the positive


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Fixes issue #9554

#### What does this implement/fix? Explain your changes.

Changes the description of the `y_true` parameter for `metrics.roc_auc_score`
and `metrics.average_precision_score` to be slightly more explicit about 
the allowed values. This is more in line with the `metrics.roc_curve` and 
`metrics.precision_recall_curve` description of `y_true`. Specifically, this PR 
makes the following modification.  

Current description:
`True binary labels in binary label indicators.`

Modified description:
`True binary labels (either {0, 1} or {-1, 1}) or binary label indicators.`

This could help with avoid confusion in situations like the following

```python
from sklearn.metrics import roc_auc_score
import numpy as np

y_true = np.array([-1, -1, 0, 0])
y_scores = np.array([0.1, 0.4, 0.35, 0.8])
roc_auc_score(y_true, y_scores)
```

which yields
 
```python
ValueError: Data is not binary and pos_label is not specified
```

Even though there are only two unique classes in `y_true`. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
