### PR TITLE
Add pass classes argument to scorers and allow_subset_labels in metrics

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -112,18 +112,18 @@ def _weighted_sum(sample_score, sample_weight, normalize=False):
         return sample_score.sum()
 
 
-def _check_labels_subset(present_labels, labels, allow_labels_subset):
+def _check_labels_subset(present_labels, labels, allow_label_subset):
     present_labels_ = set(present_labels)
     labels_ = set(labels)
 
     if present_labels_ - labels_:
-        if not allow_labels_subset:
-            warnings.warn("The `allow_labels_subset` argument should be True "
-                          "if a subset of available classes=%s was passed in "
-                          " the labels=%s argument. `allow_labels_subset` was "
-                          " added in version 0.20 and this behavior will "
-                          "result in error from version 0.22." %
-                          (present_labels, labels), DeprecationWarning)
+        if not allow_label_subset:
+            warnings.warn("The labels argument %s was a subset of the present"
+                          "classes %s. If you want to compute a metric on the"
+                          "subset of the classes, set allow_label_subset=True."
+                          "This warning was introduced in 0.20 and will turn"
+                          "into an error in version 0.22" %
+                          (labels, present_labels), DeprecationWarning)
 
 
 def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
@@ -198,7 +198,7 @@ def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
 
 
 def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
-                     allow_labels_subset=False):
+                     allow_label_subset=False):
     """Compute confusion matrix to evaluate the accuracy of a classification
 
     By definition a confusion matrix :math:`C` is such that :math:`C_{i, j}`
@@ -228,10 +228,11 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
 
-    allow_labels_subset : bool, optional default = False
+    allow_label_subset : bool, optional default = False
         This should be set to True if scoring on a subset of labels is
         required. The subset of labels to score on should be passed in the
-        ``labels`` argument.
+        ``labels`` argument. If not True and labels contains only a subset of
+        the present classes, an error will be raised starting version 0.22.
 
         .. versionadded:: 0.20
 
@@ -277,7 +278,7 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
     if labels is None:
         labels = present_labels
     else:
-        _check_labels_subset(present_labels, labels, allow_labels_subset)
+        _check_labels_subset(present_labels, labels, allow_label_subset)
         labels = np.asarray(labels)
         if np.all([l not in y_true for l in labels]):
             raise ValueError("At least one label specified must be in y_true")
@@ -316,7 +317,7 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
 
 
 def cohen_kappa_score(y1, y2, labels=None, weights=None, sample_weight=None,
-                      allow_labels_subset=False):
+                      allow_label_subset=False):
     """Cohen's kappa: a statistic that measures inter-annotator agreement.
 
     This function computes Cohen's kappa [1]_, a score that expresses the level
@@ -355,7 +356,7 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None, sample_weight=None,
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
 
-    allow_labels_subset : bool, optional default = False
+    allow_label_subset : bool, optional default = False
         This should be set to True if scoring on a subset of labels is
         required. The subset of labels to score on should be passed in the
         ``labels`` argument.
@@ -645,7 +646,7 @@ def zero_one_loss(y_true, y_pred, normalize=True, sample_weight=None):
 
 
 def f1_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
-             sample_weight=None, allow_labels_subset=False):
+             sample_weight=None, allow_label_subset=False):
     """Compute the F1 score, also known as balanced F-score or F-measure
 
     The F1 score can be interpreted as a weighted average of the precision and
@@ -714,7 +715,7 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
 
-    allow_labels_subset : bool, optional default = False
+    allow_label_subset : bool, optional default = False
         This should be set to True if scoring on a subset of labels is
         required. The subset of labels to score on should be passed in the
         ``labels`` argument.
@@ -751,12 +752,12 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
     return fbeta_score(y_true, y_pred, 1, labels=labels,
                        pos_label=pos_label, average=average,
                        sample_weight=sample_weight,
-                       allow_labels_subset=allow_labels_subset)
+                       allow_label_subset=allow_label_subset)
 
 
 def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
                 average='binary', sample_weight=None,
-                allow_labels_subset=False):
+                allow_label_subset=False):
     """Compute the F-beta score
 
     The F-beta score is the weighted harmonic mean of precision and recall,
@@ -826,7 +827,7 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
 
-    allow_labels_subset : bool, optional default = False
+    allow_label_subset : bool, optional default = False
         This should be set to True if scoring on a subset of labels is
         required. The subset of labels to score on should be passed in the
         ``labels`` argument.
@@ -875,7 +876,7 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
                                  average=average,
                                  warn_for=('f-score',),
                                  sample_weight=sample_weight,
-                                 allow_labels_subset=allow_labels_subset)
+                                 allow_label_subset=allow_label_subset)
     return f
 
 
@@ -928,7 +929,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
                                     warn_for=('precision', 'recall',
                                               'f-score'),
                                     sample_weight=None,
-                                    allow_labels_subset=False):
+                                    allow_label_subset=False):
     """Compute precision, recall, F-measure and support for each class
 
     The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
@@ -1012,7 +1013,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
 
-    allow_labels_subset : bool, optional default = False
+    allow_label_subset : bool, optional default = False
         This should be set to True if scoring on a subset of labels is
         required. The subset of labels to score on should be passed in the
         ``labels`` argument.
@@ -1083,7 +1084,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     y_type, y_true, y_pred = _check_targets(y_true, y_pred)
     present_labels = unique_labels(y_true, y_pred)
     if labels is not None:
-        _check_labels_subset(present_labels, labels, allow_labels_subset)
+        _check_labels_subset(present_labels, labels, allow_label_subset)
 
     if average == 'binary':
         if y_type == 'binary':
@@ -1224,7 +1225,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
 def precision_score(y_true, y_pred, labels=None, pos_label=1,
                     average='binary', sample_weight=None,
-                    allow_labels_subset=False):
+                    allow_label_subset=False):
     """Compute the precision
 
     The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
@@ -1290,7 +1291,7 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
 
-    allow_labels_subset : bool, optional default = False
+    allow_label_subset : bool, optional default = False
         This should be set to True if scoring on a subset of labels is
         required. The subset of labels to score on should be passed in the
         ``labels`` argument.
@@ -1328,12 +1329,12 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
                                      average=average,
                                      warn_for=('precision',),
                                      sample_weight=sample_weight,
-                                     allow_labels_subset=allow_labels_subset)
+                                     allow_label_subset=allow_label_subset)
     return p
 
 
 def recall_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
-                 sample_weight=None, allow_labels_subset=False):
+                 sample_weight=None, allow_label_subset=False):
     """Compute the recall
 
     The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number of
@@ -1398,7 +1399,7 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
 
-    allow_labels_subset : bool, optional default = False
+    allow_label_subset : bool, optional default = False
         This should be set to True if scoring on a subset of labels is
         required. The subset of labels to score on should be passed in the
         ``labels`` argument.
@@ -1435,13 +1436,13 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
                                      average=average,
                                      warn_for=('recall',),
                                      sample_weight=sample_weight,
-                                     allow_labels_subset=allow_labels_subset)
+                                     allow_label_subset=allow_label_subset)
     return r
 
 
 def classification_report(y_true, y_pred, labels=None, target_names=None,
                           sample_weight=None, digits=2,
-                          allow_labels_subset=False):
+                          allow_label_subset=False):
     """Build a text report showing the main classification metrics
 
     Read more in the :ref:`User Guide <classification_report>`.
@@ -1466,7 +1467,7 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
     digits : int
         Number of digits for formatting output floating point values
 
-    allow_labels_subset : bool, optional default = False
+    allow_label_subset : bool, optional default = False
         This should be set to True if scoring on a subset of labels is
         required. The subset of labels to score on should be passed in the
         ``labels`` argument.
@@ -1508,7 +1509,7 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
     if labels is None:
         labels = present_labels
     else:
-        _check_labels_subset(present_labels, labels, allow_labels_subset)
+        _check_labels_subset(present_labels, labels, allow_label_subset)
         labels = np.asarray(labels)
 
     if target_names is not None and len(labels) != len(target_names):
@@ -1553,7 +1554,7 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
 
 
 def hamming_loss(y_true, y_pred, labels=None, sample_weight=None,
-                 classes=None, allow_labels_subset=False):
+                 classes=None, allow_label_subset=False):
     """Compute the average Hamming loss.
 
     The Hamming loss is the fraction of labels that are incorrectly predicted.
@@ -1586,7 +1587,7 @@ def hamming_loss(y_true, y_pred, labels=None, sample_weight=None,
            This parameter has been deprecated in favor of ``labels`` in
            version 0.18 and will be removed in 0.20. Use ``labels`` instead.
 
-    allow_labels_subset : bool, optional default = False
+    allow_label_subset : bool, optional default = False
         This should be set to True if scoring on a subset of labels is
         required. The subset of labels to score on should be passed in the
         ``labels`` argument.
@@ -1651,7 +1652,7 @@ def hamming_loss(y_true, y_pred, labels=None, sample_weight=None,
     if labels is None:
         labels = present_labels
     else:
-        _check_labels_subset(present_labels, labels, allow_labels_subset)
+        _check_labels_subset(present_labels, labels, allow_label_subset)
         labels = np.asarray(labels)
 
     if sample_weight is None:
@@ -1672,7 +1673,7 @@ def hamming_loss(y_true, y_pred, labels=None, sample_weight=None,
 
 
 def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None,
-             labels=None, allow_labels_subset=False):
+             labels=None, allow_label_subset=False):
     """Log loss, aka logistic loss or cross-entropy loss.
 
     This is the loss function used in (multinomial) logistic regression
@@ -1716,7 +1717,7 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None,
         assumed to be binary and are inferred from ``y_true``.
         .. versionadded:: 0.18
 
-    allow_labels_subset : bool, optional default = False
+    allow_label_subset : bool, optional default = False
         This should be set to True if scoring on a subset of labels is
         required. The subset of labels to score on should be passed in the
         ``labels`` argument.
@@ -1749,7 +1750,7 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None,
 
     if labels is not None:
         _check_labels_subset(np.unique(y_true),
-                             labels, allow_labels_subset)
+                             labels, allow_label_subset)
         lb.fit(labels)
     else:
         lb.fit(y_true)

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -381,7 +381,8 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None, sample_weight=None,
             <https://en.wikipedia.org/wiki/Cohen%27s_kappa>`_
     """
     confusion = confusion_matrix(y1, y2, labels=labels,
-                                 sample_weight=sample_weight)
+                                 sample_weight=sample_weight,
+                                 allow_label_subset=allow_label_subset)
     n_classes = confusion.shape[0]
     sum0 = np.sum(confusion, axis=0)
     sum1 = np.sum(confusion, axis=1)

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1082,6 +1082,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
     y_type, y_true, y_pred = _check_targets(y_true, y_pred)
     present_labels = unique_labels(y_true, y_pred)
+    if labels is not None:
+        _check_labels_subset(present_labels, labels, allow_labels_subset)
 
     if average == 'binary':
         if y_type == 'binary':
@@ -1106,7 +1108,6 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         labels = present_labels
         n_labels = None
     else:
-        _check_labels_subset(present_labels, labels, allow_labels_subset)
         n_labels = len(labels)
         labels = np.hstack([labels, np.setdiff1d(present_labels, labels,
                                                  assume_unique=True)])
@@ -1747,7 +1748,7 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None,
     lb = LabelBinarizer()
 
     if labels is not None:
-        _check_labels_subset(unique_labels(y_true, y_pred),
+        _check_labels_subset(np.unique(y_true),
                              labels, allow_labels_subset)
         lb.fit(labels)
     else:

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1802,8 +1802,7 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None,
     return _weighted_sum(loss, sample_weight, normalize)
 
 
-def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None,
-               allow_labels_subset=False):
+def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None):
     """Average hinge loss (non-regularized)
 
     In binary class case, assuming labels in y_true are encoded with +1 and -1,
@@ -1834,13 +1833,6 @@ def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None,
 
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
-
-    allow_labels_subset : bool, optional default = False
-        This should be set to True if scoring on a subset of labels is
-        required. The subset of labels to score on should be passed in the
-        ``labels`` argument.
-
-        .. versionadded:: 0.20
 
     Returns
     -------

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -118,10 +118,10 @@ def _check_labels_subset(present_labels, labels, allow_label_subset):
 
     if present_labels_ - labels_:
         if not allow_label_subset:
-            warnings.warn("The labels argument %s was a subset of the present"
+            warnings.warn("The labels argument %s was a subset of the present "
                           "classes %s. If you want to compute a metric on the"
                           "subset of the classes, set allow_label_subset=True."
-                          "This warning was introduced in 0.20 and will turn"
+                          " This warning was introduced in 0.20 and will turn"
                           "into an error in version 0.22" %
                           (labels, present_labels), DeprecationWarning)
 

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -112,6 +112,23 @@ def _weighted_sum(sample_score, sample_weight, normalize=False):
         return sample_score.sum()
 
 
+def _check_labels_subset(present_labels, labels, allow_labels_subset):
+    present_labels = set(present_labels)
+    labels = set(labels)
+
+    if not present_labels.issuperset(labels):
+        raise ValueError("`labels = %s` contain a label(s) = %s not found in "
+                         "the unique values of y = %s")
+
+    if len(labels) < len(present_labels):
+        if not allow_labels_subset:
+            warnings.warn("The `allow_labels_subset` argument should be True "
+                          "if a subset of all classes=%s was passed in the "
+                          "labels=%s argument. `allow_labels_subset` was added"
+                          " in version 0.20 and this will result in error from"
+                          " version 0.22." % (present_labels, labels))
+
+
 def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
     """Accuracy classification score.
 
@@ -183,7 +200,8 @@ def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
     return _weighted_sum(score, sample_weight, normalize)
 
 
-def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
+def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
+                     allow_labels_subset=False):
     """Compute confusion matrix to evaluate the accuracy of a classification
 
     By definition a confusion matrix :math:`C` is such that :math:`C_{i, j}`
@@ -212,6 +230,13 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
 
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
+
+    allow_labels_subset : bool, optional default = False
+        This should be set to True if scoring on a subset of labels is
+        required. The subset of labels to score on should be passed in the
+        ``labels`` argument.
+
+        .. versionadded:: 0.20
 
     Returns
     -------
@@ -291,7 +316,8 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
     return CM
 
 
-def cohen_kappa_score(y1, y2, labels=None, weights=None, sample_weight=None):
+def cohen_kappa_score(y1, y2, labels=None, weights=None, sample_weight=None,
+                      allow_labels_subset=False):
     """Cohen's kappa: a statistic that measures inter-annotator agreement.
 
     This function computes Cohen's kappa [1]_, a score that expresses the level
@@ -329,6 +355,13 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None, sample_weight=None):
 
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
+
+    allow_labels_subset : bool, optional default = False
+        This should be set to True if scoring on a subset of labels is
+        required. The subset of labels to score on should be passed in the
+        ``labels`` argument.
+
+        .. versionadded:: 0.20
 
     Returns
     -------
@@ -613,7 +646,7 @@ def zero_one_loss(y_true, y_pred, normalize=True, sample_weight=None):
 
 
 def f1_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
-             sample_weight=None):
+             sample_weight=None, allow_labels_subset=False):
     """Compute the F1 score, also known as balanced F-score or F-measure
 
     The F1 score can be interpreted as a weighted average of the precision and
@@ -682,6 +715,13 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
 
+    allow_labels_subset : bool, optional default = False
+        This should be set to True if scoring on a subset of labels is
+        required. The subset of labels to score on should be passed in the
+        ``labels`` argument.
+
+        .. versionadded:: 0.20
+
     Returns
     -------
     f1_score : float or array of float, shape = [n_unique_labels]
@@ -715,7 +755,8 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
 
 
 def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
-                average='binary', sample_weight=None):
+                average='binary', sample_weight=None,
+                allow_labels_subset=False):
     """Compute the F-beta score
 
     The F-beta score is the weighted harmonic mean of precision and recall,
@@ -784,6 +825,13 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
 
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
+
+    allow_labels_subset : bool, optional default = False
+        This should be set to True if scoring on a subset of labels is
+        required. The subset of labels to score on should be passed in the
+        ``labels`` argument.
+
+        .. versionadded:: 0.20
 
     Returns
     -------
@@ -877,7 +925,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
                                     pos_label=1, average=None,
                                     warn_for=('precision', 'recall',
                                               'f-score'),
-                                    sample_weight=None):
+                                    sample_weight=None,
+                                    allow_labels_subset=False):
     """Compute precision, recall, F-measure and support for each class
 
     The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
@@ -960,6 +1009,13 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
+
+    allow_labels_subset : bool, optional default = False
+        This should be set to True if scoring on a subset of labels is
+        required. The subset of labels to score on should be passed in the
+        ``labels`` argument.
+
+        .. versionadded:: 0.20
 
     Returns
     -------
@@ -1163,7 +1219,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
 
 def precision_score(y_true, y_pred, labels=None, pos_label=1,
-                    average='binary', sample_weight=None):
+                    average='binary', sample_weight=None,
+                    allow_labels_subset=False):
     """Compute the precision
 
     The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
@@ -1229,6 +1286,13 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
 
+    allow_labels_subset : bool, optional default = False
+        This should be set to True if scoring on a subset of labels is
+        required. The subset of labels to score on should be passed in the
+        ``labels`` argument.
+
+        .. versionadded:: 0.20
+
     Returns
     -------
     precision : float (if average is not None) or array of float, shape =\
@@ -1263,7 +1327,7 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
 
 
 def recall_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
-                 sample_weight=None):
+                 sample_weight=None, allow_labels_subset=False):
     """Compute the recall
 
     The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number of
@@ -1328,6 +1392,13 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
 
+    allow_labels_subset : bool, optional default = False
+        This should be set to True if scoring on a subset of labels is
+        required. The subset of labels to score on should be passed in the
+        ``labels`` argument.
+
+        .. versionadded:: 0.20
+
     Returns
     -------
     recall : float (if average is not None) or array of float, shape =\
@@ -1361,7 +1432,8 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
 
 
 def classification_report(y_true, y_pred, labels=None, target_names=None,
-                          sample_weight=None, digits=2):
+                          sample_weight=None, digits=2,
+                          allow_labels_subset=False):
     """Build a text report showing the main classification metrics
 
     Read more in the :ref:`User Guide <classification_report>`.
@@ -1385,6 +1457,13 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
 
     digits : int
         Number of digits for formatting output floating point values
+
+    allow_labels_subset : bool, optional default = False
+        This should be set to True if scoring on a subset of labels is
+        required. The subset of labels to score on should be passed in the
+        ``labels`` argument.
+
+        .. versionadded:: 0.20
 
     Returns
     -------
@@ -1464,7 +1543,7 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
 
 
 def hamming_loss(y_true, y_pred, labels=None, sample_weight=None,
-                 classes=None):
+                 classes=None, allow_labels_subset=False):
     """Compute the average Hamming loss.
 
     The Hamming loss is the fraction of labels that are incorrectly predicted.
@@ -1496,6 +1575,13 @@ def hamming_loss(y_true, y_pred, labels=None, sample_weight=None,
         .. deprecated:: 0.18
            This parameter has been deprecated in favor of ``labels`` in
            version 0.18 and will be removed in 0.20. Use ``labels`` instead.
+
+    allow_labels_subset : bool, optional default = False
+        This should be set to True if scoring on a subset of labels is
+        required. The subset of labels to score on should be passed in the
+        ``labels`` argument.
+
+        .. versionadded:: 0.20
 
     Returns
     -------
@@ -1574,7 +1660,7 @@ def hamming_loss(y_true, y_pred, labels=None, sample_weight=None,
 
 
 def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None,
-             labels=None):
+             labels=None, allow_labels_subset=False):
     """Log loss, aka logistic loss or cross-entropy loss.
 
     This is the loss function used in (multinomial) logistic regression
@@ -1617,6 +1703,13 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None,
         is ``None`` and ``y_pred`` has shape (n_samples,) the labels are
         assumed to be binary and are inferred from ``y_true``.
         .. versionadded:: 0.18
+
+    allow_labels_subset : bool, optional default = False
+        This should be set to True if scoring on a subset of labels is
+        required. The subset of labels to score on should be passed in the
+        ``labels`` argument.
+
+        .. versionadded:: 0.20
 
     Returns
     -------
@@ -1696,7 +1789,8 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None,
     return _weighted_sum(loss, sample_weight, normalize)
 
 
-def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None):
+def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None,
+               allow_labels_subset=False):
     """Average hinge loss (non-regularized)
 
     In binary class case, assuming labels in y_true are encoded with +1 and -1,
@@ -1727,6 +1821,13 @@ def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None):
 
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
+
+    allow_labels_subset : bool, optional default = False
+        This should be set to True if scoring on a subset of labels is
+        required. The subset of labels to score on should be passed in the
+        ``labels`` argument.
+
+        .. versionadded:: 0.20
 
     Returns
     -------

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -122,16 +122,6 @@ class _BaseScorer(six.with_metaclass(ABCMeta, object)):
         if self._pass_classes in signature(self._score_func).parameters:
             # if labels passed as kwargs, return kwargs as is
             if self._pass_classes in self._kwargs:
-                if classes is not None:
-                    # labels should be a subset of classes
-                    if not set(classes).issuperset(
-                                        set(self._kwargs[self._pass_classes])):
-                        raise ValueError("%s classes=%s is not the "
-                                         "superset of scorer %s=%s" %
-                                         (type(estimator).__name__,
-                                          classes,
-                                          self._pass_classes,
-                                          self._kwargs['labels']))
                 return self._kwargs
             else:
                 kwargs = self._kwargs.copy()

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -109,6 +109,10 @@ class _BaseScorer(six.with_metaclass(ABCMeta, object)):
             The type of target y. Should be obtained using ``type_of_target``
             from ``sklearn.utils.multiclass``
         """
+
+        if self._pass_classes is None:
+            return self._kwargs
+
         classes = getattr(estimator, "classes_", None)
 
         # if classes_ parameter doesn't exist
@@ -175,11 +179,8 @@ class _PredictScorer(_BaseScorer):
         super(_PredictScorer, self).__call__(estimator, X, y_true,
                                              sample_weight=sample_weight)
         y_pred = estimator.predict(X)
-        if self._pass_classes is None:
-            kwargs = self._kwargs
-        else:
-            kwargs = self._get_labels_from_estimator(estimator,
-                                                     type_of_target(y_true))
+        kwargs = self._get_labels_from_estimator(estimator,
+                                                 type_of_target(y_true))
 
         if sample_weight is not None:
             return self._sign * self._score_func(y_true, y_pred,
@@ -219,11 +220,8 @@ class _ProbaScorer(_BaseScorer):
                                            sample_weight=sample_weight)
         y_pred = clf.predict_proba(X)
 
-        if self._pass_classes is None:
-            kwargs = self._kwargs
-        else:
-            kwargs = self._get_labels_from_estimator(clf,
-                                                     type_of_target(y))
+        kwargs = self._get_labels_from_estimator(clf,
+                                                 type_of_target(y))
 
         if sample_weight is not None:
             return self._sign * self._score_func(y, y_pred,
@@ -287,11 +285,8 @@ class _ThresholdScorer(_BaseScorer):
                 elif isinstance(y_pred, list):
                     y_pred = np.vstack([p[:, -1] for p in y_pred]).T
 
-        if self._pass_classes is None:
-            kwargs = self._kwargs
-        else:
-            kwargs = self._get_labels_from_estimator(clf,
-                                                     type_of_target(y))
+        kwargs = self._get_labels_from_estimator(clf,
+                                                 type_of_target(y))
 
         if sample_weight is not None:
             return self._sign * self._score_func(y, y_pred,

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -122,7 +122,7 @@ class _BaseScorer(six.with_metaclass(ABCMeta, object)):
                     # labels should be a subset of classes
                     if not set(classes).issuperset(
                                         set(self._kwargs[self._pass_classes])):
-                        raise ValueError("%s classes=%s is not the"
+                        raise ValueError("%s classes=%s is not the "
                                          "superset of scorer %s=%s" %
                                          (type(estimator).__name__,
                                           classes,

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -529,10 +529,10 @@ def make_scorer(score_func, greater_is_better=True, needs_proba=False,
     pass_classes : string or None, default='labels'
         The name of the scorer parameter into which the ``classes_`` attribute
         of the estimator will be passed through. If None is passed, then the
-        ``classes_`` atribute will not be copied.
+        ``classes_`` atribute will not be passed.
 
         It should be set only if a user-defined metric function is being used
-        and left as default in case of a scikit-learn API metric.
+        and left as default in case of a scikit-learn metric.
 
     **kwargs : additional arguments
         Additional parameters to be passed to score_func.

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -86,8 +86,8 @@ class _BaseScorer(six.with_metaclass(ABCMeta, object)):
                     # labels should be a subset of classes
                     if not set(classes).issuperset(
                                         set(self._kwargs[self._pass_classes])):
-                        raise ValueError("`estimator classes=%r` is not the"
-                                         "superset of `scorer %s=%r`" %
+                        raise ValueError("`estimator classes=%s` is not the"
+                                         "superset of `scorer %s=%s`" %
                                          (classes,
                                           self._pass_classes,
                                           self._kwargs['labels']))

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1587,16 +1587,16 @@ def test_check_labels_subset():
     y = [1, 1, 2, 2, 3, 3]
     labels1 = np.array([1, 2])
     labels2 = np.array([1, 2, 4])
-    expected_msg1 = ("The `allow_labels_subset` argument should be True "
-                     "if a subset of available classes=[1 2 3] was passed in "
-                     " the labels=[1 2] argument. `allow_labels_subset` was "
-                     " added in version 0.20 and this behavior will "
-                     "result in error from version 0.22.")
-    expected_msg2 = ("The `allow_labels_subset` argument should be True "
-                     "if a subset of available classes=[1 2 3] was passed in "
-                     " the labels=[1 2 4] argument. `allow_labels_subset` was "
-                     " added in version 0.20 and this behavior will "
-                     "result in error from version 0.22.")
+    expected_msg1 = ("The labels argument [1 2] was a subset of the "
+                     "present classes [1 2 3]. If you want to compute a metric"
+                     " on thesubset of the classes, set "
+                     "allow_label_subset=True. This warning was introduced in "
+                     "0.20 and will turninto an error in version 0.22")
+    expected_msg2 = ("The labels argument [1 2 4] was a subset of the present "
+                     "classes [1 2 3]. If you want to compute a metric on "
+                     "thesubset of the classes, set allow_label_subset=True. "
+                     "This warning was introduced in 0.20 and will turninto an"
+                     " error in version 0.22")
 
     scorers_to_check = [confusion_matrix, cohen_kappa_score, recall_score,
                         precision_score, precision_recall_fscore_support,

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -26,7 +26,6 @@ from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.mocking import MockDataFrame
-from sklearn.utils.testing import assert_warns_message
 
 from sklearn.metrics import accuracy_score
 from sklearn.metrics import average_precision_score
@@ -638,6 +637,7 @@ def test_confusion_matrix_sample_weight():
         sample_weight=weights[:-1])
 
 
+@ignore_warnings
 def test_confusion_matrix_multiclass_subset_labels():
     # Test confusion matrix - multi-class case with subset of labels
     y_true, y_pred, _ = make_prediction(binary=False)

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -12,7 +12,6 @@ from sklearn import svm
 from sklearn.datasets import make_multilabel_classification
 from sklearn.preprocessing import label_binarize
 from sklearn.utils.validation import check_random_state
-from sklearn.externals.funcsigs import signature
 
 from sklearn.utils.testing import assert_raises, clean_warning_registry
 from sklearn.utils.testing import assert_raise_message
@@ -1581,40 +1580,3 @@ def test_brier_score_loss():
     # calculate even if only single class in y_true (#6980)
     assert_almost_equal(brier_score_loss([0], [0.5]), 0.25)
     assert_almost_equal(brier_score_loss([1], [0.5]), 0.25)
-
-
-def test_check_labels_subset():
-    y = [1, 1, 2, 2, 3, 3]
-    labels1 = np.array([1, 2])
-    labels2 = np.array([1, 2, 4])
-    expected_msg1 = ("The labels argument [1 2] was a subset of the "
-                     "present classes [1 2 3]. If you want to compute a metric"
-                     " on thesubset of the classes, set "
-                     "allow_label_subset=True. This warning was introduced in "
-                     "0.20 and will turninto an error in version 0.22")
-    expected_msg2 = ("The labels argument [1 2 4] was a subset of the present "
-                     "classes [1 2 3]. If you want to compute a metric on "
-                     "thesubset of the classes, set allow_label_subset=True. "
-                     "This warning was introduced in 0.20 and will turninto an"
-                     " error in version 0.22")
-
-    scorers_to_check = [confusion_matrix, cohen_kappa_score, recall_score,
-                        precision_score, precision_recall_fscore_support,
-                        fbeta_score, f1_score, classification_report,
-                        hamming_loss, log_loss]
-
-    for scorer in scorers_to_check:
-        kwargs = {}
-        params = signature(scorer).parameters
-        if 'average' in params:
-            kwargs['average'] = 'micro'
-        if 'beta' in params:
-            kwargs['beta'] = 2
-
-        assert_warns_message(DeprecationWarning,
-                             expected_msg1,
-                             scorer, y, y, labels=labels1, **kwargs)
-        if scorer != log_loss:
-            assert_warns_message(DeprecationWarning,
-                                 expected_msg2,
-                                 scorer, y, y, labels=labels2, **kwargs)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -563,6 +563,13 @@ def test_pass_classes():
     scorer = make_scorer(DummyScorerWithLabels)
     assert_equal(scorer(clf, X, y), 1)
 
+    # by default, labels should be set
+    scorer = make_scorer(DummyScorerWithLabels, labels=[1, 2, 3])
+    expected_msg = ("`estimator classes=[0 1]` is not the"
+                    "superset of `scorer labels=[1, 2, 3]`")
+    assert_raise_message(ValueError, expected_msg,
+                         scorer, clf, X, y)
+
     # if an argument other than labels passed, then it should be present in
     # scorer's signature
     scorer = make_scorer(DummyScorerWithLabels, pass_classes='label_names')

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -583,12 +583,3 @@ def test_pass_classes():
     clf.fit(X, y)
     scorer = make_scorer(f1_score, average="macro", pass_classes=None)
     scores = scorer(clf, X, y)
-
-    # iterate over 2 - 5 classes and see that the scores are multiplied by
-    # right factor
-    scorer = make_scorer(f1_score, average="macro", pass_classes='labels')
-    for num_classes in range(2, 6):
-        clf = GaussianNB(classes=list(range(num_classes)))
-        clf.fit(X, y)
-        scores2 = scorer(clf, X, y)
-        assert_array_almost_equal(scores*2./num_classes, scores2)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -144,8 +144,8 @@ class DummyScorer(object):
         return 1
 
 
-def DummyScorerWithLabels(y_true, y_pred, labels=None):
-    """A dummy scorer function which returns 1 if labels argument was set
+def dummy_scorer_with_labels(y_true, y_pred, labels=None):
+    """A dummy metric function which returns 1 if labels argument was set
     else returns 0"""
     if labels is None:
         return 0
@@ -153,9 +153,9 @@ def DummyScorerWithLabels(y_true, y_pred, labels=None):
         return 1
 
 
-def DummyScorerWithLabelsNamedDifferent(y_true, y_pred,
-                                        labels_other_name=None):
-    """A dummy scorer function which returns 1 if labels argument was set
+def dummy_scorer_with_labels_named_different(y_true, y_pred,
+                                             labels_other_name=None):
+    """A dummy metric function which returns 1 if labels argument was set
     else returns 0"""
     if labels_other_name is None:
         return 0
@@ -556,14 +556,14 @@ def test_pass_classes():
     clf.fit(X, y)
 
     # copy_classes=None should not set labels
-    scorer = make_scorer(DummyScorerWithLabels, pass_classes=None)
+    scorer = make_scorer(dummy_scorer_with_labels, pass_classes=None)
     assert_equal(scorer(clf, X, y), 0)
 
     # by default, labels should be set
-    scorer = make_scorer(DummyScorerWithLabels)
+    scorer = make_scorer(dummy_scorer_with_labels)
     assert_equal(scorer(clf, X, y), 1)
 
-    scorer = make_scorer(DummyScorerWithLabels, labels=[1, 2, 3])
+    scorer = make_scorer(dummy_scorer_with_labels, labels=[1, 2, 3])
     expected_msg = ("LogisticRegression classes=[0 1] is not the superset of "
                     "scorer labels=[1, 2, 3]")
     assert_raise_message(ValueError, expected_msg,
@@ -571,13 +571,13 @@ def test_pass_classes():
 
     # if an argument other than labels passed, then it should be present in
     # scorer's signature
-    scorer = make_scorer(DummyScorerWithLabels, pass_classes='label_names')
+    scorer = make_scorer(dummy_scorer_with_labels, pass_classes='label_names')
     expected_msg = ("the scorer doesn't have label_names as a parameter,"
                     "as passed in pass_classes parameter")
     assert_raise_message(ValueError, expected_msg,
                          scorer, clf, X, y)
 
     # if custom scorer has another name for labels, it should be set
-    scorer = make_scorer(DummyScorerWithLabelsNamedDifferent,
+    scorer = make_scorer(dummy_scorer_with_labels_named_different,
                          pass_classes='labels_other_name')
     assert_equal(scorer(clf, X, y), 1)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -565,8 +565,8 @@ def test_pass_classes():
 
     # by default, labels should be set
     scorer = make_scorer(DummyScorerWithLabels, labels=[1, 2, 3])
-    expected_msg = ("`estimator classes=[0 1]` is not the"
-                    "superset of `scorer labels=[1, 2, 3]`")
+    expected_msg = ("LogisticRegression classes=[0 1] is not thesuperset of "
+                    "scorer labels=[1, 2, 3]")
     assert_raise_message(ValueError, expected_msg,
                          scorer, clf, X, y)
 

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -17,7 +17,6 @@ from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_raise_message
-from sklearn.utils.testing import assert_array_almost_equal
 
 from sklearn.base import BaseEstimator
 from sklearn.metrics import (f1_score, r2_score, roc_auc_score, fbeta_score,
@@ -41,7 +40,6 @@ from sklearn.model_selection import train_test_split, cross_val_score
 from sklearn.model_selection import GridSearchCV
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.externals import joblib
-from sklearn.naive_bayes import GaussianNB
 
 
 REGRESSION_SCORERS = ['explained_variance', 'r2',
@@ -577,9 +575,3 @@ def test_pass_classes():
     scorer = make_scorer(DummyScorerWithLabelsNamedDifferent,
                          pass_classes='labels_other_name')
     assert_equal(scorer(clf, X, y), 1)
-
-    # test that passing labels through make_scorer affects the actual scores
-    clf = GaussianNB()
-    clf.fit(X, y)
-    scorer = make_scorer(f1_score, average="macro", pass_classes=None)
-    scores = scorer(clf, X, y)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -563,12 +563,6 @@ def test_pass_classes():
     scorer = make_scorer(dummy_scorer_with_labels)
     assert_equal(scorer(clf, X, y), 1)
 
-    scorer = make_scorer(dummy_scorer_with_labels, labels=[1, 2, 3])
-    expected_msg = ("LogisticRegression classes=[0 1] is not the superset of "
-                    "scorer labels=[1, 2, 3]")
-    assert_raise_message(ValueError, expected_msg,
-                         scorer, clf, X, y)
-
     # if an argument other than labels passed, then it should be present in
     # scorer's signature
     scorer = make_scorer(dummy_scorer_with_labels, pass_classes='label_names')

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -549,7 +549,7 @@ def test_scoring_is_not_metric():
 
 
 def test_pass_classes():
-    # Test the various properties of pass_classes parameter added
+    # Test the various properties of pass_classes parameter
 
     X, y = make_blobs(random_state=0, centers=2)
     clf = LogisticRegression(random_state=0)
@@ -563,9 +563,8 @@ def test_pass_classes():
     scorer = make_scorer(DummyScorerWithLabels)
     assert_equal(scorer(clf, X, y), 1)
 
-    # by default, labels should be set
     scorer = make_scorer(DummyScorerWithLabels, labels=[1, 2, 3])
-    expected_msg = ("LogisticRegression classes=[0 1] is not thesuperset of "
+    expected_msg = ("LogisticRegression classes=[0 1] is not the superset of "
                     "scorer labels=[1, 2, 3]")
     assert_raise_message(ValueError, expected_msg,
                          scorer, clf, X, y)


### PR DESCRIPTION
Scorers pass classes from estimators into the labels argument of the metrics.
allow_subset_labels added to all the metrics allowing scoring on a subset of labels.

Issues: #6231 #8100 