### PR TITLE
[MRG] Fix plot_out_of_core_classification.py.

### DIFF
--- a/examples/applications/plot_out_of_core_classification.py
+++ b/examples/applications/plot_out_of_core_classification.py
@@ -41,7 +41,7 @@ import matplotlib.pyplot as plt
 from matplotlib import rcParams
 
 from sklearn.externals.six.moves import html_parser
-from sklearn.externals.six.moves import urllib
+from sklearn.externals.six.moves.urllib.request import urlretrieve
 from sklearn.datasets import get_data_home
 from sklearn.feature_extraction.text import HashingVectorizer
 from sklearn.linear_model import SGDClassifier
@@ -172,8 +172,8 @@ def stream_reuters_documents(data_path=None):
                       end='')
 
         archive_path = os.path.join(data_path, ARCHIVE_FILENAME)
-        urllib.request.urlretrieve(DOWNLOAD_URL, filename=archive_path,
-                                   reporthook=progress)
+        urlretrieve(DOWNLOAD_URL, filename=archive_path,
+                    reporthook=progress)
         if _not_in_sphinx():
             print('\r', end='')
         print("untarring Reuters dataset...")


### PR DESCRIPTION
Starting from an empty ~/scikit_learn_data I got `AttributeError: module
'sklearn.externals.six.moves.urllib_request' has no attribute
'urlretrieve'`.

I have to say I am not sure why this is happening and why we did not spot it earlier on CircleCI, maybe because ~/scikit_learn_data was cached.

I'll merge this when CircleCI is green.