### PR TITLE
[CI] update Travis dependencies to latest Anaconda 5.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
   include:
     # This environment tests that scikit-learn can be built against
     # versions of numpy, scipy with ATLAS that comes with Ubuntu Trusty 14.04
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" CYTHON_VERSION="0.23.4"
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" CYTHON_VERSION="0.23.5"
            COVERAGE=true
       if: type != cron
       addons:
@@ -37,23 +37,23 @@ matrix:
            NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.13.3" CYTHON_VERSION="0.23.5"
            COVERAGE=true
       if: type != cron
-    # This environment tests the newest supported Anaconda release (4.4.0)
+    # This environment tests the newest supported Anaconda release (5.0.0)
     # It also runs tests requiring Pandas.
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6.1" INSTALL_MKL="true"
-           NUMPY_VERSION="1.13" SCIPY_VERSION="0.19.0" PANDAS_VERSION="0.20.2"
-           CYTHON_VERSION="0.25.2" COVERAGE=true
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6.2" INSTALL_MKL="true"
+           NUMPY_VERSION="1.13.1" SCIPY_VERSION="0.19.1" PANDAS_VERSION="0.20.3"
+           CYTHON_VERSION="0.26.1" COVERAGE=true
       if: type != cron
     # This environment use pytest to run the tests. It uses the newest
-    # supported Anaconda release (4.4.0). It also runs tests requiring Pandas.
-    - env: USE_PYTEST="true" DISTRIB="conda" PYTHON_VERSION="3.6.1"
-           INSTALL_MKL="true" NUMPY_VERSION="1.12.1" SCIPY_VERSION="0.19.0"
-           PANDAS_VERSION="0.20.1" CYTHON_VERSION="0.25.2"
+    # supported Anaconda release (5.0.0). It also runs tests requiring Pandas.
+    - env: USE_PYTEST="true" DISTRIB="conda" PYTHON_VERSION="3.6.2"
+           INSTALL_MKL="true" NUMPY_VERSION="1.13.1" SCIPY_VERSION="0.19.1"
+           PANDAS_VERSION="0.20.3" CYTHON_VERSION="0.26.1"
            TEST_DOCSTRINGS="true"
       if: type != cron
     # flake8 linting on diff wrt common ancestor with upstream/master
     - env: RUN_FLAKE8="true" SKIP_TESTS="true"
            DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="true"
-           NUMPY_VERSION="1.13" SCIPY_VERSION="0.19.0" CYTHON_VERSION="0.23.5"
+           NUMPY_VERSION="1.13.1" SCIPY_VERSION="0.19.1" CYTHON_VERSION="0.26.1"
       if: type != cron
     # This environment tests scikit-learn against numpy and scipy master
     # installed from their CI wheels in a virtualenv with the Python


### PR DESCRIPTION
Updates Travis config to reflect the [latest Anaconda 5.0.0 release](https://www.anaconda.com/download/#macos)