### PR TITLE
FIX <BUG Inconsistent f1_score behavior when combining label indicator input with labels attribute #10307>

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1063,7 +1063,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
         # All labels are index integers for multilabel.
         # Select labels:
-        if not np.all(labels == present_labels):
+        if not np.all(labels == present_labels) & n_labels < len(labels):
             if np.max(labels) > np.max(present_labels):
                 raise ValueError('All labels must be in [0, n labels). '
                                  'Got %d > %d' %
@@ -1072,7 +1072,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
                 raise ValueError('All labels must be in [0, n labels). '
                                  'Got %d < 0' % np.min(labels))
 
-            y_true = y_true[:, labels[:n_labels]]
+            y_true = y_true[:, :n_labels]
             y_pred = y_pred[:, labels[:n_labels]]
 
         # calculate weighted counts


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

A fix for "BUG Inconsistent f1_score behavior when combining label indicator input with labels attribute #10307"


#### What does this implement/fix? Explain your changes.
Changes the slice for y_true and added now condition

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
