### PR TITLE
[MRG+1] Fix omp non normalize

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -121,7 +121,7 @@ Classifiers and regressors
   :issue:`10005` by :user:`Gaurav Dhingra <gxyd>`.
 
 - Fixed a bug in :class:`linear_model.OrthogonalMatchingPursuit` that was
-  broken for X having non-normalized columns.
+  broken when setting ``normalize=False``.
   by `Alexandre Gramfort`_.
 
 Decomposition, manifold learning and clustering

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -120,6 +120,10 @@ Classifiers and regressors
   error for prior list which summed to 1.
   :issue:`10005` by :user:`Gaurav Dhingra <gxyd>`.
 
+- Fixed a bug in :class:`linear_model.OrthogonalMatchingPursuit` that was
+  broken for X having non-normalized columns.
+  by `Alexandre Gramfort`_.
+
 Decomposition, manifold learning and clustering
 
 - Fix for uninformative error in :class:`decomposition.IncrementalPCA`:

--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -22,6 +22,9 @@ from sklearn.datasets import make_sparse_coded_signal
 n_samples, n_features, n_nonzero_coefs, n_targets = 20, 30, 5, 3
 y, X, gamma = make_sparse_coded_signal(n_targets, n_features, n_samples,
                                        n_nonzero_coefs, random_state=0)
+# Make X not of norm 1 for testing
+X *= 10
+y *= 10
 G, Xy = np.dot(X.T, X), np.dot(X.T, y)
 # this makes X (n_samples, n_features)
 # and y (n_samples, 3)

--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -116,12 +116,16 @@ def test_estimator():
     assert_equal(omp.intercept_.shape, (n_targets,))
     assert_true(np.count_nonzero(omp.coef_) <= n_targets * n_nonzero_coefs)
 
-    omp.set_params(fit_intercept=False, normalize=False)
-
+    coef_normalized = omp.coef_[0].copy()
+    omp.set_params(fit_intercept=True, normalize=False)
     omp.fit(X, y[:, 0])
+    assert_array_almost_equal(coef_normalized, omp.coef_)
+
+    omp.set_params(fit_intercept=False, normalize=False)
+    omp.fit(X, y[:, 0])
+    assert_true(np.count_nonzero(omp.coef_) <= n_nonzero_coefs)
     assert_equal(omp.coef_.shape, (n_features,))
     assert_equal(omp.intercept_, 0)
-    assert_true(np.count_nonzero(omp.coef_) <= n_nonzero_coefs)
 
     omp.fit(X, y)
     assert_equal(omp.coef_.shape, (n_targets, n_features))


### PR DESCRIPTION
#### Reference Issues/PRs

there was no open issue. I fixed directly. Basically OMP was returning
garbage as soon as norms of each column of X was not 1. This happens
when setting normalize=False as option.

#### What does this implement/fix? Explain your changes.

cf above

#### Any other comments?

thanks @josephsalmon for pointing me the bug.
