### PR TITLE
[WIP] FIX? Add eps to obviate imprecision issues in balanced class_weight

### DIFF
--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -51,9 +51,15 @@ def compute_class_weight(class_weight, classes, y):
         if not all(np.in1d(classes, le.classes_)):
             raise ValueError("classes should have valid labels that are in y")
 
-        recip_freq = len(y) / (len(le.classes_) *
-                               np.bincount(y_ind).astype(np.float64))
+        freq = np.bincount(y_ind).astype(np.float64)
+        recip_freq = len(y) / (len(le.classes_) * freq)
         weight = recip_freq[le.transform(classes)]
+        if np.any(np.diff(freq)):
+            # Numerical imprecision issues.
+            # Just in case, we will add a little eps in order to prefer
+            # true class distribution.
+            order = np.argsort(freq)
+            weight[order] += np.arange(len(freq)) * 1e-8
     else:
         # user-defined dictionary
         weight = np.ones(classes.shape[0], dtype=np.float64, order='C')

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -54,7 +54,7 @@ def compute_class_weight(class_weight, classes, y):
         freq = np.bincount(y_ind).astype(np.float64)
         recip_freq = len(y) / (len(le.classes_) * freq)
         weight = recip_freq[le.transform(classes)]
-        if np.any(np.diff(freq)):
+        if np.any(np.diff(freq * weight)):
             # Numerical imprecision issues.
             # Just in case, we will add a little eps in order to prefer
             # true class distribution.


### PR DESCRIPTION
This is a potential fix for the issue raised in #10233, wherein surprisingly good results were achieved under cross-validation due to numerical imprecision in `compute_class_weight(..., 'balanced')`. This situation is rare, but reportedly occurred in a grid search on a real-world dataset.

The fix works by making sure that when class weights can't be exactly balanced for a particular training set due to numerical imprecision, the original ranking of class distributions is marginally preferred.

What do others think of this? Is the problem substantial enough to break backwards compatibility of results in a small way? Are there alternative fixes?