### PR TITLE
[MRG+1] Fix LogisticRegression see also should include LogisticRegressiononCV

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -265,6 +265,10 @@ class _CalibratedClassifier(object):
             if None, then classes is extracted from the given target values
             in fit().
 
+    See also
+    --------
+    CalibratedClassifierCV
+
     References
     ----------
     .. [1] Obtaining calibrated probability estimates from decision trees

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -101,6 +101,11 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
     >>> selector.ranking_
     array([1, 1, 1, 1, 1, 6, 4, 3, 2, 5])
 
+    See also
+    --------
+    RFECV : Recursive feature elimination with built-in cross-validated
+        selection of the best number of features
+
     References
     ----------
 
@@ -364,6 +369,10 @@ class RFECV(RFE, MetaEstimatorMixin):
             False, False, False, False, False], dtype=bool)
     >>> selector.ranking_
     array([1, 1, 1, 1, 1, 6, 4, 3, 2, 5])
+
+    See also
+    --------
+    RFE : Recursive feature elimination
 
     References
     ----------

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -640,6 +640,8 @@ class ElasticNet(LinearModel, RegressorMixin):
 
     See also
     --------
+    ElasticNetCV : Elastic net model with best model selection by
+        cross-validation.
     SGDRegressor: implements elastic net regression with incremental training.
     SGDClassifier: implements logistic regression with elastic net penalty
         (``SGDClassifier(loss="log", penalty="elasticnet")``).
@@ -1688,7 +1690,10 @@ class MultiTaskElasticNet(Lasso):
 
     See also
     --------
-    ElasticNet, MultiTaskLasso
+    MultiTaskElasticNet : Multi-task L1/L2 ElasticNet with built-in
+        cross-validation.
+    ElasticNet
+    MultiTaskLasso
 
     Notes
     -----
@@ -1873,7 +1878,9 @@ class MultiTaskLasso(MultiTaskElasticNet):
 
     See also
     --------
-    Lasso, MultiTaskElasticNet
+    MultiTaskLasso : Multi-task L1/L2 Lasso with built-in cross-validation
+    Lasso
+    MultiTaskElasticNet
 
     Notes
     -----

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -824,6 +824,7 @@ class LassoLars(Lars):
     Lasso
     LassoCV
     LassoLarsCV
+    LassoLarsIC
     sklearn.decomposition.sparse_encode
 
     """

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1120,6 +1120,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
     SGDClassifier : incrementally trained logistic regression (when given
         the parameter ``loss="log"``).
     sklearn.svm.LinearSVC : learns SVM models using the same algorithm.
+    LogisticRegressionCV : Logistic regression with built-in cross validation
 
     Notes
     -----

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -598,7 +598,7 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
     Lars
     LassoLars
     decomposition.sparse_encode
-
+    OrthogonalMatchingPursuitCV
     """
     def __init__(self, n_nonzero_coefs=None, tol=None, fit_intercept=True,
                  normalize=True, precompute='auto'):

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -624,7 +624,10 @@ class Ridge(_BaseRidge, RegressorMixin):
 
     See also
     --------
-    RidgeClassifier, RidgeCV, :class:`sklearn.kernel_ridge.KernelRidge`
+    RidgeClassifier : Ridge classifier
+    RidgeCV : Ridge regression with built-in cross validation
+    :class:`sklearn.kernel_ridge.KernelRidge` : Kernel ridge regression
+        combines ridge regression with the kernel trick
 
     Examples
     --------
@@ -770,7 +773,8 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
 
     See also
     --------
-    Ridge, RidgeClassifierCV
+    Ridge : Ridge regression
+    RidgeClassifierCV :  Ridge classifier with built-in cross validation
 
     Notes
     -----
@@ -1233,9 +1237,9 @@ class RidgeCV(_BaseRidgeCV, RegressorMixin):
 
     See also
     --------
-    Ridge: Ridge regression
-    RidgeClassifier: Ridge classifier
-    RidgeClassifierCV: Ridge classifier with built-in cross validation
+    Ridge : Ridge regression
+    RidgeClassifier : Ridge classifier
+    RidgeClassifierCV : Ridge classifier with built-in cross validation
     """
     pass
 
@@ -1318,9 +1322,9 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
     See also
     --------
-    Ridge: Ridge regression
-    RidgeClassifier: Ridge classifier
-    RidgeCV: Ridge regression with built-in cross validation
+    Ridge : Ridge regression
+    RidgeClassifier : Ridge classifier
+    RidgeCV : Ridge regression with built-in cross validation
 
     Notes
     -----


### PR DESCRIPTION
**Reference Issues/PRs**
    Fixes #9995 

**What does this implement/fix? Explain your changes.**
Added missing cross-references to CV estimators.
  -  Added reference to LogisticRegressionCV in LogisticRegression.
  -  Added reference to OrthogonalMatchingPursuitCV in OrthogonalMatchingPursuit.
  -  Added references for ElasticNetCV, MultiTaskElasticNet, MultiTaskLasso.
  -  Cross-referenced RFE and RFECV in each others docstring.
  -  Cross-referenced CalibratedClassifierCV in _CalibrationClassifier
  -  Added reference to LassoLarsIC in docstring of LassoLars.
  -  Added description to references in See also section of Ridge, RidgeClassifier.

**Any other comments?**
While correcting this issue. I noticed that a lot of "See also" sections are missing short description about the references( some have descriptions and some don't). we can add short comment/description everywhere for consistency.