### PR TITLE
[MRG+1] classification_report: raise error if labels is None and target_names size is not equal to present classes

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1417,16 +1417,24 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
 
     """
 
+    labels_given = True
     if labels is None:
         labels = unique_labels(y_true, y_pred)
+        labels_given = False
     else:
         labels = np.asarray(labels)
 
     if target_names is not None and len(labels) != len(target_names):
-        warnings.warn(
-            "labels size, {0}, does not match size of target_names, {1}"
-            .format(len(labels), len(target_names))
-        )
+        if labels_given:
+            warnings.warn(
+                "labels size, {0}, does not match size of target_names, {1}"
+                .format(len(labels), len(target_names))
+            )
+        else:
+            raise ValueError(
+                "Number of classes, {0}, does not match size of "
+                "target_names, {1}".format(len(labels), len(target_names))
+            )
 
     last_line_heading = 'avg / total'
 

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1433,7 +1433,8 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
         else:
             raise ValueError(
                 "Number of classes, {0}, does not match size of "
-                "target_names, {1}".format(len(labels), len(target_names))
+                "target_names, {1}. Try specifying the labels "
+                "parameter".format(len(labels), len(target_names))
             )
 
     last_line_heading = 'avg / total'

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -883,7 +883,8 @@ def test_classification_report_no_labels_target_names_unequal_length():
 
     assert_raise_message(ValueError,
                          "Number of classes, 2, does not "
-                         "match size of target_names, 3",
+                         "match size of target_names, 3. "
+                         "Try specifying the labels parameter",
                          classification_report,
                          y_true, y_pred, target_names=target_names)
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -872,6 +872,19 @@ def test_classification_report_labels_target_names_unequal_length():
                          "labels size, 2, does not "
                          "match size of target_names, 3",
                          classification_report,
+                         y_true, y_pred, labels=[0, 2],
+                         target_names=target_names)
+
+
+def test_classification_report_no_labels_target_names_unequal_length():
+    y_true = [0, 0, 2, 0, 0]
+    y_pred = [0, 2, 2, 0, 0]
+    target_names = ['class 0', 'class 1', 'class 2']
+
+    assert_raise_message(ValueError,
+                         "Number of classes, 2, does not "
+                         "match size of target_names, 3",
+                         classification_report,
                          y_true, y_pred, target_names=target_names)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #9842 

#### What does this implement/fix? Explain your changes.
Raises an error if `labels` is `None` and `target_names` size is not equal to present labels.

#### Any other comments?
Previously, it raised a warning if this happened. Based on the issue discussion, I turned it into an error but I kept the warning for cases when `target_names` size is not equal to `labels` (when given). Maybe I should just raise an error there, too, to keep things consistent?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
