### PR TITLE
[MRG + 1] Fix for image.extract_patches_2d when # of patches requested > all possible patches 

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -203,6 +203,14 @@ Neighbors
   warning when no neighbors are found for samples.  :issue:`9655` by
   :user:`Andreas Bjerre-Nielsen <abjer>`.
 
+Feature Extraction
+
+- Fixed a bug in :func:`feature_extraction.image.extract_patches_2d` which would
+  throw an exception if ``max_patches`` was greater than or equal to the number
+  of all possible patches rather than simply returning the number of possible
+  patches. :issue:`10100` by :user:`Varun Agrawal <varunagrawal>`
+
+	
 API changes summary
 -------------------
 

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -229,6 +229,9 @@ def _compute_n_patches(i_h, i_w, p_h, p_w, max_patches=None):
         if (isinstance(max_patches, (numbers.Integral))
                 and max_patches < all_patches):
             return max_patches
+        elif (isinstance(max_patches, (numbers.Integral))
+              and max_patches >= all_patches):
+            return all_patches
         elif (isinstance(max_patches, (numbers.Real))
                 and 0 < max_patches < 1):
             return int(max_patches * all_patches)

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -2,6 +2,7 @@
 #          Gael Varoquaux <gael.varoquaux@normalesup.org>
 # License: BSD 3 clause
 
+from __future__ import division
 import numpy as np
 import scipy as sp
 from scipy import ndimage
@@ -168,6 +169,25 @@ def test_extract_patches_max_patches():
                   max_patches=2.0)
     assert_raises(ValueError, extract_patches_2d, face, (p_h, p_w),
                   max_patches=-1.0)
+
+
+def test_extract_patch_same_size_image():
+    face = downsampled_face
+    # Request patches of the same size as image
+    # Should return just the single patch a.k.a. the image
+    patches = extract_patches_2d(face, face.shape, max_patches=2)
+    assert_equal(patches.shape[0], 1)
+
+
+def test_extract_patches_less_than_max_patches():
+    face = downsampled_face
+    i_h, i_w = face.shape
+    p_h, p_w = 3 * i_h // 4, 3 * i_w // 4
+    # this is 3185
+    expected_n_patches = (i_h - p_h + 1) * (i_w - p_w + 1)
+
+    patches = extract_patches_2d(face, (p_h, p_w), max_patches=4000)
+    assert_equal(patches.shape, (expected_n_patches, p_h, p_w))
 
 
 def test_reconstruct_patches_perfect():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #10100 

#### What does this implement/fix? Explain your changes.

This updates the `_compute_n_patches` function to check if the max_patches value >= all_patches and return the appropriate value for number of patches.

#### Any other comments?
