### PR TITLE
This PR replaces PairWise with NearestNeighbours(more efficient, as distances of ALL points neednt be found) in trustworthiness function..)

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -23,7 +23,7 @@ from ..decomposition import PCA
 from ..metrics.pairwise import pairwise_distances
 from . import _utils
 from . import _barnes_hut_tsne
-from ..six import string_types
+from ..externals.six import string_types
 from ..utils import deprecated
 
 

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -23,7 +23,7 @@ from ..decomposition import PCA
 from ..metrics.pairwise import pairwise_distances
 from . import _utils
 from . import _barnes_hut_tsne
-from ..externals.six import string_types
+from ..six import string_types
 from ..utils import deprecated
 
 
@@ -418,13 +418,13 @@ def trustworthiness(X, X_embedded, n_neighbors=5, precomputed=False):
     trustworthiness : float
         Trustworthiness of the low-dimensional embedding.
     """
-    if precomputed:
-        dist_X = X
-    else:
-        dist_X = pairwise_distances(X, squared=True)
-    dist_X_embedded = pairwise_distances(X_embedded, squared=True)
-    ind_X = np.argsort(dist_X, axis=1)
-    ind_X_embedded = np.argsort(dist_X_embedded, axis=1)[:, 1:n_neighbors + 1]
+    nbrs=NearestNeighbors(n_neighbors, algorithm='auto').fit(X)
+    nbrs_embedded=NearestNeighbors(n_neighbors, algorithm='auto').fit(X_embedded)
+
+
+
+    ind_X = nbrs.kneighbors(X, return_distance=False)
+    ind_X_embedded = nbrs_embedded.kneighbors(X_embedded, return_distance=False)[:, 1:n_neighbors + 1]
 
     n_samples = X.shape[0]
     t = 0.0


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue 
Fixes #9737


#### What does this implement/fix? Explain your changes.
This implements NearestNeighbors instead of the original PairWise. I created the objects associated with both matrices and found indices directly with NN, instead of sorting the distances of PW. The index matrices were smaller with NN, with columns= n_neighbors, while in PW they were = no of points.

#### Any other comments?
Kindly give me feedback since its my first time contributing to any open source project.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
