### PR TITLE
[MRG+1] Improve the plot of example plot_forest_iris.py

### DIFF
--- a/examples/ensemble/plot_forest_iris.py
+++ b/examples/ensemble/plot_forest_iris.py
@@ -107,7 +107,7 @@ for pair in ([0, 1], [0, 2], [2, 3]):
         plt.subplot(3, 4, plot_idx)
         if plot_idx <= len(models):
             # Add a title at the top of each column
-            plt.title(model_title)
+            plt.title(model_title, fontsize=9)
 
         # Now plot the decision boundary using a fine mesh as input to a
         # filled contour plot
@@ -154,7 +154,7 @@ for pair in ([0, 1], [0, 2], [2, 3]):
                     edgecolor='k', s=20)
         plot_idx += 1  # move on to the next plot in sequence
 
-plt.suptitle("Classifiers on feature subsets of the Iris dataset")
+plt.suptitle("Classifiers on feature subsets of the Iris dataset", fontsize=12)
 plt.axis("tight")
-
+plt.tight_layout(h_pad=0.2, w_pad=0.2, pad=2.5)
 plt.show()


### PR DESCRIPTION
Currently, some ticks on y-axis are overlapping with other plots.
old plot:
![sphx_glr_plot_forest_iris_002](https://user-images.githubusercontent.com/12003569/31942034-8d43910a-b8f6-11e7-8c4d-971d1839a23e.png)
new plot:
![sphx_glr_plot_forest_iris_001](https://user-images.githubusercontent.com/12003569/31942044-9497c4c6-b8f6-11e7-8c91-a765ebb76215.png)

