### PR TITLE
[MRG+1] Remove hard dependency on nose

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -39,22 +39,30 @@ if [[ "$DISTRIB" == "conda" ]]; then
 
     # Configure the conda environment and put it in the path using the
     # provided versions
+    if [[ "$USE_PYTEST" == "true" ]]; then
+        TEST_RUNNER_PACKAGE=pytest
+    else
+        TEST_RUNNER_PACKAGE=nose
+    fi
+
     if [[ "$INSTALL_MKL" == "true" ]]; then
-        conda create -n testenv --yes python=$PYTHON_VERSION pip nose pytest \
-            numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
+        conda create -n testenv --yes python=$PYTHON_VERSION pip \
+            $TEST_RUNNER_PACKAGE numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
             mkl cython=$CYTHON_VERSION \
             ${PANDAS_VERSION+pandas=$PANDAS_VERSION}
             
     else
-        conda create -n testenv --yes python=$PYTHON_VERSION pip nose pytest \
-            numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
+        conda create -n testenv --yes python=$PYTHON_VERSION pip \
+            $TEST_RUNNER_PACKAGE numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
             nomkl cython=$CYTHON_VERSION \
             ${PANDAS_VERSION+pandas=$PANDAS_VERSION}
     fi
     source activate testenv
 
-    # Install nose-timer via pip
-    pip install nose-timer
+    if [[ $USE_PYTEST != "true" ]]; then
+        # Install nose-timer via pip
+        pip install nose-timer
+    fi
 
 elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # At the time of writing numpy 1.9.1 is included in the travis

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -27,7 +27,6 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import with_setup
 
 
 DATA_HOME = tempfile.mkdtemp(prefix="scikit_learn_data_home_test_")
@@ -85,33 +84,42 @@ def test_default_empty_load_files():
     assert_equal(res.DESCR, None)
 
 
-@with_setup(setup_load_files, teardown_load_files)
 def test_default_load_files():
-    res = load_files(LOAD_FILES_ROOT)
-    assert_equal(len(res.filenames), 1)
-    assert_equal(len(res.target_names), 2)
-    assert_equal(res.DESCR, None)
-    assert_equal(res.data, [b("Hello World!\n")])
+    try:
+        setup_load_files()
+        res = load_files(LOAD_FILES_ROOT)
+        assert_equal(len(res.filenames), 1)
+        assert_equal(len(res.target_names), 2)
+        assert_equal(res.DESCR, None)
+        assert_equal(res.data, [b("Hello World!\n")])
+    finally:
+        teardown_load_files()
 
 
-@with_setup(setup_load_files, teardown_load_files)
 def test_load_files_w_categories_desc_and_encoding():
-    category = os.path.abspath(TEST_CATEGORY_DIR1).split('/').pop()
-    res = load_files(LOAD_FILES_ROOT, description="test",
-                     categories=category, encoding="utf-8")
-    assert_equal(len(res.filenames), 1)
-    assert_equal(len(res.target_names), 1)
-    assert_equal(res.DESCR, "test")
-    assert_equal(res.data, [u("Hello World!\n")])
+    try:
+        setup_load_files()
+        category = os.path.abspath(TEST_CATEGORY_DIR1).split('/').pop()
+        res = load_files(LOAD_FILES_ROOT, description="test",
+                         categories=category, encoding="utf-8")
+        assert_equal(len(res.filenames), 1)
+        assert_equal(len(res.target_names), 1)
+        assert_equal(res.DESCR, "test")
+        assert_equal(res.data, [u("Hello World!\n")])
+    finally:
+        teardown_load_files()
 
 
-@with_setup(setup_load_files, teardown_load_files)
 def test_load_files_wo_load_content():
-    res = load_files(LOAD_FILES_ROOT, load_content=False)
-    assert_equal(len(res.filenames), 1)
-    assert_equal(len(res.target_names), 2)
-    assert_equal(res.DESCR, None)
-    assert_equal(res.get('data'), None)
+    try:
+        setup_load_files()
+        res = load_files(LOAD_FILES_ROOT, load_content=False)
+        assert_equal(len(res.filenames), 1)
+        assert_equal(len(res.target_names), 2)
+        assert_equal(res.DESCR, None)
+        assert_equal(res.get('data'), None)
+    finally:
+        teardown_load_files()
 
 
 def test_load_sample_images():

--- a/sklearn/datasets/tests/test_mldata.py
+++ b/sklearn/datasets/tests/test_mldata.py
@@ -44,7 +44,7 @@ def test_mldata_filename():
 
 def test_download():
     """Test that fetch_mldata is able to download and cache a data set."""
-    setup_tmpdata
+    setup_tmpdata()
     _urlopen_ref = datasets.mldata.urlopen
     datasets.mldata.urlopen = mock_mldata_urlopen({
         'mock': {
@@ -64,11 +64,11 @@ def test_download():
                       fetch_mldata, 'not_existing_name')
     finally:
         datasets.mldata.urlopen = _urlopen_ref
-        teardown_tmpdata
+        teardown_tmpdata()
 
 
 def test_fetch_one_column():
-    setup_tmpdata
+    setup_tmpdata()
     _urlopen_ref = datasets.mldata.urlopen
     try:
         dataname = 'onecol'
@@ -89,11 +89,11 @@ def test_fetch_one_column():
         assert_equal(dset.data.shape, (3, 2))
     finally:
         datasets.mldata.urlopen = _urlopen_ref
-        teardown_tmpdata
+        teardown_tmpdata()
 
 
 def test_fetch_multiple_column():
-    setup_tmpdata
+    setup_tmpdata()
     _urlopen_ref = datasets.mldata.urlopen
     try:
         # create fake data set in cache
@@ -167,4 +167,4 @@ def test_fetch_multiple_column():
 
     finally:
         datasets.mldata.urlopen = _urlopen_ref
-        teardown_tmpdata
+        teardown_tmpdata()

--- a/sklearn/datasets/tests/test_mldata.py
+++ b/sklearn/datasets/tests/test_mldata.py
@@ -13,7 +13,6 @@ from sklearn.utils.testing import assert_not_in
 from sklearn.utils.testing import mock_mldata_urlopen
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import with_setup
 from sklearn.utils.testing import assert_array_equal
 
 
@@ -43,10 +42,9 @@ def test_mldata_filename():
         assert_equal(mldata_filename(name), desired)
 
 
-@with_setup(setup_tmpdata, teardown_tmpdata)
 def test_download():
     """Test that fetch_mldata is able to download and cache a data set."""
-
+    setup_tmpdata
     _urlopen_ref = datasets.mldata.urlopen
     datasets.mldata.urlopen = mock_mldata_urlopen({
         'mock': {
@@ -66,10 +64,11 @@ def test_download():
                       fetch_mldata, 'not_existing_name')
     finally:
         datasets.mldata.urlopen = _urlopen_ref
+        teardown_tmpdata
 
 
-@with_setup(setup_tmpdata, teardown_tmpdata)
 def test_fetch_one_column():
+    setup_tmpdata
     _urlopen_ref = datasets.mldata.urlopen
     try:
         dataname = 'onecol'
@@ -90,10 +89,11 @@ def test_fetch_one_column():
         assert_equal(dset.data.shape, (3, 2))
     finally:
         datasets.mldata.urlopen = _urlopen_ref
+        teardown_tmpdata
 
 
-@with_setup(setup_tmpdata, teardown_tmpdata)
 def test_fetch_multiple_column():
+    setup_tmpdata
     _urlopen_ref = datasets.mldata.urlopen
     try:
         # create fake data set in cache
@@ -167,3 +167,4 @@ def test_fetch_multiple_column():
 
     finally:
         datasets.mldata.urlopen = _urlopen_ref
+        teardown_tmpdata

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -7,12 +7,10 @@ import scipy as sp
 from scipy import ndimage
 from scipy.sparse.csgraph import connected_components
 
-from numpy.testing import assert_raises
-
 from sklearn.feature_extraction.image import (
     img_to_graph, grid_to_graph, extract_patches_2d,
     reconstruct_from_patches_2d, PatchExtractor, extract_patches)
-from sklearn.utils.testing import assert_equal, assert_true
+from sklearn.utils.testing import assert_equal, assert_true, assert_raises
 
 
 def test_img_to_graph():

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -23,13 +23,12 @@ from sklearn.base import clone
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
-from numpy.testing import assert_raises
 from sklearn.utils.testing import (assert_equal, assert_false, assert_true,
                                    assert_not_equal, assert_almost_equal,
                                    assert_in, assert_less, assert_greater,
                                    assert_warns_message, assert_raise_message,
                                    clean_warning_registry, ignore_warnings,
-                                   SkipTest)
+                                   SkipTest, assert_raises)
 
 from collections import defaultdict, Mapping
 from functools import partial

--- a/sklearn/linear_model/tests/test_ransac.py
+++ b/sklearn/linear_model/tests/test_ransac.py
@@ -1,7 +1,7 @@
 import numpy as np
 from scipy import sparse
 
-from numpy.testing import assert_equal, assert_raises
+from numpy.testing import assert_equal
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
 
@@ -10,6 +10,7 @@ from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_raises_regexp
+from sklearn.utils.testing import assert_raises
 from sklearn.linear_model import LinearRegression, RANSACRegressor, Lasso
 from sklearn.linear_model.ransac import _dynamic_max_trials
 

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -9,14 +9,14 @@ import copy
 import sys
 
 import numpy as np
-from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_raises)
+from numpy.testing import assert_array_equal, assert_array_almost_equal
+
 from scipy import stats
 from sklearn import mixture
 from sklearn.datasets.samples_generator import make_spd_matrix
 from sklearn.utils.testing import (assert_true, assert_greater,
                                    assert_raise_message, assert_warns_message,
-                                   ignore_warnings)
+                                   ignore_warnings, assert_raises)
 from sklearn.metrics.cluster import adjusted_rand_score
 from sklearn.externals.six.moves import cStringIO as StringIO
 

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -6,10 +6,10 @@ import numpy as np
 from scipy import sparse as sp
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_equal
-from numpy.testing import assert_raises
 
 from sklearn.neighbors import NearestCentroid
 from sklearn import datasets
+from sklearn.utils.testing import assert_raises
 
 # toy sample
 X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]
@@ -57,9 +57,9 @@ def test_classification_toy():
 
 def test_precomputed():
     clf = NearestCentroid(metric='precomputed')
-    with assert_raises(ValueError) as context:
+    with assert_raises(ValueError):
         clf.fit(X, y)
-    assert_equal(ValueError, type(context.exception))
+
 
 def test_iris():
     # Check consistency on dataset iris.

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -47,6 +47,7 @@ from sklearn.base import BaseEstimator
 from sklearn.externals import joblib
 from sklearn.utils import deprecated
 
+additional_names_in_all = []
 try:
     from nose.tools import raises as _nose_raises
     deprecation_message = (
@@ -54,6 +55,7 @@ try:
         'and will be removed in 0.22. Please use '
         'sklearn.utils.testing.assert_raises instead.')
     raises = deprecated(deprecation_message)(_nose_raises)
+    additional_names_in_all.append('raises')
 except ImportError:
     pass
 
@@ -65,10 +67,9 @@ try:
         'If your code relies on with_setup, please use'
         ' nose.tools.with_setup instead.')
     with_setup = deprecated(deprecation_message)(_with_setup)
-    additional_symbols_to_export = ['raises', 'with_setup']
+    additional_names_in_all.append('with_setup')
 except ImportError:
-    additional_symbols_to_export = []
-
+    pass
 
 from numpy.testing import assert_almost_equal
 from numpy.testing import assert_array_equal
@@ -88,7 +89,7 @@ __all__ = ["assert_equal", "assert_not_equal", "assert_raises",
            "assert_less", "assert_less_equal",
            "assert_greater", "assert_greater_equal",
            "assert_approx_equal", "SkipTest"]
-__all__.extend(additional_symbols_to_export)
+__all__.extend(additional_names_in_all)
 
 _dummy = TestCase('__init__')
 assert_equal = _dummy.assertEqual

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -56,7 +56,18 @@ try:
     raises = deprecated(deprecation_message)(_nose_raises)
 except ImportError:
     pass
-from nose import with_setup
+
+try:
+    from nose.tools import with_setup as _with_setup
+    deprecation_message = (
+        'sklearn.utils.testing.with_setup has been deprecated in version 0.20 '
+        'and will be removed in 0.22.'
+        'If your code relies on with_setup, please use'
+        ' nose.tools.with_setup instead.')
+    with_setup = deprecated(deprecation_message)(_with_setup)
+except ImportError:
+    pass
+
 
 from numpy.testing import assert_almost_equal
 from numpy.testing import assert_array_equal
@@ -752,10 +763,6 @@ class TempMemmap(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         _delete_folder(self.temp_folder)
-
-
-with_network = with_setup(check_skip_network)
-with_travis = with_setup(check_skip_travis)
 
 
 class _named_check(object):

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -65,8 +65,9 @@ try:
         'If your code relies on with_setup, please use'
         ' nose.tools.with_setup instead.')
     with_setup = deprecated(deprecation_message)(_with_setup)
+    additional_symbols_to_export = ['raises', 'with_setup']
 except ImportError:
-    pass
+    additional_symbols_to_export = []
 
 
 from numpy.testing import assert_almost_equal
@@ -81,12 +82,13 @@ from sklearn.base import (ClassifierMixin, RegressorMixin, TransformerMixin,
 from sklearn.utils._unittest_backport import TestCase
 
 __all__ = ["assert_equal", "assert_not_equal", "assert_raises",
-           "assert_raises_regexp", "raises", "with_setup", "assert_true",
+           "assert_raises_regexp", "assert_true",
            "assert_false", "assert_almost_equal", "assert_array_equal",
            "assert_array_almost_equal", "assert_array_less",
            "assert_less", "assert_less_equal",
            "assert_greater", "assert_greater_equal",
            "assert_approx_equal", "SkipTest"]
+__all__.extend(additional_symbols_to_export)
 
 _dummy = TestCase('__init__')
 assert_equal = _dummy.assertEqual


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
None

#### What does this implement/fix? Explain your changes.
It removes `with_setup` and adds a deprecation in order to remove `nose` depencie

#### Any other comments?
This PR removes the dependency on nose from our python modules.