### PR TITLE
Remove deprecated mechanism for checking for deprecated params.

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -225,19 +225,7 @@ class BaseEstimator(object):
         """
         out = dict()
         for key in self._get_param_names():
-            # We need deprecation warnings to always be on in order to
-            # catch deprecated param values.
-            # This is set in utils/__init__.py but it gets overwritten
-            # when running under python3 somehow.
-            warnings.simplefilter("always", DeprecationWarning)
-            try:
-                with warnings.catch_warnings(record=True) as w:
-                    value = getattr(self, key, None)
-                if len(w) and w[0].category == DeprecationWarning:
-                    # if the parameter is deprecated, don't show it
-                    continue
-            finally:
-                warnings.filters.pop(0)
+            value = getattr(self, key, None)
 
             # XXX: should we rather test if instance of estimator?
             if deep and hasattr(value, 'get_params'):

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -61,19 +61,6 @@ class ModifyInitParams(BaseEstimator):
         self.a = a.copy()
 
 
-class DeprecatedAttributeEstimator(BaseEstimator):
-    def __init__(self, a=None, b=None):
-        self.a = a
-        if b is not None:
-            DeprecationWarning("b is deprecated and renamed 'a'")
-            self.a = b
-
-    @property
-    @deprecated("Parameter 'b' is deprecated and renamed to 'a'")
-    def b(self):
-        return self._b
-
-
 class Buggy(BaseEstimator):
     " A buggy estimator that does not set its parameters right. "
 
@@ -217,19 +204,6 @@ def test_get_params():
     test.set_params(a__d=2)
     assert_true(test.a.d == 2)
     assert_raises(ValueError, test.set_params, a__a=2)
-
-
-def test_get_params_deprecated():
-    # deprecated attribute should not show up as params
-    est = DeprecatedAttributeEstimator(a=1)
-
-    assert_true('a' in est.get_params())
-    assert_true('a' in est.get_params(deep=True))
-    assert_true('a' in est.get_params(deep=False))
-
-    assert_true('b' not in est.get_params())
-    assert_true('b' not in est.get_params(deep=True))
-    assert_true('b' not in est.get_params(deep=False))
 
 
 def test_is_classifier():


### PR DESCRIPTION
#### Reference Issue
Fixes #7346 
Related to #2755  

#### What does this implement/fix? Explain your changes.
Removes deprecated non-thread-safe mechanism for checking for deprecation warnings.