### PR TITLE
[MRG] DOC data centering in PCA

### DIFF
--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -30,6 +30,9 @@ strong assumptions on the isotropy of the signal: this is for example
 the case for Support Vector Machines with the RBF kernel and the K-Means
 clustering algorithm.
 
+Note: the :class:`PCA` object centers the input data for each feature before
+applying the SVD.
+
 Below is an example of the iris dataset, which is comprised of 4
 features, projected on the 2 dimensions that explain most variance:
 

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -23,15 +23,13 @@ scikit-learn, :class:`PCA` is implemented as a *transformer* object
 that learns :math:`n` components in its ``fit`` method, and can be used on new
 data to project it on these components.
 
-The optional parameter ``whiten=True`` makes it possible to
+PCA centers the input data for each feature before applying the SVD. The
+optional parameter parameter ``whiten=True`` makes it possible to
 project the data onto the singular space while scaling each component
 to unit variance. This is often useful if the models down-stream make
 strong assumptions on the isotropy of the signal: this is for example
 the case for Support Vector Machines with the RBF kernel and the K-Means
 clustering algorithm.
-
-Note: the :class:`PCA` object centers the input data for each feature before
-applying the SVD.
 
 Below is an example of the iris dataset, which is comprised of 4
 features, projected on the 2 dimensions that explain most variance:

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -108,11 +108,12 @@ class PCA(_BasePCA):
     """Principal component analysis (PCA)
 
     Linear dimensionality reduction using Singular Value Decomposition of the
-    data to project it to a lower dimensional space.
+    data to project it to a lower dimensional space. 
 
     It uses the LAPACK implementation of the full SVD or a randomized truncated
     SVD by the method of Halko et al. 2009, depending on the shape of the input
-    data and the number of components to extract.
+    data and the number of components to extract. It centers the data matrix
+    columnwise (but does not scale it) before performing Singular Value Decomposition.
 
     It can also use the scipy.sparse.linalg ARPACK implementation of the
     truncated SVD.

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -108,12 +108,12 @@ class PCA(_BasePCA):
     """Principal component analysis (PCA)
 
     Linear dimensionality reduction using Singular Value Decomposition of the
-    data to project it to a lower dimensional space.
+    data to project it to a lower dimensional space. The input data is centered
+    for each feature before applying the SVD.
 
     It uses the LAPACK implementation of the full SVD or a randomized truncated
     SVD by the method of Halko et al. 2009, depending on the shape of the input
-    data and the number of components to extract. The input data is centered
-    for each feature before applying the SVD.
+    data and the number of components to extract.
 
     It can also use the scipy.sparse.linalg ARPACK implementation of the
     truncated SVD.

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -112,8 +112,8 @@ class PCA(_BasePCA):
 
     It uses the LAPACK implementation of the full SVD or a randomized truncated
     SVD by the method of Halko et al. 2009, depending on the shape of the input
-    data and the number of components to extract. It centers the data matrix
-    columnwise (but does not scale it) before performing Singular Value Decomposition.
+    data and the number of components to extract. The input data is centered
+    for each feature before applying the SVD.
 
     It can also use the scipy.sparse.linalg ARPACK implementation of the
     truncated SVD.

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -108,7 +108,7 @@ class PCA(_BasePCA):
     """Principal component analysis (PCA)
 
     Linear dimensionality reduction using Singular Value Decomposition of the
-    data to project it to a lower dimensional space. 
+    data to project it to a lower dimensional space.
 
     It uses the LAPACK implementation of the full SVD or a randomized truncated
     SVD by the method of Halko et al. 2009, depending on the shape of the input


### PR DESCRIPTION
Following the discussion on the mailing list [subject: unclear help file for sklearn.decomposition.pca, author:Ismael Lemhadri, date:16 Oct 2017], modified the help file of "sklearn/decomposition/pca.py" to make it clear that the data matrix is centered (but not scaled) before performing singular value decomposition.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
improve the PCA documentation on data centering

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
