### PR TITLE
[WIP] Sample property routing

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1367,6 +1367,7 @@ Low-level methods
    utils.estimator_checks.check_estimator
    utils.extmath.safe_sparse_dot
    utils.indexable
+   utils.metaestimators.check_routing
    utils.resample
    utils.safe_indexing
    utils.shuffle

--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -40,7 +40,7 @@ is an estimator object::
     >>> estimators = [('reduce_dim', PCA()), ('clf', SVC())]
     >>> pipe = Pipeline(estimators)
     >>> pipe # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
-    Pipeline(memory=None,
+    Pipeline(memory=None, prop_routing=None,
              steps=[('reduce_dim', PCA(copy=True,...)),
                     ('clf', SVC(C=1.0,...))])
 
@@ -53,7 +53,7 @@ filling in the names automatically::
     >>> from sklearn.naive_bayes import MultinomialNB
     >>> from sklearn.preprocessing import Binarizer
     >>> make_pipeline(Binarizer(), MultinomialNB()) # doctest: +NORMALIZE_WHITESPACE
-    Pipeline(memory=None,
+    Pipeline(memory=None, prop_routing=None,
              steps=[('binarizer', Binarizer(copy=True, threshold=0.0)),
                     ('multinomialnb', MultinomialNB(alpha=1.0,
                                                     class_prior=None,
@@ -75,7 +75,7 @@ Parameters of the estimators in the pipeline can be accessed using the
 ``<estimator>__<parameter>`` syntax::
 
     >>> pipe.set_params(clf__C=10) # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
-    Pipeline(memory=None,
+    Pipeline(memory=None, prop_routing=None,
              steps=[('reduce_dim', PCA(copy=True, iterated_power='auto',...)),
                     ('clf', SVC(C=10, cache_size=200, class_weight=None,...))])
 

--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -171,7 +171,7 @@ object::
      >>> pipe = Pipeline([('reduce_dim', pca1), ('clf', svm1)])
      >>> pipe.fit(digits.data, digits.target)
      ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
-     Pipeline(memory=None,
+     Pipeline(memory=None, prop_routing=None,
               steps=[('reduce_dim', PCA(...)), ('clf', SVC(...))])
      >>> # The pca instance can be inspected directly
      >>> print(pca1.components_) # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -436,6 +436,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                              "and the estimator doesn't provide one %s"
                              % self.best_estimator_)
         score = self.scorer_[self.refit] if self.multimetric_ else self.scorer_
+        # TODO: sample props
         return score(self.best_estimator_, X, y)
 
     def _check_is_fitted(self, method_name):
@@ -612,15 +613,10 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             refit_metric = 'score'
 
         router = check_routing(self.prop_routing,
-                               {'groups': ('cv', '*'),
-                                '*': ('estimator', '*'),
-                                # FIXME: That line should be more like
-                                #        '*-groups': ('estimator', '*')
-                                #        to except groups.
-                                #        Not currently handled by _Router.
-                                })
-        (fit_props, cv_props, score_props), remainder = \
-            router(props, ['estimator', 'cv', 'scoring'])
+                               ['estimator', 'cv', 'scoring'],
+                               {'cv': 'groups',
+                                'estimator': '-groups'})
+        (fit_props, cv_props, score_props), remainder = router(props)
 
         if remainder:
             raise ValueError('Unhandled sample properties: %r'

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -926,8 +926,8 @@ class GridSearchCV(BaseSearchCV):
                          random_state=None, shrinking=True, tol=...,
                          verbose=False),
            fit_params=None, iid=..., n_jobs=1,
-           param_grid=..., pre_dispatch=..., refit=..., return_train_score=...,
-           scoring=..., verbose=...)
+           param_grid=..., pre_dispatch=..., prop_routing=..., refit=...,
+           return_train_score=..., scoring=..., verbose=...)
     >>> sorted(clf.cv_results_.keys())
     ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     ['mean_fit_time', 'mean_score_time', 'mean_test_score',...

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -101,7 +101,7 @@ class Pipeline(_BaseComposition):
     >>> # and a parameter 'C' of the svm
     >>> anova_svm.set_params(anova__k=10, svc__C=.1).fit(X, y)
     ...                      # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-    Pipeline(memory=None,
+    Pipeline(memory=None, prop_routing=None,
              steps=[('anova', SelectKBest(...)),
                     ('svc', SVC(...))])
     >>> prediction = anova_svm.predict(X)
@@ -588,7 +588,7 @@ def make_pipeline(*steps, **kwargs):
     >>> from sklearn.preprocessing import StandardScaler
     >>> make_pipeline(StandardScaler(), GaussianNB(priors=None))
     ...     # doctest: +NORMALIZE_WHITESPACE
-    Pipeline(memory=None,
+    Pipeline(memory=None, prop_routing=None,
              steps=[('standardscaler',
                      StandardScaler(copy=True, with_mean=True, with_std=True)),
                     ('gaussiannb', GaussianNB(priors=None))])

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -81,8 +81,8 @@ class Transf(NoInvTransf):
 
 class TransfFitParams(Transf):
 
-    def fit(self, X, y, **fit_params):
-        self.fit_params = fit_params
+    def fit(self, X, y, **props):
+        self.props = props
         return self
 
 
@@ -224,7 +224,7 @@ def test_pipeline_methods_anova():
     pipe.score(X, y)
 
 
-def test_pipeline_fit_params():
+def test_pipeline_props():
     # Test that the pipeline can take fit parameters
     pipe = Pipeline([('transf', Transf()), ('clf', FitParamT())])
     pipe.fit(X=None, y=None, clf__should_succeed=True)
@@ -371,17 +371,17 @@ def test_fit_predict_on_pipeline_without_fit_predict():
                         getattr, pipe, 'fit_predict')
 
 
-def test_fit_predict_with_intermediate_fit_params():
-    # tests that Pipeline passes fit_params to intermediate steps
+def test_fit_predict_with_intermediate_props():
+    # tests that Pipeline passes props to intermediate steps
     # when fit_predict is invoked
     pipe = Pipeline([('transf', TransfFitParams()), ('clf', FitParamT())])
     pipe.fit_predict(X=None,
                      y=None,
                      transf__should_get_this=True,
                      clf__should_succeed=True)
-    assert_true(pipe.named_steps['transf'].fit_params['should_get_this'])
+    assert_true(pipe.named_steps['transf'].props['should_get_this'])
     assert_true(pipe.named_steps['clf'].successful)
-    assert_false('should_succeed' in pipe.named_steps['transf'].fit_params)
+    assert_false('should_succeed' in pipe.named_steps['transf'].props)
 
 
 def test_feature_union():
@@ -555,6 +555,7 @@ def test_set_pipeline_step_none():
                        'm3': None,
                        'last': mult5,
                        'memory': None,
+                       'routing': None,
                        'm2__mult': 2,
                        'last__mult': 5,
                        })

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -239,6 +239,35 @@ def test_pipeline_props():
         "fit() got an unexpected keyword argument 'bad'",
         pipe.fit, None, None, clf__bad=True
     )
+    # Unknown step
+    assert_raise_message(
+        TypeError,
+        "fit() got unexpected keyword arguments ['foo__bar']",
+        pipe.fit, None, None, foo__bar=True
+    )
+
+
+def test_pipeline_prop_routing():
+    pipe = Pipeline([('transf', Transf()), ('clf', FitParamT())],
+                    prop_routing={'clf': ['should_succeed', 'bad']})
+    pipe.fit(X=None, y=None, should_succeed=True)
+    # classifier should return True
+    assert_true(pipe.predict(None))
+    # and transformer params should not be changed
+    assert_true(pipe.named_steps['transf'].a is None)
+    assert_true(pipe.named_steps['transf'].b is None)
+    # invalid parameters should raise an error message
+    assert_raise_message(
+        TypeError,
+        "fit() got an unexpected keyword argument 'bad'",
+        pipe.fit, None, None, bad=True
+    )
+    assert_raise_message(
+        TypeError,
+        "fit() got unexpected keyword arguments ['stuff']",
+        pipe.fit, None, None, stuff=True
+    )
+    # TODO: test '*'
 
 
 def test_pipeline_sample_weight_supported():
@@ -555,7 +584,7 @@ def test_set_pipeline_step_none():
                        'm3': None,
                        'last': mult5,
                        'memory': None,
-                       'routing': None,
+                       'prop_routing': None,
                        'm2__mult': 2,
                        'last__mult': 5,
                        })

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -287,7 +287,7 @@ class _Router:
         - a list of property names to include
         - a list of property names, each prefixed by '-', to exclude; all
           others will be provided
-        - a single identifier to include or exclude
+        - a single name to include or exclude
         - a dict mapping each target property name to its source property name
 
     dests : list of {str, iterable of str}
@@ -398,11 +398,11 @@ def check_routing(routing, dests, default=None):
         Maps each destination string to the properties that should be provided
         to that destination. Props may be:
 
-        - '*': provide all properties
+        - ``'*'``: provide all properties
         - a list of property names to include
-        - a list of property names, each prefixed by '-', to exclude; all
+        - a list of property names, each prefixed by ``-``, to exclude; all
           others will be provided
-        - a single identifier to include or exclude
+        - a single name to include or exclude (prefixed by ``-``)
         - a dict mapping each target property name to its source property name
 
     dests : list of {str, iterable of str}

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -306,8 +306,6 @@ class _Router:
             for alias in aliases:
                 alias_to_idx[alias].append(i)
 
-        # policies is a list with an element for each dest
-        # An element may be None, '*', a set of exclusions, or a dict
         policies = [None] * len(dests)
 
         # Sorted so error messages are deterministic
@@ -327,7 +325,7 @@ class _Router:
                     elif any(minuses):
                         raise ValueError('Routing props should either all '
                                          'start with "-" or none should start '
-                                         'with "-"')
+                                         'with "-". Got a mix for %r' % dest)
                     else:
                         policy = _IncludePolicy({prop: prop for prop in props})
 

--- a/sklearn/utils/tests/test_metaestimators.py
+++ b/sklearn/utils/tests/test_metaestimators.py
@@ -84,20 +84,22 @@ def test_if_delegate_has_method():
 FOO = [1, 2, 3]
 BAR = [4, 5, 6]
 TEST_ROUTER_BASIC_PARAMS = [
-    ({'*': [('*', '*')]},
+    ({'*': '*'},
      {'bar': BAR, 'foo': FOO}, {'bar': BAR, 'foo': FOO}, set()),
-    ({'foo': [('*', '*')]},
+    ({'*': 'foo'},
      {'foo': FOO}, {'foo': FOO}, {'bar'}),
-    ({'foo': ('*', '*')},
+    ({'*': ['foo']},
      {'foo': FOO}, {'foo': FOO}, {'bar'}),
-    ({'foo': [('d*1', '*')]},
+    ({'*': ['goo']},
+     {}, {}, {'bar', 'foo'}),
+    ({'dest1': {'goo': 'foo'}},
+     {'goo': FOO}, {}, {'bar'}),
+    ({'dest1': {'foo': 'goo'}},
+     {}, {}, {'bar', 'foo'}),
+    ({'dest1': '-bar'},
      {'foo': FOO}, {}, {'bar'}),
-    ({'foo': [('d*1', 'goo')]},
-     {'goo': FOO}, {}, {'bar'}),
-    ({'foo': [('dest1', 'goo')]},
-     {'goo': FOO}, {}, {'bar'}),
-    ({'foo': [('dest11', 'goo')]},
-     {}, {}, {'foo', 'bar'}),
+    ({'dest1': ['-bar']},
+     {'foo': FOO}, {}, {'bar'}),
 ]
 
 # pytest.mark.parametrize(['routing', 'expected_dest1',
@@ -109,9 +111,8 @@ def test_router_basic():
     for params in TEST_ROUTER_BASIC_PARAMS:
         print(params)
         routing, expected_dest1, expected_dest2, expected_remainder = params
-        router = _Router(routing)
-        (dest1, dest2), remainder = router({'foo': FOO, 'bar': BAR},
-                                           ['dest1', 'dest2'])
+        router = _Router(routing, [['dest1', '*'], ['dest2', '*']])
+        (dest1, dest2), remainder = router({'foo': FOO, 'bar': BAR})
         assert dest1 == expected_dest1
         assert dest2 == expected_dest2
         assert remainder == expected_remainder


### PR DESCRIPTION
## Reference issues

In an ideal world:

* Closes #4497 (Gaël's overarching issue)
* Closes #4696 (Andy's sample properties PR)
* Closes #1574 (Noel's sample_weight support everywhere PR)
* Closes #3524 (Vlad's extension of Noel's work)
* Closes #4632 (Andy's issue about weighted scoring in CV)
* Closes #8158 (issue about parameters to CV scoring)
* Closes #2630 (issue about putting a Pipeline in AdaBoost)
* Closes #7646 (issue about nested grouped CV)
* Closes #8950 (inability to use grouped CV splitters in LogisticRegressionCV)
* Closes #8127 (inability to use grouped CV splitters in permutation_test_score)
* Helps towards #6322 (time series props)

## Functionality

As derived from my ranting at Thierry's https://github.com/scikit-learn/enhancement_proposals/pull/6, this:
* maintains backwards compatibility with the routing of kwargs to `Pipeline.fit`
* maintains backwards compatibility with the routing of kwargs and `groups` to `*SearchCV.fit`
* allows the user to specify a custom routing scheme with a fairly straightforward notation ([see `check_routing` docs](https://12858-843222-gh.circle-artifacts.com/0/home/ubuntu/scikit-learn/doc/_build/html/stable/modules/generated/sklearn.utils.metaestimators.check_routing.html)), in which the `*SearchCV` default policy, but not the Pipeline default policy, can be expressed
    * each destination name takes one of: all props, all but specified props (blacklist), only specified props (whitelist) optionally renamed, no props
* a meta-estimator has a `prop_routing` parameter to facilitate this
* a meta-estimator defines:
    * a set of destinations (e.g. steps' fit methods in Pipeline; perhaps also steps' transform methods in Pipeline; {cv, estimator, scoring} in *SearchCV)
    * a set of aliases for each destination (e.g. in Pipeline the step name to route to each fit method; "*" to route to all steps' fit methods)
    * a default routing policy (a specialised function in Pipeline; {'estimator': '-groups', 'cv': 'groups'} in *SearchCV)

## Example?

Ideally we should be able to get nested CV with groups and weighted scoring working:
```python
cross_val_score(GridSearchCV(..., cv=GroupKFold(),
                             prop_routing={'estimator': '-groups',
                                           'cv': 'groups',
                                           'scoring': 'sample_weight'}),
                X, y, groups,
                fit_params={'sample_weight': sample_weight},
                cv=GroupKFold(),
                prop_routing={'estimator': '*',
                              'cv': 'groups',
                              'scoring': 'sample_weight'})
```

It's pretty intricate, but I'm not sure we're going to get better than this!

## TODO (and help wanted!)

* [ ] ensure `check_routing` API is as we want (please comment!)
* [x] documentation for `check_routing`
* [ ] documentation for `Pipeline` and `*SearchCV`
* [ ] test "*" destination alias in Pipeline.
* [ ] test prop_routing in *SearchCV, particularly to metrics
* [ ] tests for error cases in Router and check_routing
* [ ] more tests for valid cases in Router and check_routing
* [ ] make prop_routing available in all CV routines
* [ ] make prop_routing available in all metaestimators
* [ ] make prop_routing available in gaussian processes (for kernels)
* [ ] get rid of `has_fit_parameter` where possible

The last steps there are the most arduous, and if we decide this is the way forward, I would welcome collaboration when we get to that stage.