### PR TITLE
[MRG] Make csgraph imports explicit

### DIFF
--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -11,6 +11,7 @@ from scipy import sparse
 from scipy.linalg import eigh
 from scipy.sparse.linalg import eigsh, lobpcg
 from scipy.sparse.csgraph import connected_components
+from scipy.sparse.csgraph import laplacian as csgraph_laplacian
 
 from ..base import BaseEstimator
 from ..externals import six
@@ -234,8 +235,8 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
         warnings.warn("Graph is not fully connected, spectral embedding"
                       " may not work as expected.")
 
-    laplacian, dd = sparse.csgraph.laplacian(adjacency, normed=norm_laplacian,
-                                             return_diag=True)
+    laplacian, dd = csgraph_laplacian(adjacency, normed=norm_laplacian,
+                                      return_diag=True)
     if (eigen_solver == 'arpack' or eigen_solver != 'lobpcg' and
        (not sparse.isspmatrix(laplacian) or n_nodes < 5 * n_components)):
         # lobpcg used with eigen_solver='amg' has bugs for low number of nodes

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -3,6 +3,7 @@ from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
 
 from scipy import sparse
+from scipy.sparse import csgraph
 from scipy.linalg import eigh
 
 from sklearn.manifold.spectral_embedding_ import SpectralEmbedding
@@ -254,8 +255,8 @@ def test_spectral_embedding_unnormalized():
                                      drop_first=False)
 
     # Verify using manual computation with dense eigh
-    laplacian, dd = sparse.csgraph.laplacian(sims, normed=False,
-                                             return_diag=True)
+    laplacian, dd = csgraph.laplacian(sims, normed=False,
+                                      return_diag=True)
     _, diffusion_map = eigh(laplacian)
     embedding_2 = diffusion_map.T[:n_components] * dd
     embedding_2 = _deterministic_vector_sign_flip(embedding_2).T

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -60,6 +60,7 @@ from abc import ABCMeta, abstractmethod
 import warnings
 import numpy as np
 from scipy import sparse
+from scipy.sparse import csgraph
 
 from ..base import BaseEstimator, ClassifierMixin
 from ..externals import six
@@ -514,7 +515,7 @@ class LabelSpreading(BaseLabelPropagation):
             self.nn_fit = None
         n_samples = self.X_.shape[0]
         affinity_matrix = self._get_kernel(self.X_)
-        laplacian = sparse.csgraph.laplacian(affinity_matrix, normed=True)
+        laplacian = csgraph.laplacian(affinity_matrix, normed=True)
         laplacian = -laplacian
         if sparse.isspmatrix(laplacian):
             diag_mask = (laplacian.row == laplacian.col)

--- a/sklearn/utils/graph.py
+++ b/sklearn/utils/graph.py
@@ -11,6 +11,7 @@ sparse matrices.
 # License: BSD 3 clause
 
 from scipy import sparse
+from scipy.sparse import csgraph
 
 from .graph_shortest_path import graph_shortest_path  # noqa
 from .deprecation import deprecated
@@ -73,11 +74,11 @@ def single_source_shortest_path_length(graph, source, cutoff=None):
             "version 0.19 and will be removed in 0.21. Use "
             "scipy.sparse.csgraph.connected_components instead.")
 def connected_components(*args, **kwargs):
-    return sparse.csgraph.connected_components(*args, **kwargs)
+    return csgraph.connected_components(*args, **kwargs)
 
 
 @deprecated("sklearn.utils.graph.graph_laplacian was deprecated in version "
             "0.19 and will be removed in 0.21. Use "
             "scipy.sparse.csgraph.laplacian instead.")
 def graph_laplacian(*args, **kwargs):
-    return sparse.csgraph.laplacian(*args, **kwargs)
+    return csgraph.laplacian(*args, **kwargs)


### PR DESCRIPTION
with scipy 1.0, `pytest sklearn/semi_supervised` give errors:
```
(test) ❯ pytest sklearn/semi_supervised
========================================== test session starts ===========================================
platform linux -- Python 3.6.3, pytest-3.2.1, py-1.4.34, pluggy-0.4.0
rootdir: /home/lesteve/dev/scikit-learn, inifile: setup.cfg
collected 13 items                                                                                        

sklearn/semi_supervised/label_propagation.py ..F
sklearn/semi_supervised/tests/test_label_propagation.py FFFF.F.FFF

================================================ FAILURES ================================================
___________________ [doctest] sklearn.semi_supervised.label_propagation.LabelSpreading ___________________
474     --------
475     >>> from sklearn import datasets
476     >>> from sklearn.semi_supervised import LabelSpreading
477     >>> label_prop_model = LabelSpreading()
478     >>> iris = datasets.load_iris()
479     >>> rng = np.random.RandomState(42)
480     >>> random_unlabeled_points = rng.rand(len(iris.target)) < 0.3
481     >>> labels = np.copy(iris.target)
482     >>> labels[random_unlabeled_points] = -1
483     >>> label_prop_model.fit(iris.data, labels)
UNEXPECTED EXCEPTION: AttributeError("module 'scipy.sparse' has no attribute 'csgraph'",)
Traceback (most recent call last):

  File "/home/lesteve/miniconda3/envs/test/lib/python3.6/doctest.py", line 1330, in __run
    compileflags, 1), test.globs)

  File "<doctest sklearn.semi_supervised.label_propagation.LabelSpreading[8]>", line 1, in <module>

  File "/home/lesteve/dev/scikit-learn/sklearn/semi_supervised/label_propagation.py", line 229, in fit
    graph_matrix = self._build_graph()

  File "/home/lesteve/dev/scikit-learn/sklearn/semi_supervised/label_propagation.py", line 517, in _build_graph
    laplacian = sparse.csgraph.laplacian(affinity_matrix, normed=True)

AttributeError: module 'scipy.sparse' has no attribute 'csgraph'

/home/lesteve/dev/scikit-learn/sklearn/semi_supervised/label_propagation.py:483: UnexpectedException
_________________________________________ test_fit_transduction __________________________________________

    def test_fit_transduction():
        samples = [[1., 0.], [0., 2.], [1., 3.]]
        labels = [0, 1, -1]
        for estimator, parameters in ESTIMATORS:
>           clf = estimator(**parameters).fit(samples, labels)

sklearn/semi_supervised/tests/test_label_propagation.py:34: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sklearn/semi_supervised/label_propagation.py:229: in fit
    graph_matrix = self._build_graph()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = LabelSpreading(alpha=0.2, gamma=20, kernel='rbf', max_iter=30, n_jobs=1,
        n_neighbors=7, tol=0.001)

    def _build_graph(self):
        """Graph matrix for Label Spreading computes the graph laplacian"""
        # compute affinity matrix (or gram matrix)
        if self.kernel == 'knn':
            self.nn_fit = None
        n_samples = self.X_.shape[0]
        affinity_matrix = self._get_kernel(self.X_)
>       laplacian = sparse.csgraph.laplacian(affinity_matrix, normed=True)
E       AttributeError: module 'scipy.sparse' has no attribute 'csgraph'

sklearn/semi_supervised/label_propagation.py:517: AttributeError
___________________________________________ test_distribution ____________________________________________

    def test_distribution():
        samples = [[1., 0.], [0., 1.], [1., 1.]]
        labels = [0, 1, -1]
        for estimator, parameters in ESTIMATORS:
>           clf = estimator(**parameters).fit(samples, labels)

sklearn/semi_supervised/tests/test_label_propagation.py:42: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sklearn/semi_supervised/label_propagation.py:229: in fit
    graph_matrix = self._build_graph()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = LabelSpreading(alpha=0.2, gamma=20, kernel='rbf', max_iter=30, n_jobs=1,
        n_neighbors=7, tol=0.001)

    def _build_graph(self):
        """Graph matrix for Label Spreading computes the graph laplacian"""
        # compute affinity matrix (or gram matrix)
        if self.kernel == 'knn':
            self.nn_fit = None
        n_samples = self.X_.shape[0]
        affinity_matrix = self._get_kernel(self.X_)
>       laplacian = sparse.csgraph.laplacian(affinity_matrix, normed=True)
E       AttributeError: module 'scipy.sparse' has no attribute 'csgraph'

sklearn/semi_supervised/label_propagation.py:517: AttributeError
______________________________________________ test_predict ______________________________________________

    def test_predict():
        samples = [[1., 0.], [0., 2.], [1., 3.]]
        labels = [0, 1, -1]
        for estimator, parameters in ESTIMATORS:
>           clf = estimator(**parameters).fit(samples, labels)

sklearn/semi_supervised/tests/test_label_propagation.py:56: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sklearn/semi_supervised/label_propagation.py:229: in fit
    graph_matrix = self._build_graph()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = LabelSpreading(alpha=0.2, gamma=20, kernel='rbf', max_iter=30, n_jobs=1,
        n_neighbors=7, tol=0.001)

    def _build_graph(self):
        """Graph matrix for Label Spreading computes the graph laplacian"""
        # compute affinity matrix (or gram matrix)
        if self.kernel == 'knn':
            self.nn_fit = None
        n_samples = self.X_.shape[0]
        affinity_matrix = self._get_kernel(self.X_)
>       laplacian = sparse.csgraph.laplacian(affinity_matrix, normed=True)
E       AttributeError: module 'scipy.sparse' has no attribute 'csgraph'

sklearn/semi_supervised/label_propagation.py:517: AttributeError
___________________________________________ test_predict_proba ___________________________________________

    def test_predict_proba():
        samples = [[1., 0.], [0., 1.], [1., 2.5]]
        labels = [0, 1, -1]
        for estimator, parameters in ESTIMATORS:
>           clf = estimator(**parameters).fit(samples, labels)

sklearn/semi_supervised/tests/test_label_propagation.py:64: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sklearn/semi_supervised/label_propagation.py:229: in fit
    graph_matrix = self._build_graph()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = LabelSpreading(alpha=0.2, gamma=20, kernel='rbf', max_iter=30, n_jobs=1,
        n_neighbors=7, tol=0.001)

    def _build_graph(self):
        """Graph matrix for Label Spreading computes the graph laplacian"""
        # compute affinity matrix (or gram matrix)
        if self.kernel == 'knn':
            self.nn_fit = None
        n_samples = self.X_.shape[0]
        affinity_matrix = self._get_kernel(self.X_)
>       laplacian = sparse.csgraph.laplacian(affinity_matrix, normed=True)
E       AttributeError: module 'scipy.sparse' has no attribute 'csgraph'

sklearn/semi_supervised/label_propagation.py:517: AttributeError
____________________________________ test_label_spreading_closed_form ____________________________________

    def test_label_spreading_closed_form():
        n_classes = 2
        X, y = make_classification(n_classes=n_classes, n_samples=200,
                                   random_state=0)
        y[::3] = -1
>       clf = label_propagation.LabelSpreading().fit(X, y)

sklearn/semi_supervised/tests/test_label_propagation.py:87: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sklearn/semi_supervised/label_propagation.py:229: in fit
    graph_matrix = self._build_graph()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = LabelSpreading(alpha=0.2, gamma=20, kernel='rbf', max_iter=30, n_jobs=1,
        n_neighbors=7, tol=0.001)

    def _build_graph(self):
        """Graph matrix for Label Spreading computes the graph laplacian"""
        # compute affinity matrix (or gram matrix)
        if self.kernel == 'knn':
            self.nn_fit = None
        n_samples = self.X_.shape[0]
        affinity_matrix = self._get_kernel(self.X_)
>       laplacian = sparse.csgraph.laplacian(affinity_matrix, normed=True)
E       AttributeError: module 'scipy.sparse' has no attribute 'csgraph'

sklearn/semi_supervised/label_propagation.py:517: AttributeError
____________________________________________ test_valid_alpha ____________________________________________

    def test_valid_alpha():
        n_classes = 2
        X, y = make_classification(n_classes=n_classes, n_samples=200,
                                   random_state=0)
        for alpha in [-0.1, 0, 1, 1.1, None]:
            assert_raises(ValueError,
                          lambda **kwargs:
                          label_propagation.LabelSpreading(**kwargs).fit(X, y),
>                         alpha=alpha)

sklearn/semi_supervised/tests/test_label_propagation.py:137: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sklearn/utils/_unittest_backport.py:204: in assertRaises
    return context.handle('assertRaises', args, kwargs)
sklearn/utils/_unittest_backport.py:113: in handle
    callable_obj(*args, **kwargs)
sklearn/semi_supervised/tests/test_label_propagation.py:136: in <lambda>
    label_propagation.LabelSpreading(**kwargs).fit(X, y),
sklearn/semi_supervised/label_propagation.py:229: in fit
    graph_matrix = self._build_graph()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = LabelSpreading(alpha=-0.1, gamma=20, kernel='rbf', max_iter=30, n_jobs=1,
        n_neighbors=7, tol=0.001)

    def _build_graph(self):
        """Graph matrix for Label Spreading computes the graph laplacian"""
        # compute affinity matrix (or gram matrix)
        if self.kernel == 'knn':
            self.nn_fit = None
        n_samples = self.X_.shape[0]
        affinity_matrix = self._get_kernel(self.X_)
>       laplacian = sparse.csgraph.laplacian(affinity_matrix, normed=True)
E       AttributeError: module 'scipy.sparse' has no attribute 'csgraph'

sklearn/semi_supervised/label_propagation.py:517: AttributeError
_________________________________________ test_convergence_speed _________________________________________

    def test_convergence_speed():
        # This is a non-regression test for #5774
        X = np.array([[1., 0.], [0., 1.], [1., 2.5]])
        y = np.array([0, 1, -1])
        mdl = label_propagation.LabelSpreading(kernel='rbf', max_iter=5000)
>       mdl.fit(X, y)

sklearn/semi_supervised/tests/test_label_propagation.py:145: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sklearn/semi_supervised/label_propagation.py:229: in fit
    graph_matrix = self._build_graph()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = LabelSpreading(alpha=0.2, gamma=20, kernel='rbf', max_iter=5000, n_jobs=1,
        n_neighbors=7, tol=0.001)

    def _build_graph(self):
        """Graph matrix for Label Spreading computes the graph laplacian"""
        # compute affinity matrix (or gram matrix)
        if self.kernel == 'knn':
            self.nn_fit = None
        n_samples = self.X_.shape[0]
        affinity_matrix = self._get_kernel(self.X_)
>       laplacian = sparse.csgraph.laplacian(affinity_matrix, normed=True)
E       AttributeError: module 'scipy.sparse' has no attribute 'csgraph'

sklearn/semi_supervised/label_propagation.py:517: AttributeError
________________________________________ test_convergence_warning ________________________________________

    def test_convergence_warning():
        # This is a non-regression test for #5774
        X = np.array([[1., 0.], [0., 1.], [1., 2.5]])
        y = np.array([0, 1, -1])
        mdl = label_propagation.LabelSpreading(kernel='rbf', max_iter=1)
>       assert_warns(ConvergenceWarning, mdl.fit, X, y)

sklearn/semi_supervised/tests/test_label_propagation.py:157: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sklearn/utils/testing.py:143: in assert_warns
    result = func(*args, **kw)
sklearn/semi_supervised/label_propagation.py:229: in fit
    graph_matrix = self._build_graph()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = LabelSpreading(alpha=0.2, gamma=20, kernel='rbf', max_iter=1, n_jobs=1,
        n_neighbors=7, tol=0.001)

    def _build_graph(self):
        """Graph matrix for Label Spreading computes the graph laplacian"""
        # compute affinity matrix (or gram matrix)
        if self.kernel == 'knn':
            self.nn_fit = None
        n_samples = self.X_.shape[0]
        affinity_matrix = self._get_kernel(self.X_)
>       laplacian = sparse.csgraph.laplacian(affinity_matrix, normed=True)
E       AttributeError: module 'scipy.sparse' has no attribute 'csgraph'

sklearn/semi_supervised/label_propagation.py:517: AttributeError
=================================== 9 failed, 4 passed in 0.49 seconds ===================================
```

This is because `scipy.sparse.csgraph` is not imported implicitly in scipy 1.0. This snippet for example gives an AttributeError in scipy 1.0 and not in scipy < 1.0:

```py
from scipy import sparse
sparse.csgraph
```

Now if you are lucky, you import something from `scipy.sparse.sgraph` before using `sparse.csgraph` and you don't realise which is probably why the tests are passing when I tried running with scipy 1.0.
