### PR TITLE
[MRG+1] DOC Add to the FAQs instructions about setting the number of threads when MKL is used

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -282,11 +282,17 @@ documentation <https://docs.python.org/3/library/multiprocessing.html#contexts-a
 
 Why does my job use more cores than specified with n_jobs under OSX or Linux?
 -----------------------------------------------------------------------------
-This can happen when the parallelized computation is handled outside of Python by another library,
-such as MKL or OpenBLAS. In that case, the value of ``n_jobs`` is ignored by the library,
-and the number of threads must be specified via an environment variable.
-For example, to set the maximum number of threads to some integer value ``N``,
-the following environment variables must be set:
+
+This happens when vectorized numpy operations are handled outside of Python
+by libraries such as MKL or OpenBLAS.
+
+While scikit-learn adheres to the limit set by ``n_jobs``,
+numpy operations vectorized using MKL (or OpenBLAS) will make use of multiple
+threads within each scikit-learn job (thread or process).
+
+The number of threads used by the BLAS library can be set via an environment
+variable. For example, to set the maximum number of threads to some integer
+value ``N``, the following environment variables should be set:
 
 * For MKL: ``export MKL_NUM_THREADS=N``
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -283,8 +283,8 @@ documentation <https://docs.python.org/3/library/multiprocessing.html#contexts-a
 Why does my job use more cores than specified with n_jobs under OSX or Linux?
 -----------------------------------------------------------------------------
 
-This happens when vectorized numpy operations are handled outside of Python
-by libraries such as MKL or OpenBLAS.
+This happens when vectorized numpy operations are handled by libraries such
+as MKL or OpenBLAS.
 
 While scikit-learn adheres to the limit set by ``n_jobs``,
 numpy operations vectorized using MKL (or OpenBLAS) will make use of multiple

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -59,7 +59,7 @@ For bug reports or feature requests, please make use of the
 
 There is also a `scikit-learn Gitter channel
 <https://gitter.im/scikit-learn/scikit-learn>`_ where some users and developers
-might be found. 
+might be found.
 
 **Please do not email any authors directly to ask for assistance, report bugs,
 or for any other issue related to scikit-learn.**
@@ -80,10 +80,10 @@ How can I load my own datasets into a format usable by scikit-learn?
 --------------------------------------------------------------------
 
 Generally, scikit-learn works on any numeric data stored as numpy arrays
-or scipy sparse matrices. Other types that are convertible to numeric 
+or scipy sparse matrices. Other types that are convertible to numeric
 arrays such as pandas DataFrame are also acceptable.
 
-For more information on loading your data files into these usable data 
+For more information on loading your data files into these usable data
 structures, please refer to :ref:`loading external datasets <external_datasets>`.
 
 .. _new_algorithms_inclusion_criteria:
@@ -105,7 +105,7 @@ numpy array or sparse matrix, are accepted.
 The contributor should support the importance of the proposed addition with
 research papers and/or implementations in other similar packages, demonstrate
 its usefulness via common use-cases/applications and corroborate performance
-improvements, if any, with benchmarks and/or plots. It is expected that the 
+improvements, if any, with benchmarks and/or plots. It is expected that the
 proposed algorithm should outperform the methods that are already implemented
 in scikit-learn at least in some areas.
 
@@ -128,8 +128,8 @@ The package relies on core developers using their free time to
 fix bugs, maintain code and review contributions.
 Any algorithm that is added needs future attention by the developers,
 at which point the original author might long have lost interest.
-See also :ref:`new_algorithms_inclusion_criteria`. For a great read about 
-long-term maintenance issues in open-source software, look at 
+See also :ref:`new_algorithms_inclusion_criteria`. For a great read about
+long-term maintenance issues in open-source software, look at
 `the Executive Summary of Roads and Bridges
 <https://www.fordfoundation.org/media/2976/roads-and-bridges-the-unseen-labor-behind-our-digital-infrastructure.pdf#page=8>`_
 
@@ -279,6 +279,19 @@ program: Insert the following instructions in your main script::
 
 You can find more default on the new start methods in the `multiprocessing
 documentation <https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_.
+
+Why does my job use more cores than specified with n_jobs under OSX or Linux?
+-----------------------------------------------------------------------------
+This can happen when the parallelized computation is handled outside of Python by another library,
+such as MKL or OpenBLAS. In that case, the value of ``n_jobs`` is ignored by the library,
+and the number of threads must be specified via an environment variable.
+For example, to set the maximum number of threads to some integer value ``N``,
+the following environment variables must be set:
+
+* For MKL: ``export MKL_NUM_THREADS=N``
+
+* For OpenBLAS: ``export OPENBLAS_NUM_THREADS=N``
+
 
 Why is there no support for deep or reinforcement learning / Will there be support for deep or reinforcement learning in scikit-learn?
 --------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Add instructions on how to set number of threads via an environment variable for MKL and OpenBLAS.


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fix #10259
(Thanks Andreas)

#### What does this implement/fix? Explain your changes.
Add a note to the FAQs explaining that jobs can run on more threads than specified in n_jobs
if the parallel computation is handled outside of Python (by MKL or OpenBLAS).

Provide example of how to set the number of threads via environment variables.

#### Any other comments?
Tested for MKL but not OpenBLAS (not installed).

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
