### PR TITLE
Deprecate lar positive

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -242,6 +242,10 @@ Linear, kernelized and related models
   underlying implementation is not random.
   :issue:`9497` by :user:`Albert Thomas <albertcthomas>`.
 
+- Deprecate ``positive=True`` option in :class:`linear_model.Lars` as the
+  underlying implementation is broken. Use :class:`linear_model.Lasso` instead.
+  :issue:`9837` by `Alexandre Gramfort`_.
+
 Metrics
 
 - Deprecate ``reorder`` parameter in :func:`metrics.auc` as it's no longer required

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -98,11 +98,10 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
 
     positive : boolean (default=False)
         Restrict coefficients to be >= 0.
-        When using this option together with method 'lasso' the model
+        This option is only allowed with method 'lasso'. Note that the model
         coefficients will not converge to the ordinary-least-squares solution
-        for small values of alpha (neither will they when using method 'lar'
-        ..). Only coefficients up to the smallest alpha value
-        (``alphas_[alphas_ > 0.].min()`` when fit_path=True) reached by the
+        for small values of alpha. Only coefficients up to the smallest alpha
+        value (``alphas_[alphas_ > 0.].min()`` when fit_path=True) reached by the
         stepwise Lars-Lasso algorithm are typically in congruence with the
         solution of the coordinate descent lasso_path function.
 

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -145,6 +145,10 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
            <https://en.wikipedia.org/wiki/Lasso_(statistics)>`_
 
     """
+    if method == 'lar' and positive:
+        warnings.warn('positive option is broken for Least '
+                      ' Angle Regression (LAR). Use method="lasso".'
+                      ' This option will be removed in version 0.21.')
 
     n_features = X.shape[1]
     n_samples = y.size

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -147,7 +147,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
     if method == 'lar' and positive:
         warnings.warn('positive option is broken for Least'
                       ' Angle Regression (LAR). Use method="lasso".'
-                      ' This option will be removed in version 0.21.',
+                      ' This option will be removed in version 0.22.',
                       DeprecationWarning)
 
     n_features = X.shape[1]
@@ -549,7 +549,9 @@ class Lars(LinearModel, RegressorMixin):
         Restrict coefficients to be >= 0. Be aware that you might want to
         remove fit_intercept which is set True by default.
 
-        The option is broken and deprecated. It will be removed in v0.21.
+        .. deprecated:: 0.20
+        
+            The option is broken and deprecated. It will be removed in v0.22.
 
     Attributes
     ----------
@@ -1039,7 +1041,8 @@ class LarsCV(Lars):
         Restrict coefficients to be >= 0. Be aware that you might want to
         remove fit_intercept which is set True by default.
 
-        The option is broken and deprecated. It will be removed in v0.21.
+        .. deprecated:: 0.20
+            The option is broken and deprecated. It will be removed in v0.22.
 
     Attributes
     ----------

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -101,8 +101,8 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
         This option is only allowed with method 'lasso'. Note that the model
         coefficients will not converge to the ordinary-least-squares solution
         for small values of alpha. Only coefficients up to the smallest alpha
-        value (``alphas_[alphas_ > 0.].min()`` when fit_path=True) reached by the
-        stepwise Lars-Lasso algorithm are typically in congruence with the
+        value (``alphas_[alphas_ > 0.].min()`` when fit_path=True) reached by
+        the stepwise Lars-Lasso algorithm are typically in congruence with the
         solution of the coordinate descent lasso_path function.
 
     Returns
@@ -145,7 +145,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
 
     """
     if method == 'lar' and positive:
-        warnings.warn('positive option is broken for Least '
+        warnings.warn('positive option is broken for Least'
                       ' Angle Regression (LAR). Use method="lasso".'
                       ' This option will be removed in version 0.21.',
                       DeprecationWarning)
@@ -549,7 +549,7 @@ class Lars(LinearModel, RegressorMixin):
         Restrict coefficients to be >= 0. Be aware that you might want to
         remove fit_intercept which is set True by default.
 
-        The option is deprecated and will be removed in v0.21.
+        The option is broken and deprecated. It will be removed in v0.21.
 
     Attributes
     ----------
@@ -1039,7 +1039,7 @@ class LarsCV(Lars):
         Restrict coefficients to be >= 0. Be aware that you might want to
         remove fit_intercept which is set True by default.
 
-        The option is deprecated and will be removed in v0.21.
+        The option is broken and deprecated. It will be removed in v0.21.
 
     Attributes
     ----------

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -148,7 +148,8 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
     if method == 'lar' and positive:
         warnings.warn('positive option is broken for Least '
                       ' Angle Regression (LAR). Use method="lasso".'
-                      ' This option will be removed in version 0.21.')
+                      ' This option will be removed in version 0.21.',
+                      DeprecationWarning)
 
     n_features = X.shape[1]
     n_samples = y.size
@@ -548,6 +549,8 @@ class Lars(LinearModel, RegressorMixin):
     positive : boolean (default=False)
         Restrict coefficients to be >= 0. Be aware that you might want to
         remove fit_intercept which is set True by default.
+
+        The option is deprecated and will be removed in v0.21.
 
     Attributes
     ----------
@@ -1037,6 +1040,7 @@ class LarsCV(Lars):
         Restrict coefficients to be >= 0. Be aware that you might want to
         remove fit_intercept which is set True by default.
 
+        The option is deprecated and will be removed in v0.21.
 
     Attributes
     ----------

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -478,27 +478,37 @@ def test_lars_path_positive_constraint():
     # ensure that we get negative coefficients when positive=False
     # and all positive when positive=True
     # for method 'lar' (default) and lasso
-    for method in ['lar', 'lasso']:
-        alpha, active, coefs = \
-            linear_model.lars_path(diabetes['data'], diabetes['target'],
-                                   return_path=True, method=method,
-                                   positive=False)
-        assert_true(coefs.min() < 0)
 
-        alpha, active, coefs = \
-            linear_model.lars_path(diabetes['data'], diabetes['target'],
-                                   return_path=True, method=method,
-                                   positive=True)
-        assert_true(coefs.min() >= 0)
+    # Once deprecation of LAR + positive option is done use these:
+    # assert_raises(ValueError, linear_model.lars_path, diabetes['data'],
+    #               diabetes['target'], method='lar', positive=True)
+
+    with warnings.catch_warnings(record=True) as w:
+        linear_model.lars_path(diabetes['data'], diabetes['target'],
+                               return_path=True, method='lar',
+                               positive=True)
+    assert_true(len(w) == 1)
+    assert "broken" in str(w[0].message)
+
+    method = 'lasso'
+    alpha, active, coefs = \
+        linear_model.lars_path(diabetes['data'], diabetes['target'],
+                               return_path=True, method=method,
+                               positive=False)
+    assert_true(coefs.min() < 0)
+
+    alpha, active, coefs = \
+        linear_model.lars_path(diabetes['data'], diabetes['target'],
+                               return_path=True, method=method,
+                               positive=True)
+    assert_true(coefs.min() >= 0)
 
 
 # now we gonna test the positive option for all estimator classes
 
 default_parameter = {'fit_intercept': False}
 
-estimator_parameter_map = {'Lars': {'n_nonzero_coefs': 5},
-                           'LassoLars': {'alpha': 0.1},
-                           'LarsCV': {},
+estimator_parameter_map = {'LassoLars': {'alpha': 0.1},
                            'LassoLarsCV': {},
                            'LassoLarsIC': {}}
 


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #9837 

#### What does this implement/fix? Explain your changes.

Deprecate option posistive=True for Lars model.

#### Any other comments?

it was reported as broken and I could not find an easy bug fix.
I propose to deprecate and suggest to use Lasso model for which it works.