### PR TITLE
[MRG] Updates LogisticRegressionCV to use get_scorer

### DIFF
--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -34,7 +34,7 @@ from ..utils.multiclass import check_classification_targets
 from ..externals.joblib import Parallel, delayed
 from ..model_selection import check_cv
 from ..externals import six
-from ..metrics import SCORERS
+from ..metrics import get_scorer
 
 
 # .. some helper functions for logistic_regression_path ..
@@ -941,7 +941,7 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
     scores = list()
 
     if isinstance(scoring, six.string_types):
-        scoring = SCORERS[scoring]
+        scoring = get_scorer(scoring)
     for w in coefs:
         if multi_class == 'ovr':
             w = w[np.newaxis, :]

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -75,6 +75,11 @@ def test_error():
     assert_raise_message(ValueError, msg,
                          LogisticRegression(C="test").fit, X, Y1)
 
+    msg = "is not a valid scoring value"
+    assert_raise_message(ValueError, msg,
+                         LogisticRegressionCV(scoring='bad-scorer',cv=2).fit,
+                         X, Y1)
+
     for LR in [LogisticRegression, LogisticRegressionCV]:
         msg = "Tolerance for stopping criteria must be positive"
         assert_raise_message(ValueError, msg, LR(tol=-1).fit, X, Y1)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -77,7 +77,7 @@ def test_error():
 
     msg = "is not a valid scoring value"
     assert_raise_message(ValueError, msg,
-                         LogisticRegressionCV(scoring='bad-scorer',cv=2).fit,
+                         LogisticRegressionCV(scoring='bad-scorer', cv=2).fit,
                          X, Y1)
 
     for LR in [LogisticRegression, LogisticRegressionCV]:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Fixes #9564

#### What does this implement/fix? Explain your changes.

Updates `linear_model.LogisticRegressionCV` to use the `metrics.get_scorer` function instead of the currently used `metrics.SCORERS` dictionary to get scoring metric callables. 

#### Any other comments?

This PR also adds a test to check that a reasonable error message is being raised when an invalid value is passed to the `scoring` parameter in `LogisticRegressionCV`

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
