### PR TITLE
[MRG] Removing 'random_state = 0' while intializing OneClassSVM

### DIFF
--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -49,12 +49,14 @@ def check_svm_model_equal(dense_svm, sparse_svm, X_train, y_train, X_test):
     assert_true(sparse.issparse(sparse_svm.dual_coef_))
     assert_array_almost_equal(dense_svm.support_vectors_,
                               sparse_svm.support_vectors_.toarray())
-    assert_array_almost_equal(dense_svm.dual_coef_, sparse_svm.dual_coef_.toarray())
+    assert_array_almost_equal(dense_svm.dual_coef_,
+                              sparse_svm.dual_coef_.toarray())
     if dense_svm.kernel == "linear":
         assert_true(sparse.issparse(sparse_svm.coef_))
         assert_array_almost_equal(dense_svm.coef_, sparse_svm.coef_.toarray())
     assert_array_almost_equal(dense_svm.support_, sparse_svm.support_)
-    assert_array_almost_equal(dense_svm.predict(X_test_dense), sparse_svm.predict(X_test))
+    assert_array_almost_equal(dense_svm.predict(X_test_dense),
+                              sparse_svm.predict(X_test))
     assert_array_almost_equal(dense_svm.decision_function(X_test_dense),
                               sparse_svm.decision_function(X_test))
     assert_array_almost_equal(dense_svm.decision_function(X_test_dense),
@@ -122,7 +124,8 @@ def test_unsorted_indices():
 
 
 def test_svc_with_custom_kernel():
-    kfunc = lambda x, y: safe_sparse_dot(x, y.T)
+    def kfunc(x, y):
+        return safe_sparse_dot(x, y.T)
     clf_lin = svm.SVC(kernel='linear').fit(X_sp, Y)
     clf_mylin = svm.SVC(kernel=kfunc).fit(X_sp, Y)
     assert_array_equal(clf_lin.predict(X_sp), clf_mylin.predict(X_sp))
@@ -144,10 +147,10 @@ def test_svc_iris():
 
 
 def test_sparse_decision_function():
-    #Test decision_function
+    # Test decision_function
 
-    #Sanity check, test that decision_function implemented in python
-    #returns the same as the one in libsvm
+    # Sanity check, test that decision_function implemented in python
+    # returns the same as the one in libsvm
 
     # multi class:
     svc = svm.SVC(kernel='linear', C=0.1, decision_function_shape='ovo')
@@ -262,7 +265,7 @@ def test_sparse_liblinear_intercept_handling():
 
 
 def test_sparse_oneclasssvm():
-    """Check that sparse OneClassSVM gives the same result as dense OneClassSVM"""
+    # Check that sparse OneClassSVM gives the same result as dense OneClassSVM
     # many class dataset:
     X_blobs, _ = make_blobs(n_samples=100, centers=10, random_state=0)
     X_blobs = sparse.csr_matrix(X_blobs)

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -273,8 +273,8 @@ def test_sparse_oneclasssvm():
     kernels = ["linear", "poly", "rbf", "sigmoid"]
     for dataset in datasets:
         for kernel in kernels:
-            clf = svm.OneClassSVM(kernel=kernel, random_state=0)
-            sp_clf = svm.OneClassSVM(kernel=kernel, random_state=0)
+            clf = svm.OneClassSVM(kernel=kernel)
+            sp_clf = svm.OneClassSVM(kernel=kernel)
             check_svm_model_equal(clf, sp_clf, *dataset)
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Reference Issue: #10158


Hi.. Regarding issue #10158, one requirement is related to catching deprecation warnings of random_state in SVC tests.
I've found the following test where the relevant deprecation warnings are raising.
https://github.com/scikit-learn/scikit-learn/blob/57bcd075c39d8bd45c4b9b2c1378d2010f467cd1/sklearn/svm/tests/test_sparse.py#L264

In this PR, the above test is edited to remove 'random_state = 0' while initializing OneClassSVM. Also \examples and \doc are checked to have no use of random_state with OneClassSVM. 