### PR TITLE
[MRG] Remove unused variable alphas from the LARS example.

### DIFF
--- a/examples/linear_model/plot_lasso_lars.py
+++ b/examples/linear_model/plot_lasso_lars.py
@@ -27,7 +27,7 @@ X = diabetes.data
 y = diabetes.target
 
 print("Computing regularization path using the LARS ...")
-alphas, _, coefs = linear_model.lars_path(X, y, method='lasso', verbose=True)
+_, _, coefs = linear_model.lars_path(X, y, method='lasso', verbose=True)
 
 xx = np.sum(np.abs(coefs.T), axis=1)
 xx /= xx[-1]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
N/A


#### What does this implement/fix? Explain your changes.
Removes an unused variable, `alphas`, from the [Lasso path using LARS](http://scikit-learn.org/stable/auto_examples/linear_model/plot_lasso_lars.html) example, for the purpose of improving readability.

#### Any other comments?
N/A

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
