### PR TITLE
Adding a `prefit` parameter to the VotingClassifier

### DIFF
--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -73,16 +73,6 @@ def test_notfitted():
            " with appropriate arguments before using this method.")
     assert_raise_message(NotFittedError, msg, eclf.predict_proba, X)
 
-"""
-def test_notfitted2():
-    eclf = VotingClassifier(estimators=[('lr1', LogisticRegression()),
-                                        ('lr2', LogisticRegression())],
-                            prefit=True)
-    msg = ("This VotingClassifier instance is not fitted yet. Call \'fit\'"
-           " with appropriate arguments before using this method.")
-    assert_raise_message(NotFittedError, msg, eclf.predict_proba, X)
-"""
-
 
 def test_majority_label_iris():
     """Check classification by majority label on dataset iris."""
@@ -440,39 +430,35 @@ def test_transform():
     )
 
 
-def test_prefit_true_calling_fit():
+def test_prefit_predict_with_nonfitted_estimators():
 
     X = np.array([[-1.1, -1.5], [-1.2, -1.4], [-3.4, -2.2], [1.1, 1.2]])
     y = np.array([1, 1, 2, 2])
 
     lr1 = LogisticRegression()
     lr2 = LogisticRegression()
-    lr1.fit(X, y)
-    lr2.fit(X, y)
 
     eclf = VotingClassifier(estimators=[('lr1', lr1),
                                         ('lr2', lr2)],
-                            voting='soft',
                             prefit=True)
 
-    msg = ('Since `prefit=True`, call `transform`,'
-           ' `predict`, or `predict_proba directly')
+    eclf.fit(X, y)
+    msg = ('Error encountered in estimator lr1. '
+           'This LogisticRegression instance is not fitted yet')
+    assert_raise_message(NotFittedError, msg, eclf.predict, X)
 
-    assert_raise_message(ValueError, msg, eclf.fit, X, y)
 
-
-def test_prefit_predict():
+def test_prefit_predict_with_fitted_estimators():
 
     X = np.array([[-1.1, -1.5], [-1.2, -1.4], [-3.4, -2.2], [1.1, 1.2]])
     y = np.array([1, 1, 2, 2])
 
-    lr1 = LogisticRegression()
-    lr2 = LogisticRegression()
-    lr1.fit(X, y)
-    lr2.fit(X, y)
+    lr1 = LogisticRegression().fit(X, y)
+    lr2 = LogisticRegression().fit(X, y)
 
     eclf = VotingClassifier(estimators=[('lr1', lr1),
                                         ('lr2', lr2)],
                             prefit=True)
 
-    eclf.predict(X)
+    eclf.fit(X, y)
+    assert eclf.score(X, y) == 0.75

--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -73,6 +73,16 @@ def test_notfitted():
            " with appropriate arguments before using this method.")
     assert_raise_message(NotFittedError, msg, eclf.predict_proba, X)
 
+"""
+def test_notfitted2():
+    eclf = VotingClassifier(estimators=[('lr1', LogisticRegression()),
+                                        ('lr2', LogisticRegression())],
+                            prefit=True)
+    msg = ("This VotingClassifier instance is not fitted yet. Call \'fit\'"
+           " with appropriate arguments before using this method.")
+    assert_raise_message(NotFittedError, msg, eclf.predict_proba, X)
+"""
+
 
 def test_majority_label_iris():
     """Check classification by majority label on dataset iris."""
@@ -428,3 +438,41 @@ def test_transform():
             eclf3.transform(X).swapaxes(0, 1).reshape((4, 6)),
             eclf2.transform(X)
     )
+
+
+def test_prefit_true_calling_fit():
+
+    X = np.array([[-1.1, -1.5], [-1.2, -1.4], [-3.4, -2.2], [1.1, 1.2]])
+    y = np.array([1, 1, 2, 2])
+
+    lr1 = LogisticRegression()
+    lr2 = LogisticRegression()
+    lr1.fit(X, y)
+    lr2.fit(X, y)
+
+    eclf = VotingClassifier(estimators=[('lr1', lr1),
+                                        ('lr2', lr2)],
+                            voting='soft',
+                            prefit=True)
+
+    msg = ('Since `prefit=True`, call `transform`,'
+           ' `predict`, or `predict_proba directly')
+
+    assert_raise_message(ValueError, msg, eclf.fit, X, y)
+
+
+def test_prefit_predict():
+
+    X = np.array([[-1.1, -1.5], [-1.2, -1.4], [-3.4, -2.2], [1.1, 1.2]])
+    y = np.array([1, 1, 2, 2])
+
+    lr1 = LogisticRegression()
+    lr2 = LogisticRegression()
+    lr1.fit(X, y)
+    lr2.fit(X, y)
+
+    eclf = VotingClassifier(estimators=[('lr1', lr1),
+                                        ('lr2', lr2)],
+                            prefit=True)
+
+    eclf.predict(X)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

We don't have an issue for that but discussed this via the mailing list (https://mail.python.org/pipermail/scikit-learn/2017-October/001960.html)


#### What does this implement/fix? Explain your changes.

Adds a `prefit` parameter to the `VotingClassifier` so that it accepts prefitted estimators; currently, it's only possible to use the `VotingClassifier` upon refitting clones of the original estimators by running `fit`.


#### Any other comments?

This is an early PR for feedback. 

Below are todos to get to when the implementation details are sorted out.


- [ ] Add note to "What's New" docs
- [ ] Add appropriate unit tests for `predict`, `predict_proba`, and `transform` when `prefit=True`

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->