### PR TITLE
[MRG+2] Fix example for matplotlib 2.1 change

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -107,7 +107,7 @@ conda update --yes --quiet conda
 # Configure the conda environment and put it in the path using the
 # provided versions
 conda create -n $CONDA_ENV_NAME --yes --quiet python numpy scipy \
-  cython nose coverage 'matplotlib=2.0.*|>2.1.0' sphinx=1.6.2 pillow
+  cython nose coverage matplotlib sphinx=1.6.2 pillow
 source activate testenv
 pip install sphinx-gallery numpydoc
 

--- a/examples/neural_networks/plot_mlp_training_curves.py
+++ b/examples/neural_networks/plot_mlp_training_curves.py
@@ -85,5 +85,5 @@ for ax, data, name in zip(axes.ravel(), data_sets, ['iris', 'digits',
                                                     'circles', 'moons']):
     plot_on_dataset(*data, ax=ax, name=name)
 
-fig.legend(ax.get_lines(), labels=labels, ncol=3, loc="upper center")
+fig.legend(ax.get_lines(), labels, ncol=3, loc="upper center")
 plt.show()


### PR DESCRIPTION
In matplotlib 2.1 legend has to be called with either 0, 2 or 3 non keywords arguments.

To reproduce the problem:
```
ipython examples/neural_networks/plot_mlp_training_curves.py
```

Stack-trace:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
~/dev/alt-scikit-learn/examples/neural_networks/plot_mlp_training_curves.py in <module>()
     86     plot_on_dataset(*data, ax=ax, name=name)
     87 
---> 88 fig.legend(ax.get_lines(), labels=labels, ncol=3, loc="upper center")
     89 plt.show()

/volatile/le243287/miniconda3/lib/python3.6/site-packages/matplotlib/figure.py in legend(self, *args, **kwargs)
   1518 
   1519         else:
-> 1520             raise TypeError('Invalid number of arguments passed to legend. '
   1521                             'Please specify either 0 args, 2 args '
   1522                             '(artist handles, figure labels) or 3 args '

TypeError: Invalid number of arguments passed to legend. Please specify either 0 args, 2 args (artist handles, figure labels) or 3 args (artist handles, figure labels, legend location)
```