### PR TITLE
[MRG] Run make test-doc on scipy-dev-wheels build

### DIFF
--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -43,13 +43,7 @@ run_tests() {
     # Going back to git checkout folder needed to test documentation
     cd $OLDPWD
 
-    # Do not run doctests in scipy-dev-wheels build for now
-    # (broken by numpy 1.14.dev array repr/str formatting
-    # change even with np.set_printoptions(sign='legacy')).
-    # See https://github.com/numpy/numpy/issues/9804 for more details
-    if [[ "$DISTRIB" != "scipy-dev-wheels" ]]; then
-        make test-doc
-    fi
+    make test-doc
 }
 
 if [[ "$RUN_FLAKE8" == "true" ]]; then


### PR DESCRIPTION
Since https://github.com/numpy/numpy/issues/10059 has been fixed in numpy master, we can run the doctests on our doc with numpy dev failures.

This fixes #8959.

Here is a log of a scipy-dev-wheels cron job on my PR branch:
https://travis-ci.org/lesteve/scikit-learn/builds/311283367#L2460

This does show that doctests of the doc are run.

Note that the CI do not test anything and this PR will only be tested once merged and the Travis cron job runs.

