### PR TITLE
[MRG] BUG fix inconsistency between fit and fit_transform in FeatureUnion

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -733,6 +733,7 @@ class FeatureUnion(_BaseComposition, TransformerMixin):
             hstack of results of transformers. sum_n_components is the
             sum of n_components (output dimension) over transformers.
         """
+        self.transformer_list = list(self.transformer_list)
         self._validate_transformers()
         result = Parallel(n_jobs=self.n_jobs)(
             delayed(_fit_transform_one)(trans, weight, X, y,

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -28,12 +28,13 @@ from sklearn.linear_model import LogisticRegression, Lasso
 from sklearn.linear_model import LinearRegression
 from sklearn.cluster import KMeans
 from sklearn.feature_selection import SelectKBest, f_classif
-from sklearn.dummy import DummyRegressor
+from sklearn.dummy import DummyRegressor, DummyClassifier
 from sklearn.decomposition import PCA, TruncatedSVD
 from sklearn.datasets import load_iris
 from sklearn.preprocessing import StandardScaler
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.externals.joblib import Memory
+from sklearn.preprocessing import FunctionTransformer
 
 
 JUNK_FOOD_DOCS = (
@@ -214,6 +215,20 @@ def test_pipeline_init_tuple():
     # Pipeline accepts steps as tuple
     X = np.array([[1, 2]])
     pipe = Pipeline((('transf', Transf()), ('clf', FitParamT())))
+    pipe.fit(X, y=None)
+    pipe.score(X)
+
+    pipe.set_params(transf=None)
+    pipe.fit(X, y=None)
+    pipe.score(X)
+
+
+def test_pipeline_init_dict():
+    # Pipeline accepts steps as items of dict
+    X = np.array([[1, 2]])
+    pipeline_estimators = {'transf': Transf(),
+                           'clf': FitParamT()}
+    pipe = Pipeline(pipeline_estimators.items())
     pipe.fit(X, y=None)
     pipe.score(X)
 
@@ -664,6 +679,20 @@ def test_make_pipeline():
         'Unknown keyword arguments: "random_parameter"',
         make_pipeline, t1, t2, random_parameter='rnd'
     )
+
+
+def test_feature_union_init_dict():
+    # feature union accepts dict items
+    transformers = {
+        'unchanged': make_pipeline(
+            FunctionTransformer(lambda X: X, validate=False)),
+        'add_one': make_pipeline(
+            FunctionTransformer(lambda X: np.array(X)+1, validate=False))
+    }
+    X = [[0], [0], [1]]
+    y = ['x', 'y', 'y']
+    make_pipeline(FeatureUnion(transformers.items()),
+                  DummyClassifier()).fit(X, y)
 
 
 def test_feature_union_weights():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

closes #10088

#### What does this implement/fix? Explain your changes.

Solve the inconsistent behaviour between `fit` and `fit_transform` in FeatureUnion.
Add test to check that either Pipeline and FeatureUnion accept dict.items().

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
