### PR TITLE
[MRG+1] add groups support to RFECV

### DIFF
--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -381,7 +381,7 @@ class RFECV(RFE, MetaEstimatorMixin):
         self.verbose = verbose
         self.n_jobs = n_jobs
 
-    def fit(self, X, y):
+    def fit(self, X, y, groups=None):
         """Fit the RFE model and automatically tune the number of selected
            features.
 
@@ -394,6 +394,10 @@ class RFECV(RFE, MetaEstimatorMixin):
         y : array-like, shape = [n_samples]
             Target values (integers for classification, real numbers for
             regression).
+
+        groups : array-like, shape = [n_samples], optional
+            Group labels for the samples used while splitting the dataset into
+            train/test set.
         """
         X, y = check_X_y(X, y, "csr")
 
@@ -433,7 +437,7 @@ class RFECV(RFE, MetaEstimatorMixin):
 
         scores = parallel(
             func(rfe, self.estimator, X, y, train, test, scorer)
-            for train, test in cv.split(X, y))
+            for train, test in cv.split(X, y, groups))
 
         scores = np.sum(scores, axis=0)
         n_features_to_select = max(

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -459,5 +459,5 @@ class RFECV(RFE, MetaEstimatorMixin):
 
         # Fixing a normalization error, n is equal to get_n_splits(X, y) - 1
         # here, the scores are normalized by get_n_splits(X, y)
-        self.grid_scores_ = scores[::-1] / cv.get_n_splits(X, y)
+        self.grid_scores_ = scores[::-1] / cv.get_n_splits(X, y, groups)
         return self

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -11,6 +11,7 @@ from sklearn.metrics import zero_one_loss
 from sklearn.svm import SVC, SVR
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import GroupKFold
 
 from sklearn.utils import check_random_state
 from sklearn.utils.testing import ignore_warnings
@@ -328,3 +329,21 @@ def test_rfe_cv_n_jobs():
     rfecv.fit(X, y)
     assert_array_almost_equal(rfecv.ranking_, rfecv_ranking)
     assert_array_almost_equal(rfecv.grid_scores_, rfecv_grid_scores)
+
+
+def test_rfe_cv_groups():
+    # test cv with groups
+    iris = load_iris()
+    number_groups = 4
+    groups = np.floor(np.linspace(0, number_groups, len(iris.target)))
+    X = iris.data
+    y = (iris.target > 0).astype(int)
+
+    est_groups = RFECV(
+        estimator=RandomForestClassifier(),
+        step=1,
+        scoring='accuracy',
+        cv=GroupKFold(n_splits=2)
+    )
+    est_groups.fit(X, y, groups=groups)
+    assert(est_groups.n_features_ > 0)

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -332,7 +332,7 @@ def test_rfe_cv_n_jobs():
 
 
 def test_rfe_cv_groups():
-    # test cv with groups
+    generator = check_random_state(0)
     iris = load_iris()
     number_groups = 4
     groups = np.floor(np.linspace(0, number_groups, len(iris.target)))
@@ -340,10 +340,10 @@ def test_rfe_cv_groups():
     y = (iris.target > 0).astype(int)
 
     est_groups = RFECV(
-        estimator=RandomForestClassifier(),
+        estimator=RandomForestClassifier(random_state=generator),
         step=1,
         scoring='accuracy',
         cv=GroupKFold(n_splits=2)
     )
     est_groups.fit(X, y, groups=groups)
-    assert(est_groups.n_features_ > 0)
+    assert est_groups.n_features_ > 0

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1260,12 +1260,24 @@ def test_rfe_cv():
     iris = load_iris()
     number_groups = 4
     groups = np.floor(np.linspace(0, number_groups, len(iris.target)))
+    X = iris.data
+    y = (iris.target > 0).astype(int)
+
+    # test basic cv
     est = RFECV(
+        estimator=DecisionTreeClassifier(),
+        step=1,
+        scoring='accuracy',
+        cv=2,
+    )
+    est.fit(X, y)
+
+    # test cv with groups
+    est_groups = RFECV(
         estimator=DecisionTreeClassifier(),
         step=1,
         scoring='accuracy',
         cv=GroupKFold(n_splits=2)
     )
-    binary_target = (iris.target > 0).astype(int)
-    est.fit(iris.data, binary_target, groups=groups)
-    assert(est.n_features_ > 0)
+    est_groups.fit(X, y, groups=groups)
+    assert(est_groups.n_features_ > 0)

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -43,7 +43,11 @@ from sklearn.linear_model import Ridge
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.svm import SVC
+from sklearn.tree import DecisionTreeClassifier
 from sklearn.cluster import KMeans
+
+from sklearn.feature_selection import RFECV
+from sklearn.model_selection import GroupKFold
 
 from sklearn.preprocessing import Imputer
 from sklearn.pipeline import Pipeline
@@ -1250,3 +1254,17 @@ def test_cross_val_predict_sparse_prediction():
     preds_sparse = cval.cross_val_predict(classif, X_sparse, y_sparse, cv=10)
     preds_sparse = preds_sparse.toarray()
     assert_array_almost_equal(preds_sparse, preds)
+
+
+def test_rfe_cv():
+    iris = load_iris()
+    number_groups = 4
+    groups = np.floor(np.linspace(0, number_groups, len(iris.target)))
+    est = RFECV(
+        estimator=DecisionTreeClassifier(),
+        step=1,
+        scoring='roc_auc',
+        cv=GroupKFold(n_splits=2)
+    )
+    est.fit(iris.data, iris.target, groups=groups)
+    assert(est.n_features_ > 0)

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -24,10 +24,6 @@ from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.mocking import CheckingClassifier, MockDataFrame
 
-from sklearn.tree import DecisionTreeClassifier
-from sklearn.feature_selection import RFECV
-from sklearn.model_selection import GroupKFold
-
 with warnings.catch_warnings():
     warnings.simplefilter('ignore')
     from sklearn import cross_validation as cval
@@ -1254,30 +1250,3 @@ def test_cross_val_predict_sparse_prediction():
     preds_sparse = cval.cross_val_predict(classif, X_sparse, y_sparse, cv=10)
     preds_sparse = preds_sparse.toarray()
     assert_array_almost_equal(preds_sparse, preds)
-
-
-def test_rfe_cv():
-    iris = load_iris()
-    number_groups = 4
-    groups = np.floor(np.linspace(0, number_groups, len(iris.target)))
-    X = iris.data
-    y = (iris.target > 0).astype(int)
-
-    # test basic cv
-    est = RFECV(
-        estimator=DecisionTreeClassifier(),
-        step=1,
-        scoring='accuracy',
-        cv=2,
-    )
-    est.fit(X, y)
-
-    # test cv with groups
-    est_groups = RFECV(
-        estimator=DecisionTreeClassifier(),
-        step=1,
-        scoring='accuracy',
-        cv=GroupKFold(n_splits=2)
-    )
-    est_groups.fit(X, y, groups=groups)
-    assert(est_groups.n_features_ > 0)

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1263,7 +1263,7 @@ def test_rfe_cv():
     est = RFECV(
         estimator=DecisionTreeClassifier(),
         step=1,
-        scoring='roc_auc',
+        scoring='accuracy',
         cv=GroupKFold(n_splits=2)
     )
     binary_target = (iris.target > 0).astype(int)

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -24,6 +24,10 @@ from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.mocking import CheckingClassifier, MockDataFrame
 
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.feature_selection import RFECV
+from sklearn.model_selection import GroupKFold
+
 with warnings.catch_warnings():
     warnings.simplefilter('ignore')
     from sklearn import cross_validation as cval
@@ -43,11 +47,7 @@ from sklearn.linear_model import Ridge
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.svm import SVC
-from sklearn.tree import DecisionTreeClassifier
 from sklearn.cluster import KMeans
-
-from sklearn.feature_selection import RFECV
-from sklearn.model_selection import GroupKFold
 
 from sklearn.preprocessing import Imputer
 from sklearn.pipeline import Pipeline

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1266,5 +1266,6 @@ def test_rfe_cv():
         scoring='roc_auc',
         cv=GroupKFold(n_splits=2)
     )
-    est.fit(iris.data, iris.target, groups=groups)
+    binary_target = (iris.target > 0).astype(int)
+    est.fit(iris.data, binary_target, groups=groups)
     assert(est.n_features_ > 0)


### PR DESCRIPTION
#### Reference Issue

related to https://github.com/scikit-learn/scikit-learn/issues/8127

#### What does this implement/fix? Explain your changes.

Adding support for cv groups (eg `LeaveOneGroupOut`) to `RFECV`.
