### PR TITLE
[MRG+1] ENH: only call clock() if verbosity level warrants it

### DIFF
--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -61,8 +61,9 @@ cdef float compute_gradient(float[:] val_P,
         long n_samples = pos_reference.shape[0]
         int n_dimensions = qt.n_dimensions
         double[1] sum_Q
-        clock_t t1, t2
+        clock_t t1 = 0, t2 = 0
         float sQ, error
+        int take_timing = 1 if qt.verbose > 15 else 0
 
     if qt.verbose > 11:
         printf("[t-SNE] Allocating %li elements in force arrays\n",
@@ -71,19 +72,22 @@ cdef float compute_gradient(float[:] val_P,
     cdef float* pos_f = <float*> malloc(sizeof(float) * n_samples * n_dimensions)
 
     sum_Q[0] = 0.0
-    t1 = clock()
+    if take_timing:
+        t1 = clock()
     compute_gradient_negative(pos_reference, neg_f, qt, sum_Q,
                               dof, theta, start, stop)
-    t2 = clock()
-    if qt.verbose > 15:
+    if take_timing:
+        t2 = clock()
         printf("[t-SNE] Computing negative gradient: %e ticks\n", ((float) (t2 - t1)))
     sQ = sum_Q[0]
-    t1 = clock()
+
+    if take_timing:
+        t1 = clock()
     error = compute_gradient_positive(val_P, pos_reference, neighbors, indptr,
                                       pos_f, n_dimensions, dof, sQ, start,
                                       qt.verbose)
-    t2 = clock()
-    if qt.verbose > 15:
+    if take_timing:
+        t2 = clock()
         printf("[t-SNE] Computing positive gradient: %e ticks\n", ((float) (t2 - t1)))
     for i in range(start, n_samples):
         for ax in range(n_dimensions):
@@ -118,9 +122,10 @@ cdef float compute_gradient_positive(float[:] val_P,
         float C = 0.0
         float exponent = (dof + 1.0) / -2.0
         float[3] buff
-        clock_t t1, t2
+        clock_t t1 = 0, t2 = 0
 
-    t1 = clock()
+    if verbose > 10:
+        t1 = clock()
     for i in range(start, n_samples):
         # Init the gradient vector
         for ax in range(n_dimensions):
@@ -140,9 +145,9 @@ cdef float compute_gradient_positive(float[:] val_P,
                            / max(qij, FLOAT32_TINY))
             for ax in range(n_dimensions):
                 pos_f[i * n_dimensions + ax] += dij * buff[ax]
-    t2 = clock()
-    dt = ((float) (t2 - t1))
     if verbose > 10:
+        t2 = clock()
+        dt = ((float) (t2 - t1))
         printf("[t-SNE] Computed error=%1.4f in %1.1e ticks\n", C, dt)
     return C
 
@@ -170,7 +175,8 @@ cdef void compute_gradient_negative(float[:, :] pos_reference,
         double qijZ
         float[1] iQ
         float[3] force, neg_force, pos
-        clock_t t1, t2, t3
+        clock_t t1 = 0, t2 = 0, t3 = 0
+        int take_timing = 1 if qt.verbose > 20 else 0
 
     summary = <float*> malloc(sizeof(float) * n * offset)
 
@@ -183,9 +189,11 @@ cdef void compute_gradient_negative(float[:, :] pos_reference,
         iQ[0] = 0.0
         # Find which nodes are summarizing and collect their centers of mass
         # deltas, and sizes, into vectorized arrays
-        t1 = clock()
+        if take_timing:
+            t1 = clock()
         idx = qt.summarize(pos, summary, theta*theta)
-        t2 = clock()
+        if take_timing:
+            t2 = clock()
         # Compute the t-SNE negative force
         # for the digits dataset, walking the tree
         # is about 10-15x more expensive than the
@@ -200,12 +208,14 @@ cdef void compute_gradient_negative(float[:, :] pos_reference,
             mult = size * qijZ * qijZ
             for ax in range(n_dimensions):
                 neg_force[ax] += mult * summary[j * offset + ax]
-        t3 = clock()
+        if take_timing:
+            t3 = clock()
         for ax in range(n_dimensions):
             neg_f[i * n_dimensions + ax] = neg_force[ax]
-        dta += t2 - t1
-        dtb += t3 - t2
-    if qt.verbose > 20:
+        if take_timing:
+            dta += t2 - t1
+            dtb += t3 - t2
+    if take_timing:
         printf("[t-SNE] Tree: %li clock ticks | ", dta)
         printf("Force computation: %li clock ticks\n", dtb)
 


### PR DESCRIPTION
Put calls to `clock()` in routines in `_barnes_hut_tsne.pyx` inside conditional statements, so that `clock()` is only called when verbosity level warrants it.

This helps combat thread contention when executing TSNE in sklearn, when native extensions are compiled with icc.

Running TSNE on MNIST dataset (training + validation + test) of 70_000 hand-written images 28 by 28 pixels each, time of TSNE drops from 92 seconds to 81 seconds from this change alone.

This is the Intel (R) Vtune (TM) Amplifier snapshot with unmodified scikit-learn 0.19.1 sources, compiled with Intel (R) C Compiler, showing significant thread spinning, and `clock` being a bottleneck:

![image](https://user-images.githubusercontent.com/21087696/32575427-9579a8e2-c499-11e7-9f64-c0c36658cac3.png)

running the following example

```
import numpy as np
import gzip
import pickle
from sklearn.manifold.t_sne import TSNE

import os, os.path
fn = "mnist.pkl.gz"
if not os.path.exists(fn):
    def download_file(url):
        import requests
        local_filename = url.split('/')[-1]
        r = requests.get(url, stream=True)
        with open(local_filename, 'wb') as f:
            for chunk in r.iter_content(chunk_size=1024): 
                if chunk:
                    f.write(chunk)
        return local_filename

    url = "http://deeplearning.net/data/mnist/"
    download_file(url + fn)

with gzip.open(fn, "rb") as f:
    train, val, test = pickle.load(f, encoding='latin1')

X = np.vstack((train[0], val[0], test[0]))
y = np.hstack((train[1], val[1], test[1]))

sz=3000
np.random.seed(112017)
pos = np.random.choice(len(y), sz, replace=False)

def _embed(X):
    return TSNE(init='pca').fit_transform(X)

import timeit
t0 = timeit.default_timer()
X2d = _embed(X[pos])
t1 = timeit.default_timer()

print(t1-t0)
```

After the change, the VTune trace looks better (no thread spinning):

![image](https://user-images.githubusercontent.com/21087696/32575601-1ca3b93e-c49a-11e7-88f1-a3b97ffcc76e.png)

The execution also becomes faster, 81 seconds after the change, with 91 seconds before.
