### PR TITLE
[MRG+2] make_circles() now works with odd number of samples, test added

### DIFF
--- a/doc/whats_new/_contributors.rst
+++ b/doc/whats_new/_contributors.rst
@@ -141,3 +141,5 @@
 .. _Neeraj Gangwar: http://neerajgangwar.in
 
 .. _Arthur Mensch: https://amensch.fr
+
+.. _Christian Braune: https://github.com/christianbraune79

--- a/doc/whats_new/_contributors.rst
+++ b/doc/whats_new/_contributors.rst
@@ -141,5 +141,3 @@
 .. _Neeraj Gangwar: http://neerajgangwar.in
 
 .. _Arthur Mensch: https://amensch.fr
-
-.. _Christian Braune: https://github.com/christianbraune79

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -135,6 +135,10 @@ Decomposition, manifold learning and clustering
   wrapped estimator and its parameter. :issue:`9999` by :user:`Marcus Voss
   <marcus-voss>` and `Joel Nothman`_.
 
+- Fixed a bug in :func:`datasets.make_circles`, where no odd number of data 
+  points could be generated. :issue:`10037` by :user:`Christian Braune 
+  <christianbraune79>`_.
+  
 Metrics
 
 - Fixed a bug due to floating point error in :func:`metrics.roc_auc_score` with

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -613,20 +613,22 @@ def make_circles(n_samples=100, shuffle=True, noise=None, random_state=None,
 
     if factor > 1 or factor < 0:
         raise ValueError("'factor' has to be between 0 and 1.")
+    n_samples_out = n_samples // 2
+    n_samples_in = n_samples - n_samples_out
 
     generator = check_random_state(random_state)
-    # so as not to have the first point = last point, we add one and then
-    # remove it.
-    linspace = np.linspace(0, 2 * np.pi, n_samples // 2 + 1)[:-1]
-    outer_circ_x = np.cos(linspace)
-    outer_circ_y = np.sin(linspace)
-    inner_circ_x = outer_circ_x * factor
-    inner_circ_y = outer_circ_y * factor
+    # so as not to have the first point = last point, we set endpoint=False
+    linspace_out = np.linspace(0, 2 * np.pi, n_samples_out, endpoint=False)
+    linspace_in = np.linspace(0, 2 * np.pi, n_samples_in, endpoint=True)
+    outer_circ_x = np.cos(linspace_out)
+    outer_circ_y = np.sin(linspace_out)
+    inner_circ_x = np.cos(linspace_in) * factor
+    inner_circ_y = np.sin(linspace_in) * factor
 
     X = np.vstack((np.append(outer_circ_x, inner_circ_x),
                    np.append(outer_circ_y, inner_circ_y))).T
-    y = np.hstack([np.zeros(n_samples // 2, dtype=np.intp),
-                   np.ones(n_samples // 2, dtype=np.intp)])
+    y = np.hstack([np.zeros(n_samples_out, dtype=np.intp),
+                   np.ones(n_samples_in, dtype=np.intp)])
     if shuffle:
         X, y = util_shuffle(X, y, random_state=generator)
 

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -585,7 +585,8 @@ def make_circles(n_samples=100, shuffle=True, noise=None, random_state=None,
     Parameters
     ----------
     n_samples : int, optional (default=100)
-        The total number of points generated.
+        The total number of points generated. If odd, the inner circle will
+        have one point more than the outer circle.
 
     shuffle : bool, optional (default=True)
         Whether to shuffle the samples.
@@ -599,7 +600,7 @@ def make_circles(n_samples=100, shuffle=True, noise=None, random_state=None,
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    factor : double < 1 (default=.8)
+    factor : 0 < double < 1 (default=.8)
         Scale factor between inner and outer circle.
 
     Returns
@@ -611,7 +612,7 @@ def make_circles(n_samples=100, shuffle=True, noise=None, random_state=None,
         The integer labels (0 or 1) for class membership of each sample.
     """
 
-    if factor > 1 or factor < 0:
+    if factor >= 1 or factor < 0:
         raise ValueError("'factor' has to be between 0 and 1.")
 
     n_samples_out = n_samples // 2

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -614,19 +614,22 @@ def make_circles(n_samples=100, shuffle=True, noise=None, random_state=None,
     if factor > 1 or factor < 0:
         raise ValueError("'factor' has to be between 0 and 1.")
 
+    n_samples_out = n_samples // 2
+    n_samples_in = n_samples - n_samples_out
+
     generator = check_random_state(random_state)
-    # so as not to have the first point = last point, we add one and then
-    # remove it.
-    linspace = np.linspace(0, 2 * np.pi, n_samples // 2 + 1)[:-1]
-    outer_circ_x = np.cos(linspace)
-    outer_circ_y = np.sin(linspace)
-    inner_circ_x = outer_circ_x * factor
-    inner_circ_y = outer_circ_y * factor
+    # so as not to have the first point = last point, we set endpoint=False
+    linspace_out = np.linspace(0, 2 * np.pi, n_samples_out, endpoint=False)
+    linspace_in = np.linspace(0, 2 * np.pi, n_samples_in, endpoint=True)
+    outer_circ_x = np.cos(linspace_out)
+    outer_circ_y = np.sin(linspace_out)
+    inner_circ_x = np.cos(linspace_in) * factor
+    inner_circ_y = np.sin(linspace_in) * factor
 
     X = np.vstack((np.append(outer_circ_x, inner_circ_x),
                    np.append(outer_circ_y, inner_circ_y))).T
-    y = np.hstack([np.zeros(n_samples // 2, dtype=np.intp),
-                   np.ones(n_samples // 2, dtype=np.intp)])
+    y = np.hstack([np.zeros(n_samples_out, dtype=np.intp),
+                   np.ones(n_samples_in, dtype=np.intp)])
     if shuffle:
         X, y = util_shuffle(X, y, random_state=generator)
 

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -613,9 +613,7 @@ def make_circles(n_samples=100, shuffle=True, noise=None, random_state=None,
 
     if factor > 1 or factor < 0:
         raise ValueError("'factor' has to be between 0 and 1.")
-    n_samples_out = n_samples // 2
-    n_samples_in = n_samples - n_samples_out
-
+        
     n_samples_out = n_samples // 2
     n_samples_in = n_samples - n_samples_out
 

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -613,14 +613,14 @@ def make_circles(n_samples=100, shuffle=True, noise=None, random_state=None,
 
     if factor > 1 or factor < 0:
         raise ValueError("'factor' has to be between 0 and 1.")
-        
+
     n_samples_out = n_samples // 2
     n_samples_in = n_samples - n_samples_out
 
     generator = check_random_state(random_state)
     # so as not to have the first point = last point, we set endpoint=False
     linspace_out = np.linspace(0, 2 * np.pi, n_samples_out, endpoint=False)
-    linspace_in = np.linspace(0, 2 * np.pi, n_samples_in, endpoint=True)
+    linspace_in = np.linspace(0, 2 * np.pi, n_samples_in, endpoint=False)
     outer_circ_x = np.cos(linspace_out)
     outer_circ_y = np.sin(linspace_out)
     inner_circ_x = np.cos(linspace_in) * factor

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -399,3 +399,10 @@ def test_make_circles():
         dist_exp = 1.0 if label == 0 else f**2
         assert_almost_equal(dist_sqr, dist_exp,
                             err_msg="Point is not on expected circle")
+
+    X, y = make_circles(10, shuffle=False, noise=None)
+    assert_equal(X.shape, (10, 2), "X shape mismatch")
+    assert_equal(y.shape, (10,), "y shape mismatch")
+
+    assert_equal(X[y == 0].shape, (5, 2),
+                 err_msg="Samples not correctly distributed across circles.")

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -391,6 +391,7 @@ def test_make_moons():
 def test_make_circles():
     f = 0.3
 
+    # Testing odd and even case, because in the past make_circles always created an even number of samples.
     for (n_samples, n_outer, n_inner) in [(7, 3, 4), (8, 4, 4)]:
         X, y = make_circles(n_samples, shuffle=False, noise=None, factor=f)
         assert_equal(X.shape, (n_samples, 2), "X shape mismatch")

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -389,18 +389,18 @@ def test_make_moons():
 
 
 def test_make_circles():
-    f = 0.3
+    factor = 0.3
 
-    # Testing odd and even case, because in the past make_circles always
-    # created an even number of samples.
     for (n_samples, n_outer, n_inner) in [(7, 3, 4), (8, 4, 4)]:
-        X, y = make_circles(n_samples, shuffle=False, noise=None, factor=f)
+        # Testing odd and even case, because in the past make_circles always
+        # created an even number of samples.
+        X, y = make_circles(n_samples, shuffle=False, noise=None, factor=factor)
         assert_equal(X.shape, (n_samples, 2), "X shape mismatch")
         assert_equal(y.shape, (n_samples,), "y shape mismatch")
         center = [0.0, 0.0]
         for x, label in zip(X, y):
             dist_sqr = ((x - center) ** 2).sum()
-            dist_exp = 1.0 if label == 0 else f**2
+            dist_exp = 1.0 if label == 0 else factor**2
             assert_almost_equal(dist_sqr, dist_exp,
                                 err_msg="Point is not on expected circle")
 

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -25,6 +25,7 @@ from sklearn.datasets import make_friedman2
 from sklearn.datasets import make_friedman3
 from sklearn.datasets import make_low_rank_matrix
 from sklearn.datasets import make_moons
+from sklearn.datasets import make_circles
 from sklearn.datasets import make_sparse_coded_signal
 from sklearn.datasets import make_sparse_uncorrelated
 from sklearn.datasets import make_spd_matrix
@@ -385,3 +386,16 @@ def test_make_moons():
         dist_sqr = ((x - center) ** 2).sum()
         assert_almost_equal(dist_sqr, 1.0,
                             err_msg="Point is not on expected unit circle")
+
+
+def test_make_circles():
+    f = 0.3
+    X, y = make_circles(7, shuffle=False, noise=None, factor=f)
+    assert_equal(X.shape, (7, 2), "X shape mismatch")
+    assert_equal(y.shape, (7,), "y shape mismatch")
+    center = [0.0, 0.0]
+    for x, label in zip(X, y):
+        dist_sqr = ((x - center) ** 2).sum()
+        dist_exp = 1.0 if label == 0 else f**2
+        assert_almost_equal(dist_sqr, dist_exp,
+                            err_msg="Point is not on expected circle")

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -400,9 +400,10 @@ def test_make_circles():
         assert_almost_equal(dist_sqr, dist_exp,
                             err_msg="Point is not on expected circle")
 
-    X, y = make_circles(10, shuffle=False, noise=None)
-    assert_equal(X.shape, (10, 2), "X shape mismatch")
-    assert_equal(y.shape, (10,), "y shape mismatch")
-
-    assert_equal(X[y == 0].shape, (5, 2),
+    assert_equal(X[y == 0].shape, (3, 2),
                  "Samples not correctly distributed across circles.")
+    assert_equal(X[y == 1].shape, (4, 2),
+                 "Samples not correctly distributed across circles.")
+
+    assert_raises(ValueError, make_circles, factor=-0.01)
+    assert_raises(ValueError, make_circles, factor=1.)

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -391,7 +391,8 @@ def test_make_moons():
 def test_make_circles():
     f = 0.3
 
-    # Testing odd and even case, because in the past make_circles always created an even number of samples.
+    # Testing odd and even case, because in the past make_circles always
+    # created an even number of samples.
     for (n_samples, n_outer, n_inner) in [(7, 3, 4), (8, 4, 4)]:
         X, y = make_circles(n_samples, shuffle=False, noise=None, factor=f)
         assert_equal(X.shape, (n_samples, 2), "X shape mismatch")

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -405,4 +405,4 @@ def test_make_circles():
     assert_equal(y.shape, (10,), "y shape mismatch")
 
     assert_equal(X[y == 0].shape, (5, 2),
-                 err_msg="Samples not correctly distributed across circles.")
+                 "Samples not correctly distributed across circles.")

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -394,7 +394,8 @@ def test_make_circles():
     for (n_samples, n_outer, n_inner) in [(7, 3, 4), (8, 4, 4)]:
         # Testing odd and even case, because in the past make_circles always
         # created an even number of samples.
-        X, y = make_circles(n_samples, shuffle=False, noise=None, factor=factor)
+        X, y = make_circles(n_samples, shuffle=False, noise=None,
+                            factor=factor)
         assert_equal(X.shape, (n_samples, 2), "X shape mismatch")
         assert_equal(y.shape, (n_samples,), "y shape mismatch")
         center = [0.0, 0.0]

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -390,20 +390,22 @@ def test_make_moons():
 
 def test_make_circles():
     f = 0.3
-    X, y = make_circles(7, shuffle=False, noise=None, factor=f)
-    assert_equal(X.shape, (7, 2), "X shape mismatch")
-    assert_equal(y.shape, (7,), "y shape mismatch")
-    center = [0.0, 0.0]
-    for x, label in zip(X, y):
-        dist_sqr = ((x - center) ** 2).sum()
-        dist_exp = 1.0 if label == 0 else f**2
-        assert_almost_equal(dist_sqr, dist_exp,
-                            err_msg="Point is not on expected circle")
 
-    assert_equal(X[y == 0].shape, (3, 2),
-                 "Samples not correctly distributed across circles.")
-    assert_equal(X[y == 1].shape, (4, 2),
-                 "Samples not correctly distributed across circles.")
+    for (n_samples, n_outer, n_inner) in [(7, 3, 4), (8, 4, 4)]:
+        X, y = make_circles(n_samples, shuffle=False, noise=None, factor=f)
+        assert_equal(X.shape, (n_samples, 2), "X shape mismatch")
+        assert_equal(y.shape, (n_samples,), "y shape mismatch")
+        center = [0.0, 0.0]
+        for x, label in zip(X, y):
+            dist_sqr = ((x - center) ** 2).sum()
+            dist_exp = 1.0 if label == 0 else f**2
+            assert_almost_equal(dist_sqr, dist_exp,
+                                err_msg="Point is not on expected circle")
+
+        assert_equal(X[y == 0].shape, (n_outer, 2),
+                     "Samples not correctly distributed across circles.")
+        assert_equal(X[y == 1].shape, (n_inner, 2),
+                     "Samples not correctly distributed across circles.")
 
     assert_raises(ValueError, make_circles, factor=-0.01)
     assert_raises(ValueError, make_circles, factor=1.)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10037 and adds corresponding tests

#### What does this implement/fix? Explain your changes.
Fixes he faulty behaviour of ```make_circles``` when ```n_samples``` is an odd number.
Adds test ```test_make_circles``` to ```datasets/tests/test_samples_generator.py```.

#### Any other comments?
