### PR TITLE
Fix typos

### DIFF
--- a/sklearn/linear_model/sag_fast.pyx
+++ b/sklearn/linear_model/sag_fast.pyx
@@ -263,7 +263,7 @@ def sag(SequentialDataset dataset,
     cdef int *x_ind_ptr = NULL
     # the number of non-zero features for current sample
     cdef int xnnz = -1
-    # the label value for curent sample
+    # the label value for current sample
     cdef double y
     # the sample weight
     cdef double sample_weight

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -189,7 +189,7 @@ def check_hyperparameter_searcher_with_fit_params(klass, **klass_kwargs):
     clf = CheckingClassifier(expected_fit_params=['spam', 'eggs'])
     searcher = klass(clf, {'foo_param': [1, 2, 3]}, cv=2, **klass_kwargs)
 
-    # The CheckingClassifer generates an assertion error if
+    # The CheckingClassifier generates an assertion error if
     # a parameter is missing or has length != len(X).
     assert_raise_message(AssertionError,
                          "Expected fit parameter(s) ['eggs'] not seen.",

--- a/sklearn/neighbors/quad_tree.pyx
+++ b/sklearn/neighbors/quad_tree.pyx
@@ -521,7 +521,7 @@ cdef class _QuadTree:
     def __getstate__(self):
         """Getstate re-implementation, for pickling."""
         d = {}
-        # capacity is infered during the __setstate__ using nodes
+        # capacity is inferred during the __setstate__ using nodes
         d["max_depth"] = self.max_depth
         d["cell_count"] = self.cell_count
         d["capacity"] = self.capacity


### PR DESCRIPTION
This PR fixes some typos: `curent`, `Classifer`, and `infered`.