### PR TITLE
[MRG+1] DOC Fix utils.resample and utils.shuffle docstrings: 'views' -> 'copies'

### DIFF
--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -196,8 +196,8 @@ def resample(*arrays, **options):
     Returns
     -------
     resampled_arrays : sequence of indexable data-structures
-        Sequence of resampled copies of the collections. The original arrays are
-        not impacted.
+        Sequence of resampled copies of the collections. The original arrays
+        are not impacted.
 
     Examples
     --------
@@ -300,8 +300,8 @@ def shuffle(*arrays, **options):
     Returns
     -------
     shuffled_arrays : sequence of indexable data-structures
-        Sequence of shuffled copies of the collections. The original arrays are
-        not impacted.
+        Sequence of shuffled copies of the collections. The original arrays
+        are not impacted.
 
     Examples
     --------

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -196,7 +196,7 @@ def resample(*arrays, **options):
     Returns
     -------
     resampled_arrays : sequence of indexable data-structures
-        Sequence of resampled views of the collections. The original arrays are
+        Sequence of resampled copies of the collections. The original arrays are
         not impacted.
 
     Examples
@@ -300,7 +300,7 @@ def shuffle(*arrays, **options):
     Returns
     -------
     shuffled_arrays : sequence of indexable data-structures
-        Sequence of shuffled views of the collections. The original arrays are
+        Sequence of shuffled copies of the collections. The original arrays are
         not impacted.
 
     Examples


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

The docstrings currently say that views are returned, which is incorrect. Docstrings have been updated to reflect the fact that copies are returned.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
