### PR TITLE
[MRG+1] fix for erroneous max_iter and tol warnings for SGDClassifier when using partial_fit

### DIFF
--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -128,7 +128,7 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
                     "From 0.21, default max_iter will be 1000, "
                     "and default tol will be 1e-3." % type(self), FutureWarning)
                 # Before 0.19, default was n_iter=5
-                max_iter = 5
+            max_iter = 5
         else:
             max_iter = self.max_iter if self.max_iter is not None else 1000
         self._max_iter = max_iter

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -82,7 +82,7 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
     def fit(self, X, y):
         """Fit model."""
 
-    def _validate_params(self, set_max_iter=True,for_partial_fit=False):
+    def _validate_params(self, set_max_iter=True, for_partial_fit=False):
         """Validate input params. """
         if not isinstance(self.shuffle, bool):
             raise ValueError("shuffle must be either True or False")

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -82,7 +82,7 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
     def fit(self, X, y):
         """Fit model."""
 
-    def _validate_params(self, set_max_iter=True):
+    def _validate_params(self, set_max_iter=True,for_partial_fit=False):
         """Validate input params. """
         if not isinstance(self.shuffle, bool):
             raise ValueError("shuffle must be either True or False")
@@ -119,7 +119,7 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
             max_iter = self.n_iter
             self._tol = None
 
-        elif self.tol is None and self.max_iter is None:
+        elif self.tol is None and self.max_iter is None and not for_partial_fit:
             warnings.warn(
                 "max_iter and tol parameters have been added in %s in 0.19. If"
                 " both are left unset, they default to max_iter=5 and tol=None"
@@ -538,7 +538,7 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
         -------
         self : returns an instance of self.
         """
-        self._validate_params()
+        self._validate_params(for_partial_fit=True)
         if self.class_weight in ['balanced']:
             raise ValueError("class_weight '{0}' is not supported for "
                              "partial_fit. In order to use 'balanced' weights,"

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -119,15 +119,16 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
             max_iter = self.n_iter
             self._tol = None
 
-        elif self.tol is None and self.max_iter is None and not for_partial_fit:
-            warnings.warn(
-                "max_iter and tol parameters have been added in %s in 0.19. If"
-                " both are left unset, they default to max_iter=5 and tol=None"
-                ". If tol is not None, max_iter defaults to max_iter=1000. "
-                "From 0.21, default max_iter will be 1000, "
-                "and default tol will be 1e-3." % type(self), FutureWarning)
-            # Before 0.19, default was n_iter=5
-            max_iter = 5
+        elif self.tol is None and self.max_iter is None:
+            if not for_partial_fit:
+                warnings.warn(
+                    "max_iter and tol parameters have been added in %s in 0.19. If"
+                    " both are left unset, they default to max_iter=5 and tol=None"
+                    ". If tol is not None, max_iter defaults to max_iter=1000. "
+                    "From 0.21, default max_iter will be 1000, "
+                    "and default tol will be 1e-3." % type(self), FutureWarning)
+                # Before 0.19, default was n_iter=5
+                max_iter = 5
         else:
             max_iter = self.max_iter if self.max_iter is not None else 1000
         self._max_iter = max_iter

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -983,7 +983,7 @@ class BaseSGDRegressor(BaseSGD, RegressorMixin):
         -------
         self : returns an instance of self.
         """
-        self._validate_params()
+        self._validate_params(for_partial_fit=True)
         return self._partial_fit(X, y, self.alpha, C=1.0,
                                  loss=self.loss,
                                  learning_rate=self.learning_rate, max_iter=1,

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -122,11 +122,12 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
         elif self.tol is None and self.max_iter is None:
             if not for_partial_fit:
                 warnings.warn(
-                    "max_iter and tol parameters have been added in %s in 0.19. If"
-                    " both are left unset, they default to max_iter=5 and tol=None"
-                    ". If tol is not None, max_iter defaults to max_iter=1000. "
-                    "From 0.21, default max_iter will be 1000, "
-                    "and default tol will be 1e-3." % type(self), FutureWarning)
+                    "max_iter and tol parameters have been "
+                    "added in %s in 0.19. If both are left unset, "
+                    "they default to max_iter=5 and tol=None. "
+                    "If tol is not None, max_iter defaults to max_iter=1000. "
+                    "From 0.21, default max_iter will be 1000, and"
+                    " default tol will be 1e-3." % type(self), FutureWarning)
                 # Before 0.19, default was n_iter=5
             max_iter = 5
         else:

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -1194,9 +1194,9 @@ def test_tol_parameter():
 def test_future_and_deprecation_warnings():
     # Test that warnings are raised. Will be removed in 0.21
 
-    def init(max_iter=None, tol=None, n_iter=None):
+    def init(max_iter=None, tol=None, n_iter=None, for_partial_fit=False):
         sgd = SGDClassifier(max_iter=max_iter, tol=tol, n_iter=n_iter)
-        sgd._validate_params()
+        sgd._validate_params(for_partial_fit=for_partial_fit)
 
     # When all default values are used
     msg_future = "max_iter and tol parameters have been added in "
@@ -1210,6 +1210,9 @@ def test_future_and_deprecation_warnings():
     assert_no_warnings(init, 100, None, None)
     assert_no_warnings(init, None, 1e-3, None)
     assert_no_warnings(init, 100, 1e-3, None)
+
+    # Test that for_partial_fit will not throw warnings for max_iter or tol
+    assert_no_warnings(init, None, None, None, True)
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))


### PR DESCRIPTION
Fixes #10051 

Added an optional argument ```for_partial_fit=False``` to ```_validate_params``` which bypasses warnings about ```max_iter``` and ```tol```

added ```for_partial_fit=True``` to ```_validate_params``` calls in ```partial_fit``` methods for both ```sgdclassifer``` and ```sgdregressor```

I appreciate that this could have been done through the use of ```set_max_iter=False``` but it seemed clearer to me to have a dedicated flag.

first contribution to this project, so I apologize if I've done something horrifically wrong