### PR TITLE
[MRG+1] fix _BaseComposition._set_params with nested parameters

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -248,7 +248,10 @@ class BaseEstimator(object):
             # Simple optimization to gain speed (inspect is slow)
             return self
         valid_params = self.get_params(deep=True)
-        for key, value in six.iteritems(params):
+        # ensure ordered iteration
+        keys = sorted(params)
+        for key in keys:
+            value = params[key]
             split = key.split('__', 1)
             if len(split) > 1:
                 # nested objects case

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -257,7 +257,7 @@ class BaseEstimator(object):
                 raise ValueError('Invalid parameter %s for estimator %s. '
                                  'Check the list of available parameters '
                                  'with `estimator.get_params().keys()`.' %
-                                 (key, self))
+                                 (key, self.__class__.__name__))
 
             if delim:
                 nested_params[key][sub_key] = value

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -257,7 +257,7 @@ class BaseEstimator(object):
                 raise ValueError('Invalid parameter %s for estimator %s. '
                                  'Check the list of available parameters '
                                  'with `estimator.get_params().keys()`.' %
-                                 (key, self.__class__.__name__))
+                                 (key, self))
 
             if delim:
                 nested_params[key][sub_key] = value

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -5,7 +5,6 @@
 
 import copy
 import warnings
-import itertools
 from collections import defaultdict
 
 import numpy as np
@@ -251,29 +250,22 @@ class BaseEstimator(object):
             return self
         valid_params = self.get_params(deep=True)
 
-        # group by prefix
-        nested_params = defaultdict(dict)
-        simple_params = {}
+        nested_params = defaultdict(dict)  # grouped by prefix
         for key, value in params.items():
             key, delim, sub_key = key.partition('__')
-            if delim:
-                nested_params[key][sub_key] = value
-            else:
-                simple_params[key] = value
-
-        # validate keys
-        for key in itertools.chain(simple_params, nested_params):
             if key not in valid_params:
                 raise ValueError('Invalid parameter %s for estimator %s. '
                                  'Check the list of available parameters '
                                  'with `estimator.get_params().keys()`.' %
                                  (key, self))
 
-        # set
+            if delim:
+                nested_params[key][sub_key] = value
+            else:
+                setattr(self, key, value)
+
         for key, sub_params in nested_params.items():
             valid_params[key].set_params(**sub_params)
-        for key, value in simple_params.items():
-            setattr(self, key, value)
 
         return self
 

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -228,6 +228,24 @@ def test_set_params():
     #               bad__stupid_param=True)
 
 
+def test_set_params_passes_all_parameters():
+    # Make sure all parameters are passed together to set_params
+    # of nested estimator. Regression test for #9944
+
+    class TestDecisionTree(DecisionTreeClassifier):
+        def set_params(self, **kwargs):
+            super(TestDecisionTree, self).set_params(**kwargs)
+            # expected_kwargs is in test scope
+            assert kwargs == expected_kwargs
+            return self
+
+    expected_kwargs = {'max_depth': 5, 'min_samples_leaf': 2}
+    for est in [Pipeline([('estimator', TestDecisionTree())]),
+                GridSearchCV(TestDecisionTree(), {})]:
+        est.set_params(estimator__max_depth=5,
+                       estimator__min_samples_leaf=2)
+
+
 def test_score_sample_weight():
 
     rng = np.random.RandomState(0)

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -864,18 +864,14 @@ def test_step_name_validation():
                                  [[1]], [1])
 
 
-def test_set_conditional_params():
+def test_set_params_nested_pipeline():
     estimator = Pipeline([
         ('a', Pipeline([
             ('b', DummyRegressor())
         ]))
     ])
-    params = {
-        'a__b__alpha': 0.001,
-        'a__b': Lasso(),
-    }
-
     estimator.set_params(a__b__alpha=0.001, a__b=Lasso())
+    estimator.set_params(a__steps=[('b', LogisticRegression())], a__b__C=5)
 
 
 def test_pipeline_wrong_memory():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -875,7 +875,7 @@ def test_set_conditional_params():
         'a__b': Lasso(),
     }
 
-    estimator.set_params(**params)
+    estimator.set_params(a__b__alpha=0.001, a__b=Lasso())
 
 
 def test_pipeline_wrong_memory():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -24,10 +24,11 @@ from sklearn.utils.testing import assert_no_warnings
 from sklearn.base import clone, BaseEstimator
 from sklearn.pipeline import Pipeline, FeatureUnion, make_pipeline, make_union
 from sklearn.svm import SVC
-from sklearn.linear_model import LogisticRegression
+from sklearn.linear_model import LogisticRegression, Lasso
 from sklearn.linear_model import LinearRegression
 from sklearn.cluster import KMeans
 from sklearn.feature_selection import SelectKBest, f_classif
+from sklearn.dummy import DummyRegressor
 from sklearn.decomposition import PCA, TruncatedSVD
 from sklearn.datasets import load_iris
 from sklearn.preprocessing import StandardScaler
@@ -861,6 +862,20 @@ def test_step_name_validation():
             assert_raise_message(ValueError, message, est.fit, [[1]], [1])
             assert_raise_message(ValueError, message, est.fit_transform,
                                  [[1]], [1])
+
+
+def test_set_conditional_params():
+    estimator = Pipeline([
+        ('a', Pipeline([
+            ('b', DummyRegressor())
+        ]))
+    ])
+    params = {
+        'a__b__alpha': 0.001,
+        'a__b': Lasso(),
+    }
+
+    estimator.set_params(**params)
 
 
 def test_pipeline_wrong_memory():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -290,7 +290,7 @@ def test_pipeline_raise_set_params_error():
                  'with `estimator.get_params().keys()`.')
 
     assert_raise_message(ValueError,
-                         error_msg % ('fake', 'Pipeline'),
+                         error_msg % ('fake', pipe),
                          pipe.set_params,
                          fake='nope')
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -870,11 +870,6 @@ def test_set_conditional_params():
             ('b', DummyRegressor())
         ]))
     ])
-    params = {
-        'a__b__alpha': 0.001,
-        'a__b': Lasso(),
-    }
-
     estimator.set_params(a__b__alpha=0.001, a__b=Lasso())
 
 

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -38,14 +38,17 @@ class _BaseComposition(six.with_metaclass(ABCMeta, BaseEstimator)):
     def _set_params(self, attr, **params):
         # Ensure strict ordering of parameter setting:
         # 1. All steps
+        print("Pipeline.set_params", sorted(params.keys()))
         if attr in params:
             setattr(self, attr, params.pop(attr))
         # 2. Step replacement
         names, _ = zip(*getattr(self, attr))
         for name in list(six.iterkeys(params)):
             if '__' not in name and name in names:
+                print("replacing", name, 'with', params[name])
                 self._replace_estimator(attr, name, params.pop(name))
         # 3. Step parameters and other initilisation arguments
+        print("passing on", params, 'to', self)
         super(_BaseComposition, self).set_params(**params)
         return self
 

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -38,17 +38,14 @@ class _BaseComposition(six.with_metaclass(ABCMeta, BaseEstimator)):
     def _set_params(self, attr, **params):
         # Ensure strict ordering of parameter setting:
         # 1. All steps
-        print("Pipeline.set_params", sorted(params.keys()))
         if attr in params:
             setattr(self, attr, params.pop(attr))
         # 2. Step replacement
         names, _ = zip(*getattr(self, attr))
         for name in list(six.iterkeys(params)):
             if '__' not in name and name in names:
-                print("replacing", name, 'with', params[name])
                 self._replace_estimator(attr, name, params.pop(name))
         # 3. Step parameters and other initilisation arguments
-        print("passing on", params, 'to', self)
         super(_BaseComposition, self).set_params(**params)
         return self
 


### PR DESCRIPTION
Fixes #9944.

This seemed the simplest fix.

This kind of means that the protection in ``_BaseComposition._set_params`` is not enough.
We could make that method work by grouping the things in ``BaseEstimator.set_params`` according to their prefixes and call ``set_params`` only once per prefix. That seems like a slightly cleaner solution, but not sure it's worth the effort.

This will go away in Python3.6 as iteration is guaranteed to be ordered then.