### PR TITLE
Tiny docs fix for roc_auc_score

### DIFF
--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -237,7 +237,7 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
 
     See also
     --------
-    average_precision_score : Area under the precision-recall curve
+    average_precision_score : Average precision (AP) from prediction scores
 
     roc_curve : Compute Receiver operating characteristic (ROC)
 


### PR DESCRIPTION
The `roc_auc_score` docs list `average_precision_score` as "Area under the precision-recall curve". This is not correct, so I fixed the description to the correct description of `average_precision_score`.