### PR TITLE
[MRG] add n_iter_no_change parameter in MLP

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -41,6 +41,11 @@ Classifiers and regressors
   Naive Bayes classifier described in Rennie et al. (2003).
   By :user:`Michael A. Alcorn <airalcorn2>`.
 
+- :class:`neural_network.MLPClassifier`, :class:`neural_network.MLPRegressor`,
+￼  now expose a ``n_iter_no_change`` parameter, to monitor the number of
+  iteration with no improvement to wait before early stopping.
+  :issue:`9913`  by `Tom Dupre la Tour`_.
+
 Enhancements
 ............
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -44,7 +44,7 @@ Classifiers and regressors
 - :class:`neural_network.MLPClassifier`, :class:`neural_network.MLPRegressor`,
 ￼  now expose a ``n_iter_no_change`` parameter, to monitor the number of
   iteration with no improvement to wait before early stopping.
-  :issue:`9913`  by `Tom Dupre la Tour`_.
+  :issue:`9914`  by `Tom Dupre la Tour`_.
 
 Enhancements
 ............


### PR DESCRIPTION
Fixes #9456

Add a parameter `n_iter_no_change` in `MLPClassifier` and `MLPRegressor`, with the same API as in `GradientBoosting`:

- `n_iter_no_change=None` disables early stopping.
- `n_iter_no_change!=None` set the number of iter with no improvement to wait before early stopping.

____
Related: In #9043, add early stopping with validation set in `SGDClassifier` and `SGDRegressor`. Also add `n_iter_no_change` paramter.