### PR TITLE
[MRG] DOC Encourage contributors to use keywords to close issue automatically

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,9 +70,19 @@ following rules before you submit a pull request:
    [Utilities for Developers](http://scikit-learn.org/dev/developers/utilities.html#developers-utils)
    page.
 
--  If your pull request addresses an issue, please use the pull request title
-   to describe the issue and mention the issue number in the pull request description. This will make sure a link back to the original issue is
-   created.
+-  Give your pull request a helpful title that summarises what your
+   contribution does. In some cases "Fix <ISSUE TITLE>" is enough.
+   "Fix #<ISSUE NUMBER>" is not enough.
+
+-  Often pull requests resolve one or more other issues (or pull requests).
+   If merging your pull request means that some other issues/PRs should
+   be closed, you should `use keywords to create link to them
+   <https://github.com/blog/1506-closing-issues-via-pull-requests/>`_
+   (e.g., ``Fixes #1234``, ``Closes #1234``; multiple issues/PRs are
+   allowed as long as each one is preceded by a keyword). Upon merging,
+   those issues/PRs will automatically be closed by GitHub. If your pull
+   request is simply related to some other issues/PRs, create a link to
+   them without using the keywords (e.g., ``See also #1234``).
 
 -  All public methods should have informative docstrings with sample
    usage presented as doctests when appropriate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,13 +76,13 @@ following rules before you submit a pull request:
 
 -  Often pull requests resolve one or more other issues (or pull requests).
    If merging your pull request means that some other issues/PRs should
-   be closed, you should `use keywords to create link to them
-   <https://github.com/blog/1506-closing-issues-via-pull-requests/>`_
-   (e.g., ``Fixes #1234``, ``Closes #1234``; multiple issues/PRs are
-   allowed as long as each one is preceded by a keyword). Upon merging,
-   those issues/PRs will automatically be closed by GitHub. If your pull
-   request is simply related to some other issues/PRs, create a link to
-   them without using the keywords (e.g., ``See also #1234``).
+   be closed, you should
+   [use keywords to create link to them](https://github.com/blog/1506-closing-issues-via-pull-requests/)
+   (e.g., `Fixes #1234`; multiple issues/PRs are allowed as long as each one
+   is preceded by a keyword). Upon merging, those issues/PRs will
+   automatically be closed by GitHub. If your pull request is simply related
+   to some other issues/PRs, create a link to them without using the keywords
+   (e.g., `See also #1234`).
 
 -  All public methods should have informative docstrings with sample
    usage presented as doctests when appropriate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,8 @@ following rules before you submit a pull request:
    page.
 
 -  Give your pull request a helpful title that summarises what your
-   contribution does. In some cases "Fix <ISSUE TITLE>" is enough.
-   "Fix #<ISSUE NUMBER>" is not enough.
+   contribution does. In some cases `Fix <ISSUE TITLE>` is enough.
+   `Fix #<ISSUE NUMBER>` is not enough.
 
 -  Often pull requests resolve one or more other issues (or pull requests).
    If merging your pull request means that some other issues/PRs should

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Thanks for contributing a pull request! Please ensure you have taken a look at
 the contribution guidelines: http://scikit-learn.org/dev/developers/contributing.html#contributing-pull-requests
 -->
 #### Reference Issues/PRs
-<!-- Example: Fixes #1234 / Closes #2345 / See also #3456 -->
+<!-- Example: Fixes #1234. Closes #2345. See also #3456 -->
 
 
 #### What does this implement/fix? Explain your changes.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Thanks for contributing a pull request! Please ensure you have taken a look at
 the contribution guidelines: http://scikit-learn.org/dev/developers/contributing.html#contributing-pull-requests
 -->
 #### Reference Issues/PRs
-<!-- Example: Fixes #1234. Closes #2345. See also #3456 -->
+<!-- Example: Fixes #1234. Closes #2345. See also #3456. -->
 
 
 #### What does this implement/fix? Explain your changes.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -5,8 +5,9 @@ the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/m
 
 #### Reference Issues/PRs
 <!-- Example: Fixes #1234. Closes #2345. See also #3456.
-In this way, #1234 and #2345 will be automatically closed when this PR is merged.
-This is important to keep our tracker organised.
+Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
+requests you resolved, so that they will automatically be closed by GitHub
+when your pull request is merged.
 -->
 
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Thanks for contributing a pull request! Please ensure you have taken a look at
 the contribution guidelines: http://scikit-learn.org/dev/developers/contributing.html#contributing-pull-requests
 -->
 #### Reference Issue
-<!-- Example: Fixes #1234 -->
+<!-- Example: Fixes #1234 / Closes #1234 -->
 
 
 #### What does this implement/fix? Explain your changes.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,8 @@
 Thanks for contributing a pull request! Please ensure you have taken a look at
 the contribution guidelines: http://scikit-learn.org/dev/developers/contributing.html#contributing-pull-requests
 -->
-#### Reference Issue
-<!-- Example: Fixes #1234 / Closes #1234 -->
+#### Reference Issues/PRs
+<!-- Example: Fixes #1234 / Closes #2345 / See also #3456 -->
 
 
 #### What does this implement/fix? Explain your changes.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,9 @@ the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/m
 #### Reference Issues/PRs
 <!--
 Example: Fixes #1234. See also #3456.
-Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
-requests you resolved, so that they will automatically be closed when your pull
-request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
+Please use keywords (e.g., Fixes) to create link to the issues or pull requests
+you resolved, so that they will automatically be closed when your pull request
+is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
 -->
 
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 <!--
 Thanks for contributing a pull request! Please ensure you have taken a look at
-the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md
+the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
 -->
 
 #### Reference Issues/PRs
 <!--
-Example: Fixes #1234. Closes #2345. See also #3456.
+Example: Fixes #1234. See also #3456.
 Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
 requests you resolved, so that they will automatically be closed when your pull
 request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,13 @@
 <!--
 Thanks for contributing a pull request! Please ensure you have taken a look at
-the contribution guidelines: http://scikit-learn.org/dev/developers/contributing.html#contributing-pull-requests
+the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md
 -->
+
 #### Reference Issues/PRs
-<!-- Example: Fixes #1234. Closes #2345. See also #3456. -->
+<!-- Example: Fixes #1234. Closes #2345. See also #3456.
+In this way, #1234 and #2345 will be automatically closed when this PR is merged.
+This is important to keep our tracker organised.
+-->
 
 
 #### What does this implement/fix? Explain your changes.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,10 +4,11 @@ the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/m
 -->
 
 #### Reference Issues/PRs
-<!-- Example: Fixes #1234. Closes #2345. See also #3456.
+<!--
+Example: Fixes #1234. Closes #2345. See also #3456.
 Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
-requests you resolved, so that they will automatically be closed by GitHub
-when your pull request is merged.
+requests you resolved, so that they will automatically be closed when your pull
+request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
 -->
 
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 Thanks for contributing a pull request! Please ensure you have taken a look at
-the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
+the contribution guidelines: http://scikit-learn.org/dev/developers/contributing.html#contributing-pull-requests
 -->
 #### Reference Issue
 <!-- Example: Fixes #1234 -->

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -218,12 +218,17 @@ rules before submitting a pull request:
       ``sklearn.utils`` submodule.  A list of utility routines available
       for developers can be found in the :ref:`developers-utils` page.
 
-    * If your pull request addresses an issue or continues other's work,
-      please use the title to describe the original issue/PR and use `keywords
+    * Give your pull request a helpful title that summarises what your
+      contribution does. In some cases "Fix <ISSUE TITLE>" is enough.
+      "Fix #<ISSUE NUMBER>" is not enough.
+
+    * Often pull requests resolve one or more other issues (or pull requests).
+      If merging your pull request means that some other issues/PRs should
+      be closed, you should `use keywords to create link to them
       <https://help.github.com/articles/closing-issues-using-keywords/>`_
-      to create link to them (e.g., ``Fixes #1234``, ``Closes #1234``), so
-      that the original issue/PR can be automatically closed when your pull
-      request is merged into master branch.
+      (e.g., ``Fixes #1234``, ``Closes #1234``; multiple issues/PRs are
+      allowed as long as each one is preceded by a keyword). Upon merging,
+      those issues/PRs will automatically be closed by GitHub.
     
     * All public methods should have informative docstrings with sample
       usage presented as doctests when appropriate.

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -226,11 +226,11 @@ rules before submitting a pull request:
       If merging your pull request means that some other issues/PRs should
       be closed, you should `use keywords to create link to them
       <https://github.com/blog/1506-closing-issues-via-pull-requests/>`_
-      (e.g., ``Fixes #1234``, ``Closes #1234``; multiple issues/PRs are
-      allowed as long as each one is preceded by a keyword). Upon merging,
-      those issues/PRs will automatically be closed by GitHub. If your pull
-      request is simply related to some other issues/PRs, create a link to
-      them without using the keywords (e.g., ``See also #1234``).
+      (e.g., ``Fixes #1234``; multiple issues/PRs are allowed as long as each
+      one is preceded by a keyword). Upon merging, those issues/PRs will
+      automatically be closed by GitHub. If your pull request is simply
+      related to some other issues/PRs, create a link to them without using
+      the keywords (e.g., ``See also #1234``).
     
     * All public methods should have informative docstrings with sample
       usage presented as doctests when appropriate.

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -230,7 +230,7 @@ rules before submitting a pull request:
       allowed as long as each one is preceded by a keyword). Upon merging,
       those issues/PRs will automatically be closed by GitHub. If your pull
       request is simply related to some other issues/PRs, create a link to
-      them without using the keywords (e.g., ``See also #1234``)
+      them without using the keywords (e.g., ``See also #1234``).
     
     * All public methods should have informative docstrings with sample
       usage presented as doctests when appropriate.

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -228,7 +228,9 @@ rules before submitting a pull request:
       <https://help.github.com/articles/closing-issues-using-keywords/>`_
       (e.g., ``Fixes #1234``, ``Closes #1234``; multiple issues/PRs are
       allowed as long as each one is preceded by a keyword). Upon merging,
-      those issues/PRs will automatically be closed by GitHub.
+      those issues/PRs will automatically be closed by GitHub. If your pull
+      request is simply related to some other issues/PRs, create a link to
+      them without using the keywords (e.g., ``See also #1234``)
     
     * All public methods should have informative docstrings with sample
       usage presented as doctests when appropriate.

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -225,7 +225,7 @@ rules before submitting a pull request:
     * Often pull requests resolve one or more other issues (or pull requests).
       If merging your pull request means that some other issues/PRs should
       be closed, you should `use keywords to create link to them
-      <https://help.github.com/articles/closing-issues-using-keywords/>`_
+      <https://github.com/blog/1506-closing-issues-via-pull-requests/>`_
       (e.g., ``Fixes #1234``, ``Closes #1234``; multiple issues/PRs are
       allowed as long as each one is preceded by a keyword). Upon merging,
       those issues/PRs will automatically be closed by GitHub. If your pull

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -218,10 +218,13 @@ rules before submitting a pull request:
       ``sklearn.utils`` submodule.  A list of utility routines available
       for developers can be found in the :ref:`developers-utils` page.
 
-    * If your pull request addresses an issue, please use the title to describe
-      the issue and mention the issue number in the pull request description to
-      ensure a link is created to the original issue.
-
+    * If your pull request addresses an issue or continues other's work,
+      please use the title to describe the original issue/PR and use `keywords
+      <https://help.github.com/articles/closing-issues-using-keywords/>`_
+      to create link to them (e.g., ``Fixes #1234``, ``Closes #1234``), so
+      that the original issue/PR can be automatically closed when your pull
+      request is merged into master branch.
+    
     * All public methods should have informative docstrings with sample
       usage presented as doctests when appropriate.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #9948

#### What does this implement/fix? Explain your changes.
It seems useful to encourage users to use keywords to create link to issue/PR they solve so that these issue/PR can be automatically closed after merging. I also provide a link to the GitHub help page, which seems useful from my perspective.

#### Any other comments?
I also correct the link in the pull request template.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
