### PR TITLE
ENH Speedup confusion_matrix

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -169,7 +169,8 @@ Changelog
   quantile regression. :pr:`19415` by :user:`Xavier Dupré <sdpython>`
   and :user:`Oliver Grisel <ogrisel>`.
 
-- |Efficiency| Improved speed of :func:`metrics.confusion_matrix` when labels are integral.
+- |Efficiency| Improved speed of :func:`metrics.confusion_matrix` when labels
+  are integral.
   :pr:`9843` by :user:`Jon Crall <Erotemic>`.
 
 :mod:`sklearn.naive_bayes`

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -169,6 +169,9 @@ Changelog
   quantile regression. :pr:`19415` by :user:`Xavier Dupré <sdpython>`
   and :user:`Oliver Grisel <ogrisel>`.
 
+- |Efficiency| Improved speed of :func:`metrics.confusion_matrix` when labels are integral.
+  :pr:`9843` by :user:`Jon Crall <Erotemic>`.
+
 :mod:`sklearn.naive_bayes`
 ..........................
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -309,7 +309,7 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
             raise ValueError("'labels' should contains at least one label.")
         elif y_true.size == 0:
             return np.zeros((n_labels, n_labels), dtype=int)
-        elif np.all([l not in y_true for l in labels]):
+        elif len(np.intersect1d(y_true, labels)) == 0:
             raise ValueError("At least one label specified must be in y_true")
 
     if sample_weight is None:

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -324,17 +324,26 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
                          "'all', None}")
 
     n_labels = labels.size
-    label_to_ind = {y: x for x, y in enumerate(labels)}
-    # convert yt, yp into index
-    y_pred = np.array([label_to_ind.get(x, n_labels + 1) for x in y_pred])
-    y_true = np.array([label_to_ind.get(x, n_labels + 1) for x in y_true])
+    # If labels are not consecutive integers starting from zero, then
+    # yt, yp must be converted into index form
+    need_index_conversion = not (
+        labels.dtype.kind in {'i', 'u', 'b'} and
+        np.all(labels == np.arange(n_labels)) and
+        y_true.min() >= 0 and y_pred.min() >= 0
+    )
+    if need_index_conversion:
+        # convert yt, yp into index
+        label_to_ind = {y: x for x, y in enumerate(labels)}
+        y_pred = np.array([label_to_ind.get(x, n_labels + 1) for x in y_pred])
+        y_true = np.array([label_to_ind.get(x, n_labels + 1) for x in y_true])
 
     # intersect y_pred, y_true with labels, eliminate items not in labels
     ind = np.logical_and(y_pred < n_labels, y_true < n_labels)
-    y_pred = y_pred[ind]
-    y_true = y_true[ind]
-    # also eliminate weights of eliminated items
-    sample_weight = sample_weight[ind]
+    if not np.all(ind):
+        y_pred = y_pred[ind]
+        y_true = y_true[ind]
+        # also eliminate weights of eliminated items
+        sample_weight = sample_weight[ind]
 
     # Choose the accumulator dtype to always have high precision
     if sample_weight.dtype.kind in {'i', 'u', 'b'}:

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -332,7 +332,6 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
         y_true.min() >= 0 and y_pred.min() >= 0
     )
     if need_index_conversion:
-        # convert yt, yp into index
         label_to_ind = {y: x for x, y in enumerate(labels)}
         y_pred = np.array([label_to_ind.get(x, n_labels + 1) for x in y_pred])
         y_true = np.array([label_to_ind.get(x, n_labels + 1) for x in y_true])

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -325,7 +325,7 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
 
     n_labels = labels.size
     # If labels are not consecutive integers starting from zero, then
-    # yt, yp must be converted into index form
+    # yt and yp must be converted into index form
     need_index_conversion = not (
         labels.dtype.kind in {'i', 'u', 'b'} and
         np.all(labels == np.arange(n_labels)) and

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -325,7 +325,7 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
 
     n_labels = labels.size
     # If labels are not consecutive integers starting from zero, then
-    # yt and yp must be converted into index form
+    # y_true and y_pred must be converted into index form
     need_index_conversion = not (
         labels.dtype.kind in {'i', 'u', 'b'} and
         np.all(labels == np.arange(n_labels)) and


### PR DESCRIPTION
This PR is a speedup to the confusion_matrix function in the case where labels is specified and already in index form. I added check to bypass expensive label to index conversion, which results in a nice 16x speedup. 

I've labeled this as WIP because I've only tested the case where `len(labels) = 12` and `len(y_true) = len(y_pred) = 172800`.  I need to do is more comprehensive testing to ensure that I didn't slow down other cases for the sake of one particular case. I believe this will be an overall improvement, but I want to make sure. 

The one benchmark I've done so far (on the aforementioned data) resulted in a reduction of compute time from `90.0ms` to `6.0ms`. This is a 15x increase. When computing several hundred confusion matrices, this becomes quite significant. 

The running time can be further improved to a `36x` increase if we added an extra flag (called `enable_checks=True`) to allow the user to disable the `_check_targets` and `check_consistent_length` call when appropriate.  I didn't add this to the PR by default because I thought there might be some pushback on adding a argument to a function signature. However, if a reviewer thinks this is ok, let me know and I'll add it to get some extra speed. 


TODO 
- [x] baseline proof-of-concept
- [x] is adding an extra flag ok for an extra x2 speedup? (lets just keep this PR simple)
- [x] benchmark: test speed differences on arrays that satisfy the new check condition with different numbers of labels / items (with different data types). Ensure there is now significant slowdown, and find the point where the speedup becomes significant.
- [x] benchmark: test speed differences on arrays that do not satisfy the new check condition with different numbers of labels / items (with different data types). Ensure there is not a significant slowdown.
- [x] associated what's new / documentation changes if necessary