### PR TITLE
[MRG+1] FIX for Cython. import numpy as np needed in fast_dict.pxd

### DIFF
--- a/sklearn/utils/fast_dict.pxd
+++ b/sklearn/utils/fast_dict.pxd
@@ -7,6 +7,7 @@ integers, and values float.
 
 from libcpp.map cimport map as cpp_map
 
+import numpy as np
 # Import the C-level symbols of numpy
 cimport numpy as np
 


### PR DESCRIPTION


#### What does this implement/fix? Explain your changes.

With upgrade to Cython 0.26 cythonization step fails saying that cimported np does not have float64 and intp defined, import numpy as np is needed and fixes cythonization
