### PR TITLE
BUG: force pipeline steps to be list not a tuple

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -17,7 +17,6 @@ from scipy import sparse
 from .base import clone, TransformerMixin
 from .externals.joblib import Parallel, delayed, Memory
 from .externals import six
-from .utils import tosequence
 from .utils.metaestimators import if_delegate_has_method
 from .utils import Bunch
 
@@ -112,7 +111,7 @@ class Pipeline(_BaseComposition):
 
     def __init__(self, steps, memory=None):
         # shallow copy of steps
-        self.steps = tosequence(steps)
+        self.steps = list(steps)
         self._validate_steps()
         self.memory = memory
 
@@ -624,7 +623,7 @@ class FeatureUnion(_BaseComposition, TransformerMixin):
 
     """
     def __init__(self, transformer_list, n_jobs=1, transformer_weights=None):
-        self.transformer_list = tosequence(transformer_list)
+        self.transformer_list = list(transformer_list)
         self.n_jobs = n_jobs
         self.transformer_weights = transformer_weights
         self._validate_transformers()

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -215,8 +215,6 @@ def test_pipeline_init_tuple():
     pipe.fit(X, y=None)
     pipe.score(X)
 
-    X = np.array([[1, 2]])
-    pipe = Pipeline((('transf', Transf()), ('clf', FitParamT())))
     pipe.set_params(transf=None)
     pipe.fit(X, y=None)
     pipe.score(X)

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -208,6 +208,20 @@ def test_pipeline_init():
     assert_equal(params, params2)
 
 
+def test_pipeline_init_tuple():
+    # Pipeline accepts steps as tuple
+    X = np.array([[1, 2]])
+    pipe = Pipeline((('transf', Transf()), ('clf', FitParamT())))
+    pipe.fit(X, y=None)
+    pipe.score(X)
+
+    X = np.array([[1, 2]])
+    pipe = Pipeline((('transf', Transf()), ('clf', FitParamT())))
+    pipe.set_params(transf=None)
+    pipe.fit(X, y=None)
+    pipe.score(X)
+
+
 def test_pipeline_methods_anova():
     # Test the various methods of the pipeline (anova).
     iris = load_iris()
@@ -424,6 +438,10 @@ def test_feature_union():
                         'transform.*\\bNoTrans\\b',
                         FeatureUnion,
                         [("transform", Transf()), ("no_transform", NoTrans())])
+
+    # test that init accepts tuples
+    fs = FeatureUnion((("svd", svd), ("select", select)))
+    fs.fit(X, y)
 
 
 def test_make_union():

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -51,7 +51,7 @@ class _BaseComposition(six.with_metaclass(ABCMeta, BaseEstimator)):
 
     def _replace_estimator(self, attr, name, new_val):
         # assumes `name` is a valid estimator name
-        new_estimators = getattr(self, attr)[:]
+        new_estimators = list(getattr(self, attr))
         for i, (estimator_name, _) in enumerate(new_estimators):
             if estimator_name == name:
                 new_estimators[i] = (name, new_val)


### PR DESCRIPTION
Alternative to https://github.com/scikit-learn/scikit-learn/pull/9221. Combined the fix of @agramfort and suggestion of @jnothman. And added a more explicit test for it.

Fixes #9587, closes #9221

#### What does this implement/fix? Explain your changes.

Previously passing a tuple as the steps to a Pipeline worked, this broke in 0.19. 
Therefore, this PR converts the passed steps to a list.

This *is* modifying an init argument (`self.steps`). However, there is currently a problem with the Pipeline implementation that the fitted steps are saved in `self.steps` and not in `self.steps_`. Therefore, `self.steps` needs to be mutable and cannot be a tuple. 
The correct fix would be to solve the design problem, for which there is a PR (https://github.com/scikit-learn/scikit-learn/pull/8350). This PR provides a smaller temporary fix to undo the regression, until the other PR is merged (which will certainly not be in a bugfix release)


