### PR TITLE
[MRG + 1] Fix BayesianRidge() and ARDRegression() for constant target vectors 

### DIFF
--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -448,7 +448,10 @@ class ARDRegression(LinearModel, RegressorMixin):
         verbose = self.verbose
 
         # Initialization of the values of the parameters
-        alpha_ = 1. / np.var(y)
+        eps = np.spacing(1)
+        # Add `eps` in the denominator to omit division by zero if `np.var(y)`
+        # is zero
+        alpha_ = 1. / (np.var(y) + eps)
         lambda_ = np.ones(n_features)
 
         self.scores_ = list()

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -162,7 +162,7 @@ class BayesianRidge(LinearModel, RegressorMixin):
         n_samples, n_features = X.shape
 
         # Initialization of the values of the parameters
-        eps = np.spacing(1)
+        eps = np.finfo(np.float64).eps
         # Add `eps` in the denominator to omit division by zero if `np.var(y)`
         # is zero
         alpha_ = 1. / (np.var(y) + eps)
@@ -448,7 +448,7 @@ class ARDRegression(LinearModel, RegressorMixin):
         verbose = self.verbose
 
         # Initialization of the values of the parameters
-        eps = np.spacing(1)
+        eps = np.finfo(np.float64).eps
         # Add `eps` in the denominator to omit division by zero if `np.var(y)`
         # is zero
         alpha_ = 1. / (np.var(y) + eps)

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -163,6 +163,8 @@ class BayesianRidge(LinearModel, RegressorMixin):
 
         # Initialization of the values of the parameters
         eps = np.spacing(1)
+        # Add `eps` in the denominator to omit division by zero if `np.var(y)`
+        # is zero
         alpha_ = 1. / (np.var(y) + eps)
         lambda_ = 1.
 

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -161,21 +161,9 @@ class BayesianRidge(LinearModel, RegressorMixin):
         self.X_scale_ = X_scale_
         n_samples, n_features = X.shape
 
-        # Handle case when target vector is constant and intercept is fitted
-        if np.unique(y).size == 1 and self.fit_intercept:
-            self.coef_ = np.zeros(n_features)
-            self.sigma_ = np.zeros((n_features, n_features))
-            self.alpha_ = np.nan
-            self.lambda_ = np.nan
-
-            if self.compute_score:
-                self.scores_ = np.nan
-
-            self._set_intercept(X_offset_, y_offset_, X_scale_)
-            return self
-
         # Initialization of the values of the parameters
-        alpha_ = 1. / np.var(y)
+        eps = np.spacing(1)
+        alpha_ = 1. / (np.var(y) + eps)
         lambda_ = 1.
 
         verbose = self.verbose
@@ -283,12 +271,8 @@ class BayesianRidge(LinearModel, RegressorMixin):
         else:
             if self.normalize:
                 X = (X - self.X_offset_) / self.X_scale_
-            # Check if covariance matrix `self.sigma_` is zero
-            if not self.sigma_.any():
-                y_std = np.zeros(y_mean.shape)
-            else:
-                sigmas_squared_data = (np.dot(X, self.sigma_) * X).sum(axis=1)
-                y_std = np.sqrt(sigmas_squared_data + (1. / self.alpha_))
+            sigmas_squared_data = (np.dot(X, self.sigma_) * X).sum(axis=1)
+            y_std = np.sqrt(sigmas_squared_data + (1. / self.alpha_))
             return y_mean, y_std
 
 

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -169,7 +169,7 @@ class BayesianRidge(LinearModel, RegressorMixin):
             self.lambda_ = np.nan
 
             if self.compute_score:
-                self.scores_= np.nan
+                self.scores_ = np.nan
 
             self._set_intercept(X_offset_, y_offset_, X_scale_)
             return self

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -8,6 +8,7 @@ import numpy as np
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_array_less
 from sklearn.utils.testing import SkipTest
 from sklearn.linear_model.bayes import BayesianRidge, ARDRegression
 from sklearn.linear_model import Ridge
@@ -76,73 +77,17 @@ def test_prediction_bayesian_ridge_with_constant_input():
 
 def test_std_bayesian_ridge_with_constant_input():
     # Test BayesianRidge standard dev. for edge case of constant target vector
+    # The standard dev. should be relatively small (< 0.01 is tested here)
     n_samples = 4
     n_features = 5
     constant_value = np.random.rand()
     X = np.random.random((n_samples, n_features))
     y = np.full(n_samples, constant_value)
-    expected = np.zeros(n_samples)
+    expected_upper_boundary = 0.01
 
     clf = BayesianRidge()
     _, y_std = clf.fit(X, y).predict(X, return_std=True)
-    assert_array_almost_equal(y_std, expected)
-
-
-def test_score_bayesian_ridge_with_constant_input():
-    # Test BayesianRidge score for edge case of constant target vector
-    n_samples = 4
-    n_features = 5
-    constant_value = np.random.rand()
-    X = np.random.random((n_samples, n_features))
-    y = np.full(n_samples, constant_value)
-    expected = np.nan
-
-    clf = BayesianRidge(compute_score=True)
-    clf.fit(X, y)
-    assert_array_almost_equal(clf.scores_, expected)
-
-
-def test_alpha_bayesian_ridge_with_constant_input():
-    # Test BayesianRidge alpha for edge case of constant target vector
-    n_samples = 4
-    n_features = 5
-    constant_value = np.random.rand()
-    X = np.random.random((n_samples, n_features))
-    y = np.full(n_samples, constant_value)
-    expected = np.nan
-
-    clf = BayesianRidge()
-    clf.fit(X, y)
-    assert_array_equal(clf.alpha_, expected)
-
-
-def test_lambda_bayesian_ridge_with_constant_input():
-    # Test BayesianRidge lambda for edge case of constant target vector
-    n_samples = 4
-    n_features = 5
-    constant_value = np.random.rand()
-    X = np.random.random((n_samples, n_features))
-    y = np.full(n_samples, constant_value)
-    expected = np.nan
-
-    clf = BayesianRidge()
-    clf.fit(X, y)
-    assert_array_equal(clf.lambda_, expected)
-
-
-def test_prediction_bayesian_ridge_with_constant_input_no_intercept():
-    # Test BayesianRidge prediction for edge case of constant target vector
-    # when no intercept is fitted
-    n_samples = 4
-    n_features = 5
-    constant_value = np.random.rand()
-    X = np.random.random((n_samples, n_features))
-    y = np.full(n_samples, constant_value)
-    expected = np.full(n_samples, np.nan)
-
-    clf = BayesianRidge(fit_intercept=False)
-    y_pred = clf.fit(X, y).predict(X)
-    assert_array_equal(y_pred, expected)
+    assert_array_less(y_std, expected_upper_boundary)
 
 
 def test_toy_ard_object():

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -60,18 +60,28 @@ def test_toy_bayesian_ridge_object():
     assert_array_almost_equal(clf.predict(test), [1, 3, 4], 2)
 
 
-def test_bayesian_ridge_with_constant_y():
+def test_bayesian_ridge_prediction_with_constant_input():
     # Test BayesianRidge for edge case of constant target vector
     constant_value = np.random.rand()
     X = np.random.random((5, 5))
     y = np.full(5, constant_value)
-    expected_std = np.zeros(5)
-    expected_pred = np.full(5, constant_value)
+    expected = np.full(5, constant_value)
 
     clf = BayesianRidge()
-    y_pred, y_std  = clf.fit(X, y).predict(X, return_std=True)
-    assert_array_almost_equal(y_pred, expected_pred)
-    assert_array_almost_equal(y_std, expected_std)
+    y_pred = clf.fit(X, y).predict(X)
+    assert_array_almost_equal(y_pred, expected)
+
+
+def test_bayesian_ridge_std_with_constant_input():
+    # Test BayesianRidge for edge case of constant target vector
+    constant_value = np.random.rand()
+    X = np.random.random((5, 5))
+    y = np.full(5, constant_value)
+    expected = np.zeros(5)
+
+    clf = BayesianRidge()
+    _, y_std  = clf.fit(X, y).predict(X, return_std=True)
+    assert_array_almost_equal(y_std, expected)
 
 
 def test_toy_ard_object():

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -61,8 +61,9 @@ def test_toy_bayesian_ridge_object():
     assert_array_almost_equal(clf.predict(test), [1, 3, 4], 2)
 
 
-def test_prediction_bayesian_ridge_with_constant_input():
-    # Test BayesianRidge prediction for edge case of constant target vector
+def test_prediction_bayesian_ridge_ard_with_constant_input():
+    # Test BayesianRidge and ARDRegression predictions for edge case of
+    # constant target vectors
     n_samples = 4
     n_features = 5
     constant_value = np.random.rand()
@@ -70,13 +71,14 @@ def test_prediction_bayesian_ridge_with_constant_input():
     y = np.full(n_samples, constant_value)
     expected = np.full(n_samples, constant_value)
 
-    clf = BayesianRidge()
-    y_pred = clf.fit(X, y).predict(X)
-    assert_array_almost_equal(y_pred, expected)
+    for clf in [BayesianRidge(), ARDRegression()]:
+        y_pred = clf.fit(X, y).predict(X)
+        assert_array_almost_equal(y_pred, expected)
 
 
-def test_std_bayesian_ridge_with_constant_input():
-    # Test BayesianRidge standard dev. for edge case of constant target vector
+def test_std_bayesian_ridge_ard_with_constant_input():
+    # Test BayesianRidge and ARDRegression standard dev. for edge case of
+    # constant target vector
     # The standard dev. should be relatively small (< 0.1 is tested here)
     n_samples = 4
     n_features = 5
@@ -85,38 +87,9 @@ def test_std_bayesian_ridge_with_constant_input():
     y = np.full(n_samples, constant_value)
     expected_upper_boundary = 0.1
 
-    clf = BayesianRidge()
-    _, y_std = clf.fit(X, y).predict(X, return_std=True)
-    assert_array_less(y_std, expected_upper_boundary)
-
-
-def test_prediction_ard_with_constant_input():
-    # Test ARDRegression prediction for edge case of constant target vector
-    n_samples = 4
-    n_features = 5
-    constant_value = np.random.rand()
-    X = np.random.random((n_samples, n_features))
-    y = np.full(n_samples, constant_value)
-    expected = np.full(n_samples, constant_value)
-
-    clf = ARDRegression()
-    y_pred = clf.fit(X, y).predict(X)
-    assert_array_almost_equal(y_pred, expected)
-
-
-def test_std_ard_with_constant_input():
-    # Test ARDRegression standard dev. for edge case of constant target vector
-    # The standard dev. should be relatively small (< 0.1 is tested here)
-    n_samples = 4
-    n_features = 5
-    constant_value = np.random.rand()
-    X = np.random.random((n_samples, n_features))
-    y = np.full(n_samples, constant_value)
-    expected_upper_boundary = 0.1
-
-    clf = ARDRegression()
-    _, y_std = clf.fit(X, y).predict(X, return_std=True)
-    assert_array_less(y_std, expected_upper_boundary)
+    for clf in [BayesianRidge(), ARDRegression()]:
+        _, y_std = clf.fit(X, y).predict(X, return_std=True)
+        assert_array_less(y_std, expected_upper_boundary)
 
 
 def test_toy_ard_object():

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -60,6 +60,18 @@ def test_toy_bayesian_ridge_object():
     assert_array_almost_equal(clf.predict(test), [1, 3, 4], 2)
 
 
+def test_bayesian_ridge_with_constant_y():
+    constant_value = np.random.rand()
+    X = np.random.random((5, 5))
+    y = np.full(5, constant_value)
+    clf = BayesianRidge()
+    y_pred, y_std  = clf.fit(X, y).predict(X, return_std=True)
+    expected_std = np.zeros(5)
+    expected_pred = y
+    assert_array_almost_equal(y_pred, expected_pred)
+    assert_array_almost_equal(y_std, expected_std)
+
+
 def test_toy_ard_object():
     # Test BayesianRegression ARD classifier
     X = np.array([[1], [2], [3]])

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -77,7 +77,7 @@ def test_prediction_bayesian_ridge_with_constant_input():
 
 def test_std_bayesian_ridge_with_constant_input():
     # Test BayesianRidge standard dev. for edge case of constant target vector
-    # The standard dev. should be relatively small (< 0.01 is tested here)
+    # The standard dev. should be relatively small (< 0.1 is tested here)
     n_samples = 4
     n_features = 5
     constant_value = np.random.rand()
@@ -86,6 +86,35 @@ def test_std_bayesian_ridge_with_constant_input():
     expected_upper_boundary = 0.1
 
     clf = BayesianRidge()
+    _, y_std = clf.fit(X, y).predict(X, return_std=True)
+    assert_array_less(y_std, expected_upper_boundary)
+
+
+def test_prediction_ard_with_constant_input():
+    # Test ARDRegression prediction for edge case of constant target vector
+    n_samples = 4
+    n_features = 5
+    constant_value = np.random.rand()
+    X = np.random.random((n_samples, n_features))
+    y = np.full(n_samples, constant_value)
+    expected = np.full(n_samples, constant_value)
+
+    clf = ARDRegression()
+    y_pred = clf.fit(X, y).predict(X)
+    assert_array_almost_equal(y_pred, expected)
+
+
+def test_std_ard_with_constant_input():
+    # Test ARDRegression standard dev. for edge case of constant target vector
+    # The standard dev. should be relatively small (< 0.1 is tested here)
+    n_samples = 4
+    n_features = 5
+    constant_value = np.random.rand()
+    X = np.random.random((n_samples, n_features))
+    y = np.full(n_samples, constant_value)
+    expected_upper_boundary = 0.1
+
+    clf = ARDRegression()
     _, y_std = clf.fit(X, y).predict(X, return_std=True)
     assert_array_less(y_std, expected_upper_boundary)
 

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -111,7 +111,7 @@ def test_alpha_bayesian_ridge_with_constant_input():
     y = np.full(n_samples, constant_value)
     expected = np.nan
 
-    clf = BayesianRidge(compute_score=True)
+    clf = BayesianRidge()
     clf.fit(X, y)
     assert_array_equal(clf.alpha_, expected)
 
@@ -125,9 +125,24 @@ def test_lambda_bayesian_ridge_with_constant_input():
     y = np.full(n_samples, constant_value)
     expected = np.nan
 
-    clf = BayesianRidge(compute_score=True)
+    clf = BayesianRidge()
     clf.fit(X, y)
     assert_array_equal(clf.lambda_, expected)
+
+
+def test_prediction_bayesian_ridge_with_constant_input_no_intercept():
+    # Test BayesianRidge prediction for edge case of constant target vector when
+    # no intercept is fitted
+    n_samples = 4
+    n_features = 5
+    constant_value = np.random.rand()
+    X = np.random.random((n_samples, n_features))
+    y = np.full(n_samples, constant_value)
+    expected = np.full(n_samples, np.nan)
+
+    clf = BayesianRidge(fit_intercept=False)
+    y_pred  = clf.fit(X, y).predict(X)
+    assert_array_equal(y_pred, expected)
 
 
 def test_toy_ard_object():

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -62,10 +62,12 @@ def test_toy_bayesian_ridge_object():
 
 def test_prediction_bayesian_ridge_with_constant_input():
     # Test BayesianRidge prediction for edge case of constant target vector
+    n_samples = 4
+    n_features = 5
     constant_value = np.random.rand()
-    X = np.random.random((5, 5))
-    y = np.full(5, constant_value)
-    expected = np.full(5, constant_value)
+    X = np.random.random((n_samples, n_features))
+    y = np.full(n_samples, constant_value)
+    expected = np.full(n_samples, constant_value)
 
     clf = BayesianRidge()
     y_pred = clf.fit(X, y).predict(X)
@@ -74,10 +76,12 @@ def test_prediction_bayesian_ridge_with_constant_input():
 
 def test_std_bayesian_ridge_with_constant_input():
     # Test BayesianRidge standard dev. for edge case of constant target vector
+    n_samples = 4
+    n_features = 5
     constant_value = np.random.rand()
-    X = np.random.random((5, 5))
-    y = np.full(5, constant_value)
-    expected = np.zeros(5)
+    X = np.random.random((n_samples, n_features))
+    y = np.full(n_samples, constant_value)
+    expected = np.zeros(n_samples)
 
     clf = BayesianRidge()
     _, y_std  = clf.fit(X, y).predict(X, return_std=True)
@@ -86,9 +90,11 @@ def test_std_bayesian_ridge_with_constant_input():
 
 def test_score_bayesian_ridge_with_constant_input():
     # Test BayesianRidge score for edge case of constant target vector
+    n_samples = 4
+    n_features = 5
     constant_value = np.random.rand()
-    X = np.random.random((5, 5))
-    y = np.full(5, constant_value)
+    X = np.random.random((n_samples, n_features))
+    y = np.full(n_samples, constant_value)
     expected = np.nan
 
     clf = BayesianRidge(compute_score=True)
@@ -98,9 +104,11 @@ def test_score_bayesian_ridge_with_constant_input():
 
 def test_alpha_bayesian_ridge_with_constant_input():
     # Test BayesianRidge score for edge case of constant target vector
+    n_samples = 4
+    n_features = 5
     constant_value = np.random.rand()
-    X = np.random.random((5, 5))
-    y = np.full(5, constant_value)
+    X = np.random.random((n_samples, n_features))
+    y = np.full(n_samples, constant_value)
     expected = np.nan
 
     clf = BayesianRidge(compute_score=True)
@@ -110,9 +118,11 @@ def test_alpha_bayesian_ridge_with_constant_input():
 
 def test_lambda_bayesian_ridge_with_constant_input():
     # Test BayesianRidge score for edge case of constant target vector
+    n_samples = 4
+    n_features = 5
     constant_value = np.random.rand()
-    X = np.random.random((5, 5))
-    y = np.full(5, constant_value)
+    X = np.random.random((n_samples, n_features))
+    y = np.full(n_samples, constant_value)
     expected = np.nan
 
     clf = BayesianRidge(compute_score=True)

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -81,14 +81,14 @@ def test_prediction_bayesian_ridge_ard_with_constant_input():
 def test_std_bayesian_ridge_ard_with_constant_input():
     # Test BayesianRidge and ARDRegression standard dev. for edge case of
     # constant target vector
-    # The standard dev. should be relatively small (< 0.1 is tested here)
+    # The standard dev. should be relatively small (< 0.01 is tested here)
     n_samples = 4
     n_features = 5
     random_state = check_random_state(42)
     constant_value = random_state.rand()
     X = random_state.random_sample((n_samples, n_features))
     y = np.full(n_samples, constant_value)
-    expected_upper_boundary = 0.1
+    expected_upper_boundary = 0.01
 
     for clf in [BayesianRidge(), ARDRegression()]:
         _, y_std = clf.fit(X, y).predict(X, return_std=True)

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -61,13 +61,15 @@ def test_toy_bayesian_ridge_object():
 
 
 def test_bayesian_ridge_with_constant_y():
+    # Test BayesianRidge for edge case of constant target vector
     constant_value = np.random.rand()
     X = np.random.random((5, 5))
     y = np.full(5, constant_value)
+    expected_std = np.zeros(5)
+    expected_pred = np.full(5, constant_value)
+
     clf = BayesianRidge()
     y_pred, y_std  = clf.fit(X, y).predict(X, return_std=True)
-    expected_std = np.zeros(5)
-    expected_pred = y
     assert_array_almost_equal(y_pred, expected_pred)
     assert_array_almost_equal(y_std, expected_std)
 

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -83,7 +83,7 @@ def test_std_bayesian_ridge_with_constant_input():
     constant_value = np.random.rand()
     X = np.random.random((n_samples, n_features))
     y = np.full(n_samples, constant_value)
-    expected_upper_boundary = 0.01
+    expected_upper_boundary = 0.1
 
     clf = BayesianRidge()
     _, y_std = clf.fit(X, y).predict(X, return_std=True)

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -84,7 +84,7 @@ def test_std_bayesian_ridge_with_constant_input():
     expected = np.zeros(n_samples)
 
     clf = BayesianRidge()
-    _, y_std  = clf.fit(X, y).predict(X, return_std=True)
+    _, y_std = clf.fit(X, y).predict(X, return_std=True)
     assert_array_almost_equal(y_std, expected)
 
 
@@ -131,8 +131,8 @@ def test_lambda_bayesian_ridge_with_constant_input():
 
 
 def test_prediction_bayesian_ridge_with_constant_input_no_intercept():
-    # Test BayesianRidge prediction for edge case of constant target vector when
-    # no intercept is fitted
+    # Test BayesianRidge prediction for edge case of constant target vector
+    # when no intercept is fitted
     n_samples = 4
     n_features = 5
     constant_value = np.random.rand()
@@ -141,7 +141,7 @@ def test_prediction_bayesian_ridge_with_constant_input_no_intercept():
     expected = np.full(n_samples, np.nan)
 
     clf = BayesianRidge(fit_intercept=False)
-    y_pred  = clf.fit(X, y).predict(X)
+    y_pred = clf.fit(X, y).predict(X)
     assert_array_equal(y_pred, expected)
 
 

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -10,6 +10,7 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_less
 from sklearn.utils.testing import SkipTest
+from sklearn.utils import check_random_state
 from sklearn.linear_model.bayes import BayesianRidge, ARDRegression
 from sklearn.linear_model import Ridge
 from sklearn import datasets
@@ -66,8 +67,9 @@ def test_prediction_bayesian_ridge_ard_with_constant_input():
     # constant target vectors
     n_samples = 4
     n_features = 5
-    constant_value = np.random.rand()
-    X = np.random.random((n_samples, n_features))
+    random_state = check_random_state(42)
+    constant_value = random_state.rand()
+    X = random_state.random_sample((n_samples, n_features))
     y = np.full(n_samples, constant_value)
     expected = np.full(n_samples, constant_value)
 
@@ -82,8 +84,9 @@ def test_std_bayesian_ridge_ard_with_constant_input():
     # The standard dev. should be relatively small (< 0.1 is tested here)
     n_samples = 4
     n_features = 5
-    constant_value = np.random.rand()
-    X = np.random.random((n_samples, n_features))
+    random_state = check_random_state(42)
+    constant_value = random_state.rand()
+    X = random_state.random_sample((n_samples, n_features))
     y = np.full(n_samples, constant_value)
     expected_upper_boundary = 0.1
 

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -60,8 +60,8 @@ def test_toy_bayesian_ridge_object():
     assert_array_almost_equal(clf.predict(test), [1, 3, 4], 2)
 
 
-def test_bayesian_ridge_prediction_with_constant_input():
-    # Test BayesianRidge for edge case of constant target vector
+def test_prediction_bayesian_ridge_with_constant_input():
+    # Test BayesianRidge prediction for edge case of constant target vector
     constant_value = np.random.rand()
     X = np.random.random((5, 5))
     y = np.full(5, constant_value)
@@ -72,8 +72,8 @@ def test_bayesian_ridge_prediction_with_constant_input():
     assert_array_almost_equal(y_pred, expected)
 
 
-def test_bayesian_ridge_std_with_constant_input():
-    # Test BayesianRidge for edge case of constant target vector
+def test_std_bayesian_ridge_with_constant_input():
+    # Test BayesianRidge standard dev. for edge case of constant target vector
     constant_value = np.random.rand()
     X = np.random.random((5, 5))
     y = np.full(5, constant_value)
@@ -82,6 +82,42 @@ def test_bayesian_ridge_std_with_constant_input():
     clf = BayesianRidge()
     _, y_std  = clf.fit(X, y).predict(X, return_std=True)
     assert_array_almost_equal(y_std, expected)
+
+
+def test_score_bayesian_ridge_with_constant_input():
+    # Test BayesianRidge score for edge case of constant target vector
+    constant_value = np.random.rand()
+    X = np.random.random((5, 5))
+    y = np.full(5, constant_value)
+    expected = np.nan
+
+    clf = BayesianRidge(compute_score=True)
+    clf.fit(X, y)
+    assert_array_almost_equal(clf.scores_, expected)
+
+
+def test_alpha_bayesian_ridge_with_constant_input():
+    # Test BayesianRidge score for edge case of constant target vector
+    constant_value = np.random.rand()
+    X = np.random.random((5, 5))
+    y = np.full(5, constant_value)
+    expected = np.nan
+
+    clf = BayesianRidge(compute_score=True)
+    clf.fit(X, y)
+    assert_array_equal(clf.alpha_, expected)
+
+
+def test_lambda_bayesian_ridge_with_constant_input():
+    # Test BayesianRidge score for edge case of constant target vector
+    constant_value = np.random.rand()
+    X = np.random.random((5, 5))
+    y = np.full(5, constant_value)
+    expected = np.nan
+
+    clf = BayesianRidge(compute_score=True)
+    clf.fit(X, y)
+    assert_array_equal(clf.lambda_, expected)
 
 
 def test_toy_ard_object():

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -103,7 +103,7 @@ def test_score_bayesian_ridge_with_constant_input():
 
 
 def test_alpha_bayesian_ridge_with_constant_input():
-    # Test BayesianRidge score for edge case of constant target vector
+    # Test BayesianRidge alpha for edge case of constant target vector
     n_samples = 4
     n_features = 5
     constant_value = np.random.rand()
@@ -117,7 +117,7 @@ def test_alpha_bayesian_ridge_with_constant_input():
 
 
 def test_lambda_bayesian_ridge_with_constant_input():
-    # Test BayesianRidge score for edge case of constant target vector
+    # Test BayesianRidge lambda for edge case of constant target vector
     n_samples = 4
     n_features = 5
     constant_value = np.random.rand()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #10092 


#### What does this implement/fix? Explain your changes.
This PR fixes the issue that when fitting a `BayesianRidge` or `ARDRegression` classifier with a constant target vector `y`, the `predict` method yields NaN arrays for both predictions and the respective standard devitions. This occurs since the estimated precision for the noise `alpha_ ` is initialized with `1/np.var(y)` =  `inf`.

This PR fixes this issue by initializing  `alpha_` with `1/(np.var(y) + eps)`, where `eps` = `np.spacing(1)`. 


#### Any other comments?
The returned standard deviation `std` for the predictions will not be zero for a constant target vector (as suggested in #10092), but a small number instead. I added a test for this. However, `std` approaches zero as the number of samples increase, as expected:
![image](https://user-images.githubusercontent.com/7914340/32613777-0e73efb4-c56c-11e7-8541-56198d4e85da.png)


