### PR TITLE
[MRG] Fix docstring of negative_outlier_factor_ in LOF

### DIFF
--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -106,7 +106,7 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin):
     Attributes
     ----------
     negative_outlier_factor_ : numpy array, shape (n_samples,)
-        The opposite LOF of the training samples. The lower, the more normal.
+        The opposite LOF of the training samples. The lower, the more abnormal.
         Inliers tend to have a LOF score close to 1, while outliers tend
         to have a larger LOF score.
 


### PR DESCRIPTION
The docstring of `negative_outlier_factor_` in `LocalOutlierFactor` is not correct. It says "the lower the more normal". However as explained in the docstring inliers have a LOF score close to 1 while outliers have a larger LOF score. As we return the opposite of the LOF scores it should be "the lower the more abnormal".