### PR TITLE
Error in manifold.t_sne._kl_divergence #9711

### DIFF
--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -133,7 +133,7 @@ cdef float compute_gradient_positive(float[:] val_P,
             for ax in range(n_dimensions):
                 buff[ax] = pos_reference[i, ax] - pos_reference[j, ax]
                 dij += buff[ax] * buff[ax]
-            qij = (((1.0 + dij) / dof) ** exponent)
+            qij = ((1.0 + dij / dof) ** exponent)
             dij = pij * qij
             qij /= sum_Q
             C += pij * log(max(pij, FLOAT32_TINY)
@@ -195,7 +195,7 @@ cdef void compute_gradient_negative(float[:, :] pos_reference,
 
             dist2s = summary[j * offset + n_dimensions]
             size = summary[j * offset + n_dimensions + 1]
-            qijZ = ((1.0 + dist2s) / dof) ** exponent  # 1/(1+dist)
+            qijZ = (1.0 + dist2s / dof) ** exponent  # 1/(1+dist)
             sum_Q[0] += size * qijZ   # size of the node * q
             mult = size * qijZ * qijZ
             for ax in range(n_dimensions):

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -158,8 +158,8 @@ def _kl_divergence(params, P, degrees_of_freedom, n_samples, n_components,
 
     # Q is a heavy-tailed distribution: Student's t-distribution
     dist = pdist(X_embedded, "sqeuclidean")
-    dist += 1.
     dist /= degrees_of_freedom
+    dist += 1.
     dist **= (degrees_of_freedom + 1.0) / -2.0
     Q = np.maximum(dist / (2.0 * np.sum(dist)), MACHINE_EPSILON)
 


### PR DESCRIPTION
The correct formula for t-student probability distribution function is, according to wikipedia:
https://en.wikipedia.org/wiki/Student%27s_t-distribution
(gamma((v+1)/2)/gamma(sqrt(v*pi)*gamma(v/2)) * (1+(t^2)/v)^(-(v+1)/2)
= constant * (1+(t^2)/v)^(-(v+1)/2)
where v = degrees of freedom and t-sne uses the pairwise distances as the variable t. We can ignore the constant because it doesn't depend on t and it will be normalized away. The code, however is computing (1/v + (t^2)/v)^(-(v+1)/2).