### PR TITLE
Fix propagation of observation error to GP model

### DIFF
--- a/examples/gaussian_process/plot_gpr_noisy_targets.py
+++ b/examples/gaussian_process/plot_gpr_noisy_targets.py
@@ -85,8 +85,8 @@ dy = 0.5 + 1.0 * np.random.random(y.shape)
 noise = np.random.normal(0, dy)
 y += noise
 
-# Instanciate a Gaussian Process model
-gp = GaussianProcessRegressor(kernel=kernel, alpha=(dy / y) ** 2,
+# Instantiate a Gaussian Process model
+gp = GaussianProcessRegressor(kernel=kernel, alpha=dy ** 2,
                               n_restarts_optimizer=10)
 
 # Fit to data using Maximum Likelihood Estimation of the parameters


### PR DESCRIPTION
An observation y +/- dy requires `alpha = dy ** 2`, not `(dy / y) ** 2`.  This is probably a legacy from the earlier `nugget` parameter.

The example below demonstrates that `alpha = dy ** 2` is correct by comparing a plot of `y_pred +/- dy_pred` with the error bar `y +/- dy`.
```
def gptest(x=0.5, y=2, dy=0.1, fixed=False):
    alpha = dy ** 2 if fixed else (dy / y) ** 2
    # Create a squared-exp. GP with constant hyperparams.
    kernel = C(5) * RBF(2.0)
    gp = GaussianProcessRegressor(
        kernel=kernel, alpha=alpha, optimizer=None)    
    # Add a single observation y +/- dy at x
    gp.fit([[x]], [y])
    # Evaluate GP over 0 < x < 1.
    x_pred = np.linspace(0, 1, 100)
    y_pred, dy_pred = gp.predict(x_pred.reshape(-1, 1), return_std=True)
    # Compare 1-sigma limits with error on data.
    plt.errorbar(x, y, dy, fmt='k.', ms=10)
    plt.plot(x_pred, y_pred + dy_pred, 'r-')
    plt.plot(x_pred, y_pred - dy_pred, 'r-')
```

The output of `gptest(fixed=False)` is below and shows a prediction that is not compatible with the data:
![gptest_bad](https://user-images.githubusercontent.com/185007/32105134-45047840-badc-11e7-904c-11a1328b3e8c.png)

The output of `gptest(fixed=True)` is below and shows a prediction compatible with the data:
![gptest_good](https://user-images.githubusercontent.com/185007/32105143-4f578972-badc-11e7-94c8-41bb906afae8.png)
