### PR TITLE
[MRG + 1] Fix Agglomerative children_ documentation

### DIFF
--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -659,7 +659,7 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
     n_components_ : int
         The estimated number of connected components in the graph.
 
-    children_ : array-like, shape (n_nodes-1, 2)
+    children_ : array-like, shape (n_samples-1, 2)
         The children of each non-leaf node. Values less than `n_samples`
         correspond to leaves of the tree which are the original samples.
         A node `i` greater than or equal to `n_samples` is a non-leaf


### PR DESCRIPTION
#10183 
Documentation puts:
children_ : array-like, shape (n_nodes-1, 2)
but it's supposed to be:
children_ : array-like, shape (n_samples-1, 2)

The rest of the documentation is correct, but this one line makes it seem as if each element of children_ corresponds to a node, when it only refers to the merging of nodes.
Also for a full tree n_nodes = 2*(n_samples-1) -1 so the documentation is off by about 2x.
