### PR TITLE
[MRG+1] Fix #9865 - sklearn.datasets.make_classification modifies its weights parameters and add test

### DIFF
--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -162,7 +162,7 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
     n_clusters = n_classes * n_clusters_per_class
 
     if weights and len(weights) == (n_classes - 1):
-        weights.append(1.0 - sum(weights))
+        weights = weights + [1.0 - sum(weights)]
 
     if weights is None:
         weights = [1.0 / n_classes] * n_classes

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -37,12 +37,14 @@ from sklearn.utils.validation import assert_all_finite
 
 
 def test_make_classification():
+    weights = [0.1, 0.25]
     X, y = make_classification(n_samples=100, n_features=20, n_informative=5,
                                n_redundant=1, n_repeated=1, n_classes=3,
                                n_clusters_per_class=1, hypercube=False,
-                               shift=None, scale=None, weights=[0.1, 0.25],
+                               shift=None, scale=None, weights=weights,
                                random_state=0)
 
+    assert_equal(weights, [0.1, 0.25])
     assert_equal(X.shape, (100, 20), "X shape mismatch")
     assert_equal(y.shape, (100,), "y shape mismatch")
     assert_equal(np.unique(y).shape, (3,), "Unexpected number of classes")
@@ -178,6 +180,7 @@ def test_make_multilabel_classification_return_indicator():
     assert_equal(p_w_c.shape, (20, 3))
     assert_almost_equal(p_w_c.sum(axis=0), [1] * 3)
 
+
 def test_make_multilabel_classification_return_indicator_sparse():
     for allow_unlabeled, min_length in zip((True, False), (0, 1)):
         X, Y = make_multilabel_classification(n_samples=25, n_features=20,
@@ -187,6 +190,7 @@ def test_make_multilabel_classification_return_indicator_sparse():
         assert_equal(X.shape, (25, 20), "X shape mismatch")
         assert_equal(Y.shape, (25, 3), "Y shape mismatch")
         assert_true(sp.issparse(Y))
+
 
 def test_make_hastie_10_2():
     X, y = make_hastie_10_2(n_samples=100, random_state=0)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Fixes #9865 

#### Description
As in the issue, the `make_classification()` used to modify the weight input which it shouldn't.
Now, it instead creates a copy leaving the original weights intact. Also, added test to verify this.
<!-- Example: Fixes #1234 -->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
