### PR TITLE
[MRG+1] make SGDClassifier deprecation warnings nice again

### DIFF
--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -127,7 +127,8 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
                     "they default to max_iter=5 and tol=None. "
                     "If tol is not None, max_iter defaults to max_iter=1000. "
                     "From 0.21, default max_iter will be 1000, and"
-                    " default tol will be 1e-3." % type(self), FutureWarning)
+                    " default tol will be 1e-3." % type(self).__name__,
+                    FutureWarning)
                 # Before 0.19, default was n_iter=5
             max_iter = 5
         else:


### PR DESCRIPTION
Redoing #10050 which was reverted in #10053 (accidentally, I think).