### PR TITLE
[WIP] Add Utility function to read image from the file as imread is deprecated

### DIFF
--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -742,13 +742,14 @@ def load_sample_images():
     >>> first_img_data.dtype               #doctest: +SKIP
     dtype('uint8')
     """
-    # Try to import imread from scipy. We do this lazily here to prevent
-    # this module from depending on PIL.
+    # Try to import from PIL as imread is deprecated in SciPy 1.0.0,
+    # and will be removed in 1.2.0.
+    # Github Issue: https://github.com/scikit-learn/scikit-learn/issues/10147
     try:
         try:
-            from scipy.misc import imread
+            from PIL import Image
         except ImportError:
-            from scipy.misc.pilutil import imread
+            import Image
     except ImportError:
         raise ImportError("The Python Imaging Library (PIL) "
                           "is required to load data from jpeg files")
@@ -759,7 +760,7 @@ def load_sample_images():
                  for filename in os.listdir(module_path)
                  if filename.endswith(".jpg")]
     # Load image data for each image in the source folder.
-    images = [imread(filename) for filename in filenames]
+    images = [Image.open(filename) for filename in filenames]
 
     return Bunch(images=images,
                  filenames=filenames,

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -19,6 +19,7 @@ import hashlib
 
 from ..utils import Bunch
 from ..utils import check_random_state
+from sklearn.utils.image_read import _imread
 
 import numpy as np
 
@@ -742,17 +743,6 @@ def load_sample_images():
     >>> first_img_data.dtype               #doctest: +SKIP
     dtype('uint8')
     """
-    # Try to import from PIL as imread is deprecated in SciPy 1.0.0,
-    # and will be removed in 1.2.0.
-    # Github Issue: https://github.com/scikit-learn/scikit-learn/issues/10147
-    try:
-        try:
-            from PIL import Image
-        except ImportError:
-            import Image
-    except ImportError:
-        raise ImportError("The Python Imaging Library (PIL) "
-                          "is required to load data from jpeg files")
     module_path = join(dirname(__file__), "images")
     with open(join(module_path, 'README.txt')) as f:
         descr = f.read()
@@ -760,7 +750,7 @@ def load_sample_images():
                  for filename in os.listdir(module_path)
                  if filename.endswith(".jpg")]
     # Load image data for each image in the source folder.
-    images = [Image.open(filename) for filename in filenames]
+    images = [_imread(filename) for filename in filenames]
 
     return Bunch(images=images,
                  filenames=filenames,

--- a/sklearn/datasets/lfw.py
+++ b/sklearn/datasets/lfw.py
@@ -32,7 +32,7 @@ import numpy as np
 from .base import get_data_home, _fetch_remote, RemoteFileMetadata
 from ..utils import Bunch
 from ..externals.joblib import Memory
-
+from sklearn.utils.image_read import _imread
 from ..externals.six import b
 
 logger = logging.getLogger(__name__)
@@ -137,14 +137,9 @@ def check_fetch_lfw(data_home=None, funneled=True, download_if_missing=True):
 def _load_imgs(file_paths, slice_, color, resize):
     """Internally used to load images"""
 
-    # Try to import from PIL as imread is deprecated in SciPy 1.0.0,
-    # and will be removed in 1.2.0.
-    # Github Issue: https://github.com/scikit-learn/scikit-learn/issues/10147
+    # Try to import imread from scipy. We do this lazily here to prevent
+    # this module from depending on PIL.
     try:
-        try:
-            from PIL import Image
-        except ImportError:
-            import Image
         from scipy.misc import imresize
     except ImportError:
         raise ImportError("The Python Imaging Library (PIL)"
@@ -182,7 +177,7 @@ def _load_imgs(file_paths, slice_, color, resize):
 
         # Checks if jpeg reading worked. Refer to issue #3594 for more
         # details.
-        img = Image.open(file_path)
+        img = _imread(file_path)
         if img.ndim is 0:
             raise RuntimeError("Failed to read the image file %s, "
                                "Please make sure that libjpeg is installed"

--- a/sklearn/datasets/lfw.py
+++ b/sklearn/datasets/lfw.py
@@ -137,13 +137,14 @@ def check_fetch_lfw(data_home=None, funneled=True, download_if_missing=True):
 def _load_imgs(file_paths, slice_, color, resize):
     """Internally used to load images"""
 
-    # Try to import imread and imresize from PIL. We do this here to prevent
-    # the whole sklearn.datasets module from depending on PIL.
+    # Try to import from PIL as imread is deprecated in SciPy 1.0.0,
+    # and will be removed in 1.2.0.
+    # Github Issue: https://github.com/scikit-learn/scikit-learn/issues/10147
     try:
         try:
-            from scipy.misc import imread
+            from PIL import Image
         except ImportError:
-            from scipy.misc.pilutil import imread
+            import Image
         from scipy.misc import imresize
     except ImportError:
         raise ImportError("The Python Imaging Library (PIL)"
@@ -181,7 +182,7 @@ def _load_imgs(file_paths, slice_, color, resize):
 
         # Checks if jpeg reading worked. Refer to issue #3594 for more
         # details.
-        img = imread(file_path)
+        img = Image.open(file_path)
         if img.ndim is 0:
             raise RuntimeError("Failed to read the image file %s, "
                                "Please make sure that libjpeg is installed"

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -162,14 +162,8 @@ def test_load_sample_image():
 
 def test_load_missing_sample_image_error():
     have_PIL = True
-    # Try to import from PIL as imread is deprecated in SciPy 1.0.0,
-    # and will be removed in 1.2.0.
-    # Github Issue: https://github.com/scikit-learn/scikit-learn/issues/10147
     try:
-        try:
-            from PIL import Image
-        except ImportError:
-            import Image  # noqa
+        from sklearn.utils.image_read import _imread
     except ImportError:
         have_PIL = False
     if have_PIL:

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -162,11 +162,14 @@ def test_load_sample_image():
 
 def test_load_missing_sample_image_error():
     have_PIL = True
+    # Try to import from PIL as imread is deprecated in SciPy 1.0.0,
+    # and will be removed in 1.2.0.
+    # Github Issue: https://github.com/scikit-learn/scikit-learn/issues/10147
     try:
         try:
-            from scipy.misc import imread
+            from PIL import Image
         except ImportError:
-            from scipy.misc.pilutil import imread  # noqa
+            import Image  # noqa
     except ImportError:
         have_PIL = False
     if have_PIL:

--- a/sklearn/utils/image_read.py
+++ b/sklearn/utils/image_read.py
@@ -1,0 +1,62 @@
+"""Utility to read image from file as an array."""
+import numpy as np
+
+# Try to import from PIL as imread is deprecated in SciPy 1.0.0,
+# and will be removed in 1.2.0.
+# Github Issue: https://github.com/scikit-learn/scikit-learn/issues/10147
+try:
+    try:
+        from PIL import Image
+    except ImportError:
+        import Image
+except ImportError:
+    raise ImportError("The Python Imaging Library (PIL) "
+                      "is required to load data from jpeg files")
+
+
+def _imread(name, flatten=False, mode=None):
+    """
+    Read an image from a file as an array.
+    This function is only available if Python Imaging Library (PIL) is installed.
+    Parameters
+    ----------
+    name : str or file object
+        The file name or file object to be read.
+    flatten : bool, optional
+        If True, flattens the color layers into a single gray-scale layer.
+    mode : str, optional
+        Mode to convert image to, e.g. ``'RGB'``.  See the Notes for more
+        details.
+    Returns
+    -------
+    imread : ndarray
+        The array obtained by reading the image.
+    Notes
+    -----
+    `imread` uses the Python Imaging Library (PIL) to read an image.
+    The following notes are from the PIL documentation.
+    `mode` can be one of the following strings:
+    * 'L' (8-bit pixels, black and white)
+    * 'P' (8-bit pixels, mapped to any other mode using a color palette)
+    * 'RGB' (3x8-bit pixels, true color)
+    * 'RGBA' (4x8-bit pixels, true color with transparency mask)
+    * 'CMYK' (4x8-bit pixels, color separation)
+    * 'YCbCr' (3x8-bit pixels, color video format)
+    * 'I' (32-bit signed integer pixels)
+    * 'F' (32-bit floating point pixels)
+    PIL also provides limited support for a few special modes, including
+    'LA' ('L' with alpha), 'RGBX' (true color with padding) and 'RGBa'
+    (true color with premultiplied alpha).
+    When translating a color image to black and white (mode 'L', 'I' or
+    'F'), the library uses the ITU-R 601-2 luma transform::
+        L = R * 299/1000 + G * 587/1000 + B * 114/1000
+    When `flatten` is True, the image is converted using mode 'F'.
+    When `mode` is not None and `flatten` is True, the image is first
+    converted according to `mode`, and the result is then flattened using
+    mode 'F'.
+    """
+    im = Image.open(name)
+    # Check if image is PIL
+    if not Image.isImageType(im):
+        raise TypeError("Input is not a PIL image.")
+    return np.asarray(im)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #10147 

#### What does this implement/fix? Explain your changes.
Copy the implementation of scipy.misc.imread as imread is deprecated suggested using PIL/pillow directly

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
