### PR TITLE
[MRG] Travis: test pandas dev version in scipy-dev build

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -85,7 +85,7 @@ elif [[ "$DISTRIB" == "scipy-dev-wheels" ]]; then
 
     echo "Installing numpy and scipy master wheels"
     dev_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
-    pip install --pre --upgrade --timeout=60 -f $dev_url numpy scipy cython
+    pip install --pre --upgrade --timeout=60 -f $dev_url numpy scipy pandas cython
     if [[ $USE_PYTEST == "true" ]]; then
         pip install pytest
     else


### PR DESCRIPTION
I will merge this one when CIs are green.

I checked that the cron job was passing on my fork, see this [Travis log](https://travis-ci.org/lesteve/scikit-learn/builds/289005250?utm_source=email&utm_medium=notification). It is a bit unfortunate that there is no good way of testing the cron job in the PR but I think we can live with that for now.