### PR TITLE
fix a typo

### DIFF
--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -191,7 +191,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         Number of documents to use in each EM iteration. Only used in online
         learning.
 
-    evaluate_every : int optional (default=0)
+    evaluate_every : int, optional (default=0)
         How often to evaluate perplexity. Only used in `fit` method.
         set it to 0 or negative number to not evalute perplexity in
         training at all. Evaluating perplexity can help you check convergence


### PR DESCRIPTION
fix a typo:
add a comma