### PR TITLE
Added kwargs to predict method of Pipeline

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -297,7 +297,7 @@ class Pipeline(_BaseComposition):
             of the pipeline.
 
         **predict_kwargs : dict of string -> object
-            Parameters passed to the ``predict`` method fo the last step
+            Parameters passed to the ``predict`` method of the last step
 
         Returns
         -------

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -287,7 +287,7 @@ class Pipeline(_BaseComposition):
             return last_step.fit(Xt, y, **fit_params).transform(Xt)
 
     @if_delegate_has_method(delegate='_final_estimator')
-    def predict(self, X):
+    def predict(self, X, **predict_kwargs):
         """Apply transforms to the data, and predict with the final estimator
 
         Parameters
@@ -295,6 +295,9 @@ class Pipeline(_BaseComposition):
         X : iterable
             Data to predict on. Must fulfill input requirements of first step
             of the pipeline.
+
+        **predict_kwargs : dict of string -> object
+            Parameters passed to the ``predict`` method fo the last step
 
         Returns
         -------
@@ -304,7 +307,7 @@ class Pipeline(_BaseComposition):
         for name, transform in self.steps[:-1]:
             if transform is not None:
                 Xt = transform.transform(Xt)
-        return self.steps[-1][-1].predict(Xt)
+        return self.steps[-1][-1].predict(Xt, **predict_kwargs)
 
     @if_delegate_has_method(delegate='_final_estimator')
     def fit_predict(self, X, y=None, **fit_params):


### PR DESCRIPTION
The `predict` function for some estimators, like BayesianRidge, has keyword options. This modification to Pipeline lets those arguments get passed along to the final estimator.

As far as I tell, this issue is not referenced in any Issues or other Pull Requests.

I did update the documentation for the predict command of the pipeline, but did not add a test for this particular functionality (as it seems relatively minor). 

One question I did have while making this change: Should I add the ability to pass arguments to steps in the operation besides the last model? My thought was, no because (1) no data from the intermediate steps are output and (2) the kwargs to these intermediate steps should not effect the predictions and, therefore, should not affect any of the outputs for `predict`.