### PR TITLE
[MRG+1] Add average precision definitions and cross references

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -678,6 +678,24 @@ binary classification and multilabel indicator format.
     for an example of :func:`precision_recall_curve` usage to evaluate
     classifier output quality.
 
+
+.. topic:: References:
+
+  * C.D. Manning, P. Raghavan, H. Schütze, `Introduction to Information Retrieval
+  <http://nlp.stanford.edu/IR-book/html/htmledition/evaluation-of-ranked-retrieval-results-1.html>`_,
+  2008.
+  * M. Everingham, L. Van Gool, C.K.I. Williams, J. Winn, A. Zisserman,
+  `The Pascal Visual Object Classes (VOC) Challenge
+  <http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.157.5766&rep=rep1&type=pdf>`_,
+  IJCV 2010.
+  * J. Davis, M. Goadrich, `The Relationship Between Precision-Recall and ROC Curves
+  <http://www.machinelearning.org/proceedings/icml2006/030_The_Relationship_Bet.pdf>`_,
+  ICML 2006.
+  * P.A. Flach, M. Kull, `Precision-Recall-Gain Curves: PR Analysis Done Right
+  <http://papers.nips.cc/paper/5867-precision-recall-gain-curves-pr-analysis-done-right.pdf>`_,
+  NIPS 2015.
+
+
 Binary classification
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -640,7 +640,7 @@ With random predictions, the AP is the fraction of positive samples. AP is
 defined as
 
 .. math::
-    \\text{AP} = \\sum_n (R_n - R_{n-1}) P_n
+    \text{AP} = \sum_n (R_n - R_{n-1}) P_n
 
 where :math:`P_n` and :math:`R_n` are the precision and recall at the
 nth threshold.

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -688,18 +688,18 @@ binary classification and multilabel indicator format.
 .. topic:: References:
 
   * C.D. Manning, P. Raghavan, H. Schütze, `Introduction to Information Retrieval
-  <http://nlp.stanford.edu/IR-book/html/htmledition/evaluation-of-ranked-retrieval-results-1.html>`_,
-  2008.
+    <http://nlp.stanford.edu/IR-book/html/htmledition/evaluation-of-ranked-retrieval-results-1.html>`_,
+    2008.
   * M. Everingham, L. Van Gool, C.K.I. Williams, J. Winn, A. Zisserman,
-  `The Pascal Visual Object Classes (VOC) Challenge
-  <http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.157.5766&rep=rep1&type=pdf>`_,
-  IJCV 2010.
+    `The Pascal Visual Object Classes (VOC) Challenge
+    <http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.157.5766&rep=rep1&type=pdf>`_,
+    IJCV 2010.
   * J. Davis, M. Goadrich, `The Relationship Between Precision-Recall and ROC Curves
-  <http://www.machinelearning.org/proceedings/icml2006/030_The_Relationship_Bet.pdf>`_,
-  ICML 2006.
+    <http://www.machinelearning.org/proceedings/icml2006/030_The_Relationship_Bet.pdf>`_,
+    ICML 2006.
   * P.A. Flach, M. Kull, `Precision-Recall-Gain Curves: PR Analysis Done Right
-  <http://papers.nips.cc/paper/5867-precision-recall-gain-curves-pr-analysis-done-right.pdf>`_,
-  NIPS 2015.
+    <http://papers.nips.cc/paper/5867-precision-recall-gain-curves-pr-analysis-done-right.pdf>`_,
+    NIPS 2015.
 
 
 Binary classification

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -636,7 +636,14 @@ by varying a decision threshold.
 The :func:`average_precision_score` function computes the average precision
 (AP) from prediction scores. This score corresponds to the area under the
 precision-recall curve. The value is between 0 and 1 and higher is better.
-With random predictions, the AP is the fraction of positive samples.
+With random predictions, the AP is the fraction of positive samples. AP is
+defined as
+
+.. math::
+    \\text{AP} = \\sum_n (R_n - R_{n-1}) P_n
+
+where :math:`P_n` and :math:`R_n` are the precision and recall at the
+nth threshold.
 
 Several functions allow you to analyze the precision, recall and F-measures
 score:

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -633,7 +633,8 @@ The :func:`precision_recall_curve` computes a precision-recall curve
 from the ground truth label and a score given by the classifier
 by varying a decision threshold.
 
-The :func:`average_precision_score` function computes the average precision
+The :func:`average_precision_score` function computes the
+`average precision <http://en.wikipedia.org/w/index.php?title=Information_retrieval&oldid=793358396#Average_precision>`_
 (AP) from prediction scores. The value is between 0 and 1 and higher is better.
 AP is defined as
 
@@ -644,12 +645,13 @@ where :math:`P_n` and :math:`R_n` are the precision and recall at the
 nth threshold. With random predictions, the AP is the fraction of positive
 samples.
 
-The references below present alternative variants of AP that interpolate the
-precision-recall curve, which are not implemented in
-:func:`average_precision_score`. They also describe why a linear interpolation
-of points on the precision-recall curve provides an overly-optimistic measure
-of classifier performance. This linear interpolation is used when computing
-area under the curve with the trapezoidal rule in :func:`auc`.
+References [Manning2008]_ and [Everingham2010]_ present alternative variants of
+AP that interpolate the precision-recall curve. Currently,
+:func:`average_precision_score` does not implement any interpolated variant.
+References [Davis2006]_ and [Flach2015]_ describe why a linear interpolation of
+points on the precision-recall curve provides an overly-optimistic measure of
+classifier performance. This linear interpolation is used when computing area
+under the curve with the trapezoidal rule in :func:`auc`.
 
 Several functions allow you to analyze the precision, recall and F-measures
 score:
@@ -687,17 +689,17 @@ binary classification and multilabel indicator format.
 
 .. topic:: References:
 
-  * C.D. Manning, P. Raghavan, H. Schütze, `Introduction to Information Retrieval
+  * [Manning2008] C.D. Manning, P. Raghavan, H. Schütze, `Introduction to Information Retrieval
     <http://nlp.stanford.edu/IR-book/html/htmledition/evaluation-of-ranked-retrieval-results-1.html>`_,
     2008.
-  * M. Everingham, L. Van Gool, C.K.I. Williams, J. Winn, A. Zisserman,
+  * [Everingham2010] M. Everingham, L. Van Gool, C.K.I. Williams, J. Winn, A. Zisserman,
     `The Pascal Visual Object Classes (VOC) Challenge
     <http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.157.5766&rep=rep1&type=pdf>`_,
     IJCV 2010.
-  * J. Davis, M. Goadrich, `The Relationship Between Precision-Recall and ROC Curves
+  * [Davis2006] J. Davis, M. Goadrich, `The Relationship Between Precision-Recall and ROC Curves
     <http://www.machinelearning.org/proceedings/icml2006/030_The_Relationship_Bet.pdf>`_,
     ICML 2006.
-  * P.A. Flach, M. Kull, `Precision-Recall-Gain Curves: PR Analysis Done Right
+  * [Flach2015] P.A. Flach, M. Kull, `Precision-Recall-Gain Curves: PR Analysis Done Right
     <http://papers.nips.cc/paper/5867-precision-recall-gain-curves-pr-analysis-done-right.pdf>`_,
     NIPS 2015.
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -634,16 +634,22 @@ from the ground truth label and a score given by the classifier
 by varying a decision threshold.
 
 The :func:`average_precision_score` function computes the average precision
-(AP) from prediction scores. This score corresponds to the area under the
-precision-recall curve. The value is between 0 and 1 and higher is better.
-With random predictions, the AP is the fraction of positive samples. AP is
-defined as
+(AP) from prediction scores. The value is between 0 and 1 and higher is better.
+AP is defined as
 
 .. math::
     \text{AP} = \sum_n (R_n - R_{n-1}) P_n
 
 where :math:`P_n` and :math:`R_n` are the precision and recall at the
-nth threshold.
+nth threshold. With random predictions, the AP is the fraction of positive
+samples.
+
+The references below present alternative variants of AP that interpolate the
+precision-recall curve, which are not implemented in
+:func:`average_precision_score`. They also describe why a linear interpolation
+of points on the precision-recall curve provides an overly-optimistic measure
+of classifier performance. This linear interpolation is used when computing
+area under the curve with the trapezoidal rule in :func:`auc`.
 
 Several functions allow you to analyze the precision, recall and F-measures
 score:

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -689,19 +689,19 @@ binary classification and multilabel indicator format.
 
 .. topic:: References:
 
-  * [Manning2008] C.D. Manning, P. Raghavan, H. Schütze, `Introduction to Information Retrieval
-    <http://nlp.stanford.edu/IR-book/html/htmledition/evaluation-of-ranked-retrieval-results-1.html>`_,
-    2008.
-  * [Everingham2010] M. Everingham, L. Van Gool, C.K.I. Williams, J. Winn, A. Zisserman,
-    `The Pascal Visual Object Classes (VOC) Challenge
-    <http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.157.5766&rep=rep1&type=pdf>`_,
-    IJCV 2010.
-  * [Davis2006] J. Davis, M. Goadrich, `The Relationship Between Precision-Recall and ROC Curves
-    <http://www.machinelearning.org/proceedings/icml2006/030_The_Relationship_Bet.pdf>`_,
-    ICML 2006.
-  * [Flach2015] P.A. Flach, M. Kull, `Precision-Recall-Gain Curves: PR Analysis Done Right
-    <http://papers.nips.cc/paper/5867-precision-recall-gain-curves-pr-analysis-done-right.pdf>`_,
-    NIPS 2015.
+  .. [Manning2008] C.D. Manning, P. Raghavan, H. Schütze, `Introduction to Information Retrieval
+     <http://nlp.stanford.edu/IR-book/html/htmledition/evaluation-of-ranked-retrieval-results-1.html>`_,
+     2008.
+  .. [Everingham2010] M. Everingham, L. Van Gool, C.K.I. Williams, J. Winn, A. Zisserman,
+     `The Pascal Visual Object Classes (VOC) Challenge
+     <http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.157.5766&rep=rep1&type=pdf>`_,
+     IJCV 2010.
+  .. [Davis2006] J. Davis, M. Goadrich, `The Relationship Between Precision-Recall and ROC Curves
+     <http://www.machinelearning.org/proceedings/icml2006/030_The_Relationship_Bet.pdf>`_,
+     ICML 2006.
+  .. [Flach2015] P.A. Flach, M. Kull, `Precision-Recall-Gain Curves: PR Analysis Done Right
+     <http://papers.nips.cc/paper/5867-precision-recall-gain-curves-pr-analysis-done-right.pdf>`_,
+     NIPS 2015.
 
 
 Binary classification

--- a/examples/model_selection/plot_precision_recall.py
+++ b/examples/model_selection/plot_precision_recall.py
@@ -69,7 +69,8 @@ threshold used as the weight:
 
 where :math:`P_n` and :math:`R_n` are the precision and recall at the
 nth threshold. A pair :math:`(R_k, P_k)` is referred to as an
-*operating point*.
+*operating point*. When summarizing a precision-recall curve, AP is preferable
+to computing the trapezoidal area under the operating points.
 
 Precision-recall curves are typically used in binary classification to study
 the output of a classifier. In order to extend the precision-recall curve and

--- a/examples/model_selection/plot_precision_recall.py
+++ b/examples/model_selection/plot_precision_recall.py
@@ -61,16 +61,19 @@ stairstep area of the plot - at the edges of these steps a small change
 in the threshold considerably reduces precision, with only a minor gain in
 recall.
 
-**Average precision** summarizes such a plot as the weighted mean of precisions
-achieved at each threshold, with the increase in recall from the previous
-threshold used as the weight:
+**Average precision** (AP) summarizes such a plot as the weighted mean of
+precisions achieved at each threshold, with the increase in recall from the
+previous threshold used as the weight:
 
 :math:`\\text{AP} = \\sum_n (R_n - R_{n-1}) P_n`
 
 where :math:`P_n` and :math:`R_n` are the precision and recall at the
 nth threshold. A pair :math:`(R_k, P_k)` is referred to as an
-*operating point*. When summarizing a precision-recall curve, AP is preferable
-to computing the trapezoidal area under the operating points.
+*operating point*.
+
+AP and the trapezoidal area under the operating points
+(:func:`sklearn.metrics.auc`) are common ways to summarize a precision-recall
+curve. Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
 
 Precision-recall curves are typically used in binary classification to study
 the output of a classifier. In order to extend the precision-recall curve and

--- a/examples/model_selection/plot_precision_recall.py
+++ b/examples/model_selection/plot_precision_recall.py
@@ -145,7 +145,7 @@ plt.xlabel('Recall')
 plt.ylabel('Precision')
 plt.ylim([0.0, 1.05])
 plt.xlim([0.0, 1.0])
-plt.title('2-class Precision-Recall curve: AUC={0:0.2f}'.format(
+plt.title('2-class Precision-Recall curve: AP={0:0.2f}'.format(
           average_precision))
 
 ###############################################################################
@@ -216,7 +216,7 @@ plt.ylabel('Precision')
 plt.ylim([0.0, 1.05])
 plt.xlim([0.0, 1.0])
 plt.title(
-    'Average precision score, micro-averaged over all classes: AUC={0:0.2f}'
+    'Average precision score, micro-averaged over all classes: AP={0:0.2f}'
     .format(average_precision["micro"]))
 
 ###############################################################################

--- a/examples/model_selection/plot_precision_recall.py
+++ b/examples/model_selection/plot_precision_recall.py
@@ -73,7 +73,8 @@ nth threshold. A pair :math:`(R_k, P_k)` is referred to as an
 
 AP and the trapezoidal area under the operating points
 (:func:`sklearn.metrics.auc`) are common ways to summarize a precision-recall
-curve. Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+curve that lead to different results. Read more in the
+:ref:`User Guide <precision_recall_f_measure_metrics>`.
 
 Precision-recall curves are typically used in binary classification to study
 the output of a classifier. In order to extend the precision-recall curve and

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -40,7 +40,8 @@ def auc(x, y, reorder=False):
     """Compute Area Under the Curve (AUC) using the trapezoidal rule
 
     This is a general function, given points on a curve.  For computing the
-    area under the ROC-curve, see :func:`roc_auc_score`.
+    area under the ROC-curve, see :func:`roc_auc_score`.  For summarizing a
+    precision-recall curve, see :func:`average_precision_score`.
 
     Parameters
     ----------
@@ -68,7 +69,8 @@ def auc(x, y, reorder=False):
 
     See also
     --------
-    roc_auc_score : Computes the area under the ROC curve
+    roc_auc_score : Compute the area under the ROC curve
+    average_precision_score : Compute average precision from prediction scores
     precision_recall_curve :
         Compute precision-recall pairs for different probability thresholds
     """
@@ -107,6 +109,16 @@ def auc(x, y, reorder=False):
 def average_precision_score(y_true, y_score, average="macro",
                             sample_weight=None):
     """Compute average precision (AP) from prediction scores
+
+    AP summarizes a precision-recall curve as the weighted mean of precisions
+    achieved at each threshold, with the increase in recall from the previous
+    threshold used as the weight:
+
+    .. math::
+        \\text{AP} = \\sum_n (R_n - R_{n-1}) P_n
+
+    where :math:`P_n` and :math:`R_n` are the precision and recall at the nth
+    threshold [1]_.
 
     Note: this implementation is restricted to the binary classification task
     or multilabel classification task.
@@ -149,13 +161,8 @@ def average_precision_score(y_true, y_score, average="macro",
     References
     ----------
     .. [1] `Wikipedia entry for the Average precision
-           <http://en.wikipedia.org/wiki/Average_precision>`_
-    .. [2] `Stanford Information Retrieval book
-            <http://nlp.stanford.edu/IR-book/html/htmledition/
-            evaluation-of-ranked-retrieval-results-1.html>`_
-    .. [3] `The PASCAL Visual Object Classes (VOC) Challenge
-            <http://citeseerx.ist.psu.edu/viewdoc/
-            download?doi=10.1.1.157.5766&rep=rep1&type=pdf>`_
+           <http://en.wikipedia.org/w/index.php?title=Information_retrieval&
+           oldid=793358396#Average_precision>`_
 
     See also
     --------
@@ -395,6 +402,10 @@ def precision_recall_curve(y_true, probas_pred, pos_label=None,
     thresholds : array, shape = [n_thresholds <= len(np.unique(probas_pred))]
         Increasing thresholds on the decision function used to compute
         precision and recall.
+
+    See also
+    --------
+    average_precision_score : Compute average precision from prediction scores
 
     Examples
     --------

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -40,8 +40,9 @@ def auc(x, y, reorder=False):
     """Compute Area Under the Curve (AUC) using the trapezoidal rule
 
     This is a general function, given points on a curve.  For computing the
-    area under the ROC-curve, see :func:`roc_auc_score`.  For summarizing a
-    precision-recall curve, see :func:`average_precision_score`.
+    area under the ROC-curve, see :func:`roc_auc_score`.  For an alternative
+    way to summarize a precision-recall curve, see
+    :func:`average_precision_score`.
 
     Parameters
     ----------

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -119,7 +119,10 @@ def average_precision_score(y_true, y_score, average="macro",
         \\text{AP} = \\sum_n (R_n - R_{n-1}) P_n
 
     where :math:`P_n` and :math:`R_n` are the precision and recall at the nth
-    threshold [1]_.
+    threshold [1]_. This implementation is not interpolated and is different
+    from computing the area under the precision-recall curve with the
+    trapezoidal rule, which uses linear interpolation and can be too
+    optimistic.
 
     Note: this implementation is restricted to the binary classification task
     or multilabel classification task.
@@ -167,7 +170,7 @@ def average_precision_score(y_true, y_score, average="macro",
 
     See also
     --------
-    roc_auc_score : Area under the ROC curve
+    roc_auc_score : Compute the area under the ROC curve
 
     precision_recall_curve :
         Compute precision-recall pairs for different probability thresholds
@@ -198,7 +201,8 @@ def average_precision_score(y_true, y_score, average="macro",
 
 
 def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
-    """Compute Area Under the Curve (AUC) from prediction scores
+    """Compute Area Under the Receiver Operating Characteristic Curve (ROC AUC)
+    from prediction scores.
 
     Note: this implementation is restricted to the binary classification task
     or multilabel classification task in label indicator format.
@@ -247,7 +251,7 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
     --------
     average_precision_score : Area under the precision-recall curve
 
-    roc_curve : Compute Receiver operating characteristic (ROC)
+    roc_curve : Compute Receiver operating characteristic (ROC) curve
 
     Examples
     --------
@@ -408,6 +412,8 @@ def precision_recall_curve(y_true, probas_pred, pos_label=None,
     --------
     average_precision_score : Compute average precision from prediction scores
 
+    roc_curve : Compute Receiver operating characteristic (ROC) curve
+
     Examples
     --------
     >>> import numpy as np
@@ -489,7 +495,7 @@ def roc_curve(y_true, y_score, pos_label=None, sample_weight=None,
 
     See also
     --------
-    roc_auc_score : Compute Area Under the Curve (AUC) from prediction scores
+    roc_auc_score : Compute the area under the ROC curve
 
     Notes
     -----


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Adds documentation requested in #4577 regarding pull request #9017.  Improved documentation may also address the concerns in #5379.

#### What does this implement/fix? Explain your changes.
The changes include:
- Remove both references to interpolated precision in the `average_precision_score` docstring
- Use a Wikipedia permalink for the AP reference in the `average_precision_score` docstring
- Copy the AP definition from `plot_precision_recall.py` to the `average_precision_score` docstring and `model_evaluation.rst`
- Recommend AP instead of trapezoidal AUC on PR curve operating points
- Add `average_precision_score` references to docstrings of related functions

#### Any other comments?
There has been some confusion about area under the curve for precision-recall curves in scikit-learn.  Currently, some documents refer to the AP computed by `average_precision_score` as the **area**.  Others refer to it as a **summarization**.  It would improve consistency to call AP the official area under the precision-recall curve in all documentation, but is that generally accepted?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
