### PR TITLE
[MRG] Fix minor typos in ShuffleSplit docstring and effective_n_jobs

### DIFF
--- a/sklearn/externals/joblib/parallel.py
+++ b/sklearn/externals/joblib/parallel.py
@@ -245,7 +245,7 @@ def register_parallel_backend(name, factory, make_default=False):
 def effective_n_jobs(n_jobs=-1):
     """Determine the number of jobs that can actually run in parallel
 
-    n_jobs is the is the number of workers requested by the callers.
+    n_jobs is the number of workers requested by the callers.
     Passing n_jobs=-1 means requesting all available workers for instance
     matching the number of CPU cores on the worker host(s).
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1253,7 +1253,7 @@ class ShuffleSplit(BaseShuffleSplit):
         If float, should be between 0.0 and 1.0 and represent the proportion
         of the dataset to include in the test split. If int, represents the
         absolute number of test samples. If None, the value is set to the
-        complement of the train size. By default (the is parameter
+        complement of the train size. By default (the parameter is
         unspecified), the value is set to 0.1.
         The default will change in version 0.21. It will remain 0.1 only
         if ``train_size`` is unspecified, otherwise it will complement


### PR DESCRIPTION

#### What does this implement/fix? Explain your changes.
Two minor typos in docstrings.