### PR TITLE
FIX Improve check to ensure that ROC curve starts at (0,0) point

### DIFF
--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -547,12 +547,13 @@ def roc_curve(y_true, y_score, pos_label=None, sample_weight=None,
         tps = tps[optimal_idxs]
         thresholds = thresholds[optimal_idxs]
 
-    if tps.size == 0 or fps[0] != 0:
-        # Add an extra threshold position if necessary
-        tps = np.r_[0, tps]
-        fps = np.r_[0, fps]
-        thresholds = np.r_[thresholds[0] + 1, thresholds]
-
+    if tps.size == 0 or fps[0] != 0 or tps[0] != 0:
+        # Add an extra threshold to ensure that ROC curve always starts at (0,0)
+        # point  
+         tps = np.r_[0, tps]
+         fps = np.r_[0, fps]
+         thresholds = np.r_[thresholds[0] + 1, thresholds]
+                                                
     if fps[-1] <= 0:
         warnings.warn("No negative samples in y_true, "
                       "false positive value should be meaningless",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #9790

#### What does this implement/fix? Explain your changes.
roc_curve will always arbitrarily set thresholds[0] to max(y_score) + 1

#### Any other comments?
Not checked yet on a large dataset.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
