### PR TITLE
[MRG+1] correct comparison in GaussianNB for 'priors'

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -374,7 +374,7 @@ class GaussianNB(BaseNB):
                     raise ValueError('Number of priors must match number of'
                                      ' classes.')
                 # Check that the sum is 1
-                if priors.sum() != 1.0:
+                if not np.isclose(priors.sum(), 1.0):
                     raise ValueError('The sum of the priors should be 1.')
                 # Check that the prior are non-negative
                 if (priors < 0).any():

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -115,12 +115,14 @@ def test_gnb_priors():
 
 
 def test_gnb_priors_sum_isclose():
-    """Test whether the class prior sum is properly tested"""
+    # test whether the class prior sum is properly tested"""
     X = np.array([[-1, -1], [-2, -1], [-3, -2], [-4, -5], [-5, -4],
-        [1, 1], [2, 1], [3, 2], [4, 4], [5, 5]])
-    priors = np.array([0.08, 0.14, 0.03, 0.16, 0.11, 0.16, 0.07, 0.14, 0.11, 0.0])
+                 [1, 1], [2, 1], [3, 2], [4, 4], [5, 5]])
+    priors = np.array([0.08, 0.14, 0.03, 0.16, 0.11, 0.16, 0.07, 0.14,
+                       0.11, 0.0])
     Y = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     clf = GaussianNB(priors)
+    # smoke test for issue #9633
     clf.fit(X, Y)
 
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -114,6 +114,16 @@ def test_gnb_priors():
     assert_array_almost_equal(clf.class_prior_, np.array([0.3, 0.7]))
 
 
+def test_gnb_priors_sum_isclose():
+    """Test whether the class prior sum is properly tested"""
+    X = np.array([[-1, -1], [-2, -1], [-3, -2], [-4, -5], [-5, -4],
+        [1, 1], [2, 1], [3, 2], [4, 4], [5, 5]])
+    priors = np.array([0.08, 0.14, 0.03, 0.16, 0.11, 0.16, 0.07, 0.14, 0.11, 0.0])
+    Y = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    clf = GaussianNB(priors)
+    clf.fit(X, Y)
+
+
 def test_gnb_wrong_nb_priors():
     """ Test whether an error is raised if the number of prior is different
     from the number of class"""


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

Fixes #9633 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

correct comparison in GaussianNB for 'priors'

#### Any other comments?

I am not fully sure if I have written the test as correctly since, I have written it as `clf.fit(X, Y)` and I don't know if I should use `assert_....` or not. That is why I have not put `MRG` on title of PR.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
