### PR TITLE
[WIP] : Added assert_consistent_docs() and related tests

### DIFF
--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1631,6 +1631,7 @@ def test_brier_score_loss():
     assert_almost_equal(brier_score_loss([1], [0.5]), 0.25)
 
 
+@if_numpydoc
 def test_docstring():
     # Test for consistency among docstring of different metrics
     assert_consistent_docs([precision_recall_fscore_support, precision_score,

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -23,7 +23,7 @@ from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_not_equal
-from sklearn.utils.testing import ignore_warnings
+from sklearn.utils.testing import if_numpydoc, ignore_warnings
 from sklearn.utils.testing import assert_consistent_docs
 from sklearn.utils.mocking import MockDataFrame
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -24,6 +24,7 @@ from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import ignore_warnings
+from sklearn.utils.testing import assert_consistent_docs
 from sklearn.utils.mocking import MockDataFrame
 
 from sklearn.metrics import accuracy_score
@@ -1628,3 +1629,19 @@ def test_brier_score_loss():
     # calculate even if only single class in y_true (#6980)
     assert_almost_equal(brier_score_loss([0], [0.5]), 0.25)
     assert_almost_equal(brier_score_loss([1], [0.5]), 0.25)
+
+
+def test_docstring():
+    # Test for consistency among docstring of different metrics
+    assert_consistent_docs([precision_recall_fscore_support, precision_score,
+                            recall_score, f1_score, fbeta_score],
+                           include_returns=False,
+                           exclude_params=['labels', 'average', 'beta'])
+
+    error_str = ("Parameter 'labels' of 'precision_score' has inconsistent "
+                 "description with that of 'precision_recall_fscore_support'.")
+    assert_raise_message(AssertionError, error_str, assert_consistent_docs,
+                         [precision_recall_fscore_support, precision_score,
+                          recall_score, f1_score, fbeta_score],
+                         include_returns=False,
+                         exclude_params=['average', 'beta'])

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -959,11 +959,13 @@ def assert_consistent_docs(objects,
     >>> from sklearn.metrics import (mean_absolute_error, mean_squared_error,
     ... median_absolute_error)
     >>> from sklearn.utils.testing import assert_consistent_docs
+    ... # doctest: +SKIP
     >>> assert_consistent_docs([mean_absolute_error, mean_squared_error],
     ... include_params=['y_true', 'y_pred', 'sample_weight'],
-    ... exclude_attribs='*', exclude_returns='*')
+    ... exclude_attribs='*', exclude_returns='*')  # doctest: +SKIP
     >>> assert_consistent_docs([median_absolute_error, mean_squared_error],
     ... include_params='*', exclude_attribs='*', exclude_returns='*')
+    ... # doctest: +SKIP
     Traceback (most recent call last):
         ...
     AssertionError: Parameter y_true of mean_squared_error has inconsistency.

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -19,7 +19,6 @@ import struct
 
 import scipy as sp
 import scipy.io
-from numpydoc import docscrape
 from functools import wraps
 from operator import itemgetter
 try:
@@ -825,6 +824,7 @@ def check_docstring_parameters(func, doc=None, ignore=None, class_name=None):
     incorrect : list
         A list of string describing the incorrect results.
     """
+    from numpydoc import docscrape
     incorrect = []
     ignore = [] if ignore is None else ignore
 
@@ -955,6 +955,8 @@ def assert_consistent_docs(objects,
         List of Returns to be excluded. '*' for excluding all returns.
 
     """
+    from numpydoc import docscrape
+
     # Dictionary of all different Parameters/Attributes/Returns found
     param_dict = {}
     attrib_dict = {}

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -930,16 +930,19 @@ def _check_matching_docstrings(doc_list, type_dict, type_name, object_name,
 
             if name in type_dict:
                 u_dict = type_dict[name]
-                msg1 = (type_name + " " + name + " of " + object_name +
-                        " has inconsistent type definition.")
-                msg2 = (type_name + " " + name + " of " + object_name +
-                        " has inconsistent description.")
+                msg1 = (type_name + " '" + name + "' of '" + object_name +
+                        "' has inconsistent type definition with that of '" +
+                        u_dict['object'] + "'.")
+                msg2 = (type_name + " '" + name + "' of '" + object_name +
+                        "' has inconsistent description with that of '" +
+                        u_dict['object'] + "'.")
 
                 assert u_dict['type_definition'] == type_definition, msg1
                 assert u_dict['description'] == description, msg2
             else:
                 add_dict = {'type_definition': type_definition,
-                            'description': description}
+                            'description': description,
+                            'object': object_name}
                 type_dict[name] = add_dict
 
     return type_dict
@@ -966,19 +969,22 @@ def assert_consistent_docs(objects,
         List of Parameters to be included. True, for including all parameters.
 
     exclude_params : list or None (default)
-        List of Parameters to be excluded. Set only if include_params is True.
+        List of Parameters to be excluded. Set only if ``include_params`` is
+        True.
 
     include_attribs : list, False or True (default)
         List of Attributes to be included. True, for including all attributes.
 
     exclude_attribs : list or None (default)
-        List of Attributes to be excluded. Set only if include_attribs is True.
+        List of Attributes to be excluded. Set only if ``include_attribs`` is
+        True.
 
     include_returns : list, False or True (default)
         List of Returns to be included. True, for including all returns.
 
     exclude_returns : list or None (default)
-        List of Returns to be excluded. Set only if include_returns is True.
+        List of Returns to be excluded. Set only if ``include_returns`` is
+        True.
 
     Notes
     -----
@@ -1005,6 +1011,16 @@ def assert_consistent_docs(objects,
     AssertionError: Parameter y_true of mean_squared_error has inconsistency.
 
     """
+    if isinstance(exclude_params, list) and include_params is not True:
+        raise TypeError("exclude_params can be set only if include_params is"
+                        " True.")
+    if isinstance(exclude_attribs, list) and include_attribs is not True:
+        raise TypeError("exclude_attribs can be set only if include_attribs is"
+                        " True.")
+    if isinstance(exclude_returns, list) and include_returns is not True:
+        raise TypeError("exclude_returns can be set only if include_returns is"
+                        " True.")
+
     from numpydoc import docscrape
 
     # Dictionary of all different Parameters/Attributes/Returns found

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -926,10 +926,7 @@ def _check_matching_docstrings(doc_list, type_dict, type_name, object_name,
             # remove all whitespaces
             type_definition = " ".join(type_definition.split())
             description = [" ".join(s.split()) for s in description]
-            try:
-                description.remove('')
-            except (ValueError):
-                pass
+            description = list(filter(None, description))
 
             if name in type_dict:
                 u_dict = type_dict[name]

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -969,7 +969,12 @@ def assert_consistent_docs(objects,
     AssertionError: Parameter y_true of mean_squared_error has inconsistency.
 
     """
-    from numpydoc import docscrape
+    try:
+        import numpydoc  # noqa
+        assert sys.version_info >= (3, 5)
+    except (ImportError, AssertionError):
+        raise SkipTest("numpydoc is required to test the docstrings, "
+                       "as well as python version >= 3.5")
 
     # Dictionary of all different Parameters/Attributes/Returns found
     param_dict = {}
@@ -977,12 +982,12 @@ def assert_consistent_docs(objects,
     return_dict = {}
 
     for u in objects:
-        if isinstance(u, docscrape.NumpyDocString):
+        if isinstance(u, numpydoc.docscrape.NumpyDocString):
             doc = u
             name = 'NumpyDocString'
         elif (inspect.isdatadescriptor(u) or inspect.isfunction(u) or
                 inspect.isclass(u)):
-            doc = docscrape.NumpyDocString(inspect.getdoc(u))
+            doc = numpydoc.docscrape.NumpyDocString(inspect.getdoc(u))
             name = u.__name__
         else:
             raise TypeError("Object passed not a Function, Class, "

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -914,7 +914,7 @@ def _check_matching_docstrings(doc_list, type_dict, type_name, object_name,
 
     If a matching key is not found in ``type_dict``, the docstring element is
     added in it with it's name as the key and value being a dictionary of it's
-    type_definition and description.
+    type definition and description.
 
     """
     for name, type_definition, description in doc_list:
@@ -960,31 +960,33 @@ def assert_consistent_docs(objects,
 
     Parameters
     ----------
-    objects : list
-        The list of objects that may be either ``NumpyDocString`` instances or
-        objects (classes, functions, descriptors) with docstrings that can be
-        parsed as numpydoc.
+    objects : collection
+        The collection (list, set etc.) of objects that may be either
+        ``NumpyDocString`` instances or objects (classes, functions,
+        descriptors) with docstrings that can be parsed by numpydoc.
 
-    include_params : list, False or True (default)
-        List of Parameters to be included. True, for including all parameters.
+    include_params : collection, False or True (default)
+        Collection of Parameters to be included. True, for including all
+        parameters.
 
-    exclude_params : list or None (default)
-        List of Parameters to be excluded. Set only if ``include_params`` is
-        True.
+    exclude_params : collection or None (default)
+        Collection of Parameters to be excluded. Set only if
+        ``include_params`` is True.
 
-    include_attribs : list, False or True (default)
-        List of Attributes to be included. True, for including all attributes.
+    include_attribs : collection, False or True (default)
+        Collection of Attributes to be included. True, for including all
+        attributes.
 
-    exclude_attribs : list or None (default)
-        List of Attributes to be excluded. Set only if ``include_attribs`` is
-        True.
+    exclude_attribs : collection or None (default)
+        Collection of Attributes to be excluded. Set only if
+        ``include_attribs`` is True.
 
-    include_returns : list, False or True (default)
-        List of Returns to be included. True, for including all returns.
+    include_returns : collection, False or True (default)
+        Collection of Returns to be included. True, for including all returns.
 
-    exclude_returns : list or None (default)
-        List of Returns to be excluded. Set only if ``include_returns`` is
-        True.
+    exclude_returns : collection or None (default)
+        Collection of Returns to be excluded. Set only if ``include_returns``
+        is True.
 
     Notes
     -----
@@ -1002,20 +1004,21 @@ def assert_consistent_docs(objects,
     ... # doctest: +SKIP
     >>> assert_consistent_docs([mean_absolute_error, mean_squared_error],
     ... include_params=['y_true', 'y_pred', 'sample_weight'],
-    ... exclude_attribs='*', exclude_returns='*')  # doctest: +SKIP
+    ... include_attribs=False, include_returns=False)  # doctest: +SKIP
     >>> assert_consistent_docs([median_absolute_error, mean_squared_error],
-    ... include_params='*', exclude_attribs='*', exclude_returns='*')
-    ... # doctest: +SKIP
+    ... include_params=True, include_attribs=False, include_returns=False)
+    ... # doctest: +NORMALIZE_WHITESPACE, +SKIP
     Traceback (most recent call last):
         ...
-    AssertionError: Parameter y_true of mean_squared_error has inconsistency.
+    AssertionError: Parameter 'y_true' of 'mean_squared_error' has inconsistent
+    type definition with that of 'median_absolute_error'.
 
     """
-    if ((isinstance(exclude_params, list) and include_params is not True) or
-       (isinstance(exclude_attribs, list) and include_attribs is not True) or
-       (isinstance(exclude_returns, list) and include_returns is not True)):
+    if ((exclude_params and include_params is not True) or
+       (exclude_attribs and include_attribs is not True) or
+       (exclude_returns and include_returns is not True)):
         raise TypeError("exclude_ argument can be set only if include_"
-                        "argument is True.")
+                        " argument is True.")
 
     from numpydoc import docscrape
 
@@ -1024,10 +1027,11 @@ def assert_consistent_docs(objects,
     attrib_dict = {}
     return_dict = {}
 
+    i = 1  # sequence of object in the collection
     for u in objects:
         if isinstance(u, docscrape.NumpyDocString):
             doc = u
-            name = 'NumpyDocString'
+            name = 'Object '+str(i)
         elif (inspect.isdatadescriptor(u) or inspect.isfunction(u) or
               inspect.isclass(u)):
             doc = docscrape.NumpyDocString(inspect.getdoc(u))
@@ -1035,6 +1039,7 @@ def assert_consistent_docs(objects,
         else:
             raise TypeError("Object passed not a Function, Class, "
                             "Descriptor or NumpyDocString.")
+        i = i + 1
 
         # check for inconsistency in Parameters
         if include_params is not False:

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -954,6 +954,20 @@ def assert_consistent_docs(objects,
     exclude_returns : list, '*' or None (default)
         List of Returns to be excluded. '*' for excluding all returns.
 
+    Examples
+    --------
+    >>> from sklearn.metrics import (mean_absolute_error, mean_squared_error,
+    ... median_absolute_error)
+    >>> from sklearn.utils.testing import assert_consistent_docs
+    >>> assert_consistent_docs([mean_absolute_error, mean_squared_error],
+    ... include_params=['y_true', 'y_pred', 'sample_weight'],
+    ... exclude_attribs='*', exclude_returns='*')
+    >>> assert_consistent_docs([median_absolute_error, mean_squared_error],
+    ... include_params='*', exclude_attribs='*', exclude_returns='*')
+    Traceback (most recent call last):
+        ...
+    AssertionError: Parameter y_true of mean_squared_error has inconsistency.
+
     """
     from numpydoc import docscrape
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -926,6 +926,10 @@ def _check_matching_docstrings(doc_list, type_dict, type_name, object_name,
             # remove all whitespaces
             type_definition = " ".join(type_definition.split())
             description = [" ".join(s.split()) for s in description]
+            try:
+                description.remove('')
+            except (ValueError):
+                pass
 
             if name in type_dict:
                 u_dict = type_dict[name]

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -1011,15 +1011,11 @@ def assert_consistent_docs(objects,
     AssertionError: Parameter y_true of mean_squared_error has inconsistency.
 
     """
-    if isinstance(exclude_params, list) and include_params is not True:
-        raise TypeError("exclude_params can be set only if include_params is"
-                        " True.")
-    if isinstance(exclude_attribs, list) and include_attribs is not True:
-        raise TypeError("exclude_attribs can be set only if include_attribs is"
-                        " True.")
-    if isinstance(exclude_returns, list) and include_returns is not True:
-        raise TypeError("exclude_returns can be set only if include_returns is"
-                        " True.")
+    if ((isinstance(exclude_params, list) and include_params is not True) or
+       (isinstance(exclude_attribs, list) and include_attribs is not True) or
+       (isinstance(exclude_returns, list) and include_returns is not True)):
+        raise TypeError("exclude_ argument can be set only if include_"
+                        "argument is True.")
 
     from numpydoc import docscrape
 
@@ -1033,7 +1029,7 @@ def assert_consistent_docs(objects,
             doc = u
             name = 'NumpyDocString'
         elif (inspect.isdatadescriptor(u) or inspect.isfunction(u) or
-                inspect.isclass(u)):
+              inspect.isclass(u)):
             doc = docscrape.NumpyDocString(inspect.getdoc(u))
             name = u.__name__
         else:

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -601,6 +601,7 @@ def test_assert_consistent_docs():
         doc1[typ] = doc2[typ] = []
 
 
+@if_numpydoc
 def test_precedence_assert_consistent_docs():
     # Test order of error reporting
     from numpydoc import docscrape

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -1,8 +1,10 @@
 import warnings
 import unittest
+import inspect
 import sys
 import numpy as np
 from scipy import sparse
+from numpydoc import docscrape
 
 from sklearn.utils.deprecation import deprecated
 from sklearn.utils.metaestimators import if_delegate_has_method
@@ -16,6 +18,7 @@ from sklearn.utils.testing import (
     assert_warns,
     assert_no_warnings,
     assert_equal,
+    assert_consistent_docs,
     set_random_state,
     assert_raise_message,
     ignore_warnings,
@@ -26,6 +29,9 @@ from sklearn.utils.testing import (
 from sklearn.utils.testing import SkipTest
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
+from sklearn.metrics import (f1_score, fbeta_score, mean_absolute_error,
+                             precision_score, precision_recall_fscore_support,
+                             recall_score)
 
 
 def test_assert_less():
@@ -491,3 +497,31 @@ def test_check_docstring_parameters():
          'type definition for param: "c " (type definition was "")',
          'sklearn.utils.tests.test_testing.f_check_param_definition There was '
          'no space between the param name and colon ("d:int")'])
+
+
+def test_assert_consistent_docs():
+    # Test function assert_consistent_docs
+    assert_consistent_docs([precision_recall_fscore_support, precision_score,
+                            recall_score, f1_score, fbeta_score],
+                           exclude_returns='*',
+                           exclude_params=['labels', 'average', 'beta'],
+                           exclude_attribs='*')
+
+    # Consider all parameters, attributes and returns
+    assert_raises(AssertionError, assert_consistent_docs,
+                  [precision_recall_fscore_support, precision_score,
+                   recall_score, f1_score, fbeta_score], include_returns='*',
+                  include_params='*', include_attribs='*')
+
+    # Consider a classification and a regression metric
+    assert_raises(AssertionError, assert_consistent_docs,
+                  [mean_absolute_error, precision_score], exclude_returns='*',
+                  include_params='*', exclude_attribs='*')
+
+    # Using NumpyDocString object
+    doc = docscrape.NumpyDocString(inspect.getdoc(precision_score))
+    assert_consistent_docs([precision_recall_fscore_support, recall_score,
+                            f1_score, fbeta_score, doc],
+                           exclude_returns='*',
+                           exclude_params=['labels', 'average', 'beta'],
+                           exclude_attribs='*')

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -572,7 +572,7 @@ def func_doc3(y_true, y_pred, sample_weight):
 
 @if_numpydoc
 def test_assert_consistent_docs():
-    # Test for consistent parameters
+    # Test with dummy functions
     assert_consistent_docs([func_doc1, func_doc2, func_doc3],
                            include_params=['y_true', 'y_pred'],
                            include_returns=False)
@@ -580,49 +580,29 @@ def test_assert_consistent_docs():
                            exclude_params=['sample_weight'],
                            include_returns=False)
 
-    # Test for returns
-    assert_consistent_docs([func_doc1, func_doc2], include_params=False)
-    assert_consistent_docs([func_doc1, func_doc2],
-                           exclude_params=['y_pred', 'y_true',
-                                           'sample_weight'])
+    # Using NumpyDocString object
+    from numpydoc import docscrape
 
-    # Test for inconsistent parameter 'sample_weight'
-    assert_raises(AssertionError, assert_consistent_docs,
-                  [func_doc1, func_doc2], include_params=['sample_weight'],
-                  include_returns=False)
-    assert_raises(AssertionError, assert_consistent_docs,
-                  [func_doc1, func_doc3], include_params=['sample_weight'],
-                  include_returns=False)
+    doc = docscrape.NumpyDocString(inspect.getdoc(precision_score))
+    assert_consistent_docs([precision_recall_fscore_support, f1_score, doc],
+                           include_returns=False,
+                           exclude_params=['labels', 'average', 'beta'],
+                           include_attribs=False)
 
-    # Test for inconsistent return 'recall'
-    assert_raises(AssertionError, assert_consistent_docs,
+    doc1 = docscrape.NumpyDocString(inspect.getdoc(func_doc1))
+    doc2 = docscrape.NumpyDocString(inspect.getdoc(func_doc2))
+    doc3 = docscrape.NumpyDocString(inspect.getdoc(func_doc3))
+
+    # Test for incorrect usage
+    assert_raises(TypeError, assert_consistent_docs,
                   [func_doc1, func_doc3], include_params=False,
-                  include_returns=['recall'])
-    assert_raises(AssertionError, assert_consistent_docs,
-                  [func_doc1, func_doc3], include_params=False,
-                  exclude_returns=['fbeta_score', 'precision'])
+                  exclude_params=['y_true'])
 
     # Test with actual classification metrics
     assert_consistent_docs([precision_recall_fscore_support, precision_score,
                             recall_score, f1_score, fbeta_score],
                            include_returns=False,
                            exclude_params=['labels', 'average', 'beta'])
-
-    # Consider a classification and a regression metric
-    assert_raises(AssertionError, assert_consistent_docs,
-                  [mean_absolute_error, precision_score],
-                  include_returns=False, include_params=True,
-                  include_attribs=False)
-
-    # Using NumpyDocString object
-    from numpydoc import docscrape
-
-    doc = docscrape.NumpyDocString(inspect.getdoc(precision_score))
-    assert_consistent_docs([precision_recall_fscore_support, recall_score,
-                            f1_score, fbeta_score, doc],
-                           include_returns=False,
-                           exclude_params=['labels', 'average', 'beta'],
-                           include_attribs=False)
 
     # Testing invalid object type
     assert_raises(TypeError, assert_consistent_docs,

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -576,6 +576,11 @@ def test_assert_consistent_docs():
                          [doc1, doc2], include_returns=['precision'],
                          include_params=False)  # type definition mismatch
 
+    doc3 = doc1  # both doc1 and doc3 return 'recall' whereas doc2 does not
+    assert_consistent_docs([doc1, doc2, doc3],
+                           include_returns=['fbeta_score', 'recall'],
+                           include_attribs=False, include_params=False)
+
     # Test for incorrect usage
     test_list1 = doc1['Parameters']
     test_list2 = doc2['Parameters']
@@ -589,7 +594,7 @@ def test_assert_consistent_docs():
         doc1[typ] = test_list1
         doc2[typ] = test_list2
 
-        # Pssing lists to both include_ and exclude_ arguments
+        # Passing lists to both include_ and exclude_ arguments
         kwargs = {include: ['sample_weight'], exclude: ['sample_weight']}
         assert_raises(TypeError, assert_consistent_docs, [doc1, doc2],
                       **kwargs)

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -498,20 +498,115 @@ def test_check_docstring_parameters():
          'no space between the param name and colon ("d:int")'])
 
 
+def func_doc1(y_true, y_pred, sample_weight):
+    """Dummy function for docstring testing.
+
+    Parameters
+    ----------
+    y_true : 1d array-like
+        Ground truth (correct) target values.
+
+    y_pred : 1d array-like
+        Estimated targets as returned by a classifier.
+
+    sample_weight : array-like of shape = [n_samples], optional
+        Sample weights.
+
+    Returns
+    -------
+    fbeta_score : float or array of float, shape = [n_unique_labels]
+        F-beta score of the positive class in binary classification.
+
+    precision : float or array of float, shape = [n_unique_labels]
+
+    recall : float or array of float, shape = [n_unique_labels]
+
+    """
+    pass
+
+
+def func_doc2(y_true, y_pred, sample_weight):
+    """Dummy function for docstring testing.
+
+    Parameters
+    ----------
+    y_true : 1d array-like
+        Ground truth (correct) target values.
+
+    y_pred : 1d array-like
+        Estimated targets as returned by a classifier.
+
+    sample_weight : array-like of shape = [n_samples], optional
+
+    Returns
+    -------
+    fbeta_score : float or array of float, shape = [n_unique_labels]
+        F-beta score of the positive class in binary classification.
+
+    """
+    pass
+
+
+def func_doc3(y_true, y_pred, sample_weight):
+    """Dummy function for docstring testing.
+
+    Parameters
+    ----------
+    y_true : 1d array-like
+        Ground truth (correct) target values.
+
+    y_pred : 1d array-like
+        Estimated targets as returned by a classifier.
+
+    sample_weight : array-like of shape = [n_samples]
+        Sample weights.
+
+    Returns
+    -------
+    recall : float or array of float, shape = [n_unique_labels]
+        Recall value(s).
+
+    """
+    pass
+
+
 @if_numpydoc
 def test_assert_consistent_docs():
-    # Test function assert_consistent_docs
+    # Test for consistent parameters
+    assert_consistent_docs([func_doc1, func_doc2, func_doc3],
+                           include_params=['y_true', 'y_pred'],
+                           include_returns=False)
+    assert_consistent_docs([func_doc1, func_doc2, func_doc3],
+                           exclude_params=['sample_weight'],
+                           include_returns=False)
+
+    # Test for returns
+    assert_consistent_docs([func_doc1, func_doc2], include_params=False)
+    assert_consistent_docs([func_doc1, func_doc2],
+                           exclude_params=['y_pred', 'y_true',
+                                           'sample_weight'])
+
+    # Test for inconsistent parameter 'sample_weight'
+    assert_raises(AssertionError, assert_consistent_docs,
+                  [func_doc1, func_doc2], include_params=['sample_weight'],
+                  include_returns=False)
+    assert_raises(AssertionError, assert_consistent_docs,
+                  [func_doc1, func_doc3], include_params=['sample_weight'],
+                  include_returns=False)
+
+    # Test for inconsistent return 'recall'
+    assert_raises(AssertionError, assert_consistent_docs,
+                  [func_doc1, func_doc3], include_params=False,
+                  include_returns=['recall'])
+    assert_raises(AssertionError, assert_consistent_docs,
+                  [func_doc1, func_doc3], include_params=False,
+                  exclude_returns=['fbeta_score', 'precision'])
+
+    # Test with actual classification metrics
     assert_consistent_docs([precision_recall_fscore_support, precision_score,
                             recall_score, f1_score, fbeta_score],
                            include_returns=False,
-                           exclude_params=['labels', 'average', 'beta'],
-                           include_attribs=False)
-
-    # Consider all parameters, attributes and returns
-    assert_raises(AssertionError, assert_consistent_docs,
-                  [precision_recall_fscore_support, precision_score,
-                   recall_score, f1_score, fbeta_score], include_returns=True,
-                  include_params=True, include_attribs=True)
+                           exclude_params=['labels', 'average', 'beta'])
 
     # Consider a classification and a regression metric
     assert_raises(AssertionError, assert_consistent_docs,

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -28,9 +28,8 @@ from sklearn.utils.testing import (
 from sklearn.utils.testing import if_numpydoc, SkipTest
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
-from sklearn.metrics import (f1_score, fbeta_score, mean_absolute_error,
-                             precision_score, precision_recall_fscore_support,
-                             recall_score)
+from sklearn.metrics import (f1_score, fbeta_score, precision_score,
+                             precision_recall_fscore_support, recall_score)
 
 
 def test_assert_less():
@@ -518,6 +517,7 @@ def func_doc1(y_true, y_pred, sample_weight):
         F-beta score of the positive class in binary classification.
 
     precision : float or array of float, shape = [n_unique_labels]
+        Precision values.
 
     recall : float or array of float, shape = [n_unique_labels]
 
@@ -543,28 +543,8 @@ def func_doc2(y_true, y_pred, sample_weight):
     fbeta_score : float or array of float, shape = [n_unique_labels]
         F-beta score of the positive class in binary classification.
 
-    """
-    pass
-
-
-def func_doc3(y_true, y_pred, sample_weight):
-    """Dummy function for docstring testing.
-
-    Parameters
-    ----------
-    y_true : 1d array-like
-        Ground truth (correct) target values.
-
-    y_pred : 1d array-like
-        Estimated targets as returned by a classifier.
-
-    sample_weight : array-like of shape = [n_samples]
-        Sample weights.
-
-    Returns
-    -------
-    recall : float or array of float, shape = [n_unique_labels]
-        Recall value(s).
+    precision : float or array of float
+        Precision values.
 
     """
     pass
@@ -573,39 +553,36 @@ def func_doc3(y_true, y_pred, sample_weight):
 @if_numpydoc
 def test_assert_consistent_docs():
     # Test with dummy functions
-    assert_consistent_docs([func_doc1, func_doc2, func_doc3],
+    assert_consistent_docs([func_doc1, func_doc2],
                            include_params=['y_true', 'y_pred'],
                            include_returns=False)
-    assert_consistent_docs([func_doc1, func_doc2, func_doc3],
+    assert_consistent_docs([func_doc1, func_doc2],
                            exclude_params=['sample_weight'],
                            include_returns=False)
 
     # Using NumpyDocString object
     from numpydoc import docscrape
 
-    doc = docscrape.NumpyDocString(inspect.getdoc(precision_score))
-    assert_consistent_docs([precision_recall_fscore_support, f1_score, doc],
-                           include_returns=False,
-                           exclude_params=['labels', 'average', 'beta'],
-                           include_attribs=False)
-
     doc1 = docscrape.NumpyDocString(inspect.getdoc(func_doc1))
     doc2 = docscrape.NumpyDocString(inspect.getdoc(func_doc2))
-    doc3 = docscrape.NumpyDocString(inspect.getdoc(func_doc3))
+
+    assert_raises(AssertionError, assert_consistent_docs, [doc1, doc2],
+                  include_params=['sample_weight'], include_returns=False)
+    assert_raises(AssertionError, assert_consistent_docs, [doc1, doc2],
+                  include_returns=['precision'], include_params=False)
 
     # Test for incorrect usage
+    assert_raises(TypeError, assert_consistent_docs, [doc1, doc2],
+                  include_params=False, exclude_params=['y_true'])
+
+    # Testing invalid object type
     assert_raises(TypeError, assert_consistent_docs,
-                  [func_doc1, func_doc3], include_params=False,
-                  exclude_params=['y_true'])
+                  ["precision_recall_fscore_support", doc1, doc2],
+                  include_returns=True, include_params=True,
+                  include_attribs=True)
 
     # Test with actual classification metrics
     assert_consistent_docs([precision_recall_fscore_support, precision_score,
                             recall_score, f1_score, fbeta_score],
                            include_returns=False,
                            exclude_params=['labels', 'average', 'beta'])
-
-    # Testing invalid object type
-    assert_raises(TypeError, assert_consistent_docs,
-                  ["precision_recall_fscore_support", precision_score,
-                   recall_score, f1_score, fbeta_score], include_returns=True,
-                  include_params=True, include_attribs=True)

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -4,7 +4,6 @@ import inspect
 import sys
 import numpy as np
 from scipy import sparse
-from numpydoc import docscrape
 
 from sklearn.utils.deprecation import deprecated
 from sklearn.utils.metaestimators import if_delegate_has_method
@@ -501,6 +500,13 @@ def test_check_docstring_parameters():
 
 def test_assert_consistent_docs():
     # Test function assert_consistent_docs
+    try:
+        import numpydoc  # noqa
+        assert sys.version_info >= (3, 5)
+    except (ImportError, AssertionError):
+        raise SkipTest("numpydoc is required to test the docstrings, "
+                       "as well as python version >= 3.5")
+
     assert_consistent_docs([precision_recall_fscore_support, precision_score,
                             recall_score, f1_score, fbeta_score],
                            exclude_returns='*',
@@ -519,7 +525,7 @@ def test_assert_consistent_docs():
                   include_params='*', exclude_attribs='*')
 
     # Using NumpyDocString object
-    doc = docscrape.NumpyDocString(inspect.getdoc(precision_score))
+    doc = numpydoc.docscrape.NumpyDocString(inspect.getdoc(precision_score))
     assert_consistent_docs([precision_recall_fscore_support, recall_score,
                             f1_score, fbeta_score, doc],
                            exclude_returns='*',

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -25,7 +25,7 @@ from sklearn.utils.testing import (
     assert_allclose_dense_sparse,
     assert_raises_regex)
 
-from sklearn.utils.testing import SkipTest
+from sklearn.utils.testing import if_numpydoc, SkipTest
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
 from sklearn.metrics import (f1_score, fbeta_score, mean_absolute_error,
@@ -498,47 +498,39 @@ def test_check_docstring_parameters():
          'no space between the param name and colon ("d:int")'])
 
 
+@if_numpydoc
 def test_assert_consistent_docs():
     # Test function assert_consistent_docs
-    try:
-        import numpydoc  # noqa
-        assert sys.version_info >= (3, 5)
-    except (ImportError, AssertionError):
-        raise SkipTest("numpydoc is required to test the docstrings, "
-                       "as well as python version >= 3.5")
-
     assert_consistent_docs([precision_recall_fscore_support, precision_score,
                             recall_score, f1_score, fbeta_score],
-                           exclude_returns='*',
+                           include_returns=False,
                            exclude_params=['labels', 'average', 'beta'],
-                           exclude_attribs='*')
-
-    assert_raises(AssertionError, assert_consistent_docs,
-                  [precision_recall_fscore_support, precision_score,
-                   recall_score, f1_score, fbeta_score], exclude_returns='*',
-                  exclude_params=['labels', 'beta'], exclude_attribs='*')
+                           include_attribs=False)
 
     # Consider all parameters, attributes and returns
     assert_raises(AssertionError, assert_consistent_docs,
                   [precision_recall_fscore_support, precision_score,
-                   recall_score, f1_score, fbeta_score], include_returns='*',
-                  include_params='*', include_attribs='*')
+                   recall_score, f1_score, fbeta_score], include_returns=True,
+                  include_params=True, include_attribs=True)
 
     # Consider a classification and a regression metric
     assert_raises(AssertionError, assert_consistent_docs,
-                  [mean_absolute_error, precision_score], exclude_returns='*',
-                  include_params='*', exclude_attribs='*')
+                  [mean_absolute_error, precision_score],
+                  include_returns=False, include_params=True,
+                  include_attribs=False)
 
     # Using NumpyDocString object
-    doc = numpydoc.docscrape.NumpyDocString(inspect.getdoc(precision_score))
+    from numpydoc import docscrape
+
+    doc = docscrape.NumpyDocString(inspect.getdoc(precision_score))
     assert_consistent_docs([precision_recall_fscore_support, recall_score,
                             f1_score, fbeta_score, doc],
-                           exclude_returns='*',
+                           include_returns=False,
                            exclude_params=['labels', 'average', 'beta'],
-                           exclude_attribs='*')
+                           include_attribs=False)
 
     # Testing invalid object type
     assert_raises(TypeError, assert_consistent_docs,
                   ["precision_recall_fscore_support", precision_score,
-                   recall_score, f1_score, fbeta_score], include_returns='*',
-                  include_params='*', include_attribs='*')
+                   recall_score, f1_score, fbeta_score], include_returns=True,
+                  include_params=True, include_attribs=True)

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -513,6 +513,11 @@ def test_assert_consistent_docs():
                            exclude_params=['labels', 'average', 'beta'],
                            exclude_attribs='*')
 
+    assert_raises(AssertionError, assert_consistent_docs,
+                  [precision_recall_fscore_support, precision_score,
+                   recall_score, f1_score, fbeta_score], exclude_returns='*',
+                  exclude_params=['labels', 'beta'], exclude_attribs='*')
+
     # Consider all parameters, attributes and returns
     assert_raises(AssertionError, assert_consistent_docs,
                   [precision_recall_fscore_support, precision_score,
@@ -531,3 +536,9 @@ def test_assert_consistent_docs():
                            exclude_returns='*',
                            exclude_params=['labels', 'average', 'beta'],
                            exclude_attribs='*')
+
+    # Testing invalid object type
+    assert_raises(TypeError, assert_consistent_docs,
+                  ["precision_recall_fscore_support", precision_score,
+                   recall_score, f1_score, fbeta_score], include_returns='*',
+                  include_params='*', include_attribs='*')


### PR DESCRIPTION

Fixes #9388 

Added a function to check for consistency between docstring of objects.

In this approach there is a python dictionary for each of Parameters, Attributes and Returns. Indexed by the name of the parameter/attribute/return with the value being a Python dictionary containing its type definition and description. The function checks for each object if the docstring is identical (excluding whitespaces) for a given parameter/attribute/return in the main dictionary. If a new parameter/attribute/return are found they are added in the main dictionary.