### PR TITLE
[MRG] SVM: Ensure nonnegative sample weights (#9494)

### DIFF
--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -170,6 +170,9 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
                              "boolean masks (use `indices=True` in CV)."
                              % (sample_weight.shape, X.shape))
 
+        if sample_weight.shape[0] > 0 and np.min(sample_weight) < 0:
+            raise ValueError("Sample weights must not be negative")
+
         if self.gamma == 'auto':
             self._gamma = 1.0 / X.shape[1]
         else:

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -975,3 +975,10 @@ def test_ovr_decision_function():
     # Test if the first point has lower decision value on every quadrant
     # compared to the second point
     assert_true(np.all(pred_class_deci_val[:, 0] < pred_class_deci_val[:, 1]))
+
+
+def test_negative_weights():
+    sample_weights = np.array([1, 1, 1, -1, -1, -1])
+
+    clf = svm.SVC(kernel='linear')
+    assert_raises(ValueError, clf.fit, X, Y, sample_weight=sample_weights)


### PR DESCRIPTION
As a first step for dealing with #9494, this reproduces the issue in a unit test.

This should fail with the same IndexError as in the original report.
It only fails when _all_ of the weights of the second class are negative.
