### PR TITLE
[WIP] Updates to README.rst about installation from source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,20 +55,6 @@ to create a pull request from your fork. This will send an email to the committe
 (If any of the above seems like magic to you, please look up the
 [Git documentation](https://git-scm.com/documentation) on the web, or ask a friend or another contributor for help.)
 
-Installing from Source
-----------------------
-
-Before installing scikit-learn from source (development version), make sure these following
-packages are installed first:
-
--  [Python](https://www.python.org/downloads) (>= 2.7 or >= 3.4)
--  [Numpy](https://pypi.python.org/pypi/numpy) (>= 1.8.2)
--  [Scipy](https://pypi.python.org/pypi/scipy) (>= 0.13.3)
--  [Cython](https://pypi.python.org/pypi/Cython) Latest version. (As of this writing 0.27.3)
-
-Once ready with these packages, follow [these guidelines](http://scikit-learn.org/stable/developers/contributing.html#retrieving-the-latest-code)
-to install the development version.
-
 Pull Request Checklist
 ----------------------
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,15 @@ to create a pull request from your fork. This will send an email to the committe
 (If any of the above seems like magic to you, please look up the
 [Git documentation](https://git-scm.com/documentation) on the web, or ask a friend or another contributor for help.)
 
+Installing from Source
+----------------------
+
+For installing scikit-learn from source (also refered as development version), following
+packages are required:
+
+
+
+
 Pull Request Checklist
 ----------------------
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,11 +58,19 @@ to create a pull request from your fork. This will send an email to the committe
 Installing from Source
 ----------------------
 
-For installing scikit-learn from source (also refered as development version), following
-packages are required:
+Before installing scikit-learn from source (development version), make sure these following
+packages are installed first:
 
+-  [Python](https://www.python.org/downloads) (>= 2.7 or >= 3.4)
 
+-  [Numpy](https://pypi.python.org/pypi/numpy) (>= 1.8.2)
 
+-  [Scipy](https://pypi.python.org/pypi/scipy) (>= 0.13.3)
+
+-  [Cython](https://pypi.python.org/pypi/Cython) Latest version. (As of this writing 0.27.3)
+
+Follow [these guidelines](http://scikit-learn.org/stable/developers/contributing.html#retrieving-the-latest-code)
+to install the development version.
 
 Pull Request Checklist
 ----------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,14 +62,11 @@ Before installing scikit-learn from source (development version), make sure thes
 packages are installed first:
 
 -  [Python](https://www.python.org/downloads) (>= 2.7 or >= 3.4)
-
 -  [Numpy](https://pypi.python.org/pypi/numpy) (>= 1.8.2)
-
 -  [Scipy](https://pypi.python.org/pypi/scipy) (>= 0.13.3)
-
 -  [Cython](https://pypi.python.org/pypi/Cython) Latest version. (As of this writing 0.27.3)
 
-Follow [these guidelines](http://scikit-learn.org/stable/developers/contributing.html#retrieving-the-latest-code)
+Once ready with these packages, follow [these guidelines](http://scikit-learn.org/stable/developers/contributing.html#retrieving-the-latest-code)
 to install the development version.
 
 Pull Request Checklist

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,19 @@ or ``conda``::
 
 The documentation includes more detailed `installation instructions <http://scikit-learn.org/stable/install.html>`_.
 
+Source installation
+~~~~~~~~~~~~~~~~~~~
+
+Before installing scikit-learn from source (development version), you need these following packages installed:
+
+-  `Python <https://www.python.org/downloads>`_ (>= 2.7 or >= 3.4)
+-  `Numpy <https://pypi.python.org/pypi/numpy>`_ (>= 1.8.2)
+-  `Scipy <https://pypi.python.org/pypi/scipy>`_ (>= 0.13.3)
+-  `Cython <https://pypi.python.org/pypi/Cython>`_ Latest version. (As of this writing 0.27.3)
+
+For source installation commands, follow `these guidelines <http://scikit-learn.org/stable/developers/contributing.html#retrieving-the-latest-code>`_
+to install the development version.
+
 
 Development
 -----------

--- a/README.rst
+++ b/README.rst
@@ -79,16 +79,12 @@ The documentation includes more detailed `installation instructions <http://scik
 Source installation
 ~~~~~~~~~~~~~~~~~~~
 
-Before installing scikit-learn from source (development version), you need these following packages installed:
+Before installing scikit-learn from source (development version), make sure the above dependencies are installed,
+along with the latest version of `Cython <https://pypi.python.org/pypi/Cython>`_.
 
--  `Python <https://www.python.org/downloads>`_ (>= 2.7 or >= 3.4)
--  `Numpy <https://pypi.python.org/pypi/numpy>`_ (>= 1.8.2)
--  `Scipy <https://pypi.python.org/pypi/scipy>`_ (>= 0.13.3)
--  `Cython <https://pypi.python.org/pypi/Cython>`_ Latest version. (As of this writing 0.27.3)
+It is recommended that you have latest versions of all the dependencies if you are installing from source.
 
-For source installation commands, follow `these guidelines <http://scikit-learn.org/stable/developers/contributing.html#retrieving-the-latest-code>`_
-to install the development version.
-
+For details about installation commands, follow `these guidelines <http://scikit-learn.org/stable/developers/contributing.html#retrieving-the-latest-code>`_.
 
 Development
 -----------


### PR DESCRIPTION
**Reference Issues/PRs**

No issue filed for this.

**What does this implement/fix?**

This pull request will update the README.rst file about instructions for installing from source, since there is non at this point in the Installation section.

**Any other comments?**

Installing scikit-learn from source gives error, if Cython is not the latest. Documentation should recommended that Cython and all the other dependencies should be latest, if someone is installing from source.