### PR TITLE
[MRG] MAINT remove unicode character from URL for doc linkcheck friendliness

### DIFF
--- a/doc/tutorial/text_analytics/working_with_text_data.rst
+++ b/doc/tutorial/text_analytics/working_with_text_data.rst
@@ -251,7 +251,7 @@ corpus.
 This downscaling is called `tf–idf`_ for "Term Frequency times
 Inverse Document Frequency".
 
-.. _`tf–idf`: https://en.wikipedia.org/wiki/Tf–idf
+.. _`tf–idf`: https://en.wikipedia.org/wiki/Tf-idf
 
 
 Both **tf** and **tf–idf** can be computed as follows::


### PR DESCRIPTION
With python 3.6 and sphinx 1.6.3, when running `cd doc && make linkcheck` I get an error like this and then sphinx-build hangs:
```
Exception in thread Thread-5:
Traceback (most recent call last):
  File "/home/local/lesteve/miniconda3/lib/python3.6/site-packages/sphinx/builders/linkcheck.py", line 140, in check_uri
    req_url.encode('ascii')
UnicodeEncodeError: 'ascii' codec can't encode character '\u2013' in position 32: ordinal not in range(128)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/local/lesteve/miniconda3/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/home/local/lesteve/miniconda3/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/home/local/lesteve/miniconda3/lib/python3.6/site-packages/sphinx/builders/linkcheck.py", line 225, in check_thread
    status, info, code = check()
  File "/home/local/lesteve/miniconda3/lib/python3.6/site-packages/sphinx/builders/linkcheck.py", line 208, in check
    status, info, code = check_uri()
  File "/home/local/lesteve/miniconda3/lib/python3.6/site-packages/sphinx/builders/linkcheck.py", line 142, in check_uri
    req_url = encode_uri(req_url)
  File "/home/local/lesteve/miniconda3/lib/python3.6/site-packages/sphinx/util/__init__.py", line 560, in encode_uri
    split[2] = quote_plus(split[2].encode('utf-8'), '/').decode('ascii')
AttributeError: 'str' object has no attribute 'decode'
```

For the record, with this fix, `make linkcheck` in `doc` finishes in approx 14 minutes.