### PR TITLE
[MRG] Backport np.unique with return_counts in sklearn.utils.fixes

### DIFF
--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -193,3 +193,54 @@ if np_version < (1, 12):
                                  self._fill_value)
 else:
     from numpy.ma import MaskedArray    # noqa
+
+
+if np_version < (1, 9, 0):
+    # Allow unique to return counts
+    # https://github.com/numpy/numpy/commit/da3c6a28f651877dfb4cfdbbbe76dab985669252
+
+    def unique(ar, return_index=False, return_inverse=False,
+               return_counts=False):
+        ar = np.asanyarray(ar).flatten()
+
+        optional_indices = return_index or return_inverse
+        optional_returns = optional_indices or return_counts
+
+        if ar.size == 0:
+            if not optional_returns:
+                ret = ar
+            else:
+                ret = (ar,)
+                if return_index:
+                    ret += (np.empty(0, np.bool),)
+                if return_inverse:
+                    ret += (np.empty(0, np.bool),)
+                if return_counts:
+                    ret += (np.empty(0, np.intp),)
+            return ret
+
+        if optional_indices:
+            perm = ar.argsort(
+                kind='mergesort' if return_index else 'quicksort')
+            aux = ar[perm]
+        else:
+            ar.sort()
+            aux = ar
+        flag = np.concatenate(([True], aux[1:] != aux[:-1]))
+
+        if not optional_returns:
+            ret = aux[flag]
+        else:
+            ret = (aux[flag],)
+            if return_index:
+                ret += (perm[flag],)
+            if return_inverse:
+                iflag = np.cumsum(flag) - 1
+                iperm = perm.argsort()
+                ret += (np.take(iflag, iperm),)
+            if return_counts:
+                idx = np.concatenate(np.nonzero(flag) + ([ar.size],))
+                ret += (np.diff(idx),)
+        return ret
+else:
+    from numpy import unique    # noqa

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -197,7 +197,7 @@ else:
 
 if np_version < (1, 9, 0):
     # Allow unique to return counts
-    # https://github.com/numpy/numpy/commit/da3c6a28f651877dfb4cfdbbbe76dab985669252
+    # https://github.com/numpy/numpy/commit/09fb4205a1d56090e13257a181f23514684f532b
 
     def unique(ar, return_index=False, return_inverse=False,
                return_counts=False):

--- a/sklearn/utils/tests/test_fixes.py
+++ b/sklearn/utils/tests/test_fixes.py
@@ -10,6 +10,7 @@ from sklearn.utils.testing import assert_array_equal
 
 from sklearn.utils.fixes import divide
 from sklearn.utils.fixes import MaskedArray
+from sklearn.utils.fixes import unique
 
 
 def test_divide():
@@ -24,3 +25,29 @@ def test_masked_array_obj_dtype_pickleable():
         marr_pickled = pickle.loads(pickle.dumps(marr))
         assert_array_equal(marr.data, marr_pickled.data)
         assert_array_equal(marr.mask, marr_pickled.mask)
+
+
+def test_unique():
+    ar = []
+
+    # 0-length array, no optional_returns
+    u_values = unique([])
+
+    # 0-length array, all optional_returns
+    u_values, ind, inv, counts = unique(
+        ar, return_index=True, return_inverse=True, return_counts=True)
+
+    ar = [4, 2, 5, 5, 3, 1, 4]
+
+    # Normal array, no optional_returns
+    u_values = unique(ar)
+    assert_array_equal(u_values, [1, 2, 3, 4, 5])
+
+    # Normal array, all optional_returns
+    u_values, ind, inv, counts = unique(
+        ar, return_index=True, return_inverse=True, return_counts=True)
+
+    assert_array_equal(u_values, [1, 2, 3, 4, 5])
+    assert_array_equal(ind, [5, 1, 4, 0, 2])
+    assert_array_equal(inv, [3, 1, 4, 4, 2, 0, 3])
+    assert_array_equal(counts, [1, 1, 1, 2, 2])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

During the discussion of https://github.com/scikit-learn/scikit-learn/pull/8602#discussion_r143426082 , it came up that maybe the newer (since 1.9.0) unique function 
of numpy that also returns counts of the unique elements might be useful and should be backported, 
since the required numpy version is not going to be 1.9.0 in the near future.

#### What does this implement/fix? Explain your changes.

Backports the `return_counts` functionality of `np.unique` to builds with numpy version < 1.9.0. 
I copied the function body from the latest commit in numpy 1.9.X to sklearn.utils.fixes.

#### Any other comments?

No.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
