### PR TITLE
[MRG+1] ENH Add standardize flag to PowerTransformer

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -325,7 +325,7 @@ parameterized by :math:`\lambda`, which is determined through maximum likelihood
 estimation. Here is an example of using Box-Cox to map samples drawn from a
 lognormal distribution to a normal distribution::
 
-  >>> pt = preprocessing.PowerTransformer(method='box-cox')
+  >>> pt = preprocessing.PowerTransformer(method='box-cox', standardize=False)
   >>> X_lognormal = np.random.RandomState(616).lognormal(size=(3, 3))
   >>> X_lognormal                                         # doctest: +ELLIPSIS
   array([[ 1.28...,  1.18...,  0.84...],
@@ -335,6 +335,10 @@ lognormal distribution to a normal distribution::
   array([[ 0.49...,  0.17..., -0.15...],
          [-0.05...,  0.58..., -0.57...],
          [ 0.69..., -0.84...,  0.10...]])
+
+While the above example sets the `standardize` option to `False`, by default,
+:class:`PowerTransformer` will apply zero-mean, unit-variance normalization
+to the transformed output.
 
 Below are examples of Box-Cox applied to various probability distributions.
 Note that when applied to certain distributions, Box-Cox achieves very

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -336,9 +336,9 @@ lognormal distribution to a normal distribution::
          [-0.05...,  0.58..., -0.57...],
          [ 0.69..., -0.84...,  0.10...]])
 
-While the above example sets the `standardize` option to `False`, by default,
+While the above example sets the `standardize` option to `False`,
 :class:`PowerTransformer` will apply zero-mean, unit-variance normalization
-to the transformed output.
+to the transformed output by default.
 
 Below are examples of Box-Cox applied to various probability distributions.
 Note that when applied to certain distributions, Box-Cox achieves very

--- a/examples/preprocessing/plot_all_scaling.py
+++ b/examples/preprocessing/plot_all_scaling.py
@@ -297,15 +297,14 @@ make_plot(4)
 #
 # ``PowerTransformer`` applies a power transformation to each
 # feature to make the data more Gaussian-like. Currently,
-# ``PowerTransformer`` implements the Box-Cox transform. It differs from
-# QuantileTransformer (Gaussian output) in that it does not map the
-# data to a zero-mean, unit-variance Gaussian distribution. Instead, Box-Cox
+# ``PowerTransformer`` implements the Box-Cox transform. The Box-Cox transform
 # finds the optimal scaling factor to stabilize variance and mimimize skewness
-# through maximum likelihood estimation. Note that Box-Cox can only be applied
-# to positive, non-zero data. Income and number of households happen to be
-# strictly positive, but if negative values are present, a constant can be
-# added to each feature to shift it into the positive range - this is known as
-# the two-parameter Box-Cox transform.
+# through maximum likelihood estimation. By default, ``PowerTransformer`` also
+# applies zero-mean, unit variance normalization to the transformed output.
+# Note that Box-Cox can only be applied to positive, non-zero data. Income and
+# number of households happen to be strictly positive, but if negative values
+# are present, a constant can be added to each feature to shift it into the
+# positive range - this is known as the two-parameter Box-Cox transform.
 
 make_plot(5)
 

--- a/examples/preprocessing/plot_power_transformer.py
+++ b/examples/preprocessing/plot_power_transformer.py
@@ -15,7 +15,9 @@ Weibull, Gaussian, Uniform, and Bimodal.
 Note that the transformation successfully maps the data to a normal
 distribution when applied to certain datasets, but is ineffective with others.
 This highlights the importance of visualizing the data before and after
-transformation.
+transformation. Also note that while the standardize option is set to False for
+the plot examples, by default, :class:`preprocessing.PowerTransformer` also
+applies zero-mean, unit-variance standardization to the transformed outputs.
 """
 
 # Author: Eric Chang <ericchang2017@u.northwestern.edu>
@@ -34,7 +36,7 @@ FONT_SIZE = 6
 BINS = 100
 
 
-pt = PowerTransformer(method='box-cox')
+pt = PowerTransformer(method='box-cox', standardize=False)
 rng = np.random.RandomState(304)
 size = (N_SAMPLES, 1)
 
@@ -54,7 +56,7 @@ X_weibull = rng.weibull(a=a, size=size)
 loc = 100
 X_gaussian = rng.normal(loc=loc, size=size)
 
-# uniform distirbution
+# uniform distribution
 X_uniform = rng.uniform(low=0, high=1, size=size)
 
 # bimodal distribution

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2599,8 +2599,8 @@ class PowerTransformer(BaseEstimator, TransformerMixin):
     for stabilizing variance and minimizing skewness is estimated through
     maximum likelihood.
 
-    By default, the transformed data is normalized to zero-mean,
-    unit-variance.
+    By default, zero-mean, unit-variance normalization is applied to the
+    transformed data.
 
     Read more in the :ref:`User Guide <preprocessing_transformer>`.
 
@@ -2610,8 +2610,9 @@ class PowerTransformer(BaseEstimator, TransformerMixin):
         The power transform method. Currently, 'box-cox' (Box-Cox transform)
         is the only option available.
 
-    standardize : boolean, default=true
-        If True, standardize output to zero-mean, unit-variance.
+    standardize : boolean, default=True
+        Set to True to apply zero-mean, unit-variance normalization to the
+        transformed output.
 
     copy : boolean, optional, default=True
         Set to False to perform inplace computation during transformation.
@@ -2798,8 +2799,8 @@ def power_transform(X, method='box-cox', standardize=True, copy=True):
     for stabilizing variance and minimizing skewness is estimated
     through maximum likelihood.
 
-    By default, the transformed data is normalized to zero-mean,
-    unit-variance.
+    By default, zero-mean, unit-variance normalization is applied to the
+    transformed data.
 
     Read more in the :ref:`User Guide <preprocessing_transformer>`.
 
@@ -2808,12 +2809,13 @@ def power_transform(X, method='box-cox', standardize=True, copy=True):
     X : array-like, shape (n_samples, n_features)
         The data to be transformed using a power transformation.
 
-    standardize : boolean, default=true
-        If True, standardize output to zero-mean, unit-variance.
-
     method : str, (default='box-cox')
         The power transform method. Currently, 'box-cox' (Box-Cox transform)
         is the only option available.
+
+    standardize : boolean, default=True
+        Set to True to apply zero-mean, unit-variance normalization to the
+        transformed output.
 
     copy : boolean, optional, default=True
         Set to False to perform inplace computation.

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2682,10 +2682,19 @@ class PowerTransformer(BaseEstimator, TransformerMixin):
         X = self._check_input(X, check_positive=True, check_method=True)
 
         self.lambdas_ = []
+        transformed = []
+
         for col in X.T:
-            _, lmbda = stats.boxcox(col, lmbda=None)
+            col_trans, lmbda = stats.boxcox(col, lmbda=None)
             self.lambdas_.append(lmbda)
+            transformed.append(col_trans)
+
         self.lambdas_ = np.array(self.lambdas_)
+        transformed = np.array(transformed)
+
+        if self.standardize:
+            self._scaler = StandardScaler()
+            self._scaler.fit(X=transformed.T)
 
         return self
 
@@ -2704,8 +2713,7 @@ class PowerTransformer(BaseEstimator, TransformerMixin):
             X[:, i] = stats.boxcox(X[:, i], lmbda=lmbda)
 
         if self.standardize:
-            self._scaler = StandardScaler()
-            X = self._scaler.fit_transform(X)
+            X = self._scaler.transform(X)
 
         return X
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2628,13 +2628,13 @@ class PowerTransformer(BaseEstimator, TransformerMixin):
     >>> pt = PowerTransformer()
     >>> data = [[1, 2], [3, 2], [4, 5]]
     >>> print(pt.fit(data))
-    PowerTransformer(copy=True, method='box-cox')
+    PowerTransformer(copy=True, method='box-cox', standardize=True)
     >>> print(pt.lambdas_)  # doctest: +ELLIPSIS
     [ 1.051... -2.345...]
     >>> print(pt.transform(data))  # doctest: +ELLIPSIS
-    [[ 0...      0.342...]
-     [ 2.068...  0.342...]
-     [ 3.135...  0.416...]]
+    [[-1.332... -0.707...]
+     [ 0.256... -0.707...]
+     [ 1.076...  1.414...]]
 
     See also
     --------
@@ -2815,10 +2815,10 @@ def power_transform(X, method='box-cox', standardize=True, copy=True):
     >>> import numpy as np
     >>> from sklearn.preprocessing import power_transform
     >>> data = [[1, 2], [3, 2], [4, 5]]
-    >>> print(power_transform(data, method='box-cox'))  # doctest: +ELLIPSIS
-    [[ 0...      0.342...]
-     [ 2.068...  0.342...]
-     [ 3.135...  0.416...]]
+    >>> print(power_transform(data))  # doctest: +ELLIPSIS
+    [[-1.332... -0.707...]
+     [ 0.256... -0.707...]
+     [ 1.076...  1.414...]]
 
     See also
     --------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #10311 

#### What does this implement/fix? Explain your changes.

This PR adds a `standardize` option to `sklearn.preprocessing.PowerTransformer`. When `standardize=True`, the transformed outputs are normalized to zero mean and unit variance using `StandardScaler`.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
