### PR TITLE
[MRG + 1] MNT Platform independent hash collision tests in FeatureHasher

### DIFF
--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -112,7 +112,7 @@ def test_hasher_zeros():
 
 @ignore_warnings(category=DeprecationWarning)
 def test_hasher_alternate_sign():
-    X = [["a", "b", "c", "d", "e", "f", "g", "h"]]
+    X = [list("Thequickbrownfoxjumped")]
 
     Xt = FeatureHasher(alternate_sign=True, non_negative=False,
                        input_type='string').fit_transform(X)
@@ -134,7 +134,7 @@ def test_hasher_alternate_sign():
 
 @ignore_warnings(category=DeprecationWarning)
 def test_hash_collisions():
-    X = [["a", "b", "c", "d", "e", "f", "g", "h"]]
+    X = [list("Thequickbrownfoxjumped")]
 
     Xt = FeatureHasher(alternate_sign=True, non_negative=False,
                        n_features=1, input_type='string').fit_transform(X)

--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -112,28 +112,43 @@ def test_hasher_zeros():
 
 @ignore_warnings(category=DeprecationWarning)
 def test_hasher_alternate_sign():
-    # the last two tokens produce a hash collision that sums as 0
-    X = [["foo", "bar", "baz", "investigation need", "records"]]
+    X = [["a", "b", "c", "d", "e", "f", "g", "h"]]
 
     Xt = FeatureHasher(alternate_sign=True, non_negative=False,
                        input_type='string').fit_transform(X)
-    assert_true(Xt.data.min() < 0 and Xt.data.max() > 0)
-    # check that we have a collision that produces a 0 count
-    assert_true(len(Xt.data) < len(X[0]))
-    assert_true((Xt.data == 0.).any())
+    assert Xt.data.min() < 0 and Xt.data.max() > 0
 
     Xt = FeatureHasher(alternate_sign=True, non_negative=True,
                        input_type='string').fit_transform(X)
-    assert_true((Xt.data >= 0).all())   # all counts are positive
-    assert_true((Xt.data == 0.).any())  # we still have a collision
+    assert Xt.data.min() > 0
+
     Xt = FeatureHasher(alternate_sign=False, non_negative=True,
                        input_type='string').fit_transform(X)
-    assert_true((Xt.data > 0).all())    # strictly positive counts
+    assert Xt.data.min() > 0
     Xt_2 = FeatureHasher(alternate_sign=False, non_negative=False,
                          input_type='string').fit_transform(X)
     # With initially positive features, the non_negative option should
     # have no impact when alternate_sign=False
     assert_array_equal(Xt.data, Xt_2.data)
+
+
+@ignore_warnings(category=DeprecationWarning)
+def test_hash_collisions():
+    X = [["a", "b", "c", "d", "e", "f", "g", "h"]]
+
+    Xt = FeatureHasher(alternate_sign=True, non_negative=False,
+                       n_features=1, input_type='string').fit_transform(X)
+    # check that some of the hashed tokens are added
+    # with an opposite sign and cancel out
+    assert abs(Xt.data[0]) < len(X[0])
+
+    Xt = FeatureHasher(alternate_sign=True, non_negative=True,
+                       n_features=1, input_type='string').fit_transform(X)
+    assert abs(Xt.data[0]) < len(X[0])
+
+    Xt = FeatureHasher(alternate_sign=False, non_negative=True,
+                       n_features=1, input_type='string').fit_transform(X)
+    assert Xt.data[0] == len(X[0])
 
 
 @ignore_warnings(category=DeprecationWarning)


### PR DESCRIPTION
This PR aims to address the current failures of `test_hasher_alternate_sign` on non amd64 platforms https://github.com/scikit-learn/scikit-learn/issues/9393#issuecomment-327652993  that is likely due to the fact the current test rely on Murmurhash3 results to yield a particular hash value (that produces a collision) while it is actually platform dependent https://github.com/scikit-learn/scikit-learn/issues/9393#issuecomment-323953661 . Since the original issue couldn't be reproduced, there is no guarantee that this would fix it (hopefully it would), but in any case, it would make the `test_hasher_alternate_sign` more robust ... 

**Note:** these tests here rely on the fact that when hashing 8 strings with `alternate_sign=True`, some of them will get a negative sign and some a positive one (it's a 50%/50% probability). However, there is still a (0.5)**2 = .004 probability that on a given platform all the signs will be positive (in which case these tests will fail) but hopefully, that's unlikely enough...
 
cc @jnothman 