### PR TITLE
[MRG+1] TST Move roc_auc_score from METRIC_UNDEFINED_BINARY to METRIC_UNDEFINED_MULTICLASS

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -17,6 +17,7 @@ random sampling procedures.
 
 - :class:`decomposition.IncrementalPCA` in Python 2 (bug fix)
 - :class:`isotonic.IsotonicRegression` (bug fix)
+- :class:`metrics.roc_auc_score` (enhancement)
 
 Details are listed in the changelog below.
 
@@ -54,11 +55,14 @@ Classifiers and regressors
   :class:`sklearn.ensemble.voting_classifier` to access fitted
   estimators. :issue:`9157` by :user:`Herilalaina Rakotoarison <herilalaina>`.
 
-
 Model evaluation and meta-estimators
 
 - A scorer based on :func:`metrics.brier_score_loss` is also available.
   :issue:`9521` by :user:`Hanmin Qin <qinhanmin2014>`.
+
+- Improve the efficiency and stability of :func:`metrics.roc_auc_score`
+  through removing unnecessary sorting process.
+  :issue:`9786` by :user:`Hanmin Qin <qinhanmin2014>`.
 
 Linear, kernelized and related models
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -68,7 +68,6 @@ Model evaluation and meta-estimators
   through removing unnecessary sorting process.
   :issue:`9786` by :user:`Hanmin Qin <qinhanmin2014>`.
 
-
 Linear, kernelized and related models
 
 - Deprecate ``random_state`` parameter in :class:`svm.OneClassSVM` as the

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -107,10 +107,10 @@ Decomposition, manifold learning and clustering
 - Fixed a bug in :func:`datasets.fetch_kddcup99`, where data were not properly
   shuffled. :issue:`9731` by `Nicolas Goix`_.
 
-Model evaluation and meta-estimators
+Metrics
 
-- Fixed a bug in :func:`metrics.roc_auc_score`, where float calculations sometimes
-  introduce significant error. :issue:`9786` by :user:`Hanmin Qin <qinhanmin2014>`.
+- Fixed a bug due to floating point error in :func:`metrics.roc_auc_score` with
+  non-integer sample weights. :issue:`9786` by :user:`Hanmin Qin <qinhanmin2014>`.
 
 API changes summary
 -------------------

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -68,6 +68,7 @@ Model evaluation and meta-estimators
   through removing unnecessary sorting process.
   :issue:`9786` by :user:`Hanmin Qin <qinhanmin2014>`.
 
+
 Linear, kernelized and related models
 
 - Deprecate ``random_state`` parameter in :class:`svm.OneClassSVM` as the

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -18,6 +18,7 @@ random sampling procedures.
 - :class:`decomposition.IncrementalPCA` in Python 2 (bug fix)
 - :class:`isotonic.IsotonicRegression` (bug fix)
 - :class:`metrics.roc_auc_score` (enhancement)
+- :class:`metrics.roc_curve` (enhancement)
 
 Details are listed in the changelog below.
 
@@ -64,8 +65,8 @@ Model evaluation and meta-estimators
 - A scorer based on :func:`metrics.brier_score_loss` is also available.
   :issue:`9521` by :user:`Hanmin Qin <qinhanmin2014>`.
 
-- Improve the efficiency and stability of :func:`metrics.roc_auc_score`
-  through removing unnecessary sorting process.
+- Improve the stability of :func:`metrics.roc_auc_score`
+  and :func:`metrics.roc_curve` in float calculations.
   :issue:`9786` by :user:`Hanmin Qin <qinhanmin2014>`.
 
 Linear, kernelized and related models

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -17,8 +17,7 @@ random sampling procedures.
 
 - :class:`decomposition.IncrementalPCA` in Python 2 (bug fix)
 - :class:`isotonic.IsotonicRegression` (bug fix)
-- :class:`metrics.roc_auc_score` (enhancement)
-- :class:`metrics.roc_curve` (enhancement)
+- :class:`metrics.roc_auc_score` (bug fix)
 
 Details are listed in the changelog below.
 
@@ -65,10 +64,6 @@ Model evaluation and meta-estimators
 - A scorer based on :func:`metrics.brier_score_loss` is also available.
   :issue:`9521` by :user:`Hanmin Qin <qinhanmin2014>`.
 
-- Improve the stability of :func:`metrics.roc_auc_score`
-  and :func:`metrics.roc_curve` in float calculations.
-  :issue:`9786` by :user:`Hanmin Qin <qinhanmin2014>`.
-
 Linear, kernelized and related models
 
 - Deprecate ``random_state`` parameter in :class:`svm.OneClassSVM` as the
@@ -111,6 +106,11 @@ Decomposition, manifold learning and clustering
 
 - Fixed a bug in :func:`datasets.fetch_kddcup99`, where data were not properly
   shuffled. :issue:`9731` by `Nicolas Goix`_.
+
+Model evaluation and meta-estimators
+
+- Fixed a bug in :func:`metrics.roc_auc_score`, where float calculations sometimes
+  introduce significant error. :issue:`9786` by :user:`Hanmin Qin <qinhanmin2014>`.
 
 API changes summary
 -------------------

--- a/sklearn/metrics/base.py
+++ b/sklearn/metrics/base.py
@@ -67,6 +67,8 @@ def _average_binary_score(binary_metric, y_true, y_score, average,
         raise ValueError('average has to be one of {0}'
                          ''.format(average_options))
 
+    check_consistent_length(y_true, y_score, sample_weight)
+
     y_type = type_of_target(y_true)
     if y_type not in ("binary", "multilabel-indicator"):
         raise ValueError("{0} format is not supported".format(y_type))
@@ -74,7 +76,6 @@ def _average_binary_score(binary_metric, y_true, y_score, average,
     if y_type == "binary":
         return binary_metric(y_true, y_score, sample_weight=sample_weight)
 
-    check_consistent_length(y_true, y_score, sample_weight)
     y_true = check_array(y_true)
     y_score = check_array(y_score)
 

--- a/sklearn/metrics/base.py
+++ b/sklearn/metrics/base.py
@@ -71,11 +71,10 @@ def _average_binary_score(binary_metric, y_true, y_score, average,
     if y_type not in ("binary", "multilabel-indicator"):
         raise ValueError("{0} format is not supported".format(y_type))
 
-    check_consistent_length(y_true, y_score, sample_weight)
-
     if y_type == "binary":
         return binary_metric(y_true, y_score, sample_weight=sample_weight)
 
+    check_consistent_length(y_true, y_score, sample_weight)
     y_true = check_array(y_true)
     y_score = check_array(y_score)
 

--- a/sklearn/metrics/base.py
+++ b/sklearn/metrics/base.py
@@ -67,11 +67,11 @@ def _average_binary_score(binary_metric, y_true, y_score, average,
         raise ValueError('average has to be one of {0}'
                          ''.format(average_options))
 
-    check_consistent_length(y_true, y_score, sample_weight)
-
     y_type = type_of_target(y_true)
     if y_type not in ("binary", "multilabel-indicator"):
         raise ValueError("{0} format is not supported".format(y_type))
+
+    check_consistent_length(y_true, y_score, sample_weight)
 
     if y_type == "binary":
         return binary_metric(y_true, y_score, sample_weight=sample_weight)

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -88,8 +88,8 @@ def auc(x, y, reorder=False):
         x, y = x[order], y[order]
     else:
         dx = np.diff(x)
-        if np.any(dx < 0):
-            if np.all(dx <= 0):
+        if np.any(dx < -1e-10):
+            if np.all(dx <= 1e-10):
                 direction = -1
             else:
                 raise ValueError("Reordering is not turned on, and "
@@ -258,7 +258,7 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
 
         fpr, tpr, tresholds = roc_curve(y_true, y_score,
                                         sample_weight=sample_weight)
-        return auc(fpr, tpr, reorder=True)
+        return auc(fpr, tpr, reorder=False)
 
     return _average_binary_score(
         _binary_roc_auc_score, y_true, y_score, average,

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -258,7 +258,7 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
 
         fpr, tpr, tresholds = roc_curve(y_true, y_score,
                                         sample_weight=sample_weight)
-        return np.trapz(tpr, fpr)
+        return auc(fpr, tpr, reorder=False)
 
     return _average_binary_score(
         _binary_roc_auc_score, y_true, y_score, average,

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -258,6 +258,7 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
 
         fpr, tpr, tresholds = roc_curve(y_true, y_score,
                                         sample_weight=sample_weight)
+
         return np.trapz(tpr, fpr)
 
     return _average_binary_score(

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -258,7 +258,7 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
 
         fpr, tpr, tresholds = roc_curve(y_true, y_score,
                                         sample_weight=sample_weight)
-        return auc(fpr, tpr, reorder=False)
+        return auc(fpr, tpr)
 
     return _average_binary_score(
         _binary_roc_auc_score, y_true, y_score, average,
@@ -341,6 +341,8 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     # accumulate the true positives with decreasing threshold
     tps = stable_cumsum(y_true * weight)[threshold_idxs]
     if sample_weight is not None:
+        # express fps as a cumsum to ensure fps is increasing even in
+        # the presense of floating point errors
         fps = stable_cumsum((1 - y_true) * weight)[threshold_idxs]
     else:
         fps = 1 + threshold_idxs - tps

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -299,7 +299,7 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     thresholds : array, shape = [n_thresholds]
         Decreasing score values.
     """
-    check_consistent_length(y_true, y_score)
+    check_consistent_length(y_true, y_score, sample_weight)
     y_true = column_or_1d(y_true)
     y_score = column_or_1d(y_score)
     assert_all_finite(y_true)

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -88,8 +88,8 @@ def auc(x, y, reorder=False):
         x, y = x[order], y[order]
     else:
         dx = np.diff(x)
-        if np.any(dx < -1e-10):
-            if np.all(dx <= 1e-10):
+        if np.any(dx < 0):
+            if np.all(dx <= 0):
                 direction = -1
             else:
                 raise ValueError("Reordering is not turned on, and "
@@ -258,7 +258,7 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
 
         fpr, tpr, tresholds = roc_curve(y_true, y_score,
                                         sample_weight=sample_weight)
-        return auc(fpr, tpr, reorder=False)
+        return np.trapz(tpr, fpr)
 
     return _average_binary_score(
         _binary_roc_auc_score, y_true, y_score, average,

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -258,7 +258,6 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
 
         fpr, tpr, tresholds = roc_curve(y_true, y_score,
                                         sample_weight=sample_weight)
-
         return np.trapz(tpr, fpr)
 
     return _average_binary_score(

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -341,7 +341,7 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     # accumulate the true positives with decreasing threshold
     tps = stable_cumsum(y_true * weight)[threshold_idxs]
     if sample_weight is not None:
-        fps = stable_cumsum(weight)[threshold_idxs] - tps
+        fps = stable_cumsum((1 - y_true) * weight)[threshold_idxs]
     else:
         fps = 1 + threshold_idxs - tps
     return fps, tps, y_score[threshold_idxs]

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -996,7 +996,7 @@ def check_sample_weight_invariance(name, metric, y1, y2):
                  (weighted_score_zeroed, weighted_score_subset, name)))
 
     if not name.startswith('unnormalized'):
-        # Check that the score is invariant under scaling of the weights by a
+        # check that the score is invariant under scaling of the weights by a
         # common factor
         for scaling in [2, 0.3]:
             assert_almost_equal(

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -999,10 +999,10 @@ def check_sample_weight_invariance(name, metric, y1, y2):
         # check that the score is invariant under scaling of the weights by a
         # common factor
         for scaling in [2, 0.3]:
-            assert_almost_equal(
+            np.testing.assert_allclose(
                 weighted_score,
                 metric(y1, y2, sample_weight=sample_weight * scaling),
-                decimal=1,
+                atol=1e-2,
                 err_msg="%s sample_weight is not invariant "
                         "under scaling" % name)
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -998,12 +998,6 @@ def check_sample_weight_invariance(name, metric, y1, y2):
     if not name.startswith('unnormalized'):
         # check that the score is invariant under scaling of the weights by a
         # common factor
-
-        # FIXME: roc_auc scores are more unstable than other scores
-        if 'roc_auc' in name:
-            y2 = np.round(y2, 1)
-            weighted_score = metric(y1, y2, sample_weight=sample_weight)
-
         for scaling in [2, 0.3]:
             assert_almost_equal(
                 weighted_score,
@@ -1032,7 +1026,7 @@ def test_sample_weight_invariance(n_samples=50):
             metric, y_true, y_pred
 
     # binary
-    random_state = check_random_state(10)
+    random_state = check_random_state(0)
     y_true = random_state.randint(0, 2, size=(n_samples, ))
     y_pred = random_state.randint(0, 2, size=(n_samples, ))
     y_score = random_state.random_sample(size=(n_samples,))

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -943,7 +943,7 @@ def test_averaging_multilabel_all_ones():
 
 @ignore_warnings
 def check_sample_weight_invariance(name, metric, y1, y2):
-    rng = np.random.RandomState(10)
+    rng = np.random.RandomState(0)
     sample_weight = rng.randint(1, 10, size=len(y1))
 
     # check that unit weights gives the same score as no weight
@@ -999,9 +999,10 @@ def check_sample_weight_invariance(name, metric, y1, y2):
         # check that the score is invariant under scaling of the weights by a
         # common factor
         for scaling in [2, 0.3]:
-            assert_almost_equal(
+            np.testing.assert_allclose(
                 weighted_score,
                 metric(y1, y2, sample_weight=sample_weight * scaling),
+                atol=1e-2,
                 err_msg="%s sample_weight is not invariant "
                         "under scaling" % name)
 
@@ -1026,7 +1027,7 @@ def test_sample_weight_invariance(n_samples=50):
             metric, y_true, y_pred
 
     # binary
-    random_state = check_random_state(10)
+    random_state = check_random_state(0)
     y_true = random_state.randint(0, 2, size=(n_samples, ))
     y_pred = random_state.randint(0, 2, size=(n_samples, ))
     y_score = random_state.random_sample(size=(n_samples,))

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1000,15 +1000,16 @@ def check_sample_weight_invariance(name, metric, y1, y2):
         # common factor
 
         # FIXME: roc_auc scores are more unstable than other scores
-        kwargs = {'atol': 1e-2} if 'roc_auc' in name else {}
+        if 'roc_auc' in name:
+            y2 = np.round(y2, 1)
+            weighted_score = metric(y1, y2, sample_weight=sample_weight)
 
         for scaling in [2, 0.3]:
-            np.testing.assert_allclose(
+            assert_almost_equal(
                 weighted_score,
                 metric(y1, y2, sample_weight=sample_weight * scaling),
                 err_msg="%s sample_weight is not invariant "
-                        "under scaling" % name,
-                **kwargs)
+                        "under scaling" % name)
 
     # Check that if sample_weight.shape[0] != y_true.shape[0], it raised an
     # error
@@ -1031,7 +1032,7 @@ def test_sample_weight_invariance(n_samples=50):
             metric, y_true, y_pred
 
     # binary
-    random_state = check_random_state(0)
+    random_state = check_random_state(10)
     y_true = random_state.randint(0, 2, size=(n_samples, ))
     y_pred = random_state.randint(0, 2, size=(n_samples, ))
     y_score = random_state.random_sample(size=(n_samples,))

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -997,12 +997,12 @@ def check_sample_weight_invariance(name, metric, y1, y2):
 
     if not name.startswith('unnormalized'):
         # Check that the score is invariant under scaling of the weights by a
-        # common factor. The scaling value is carefully chosen to reduce minor
-        # errors introduced by python when doing floating operations.
-        for scaling in [5, 0.5]:
+        # common factor
+        for scaling in [2, 0.3]:
             assert_almost_equal(
                 weighted_score,
                 metric(y1, y2, sample_weight=sample_weight * scaling),
+                decimal=2,
                 err_msg="%s sample_weight is not invariant "
                         "under scaling" % name)
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -198,12 +198,6 @@ METRIC_UNDEFINED_BINARY = [
     "samples_recall_score",
     "coverage_error",
 
-    "roc_auc_score",
-    "micro_roc_auc",
-    "weighted_roc_auc",
-    "macro_roc_auc",
-    "samples_roc_auc",
-
     "average_precision_score",
     "weighted_average_precision_score",
     "micro_average_precision_score",
@@ -218,6 +212,11 @@ METRIC_UNDEFINED_BINARY = [
 METRIC_UNDEFINED_MULTICLASS = [
     "brier_score_loss",
 
+    "roc_auc_score",
+    "micro_roc_auc",
+    "weighted_roc_auc",
+    "macro_roc_auc",
+    "samples_roc_auc",
     # with default average='binary', multiclass is prohibited
     "precision_score",
     "recall_score",
@@ -996,9 +995,10 @@ def check_sample_weight_invariance(name, metric, y1, y2):
                  (weighted_score_zeroed, weighted_score_subset, name)))
 
     if not name.startswith('unnormalized'):
-        # check that the score is invariant under scaling of the weights by a
-        # common factor
-        for scaling in [2, 0.3]:
+        # Check that the score is invariant under scaling of the weights by a
+        # common factor. The scaling value is carefully chosen to reduce minor
+        # errors introduced by python when doing floating operations.
+        for scaling in [5, 0.5]:
             assert_almost_equal(
                 weighted_score,
                 metric(y1, y2, sample_weight=sample_weight * scaling),

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -943,7 +943,7 @@ def test_averaging_multilabel_all_ones():
 
 @ignore_warnings
 def check_sample_weight_invariance(name, metric, y1, y2):
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(10)
     sample_weight = rng.randint(1, 10, size=len(y1))
 
     # check that unit weights gives the same score as no weight
@@ -999,10 +999,9 @@ def check_sample_weight_invariance(name, metric, y1, y2):
         # check that the score is invariant under scaling of the weights by a
         # common factor
         for scaling in [2, 0.3]:
-            np.testing.assert_allclose(
+            assert_almost_equal(
                 weighted_score,
                 metric(y1, y2, sample_weight=sample_weight * scaling),
-                atol=1e-2,
                 err_msg="%s sample_weight is not invariant "
                         "under scaling" % name)
 
@@ -1027,7 +1026,7 @@ def test_sample_weight_invariance(n_samples=50):
             metric, y_true, y_pred
 
     # binary
-    random_state = check_random_state(0)
+    random_state = check_random_state(10)
     y_true = random_state.randint(0, 2, size=(n_samples, ))
     y_pred = random_state.randint(0, 2, size=(n_samples, ))
     y_score = random_state.random_sample(size=(n_samples,))

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1002,7 +1002,7 @@ def check_sample_weight_invariance(name, metric, y1, y2):
             assert_almost_equal(
                 weighted_score,
                 metric(y1, y2, sample_weight=sample_weight * scaling),
-                decimal=2,
+                decimal=1,
                 err_msg="%s sample_weight is not invariant "
                         "under scaling" % name)
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -217,6 +217,7 @@ METRIC_UNDEFINED_MULTICLASS = [
     "weighted_roc_auc",
     "macro_roc_auc",
     "samples_roc_auc",
+
     # with default average='binary', multiclass is prohibited
     "precision_score",
     "recall_score",

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -998,13 +998,17 @@ def check_sample_weight_invariance(name, metric, y1, y2):
     if not name.startswith('unnormalized'):
         # check that the score is invariant under scaling of the weights by a
         # common factor
+
+        # FIXME: roc_auc scores are more unstable than other scores
+        kwargs = {'atol': 1e-2} if 'roc_auc' in name else {}
+
         for scaling in [2, 0.3]:
             np.testing.assert_allclose(
                 weighted_score,
                 metric(y1, y2, sample_weight=sample_weight * scaling),
-                atol=1e-2,
                 err_msg="%s sample_weight is not invariant "
-                        "under scaling" % name)
+                        "under scaling" % name,
+                **kwargs)
 
     # Check that if sample_weight.shape[0] != y_true.shape[0], it raised an
     # error

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -372,16 +372,13 @@ def test_roc_curve_drop_intermediate():
 
 
 def test_roc_curve_fpr_tpr_increasing():
-    # Ensure that fpr and tpr returned by roc_curve are increasing
-    n_samples = 50
-    rng = np.random.RandomState(0)
-    y_true = rng.randint(0, 2, size=(n_samples, ))
-    y_score = rng.random_sample(size=(n_samples,))
-    sample_weight = rng.randint(1, 10, size=(n_samples, ))
+    # Ensure that fpr and tpr returned by roc_curve are increasing.
     # Construct an edge case with float y_score and sample_weight
-    # when some adjacent values of fpr and tpr are actually the same.
-    fpr, tpr, _ = roc_curve(y_true, y_score,
-                            sample_weight=sample_weight * 0.2)
+    # when some adjacent values of fpr and tpr are the same.
+    y_true = [0, 0, 1, 1, 1]
+    y_score = [0.1, 0.7, 0.3, 0.4, 0.5]
+    sample_weight = np.repeat(0.2, 5)
+    fpr, tpr, _ = roc_curve(y_true, y_score, sample_weight=sample_weight)
     assert_equal((np.diff(fpr) < 0).sum(), 0)
     assert_equal((np.diff(tpr) < 0).sum(), 0)
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -373,12 +373,13 @@ def test_roc_curve_drop_intermediate():
 
 def test_roc_curve_fpr_tpr_increasing():
     # Ensure that fpr and tpr returned by roc_curve are increasing
-    # Regression test for issue #9786
     n_samples = 50
     rng = np.random.RandomState(0)
     y_true = rng.randint(0, 2, size=(n_samples, ))
     y_score = rng.random_sample(size=(n_samples,))
     sample_weight = rng.randint(1, 10, size=(n_samples, ))
+    # Construct an edge case with float y_score and sample_weight
+    # when some adjacent values of fpr and tpr are the same.
     fpr, tpr, _ = roc_curve(y_true, y_score,
                             sample_weight=sample_weight * 0.2)
     assert_equal((np.diff(fpr) < 0).sum(), 0)

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -379,7 +379,7 @@ def test_roc_curve_fpr_tpr_increasing():
     y_score = rng.random_sample(size=(n_samples,))
     sample_weight = rng.randint(1, 10, size=(n_samples, ))
     # Construct an edge case with float y_score and sample_weight
-    # when some adjacent values of fpr and tpr are the same.
+    # when some adjacent values of fpr and tpr are actually the same.
     fpr, tpr, _ = roc_curve(y_true, y_score,
                             sample_weight=sample_weight * 0.2)
     assert_equal((np.diff(fpr) < 0).sum(), 0)

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -374,7 +374,7 @@ def test_roc_curve_drop_intermediate():
 def test_roc_curve_fpr_tpr_increasing():
     # Ensure that fpr and tpr returned by roc_curve are increasing.
     # Construct an edge case with float y_score and sample_weight
-    # when some adjacent values of fpr and tpr are the same.
+    # when some adjacent values of fpr and tpr are actually the same.
     y_true = [0, 0, 1, 1, 1]
     y_score = [0.1, 0.7, 0.3, 0.4, 0.5]
     sample_weight = np.repeat(0.2, 5)

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -371,6 +371,20 @@ def test_roc_curve_drop_intermediate():
                               [1.0, 0.9, 0.7, 0.6, 0.])
 
 
+def test_roc_curve_fpr_tpr_increasing():
+    # Ensure that fpr and tpr returned by roc_curve are increasing
+    # Regression test for issue #9786
+    n_samples = 50
+    rng = np.random.RandomState(0)
+    y_true = rng.randint(0, 2, size=(n_samples, ))
+    y_score = rng.random_sample(size=(n_samples,))
+    sample_weight = rng.randint(1, 10, size=(n_samples, ))
+    fpr, tpr, _ = roc_curve(y_true, y_score,
+                            sample_weight=sample_weight * 0.2)
+    assert_equal((np.diff(fpr) < 0).sum(), 0)
+    assert_equal((np.diff(tpr) < 0).sum(), 0)
+
+
 def test_auc():
     # Test Area Under Curve (AUC) computation
     x = [0, 1]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Proposed in #9567 by @jnothman 

#### What does this implement/fix? Explain your changes.
METRIC_UNDEFINED_BINARY are metrics don't support binary inputs, METRIC_UNDEFINED_MULTICLASS are metrics don't support multiclass inputs, so seems that roc_auc_score belongs to METRIC_UNDEFINED_MULTICLASS .
In order to pass the tests in test_common.py, I have to:
(1)add the check to ensure that the shape of sample_weight is [n_samples] (regression test already in test_common.py)
(2)Carefully choose the scaling value in the test to reduce minor errors introduced by python when doing floating operations(e.g., `4.2 + 2.1 == 6.3` is False).

#### Any other comments?
cc @jnothman 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
