### PR TITLE
[MRG] document good first issue and help wanted labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,13 +199,13 @@ following rules before submitting:
 New contributor tips
 --------------------
 
-A great way to start contributing to scikit-learn is to pick an item
-from the list of [Easy issues](https://github.com/scikit-learn/scikit-learn/issues?labels=Easy)
-in the issue tracker. Resolving these issues allow you to start
-contributing to the project without much prior knowledge. Your
-assistance in this area will be greatly appreciated by the more
-experienced developers as it helps free up their time to concentrate on
-other issues.
+A great way to start contributing to scikit-learn is to pick an item from the
+list of [good first issues](https://github.com/scikit-learn/scikit-learn/labels/good%20first%20issue)
+or [Easy issues](https://github.com/scikit-learn/scikit-learn/labels/Easy) in
+the issue tracker. Resolving these issues allow you to start contributing to the
+project without much prior knowledge. Your assistance in this area will be
+greatly appreciated by the more experienced developers as it helps free up their
+time to concentrate on other issues.
 
 Documentation
 -------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,12 +200,14 @@ New contributor tips
 --------------------
 
 A great way to start contributing to scikit-learn is to pick an item from the
-list of [good first issues](https://github.com/scikit-learn/scikit-learn/labels/good%20first%20issue)
-or [Easy issues](https://github.com/scikit-learn/scikit-learn/labels/Easy) in
-the issue tracker. Resolving these issues allow you to start contributing to the
-project without much prior knowledge. Your assistance in this area will be
-greatly appreciated by the more experienced developers as it helps free up their
-time to concentrate on other issues.
+list of
+[good first issues](https://github.com/scikit-learn/scikit-learn/labels/good%20first%20issue). If
+you have already contributed to scikit-learn look at
+[Easy issues](https://github.com/scikit-learn/scikit-learn/labels/Easy)
+instead. Resolving these issues allow you to start contributing to the project
+without much prior knowledge. Your assistance in this area will be greatly
+appreciated by the more experienced developers as it helps free up their time to
+concentrate on other issues.
 
 Documentation
 -------------

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -377,29 +377,36 @@ following rules before submitting:
 Issues for New Contributors
 ---------------------------
 
-New contributors should look for the following tags when looking for issues.
-We strongly recommend that new contributors tackle "easy" issues first: this
-helps the contributor become familiar with the contribution workflow, and
-for the core devs to become acquainted with the contributor; besides which,
-we frequently underestimate how easy an issue is to solve!
+New contributors should look for the following tags when looking for issues.  We
+strongly recommend that new contributors tackle "easy" issues first: this helps
+the contributor become familiar with the contribution workflow, and for the core
+devs to become acquainted with the contributor; besides which, we frequently
+underestimate how easy an issue is to solve!
 
-.. topic:: Easy Tags
+.. topic:: good first issue tag
 
-    A great way to start contributing to scikit-learn is to pick an item from the
-    list of `Easy issues
-    <https://github.com/scikit-learn/scikit-learn/issues?q=is%3Aopen+label%3AEasy+is%3Aissue>`_
+    A great way to start contributing to scikit-learn is to pick an item from
+    the list of `good first issues
+    <https://github.com/scikit-learn/scikit-learn/labels/good%20first%20issue>`_
     in the issue tracker. Resolving these issues allow you to start contributing
-    to the project without much prior knowledge. Your assistance in this area will
-    be greatly appreciated by the more experienced developers as it helps free up
-    their time to concentrate on other issues.
+    to the project without much prior knowledge. Your assistance in this area
+    will be greatly appreciated by the more experienced developers as it helps
+    free up their time to concentrate on other issues.
 
-.. topic:: Need Contributor Tags
+.. topic:: Easy tag
 
-    We often use the Need Contributor tag to mark issues regardless of difficulty. Additionally,
-    we use the Need Contributor tag to mark Pull Requests which have been abandoned
+    Another great way to contribute to scikit-learn is to pick an item
+    from the list of `Easy issues
+    <https://github.com/scikit-learn/scikit-learn/labels/Easy>`_ in the issue
+    tracker.
+
+.. topic:: help wanted tag
+
+    We often use the help wanted tag to mark issues regardless of difficulty. Additionally,
+    we use the help wanted tag to mark Pull Requests which have been abandoned
     by their original contributor and are available for someone to pick up where the original
-    contributor left off. The list of issues with the Need Contributor tag can be found
-    `here <https://github.com/scikit-learn/scikit-learn/labels/Need%20Contributor>`_ .
+    contributor left off. The list of issues with the help wanted tag can be found
+    `here <https://github.com/scikit-learn/scikit-learn/labels/help%20wanted>`_ .
 
     Note that not all issues which need contributors will have this tag.
 
@@ -553,17 +560,20 @@ should have (at least) one of the following tags:
 :New Feature:
     Feature requests and pull requests implementing a new feature.
 
-There are three other tags to help new contributors:
+There are four other tags to help new contributors:
+
+:good first issue:
+    This issue is ideal for a first contribution to scikit-learn. Ask for help
+    if the formulation is unclear.
 
 :Easy:
-    This issue can be tackled by anyone, no experience needed.
-    Ask for help if the formulation is unclear.
+    This issue can be tackled without much prior experience.
 
 :Moderate:
     Might need some knowledge of machine learning or the package,
     but is still approachable for someone new to the project.
 
-:Needs Contributor:
+:help wanted:
     This tag marks an issue which currently lacks a contributor or a
     PR that needs another contributor to take over the work. These
     issues can range in difficulty, and may not be approachable

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -389,16 +389,17 @@ underestimate how easy an issue is to solve!
     the list of `good first issues
     <https://github.com/scikit-learn/scikit-learn/labels/good%20first%20issue>`_
     in the issue tracker. Resolving these issues allow you to start contributing
-    to the project without much prior knowledge. Your assistance in this area
-    will be greatly appreciated by the more experienced developers as it helps
-    free up their time to concentrate on other issues.
+    to the project without much prior knowledge. If you have already contributed
+    to scikit-learn, you should look at Easy issues instead.
 
 .. topic:: Easy tag
 
-    Another great way to contribute to scikit-learn is to pick an item
-    from the list of `Easy issues
+    Another great way to contribute to scikit-learn is to pick an item from the
+    list of `Easy issues
     <https://github.com/scikit-learn/scikit-learn/labels/Easy>`_ in the issue
-    tracker.
+    tracker.  Your assistance in this area will be greatly appreciated by the
+    more experienced developers as it helps free up their time to concentrate on
+    other issues.
 
 .. topic:: help wanted tag
 
@@ -564,7 +565,8 @@ There are four other tags to help new contributors:
 
 :good first issue:
     This issue is ideal for a first contribution to scikit-learn. Ask for help
-    if the formulation is unclear.
+    if the formulation is unclear. If you have already contributed to
+    scikit-learn, look at Easy issues instead.
 
 :Easy:
     This issue can be tackled without much prior experience.


### PR DESCRIPTION
Fix #9652.

At the moment it is not really clear what the difference between "good first issue" and "Easy" is. I try to word the documentation in a way that makes "good first issue" the first point of entry for new contributors.

Note: at the moment there is no issues with the "good first issue" tag. I am hoping that this will get populated with time.