### PR TITLE
[MRG] move flake8 options from shell script to setup.cfg fixes #10067

### DIFF
--- a/build_tools/travis/flake8_diff.sh
+++ b/build_tools/travis/flake8_diff.sh
@@ -20,6 +20,9 @@ set -o pipefail
 PROJECT=scikit-learn/scikit-learn
 PROJECT_URL=https://github.com/$PROJECT.git
 
+DEFAULT_FLAKE8_CONFIG=./setup.cfg
+EXAMPLES_FLAKE8_CONFIG=./examples/.flake8
+
 # Find the remote with the project name (upstream in most cases)
 REMOTE=$(git remote -v | grep $PROJECT | cut -f1 | head -1 || echo '')
 
@@ -138,8 +141,10 @@ if [[ "$MODIFIED_FILES" == "no_match" ]]; then
     echo "No file outside sklearn/externals and doc/sphinxext/sphinx_gallery has been modified"
 else
 
-    check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)"
+    check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)" \
+        --config $DEFAULT_FLAKE8_CONFIG
     # Examples are allowed to not have imports at top of file
-    check_files "$(echo "$MODIFIED_FILES" | grep ^examples)" --ignore E402
+    check_files "$(echo "$MODIFIED_FILES" | grep ^examples)" \
+        --config $EXAMPLES_FLAKE8_CONFIG
 fi
 echo -e "No problem detected by flake8\n"

--- a/build_tools/travis/flake8_diff.sh
+++ b/build_tools/travis/flake8_diff.sh
@@ -137,12 +137,9 @@ check_files() {
 if [[ "$MODIFIED_FILES" == "no_match" ]]; then
     echo "No file outside sklearn/externals and doc/sphinxext/sphinx_gallery has been modified"
 else
-    # Default ignore PEP8 violations are from flake8 3.3.0
-    DEFAULT_IGNORED_PEP8=E121,E123,E126,E226,E24,E704,W503,W504
-    check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)" \
-           --ignore $DEFAULT_IGNORED_PEP8
+
+    check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)"
     # Examples are allowed to not have imports at top of file
-    check_files "$(echo "$MODIFIED_FILES" | grep ^examples)" \
-           --ignore $DEFAULT_IGNORED_PEP8 --ignore E402
+    check_files "$(echo "$MODIFIED_FILES" | grep ^examples)" --ignore E402
 fi
 echo -e "No problem detected by flake8\n"

--- a/build_tools/travis/flake8_diff.sh
+++ b/build_tools/travis/flake8_diff.sh
@@ -20,9 +20,6 @@ set -o pipefail
 PROJECT=scikit-learn/scikit-learn
 PROJECT_URL=https://github.com/$PROJECT.git
 
-DEFAULT_FLAKE8_CONFIG=./setup.cfg
-EXAMPLES_FLAKE8_CONFIG=./examples/.flake8
-
 # Find the remote with the project name (upstream in most cases)
 REMOTE=$(git remote -v | grep $PROJECT | cut -f1 | head -1 || echo '')
 
@@ -141,10 +138,8 @@ if [[ "$MODIFIED_FILES" == "no_match" ]]; then
     echo "No file outside sklearn/externals and doc/sphinxext/sphinx_gallery has been modified"
 else
 
-    check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)" \
-        --config $DEFAULT_FLAKE8_CONFIG
-    # Examples are allowed to not have imports at top of file
+    check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)"
     check_files "$(echo "$MODIFIED_FILES" | grep ^examples)" \
-        --config $EXAMPLES_FLAKE8_CONFIG
+        --config ./examples/.flake8
 fi
 echo -e "No problem detected by flake8\n"

--- a/examples/.flake8
+++ b/examples/.flake8
@@ -1,4 +1,5 @@
 # Examples specific flake8 configuration
-# Same as project-wide with E402 (imports not at top of file) added
+
 [flake8]
-ignore = E121,E123,E126,E24,E402,E226,E704,W503,W504
+# Same ignore as project-wide plus E402 (imports not at top of file)
+ignore=E121,E123,E126,E24,E226,E704,W503,W504,E402

--- a/examples/.flake8
+++ b/examples/.flake8
@@ -1,4 +1,4 @@
 # Examples specific flake8 configuration
 # Same as project-wide with E402 (imports not at top of file) added
 [flake8]
-ignore = E121,E123,E126,E24,E402,E704,W503,W504
+ignore = E121,E123,E126,E24,E402,E226,E704,W503,W504

--- a/examples/.flake8
+++ b/examples/.flake8
@@ -1,0 +1,4 @@
+# Examples specific flake8 configuration
+# Same as project-wide with E402 (imports not at top of file) added
+[flake8]
+ignore = E121,E123,E126,E24,E402,E704,W503,W504

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,9 @@ artifact_indexes=
     # https://ci.appveyor.com/project/sklearn-ci/scikit-learn/
     http://windows-wheels.scikit-learn.org/
 
+[flake8]
+ignore=E121,E123,E126,E24,E704,W503,W504
+
 # Uncomment the following under windows to build using:
 # http://sourceforge.net/projects/mingw/
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,8 @@ artifact_indexes=
     http://windows-wheels.scikit-learn.org/
 
 [flake8]
-# Default flake8 ignored flags minus E226
-ignore=E121,E123,E126,E24,E704,W503,W504
+# Default flake8 ignored flags
+ignore=E121,E123,E126,E24,E226,E704,W503,W504
 
 # Uncomment the following under windows to build using:
 # http://sourceforge.net/projects/mingw/

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ artifact_indexes=
     http://windows-wheels.scikit-learn.org/
 
 [flake8]
+# Default flake8 ignored flags minus E226
 ignore=E121,E123,E126,E24,E704,W503,W504
 
 # Uncomment the following under windows to build using:

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,8 @@ artifact_indexes=
     http://windows-wheels.scikit-learn.org/
 
 [flake8]
-# Default flake8 ignored flags
-ignore=E121,E123,E126,E24,E226,E704,W503,W504
+# Default flake8 3.5 ignored flags
+ignore=E121,E123,E126,E226,E24,E704,W503,W504
 
 # Uncomment the following under windows to build using:
 # http://sourceforge.net/projects/mingw/

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -162,7 +162,11 @@ class BayesianRidge(LinearModel, RegressorMixin):
         n_samples, n_features = X.shape
 
         # Initialization of the values of the parameters
-        alpha_ = 1. / np.var(y)
+        var_y = np.var(y)
+        if var_y:
+            alpha_ = 1. / var_y
+        else:
+            alpha_ = 0.1
         lambda_ = 1.
 
         verbose = self.verbose

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -163,7 +163,7 @@ class BayesianRidge(LinearModel, RegressorMixin):
 
         # Initialization of the values of the parameters
         alpha_ = 1. / np.var(y)
-
+        lambda_ = 1.
 
         verbose = self.verbose
         lambda_1 = self.lambda_1

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -162,12 +162,8 @@ class BayesianRidge(LinearModel, RegressorMixin):
         n_samples, n_features = X.shape
 
         # Initialization of the values of the parameters
-        var_y = np.var(y)
-        if var_y:
-            alpha_ = 1. / var_y
-        else:
-            alpha_ = 0.1
-        lambda_ = 1.
+        alpha_ = 1. / np.var(y)
+
 
         verbose = self.verbose
         lambda_1 = self.lambda_1


### PR DESCRIPTION
Pulled ignore flags from ```build_tools/travis/flake8_diff.sh``` into ```setup.cfg```.

Left ```--diff``` and ```--show-source``` flags in ```build_tools/travis/flake8_diff.sh``` since it seemed unwise to separate them from the actual call to ```flake8```. If they should be merged into ```setup.cfg``` as well I can do that.

fixes #10067 