### PR TITLE
[MRG] Travis install flake8 3.5 from pip

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -124,8 +124,7 @@ except ImportError:
 fi
 
 if [[ "$RUN_FLAKE8" == "true" ]]; then
-    # flake8 version is temporarily set to 2.5.1 because the next
-    # version available on conda (3.3.0) has a bug that checks non
-    # python files and cause non meaningful flake8 errors
-    conda install --yes flake8=2.5.1
+    # flake8 3.5 only available from pip at the time of writing (2017-11-08)
+    # bug fixed in flake8 3.5 is https://gitlab.com/pycqa/flake8/issues/362
+    pip install flake8
 fi


### PR DESCRIPTION
There was a bug in flake8 that affected flake8_diff.sh and forced us to use flake8 2.5. See https://gitlab.com/pycqa/flake8/issues/362 for more details.

flake8 3.5 has the bug-fix and has been released recently (only available from pip and not conda at the time of writing).