### PR TITLE
[MRG+1] Add norm parameter to ComplementNB.

### DIFF
--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -154,7 +154,7 @@ calculating the weights is as follows:
 
     w_{ci} = \log \hat{\theta}_{ci}
 
-    w_{ci} = \frac{w_{ci}}{\sum_{j} w_{cj}}
+    w_{ci} = \frac{w_{ci}}{\sum_{j} |w_{cj}|}
 
 where the summations are over all documents :math:`j` not in class :math:`c`,
 :math:`d_{ij}` is either the count or tf-idf value of term :math:`i` in document

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -816,6 +816,7 @@ class ComplementNB(BaseDiscreteNB):
         """Apply smoothing to raw counts and compute the weights."""
         comp_count = self.feature_all_ + alpha - self.feature_count_
         logged = np.log(comp_count / comp_count.sum(axis=1, keepdims=True))
+        # BaseNB.predict uses argmax, but ComplementNB operates with argmin.
         feature_log_prob = -logged
         if self.norm:
             summed = logged.sum(axis=1, keepdims=True)

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -754,7 +754,10 @@ class ComplementNB(BaseDiscreteNB):
         Prior probabilities of the classes. Not used.
 
     norm : boolean, optional (default=False)
-        Whether or not to perform second normalization of weights.
+        Whether or not a second normalization of the weights is performed. The
+        default behavior mirrors the implementations found in Mahout and Weka,
+        which do not follow the full algorithm described in Table 9 of the
+        paper.
 
     Attributes
     ----------

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -557,7 +557,7 @@ def test_cnb():
     Y = np.array([0, 0, 0, 1])
 
     # Verify inputs are nonnegative.
-    clf = ComplementNB(alpha=1.0)
+    clf = ComplementNB(alpha=1.0, norm=True)
     assert_raises(ValueError, clf.fit, -X, Y)
 
     clf.fit(X, Y)

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -556,20 +556,6 @@ def test_cnb():
     # Classes are China (0), Japan (1).
     Y = np.array([0, 0, 0, 1])
 
-    # Verify inputs are nonnegative.
-    clf = ComplementNB(alpha=1.0, norm=True)
-    assert_raises(ValueError, clf.fit, -X, Y)
-
-    clf.fit(X, Y)
-
-    # Check that counts are correct.
-    feature_count = np.array([[1, 3, 0, 1, 1, 0], [0, 1, 1, 0, 0, 1]])
-    assert_array_equal(clf.feature_count_, feature_count)
-    class_count = np.array([3, 1])
-    assert_array_equal(clf.class_count_, class_count)
-    feature_all = np.array([1, 4, 1, 1, 1, 1])
-    assert_array_equal(clf.feature_all_, feature_all)
-
     # Check that weights are correct. See steps 4-6 in Table 4 of
     # Rennie et al. (2003).
     theta = np.array([
@@ -591,11 +577,29 @@ def test_cnb():
         ]])
 
     weights = np.zeros(theta.shape)
+    normed_weights = np.zeros(theta.shape)
     for i in range(2):
-        weights[i] = np.log(theta[i])
-        weights[i] /= weights[i].sum()
+        weights[i] = -np.log(theta[i])
+        normed_weights[i] = weights[i] / weights[i].sum()
 
+    # Verify inputs are nonnegative.
+    clf = ComplementNB(alpha=1.0)
+    assert_raises(ValueError, clf.fit, -X, Y)
+
+    clf.fit(X, Y)
+
+    # Check that counts/weights are correct.
+    feature_count = np.array([[1, 3, 0, 1, 1, 0], [0, 1, 1, 0, 0, 1]])
+    assert_array_equal(clf.feature_count_, feature_count)
+    class_count = np.array([3, 1])
+    assert_array_equal(clf.class_count_, class_count)
+    feature_all = np.array([1, 4, 1, 1, 1, 1])
+    assert_array_equal(clf.feature_all_, feature_all)
     assert_array_almost_equal(clf.feature_log_prob_, weights)
+
+    clf = ComplementNB(alpha=1.0, norm=True)
+    clf.fit(X, Y)
+    assert_array_almost_equal(clf.feature_log_prob_, normed_weights)
 
 
 def test_naive_bayes_scale_invariance():

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1264,9 +1264,6 @@ def check_supervised_y_2d(name, estimator_orig):
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))
 def check_classifiers_classes(name, classifier_orig):
-    # This is a pathological data set for ComplementNB.
-    if name == "ComplementNB":
-        return
     X, y = make_blobs(n_samples=30, random_state=0, cluster_std=0.1)
     X, y = shuffle(X, y, random_state=7)
     X = StandardScaler().fit_transform(X)
@@ -1292,7 +1289,9 @@ def check_classifiers_classes(name, classifier_orig):
 
         y_pred = classifier.predict(X)
         # training set performance
-        assert_array_equal(np.unique(y_), np.unique(y_pred))
+        if name != "ComplementNB":
+            # This is a pathological data set for ComplementNB.
+            assert_array_equal(np.unique(y_), np.unique(y_pred))
         if np.any(classifier.classes_ != classes):
             print("Unexpected classes_ attribute for %r: "
                   "expected %s, got %s" %

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1264,6 +1264,9 @@ def check_supervised_y_2d(name, estimator_orig):
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))
 def check_classifiers_classes(name, classifier_orig):
+    # This is a pathological data set for ComplementNB.
+    if name == "ComplementNB":
+        return
     X, y = make_blobs(n_samples=30, random_state=0, cluster_std=0.1)
     X, y = shuffle(X, y, random_state=7)
     X = StandardScaler().fit_transform(X)
@@ -1281,7 +1284,7 @@ def check_classifiers_classes(name, classifier_orig):
 
         classes = np.unique(y_)
         classifier = clone(classifier_orig)
-        if name in ['BernoulliNB', 'ComplementNB']:
+        if name == 'BernoulliNB':
             X = X > X.mean()
         set_random_state(classifier)
         # fit


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
N/A

#### What does this implement/fix? Explain your changes.
This change adds a `norm` parameter to `ComplementNB`, which controls whether or not a second normalization of the weights is performed. We noticed that the scikit-learn implementation of CNB was consistently achieving ~1% lower accuracy than the Mahout implementation on our data set. It turns out, the Mahout implementation [does not perform the second normalization](https://github.com/twitter/mahout/blob/master/core/src/main/java/org/apache/mahout/classifier/naivebayes/ComplementaryNaiveBayesClassifier.java#L32) described in the paper. Based on these observations, it seems appropriate to allow the user to control whether or not the second normalization occurs and to set it to `False` by default.

#### Any other comments?
No.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
