### PR TITLE
[MRG] Ensure that ROC curve starts at (0, 0)

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1137,11 +1137,11 @@ Here is a small example of how to use the :func:`roc_curve` function::
     >>> scores = np.array([0.1, 0.4, 0.35, 0.8])
     >>> fpr, tpr, thresholds = roc_curve(y, scores, pos_label=2)
     >>> fpr
-    array([ 0. ,  0.5,  0.5,  1. ])
+    array([ 0. ,  0. ,  0.5,  0.5,  1. ])
     >>> tpr
-    array([ 0.5,  0.5,  1. ,  1. ])
+    array([ 0. ,  0.5,  0.5,  1. ,  1. ])
     >>> thresholds
-    array([ 0.8 ,  0.4 ,  0.35,  0.1 ])
+    array([ 1.8 ,  0.8 ,  0.4 ,  0.35,  0.1 ])
 
 This figure shows an example of such an ROC curve:
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -18,6 +18,7 @@ random sampling procedures.
 - :class:`decomposition.IncrementalPCA` in Python 2 (bug fix)
 - :class:`isotonic.IsotonicRegression` (bug fix)
 - :class:`metrics.roc_auc_score` (bug fix)
+- :class:`metrics.roc_curve` (bug fix)
 - :class:`neural_network.BaseMultilayerPerceptron` (bug fix)
 - :class:`neural_network.MLPRegressor` (bug fix)
 - :class:`neural_network.MLPClassifier` (bug fix)
@@ -159,6 +160,11 @@ Metrics
 
 - Fixed a bug due to floating point error in :func:`metrics.roc_auc_score` with
   non-integer sample weights. :issue:`9786` by :user:`Hanmin Qin <qinhanmin2014>`.
+
+- Fixed a bug where :func:`metrics.roc_curve` sometimes starts on y-axis instead 
+  of (0, 0), which is inconsistent with the document and other implementations.
+  :issue:`10093` by :user:`alexryndin <alexryndin>`
+  and :user:`Hanmin Qin <qinhanmin2014>`.
 
 API changes summary
 -------------------

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -161,7 +161,7 @@ Metrics
 - Fixed a bug due to floating point error in :func:`metrics.roc_auc_score` with
   non-integer sample weights. :issue:`9786` by :user:`Hanmin Qin <qinhanmin2014>`.
 
-- Fixed a bug where :func:`metrics.roc_curve` sometimes starts on y-axis instead 
+- Fixed a bug where :func:`metrics.roc_curve` sometimes starts on y-axis instead
   of (0, 0), which is inconsistent with the document and other implementations.
   :issue:`10093` by :user:`alexryndin <alexryndin>`
   and :user:`Hanmin Qin <qinhanmin2014>`.

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -163,6 +163,7 @@ Metrics
 
 - Fixed a bug where :func:`metrics.roc_curve` sometimes starts on y-axis instead
   of (0, 0), which is inconsistent with the document and other implementations.
+  Note that this will not influence the result from :func:`metrics.roc_auc_score`
   :issue:`10093` by :user:`alexryndin <alexryndin>`
   and :user:`Hanmin Qin <qinhanmin2014>`.
 

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -217,7 +217,6 @@ def average_precision_score(y_true, y_score, average="macro",
                                  sample_weight=sample_weight)
 
 
-
 def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
     """Compute Area Under the Receiver Operating Characteristic Curve (ROC AUC)
     from prediction scores.
@@ -266,6 +265,9 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
     ----------
     .. [1] `Wikipedia entry for the Receiver operating characteristic
             <https://en.wikipedia.org/wiki/Receiver_operating_characteristic>`_
+
+    .. [2] Fawcett T. An introduction to ROC analysis[J]. Pattern Recognition
+           Letters, 2006, 27(8):861-874.
 
     See also
     --------
@@ -541,6 +543,8 @@ def roc_curve(y_true, y_score, pos_label=None, sample_weight=None,
     .. [1] `Wikipedia entry for the Receiver operating characteristic
             <https://en.wikipedia.org/wiki/Receiver_operating_characteristic>`_
 
+    .. [2] Fawcett T. An introduction to ROC analysis[J]. Pattern Recognition
+           Letters, 2006, 27(8):861-874.
 
     Examples
     --------

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -550,11 +550,11 @@ def roc_curve(y_true, y_score, pos_label=None, sample_weight=None,
     >>> scores = np.array([0.1, 0.4, 0.35, 0.8])
     >>> fpr, tpr, thresholds = metrics.roc_curve(y, scores, pos_label=2)
     >>> fpr
-    array([ 0. ,  0.5,  0.5,  1. ])
+    array([ 0. ,  0. ,  0.5,  0.5,  1. ])
     >>> tpr
-    array([ 0.5,  0.5,  1. ,  1. ])
+    array([ 0. ,  0.5,  0.5,  1. ,  1. ])
     >>> thresholds
-    array([ 0.8 ,  0.4 ,  0.35,  0.1 ])
+    array([ 1.8 ,  0.8 ,  0.4 ,  0.35,  0.1 ])
 
     """
     fps, tps, thresholds = _binary_clf_curve(
@@ -578,8 +578,9 @@ def roc_curve(y_true, y_score, pos_label=None, sample_weight=None,
         tps = tps[optimal_idxs]
         thresholds = thresholds[optimal_idxs]
 
-    if tps.size == 0 or fps[0] != 0:
+    if tps.size == 0 or fps[0] != 0 or tps[0] != 0:
         # Add an extra threshold position if necessary
+        # to make sure that the curve starts at (0, 0)
         tps = np.r_[0, tps]
         fps = np.r_[0, fps]
         thresholds = np.r_[thresholds[0] + 1, thresholds]

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -270,8 +270,8 @@ def test_roc_curve_toydata():
     y_score = [0, 1]
     tpr, fpr, _ = roc_curve(y_true, y_score)
     roc_auc = roc_auc_score(y_true, y_score)
-    assert_array_almost_equal(tpr, [0, 1])
-    assert_array_almost_equal(fpr, [1, 1])
+    assert_array_almost_equal(tpr, [0, 0, 1])
+    assert_array_almost_equal(fpr, [0, 1, 1])
     assert_almost_equal(roc_auc, 1.)
 
     y_true = [0, 1]
@@ -294,8 +294,8 @@ def test_roc_curve_toydata():
     y_score = [1, 0]
     tpr, fpr, _ = roc_curve(y_true, y_score)
     roc_auc = roc_auc_score(y_true, y_score)
-    assert_array_almost_equal(tpr, [0, 1])
-    assert_array_almost_equal(fpr, [1, 1])
+    assert_array_almost_equal(tpr, [0, 0, 1])
+    assert_array_almost_equal(fpr, [0, 1, 1])
     assert_almost_equal(roc_auc, 1.)
 
     y_true = [1, 0]
@@ -319,8 +319,8 @@ def test_roc_curve_toydata():
     # assert UndefinedMetricWarning because of no negative sample in y_true
     tpr, fpr, _ = assert_warns(UndefinedMetricWarning, roc_curve, y_true, y_score)
     assert_raises(ValueError, roc_auc_score, y_true, y_score)
-    assert_array_almost_equal(tpr, [np.nan, np.nan])
-    assert_array_almost_equal(fpr, [0.5, 1.])
+    assert_array_almost_equal(tpr, [np.nan, np.nan, np.nan])
+    assert_array_almost_equal(fpr, [0., 0.5, 1.])
 
     # Multi-label classification task
     y_true = np.array([[0, 1], [0, 1]])
@@ -359,7 +359,7 @@ def test_roc_curve_drop_intermediate():
     y_true = [0, 0, 0, 0, 1, 1]
     y_score = [0., 0.2, 0.5, 0.6, 0.7, 1.0]
     tpr, fpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
-    assert_array_almost_equal(thresholds, [1., 0.7, 0.])
+    assert_array_almost_equal(thresholds, [2., 1., 0.7, 0.])
 
     # Test dropping thresholds with repeating scores
     y_true = [0, 0, 0, 0, 0, 0, 0,
@@ -368,7 +368,7 @@ def test_roc_curve_drop_intermediate():
                0.6, 0.7, 0.8, 0.9, 0.9, 1.0]
     tpr, fpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
     assert_array_almost_equal(thresholds,
-                              [1.0, 0.9, 0.7, 0.6, 0.])
+                              [2.0, 1.0, 0.9, 0.7, 0.6, 0.])
 
 
 def test_roc_curve_fpr_tpr_increasing():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #9790 
See also #9850 

#### What does this implement/fix? Explain your changes.
Currently, when the first point of ROC curve is on y-axis, we don't add a point (0, 0), which is not consistent with doc & some papers & some R packages.
Reference:
(1)scikit-learn [doc](http://scikit-learn.org/stable/modules/generated/sklearn.metrics.roc_curve.html)
thresholds : array, shape = [n_thresholds]
Decreasing thresholds on the decision function used to compute fpr and tpr. thresholds[0] represents no instances being predicted and is arbitrarily set to max(y_score) + 1.
(2)@jnothman's comment
our concern should be that in all cases, the curve includes a point that represents predicting nothing in the positive class, and that every further point represents predicting more than nothing, for every threshold at which this changes the fpr or tpr, until all are predicted. 
(3)An introduction to ROC analysis cite >7000 [link](https://ac.els-cdn.com/S016786550500303X/1-s2.0-S016786550500303X-main.pdf?_tid=ebfa82f6-c4ec-11e7-9216-00000aab0f01&acdnat=1510190931_6e423c724fec8ba7d55343a6fd0eb8cc)
(4)R package [ROCR](https://cran.r-project.org/web/packages/ROCR/ROCR.pdf)
```R
library(ROCR)
pred <- prediction(c(0.1, 0.4, 0.35, 0.8), c(0, 0, 1, 1))
perf <- performance(pred,"tpr","fpr")
plot(perf)
```

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
