### PR TITLE
Added gini coefficient to ranking and scorer

### DIFF
--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -14,6 +14,7 @@ from .ranking import roc_auc_score
 from .ranking import roc_curve
 from .ranking import dcg_score
 from .ranking import ndcg_score
+from .ranking import gini
 
 from .classification import accuracy_score
 from .classification import classification_report

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -858,3 +858,33 @@ def ndcg_score(y_true, y_score, k=5):
         scores.append(actual / best)
 
     return np.mean(scores)
+
+
+def gini(y_true, y_score):
+    """ Compute Gini coefficient 
+
+    Compute the Gini coefficient as Gini = 2 × AUC - 1 [1].
+
+    Parameters
+    ----------
+    
+    y_true : array, shape = [n]
+            Actual target values for X.
+
+    y_score : array, shape = [n]
+        Probability estimates of the positive class.
+
+    Returns
+    -------
+    gini : float
+
+    References
+    ----------
+    .. [1] David J. Hand  and Robert J. Till (2001).
+            A Simple Generalisation of the Area Under the ROC Curve for
+            Multiple Class Classification Problems. In Machine Learning, 45,
+            pp.171–186 (Kluwer Academic Publishers).
+
+    """
+
+    return 2*roc_auc_score(y_true, y_score)-1

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -514,7 +514,8 @@ deprecation_msg = ('Scoring method log_loss was renamed to '
 log_loss_scorer = make_scorer(log_loss, greater_is_better=False,
                               needs_proba=True)
 log_loss_scorer._deprecation_msg = deprecation_msg
-
+gini_scorer = make_scorer(gini, greater_is_better=True,
+                          needs_proba=True)
 
 # Clustering scores
 adjusted_rand_scorer = make_scorer(adjusted_rand_score)

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -514,8 +514,7 @@ deprecation_msg = ('Scoring method log_loss was renamed to '
 log_loss_scorer = make_scorer(log_loss, greater_is_better=False,
                               needs_proba=True)
 log_loss_scorer._deprecation_msg = deprecation_msg
-gini_scorer = make_scorer(gini, greater_is_better=True,
-                          needs_proba=True)
+gini_scorer = make_scorer(gini, greater_is_better=True)
 
 # Clustering scores
 adjusted_rand_scorer = make_scorer(adjusted_rand_score)


### PR DESCRIPTION
Added a function at the end of `sklearn\metrics\ranking.py` to compute the Gini coefficient which is being used in some Kaggle competitions.

I added the corresponding import declaration in `sklearn\metrics\__init__.py`

Finally, I create a `scorer` _à la_ `sklearn` in sklearn\metrics\sorer.py, so that the gini coefficient can be used across `sklearn `validation/metrics functions, e.g. `cross_val_score` .

Reference was taken [here](https://link.springer.com/content/pdf/10.1023%2FA%3A1010920819831.pdf) and results were checked against several entries on Kaggle and sklearn AUC/ROC score (is it not rocket_science, to be honest).