### PR TITLE
[MRG] DOC AgglomerativeClustering metric in fit method

### DIFF
--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -685,7 +685,8 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
         Parameters
         ----------
         X : array-like, shape = [n_samples, n_features]
-            The samples a.k.a. observations.
+            Training data. Shape [n_samples, n_features], or [n_samples,
+            n_samples] if affinity=='precomputed'.
 
         y : Ignored
 


### PR DESCRIPTION
This adds a precision to the docstring of the method fit of [AgglomerativeClustering](http://scikit-learn.org/stable/modules/generated/sklearn.cluster.AgglomerativeClustering.html): if one wants to use a precomputed metric, one has to provide a pairwise distance matrix of size (n_samples, n_samples) as input. This precision is done to be coherent with the documentation in other classes like [KNeighborsClassifier](http://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html)