### PR TITLE
[MRG + 1] Labels of clustering should start at 0 or -1 if noise

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1051,15 +1051,20 @@ def check_clustering(name, clusterer_orig):
     assert_in(pred.dtype, [np.dtype('int32'), np.dtype('int64')])
     assert_in(pred2.dtype, [np.dtype('int32'), np.dtype('int64')])
 
+    # Add noise to X to test the possible values of the labels
+    rng = np.random.RandomState(7)
+    X_noise = np.concatenate([X, rng.uniform(low=-3, high=3, size=(5, 2))])
+    labels = clusterer.fit_predict(X_noise)
+
     # There should be at least one sample in every cluster. Equivalently
     # labels_ should contain all the consecutive values between its
     # min and its max.
-    labels_sorted = np.unique(pred)
+    labels_sorted = np.unique(labels)
     assert_array_equal(labels_sorted, np.arange(labels_sorted[0],
                                                 labels_sorted[-1] + 1))
 
     # Labels are expected to start at 0 (no noise) or -1 (if noise)
-    assert_true(labels_sorted[0] in [0, 1])
+    assert_true(labels_sorted[0] in [0, -1])
     # Labels should be less than n_clusters - 1
     if hasattr(clusterer, 'n_clusters'):
         n_clusters = getattr(clusterer, 'n_clusters')

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1059,7 +1059,7 @@ def check_clustering(name, clusterer_orig):
                                                 labels_sorted[-1] + 1))
 
     # Labels are expected to start at 0 (no noise) or -1 (if noise)
-    assert_true((labels_sorted[0] == -1) or (labels_sorted[0] == 0))
+    assert_true(labels_sorted[0] in [0, 1])
     # Labels should be less than n_clusters - 1
     if hasattr(clusterer, 'n_clusters'):
         n_clusters = getattr(clusterer, 'n_clusters')

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1054,17 +1054,17 @@ def check_clustering(name, clusterer_orig):
     # There should be at least one sample in every cluster. Equivalently
     # labels_ should contain all the consecutive values between its
     # min and its max.
-    pred_sorted = np.unique(pred)
-    assert_array_equal(pred_sorted, np.arange(pred_sorted[0],
-                                              pred_sorted[-1] + 1))
+    labels_sorted = np.unique(pred)
+    assert_array_equal(labels_sorted, np.arange(labels_sorted[0],
+                                                labels_sorted[-1] + 1))
 
-    # labels_ should be greater than -1
-    assert_greater_equal(pred_sorted[0], -1)
-    # labels_ should be less than n_clusters - 1
+    # Labels are expected to start at 0 (no noise) or -1 (if noise)
+    assert_true((labels_sorted[0] == -1) or (labels_sorted[0] == 0))
+    # Labels should be less than n_clusters - 1
     if hasattr(clusterer, 'n_clusters'):
         n_clusters = getattr(clusterer, 'n_clusters')
-        assert_greater_equal(n_clusters - 1, pred_sorted[-1])
-    # else labels_ should be less than max(labels_) which is necessarily true
+        assert_greater_equal(n_clusters - 1, labels_sorted[-1])
+    # else labels should be less than max(labels_) which is necessarily true
 
 
 @ignore_warnings(category=DeprecationWarning)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Addresses comments in PR #1984 about the first value of the clustering labels. It should start at 0 or -1 (if noise) for consistency.


#### What does this implement/fix? Explain your changes.
This adds a common test ensuring this behavior.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
