### PR TITLE
[MRG+1] Reduce runtime of graph_lasso

### DIFF
--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -207,14 +207,9 @@ def graph_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
         sub_covariance = np.ascontiguousarray(covariance_[1:, 1:])
         for i in range(max_iter):
             for idx in range(n_features):
-                # for each idx, the sub_covariance matrix is the covariance_
-                # matrix lacking one row/column corresponding to the r/c
-                # being solved. when the next loop occurs, the previous r/c
-                # should be inserted again and the next r/c inserted in that
-                # location. no other r/c change during this operation, except
-                # at the c/r being re-added, which leave the matrix in an
-                # identical state as if it had been reconstructed as a
-                # contiguous matrix using [indices != idx] along each axis.
+                # To keep the contiguous matrix `sub_covariance` equal to
+                # covariance_[indices != idx].T[indices != idx]
+                # we only need to update 1 column and 1 line when idx changes
                 if idx > 0:
                     di = idx - 1
                     sub_covariance[di] = covariance_[di][indices != idx]

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -203,10 +203,15 @@ def graph_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
         # be robust to the max_iter=0 edge case, see:
         # https://github.com/scikit-learn/scikit-learn/issues/4134
         d_gap = np.inf
+        # set a sub_covariance buffer
+        sub_covariance = np.ascontiguousarray(covariance_[1:, 1:])
         for i in range(max_iter):
             for idx in range(n_features):
-                sub_covariance = np.ascontiguousarray(
-                    covariance_[indices != idx].T[indices != idx])
+                if idx > 0:
+                    sub_covariance[idx-1] = covariance_[idx-1][indices != idx]
+                    sub_covariance[:, idx-1] = covariance_[:, idx-1][indices != idx]
+                else:
+                    sub_covariance[:] = covariance_[1:, 1:]
                 row = emp_cov[idx, indices != idx]
                 with np.errstate(**errors):
                     if mode == 'cd':

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -207,6 +207,14 @@ def graph_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
         sub_covariance = np.ascontiguousarray(covariance_[1:, 1:])
         for i in range(max_iter):
             for idx in range(n_features):
+                # for each idx, the sub_covariance matrix is the covariance_
+                # matrix lacking one row/column corresponding to the r/c
+                # being solved. when the next loop occurs, the previous r/c
+                # should be inserted again and the next r/c inserted in that
+                # location. no other r/c change during this operation, except
+                # at the c/r being re-added, which leave the matrix in an
+                # identical state as if it had been reconstructed as a
+                # contiguous matrix using [indices != idx] along each axis.
                 if idx > 0:
                     di = idx - 1
                     sub_covariance[di] = covariance_[di][indices != idx]

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -208,8 +208,9 @@ def graph_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
         for i in range(max_iter):
             for idx in range(n_features):
                 if idx > 0:
-                    sub_covariance[idx-1] = covariance_[idx-1][indices != idx]
-                    sub_covariance[:, idx-1] = covariance_[:, idx-1][indices != idx]
+                    di = idx - 1
+                    sub_covariance[di] = covariance_[di][indices != idx]
+                    sub_covariance[:, di] = covariance_[:, di][indices != idx]
                 else:
                     sub_covariance[:] = covariance_[1:, 1:]
                 row = emp_cov[idx, indices != idx]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
None.

#### What does this implement/fix? Explain your changes.
For a 1288x1288 empirical covariance matrix, `sklearn.covariance.graph_lasso` currently spends 70-80% of it's runtime creating `sub_covariance` on my computer. This change reduces that to ~3.5% of the function's runtime, and `np.allclose(...)` comparing both of the arrays in the result tuple return `True` for each. Iterations have the same losses & dual gaps, and calls to `graph_lasso` end after the same number of iterations, so I don't see a functional change with my data.

#### Any other comments?
Just noticed that this may interact with #4787. My dataset is quite dense, so the runtime of `graph_lasso` based on that PR is almost double that of the original function.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
