### PR TITLE
[MRG+1] Warning in KMeans if too few clusters were found

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -135,8 +135,8 @@ Decomposition, manifold learning and clustering
   wrapped estimator and its parameter. :issue:`9999` by :user:`Marcus Voss
   <marcus-voss>` and `Joel Nothman`_.
   
-- ```k_means``` now gives a warning, if the number of distinct clusters found
-  is smaller than ```n_clusters```. This may occur when the number of distinct 
+- ``k_means`` now gives a warning, if the number of distinct clusters found
+  is smaller than ``n_clusters``. This may occur when the number of distinct 
   points in the data set is actually smaller than the number of cluster one is 
   looking for. :issue:`10059` by :user:`Christian Braune <christianbraune79>`.
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -134,6 +134,11 @@ Decomposition, manifold learning and clustering
 - Fixed a bug when setting parameters on meta-estimator, involving both a
   wrapped estimator and its parameter. :issue:`9999` by :user:`Marcus Voss
   <marcus-voss>` and `Joel Nothman`_.
+  
+- ```k_means``` now gives a warning, if the number of distinct clusters found
+  is smaller than ```n_clusters```. This may occur when the number of distinct 
+  points in the data set is actually smaller than the number of cluster one is 
+  looking for. :issue:`10059` by :user:`Christian Braune <christianbraune79>`.
 
 Metrics
 

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -374,10 +374,12 @@ def k_means(X, n_clusters, init='k-means++', precompute_distances='auto',
             X += X_mean
         best_centers += X_mean
 
-    if len(set(best_labels)) < n_clusters:
-        warnings.warn("number of distinct clusters found smaller than "
-                      "n_clusters. Possibly due to duplicate points "
-                      "in X.", ConvergenceWarning, stacklevel=2)
+    distinct_clusters = len(set(best_labels))
+    if distinct_clusters < n_clusters:
+        warnings.warn("Number of distinct clusters ({}) found smaller than "
+                      "n_clusters ({}). Possibly due to duplicate points "
+                      "in X.".format(distinct_clusters, n_clusters),
+                      ConvergenceWarning, stacklevel=2)
 
     if return_n_iter:
         return best_centers, best_labels, best_inertia, best_n_iter

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -374,6 +374,10 @@ def k_means(X, n_clusters, init='k-means++', precompute_distances='auto',
             X += X_mean
         best_centers += X_mean
 
+    if len(set(best_labels)) < n_clusters:
+        warnings.warn("number of distinct clusters found smaller than n_clusters. "
+                      "Possibly due to duplicate points in X", RuntimeWarning, stacklevel=2)
+
     if return_n_iter:
         return best_centers, best_labels, best_inertia, best_n_iter
     else:

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -31,7 +31,7 @@ from ..utils.validation import FLOAT_DTYPES
 from ..externals.joblib import Parallel
 from ..externals.joblib import delayed
 from ..externals.six import string_types
-
+from ..exceptions import ConvergenceWarning
 from . import _k_means
 from ._k_means_elkan import k_means_elkan
 
@@ -375,8 +375,9 @@ def k_means(X, n_clusters, init='k-means++', precompute_distances='auto',
         best_centers += X_mean
 
     if len(set(best_labels)) < n_clusters:
-        warnings.warn("number of distinct clusters found smaller than n_clusters. "
-                      "Possibly due to duplicate points in X", RuntimeWarning, stacklevel=2)
+        warnings.warn("number of distinct clusters found smaller than "
+                      "n_clusters. Possibly due to duplicate points "
+                      "in X.", ConvergenceWarning, stacklevel=2)
 
     if return_n_iter:
         return best_centers, best_labels, best_inertia, best_n_iter

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -15,6 +15,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import if_safe_multiprocessing_with_blas
 from sklearn.utils.testing import assert_raise_message
 from sklearn.exceptions import ConvergenceWarning
@@ -883,4 +884,6 @@ def test_less_centers_than_unique_points():
 
     # k_means should warn that fewer labels than cluster
     # centers have been used
-    assert_warns(ConvergenceWarning, k_means, X, n_clusters=4)
+    msg = ("Number of distinct clusters (3) found smaller than "
+           "n_clusters (4). Possibly due to duplicate points in X.")
+    assert_warns_message(ConvergenceWarning, msg, k_means, X, n_clusters=4)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -17,7 +17,7 @@ from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import if_safe_multiprocessing_with_blas
 from sklearn.utils.testing import assert_raise_message
-
+from sklearn.exceptions import ConvergenceWarning
 
 from sklearn.utils.extmath import row_norms
 from sklearn.metrics.cluster import v_measure_score
@@ -877,6 +877,10 @@ def test_less_centers_than_unique_points():
 
     km = KMeans(n_clusters=4).fit(X)
 
+    # only three distinct points, so only three clusters
+    # can have points assigned to them
     assert_equal(set(km.labels_), set(range(3)))
-    assert_warns(RuntimeWarning, k_means, X, n_clusters=4)
 
+    # k_means should warn that fewer labels than cluster
+    # centers have been used
+    assert_warns(ConvergenceWarning, k_means, X, n_clusters=4)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -878,6 +878,5 @@ def test_less_centers_than_unique_points():
     km = KMeans(n_clusters=4).fit(X)
 
     assert_equal(set(km.labels_), set(range(3)))
-    # check warning when centers are passed
     assert_warns(RuntimeWarning, k_means, X, n_clusters=4)
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -867,3 +867,17 @@ def test_sparse_validate_centers():
     msg = "The shape of the initial centers \(\(4L?, 4L?\)\) " \
           "does not match the number of clusters 3"
     assert_raises_regex(ValueError, msg, classifier.fit, X)
+
+
+def test_less_centers_than_unique_points():
+    X = np.asarray([[0, 0],
+                    [0, 1],
+                    [1, 0],
+                    [1, 0]])  # last point is duplicated
+
+    km = KMeans(n_clusters=4).fit(X)
+
+    assert_equal(set(km.labels_), set(range(3)))
+    # check warning when centers are passed
+    assert_warns(RuntimeWarning, k_means, X, n_clusters=4)
+


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10059 

#### What does this implement/fix? Explain your changes.
Gives a warning if the number of distinct cluster centers found is smaller than the number of expected clusters (given by ```n_clusters```). 

Added a test, where exactly this behaviour can be seen and check whether the set of labels actually is too small and if the warning is raised properly.

#### Any other comments?
This is sort-of a minimal solution. The problem remains annoying (I understand @ilectra here, although it is expected behaviour of the algorithm). 

I could also implement something like a sanitizing routine, which also removes the duplicate center (then ```set(labels)``` and ```set(cluster_centers)``` would have at least the same size. This actually would take more effort, since the missing label could be any label and it could also be more than just one label missing. 

I marked this as WIP since I'm not confident if a warning alone is sufficient. 