### PR TITLE
[MRG] Feature: calculate normed stress (Stress-1) in sklearn.manifold.MDS

### DIFF
--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -62,16 +62,17 @@ def test_MDS():
 
 
 def test_normed_stress():
-    # Generate random, symmetric matrix
-    sim = np.random.rand(4, 4)
-    sim = (sim + sim.T)/2
+    sim = np.array([[0, 5, 3, 4],
+                    [5, 0, 2, 2],
+                    [3, 2, 0, 1],
+                    [4, 2, 1, 0]])
 
     # Calculate normed stress for matrix
     # and its multiplied copy
-    k = 15
+    k = 2
     X1, stress1 = mds.smacof(sim, normalize=True)
     X2, stress2 = mds.smacof(k * sim, normalize=True)
 
     # Normed stress should be the same for
     # values multiplied by some factor "k"
-    assert_array_almost_equal(stress1, stress2, decimal=3)
+    assert_array_almost_equal(stress1, stress2, decimal=2)

--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -59,3 +59,19 @@ def test_MDS():
                     [4, 2, 1, 0]])
     mds_clf = mds.MDS(metric=False, n_jobs=3, dissimilarity="precomputed")
     mds_clf.fit(sim)
+
+
+def test_normed_stress():
+    # Generate random, symmetric matrix
+    sim = np.random.rand(4, 4)
+    sim = (sim + sim.T)/2
+
+    # Calculate normed stress for matrix
+    # and its multiplied copy
+    k = 15
+    X1, stress1 = mds.smacof(sim, normalize=True)
+    X2, stress2 = mds.smacof(k * sim, normalize=True)
+
+    # Normed stress should be the same for
+    # values multiplied by some factor "k"
+    assert_array_almost_equal(stress1, stress2, decimal=3)


### PR DESCRIPTION
Change introduces additional parameter to _sklearn.manifold.MDS_, namely _normalize_ (default _False_), that can be used to return and use _Stress-1_ instead of raw Stress value. Already implemented _stress\__ attribute contains raw stress defined as:

<img width="324" alt="zrzut ekranu 2017-11-19 o 02 00 40" src="https://user-images.githubusercontent.com/12532185/32986219-b04f752a-cccd-11e7-89ac-d0651db72796.png">

The raw Stress value itself is not very informative, and its high value does not necessarily indicate bad fit. A better way of communicating reliability is to calculate a normed stress, eg. with Stress-1  implemented in current PR:

<img width="349" alt="zrzut ekranu 2017-11-19 o 02 00 48" src="https://user-images.githubusercontent.com/12532185/32986216-a49f3a30-cccd-11e7-8092-a9869f648d3a.png">

According to Kruskal (1964, p. 3): value 0 indicates "perfect" fit, 0.025 excellent, 0.05 good, 0.1 fair, and 0.2 poor.

For more information cf. Kruskal (1964, p. 8-9) and Borg (2005, p. 41-43).

