### PR TITLE
[MRG] clarify random_state docstring for fetch_kddcup99

### DIFF
--- a/sklearn/datasets/kddcup99.py
+++ b/sklearn/datasets/kddcup99.py
@@ -140,7 +140,9 @@ def fetch_kddcup99(subset=None, data_home=None, shuffle=False,
         Whether to shuffle dataset.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        Random state for shuffling the dataset.
+        Random state for shuffling the dataset. If subset='SA', this random
+        state is also used to randomly select the small proportion of abnormal
+        samples.
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This clarifies the docstring of `random_state` in `fetch_kddcup99` as this random state is not only used to shuffle the dataset but also to randomly select the small proportion of abnormal samples when `subset='SA'`.

```python
fetch_kddcup99(subset='SA', shuffle=False,
               percent10=False, random_state=None)
```
is random even if `shuffle=False` which makes the current docstring ("Random state for shuffling the dataset.") misleading.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
