### PR TITLE
Balanced accuracy doc - 2

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -464,22 +464,13 @@ given binary ``y_true`` and ``y_pred``:
     There is no clear consensus on the definition of a balanced accuracy for the
     multiclass setting. Here are some definitions that can be found in the literature:
 
-    * Normalized class-wise accuracy average as described in [Guyon2015]_: for multi-class
-      classification problem, each sample is assigned the class with maximum prediction value.
-      The predictions are then binarized to compute the accuracy of each class on a
-      one-vs-rest fashion. The balanced accuracy is obtained by averaging the individual
-      accuracies over all classes and then normalized by the expected value of balanced
-      accuracy for random predictions (:math:`0.5` for binary classification, :math:`1/C`
-      for C-class classification problem).
-    * Macro-average recall as described in [Mosley2013]_ and [Kelleher2015]_: the recall
-      for each class is computed independently and the average is taken over all classes.
-    * Class balanced accuracy as described in [Mosley2013]_: for each class, the number
-      of correctly predicted samples (diagonal element in the confusion matrix) is normalized
-      by the maximum value of either the total number of observations predicted to the class
-      (sum of the class' column in the confusion matrix) or the actual number
-      of observations in that class (sum of the class' row in the confusion matrix).
-      In other words, we take the minimum between the precision and the recall for each class.
-      The individual accuracies are then averaged to get the class balanced accuracy.
+    * Macro-average recall as described in [Mosley2013]_, [Kelleher2015]_ and [Guyon2015]_:
+      the recall for each class is computed independently and the average is taken over all classes.
+      In [Guyon2015]_, the macro-average recall is then adjusted to ensure that random predictions
+      have a score of :math:`0` while perfect predictions have a score of :math:`1`.
+    * Class balanced accuracy as described in [Mosley2013]_: the minimum between the precision
+      and the recall for each class is computed. Those values are then averaged over the total
+      number of classes to get the balanced accuracy.
 
     Note that none of these different definitions are currently implemented within
     the :func:`balanced_accuracy_score` function. However, the macro-averaged recall

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -467,7 +467,8 @@ given binary ``y_true`` and ``y_pred``:
     * Normalized class-wise accuracy average as described in [Guyon2015]_
     * Macro-average recall as described in [Mosley2013]_ and [Kelleher2015]_
 
-    Note that none of these different definitions are currently implemented in scikit-learn.
+    Note that none of these different definitions are currently implemented within
+    the :func:`balanced_accuracy_score` function.
 
 .. topic:: References:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -464,8 +464,15 @@ given binary ``y_true`` and ``y_pred``:
     There is no clear consensus on the definition of a balanced accuracy for the
     multiclass setting. Here are some definitions that can be found in the literature:
 
-    * Normalized class-wise accuracy average as described in [Guyon2015]_
-    * Macro-average recall as described in [Mosley2013]_ and [Kelleher2015]_
+    * Normalized class-wise accuracy average as described in [Guyon2015]_: for multi-class
+      classification problem, each sample is assigned the class with maximum prediction value.
+      The predictions are then binarized to compute the accuracy of each class on a
+      one-vs-rest fashion. The balanced accuracy is obtained by averaging the individual
+      accuracies over all classes and then normalized by the expected value of balanced
+      accuracy for random predictions (:math:`0.5` for binary classification, :math:`1/C`
+      for C-class classification problem).
+    * Macro-average recall as described in [Mosley2013]_ and [Kelleher2015]_: the recall
+      for each class is computed independently and the average is taken over all classes.
 
     Note that none of these different definitions are currently implemented within
     the :func:`balanced_accuracy_score` function.

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -467,6 +467,8 @@ given binary ``y_true`` and ``y_pred``:
     * Normalized class-wise accuracy average as described in [Guyon2015]_
     * Macro-average recall as described in [Mosley2013]_
 
+    Note that none of these different definitions are currently implemented in scikit-learn.
+
 .. topic:: References:
 
   .. [Guyon2015] I. Guyon, K. Bennett, G. Cawley, H.J. Escalante, S. Escalera, T.K. Ho, N. Macià,

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -465,7 +465,7 @@ given binary ``y_true`` and ``y_pred``:
     multiclass setting. Here are some definitions that can be found in the literature:
 
     * Normalized class-wise accuracy average as described in [Guyon2015]_
-    * Macro-average recall as described in [Mosley2013]_
+    * Macro-average recall as described in [Mosley2013]_ and [Kelleher2015]_
 
     Note that none of these different definitions are currently implemented in scikit-learn.
 
@@ -478,6 +478,10 @@ given binary ``y_true`` and ``y_pred``:
   .. [Mosley2013] L. Mosley, `A balanced approach to the multi-class imbalance problem
      <http://lib.dr.iastate.edu/etd/13537/>`_,
      IJCV 2010.
+  .. [Kelleher2015] John. D. Kelleher, Brian Mac Namee, Aoife D'Arcy, `Fundamentals of
+     Machine Learning for Predictive Data Analytics: Algorithms, Worked Examples,
+     and Case Studies <https://mitpress.mit.edu/books/fundamentals-machine-learning-predictive-data-analytics>`_,
+     2015.
 
 .. _cohen_kappa:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -468,6 +468,7 @@ given binary ``y_true`` and ``y_pred``:
       the recall for each class is computed independently and the average is taken over all classes.
       In [Guyon2015]_, the macro-average recall is then adjusted to ensure that random predictions
       have a score of :math:`0` while perfect predictions have a score of :math:`1`.
+      One can compute the macro-average recall using ``recall_score(average="macro")`` in :func:`recall_score`.
     * Class balanced accuracy as described in [Mosley2013]_: the minimum between the precision
       and the recall for each class is computed. Those values are then averaged over the total
       number of classes to get the balanced accuracy.
@@ -475,9 +476,7 @@ given binary ``y_true`` and ``y_pred``:
       is computed for each class and then averaged over total number of classes.
 
     Note that none of these different definitions are currently implemented within
-    the :func:`balanced_accuracy_score` function. However, the macro-averaged recall
-    is implemented in :func:`sklearn.metrics.recall_score`: set ``average`` parameter
-    to ``"macro"``.
+    the :func:`balanced_accuracy_score` function.
 
 .. topic:: References:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -478,6 +478,7 @@ given binary ``y_true`` and ``y_pred``:
       by the maximum value of either the total number of observations predicted to the class
       (sum of the class' column in the confusion matrix) or the actual number
       of observations in that class (sum of the class' row in the confusion matrix).
+      In other words, we take the minimum between the precision and th recall for each class.
       The individual accuracies are then averaged to get the class balanced accuracy.
 
     Note that none of these different definitions are currently implemented within

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -475,7 +475,9 @@ given binary ``y_true`` and ``y_pred``:
       for each class is computed independently and the average is taken over all classes.
 
     Note that none of these different definitions are currently implemented within
-    the :func:`balanced_accuracy_score` function.
+    the :func:`balanced_accuracy_score` function. However, the macro-averaged recall
+    is implemented in :func:`sklearn.metrics.recall_score`: set ``average`` parameter
+    to ``"macro"``.
 
 .. topic:: References:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -473,7 +473,7 @@ given binary ``y_true`` and ``y_pred``:
       for C-class classification problem).
     * Macro-average recall as described in [Mosley2013]_ and [Kelleher2015]_: the recall
       for each class is computed independently and the average is taken over all classes.
-    * Class balance accuracy as described in [Mosley2013]_: for each class, the number
+    * Class balanced accuracy as described in [Mosley2013]_: for each class, the number
       of correctly predicted samples (diagonal element in the confusion matrix) is normalized
       by the maximum value of either the total number of observations predicted to the class
       (sum of the class' column in the confusion matrix) or the actual number

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -478,7 +478,7 @@ given binary ``y_true`` and ``y_pred``:
       by the maximum value of either the total number of observations predicted to the class
       (sum of the class' column in the confusion matrix) or the actual number
       of observations in that class (sum of the class' row in the confusion matrix).
-      In other words, we take the minimum between the precision and th recall for each class.
+      In other words, we take the minimum between the precision and the recall for each class.
       The individual accuracies are then averaged to get the class balanced accuracy.
 
     Note that none of these different definitions are currently implemented within

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -461,6 +461,22 @@ given binary ``y_true`` and ``y_pred``:
     Currently this score function is only defined for binary classification problems, you
     may need to wrap it by yourself if you want to use it for multilabel problems.
 
+    There is no clear consensus on the definition of a balanced accuracy for the
+    multiclass setting. Here are some definitions that can be found in the literature:
+
+    * Normalized class-wise accuracy average as described in [Guyon2015]_
+    * Macro-average recall as described in [Mosley2013]_
+
+.. topic:: References:
+
+  .. [Guyon2015] I. Guyon, K. Bennett, G. Cawley, H.J. Escalante, S. Escalera, T.K. Ho, N. Macià,
+     B. Ray, M. Saeed, A.R. Statnikov, E. Viegas, `Design of the 2015 ChaLearn AutoML Challenge
+     <http://ieeexplore.ieee.org/document/7280767/>`_,
+     IJCNN 2015.
+  .. [Mosley2013] L. Mosley, `A balanced approach to the multi-class imbalance problem
+     <http://lib.dr.iastate.edu/etd/13537/>`_,
+     IJCV 2010.
+
 .. _cohen_kappa:
 
 Cohen's kappa

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -471,6 +471,8 @@ given binary ``y_true`` and ``y_pred``:
     * Class balanced accuracy as described in [Mosley2013]_: the minimum between the precision
       and the recall for each class is computed. Those values are then averaged over the total
       number of classes to get the balanced accuracy.
+    * Balanced Accuracy as described in [Urbanowicz2015]_: the average of sensitivity and selectivity
+      is computed for each class and then averaged over total number of classes.
 
     Note that none of these different definitions are currently implemented within
     the :func:`balanced_accuracy_score` function. However, the macro-averaged recall
@@ -490,6 +492,8 @@ given binary ``y_true`` and ``y_pred``:
      Machine Learning for Predictive Data Analytics: Algorithms, Worked Examples,
      and Case Studies <https://mitpress.mit.edu/books/fundamentals-machine-learning-predictive-data-analytics>`_,
      2015.
+  .. [Urbanowicz2015] Urbanowicz R.J.,  Moore, J.H. `ExSTraCS 2.0: description and evaluation of a scalable learning
+     classifier system < https://doi.org/10.1007/s12065-015-0128-8>`_, Evol. Intel. (2015) 8: 89.
 
 .. _cohen_kappa:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -473,6 +473,12 @@ given binary ``y_true`` and ``y_pred``:
       for C-class classification problem).
     * Macro-average recall as described in [Mosley2013]_ and [Kelleher2015]_: the recall
       for each class is computed independently and the average is taken over all classes.
+    * Class balance accuracy as described in [Mosley2013]_: for each class, the number
+      of correctly predicted samples (diagonal element in the confusion matrix) is normalized
+      by the maximum value of either the total number of observations predicted to the class
+      (sum of the class' column in the confusion matrix) or the actual number
+      of observations in that class (sum of the class' row in the confusion matrix).
+      The individual accuracies are then averaged to get the class balanced accuracy.
 
     Note that none of these different definitions are currently implemented within
     the :func:`balanced_accuracy_score` function. However, the macro-averaged recall


### PR DESCRIPTION
Reference Issues/PRs

In addition to #8066

What does this implement/fix? Explain your changes.

I added some references from the literature for the multiclass balanced accuracy. The threads #6747 and #8066 cited some papers and their different implementations of the metric. There was no real consensus about what was the definition to use, so the user might want to implement the one of his/her/their choice.