### PR TITLE
[MRG] DOC Fix error in documentation of trustworthiness

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -387,10 +387,11 @@ def trustworthiness(X, X_embedded, n_neighbors=5, precomputed=False):
         T(k) = 1 - \frac{2}{nk (2n - 3k - 1)} \sum^n_{i=1}
             \sum_{j \in U^{(k)}_i} (r(i, j) - k)
 
-    where :math:`r(i, j)` is the rank of datapoint j according to the pairwise
-    distances between the datapoints in the original space, :math:`U^{(k)}_i`
-    is the set of points that are in the k nearest neighbors in the embedded
-    space but not in the original space.
+    where for each sample i, :math:`U^{(k)}_i` are all samples j that are in
+    the k-nearest neighbor of i in the embedded space but are the :math:`r(i,
+    j)`-th nearest neighbor of i in the input space with r(i, j) > k. In other
+    words, any unexpected nearest neighbors in the embedded space are penalised
+    in proportion to their rank in the original space.
 
     * "Neighborhood Preservation in Nonlinear Projection Methods: An
       Experimental Study"

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -387,10 +387,10 @@ def trustworthiness(X, X_embedded, n_neighbors=5, precomputed=False):
         T(k) = 1 - \frac{2}{nk (2n - 3k - 1)} \sum^n_{i=1}
             \sum_{j \in U^{(k)}_i} (r(i, j) - k)
 
-    where :math:`r(i, j)` is the rank of the embedded datapoint j
-    according to the pairwise distances between the embedded datapoints,
-    :math:`U^{(k)}_i` is the set of points that are in the k nearest
-    neighbors in the embedded space but not in the original space.
+    where :math:`r(i, j)` is the rank of datapoint j according to the pairwise
+    distances between the datapoints in the original space, :math:`U^{(k)}_i`
+    is the set of points that are in the k nearest neighbors in the embedded
+    space but not in the original space.
 
     * "Neighborhood Preservation in Nonlinear Projection Methods: An
       Experimental Study"

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -385,12 +385,13 @@ def trustworthiness(X, X_embedded, n_neighbors=5, precomputed=False):
     .. math::
 
         T(k) = 1 - \frac{2}{nk (2n - 3k - 1)} \sum^n_{i=1}
-            \sum_{j} \max(0, (r(i, j) - k))
+            \sum_{j \in \mathcal{N}_{i}^{k}} \max(0, (r(i, j) - k))
 
-    where for each sample i, j is among its k nearest neighbors in the output
-    space and is its :math:`r(i, j)`-th nearest neighbor in the input space. In
-    other words, any unexpected nearest neighbors in the output space are
-    penalised in proportion to their rank in the input space.
+    where for each sample i, :math:`\mathcal{N}_{i}^{k}` are its k nearest
+    neighbors in the output space, and every sample j is its :math:`r(i, j)`-th
+    nearest neighbor in the input space. In other words, any unexpected nearest
+    neighbors in the output space are penalised in proportion to their rank in
+    the input space.
 
     * "Neighborhood Preservation in Nonlinear Projection Methods: An
       Experimental Study"

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -385,13 +385,12 @@ def trustworthiness(X, X_embedded, n_neighbors=5, precomputed=False):
     .. math::
 
         T(k) = 1 - \frac{2}{nk (2n - 3k - 1)} \sum^n_{i=1}
-            \sum_{j \in U^{(k)}_i} (r(i, j) - k)
+            \sum_{j} \max(0, (r(i, j) - k))
 
-    where for each sample i, :math:`U^{(k)}_i` are all samples j that are in
-    the k-nearest neighbor of i in the output space but are the :math:`r(i,
-    j)`-th nearest neighbor of i in the input space with r(i, j) > k. In other
-    words, any unexpected nearest neighbors in the output space are penalised
-    in proportion to their rank in the input space.
+    where for each sample i, j is among its k nearest neighbors in the output
+    space and is its :math:`r(i, j)`-th nearest neighbor in the input space. In
+    other words, any unexpected nearest neighbors in the output space are
+    penalised in proportion to their rank in the input space.
 
     * "Neighborhood Preservation in Nonlinear Projection Methods: An
       Experimental Study"

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -391,7 +391,7 @@ def trustworthiness(X, X_embedded, n_neighbors=5, precomputed=False):
     the k-nearest neighbor of i in the embedded space but are the :math:`r(i,
     j)`-th nearest neighbor of i in the input space with r(i, j) > k. In other
     words, any unexpected nearest neighbors in the embedded space are penalised
-    in proportion to their rank in the original space.
+    in proportion to their rank in the input space.
 
     * "Neighborhood Preservation in Nonlinear Projection Methods: An
       Experimental Study"

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -388,9 +388,9 @@ def trustworthiness(X, X_embedded, n_neighbors=5, precomputed=False):
             \sum_{j \in U^{(k)}_i} (r(i, j) - k)
 
     where for each sample i, :math:`U^{(k)}_i` are all samples j that are in
-    the k-nearest neighbor of i in the embedded space but are the :math:`r(i,
+    the k-nearest neighbor of i in the output space but are the :math:`r(i,
     j)`-th nearest neighbor of i in the input space with r(i, j) > k. In other
-    words, any unexpected nearest neighbors in the embedded space are penalised
+    words, any unexpected nearest neighbors in the output space are penalised
     in proportion to their rank in the input space.
 
     * "Neighborhood Preservation in Nonlinear Projection Methods: An


### PR DESCRIPTION
#### Reference Issue

Fixes #9799

#### What does this implement/fix? Explain your changes.

It fixes an error in the docstring of function manifold.t_sne.trustworthiness: the rank in the formula should be the rank in the original input space.
