### PR TITLE
fix typo in docs - modules/model_persistence

### DIFF
--- a/doc/modules/model_persistence.rst
+++ b/doc/modules/model_persistence.rst
@@ -73,7 +73,7 @@ and security. Because of this,
 In order to rebuild a similar model with future versions of scikit-learn,
 additional metadata should be saved along the pickled model:
 
-* The training data, e.g. a reference to a immutable snapshot
+* The training data, e.g. a reference to an immutable snapshot
 * The python source code used to generate the model
 * The versions of scikit-learn and its dependencies
 * The cross validation score obtained on the training data


### PR DESCRIPTION
 **What does this implement/fix? Explain your changes.**

Fixes a small typo/grammar error.  a -> an.

