### PR TITLE
Add new cross validation and test

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -44,6 +44,7 @@ __all__ = ['BaseCrossValidator',
            'GroupShuffleSplit',
            'StratifiedKFold',
            'StratifiedShuffleSplit',
+           'GroupStratifiedShuffleSplit',
            'PredefinedSplit',
            'train_test_split',
            'check_cv']
@@ -1701,6 +1702,48 @@ def _validate_shuffle_split(n_samples, test_size, train_size):
                          'train_size.' % (n_train + n_test, n_samples))
 
     return int(n_train), int(n_test)
+
+
+class GroupStratifiedShuffleSplit(StratifiedShuffleSplit):
+    def split(self, X, y, groups=None):
+        """Generate indices to split data into training and test set.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+            Training data, where n_samples is the number of samples
+            and n_features is the number of features.
+
+            Note that providing ``y`` is sufficient to generate the splits and
+            hence ``np.zeros(n_samples)`` may be used as a placeholder for
+            ``X`` instead of actual training data.
+
+        y : array-like, shape (n_samples,)
+            The target variable for supervised learning problems.
+            Stratification is done based on the y labels.
+
+        groups : object
+            If provided, used instead of y to stratify.
+
+        Returns
+        -------
+        train : ndarray
+            The training set indices for that split.
+
+        test : ndarray
+            The testing set indices for that split.
+
+        Notes
+        -----
+        Randomized CV splitters may return different results for each call of
+        split. You can make the results identical by setting ``random_state``
+        to an integer.
+        """
+        y = check_array(y, ensure_2d=False, dtype=None)
+
+        if groups is not None:
+            y = groups
+        return super(StratifiedShuffleSplit, self).split(X, y, groups)
 
 
 class PredefinedSplit(BaseCrossValidator):


### PR DESCRIPTION
This adds a `model_selection.GroupStratifiedShuffleSplit` cross validation object. In contrast to `StratifiedShuffleSplit`, this gives you the option to stratify based on arbitrary groups. In contraction to `GroupShuffleSplit`, the folds are chosen to keep group proportions approximately constant, as opposed to holding out groups in turn. 

Identical behavior can be achieved with `StratifiedShuffleSplit` by passing `group` in as the `y` argument to `split` (in fact, that's exactly what `GroupStratifiedShuffleSplit` does).

By creating a new object with this behavior, it opens up the use of group stratification with, e.g. `cross_val_score`, without changing the documented behavior of `StratifiedShuffleSplit`. 

Alternatively, I would also support adding this as a new feature for `StratifiedShuffleSplit`.
