### PR TITLE
[MRG] Compute grid_ranking_ inside _fit method

### DIFF
--- a/examples/feature_selection/plot_rfe_digits.py
+++ b/examples/feature_selection/plot_rfe_digits.py
@@ -36,7 +36,6 @@ for n, r in enumerate(rankings):
         plt.matshow(r, cmap=plt.cm.Blues)
         plt.colorbar()
         plt.title("Ranking of pixels at step {}".format(n))
-plt.show()
 
 # Plot pixel ranking
 plt.matshow(ranking, cmap=plt.cm.Blues)

--- a/examples/feature_selection/plot_rfe_digits.py
+++ b/examples/feature_selection/plot_rfe_digits.py
@@ -29,6 +29,15 @@ rfe = RFE(estimator=svc, n_features_to_select=1, step=1)
 rfe.fit(X, y)
 ranking = rfe.ranking_.reshape(digits.images[0].shape)
 
+# Plot pixel in grid_ranking_ every 10 steps
+rankings = [r.reshape(digits.images[0].shape) for r in rfe.grid_ranking_]
+for n, r in enumerate(rankings):
+    if n%10==0:
+        plt.matshow(r, cmap=plt.cm.Blues)
+        plt.colorbar()
+        plt.title("Ranking of pixels at step {}".format(n))
+plt.show()
+
 # Plot pixel ranking
 plt.matshow(ranking, cmap=plt.cm.Blues)
 plt.colorbar()

--- a/examples/feature_selection/plot_rfe_digits.py
+++ b/examples/feature_selection/plot_rfe_digits.py
@@ -25,7 +25,7 @@ y = digits.target
 
 # Create the RFE object and rank each pixel
 svc = SVC(kernel="linear", C=1)
-rfe = RFE(estimator=svc, n_features_to_select=1, step=1)
+rfe = RFE(estimator=svc, n_features_to_select=1, step=1, step_ranking=True)
 rfe.fit(X, y)
 ranking = rfe.ranking_.reshape(digits.images[0].shape)
 

--- a/examples/feature_selection/plot_rfe_digits.py
+++ b/examples/feature_selection/plot_rfe_digits.py
@@ -32,7 +32,7 @@ ranking = rfe.ranking_.reshape(digits.images[0].shape)
 # Plot pixel in grid_ranking_ every 10 steps
 rankings = [r.reshape(digits.images[0].shape) for r in rfe.grid_ranking_]
 for n, r in enumerate(rankings):
-    if n%10==0:
+    if n % 10 == 0:
         plt.matshow(r, cmap=plt.cm.Blues)
         plt.colorbar()
         plt.title("Ranking of pixels at step {}".format(n))

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -80,6 +80,10 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         ranking position of the i-th feature. Selected (i.e., estimated
         best) features are assigned rank 1.
 
+    grid_ranking_: array of shape [n_steps, n_features]
+        The grid representing rankings at each step, such that
+        ``grid_ranking_[i]`` corresponds to ranking_ at i-th step.
+
     estimator_ : object
         The external estimator fit on the reduced dataset.
 

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -156,6 +156,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
 
         support_ = np.ones(n_features, dtype=np.bool)
         ranking_ = np.ones(n_features, dtype=np.int)
+        grid_ranking_ = []
 
         if step_score:
             self.scores_ = []
@@ -201,6 +202,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
                 self.scores_.append(step_score(estimator, features))
             support_[features[ranks][:threshold]] = False
             ranking_[np.logical_not(support_)] += 1
+            grid_ranking_.append(ranking_)
 
         # Set final attributes
         features = np.arange(n_features)[support_]
@@ -213,6 +215,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         self.n_features_ = support_.sum()
         self.support_ = support_
         self.ranking_ = ranking_
+        self.grid_ranking_ = np.array(grid_ranking_)
 
         return self
 

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -64,6 +64,10 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         If within (0.0, 1.0), then `step` corresponds to the percentage
         (rounded down) of features to remove at each iteration.
 
+    step_ranking : bool of None, optional (default=None)
+        If specified, ranking at each step will be saved as a row of
+        `grid_ranking_` array.
+
     verbose : int, default=0
         Controls verbosity of output.
 
@@ -80,9 +84,10 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         ranking position of the i-th feature. Selected (i.e., estimated
         best) features are assigned rank 1.
 
-    grid_ranking_: array of shape [n_steps, n_features]
+    grid_ranking_: array of shape [n_steps, n_features], optional
         The grid representing rankings at each step, such that
-        ``grid_ranking_[i]`` corresponds to ranking_ at i-th step.
+        ``grid_ranking_[i]`` corresponds to ranking_ at i-th step (if you have
+        initialized `step_ranking=True`)
 
     estimator_ : object
         The external estimator fit on the reduced dataset.
@@ -113,11 +118,12 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
            Mach. Learn., 46(1-3), 389--422, 2002.
     """
     def __init__(self, estimator, n_features_to_select=None, step=1,
-                 verbose=0):
+                 step_ranking=None, verbose=0):
         self.estimator = estimator
         self.n_features_to_select = n_features_to_select
         self.step = step
         self.verbose = verbose
+        self.step_ranking = step_ranking
 
     @property
     def _estimator_type(self):
@@ -160,7 +166,8 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
 
         support_ = np.ones(n_features, dtype=np.bool)
         ranking_ = np.ones(n_features, dtype=np.int)
-        grid_ranking_ = []
+        if self.step_ranking:
+            grid_ranking_ = []
 
         if step_score:
             self.scores_ = []
@@ -206,7 +213,8 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
                 self.scores_.append(step_score(estimator, features))
             support_[features[ranks][:threshold]] = False
             ranking_[np.logical_not(support_)] += 1
-            grid_ranking_.append(ranking_.copy())
+            if self.step_ranking:
+                grid_ranking_.append(ranking_.copy())
 
         # Set final attributes
         features = np.arange(n_features)[support_]
@@ -219,7 +227,8 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         self.n_features_ = support_.sum()
         self.support_ = support_
         self.ranking_ = ranking_
-        self.grid_ranking_ = np.array(grid_ranking_)
+        if self.step_ranking:
+            self.grid_ranking_ = np.array(grid_ranking_)
 
         return self
 

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -206,7 +206,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
                 self.scores_.append(step_score(estimator, features))
             support_[features[ranks][:threshold]] = False
             ranking_[np.logical_not(support_)] += 1
-            grid_ranking_.append(ranking_)
+            grid_ranking_.append(ranking_.copy())
 
         # Set final attributes
         features = np.arange(n_features)[support_]


### PR DESCRIPTION
#### Reference Issue

#### What does this implement/fix? Explain your changes.
This changes allow an user to track feature ranking during the recursive step (inside ```while``` loop) by appending the ```ranking_``` array to the new list ```grid_ranking_```. As final step, grid_ranking_ is visible to the user as a numpy array with shape (n_of_steps, n_of_features), ordered as computed by RFE.

#### Any other comments?
It is a minor issue but it was quite useful to me keep track of changing in feature selected during the fitting.