### PR TITLE
Improve readability of LOF example

### DIFF
--- a/examples/neighbors/plot_lof.py
+++ b/examples/neighbors/plot_lof.py
@@ -26,10 +26,12 @@ from sklearn.neighbors import LocalOutlierFactor
 np.random.seed(42)
 
 # Generate train data
-X = 0.3 * np.random.randn(100, 2)
+X_inliers = 0.3 * np.random.randn(100, 2)
+X_inliers = np.r_[X_inliers + 2, X_inliers - 2]
+
 # Generate some abnormal novel observations
 X_outliers = np.random.uniform(low=-4, high=4, size=(20, 2))
-X = np.r_[X + 2, X - 2, X_outliers]
+X = np.r_[X_inliers, X_outliers]
 
 # fit the model
 clf = LocalOutlierFactor(n_neighbors=20)
@@ -43,9 +45,9 @@ Z = Z.reshape(xx.shape)
 plt.title("Local Outlier Factor (LOF)")
 plt.contourf(xx, yy, Z, cmap=plt.cm.Blues_r)
 
-a = plt.scatter(X[:200, 0], X[:200, 1], c='white',
+a = plt.scatter(X_inliers[:, 0], X_inliers[:, 1], c='white',
                 edgecolor='k', s=20)
-b = plt.scatter(X[200:, 0], X[200:, 1], c='red',
+b = plt.scatter(X_outliers[:, 0], X_outliers[:, 1], c='red',
                 edgecolor='k', s=20)
 plt.axis('tight')
 plt.xlim((-5, 5))

--- a/examples/neighbors/plot_lof.py
+++ b/examples/neighbors/plot_lof.py
@@ -34,7 +34,6 @@ X = np.r_[X + 2, X - 2, X_outliers]
 # fit the model
 clf = LocalOutlierFactor(n_neighbors=20)
 y_pred = clf.fit_predict(X)
-y_pred_outliers = y_pred[200:]
 
 # plot the level sets of the decision function
 xx, yy = np.meshgrid(np.linspace(-5, 5, 50), np.linspace(-5, 5, 50))


### PR DESCRIPTION
Greetings, 

This is a minor fix in the Local Outlier Factor (LOF) example.

First I removed an unused `y_pred_outliers` variable.
Then I introduced a new variable `X_inliers` to improve readability.

Thanks for reviewing this!
Let me know if I can help further more.