### PR TITLE
[MRG+1] Travis: move scipy-dev-wheels build to a cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
     # versions of numpy, scipy with ATLAS that comes with Ubuntu Trusty 14.04
     - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" CYTHON_VERSION="0.23.4"
            COVERAGE=true
+      if: type != cron
       addons:
         apt:
           packages:
@@ -35,30 +36,31 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" INSTALL_MKL="false"
            NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.13.3" CYTHON_VERSION="0.23.5"
            COVERAGE=true
+      if: type != cron
     # This environment tests the newest supported Anaconda release (4.4.0)
     # It also runs tests requiring Pandas.
     - env: DISTRIB="conda" PYTHON_VERSION="3.6.1" INSTALL_MKL="true"
            NUMPY_VERSION="1.13" SCIPY_VERSION="0.19.0" PANDAS_VERSION="0.20.2"
            CYTHON_VERSION="0.25.2" COVERAGE=true
+      if: type != cron
     # This environment use pytest to run the tests. It uses the newest
     # supported Anaconda release (4.4.0). It also runs tests requiring Pandas.
     - env: USE_PYTEST="true" DISTRIB="conda" PYTHON_VERSION="3.6.1"
            INSTALL_MKL="true" NUMPY_VERSION="1.12.1" SCIPY_VERSION="0.19.0"
            PANDAS_VERSION="0.20.1" CYTHON_VERSION="0.25.2"
            TEST_DOCSTRINGS="true"
+      if: type != cron
     # flake8 linting on diff wrt common ancestor with upstream/master
     - env: RUN_FLAKE8="true" SKIP_TESTS="true"
            DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="true"
            NUMPY_VERSION="1.13" SCIPY_VERSION="0.19.0" CYTHON_VERSION="0.23.5"
+      if: type != cron
     # This environment tests scikit-learn against numpy and scipy master
     # installed from their CI wheels in a virtualenv with the Python
     # interpreter provided by travis.
-    -  python: 3.5
-       env: DISTRIB="scipy-dev-wheels"
-  allow_failures:
-    # allow_failures seems to be keyed on the python version
-    # We are using this to allow failures for DISTRIB=scipy-dev-wheels
-    - python: 3.5
+    -  python: 3.6
+       env: USE_PYTEST="true" DISTRIB="scipy-dev-wheels"
+       if: type = cron
 
 install: source build_tools/travis/install.sh
 script: bash build_tools/travis/test_script.sh

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -87,7 +87,12 @@ elif [[ "$DISTRIB" == "scipy-dev-wheels" ]]; then
     echo "Installing numpy and scipy master wheels"
     dev_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
     pip install --pre --upgrade --timeout=60 -f $dev_url numpy scipy cython
-    pip install nose nose-timer
+    if [[ $USE_PYTEST == "true" ]]; then
+        pip install pytest
+    else
+        # Install nose-timer via pip
+        pip install nose nose-timer
+    fi
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then

--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -38,12 +38,6 @@ run_tests() {
     # disk caching does not work.
     export SKLEARN_SKIP_NETWORK_TESTS=1
 
-    if [[ "$DISTRIB" == "scipy-dev-wheels" ]]; then
-        # Do not run doctests in scipy-dev-wheels build for now
-        # (broken by numpy 1.14.dev array repr/str formatting change)
-        export PYTEST_ADDOPTS="-p no:doctest"
-    fi
-
     if [[ "$COVERAGE" == "true" ]]; then
         TEST_CMD="$TEST_CMD --with-coverage"
     fi
@@ -53,15 +47,7 @@ run_tests() {
     cd $OLDPWD
 
     if [[ "$USE_PYTEST" == "true" ]]; then
-        # Do not run doctests in scipy-dev-wheels build for now
-        # (broken by numpy 1.14.dev array repr/str formatting
-        # change). Need to skip explicly like this because using -p
-        # 'no:doctest' does disable doctests but still exits with an
-        # non-zero exit code when you pass explicit rst files like
-        # this
-        if [[ "$DISTRIB" != "scipy-dev-wheels" ]]; then
-            pytest $(find doc -name '*.rst' | sort)
-        fi
+        pytest $(find doc -name '*.rst' | sort)
     else
         # Makefile is using nose
         make test-doc

--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -38,6 +38,12 @@ run_tests() {
     # disk caching does not work.
     export SKLEARN_SKIP_NETWORK_TESTS=1
 
+    if [[ "$DISTRIB" == "scipy-dev-wheels" ]]; then
+        # Do not run doctests in scipy-dev-wheels build for now
+        # (broken by numpy 1.14.dev array repr/str formatting change)
+        export PYTEST_ADDOPTS="-p no:doctest"
+    fi
+
     if [[ "$COVERAGE" == "true" ]]; then
         TEST_CMD="$TEST_CMD --with-coverage"
     fi
@@ -47,7 +53,15 @@ run_tests() {
     cd $OLDPWD
 
     if [[ "$USE_PYTEST" == "true" ]]; then
-        pytest $(find doc -name '*.rst' | sort)
+        # Do not run doctests in scipy-dev-wheels build for now
+        # (broken by numpy 1.14.dev array repr/str formatting
+        # change). Need to skip explicly like this because using -p
+        # 'no:doctest' does disable doctests but still exits with an
+        # non-zero exit code when you pass explicit rst files like
+        # this
+        if [[ "$DISTRIB" != "scipy-dev-wheels" ]]; then
+            pytest $(find doc -name '*.rst' | sort)
+        fi
     else
         # Makefile is using nose
         make test-doc

--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -47,7 +47,13 @@ run_tests() {
     cd $OLDPWD
 
     if [[ "$USE_PYTEST" == "true" ]]; then
-        pytest $(find doc -name '*.rst' | sort)
+        # Do not run doctests in scipy-dev-wheels build for now
+        # (broken by numpy 1.14.dev array repr/str formatting
+        # change even with np.set_printoptions(sign='legacy').
+        # See https://github.com/numpy/numpy/issues/9804 for more details
+        if [[ "$DISTRIB" != "scipy-dev-wheels" ]]; then
+            pytest $(find doc -name '*.rst' | sort)
+        fi
     else
         # Makefile is using nose
         make test-doc

--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -49,7 +49,7 @@ run_tests() {
     if [[ "$USE_PYTEST" == "true" ]]; then
         # Do not run doctests in scipy-dev-wheels build for now
         # (broken by numpy 1.14.dev array repr/str formatting
-        # change even with np.set_printoptions(sign='legacy').
+        # change even with np.set_printoptions(sign='legacy')).
         # See https://github.com/numpy/numpy/issues/9804 for more details
         if [[ "$DISTRIB" != "scipy-dev-wheels" ]]; then
             pytest $(find doc -name '*.rst' | sort)

--- a/conftest.py
+++ b/conftest.py
@@ -5,7 +5,7 @@
 # doc/modules/clustering.rst and use sklearn from the local folder
 # rather than the one from site-packages.
 
-# Set numpy arr str/repr to legacy behaviour on numpy > 1.13 to make
+# Set numpy array str/repr to legacy behaviour on numpy > 1.13 to make
 # the doctests pass
 import numpy as np
 try:

--- a/conftest.py
+++ b/conftest.py
@@ -4,3 +4,11 @@
 # For example, this allows to build extensions in place and run pytest
 # doc/modules/clustering.rst and use sklearn from the local folder
 # rather than the one from site-packages.
+
+# Set numpy arr str/repr to legacy behaviour on numpy > 1.13 to make
+# the doctests pass
+import numpy as np
+try:
+    np.set_printoptions(sign='legacy')
+except TypeError:
+    pass


### PR DESCRIPTION
The plan is to use a daily cron job to test the development numpy and scipy wheels. The idea behind this is that it is very rare that a particular numpy-dev or scipy-dev related failure is due to a change in the PR.

The cron job will be daily and the numpy-dev scipy-dev will not be allowed to fail. I think it fails quite rarely and allow_failures means we tend not to pay enough attention to failures. Also because it only runs daily it does not mean that many emails in case of failure.

I am skipping doctests in scipy-dev build because they are broken on numpy dev due to a change in the numpy array repr/str with spaces. Note I switched to pytest for the scipy-dev build, mostly because it is easier to skip doctests.

I have tested the cron job and the .travis.yml on lesteve/scikit-learn in Travis and everything works. I'll wait to see if anyone has comments/concerns and if not I'll merge this one.

#### More details about the numpy array repr/str changes
```py
import numpy as np
print(repr(np.array([0., 1., 2.5])))
```

1.13.1:
```
array([ 0. ,  1. ,  2.5])
```

1.14dev:
```
array([0. , 1. , 2.5])
```

Part of the gory details: https://github.com/numpy/numpy/pull/9139.