### PR TITLE
[MRG] Fix float array comparisons for naive_bayes.

### DIFF
--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -111,7 +111,7 @@ def test_gnb_priors():
     assert_array_almost_equal(clf.predict_proba([[-0.1, -0.1]]),
                               np.array([[0.825303662161683,
                                          0.174696337838317]]), 8)
-    assert_array_equal(clf.class_prior_, np.array([0.3, 0.7]))
+    assert_array_almost_equal(clf.class_prior_, np.array([0.3, 0.7]))
 
 
 def test_gnb_wrong_nb_priors():
@@ -345,7 +345,7 @@ def test_discretenb_uniform_prior():
         clf.set_params(fit_prior=False)
         clf.fit([[0], [0], [1]], [0, 0, 1])
         prior = np.exp(clf.class_log_prior_)
-        assert_array_equal(prior, np.array([.5, .5]))
+        assert_array_almost_equal(prior, np.array([.5, .5]))
 
 
 def test_discretenb_provide_prior():
@@ -355,7 +355,7 @@ def test_discretenb_provide_prior():
         clf = cls(class_prior=[0.5, 0.5])
         clf.fit([[0], [0], [1]], [0, 0, 1])
         prior = np.exp(clf.class_log_prior_)
-        assert_array_equal(prior, np.array([.5, .5]))
+        assert_array_almost_equal(prior, np.array([.5, .5]))
 
         # Inconsistent number of classes with prior
         assert_raises(ValueError, clf.fit, [[0], [1], [2]], [0, 1, 2])
@@ -592,7 +592,7 @@ def test_cnb():
         weights[i] = np.log(theta[i])
         weights[i] /= weights[i].sum()
 
-    assert_array_equal(clf.feature_log_prob_, weights)
+    assert_array_almost_equal(clf.feature_log_prob_, weights)
 
 
 def test_naive_bayes_scale_invariance():
@@ -601,8 +601,8 @@ def test_naive_bayes_scale_invariance():
     X, y = iris.data, iris.target
     labels = [GaussianNB().fit(f * X, y).predict(f * X)
               for f in [1E-10, 1, 1E10]]
-    assert_array_equal(labels[0], labels[1])
-    assert_array_equal(labels[1], labels[2])
+    assert_array_almost_equal(labels[0], labels[1])
+    assert_array_almost_equal(labels[1], labels[2])
 
 
 def test_alpha():


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Deal with #4400 in `test_naive_bayes.py`

#### What does this implement/fix? Explain your changes.

Replace `assert_array_equal` w/ `assert_array_almost_equal` where we compare flaots.

#### Any other comments?

Since the task is very big, I'll try to create several PRs one per module.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
