### PR TITLE
[WIP] Pre-compute norms to speed-up NearestNeighbors.kneighbors algorith='brute' metric='euclidean'

### DIFF
--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -202,7 +202,7 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
             self._fit_method = 'kd_tree'
             return self
 
-        X = check_array(X, accept_sparse='csr')
+        X = check_array(X, accept_sparse='csr', dtype=[np.float64, np.float32])
 
         n_samples = X.shape[0]
         if n_samples == 0:


### PR DESCRIPTION
This problem was spotted in the context of https://github.com/erikbern/ann-benchmarks. In particular look at http://www.itu.dk/people/pagh/SSS/ann-benchmarks/rand-euclidean-data_10_-1_rand-euclidean-query_euclidean.html where bruteforce (NearestNeighbors with `algorithm='brute'`) is a lot slower than bruteforce-blas (similar to `fast_euclidean_neighbors` in the snippet below):

This is a simple snippet showing a 3x speed-up in `NearestNeighbors.kneighbors`. The cost is to store the precomputed norms of `X` at fit time.

```py
import numpy as np

from sklearn.utils.extmath import row_norms
from sklearn.neighbors import NearestNeighbors

n_samples = int(1e6)
n_features = 1000
n_neighbors = 10
n_queries = 1
metric = 'euclidean'

rng = np.random.RandomState(42)
X = rng.randn(n_samples, n_features)
X_norms = row_norms(X, squared=True)

def fast_euclidean_neighbors(X_queries, n_neighbors):
    """Quick function extracting bits of pieces from the NearestNeighbors code"""
    norms_squared = np.dot(X_queries, X.T)
    norms_squared *= -2
    norms_squared += row_norms(X_queries, squared=True)[:, np.newaxis]
    norms_squared += X_norms
    indices = np.argpartition(norms_squared, n_neighbors - 1, axis=1)
    indices = indices[:, :n_neighbors]

    neighbors_range = np.arange(n_queries)[:, np.newaxis]
    norms_squared = norms_squared[neighbors_range, indices]
    arg_ind = np.argsort(norms_squared, axis=1)
    norms = np.sqrt(norms_squared[neighbors_range, arg_ind])
    indices = indices[neighbors_range, arg_ind]
    return norms, indices

X_queries = rng.randn(n_queries, n_features)

res_fast = fast_euclidean_neighbors(X_queries, n_neighbors)

nn = NearestNeighbors(algorithm='brute', metric=metric)
nn.fit(X)
res_kneighbors = nn.kneighbors(X_queries, n_neighbors=n_neighbors)

np.testing.assert_allclose(res_fast, res_kneighbors)

print('fast_euclidean_neighbors')
%timeit fast_euclidean_neighbors(X_queries, n_neighbors)
print('NearestNeighbors.kneighbors')
%timeit nn.kneighbors(X_queries, n_neighbors=n_neighbors)
```

scikit-learn master:
```
fast_euclidean_neighbors
430 ms ± 7.94 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
NearestNeighbors.kneighbors
1.44 s ± 19.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

This PR:
```
fast_euclidean_neighbors
424 ms ± 9.23 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
NearestNeighbors.kneighbors
421 ms ± 6.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

I'd like to do more extensive benchmarks, suggestions about which parameters to vary and parameters range more than welcome.