### PR TITLE
[MRG] Add check for n_components in pca

### DIFF
--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -11,6 +11,7 @@
 # License: BSD 3 clause
 
 from math import log, sqrt
+import numbers
 
 import numpy as np
 from scipy import linalg
@@ -418,7 +419,7 @@ class PCA(_BasePCA):
                              "svd_solver='full'"
                              % (n_components, min(n_samples, n_features)))
         elif n_components >= 1:
-            if not isinstance(n_components, (int, np.integer)):
+            if not isinstance(n_components, (numbers.Integral, np.integer)):
                 raise ValueError("n_components=%r must be of type int "
                                  "when greater than or equal to 1, "
                                  "was of type=%r"
@@ -483,7 +484,7 @@ class PCA(_BasePCA):
                              "svd_solver='%s'"
                              % (n_components, min(n_samples, n_features),
                                 svd_solver))
-        elif not isinstance(n_components, (int, np.integer)):
+        elif not isinstance(n_components, (numbers.Integral, np.integer)):
             raise ValueError("n_components=%r must be of type int "
                              "when greater than or equal to 1, was of type=%r"
                              % (n_components, type(n_components)))

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -383,13 +383,6 @@ class PCA(_BasePCA):
         else:
             n_components = self.n_components
 
-        if n_components != "mle" and \
-                (n_components > 1 and
-                 not (np.issubdtype(type(n_components), np.integer))):
-            raise ValueError("n_components=%r must be of type int "
-                             "when bigger than 1, was of type=%r"
-                             % (n_components, type(n_components)))
-
         # Handle svd_solver
         svd_solver = self.svd_solver
         if svd_solver == 'auto':
@@ -424,6 +417,11 @@ class PCA(_BasePCA):
                              "min(n_samples, n_features)=%r with "
                              "svd_solver='full'"
                              % (n_components, min(n_samples, n_features)))
+        elif n_components >= 1:
+            if not np.issubdtype(type(n_components), np.integer):
+                raise ValueError("n_components=%r must be of type int "
+                                 "when greater or equal to 1, was of type=%r"
+                                 % (n_components, type(n_components)))
 
         # Center data
         self.mean_ = np.mean(X, axis=0)
@@ -484,6 +482,10 @@ class PCA(_BasePCA):
                              "svd_solver='%s'"
                              % (n_components, min(n_samples, n_features),
                                 svd_solver))
+        elif not np.issubdtype(type(n_components), np.integer):
+            raise ValueError("n_components=%r must be of type int "
+                             "when greater or equal to 1, was of type=%r"
+                             % (n_components, type(n_components)))
         elif svd_solver == 'arpack' and n_components == min(n_samples,
                                                             n_features):
             raise ValueError("n_components=%r must be strictly less than "

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -383,6 +383,13 @@ class PCA(_BasePCA):
         else:
             n_components = self.n_components
 
+        if n_components != "mle" and \
+                (n_components > 1 and
+                 not (np.issubdtype(type(n_components), np.integer))):
+            raise ValueError("n_components=%r must be of type int "
+                             "when bigger than 1, was of type=%r"
+                             % (n_components, type(n_components)))
+
         # Handle svd_solver
         svd_solver = self.svd_solver
         if svd_solver == 'auto':

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -420,7 +420,8 @@ class PCA(_BasePCA):
         elif n_components >= 1:
             if not np.issubdtype(type(n_components), np.integer):
                 raise ValueError("n_components=%r must be of type int "
-                                 "when greater or equal to 1, was of type=%r"
+                                 "when greater than or equal to 1, "
+                                 "was of type=%r"
                                  % (n_components, type(n_components)))
 
         # Center data
@@ -484,7 +485,7 @@ class PCA(_BasePCA):
                                 svd_solver))
         elif not np.issubdtype(type(n_components), np.integer):
             raise ValueError("n_components=%r must be of type int "
-                             "when greater or equal to 1, was of type=%r"
+                             "when greater than or equal to 1, was of type=%r"
                              % (n_components, type(n_components)))
         elif svd_solver == 'arpack' and n_components == min(n_samples,
                                                             n_features):

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -418,7 +418,7 @@ class PCA(_BasePCA):
                              "svd_solver='full'"
                              % (n_components, min(n_samples, n_features)))
         elif n_components >= 1:
-            if not np.issubdtype(type(n_components), np.integer):
+            if not isinstance(n_components, (int, np.integer)):
                 raise ValueError("n_components=%r must be of type int "
                                  "when greater than or equal to 1, "
                                  "was of type=%r"
@@ -483,7 +483,7 @@ class PCA(_BasePCA):
                              "svd_solver='%s'"
                              % (n_components, min(n_samples, n_features),
                                 svd_solver))
-        elif not np.issubdtype(type(n_components), np.integer):
+        elif not isinstance(n_components, (int, np.integer)):
             raise ValueError("n_components=%r must be of type int "
                              "when greater than or equal to 1, was of type=%r"
                              % (n_components, type(n_components)))

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -394,9 +394,9 @@ def test_pca_validation():
         type_ncom = type(n_components)
         assert_raise_message(ValueError,
                              "n_components={} must be of type int "
-                             "when greater or equal to 1, was of type={}"
+                             "when greater than or equal to 1, was of type={}"
                              .format(n_components, type_ncom),
-                             PCA(n_components).fit, data)
+                             PCA(n_components, svd_solver=solver).fit, data)
 
 
 

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -9,6 +9,7 @@ from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raises_regex
+from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import ignore_warnings
@@ -389,6 +390,12 @@ def test_pca_validation():
                                     PCA(n_components, svd_solver=solver)
                                     .fit, data)
 
+    n_components = 1.2
+    type_ncom = type(n_components)
+    assert_raise_message(ValueError, "n_components={} must be of type int "
+                                     "when bigger than 1, was of type={}"
+                                     .format(n_components, type_ncom),
+                                     PCA(n_components).fit, data)
 
 def test_n_components_none():
     # Ensures that n_components == None is handled correctly

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -390,12 +390,16 @@ def test_pca_validation():
                                     PCA(n_components, svd_solver=solver)
                                     .fit, data)
 
-    n_components = 1.2
-    type_ncom = type(n_components)
-    assert_raise_message(ValueError, "n_components={} must be of type int "
-                                     "when bigger than 1, was of type={}"
+                n_components = 1.0
+                type_ncom = type(n_components)
+                assert_raise_message(ValueError,
+                                     "n_components={} must be of type int "
+                                     "when greater or equal to 1, "
+                                     "was of type={}"
                                      .format(n_components, type_ncom),
                                      PCA(n_components).fit, data)
+
+
 
 def test_n_components_none():
     # Ensures that n_components == None is handled correctly

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -390,14 +390,13 @@ def test_pca_validation():
                                     PCA(n_components, svd_solver=solver)
                                     .fit, data)
 
-                n_components = 1.0
-                type_ncom = type(n_components)
-                assert_raise_message(ValueError,
-                                     "n_components={} must be of type int "
-                                     "when greater or equal to 1, "
-                                     "was of type={}"
-                                     .format(n_components, type_ncom),
-                                     PCA(n_components).fit, data)
+        n_components = 1.0
+        type_ncom = type(n_components)
+        assert_raise_message(ValueError,
+                             "n_components={} must be of type int "
+                             "when greater or equal to 1, was of type={}"
+                             .format(n_components, type_ncom),
+                             PCA(n_components).fit, data)
 
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10034 

#### What does this implement/fix? Explain your changes.
Previously, passing a `n_components` bigger than 1 that wasn't a integer would originate confusing errors. I fixed this by doing explicit verification and rasing a ValueError for it (+ tests ofcourse)

#### Any other comments?
I opted for doing it in the `_fit` method, but could have been done in `_fit_full` or `_fit_truncate`, where other verifications are done. Can change if reviewers prefer