### PR TITLE
[MRG+1] Hide train_test_split from nose test discovery.

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2058,6 +2058,7 @@ def train_test_split(*arrays, **options):
     return list(chain.from_iterable((safe_indexing(a, train),
                                      safe_indexing(a, test)) for a in arrays))
 
+train_test_split.__test__ = False
 
 def _build_repr(self):
     # XXX This is copied from BaseEstimator's get_params

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2058,6 +2058,8 @@ def train_test_split(*arrays, **options):
     return list(chain.from_iterable((safe_indexing(a, train),
                                      safe_indexing(a, test)) for a in arrays))
 
+
+# Tell nose that train_test_split is not a test
 train_test_split.__test__ = False
 
 def _build_repr(self):


### PR DESCRIPTION
This was removed when scikit-learn switched from nose to pytest.
However, other projects that still use nose may import this function
into their test suites. For example, scikit-learn-garden does this.