### PR TITLE
[MRG+2] retrieve embedded neighbor indexes using KNN search

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -424,8 +424,8 @@ def trustworthiness(X, X_embedded, n_neighbors=5, precomputed=False):
     else:
         dist_X = pairwise_distances(X, squared=True)
     ind_X = np.argsort(dist_X, axis=1)
-    ind_X_embedded = NearestNeighbors(n_neighbors).fit(
-        X_embedded).kneighbors(return_distance=False)
+    ind_X_embedded = NearestNeighbors(n_neighbors).fit(X_embedded).kneighbors(
+        return_distance=False)
 
     n_samples = X.shape[0]
     t = 0.0

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -424,9 +424,8 @@ def trustworthiness(X, X_embedded, n_neighbors=5, precomputed=False):
     else:
         dist_X = pairwise_distances(X, squared=True)
     ind_X = np.argsort(dist_X, axis=1)
-    neigh_embedded = NearestNeighbors(n_neighbors).fit(X_embedded)
-    ind_X_embedded = neigh_embedded.kneighbors(
-        None, n_neighbors, return_distance=False
+    ind_X_embedded = NearestNeighbors(n_neighbors).fit(X_embedded).kneighbors(
+        None, return_distance=False
     )
 
     n_samples = X.shape[0]

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -423,9 +423,11 @@ def trustworthiness(X, X_embedded, n_neighbors=5, precomputed=False):
         dist_X = X
     else:
         dist_X = pairwise_distances(X, squared=True)
-    dist_X_embedded = pairwise_distances(X_embedded, squared=True)
     ind_X = np.argsort(dist_X, axis=1)
-    ind_X_embedded = np.argsort(dist_X_embedded, axis=1)[:, 1:n_neighbors + 1]
+    neigh_embedded = NearestNeighbors(n_neighbors).fit(X_embedded)
+    ind_X_embedded = neigh_embedded.kneighbors(
+        X_embedded, n_neighbors + 1, return_distance=False
+    )[:, 1:]
 
     n_samples = X.shape[0]
     t = 0.0

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -426,8 +426,8 @@ def trustworthiness(X, X_embedded, n_neighbors=5, precomputed=False):
     ind_X = np.argsort(dist_X, axis=1)
     neigh_embedded = NearestNeighbors(n_neighbors).fit(X_embedded)
     ind_X_embedded = neigh_embedded.kneighbors(
-        X_embedded, n_neighbors + 1, return_distance=False
-    )[:, 1:]
+        None, n_neighbors, return_distance=False
+    )
 
     n_samples = X.shape[0]
     t = 0.0

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -424,9 +424,8 @@ def trustworthiness(X, X_embedded, n_neighbors=5, precomputed=False):
     else:
         dist_X = pairwise_distances(X, squared=True)
     ind_X = np.argsort(dist_X, axis=1)
-    ind_X_embedded = NearestNeighbors(n_neighbors).fit(X_embedded).kneighbors(
-        None, return_distance=False
-    )
+    ind_X_embedded = NearestNeighbors(n_neighbors).fit(
+        X_embedded).kneighbors(return_distance=False)
 
     n_samples = X.shape[0]
     t = 0.0


### PR DESCRIPTION
#### Reference Issue
Fixes #9737 


#### What does this implement/fix? Explain your changes.
Use KNN search for retrieving the indexes of the K-nearest neighbours in the embedded space
instead of computing pairwise distances and sorting the whole matrix


#### Any other comments?
it's a small enhancement since it's only improving the avg time complexity of  the searches only in the embedded space. An optimisation that would allow not performing pairwise distances and sorting in the original space at least in some cases would be much more profitable.

__update__ 
as pointed bellow it is a significant improvement

