### PR TITLE
[MRG] better error message for docstring tests

### DIFF
--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -147,7 +147,7 @@ def test_docstring_parameters():
                 incorrect += check_docstring_parameters(func)
     msg = '\n' + '\n'.join(sorted(list(set(incorrect))))
     if len(incorrect) > 0:
-        raise AssertionError(msg)
+        raise AssertionError("Docstring Error: " + msg)
 
 
 @ignore_warnings(category=DeprecationWarning)


### PR DESCRIPTION
add "docstring error" to docstring error message for context.

[It's somewhat cryptic right now](https://github.com/scikit-learn/scikit-learn/pull/9614#issuecomment-326034390).