### PR TITLE
[MRG+2] Update libatlas version in advanced installation instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
           packages:
             # these only required by the DISTRIB="ubuntu" builds:
             - python-scipy
-            - libatlas3gf-base
+            - libatlas3-base
             - libatlas-dev
     # This environment tests the oldest supported anaconda env
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" INSTALL_MKL="false"

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -67,15 +67,15 @@ Python 2 you can install all these requirements by issuing::
 
     sudo apt-get install build-essential python-dev python-setuptools \
                          python-numpy python-scipy \
-                         libatlas-dev libatlas3gf-base
+                         libatlas-dev libatlas3-base
 
 If you have Python 3::
 
     sudo apt-get install build-essential python3-dev python3-setuptools \
                          python3-numpy python3-scipy \
-                         libatlas-dev libatlas3gf-base
+                         libatlas-dev libatlas3-base
 
-On recent Debian and Ubuntu (e.g. Ubuntu 13.04 or later) make sure that ATLAS
+On recent Debian and Ubuntu (e.g. Ubuntu 14.04 or later) make sure that ATLAS
 is used to provide the implementation of the BLAS and LAPACK linear algebra
 routines::
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
None

#### What does this implement/fix? Explain your changes.

[libatlas3gf-base](https://packages.ubuntu.com/trusty/libatlas3gf-base) is only available for Trusty 14.04 as it is a transition package. [libatlas3-base](https://packages.ubuntu.com/trusty/libatlas3-base) is available for all recent Ubuntu releases. Following the advanced installation instructions on Xenial 16.04 for example will show that libatlas3gf-base cannot be found by apt.

#### Any other comments?

Updating the Travis build matrix to check that nothing breaks in Trusty -- might need to have two comments on installing ATLAS depending on Ubuntu version if it does...

Also updating what a "recent" Ubuntu release is as 13.04 is way beyond its end of life. :smiley: 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
