### PR TITLE
[MRG+1] Fix LOF and Isolation benchmarks

### DIFF
--- a/benchmarks/bench_isolation_forest.py
+++ b/benchmarks/bench_isolation_forest.py
@@ -3,6 +3,17 @@
 IsolationForest benchmark
 ==========================================
 A test of IsolationForest on classical anomaly detection datasets.
+
+The benchmark is run as follows:
+1. The dataset is randomly split into a training set and a test set, both
+assumed to contain outliers.
+2. Isolation Forest is trained on the training set.
+3. The ROC curve is computed on the test set using the knowledge of the labels.
+
+Note that the smtp dataset contains a very small proportion of outliers.
+Therefore, depending on the seed of the random number generator, randomly
+splitting the data set might lead to a test set containing no outliers. In this
+case a warning is raised when computing the ROC curve.
 """
 
 from time import time
@@ -30,14 +41,13 @@ def print_outlier_ratio(y):
     print("----- Outlier ratio: %.5f" % (np.min(cnt) / len(y)))
 
 
-np.random.seed(1)
+SEED = 1
 fig_roc, ax_roc = plt.subplots(1, 1, figsize=(8, 5))
 
 # Set this to true for plotting score histograms for each dataset:
 with_decision_function_histograms = False
 
-# Removed the shuttle dataset because as of 2017-03-23 mldata.org is down:
-# datasets = ['http', 'smtp', 'SA', 'SF', 'shuttle', 'forestcover']
+# datasets available = ['http', 'smtp', 'SA', 'SF', 'shuttle', 'forestcover']
 datasets = ['http', 'smtp', 'SA', 'SF', 'shuttle', 'forestcover']
 
 # Loop over all datasets for fitting and scoring the estimator:
@@ -47,7 +57,8 @@ for dat in datasets:
     print('====== %s ======' % dat)
     print('--- Fetching data...')
     if dat in ['http', 'smtp', 'SF', 'SA']:
-        dataset = fetch_kddcup99(subset=dat, shuffle=True, percent10=True)
+        dataset = fetch_kddcup99(subset=dat, shuffle=True,
+                                 percent10=True, random_state=SEED)
         X = dataset.data
         y = dataset.target
 
@@ -55,7 +66,7 @@ for dat in datasets:
         dataset = fetch_mldata('shuttle')
         X = dataset.data
         y = dataset.target
-        X, y = sh(X, y)
+        X, y = sh(X, y, random_state=SEED)
         # we remove data with label 4
         # normal data are then those of class 1
         s = (y != 4)
@@ -65,7 +76,7 @@ for dat in datasets:
         print('----- ')
 
     if dat == 'forestcover':
-        dataset = fetch_covtype(shuffle=True)
+        dataset = fetch_covtype(shuffle=True, random_state=SEED)
         X = dataset.data
         y = dataset.target
         # normal data are those with attribute 2
@@ -108,7 +119,7 @@ for dat in datasets:
     y_test = y[n_samples_train:]
 
     print('--- Fitting the IsolationForest estimator...')
-    model = IsolationForest(n_jobs=-1)
+    model = IsolationForest(n_jobs=-1, random_state=SEED)
     tstart = time()
     model.fit(X_train)
     fit_time = time() - tstart

--- a/benchmarks/bench_isolation_forest.py
+++ b/benchmarks/bench_isolation_forest.py
@@ -41,7 +41,7 @@ def print_outlier_ratio(y):
     print("----- Outlier ratio: %.5f" % (np.min(cnt) / len(y)))
 
 
-SEED = 1
+random_state = 1
 fig_roc, ax_roc = plt.subplots(1, 1, figsize=(8, 5))
 
 # Set this to true for plotting score histograms for each dataset:
@@ -58,7 +58,7 @@ for dat in datasets:
     print('--- Fetching data...')
     if dat in ['http', 'smtp', 'SF', 'SA']:
         dataset = fetch_kddcup99(subset=dat, shuffle=True,
-                                 percent10=True, random_state=SEED)
+                                 percent10=True, random_state=random_state)
         X = dataset.data
         y = dataset.target
 
@@ -66,7 +66,7 @@ for dat in datasets:
         dataset = fetch_mldata('shuttle')
         X = dataset.data
         y = dataset.target
-        X, y = sh(X, y, random_state=SEED)
+        X, y = sh(X, y, random_state=random_state)
         # we remove data with label 4
         # normal data are then those of class 1
         s = (y != 4)
@@ -76,7 +76,7 @@ for dat in datasets:
         print('----- ')
 
     if dat == 'forestcover':
-        dataset = fetch_covtype(shuffle=True, random_state=SEED)
+        dataset = fetch_covtype(shuffle=True, random_state=random_state)
         X = dataset.data
         y = dataset.target
         # normal data are those with attribute 2
@@ -119,7 +119,7 @@ for dat in datasets:
     y_test = y[n_samples_train:]
 
     print('--- Fitting the IsolationForest estimator...')
-    model = IsolationForest(n_jobs=-1, random_state=SEED)
+    model = IsolationForest(n_jobs=-1, random_state=random_state)
     tstart = time()
     model.fit(X_train)
     fit_time = time() - tstart

--- a/benchmarks/bench_isolation_forest.py
+++ b/benchmarks/bench_isolation_forest.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 from sklearn.ensemble import IsolationForest
 from sklearn.metrics import roc_curve, auc
 from sklearn.datasets import fetch_kddcup99, fetch_covtype, fetch_mldata
-from sklearn.preprocessing import MultiLabelBinarizer
+from sklearn.preprocessing import LabelBinarizer
 from sklearn.utils import shuffle as sh
 
 print(__doc__)
@@ -38,7 +38,7 @@ with_decision_function_histograms = False
 
 # Removed the shuttle dataset because as of 2017-03-23 mldata.org is down:
 # datasets = ['http', 'smtp', 'SA', 'SF', 'shuttle', 'forestcover']
-datasets = ['http', 'smtp', 'SA', 'SF', 'forestcover']
+datasets = ['http', 'smtp', 'SA', 'SF', 'shuttle', 'forestcover']
 
 # Loop over all datasets for fitting and scoring the estimator:
 for dat in datasets:
@@ -79,17 +79,17 @@ for dat in datasets:
     print('--- Vectorizing data...')
 
     if dat == 'SF':
-        lb = MultiLabelBinarizer()
-        x1 = lb.fit_transform(X[:, 1])
+        lb = LabelBinarizer()
+        x1 = lb.fit_transform(X[:, 1].astype(str))
         X = np.c_[X[:, :1], x1, X[:, 2:]]
         y = (y != b'normal.').astype(int)
         print_outlier_ratio(y)
 
     if dat == 'SA':
-        lb = MultiLabelBinarizer()
-        x1 = lb.fit_transform(X[:, 1])
-        x2 = lb.fit_transform(X[:, 2])
-        x3 = lb.fit_transform(X[:, 3])
+        lb = LabelBinarizer()
+        x1 = lb.fit_transform(X[:, 1].astype(str))
+        x2 = lb.fit_transform(X[:, 2].astype(str))
+        x3 = lb.fit_transform(X[:, 3].astype(str))
         X = np.c_[X[:, :1], x1, x2, x3, X[:, 4:]]
         y = (y != b'normal.').astype(int)
         print_outlier_ratio(y)

--- a/benchmarks/bench_lof.py
+++ b/benchmarks/bench_lof.py
@@ -7,9 +7,13 @@ A test of LocalOutlierFactor on classical anomaly detection datasets.
 
 Note that LocalOutlierFactor is not meant to predict on a test set and its
 performance is assessed in an outlier detection context:
-1. The model is trained on a dataset containing outliers.
-2. The ROC curve is computed on the whole dataset using the knowledge of the
+1. The model is trained on the whole dataset which is assumed to contain
+outliers.
+2. The ROC curve is computed on the same dataset using the knowledge of the
 labels.
+In this context there is no need to shuffle the dataset because the model
+is trained and tested on the whole dataset. The randomness of this benchmark
+is only caused by the random selection of anomalies in the SA dataset.
 
 """
 
@@ -20,21 +24,21 @@ from sklearn.neighbors import LocalOutlierFactor
 from sklearn.metrics import roc_curve, auc
 from sklearn.datasets import fetch_kddcup99, fetch_covtype, fetch_mldata
 from sklearn.preprocessing import LabelBinarizer
-from sklearn.utils import shuffle as sh
 
 print(__doc__)
 
-np.random.seed(2)
+SEED = 2  # to control the random selection of anomalies in the SA dataset
 
 # datasets available: ['http', 'smtp', 'SA', 'SF', 'shuttle', 'forestcover']
 datasets = ['http', 'smtp', 'SA', 'SF', 'shuttle', 'forestcover']
 
+plt.figure()
 for dataset_name in datasets:
     # loading and vectorization
     print('loading data')
     if dataset_name in ['http', 'smtp', 'SA', 'SF']:
-        dataset = fetch_kddcup99(subset=dataset_name, shuffle=True,
-                                 percent10=False)
+        dataset = fetch_kddcup99(subset=dataset_name, percent10=True,
+                                 random_state=SEED)
         X = dataset.data
         y = dataset.target
 
@@ -42,7 +46,6 @@ for dataset_name in datasets:
         dataset = fetch_mldata('shuttle')
         X = dataset.data
         y = dataset.target
-        X, y = sh(X, y)
         # we remove data with label 4
         # normal data are then those of class 1
         s = (y != 4)
@@ -51,7 +54,7 @@ for dataset_name in datasets:
         y = (y != 1).astype(int)
 
     if dataset_name == 'forestcover':
-        dataset = fetch_covtype(shuffle=True)
+        dataset = fetch_covtype()
         X = dataset.data
         y = dataset.target
         # normal data are those with attribute 2

--- a/benchmarks/bench_lof.py
+++ b/benchmarks/bench_lof.py
@@ -21,7 +21,7 @@ print(__doc__)
 np.random.seed(2)
 
 # datasets available: ['http', 'smtp', 'SA', 'SF', 'shuttle', 'forestcover']
-datasets = ['shuttle']
+datasets = ['SA', 'SF', 'shuttle']
 
 novelty_detection = True  # if False, training set polluted by outliers
 
@@ -61,24 +61,20 @@ for dataset_name in datasets:
 
     if dataset_name == 'SF':
         lb = LabelBinarizer()
-        lb.fit(X[:, 1])
-        x1 = lb.transform(X[:, 1])
+        x1 = lb.fit_transform(X[:, 1].astype(str))
         X = np.c_[X[:, :1], x1, X[:, 2:]]
-        y = (y != 'normal.').astype(int)
+        y = (y != b'normal.').astype(int)
 
     if dataset_name == 'SA':
         lb = LabelBinarizer()
-        lb.fit(X[:, 1])
-        x1 = lb.transform(X[:, 1])
-        lb.fit(X[:, 2])
-        x2 = lb.transform(X[:, 2])
-        lb.fit(X[:, 3])
-        x3 = lb.transform(X[:, 3])
+        x1 = lb.fit_transform(X[:, 1].astype(str))
+        x2 = lb.fit_transform(X[:, 2].astype(str))
+        x3 = lb.fit_transform(X[:, 3].astype(str))
         X = np.c_[X[:, :1], x1, x2, x3, X[:, 4:]]
-        y = (y != 'normal.').astype(int)
+        y = (y != b'normal.').astype(int)
 
     if dataset_name == 'http' or dataset_name == 'smtp':
-        y = (y != 'normal.').astype(int)
+        y = (y != b'normal.').astype(int)
 
     n_samples, n_features = np.shape(X)
     n_samples_train = n_samples // 2
@@ -101,7 +97,7 @@ for dataset_name in datasets:
     fit_time = time() - tstart
     tstart = time()
 
-    scoring = -model.decision_function(X_test)  # the lower, the more normal
+    scoring = -model._decision_function(X_test)  # the lower, the more normal
     predict_time = time() - tstart
     fpr, tpr, thresholds = roc_curve(y_test, scoring)
     AUC = auc(fpr, tpr)

--- a/benchmarks/bench_lof.py
+++ b/benchmarks/bench_lof.py
@@ -27,7 +27,7 @@ from sklearn.preprocessing import LabelBinarizer
 
 print(__doc__)
 
-SEED = 2  # to control the random selection of anomalies in the SA dataset
+random_state = 2  # to control the random selection of anomalies in SA
 
 # datasets available: ['http', 'smtp', 'SA', 'SF', 'shuttle', 'forestcover']
 datasets = ['http', 'smtp', 'SA', 'SF', 'shuttle', 'forestcover']
@@ -38,7 +38,7 @@ for dataset_name in datasets:
     print('loading data')
     if dataset_name in ['http', 'smtp', 'SA', 'SF']:
         dataset = fetch_kddcup99(subset=dataset_name, percent10=True,
-                                 random_state=SEED)
+                                 random_state=random_state)
         X = dataset.data
         y = dataset.target
 

--- a/benchmarks/bench_lof.py
+++ b/benchmarks/bench_lof.py
@@ -80,6 +80,8 @@ for dataset_name in datasets:
     if dataset_name == 'http' or dataset_name == 'smtp':
         y = (y != b'normal.').astype(int)
 
+    X = X.astype(float)
+
     print('LocalOutlierFactor processing...')
     model = LocalOutlierFactor(n_neighbors=20)
     tstart = time()

--- a/benchmarks/bench_lof.py
+++ b/benchmarks/bench_lof.py
@@ -85,16 +85,12 @@ for dataset_name in datasets:
     tstart = time()
     model.fit(X)
     fit_time = time() - tstart
-    tstart = time()
-
     scoring = -model.negative_outlier_factor_  # the lower, the more normal
-    predict_time = time() - tstart
     fpr, tpr, thresholds = roc_curve(y, scoring)
     AUC = auc(fpr, tpr)
     plt.plot(fpr, tpr, lw=1,
-             label=('ROC for %s (area = %0.3f, train-time: %0.2fs,'
-                    'test-time: %0.2fs)' % (dataset_name, AUC, fit_time,
-                                            predict_time)))
+             label=('ROC for %s (area = %0.3f, train-time: %0.2fs)'
+                    % (dataset_name, AUC, fit_time)))
 
 plt.xlim([-0.05, 1.05])
 plt.ylim([-0.05, 1.05])


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The fix for the benchmark of IsolationForest merged in #8638 leads to the following

````python
import numpy as np
from sklearn.preprocessing import MultiLabelBinarizer
from sklearn.datasets import fetch_kddcup99
dataset = fetch_kddcup99(subset='SA', shuffle=True, percent10=True)
X = dataset.data
y = dataset.target
print(X.dtype)  # object

lb = MultiLabelBinarizer()
x1 = lb.fit_transform(X[:, 1])

print(np.unique(X[:,1]))  # [b'icmp' b'tcp' b'udp']
print(x1.shape)  # (100655, 7)
````
which does not correspond to what LabelBinarizer was doing because strings are viewed as iterables (and we obtain an array with 7 features instead of 3). This fix suggests to apply LabelBinarizer as follows:

````python
from sklearn.preprocessing import LabelBinarizer
lb = LabelBinarizer()
x1 = lb.fit_transform(X[:, 1].astype(str))
print(x1.shape)  # (100655, 3)
````

#### Any other comments?
This also fixes the benchmark of LocalOutlierFactor.

**EDIT**: The benchmark of LocalOutlierFactor was predicting on a test set whereas LocalOutlierFactor is not meant to predict on a test set. This is fixed by doing the benchmark in an outlier detection context only.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
