### PR TITLE
[MRG+1] Affinity propagation edge cases (#9612)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -59,6 +59,13 @@ Decomposition, manifold learning and clustering
   division on Python 2 versions. :issue:`9492` by
   :user:`James Bourbeau <jrbourbeau>`.
 
+- Fixed a bug where the ``fit`` method of
+  :class:`cluster.affinity_propagation_.AffinityPropagation` stored cluster
+  centers as 3d array instead of 2d array in case of non-convergence. For the
+  same class, fixed undefined and arbitrary behavior in case of training data
+  where all samples had equal similarity.
+  :issue:`9612`. By :user:`Jonatan Samoocha <jsamoocha>`.
+
 Version 0.19
 ============
 

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -22,10 +22,11 @@ def _equal_similarities_and_preferences(S, preference):
         return np.all(multi_preferences == multi_preferences.flat[0])
 
     def all_equal_similarities():
-        # Fill "diagonal" of S with first similarity value in S
-        S.flat[::S.shape[0] + 1] = S.flat[1]
+        # Create mask to ignore diagonal of S
+        mask = np.ones(S.shape, dtype=bool)
+        np.fill_diagonal(mask, 0)
 
-        return np.all(S.flat == S.flat[0])
+        return np.all(S[mask].flat == S[mask].flat[0])
 
     return all_equal_preferences() and all_equal_similarities()
 

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -19,6 +19,23 @@ from ..metrics import pairwise_distances_argmin
 logger = logging.getLogger(__name__)
 
 
+def equal_similarities_and_preferences(S, preference):
+    def all_equal_preferences():
+        if isinstance(preference, (int, float)):
+            return True
+        elif isinstance(preference, (list, tuple, np.ndarray)):
+            multi_preferences = np.array(preference)
+            return np.all(multi_preferences == multi_preferences[0])
+        else:
+            return False
+
+    def all_equal_similarities():
+        S.flat[::S.shape[0] + 1] = S.flat[1]  # Fill "diagonal" of S with first similarity value in S
+        return np.all(S.flat == S.flat[0])
+
+    return all_equal_preferences() and all_equal_similarities()
+
+
 def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
                          damping=0.5, copy=True, verbose=False,
                          return_n_iter=False):

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -90,6 +90,16 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
     For an example, see :ref:`examples/cluster/plot_affinity_propagation.py
     <sphx_glr_auto_examples_cluster_plot_affinity_propagation.py>`.
 
+    When the algorithm does not converge, it returns an empty array as
+    ``cluster_center_indices`` and ``-1`` as label for each training sample.
+
+    When all training samples have equal similarities and equal preferences,
+    the assignment of cluster centers and labels depends on the preference.
+    If the preference is smaller than the similarities, a single cluster center
+    and label ``0`` for every sample will be returned. Otherwise, every
+    training sample becomes its own cluster center and is assigned a unique
+    label.
+
     References
     ----------
     Brendan J. Frey and Delbert Dueck, "Clustering by Passing Messages
@@ -287,6 +297,17 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
 
     The algorithmic complexity of affinity propagation is quadratic
     in the number of points.
+
+    When ``fit`` does not converge, ``cluster_centers_`` becomes an empty
+    array and all training samples will be labelled as ``-1``. In addition,
+    ``predict`` will then label every sample as ``-1``.
+
+    When all training samples have equal similarities and equal preferences,
+    the assignment of cluster centers and labels depends on the preference.
+    If the preference is smaller than the similarities, ``fit`` will result in
+    a single cluster center and label ``0`` for every sample. Otherwise, every
+    training sample becomes its own cluster center and is assigned a unique
+    label.
 
     References
     ----------

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -112,6 +112,16 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
     if damping < 0.5 or damping >= 1:
         raise ValueError('damping must be >= 0.5 and < 1')
 
+    if equal_similarities_and_preferences(S, preference):
+        # It makes no sense to run the algorithm in this case, so simply return 1 or n_samples clusters,
+        # depending on preferences
+        if np.array(preference).flat[0] >= S.flat[1]:
+            return (np.arange(n_samples), np.arange(n_samples), 0) if return_n_iter \
+                else (np.arange(n_samples), np.arange(n_samples))
+        else:
+            return (np.array([0]), np.array([0] * n_samples), 0) if return_n_iter \
+                else (np.array([0]), np.array([0] * n_samples))
+
     random_state = np.random.RandomState(0)
 
     # Place preference on the diagonal of S

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -21,13 +21,8 @@ logger = logging.getLogger(__name__)
 
 def equal_similarities_and_preferences(S, preference):
     def all_equal_preferences():
-        if isinstance(preference, (int, float)):
-            return True
-        elif isinstance(preference, (list, tuple, np.ndarray)):
-            multi_preferences = np.array(preference)
-            return np.all(multi_preferences == multi_preferences[0])
-        else:
-            return False
+        multi_preferences = np.array(preference)
+        return np.all(multi_preferences == multi_preferences.flat[0])
 
     def all_equal_similarities():
         S.flat[::S.shape[0] + 1] = S.flat[1]  # Fill "diagonal" of S with first similarity value in S

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -212,7 +212,7 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
     else:
         warnings.warn("Affinity propagation did not converge, this model "
                       "will not have any cluster centers.", ConvergenceWarning)
-        labels = np.array([-1] * S.shape[0])
+        labels = np.array([-1] * n_samples)
         cluster_centers_indices = []
 
     if return_n_iter:

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -108,7 +108,8 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
 
     preference_array = np.array(preference)
 
-    if n_samples == 1 or _equal_similarities_and_preferences(S, preference_array):
+    if (n_samples == 1 or
+            _equal_similarities_and_preferences(S, preference_array)):
         # It makes no sense to run the algorithm in this case, so return 1 or
         # n_samples clusters, depending on preferences
         warnings.warn("All samples have mutually equal similarities. "

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -107,8 +107,11 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
     if damping < 0.5 or damping >= 1:
         raise ValueError('damping must be >= 0.5 and < 1')
 
-    if equal_similarities_and_preferences(S, preference):
-        # It makes no sense to run the algorithm in this case, so simply return 1 or n_samples clusters,
+    if n_samples == 1:
+        # It makes no sense to run the algorithm in this case, so return 1 cluster equal to the single sample
+        return (np.array([0]), np.array([0]), 0) if return_n_iter else (np.array([0], np.array([0])))
+    elif equal_similarities_and_preferences(S, preference):
+        # It makes no sense to run the algorithm in this case, so return 1 or n_samples clusters,
         # depending on preferences
         if np.array(preference).flat[0] >= S.flat[1]:
             return (np.arange(n_samples), np.arange(n_samples), 0) if return_n_iter \

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -16,10 +16,9 @@ from ..metrics import euclidean_distances
 from ..metrics import pairwise_distances_argmin
 
 
-def _equal_similarities_and_preferences(S, preference):
+def _equal_similarities_and_preferences(S, preference_array):
     def all_equal_preferences():
-        multi_preferences = np.array(preference)
-        return np.all(multi_preferences == multi_preferences.flat[0])
+        return np.all(preference_array == preference_array.flat[0])
 
     def all_equal_similarities():
         # Create mask to ignore diagonal of S
@@ -107,12 +106,14 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
     if damping < 0.5 or damping >= 1:
         raise ValueError('damping must be >= 0.5 and < 1')
 
-    if n_samples == 1 or _equal_similarities_and_preferences(S, preference):
+    preference_array = np.array(preference)
+
+    if n_samples == 1 or _equal_similarities_and_preferences(S, preference_array):
         # It makes no sense to run the algorithm in this case, so return 1 or
         # n_samples clusters, depending on preferences
         warnings.warn("All samples have mutually equal similarities. "
                       "Returning arbitrary cluster center(s).")
-        if np.array(preference).flat[0] >= S.flat[n_samples - 1]:
+        if preference_array.flat[0] >= S.flat[n_samples - 1]:
             return (np.arange(n_samples), np.arange(n_samples), 0) \
                 if return_n_iter \
                 else (np.arange(n_samples), np.arange(n_samples))

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -5,18 +5,15 @@
 
 # License: BSD 3 clause
 
-import logging
-
 import numpy as np
+import warnings
 
+from sklearn.exceptions import ConvergenceWarning
 from ..base import BaseEstimator, ClusterMixin
 from ..utils import as_float_array, check_array
 from ..utils.validation import check_is_fitted
 from ..metrics import euclidean_distances
 from ..metrics import pairwise_distances_argmin
-
-
-logger = logging.getLogger(__name__)
 
 
 def equal_similarities_and_preferences(S, preference):
@@ -112,6 +109,8 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
     if n_samples == 1 or equal_similarities_and_preferences(S, preference):
         # It makes no sense to run the algorithm in this case, so return 1 or
         # n_samples clusters, depending on preferences
+        warnings.warn("All samples have mutually equal similarities, "
+                      "returning arbitrary cluster center(s).")
         if np.array(preference).flat[0] >= S.flat[n_samples - 1]:
             return (np.arange(n_samples), np.arange(n_samples), 0) \
                 if return_n_iter \
@@ -208,8 +207,8 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
         cluster_centers_indices = np.unique(labels)
         labels = np.searchsorted(cluster_centers_indices, labels)
     else:
-        logger.warning("Affinity propagation did not converge, this model "
-                       "will not have any cluster centers.")
+        warnings.warn("Affinity propagation did not converge, this model "
+                      "will not have any cluster centers.", ConvergenceWarning)
         labels = np.arange(S.shape[0])
         cluster_centers_indices = []
 
@@ -362,7 +361,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         if self.cluster_centers_.size > 0:
             return pairwise_distances_argmin(X, self.cluster_centers_)
         else:
-            logger.warning("This model does not have any cluster centers "
-                           "because affinity propagation did not converge. "
-                           "Returning unique labels for the provided samples.")
+            warnings.warn("This model does not have any cluster centers "
+                          "because affinity propagation did not converge. "
+                          "Returning unique labels for the provided samples.")
             return np.arange(X.shape[0])

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -114,13 +114,13 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
         warnings.warn("All samples have mutually equal similarities. "
                       "Returning arbitrary cluster center(s).")
         if preference_array.flat[0] >= S.flat[n_samples - 1]:
-            return (np.arange(n_samples), np.arange(n_samples), 0) \
-                if return_n_iter \
-                else (np.arange(n_samples), np.arange(n_samples))
+            return ((np.arange(n_samples), np.arange(n_samples), 0)
+                    if return_n_iter
+                    else (np.arange(n_samples), np.arange(n_samples)))
         else:
-            return (np.array([0]), np.array([0] * n_samples), 0) \
-                if return_n_iter \
-                else (np.array([0]), np.array([0] * n_samples))
+            return ((np.array([0]), np.array([0] * n_samples), 0)
+                    if return_n_iter
+                    else (np.array([0]), np.array([0] * n_samples)))
 
     random_state = np.random.RandomState(0)
 

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -366,4 +366,4 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
             warnings.warn("This model does not have any cluster centers "
                           "because affinity propagation did not converge. "
                           "Returning unique labels for the provided samples.")
-            return np.arange(X.shape[0])
+            return np.array([-1] * X.shape[0])

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -16,7 +16,7 @@ from ..metrics import euclidean_distances
 from ..metrics import pairwise_distances_argmin
 
 
-def equal_similarities_and_preferences(S, preference):
+def _equal_similarities_and_preferences(S, preference):
     def all_equal_preferences():
         multi_preferences = np.array(preference)
         return np.all(multi_preferences == multi_preferences.flat[0])
@@ -106,7 +106,7 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
     if damping < 0.5 or damping >= 1:
         raise ValueError('damping must be >= 0.5 and < 1')
 
-    if n_samples == 1 or equal_similarities_and_preferences(S, preference):
+    if n_samples == 1 or _equal_similarities_and_preferences(S, preference):
         # It makes no sense to run the algorithm in this case, so return 1 or
         # n_samples clusters, depending on preferences
         warnings.warn("All samples have mutually equal similarities, "

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -25,7 +25,9 @@ def equal_similarities_and_preferences(S, preference):
         return np.all(multi_preferences == multi_preferences.flat[0])
 
     def all_equal_similarities():
-        S.flat[::S.shape[0] + 1] = S.flat[1]  # Fill "diagonal" of S with first similarity value in S
+        # Fill "diagonal" of S with first similarity value in S
+        S.flat[::S.shape[0] + 1] = S.flat[1]
+
         return np.all(S.flat == S.flat[0])
 
     return all_equal_preferences() and all_equal_similarities()
@@ -108,16 +110,20 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
         raise ValueError('damping must be >= 0.5 and < 1')
 
     if n_samples == 1:
-        # It makes no sense to run the algorithm in this case, so return 1 cluster equal to the single sample
-        return (np.array([0]), np.array([0]), 0) if return_n_iter else (np.array([0], np.array([0])))
+        # It makes no sense to run the algorithm in this case, so return 1
+        # cluster equal to the single sample
+        return (np.array([0]), np.array([0]), 0) if return_n_iter \
+            else (np.array([0], np.array([0])))
     elif equal_similarities_and_preferences(S, preference):
-        # It makes no sense to run the algorithm in this case, so return 1 or n_samples clusters,
-        # depending on preferences
+        # It makes no sense to run the algorithm in this case, so return 1 or
+        # n_samples clusters, depending on preferences
         if np.array(preference).flat[0] >= S.flat[1]:
-            return (np.arange(n_samples), np.arange(n_samples), 0) if return_n_iter \
+            return (np.arange(n_samples), np.arange(n_samples), 0) \
+                if return_n_iter \
                 else (np.arange(n_samples), np.arange(n_samples))
         else:
-            return (np.array([0]), np.array([0] * n_samples), 0) if return_n_iter \
+            return (np.array([0]), np.array([0] * n_samples), 0) \
+                if return_n_iter \
                 else (np.array([0]), np.array([0] * n_samples))
 
     random_state = np.random.RandomState(0)
@@ -207,7 +213,8 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
         cluster_centers_indices = np.unique(labels)
         labels = np.searchsorted(cluster_centers_indices, labels)
     else:
-        logger.warning("Affinity propagation did not converge, this model will not have any cluster centers.")
+        logger.warning("Affinity propagation did not converge, this model "
+                       "will not have any cluster centers.")
         labels = np.arange(S.shape[0])
         cluster_centers_indices = []
 
@@ -360,6 +367,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         if self.cluster_centers_.size > 0:
             return pairwise_distances_argmin(X, self.cluster_centers_)
         else:
-            logger.warning("This model does not have any cluster centers because affinity propagation did not "
-                           "converge. Returning unique labels for the provided samples.")
+            logger.warning("This model does not have any cluster centers "
+                           "because affinity propagation did not converge. "
+                           "Returning unique labels for the provided samples.")
             return np.arange(X.shape[0])

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -5,6 +5,8 @@
 
 # License: BSD 3 clause
 
+import logging
+
 import numpy as np
 
 from ..base import BaseEstimator, ClusterMixin
@@ -12,6 +14,9 @@ from ..utils import as_float_array, check_array
 from ..utils.validation import check_is_fitted
 from ..metrics import euclidean_distances
 from ..metrics import pairwise_distances_argmin
+
+
+logger = logging.getLogger(__name__)
 
 
 def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
@@ -177,6 +182,7 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
         cluster_centers_indices = np.unique(labels)
         labels = np.searchsorted(cluster_centers_indices, labels)
     else:
+        logger.warning("Affinity propagation did not converge, this model will not have any cluster centers.")
         labels = np.arange(S.shape[0])
         cluster_centers_indices = []
 
@@ -326,4 +332,9 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
             raise ValueError("Predict method is not supported when "
                              "affinity='precomputed'.")
 
-        return pairwise_distances_argmin(X, self.cluster_centers_)
+        if self.cluster_centers_.size > 0:
+            return pairwise_distances_argmin(X, self.cluster_centers_)
+        else:
+            logger.warning("This model does not have any cluster centers because affinity propagation did not "
+                           "converge. Returning unique labels for the provided samples.")
+            return np.arange(X.shape[0])

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -109,15 +109,10 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
     if damping < 0.5 or damping >= 1:
         raise ValueError('damping must be >= 0.5 and < 1')
 
-    if n_samples == 1:
-        # It makes no sense to run the algorithm in this case, so return 1
-        # cluster equal to the single sample
-        return (np.array([0]), np.array([0]), 0) if return_n_iter \
-            else (np.array([0], np.array([0])))
-    elif equal_similarities_and_preferences(S, preference):
+    if n_samples == 1 or equal_similarities_and_preferences(S, preference):
         # It makes no sense to run the algorithm in this case, so return 1 or
         # n_samples clusters, depending on preferences
-        if np.array(preference).flat[0] >= S.flat[1]:
+        if np.array(preference).flat[0] >= S.flat[n_samples - 1]:
             return (np.arange(n_samples), np.arange(n_samples), 0) \
                 if return_n_iter \
                 else (np.arange(n_samples), np.arange(n_samples))

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -16,9 +16,9 @@ from ..metrics import euclidean_distances
 from ..metrics import pairwise_distances_argmin
 
 
-def _equal_similarities_and_preferences(S, preference_array):
+def _equal_similarities_and_preferences(S, preference):
     def all_equal_preferences():
-        return np.all(preference_array == preference_array.flat[0])
+        return np.all(preference == preference.flat[0])
 
     def all_equal_similarities():
         # Create mask to ignore diagonal of S
@@ -106,15 +106,15 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
     if damping < 0.5 or damping >= 1:
         raise ValueError('damping must be >= 0.5 and < 1')
 
-    preference_array = np.array(preference)
+    preference = np.array(preference)
 
     if (n_samples == 1 or
-            _equal_similarities_and_preferences(S, preference_array)):
+            _equal_similarities_and_preferences(S, preference)):
         # It makes no sense to run the algorithm in this case, so return 1 or
         # n_samples clusters, depending on preferences
         warnings.warn("All samples have mutually equal similarities. "
                       "Returning arbitrary cluster center(s).")
-        if preference_array.flat[0] >= S.flat[n_samples - 1]:
+        if preference.flat[0] >= S.flat[n_samples - 1]:
             return ((np.arange(n_samples), np.arange(n_samples), 0)
                     if return_n_iter
                     else (np.arange(n_samples), np.arange(n_samples)))

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -177,9 +177,8 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
         cluster_centers_indices = np.unique(labels)
         labels = np.searchsorted(cluster_centers_indices, labels)
     else:
-        labels = np.empty((n_samples, 1))
-        cluster_centers_indices = None
-        labels.fill(np.nan)
+        labels = np.arange(S.shape[0])
+        cluster_centers_indices = []
 
     if return_n_iter:
         return cluster_centers_indices, labels, it + 1

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -212,7 +212,7 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
     else:
         warnings.warn("Affinity propagation did not converge, this model "
                       "will not have any cluster centers.", ConvergenceWarning)
-        labels = np.arange(S.shape[0])
+        labels = np.array([-1] * S.shape[0])
         cluster_centers_indices = []
 
     if return_n_iter:

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -110,8 +110,8 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
     if n_samples == 1 or _equal_similarities_and_preferences(S, preference):
         # It makes no sense to run the algorithm in this case, so return 1 or
         # n_samples clusters, depending on preferences
-        warnings.warn("All samples have mutually equal similarities, "
-                      "returning arbitrary cluster center(s).")
+        warnings.warn("All samples have mutually equal similarities. "
+                      "Returning arbitrary cluster center(s).")
         if np.array(preference).flat[0] >= S.flat[n_samples - 1]:
             return (np.arange(n_samples), np.arange(n_samples), 0) \
                 if return_n_iter \

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -366,5 +366,5 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         else:
             warnings.warn("This model does not have any cluster centers "
                           "because affinity propagation did not converge. "
-                          "Returning unique labels for the provided samples.")
+                          "Labeling every sample as '-1'.")
             return np.array([-1] * X.shape[0])

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -5,14 +5,14 @@ Testing for Clustering methods
 
 import numpy as np
 
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_false
-from sklearn.utils.testing import assert_true
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import (
+    assert_equal, assert_false, assert_true, assert_array_equal, assert_raises
+)
 
 from sklearn.cluster.affinity_propagation_ import AffinityPropagation
-from sklearn.cluster.affinity_propagation_ import equal_similarities_and_preferences
+from sklearn.cluster.affinity_propagation_ import (
+    equal_similarities_and_preferences
+)
 from sklearn.cluster.affinity_propagation_ import affinity_propagation
 from sklearn.datasets.samples_generator import make_blobs
 from sklearn.metrics import euclidean_distances

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -78,3 +78,14 @@ def test_affinity_propagation_predict_error():
     af = AffinityPropagation(affinity="precomputed")
     af.fit(S)
     assert_raises(ValueError, af.predict, X)
+
+
+def test_affinity_propagation_fit_non_convergence():
+    # In case of non-convergence of affinity_propagation(), the cluster centers should be an empty array
+    X = np.array([[0, 0], [1, 1], [-2, -2]])
+
+    # Force non-convergence by allowing only a single iteration
+    af = AffinityPropagation(preference=-10, max_iter=1).fit(X)
+
+    assert_equal(np.array([]), af.cluster_centers_)
+    assert_equal(np.array([0, 1, 2]), af.labels_)

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -89,3 +89,13 @@ def test_affinity_propagation_fit_non_convergence():
 
     assert_array_equal(np.empty((0, 2)), af.cluster_centers_)
     assert_array_equal(np.array([0, 1, 2]), af.labels_)
+
+
+def test_affinity_propagation_predict_non_convergence():
+    # In case of non-convergence of affinity_propagation(), the cluster centers should be an empty array
+    X = np.array([[0, 0], [1, 1], [-2, -2]])
+
+    # Force non-convergence by allowing only a single iteration
+    af = AffinityPropagation(preference=-10, max_iter=1).fit(X)
+
+    assert_array_equal(np.array([0, 1, 2]), af.predict(X))

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -87,5 +87,5 @@ def test_affinity_propagation_fit_non_convergence():
     # Force non-convergence by allowing only a single iteration
     af = AffinityPropagation(preference=-10, max_iter=1).fit(X)
 
-    assert_equal(np.array([]), af.cluster_centers_)
-    assert_equal(np.array([0, 1, 2]), af.labels_)
+    assert_array_equal(np.empty((0, 2)), af.cluster_centers_)
+    assert_array_equal(np.array([0, 1, 2]), af.labels_)

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -134,7 +134,10 @@ def test_affinity_propagation_predict_non_convergence():
     # Force non-convergence by allowing only a single iteration
     af = AffinityPropagation(preference=-10, max_iter=1).fit(X)
 
-    assert_array_equal(np.array([0, 1, 2]), af.predict(X))
+    # At prediction time, consider new samples as noise since there are no
+    # clusters
+    assert_array_equal(np.array([-1, -1, -1]),
+                       af.predict(np.array([[2, 2], [3, 3], [4, 4]])))
 
 
 def test_equal_similarities_and_preferences():

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -5,11 +5,11 @@ Testing for Clustering methods
 
 import numpy as np
 
-from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_equal, assert_false, assert_true
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raises
 
-from sklearn.cluster.affinity_propagation_ import AffinityPropagation
+from sklearn.cluster.affinity_propagation_ import AffinityPropagation, equal_similarities_and_preferences
 from sklearn.cluster.affinity_propagation_ import affinity_propagation
 from sklearn.datasets.samples_generator import make_blobs
 from sklearn.metrics import euclidean_distances
@@ -99,3 +99,19 @@ def test_affinity_propagation_predict_non_convergence():
     af = AffinityPropagation(preference=-10, max_iter=1).fit(X)
 
     assert_array_equal(np.array([0, 1, 2]), af.predict(X))
+
+
+def test_equal_similarities_and_preferences():
+    X = np.array([[0, 0], [1, 1], [-2, -2]])  # Unequal distances
+    S = -euclidean_distances(X, squared=True)
+
+    assert_false(equal_similarities_and_preferences(S, 0))
+    assert_false(equal_similarities_and_preferences(S, [0, 0]))
+    assert_false(equal_similarities_and_preferences(S, [0, 1]))
+
+    X = np.array([[0, 0], [1, 1]])  # Equal distances
+    S = -euclidean_distances(X, squared=True)
+
+    assert_false(equal_similarities_and_preferences(S, [0, 1]))  # Different preferences
+    assert_true(equal_similarities_and_preferences(S, [0, 0]))
+    assert_true(equal_similarities_and_preferences(S, 0))

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -5,9 +5,7 @@ Testing for Clustering methods
 
 import numpy as np
 
-from sklearn.utils.testing import assert_equal, assert_false, assert_true
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_equal, assert_false, assert_true, assert_array_equal, assert_raises
 
 from sklearn.cluster.affinity_propagation_ import AffinityPropagation, equal_similarities_and_preferences
 from sklearn.cluster.affinity_propagation_ import affinity_propagation

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -94,7 +94,7 @@ def test_affinity_propagation_fit_non_convergence():
 
     assert_warns(ConvergenceWarning, af.fit, X)
     assert_array_equal(np.empty((0, 2)), af.cluster_centers_)
-    assert_array_equal(np.array([0, 1, 2]), af.labels_)
+    assert_array_equal(np.array([-1, -1, -1]), af.labels_)
 
 
 def test_affinity_propagation_equal_mutual_similarities():

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -12,7 +12,7 @@ from sklearn.utils.testing import (
 
 from sklearn.cluster.affinity_propagation_ import AffinityPropagation
 from sklearn.cluster.affinity_propagation_ import (
-    equal_similarities_and_preferences
+    _equal_similarities_and_preferences
 )
 from sklearn.cluster.affinity_propagation_ import affinity_propagation
 from sklearn.datasets.samples_generator import make_blobs
@@ -142,17 +142,17 @@ def test_equal_similarities_and_preferences():
     X = np.array([[0, 0], [1, 1], [-2, -2]])
     S = -euclidean_distances(X, squared=True)
 
-    assert_false(equal_similarities_and_preferences(S, 0))
-    assert_false(equal_similarities_and_preferences(S, [0, 0]))
-    assert_false(equal_similarities_and_preferences(S, [0, 1]))
+    assert_false(_equal_similarities_and_preferences(S, 0))
+    assert_false(_equal_similarities_and_preferences(S, [0, 0]))
+    assert_false(_equal_similarities_and_preferences(S, [0, 1]))
 
     # Equal distances
     X = np.array([[0, 0], [1, 1]])
     S = -euclidean_distances(X, squared=True)
 
     # Different preferences
-    assert_false(equal_similarities_and_preferences(S, [0, 1]))
+    assert_false(_equal_similarities_and_preferences(S, [0, 1]))
 
     # Same preferences
-    assert_true(equal_similarities_and_preferences(S, [0, 0]))
-    assert_true(equal_similarities_and_preferences(S, 0))
+    assert_true(_equal_similarities_and_preferences(S, [0, 0]))
+    assert_true(_equal_similarities_and_preferences(S, 0))

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -86,7 +86,8 @@ def test_affinity_propagation_predict_error():
 
 def test_affinity_propagation_fit_non_convergence():
     # In case of non-convergence of affinity_propagation(), the cluster
-    # centers should be an empty array
+    # centers should be an empty array and training samples should be labelled
+    # as noise (-1)
     X = np.array([[0, 0], [1, 1], [-2, -2]])
 
     # Force non-convergence by allowing only a single iteration

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -142,17 +142,17 @@ def test_equal_similarities_and_preferences():
     X = np.array([[0, 0], [1, 1], [-2, -2]])
     S = -euclidean_distances(X, squared=True)
 
-    assert_false(_equal_similarities_and_preferences(S, 0))
-    assert_false(_equal_similarities_and_preferences(S, [0, 0]))
-    assert_false(_equal_similarities_and_preferences(S, [0, 1]))
+    assert_false(_equal_similarities_and_preferences(S, np.array(0)))
+    assert_false(_equal_similarities_and_preferences(S, np.array([0, 0])))
+    assert_false(_equal_similarities_and_preferences(S, np.array([0, 1])))
 
     # Equal distances
     X = np.array([[0, 0], [1, 1]])
     S = -euclidean_distances(X, squared=True)
 
     # Different preferences
-    assert_false(_equal_similarities_and_preferences(S, [0, 1]))
+    assert_false(_equal_similarities_and_preferences(S, np.array([0, 1])))
 
     # Same preferences
-    assert_true(_equal_similarities_and_preferences(S, [0, 0]))
-    assert_true(_equal_similarities_and_preferences(S, 0))
+    assert_true(_equal_similarities_and_preferences(S, np.array([0, 0])))
+    assert_true(_equal_similarities_and_preferences(S, np.array(0)))

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -89,6 +89,30 @@ def test_affinity_propagation_fit_non_convergence():
     assert_array_equal(np.array([0, 1, 2]), af.labels_)
 
 
+def test_affinity_propagation_equal_mutual_similarities():
+    X = np.array([[-1, 1], [1, -1]])
+    S = -euclidean_distances(X, squared=True)
+
+    res = affinity_propagation(S, preference=0)  # preference > similarity
+    cluster_center_indices, labels = res
+
+    # expect every sample to become an exemplar
+    assert_array_equal([0, 1], cluster_center_indices)
+    assert_array_equal([0, 1], labels)
+
+    cluster_center_indices, labels = affinity_propagation(S, preference=-10)  # preference < similarity
+
+    # expect one cluster, with arbitrary (first) sample as exemplar
+    assert_array_equal([0], cluster_center_indices)
+    assert_array_equal([0, 0], labels)
+
+    cluster_center_indices, labels = affinity_propagation(S, preference=[-20, -10])  # different preferences
+
+    # expect one cluster, with highest-preference sample as exemplar
+    assert_array_equal([1], cluster_center_indices)
+    assert_array_equal([0, 0], labels)
+
+
 def test_affinity_propagation_predict_non_convergence():
     # In case of non-convergence of affinity_propagation(), the cluster centers should be an empty array
     X = np.array([[0, 0], [1, 1], [-2, -2]])

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -5,9 +5,14 @@ Testing for Clustering methods
 
 import numpy as np
 
-from sklearn.utils.testing import assert_equal, assert_false, assert_true, assert_array_equal, assert_raises
+from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_false
+from sklearn.utils.testing import assert_true
+from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_raises
 
-from sklearn.cluster.affinity_propagation_ import AffinityPropagation, equal_similarities_and_preferences
+from sklearn.cluster.affinity_propagation_ import AffinityPropagation
+from sklearn.cluster.affinity_propagation_ import equal_similarities_and_preferences
 from sklearn.cluster.affinity_propagation_ import affinity_propagation
 from sklearn.datasets.samples_generator import make_blobs
 from sklearn.metrics import euclidean_distances
@@ -79,7 +84,8 @@ def test_affinity_propagation_predict_error():
 
 
 def test_affinity_propagation_fit_non_convergence():
-    # In case of non-convergence of affinity_propagation(), the cluster centers should be an empty array
+    # In case of non-convergence of affinity_propagation(), the cluster
+    # centers should be an empty array
     X = np.array([[0, 0], [1, 1], [-2, -2]])
 
     # Force non-convergence by allowing only a single iteration
@@ -93,20 +99,24 @@ def test_affinity_propagation_equal_mutual_similarities():
     X = np.array([[-1, 1], [1, -1]])
     S = -euclidean_distances(X, squared=True)
 
-    res = affinity_propagation(S, preference=0)  # preference > similarity
+    # setting preference > similarity
+    res = affinity_propagation(S, preference=0)
     cluster_center_indices, labels = res
 
     # expect every sample to become an exemplar
     assert_array_equal([0, 1], cluster_center_indices)
     assert_array_equal([0, 1], labels)
 
-    cluster_center_indices, labels = affinity_propagation(S, preference=-10)  # preference < similarity
+    # setting preference < similarity
+    cluster_center_indices, labels = affinity_propagation(S, preference=-10)
 
     # expect one cluster, with arbitrary (first) sample as exemplar
     assert_array_equal([0], cluster_center_indices)
     assert_array_equal([0, 0], labels)
 
-    cluster_center_indices, labels = affinity_propagation(S, preference=[-20, -10])  # different preferences
+    # setting different preferences
+    cluster_center_indices, labels = affinity_propagation(
+        S, preference=[-20, -10])
 
     # expect one cluster, with highest-preference sample as exemplar
     assert_array_equal([1], cluster_center_indices)
@@ -114,7 +124,8 @@ def test_affinity_propagation_equal_mutual_similarities():
 
 
 def test_affinity_propagation_predict_non_convergence():
-    # In case of non-convergence of affinity_propagation(), the cluster centers should be an empty array
+    # In case of non-convergence of affinity_propagation(), the cluster
+    # centers should be an empty array
     X = np.array([[0, 0], [1, 1], [-2, -2]])
 
     # Force non-convergence by allowing only a single iteration
@@ -124,16 +135,21 @@ def test_affinity_propagation_predict_non_convergence():
 
 
 def test_equal_similarities_and_preferences():
-    X = np.array([[0, 0], [1, 1], [-2, -2]])  # Unequal distances
+    # Unequal distances
+    X = np.array([[0, 0], [1, 1], [-2, -2]])
     S = -euclidean_distances(X, squared=True)
 
     assert_false(equal_similarities_and_preferences(S, 0))
     assert_false(equal_similarities_and_preferences(S, [0, 0]))
     assert_false(equal_similarities_and_preferences(S, [0, 1]))
 
-    X = np.array([[0, 0], [1, 1]])  # Equal distances
+    # Equal distances
+    X = np.array([[0, 0], [1, 1]])
     S = -euclidean_distances(X, squared=True)
 
-    assert_false(equal_similarities_and_preferences(S, [0, 1]))  # Different preferences
+    # Different preferences
+    assert_false(equal_similarities_and_preferences(S, [0, 1]))
+
+    # Same preferences
     assert_true(equal_similarities_and_preferences(S, [0, 0]))
     assert_true(equal_similarities_and_preferences(S, 0))


### PR DESCRIPTION
#### Reference Issue
Fixes #9612


#### What does this implement/fix? Explain your changes.

1. `AffinityPropagation.predict(X)` would fail in case of non-convergence of the algorithm when fitting the model. It now returns the same label ('-1' for noise) for every sample in `X` in that case.
2. `AffinityPropagation.fit()` behavior was undefined and sometimes arbitrary (depending on preference and/or damping values) for cases when training samples had equal mutual similarities. It now behaves in a consistent way for these edge cases, i.e. returning one cluster when preference < mutual similarities and returning `n_samples` clusters when preference >= mutual similarities.
