### PR TITLE
Add sklearn-xarray package

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -23,6 +23,9 @@ enhance the functionality of scikit-learn's estimators.
 
 - `sklearn_pandas <https://github.com/paulgb/sklearn-pandas/>`_ bridge for
   scikit-learn pipelines and pandas data frame with dedicated transformers.
+  
+- `sklearn_xarray <https://github.com/phausamann/sklearn-xarray/>`_ provides
+  compatibility of scikit-learn estimators with xarray data structures.
 
 **Auto-ML**
 


### PR DESCRIPTION
Adds a new package to *related projects*:

sklearn-xarray provides a scikit-learn interface for xarray users, making it possible to apply estimators, pipelines and model selection tools directly to xarray types.

- [Package repository](https://github.com/phausamann/sklearn-xarray)
- [Package documentation](https://phausamann.github.io/sklearn-xarray/index.html)
