### PR TITLE
[MRG + 1] Fix cardinality vs. l0 norm in multilabel ranking documentation

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1365,29 +1365,33 @@ implements label ranking average precision (LRAP). This metric is linked to
 the :func:`average_precision_score` function, but is based on the notion of
 label ranking instead of precision and recall.
 
-Label ranking average precision (LRAP) is the average over each ground truth
-label assigned to each sample, of the ratio of true vs. total labels with lower
-score. This metric will yield better scores if you are able to give better rank
-to the labels associated with each sample. The obtained score is always strictly
-greater than 0, and the best value is 1. If there is exactly one relevant
-label per sample, label ranking average precision is equivalent to the `mean
+Label ranking average precision (LRAP) averages over the samples the answer to
+the following question: for each ground truth label, what fraction of
+higher-ranked labels were true labels? This performance measure will be higher
+if you are able to give better rank to the labels associated with each sample.
+The obtained score is always strictly greater than 0, and the best value is 1.
+If there is exactly one relevant label per sample, label ranking average
+precision is equivalent to the `mean
 reciprocal rank <https://en.wikipedia.org/wiki/Mean_reciprocal_rank>`_.
 
 Formally, given a binary indicator matrix of the ground truth labels
-:math:`y \in \mathcal{R}^{n_\text{samples} \times n_\text{labels}}` and the
-score associated with each label
-:math:`\hat{f} \in \mathcal{R}^{n_\text{samples} \times n_\text{labels}}`,
+:math:`y \in \left\{0, 1\right\}^{n_\text{samples} \times n_\text{labels}}`
+and the score associated with each label
+:math:`\hat{f} \in \mathbb{R}^{n_\text{samples} \times n_\text{labels}}`,
 the average precision is defined as
 
 .. math::
   LRAP(y, \hat{f}) = \frac{1}{n_{\text{samples}}}
-    \sum_{i=0}^{n_{\text{samples}} - 1} \frac{1}{|y_i|}
+    \sum_{i=0}^{n_{\text{samples}} - 1} \frac{1}{||y_i||_0}
     \sum_{j:y_{ij} = 1} \frac{|\mathcal{L}_{ij}|}{\text{rank}_{ij}}
 
 
-with :math:`\mathcal{L}_{ij} = \left\{k: y_{ik} = 1, \hat{f}_{ik} \geq \hat{f}_{ij} \right\}`,
-:math:`\text{rank}_{ij} = \left|\left\{k: \hat{f}_{ik} \geq \hat{f}_{ij} \right\}\right|`
-and :math:`|\cdot|` is the l0 norm or the cardinality of the set.
+where
+:math:`\mathcal{L}_{ij} = \left\{k: y_{ik} = 1, \hat{f}_{ik} \geq \hat{f}_{ij} \right\}`,
+:math:`\text{rank}_{ij} = \left|\left\{k: \hat{f}_{ik} \geq \hat{f}_{ij} \right\}\right|`,
+:math:`|\cdot|` computes the cardinality of the set (i.e., the number of
+elements in the set), and :math:`||\cdot||_0` is the :math:`\ell_0` "norm"
+(which computes the number of nonzero elements in a vector).
 
 Here is a small example of usage of this function::
 
@@ -1406,8 +1410,8 @@ Ranking loss
 The :func:`label_ranking_loss` function computes the ranking loss which
 averages over the samples the number of label pairs that are incorrectly
 ordered, i.e. true labels have a lower score than false labels, weighted by
-the inverse number of false and true labels. The lowest achievable
-ranking loss is zero.
+the inverse of the number of ordered pairs of false and true labels.
+The lowest achievable ranking loss is zero.
 
 Formally, given a binary indicator matrix of the ground truth labels
 :math:`y \in \left\{0, 1\right\}^{n_\text{samples} \times n_\text{labels}}` and the
@@ -1417,10 +1421,12 @@ the ranking loss is defined as
 
 .. math::
   \text{ranking\_loss}(y, \hat{f}) =  \frac{1}{n_{\text{samples}}}
-    \sum_{i=0}^{n_{\text{samples}} - 1} \frac{1}{|y_i|(n_\text{labels} - |y_i|)}
-    \left|\left\{(k, l): \hat{f}_{ik} < \hat{f}_{il}, y_{ik} = 1, y_{il} = 0 \right\}\right|
+    \sum_{i=0}^{n_{\text{samples}} - 1} \frac{1}{||y_i||_0(n_\text{labels} - ||y_i||_0)}
+    \left|\left\{(k, l): \hat{f}_{ik} \leq \hat{f}_{il}, y_{ik} = 1, y_{il} = 0 \right\}\right|
 
-where :math:`|\cdot|` is the :math:`\ell_0` norm or the cardinality of the set.
+where :math:`|\cdot|` computes the cardinality of the set (i.e., the number of
+elements in the set) and :math:`||\cdot||_0` is the :math:`\ell_0` "norm"
+(which computes the number of nonzero elements in a vector).
 
 Here is a small example of usage of this function::
 


### PR DESCRIPTION
This PR is the same as #9773. I created this duplicate of #9773 because I deleted my fork and therefore wasn't able to add another commit to the PR (see [this comment](https://github.com/scikit-learn/scikit-learn/pull/9773#issuecomment-347856763)). This PR has the same changes as in #9773, and in addition to those changes, here I implemented the changes that @jnothman requested 11 hours ago (namely, removing the duplicate definition of rank and keeping lines to <80 characters).

Descriptions of changes made to the documentation of LRAP and ranking loss can be found in the discussion of PR #9773. For convenience, I've copied below the relevant text from the discussion in #9773 (and added section headings).

## Changes made in this PR 

### cardinality vs. l0 "norm"
The mathematical definitions and the associated descriptions of label_ranking_average_precision_score and label_ranking_loss had errors resulting from a confusion of cardinality and the number of nonzero elements in a vector. This confusion likely resulted from copying the notation in the reference given in Section 3.3.3.3 ("Mining multi-label data" by Tsoumakas et al., 2010) because that paper has notation for $Y_i \subset L$, the subset of labels associated with the $i$th sample, whereas here $y_i$ is a vector (a row vector in the target $y \in {0, 1}^{n_\text{samples} \cross n_\text{labels}}$).

I corrected $|y_i|$ to be $||y_i||_0$ in sections 3.3.3.2 and 3.3.3.3, where $||\cdot||_0$ is the definition of the l0 "norm" often used in practice that "most mathematicians and engineers use" (the number of non-zero elements of a vector); that quote is from https://rorasa.wordpress.com/2012/05/13/l0-norm-l1-norm-l2-norm-l-infinity-norm/

I also updated the descriptions of these two inset equations accordingly so that $|\cdot|$ means cardinality (number of elements in a set), as it is used in a section I did not edit (3.3.3.1), and $||\cdot||_0$ is the l0 "norm" as defined above (the number of nonzero elements in a vector).

### notation for reals
I also made one other minor fix: in section 3.3.3.2 I changed the two instances of $\mathcal{R}$ to be $\mathbb{R}$ for the scores $\hat f$ and to ${0, 1}$ for the true binary labels. With this change, the notation used in section 3.3.3.2 now matches that used in the sections immediately before and after it.

### Ranking loss

I also improved the explanation of the denominator in the definition of ranking loss: "number of false and true labels" is hard to understand (and seems incorrect); it's the number of ordered pairs of true and false labels.

In the mathematical definition of ranking_loss (the inset equation in section 3.3.3.3), the less than sign should be less than or equal to. It takes some effort to see this in the code: true_at_reversed_rank.cumsum() (in this line) has as its first entry the first entry in true_at_reversed_rank, and dotting that with false_at_reversed_rank means we are counting all the pairs of true and false labels that got ranked in the "wrong" order or got ranked equally (the "or got ranked equally " means that we need less than or equal to in the mathematical definition of ranking_loss).

You can also verify that $<$ should be $\leq$ using this simple example in which a true and false label both got the exact same score:

```
>>> y_score = np.array([[1, 1]])
>>. label_ranking_loss(y_true, y_score)
1.0
```
In this example, n_samples is 1, ||y_0|| is 1, and n_labels - ||y_0|| is 1. The set in the right-hand side of the definition of ranking_loss in the User Guide (section 3.3.3.3) as it's currently written has zero elements because of the $<$ symbol. Changing $<$ to $\leq$ fixes that mathematical definition: with that change, the set has one element, namely $(0, 1)$, so the right-hand side of the equation has the value of 1.0, which agrees with the output of the code shown above.