### PR TITLE
[MRG+1] Export ClassificationCriterion and RegressionCriterion

### DIFF
--- a/sklearn/tree/_criterion.pxd
+++ b/sklearn/tree/_criterion.pxd
@@ -65,3 +65,14 @@ cdef class Criterion:
     cdef void node_value(self, double* dest) nogil
     cdef double impurity_improvement(self, double impurity) nogil
     cdef double proxy_impurity_improvement(self) nogil
+
+cdef class ClassificationCriterion(Criterion):
+    """Abstract criterion for classification."""
+
+    cdef SIZE_t* n_classes
+    cdef SIZE_t sum_stride
+
+cdef class RegressionCriterion(Criterion):
+    """Abstract regression criterion."""
+
+    cdef double sq_sum_total

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -212,9 +212,6 @@ cdef class Criterion:
 cdef class ClassificationCriterion(Criterion):
     """Abstract criterion for classification."""
 
-    cdef SIZE_t* n_classes
-    cdef SIZE_t sum_stride
-
     def __cinit__(self, SIZE_t n_outputs,
                   np.ndarray[SIZE_t, ndim=1] n_classes):
         """Initialize attributes for this criterion.
@@ -703,8 +700,6 @@ cdef class RegressionCriterion(Criterion):
         var = \sum_i^n (y_i - y_bar) ** 2
             = (\sum_i^n y_i ** 2) - n_samples * y_bar ** 2
     """
-
-    cdef double sq_sum_total
 
     def __cinit__(self, SIZE_t n_outputs, SIZE_t n_samples):
         """Initialize parameters for this criterion.


### PR DESCRIPTION
#### Reference Issues/PRs
Resolves #10251.

#### What does this implement/fix? Explain your changes.
This allows extending of `ClassificationCriterion` and `RegressionCriterion`. For an example use case, see https://stats.stackexchange.com/q/316954/98500.

#### Any other comments?
I wasn't sure what to do with the documentation. The documentation on `Criterion` is different in the pyx and the pxd, and the latter is not a docstring. I copied the very succinct docstring for `ClassificationCriterion` and wrote a similar one for `RegressionCriterion`. But as `Criterion` does something weird, which I cannot find in the coding guidelines, I don't know what I should do there. Advise appreciated.

Because this is not a public API, I did not provide usage examples. (A usage example would by any of the subclasses defined in the pyx.) Please let me know if they should be added.

Thanks for reviewing!