### PR TITLE
Add mean square error as an alternative to R^2

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -386,6 +386,28 @@ class RegressorMixin(object):
         from .metrics import r2_score
         return r2_score(y, self.predict(X), sample_weight=sample_weight,
                         multioutput='variance_weighted')
+    
+    
+    def score_mse(self, X, y):
+        """Returns the mean squared error of the prediction.
+        
+        The mean squared error is provided in the unit of the domain.
+        
+        Parameters
+        ----------
+        X : array-like, shape = (n_samples, n_features)
+            Test samples.
+
+        y : array-like, shape = (n_samples) or (n_samples, n_outputs)
+            True values for X.
+        
+        Returns
+        -------
+        score : float
+            MSE of self.predict(X) wrt. y.
+        """
+        from .metrics import mean_squared_error
+        return mean_squared_error(y, self.predict(X))
 
 
 ###############################################################################

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -390,9 +390,9 @@ class RegressorMixin(object):
     
     def score_mse(self, X, y):
         """Returns the mean squared error of the prediction.
-        
+
         The mean squared error is provided in the unit of the domain.
-        
+
         Parameters
         ----------
         X : array-like, shape = (n_samples, n_features)
@@ -400,7 +400,7 @@ class RegressorMixin(object):
 
         y : array-like, shape = (n_samples) or (n_samples, n_outputs)
             True values for X.
-        
+
         Returns
         -------
         score : float


### PR DESCRIPTION
In several research domains the mean square error and as a derivative the root mean square error are of importance. As model evaluation criteria differ over different research domains, this is a great addition for a fast and efficient evaluation of a retrieved model when R^2 is not the desired measurement.


#### What does this implement/fix? Explain your changes.

It allows to get the MSE instead of the R^2 for scoring a model.

