### PR TITLE
[MRG+1] Don't modify steps in Pipeline.__init__

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -110,7 +110,6 @@ class Pipeline(_BaseComposition):
     # BaseEstimator interface
 
     def __init__(self, steps, memory=None):
-        # shallow copy of steps
         self.steps = steps
         self._validate_steps()
         self.memory = memory

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -111,7 +111,7 @@ class Pipeline(_BaseComposition):
 
     def __init__(self, steps, memory=None):
         # shallow copy of steps
-        self.steps = list(steps)
+        self.steps = steps
         self._validate_steps()
         self.memory = memory
 
@@ -184,6 +184,8 @@ class Pipeline(_BaseComposition):
     # Estimator interface
 
     def _fit(self, X, y=None, **fit_params):
+        # shallow copy of steps - this should really be steps_
+        self.steps = list(self.steps)
         self._validate_steps()
         # Setup the memory
         memory = check_memory(self.memory)

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -614,7 +614,7 @@ class FeatureUnion(_BaseComposition, TransformerMixin):
 
     """
     def __init__(self, transformer_list, n_jobs=1, transformer_weights=None):
-        self.transformer_list = list(transformer_list)
+        self.transformer_list = transformer_list
         self.n_jobs = n_jobs
         self.transformer_weights = transformer_weights
         self._validate_transformers()
@@ -705,6 +705,7 @@ class FeatureUnion(_BaseComposition, TransformerMixin):
         self : FeatureUnion
             This estimator
         """
+        self.transformer_list = list(self.transformer_list)
         self._validate_transformers()
         transformers = Parallel(n_jobs=self.n_jobs)(
             delayed(_fit_one_transformer)(trans, X, y)

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -188,7 +188,7 @@ def test_pipeline_init():
     assert_raises(ValueError, pipe.set_params, anova__C=0.1)
 
     # Test clone
-    pipe2 = assert_no_warnings(clone(pipe))
+    pipe2 = assert_no_warnings(clone, pipe)
     assert_false(pipe.named_steps['svc'] is pipe2.named_steps['svc'])
 
     # Check that apart from estimators, the parameters are the same

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -422,6 +422,10 @@ def test_feature_union():
     X_sp_transformed = fs.fit_transform(X_sp, y)
     assert_array_almost_equal(X_transformed, X_sp_transformed.toarray())
 
+    # Test clone
+    fs2 = assert_no_warnings(clone, fs)
+    assert_false(fs.named_steps['svd'] is fs2.named_steps['svd'])
+
     # test setting parameters
     fs.set_params(select__k=2)
     assert_equal(fs.fit_transform(X, y).shape, (X.shape[0], 4))

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -19,6 +19,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_dict_equal
+from sklearn.utils.testing import assert_no_warnings
 
 from sklearn.base import clone, BaseEstimator
 from sklearn.pipeline import Pipeline, FeatureUnion, make_pipeline, make_union
@@ -187,7 +188,7 @@ def test_pipeline_init():
     assert_raises(ValueError, pipe.set_params, anova__C=0.1)
 
     # Test clone
-    pipe2 = clone(pipe)
+    pipe2 = assert_no_warnings(clone(pipe))
     assert_false(pipe.named_steps['svc'] is pipe2.named_steps['svc'])
 
     # Check that apart from estimators, the parameters are the same

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -424,7 +424,7 @@ def test_feature_union():
 
     # Test clone
     fs2 = assert_no_warnings(clone, fs)
-    assert_false(fs.named_steps['svd'] is fs2.named_steps['svd'])
+    assert_false(fs.transformer_list[0][1] is fs2.transformer_list[0][1])
 
     # test setting parameters
     fs.set_params(select__k=2)


### PR DESCRIPTION
Fixes #9715.

Changing anything in ``__init__`` will break clone in 0.20 and raises a warning since 0.18.