### PR TITLE
[WIP] Introducing SoftImpute FactorizationImputer for scikit-learn

### DIFF
--- a/sklearn/preprocessing/__init__.py
+++ b/sklearn/preprocessing/__init__.py
@@ -30,11 +30,12 @@ from .label import LabelBinarizer
 from .label import LabelEncoder
 from .label import MultiLabelBinarizer
 
-from .imputation import Imputer
+from .imputation import Imputer, FactorizationImputer
 
 
 __all__ = [
     'Binarizer',
+    'FactorizationImputer',
     'FunctionTransformer',
     'Imputer',
     'KernelCenterer',


### PR DESCRIPTION
Continuing work from #4237 and #2387. 

Rather than minimizing the funcSVD-type lost functions specified in the previous attempts, this PR follows advice from @amueller and @GaelVaroquaux , and imports SoftImpute from [FancyImpute](https://github.com/hammerlab/fancyimpute) instead. 

Here is the new cost function being minimized:

![image](https://user-images.githubusercontent.com/1597013/29642894-342457c8-8820-11e7-9acc-93c1e9e27f40.png)


#### What this implements/fixes

A new transformer `sklearn.preprocessing.FactorizationImputer`, that uses tests/structure originally created by the previous author as part of #4237

#### What I'd like to hear back

1. Any general feedback on how to improve this.
2. How I can add the fancyimpute dependency to scikit-learn

#### Other comments

Thanks to @sergeyf and iskandr, the authors who created this initial implementation of SoftImpute in python.

Here is [the original paper](http://web.stanford.edu/~hastie/Papers/mazumder10a.pdf) where the SoftImpute algorithm was introduced. Here is [another helpful introduction](https://web.stanford.edu/~hastie/swData/softImpute/vignette.html) to how the algorithm works.
