### PR TITLE
Add references for multiclass balanced-accuracy definitions

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -467,7 +467,8 @@ given binary ``y_true`` and ``y_pred``:
     * Normalized class-wise accuracy average as described in [Guyon2015]_
     * Macro-average recall as described in [Mosley2013]_ and [Kelleher2015]_
 
-    Note that none of these different definitions are currently implemented in scikit-learn.
+    Note that none of these different definitions are currently implemented within
+    the :func:`balanced_accuracy_score` function.
 
 .. topic:: References:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -464,8 +464,15 @@ given binary ``y_true`` and ``y_pred``:
     There is no clear consensus on the definition of a balanced accuracy for the
     multiclass setting. Here are some definitions that can be found in the literature:
 
-    * Normalized class-wise accuracy average as described in [Guyon2015]_
-    * Macro-average recall as described in [Mosley2013]_ and [Kelleher2015]_
+    * Normalized class-wise accuracy average as described in [Guyon2015]_: for multi-class
+      classification problem, each sample is assigned the class with maximum prediction value.
+      The predictions are then binarized to compute the accuracy of each class on a
+      one-vs-rest fashion. The balanced accuracy is obtained by averaging the individual
+      accuracies over all classes and then normalized by the expected value of balanced
+      accuracy for random predictions (:math:`0.5` for binary classification, :math:`1/C`
+      for C-class classification problem).
+    * Macro-average recall as described in [Mosley2013]_ and [Kelleher2015]_: the recall
+      for each class is computed independently and the average is taken over all classes.
 
     Note that none of these different definitions are currently implemented within
     the :func:`balanced_accuracy_score` function.

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -467,6 +467,8 @@ given binary ``y_true`` and ``y_pred``:
     * Normalized class-wise accuracy average as described in [Guyon2015]_
     * Macro-average recall as described in [Mosley2013]_
 
+    Note that none of these different definitions are currently implemented in scikit-learn.
+
 .. topic:: References:
 
   .. [Guyon2015] I. Guyon, K. Bennett, G. Cawley, H.J. Escalante, S. Escalera, T.K. Ho, N. Macià,

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -465,7 +465,7 @@ given binary ``y_true`` and ``y_pred``:
     multiclass setting. Here are some definitions that can be found in the literature:
 
     * Normalized class-wise accuracy average as described in [Guyon2015]_
-    * Macro-average recall as described in [Mosley2013]_
+    * Macro-average recall as described in [Mosley2013]_ and [Kelleher2015]_
 
     Note that none of these different definitions are currently implemented in scikit-learn.
 
@@ -478,6 +478,10 @@ given binary ``y_true`` and ``y_pred``:
   .. [Mosley2013] L. Mosley, `A balanced approach to the multi-class imbalance problem
      <http://lib.dr.iastate.edu/etd/13537/>`_,
      IJCV 2010.
+  .. [Kelleher2015] John. D. Kelleher, Brian Mac Namee, Aoife D'Arcy, `Fundamentals of
+     Machine Learning for Predictive Data Analytics: Algorithms, Worked Examples,
+     and Case Studies <https://mitpress.mit.edu/books/fundamentals-machine-learning-predictive-data-analytics>`_,
+     2015.
 
 .. _cohen_kappa:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -475,7 +475,9 @@ given binary ``y_true`` and ``y_pred``:
       for each class is computed independently and the average is taken over all classes.
 
     Note that none of these different definitions are currently implemented within
-    the :func:`balanced_accuracy_score` function.
+    the :func:`balanced_accuracy_score` function. However, the macro-averaged recall
+    is implemented in :func:`sklearn.metrics.recall_score`: set ``average`` parameter
+    to ``"macro"``.
 
 .. topic:: References:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -461,6 +461,22 @@ given binary ``y_true`` and ``y_pred``:
     Currently this score function is only defined for binary classification problems, you
     may need to wrap it by yourself if you want to use it for multilabel problems.
 
+    There is no clear consensus on the definition of a balanced accuracy for the
+    multiclass setting. Here are some definitions that can be found in the literature:
+
+    * Normalized class-wise accuracy average as described in [Guyon2015]_
+    * Macro-average recall as described in [Mosley2013]_
+
+.. topic:: References:
+
+  .. [Guyon2015] I. Guyon, K. Bennett, G. Cawley, H.J. Escalante, S. Escalera, T.K. Ho, N. Macià,
+     B. Ray, M. Saeed, A.R. Statnikov, E. Viegas, `Design of the 2015 ChaLearn AutoML Challenge
+     <http://ieeexplore.ieee.org/document/7280767/>`_,
+     IJCNN 2015.
+  .. [Mosley2013] L. Mosley, `A balanced approach to the multi-class imbalance problem
+     <http://lib.dr.iastate.edu/etd/13537/>`_,
+     IJCV 2010.
+
 .. _cohen_kappa:
 
 Cohen's kappa


### PR DESCRIPTION
#### Reference Issues/PRs
In addition to #8066 

#### What does this implement/fix? Explain your changes.

I added some references from the literature for the multiclass balanced accuracy. The threads #6747 and #8066 cited some papers and their different implementations of the metric. There was no real consensus about what was the definition to use, so the user might want to implement the one of his/her/their choice.