### PR TITLE
[MRG] DOC Add missing base classes

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -26,8 +26,10 @@ Base classes
    :template: class.rst
 
    base.BaseEstimator
+   base.BiclusterMixin
    base.ClassifierMixin
    base.ClusterMixin
+   base.DensityMixin
    base.RegressorMixin
    base.TransformerMixin
 


### PR DESCRIPTION
It seems reasonable that since we already have some base classes in the doc, it might be better to include all the base classes there. Otherwise, we might consider to remove all of them. Closes #9718  
