### PR TITLE
[MRG+1] Fix cardinality vs. l0 norm in the user guide of multi-label ranking metrics

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1266,20 +1266,19 @@ label per sample, label ranking average precision is equivalent to the `mean
 reciprocal rank <https://en.wikipedia.org/wiki/Mean_reciprocal_rank>`_.
 
 Formally, given a binary indicator matrix of the ground truth labels
-:math:`y \in \mathcal{R}^{n_\text{samples} \times n_\text{labels}}` and the
+:math:`y \in \left\{0, 1\right\}^{n_\text{samples} \times n_\text{labels}}` and the
 score associated with each label
-:math:`\hat{f} \in \mathcal{R}^{n_\text{samples} \times n_\text{labels}}`,
+:math:`\hat{f} \in \mathbb{R}^{n_\text{samples} \times n_\text{labels}}`,
 the average precision is defined as
 
 .. math::
   LRAP(y, \hat{f}) = \frac{1}{n_{\text{samples}}}
-    \sum_{i=0}^{n_{\text{samples}} - 1} \frac{1}{|y_i|}
+    \sum_{i=0}^{n_{\text{samples}} - 1} \frac{1}{||y_i||_0}
     \sum_{j:y_{ij} = 1} \frac{|\mathcal{L}_{ij}|}{\text{rank}_{ij}}
 
 
-with :math:`\mathcal{L}_{ij} = \left\{k: y_{ik} = 1, \hat{f}_{ik} \geq \hat{f}_{ij} \right\}`,
-:math:`\text{rank}_{ij} = \left|\left\{k: \hat{f}_{ik} \geq \hat{f}_{ij} \right\}\right|`
-and :math:`|\cdot|` is the l0 norm or the cardinality of the set.
+where :math:`\mathcal{L}_{ij} = \left\{k: y_{ik} = 1, \hat{f}_{ik} \geq \hat{f}_{ij} \right\}`,
+:math:`\text{rank}_{ij} = \left|\left\{k: \hat{f}_{ik} \geq \hat{f}_{ij} \right\}\right|`, :math:`|\cdot|` computes the cardinality of the set (i.e., the number of elements in the set), and :math:`||\cdot||_0` is the :math:`\ell_0` "norm" (which computes the number of nonzero elements in a vector).
 
 Here is a small example of usage of this function::
 
@@ -1298,7 +1297,7 @@ Ranking loss
 The :func:`label_ranking_loss` function computes the ranking loss which
 averages over the samples the number of label pairs that are incorrectly
 ordered, i.e. true labels have a lower score than false labels, weighted by
-the inverse number of false and true labels. The lowest achievable
+the inverse of the number of ordered pairs of false and true labels. The lowest achievable
 ranking loss is zero.
 
 Formally, given a binary indicator matrix of the ground truth labels
@@ -1309,10 +1308,10 @@ the ranking loss is defined as
 
 .. math::
   \text{ranking\_loss}(y, \hat{f}) =  \frac{1}{n_{\text{samples}}}
-    \sum_{i=0}^{n_{\text{samples}} - 1} \frac{1}{|y_i|(n_\text{labels} - |y_i|)}
+    \sum_{i=0}^{n_{\text{samples}} - 1} \frac{1}{||y_i||_0(n_\text{labels} - ||y_i||_0)}
     \left|\left\{(k, l): \hat{f}_{ik} < \hat{f}_{il}, y_{ik} = 1, y_{il} = 0 \right\}\right|
 
-where :math:`|\cdot|` is the :math:`\ell_0` norm or the cardinality of the set.
+where :math:`|\cdot|` computes the cardinality of the set (i.e., the number of elements in the set) and :math:`||\cdot||_0` is the :math:`\ell_0` "norm" (which computes the number of nonzero elements in a vector).
 
 Here is a small example of usage of this function::
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1257,9 +1257,12 @@ implements label ranking average precision (LRAP). This metric is linked to
 the :func:`average_precision_score` function, but is based on the notion of
 label ranking instead of precision and recall.
 
-Label ranking average precision (LRAP) is the average over each ground truth
-label assigned to each sample, of the ratio of true vs. total labels with lower
-score. This metric will yield better scores if you are able to give better rank
+Label ranking average precision (LRAP) averages over the samples the answer to
+the following question: for each ground truth label, what fraction of higher-ranked
+labels were true labels? ("Higher-ranked" means that the algorithm assigned a higher
+score :math:`\hat{f}_{ik}` and a lower value of
+:math:`\text{rank}_{ik} = \left|\left\{l: \hat{f}_{il} \geq \hat{f}_{ik} \right\}\right|`.)
+This metric will yield better scores if you are able to give better rank
 to the labels associated with each sample. The obtained score is always strictly
 greater than 0, and the best value is 1. If there is exactly one relevant
 label per sample, label ranking average precision is equivalent to the `mean

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1309,7 +1309,7 @@ the ranking loss is defined as
 .. math::
   \text{ranking\_loss}(y, \hat{f}) =  \frac{1}{n_{\text{samples}}}
     \sum_{i=0}^{n_{\text{samples}} - 1} \frac{1}{||y_i||_0(n_\text{labels} - ||y_i||_0)}
-    \left|\left\{(k, l): \hat{f}_{ik} < \hat{f}_{il}, y_{ik} = 1, y_{il} = 0 \right\}\right|
+    \left|\left\{(k, l): \hat{f}_{ik} \leq \hat{f}_{il}, y_{ik} = 1, y_{il} = 0 \right\}\right|
 
 where :math:`|\cdot|` computes the cardinality of the set (i.e., the number of elements in the set) and :math:`||\cdot||_0` is the :math:`\ell_0` "norm" (which computes the number of nonzero elements in a vector).
 


### PR DESCRIPTION
The mathematical definitions and the associated descriptions of `label_ranking_average_precision_score` and `label_ranking_loss` had errors resulting from a confusion of cardinality and the number of nonzero elements in a vector. This confusion likely resulted from copying the notation in the reference given in Section 3.3.3.3 ("Mining multi-label data" by Tsoumakas et al., 2010) because that paper has notation for $Y_i \subset L$, the subset of labels associated with the $i$th sample, whereas here $y_i$ is a vector (a row vector in the target $y \in \{0, 1\}^{n_\text{samples} \cross n_\text{labels}}$).

I corrected $|y_i|$ to be $||y_i||_0$ in sections 3.3.3.2 and 3.3.3.3, where $||\cdot||_0$ is the definition of the l0 "norm" often used in practice that "most mathematicians and engineers use" (the number of non-zero elements of a vector); that quote is from  https://rorasa.wordpress.com/2012/05/13/l0-norm-l1-norm-l2-norm-l-infinity-norm/

I also updated the descriptions of these two inset equations accordingly so that $|\cdot|$ means cardinality (number of elements in a set), as it is used in a section I did not edit (3.3.3.1), and $||\cdot||_0$ is the l0 "norm" as defined above (the number of nonzero elements in a vector).

I also made one other minor fix: in section 3.3.3.2 I changed the two instances of $\mathcal{R}$ to be $\mathbb{R}$ for the scores $\hat f$ and to $\{0, 1\}$ for the true binary labels. With this change, the notation used in section 3.3.3.2 now matches that used in the sections immediately before and after it.

I also improved the explanation of the denominator in the definition of ranking loss: "number of false and true labels" is hard to understand (and seems incorrect); it's the number of ordered pairs of true and false labels.