### PR TITLE
[MRG + 1] enable metric = 'cosine' for tsne computation

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -711,10 +711,7 @@ class TSNE(BaseEstimator):
                 print("[t-SNE] Computing {} nearest neighbors...".format(k))
 
             # Find the nearest neighbors for every point
-            neighbors_method = 'ball_tree'
-            if (self.metric == 'precomputed') or (self.metric == "cosine"):
-                neighbors_method = 'brute'
-            knn = NearestNeighbors(algorithm=neighbors_method, n_neighbors=k,
+            knn = NearestNeighbors(algorithm='auto', n_neighbors=k,
                                    metric=self.metric)
             t0 = time()
             knn.fit(X)

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -764,7 +764,7 @@ class TSNE(BaseEstimator):
         # Laurens van der Maaten, 2009.
         degrees_of_freedom = max(self.n_components - 1.0, 1)
 
-        return self._tsne(P, degrees_of_freedom, n_samples, random_state,
+        return self._tsne(P, degrees_of_freedom, n_samples,
                           X_embedded=X_embedded,
                           neighbors=neighbors_nn,
                           skip_num_points=skip_num_points)
@@ -775,7 +775,7 @@ class TSNE(BaseEstimator):
     def n_iter_final(self):
         return self.n_iter_
 
-    def _tsne(self, P, degrees_of_freedom, n_samples, random_state, X_embedded,
+    def _tsne(self, P, degrees_of_freedom, n_samples, X_embedded,
               neighbors=None, skip_num_points=0):
         """Runs t-SNE."""
         # t-SNE minimizes the Kullback-Leiber divergence of the Gaussians P

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -712,7 +712,7 @@ class TSNE(BaseEstimator):
 
             # Find the nearest neighbors for every point
             neighbors_method = 'ball_tree'
-            if (self.metric == 'precomputed'):
+            if (self.metric == 'precomputed') or (self.metric == "cosine"):
                 neighbors_method = 'brute'
             knn = NearestNeighbors(algorithm=neighbors_method, n_neighbors=k,
                                    metric=self.metric)

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -719,9 +719,13 @@ def test_accessible_kl_divergence():
 def check_uniform_grid(method, seeds=[0, 1, 2], n_iter=1000):
     """Make sure that TSNE can approximately recover a uniform 2D grid"""
     for seed in seeds:
+        # Add small perturbation noise to break ties for nearest neighbors
+        rng = check_random_state(seed)
+        X = X_2d_grid + 1e-5 * rng.normal(size=X_2d_grid.shape)
+
         tsne = TSNE(n_components=2, init='random', random_state=seed,
                     perplexity=10, n_iter=n_iter, method=method)
-        Y = tsne.fit_transform(X_2d_grid)
+        Y = tsne.fit_transform(X)
 
         # Ensure that the convergence criterion has been triggered
         assert tsne.n_iter_ < n_iter

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -802,5 +802,4 @@ def test_tsne_with_different_distance_metrics():
         tsne_2 = TSNE(metric='precomputed',
                       n_components=n_components_embedding,
                       random_state=0).fit_transform(dist_func(X))
-        t = trustworthiness(tsne_1, tsne_2, n_neighbors=1)
-        assert_greater(t, 0.9)
+        assert_array_equal(tsne_1, tsne_2)

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -777,11 +777,10 @@ def test_tsne_with_different_distance_metrics():
     metrics = ['manhattan', 'cosine']
     dist_funcs = [manhattan_distances, cosine_distances]
     for metric, dist_func in zip(metrics, dist_funcs):
-        tsne_1 = TSNE(metric=metric, 
-                  n_components=n_components_embedding, 
-                  random_state=0).fit_transform(X)
-        tsne_2 = TSNE(metric='precomputed', 
-                  n_components=n_components_embedding, 
-                  random_state=0).fit_transform(dist_func(X))
+        tsne_1 = TSNE(metric=metric, n_components=n_components_embedding,
+                      random_state=0).fit_transform(X)
+        tsne_2 = TSNE(metric='precomputed',
+                      n_components=n_components_embedding,
+                      random_state=0).fit_transform(dist_func(X))
         t = trustworthiness(tsne_1, tsne_2, n_neighbors=1)
         assert_greater(t, 0.9)

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -775,13 +775,13 @@ def test_tsne_with_different_distance_metrics():
     n_components_embedding = 2
     X = random_state.randn(50, n_components_original).astype(np.float32)
     metrics = ['manhattan', 'cosine']
-    dist_fkts = [manhattan_distances, cosine_distances]
-    for metric, dist_fkt in zip(metrics, dist_fkts):
+    dist_funcs = [manhattan_distances, cosine_distances]
+    for metric, dist_func in zip(metrics, dist_funcs):
         tsne_1 = TSNE(metric=metric, 
                   n_components=n_components_embedding, 
                   random_state=0).fit_transform(X)
-        tsne_2 = TSNE(metric=metric, 
+        tsne_2 = TSNE(metric='precomputed', 
                   n_components=n_components_embedding, 
-                  random_state=0).fit_transform(dist_fkt(X))
+                  random_state=0).fit_transform(dist_func(X))
         t = trustworthiness(tsne_1, tsne_2, n_neighbors=1)
         assert_greater(t, 0.9)

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -797,9 +797,10 @@ def test_tsne_with_different_distance_metrics():
     metrics = ['manhattan', 'cosine']
     dist_funcs = [manhattan_distances, cosine_distances]
     for metric, dist_func in zip(metrics, dist_funcs):
-        tsne_1 = TSNE(metric=metric, n_components=n_components_embedding,
-                      random_state=0).fit_transform(X)
-        tsne_2 = TSNE(metric='precomputed',
-                      n_components=n_components_embedding,
-                      random_state=0).fit_transform(dist_func(X))
-        assert_array_equal(tsne_1, tsne_2)
+        X_transformed_tsne = TSNE(
+            metric=metric, n_components=n_components_embedding,
+            random_state=0).fit_transform(X)
+        X_transformed_tsne_precomputed = TSNE(
+            metric='precomputed', n_components=n_components_embedding,
+            random_state=0).fit_transform(dist_func(X))
+        assert_array_equal(X_transformed_tsne, X_transformed_tsne_precomputed)


### PR DESCRIPTION
set `neighbors_method `to "brute" for `metric='cosine'`, as for `metric="cosine"`  with `neighbors_method="ball_tree"` the `NearestNeighbor` method raises the error:

> ValueError: Metric 'cosine' not valid for algorithm 'ball_tree'


The following code snippet is working for me in version 0.18.1, but is not working for version 0.19 anymore. With the change I added the snippet works.


```
from sklearn.manifold import TSNE
import numpy as np

z = np.random.rand(1000*256).reshape((1000, 256))

tsne = TSNE(n_components=2, 
            random_state=0, 
            metric = 'cosine', 
            learning_rate=1000)

tsne.fit_transform(z)
```