### PR TITLE
[MRG + 1] Remove redundancy in #9552

### DIFF
--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -934,7 +934,8 @@ def test_quantile_transform_check_error():
                         " 'normal' or 'uniform'. Got 'rnd' instead.",
                         transformer.inverse_transform, X_tran)
     # check that an error is raised if input is scalar
-    assert_raise_message(ValueError, 'Expected 2D array, got scalar array instead',
+    assert_raise_message(ValueError,
+                         'Expected 2D array, got scalar array instead',
                          transformer.transform, 10)
 
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -13,6 +13,7 @@ from distutils.version import LooseVersion
 
 from sklearn.utils import gen_batches
 
+from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import clean_warning_registry
 from sklearn.utils.testing import assert_array_almost_equal
@@ -932,6 +933,9 @@ def test_quantile_transform_check_error():
     assert_raises_regex(ValueError, "'output_distribution' has to be either"
                         " 'normal' or 'uniform'. Got 'rnd' instead.",
                         transformer.inverse_transform, X_tran)
+    # check that an error is raised if input is scalar
+    assert_raise_message(ValueError, 'Expected 2D array, got scalar array instead',
+                         transformer.transform, 10)
 
 
 def test_quantile_transform_sparse_ignore_zeros():
@@ -1157,14 +1161,14 @@ def test_quantile_transform_bounds():
     X = np.random.random((1000, 1))
     transformer = QuantileTransformer()
     transformer.fit(X)
-    assert_equal(transformer.transform(-10), transformer.transform(np.min(X)))
-    assert_equal(transformer.transform(10), transformer.transform(np.max(X)))
-    assert_equal(transformer.inverse_transform(-10),
+    assert_equal(transformer.transform([[-10]]), transformer.transform([[np.min(X)]]))
+    assert_equal(transformer.transform([[10]]), transformer.transform([[np.max(X)]]))
+    assert_equal(transformer.inverse_transform([[-10]]),
                  transformer.inverse_transform(
-                     np.min(transformer.references_)))
-    assert_equal(transformer.inverse_transform(10),
+                     [[np.min(transformer.references_)]]))
+    assert_equal(transformer.inverse_transform([[10]]),
                  transformer.inverse_transform(
-                     np.max(transformer.references_)))
+                     [[np.max(transformer.references_)]]))
 
 
 def test_quantile_transform_and_inverse():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1161,8 +1161,10 @@ def test_quantile_transform_bounds():
     X = np.random.random((1000, 1))
     transformer = QuantileTransformer()
     transformer.fit(X)
-    assert_equal(transformer.transform([[-10]]), transformer.transform([[np.min(X)]]))
-    assert_equal(transformer.transform([[10]]), transformer.transform([[np.max(X)]]))
+    assert_equal(transformer.transform([[-10]]),
+                 transformer.transform([[np.min(X)]]))
+    assert_equal(transformer.transform([[10]]),
+                 transformer.transform([[np.max(X)]]))
     assert_equal(transformer.inverse_transform([[-10]]),
                  transformer.inverse_transform(
                      [[np.min(transformer.references_)]]))

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -142,7 +142,8 @@ def test_check_array():
     assert_raise_message(ValueError, 'Expected 2D array, got 1D array instead',
                          check_array, [0, 1, 2], ensure_2d=True)
     # ensure_2d=True with scalar array
-    assert_raise_message(ValueError, 'Expected 2D array, got scalar array instead',
+    assert_raise_message(ValueError,
+                         'Expected 2D array, got scalar array instead',
                          check_array, 10, ensure_2d=True)
     # don't allow ndim > 3
     X_ndim = np.arange(8).reshape(2, 2, 2)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -138,9 +138,12 @@ def test_check_array():
     # ensure_2d=False
     X_array = check_array([0, 1, 2], ensure_2d=False)
     assert_equal(X_array.ndim, 1)
-    # ensure_2d=True
+    # ensure_2d=True with 1d array
     assert_raise_message(ValueError, 'Expected 2D array, got 1D array instead',
                          check_array, [0, 1, 2], ensure_2d=True)
+    # ensure_2d=True with scalar array
+    assert_raise_message(ValueError, 'Expected 2D array, got scalar array instead',
+                         check_array, 10, ensure_2d=True)
     # don't allow ndim > 3
     X_ndim = np.arange(8).reshape(2, 2, 2)
     assert_raises(ValueError, check_array, X_ndim)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -402,6 +402,14 @@ def check_array(array, accept_sparse=False, dtype="numeric", order=None,
         array = np.array(array, dtype=dtype, order=order, copy=copy)
 
         if ensure_2d:
+            # If input is scalar raise error
+            if array.ndim == 0:
+                raise ValueError(
+                    "Expected 2D array, got scalar array instead:\narray={}.\n"
+                    "Reshape your data either using array.reshape(-1, 1) if "
+                    "your data has a single feature or array.reshape(1, -1) "
+                    "if it contains a single sample.".format(array))
+            # If input is 1D raise error
             if array.ndim == 1:
                 raise ValueError(
                     "Expected 2D array, got 1D array instead:\narray={}.\n"

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -408,7 +408,6 @@ def check_array(array, accept_sparse=False, dtype="numeric", order=None,
                     "Reshape your data either using array.reshape(-1, 1) if "
                     "your data has a single feature or array.reshape(1, -1) "
                     "if it contains a single sample.".format(array))
-            array = np.atleast_2d(array)
             # To ensure that array flags are maintained
             array = np.array(array, dtype=dtype, order=order, copy=copy)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Fixes #9552


#### What does this implement/fix? Explain your changes.
Fixes the redundancy in #9552 by removing the second `array = np.atleast_2d(array)` check.

#### Any other comments?
All `check_array` tests pass.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
