### PR TITLE
different activation functions at each hidden layer of MLP

### DIFF
--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -332,6 +332,11 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
             hidden_layer_sizes = [hidden_layer_sizes]
         hidden_layer_sizes = list(hidden_layer_sizes)
 
+        # If a single activation function is given,
+        # use it for each hidden layer
+        if type(self.activation) == str:
+            self.activation = [self.activation] * len(hidden_layer_sizes)
+
         # Validate input parameters.
         self._validate_hyperparameters()
         if np.any(np.array(hidden_layer_sizes) <= 0):

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -291,12 +291,12 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
 
         # for output layer, use the rule according to the activation function
         # in the previous layer.
-        coef_init, intercept_init = self._init_coef(layer_units[self.n_layers_ - 2],
-                                                    layer_units[self.n_layers_ - 1],
-                                                    self.activation[self.n_layers_ - 3] )
+        coef_init, intercept_init = self._init_coef(
+            layer_units[self.n_layers_ - 2],
+            layer_units[self.n_layers_ - 1],
+            self.activation[self.n_layers_ - 3])
         self.coefs_.append(coef_init)
         self.intercepts_.append(intercept_init)
-
 
         if self.solver in _STOCHASTIC_SOLVERS:
             self.loss_curve_ = []
@@ -430,9 +430,10 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
         supported_activations = ('identity', 'logistic', 'tanh', 'relu')
         for idx_activation in range(len(self.activation)):
             if self.activation[idx_activation] not in supported_activations:
-                raise ValueError("The activation '%s' is not supported. Supported "
-                                 "activations are %s." % (self.activation[idx_activation],
-                                                          supported_activations))
+                raise ValueError("The activation '%s' is not supported. "
+                                 "Supported activations are %s."
+                                 % (self.activation[idx_activation],
+                                    supported_activations))
         if self.learning_rate not in ["constant", "invscaling", "adaptive"]:
             raise ValueError("learning rate %s is not supported. " %
                              self.learning_rate)

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -723,7 +723,9 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         hidden layer.
 
     activation : {'identity', 'logistic', 'tanh', 'relu'}, default 'relu'
-        Activation function for the hidden layer.
+        Activation function for the hidden layer. It can be a list of functions
+        for different activation function at each hidden layer such as
+        ['identity', 'relu'].
 
         - 'identity', no-op activation, useful to implement linear bottleneck,
           returns f(x) = x

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -342,7 +342,10 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
         if np.any(np.array(hidden_layer_sizes) <= 0):
             raise ValueError("hidden_layer_sizes must be > 0, got %s." %
                              hidden_layer_sizes)
-
+        if len(self.activation) != len(hidden_layer_sizes):
+            raise ValueError("Number of activation functions "
+                             "cannot be different than the number "
+                             "of hidden layers")
         X, y = self._validate_input(X, y, incremental)
         n_samples, n_features = X.shape
 
@@ -726,6 +729,9 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
 
         - 'relu', the rectified linear unit function,
           returns f(x) = max(0, x)
+
+        - can be a list of function for different activation function
+         at each hidden layer
 
     solver : {'lbfgs', 'sgd', 'adam'}, default 'adam'
         The solver for weight optimization.

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -425,7 +425,7 @@ def test_params_errors():
     assert_raises(ValueError, clf(learning_rate='converge').fit, X, y)
     assert_raises(ValueError, clf(activation='cloak').fit, X, y)
 
-    assert_raises(ValueError, clf(activation=['identity','softmax'],
+    assert_raises(ValueError, clf(activation=['identity' , 'softmax'],
                                   hidden_layer_sizes=10).fit, X, y)
 
 def test_predict_proba_binary():

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -425,6 +425,8 @@ def test_params_errors():
     assert_raises(ValueError, clf(learning_rate='converge').fit, X, y)
     assert_raises(ValueError, clf(activation='cloak').fit, X, y)
 
+    assert_raises(ValueError, clf(activation=['identity','softmax'],
+                                  hidden_layer_sizes=10).fit, X, y)
 
 def test_predict_proba_binary():
     # Test that predict_proba works as expected for binary class.

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -425,7 +425,7 @@ def test_params_errors():
     assert_raises(ValueError, clf(learning_rate='converge').fit, X, y)
     assert_raises(ValueError, clf(activation='cloak').fit, X, y)
 
-    assert_raises(ValueError, clf(activation=['identity' , 'softmax'],
+    assert_raises(ValueError, clf(activation=['identity', 'softmax'],
                                   hidden_layer_sizes=10).fit, X, y)
 
 def test_predict_proba_binary():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Based on our conversation with @ogrisel.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
multilayer_perceptron.py did not accept multiple activation functions previously. Now, users can enter a list of activation functions for each hidden layer. If a single activation function is entered, it will be used for all hidden layers as previously.

#### Any other comments?
Initialization of coefficients are done based on the activation functions. However, it is not clear how to do initialization for the output layer where the activation function is ``softmax`` or ``logistic``. For such cases, I did the initialization based on the activation function in the previous layer. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
