### PR TITLE
[MRG] Caught deprecation warning for min_impurity_split 

### DIFF
--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -526,7 +526,7 @@ def test_error():
         # catch deprecation warnings for min_impurity_split
         with ignore_warnings(category=DeprecationWarning):
             assert_raises(ValueError,
-                          TreeEstimator(min_impurity_split=-1.0).fit,X, y)
+                          TreeEstimator(min_impurity_split=-1.0).fit, X, y)
         assert_raises(ValueError,
                       TreeEstimator(min_impurity_decrease=-1.0).fit, X, y)
 
@@ -1239,7 +1239,8 @@ def test_arrays_persist():
     # non-regression for #2726
     for attr in ['n_classes', 'value', 'children_left', 'children_right',
                  'threshold', 'impurity', 'feature', 'n_node_samples']:
-        value = getattr(DecisionTreeClassifier().fit([[0], [1]], [0, 1]).tree_, attr)
+        value = getattr(DecisionTreeClassifier().fit([[0], [1]],
+                                                     [0, 1]).tree_, attr)
         # if pointing to freed memory, contents may be arbitrary
         assert_true(-3 <= value.flat[0] < 3,
                     'Array points to arbitrary memory')

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -523,8 +523,10 @@ def test_error():
                       X, y)
         assert_raises(ValueError, TreeEstimator(max_depth=-1).fit, X, y)
         assert_raises(ValueError, TreeEstimator(max_features=42).fit, X, y)
-        assert_raises(ValueError, TreeEstimator(min_impurity_split=-1.0).fit,
-                      X, y)
+        # catch deprecation warnings for min_impurity_split
+        with ignore_warnings(category=DeprecationWarning):
+            assert_raises(ValueError,
+                          TreeEstimator(min_impurity_split=-1.0).fit,X, y)
         assert_raises(ValueError,
                       TreeEstimator(min_impurity_decrease=-1.0).fit, X, y)
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -523,7 +523,7 @@ def test_error():
                       X, y)
         assert_raises(ValueError, TreeEstimator(max_depth=-1).fit, X, y)
         assert_raises(ValueError, TreeEstimator(max_features=42).fit, X, y)
-        # catch deprecation warnings for min_impurity_split
+        # min_impurity_split warning
         with ignore_warnings(category=DeprecationWarning):
             assert_raises(ValueError,
                           TreeEstimator(min_impurity_split=-1.0).fit, X, y)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes part of #10158



#### What does this implement/fix? Explain your changes.

After running pytest for sklearn, I have seen that deprecation warning for `min_impurity_split` is raised in the test `test_error()` in `test_tree.py`. I have changed it in this PR, and added `ignore_warnings() method` to catch the deprecation.  Please let me know if this needs to be altered in some way.


