### PR TITLE
Median Overlapping Mode for 2d reconstruction

### DIFF
--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -438,7 +438,8 @@ def reconstruct_from_patches_2d(patches, image_size, overlap_mode='average'):
         for i in range(i_h):
             for j in range(i_w):
                 # divide by the amount of overlap
-                # XXX: is this the most efficient way? memory-wise yes, cpu wise?
+                # XXX: is this the most efficient way? memory-wise yes,
+                #      cpu wise?
                 img[i, j] /= float(min(i + 1, p_h, i_h - i) *
                                    min(j + 1, p_w, i_w - j))
         return img

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -426,8 +426,8 @@ def reconstruct_from_patches_2d(patches, image_size, overlap_mode='average'):
     n_h = i_h - p_h + 1
     n_w = i_w - p_w + 1
     img = np.zeros(image_size)
-    img[:] = np.nan
     if overlap_mode == 'median':
+        img[:] = np.nan
         imgs = [img.copy() for _ in range(p_h * p_w)]
         for p, (i, j) in zip(patches, product(range(n_h), range(n_w))):
             imgs[(i % p_h) * p_w + j % p_w][i:i + p_h, j:j + p_w] = p

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -396,7 +396,7 @@ def reconstruct_from_patches_2d(patches, image_size, overlap_mode='average'):
     """Reconstruct the image from all of its patches.
 
     Patches are assumed to overlap and the image is constructed by filling in
-    the patches from left to right, top to bottom, computing the average or 
+    the patches from left to right, top to bottom, computing the average or
     the median of the overlapping regions.
 
     Read more in the :ref:`User Guide <image_feature_extraction>`.

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -431,7 +431,7 @@ def reconstruct_from_patches_2d(patches, image_size, overlap_mode='average'):
         imgs = [img.copy() for _ in range(p_h * p_w)]
         for p, (i, j) in zip(patches, product(range(n_h), range(n_w))):
             imgs[(i % p_h) * p_w + j % p_w][i:i + p_h, j:j + p_w] = p
-        return np.ma.median(imgs, axis=0)
+        return np.ma.median(np.ma.masked_invalid(imgs), axis=0).filled()
     elif overlap_mode == 'average':
         for p, (i, j) in zip(patches, product(range(n_h), range(n_w))):
             img[i:i + p_h, j:j + p_w] += p

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -422,14 +422,13 @@ def reconstruct_from_patches_2d(patches, image_size, overlap_mode='average'):
     """
     i_h, i_w = image_size[:2]
     p_h, p_w = patches.shape[1:3]
+    # compute the dimensions of the patches array
     n_h = i_h - p_h + 1
     n_w = i_w - p_w + 1
     img = np.zeros(image_size)
     img[:] = np.nan
     if overlap_mode == 'median':
         imgs = [img.copy() for _ in range(p_h * p_w)]
-        # compute the dimensions of the patches array
-
         for p, (i, j) in zip(patches, product(range(n_h), range(n_w))):
             imgs[(i % p_h) * p_w + j % p_w][i:i + p_h, j:j + p_w] = p
         return np.ma.median(imgs, axis=0)

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -422,13 +422,14 @@ def reconstruct_from_patches_2d(patches, image_size, overlap_mode='average'):
     """
     i_h, i_w = image_size[:2]
     p_h, p_w = patches.shape[1:3]
+    n_h = i_h - p_h + 1
+    n_w = i_w - p_w + 1
     img = np.zeros(image_size)
     img[:] = np.nan
     if overlap_mode == 'median':
         imgs = [img.copy() for _ in range(p_h * p_w)]
         # compute the dimensions of the patches array
-        n_h = i_h - p_h + 1
-        n_w = i_w - p_w + 1
+
         for p, (i, j) in zip(patches, product(range(n_h), range(n_w))):
             imgs[(i % p_h) * p_w + j % p_w][i:i + p_h, j:j + p_w] = p
         return np.ma.median(imgs, axis=0)


### PR DESCRIPTION
Added new overlapping mode to the method reconstruct_from_patches_2d() . Median computation is particularly useful when one has computed labels for each patch and wants to get the original labeled image from the data. The way this is implemented gets a balance between CPU and memory usage. The higher the patch size, the higher the memory usage, as multiple copies of the image are created, equal to the total number of the patch pixels. This way, any overlap between the patches is allowed.
