### PR TITLE
Allow instances of derived classes from joblib.Memory in cluster.hierarchy

### DIFF
--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -698,11 +698,11 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
             memory = Memory(cachedir=None, verbose=0)
         elif isinstance(memory, six.string_types):
             memory = Memory(cachedir=memory, verbose=0)
-        elif not isinstance(memory, Memory):
+        elif not issubclass(type(memory), Memory):
             raise ValueError("'memory' should either be a string or"
-                             " a sklearn.externals.joblib.Memory"
-                             " instance, got 'memory={!r}' instead.".format(
-                                 type(memory)))
+                             " an instance of sklearn.externals.joblib.Memory"
+                             " (or a derived class), got"
+                             " 'memory={!r}' instead.".format(type(memory)))
 
         if self.n_clusters <= 0:
             raise ValueError("n_clusters should be an integer greater than 0."


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
This change fixes an error reported in librosa: https://github.com/librosa/librosa/issues/614 .  


#### What does this implement/fix? Explain your changes.

The summary of the error is that librosa extends the `Memory` class to add some additional bookkeeping, and we'd like to allow instances of that derived class to function within `sklearn`.  The `isinstance` check added in v0.19 makes this impossible.  However, if we replace the `isinstance(memory, Memory)` check by a more permissive subclass check `issubclass(type(memory), Memory)`, then it should still function properly.

#### Any other comments?

I understand that this is a rather strange modification, so I'm open to argument about whether such behavior should be supported.  Are there arguments for why a strict type test is necessary here?

If folks think this is worth including, I'm happy to implement this change elsewhere in the package (ie, `pipeline`, `linear_model/randomized_l1`).

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
