### PR TITLE
[WIP] Add verbose option for Pipeline and Feature Union [rebased 8568]

### DIFF
--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -47,7 +47,7 @@ is an estimator object::
     >>> pipe # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
     Pipeline(memory=None,
              steps=[('reduce_dim', PCA(copy=True,...)),
-                    ('clf', SVC(C=1.0,...))])
+                    ('clf', SVC(C=1.0,...))], verbose=False)
 
 The utility function :func:`make_pipeline` is a shorthand
 for constructing pipelines;
@@ -62,7 +62,7 @@ filling in the names automatically::
              steps=[('binarizer', Binarizer(copy=True, threshold=0.0)),
                     ('multinomialnb', MultinomialNB(alpha=1.0,
                                                     class_prior=None,
-                                                    fit_prior=True))])
+                                                    fit_prior=True))], verbose=False)
 
 The estimators of a pipeline are stored as a list in the ``steps`` attribute::
 
@@ -82,7 +82,8 @@ Parameters of the estimators in the pipeline can be accessed using the
     >>> pipe.set_params(clf__C=10) # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
     Pipeline(memory=None,
              steps=[('reduce_dim', PCA(copy=True, iterated_power='auto',...)),
-                    ('clf', SVC(C=10, cache_size=200, class_weight=None,...))])
+                    ('clf', SVC(C=10, cache_size=200, class_weight=None,...))],
+                    verbose=False)
 
 Attributes of named_steps map to keys, enabling tab completion in interactive environments::
 
@@ -160,7 +161,7 @@ object::
     >>> pipe # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
     Pipeline(...,
              steps=[('reduce_dim', PCA(copy=True,...)),
-                    ('clf', SVC(C=1.0,...))])
+                    ('clf', SVC(C=1.0,...))], verbose=False)
     >>> # Clear the cache directory when you don't need it anymore
     >>> rmtree(cachedir)
 
@@ -177,7 +178,7 @@ object::
      >>> pipe.fit(digits.data, digits.target)
      ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
      Pipeline(memory=None,
-              steps=[('reduce_dim', PCA(...)), ('clf', SVC(...))])
+              steps=[('reduce_dim', PCA(...)), ('clf', SVC(...))], verbose=False)
      >>> # The pca instance can be inspected directly
      >>> print(pca1.components_) # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
          [[ -1.77484909e-19  ... 4.07058917e-18]]
@@ -199,7 +200,7 @@ object::
      >>> cached_pipe.fit(digits.data, digits.target)
      ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
       Pipeline(memory=...,
-               steps=[('reduce_dim', PCA(...)), ('clf', SVC(...))])
+               steps=[('reduce_dim', PCA(...)), ('clf', SVC(...))], verbose=False)
      >>> print(cached_pipe.named_steps['reduce_dim'].components_)
      ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
          [[ -1.77484909e-19  ... 4.07058917e-18]]

--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -254,7 +254,7 @@ and ``value`` is an estimator object::
     FeatureUnion(n_jobs=1,
                  transformer_list=[('linear_pca', PCA(copy=True,...)),
                                    ('kernel_pca', KernelPCA(alpha=1.0,...))],
-                 transformer_weights=None)
+                 transformer_weights=None, verbose=False)
 
 
 Like pipelines, feature unions have a shorthand constructor called
@@ -269,7 +269,7 @@ and ignored by setting to ``None``::
     FeatureUnion(n_jobs=1,
                  transformer_list=[('linear_pca', PCA(copy=True,...)),
                                    ('kernel_pca', None)],
-                 transformer_weights=None)
+                 transformer_weights=None, verbose=False)
 
 .. topic:: Examples:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -54,6 +54,11 @@ Miscellaneous
   :class:`pipeline.FeatureUnion` for showing progress and timing of each
      step. :issue:`8568` by :user:`Karan Desai <karandesai-96>`.
 
+- Added optional parameter ``verbose`` in functions `pipeline.make_pipeline`
+  and `pipeline.make_union` to extend the same functionality as the
+  corresponding classes. :issue:`9668` by
+  :user:`Baze Petrushev <petrushev>`.
+
 
 Bug fixes
 .........

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -415,6 +415,113 @@ Miscellaneous
 
 - :class:`dummy.DummyClassifier` and :class:`dummy.DummyRegressor`
   now accept non-finite features. :issue:`8931` by :user:`Attractadore`.
+   - Added optional parameter ``verbose`` in :class:`pipeline.Pipeline` and
+     :class:`pipeline.FeatureUnion` for showing progress and timing of each
+     step. :issue:`8568` by :user:`Karan Desai <karandesai-96>`.
+
+   - Update Sphinx-Gallery from 0.1.4 to 0.1.7 for resolving links in
+     documentation build with Sphinx>1.5 :issue:`8010`, :issue:`7986`
+     :user:`Oscar Najera <Titan-C>`
+
+   - :class:`multioutput.MultiOutputRegressor` and :class:`multioutput.MultiOutputClassifier`
+     now support online learning using `partial_fit`.
+     issue: `8053` by :user:`Peng Yu <yupbank>`.
+   - :class:`pipeline.Pipeline` allows to cache transformers
+     within a pipeline by using the ``memory`` constructor parameter.
+     By :issue:`7990` by :user:`Guillaume Lemaitre <glemaitre>`.
+
+   - :class:`decomposition.PCA`, :class:`decomposition.IncrementalPCA` and
+     :class:`decomposition.TruncatedSVD` now expose the singular values
+     from the underlying SVD. They are stored in the attribute
+     ``singular_values_``, like in :class:`decomposition.IncrementalPCA`.
+
+   - :class:`cluster.MiniBatchKMeans` and :class:`cluster.KMeans`
+     now uses significantly less memory when assigning data points to their
+     nearest cluster center. :issue:`7721` by :user:`Jon Crall <Erotemic>`.
+
+   - Added ``classes_`` attribute to :class:`model_selection.GridSearchCV`,
+     :class:`model_selection.RandomizedSearchCV`,  :class:`grid_search.GridSearchCV`,
+     and  :class:`grid_search.RandomizedSearchCV` that matches the ``classes_``
+     attribute of ``best_estimator_``. :issue:`7661` and :issue:`8295`
+     by :user:`Alyssa Batula <abatula>`, :user:`Dylan Werner-Meier <unautre>`,
+     and :user:`Stephen Hoover <stephen-hoover>`.
+
+   - The ``min_weight_fraction_leaf`` constraint in tree construction is now
+     more efficient, taking a fast path to declare a node a leaf if its weight
+     is less than 2 * the minimum. Note that the constructed tree will be
+     different from previous versions where ``min_weight_fraction_leaf`` is
+     used. :issue:`7441` by :user:`Nelson Liu <nelson-liu>`.
+
+   - Added ``average`` parameter to perform weights averaging in
+     :class:`linear_model.PassiveAggressiveClassifier`. :issue:`4939`
+     by :user:`Andrea Esuli <aesuli>`.
+
+   - Custom metrics for the :mod:`sklearn.neighbors` binary trees now have
+     fewer constraints: they must take two 1d-arrays and return a float.
+     :issue:`6288` by `Jake Vanderplas`_.
+
+   - :class:`ensemble.GradientBoostingClassifier` and :class:`ensemble.GradientBoostingRegressor`
+     now support sparse input for prediction.
+     :issue:`6101` by :user:`Ibraim Ganiev <olologin>`.
+
+   - Added ``shuffle`` and ``random_state`` parameters to shuffle training
+     data before taking prefixes of it based on training sizes in
+     :func:`model_selection.learning_curve`.
+     :issue:`7506` by :user:`Narine Kokhlikyan <NarineK>`.
+
+   - Added ``norm_order`` parameter to :class:`feature_selection.SelectFromModel`
+     to enable selection of the norm order when ``coef_`` is more than 1D
+
+   - Added ``sample_weight`` parameter to :meth:`pipeline.Pipeline.score`.
+     :issue:`7723` by :user:`Mikhail Korobov <kmike>`.
+
+   - ``check_estimator`` now attempts to ensure that methods transform, predict, etc.
+     do not set attributes on the estimator.
+     :issue:`7533` by :user:`Ekaterina Krivich <kiote>`.
+
+   - For sparse matrices, :func:`preprocessing.normalize` with ``return_norm=True``
+     will now raise a ``NotImplementedError`` with 'l1' or 'l2' norm and with
+     norm 'max' the norms returned will be the same as for dense matrices.
+     :issue:`7771` by `Ang Lu <https://github.com/luang008>`_.
+
+   - :class:`sklearn.linear_model.RANSACRegressor` no longer throws an error
+     when calling ``fit`` if no inliers are found in its first iteration.
+     Furthermore, causes of skipped iterations are tracked in newly added
+     attributes, ``n_skips_*``.
+     :issue:`7914` by :user:`Michael Horrell <mthorrell>`.
+
+   - :func:`model_selection.cross_val_predict` now returns output of the
+     correct shape for all values of the argument ``method``.
+     :issue:`7863` by :user:`Aman Dalmia <dalmia>`.
+
+   - Fix a bug where :class:`sklearn.feature_selection.SelectFdr` did not
+     exactly implement Benjamini-Hochberg procedure. It formerly may have
+     selected fewer features than it should.
+     :issue:`7490` by :user:`Peng Meng <mpjlu>`.
+
+   - Added ability to set ``n_jobs`` parameter to :func:`pipeline.make_union`.
+     A ``TypeError`` will be raised for any other kwargs. :issue:`8028`
+     by :user:`Alexander Booth <alexandercbooth>`.
+
+   - Added type checking to the ``accept_sparse`` parameter in
+     :mod:`sklearn.utils.validation` methods. This parameter now accepts only
+     boolean, string, or list/tuple of strings. ``accept_sparse=None`` is deprecated
+     and should be replaced by ``accept_sparse=False``.
+     :issue:`7880` by :user:`Josh Karnofsky <jkarno>`.
+
+   - :class:`model_selection.GridSearchCV`, :class:`model_selection.RandomizedSearchCV`
+     and :func:`model_selection.cross_val_score` now allow estimators with callable
+     kernels which were previously prohibited. :issue:`8005` by `Andreas Müller`_ .
+
+
+   - Added ability to use sparse matrices in :func:`feature_selection.f_regression`
+     with ``center=True``. :issue:`8065` by :user:`Daniel LeJeune <acadiansith>`.
+
+   - Add ``sample_weight`` parameter to :func:`metrics.cohen_kappa_score` by
+     Victor Poughon.
+
+   - In :class:`gaussian_process.GaussianProcessRegressor`, method ``predict`` 
+     is a lot faster with ``return_std=True`` by :user:`Hadrien Bertrand <hbertrand>`.
 
 Bug fixes
 .........
@@ -5754,3 +5861,5 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 
 .. _Neeraj Gangwar: http://neerajgangwar.in
 .. _Arthur Mensch: https://amensch.fr
+
+.. _Karan Desai: https://www.github.com/karandesai-96

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -57,7 +57,7 @@ Miscellaneous
 - Added optional parameter ``verbose`` in functions `pipeline.make_pipeline`
   and `pipeline.make_union` to extend the same functionality as the
   corresponding classes. :issue:`9668` by
-  :user:`Baze Petrushev <petrushev>`.
+  :user:`Baze Petrushev <petrushev>` and :user:`Karan Desai <karandesai-96>`.
 
 
 Bug fixes
@@ -5766,5 +5766,4 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 
 .. _Neeraj Gangwar: http://neerajgangwar.in
 .. _Arthur Mensch: https://amensch.fr
-
 .. _Karan Desai: https://www.github.com/karandesai-96

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -48,6 +48,13 @@ Model evaluation and meta-estimators
 - A scorer based on :func:`metrics.brier_score_loss` is also available.
   :issue:`9521` by :user:`Hanmin Qin <qinhanmin2014>`.
 
+Miscellaneous
+
+- Added optional parameter ``verbose`` in :class:`pipeline.Pipeline` and
+  :class:`pipeline.FeatureUnion` for showing progress and timing of each
+     step. :issue:`8568` by :user:`Karan Desai <karandesai-96>`.
+
+
 Bug fixes
 .........
 
@@ -415,113 +422,6 @@ Miscellaneous
 
 - :class:`dummy.DummyClassifier` and :class:`dummy.DummyRegressor`
   now accept non-finite features. :issue:`8931` by :user:`Attractadore`.
-   - Added optional parameter ``verbose`` in :class:`pipeline.Pipeline` and
-     :class:`pipeline.FeatureUnion` for showing progress and timing of each
-     step. :issue:`8568` by :user:`Karan Desai <karandesai-96>`.
-
-   - Update Sphinx-Gallery from 0.1.4 to 0.1.7 for resolving links in
-     documentation build with Sphinx>1.5 :issue:`8010`, :issue:`7986`
-     :user:`Oscar Najera <Titan-C>`
-
-   - :class:`multioutput.MultiOutputRegressor` and :class:`multioutput.MultiOutputClassifier`
-     now support online learning using `partial_fit`.
-     issue: `8053` by :user:`Peng Yu <yupbank>`.
-   - :class:`pipeline.Pipeline` allows to cache transformers
-     within a pipeline by using the ``memory`` constructor parameter.
-     By :issue:`7990` by :user:`Guillaume Lemaitre <glemaitre>`.
-
-   - :class:`decomposition.PCA`, :class:`decomposition.IncrementalPCA` and
-     :class:`decomposition.TruncatedSVD` now expose the singular values
-     from the underlying SVD. They are stored in the attribute
-     ``singular_values_``, like in :class:`decomposition.IncrementalPCA`.
-
-   - :class:`cluster.MiniBatchKMeans` and :class:`cluster.KMeans`
-     now uses significantly less memory when assigning data points to their
-     nearest cluster center. :issue:`7721` by :user:`Jon Crall <Erotemic>`.
-
-   - Added ``classes_`` attribute to :class:`model_selection.GridSearchCV`,
-     :class:`model_selection.RandomizedSearchCV`,  :class:`grid_search.GridSearchCV`,
-     and  :class:`grid_search.RandomizedSearchCV` that matches the ``classes_``
-     attribute of ``best_estimator_``. :issue:`7661` and :issue:`8295`
-     by :user:`Alyssa Batula <abatula>`, :user:`Dylan Werner-Meier <unautre>`,
-     and :user:`Stephen Hoover <stephen-hoover>`.
-
-   - The ``min_weight_fraction_leaf`` constraint in tree construction is now
-     more efficient, taking a fast path to declare a node a leaf if its weight
-     is less than 2 * the minimum. Note that the constructed tree will be
-     different from previous versions where ``min_weight_fraction_leaf`` is
-     used. :issue:`7441` by :user:`Nelson Liu <nelson-liu>`.
-
-   - Added ``average`` parameter to perform weights averaging in
-     :class:`linear_model.PassiveAggressiveClassifier`. :issue:`4939`
-     by :user:`Andrea Esuli <aesuli>`.
-
-   - Custom metrics for the :mod:`sklearn.neighbors` binary trees now have
-     fewer constraints: they must take two 1d-arrays and return a float.
-     :issue:`6288` by `Jake Vanderplas`_.
-
-   - :class:`ensemble.GradientBoostingClassifier` and :class:`ensemble.GradientBoostingRegressor`
-     now support sparse input for prediction.
-     :issue:`6101` by :user:`Ibraim Ganiev <olologin>`.
-
-   - Added ``shuffle`` and ``random_state`` parameters to shuffle training
-     data before taking prefixes of it based on training sizes in
-     :func:`model_selection.learning_curve`.
-     :issue:`7506` by :user:`Narine Kokhlikyan <NarineK>`.
-
-   - Added ``norm_order`` parameter to :class:`feature_selection.SelectFromModel`
-     to enable selection of the norm order when ``coef_`` is more than 1D
-
-   - Added ``sample_weight`` parameter to :meth:`pipeline.Pipeline.score`.
-     :issue:`7723` by :user:`Mikhail Korobov <kmike>`.
-
-   - ``check_estimator`` now attempts to ensure that methods transform, predict, etc.
-     do not set attributes on the estimator.
-     :issue:`7533` by :user:`Ekaterina Krivich <kiote>`.
-
-   - For sparse matrices, :func:`preprocessing.normalize` with ``return_norm=True``
-     will now raise a ``NotImplementedError`` with 'l1' or 'l2' norm and with
-     norm 'max' the norms returned will be the same as for dense matrices.
-     :issue:`7771` by `Ang Lu <https://github.com/luang008>`_.
-
-   - :class:`sklearn.linear_model.RANSACRegressor` no longer throws an error
-     when calling ``fit`` if no inliers are found in its first iteration.
-     Furthermore, causes of skipped iterations are tracked in newly added
-     attributes, ``n_skips_*``.
-     :issue:`7914` by :user:`Michael Horrell <mthorrell>`.
-
-   - :func:`model_selection.cross_val_predict` now returns output of the
-     correct shape for all values of the argument ``method``.
-     :issue:`7863` by :user:`Aman Dalmia <dalmia>`.
-
-   - Fix a bug where :class:`sklearn.feature_selection.SelectFdr` did not
-     exactly implement Benjamini-Hochberg procedure. It formerly may have
-     selected fewer features than it should.
-     :issue:`7490` by :user:`Peng Meng <mpjlu>`.
-
-   - Added ability to set ``n_jobs`` parameter to :func:`pipeline.make_union`.
-     A ``TypeError`` will be raised for any other kwargs. :issue:`8028`
-     by :user:`Alexander Booth <alexandercbooth>`.
-
-   - Added type checking to the ``accept_sparse`` parameter in
-     :mod:`sklearn.utils.validation` methods. This parameter now accepts only
-     boolean, string, or list/tuple of strings. ``accept_sparse=None`` is deprecated
-     and should be replaced by ``accept_sparse=False``.
-     :issue:`7880` by :user:`Josh Karnofsky <jkarno>`.
-
-   - :class:`model_selection.GridSearchCV`, :class:`model_selection.RandomizedSearchCV`
-     and :func:`model_selection.cross_val_score` now allow estimators with callable
-     kernels which were previously prohibited. :issue:`8005` by `Andreas Müller`_ .
-
-
-   - Added ability to use sparse matrices in :func:`feature_selection.f_regression`
-     with ``center=True``. :issue:`8065` by :user:`Daniel LeJeune <acadiansith>`.
-
-   - Add ``sample_weight`` parameter to :func:`metrics.cohen_kappa_score` by
-     Victor Poughon.
-
-   - In :class:`gaussian_process.GaussianProcessRegressor`, method ``predict`` 
-     is a lot faster with ``return_std=True`` by :user:`Hadrien Bertrand <hbertrand>`.
 
 Bug fixes
 .........

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -22,7 +22,8 @@ import numpy as np
 import scipy.sparse as sp
 
 from .base import is_classifier, clone
-from .utils import indexable, check_random_state, safe_indexing
+from .utils import (indexable, check_random_state, safe_indexing,
+                    message_with_time)
 from .utils.validation import (_is_arraylike, _num_samples,
                                column_or_1d)
 from .utils.multiclass import type_of_target
@@ -1700,8 +1701,7 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     if verbose > 2:
         msg += ", score=%f" % test_score
     if verbose > 1:
-        end_msg = "%s -%s" % (msg, logger.short_format_time(scoring_time))
-        print("[CV] %s %s" % ((64 - len(end_msg)) * '.', end_msg))
+        print(message_with_time('CV', msg, scoring_time))
 
     ret = [train_score] if return_train_score else []
     ret.extend([test_score, _num_samples(X_test), scoring_time])

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -20,10 +20,11 @@ import numpy as np
 import scipy.sparse as sp
 
 from ..base import is_classifier, clone
-from ..utils import indexable, check_random_state, safe_indexing
+from ..utils import (indexable, check_random_state, safe_indexing,
+                     message_with_time)
 from ..utils.validation import _is_arraylike, _num_samples
 from ..utils.metaestimators import _safe_split
-from ..externals.joblib import Parallel, delayed, logger
+from ..externals.joblib import Parallel, delayed
 from ..externals.six.moves import zip
 from ..metrics.scorer import check_scoring, _check_multimetric_scoring
 from ..exceptions import FitFailedWarning
@@ -480,8 +481,7 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
             msg += ", score=%s" % test_scores
     if verbose > 1:
         total_time = score_time + fit_time
-        end_msg = "%s, total=%s" % (msg, logger.short_format_time(total_time))
-        print("[CV] %s %s" % ((64 - len(end_msg)) * '.', end_msg))
+        print(message_with_time('CV', msg, total_time))
 
     ret = [train_scores, test_scores] if return_train_score else [test_scores]
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -10,7 +10,6 @@ estimator, as a chain of transforms and estimators.
 # License: BSD
 
 from collections import defaultdict
-from abc import ABCMeta, abstractmethod
 import time
 
 import numpy as np
@@ -43,65 +42,7 @@ def _pretty_print(step_info):
     print('%s%s%s' % (name, '.' * (70 - len(name + elapsed)), elapsed))
 
 
-class _BasePipeline(six.with_metaclass(ABCMeta, _BaseComposition)):
-    """Handles parameter management for classifiers composed of named steps.
-    """
-
-    @abstractmethod
-    def __init__(self):
-        pass
-
-    def _replace_step(self, steps_attr, name, new_val):
-        # assumes `name` is a valid step name
-        new_steps = getattr(self, steps_attr)[:]
-        for i, (step_name, _) in enumerate(new_steps):
-            if step_name == name:
-                new_steps[i] = (name, new_val)
-                break
-        setattr(self, steps_attr, new_steps)
-
-    def _get_params(self, steps_attr, deep=True):
-        out = super(_BasePipeline, self).get_params(deep=False)
-        if not deep:
-            return out
-        steps = getattr(self, steps_attr)
-        out.update(steps)
-        for name, estimator in steps:
-            if estimator is None:
-                continue
-            for key, value in six.iteritems(estimator.get_params(deep=True)):
-                out['%s__%s' % (name, key)] = value
-        return out
-
-    def _set_params(self, steps_attr, **params):
-        # Ensure strict ordering of parameter setting:
-        # 1. All steps
-        if steps_attr in params:
-            setattr(self, steps_attr, params.pop(steps_attr))
-        # 2. Step replacement
-        step_names, _ = zip(*getattr(self, steps_attr))
-        for name in list(six.iterkeys(params)):
-            if '__' not in name and name in step_names:
-                self._replace_step(steps_attr, name, params.pop(name))
-        # 3. Step parameters and other initilisation arguments
-        super(_BasePipeline, self).set_params(**params)
-        return self
-
-    def _validate_names(self, names):
-        if len(set(names)) != len(names):
-            raise ValueError('Names provided are not unique: '
-                             '{0!r}'.format(list(names)))
-        invalid_names = set(names).intersection(self.get_params(deep=False))
-        if invalid_names:
-            raise ValueError('Step names conflict with constructor arguments: '
-                             '{0!r}'.format(sorted(invalid_names)))
-        invalid_names = [name for name in names if '__' in name]
-        if invalid_names:
-            raise ValueError('Step names must not contain __: got '
-                             '{0!r}'.format(invalid_names))
-
-
-class Pipeline(_BasePipeline):
+class Pipeline(_BaseComposition):
     """Pipeline of transforms with a final estimator.
 
     Sequentially apply a list of transforms and a final estimator.
@@ -721,7 +662,7 @@ def _fit_transform_one(trans, weight, X, y, verbose=False, idx=None,
     return res * weight, trans
 
 
-class FeatureUnion(_BasePipeline, TransformerMixin):
+class FeatureUnion(_BaseComposition, TransformerMixin):
     """Concatenates results of multiple transformer objects.
 
     This estimator applies a list of transformer objects in parallel to the

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -676,10 +676,11 @@ def make_pipeline(*steps, **kwargs):
     p : Pipeline
     """
     memory = kwargs.pop('memory', None)
+    verbose = kwargs.pop('verbose', False)
     if kwargs:
         raise TypeError('Unknown keyword arguments: "{}"'
                         .format(list(kwargs.keys())[0]))
-    return Pipeline(_name_estimators(steps), memory=memory)
+    return Pipeline(_name_estimators(steps), memory=memory, verbose=verbose)
 
 
 def _fit_one_transformer(trans, X, y, verbose=False, idx=None,

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -20,7 +20,7 @@ from .base import clone, TransformerMixin
 from .externals.joblib import Parallel, delayed
 from .externals import six
 from .utils.metaestimators import if_delegate_has_method, _BaseComposition
-from .utils import Bunch
+from .utils import Bunch, tosequence
 from .utils.validation import check_memory
 
 
@@ -934,10 +934,10 @@ class FeatureUnion(_BasePipeline, TransformerMixin):
 
     def _update_transformer_list(self, transformers):
         transformers = iter(transformers)
-        self.transformer_list[:] = [
+        self.transformer_list = tosequence([
             (name, None if old is None else next(transformers))
             for name, old in self.transformer_list
-        ]
+        ])
 
 
 def make_union(*transformers, **kwargs):

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -601,6 +601,9 @@ def make_pipeline(*steps, **kwargs):
         inspect estimators within the pipeline. Caching the
         transformers is advantageous when fitting is time consuming.
 
+    verbose : boolean, optional
+        Verbosity mode.
+
     Examples
     --------
     >>> from sklearn.naive_bayes import GaussianNB
@@ -896,6 +899,9 @@ def make_union(*transformers, **kwargs):
     n_jobs : int, optional
         Number of jobs to run in parallel (default 1).
 
+    verbose : boolean, optional
+         Verbosity mode.
+
     Returns
     -------
     f : FeatureUnion
@@ -917,9 +923,11 @@ def make_union(*transformers, **kwargs):
            transformer_weights=None, verbose=False)
     """
     n_jobs = kwargs.pop('n_jobs', 1)
+    verbose = kwargs.pop('verbose', False)
     if kwargs:
         # We do not currently support `transformer_weights` as we may want to
         # change its type spec in make_union
         raise TypeError('Unknown keyword arguments: "{}"'
                         .format(list(kwargs.keys())[0]))
-    return FeatureUnion(_name_estimators(transformers), n_jobs=n_jobs)
+    return FeatureUnion(_name_estimators(transformers), n_jobs=n_jobs,
+                        verbose=verbose)

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -19,7 +19,7 @@ from .base import clone, TransformerMixin
 from .externals.joblib import Parallel, delayed
 from .externals import six
 from .utils.metaestimators import if_delegate_has_method, _BaseComposition
-from .utils import Bunch, tosequence
+from .utils import Bunch
 from .utils.validation import check_memory
 
 
@@ -696,7 +696,7 @@ class FeatureUnion(_BaseComposition, TransformerMixin):
 
     def __init__(self, transformer_list, n_jobs=1, transformer_weights=None,
                  verbose=False):
-        self.transformer_list = tosequence(transformer_list)
+        self.transformer_list = list(transformer_list)
         self.n_jobs = n_jobs
         self.transformer_weights = transformer_weights
         self.verbose = verbose
@@ -876,10 +876,10 @@ class FeatureUnion(_BaseComposition, TransformerMixin):
 
     def _update_transformer_list(self, transformers):
         transformers = iter(transformers)
-        self.transformer_list = tosequence([
+        self.transformer_list[:] = [
             (name, None if old is None else next(transformers))
             for name, old in self.transformer_list
-        ])
+        ]
 
 
 def make_union(*transformers, **kwargs):

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -67,12 +67,12 @@ class NoTrans(NoFit):
 
 
 class NoInvTransf(NoTrans):
-    def transform(self, X, y=None):
+    def transform(self, X):
         return X
 
 
 class Transf(NoInvTransf):
-    def transform(self, X, y=None):
+    def transform(self, X):
         return X
 
     def inverse_transform(self, X):

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -983,10 +983,11 @@ def check_pipeline_verbosity_fit_predict(pipe_method):
     # check output
     verbose_output.seek(0)
     lines = verbose_output.readlines()
-    assert_true('[Pipeline] (step 1 of 2) transf ...' in lines[0])
-    assert_true('[Pipeline] (step 2 of 2) clf ...' in lines[1])
-    assert_true('[Pipeline] Total time elapsed: ' in lines[2])
-
+    assert_true('(step 1 of 2) transf' in lines[0])
+    assert_true('(step 2 of 2) clf' in lines[1])
+    assert_true('Total time elapsed' in lines[2])
+    for line in lines:
+        assert line.startswith('[Pipeline]')
 
 def test_pipeline_fit_verbosity():
     pipe = Pipeline([('transf', Transf()), ('clf', FitParamT())], verbose=True)
@@ -1007,12 +1008,13 @@ def check_pipeline_verbosity_fit_transform(pipe_method, last_was_none=False):
     # check output
     verbose_output.seek(0)
     lines = verbose_output.readlines()
-    assert_true('[Pipeline] (step 1 of 2) mult1 ...' in lines[0])
+    assert_true('(step 1 of 2) mult1' in lines[0])
+    assert_true(lines[0].startswith('[Pipeline]'))
     if last_was_none:
-        assert_true('[Pipeline] Step mult2 is NoneType ...' in lines[1])
+        assert_true('Step mult2 is NoneType' in lines[1])
     else:
-        assert_true('[Pipeline] (step 2 of 2) mult2 ...' in lines[1])
-    assert_true('[Pipeline] Total time elapsed: ' in lines[2])
+        assert_true('(step 2 of 2) mult2' in lines[1])
+    assert_true('Total time elapsed' in lines[2])
 
 
 def test_pipeline_verbosity_fit_transform():
@@ -1037,9 +1039,12 @@ def check_feature_union_verbosity(feature_union_method):
     # check output
     verbose_output.seek(0)
     lines = verbose_output.readlines()
-    assert_true('[FeatureUnion] (step 1 of 2) mult1 ...' in lines[0])
-    assert_true('[FeatureUnion] (step 2 of 2) mult2 ...' in lines[1])
-    assert_true('[FeatureUnion] Total time elapsed: ' in lines[2])
+    assert_true('(step 1 of 2) mult1' in lines[0])
+    assert_true('(step 2 of 2) mult2' in lines[1])
+    assert_true('Total time elapsed' in lines[2])
+    assert_true(lines[0].startswith('[FeatureUnion]'))
+    assert_true(lines[1].startswith('[FeatureUnion]'))
+    assert_true(lines[2].startswith('[FeatureUnion]'))
 
 
 def test_feature_union_verbosity():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -983,8 +983,8 @@ def check_pipeline_verbosity_fit_predict(pipe_method):
     # check output
     verbose_output.seek(0)
     lines = verbose_output.readlines()
-    assert_true('[Pipeline] (step 1 of 2) transf ... ' in lines[0])
-    assert_true('[Pipeline] (step 2 of 2) clf ... ' in lines[1])
+    assert_true('[Pipeline] (step 1 of 2) transf ...' in lines[0])
+    assert_true('[Pipeline] (step 2 of 2) clf ...' in lines[1])
     assert_true('[Pipeline] Total time elapsed: ' in lines[2])
 
 
@@ -1007,11 +1007,11 @@ def check_pipeline_verbosity_fit_transform(pipe_method, last_was_none=False):
     # check output
     verbose_output.seek(0)
     lines = verbose_output.readlines()
-    assert_true('[Pipeline] (step 1 of 2) mult1 ... ' in lines[0])
+    assert_true('[Pipeline] (step 1 of 2) mult1 ...' in lines[0])
     if last_was_none:
-        assert_true('[Pipeline] Step mult2 is NoneType.' in lines[1])
+        assert_true('[Pipeline] Step mult2 is NoneType ...' in lines[1])
     else:
-        assert_true('[Pipeline] (step 2 of 2) mult2 ... ' in lines[1])
+        assert_true('[Pipeline] (step 2 of 2) mult2 ...' in lines[1])
     assert_true('[Pipeline] Total time elapsed: ' in lines[2])
 
 
@@ -1037,8 +1037,8 @@ def check_feature_union_verbosity(feature_union_method):
     # check output
     verbose_output.seek(0)
     lines = verbose_output.readlines()
-    assert_true('[FeatureUnion] (step 1 of 2) mult1 ... ' in lines[0])
-    assert_true('[FeatureUnion] (step 2 of 2) mult2 ... ' in lines[1])
+    assert_true('[FeatureUnion] (step 1 of 2) mult1 ...' in lines[0])
+    assert_true('[FeatureUnion] (step 2 of 2) mult2 ...' in lines[1])
     assert_true('[FeatureUnion] Total time elapsed: ' in lines[2])
 
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -834,9 +834,9 @@ def test_step_name_validation():
         # we validate in construction (despite scikit-learn convention)
         bad_steps3 = [('a', Mult(2)), (param, Mult(3))]
         for bad_steps, message in [
-            (bad_steps1, "Estimator names must not contain __: got ['a__q']"),
+            (bad_steps1, "Step names must not contain __: got ['a__q']"),
             (bad_steps2, "Names provided are not unique: ['a', 'a']"),
-            (bad_steps3, "Estimator names conflict with constructor "
+            (bad_steps3, "Step names conflict with constructor "
                          "arguments: ['%s']" % param),
         ]:
             # three ways to make invalid:

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -834,9 +834,9 @@ def test_step_name_validation():
         # we validate in construction (despite scikit-learn convention)
         bad_steps3 = [('a', Mult(2)), (param, Mult(3))]
         for bad_steps, message in [
-            (bad_steps1, "Step names must not contain __: got ['a__q']"),
+            (bad_steps1, "Estimator names must not contain __: got ['a__q']"),
             (bad_steps2, "Names provided are not unique: ['a', 'a']"),
-            (bad_steps3, "Step names conflict with constructor "
+            (bad_steps3, "Estimator names conflict with constructor "
                          "arguments: ['%s']" % param),
         ]:
             # three ways to make invalid:

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -1022,3 +1022,28 @@ def test_pipeline_verbosity_fit_transform():
     pipe = Pipeline([('mult1', Mult(mult=1)), ('mult2', None)],
                     verbose=True)
     yield check_pipeline_verbosity_fit_transform, pipe.fit_transform, True
+
+
+def check_feature_union_verbosity(feature_union_method):
+    # Test that the verbosity of feature union is proper
+    from sklearn.externals.six.moves import cStringIO as StringIO
+    import sys
+    old_stdout = sys.stdout
+    sys.stdout = StringIO()
+    feature_union_method(X=[[1, 2, 3], [4, 5, 6]], y=[[7], [8]])
+    verbose_output = sys.stdout
+    sys.stdout = old_stdout
+
+    # check output
+    verbose_output.seek(0)
+    lines = verbose_output.readlines()
+    assert_true('[FeatureUnion] (step 1 of 2) mult1 ... ' in lines[0])
+    assert_true('[FeatureUnion] (step 2 of 2) mult2 ... ' in lines[1])
+    assert_true('[FeatureUnion] Total time elapsed: ' in lines[2])
+
+
+def test_feature_union_verbosity():
+    union = FeatureUnion([('mult1', Mult(mult=1)), ('mult2', Mult(mult=2))],
+                         verbose=True)
+    yield check_feature_union_verbosity, union.fit
+    yield check_feature_union_verbosity, union.fit_transform

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -14,7 +14,7 @@ from .validation import (as_float_array,
                          check_consistent_length, check_X_y, indexable,
                          check_symmetric)
 from .class_weight import compute_class_weight, compute_sample_weight
-from ..externals.joblib import cpu_count
+from ..externals.joblib import cpu_count, logger
 from ..exceptions import DataConversionWarning
 from .deprecation import deprecated
 
@@ -506,3 +506,23 @@ def indices_to_mask(indices, mask_length):
     mask[indices] = True
 
     return mask
+
+
+def message_with_time(source, message, time_):
+    """Create one line message for logging purposes
+
+    Parameters
+    ----------
+    source: str
+        String indicating the source or the reference of the message
+
+    message: str
+        Short message
+
+    time_: int
+        Time in seconds
+    """
+    start_message = '[%s]' % (source,)
+    end_message = "%s, total=%s" % (message, logger.short_format_time(time_))
+    dots_len = (68 - len(start_message) - len(end_message))
+    return ("%s %s %s" % (start_message, dots_len * '.', end_message))


### PR DESCRIPTION
#### Reference Issue
Rebases #8568
Fixes #5298, #5321

#### What does this implement/fix? Explain your changes.

Rebases #8568 which has the following description:

> This PR adds a new argument verbose to Pipeline and FeatureUnion, which is False by default. Setting this True will print useful information during execution. 

Also, it extends the `make_pipeline` helper to support the `verbose` kwarg.

The snippets in the original PR produce the expected output.

Also checked with the example `feature_selection/plot_feature_selection_pipeline.py 
` which produces a nice output:
```
[Pipeline] (step 1 of 2) selectkbest ........................ 0.00057s
[Pipeline] (step 2 of 2) svc ................................ 0.00067s
[Pipeline] Total time elapsed: .............................. 0.00123s
```