### PR TITLE
[MRG] Turn off codecov comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,4 @@
-comment: off
+comment: false
 
 coverage:
   status:


### PR DESCRIPTION
Following https://docs.codecov.io/v4.3.6/docs/pull-request-comments#section-disable-comment.

Closes #10136, closes #10086 which were WIP PRs and seem to indicate that `comment: false` does remove codecov comments which seemed to appear last week or the last couple of weeks.

This is just a FYI PR and I'll merge this one right away.