### PR TITLE
[MRG] Fix numpy-dev build

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,6 @@
 # the doctests pass
 import numpy as np
 try:
-    np.set_printoptions(sign='legacy')
+    np.set_printoptions(legacy=True)
 except TypeError:
     pass


### PR DESCRIPTION
https://github.com/numpy/numpy/pull/9332/files change `sign='legacy'` to `legacy=True` in the np.set_printoptions arguments.

I have a Cron build that will run on my fork to double-check that the numpy-dev build pass:
https://travis-ci.org/lesteve/scikit-learn/builds/301861240.

Closes https://github.com/scikit-learn/scikit-learn/issues/10074.