### PR TITLE
[MRG+1] Added tests for parameter checks in GradientBoostingRegressor

### DIFF
--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -404,7 +404,6 @@ class QuantileLossFunction(RegressionLossFunction):
 
     def __init__(self, n_classes, alpha=0.9):
         super(QuantileLossFunction, self).__init__(n_classes)
-        assert 0 < alpha < 1.0
         self.alpha = alpha
         self.percentile = alpha * 100.0
 

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -25,6 +25,7 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_less
+from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_warns
@@ -142,13 +143,21 @@ def test_classifier_parameter_checks():
 
 def test_regressor_parameter_checks():
     # Check input parameter validation for GradientBoostingRegressor
-    assert_raises(ValueError,
-                  GradientBoostingRegressor(loss='huber', alpha=1.2).fit, X, y)
-    assert_raises(ValueError,
-                  GradientBoostingRegressor(max_features='invalid').fit, X, y)
-    assert_raises(ValueError,
-                  GradientBoostingRegressor(n_iter_no_change='invalid').fit, X,
-                  y)
+    assert_raise_message(ValueError, "alpha must be in (0.0, 1.0) but was 1.2",
+                         GradientBoostingRegressor(loss='huber', alpha=1.2)
+                         .fit, X, y)
+    assert_raise_message(ValueError, "alpha must be in (0.0, 1.0) but was 1.2",
+                         GradientBoostingRegressor(loss='quantile', alpha=1.2)
+                         .fit, X, y)
+    assert_raise_message(ValueError, "Invalid value for max_features: "
+                         "'invalid'. Allowed string values are 'auto', 'sqrt'"
+                         " or 'log2'.",
+                         GradientBoostingRegressor(max_features='invalid').fit,
+                         X, y)
+    assert_raise_message(ValueError, "n_iter_no_change should either be None"
+                         " or an integer. 'invalid' was passed",
+                         GradientBoostingRegressor(n_iter_no_change='invalid')
+                         .fit, X, y)
 
 
 def test_loss_function():

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -79,8 +79,8 @@ def test_classification_toy():
         yield check_classification_toy, presort, loss
 
 
-def test_parameter_checks():
-    # Check input parameter validation.
+def test_classifier_parameter_checks():
+    # Check input parameter validation for GradientBoostingClassifier.
 
     assert_raises(ValueError,
                   GradientBoostingClassifier(n_estimators=0).fit, X, y)
@@ -138,6 +138,17 @@ def test_parameter_checks():
                   lambda X, y: GradientBoostingClassifier(
                       loss='deviance').fit(X, y),
                   X, [0, 0, 0, 0])
+
+
+def test_regressor_parameter_checks():
+    # Check input parameter validation for GradientBoostingRegressor
+    assert_raises(ValueError,
+                  GradientBoostingRegressor(loss='huber', alpha=1.2).fit, X, y)
+    assert_raises(ValueError,
+                  GradientBoostingRegressor(max_features='invalid').fit, X, y)
+    assert_raises(ValueError,
+                  GradientBoostingRegressor(n_iter_no_change='invalid').fit, X,
+                  y)
 
 
 def test_loss_function():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #10009 

#### What does this implement/fix? Explain your changes.
Adds tests to improve code coverage wrt parameter checks in `test_gradient_boosting.py`
Refactor previous method to split into two different methods for parameter checks in `GradientBoostingClassifier` and `GradientBoostingRegressor`

#### Any other comments?
In case of `QuantileEstimator`, the ValueError supposed to be thrown when alpha is being checked, won't ever be executed as there is an assertion already in `QuantileLossFunction`. Should we ignore this?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
