### PR TITLE
[MRG + 1] Fix negative inputs checking in mean_squared_log_error

### DIFF
--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -310,7 +310,7 @@ def mean_squared_log_error(y_true, y_pred,
         y_true, y_pred, multioutput)
     check_consistent_length(y_true, y_pred, sample_weight)
 
-    if not (y_true >= 0).all() and not (y_pred >= 0).all():
+    if (y_true < 0).any() or (y_pred < 0).any():
         raise ValueError("Mean Squared Logarithmic Error cannot be used when "
                          "targets contain negative values.")
 

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -64,6 +64,13 @@ def test_regression_metrics_at_limits():
     assert_raises_regex(ValueError, "Mean Squared Logarithmic Error cannot be "
                         "used when targets contain negative values.",
                         mean_squared_log_error, [-1.], [-1.])
+    assert_raises_regex(ValueError, "Mean Squared Logarithmic Error cannot be "
+                        "used when targets contain negative values.",
+                        mean_squared_log_error, [1., 2., 3.], [1., -2., 3.])
+    assert_raises_regex(ValueError, "Mean Squared Logarithmic Error cannot be "
+                        "used when targets contain negative values.",
+                        mean_squared_log_error, [1., -2., 3.], [1., 2., 3.])
+
 
 
 def test__check_reg_targets():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #9963 

#### What does this implement/fix? Explain your changes.

The logic below had some flaw when just one array has some negative value.

```python
if not (y_true >= 0).all() and not (y_pred >= 0).all():
   raise ValueError("Mean Squared Logarithmic Error cannot be used when "
                         "targets contain negative values.")
```

For example:

```python
import numpy as np

y_true = np.array([1, 2, 3])
y_pred = np.array([1, -2, 3])

not (y_true >= 0).all()
False

not (y_pred >= 0).all()
True

not (y_true >= 0).all() and not (y_pred >= 0).all()
False
```

Now, with the change this doesn't occurs anymore.

```python
(y_true < 0).any() or (y_pred < 0).any()
True
```


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
