### PR TITLE
[MRG+1] discrete branch: add encoding option to KBinsDiscretizer

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -455,7 +455,7 @@ K-bins discretization
   >>> X = np.array([[ -3., 5., 15 ],
   ...               [  0., 6., 14 ],
   ...               [  6., 3., 11 ]])
-  >>> est = preprocessing.KBinsDiscretizer(n_bins=[3, 3, 2]).fit(X)
+  >>> est = preprocessing.KBinsDiscretizer(n_bins=[3, 3, 2], encode='ordinal').fit(X)
   >>> est.bin_width_
   array([ 3.,  1.,  2.])
 

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -459,7 +459,8 @@ K-bins discretization
   >>> est.bin_width_
   array([ 3.,  1.,  2.])
 
-By default the output is one-hot encoded into a sparse matrix (See :class:`OneHotEncoder`)
+By default the output is one-hot encoded into a sparse matrix
+(See :ref:`preprocessing_categorical_features`)
 and this can be configured with the ``encode`` parameter.
 For each feature, the bin width is computed during ``fit`` and together with
 the number of bins, they will define the intervals. Therefore, for the current

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -459,6 +459,8 @@ K-bins discretization
   >>> est.bin_width_
   array([ 3.,  1.,  2.])
 
+By default the output is one-hot encoded into a sparse matrix (See :class:`OneHotEncoder`)
+and this can be configured with the ``encode`` parameter.
 For each feature, the bin width is computed during ``fit`` and together with
 the number of bins, they will define the intervals. Therefore, for the current
 example, these intervals are defined as:

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -455,7 +455,7 @@ K-bins discretization
   >>> X = np.array([[ -3., 5., 15 ],
   ...               [  0., 6., 14 ],
   ...               [  6., 3., 11 ]])
-  >>> est = preprocessing.KBinsDiscretizer(n_bins=[3, 3, 2], encode='ordinal').fit(X)
+  >>> est = preprocessing.KBinsDiscretizer(n_bins=[3, 3, 2]).fit(X)
   >>> est.bin_width_
   array([ 3.,  1.,  2.])
 

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -38,10 +38,12 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
 
         onehot:
             Encode the transformed result with one-hot encoding
-            and return a sparse matrix.
+            and return a sparse matrix. Ignored features are always
+            stacked to the right.
         onehot-dense:
             Encode the transformed result with one-hot encoding
-            and return a dense array.
+            and return a dense array. Ignored features are always
+            stacked to the right.
         ordinal:
             Return the bin identifier encoded as an integer value.
 

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -231,23 +231,19 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
                                  self.transformed_features_, copy=True,
                                  retain_order=True)
 
-        # only one-hot encode discretized features
+        if self.encode == 'ordinal':
+            return Xt
+
+        # Only one-hot encode discretized features
         mask = np.ones(X.shape[1], dtype=bool)
         if self.ignored_features is not None:
             mask[self.ignored_features] = False
 
-        if self.encode == 'onehot':
-            return OneHotEncoder(n_values=np.array(self.n_bins_)[mask],
-                                 categorical_features='all'
-                                 if self.ignored_features is None else mask,
-                                 sparse=True).fit_transform(Xt)
-        elif self.encode == 'onehot-dense':
-            return OneHotEncoder(n_values=np.array(self.n_bins_)[mask],
-                                 categorical_features='all'
-                                 if self.ignored_features is None else mask,
-                                 sparse=False).fit_transform(Xt)
-        else:
-            return Xt
+        encode_sparse = (self.encode == 'onehot')
+        return OneHotEncoder(n_values=np.array(self.n_bins_)[mask],
+                             categorical_features='all'
+                             if self.ignored_features is None else mask,
+                             sparse=encode_sparse).fit_transform(Xt)
 
     def _validate_X_post_fit(self, X):
         X = check_array(X, dtype='numeric')
@@ -300,10 +296,10 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
         """
         check_is_fitted(self, ["offset_", "bin_width_"])
 
-        # currently, preprocessing.OneHotEncoder
-        # don't support inverse_transform
+        # Currently, preprocessing.OneHotEncoder
+        # doesn't support inverse_transform
         if self.encode != 'ordinal':
-            raise ValueError("inverse_transform only support "
+            raise ValueError("inverse_transform only supports "
                              "'encode = ordinal'. "
                              "Got 'encode = {}' instead."
                              .format(self.encode))

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -36,15 +36,15 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
     encode : {'onehot', 'onehot-dense', 'ordinal'}, (default='onehot')
         Method used to encode the transformed result.
 
-        onehot:
+        onehot
             Encode the transformed result with one-hot encoding
             and return a sparse matrix. Ignored features are always
             stacked to the right.
-        onehot-dense:
+        onehot-dense
             Encode the transformed result with one-hot encoding
             and return a dense array. Ignored features are always
             stacked to the right.
-        ordinal:
+        ordinal
             Return the bin identifier encoded as an integer value.
 
     Attributes
@@ -221,7 +221,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        Xt : numeric array-like
+        Xt : numeric array-like or sparse matrix
             Data in the binned space.
         """
         check_is_fitted(self, ["offset_", "bin_width_"])
@@ -238,11 +238,13 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
 
         if self.encode == 'onehot':
             return OneHotEncoder(n_values=np.array(self.n_bins_)[mask],
-                                 categorical_features=mask,
+                                 categorical_features='all'
+                                 if self.ignored_features is None else mask,
                                  sparse=True).fit_transform(Xt)
         elif self.encode == 'onehot-dense':
             return OneHotEncoder(n_values=np.array(self.n_bins_)[mask],
-                                 categorical_features=mask,
+                                 categorical_features='all'
+                                 if self.ignored_features is None else mask,
                                  sparse=False).fit_transform(Xt)
         else:
             return Xt

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -33,7 +33,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
         Column indices of ignored features. (Example: Categorical features.)
         If ``None``, all features will be discretized.
 
-    encode : string {'onehot', 'onehot-sparse', 'ordinal'} (default='ordinal')
+    encode : string {'onehot', 'onehot-dense', 'ordinal'} (default='ordinal')
         method used to encode the transformed result.
 
         onehot:

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -239,7 +239,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
         if self.ignored_features is not None:
             mask[self.ignored_features] = False
 
-        encode_sparse = (self.encode == 'onehot')
+        encode_sparse = self.encode == 'onehot'
         return OneHotEncoder(n_values=np.array(self.n_bins_)[mask],
                              categorical_features='all'
                              if self.ignored_features is None else mask,
@@ -296,8 +296,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
         """
         check_is_fitted(self, ["offset_", "bin_width_"])
 
-        # Currently, preprocessing.OneHotEncoder
-        # doesn't support inverse_transform
+        # Currently, OneHotEncoder doesn't support inverse_transform
         if self.encode != 'ordinal':
             raise ValueError("inverse_transform only supports "
                              "'encode = ordinal'. "

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -130,9 +130,9 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
 
         valid_encode = ['onehot', 'onehot-dense', 'ordinal']
         if self.encode not in valid_encode:
-            raise ValueError('Invalid encode value. '
-                             'Valid options are %s'
-                             % (sorted(valid_encode)))
+            raise ValueError("Valid options for 'encode' are {}. "
+                             "Got 'encode = {}' instead."
+                             .format(sorted(valid_encode), self.encode))
 
         n_features = X.shape[1]
         ignored = self._validate_ignored_features(n_features)
@@ -230,7 +230,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
                                  retain_order=True)
 
         # only one-hot encode discretized features
-        mask = np.array([True] * X.shape[1])
+        mask = np.repeat(True, X.shape[1])
         if self.ignored_features is not None:
             mask[self.ignored_features] = False
 
@@ -300,7 +300,9 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
         # don't support inverse_transform
         if self.encode != 'ordinal':
             raise ValueError("inverse_transform only support "
-                             "encode='ordinal'.")
+                             "'encode = ordinal'. "
+                             "Got 'encode = {}' instead."
+                             .format(self.encode))
 
         Xt = self._validate_X_post_fit(Xt)
         trans = self.transformed_features_

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -33,17 +33,17 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
         Column indices of ignored features. (Example: Categorical features.)
         If ``None``, all features will be discretized.
 
-    encode : {'ordinal', 'onehot', 'onehot-dense'} (default='ordinal')
-        method used to encode the transformed result.
+    encode : {'ordinal', 'onehot', 'onehot-dense'}, (default='ordinal')
+        Method used to encode the transformed result.
 
         onehot:
-            encode the transformed result with one-hot encoding
+            Encode the transformed result with one-hot encoding
             and return a sparse matrix.
         onehot-dense:
-            encode the transformed result with one-hot encoding
+            Encode the transformed result with one-hot encoding
             and return a dense array.
         ordinal:
-            return the bin identifier encoded as an integer value.
+            Return the bin identifier encoded as an integer value.
 
     Attributes
     ----------
@@ -128,11 +128,11 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
         """
         X = check_array(X, dtype='numeric')
 
-        valid_encode = ['onehot', 'onehot-dense', 'ordinal']
+        valid_encode = ('onehot', 'onehot-dense', 'ordinal')
         if self.encode not in valid_encode:
             raise ValueError("Valid options for 'encode' are {}. "
                              "Got 'encode = {}' instead."
-                             .format(sorted(valid_encode), self.encode))
+                             .format(valid_encode, self.encode))
 
         n_features = X.shape[1]
         ignored = self._validate_ignored_features(n_features)
@@ -230,7 +230,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
                                  retain_order=True)
 
         # only one-hot encode discretized features
-        mask = np.repeat(True, X.shape[1])
+        mask = np.ones(X.shape[1], dtype=bool)
         if self.ignored_features is not None:
             mask[self.ignored_features] = False
 

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -41,9 +41,9 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
             and return a sparse matrix.
         onehot-dense:
             encode the transformed result with one-hot encoding
-            and return a dense matrix.
+            and return a dense array.
         ordinal:
-            do not encode the transformed result.
+            return the bin identifier encoded as an integer value.
 
     Attributes
     ----------

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -33,7 +33,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
         Column indices of ignored features. (Example: Categorical features.)
         If ``None``, all features will be discretized.
 
-    encode : {'ordinal', 'onehot', 'onehot-dense'}, (default='ordinal')
+    encode : {'onehot', 'onehot-dense', 'ordinal'}, (default='onehot')
         Method used to encode the transformed result.
 
         onehot:
@@ -68,7 +68,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
     ...      [-1, 2, -3, -0.5],
     ...      [ 0, 3, -2,  0.5],
     ...      [ 1, 4, -1,    2]]
-    >>> est = KBinsDiscretizer(n_bins=3)
+    >>> est = KBinsDiscretizer(n_bins=3, encode='ordinal')
     >>> est.fit(X)  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     KBinsDiscretizer(...)
     >>> Xt = est.transform(X)
@@ -107,7 +107,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
         ``1`` based on a parameter ``threshold``.
     """
 
-    def __init__(self, n_bins=2, ignored_features=None, encode='ordinal'):
+    def __init__(self, n_bins=2, ignored_features=None, encode='onehot'):
         self.n_bins = n_bins
         self.ignored_features = ignored_features
         self.encode = encode

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -19,6 +19,8 @@ from sklearn.utils.validation import column_or_1d
 class KBinsDiscretizer(BaseEstimator, TransformerMixin):
     """Bins continuous data into k equal width intervals.
 
+    Read more in the :ref:`User Guide <discretization>`.
+
     Parameters
     ----------
     n_bins : int or array-like, shape (n_features,) (default=2)

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -33,7 +33,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
         Column indices of ignored features. (Example: Categorical features.)
         If ``None``, all features will be discretized.
 
-    encode : string {'onehot', 'onehot-dense', 'ordinal'} (default='ordinal')
+    encode : {'ordinal', 'onehot', 'onehot-dense'} (default='ordinal')
         method used to encode the transformed result.
 
         onehot:

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -240,7 +240,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
             mask[self.ignored_features] = False
 
         encode_sparse = self.encode == 'onehot'
-        return OneHotEncoder(n_values=np.array(self.n_bins_)[mask],
+        return OneHotEncoder(n_values=self.n_bins_[mask],
                              categorical_features='all'
                              if self.ignored_features is None else mask,
                              sparse=encode_sparse).fit_transform(Xt)

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -133,7 +133,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
             raise ValueError('Invalid encode value. '
                              'Valid options are %s'
                              % (sorted(valid_encode)))
- 
+
         n_features = X.shape[1]
         ignored = self._validate_ignored_features(n_features)
         self.transformed_features_ = np.delete(np.arange(n_features), ignored)
@@ -228,19 +228,19 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
         Xt = _transform_selected(X, self._transform,
                                  self.transformed_features_, copy=True,
                                  retain_order=True)
-        
+
         # only one-hot encode discretized features
         mask = np.array([True] * X.shape[1])
-        if self.ignored_features != None:
+        if self.ignored_features is not None:
             mask[self.ignored_features] = False
 
-		if self.encode == 'onehot':
+        if self.encode == 'onehot':
             return OneHotEncoder(n_values=np.array(self.n_bins_)[mask],
                                  categorical_features=mask,
-                                 sparse=True).fit_transform(Xt)      
+                                 sparse=True).fit_transform(Xt)
         elif self.encode == 'onehot-dense':
             return OneHotEncoder(n_values=np.array(self.n_bins_)[mask],
-                                 categorical_features=mask, 
+                                 categorical_features=mask,
                                  sparse=False).fit_transform(Xt)
         else:
             return Xt
@@ -295,12 +295,13 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
             Data in the original feature space.
         """
         check_is_fitted(self, ["offset_", "bin_width_"])
-        
-        # currently, preprocessing.OneHotEncoder 
+
+        # currently, preprocessing.OneHotEncoder
         # don't support inverse_transform
         if self.encode != 'ordinal':
-            raise ValueError("inverse_transform only support encode='ordinal'.")
-        
+            raise ValueError("inverse_transform only support "
+                             "encode='ordinal'.")
+
         Xt = self._validate_X_post_fit(Xt)
         trans = self.transformed_features_
         Xinv = Xt.copy()

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -110,6 +110,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
     def __init__(self, n_bins=2, ignored_features=None, encode='ordinal'):
         self.n_bins = n_bins
         self.ignored_features = ignored_features
+        self.encode = encode
 
     def fit(self, X, y=None):
         """Fits the estimator.
@@ -228,7 +229,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
                                  self.transformed_features_, copy=True,
                                  retain_order=True)
         
-        # only one hot encode discretized features
+        # only one-hot encode discretized features
         mask = np.array([True] * X.shape[1])
         if self.ignored_features != None:
             mask[self.ignored_features] = False

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -68,7 +68,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
     ...      [-1, 2, -3, -0.5],
     ...      [ 0, 3, -2,  0.5],
     ...      [ 1, 4, -1,    2]]
-    >>> est = KBinsDiscretizer(n_bins=3, encode='ordinal')
+    >>> est = KBinsDiscretizer(n_bins=3)
     >>> est.fit(X)  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     KBinsDiscretizer(...)
     >>> Xt = est.transform(X)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -178,10 +178,11 @@ def test_numeric_stability():
 
 
 def test_encode():
-    # test invalid encode
+    # test invalid encode option
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], encode='invalid-encode')
     assert_raises(ValueError, est.fit, X)
 
+    # test encode options through comparison
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3],
                            encode='ordinal').fit(X)
     expected1 = est.transform(X)
@@ -200,6 +201,7 @@ def test_encode():
                        expected3.toarray())
     assert_raises(ValueError, est.inverse_transform, X)
 
+    # test one hot encode with ignored features
     est = KBinsDiscretizer(n_bins=3, ignored_features=[1,2],
                            encode='onehot-dense').fit(X)
     expected1 = est.transform(X)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -178,12 +178,13 @@ def test_numeric_stability():
         assert_array_equal(Xt_expected, Xt)
 
 
-def test_encode():
-    # test invalid encode option
+def test_invalid_encode_option():
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], encode='invalid-encode')
     assert_raises(ValueError, est.fit, X)
 
-    # test encode options through comparison
+
+def test_encode_options():
+    # test valid encode options through comparison
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3],
                            encode='ordinal').fit(X)
     expected1 = est.transform(X)
@@ -204,7 +205,8 @@ def test_encode():
                        expected3.toarray())
     assert_raises(ValueError, est.inverse_transform, X)
 
-    # test one-hot encode with ignored features
+
+def test_one_hot_encode_with_ignored_features():
     est = KBinsDiscretizer(n_bins=3, ignored_features=[1, 2],
                            encode='onehot-dense').fit(X)
     expected1 = est.transform(X)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 
 import numpy as np
 import scipy.sparse as sp
-from six.moves import range
 import warnings
 
+from sklearn.externals.six.moves import xrange as range
 from sklearn.preprocessing import KBinsDiscretizer
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.utils.testing import (

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -202,7 +202,7 @@ def test_encode():
     assert_raises(ValueError, est.inverse_transform, X)
 
     # test one hot encode with ignored features
-    est = KBinsDiscretizer(n_bins=3, ignored_features=[1,2],
+    est = KBinsDiscretizer(n_bins=3, ignored_features=[1, 2],
                            encode='onehot-dense').fit(X)
     expected1 = est.transform(X)
     expected2 = np.array([[1, 0, 0, 1, 0, 0, 1.5, -4],
@@ -210,4 +210,3 @@ def test_encode():
                           [0, 0, 1, 0, 1, 0, 3.5, -2],
                           [0, 0, 1, 0, 0, 1, 4.5, -1]])
     assert_array_equal(expected1, expected2)
-

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -21,7 +21,7 @@ X = np.array([[-2, 1.5, -4, -1],
 
 
 def test_fit_transform():
-    est = KBinsDiscretizer(n_bins=3).fit(X)
+    est = KBinsDiscretizer(n_bins=3, encode='ordinal').fit(X)
     expected = [[0, 0, 0, 0],
                 [1, 1, 1, 0],
                 [2, 2, 2, 1],
@@ -76,7 +76,7 @@ def test_invalid_n_bins_array():
 
 
 def test_fit_transform_n_bins_array():
-    est = KBinsDiscretizer(n_bins=[2, 3, 3, 3]).fit(X)
+    est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], encode='ordinal').fit(X)
     expected = [[0, 0, 0, 0],
                 [0, 1, 1, 0],
                 [1, 2, 2, 1],
@@ -94,7 +94,8 @@ def test_invalid_n_features():
 
 def test_ignored_transform():
     # Feature at col_idx=1 should not change
-    est = KBinsDiscretizer(n_bins=3, ignored_features=[1]).fit(X)
+    est = KBinsDiscretizer(n_bins=3, ignored_features=[1],
+                           encode='ordinal').fit(X)
 
     expected = [[0., 1.5, 0., 0.],
                 [1., 2.5, 1., 0.],
@@ -131,7 +132,8 @@ def test_same_min_max():
                   [1, 1]])
     est = assert_warns_message(UserWarning,
                                "Features 0 are constant and will be replaced "
-                               "with 0.", KBinsDiscretizer(n_bins=3).fit, X)
+                               "with 0.", KBinsDiscretizer
+                               (n_bins=3, encode='ordinal').fit, X)
     Xt = est.transform(X)
 
     expected = [[0, 0],
@@ -152,7 +154,8 @@ def test_transform_1d_behavior():
 
 
 def test_inverse_transform_with_ignored():
-    est = KBinsDiscretizer(n_bins=[2, 3, 0, 3], ignored_features=[1, 2]).fit(X)
+    est = KBinsDiscretizer(n_bins=[2, 3, 0, 3], ignored_features=[1, 2],
+                           encode='ordinal').fit(X)
     Xt = [[0, 1, -4.5, 0],
           [0, 2, -3.5, 0],
           [1, 3, -2.5, 1],
@@ -174,7 +177,7 @@ def test_numeric_stability():
     # Test up to discretizing nano units
     for i in range(1, 9):
         X = X_init / 10**i
-        Xt = KBinsDiscretizer(n_bins=2).fit_transform(X)
+        Xt = KBinsDiscretizer(n_bins=2, encode='ordinal').fit_transform(X)
         assert_array_equal(Xt_expected, Xt)
 
 

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 
 import numpy as np
+import scipy.sparse as sp
 from six.moves import range
 import warnings
-import scipy.sparse as sp
 
 from sklearn.preprocessing import KBinsDiscretizer
 from sklearn.preprocessing import OneHotEncoder
@@ -211,9 +211,9 @@ def test_encode_options():
 def test_one_hot_encode_with_ignored_features():
     est = KBinsDiscretizer(n_bins=3, ignored_features=[1, 2],
                            encode='onehot-dense').fit(X)
-    Xt_1 = est.transform(X)
-    Xt_2 = np.array([[1, 0, 0, 1, 0, 0, 1.5, -4],
-                     [0, 1, 0, 1, 0, 0, 2.5, -3],
-                     [0, 0, 1, 0, 1, 0, 3.5, -2],
-                     [0, 0, 1, 0, 0, 1, 4.5, -1]])
-    assert_array_equal(Xt_1, Xt_2)
+    Xt = est.transform(X)
+    Xt_expected = [[1, 0, 0, 1, 0, 0, 1.5, -4],
+                   [0, 1, 0, 1, 0, 0, 2.5, -3],
+                   [0, 0, 1, 0, 1, 0, 3.5, -2],
+                   [0, 0, 1, 0, 0, 1, 4.5, -1]]
+    assert_array_equal(Xt_expected, Xt)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -183,11 +183,13 @@ def test_numeric_stability():
 
 def test_invalid_encode_option():
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], encode='invalid-encode')
-    assert_raises(ValueError, est.fit, X)
+    assert_raise_message(ValueError, "Valid options for 'encode' are "
+                         "('onehot', 'onehot-dense', 'ordinal'). "
+                         "Got 'encode = invalid-encode' instead.",
+                         est.fit, X)
 
 
 def test_encode_options():
-    # test valid encode options through comparison
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3],
                            encode='ordinal').fit(X)
     Xt_1 = est.transform(X)
@@ -197,7 +199,9 @@ def test_encode_options():
     assert not sp.issparse(Xt_2)
     assert_array_equal(OneHotEncoder(n_values=[2, 3, 3, 3], sparse=False)
                        .fit_transform(Xt_1), Xt_2)
-    assert_raises(ValueError, est.inverse_transform, Xt_2)
+    assert_raise_message(ValueError, "inverse_transform only supports "
+                         "'encode = ordinal'. Got 'encode = onehot-dense' "
+                         "instead.", est.inverse_transform, Xt_2)
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3],
                            encode='onehot').fit(X)
     Xt_3 = est.transform(X)
@@ -205,7 +209,9 @@ def test_encode_options():
     assert_array_equal(OneHotEncoder(n_values=[2, 3, 3, 3], sparse=True)
                        .fit_transform(Xt_1).toarray(),
                        Xt_3.toarray())
-    assert_raises(ValueError, est.inverse_transform, Xt_3)
+    assert_raise_message(ValueError, "inverse_transform only supports "
+                         "'encode = ordinal'. Got 'encode = onehot' "
+                         "instead.", est.inverse_transform, Xt_2)
 
 
 def test_one_hot_encode_with_ignored_features():

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -201,7 +201,7 @@ def test_encode():
                        expected3.toarray())
     assert_raises(ValueError, est.inverse_transform, X)
 
-    # test one hot encode with ignored features
+    # test one-hot encode with ignored features
     est = KBinsDiscretizer(n_bins=3, ignored_features=[1, 2],
                            encode='onehot-dense').fit(X)
     expected1 = est.transform(X)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -190,31 +190,30 @@ def test_encode_options():
     # test valid encode options through comparison
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3],
                            encode='ordinal').fit(X)
-    expected1 = est.transform(X)
+    Xt_1 = est.transform(X)
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3],
                            encode='onehot-dense').fit(X)
-    expected2 = est.transform(X)
-    assert not sp.issparse(expected2)
+    Xt_2 = est.transform(X)
+    assert not sp.issparse(Xt_2)
     assert_array_equal(OneHotEncoder(n_values=[2, 3, 3, 3], sparse=False)
-                       .fit_transform(expected1),
-                       expected2)
-    assert_raises(ValueError, est.inverse_transform, expected2)
+                       .fit_transform(Xt_1), Xt_2)
+    assert_raises(ValueError, est.inverse_transform, Xt_2)
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3],
                            encode='onehot').fit(X)
-    expected3 = est.transform(X)
-    assert sp.issparse(expected3)
+    Xt_3 = est.transform(X)
+    assert sp.issparse(Xt_3)
     assert_array_equal(OneHotEncoder(n_values=[2, 3, 3, 3], sparse=True)
-                       .fit_transform(expected1).toarray(),
-                       expected3.toarray())
-    assert_raises(ValueError, est.inverse_transform, expected3)
+                       .fit_transform(Xt_1).toarray(),
+                       Xt_3.toarray())
+    assert_raises(ValueError, est.inverse_transform, Xt_3)
 
 
 def test_one_hot_encode_with_ignored_features():
     est = KBinsDiscretizer(n_bins=3, ignored_features=[1, 2],
                            encode='onehot-dense').fit(X)
-    expected1 = est.transform(X)
-    expected2 = np.array([[1, 0, 0, 1, 0, 0, 1.5, -4],
-                          [0, 1, 0, 1, 0, 0, 2.5, -3],
-                          [0, 0, 1, 0, 1, 0, 3.5, -2],
-                          [0, 0, 1, 0, 0, 1, 4.5, -1]])
-    assert_array_equal(expected1, expected2)
+    Xt_1 = est.transform(X)
+    Xt_2 = np.array([[1, 0, 0, 1, 0, 0, 1.5, -4],
+                     [0, 1, 0, 1, 0, 0, 2.5, -3],
+                     [0, 0, 1, 0, 1, 0, 3.5, -2],
+                     [0, 0, 1, 0, 0, 1, 4.5, -1]])
+    assert_array_equal(Xt_1, Xt_2)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -198,7 +198,7 @@ def test_encode_options():
     assert_array_equal(OneHotEncoder(n_values=[2, 3, 3, 3], sparse=False)
                        .fit_transform(expected1),
                        expected2)
-    assert_raises(ValueError, est.inverse_transform, X)
+    assert_raises(ValueError, est.inverse_transform, expected2)
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3],
                            encode='onehot').fit(X)
     expected3 = est.transform(X)
@@ -206,7 +206,7 @@ def test_encode_options():
     assert_array_equal(OneHotEncoder(n_values=[2, 3, 3, 3], sparse=True)
                        .fit_transform(expected1).toarray(),
                        expected3.toarray())
-    assert_raises(ValueError, est.inverse_transform, X)
+    assert_raises(ValueError, est.inverse_transform, expected3)
 
 
 def test_one_hot_encode_with_ignored_features():

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import numpy as np
 from six.moves import range
 import warnings
+import scipy.sparse as sp
 
 from sklearn.preprocessing import KBinsDiscretizer
 from sklearn.preprocessing import OneHotEncoder
@@ -189,6 +190,7 @@ def test_encode():
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3],
                            encode='onehot-dense').fit(X)
     expected2 = est.transform(X)
+    assert not sp.issparse(expected2)
     assert_array_equal(OneHotEncoder(n_values=[2, 3, 3, 3], sparse=False)
                        .fit_transform(expected1),
                        expected2)
@@ -196,6 +198,7 @@ def test_encode():
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3],
                            encode='onehot').fit(X)
     expected3 = est.transform(X)
+    assert sp.issparse(expected3)
     assert_array_equal(OneHotEncoder(n_values=[2, 3, 3, 3], sparse=True)
                        .fit_transform(expected1).toarray(),
                        expected3.toarray())


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #9336

#### What does this implement/fix? Explain your changes.
add encoding option to KBinsDiscretizer
(1)encode option support {'onehot', 'onehot-dense', 'ordinal'}, the default value is set to 'ordinal' mainly because of (3)
(2)only one-hot encode discretized features when ignored_features is set.
(according to OneHotEncoder, non-categorical features are always stacked to the right of the matrix.)
(3)seems hard to support inverse_transform for one-hot because OneHotEncoder don't support inverse_transform

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
