### PR TITLE
[MRG] Remove counter reset in SGD when warm_start=True

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -18,6 +18,10 @@ random sampling procedures.
 - :class:`decomposition.IncrementalPCA` in Python 2 (bug fix)
 - :class:`isotonic.IsotonicRegression` (bug fix)
 - :class:`metrics.roc_auc_score` (bug fix)
+- :class:`linear_model.SGDClassifier`, :class:`linear_model.SGDRegressor`,
+  :class:`linear_model.PassiveAggressiveClassifier`,
+  :class:`linear_model.PassiveAggressiveRegressor`, and
+  :class:`linear_model.Perceptron` (bug fix)
 
 Details are listed in the changelog below.
 
@@ -95,6 +99,13 @@ Classifiers and regressors
   combined weights when fitting a model to data involving points with
   identical X values.
   :issue:`9432` by :user:`Dallas Card <dallascard>`
+
+- Fixed a bug in :class:`linear_model.SGDClassifier`,
+  :class:`linear_model.SGDRegressor`,
+  :class:`linear_model.PassiveAggressiveClassifier`,
+  :class:`linear_model.PassiveAggressiveRegressor`, and
+  :class:`linear_model.Perceptron`, where the counter for dynamic learning rate
+  was incorrectly reset when ``warm_start=True``.
 
 Decomposition, manifold learning and clustering
 

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -439,7 +439,8 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
             self.average_intercept_ = None
 
         # Clear iteration count for multiple call to fit.
-        self.t_ = 1.0
+        if not self.warm_start:
+            self.t_ = 1.0
 
         self._partial_fit(X, y, alpha, C, loss, learning_rate, self._max_iter,
                           classes, sample_weight, coef_init, intercept_init)
@@ -1009,7 +1010,8 @@ class BaseSGDRegressor(BaseSGD, RegressorMixin):
             self.average_intercept_ = None
 
         # Clear iteration count for multiple call to fit.
-        self.t_ = 1.0
+        if not self.warm_start:
+            self.t_ = 1.0
 
         self._partial_fit(X, y, alpha, C, loss, learning_rate,
                           self._max_iter, sample_weight, coef_init,


### PR DESCRIPTION
Fixes the first part of #10011

In SGD, the counter `self.t_` for dynamic learning rate was incorrectly reset when ``warm_start=True``