### PR TITLE
[MRG+1]: avoid FutureWarning in BaseSGD.set_params

### DIFF
--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -50,7 +50,7 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
                  l1_ratio=0.15, fit_intercept=True, max_iter=None, tol=None,
                  shuffle=True, verbose=0, epsilon=0.1, random_state=None,
                  learning_rate="optimal", eta0=0.0, power_t=0.5,
-                 warm_start=False, average=False, n_iter=None, set_future_warning=True):
+                 warm_start=False, average=False, n_iter=None):
         self.loss = loss
         self.penalty = penalty
         self.learning_rate = learning_rate
@@ -69,21 +69,20 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
         self.n_iter = n_iter
         self.max_iter = max_iter
         self.tol = tol
-        self.set_future_warning = set_future_warning
         # current tests expect init to do parameter validation
         # but we are not allowed to set attributes
-        self._validate_params(set_max_iter=False, set_future_warning=False)
+        self._validate_params(set_max_iter=False, ignore_future_warning=True)
 
     def set_params(self, *args, **kwargs):
         super(BaseSGD, self).set_params(*args, **kwargs)
-        self._validate_params(set_future_warning=False)
+        self._validate_params(ignore_future_warning=True)
         return self
 
     @abstractmethod
     def fit(self, X, y):
         """Fit model."""
 
-    def _validate_params(self, set_max_iter=True):
+    def _validate_params(self, set_max_iter=True, ignore_future_warning=False):
         """Validate input params. """
         if not isinstance(self.shuffle, bool):
             raise ValueError("shuffle must be either True or False")
@@ -121,7 +120,7 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
             self._tol = None
 
         elif self.tol is None and self.max_iter is None:
-            if self.set_future_warning:
+            if not ignore_future_warning:
                 warnings.warn(
                     "max_iter and tol parameters have been added in %s in 0.19. If"
                     " both are left unset, they default to max_iter=5 and tol=None"

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -69,13 +69,14 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
         self.n_iter = n_iter
         self.max_iter = max_iter
         self.tol = tol
+        self.set_future_warning = set_future_warning
         # current tests expect init to do parameter validation
         # but we are not allowed to set attributes
-        self._validate_params(set_max_iter=False)
+        self._validate_params(set_max_iter=False, set_future_warning=True)
 
     def set_params(self, *args, **kwargs):
         super(BaseSGD, self).set_params(*args, **kwargs)
-        self._validate_params()
+        self._validate_params(set_future_warning=True)
         return self
 
     @abstractmethod
@@ -120,14 +121,15 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
             self._tol = None
 
         elif self.tol is None and self.max_iter is None:
-            warnings.warn(
-                "max_iter and tol parameters have been added in %s in 0.19. If"
-                " both are left unset, they default to max_iter=5 and tol=None"
-                ". If tol is not None, max_iter defaults to max_iter=1000. "
-                "From 0.21, default max_iter will be 1000, "
-                "and default tol will be 1e-3." % type(self), FutureWarning)
-            # Before 0.19, default was n_iter=5
-            max_iter = 5
+            if not self.set_future_warning:
+                warnings.warn(
+                    "max_iter and tol parameters have been added in %s in 0.19. If"
+                    " both are left unset, they default to max_iter=5 and tol=None"
+                    ". If tol is not None, max_iter defaults to max_iter=1000. "
+                    "From 0.21, default max_iter will be 1000, "
+                    "and default tol will be 1e-3." % type(self), FutureWarning)
+                # Before 0.19, default was n_iter=5
+                max_iter = 5
         else:
             max_iter = self.max_iter if self.max_iter is not None else 1000
         self._max_iter = max_iter

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -71,18 +71,18 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
         self.tol = tol
         # current tests expect init to do parameter validation
         # but we are not allowed to set attributes
-        self._validate_params(set_max_iter=False, ignore_future_warning=True)
+        self._validate_params(set_max_iter=False)
 
     def set_params(self, *args, **kwargs):
         super(BaseSGD, self).set_params(*args, **kwargs)
-        self._validate_params(ignore_future_warning=True)
+        self._validate_params(set_max_iter=False)
         return self
 
     @abstractmethod
     def fit(self, X, y):
         """Fit model."""
 
-    def _validate_params(self, set_max_iter=True, ignore_future_warning=False):
+    def _validate_params(self, set_max_iter=True):
         """Validate input params. """
         if not isinstance(self.shuffle, bool):
             raise ValueError("shuffle must be either True or False")
@@ -120,15 +120,14 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
             self._tol = None
 
         elif self.tol is None and self.max_iter is None:
-            if not ignore_future_warning:
-                warnings.warn(
-                    "max_iter and tol parameters have been added in %s in 0.19. If"
-                    " both are left unset, they default to max_iter=5 and tol=None"
-                    ". If tol is not None, max_iter defaults to max_iter=1000. "
-                    "From 0.21, default max_iter will be 1000, "
-                    "and default tol will be 1e-3." % type(self), FutureWarning)
-                # Before 0.19, default was n_iter=5
-                max_iter = 5
+            warnings.warn(
+                "max_iter and tol parameters have been added in %s in 0.19. If"
+                " both are left unset, they default to max_iter=5 and tol=None"
+                ". If tol is not None, max_iter defaults to max_iter=1000. "
+                "From 0.21, default max_iter will be 1000, "
+                "and default tol will be 1e-3." % type(self), FutureWarning)
+            # Before 0.19, default was n_iter=5
+            max_iter = 5
         else:
             max_iter = self.max_iter if self.max_iter is not None else 1000
         self._max_iter = max_iter

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -50,7 +50,7 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
                  l1_ratio=0.15, fit_intercept=True, max_iter=None, tol=None,
                  shuffle=True, verbose=0, epsilon=0.1, random_state=None,
                  learning_rate="optimal", eta0=0.0, power_t=0.5,
-                 warm_start=False, average=False, n_iter=None):
+                 warm_start=False, average=False, n_iter=None, set_future_warning=True):
         self.loss = loss
         self.penalty = penalty
         self.learning_rate = learning_rate
@@ -72,11 +72,11 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
         self.set_future_warning = set_future_warning
         # current tests expect init to do parameter validation
         # but we are not allowed to set attributes
-        self._validate_params(set_max_iter=False, set_future_warning=True)
+        self._validate_params(set_max_iter=False, set_future_warning=False)
 
     def set_params(self, *args, **kwargs):
         super(BaseSGD, self).set_params(*args, **kwargs)
-        self._validate_params(set_future_warning=True)
+        self._validate_params(set_future_warning=False)
         return self
 
     @abstractmethod
@@ -121,7 +121,7 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
             self._tol = None
 
         elif self.tol is None and self.max_iter is None:
-            if not self.set_future_warning:
+            if self.set_future_warning:
                 warnings.warn(
                     "max_iter and tol parameters have been added in %s in 0.19. If"
                     " both are left unset, they default to max_iter=5 and tol=None"


### PR DESCRIPTION
#### Reference Issue
Fixes #9752


#### What does this implement/fix? Explain your changes.
Adds a set_future_warning flag in BaseSGD to help avoid FutureWarnings
in uses of __init__ or set_params.