### PR TITLE
CI use numpydoc master when building dev docs

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -109,12 +109,9 @@ conda update --yes --quiet conda
 conda create -n $CONDA_ENV_NAME --yes --quiet python numpy scipy \
   cython nose coverage matplotlib sphinx=1.6.2 pillow
 source activate testenv
-pip install sphinx-gallery numpydoc
-if [[ "$CIRCLE_BRANCH" =~ ^master$ ]]
-then
-	# Use numpydoc master when compiling dev docs
-	pip install -U git+https://github.com/numpy/numpydoc
-fi
+pip install sphinx-gallery
+# Use numpydoc master (for now)
+pip install -U git+https://github.com/numpy/numpydoc
 
 # Build and install scikit-learn in dev mode
 python setup.py develop

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -110,6 +110,11 @@ conda create -n $CONDA_ENV_NAME --yes --quiet python numpy scipy \
   cython nose coverage matplotlib sphinx=1.6.2 pillow
 source activate testenv
 pip install sphinx-gallery numpydoc
+if [[ "$CIRCLE_BRANCH" =~ ^master$ ]]
+then
+	# Use numpydoc master when compiling dev docs
+	pip install -U git+https://github.com/numpy/numpydoc
+fi
 
 # Build and install scikit-learn in dev mode
 python setup.py develop

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -111,7 +111,7 @@ conda create -n $CONDA_ENV_NAME --yes --quiet python numpy scipy \
 source activate testenv
 pip install sphinx-gallery
 # Use numpydoc master (for now)
-pip install -U git+https://github.com/numpy/numpydoc
+pip install git+https://github.com/numpy/numpydoc
 
 # Build and install scikit-learn in dev mode
 python setup.py develop


### PR DESCRIPTION
Only for the current (0.20) cycle have we been relying on the published numpydoc package. As a result we have had to fix a number of issues with numpydoc. I think that, at least for now, we should build the /dev docs with numpydoc master so that we can help test the numpydoc release and its integration here.

I am currently excluding this from PR Circle builds, as I don't want to bother contributors if something fails, but maybe that's unnecessary and we should just use numpydoc master, for now, in all doc builds.