### PR TITLE
[MRG] Improve MinCovDet error when covariance of support data is 0

### DIFF
--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -405,7 +405,7 @@ def fast_mcd(X, support_fraction=None,
             # get precision matrix in an optimized way
             precision = linalg.pinvh(covariance)
             dist = (np.dot(X_centered, precision) * (X_centered)).sum(axis=1)
-# Starting FastMCD algorithm for p-dimensional case
+    # Starting FastMCD algorithm for p-dimensional case
     if (n_samples > 500) and (n_features > 1):
         # 1. Find candidate supports on subsets
         # a. split the set in subsets of size ~ 300
@@ -672,6 +672,14 @@ class MinCovDet(EmpiricalCovariance):
             Corrected robust covariance estimate.
 
         """
+
+        # Check that the covariance of the support data is not equal to 0.
+        # Otherwise self.dist_ = 0 and thus correction = 0.
+        n_samples = len(self.dist_)
+        n_support = np.sum(self.support_)
+        if n_support < n_samples and np.allclose(self.raw_covariance_, 0):
+            raise ValueError('The covariance matrix of the support data '
+                             'is equal to 0, try to increase support_fraction')
         correction = np.median(self.dist_) / chi2(data.shape[1]).isf(0.5)
         covariance_corrected = self.raw_covariance_ * correction
         self.dist_ /= correction

--- a/sklearn/covariance/tests/test_robust_covariance.py
+++ b/sklearn/covariance/tests/test_robust_covariance.py
@@ -126,6 +126,19 @@ def test_mcd_issue3367():
     MinCovDet(random_state=rand_gen).fit(data)
 
 
+def test_mcd_support_covariance_is_zero():
+    # Check that MCD returns a ValueError with informative message when the
+    # covariance of the support data is equal to 0.
+    X_1 = np.array([0.5, 0.1, 0.1, 0.1, 0.957, 0.1, 0.1, 0.1, 0.4285, 0.1])
+    X_1 = X_1.reshape(-1, 1)
+    X_2 = np.array([0.5, 0.3, 0.3, 0.3, 0.957, 0.3, 0.3, 0.3, 0.4285, 0.3])
+    X_2 = X_2.reshape(-1, 1)
+    msg = ('The covariance matrix of the support data is equal to 0, try to '
+           'increase support_fraction')
+    for X in [X_1, X_2]:
+        assert_raise_message(ValueError, msg, MinCovDet().fit, X)
+
+
 def test_outlier_detection():
     rnd = np.random.RandomState(0)
     X = rnd.randn(100, 10)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Fixes #9864 


#### What does this implement/fix? Explain your changes.
This improves the MinCovDet error message when the covariance matrix of the support data is equal to 0. This also adds non-regression tests.

**EDIT**: When the support data or more lie on a hyperplane, the algorithm described in the original paper returns the minimum covariance determinant estimates of the location and the (singular) covariance matrix. The algorithm then computes the equation of the hyperplane. I don't think (although I'm not certain about it) that `MinCovDet` implements such a particular case and I don't know if this should be handled but we might want to test what happens in this case. I can try the example of the original paper for such a situation and see what happens. My guess is that using `pinvh` makes `MinCovDet` return a solution anyway from which we can compute a Mahalanobis distance.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
