### PR TITLE
[MRG+1] EHN Accept 1D array for preprocessing functions and update doc

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -239,11 +239,11 @@ data.
   or :class:`sklearn.decomposition.RandomizedPCA` with ``whiten=True``
   to further remove the linear correlation across features.
 
-.. topic:: Scaling target variables in regression
+.. topic:: Scaling a 1D array
 
-    :func:`scale` and :class:`StandardScaler` work out-of-the-box with 1d arrays.
-    This is very useful for scaling the target / response variables used
-    for regression.
+   All above functions (i.e. :func:`scale`, :func:`minmax_scale`,
+   :func:`maxabs_scale`, and :func:`robust_scale`) accept 1D array which can be
+   useful in some specific case.
 
 .. _kernel_centering:
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1169,12 +1169,24 @@ def robust_scale(X, axis=0, with_centering=True, with_scaling=True,
     RobustScaler: Performs centering and scaling using the ``Transformer`` API
         (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
     """
+    X = check_array(X, accept_sparse=('csr', 'csc'), copy=False,
+                    ensure_2d=False, dtype=FLOAT_DTYPES)
+    original_ndim = X.ndim
+
+    if original_ndim == 1:
+        X = X.reshape(X.shape[0], 1)
+
     s = RobustScaler(with_centering=with_centering, with_scaling=with_scaling,
                      quantile_range=quantile_range, copy=copy)
     if axis == 0:
-        return s.fit_transform(X)
+        X = s.fit_transform(X)
     else:
-        return s.fit_transform(X.T).T
+        X = s.fit_transform(X.T).T
+
+    if original_ndim == 1:
+        X = X.ravel()
+
+    return X
 
 
 class PolynomialFeatures(BaseEstimator, TransformerMixin):

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1233,6 +1233,15 @@ def test_robust_scale_axis1():
     assert_array_almost_equal(iqr, 1)
 
 
+def test_robust_scale_1d_array():
+    X = iris.data[:, 1]
+    X_trans = robust_scale(X)
+    assert_array_almost_equal(np.median(X_trans), 0)
+    q = np.percentile(X_trans, q=(25, 75))
+    iqr = q[1] - q[0]
+    assert_array_almost_equal(iqr, 1)
+
+
 def test_robust_scaler_zero_variance_features():
     # Check RobustScaler on toy data with zero variance features
     X = [[0., 1., +0.5],


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
closes #9582 


#### What does this implement/fix? Explain your changes.
`robust_scale` accept 1D array for consistency with others preprocessing scaling functions.
In addition, the documentation has been updated.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
