### PR TITLE
[MRG + 1] use Python 3.4 in first conda build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
   include:
     # This environment tests that scikit-learn can be built against
     # versions of numpy, scipy with ATLAS that comes with Ubuntu Trusty 14.04
+    # i.e. numpy 1.8.2 and scipy 0.13.3
     - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" CYTHON_VERSION="0.23.5"
            COVERAGE=true
       if: type != cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ matrix:
             - python-scipy
             - libatlas3gf-base
             - libatlas-dev
-    # Python 3.5 build
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="false"
-           NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.17.1" CYTHON_VERSION="0.25.2"
+    # Python 3.4 build
+    - env: DISTRIB="conda" PYTHON_VERSION="3.4" INSTALL_MKL="false"
+           NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.16.1" CYTHON_VERSION="0.25.2"
            COVERAGE=true
       if: type != cron
     # This environment tests the newest supported Anaconda release (5.0.0)

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ matrix:
             - python-scipy
             - libatlas3gf-base
             - libatlas-dev
-    # This environment tests the oldest supported anaconda env
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" INSTALL_MKL="false"
-           NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.13.3" CYTHON_VERSION="0.23.5"
+    # Python 3.5 build
+    - env: DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="false"
+           NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.17.1" CYTHON_VERSION="0.25.2"
            COVERAGE=true
       if: type != cron
     # This environment tests the newest supported Anaconda release (5.0.0)

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Dependencies
 
 scikit-learn requires:
 
-- Python (>= 2.7 or >= 3.3)
+- Python (>= 2.7 or >= 3.4)
 - NumPy (>= 1.8.2)
 - SciPy (>= 0.13.3)
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -35,7 +35,7 @@ Installing an official release
 
 Scikit-learn requires:
 
-- Python (>= 2.7 or >= 3.3),
+- Python (>= 2.7 or >= 3.4),
 - NumPy (>= 1.8.2),
 - SciPy (>= 0.13.3).
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -15,7 +15,7 @@ Installing the latest release
 
 Scikit-learn requires:
 
-- Python (>= 2.7 or >= 3.3),
+- Python (>= 2.7 or >= 3.4),
 - NumPy (>= 1.8.2),
 - SciPy (>= 0.13.3).
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -32,7 +32,7 @@ cannot assure that this list is complete.)
 Changelog
 ---------
 
-Support for Python 3.3 has been dropped.
+Support for Python 3.3 has been officially dropped.
 
 New features
 ............

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -32,6 +32,8 @@ cannot assure that this list is complete.)
 Changelog
 ---------
 
+Support for Python 3.3 has been dropped.
+
 New features
 ............
 


### PR DESCRIPTION
See #10189 and in particular https://github.com/scikit-learn/scikit-learn/issues/10189#issuecomment-346611512.

> Note that we have a conda Python 2 build at the moment which I don't think has any use since the numpy, scipy, etc... versions match the ubuntu build. I would be in favor of using Python 3.5 in this build and using dependencies in between our minimal dependencies and the latest version of our dependencies.

Close #10194.
Fix #10189.