### PR TITLE
[MRG] Fix test class to be runnable by pytest

### DIFF
--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -15,35 +15,39 @@ def dist_func(x1, x2, p):
     return np.sum((x1 - x2) ** p) ** (1. / p)
 
 
-class TestMetrics:
-    def __init__(self, n1=20, n2=25, d=4, zero_frac=0.5,
-                 rseed=0, dtype=np.float64):
-        rng = check_random_state(rseed)
-        self.X1 = rng.random_sample((n1, d)).astype(dtype)
-        self.X2 = rng.random_sample((n2, d)).astype(dtype)
+class TestMetrics(object):
+    n1 = 20
+    n2 = 25
+    d = 4
+    zero_frac = 0.5
+    rseed = 0
+    dtype = np.float64
+    rng = check_random_state(rseed)
+    X1 = rng.random_sample((n1, d)).astype(dtype)
+    X2 = rng.random_sample((n2, d)).astype(dtype)
 
-        # make boolean arrays: ones and zeros
-        self.X1_bool = self.X1.round(0)
-        self.X2_bool = self.X2.round(0)
+    # make boolean arrays: ones and zeros
+    X1_bool = X1.round(0)
+    X2_bool = X2.round(0)
 
-        V = rng.random_sample((d, d))
-        VI = np.dot(V, V.T)
+    V = rng.random_sample((d, d))
+    VI = np.dot(V, V.T)
 
-        self.metrics = {'euclidean': {},
-                        'cityblock': {},
-                        'minkowski': dict(p=(1, 1.5, 2, 3)),
-                        'chebyshev': {},
-                        'seuclidean': dict(V=(rng.random_sample(d),)),
-                        'wminkowski': dict(p=(1, 1.5, 3),
-                                           w=(rng.random_sample(d),)),
-                        'mahalanobis': dict(VI=(VI,)),
-                        'hamming': {},
-                        'canberra': {},
-                        'braycurtis': {}}
+    metrics = {'euclidean': {},
+               'cityblock': {},
+               'minkowski': dict(p=(1, 1.5, 2, 3)),
+               'chebyshev': {},
+               'seuclidean': dict(V=(rng.random_sample(d),)),
+               'wminkowski': dict(p=(1, 1.5, 3),
+                                  w=(rng.random_sample(d),)),
+               'mahalanobis': dict(VI=(VI,)),
+               'hamming': {},
+               'canberra': {},
+               'braycurtis': {}}
 
-        self.bool_metrics = ['matching', 'jaccard', 'dice',
-                             'kulsinski', 'rogerstanimoto', 'russellrao',
-                             'sokalmichener', 'sokalsneath']
+    bool_metrics = ['matching', 'jaccard', 'dice',
+                    'kulsinski', 'rogerstanimoto', 'russellrao',
+                    'sokalmichener', 'sokalsneath']
 
     def test_cdist(self):
         for metric, argdict in self.metrics.items():


### PR DESCRIPTION
Test class with `__init__` is not run by pytest. I'll merge this one when the CIs are green.

More details (you need to edit setup.cfg to enable pytest warnings):
```
❯ pytest sklearn/neighbors/tests/test_dist_metrics.py -v
================================================ test session starts ================================================
platform linux -- Python 3.6.2, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- /volatile/le243287/miniconda3/bin/python
cachedir: .cache
rootdir: /home/le243287/dev/alt-scikit-learn, inifile: setup.cfg
plugins: cov-2.3.1
collected 4 items                                                                                                    

sklearn/neighbors/tests/test_dist_metrics.py::test_haversine_metric PASSED
sklearn/neighbors/tests/test_dist_metrics.py::test_pyfunc_metric PASSED
sklearn/neighbors/tests/test_dist_metrics.py::test_bad_pyfunc_metric PASSED
sklearn/neighbors/tests/test_dist_metrics.py::test_input_data_size PASSED

================================================= warnings summary ==================================================
sklearn/neighbors/tests/test_dist_metrics.py::TestMetrics
  cannot collect test class 'TestMetrics' because it has a __init__ constructor

-- Docs: http://doc.pytest.org/en/latest/warnings.html
======================================= 4 passed, 1 warnings in 0.56 seconds ========================================
```
