### PR TITLE
[MRG+1] Fix #9743: Adding parameter information to docstring.

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1713,11 +1713,11 @@ class PredefinedSplit(BaseCrossValidator):
 
     Parameters
     ----------
-    test_fold : array-like, shape (n_samples,)        
+    test_fold : array-like, shape (n_samples,)
         The entry ``test_fold[i]`` represents the index of the test set that
-        sample ``i`` belongs to. It is possible to exclude sample ``i`` from any
-        test set (i.e. include sample ``i`` in every training set) by setting
-        ``test_fold[i]`` equal to -1.
+        sample ``i`` belongs to. It is possible to exclude sample ``i`` from
+        any test set (i.e. include sample ``i`` in every training set) by
+        setting ``test_fold[i]`` equal to -1.
 
     Examples
     --------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1708,9 +1708,9 @@ class PredefinedSplit(BaseCrossValidator):
 
     Provides train/test indices to split data into train/test sets using a
     predefined scheme specified by the user with the ``test_fold`` parameter.
-    The entry ``test_fold[i]`` represents the index of the test set that 
+    The entry ``test_fold[i]`` represents the index of the test set that
     sample ``i`` belongs to. It is possible to exclude sample ``i`` from any
-    test set (i.e. include sample ``i`` in every training set) by setting 
+    test set (i.e. include sample ``i`` in every training set) by setting
     ``test_fold[i]`` equal to -1.
 
     Read more in the :ref:`User Guide <cross_validation>`.

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1706,9 +1706,12 @@ def _validate_shuffle_split(n_samples, test_size, train_size):
 class PredefinedSplit(BaseCrossValidator):
     """Predefined split cross-validator
 
-    Splits the data into training/test set folds according to a predefined
-    scheme. Each sample can be assigned to at most one test set fold, as
-    specified by the user through the ``test_fold`` parameter.
+    Provides train/test indices to split data into train/test sets using a
+    predefined scheme specified by the user with the ``test_fold`` parameter.
+    The entry ``test_fold[i]`` represents the index of the test set that 
+    sample ``i`` belongs to. It is possible to exclude sample ``i`` from any
+    test set (i.e. include sample ``i`` in every training set) by setting 
+    ``test_fold[i]`` equal to -1.
 
     Read more in the :ref:`User Guide <cross_validation>`.
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1708,12 +1708,16 @@ class PredefinedSplit(BaseCrossValidator):
 
     Provides train/test indices to split data into train/test sets using a
     predefined scheme specified by the user with the ``test_fold`` parameter.
-    The entry ``test_fold[i]`` represents the index of the test set that
-    sample ``i`` belongs to. It is possible to exclude sample ``i`` from any
-    test set (i.e. include sample ``i`` in every training set) by setting
-    ``test_fold[i]`` equal to -1.
 
     Read more in the :ref:`User Guide <cross_validation>`.
+
+    Parameters
+    ----------
+    test_fold : array-like, shape (n_samples,)        
+        The entry ``test_fold[i]`` represents the index of the test set that
+        sample ``i`` belongs to. It is possible to exclude sample ``i`` from any
+        test set (i.e. include sample ``i`` in every training set) by setting
+        ``test_fold[i]`` equal to -1.
 
     Examples
     --------


### PR DESCRIPTION
#### Reference Issue
Example: Fixes #9743 


#### What does this implement/fix? Explain your changes.
Using docstring for ``sklearn.model_selection.KFold`` as a model, I added a description of how the ``test_fold`` parameter can be used.

#### Any other comments?
There are no checks to see if ``test_fold`` parameter is valid, and it is possible that it has more/less entries than the number of samples.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
