### PR TITLE
[MRG] TRAVIS add Python 3.4 cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,10 @@ matrix:
     -  python: 3.6
        env: DISTRIB="scipy-dev-wheels"
        if: type = cron
+    # Python 3.4 build
+    - env: DISTRIB="conda" PYTHON_VERSION="3.4"
+           NUMPY_VERSION="1.11.3" SCIPY_VERSION="0.18.1" CYTHON_VERSION="0.25.2"
+      if: type = cron
 
 install: source build_tools/travis/install.sh
 script: bash build_tools/travis/test_script.sh


### PR DESCRIPTION
As discussed in https://github.com/scikit-learn/scikit-learn/issues/10189#issuecomment-346462739, maybe we should still test on Python 3.4.

Note that Python 3.4 build will actually run in the next Cron job (probably in something like 12 hours). This is passing on my fork, see this [Travis log](https://travis-ci.org/lesteve/scikit-learn/builds/306332273).

