### PR TITLE
[MRG+2] Deprecate reorder parameter in auc

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -123,8 +123,7 @@ Linear, kernelized and related models
 
 Metrics
 
-- Deprecate ``reorder`` parameter in :class:`metrics.auc` as it's introduced
-  for roc_auc_score (not for general use) and is no longer used there. What's
-  more, the result from auc will be significantly influenced if x is sorted
-  unexpectedly due to slight floating point error.
+- Deprecate ``reorder`` parameter in :func:`metrics.auc` as it's no longer required
+  for :func:`metrics.roc_auc_score`. Moreover using ``reorder=True`` can hide bugs
+  due to floating point error in the input.
   :issue:`9851` by :user:`Hanmin Qin <qinhanmin2014>`.

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -120,3 +120,9 @@ Linear, kernelized and related models
 - Deprecate ``random_state`` parameter in :class:`svm.OneClassSVM` as the
   underlying implementation is not random.
   :issue:`9497` by :user:`Albert Thomas <albertcthomas>`.
+
+Metrics
+
+- Deprecate ``reorder`` parameter in :class:`metrics.auc` as it is introduced
+  for roc_auc_score and is no longer used there.
+  :issue:`9851` by :user:`Hanmin Qin <qinhanmin2014>`.

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -123,7 +123,8 @@ Linear, kernelized and related models
 
 Metrics
 
-- Deprecate ``reorder`` parameter in :class:`metrics.auc` as the result
-  from auc will be significantly influenced if x is sorted unexpectedly
-  due to slight floating point error.
+- Deprecate ``reorder`` parameter in :class:`metrics.auc` as it's introduced
+  for roc_auc_score (not for general use) and is no longer used there. What's
+  more, the result from auc will be significantly influenced if x is sorted
+  unexpectedly due to slight floating point error.
   :issue:`9851` by :user:`Hanmin Qin <qinhanmin2014>`.

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -123,6 +123,7 @@ Linear, kernelized and related models
 
 Metrics
 
-- Deprecate ``reorder`` parameter in :class:`metrics.auc` as it is introduced
-  for roc_auc_score and is no longer used there.
+- Deprecate ``reorder`` parameter in :class:`metrics.auc` as the result
+  from auc will be significantly influenced if x is sorted unexpectedly
+  due to slight floating point error.
   :issue:`9851` by :user:`Hanmin Qin <qinhanmin2014>`.

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -63,7 +63,7 @@ def auc(x, y, reorder='deprecated'):
           general use) and is no longer used there. What's more, the result
           from auc will be significantly influenced if x is sorted
           unexpectedly due to slight floating point error (See issue #9786).
-          Future (and default) behavior is equivalent to `reorder=False`.
+          Future (and default) behavior is equivalent to ``reorder=False``.
 
     Returns
     -------
@@ -95,8 +95,10 @@ def auc(x, y, reorder='deprecated'):
                          ' area under curve, but x.shape = %s' % x.shape)
 
     if reorder != 'deprecated':
-        warnings.warn("The `reorder` parameter has been deprecated "
-                      "in version 0.20 and will be removed in 0.22.",
+        warnings.warn("The 'reorder' parameter has been deprecated in "
+                      "version 0.20 and will be removed in 0.22. It is "
+                      "recommended not to set 'reorder' and ensure that x "
+                      "is monotonic increasing or monotonic decreasing.",
                       DeprecationWarning)
 
     direction = 1

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -59,10 +59,6 @@ def auc(x, y, reorder=None):
           be removed in 0.22. Future (and default) behavior is equivalent to
           `reorder=False`.
 
-    tol : float, optional (default=0)
-        Tolerance allowed when checking whether x is increasing.
-        Ignored when ``reorder=True``.
-
     Returns
     -------
     auc : float

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -36,7 +36,7 @@ from ..preprocessing import LabelBinarizer
 from .base import _average_binary_score
 
 
-def auc(x, y, reorder=None, tol=0):
+def auc(x, y, reorder=None):
     """Compute Area Under the Curve (AUC) using the trapezoidal rule
 
     This is a general function, given points on a curve.  For computing the
@@ -105,8 +105,8 @@ def auc(x, y, reorder=None, tol=0):
         x, y = x[order], y[order]
     else:
         dx = np.diff(x)
-        if np.any(dx < -abs(tol)):
-            if np.all(dx <= abs(tol)):
+        if np.any(dx < 0):
+            if np.all(dx <= 0):
                 direction = -1
             else:
                 raise ValueError("Reordering is not turned on, and the x "

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -57,13 +57,13 @@ def auc(x, y, reorder='deprecated'):
         used to break ties when sorting x. Make sure that y has a monotonic
         relation to x when setting reorder to True.
 
-        ..deprecated:: 0.20
-          Parameter ``reorder`` has been deprecated in version 0.20 and will
-          be removed in 0.22. It's introduced for roc_auc_score (not for
-          general use) and is no longer used there. What's more, the result
-          from auc will be significantly influenced if x is sorted
-          unexpectedly due to slight floating point error (See issue #9786).
-          Future (and default) behavior is equivalent to ``reorder=False``.
+        .. deprecated:: 0.20
+           Parameter ``reorder`` has been deprecated in version 0.20 and will
+           be removed in 0.22. It's introduced for roc_auc_score (not for
+           general use) and is no longer used there. What's more, the result
+           from auc will be significantly influenced if x is sorted
+           unexpectedly due to slight floating point error (See issue #9786).
+           Future (and default) behavior is equivalent to ``reorder=False``.
 
     Returns
     -------

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -58,8 +58,9 @@ def auc(x, y, reorder='deprecated'):
 
         ..deprecated:: 0.20
           Parameter ``reorder`` has been deprecated in version 0.20 and will
-          be removed in 0.22. It is introduced for roc_auc_score and is no
-          longer used there due to issue #9786. Future (and default) behavior
+          be removed in 0.22. The result from auc will be significantly
+          influenced if x is sorted unexpectedly due to slight floating point
+          error (See issue #9786). Future (and default) behavior
           is equivalent to `reorder=False`.
 
     Returns

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -60,8 +60,8 @@ def auc(x, y, reorder='deprecated'):
           Parameter ``reorder`` has been deprecated in version 0.20 and will
           be removed in 0.22. The result from auc will be significantly
           influenced if x is sorted unexpectedly due to slight floating point
-          error (See issue #9786). Future (and default) behavior
-          is equivalent to `reorder=False`.
+          error (See issue #9786). Future (and default) behavior is equivalent
+          to `reorder=False`.
 
     Returns
     -------

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -50,7 +50,7 @@ def auc(x, y, reorder=None):
         Increasing or decreasing x coordinates.
     y : array, shape = [n]
         y coordinates.
-    reorder : boolean, optional (default=False)
+    reorder : boolean, optional (default=None)
         If True, assume that the curve is ascending in the case of ties, as for
         an ROC curve. If the curve is non-ascending, the result will be wrong.
 

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -36,7 +36,7 @@ from ..preprocessing import LabelBinarizer
 from .base import _average_binary_score
 
 
-def auc(x, y, reorder=None):
+def auc(x, y, reorder='deprecated'):
     """Compute Area Under the Curve (AUC) using the trapezoidal rule
 
     This is a general function, given points on a curve.  For computing the

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -54,7 +54,8 @@ def auc(x, y, reorder='deprecated'):
     reorder : boolean, optional (default='deprecated')
         Whether to sort x before computing. If False, assume that x must be
         either monotonic increasing or monotonic decreasing. If True, y is
-        used to break ties when sorting x.
+        used to break ties when sorting x. Make sure that y has a monotonic
+        relation to x when setting reorder to True.
 
         ..deprecated:: 0.20
           Parameter ``reorder`` has been deprecated in version 0.20 and will

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -47,10 +47,11 @@ def auc(x, y, reorder=None):
     Parameters
     ----------
     x : array, shape = [n]
-        Increasing or decreasing x coordinates.
+        x coordinates. These must be either monotonic increasing or monotonic
+        decreasing.
     y : array, shape = [n]
         y coordinates.
-    reorder : boolean, optional (default=None)
+    reorder : boolean, optional (default='deprecated')
         If True, assume that the curve is ascending in the case of ties, as for
         an ROC curve. If the curve is non-ascending, the result will be wrong.
 
@@ -88,13 +89,13 @@ def auc(x, y, reorder=None):
         raise ValueError('At least 2 points are needed to compute'
                          ' area under curve, but x.shape = %s' % x.shape)
 
-    if reorder is not None:
+    if reorder != 'deprecated':
         warnings.warn("The `reorder` parameter has been deprecated "
                       "in version 0.20 and will be removed in 0.22.",
                       DeprecationWarning)
 
     direction = 1
-    if reorder:
+    if reorder is True:
         # reorder the data points according to the x axis and using y to
         # break ties
         order = np.lexsort((y, x))
@@ -105,16 +106,15 @@ def auc(x, y, reorder=None):
             if np.all(dx <= 0):
                 direction = -1
             else:
+                # Output the most positive value and most negative value in
+                # np.diff(x) for debugging.
                 maxpos = dx.argmax()
                 minpos = dx.argmin()
                 raise ValueError("x is neither increasing nor decreasing "
-                                 ": {}. np.diff(x) contains {} positive "
-                                 "values and {} negative values. The most "
-                                 "positive value in np.diff(x) : x[{}] - "
-                                 "x[{}] = {}. The most negative value in "
-                                 "np.diff(x) : x[{}] - x[{}] = {}."
-                                 .format(x, (dx > 0).sum(), (dx < 0).sum(),
-                                         maxpos + 1, maxpos, dx.max(),
+                                 ": {}. The most positive value in np.diff(x)"
+                                 " : x[{}] - x[{}] = {}. The most negative "
+                                 "value in np.diff(x) : x[{}] - x[{}] = {}."
+                                 .format(x, maxpos + 1, maxpos, dx.max(),
                                          minpos + 1, minpos, dx.min()))
 
     area = direction * np.trapz(y, x)

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -36,7 +36,7 @@ from ..preprocessing import LabelBinarizer
 from .base import _average_binary_score
 
 
-def auc(x, y, reorder=False):
+def auc(x, y, reorder=False, tol=0):
     """Compute Area Under the Curve (AUC) using the trapezoidal rule
 
     This is a general function, given points on a curve.  For computing the
@@ -53,6 +53,9 @@ def auc(x, y, reorder=False):
     reorder : boolean, optional (default=False)
         If True, assume that the curve is ascending in the case of ties, as for
         an ROC curve. If the curve is non-ascending, the result will be wrong.
+    tol : float, optional (default=0)
+        Tolerance allowed when checking whether x is increasing.
+        Ignored when ``reorder=True``.
 
     Returns
     -------
@@ -91,8 +94,8 @@ def auc(x, y, reorder=False):
         x, y = x[order], y[order]
     else:
         dx = np.diff(x)
-        if np.any(dx < 0):
-            if np.all(dx <= 0):
+        if np.any(dx < -abs(tol)):
+            if np.all(dx <= abs(tol)):
                 direction = -1
             else:
                 raise ValueError("Reordering is not turned on, and "

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -109,8 +109,7 @@ def auc(x, y, reorder=None):
             if np.all(dx <= 0):
                 direction = -1
             else:
-                raise ValueError("Reordering is not turned on, and the x "
-                                 "array is neither increasing nor decreasing"
+                raise ValueError("x is neither increasing nor decreasing"
                                  " : {}. np.diff(x) contains {} positive "
                                  "values and {} negative values."
                                  .format(x, (dx > 0).sum(), (dx < 0).sum()))

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -105,6 +105,8 @@ def auc(x, y, reorder=None):
             if np.all(dx <= 0):
                 direction = -1
             else:
+                maxpos = dx.argmax()
+                minpos = dx.argmin()
                 raise ValueError("x is neither increasing nor decreasing "
                                  ": {}. np.diff(x) contains {} positive "
                                  "values and {} negative values. The most "
@@ -112,9 +114,8 @@ def auc(x, y, reorder=None):
                                  "x[{}] = {}. The most negative value in "
                                  "np.diff(x) : x[{}] - x[{}] = {}."
                                  .format(x, (dx > 0).sum(), (dx < 0).sum(),
-                                         dx.argmax() + 1, dx.argmax(),
-                                         dx.max(), dx.argmin() + 1,
-                                         dx.argmin(), dx.min()))
+                                         maxpos + 1, maxpos, dx.max(),
+                                         minpos + 1, minpos, dx.min()))
 
     area = direction * np.trapz(y, x)
     if isinstance(area, np.memmap):

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -52,8 +52,9 @@ def auc(x, y, reorder='deprecated'):
     y : array, shape = [n]
         y coordinates.
     reorder : boolean, optional (default='deprecated')
-        If True, assume that the curve is ascending in the case of ties, as for
-        an ROC curve. If the curve is non-ascending, the result will be wrong.
+        Whether to sort x before computing. If False, assume that x must be
+        either monotonic increasing or monotonic decreasing. If True, y is
+        used to break ties when sorting x.
 
         ..deprecated:: 0.20
           Parameter ``reorder`` has been deprecated in version 0.20 and will

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -107,16 +107,8 @@ def auc(x, y, reorder='deprecated'):
             if np.all(dx <= 0):
                 direction = -1
             else:
-                # Output the most positive value and most negative value in
-                # np.diff(x) for debugging.
-                maxpos = dx.argmax()
-                minpos = dx.argmin()
                 raise ValueError("x is neither increasing nor decreasing "
-                                 ": {}. The most positive value in np.diff(x)"
-                                 " : x[{}] - x[{}] = {}. The most negative "
-                                 "value in np.diff(x) : x[{}] - x[{}] = {}."
-                                 .format(x, maxpos + 1, maxpos, dx.max(),
-                                         minpos + 1, minpos, dx.min()))
+                                 ": {}.".format(x))
 
     area = direction * np.trapz(y, x)
     if isinstance(area, np.memmap):

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -58,8 +58,9 @@ def auc(x, y, reorder='deprecated'):
 
         ..deprecated:: 0.20
           Parameter ``reorder`` has been deprecated in version 0.20 and will
-          be removed in 0.22. Future (and default) behavior is equivalent to
-          `reorder=False`.
+          be removed in 0.22. It is introduced for roc_auc_score and is no
+          longer used there due to issue #9786. Future (and default) behavior
+          is equivalent to `reorder=False`.
 
     Returns
     -------

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -58,10 +58,11 @@ def auc(x, y, reorder='deprecated'):
 
         ..deprecated:: 0.20
           Parameter ``reorder`` has been deprecated in version 0.20 and will
-          be removed in 0.22. The result from auc will be significantly
-          influenced if x is sorted unexpectedly due to slight floating point
-          error (See issue #9786). Future (and default) behavior is equivalent
-          to `reorder=False`.
+          be removed in 0.22. It's introduced for roc_auc_score (not for
+          general use) and is no longer used there. What's more, the result
+          from auc will be significantly influenced if x is sorted
+          unexpectedly due to slight floating point error (See issue #9786).
+          Future (and default) behavior is equivalent to `reorder=False`.
 
     Returns
     -------

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -109,10 +109,16 @@ def auc(x, y, reorder=None):
             if np.all(dx <= 0):
                 direction = -1
             else:
-                raise ValueError("x is neither increasing nor decreasing"
-                                 " : {}. np.diff(x) contains {} positive "
-                                 "values and {} negative values."
-                                 .format(x, (dx > 0).sum(), (dx < 0).sum()))
+                raise ValueError("x is neither increasing nor decreasing "
+                                 ": {}. np.diff(x) contains {} positive "
+                                 "values and {} negative values. The most "
+                                 "positive value in np.diff(x) : x[{}] - "
+                                 "x[{}] = {}. The most negative value in "
+                                 "np.diff(x) : x[{}] - x[{}] = {}."
+                                 .format(x, (dx > 0).sum(), (dx < 0).sum(),
+                                         dx.argmax() + 1, dx.argmax(),
+                                         dx.max(), dx.argmin() + 1,
+                                         dx.argmin(), dx.min()))
 
     area = direction * np.trapz(y, x)
     if isinstance(area, np.memmap):

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -427,13 +427,14 @@ def test_auc_errors():
     assert_raises(ValueError, auc, [0.0], [0.1])
 
     # x is not in order
-    error_message = ("x is neither increasing nor decreasing : [2 1 3 4]. "
-                     "np.diff(x) contains 2 positive values and 1 negative "
-                     "values. The most positive value in np.diff(x) : x[2] "
-                     "- x[1] = 2. The most negative value in np.diff(x) : "
-                     "x[1] - x[0] = -1.")
-    assert_raise_message(ValueError, error_message, auc,
-                         [2, 1, 3, 4], [5, 6, 7, 8])
+    x = [2, 1, 3, 4]
+    y = [5, 6, 7, 8]
+    error_message = ("x is neither increasing nor decreasing : {}. np.diff(x)"
+                     " contains 2 positive values and 1 negative values. The"
+                     " most positive value in np.diff(x) : x[2] - x[1] = 2."
+                     " The most negative value in np.diff(x) : x[1] - x[0] ="
+                     " -1.".format(np.array(x)))
+    assert_raise_message(ValueError, error_message, auc, x, y)
 
 
 def test_deprecated_auc_reorder():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -429,10 +429,8 @@ def test_auc_errors():
     # x is not in order
     x = [2, 1, 3, 4]
     y = [5, 6, 7, 8]
-    error_message = ("x is neither increasing nor decreasing : {}. The most "
-                     "positive value in np.diff(x) : x[2] - x[1] = 2. The "
-                     "most negative value in np.diff(x) : x[1] - x[0] = "
-                     "-1.".format(np.array(x)))
+    error_message = ("x is neither increasing nor decreasing : "
+                     "{}".format(np.array(x)))
     assert_raise_message(ValueError, error_message, auc, x, y)
 
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -430,14 +430,6 @@ def test_auc_errors():
     assert_raises(ValueError, auc, [1.0, 0.0, 0.5], [0.0, 0.0, 0.0])
 
 
-def test_auc_tol():
-    x1 = [1.0, 1.0, 3.0, 4.0]
-    x2 = [1.0 + 1e-10, 1.0 - 1e-10, 3.0, 4.0]
-    y = [1.0, 2.0, 3.0, 3.0]
-    assert_raises(ValueError, auc, x2, y, tol=0)
-    assert_almost_equal(auc(x1, y, tol=0), auc(x2, y, tol=1e-8))
-
-
 def test_deprecated_auc_reorder():
     depr_message = ("The `reorder` parameter has been deprecated "
                     "in version 0.20 and will be removed in 0.22.")

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -435,8 +435,10 @@ def test_auc_errors():
 
 
 def test_deprecated_auc_reorder():
-    depr_message = ("The `reorder` parameter has been deprecated "
-                    "in version 0.20 and will be removed in 0.22.")
+    depr_message = ("The 'reorder' parameter has been deprecated in version "
+                    "0.20 and will be removed in 0.22. It is recommended not "
+                    "to set 'reorder' and ensure that x is monotonic "
+                    "increasing or monotonic decreasing.")
     assert_warns_message(DeprecationWarning, depr_message, auc,
                          [1, 2], [2, 3], reorder=True)
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -429,11 +429,10 @@ def test_auc_errors():
     # x is not in order
     x = [2, 1, 3, 4]
     y = [5, 6, 7, 8]
-    error_message = ("x is neither increasing nor decreasing : {}. np.diff(x)"
-                     " contains 2 positive values and 1 negative values. The"
-                     " most positive value in np.diff(x) : x[2] - x[1] = 2."
-                     " The most negative value in np.diff(x) : x[1] - x[0] ="
-                     " -1.".format(np.array(x)))
+    error_message = ("x is neither increasing nor decreasing : {}. The most "
+                     "positive value in np.diff(x) : x[2] - x[1] = 2. The "
+                     "most negative value in np.diff(x) : x[1] - x[0] = "
+                     "-1.".format(np.array(x)))
     assert_raise_message(ValueError, error_message, auc, x, y)
 
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -427,13 +427,13 @@ def test_auc_errors():
     assert_raises(ValueError, auc, [0.0], [0.1])
 
     # x is not in order
-    error_message = ("x is neither increasing nor decreasing : "
-                     "[ 2.5  1.6  3.7  4.8]. np.diff(x) contains 2 positive "
-                     "values and 1 negative values. The most positive value "
-                     "in np.diff(x) : x[2] - x[1] = 2.1. The most negative "
-                     "value in np.diff(x) : x[1] - x[0] = -0.9.")
+    error_message = ("x is neither increasing nor decreasing : [2 1 3 4]. "
+                     "np.diff(x) contains 2 positive values and 1 negative "
+                     "values. The most positive value in np.diff(x) : x[2] "
+                     "- x[1] = 2. The most negative value in np.diff(x) : "
+                     "x[1] - x[0] = -1.")
     assert_raise_message(ValueError, error_message, auc,
-                         [2.5, 1.6, 3.7, 4.8], [5, 6, 7, 8])
+                         [2, 1, 3, 4], [5, 6, 7, 8])
 
 
 def test_deprecated_auc_reorder():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -20,6 +20,7 @@ from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import assert_warns_message
 
 from sklearn.metrics import auc
 from sklearn.metrics import average_precision_score
@@ -435,6 +436,13 @@ def test_auc_tol():
     y = [1.0, 2.0, 3.0, 3.0]
     assert_raises(ValueError, auc, x2, y, tol=0)
     assert_almost_equal(auc(x1, y, tol=0), auc(x2, y, tol=1e-8))
+
+
+def test_deprecated_auc_reorder():
+    depr_message = ("The `reorder` parameter has been deprecated "
+                    "in version 0.20 and will be removed in 0.22.")
+    assert_warns_message(DeprecationWarning, depr_message, auc,
+                         [1, 2], [2, 3], reorder=True)
 
 
 def test_auc_score_non_binary_class():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -427,7 +427,13 @@ def test_auc_errors():
     assert_raises(ValueError, auc, [0.0], [0.1])
 
     # x is not in order
-    assert_raises(ValueError, auc, [1.0, 0.0, 0.5], [0.0, 0.0, 0.0])
+    error_message = ("x is neither increasing nor decreasing : "
+                     "[ 2.5  1.6  3.7  4.8]. np.diff(x) contains 2 positive "
+                     "values and 1 negative values. The most positive value "
+                     "in np.diff(x) : x[2] - x[1] = 2.1. The most negative "
+                     "value in np.diff(x) : x[1] - x[0] = -0.9.")
+    assert_raise_message(ValueError, error_message, auc,
+                         [2.5, 1.6, 3.7, 4.8], [5, 6, 7, 8])
 
 
 def test_deprecated_auc_reorder():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -429,6 +429,14 @@ def test_auc_errors():
     assert_raises(ValueError, auc, [1.0, 0.0, 0.5], [0.0, 0.0, 0.0])
 
 
+def test_auc_tol():
+    x1 = [1.0, 1.0, 3.0, 4.0]
+    x2 = [1.0 + 1e-10, 1.0 - 1e-10, 3.0, 4.0]
+    y = [1.0, 2.0, 3.0, 3.0]
+    assert_raises(ValueError, auc, x2, y, tol=0)
+    assert_almost_equal(auc(x1, y, tol=0), auc(x2, y, tol=1e-8))
+
+
 def test_auc_score_non_binary_class():
     # Test that roc_auc_score function returns an error when trying
     # to compute AUC for non-binary class values.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
proposed in #9786 by @lesteve 

> with this change reorder=False(reorder=True?) in the auc function is not used in our code. I think we should deprecate the reorder=False(reorder=True?) parameter and potentially (up for debate) have some threshold in case there are some small negative values in np.diff(tpr) or np.diff(fpr)

#### What does this implement/fix? Explain your changes.
#### (1)add tolerance to roc_auc_score when checking whether x is increasing. (discarded)
<!--
Currently, when setting reordering=False, auc will check whether x is increasing and raise error if not. But sometimes python will introduce slight error when doing float calculation and users will unexpectedly get an error indicating that x is not sorted. So it might be better to allow some tolerance when checking whether x is increasing.
-->
#### (2)improve error message when x is neither increasing nor decreasing.
#### (3)deprecate reorder parameter. reorder=False is now the default behaviour.
reorder=True is introduced in https://github.com/scikit-learn/scikit-learn/commit/9f18586ebfc835810afff50fcc3449265501bbcb for roc_auc_score. Now it is not used in roc_auc_score due to #9786.

#### Any other comments?
cc @jnothman @lesteve 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
