### PR TITLE
[MRG] DOC: Use setattr(self, ...) instead of self.setattr(...) in rolling your own estimator section

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1089,7 +1089,7 @@ implement the interface is::
 
     def set_params(self, **parameters):
         for parameter, value in parameters.items():
-            self.setattr(parameter, value)
+            setattr(self, parameter, value)
         return self
 
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The current example interface for `set_params` [here](http://scikit-learn.org/stable/developers/contributing.html#get-params-and-set-params) is:

```python
def set_params(self, **parameters):
    for parameter, value in parameters.items():
        self.setattr(parameter, value)
    return self
```

I don't think that `self.setattr` is valid.  It doesn't look like `BaseEstimator` or the mixins have a `self.setattr`, and it isn't mentioned earlier in the documentation.  I can't find any references to `self.setattr` in the codebase either (unless `self.__setattr__` is what's meant).

Using the Python built-in `setattr` appears to be more common, so I propose changing to:

```python
def set_params(self, **parameters):
    for parameter, value in parameters.items():
        setattr(self, parameter, value)
    return self
```

