### PR TITLE
Clarify docs for `make_classification`

### DIFF
--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -43,8 +43,8 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
 
     This initially creates clusters of points normally distributed (std=1)
     about vertices of an `n_informative`-dimensional hypercube, and assigns
-    an equal number of clusters to each class. It introduces interdependence 
-    between these features and adds various types of further noise to the 
+    an equal number of clusters to each class. It introduces interdependence
+    between these features and adds various types of further noise to the
     data.
 
     Prior to shuffling, `X` stacks a number of these primary "informative"
@@ -62,8 +62,7 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
         The total number of features. These comprise `n_informative`
         informative features, `n_redundant` redundant features, `n_repeated`
         duplicated features and `n_features-n_informative-n_redundant-
-        n_repeated` useless features drawn at random.  A larger number of
-        features generally makes the classification task more difficult.
+        n_repeated` useless features drawn at random.
 
     n_informative : int, optional (default=2)
         The number of informative features. Each class is composed of a number
@@ -96,7 +95,7 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
         exceeds 1.
 
     flip_y : float, optional (default=0.01)
-        The fraction of samples whose class are randomly exchanged. Larger 
+        The fraction of samples whose class are randomly exchanged. Larger
         values introduce noise in the labels and make the classification
         task harder.
 

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -42,9 +42,10 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
     """Generate a random n-class classification problem.
 
     This initially creates clusters of points normally distributed (std=1)
-    about vertices of a `2 * class_sep`-sided hypercube, and assigns an equal
-    number of clusters to each class. It introduces interdependence between
-    these features and adds various types of further noise to the data.
+    about vertices of an `n_informative`-dimensional hypercube, and assigns
+    an equal number of clusters to each class. It introduces interdependence 
+    between these features and adds various types of further noise to the 
+    data.
 
     Prior to shuffling, `X` stacks a number of these primary "informative"
     features, "redundant" linear combinations of these, "repeated" duplicates
@@ -61,7 +62,8 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
         The total number of features. These comprise `n_informative`
         informative features, `n_redundant` redundant features, `n_repeated`
         duplicated features and `n_features-n_informative-n_redundant-
-        n_repeated` useless features drawn at random.
+        n_repeated` useless features drawn at random.  A larger number of
+        features generally makes the classification task more difficult.
 
     n_informative : int, optional (default=2)
         The number of informative features. Each class is composed of a number
@@ -94,10 +96,13 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
         exceeds 1.
 
     flip_y : float, optional (default=0.01)
-        The fraction of samples whose class are randomly exchanged.
+        The fraction of samples whose class are randomly exchanged. Larger 
+        values introduce noise in the labels and make the classification
+        task harder.
 
     class_sep : float, optional (default=1.0)
-        The factor multiplying the hypercube dimension.
+        The factor multiplying the hypercube size.  Larger values spread
+        out the clusters/classes and make the classification task easier.
 
     hypercube : boolean, optional (default=True)
         If True, the clusters are put on the vertices of a hypercube. If

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -42,10 +42,10 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
     """Generate a random n-class classification problem.
 
     This initially creates clusters of points normally distributed (std=1)
-    about vertices of an `n_informative`-dimensional hypercube, and assigns
-    an equal number of clusters to each class. It introduces interdependence
-    between these features and adds various types of further noise to the
-    data.
+    about vertices of an `n_informative`-dimensional hypercube with sides of
+    length `2*class_sep` and assigns an equal number of clusters to each
+    class. It introduces interdependence between these features and adds 
+    various types of further noise to the data.
 
     Prior to shuffling, `X` stacks a number of these primary "informative"
     features, "redundant" linear combinations of these, "repeated" duplicates


### PR DESCRIPTION
The docs for `make_classification` say it "creates clusters of points normally distributed (std=1) about vertices of a `2 * class_sep`-sided hypercube," but this doesn't really make much sense, as `class_sep` is a float, nor does it match the docs for the `n_informative` parameter, nor does it seem to match the actual behavior.  

The actual (and desired) behavior seems to be creating points around an `n_informative`-dimensional hypercube, as can be seen from the call to `_generate_hypercube`:

```
def _generate_hypercube(samples, dimensions, rng):
    ...

_generate_hypercube(n_clusters, n_informative, generator)
```

And the docs for `n_informative`: "Each class is composed of a number of gaussian clusters each located around the vertices of a hypercube in a subspace of dimension `n_informative`."

I also found it difficult to understand how the various parameters influence the difficulty of the classification task, so I've also added text describing how `n_features`, `flip_y`, and `class_sep`, the primary knobs for this, affect task difficulty.