### PR TITLE
Changing UserWarnings to ConvergenceWarnings

### DIFF
--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -17,6 +17,7 @@ from ..utils.extmath import row_norms, safe_sparse_dot
 from ..utils.validation import check_is_fitted
 from ..exceptions import NotFittedError
 from .hierarchical import AgglomerativeClustering
+from ..exceptions import ConvergenceWarning
 
 
 def _iterate_sparse_X(X):
@@ -626,7 +627,8 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
                 warnings.warn(
                     "Number of subclusters found (%d) by Birch is less "
                     "than (%d). Decrease the threshold."
-                    % (len(centroids), self.n_clusters))
+                    % (len(centroids), self.n_clusters), 
+                    ConvergenceWarning)
         else:
             # The global clustering step that clusters the subclusters of
             # the leaves. It assumes the centroids of the subclusters as

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -21,6 +21,7 @@ from ..externals.six import string_types
 from ..utils import check_array, as_float_array, check_random_state
 from ..utils.validation import check_is_fitted
 from ..utils.validation import FLOAT_DTYPES
+from ..exceptions import ConvergenceWarning
 
 __all__ = ['fastica', 'FastICA']
 
@@ -116,7 +117,8 @@ def _ica_par(X, tol, g, fun_args, max_iter, w_init):
             break
     else:
         warnings.warn('FastICA did not converge. Consider increasing '
-                      'tolerance or the maximum number of iterations.')
+                      'tolerance or the maximum number of iterations.',
+                      ConvergenceWarning)
 
     return W, ii + 1
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #10173 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fixing Warning type to ConvergenceWarng from UserWarning as those occur when convergence fails

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
