### PR TITLE
DOC Fixed BinaryTree Documentation Examples (issue #10199)

### DIFF
--- a/sklearn/neighbors/ball_tree.pyx
+++ b/sklearn/neighbors/ball_tree.pyx
@@ -23,33 +23,14 @@ VALID_METRICS = ['EuclideanDistance', 'SEuclideanDistance',
 
 
 include "binary_tree.pxi"
-import types
-import functools
-
-class SubstituteDoc(type):
-    def __init__(cls, clsname, superclasses, attributedict):
-        for d in dir(cls):
-            #Exclude special methods and non functions
-            if d.startswith("__"):
-                continue
-            dc = getattr(cls, d)
-            if not callable(dc):
-                continue
-            #Copy the function, this is necessary to avoid modifying the docstrings of the superclass
-            g = types.FunctionType(dc.__code__, dc.__globals__, name=dc.__name__,
-                           argdefs=dc.__defaults__,
-                           closure=dc.__closure__)
-            g = functools.update_wrapper(g, dc)
-            g.__kwdefaults__ = dc.__kwdefaults__
-
-            g.__doc__ = dc.__doc__.format(**DOC_DICT)
-            setattr(cls,d,g)
 
 # Inherit BallTree from BinaryTree
 cdef class BallTree(BinaryTree):
-    __metaclass__ = SubstituteDoc
     __doc__ = CLASS_DOC.format(**DOC_DICT)
-    pass
+
+    def __init__(self, data, leaf_size=40, metric='minkowski', **kwargs):
+        super(BallTree,self).__init__(data, leaf_size, metric, **kwargs)
+        self.substituteDoc(DOC_DICT)
 
 #----------------------------------------------------------------------
 # The functions below specialized the Binary Tree as a Ball Tree
@@ -60,6 +41,10 @@ cdef class BallTree(BinaryTree):
 #   relative rankings of the true distance.  For example, the reduced
 #   distance for the Euclidean metric is the squared-euclidean distance.
 #   For some metrics, the reduced distance is simply the distance.
+
+
+
+
 
 
 cdef int allocate_data(BinaryTree tree, ITYPE_t n_nodes,

--- a/sklearn/neighbors/ball_tree.pyx
+++ b/sklearn/neighbors/ball_tree.pyx
@@ -28,9 +28,8 @@ include "binary_tree.pxi"
 cdef class BallTree(BinaryTree):
     __doc__ = CLASS_DOC.format(**DOC_DICT)
 
-    def __init__(self, data, leaf_size=40, metric='minkowski', **kwargs):
-        super(BallTree,self).__init__(data, leaf_size, metric, **kwargs)
-        self.substituteDoc(DOC_DICT)
+
+substitute_method_doc(BallTree,DOC_DICT)
 
 #----------------------------------------------------------------------
 # The functions below specialized the Binary Tree as a Ball Tree

--- a/sklearn/neighbors/ball_tree.pyx
+++ b/sklearn/neighbors/ball_tree.pyx
@@ -27,6 +27,7 @@ include "binary_tree.pxi"
 # Inherit BallTree from BinaryTree
 cdef class BallTree(BinaryTree):
     __doc__ = CLASS_DOC.format(**DOC_DICT)
+    pass
 
 
 substitute_method_doc(BallTree,DOC_DICT)

--- a/sklearn/neighbors/ball_tree.pyx
+++ b/sklearn/neighbors/ball_tree.pyx
@@ -30,7 +30,7 @@ cdef class BallTree(BinaryTree):
     pass
 
 #----------------------------------------------------------------------
-# The functions below specialized the Binary Tree as a Ball Tree
+# The functions below specialized the Binary Tree as a Ball Tree 
 #
 #   Note that these functions use the concept of "reduced distance".
 #   The reduced distance, defined for some metrics, is a quantity which

--- a/sklearn/neighbors/ball_tree.pyx
+++ b/sklearn/neighbors/ball_tree.pyx
@@ -30,8 +30,6 @@ cdef class BallTree(BinaryTree):
     pass
 
 
-substitute_method_doc(BallTree,DOC_DICT)
-
 #----------------------------------------------------------------------
 # The functions below specialized the Binary Tree as a Ball Tree
 #
@@ -41,11 +39,6 @@ substitute_method_doc(BallTree,DOC_DICT)
 #   relative rankings of the true distance.  For example, the reduced
 #   distance for the Euclidean metric is the squared-euclidean distance.
 #   For some metrics, the reduced distance is simply the distance.
-
-
-
-
-
 
 cdef int allocate_data(BinaryTree tree, ITYPE_t n_nodes,
                        ITYPE_t n_features) except -1:

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -312,7 +312,7 @@ pickle operation: the tree needs not be rebuilt upon unpickling.
     >>> tree = {BinaryTree}(X, leaf_size=2)        # doctest: +SKIP
     >>> s = pickle.dumps(tree)                     # doctest: +SKIP
     >>> tree_copy = pickle.loads(s)                # doctest: +SKIP
-    >>> dist, ind = tree_copy.query(X[0], k=3)     # doctest: +SKIP
+    >>> dist, ind = tree_copy.query([X[0]], k=3)     # doctest: +SKIP
     >>> print(ind)  # indices of 3 closest neighbors
     [0 3 1]
     >>> print(dist)  # distances to 3 closest neighbors
@@ -324,9 +324,9 @@ Query for neighbors within a given radius
     >>> np.random.seed(0)
     >>> X = np.random.random((10, 3))  # 10 points in 3 dimensions
     >>> tree = {BinaryTree}(X, leaf_size=2)     # doctest: +SKIP
-    >>> print(tree.query_radius(X[0], r=0.3, count_only=True))
+    >>> print(tree.query_radius([X[0]], r=0.3, count_only=True))
     3
-    >>> ind = tree.query_radius(X[0], r=0.3)  # doctest: +SKIP
+    >>> ind = tree.query_radius([X[0]], r=0.3)  # doctest: +SKIP
     >>> print(ind)  # indices of neighbors within distance 0.3
     [3 0 1]
 
@@ -1280,8 +1280,8 @@ cdef class BinaryTree:
             >>> import numpy as np
             >>> np.random.seed(0)
             >>> X = np.random.random((10, 3))  # 10 points in 3 dimensions
-            >>> tree = BinaryTree(X, leaf_size=2)    # doctest: +SKIP
-            >>> dist, ind = tree.query(X[0], k=3)    # doctest: +SKIP
+            >>> tree = {BinaryTree}(X, leaf_size=2)    # doctest: +SKIP
+            >>> dist, ind = tree.query([X[0]], k=3)    # doctest: +SKIP
             >>> print(ind)  # indices of 3 closest neighbors
             [0 3 1]
             >>> print(dist)  # distances to 3 closest neighbors
@@ -1414,10 +1414,10 @@ cdef class BinaryTree:
         >>> import numpy as np
         >>> np.random.seed(0)
         >>> X = np.random.random((10, 3))  # 10 points in 3 dimensions
-        >>> tree = BinaryTree(X, leaf_size=2)     # doctest: +SKIP
-        >>> print(tree.query_radius(X[0], r=0.3, count_only=True))
+        >>> tree = {BinaryTree}(X, leaf_size=2)     # doctest: +SKIP
+        >>> print(tree.query_radius([X[0]], r=0.3, count_only=True))
         3
-        >>> ind = tree.query_radius(X[0], r=0.3)  # doctest: +SKIP
+        >>> ind = tree.query_radius([X[0]], r=0.3)  # doctest: +SKIP
         >>> print(ind)  # indices of neighbors within distance 0.3
         [3 0 1]
         """
@@ -1552,7 +1552,7 @@ cdef class BinaryTree:
         >>> import numpy as np
         >>> np.random.seed(1)
         >>> X = np.random.random((100, 3))
-        >>> tree = BinaryTree(X)           # doctest: +SKIP
+        >>> tree = {BinaryTree}(X)           # doctest: +SKIP
         >>> tree.kernel_density(X[:3], h=0.1, kernel='gaussian')
         array([ 6.94114649,  7.83281226,  7.2071716 ])
         """
@@ -1681,7 +1681,7 @@ cdef class BinaryTree:
         >>> np.random.seed(0)
         >>> X = np.random.random((30, 3))
         >>> r = np.linspace(0, 1, 5)
-        >>> tree = BinaryTree(X)     # doctest: +SKIP
+        >>> tree = {BinaryTree}(X)     # doctest: +SKIP
         >>> tree.two_point_correlation(X, r)
         array([ 30,  62, 278, 580, 820])
         """

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -149,8 +149,6 @@ from sklearn.utils.lgamma cimport lgamma
 import numpy as np
 import warnings
 from ..utils import check_array
-import types
-import functools
 
 from typedefs cimport DTYPE_t, ITYPE_t, DITYPE_t
 from typedefs import DTYPE, ITYPE
@@ -1231,8 +1229,6 @@ cdef class BinaryTree:
             self._recursive_build(2 * i_node + 2,
                                   idx_start + n_mid, idx_end)
 
-
-
     def query(self, X, k=1, return_distance=True,
               dualtree=False, breadth_first=False,
               sort_results=True):
@@ -1276,20 +1272,6 @@ cdef class BinaryTree:
         i : array of integers - shape: x.shape[:-1] + (k,)
             each entry gives the list of indices of
             neighbors of the corresponding point
-
-        Examples
-        --------
-        Query for k-nearest neighbors
-
-            >>> import numpy as np
-            >>> np.random.seed(0)
-            >>> X = np.random.random((10, 3))  # 10 points in 3 dimensions
-            >>> tree = {BinaryTree}(X, leaf_size=2)    # doctest: +SKIP
-            >>> dist, ind = tree.query(X[:1], k=3)    # doctest: +SKIP
-            >>> print(ind)  # indices of 3 closest neighbors
-            [0 3 1]
-            >>> print(dist)  # distances to 3 closest neighbors
-            [ 0.          0.19662693  0.29473397]
         """
         # XXX: we should allow X to be a pre-built tree.
         X = check_array(X, dtype=DTYPE, order='C')
@@ -1410,20 +1392,6 @@ cdef class BinaryTree:
         dist : array of objects, shape = X.shape[:-1]
             each element is a numpy double array
             listing the distances corresponding to indices in i.
-
-        Examples
-        --------
-        Query for neighbors in a given radius
-
-        >>> import numpy as np
-        >>> np.random.seed(0)
-        >>> X = np.random.random((10, 3))  # 10 points in 3 dimensions
-        >>> tree = {BinaryTree}(X, leaf_size=2)     # doctest: +SKIP
-        >>> print(tree.query_radius(X[:1], r=0.3, count_only=True))
-        3
-        >>> ind = tree.query_radius(X[:1], r=0.3)  # doctest: +SKIP
-        >>> print(ind)  # indices of neighbors within distance 0.3
-        [3 0 1]
         """
         if count_only and return_distance:
             raise ValueError("count_only and return_distance "
@@ -1548,17 +1516,6 @@ cdef class BinaryTree:
         -------
         density : ndarray
             The array of (log)-density evaluations, shape = X.shape[:-1]
-
-        Examples
-        --------
-        Compute a gaussian kernel density estimate:
-
-        >>> import numpy as np
-        >>> np.random.seed(1)
-        >>> X = np.random.random((100, 3))
-        >>> tree = {BinaryTree}(X)           # doctest: +SKIP
-        >>> tree.kernel_density(X[:3], h=0.1, kernel='gaussian')
-        array([ 6.94114649,  7.83281226,  7.2071716 ])
         """
         cdef DTYPE_t h_c = h
         cdef DTYPE_t log_atol = log(atol)
@@ -1676,18 +1633,6 @@ cdef class BinaryTree:
         counts : ndarray
             counts[i] contains the number of pairs of points with distance
             less than or equal to r[i]
-
-        Examples
-        --------
-        Compute the two-point autocorrelation function of X:
-
-        >>> import numpy as np
-        >>> np.random.seed(0)
-        >>> X = np.random.random((30, 3))
-        >>> r = np.linspace(0, 1, 5)
-        >>> tree = {BinaryTree}(X)     # doctest: +SKIP
-        >>> tree.two_point_correlation(X, r)
-        array([ 30,  62, 278, 580, 820])
         """
         cdef ITYPE_t n_features = self.data.shape[1]
         cdef ITYPE_t i
@@ -2473,26 +2418,6 @@ cdef class BinaryTree:
 
 ######################################################################
 # Python functions for benchmarking and testing C implementations
-
-def substitute_method_doc(cls, DOC_DICT):
-    """Format every method in the class according to the given dictionary"""
-    for d in dir(cls):
-        #Exclude special methods and non functions
-        if d.startswith("__"):
-            continue
-        dc = getattr(cls, d)
-        if not callable(dc):
-            continue
-        if dc.__doc__ != None and hasattr(dc, '__code__'):
-            #Copy the function, this is necessary to avoid modifying the docstrings of the superclass
-            g = types.FunctionType(dc.__code__, dc.__globals__, name=dc.__name__,
-                           argdefs=dc.__defaults__,
-                           closure=dc.__closure__)
-            g = functools.update_wrapper(g, dc)
-            g.__kwdefaults__ = dc.__kwdefaults__
-
-            g.__doc__ = dc.__doc__.format(**DOC_DICT)
-            setattr(cls, d, g)
 
 def load_heap(DTYPE_t[:, ::1] X, ITYPE_t k):
     """test fully loading the heap"""

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -1513,7 +1513,7 @@ cdef class BinaryTree:
 
         Parameters
         ----------
-        X : array_like
+        X : array-like, shape = [n_samples, n_features]
             An array of points to query.  Last dimension should match dimension
             of training data.
         h : float
@@ -1657,7 +1657,7 @@ cdef class BinaryTree:
 
         Parameters
         ----------
-        X : array_like
+        X : array-like, shape = [n_samples, n_features]
             An array of points to query.  Last dimension should match dimension
             of training data.
         r : array_like

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -296,7 +296,7 @@ Query for k-nearest neighbors
     >>> np.random.seed(0)
     >>> X = np.random.random((10, 3))  # 10 points in 3 dimensions
     >>> tree = {BinaryTree}(X, leaf_size=2)              # doctest: +SKIP
-    >>> dist, ind = tree.query([X[0]], k=3)                # doctest: +SKIP
+    >>> dist, ind = tree.query(X[:1], k=3)                # doctest: +SKIP
     >>> print(ind)  # indices of 3 closest neighbors
     [0 3 1]
     >>> print(dist)  # distances to 3 closest neighbors
@@ -312,7 +312,7 @@ pickle operation: the tree needs not be rebuilt upon unpickling.
     >>> tree = {BinaryTree}(X, leaf_size=2)        # doctest: +SKIP
     >>> s = pickle.dumps(tree)                     # doctest: +SKIP
     >>> tree_copy = pickle.loads(s)                # doctest: +SKIP
-    >>> dist, ind = tree_copy.query([X[0]], k=3)     # doctest: +SKIP
+    >>> dist, ind = tree_copy.query(X[:1], k=3)     # doctest: +SKIP
     >>> print(ind)  # indices of 3 closest neighbors
     [0 3 1]
     >>> print(dist)  # distances to 3 closest neighbors
@@ -324,9 +324,9 @@ Query for neighbors within a given radius
     >>> np.random.seed(0)
     >>> X = np.random.random((10, 3))  # 10 points in 3 dimensions
     >>> tree = {BinaryTree}(X, leaf_size=2)     # doctest: +SKIP
-    >>> print(tree.query_radius([X[0]], r=0.3, count_only=True))
+    >>> print(tree.query_radius(X[:1], r=0.3, count_only=True))
     3
-    >>> ind = tree.query_radius([X[0]], r=0.3)  # doctest: +SKIP
+    >>> ind = tree.query_radius(X[:1], r=0.3)  # doctest: +SKIP
     >>> print(ind)  # indices of neighbors within distance 0.3
     [3 0 1]
 
@@ -1240,7 +1240,7 @@ cdef class BinaryTree:
 
         Parameters
         ----------
-        X : array-like, last dimension self.dim
+        X : array-like, shape = [n_samples, n_features]
             An array of points to query
         k : integer  (default = 1)
             The number of nearest neighbors to return
@@ -1281,7 +1281,7 @@ cdef class BinaryTree:
             >>> np.random.seed(0)
             >>> X = np.random.random((10, 3))  # 10 points in 3 dimensions
             >>> tree = {BinaryTree}(X, leaf_size=2)    # doctest: +SKIP
-            >>> dist, ind = tree.query([X[0]], k=3)    # doctest: +SKIP
+            >>> dist, ind = tree.query(X[:1], k=3)    # doctest: +SKIP
             >>> print(ind)  # indices of 3 closest neighbors
             [0 3 1]
             >>> print(dist)  # distances to 3 closest neighbors
@@ -1364,7 +1364,7 @@ cdef class BinaryTree:
 
         Parameters
         ----------
-        X : array-like, last dimension self.dim
+        X : array-like, shape = [n_samples, n_features]
             An array of points to query
         r : distance within which neighbors are returned
             r can be a single value, or an array of values of shape
@@ -1415,9 +1415,9 @@ cdef class BinaryTree:
         >>> np.random.seed(0)
         >>> X = np.random.random((10, 3))  # 10 points in 3 dimensions
         >>> tree = {BinaryTree}(X, leaf_size=2)     # doctest: +SKIP
-        >>> print(tree.query_radius([X[0]], r=0.3, count_only=True))
+        >>> print(tree.query_radius(X[:1], r=0.3, count_only=True))
         3
-        >>> ind = tree.query_radius([X[0]], r=0.3)  # doctest: +SKIP
+        >>> ind = tree.query_radius(X[:1], r=0.3)  # doctest: +SKIP
         >>> print(ind)  # indices of neighbors within distance 0.3
         [3 0 1]
         """

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -149,6 +149,8 @@ from sklearn.utils.lgamma cimport lgamma
 import numpy as np
 import warnings
 from ..utils import check_array
+import types
+import functools
 
 from typedefs cimport DTYPE_t, ITYPE_t, DITYPE_t
 from typedefs import DTYPE, ITYPE
@@ -1228,6 +1230,25 @@ cdef class BinaryTree:
                                   idx_start, idx_start + n_mid)
             self._recursive_build(2 * i_node + 2,
                                   idx_start + n_mid, idx_end)
+
+    def substituteDoc(self, DOC_DICT):
+        for d in dir(self):
+            #Exclude special methods and non functions
+            if d.startswith("__"):
+                continue
+            dc = getattr(self, d)
+            if not callable(dc):
+                continue
+            if dc.__doc__ != None and hasattr(dc, '__code__'):
+                #Copy the function, this is necessary to avoid modifying the docstrings of the superclass
+                g = types.FunctionType(dc.__code__, dc.__globals__, name=dc.__name__,
+                               argdefs=dc.__defaults__,
+                               closure=dc.__closure__)
+                g = functools.update_wrapper(g, dc)
+                g.__kwdefaults__ = dc.__kwdefaults__
+
+                g.__doc__ = dc.__doc__.format(**DOC_DICT)
+                setattr(self,d,g)
 
     def query(self, X, k=1, return_distance=True,
               dualtree=False, breadth_first=False,

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -1231,6 +1231,8 @@ cdef class BinaryTree:
             self._recursive_build(2 * i_node + 2,
                                   idx_start + n_mid, idx_end)
 
+
+
     def query(self, X, k=1, return_distance=True,
               dualtree=False, breadth_first=False,
               sort_results=True):
@@ -2473,7 +2475,7 @@ cdef class BinaryTree:
 # Python functions for benchmarking and testing C implementations
 
 def substitute_method_doc(cls, DOC_DICT):
-    """Format every method in the class according to the given dictionary""""
+    """Format every method in the class according to the given dictionary"""
     for d in dir(cls):
         #Exclude special methods and non functions
         if d.startswith("__"):
@@ -2491,7 +2493,6 @@ def substitute_method_doc(cls, DOC_DICT):
 
             g.__doc__ = dc.__doc__.format(**DOC_DICT)
             setattr(cls, d, g)
-
 
 def load_heap(DTYPE_t[:, ::1] X, ITYPE_t k):
     """test fully loading the heap"""

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -1231,25 +1231,6 @@ cdef class BinaryTree:
             self._recursive_build(2 * i_node + 2,
                                   idx_start + n_mid, idx_end)
 
-    def substituteDoc(self, DOC_DICT):
-        for d in dir(self):
-            #Exclude special methods and non functions
-            if d.startswith("__"):
-                continue
-            dc = getattr(self, d)
-            if not callable(dc):
-                continue
-            if dc.__doc__ != None and hasattr(dc, '__code__'):
-                #Copy the function, this is necessary to avoid modifying the docstrings of the superclass
-                g = types.FunctionType(dc.__code__, dc.__globals__, name=dc.__name__,
-                               argdefs=dc.__defaults__,
-                               closure=dc.__closure__)
-                g = functools.update_wrapper(g, dc)
-                g.__kwdefaults__ = dc.__kwdefaults__
-
-                g.__doc__ = dc.__doc__.format(**DOC_DICT)
-                setattr(self,d,g)
-
     def query(self, X, k=1, return_distance=True,
               dualtree=False, breadth_first=False,
               sort_results=True):
@@ -2490,6 +2471,27 @@ cdef class BinaryTree:
 
 ######################################################################
 # Python functions for benchmarking and testing C implementations
+
+def substitute_method_doc(cls, DOC_DICT):
+    """Format every method in the class according to the given dictionary""""
+    for d in dir(cls):
+        #Exclude special methods and non functions
+        if d.startswith("__"):
+            continue
+        dc = getattr(cls, d)
+        if not callable(dc):
+            continue
+        if dc.__doc__ != None and hasattr(dc, '__code__'):
+            #Copy the function, this is necessary to avoid modifying the docstrings of the superclass
+            g = types.FunctionType(dc.__code__, dc.__globals__, name=dc.__name__,
+                           argdefs=dc.__defaults__,
+                           closure=dc.__closure__)
+            g = functools.update_wrapper(g, dc)
+            g.__kwdefaults__ = dc.__kwdefaults__
+
+            g.__doc__ = dc.__doc__.format(**DOC_DICT)
+            setattr(cls, d, g)
+
 
 def load_heap(DTYPE_t[:, ::1] X, ITYPE_t k):
     """test fully loading the heap"""

--- a/sklearn/neighbors/kd_tree.pyx
+++ b/sklearn/neighbors/kd_tree.pyx
@@ -15,34 +15,19 @@ VALID_METRICS = ['EuclideanDistance', 'ManhattanDistance',
                  'ChebyshevDistance', 'MinkowskiDistance']
 
 
-class SubstituteDoc(type):
-    def __init__(cls, clsname, superclasses, attributedict):
-        for d in dir(cls):
-            #Exclude special methods and non functions
-            if d.startswith("__"):
-                continue
-            dc = getattr(cls, d)
-            if not callable(dc):
-                continue
-            #Copy the function, this is necessary to avoid modifying the docstrings of the superclass
-            g = types.FunctionType(dc.__code__, dc.__globals__, name=dc.__name__,
-                           argdefs=dc.__defaults__,
-                           closure=dc.__closure__)
-            g = functools.update_wrapper(g, dc)
-            g.__kwdefaults__ = dc.__kwdefaults__
 
-            g.__doc__ = dc.__doc__.format(**DOC_DICT)
-            setattr(cls,d,g)
 
 # Inherit KDTree from BinaryTree
 include "binary_tree.pxi"
-import types
-import functools
+
 
 cdef class KDTree(BinaryTree):
-    __metaclass__ = SubstituteDoc
+    # __metaclass__ = SubstituteDoc
     __doc__ = CLASS_DOC.format(**DOC_DICT)
-    pass
+
+    def __init__(self, data, leaf_size=40, metric='minkowski', **kwargs):
+        super(KDTree,self).__init__(data, leaf_size, metric, **kwargs)
+        self.substituteDoc(DOC_DICT)
 
 #----------------------------------------------------------------------
 # The functions below specialized the Binary Tree as a KD Tree

--- a/sklearn/neighbors/kd_tree.pyx
+++ b/sklearn/neighbors/kd_tree.pyx
@@ -23,7 +23,7 @@ cdef class KDTree(BinaryTree):
     pass
 
 #----------------------------------------------------------------------
-# The functions below specialized the Binary Tree as a KD Tree
+# The functions below specialized the Binary Tree as a KD Tree 
 #
 #   Note that these functions use the concept of "reduced distance".
 #   The reduced distance, defined for some metrics, is a quantity which

--- a/sklearn/neighbors/kd_tree.pyx
+++ b/sklearn/neighbors/kd_tree.pyx
@@ -15,15 +15,37 @@ VALID_METRICS = ['EuclideanDistance', 'ManhattanDistance',
                  'ChebyshevDistance', 'MinkowskiDistance']
 
 
+class SubstituteDoc(type):
+    def __init__(cls, clsname, superclasses, attributedict):
+        for d in dir(cls):
+            #Exclude special methods and non functions
+            if d.startswith("__"):
+                continue
+            dc = getattr(cls, d)
+            if not callable(dc):
+                continue
+            #Copy the function, this is necessary to avoid modifying the docstrings of the superclass
+            g = types.FunctionType(dc.__code__, dc.__globals__, name=dc.__name__,
+                           argdefs=dc.__defaults__,
+                           closure=dc.__closure__)
+            g = functools.update_wrapper(g, dc)
+            g.__kwdefaults__ = dc.__kwdefaults__
+
+            g.__doc__ = dc.__doc__.format(**DOC_DICT)
+            setattr(cls,d,g)
+
 # Inherit KDTree from BinaryTree
 include "binary_tree.pxi"
+import types
+import functools
 
 cdef class KDTree(BinaryTree):
+    __metaclass__ = SubstituteDoc
     __doc__ = CLASS_DOC.format(**DOC_DICT)
     pass
 
 #----------------------------------------------------------------------
-# The functions below specialized the Binary Tree as a KD Tree 
+# The functions below specialized the Binary Tree as a KD Tree
 #
 #   Note that these functions use the concept of "reduced distance".
 #   The reduced distance, defined for some metrics, is a quantity which

--- a/sklearn/neighbors/kd_tree.pyx
+++ b/sklearn/neighbors/kd_tree.pyx
@@ -20,14 +20,10 @@ VALID_METRICS = ['EuclideanDistance', 'ManhattanDistance',
 # Inherit KDTree from BinaryTree
 include "binary_tree.pxi"
 
-
 cdef class KDTree(BinaryTree):
-    # __metaclass__ = SubstituteDoc
     __doc__ = CLASS_DOC.format(**DOC_DICT)
 
-    def __init__(self, data, leaf_size=40, metric='minkowski', **kwargs):
-        super(KDTree,self).__init__(data, leaf_size, metric, **kwargs)
-        self.substituteDoc(DOC_DICT)
+substitute_method_doc(KDTree,DOC_DICT)
 
 #----------------------------------------------------------------------
 # The functions below specialized the Binary Tree as a KD Tree

--- a/sklearn/neighbors/kd_tree.pyx
+++ b/sklearn/neighbors/kd_tree.pyx
@@ -15,16 +15,35 @@ VALID_METRICS = ['EuclideanDistance', 'ManhattanDistance',
                  'ChebyshevDistance', 'MinkowskiDistance']
 
 
-
+# def substitute_method_doc(cls, DOC_DICT):
+#     """Format every method in the class according to the given dictionary"""
+#     for d in dir(cls):
+#         #Exclude special methods and non functions
+#         if d.startswith("__"):
+#             continue
+#         dc = getattr(cls, d)
+#         if not callable(dc):
+#             continue
+#         if dc.__doc__ != None and hasattr(dc, '__code__'):
+#             #Copy the function, this is necessary to avoid modifying the docstrings of the superclass
+#             g = types.FunctionType(dc.__code__, dc.__globals__, name=dc.__name__,
+#                            argdefs=dc.__defaults__,
+#                            closure=dc.__closure__)
+#             g = functools.update_wrapper(g, dc)
+#             g.__kwdefaults__ = dc.__kwdefaults__
+#
+#             g.__doc__ = dc.__doc__.format(**DOC_DICT)
+#             setattr(cls, d, g)
 
 # Inherit KDTree from BinaryTree
 include "binary_tree.pxi"
 
 cdef class KDTree(BinaryTree):
     __doc__ = CLASS_DOC.format(**DOC_DICT)
+    pass
+
 
 substitute_method_doc(KDTree,DOC_DICT)
-
 #----------------------------------------------------------------------
 # The functions below specialized the Binary Tree as a KD Tree
 #

--- a/sklearn/neighbors/kd_tree.pyx
+++ b/sklearn/neighbors/kd_tree.pyx
@@ -15,35 +15,14 @@ VALID_METRICS = ['EuclideanDistance', 'ManhattanDistance',
                  'ChebyshevDistance', 'MinkowskiDistance']
 
 
-# def substitute_method_doc(cls, DOC_DICT):
-#     """Format every method in the class according to the given dictionary"""
-#     for d in dir(cls):
-#         #Exclude special methods and non functions
-#         if d.startswith("__"):
-#             continue
-#         dc = getattr(cls, d)
-#         if not callable(dc):
-#             continue
-#         if dc.__doc__ != None and hasattr(dc, '__code__'):
-#             #Copy the function, this is necessary to avoid modifying the docstrings of the superclass
-#             g = types.FunctionType(dc.__code__, dc.__globals__, name=dc.__name__,
-#                            argdefs=dc.__defaults__,
-#                            closure=dc.__closure__)
-#             g = functools.update_wrapper(g, dc)
-#             g.__kwdefaults__ = dc.__kwdefaults__
-#
-#             g.__doc__ = dc.__doc__.format(**DOC_DICT)
-#             setattr(cls, d, g)
-
-# Inherit KDTree from BinaryTree
 include "binary_tree.pxi"
 
+# Inherit KDTree from BinaryTree
 cdef class KDTree(BinaryTree):
     __doc__ = CLASS_DOC.format(**DOC_DICT)
     pass
 
 
-substitute_method_doc(KDTree,DOC_DICT)
 #----------------------------------------------------------------------
 # The functions below specialized the Binary Tree as a KD Tree
 #


### PR DESCRIPTION

#### Reference Issues/PRs
Fixes #10199

#### What does this implement/fix? Explain your changes.
Some of the examples provided on the documentation suggested to pass 1d data, which was deprecated:
`dist, ind = tree_copy.query(X[0], k=3) `
I replaced these examples with the likes of:
`dist, ind = tree_copy.query([X[0]], k=3) `

Also, I noticed that on the documentation for sklearn.neighbors.BallTree, some of the examples on the doc read:
`tree = BinaryTree(X)    `
which I fixed by replacing
`tree = BinaryTree(X, leaf_size=2)`
with
`tree = {BinaryTree}(X, leaf_size=2)`
which allows the BallTree Documentation to replace `BinaryTree` with the correct name:
`DOC_DICT = {'BinaryTree': 'BallTree', 'binary_tree': 'ball_tree'}`
as per  per the rest of the DOC. 
