### PR TITLE
[MRG+1] Fix underflow in nmf._beta_divergence

### DIFF
--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -114,8 +114,9 @@ def _beta_divergence(X, W, H, beta, square_root=False):
         X_data = X.ravel()
 
     # do not affect the zeros: here 0 ** (-1) = 0 and not infinity
-    WH_data = WH_data[X_data != 0]
-    X_data = X_data[X_data != 0]
+    indices = X_data > EPSILON
+    WH_data = WH_data[indices]
+    X_data = X_data[indices]
 
     # used to avoid division by zero
     WH_data[WH_data == 0] = EPSILON

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -479,3 +479,18 @@ def test_nmf_decreasing():
                 if previous_loss is not None:
                     assert_greater(previous_loss, loss)
                 previous_loss = loss
+
+
+def test_nmf_underflow():
+    # Regression test for an underflow issue in _beta_divergence
+    rng = np.random.RandomState(0)
+    n_samples, n_features, n_components = 10, 2, 2
+    X = np.abs(rng.randn(n_samples, n_features)) * 10
+    W = np.abs(rng.randn(n_samples, n_components)) * 10
+    H = np.abs(rng.randn(n_components, n_features))
+
+    X[0, 0] = 0
+    ref = nmf._beta_divergence(X, W, H, beta=1.0)
+    X[0, 0] = 1e-323
+    res = nmf._beta_divergence(X, W, H, beta=1.0)
+    assert_almost_equal(res, ref)


### PR DESCRIPTION
Fix an underflow when computing the Kullback-Leibler divergence in `nmf._beta_divergence`.

We want to compute `sum(X * log(X / WH))`, which is zero where X is zero.
So we compute it only where `X != 0`.
But if X is very small, we can have an underflow: `X != 0` but `X / WH == 0`.

The proposed fix is to compute the expression only where `X > epsilon`.
___
To reproduce the underflow:
```py
import numpy as np
from sklearn.decomposition import nmf
rng = np.random.RandomState(0)
n_samples, n_features, n_components = 10, 2, 2
X = np.abs(rng.randn(n_samples, n_features)) * 10
W = np.abs(rng.randn(n_samples, n_components)) * 10
H = np.abs(rng.randn(n_components, n_features))

X[0, 0] = 0
ref = nmf._beta_divergence(X, W, H, beta=1.0)
X[0, 0] = 1e-323
res = nmf._beta_divergence(X, W, H, beta=1.0)
print(res, ref)
# /cal/homes/tdupre/work/src/scikit-learn/sklearn/decomposition/nmf.py:129:
# RuntimeWarning: divide by zero encountered in log
# -inf 316.590497013

```