### PR TITLE
[MRG+1] BUG Avoid unexpected error in PCA when n_components='mle'

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -107,6 +107,10 @@ Decomposition, manifold learning and clustering
 - Fixed a bug in :func:`datasets.fetch_kddcup99`, where data were not properly
   shuffled. :issue:`9731` by `Nicolas Goix`_.
 
+- Fixed a bug in :class:`decomposition.PCA` where users will get unexpected error
+  with large dataset when ``n_components='mle'`` on Python 3 versions.
+  :issue:`9886` by :user:`Hanmin Qin <qinhanmin2014>`.
+
 Metrics
 
 - Fixed a bug due to floating point error in :func:`metrics.roc_auc_score` with

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -108,7 +108,7 @@ Decomposition, manifold learning and clustering
   shuffled. :issue:`9731` by `Nicolas Goix`_.
 
 - Fixed a bug in :class:`decomposition.PCA` where users will get unexpected error
-  with large dataset when ``n_components='mle'`` on Python 3 versions.
+  with large datasets when ``n_components='mle'`` on Python 3 versions.
   :issue:`9886` by :user:`Hanmin Qin <qinhanmin2014>`.
 
 Metrics

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -130,14 +130,19 @@ class PCA(_BasePCA):
 
             n_components == min(n_samples, n_features)
 
-        if n_components == 'mle' and svd_solver == 'full', Minka\'s MLE is used
-        to guess the dimension
-        if ``0 < n_components < 1`` and svd_solver == 'full', select the number
-        of components such that the amount of variance that needs to be
+        If ``n_components == 'mle'`` and ``svd_solver == 'full'``, Minka\'s
+        MLE is used to guess the dimension. ``n_components == 'mle'`` only
+        works for full svd_solver or auto svd_solver (equivalent to full
+        svd_solver in this case).
+
+        If ``0 < n_components < 1`` and ``svd_solver == 'full'``, select the
+        number of components such that the amount of variance that needs to be
         explained is greater than the percentage specified by n_components.
-        If svd_solver == 'arpack', the number of components must be strictly
-        less than the minimum of n_features and n_samples.
-        Hence, the None case results in:
+
+        If ``svd_solver == 'arpack'``, the number of components must be
+        strictly less than the minimum of n_features and n_samples.
+
+        Hence, the None case results in::
 
             n_components == min(n_samples, n_features) - 1
 

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -131,9 +131,8 @@ class PCA(_BasePCA):
             n_components == min(n_samples, n_features)
 
         If ``n_components == 'mle'`` and ``svd_solver == 'full'``, Minka\'s
-        MLE is used to guess the dimension. ``n_components == 'mle'`` only
-        works for full svd_solver or auto svd_solver (equivalent to full
-        svd_solver in this case).
+        MLE is used to guess the dimension. Use of ``n_components == 'mle'``
+        will interpret ``svd_solver == 'auto'`` as ``svd_solver == 'full'``.
 
         If ``0 < n_components < 1`` and ``svd_solver == 'full'``, select the
         number of components such that the amount of variance that needs to be

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -386,8 +386,8 @@ class PCA(_BasePCA):
         # Handle svd_solver
         svd_solver = self.svd_solver
         if svd_solver == 'auto':
-            # Small problem, just call full PCA
-            if max(X.shape) <= 500:
+            # Small problem or n_components == 'mle', just call full PCA
+            if max(X.shape) <= 500 or n_components == 'mle':
                 svd_solver = 'full'
             elif n_components >= 1 and n_components < .8 * min(X.shape):
                 svd_solver = 'randomized'

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -456,7 +456,7 @@ def test_randomized_pca_inverse():
 
 def test_n_components_mle():
     # Ensure that n_components == 'mle' doesn't raise error for auto/full
-    # svd_solver and raises error for arpack/randomized solver
+    # svd_solver and raises error for arpack/randomized svd_solver
     rng = np.random.RandomState(0)
     n_samples = 600
     n_features = 10

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -461,14 +461,17 @@ def test_n_components_mle():
     n_samples = 600
     n_features = 10
     X = rng.randn(n_samples, n_features)
+    n_components_dict = {}
     for solver in solver_list:
         pca = PCA(n_components='mle', svd_solver=solver)
         if solver in ['auto', 'full']:
             pca.fit(X)
+            n_components_dict[solver] = pca.n_components_
         else:  # arpack/randomized solver
             error_message = ("n_components='mle' cannot be a string with "
                              "svd_solver='{}'".format(solver))
             assert_raise_message(ValueError, error_message, pca.fit, X)
+    assert_equal(n_components_dict['auto'], n_components_dict['full'])
 
 
 def test_pca_dim():

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -7,6 +7,7 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.testing import assert_no_warnings
@@ -451,6 +452,23 @@ def test_randomized_pca_inverse():
     Y_inverse = pca.inverse_transform(Y)
     relative_max_delta = (np.abs(X - Y_inverse) / np.abs(X).mean()).max()
     assert_less(relative_max_delta, 1e-5)
+
+
+def test_n_components_mle():
+    # Ensure that n_components == 'mle' doesn't raise error for auto/full
+    # svd_solver and raises error for arpack/randomized solver
+    rng = np.random.RandomState(0)
+    n_samples = 600
+    n_features = 10
+    X = rng.randn(n_samples, n_features)
+    for solver in solver_list:
+        pca = PCA(n_components='mle', svd_solver=solver)
+        if solver in ['auto', 'full']:
+            pca.fit(X)
+        else:  # arpack/randomized solver
+            error_message = ("n_components='mle' cannot be a string with "
+                             "svd_solver='{}'".format(solver))
+            assert_raise_message(ValueError, error_message, pca.fit, X)
 
 
 def test_pca_dim():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #9884 

#### What does this implement/fix? Explain your changes.
Currently, in python3.X, when we call PCA with large dataset (max(X.shape) > 500) and n_components='mle' without explicitly setting svd_solver='full', we will get an error.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
