### PR TITLE
[MRG] Add verbose level into the RFE at the end of RFECV

### DIFF
--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -442,7 +442,8 @@ class RFECV(RFE, MetaEstimatorMixin):
 
         # Re-execute an elimination with best_k over the whole set
         rfe = RFE(estimator=self.estimator,
-                  n_features_to_select=n_features_to_select, step=self.step)
+                  n_features_to_select=n_features_to_select,
+                  step=self.step, verbose=self.verbose)
 
         rfe.fit(X, y)
 


### PR DESCRIPTION
Reference Issue
Fixes #9844 

RFECV should pass the verbose level into the RFE it fits at the end. This would make the logs more useful in terms of getting a status update for how long fitting is taking.