### PR TITLE
[MRG+1] Replace assert_array_equal with -assert_array_almost_equal where necessary.

### DIFF
--- a/sklearn/cluster/tests/test_birch.py
+++ b/sklearn/cluster/tests/test_birch.py
@@ -17,6 +17,7 @@ from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
 
@@ -41,8 +42,8 @@ def test_partial_fit():
     brc_partial = Birch(n_clusters=None)
     brc_partial.partial_fit(X[:50])
     brc_partial.partial_fit(X[50:])
-    assert_array_equal(brc_partial.subcluster_centers_,
-                       brc.subcluster_centers_)
+    assert_array_almost_equal(brc_partial.subcluster_centers_,
+                              brc.subcluster_centers_)
 
     # Test that same global labels are obtained after calling partial_fit
     # with None
@@ -106,8 +107,8 @@ def test_sparse_X():
     brc_sparse.fit(csr)
 
     assert_array_equal(brc.labels_, brc_sparse.labels_)
-    assert_array_equal(brc.subcluster_centers_,
-                       brc_sparse.subcluster_centers_)
+    assert_array_almost_equal(brc.subcluster_centers_,
+                              brc_sparse.subcluster_centers_)
 
 
 def check_branching_factor(node, branching_factor):

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -678,7 +678,7 @@ def test_transform():
 def test_fit_transform():
     X1 = KMeans(n_clusters=3, random_state=51).fit(X).transform(X)
     X2 = KMeans(n_clusters=3, random_state=51).fit_transform(X)
-    assert_array_equal(X1, X2)
+    assert_array_almost_equal(X1, X2)
 
 
 def test_predict_equal_labels():

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -300,7 +300,7 @@ def test_k_means_fortran_aligned_data():
     km = KMeans(n_init=1, init=centers, precompute_distances=False,
                 random_state=42, n_clusters=2)
     km.fit(X)
-    assert_array_equal(km.cluster_centers_, centers)
+    assert_array_almost_equal(km.cluster_centers_, centers)
     assert_array_equal(km.labels_, labels)
 
 
@@ -660,7 +660,7 @@ def test_int_input():
         expected_labels = [0, 1, 1, 0, 0, 1]
         scores = np.array([v_measure_score(expected_labels, km.labels_)
                            for km in fitted_models])
-        assert_array_equal(scores, np.ones(scores.shape[0]))
+        assert_array_almost_equal(scores, np.ones(scores.shape[0]))
 
 
 def test_transform():
@@ -757,7 +757,7 @@ def test_x_squared_norms_init_centroids():
     X_norms = np.sum(X**2, axis=1)
     precompute = _init_centroids(
         X, 3, "k-means++", random_state=0, x_squared_norms=X_norms)
-    assert_array_equal(
+    assert_array_almost_equal(
         precompute,
         _init_centroids(X, 3, "k-means++", random_state=0))
 

--- a/sklearn/cluster/tests/test_mean_shift.py
+++ b/sklearn/cluster/tests/test_mean_shift.py
@@ -12,6 +12,7 @@ from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_raise_message
 
 from sklearn.cluster import MeanShift
@@ -114,7 +115,7 @@ def test_bin_seeds():
     # we bail and use the whole data here.
     with warnings.catch_warnings(record=True):
         test_bins = get_bin_seeds(X, 0.01, 1)
-    assert_array_equal(test_bins, X)
+    assert_array_almost_equal(test_bins, X)
 
     # tight clusters around [0, 0] and [1, 1], only get two bins
     X, _ = make_blobs(n_samples=100, n_features=2, centers=[[0, 0], [1, 1]],

--- a/sklearn/cluster/tests/test_mean_shift.py
+++ b/sklearn/cluster/tests/test_mean_shift.py
@@ -64,7 +64,7 @@ def test_parallel():
     ms2 = MeanShift()
     ms2.fit(X)
 
-    assert_array_equal(ms1.cluster_centers_, ms2.cluster_centers_)
+    assert_array_almost_equal(ms1.cluster_centers_, ms2.cluster_centers_)
     assert_array_equal(ms1.labels_, ms2.labels_)
 
 

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -27,7 +27,6 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_array_almost_equal
 
 
 DATA_HOME = tempfile.mkdtemp(prefix="scikit_learn_data_home_test_")
@@ -142,7 +141,7 @@ def test_load_digits():
     X_y_tuple = load_digits(return_X_y=True)
     bunch = load_digits()
     assert_true(isinstance(X_y_tuple, tuple))
-    assert_array_almost_equal(X_y_tuple[0], bunch.data)
+    assert_array_equal(X_y_tuple[0], bunch.data)
     assert_array_equal(X_y_tuple[1], bunch.target)
 
 
@@ -188,8 +187,8 @@ def test_load_diabetes():
     X_y_tuple = load_diabetes(return_X_y=True)
     bunch = load_diabetes()
     assert_true(isinstance(X_y_tuple, tuple))
-    assert_array_almost_equal(X_y_tuple[0], bunch.data)
-    assert_array_almost_equal(X_y_tuple[1], bunch.target)
+    assert_array_equal(X_y_tuple[0], bunch.data)
+    assert_array_equal(X_y_tuple[1], bunch.target)
 
 
 def test_load_linnerud():
@@ -203,8 +202,8 @@ def test_load_linnerud():
     X_y_tuple = load_linnerud(return_X_y=True)
     bunch = load_linnerud()
     assert_true(isinstance(X_y_tuple, tuple))
-    assert_array_almost_equal(X_y_tuple[0], bunch.data)
-    assert_array_almost_equal(X_y_tuple[1], bunch.target)
+    assert_array_equal(X_y_tuple[0], bunch.data)
+    assert_array_equal(X_y_tuple[1], bunch.target)
 
 
 def test_load_iris():
@@ -218,7 +217,7 @@ def test_load_iris():
     X_y_tuple = load_iris(return_X_y=True)
     bunch = load_iris()
     assert_true(isinstance(X_y_tuple, tuple))
-    assert_array_almost_equal(X_y_tuple[0], bunch.data)
+    assert_array_equal(X_y_tuple[0], bunch.data)
     assert_array_equal(X_y_tuple[1], bunch.target)
 
 
@@ -233,7 +232,7 @@ def test_load_wine():
     X_y_tuple = load_wine(return_X_y=True)
     bunch = load_wine()
     assert_true(isinstance(X_y_tuple, tuple))
-    assert_array_almost_equal(X_y_tuple[0], bunch.data)
+    assert_array_equal(X_y_tuple[0], bunch.data)
     assert_array_equal(X_y_tuple[1], bunch.target)
 
 
@@ -248,7 +247,7 @@ def test_load_breast_cancer():
     X_y_tuple = load_breast_cancer(return_X_y=True)
     bunch = load_breast_cancer()
     assert_true(isinstance(X_y_tuple, tuple))
-    assert_array_almost_equal(X_y_tuple[0], bunch.data)
+    assert_array_equal(X_y_tuple[0], bunch.data)
     assert_array_equal(X_y_tuple[1], bunch.target)
 
 
@@ -263,8 +262,8 @@ def test_load_boston():
     X_y_tuple = load_boston(return_X_y=True)
     bunch = load_boston()
     assert_true(isinstance(X_y_tuple, tuple))
-    assert_array_almost_equal(X_y_tuple[0], bunch.data)
-    assert_array_almost_equal(X_y_tuple[1], bunch.target)
+    assert_array_equal(X_y_tuple[0], bunch.data)
+    assert_array_equal(X_y_tuple[1], bunch.target)
 
 
 def test_loads_dumps_bunch():

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -27,6 +27,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_array_almost_equal
 
 
 DATA_HOME = tempfile.mkdtemp(prefix="scikit_learn_data_home_test_")
@@ -141,7 +142,7 @@ def test_load_digits():
     X_y_tuple = load_digits(return_X_y=True)
     bunch = load_digits()
     assert_true(isinstance(X_y_tuple, tuple))
-    assert_array_equal(X_y_tuple[0], bunch.data)
+    assert_array_almost_equal(X_y_tuple[0], bunch.data)
     assert_array_equal(X_y_tuple[1], bunch.target)
 
 
@@ -187,8 +188,8 @@ def test_load_diabetes():
     X_y_tuple = load_diabetes(return_X_y=True)
     bunch = load_diabetes()
     assert_true(isinstance(X_y_tuple, tuple))
-    assert_array_equal(X_y_tuple[0], bunch.data)
-    assert_array_equal(X_y_tuple[1], bunch.target)
+    assert_array_almost_equal(X_y_tuple[0], bunch.data)
+    assert_array_almost_equal(X_y_tuple[1], bunch.target)
 
 
 def test_load_linnerud():
@@ -202,8 +203,8 @@ def test_load_linnerud():
     X_y_tuple = load_linnerud(return_X_y=True)
     bunch = load_linnerud()
     assert_true(isinstance(X_y_tuple, tuple))
-    assert_array_equal(X_y_tuple[0], bunch.data)
-    assert_array_equal(X_y_tuple[1], bunch.target)
+    assert_array_almost_equal(X_y_tuple[0], bunch.data)
+    assert_array_almost_equal(X_y_tuple[1], bunch.target)
 
 
 def test_load_iris():
@@ -217,7 +218,7 @@ def test_load_iris():
     X_y_tuple = load_iris(return_X_y=True)
     bunch = load_iris()
     assert_true(isinstance(X_y_tuple, tuple))
-    assert_array_equal(X_y_tuple[0], bunch.data)
+    assert_array_almost_equal(X_y_tuple[0], bunch.data)
     assert_array_equal(X_y_tuple[1], bunch.target)
 
 
@@ -232,7 +233,7 @@ def test_load_wine():
     X_y_tuple = load_wine(return_X_y=True)
     bunch = load_wine()
     assert_true(isinstance(X_y_tuple, tuple))
-    assert_array_equal(X_y_tuple[0], bunch.data)
+    assert_array_almost_equal(X_y_tuple[0], bunch.data)
     assert_array_equal(X_y_tuple[1], bunch.target)
 
 
@@ -247,7 +248,7 @@ def test_load_breast_cancer():
     X_y_tuple = load_breast_cancer(return_X_y=True)
     bunch = load_breast_cancer()
     assert_true(isinstance(X_y_tuple, tuple))
-    assert_array_equal(X_y_tuple[0], bunch.data)
+    assert_array_almost_equal(X_y_tuple[0], bunch.data)
     assert_array_equal(X_y_tuple[1], bunch.target)
 
 
@@ -262,8 +263,8 @@ def test_load_boston():
     X_y_tuple = load_boston(return_X_y=True)
     bunch = load_boston()
     assert_true(isinstance(X_y_tuple, tuple))
-    assert_array_equal(X_y_tuple[0], bunch.data)
-    assert_array_equal(X_y_tuple[1], bunch.target)
+    assert_array_almost_equal(X_y_tuple[0], bunch.data)
+    assert_array_almost_equal(X_y_tuple[1], bunch.target)
 
 
 def test_loads_dumps_bunch():

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -171,7 +171,7 @@ def test_make_multilabel_classification_return_indicator():
         n_samples=25, n_features=20, n_classes=3, random_state=0,
         allow_unlabeled=allow_unlabeled, return_distributions=True)
 
-    assert_array_equal(X, X2)
+    assert_array_almost_equal(X, X2)
     assert_array_equal(Y, Y2)
     assert_equal(p_c.shape, (3,))
     assert_almost_equal(p_c.sum(), 1)
@@ -371,7 +371,7 @@ def test_make_checkerboard():
                                  shuffle=True, random_state=0)
     X2, _, _ = make_checkerboard(shape=(100, 100), n_clusters=2,
                                  shuffle=True, random_state=0)
-    assert_array_equal(X1, X2)
+    assert_array_almost_equal(X1, X2)
 
 
 def test_make_moons():

--- a/sklearn/datasets/tests/test_svmlight_format.py
+++ b/sklearn/datasets/tests/test_svmlight_format.py
@@ -67,8 +67,8 @@ def test_load_svmlight_file_fd():
     fd = os.open(datafile, os.O_RDONLY)
     try:
         X2, y2 = load_svmlight_file(fd)
-        assert_array_equal(X1.data, X2.data)
-        assert_array_equal(y1, y2)
+        assert_array_almost_equal(X1.data, X2.data)
+        assert_array_almost_equal(y1, y2)
     finally:
         os.close(fd)
 
@@ -82,7 +82,7 @@ def test_load_svmlight_files():
     X_train, y_train, X_test, y_test = load_svmlight_files([datafile] * 2,
                                                            dtype=np.float32)
     assert_array_equal(X_train.toarray(), X_test.toarray())
-    assert_array_equal(y_train, y_test)
+    assert_array_almost_equal(y_train, y_test)
     assert_equal(X_train.dtype, np.float32)
     assert_equal(X_test.dtype, np.float32)
 
@@ -122,8 +122,8 @@ def test_load_compressed():
         # because we "close" it manually and write to it,
         # we need to remove it manually.
         os.remove(tmp.name)
-    assert_array_equal(X.toarray(), Xgz.toarray())
-    assert_array_equal(y, ygz)
+    assert_array_almost_equal(X.toarray(), Xgz.toarray())
+    assert_array_almost_equal(y, ygz)
 
     with NamedTemporaryFile(prefix="sklearn-test", suffix=".bz2") as tmp:
         tmp.close()  # necessary under windows
@@ -133,8 +133,8 @@ def test_load_compressed():
         # because we "close" it manually and write to it,
         # we need to remove it manually.
         os.remove(tmp.name)
-    assert_array_equal(X.toarray(), Xbz.toarray())
-    assert_array_equal(y, ybz)
+    assert_array_almost_equal(X.toarray(), Xbz.toarray())
+    assert_array_almost_equal(y, ybz)
 
 
 def test_load_invalid_file():
@@ -305,7 +305,7 @@ def test_dump_concise():
     # make sure it's correct too :)
     X2, y2 = load_svmlight_file(f)
     assert_array_almost_equal(X, X2.toarray())
-    assert_array_equal(y, y2)
+    assert_array_almost_equal(y, y2)
 
 
 def test_dump_comment():
@@ -319,7 +319,7 @@ def test_dump_comment():
 
     X2, y2 = load_svmlight_file(f, zero_based=False)
     assert_array_almost_equal(X, X2.toarray())
-    assert_array_equal(y, y2)
+    assert_array_almost_equal(y, y2)
 
     # XXX we have to update this to support Python 3.x
     utf8_comment = b("It is true that\n\xc2\xbd\xc2\xb2 = \xc2\xbc")
@@ -334,7 +334,7 @@ def test_dump_comment():
 
     X2, y2 = load_svmlight_file(f, zero_based=False)
     assert_array_almost_equal(X, X2.toarray())
-    assert_array_equal(y, y2)
+    assert_array_almost_equal(y, y2)
 
     f = BytesIO()
     assert_raises(ValueError,
@@ -410,8 +410,8 @@ def test_load_zeros():
     for zero_based in ['auto', True, False]:
         f.seek(0)
         X, y = load_svmlight_file(f, n_features=4, zero_based=zero_based)
-        assert_array_equal(y, true_y)
-        assert_array_equal(X.toarray(), true_X.toarray())
+        assert_array_almost_equal(y, true_y)
+        assert_array_almost_equal(X.toarray(), true_X.toarray())
 
 
 def test_load_with_offsets():
@@ -446,7 +446,7 @@ def test_load_with_offsets():
 
         y_concat = np.concatenate([y_0, y_1, y_2])
         X_concat = sp.vstack([X_0, X_1, X_2])
-        assert_array_equal(y, y_concat)
+        assert_array_almost_equal(y, y_concat)
         assert_array_almost_equal(X.toarray(), X_concat.toarray())
 
     # Generate a uniformly random sparse matrix
@@ -494,7 +494,7 @@ def test_load_offset_exhaustive_splits():
         q_concat = np.concatenate([q_0, q_1])
         y_concat = np.concatenate([y_0, y_1])
         X_concat = sp.vstack([X_0, X_1])
-        assert_array_equal(y, y_concat)
+        assert_array_almost_equal(y, y_concat)
         assert_array_equal(query_id, q_concat)
         assert_array_almost_equal(X.toarray(), X_concat.toarray())
 

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -121,8 +121,8 @@ def test_dict_learning_split():
     dico.split_sign = True
     split_code = dico.transform(X)
 
-    assert_array_equal(split_code[:, :n_components] -
-                       split_code[:, n_components:], code)
+    assert_array_almost_equal(split_code[:, :n_components] -
+                              split_code[:, n_components:], code)
 
 
 def test_dict_learning_online_shapes():

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -213,9 +213,9 @@ def test_sparse_regression():
             sparse_type = type(X_train_sparse)
             types = [i.data_type_ for i in sparse_classifier.estimators_]
 
-            assert_array_equal(sparse_results, dense_results)
+            assert_array_almost_equal(sparse_results, dense_results)
             assert all([t == sparse_type for t in types])
-            assert_array_equal(sparse_results, dense_results)
+            assert_array_almost_equal(sparse_results, dense_results)
 
 
 def test_bootstrap_samples():
@@ -376,7 +376,7 @@ def test_single_estimator():
 
     clf2 = KNeighborsRegressor().fit(X_train, y_train)
 
-    assert_array_equal(clf1.predict(X_test), clf2.predict(X_test))
+    assert_array_almost_equal(clf1.predict(X_test), clf2.predict(X_test))
 
 
 def test_error():

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -847,43 +847,43 @@ def check_memory_layout(name, dtype):
     # Nothing
     X = np.asarray(iris.data, dtype=dtype)
     y = iris.target
-    assert_array_equal(est.fit(X, y).predict(X), y)
+    assert_array_almost_equal(est.fit(X, y).predict(X), y)
 
     # C-order
     X = np.asarray(iris.data, order="C", dtype=dtype)
     y = iris.target
-    assert_array_equal(est.fit(X, y).predict(X), y)
+    assert_array_almost_equal(est.fit(X, y).predict(X), y)
 
     # F-order
     X = np.asarray(iris.data, order="F", dtype=dtype)
     y = iris.target
-    assert_array_equal(est.fit(X, y).predict(X), y)
+    assert_array_almost_equal(est.fit(X, y).predict(X), y)
 
     # Contiguous
     X = np.ascontiguousarray(iris.data, dtype=dtype)
     y = iris.target
-    assert_array_equal(est.fit(X, y).predict(X), y)
+    assert_array_almost_equal(est.fit(X, y).predict(X), y)
 
     if est.base_estimator.splitter in SPARSE_SPLITTERS:
         # csr matrix
         X = csr_matrix(iris.data, dtype=dtype)
         y = iris.target
-        assert_array_equal(est.fit(X, y).predict(X), y)
+        assert_array_almost_equal(est.fit(X, y).predict(X), y)
 
         # csc_matrix
         X = csc_matrix(iris.data, dtype=dtype)
         y = iris.target
-        assert_array_equal(est.fit(X, y).predict(X), y)
+        assert_array_almost_equal(est.fit(X, y).predict(X), y)
 
         # coo_matrix
         X = coo_matrix(iris.data, dtype=dtype)
         y = iris.target
-        assert_array_equal(est.fit(X, y).predict(X), y)
+        assert_array_almost_equal(est.fit(X, y).predict(X), y)
 
     # Strided
     X = np.asarray(iris.data[::3], dtype=dtype)
     y = iris.target[::3]
-    assert_array_equal(est.fit(X, y).predict(X), y)
+    assert_array_almost_equal(est.fit(X, y).predict(X), y)
 
 
 def test_memory_layout():

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -442,7 +442,7 @@ def test_staged_predict():
     for y in clf.staged_predict(X_test):
         assert_equal(y.shape, y_pred.shape)
 
-    assert_array_equal(y_pred, y)
+    assert_array_almost_equal(y_pred, y)
 
 
 def test_staged_predict_proba():
@@ -470,7 +470,7 @@ def test_staged_predict_proba():
         assert_equal(y_test.shape[0], staged_proba.shape[0])
         assert_equal(2, staged_proba.shape[1])
 
-    assert_array_equal(clf.predict_proba(X_test), staged_proba)
+    assert_array_almost_equal(clf.predict_proba(X_test), staged_proba)
 
 
 def test_staged_functions_defensive():

--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -1,7 +1,7 @@
 """Testing for the VotingClassifier"""
 
 import numpy as np
-from sklearn.utils.testing import assert_almost_equal, assert_array_equal
+from sklearn.utils.testing import assert_almost_equal, assert_array_equal, assert_array_almost_equal
 from sklearn.utils.testing import assert_equal, assert_true, assert_false
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_warns_message
@@ -243,7 +243,7 @@ def test_parallel_fit():
         n_jobs=2).fit(X, y)
 
     assert_array_equal(eclf1.predict(X), eclf2.predict(X))
-    assert_array_equal(eclf1.predict_proba(X), eclf2.predict_proba(X))
+    assert_array_almost_equal(eclf1.predict_proba(X), eclf2.predict_proba(X))
 
 
 def test_sample_weight():
@@ -258,14 +258,14 @@ def test_sample_weight():
         ('lr', clf1), ('rf', clf2), ('svc', clf3)],
         voting='soft').fit(X, y)
     assert_array_equal(eclf1.predict(X), eclf2.predict(X))
-    assert_array_equal(eclf1.predict_proba(X), eclf2.predict_proba(X))
+    assert_array_almost_equal(eclf1.predict_proba(X), eclf2.predict_proba(X))
 
     sample_weight = np.random.RandomState(123).uniform(size=(len(y),))
     eclf3 = VotingClassifier(estimators=[('lr', clf1)], voting='soft')
     eclf3.fit(X, y, sample_weight)
     clf1.fit(X, y, sample_weight)
     assert_array_equal(eclf3.predict(X), clf1.predict(X))
-    assert_array_equal(eclf3.predict_proba(X), clf1.predict_proba(X))
+    assert_array_almost_equal(eclf3.predict_proba(X), clf1.predict_proba(X))
 
     clf4 = KNeighborsClassifier()
     eclf3 = VotingClassifier(estimators=[
@@ -310,7 +310,7 @@ def test_set_params():
     assert_false(hasattr(eclf2, 'nb'))
 
     assert_array_equal(eclf1.predict(X), eclf2.predict(X))
-    assert_array_equal(eclf1.predict_proba(X), eclf2.predict_proba(X))
+    assert_array_almost_equal(eclf1.predict_proba(X), eclf2.predict_proba(X))
     assert_equal(eclf2.estimators[0][1].get_params(), clf1.get_params())
     assert_equal(eclf2.estimators[1][1].get_params(), clf2.get_params())
 
@@ -348,7 +348,7 @@ def test_set_estimator_none():
     eclf1.set_params(voting='soft').fit(X, y)
     eclf2.set_params(voting='soft').fit(X, y)
     assert_array_equal(eclf1.predict(X), eclf2.predict(X))
-    assert_array_equal(eclf1.predict_proba(X), eclf2.predict_proba(X))
+    assert_array_almost_equal(eclf1.predict_proba(X), eclf2.predict_proba(X))
     msg = ('All estimators are None. At least one is required'
            ' to be a classifier!')
     assert_raise_message(
@@ -363,9 +363,12 @@ def test_set_estimator_none():
     eclf2 = VotingClassifier(estimators=[('rf', clf2), ('nb', clf3)],
                              voting='soft', weights=[1, 0.5])
     eclf2.set_params(rf=None).fit(X1, y1)
-    assert_array_equal(eclf1.transform(X1), np.array([[[0.7, 0.3], [0.3, 0.7]],
-                                                      [[1., 0.], [0., 1.]]]))
-    assert_array_equal(eclf2.transform(X1), np.array([[[1., 0.], [0., 1.]]]))
+    assert_array_almost_equal(eclf1.transform(X1),
+                              np.array([[[0.7, 0.3], [0.3, 0.7]],
+                                        [[1., 0.], [0., 1.]]]))
+    assert_array_almost_equal(eclf2.transform(X1),
+                              np.array([[[1., 0.],
+                                         [0., 1.]]]))
     eclf1.set_params(voting='hard')
     eclf2.set_params(voting='hard')
     assert_array_equal(eclf1.transform(X1), np.array([[0, 0], [1, 1]]))
@@ -386,7 +389,7 @@ def test_estimator_weights_format():
                 voting='soft')
     eclf1.fit(X, y)
     eclf2.fit(X, y)
-    assert_array_equal(eclf1.predict_proba(X), eclf2.predict_proba(X))
+    assert_array_almost_equal(eclf1.predict_proba(X), eclf2.predict_proba(X))
 
 
 def test_transform():
@@ -418,7 +421,7 @@ def test_transform():
     assert_array_equal(res.shape, (3, 4, 2))
     assert_array_equal(eclf2.transform(X).shape, (4, 6))
     assert_array_equal(eclf3.transform(X).shape, (3, 4, 2))
-    assert_array_equal(res.swapaxes(0, 1).reshape((4, 6)),
-                       eclf2.transform(X))
-    assert_array_equal(eclf3.transform(X).swapaxes(0, 1).reshape((4, 6)),
-                       eclf2.transform(X))
+    assert_array_almost_equal(res.swapaxes(0, 1).reshape((4, 6)),
+                              eclf2.transform(X))
+    assert_array_almost_equal(eclf3.transform(X).swapaxes(0, 1).reshape((4, 6)),
+                              eclf2.transform(X))

--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -1,7 +1,8 @@
 """Testing for the VotingClassifier"""
 
 import numpy as np
-from sklearn.utils.testing import assert_almost_equal, assert_array_equal, assert_array_almost_equal
+from sklearn.utils.testing import assert_almost_equal, assert_array_equal
+from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_equal, assert_true, assert_false
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_warns_message
@@ -423,5 +424,7 @@ def test_transform():
     assert_array_equal(eclf3.transform(X).shape, (3, 4, 2))
     assert_array_almost_equal(res.swapaxes(0, 1).reshape((4, 6)),
                               eclf2.transform(X))
-    assert_array_almost_equal(eclf3.transform(X).swapaxes(0, 1).reshape((4, 6)),
-                              eclf2.transform(X))
+    assert_array_almost_equal(
+            eclf3.transform(X).swapaxes(0, 1).reshape((4, 6)),
+            eclf2.transform(X)
+    )

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -80,7 +80,7 @@ def test_oneclass_adaboost_proba():
     # https://github.com/scikit-learn/scikit-learn/issues/7501
     y_t = np.ones(len(X))
     clf = AdaBoostClassifier().fit(X, y_t)
-    assert_array_equal(clf.predict_proba(X), np.ones((len(X), 1)))
+    assert_array_almost_equal(clf.predict_proba(X), np.ones((len(X), 1)))
 
 
 def test_classification_toy():
@@ -451,13 +451,13 @@ def test_sparse_regression():
         # predict
         sparse_results = sparse_classifier.predict(X_test_sparse)
         dense_results = dense_classifier.predict(X_test)
-        assert_array_equal(sparse_results, dense_results)
+        assert_array_almost_equal(sparse_results, dense_results)
 
         # staged_predict
         sparse_results = sparse_classifier.staged_predict(X_test_sparse)
         dense_results = dense_classifier.staged_predict(X_test)
         for sprase_res, dense_res in zip(sparse_results, dense_results):
-            assert_array_equal(sprase_res, dense_res)
+            assert_array_almost_equal(sprase_res, dense_res)
 
         types = [i.data_type_ for i in sparse_classifier.estimators_]
 

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -364,29 +364,29 @@ def test_sparse_classification():
         # decision_function
         sparse_results = sparse_classifier.decision_function(X_test_sparse)
         dense_results = dense_classifier.decision_function(X_test)
-        assert_array_equal(sparse_results, dense_results)
+        assert_array_almost_equal(sparse_results, dense_results)
 
         # predict_log_proba
         sparse_results = sparse_classifier.predict_log_proba(X_test_sparse)
         dense_results = dense_classifier.predict_log_proba(X_test)
-        assert_array_equal(sparse_results, dense_results)
+        assert_array_almost_equal(sparse_results, dense_results)
 
         # predict_proba
         sparse_results = sparse_classifier.predict_proba(X_test_sparse)
         dense_results = dense_classifier.predict_proba(X_test)
-        assert_array_equal(sparse_results, dense_results)
+        assert_array_almost_equal(sparse_results, dense_results)
 
         # score
         sparse_results = sparse_classifier.score(X_test_sparse, y_test)
         dense_results = dense_classifier.score(X_test, y_test)
-        assert_array_equal(sparse_results, dense_results)
+        assert_array_almost_equal(sparse_results, dense_results)
 
         # staged_decision_function
         sparse_results = sparse_classifier.staged_decision_function(
             X_test_sparse)
         dense_results = dense_classifier.staged_decision_function(X_test)
         for sprase_res, dense_res in zip(sparse_results, dense_results):
-            assert_array_equal(sprase_res, dense_res)
+            assert_array_almost_equal(sprase_res, dense_res)
 
         # staged_predict
         sparse_results = sparse_classifier.staged_predict(X_test_sparse)
@@ -398,7 +398,7 @@ def test_sparse_classification():
         sparse_results = sparse_classifier.staged_predict_proba(X_test_sparse)
         dense_results = dense_classifier.staged_predict_proba(X_test)
         for sprase_res, dense_res in zip(sparse_results, dense_results):
-            assert_array_equal(sprase_res, dense_res)
+            assert_array_almost_equal(sprase_res, dense_res)
 
         # staged_score
         sparse_results = sparse_classifier.staged_score(X_test_sparse,

--- a/sklearn/feature_selection/tests/test_chi2.py
+++ b/sklearn/feature_selection/tests/test_chi2.py
@@ -51,7 +51,7 @@ def test_chi2():
     # == doesn't work on scipy.sparse matrices
     Xtrans = Xtrans.toarray()
     Xtrans2 = mkchi2(k=2).fit_transform(Xsp, y).toarray()
-    assert_array_equal(Xtrans, Xtrans2)
+    assert_array_almost_equal(Xtrans, Xtrans2)
 
 
 def test_chi2_coo():

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -281,7 +281,7 @@ def assert_best_scores_kept(score_filter):
     scores = score_filter.scores_
     support = score_filter.get_support()
     assert_array_almost_equal(np.sort(scores[support]),
-                       np.sort(scores)[-support.sum():])
+                              np.sort(scores)[-support.sum():])
 
 
 def test_select_percentile_regression():

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -280,7 +280,7 @@ def test_select_heuristics_classif():
 def assert_best_scores_kept(score_filter):
     scores = score_filter.scores_
     support = score_filter.get_support()
-    assert_array_equal(np.sort(scores[support]),
+    assert_array_almost_equal(np.sort(scores[support]),
                        np.sort(scores)[-support.sum():])
 
 

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -76,7 +76,7 @@ def test_feature_importances():
     transformer.fit(X, y)
     X_new = transformer.transform(X)
     mask = np.abs(transformer.estimator_.coef_) > 1e-5
-    assert_array_equal(X_new, X[:, mask])
+    assert_array_almost_equal(X_new, X[:, mask])
 
 
 @skip_if_32bit
@@ -101,7 +101,7 @@ def test_feature_importances_2d_coef():
             est.fit(X, y)
             importances = np.linalg.norm(est.coef_, axis=0, ord=order)
             feature_mask = importances > func(importances)
-            assert_array_equal(X_new, X[:, feature_mask])
+            assert_array_almost_equal(X_new, X[:, feature_mask])
 
 
 def test_partial_fit():
@@ -118,7 +118,7 @@ def test_partial_fit():
 
     X_transform = transformer.transform(data)
     transformer.fit(np.vstack((data, data)), np.concatenate((y, y)))
-    assert_array_equal(X_transform, transformer.transform(data))
+    assert_array_almost_equal(X_transform, transformer.transform(data))
 
     # check that if est doesn't have partial_fit, neither does SelectFromModel
     transformer = SelectFromModel(estimator=RandomForestClassifier())
@@ -146,13 +146,13 @@ def test_prefit():
     X_transform = model.transform(data)
     clf.fit(data, y)
     model = SelectFromModel(clf, prefit=True)
-    assert_array_equal(model.transform(data), X_transform)
+    assert_array_almost_equal(model.transform(data), X_transform)
 
     # Check that the model is rewritten if prefit=False and a fitted model is
     # passed
     model = SelectFromModel(clf, prefit=False)
     model.fit(data, y)
-    assert_array_equal(model.transform(data), X_transform)
+    assert_array_almost_equal(model.transform(data), X_transform)
 
     # Check that prefit=True and calling fit raises a ValueError
     model = SelectFromModel(clf, prefit=True)
@@ -169,7 +169,7 @@ def test_threshold_string():
     est.fit(data, y)
     threshold = 0.5 * np.mean(est.feature_importances_)
     mask = est.feature_importances_ > threshold
-    assert_array_equal(X_transform, data[:, mask])
+    assert_array_almost_equal(X_transform, data[:, mask])
 
 
 def test_threshold_without_refitting():

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -31,7 +31,7 @@ def _check_statistics(X, X_true,
               "axis = {0}, sparse = {1}" % (strategy, missing_values)
 
     assert_ae = assert_array_equal
-    if issubclass(X.dtype.type, np.float) or issubclass(X_true.dtype.type, np.float):
+    if X.dtype.kind == 'f' or X_true.dtype.kind == 'f':
         assert_ae = assert_array_almost_equal
 
     # Normal matrix, axis = 0

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -290,10 +290,12 @@ def test_imputation_pickle():
 
         imputer_pickled = pickle.loads(pickle.dumps(imputer))
 
-        assert_array_almost_equal(imputer.transform(X.copy()),
-                                  imputer_pickled.transform(X.copy()),
-                                  err_msg="Fail to transform the data after pickling "
-                                  "(strategy = %s)" % (strategy))
+        assert_array_almost_equal(
+            imputer.transform(X.copy()),
+            imputer_pickled.transform(X.copy()),
+            err_msg="Fail to transform the data after pickling "
+            "(strategy = %s)" % (strategy)
+        )
 
 
 def test_imputation_copy():

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -4,6 +4,7 @@ from scipy import sparse
 
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_false
 
@@ -29,12 +30,16 @@ def _check_statistics(X, X_true,
     err_msg = "Parameters: strategy = %s, missing_values = %s, " \
               "axis = {0}, sparse = {1}" % (strategy, missing_values)
 
+    assert_ae = assert_array_equal
+    if issubclass(X.dtype.type, np.float) or issubclass(X_true.dtype.type, np.float):
+        assert_ae = assert_array_almost_equal
+
     # Normal matrix, axis = 0
     imputer = Imputer(missing_values, strategy=strategy, axis=0)
     X_trans = imputer.fit(X).transform(X.copy())
-    assert_array_equal(imputer.statistics_, statistics,
-                       err_msg.format(0, False))
-    assert_array_equal(X_trans, X_true, err_msg.format(0, False))
+    assert_ae(imputer.statistics_, statistics,
+              err_msg=err_msg.format(0, False))
+    assert_ae(X_trans, X_true, err_msg=err_msg.format(0, False))
 
     # Normal matrix, axis = 1
     imputer = Imputer(missing_values, strategy=strategy, axis=1)
@@ -43,8 +48,8 @@ def _check_statistics(X, X_true,
         assert_raises(ValueError, imputer.transform, X.copy().transpose())
     else:
         X_trans = imputer.transform(X.copy().transpose())
-        assert_array_equal(X_trans, X_true.transpose(),
-                           err_msg.format(1, False))
+        assert_ae(X_trans, X_true.transpose(),
+                  err_msg=err_msg.format(1, False))
 
     # Sparse matrix, axis = 0
     imputer = Imputer(missing_values, strategy=strategy, axis=0)
@@ -54,9 +59,9 @@ def _check_statistics(X, X_true,
     if sparse.issparse(X_trans):
         X_trans = X_trans.toarray()
 
-    assert_array_equal(imputer.statistics_, statistics,
-                       err_msg.format(0, True))
-    assert_array_equal(X_trans, X_true, err_msg.format(0, True))
+    assert_ae(imputer.statistics_, statistics,
+              err_msg=err_msg.format(0, True))
+    assert_ae(X_trans, X_true, err_msg=err_msg.format(0, True))
 
     # Sparse matrix, axis = 1
     imputer = Imputer(missing_values, strategy=strategy, axis=1)
@@ -70,8 +75,8 @@ def _check_statistics(X, X_true,
         if sparse.issparse(X_trans):
             X_trans = X_trans.toarray()
 
-        assert_array_equal(X_trans, X_true.transpose(),
-                           err_msg.format(1, True))
+        assert_ae(X_trans, X_true.transpose(),
+                  err_msg=err_msg.format(1, True))
 
 
 def test_imputation_shape():
@@ -285,10 +290,10 @@ def test_imputation_pickle():
 
         imputer_pickled = pickle.loads(pickle.dumps(imputer))
 
-        assert_array_equal(imputer.transform(X.copy()),
-                           imputer_pickled.transform(X.copy()),
-                           "Fail to transform the data after pickling "
-                           "(strategy = %s)" % (strategy))
+        assert_array_almost_equal(imputer.transform(X.copy()),
+                                  imputer_pickled.transform(X.copy()),
+                                  err_msg="Fail to transform the data after pickling "
+                                  "(strategy = %s)" % (strategy))
 
 
 def test_imputation_copy():
@@ -314,7 +319,7 @@ def test_imputation_copy():
     imputer = Imputer(missing_values=0, strategy="mean", copy=False)
     Xt = imputer.fit(X).transform(X)
     Xt[0, 0] = -1
-    assert_array_equal(X, Xt)
+    assert_array_almost_equal(X, Xt)
 
     # copy=False, sparse csr, axis=1 => no copy
     X = X_orig.copy()
@@ -322,7 +327,7 @@ def test_imputation_copy():
                       copy=False, axis=1)
     Xt = imputer.fit(X).transform(X)
     Xt.data[0] = -1
-    assert_array_equal(X.data, Xt.data)
+    assert_array_almost_equal(X.data, Xt.data)
 
     # copy=False, sparse csc, axis=0 => no copy
     X = X_orig.copy().tocsc()
@@ -330,7 +335,7 @@ def test_imputation_copy():
                       copy=False, axis=0)
     Xt = imputer.fit(X).transform(X)
     Xt.data[0] = -1
-    assert_array_equal(X.data, Xt.data)
+    assert_array_almost_equal(X.data, Xt.data)
 
     # copy=False, sparse csr, axis=0 => copy
     X = X_orig.copy()

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -90,7 +90,7 @@ def test_most_frequent_and_prior_strategy():
     for strategy in ("most_frequent", "prior"):
         clf = DummyClassifier(strategy=strategy, random_state=0)
         clf.fit(X, y)
-        assert_array_almost_equal(clf.predict(X), np.ones(len(X)))
+        assert_array_equal(clf.predict(X), np.ones(len(X)))
         _check_predict_proba(clf, X, y)
 
         if strategy == "prior":
@@ -113,9 +113,9 @@ def test_most_frequent_and_prior_strategy_multioutput():
     for strategy in ("prior", "most_frequent"):
         clf = DummyClassifier(strategy=strategy, random_state=0)
         clf.fit(X, y)
-        assert_array_almost_equal(clf.predict(X),
-                                  np.hstack([np.ones((n_samples, 1)),
-                                             np.zeros((n_samples, 1))]))
+        assert_array_equal(clf.predict(X),
+                           np.hstack([np.ones((n_samples, 1)),
+                                      np.zeros((n_samples, 1))]))
         _check_predict_proba(clf, X, y)
         _check_behavior_2d(clf)
 
@@ -450,7 +450,7 @@ def test_constant_strategy():
 
     clf = DummyClassifier(strategy="constant", random_state=0, constant=1)
     clf.fit(X, y)
-    assert_array_almost_equal(clf.predict(X), np.ones(len(X)))
+    assert_array_equal(clf.predict(X), np.ones(len(X)))
     _check_predict_proba(clf, X, y)
 
     X = [[0], [0], [0], [0]]  # ignored
@@ -473,9 +473,9 @@ def test_constant_strategy_multioutput():
     clf = DummyClassifier(strategy="constant", random_state=0,
                           constant=[1, 0])
     clf.fit(X, y)
-    assert_array_almost_equal(clf.predict(X),
-                              np.hstack([np.ones((n_samples, 1)),
-                                         np.zeros((n_samples, 1))]))
+    assert_array_equal(clf.predict(X),
+                       np.hstack([np.ones((n_samples, 1)),
+                                  np.zeros((n_samples, 1))]))
     _check_predict_proba(clf, X, y)
 
 
@@ -512,9 +512,8 @@ def test_constant_strategy_sparse_target():
     clf.fit(X, y)
     y_pred = clf.predict(X)
     assert_true(sp.issparse(y_pred))
-    assert_array_almost_equal(y_pred.toarray(),
-                              np.hstack([np.ones((n_samples, 1)),
-                                         np.zeros((n_samples, 1))]))
+    assert_array_equal(y_pred.toarray(), np.hstack([np.ones((n_samples, 1)),
+                                                    np.zeros((n_samples, 1))]))
 
 
 def test_uniform_strategy_sparse_target_warning():
@@ -579,7 +578,7 @@ def test_most_frequent_and_prior_strategy_sparse_target():
 
         y_pred = clf.predict(X)
         assert_true(sp.issparse(y_pred))
-        assert_array_almost_equal(y_pred.toarray(), y_expected)
+        assert_array_equal(y_pred.toarray(), y_expected)
 
 
 def test_dummy_regressor_sample_weight(n_samples=10):

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -37,9 +37,9 @@ def _check_predict_proba(clf, X, y):
     for k in range(n_outputs):
         assert_equal(proba[k].shape[0], n_samples)
         assert_equal(proba[k].shape[1], len(np.unique(y[:, k])))
-        assert_array_equal(proba[k].sum(axis=1), np.ones(len(X)))
+        assert_array_almost_equal(proba[k].sum(axis=1), np.ones(len(X)))
         # We know that we can have division by zero
-        assert_array_equal(np.log(proba[k]), log_proba[k])
+        assert_array_almost_equal(np.log(proba[k]), log_proba[k])
 
 
 def _check_behavior_2d(clf):
@@ -77,10 +77,10 @@ def _check_behavior_2d_for_constant(clf):
 
 def _check_equality_regressor(statistic, y_learn, y_pred_learn,
                               y_test, y_pred_test):
-    assert_array_equal(np.tile(statistic, (y_learn.shape[0], 1)),
-                       y_pred_learn)
-    assert_array_equal(np.tile(statistic, (y_test.shape[0], 1)),
-                       y_pred_test)
+    assert_array_almost_equal(np.tile(statistic, (y_learn.shape[0], 1)),
+                              y_pred_learn)
+    assert_array_almost_equal(np.tile(statistic, (y_test.shape[0], 1)),
+                              y_pred_test)
 
 
 def test_most_frequent_and_prior_strategy():
@@ -90,15 +90,15 @@ def test_most_frequent_and_prior_strategy():
     for strategy in ("most_frequent", "prior"):
         clf = DummyClassifier(strategy=strategy, random_state=0)
         clf.fit(X, y)
-        assert_array_equal(clf.predict(X), np.ones(len(X)))
+        assert_array_almost_equal(clf.predict(X), np.ones(len(X)))
         _check_predict_proba(clf, X, y)
 
         if strategy == "prior":
-            assert_array_equal(clf.predict_proba([X[0]]),
-                               clf.class_prior_.reshape((1, -1)))
+            assert_array_almost_equal(clf.predict_proba([X[0]]),
+                                      clf.class_prior_.reshape((1, -1)))
         else:
-            assert_array_equal(clf.predict_proba([X[0]]),
-                               clf.class_prior_.reshape((1, -1)) > 0.5)
+            assert_array_almost_equal(clf.predict_proba([X[0]]),
+                                      clf.class_prior_.reshape((1, -1)) > 0.5)
 
 
 def test_most_frequent_and_prior_strategy_multioutput():
@@ -113,9 +113,9 @@ def test_most_frequent_and_prior_strategy_multioutput():
     for strategy in ("prior", "most_frequent"):
         clf = DummyClassifier(strategy=strategy, random_state=0)
         clf.fit(X, y)
-        assert_array_equal(clf.predict(X),
-                           np.hstack([np.ones((n_samples, 1)),
-                                      np.zeros((n_samples, 1))]))
+        assert_array_almost_equal(clf.predict(X),
+                                  np.hstack([np.ones((n_samples, 1)),
+                                             np.zeros((n_samples, 1))]))
         _check_predict_proba(clf, X, y)
         _check_behavior_2d(clf)
 
@@ -450,7 +450,7 @@ def test_constant_strategy():
 
     clf = DummyClassifier(strategy="constant", random_state=0, constant=1)
     clf.fit(X, y)
-    assert_array_equal(clf.predict(X), np.ones(len(X)))
+    assert_array_almost_equal(clf.predict(X), np.ones(len(X)))
     _check_predict_proba(clf, X, y)
 
     X = [[0], [0], [0], [0]]  # ignored
@@ -473,9 +473,9 @@ def test_constant_strategy_multioutput():
     clf = DummyClassifier(strategy="constant", random_state=0,
                           constant=[1, 0])
     clf.fit(X, y)
-    assert_array_equal(clf.predict(X),
-                       np.hstack([np.ones((n_samples, 1)),
-                                  np.zeros((n_samples, 1))]))
+    assert_array_almost_equal(clf.predict(X),
+                              np.hstack([np.ones((n_samples, 1)),
+                                         np.zeros((n_samples, 1))]))
     _check_predict_proba(clf, X, y)
 
 
@@ -512,8 +512,9 @@ def test_constant_strategy_sparse_target():
     clf.fit(X, y)
     y_pred = clf.predict(X)
     assert_true(sp.issparse(y_pred))
-    assert_array_equal(y_pred.toarray(), np.hstack([np.ones((n_samples, 1)),
-                                                    np.zeros((n_samples, 1))]))
+    assert_array_almost_equal(y_pred.toarray(),
+                              np.hstack([np.ones((n_samples, 1)),
+                                         np.zeros((n_samples, 1))]))
 
 
 def test_uniform_strategy_sparse_target_warning():
@@ -578,7 +579,7 @@ def test_most_frequent_and_prior_strategy_sparse_target():
 
         y_pred = clf.predict(X)
         assert_true(sp.issparse(y_pred))
-        assert_array_equal(y_pred.toarray(), y_expected)
+        assert_array_almost_equal(y_pred.toarray(), y_expected)
 
 
 def test_dummy_regressor_sample_weight(n_samples=10):

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -218,14 +218,14 @@ def check_partial_fit(cls):
 
     clf2 = cls()
     clf2.partial_fit([[0, 1], [1, 0]], [0, 1], classes=[0, 1])
-    assert_array_almost_equal(clf1.class_count_, clf2.class_count_)
-    assert_array_almost_equal(clf1.feature_count_, clf2.feature_count_)
+    assert_array_equal(clf1.class_count_, clf2.class_count_)
+    assert_array_equal(clf1.feature_count_, clf2.feature_count_)
 
     clf3 = cls()
     clf3.partial_fit([[0, 1]], [0], classes=[0, 1])
     clf3.partial_fit([[1, 0]], [1])
-    assert_array_almost_equal(clf1.class_count_, clf3.class_count_)
-    assert_array_almost_equal(clf1.feature_count_, clf3.feature_count_)
+    assert_array_equal(clf1.class_count_, clf3.class_count_)
+    assert_array_equal(clf1.feature_count_, clf3.feature_count_)
 
 
 def test_discretenb_partial_fit():
@@ -561,11 +561,11 @@ def test_cnb():
 
     # Check that counts are correct.
     feature_count = np.array([[1, 3, 0, 1, 1, 0], [0, 1, 1, 0, 0, 1]])
-    assert_array_almost_equal(clf.feature_count_, feature_count)
+    assert_array_equal(clf.feature_count_, feature_count)
     class_count = np.array([3, 1])
-    assert_array_almost_equal(clf.class_count_, class_count)
+    assert_array_equal(clf.class_count_, class_count)
     feature_all = np.array([1, 4, 1, 1, 1, 1])
-    assert_array_almost_equal(clf.feature_all_, feature_all)
+    assert_array_equal(clf.feature_all_, feature_all)
 
     # Check that weights are correct. See steps 4-6 in Table 4 of
     # Rennie et al. (2003).
@@ -601,8 +601,8 @@ def test_naive_bayes_scale_invariance():
     X, y = iris.data, iris.target
     labels = [GaussianNB().fit(f * X, y).predict(f * X)
               for f in [1E-10, 1, 1E10]]
-    assert_array_almost_equal(labels[0], labels[1])
-    assert_array_almost_equal(labels[1], labels[2])
+    assert_array_equal(labels[0], labels[1])
+    assert_array_equal(labels[1], labels[2])
 
 
 def test_alpha():

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -111,7 +111,7 @@ def test_gnb_priors():
     assert_array_almost_equal(clf.predict_proba([[-0.1, -0.1]]),
                               np.array([[0.825303662161683,
                                          0.174696337838317]]), 8)
-    assert_array_equal(clf.class_prior_, np.array([0.3, 0.7]))
+    assert_array_almost_equal(clf.class_prior_, np.array([0.3, 0.7]))
 
 
 def test_gnb_wrong_nb_priors():
@@ -218,14 +218,14 @@ def check_partial_fit(cls):
 
     clf2 = cls()
     clf2.partial_fit([[0, 1], [1, 0]], [0, 1], classes=[0, 1])
-    assert_array_equal(clf1.class_count_, clf2.class_count_)
-    assert_array_equal(clf1.feature_count_, clf2.feature_count_)
+    assert_array_almost_equal(clf1.class_count_, clf2.class_count_)
+    assert_array_almost_equal(clf1.feature_count_, clf2.feature_count_)
 
     clf3 = cls()
     clf3.partial_fit([[0, 1]], [0], classes=[0, 1])
     clf3.partial_fit([[1, 0]], [1])
-    assert_array_equal(clf1.class_count_, clf3.class_count_)
-    assert_array_equal(clf1.feature_count_, clf3.feature_count_)
+    assert_array_almost_equal(clf1.class_count_, clf3.class_count_)
+    assert_array_almost_equal(clf1.feature_count_, clf3.feature_count_)
 
 
 def test_discretenb_partial_fit():
@@ -345,7 +345,7 @@ def test_discretenb_uniform_prior():
         clf.set_params(fit_prior=False)
         clf.fit([[0], [0], [1]], [0, 0, 1])
         prior = np.exp(clf.class_log_prior_)
-        assert_array_equal(prior, np.array([.5, .5]))
+        assert_array_almost_equal(prior, np.array([.5, .5]))
 
 
 def test_discretenb_provide_prior():
@@ -355,7 +355,7 @@ def test_discretenb_provide_prior():
         clf = cls(class_prior=[0.5, 0.5])
         clf.fit([[0], [0], [1]], [0, 0, 1])
         prior = np.exp(clf.class_log_prior_)
-        assert_array_equal(prior, np.array([.5, .5]))
+        assert_array_almost_equal(prior, np.array([.5, .5]))
 
         # Inconsistent number of classes with prior
         assert_raises(ValueError, clf.fit, [[0], [1], [2]], [0, 1, 2])
@@ -561,11 +561,11 @@ def test_cnb():
 
     # Check that counts are correct.
     feature_count = np.array([[1, 3, 0, 1, 1, 0], [0, 1, 1, 0, 0, 1]])
-    assert_array_equal(clf.feature_count_, feature_count)
+    assert_array_almost_equal(clf.feature_count_, feature_count)
     class_count = np.array([3, 1])
-    assert_array_equal(clf.class_count_, class_count)
+    assert_array_almost_equal(clf.class_count_, class_count)
     feature_all = np.array([1, 4, 1, 1, 1, 1])
-    assert_array_equal(clf.feature_all_, feature_all)
+    assert_array_almost_equal(clf.feature_all_, feature_all)
 
     # Check that weights are correct. See steps 4-6 in Table 4 of
     # Rennie et al. (2003).
@@ -592,7 +592,7 @@ def test_cnb():
         weights[i] = np.log(theta[i])
         weights[i] /= weights[i].sum()
 
-    assert_array_equal(clf.feature_log_prob_, weights)
+    assert_array_almost_equal(clf.feature_log_prob_, weights)
 
 
 def test_naive_bayes_scale_invariance():
@@ -601,8 +601,8 @@ def test_naive_bayes_scale_invariance():
     X, y = iris.data, iris.target
     labels = [GaussianNB().fit(f * X, y).predict(f * X)
               for f in [1E-10, 1, 1E10]]
-    assert_array_equal(labels[0], labels[1])
-    assert_array_equal(labels[1], labels[2])
+    assert_array_almost_equal(labels[0], labels[1])
+    assert_array_almost_equal(labels[1], labels[2])
 
 
 def test_alpha():


### PR DESCRIPTION
#### Reference Issue
Fix #4400


#### What does this implement/fix? Explain your changes.

Replaces `assert_array_equal` with `assert_array_almost_equal` in unit tests where necessary.

#### Any other comments?
