### PR TITLE
[MRG] TST More informative error message in test_preserve_trustworthiness_approximately

### DIFF
--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -244,7 +244,9 @@ def test_preserve_trustworthiness_approximately():
                         method=method)
             X_embedded = tsne.fit_transform(X)
             t = trustworthiness(X, X_embedded, n_neighbors=1)
-            assert_greater(t, 0.9)
+            assert_greater(t, 0.9, msg='Trustworthiness={:0.3f} < 0.9 '
+                                       'for method={} and '
+                                       'init={}'.format(t, method, init))
 
 
 def test_optimization_minimizes_kl_divergence():


### PR DESCRIPTION
To help us understand the failure in #9393.

This change would be unnecessary with pytest and a parametrised test