### PR TITLE
[MRG+2] Adds helpful messages in all error assertions in estimator_checks

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -691,7 +691,7 @@ def check_transformers_unfitted(name, transformer):
     with assert_raises((AttributeError, ValueError), msg="The unfitted "
                        "transformer {} does not raise an error when "
                        "transform is called. Perhaps use "
-                       "check_is_fitted.".format(name)):
+                       "check_is_fitted in transform.".format(name)):
         transformer.transform(X)
 
 
@@ -865,7 +865,7 @@ def check_estimators_empty_data_messages(name, estimator_orig):
     with assert_raises(ValueError, msg="The estimator {} does not"
                        " raise an error when an empty data is used "
                        "to train. Perhaps use "
-                       "check_array.".format(name)):
+                       "check_array in train.".format(name)):
         e.fit(X_zero_samples, [])
 
     X_zero_features = np.empty(0).reshape(3, 0)
@@ -1003,8 +1003,8 @@ def check_estimators_partial_fit_n_features(name, estimator_orig):
 
     with assert_raises(ValueError,
                        msg="The estimator {} does not raise an"
-                           " error when number of features changes "
-                           "between calls to "
+                           " error when the number of features"
+                           " changes between calls to "
                            "partial_fit.".format(name)):
         estimator.partial_fit(X[:, :-1], y)
 
@@ -1112,9 +1112,9 @@ def check_classifiers_train(name, classifier_orig):
         # raises error on malformed input for fit
         with assert_raises(ValueError, msg="The classifer {} does not"
                            " raise an error when incorrect/malformed input "
-                           "data for fit is passed. Number of training "
-                           "examples is not the same as the number of "
-                           "labels. Perhapse use check_X_y.".format(name)):
+                           "data for fit is passed. The number of training "
+                           "examples is not the same as the number of labels."
+                           " Perhaps use check_X_y in fit.".format(name)):
             classifier.fit(X, y[:-1])
 
         # fit
@@ -1335,9 +1335,9 @@ def check_regressors_train(name, regressor_orig):
     # raises error on malformed input for fit
     with assert_raises(ValueError, msg="The classifer {} does not"
                        " raise an error when incorrect/malformed input "
-                       "data for fit is passed. Number of training "
+                       "data for fit is passed. The number of training "
                        "examples is not the same as the number of "
-                       "labels. Perhapse use check_X_y.".format(name)):
+                       "labels. Perhaps use check_X_y in fit.".format(name)):
         regressor.fit(X, y[:-1])
     # fit
     if name in CROSS_DECOMPOSITION:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1154,10 +1154,10 @@ def check_classifiers_train(name, classifier_orig):
                 # raises error on malformed input for decision_function
                 with assert_raises(ValueError, msg="The classifer {name} does "
                                    "not raise an error when incorrect/malforme"
-                                   "d input for predict is passed. Number of f"
-                                   "eatures in predict dataset does not match "
-                                   "the number of features in fit dataset. "
-                                   "Perhaps use check_array"):
+                                   "d input for decision_function is passed. N"
+                                   "umber of features in predict dataset does "
+                                   "not match the number of features in fit da"
+                                   "taset. Perhaps use check_array"):
                     classifier.decision_function(X.T)
             except NotImplementedError:
                 pass
@@ -1171,9 +1171,9 @@ def check_classifiers_train(name, classifier_orig):
             # raises error on malformed input
             with assert_raises(ValueError, msg="The classifer {name} does not"
                                " raise an error when incorrect/malformed inpu"
-                               "t  for predict is passed. Number of features "
-                               "in predict dataset does not match the number "
-                               "of features in fit dataset. "
+                               "t  for predict_proba is passed. Number of fea"
+                               "tures in predict dataset does not match the n"
+                               "umber of features in fit dataset. "
                                "Perhaps use check_array"):
                 classifier.predict_proba(X.T)
             # raises error on malformed input for predict_proba

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -763,10 +763,10 @@ def _check_transformer(name, transformer_orig, X, y):
         # raises error on malformed input for transform
         if hasattr(X, 'T'):
             # If it's not an array, it does not have a 'T' property
-            with assert_raises(ValueError, msg= "The transformer {name} does not"
-                               " raise an error when the number of features "
-                               "in transform is different from the number of"
-                               " features in fit"):
+            with assert_raises(ValueError, msg="The transformer {name} does "
+                               "not raise an error when the number of featur"
+                               "es in transform is different from the number"
+                               " of features in fit"):
                 transformer.transform(X.T)
 
 
@@ -1126,9 +1126,9 @@ def check_classifiers_train(name, classifier_orig):
 
         # raises error on malformed input for predict
         with assert_raises(ValueError, msg="The classifier {name} does not"
-                               " raise an error when the number of features "
-                               "in predict is different from the number of"
-                               " features in fit"):
+                           " raise an error when the number of features "
+                           "in predict is different from the number of"
+                           " features in fit"):
             classifier.predict(X.T)
         if hasattr(classifier, "decision_function"):
             try:
@@ -1148,10 +1148,10 @@ def check_classifiers_train(name, classifier_orig):
                 with assert_raises(ValueError, msg="Malformed inputs"):
                     classifier.decision_function(X.T)
                 # raises error on malformed input for decision_function
-                with assert_raises(ValueError, msg="The classifier {name} does not"
-                               " raise an error when the number of features "
-                               "in decision_function is different from the number of"
-                               " features in fit"):
+                with assert_raises(ValueError, msg="The classifier {name} does"
+                                   " not raise an error when the number of fea"
+                                   "tures in decision_function is different "
+                                   "from the number of features in fit"):
                     classifier.decision_function(X.T)
             except NotImplementedError:
                 pass
@@ -1165,8 +1165,8 @@ def check_classifiers_train(name, classifier_orig):
             # raises error on malformed input
             with assert_raises(ValueError, msg="The classifier {name} does not"
                                " raise an error when the number of features "
-                               "in predict_proba is different from the number of"
-                               " features in fit"):
+                               "in predict_proba is different from the number "
+                               "of features in fit"):
                 classifier.predict_proba(X.T)
             # raises error on malformed input for predict_proba
             with assert_raises(ValueError,

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -689,9 +689,9 @@ def check_transformers_unfitted(name, transformer):
 
     transformer = clone(transformer)
     with assert_raises((AttributeError, ValueError), msg="The unfitted "
-                       "transformer {} does not raise an error when tra"
-                       "nsform is called. Perhaps use check_is_fitted."
-                       .format(name)):
+                       "transformer {} does not raise an error when "
+                       "transform is called. Perhaps use "
+                       "check_is_fitted.".format(name)):
         transformer.transform(X)
 
 
@@ -765,9 +765,10 @@ def _check_transformer(name, transformer_orig, X, y):
         if hasattr(X, 'T'):
             # If it's not an array, it does not have a 'T' property
             with assert_raises(ValueError, msg="The transformer {} does "
-                               "not raise an error when the number of featur"
-                               "es in transform is different from the number"
-                               " of features in fit.".format(name)):
+                               "not raise an error when the number of "
+                               "features in transform is different from"
+                               " the number of features in "
+                               "fit.".format(name)):
                 transformer.transform(X.T)
 
 
@@ -863,8 +864,8 @@ def check_estimators_empty_data_messages(name, estimator_orig):
     # validated first. Let us test the type of exception only:
     with assert_raises(ValueError, msg="The estimator {} does not"
                        " raise an error when an empty data is used "
-                       "to train. "
-                       "Perhaps use check_array.".format(name)):
+                       "to train. Perhaps use "
+                       "check_array.".format(name)):
         e.fit(X_zero_samples, [])
 
     X_zero_features = np.empty(0).reshape(3, 0)
@@ -1003,8 +1004,8 @@ def check_estimators_partial_fit_n_features(name, estimator_orig):
     with assert_raises(ValueError,
                        msg="The estimator {} does not raise an"
                            " error when number of features changes "
-                           "between calls to partial_"
-                           "fit.".format(name)):
+                           "between calls to "
+                           "partial_fit.".format(name)):
         estimator.partial_fit(X[:, :-1], y)
 
 
@@ -1111,10 +1112,9 @@ def check_classifiers_train(name, classifier_orig):
         # raises error on malformed input for fit
         with assert_raises(ValueError, msg="The classifer {} does not"
                            " raise an error when incorrect/malformed input "
-                           "data for fit is passed. Number of training exam"
-                           "ples is not the same as the number of "
-                           "labels. Perhapse use "
-                           "check_X_y.".format(name)):
+                           "data for fit is passed. Number of training "
+                           "examples is not the same as the number of "
+                           "labels. Perhapse use check_X_y.".format(name)):
             classifier.fit(X, y[:-1])
 
         # fit
@@ -1150,10 +1150,10 @@ def check_classifiers_train(name, classifier_orig):
 
                 # raises error on malformed input for decision_function
                 with assert_raises(ValueError, msg="The classifier {} does"
-                                   " not raise an error when the number of fea"
-                                   "tures in decision_function is different "
-                                   "from the number of features in "
-                                   "fit.".format(name)):
+                                   " not raise an error when the number of "
+                                   "features in decision_function is "
+                                   "different from the number of features"
+                                   " in fit.".format(name)):
                     classifier.decision_function(X.T)
             except NotImplementedError:
                 pass
@@ -1335,8 +1335,8 @@ def check_regressors_train(name, regressor_orig):
     # raises error on malformed input for fit
     with assert_raises(ValueError, msg="The classifer {} does not"
                        " raise an error when incorrect/malformed input "
-                       "data for fit is passed. Number of training exam"
-                       "ples is not the same as the number of "
+                       "data for fit is passed. Number of training "
+                       "examples is not the same as the number of "
                        "labels. Perhapse use check_X_y.".format(name)):
         regressor.fit(X, y[:-1])
     # fit

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -763,8 +763,9 @@ def _check_transformer(name, transformer_orig, X, y):
         # raises error on malformed input for transform
         if hasattr(X, 'T'):
             # If it's not an array, it does not have a 'T' property
-            with assert_raises(ValueError,
-                               msg="Malformed input for transform"):
+            with assert_raises(ValueError, msg="The transformer {name} does not"
+                               " raise an error when incorrect/malformed input "
+                               "array is passed"):
                 transformer.transform(X.T)
 
 
@@ -858,7 +859,8 @@ def check_estimators_empty_data_messages(name, estimator_orig):
     X_zero_samples = np.empty(0).reshape(0, 3)
     # The precise message can change depending on whether X or y is
     # validated first. Let us test the type of exception only:
-    with assert_raises(ValueError, msg="Empty data messages"):
+    with assert_raises(ValueError, msg="The estimators {name} does not"
+                               " raise an error when"):
         e.fit(X_zero_samples, [])
 
     X_zero_features = np.empty(0).reshape(3, 0)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -688,7 +688,8 @@ def check_transformers_unfitted(name, transformer):
     X, y = _boston_subset()
 
     transformer = clone(transformer)
-    with assert_raises((AttributeError, ValueError), msg="Transformers unfitted"):
+    with assert_raises((AttributeError, ValueError),
+                       msg="Transformers unfitted"):
         transformer.transform(X)
 
 
@@ -761,7 +762,8 @@ def _check_transformer(name, transformer_orig, X, y):
         # raises error on malformed input for transform
         if hasattr(X, 'T'):
             # If it's not an array, it does not have a 'T' property
-            with assert_raises(ValueError, msg="Malformed input for transform"):
+            with assert_raises(ValueError,
+                               msg="Malformed input for transform"):
                 transformer.transform(X.T)
 
 
@@ -991,7 +993,9 @@ def check_estimators_partial_fit_n_features(name, estimator_orig):
     except NotImplementedError:
         return
 
-    with assert_raises(ValueError, msg="Number of features changes between calls to partial_fit"):
+    with assert_raises(ValueError,
+                       msg="Number of features "
+                       "changes between calls to partial_fit"):
         estimator.partial_fit(X[:, :-1], y)
 
 
@@ -1131,7 +1135,9 @@ def check_classifiers_train(name, classifier_orig):
                 with assert_raises(ValueError, msg="Malformed inputs"):
                     classifier.decision_function(X.T)
                 # raises error on malformed input for decision_function
-                with assert_raises(ValueError, msg="Malformed input for decision_function"):
+                with assert_raises(ValueError,
+                                   msg="Malformed input "
+                                   "for decision_function"):
                     classifier.decision_function(X.T)
             except NotImplementedError:
                 pass
@@ -1146,7 +1152,8 @@ def check_classifiers_train(name, classifier_orig):
             with assert_raises(ValueError, msg="Malformed input"):
                 classifier.predict_proba(X.T)
             # raises error on malformed input for predict_proba
-            with assert_raises(ValueError, msg="Malformed input for predict_proba"):
+            with assert_raises(ValueError,
+                               msg="Malformed input for predict_proba"):
                 classifier.predict_proba(X.T)
             if hasattr(classifier, "predict_log_proba"):
                 # predict_log_proba is a transformation of predict_proba

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -690,7 +690,7 @@ def check_transformers_unfitted(name, transformer):
     transformer = clone(transformer)
     with assert_raises((AttributeError, ValueError), msg="The unfitted "
                        "transformer {name} does not raise an error when "
-                       "transform is called. Perhaps use check_is_fitted"):
+                       "transform is called. Perhaps use check_is_fitted."):
         transformer.transform(X)
 
 
@@ -766,7 +766,7 @@ def _check_transformer(name, transformer_orig, X, y):
             with assert_raises(ValueError, msg="The transformer {name} does "
                                "not raise an error when the number of featur"
                                "es in transform is different from the number"
-                               " of features in fit"):
+                               " of features in fit."):
                 transformer.transform(X.T)
 
 
@@ -862,7 +862,7 @@ def check_estimators_empty_data_messages(name, estimator_orig):
     # validated first. Let us test the type of exception only:
     with assert_raises(ValueError, msg="The estimator {name} does not"
                        " raise an error when an empty data is used "
-                       "to train. Perhaps use check_array"):
+                       "to train. Perhaps use check_array."):
         e.fit(X_zero_samples, [])
 
     X_zero_features = np.empty(0).reshape(3, 0)
@@ -1001,7 +1001,7 @@ def check_estimators_partial_fit_n_features(name, estimator_orig):
     with assert_raises(ValueError,
                        msg="The estimator {name} does not raise an"
                            " error when number of features changes "
-                           "between calls to partial_fit. Perhaps"):
+                           "between calls to partial_fit."):
         estimator.partial_fit(X[:, :-1], y)
 
 
@@ -1110,7 +1110,7 @@ def check_classifiers_train(name, classifier_orig):
                            " raise an error when incorrect/malformed input "
                            "data for fit is passed. Number of training exam"
                            "ples is not the same as the number of "
-                           "labels. Perhapse use check_X_y"):
+                           "labels. Perhapse use check_X_y."):
             classifier.fit(X, y[:-1])
 
         # fit
@@ -1128,7 +1128,7 @@ def check_classifiers_train(name, classifier_orig):
         with assert_raises(ValueError, msg="The classifier {name} does not"
                            " raise an error when the number of features "
                            "in predict is different from the number of"
-                           " features in fit"):
+                           " features in fit."):
             classifier.predict(X.T)
         if hasattr(classifier, "decision_function"):
             try:
@@ -1144,14 +1144,11 @@ def check_classifiers_train(name, classifier_orig):
                     assert_equal(decision.shape, (n_samples, n_classes))
                     assert_array_equal(np.argmax(decision, axis=1), y_pred)
 
-                # raises error on malformed input
-                with assert_raises(ValueError, msg="Malformed inputs"):
-                    classifier.decision_function(X.T)
                 # raises error on malformed input for decision_function
                 with assert_raises(ValueError, msg="The classifier {name} does"
                                    " not raise an error when the number of fea"
                                    "tures in decision_function is different "
-                                   "from the number of features in fit"):
+                                   "from the number of features in fit."):
                     classifier.decision_function(X.T)
             except NotImplementedError:
                 pass
@@ -1162,15 +1159,11 @@ def check_classifiers_train(name, classifier_orig):
             assert_array_equal(np.argmax(y_prob, axis=1), y_pred)
             # check that probas for all classes sum to one
             assert_allclose(np.sum(y_prob, axis=1), np.ones(n_samples))
-            # raises error on malformed input
+            # raises error on malformed input for predict_proba
             with assert_raises(ValueError, msg="The classifier {name} does not"
                                " raise an error when the number of features "
                                "in predict_proba is different from the number "
-                               "of features in fit"):
-                classifier.predict_proba(X.T)
-            # raises error on malformed input for predict_proba
-            with assert_raises(ValueError,
-                               msg="Malformed input for predict_proba"):
+                               "of features in fit."):
                 classifier.predict_proba(X.T)
             if hasattr(classifier, "predict_log_proba"):
                 # predict_log_proba is a transformation of predict_proba
@@ -1339,7 +1332,7 @@ def check_regressors_train(name, regressor_orig):
                        " raise an error when incorrect/malformed input "
                        "data for fit is passed. Number of training exam"
                        "ples is not the same as the number of "
-                       "labels. Perhapse use check_X_y"):
+                       "labels. Perhapse use check_X_y."):
         regressor.fit(X, y[:-1])
     # fit
     if name in CROSS_DECOMPOSITION:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -689,8 +689,9 @@ def check_transformers_unfitted(name, transformer):
 
     transformer = clone(transformer)
     with assert_raises((AttributeError, ValueError), msg="The unfitted "
-                       "transformer {name} does not raise an error when "
-                       "transform is called. Perhaps use check_is_fitted."):
+                       "transformer {} does not raise an error when tra"
+                       "nsform is called. Perhaps use check_is_fitted."
+                       .format(name)):
         transformer.transform(X)
 
 
@@ -763,10 +764,10 @@ def _check_transformer(name, transformer_orig, X, y):
         # raises error on malformed input for transform
         if hasattr(X, 'T'):
             # If it's not an array, it does not have a 'T' property
-            with assert_raises(ValueError, msg="The transformer {name} does "
+            with assert_raises(ValueError, msg="The transformer {} does "
                                "not raise an error when the number of featur"
                                "es in transform is different from the number"
-                               " of features in fit."):
+                               " of features in fit.".format(name)):
                 transformer.transform(X.T)
 
 
@@ -860,9 +861,10 @@ def check_estimators_empty_data_messages(name, estimator_orig):
     X_zero_samples = np.empty(0).reshape(0, 3)
     # The precise message can change depending on whether X or y is
     # validated first. Let us test the type of exception only:
-    with assert_raises(ValueError, msg="The estimator {name} does not"
+    with assert_raises(ValueError, msg="The estimator {} does not"
                        " raise an error when an empty data is used "
-                       "to train. Perhaps use check_array."):
+                       "to train. "
+                       "Perhaps use check_array.".format(name)):
         e.fit(X_zero_samples, [])
 
     X_zero_features = np.empty(0).reshape(3, 0)
@@ -999,9 +1001,10 @@ def check_estimators_partial_fit_n_features(name, estimator_orig):
         return
 
     with assert_raises(ValueError,
-                       msg="The estimator {name} does not raise an"
+                       msg="The estimator {} does not raise an"
                            " error when number of features changes "
-                           "between calls to partial_fit."):
+                           "between calls to partial_"
+                           "fit.".format(name)):
         estimator.partial_fit(X[:, :-1], y)
 
 
@@ -1106,11 +1109,12 @@ def check_classifiers_train(name, classifier_orig):
             X -= X.min()
         set_random_state(classifier)
         # raises error on malformed input for fit
-        with assert_raises(ValueError, msg="The classifer {name} does not"
+        with assert_raises(ValueError, msg="The classifer {} does not"
                            " raise an error when incorrect/malformed input "
                            "data for fit is passed. Number of training exam"
                            "ples is not the same as the number of "
-                           "labels. Perhapse use check_X_y."):
+                           "labels. Perhapse use "
+                           "check_X_y.".format(name)):
             classifier.fit(X, y[:-1])
 
         # fit
@@ -1125,10 +1129,10 @@ def check_classifiers_train(name, classifier_orig):
             assert_greater(accuracy_score(y, y_pred), 0.83)
 
         # raises error on malformed input for predict
-        with assert_raises(ValueError, msg="The classifier {name} does not"
+        with assert_raises(ValueError, msg="The classifier {} does not"
                            " raise an error when the number of features "
                            "in predict is different from the number of"
-                           " features in fit."):
+                           " features in fit.".format(name)):
             classifier.predict(X.T)
         if hasattr(classifier, "decision_function"):
             try:
@@ -1145,10 +1149,11 @@ def check_classifiers_train(name, classifier_orig):
                     assert_array_equal(np.argmax(decision, axis=1), y_pred)
 
                 # raises error on malformed input for decision_function
-                with assert_raises(ValueError, msg="The classifier {name} does"
+                with assert_raises(ValueError, msg="The classifier {} does"
                                    " not raise an error when the number of fea"
                                    "tures in decision_function is different "
-                                   "from the number of features in fit."):
+                                   "from the number of features in "
+                                   "fit.".format(name)):
                     classifier.decision_function(X.T)
             except NotImplementedError:
                 pass
@@ -1160,10 +1165,10 @@ def check_classifiers_train(name, classifier_orig):
             # check that probas for all classes sum to one
             assert_allclose(np.sum(y_prob, axis=1), np.ones(n_samples))
             # raises error on malformed input for predict_proba
-            with assert_raises(ValueError, msg="The classifier {name} does not"
+            with assert_raises(ValueError, msg="The classifier {} does not"
                                " raise an error when the number of features "
                                "in predict_proba is different from the number "
-                               "of features in fit."):
+                               "of features in fit.".format(name)):
                 classifier.predict_proba(X.T)
             if hasattr(classifier, "predict_log_proba"):
                 # predict_log_proba is a transformation of predict_proba
@@ -1328,11 +1333,11 @@ def check_regressors_train(name, regressor_orig):
         regressor.C = 0.01
 
     # raises error on malformed input for fit
-    with assert_raises(ValueError, msg="The classifer {name} does not"
+    with assert_raises(ValueError, msg="The classifer {} does not"
                        " raise an error when incorrect/malformed input "
                        "data for fit is passed. Number of training exam"
                        "ples is not the same as the number of "
-                       "labels. Perhapse use check_X_y."):
+                       "labels. Perhapse use check_X_y.".format(name)):
         regressor.fit(X, y[:-1])
     # fit
     if name in CROSS_DECOMPOSITION:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -763,12 +763,10 @@ def _check_transformer(name, transformer_orig, X, y):
         # raises error on malformed input for transform
         if hasattr(X, 'T'):
             # If it's not an array, it does not have a 'T' property
-            with assert_raises(ValueError, msg="The classifer {name} does not "
-                               "raise an error when incorrect/malformed input "
-                               " for predict is passed. Number of features in "
-                               "predict dataset does not match the number of f"
-                               "eatures in fit dataset."
-                               " Perhaps use check_array"):
+            with assert_raises(ValueError, msg= "The transformer {name} does not"
+                               " raise an error when the number of features "
+                               "in transform is different from the number of"
+                               " features in fit"):
                 transformer.transform(X.T)
 
 
@@ -1003,8 +1001,7 @@ def check_estimators_partial_fit_n_features(name, estimator_orig):
     with assert_raises(ValueError,
                        msg="The estimator {name} does not raise an"
                            " error when number of features changes "
-                           "between calls to partial_fit. Perhaps"
-                           " use check_X_y"):
+                           "between calls to partial_fit. Perhaps"):
         estimator.partial_fit(X[:, :-1], y)
 
 
@@ -1113,7 +1110,7 @@ def check_classifiers_train(name, classifier_orig):
                            " raise an error when incorrect/malformed input "
                            "data for fit is passed. Number of training exam"
                            "ples is not the same as the number of "
-                           "labels. Perhapse use check_array"):
+                           "labels. Perhapse use check_X_y"):
             classifier.fit(X, y[:-1])
 
         # fit
@@ -1128,11 +1125,10 @@ def check_classifiers_train(name, classifier_orig):
             assert_greater(accuracy_score(y, y_pred), 0.83)
 
         # raises error on malformed input for predict
-        with assert_raises(ValueError, msg="The classifer {name} does not"
-                           " raise an error when incorrect/malformed input "
-                           " for predict is passed. Number of features in p"
-                           "redict dataset does not match the number of fea"
-                           "tures in fit dataset. Perhaps use check_array"):
+        with assert_raises(ValueError, msg="The classifier {name} does not"
+                               " raise an error when the number of features "
+                               "in predict is different from the number of"
+                               " features in fit"):
             classifier.predict(X.T)
         if hasattr(classifier, "decision_function"):
             try:
@@ -1152,12 +1148,10 @@ def check_classifiers_train(name, classifier_orig):
                 with assert_raises(ValueError, msg="Malformed inputs"):
                     classifier.decision_function(X.T)
                 # raises error on malformed input for decision_function
-                with assert_raises(ValueError, msg="The classifer {name} does "
-                                   "not raise an error when incorrect/malforme"
-                                   "d input for decision_function is passed. N"
-                                   "umber of features in predict dataset does "
-                                   "not match the number of features in fit da"
-                                   "taset. Perhaps use check_array"):
+                with assert_raises(ValueError, msg="The classifier {name} does not"
+                               " raise an error when the number of features "
+                               "in decision_function is different from the number of"
+                               " features in fit"):
                     classifier.decision_function(X.T)
             except NotImplementedError:
                 pass
@@ -1169,12 +1163,10 @@ def check_classifiers_train(name, classifier_orig):
             # check that probas for all classes sum to one
             assert_allclose(np.sum(y_prob, axis=1), np.ones(n_samples))
             # raises error on malformed input
-            with assert_raises(ValueError, msg="The classifer {name} does not"
-                               " raise an error when incorrect/malformed inpu"
-                               "t  for predict_proba is passed. Number of fea"
-                               "tures in predict dataset does not match the n"
-                               "umber of features in fit dataset. "
-                               "Perhaps use check_array"):
+            with assert_raises(ValueError, msg="The classifier {name} does not"
+                               " raise an error when the number of features "
+                               "in predict_proba is different from the number of"
+                               " features in fit"):
                 classifier.predict_proba(X.T)
             # raises error on malformed input for predict_proba
             with assert_raises(ValueError,
@@ -1347,7 +1339,7 @@ def check_regressors_train(name, regressor_orig):
                        " raise an error when incorrect/malformed input "
                        "data for fit is passed. Number of training exam"
                        "ples is not the same as the number of "
-                       "labels. Perhapse use check_array"):
+                       "labels. Perhapse use check_X_y"):
         regressor.fit(X, y[:-1])
     # fit
     if name in CROSS_DECOMPOSITION:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -688,7 +688,8 @@ def check_transformers_unfitted(name, transformer):
     X, y = _boston_subset()
 
     transformer = clone(transformer)
-    assert_raises((AttributeError, ValueError), transformer.transform, X)
+    with assert_raises((AttributeError, ValueError), msg="Transformers unfitted"):
+        transformer.transform(X)
 
 
 def _check_transformer(name, transformer_orig, X, y):
@@ -760,7 +761,8 @@ def _check_transformer(name, transformer_orig, X, y):
         # raises error on malformed input for transform
         if hasattr(X, 'T'):
             # If it's not an array, it does not have a 'T' property
-            assert_raises(ValueError, transformer.transform, X.T)
+            with assert_raises(ValueError, msg="Malformed input for transform"):
+                transformer.transform(X.T)
 
 
 @ignore_warnings
@@ -853,7 +855,8 @@ def check_estimators_empty_data_messages(name, estimator_orig):
     X_zero_samples = np.empty(0).reshape(0, 3)
     # The precise message can change depending on whether X or y is
     # validated first. Let us test the type of exception only:
-    assert_raises(ValueError, e.fit, X_zero_samples, [])
+    with assert_raises(ValueError, msg="Empty data messages"):
+        e.fit(X_zero_samples, [])
 
     X_zero_features = np.empty(0).reshape(3, 0)
     # the following y should be accepted by both classifiers and regressors
@@ -988,7 +991,8 @@ def check_estimators_partial_fit_n_features(name, estimator_orig):
     except NotImplementedError:
         return
 
-    assert_raises(ValueError, estimator.partial_fit, X[:, :-1], y)
+    with assert_raises(ValueError, msg="Number of features changes between calls to partial_fit"):
+        estimator.partial_fit(X[:, :-1], y)
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))
@@ -1092,7 +1096,8 @@ def check_classifiers_train(name, classifier_orig):
             X -= X.min()
         set_random_state(classifier)
         # raises error on malformed input for fit
-        assert_raises(ValueError, classifier.fit, X, y[:-1])
+        with assert_raises(ValueError, msg="Malformed input for fit"):
+            classifier.fit(X, y[:-1])
 
         # fit
         classifier.fit(X, y)
@@ -1106,7 +1111,8 @@ def check_classifiers_train(name, classifier_orig):
             assert_greater(accuracy_score(y, y_pred), 0.83)
 
         # raises error on malformed input for predict
-        assert_raises(ValueError, classifier.predict, X.T)
+        with assert_raises(ValueError, msg="Malformed input for predict"):
+            classifier.predict(X.T)
         if hasattr(classifier, "decision_function"):
             try:
                 # decision_function agrees with predict
@@ -1122,11 +1128,11 @@ def check_classifiers_train(name, classifier_orig):
                     assert_array_equal(np.argmax(decision, axis=1), y_pred)
 
                 # raises error on malformed input
-                assert_raises(ValueError,
-                              classifier.decision_function, X.T)
+                with assert_raises(ValueError, msg="Malformed inputs"):
+                    classifier.decision_function(X.T)
                 # raises error on malformed input for decision_function
-                assert_raises(ValueError,
-                              classifier.decision_function, X.T)
+                with assert_raises(ValueError, msg="Malformed input for decision_function"):
+                    classifier.decision_function(X.T)
             except NotImplementedError:
                 pass
         if hasattr(classifier, "predict_proba"):
@@ -1137,9 +1143,11 @@ def check_classifiers_train(name, classifier_orig):
             # check that probas for all classes sum to one
             assert_allclose(np.sum(y_prob, axis=1), np.ones(n_samples))
             # raises error on malformed input
-            assert_raises(ValueError, classifier.predict_proba, X.T)
+            with assert_raises(ValueError, msg="Malformed input"):
+                classifier.predict_proba(X.T)
             # raises error on malformed input for predict_proba
-            assert_raises(ValueError, classifier.predict_proba, X.T)
+            with assert_raises(ValueError, msg="Malformed input for predict_proba"):
+                classifier.predict_proba(X.T)
             if hasattr(classifier, "predict_log_proba"):
                 # predict_log_proba is a transformation of predict_proba
                 y_log_prob = classifier.predict_log_proba(X)
@@ -1303,7 +1311,8 @@ def check_regressors_train(name, regressor_orig):
         regressor.C = 0.01
 
     # raises error on malformed input for fit
-    assert_raises(ValueError, regressor.fit, X, y[:-1])
+    with assert_raises(ValueError, msg="Malformed input for fit"):
+        regressor.fit(X, y[:-1])
     # fit
     if name in CROSS_DECOMPOSITION:
         y_ = np.vstack([y, 2 * y + rnd.randint(2, size=len(y))])

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -763,9 +763,9 @@ def _check_transformer(name, transformer_orig, X, y):
         # raises error on malformed input for transform
         if hasattr(X, 'T'):
             # If it's not an array, it does not have a 'T' property
-            with assert_raises(ValueError, msg="The transformer {name} does not"
-                               " raise an error when incorrect/malformed input "
-                               "array is passed"):
+            with assert_raises(ValueError, msg="The transformer {name} does "
+                               "not raise an error when incorrect/malformed"
+                               " input is passed. Perhaps use check_array"):
                 transformer.transform(X.T)
 
 
@@ -861,7 +861,7 @@ def check_estimators_empty_data_messages(name, estimator_orig):
     # validated first. Let us test the type of exception only:
     with assert_raises(ValueError, msg="The estimators {name} does not"
                        " raise an error when an empty data is used "
-                       "to train. Perhaps use check_is_fitted"):
+                       "to train. Perhaps use check_array"):
         e.fit(X_zero_samples, [])
 
     X_zero_features = np.empty(0).reshape(3, 0)
@@ -998,9 +998,10 @@ def check_estimators_partial_fit_n_features(name, estimator_orig):
         return
 
     with assert_raises(ValueError,
-                       msg="The estimators {name} does not"
-                       " raise an error when number of features"
-                       " changes between calls to partial_fit"):
+                       msg="The estimators {name} does not raise an"
+                           " error when number of features changes "
+                           "between calls to partial_fit. Perhaps"
+                           " use check_X_y"):
         estimator.partial_fit(X[:, :-1], y)
 
 
@@ -1107,7 +1108,7 @@ def check_classifiers_train(name, classifier_orig):
         # raises error on malformed input for fit
         with assert_raises(ValueError, msg="The classifers {name} does not"
                            " raise an error when incorrect/malformed input "
-                           "data for fit is passed"):
+                           "data for fit is passed. Perhapse use check_array"):
             classifier.fit(X, y[:-1])
 
         # fit
@@ -1124,7 +1125,7 @@ def check_classifiers_train(name, classifier_orig):
         # raises error on malformed input for predict
         with assert_raises(ValueError, msg="The classifers {name} does not"
                            " raise an error when incorrect/malformed input "
-                           "data for predict is passed"):
+                           " for predict is passed. Perhaps use check_array"):
             classifier.predict(X.T)
         if hasattr(classifier, "decision_function"):
             try:
@@ -1144,9 +1145,10 @@ def check_classifiers_train(name, classifier_orig):
                 with assert_raises(ValueError, msg="Malformed inputs"):
                     classifier.decision_function(X.T)
                 # raises error on malformed input for decision_function
-                with assert_raises(ValueError, msg="The classifers {name} does not"
-                                   " raise an error when incorrect/malformed input "
-                                   "data for decision function is passed"):
+                with assert_raises(ValueError, msg="The classifers {name} does"
+                                   " not raise an error when incorrect/malform"
+                                   "ed input for decision function is passed. "
+                                   "Perhaps use check_array"):
                     classifier.decision_function(X.T)
             except NotImplementedError:
                 pass
@@ -1159,8 +1161,9 @@ def check_classifiers_train(name, classifier_orig):
             assert_allclose(np.sum(y_prob, axis=1), np.ones(n_samples))
             # raises error on malformed input
             with assert_raises(ValueError, msg="The classifers {name} does not"
-                               " raise an error when incorrect/malformed input "
-                               "data for predict is passed"):
+                               " raise an error when incorrect/malformed input"
+                               " for predict is passed. Perhaps use "
+                               "check_array"):
                 classifier.predict_proba(X.T)
             # raises error on malformed input for predict_proba
             with assert_raises(ValueError,
@@ -1330,8 +1333,8 @@ def check_regressors_train(name, regressor_orig):
 
     # raises error on malformed input for fit
     with assert_raises(ValueError, msg="The regressors {name} does not"
-                                   " raise an error when incorrect/malformed input "
-                                   "data for fit is passed"):
+                       " raise an error when incorrect/malformed input "
+                       "data for fit is passed. Perhaps use check_array"):
         regressor.fit(X, y[:-1])
     # fit
     if name in CROSS_DECOMPOSITION:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -688,8 +688,9 @@ def check_transformers_unfitted(name, transformer):
     X, y = _boston_subset()
 
     transformer = clone(transformer)
-    with assert_raises((AttributeError, ValueError),
-                       msg="Transformers unfitted"):
+    with assert_raises((AttributeError, ValueError), msg="The unfitted "
+                       "transformer {name} does not raise an error when "
+                       "transform is called. Perhaps use check_is_fitted"):
         transformer.transform(X)
 
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -860,7 +860,8 @@ def check_estimators_empty_data_messages(name, estimator_orig):
     # The precise message can change depending on whether X or y is
     # validated first. Let us test the type of exception only:
     with assert_raises(ValueError, msg="The estimators {name} does not"
-                               " raise an error when"):
+                       " raise an error when an empty data is used "
+                       "to train. Perhaps use check_is_fitted"):
         e.fit(X_zero_samples, [])
 
     X_zero_features = np.empty(0).reshape(3, 0)
@@ -997,8 +998,9 @@ def check_estimators_partial_fit_n_features(name, estimator_orig):
         return
 
     with assert_raises(ValueError,
-                       msg="Number of features "
-                       "changes between calls to partial_fit"):
+                       msg="The estimators {name} does not"
+                       " raise an error when number of features"
+                       " changes between calls to partial_fit"):
         estimator.partial_fit(X[:, :-1], y)
 
 
@@ -1103,7 +1105,9 @@ def check_classifiers_train(name, classifier_orig):
             X -= X.min()
         set_random_state(classifier)
         # raises error on malformed input for fit
-        with assert_raises(ValueError, msg="Malformed input for fit"):
+        with assert_raises(ValueError, msg="The classifers {name} does not"
+                           " raise an error when incorrect/malformed input "
+                           "data for fit is passed"):
             classifier.fit(X, y[:-1])
 
         # fit
@@ -1118,7 +1122,9 @@ def check_classifiers_train(name, classifier_orig):
             assert_greater(accuracy_score(y, y_pred), 0.83)
 
         # raises error on malformed input for predict
-        with assert_raises(ValueError, msg="Malformed input for predict"):
+        with assert_raises(ValueError, msg="The classifers {name} does not"
+                           " raise an error when incorrect/malformed input "
+                           "data for predict is passed"):
             classifier.predict(X.T)
         if hasattr(classifier, "decision_function"):
             try:
@@ -1138,9 +1144,9 @@ def check_classifiers_train(name, classifier_orig):
                 with assert_raises(ValueError, msg="Malformed inputs"):
                     classifier.decision_function(X.T)
                 # raises error on malformed input for decision_function
-                with assert_raises(ValueError,
-                                   msg="Malformed input "
-                                   "for decision_function"):
+                with assert_raises(ValueError, msg="The classifers {name} does not"
+                                   " raise an error when incorrect/malformed input "
+                                   "data for decision function is passed"):
                     classifier.decision_function(X.T)
             except NotImplementedError:
                 pass
@@ -1152,7 +1158,9 @@ def check_classifiers_train(name, classifier_orig):
             # check that probas for all classes sum to one
             assert_allclose(np.sum(y_prob, axis=1), np.ones(n_samples))
             # raises error on malformed input
-            with assert_raises(ValueError, msg="Malformed input"):
+            with assert_raises(ValueError, msg="The classifers {name} does not"
+                               " raise an error when incorrect/malformed input "
+                               "data for predict is passed"):
                 classifier.predict_proba(X.T)
             # raises error on malformed input for predict_proba
             with assert_raises(ValueError,
@@ -1321,7 +1329,9 @@ def check_regressors_train(name, regressor_orig):
         regressor.C = 0.01
 
     # raises error on malformed input for fit
-    with assert_raises(ValueError, msg="Malformed input for fit"):
+    with assert_raises(ValueError, msg="The regressors {name} does not"
+                                   " raise an error when incorrect/malformed input "
+                                   "data for fit is passed"):
         regressor.fit(X, y[:-1])
     # fit
     if name in CROSS_DECOMPOSITION:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -763,9 +763,12 @@ def _check_transformer(name, transformer_orig, X, y):
         # raises error on malformed input for transform
         if hasattr(X, 'T'):
             # If it's not an array, it does not have a 'T' property
-            with assert_raises(ValueError, msg="The transformer {name} does "
-                               "not raise an error when incorrect/malformed"
-                               " input is passed. Perhaps use check_array"):
+            with assert_raises(ValueError, msg="The classifer {name} does not "
+                               "raise an error when incorrect/malformed input "
+                               " for predict is passed. Number of features in "
+                               "predict dataset does not match the number of f"
+                               "eatures in fit dataset."
+                               " Perhaps use check_array"):
                 transformer.transform(X.T)
 
 
@@ -859,7 +862,7 @@ def check_estimators_empty_data_messages(name, estimator_orig):
     X_zero_samples = np.empty(0).reshape(0, 3)
     # The precise message can change depending on whether X or y is
     # validated first. Let us test the type of exception only:
-    with assert_raises(ValueError, msg="The estimators {name} does not"
+    with assert_raises(ValueError, msg="The estimator {name} does not"
                        " raise an error when an empty data is used "
                        "to train. Perhaps use check_array"):
         e.fit(X_zero_samples, [])
@@ -998,7 +1001,7 @@ def check_estimators_partial_fit_n_features(name, estimator_orig):
         return
 
     with assert_raises(ValueError,
-                       msg="The estimators {name} does not raise an"
+                       msg="The estimator {name} does not raise an"
                            " error when number of features changes "
                            "between calls to partial_fit. Perhaps"
                            " use check_X_y"):
@@ -1106,9 +1109,11 @@ def check_classifiers_train(name, classifier_orig):
             X -= X.min()
         set_random_state(classifier)
         # raises error on malformed input for fit
-        with assert_raises(ValueError, msg="The classifers {name} does not"
+        with assert_raises(ValueError, msg="The classifer {name} does not"
                            " raise an error when incorrect/malformed input "
-                           "data for fit is passed. Perhapse use check_array"):
+                           "data for fit is passed. Number of training exam"
+                           "ples is not the same as the number of "
+                           "labels. Perhapse use check_array"):
             classifier.fit(X, y[:-1])
 
         # fit
@@ -1123,9 +1128,11 @@ def check_classifiers_train(name, classifier_orig):
             assert_greater(accuracy_score(y, y_pred), 0.83)
 
         # raises error on malformed input for predict
-        with assert_raises(ValueError, msg="The classifers {name} does not"
+        with assert_raises(ValueError, msg="The classifer {name} does not"
                            " raise an error when incorrect/malformed input "
-                           " for predict is passed. Perhaps use check_array"):
+                           " for predict is passed. Number of features in p"
+                           "redict dataset does not match the number of fea"
+                           "tures in fit dataset. Perhaps use check_array"):
             classifier.predict(X.T)
         if hasattr(classifier, "decision_function"):
             try:
@@ -1145,9 +1152,11 @@ def check_classifiers_train(name, classifier_orig):
                 with assert_raises(ValueError, msg="Malformed inputs"):
                     classifier.decision_function(X.T)
                 # raises error on malformed input for decision_function
-                with assert_raises(ValueError, msg="The classifers {name} does"
-                                   " not raise an error when incorrect/malform"
-                                   "ed input for decision function is passed. "
+                with assert_raises(ValueError, msg="The classifer {name} does "
+                                   "not raise an error when incorrect/malforme"
+                                   "d input for predict is passed. Number of f"
+                                   "eatures in predict dataset does not match "
+                                   "the number of features in fit dataset. "
                                    "Perhaps use check_array"):
                     classifier.decision_function(X.T)
             except NotImplementedError:
@@ -1160,10 +1169,12 @@ def check_classifiers_train(name, classifier_orig):
             # check that probas for all classes sum to one
             assert_allclose(np.sum(y_prob, axis=1), np.ones(n_samples))
             # raises error on malformed input
-            with assert_raises(ValueError, msg="The classifers {name} does not"
-                               " raise an error when incorrect/malformed input"
-                               " for predict is passed. Perhaps use "
-                               "check_array"):
+            with assert_raises(ValueError, msg="The classifer {name} does not"
+                               " raise an error when incorrect/malformed inpu"
+                               "t  for predict is passed. Number of features "
+                               "in predict dataset does not match the number "
+                               "of features in fit dataset. "
+                               "Perhaps use check_array"):
                 classifier.predict_proba(X.T)
             # raises error on malformed input for predict_proba
             with assert_raises(ValueError,
@@ -1332,9 +1343,11 @@ def check_regressors_train(name, regressor_orig):
         regressor.C = 0.01
 
     # raises error on malformed input for fit
-    with assert_raises(ValueError, msg="The regressors {name} does not"
+    with assert_raises(ValueError, msg="The classifer {name} does not"
                        " raise an error when incorrect/malformed input "
-                       "data for fit is passed. Perhaps use check_array"):
+                       "data for fit is passed. Number of training exam"
+                       "ples is not the same as the number of "
+                       "labels. Perhapse use check_array"):
         regressor.fit(X, y[:-1])
     # fit
     if name in CROSS_DECOMPOSITION:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Fixes #9572 


#### What does this implement/fix? Explain your changes.
Added a context manager for each occurrence of `assert_raises`. 
The `msg` arguments have not been changed which returns nice error messages. 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
