### PR TITLE
[MRG] Avoid subplot overlapping in example plot_regression.py

### DIFF
--- a/examples/neighbors/plot_regression.py
+++ b/examples/neighbors/plot_regression.py
@@ -46,4 +46,5 @@ for i, weights in enumerate(['uniform', 'distance']):
     plt.title("KNeighborsRegressor (k = %i, weights = '%s')" % (n_neighbors,
                                                                 weights))
 
+plt.tight_layout()
 plt.show()


### PR DESCRIPTION
before:
![sphx_glr_plot_regression_001](https://user-images.githubusercontent.com/12003569/32932657-9625f104-cba3-11e7-9122-9faded004dcd.png)
after:
![sphx_glr_plot_regression_001](https://user-images.githubusercontent.com/12003569/32935117-926772d0-cba9-11e7-8bd2-a351de41b7d7.png)
