### PR TITLE
[MRG] Fix float array comparisons in test_dummy.

### DIFF
--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -39,7 +39,7 @@ def _check_predict_proba(clf, X, y):
         assert_equal(proba[k].shape[1], len(np.unique(y[:, k])))
         assert_array_equal(proba[k].sum(axis=1), np.ones(len(X)))
         # We know that we can have division by zero
-        assert_array_equal(np.log(proba[k]), log_proba[k])
+        assert_array_almost_equal(np.log(proba[k]), log_proba[k])
 
 
 def _check_behavior_2d(clf):
@@ -77,9 +77,9 @@ def _check_behavior_2d_for_constant(clf):
 
 def _check_equality_regressor(statistic, y_learn, y_pred_learn,
                               y_test, y_pred_test):
-    assert_array_equal(np.tile(statistic, (y_learn.shape[0], 1)),
+    assert_array_almost_equal(np.tile(statistic, (y_learn.shape[0], 1)),
                        y_pred_learn)
-    assert_array_equal(np.tile(statistic, (y_test.shape[0], 1)),
+    assert_array_almost_equal(np.tile(statistic, (y_test.shape[0], 1)),
                        y_pred_test)
 
 
@@ -94,10 +94,10 @@ def test_most_frequent_and_prior_strategy():
         _check_predict_proba(clf, X, y)
 
         if strategy == "prior":
-            assert_array_equal(clf.predict_proba([X[0]]),
+            assert_array_almost_equal(clf.predict_proba([X[0]]),
                                clf.class_prior_.reshape((1, -1)))
         else:
-            assert_array_equal(clf.predict_proba([X[0]]),
+            assert_array_almost_equal(clf.predict_proba([X[0]]),
                                clf.class_prior_.reshape((1, -1)) > 0.5)
 
 
@@ -217,7 +217,7 @@ def test_mean_strategy_regressor():
 
     reg = DummyRegressor()
     reg.fit(X, y)
-    assert_array_equal(reg.predict(X), [np.mean(y)] * len(X))
+    assert_array_almost_equal(reg.predict(X), [np.mean(y)] * len(X))
 
 
 def test_mean_strategy_multioutput_regressor():
@@ -256,7 +256,7 @@ def test_median_strategy_regressor():
 
     reg = DummyRegressor(strategy="median")
     reg.fit(X, y)
-    assert_array_equal(reg.predict(X), [np.median(y)] * len(X))
+    assert_array_almost_equal(reg.predict(X), [np.median(y)] * len(X))
 
 
 def test_median_strategy_multioutput_regressor():
@@ -291,19 +291,19 @@ def test_quantile_strategy_regressor():
 
     reg = DummyRegressor(strategy="quantile", quantile=0.5)
     reg.fit(X, y)
-    assert_array_equal(reg.predict(X), [np.median(y)] * len(X))
+    assert_array_almost_equal(reg.predict(X), [np.median(y)] * len(X))
 
     reg = DummyRegressor(strategy="quantile", quantile=0)
     reg.fit(X, y)
-    assert_array_equal(reg.predict(X), [np.min(y)] * len(X))
+    assert_array_almost_equal(reg.predict(X), [np.min(y)] * len(X))
 
     reg = DummyRegressor(strategy="quantile", quantile=1)
     reg.fit(X, y)
-    assert_array_equal(reg.predict(X), [np.max(y)] * len(X))
+    assert_array_almost_equal(reg.predict(X), [np.max(y)] * len(X))
 
     reg = DummyRegressor(strategy="quantile", quantile=0.3)
     reg.fit(X, y)
-    assert_array_equal(reg.predict(X), [np.percentile(y, q=30)] * len(X))
+    assert_array_almost_equal(reg.predict(X), [np.percentile(y, q=30)] * len(X))
 
 
 def test_quantile_strategy_multioutput_regressor():


### PR DESCRIPTION
Deals with #4400

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Deal with #4400 in test_dummy.py

#### What does this implement/fix? Explain your changes.

Replace assert_array_equal w/ assert_array_almost_equal where we compare flaots.

#### Any other comments?
Since the task is very big, I'll try to create several PRs one per module.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
