### PR TITLE
[MRG+1] Adding objective function in Ridge regression docstring

### DIFF
--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -512,6 +512,10 @@ class _BaseRidge(six.with_metaclass(ABCMeta, LinearModel)):
 class Ridge(_BaseRidge, RegressorMixin):
     """Linear least squares with l2 regularization.
 
+    Minimizes the objective function::
+
+    ||y - Xw||^2_2 + alpha * ||w||^2_2
+
     This model solves a regression model where the loss function is
     the linear least squares function and regularization is given by
     the l2-norm. Also known as Ridge Regression or Tikhonov regularization.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This adds the optimization criterion of Ridge regression inside the dosctring itself (as in Lasso and other cases).
This clarifies that the normalization is 1 / 2  for Ridge, while it is 1 / (2 * n_samples) for Lasso.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
