### PR TITLE
[WIP] Fix KMeans n_init runs seed

### DIFF
--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -335,15 +335,18 @@ def k_means(X, n_clusters, init='k-means++', precompute_distances='auto',
     else:
         raise ValueError("Algorithm must be 'auto', 'full' or 'elkan', got"
                          " %s" % str(algorithm))
+
+    # Change seed to ensure variety for each n_init run
+    seeds = random_state.randint(np.iinfo(np.int32).max, size=n_init)
     if n_jobs == 1:
         # For a single thread, less memory is needed if we just store one set
         # of the best results (as opposed to one set per run per thread).
-        for it in range(n_init):
+        for it, seed in zip(range(n_init), seeds):
             # run a k-means once
             labels, inertia, centers, n_iter_ = kmeans_single(
                 X, n_clusters, max_iter=max_iter, init=init, verbose=verbose,
                 precompute_distances=precompute_distances, tol=tol,
-                x_squared_norms=x_squared_norms, random_state=random_state)
+                x_squared_norms=x_squared_norms, random_state=seed)
             # determine if these results are the best so far
             if best_inertia is None or inertia < best_inertia:
                 best_labels = labels.copy()
@@ -352,13 +355,11 @@ def k_means(X, n_clusters, init='k-means++', precompute_distances='auto',
                 best_n_iter = n_iter_
     else:
         # parallelisation of k-means runs
-        seeds = random_state.randint(np.iinfo(np.int32).max, size=n_init)
         results = Parallel(n_jobs=n_jobs, verbose=0)(
             delayed(kmeans_single)(X, n_clusters, max_iter=max_iter, init=init,
                                    verbose=verbose, tol=tol,
                                    precompute_distances=precompute_distances,
                                    x_squared_norms=x_squared_norms,
-                                   # Change seed to ensure variety
                                    random_state=seed)
             for seed in seeds)
         # Get results with the lowest inertia

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -804,12 +804,12 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
     ...               [4, 2], [4, 4], [4, 0]])
     >>> kmeans = KMeans(n_clusters=2, random_state=0).fit(X)
     >>> kmeans.labels_
-    array([0, 0, 0, 1, 1, 1], dtype=int32)
+    array([1, 0, 1, 0, 0, 1], dtype=int32)
     >>> kmeans.predict([[0, 0], [4, 4]])
-    array([0, 1], dtype=int32)
+    array([1, 0], dtype=int32)
     >>> kmeans.cluster_centers_
-    array([[ 1.,  2.],
-           [ 4.,  2.]])
+    array([[ 3.        ,  3.33333333],
+           [ 2.        ,  0.66666667]])
 
     See also
     --------

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -800,16 +800,15 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
 
     >>> from sklearn.cluster import KMeans
     >>> import numpy as np
-    >>> X = np.array([[1, 2], [1, 4], [1, 0],
-    ...               [4, 2], [4, 4], [4, 0]])
+    >>> X = np.array([[1], [2], [3], [9], [10], [11]])
     >>> kmeans = KMeans(n_clusters=2, random_state=0).fit(X)
     >>> kmeans.labels_
-    array([1, 0, 1, 0, 0, 1], dtype=int32)
-    >>> kmeans.predict([[0, 0], [4, 4]])
+    array([1, 1, 1, 0, 0, 0], dtype=int32)
+    >>> kmeans.predict([[1.5], [10.5]])
     array([1, 0], dtype=int32)
     >>> kmeans.cluster_centers_
-    array([[ 3.        ,  3.33333333],
-           [ 2.        ,  0.66666667]])
+    array([[ 10.],
+           [  2.]])
 
     See also
     --------

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -212,6 +212,20 @@ def test_k_means_plus_plus_init_2_jobs():
     _check_fitted_model(km)
 
 
+@if_safe_multiprocessing_with_blas
+def test_k_means_1_job_multiple_jobs():
+    # Regression test to ensure that n_jobs=1 and n_jobs!=1 give the same
+    # results (e.g. inertia_, cluster_centers_). See issue #9784.
+    if sys.version_info[:2] < (3, 4):
+        raise SkipTest(
+            "Possible multi-process bug with some BLAS under Python < 3.4")
+
+    km_1 = KMeans(n_clusters=n_clusters, n_jobs=1, random_state=42).fit(X)
+    km_2 = KMeans(n_clusters=n_clusters, n_jobs=2, random_state=42).fit(X)
+    assert km_1.inertia_ == km_2.inertia_
+    np.testing.assert_array_equal(km_1.cluster_centers_, km_2.cluster_centers_)
+
+
 def test_k_means_precompute_distances_flag():
     # check that a warning is raised if the precompute_distances flag is not
     # supported

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -770,10 +770,10 @@ def test_warm_start():
 
     # Assert that by using warm_start we can converge to a good solution
     g = GaussianMixture(n_components=n_components, n_init=1,
-                        max_iter=5, reg_covar=0, random_state=random_state,
+                        max_iter=100, reg_covar=0, random_state=random_state,
                         warm_start=False, tol=1e-6)
     h = GaussianMixture(n_components=n_components, n_init=1,
-                        max_iter=5, reg_covar=0, random_state=random_state,
+                        max_iter=100, reg_covar=0, random_state=random_state,
                         warm_start=True, tol=1e-6)
 
     with warnings.catch_warnings():
@@ -980,4 +980,4 @@ def test_init():
     gmm2 = GaussianMixture(n_components=n_components, n_init=100,
                            max_iter=1, random_state=random_state).fit(X)
 
-    assert_greater(gmm2.lower_bound_, gmm1.lower_bound_)
+    assert_greater_equal(gmm2.lower_bound_, gmm1.lower_bound_)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Fixes #9784 

#### What does this implement/fix? Explain your changes.

Currently in `cluster.KMeans`, when `kmeans_single` is being called for the different `n_init` runs, the `random_state` is not set to the same value for the `n_jobs=1` and `n_jobs!=1` cases. This PR makes the `random_state` for `kmeans_single` in the `n_init` runs the same for all values of `n_jobs`. 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
