### PR TITLE
added unicode catch to predict_proba function in SVC

### DIFF
--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -642,7 +642,7 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
         kernel = self.kernel
         if callable(kernel):
             kernel = 'precomputed'
-        
+
         if six.PY2:
             # In python2 ensure kernel is ascii bytes to prevent a TypeError
             if isinstance(kernel, six.types.UnicodeType):

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -637,6 +637,15 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
         kernel = self.kernel
         if callable(kernel):
             kernel = 'precomputed'
+        
+        if six.PY2:
+	        # In python2 ensure kernel is ascii bytes to prevent a TypeError
+	        if isinstance(kernel, six.types.UnicodeType):
+	            kernel = str(kernel)
+        if six.PY3:
+            # In python3 ensure kernel is utf8 unicode to prevent a TypeError
+            if isinstance(kernel, bytes):
+	            kernel = str(kernel, 'utf8')
 
         svm_type = LIBSVM_IMPL.index(self._impl)
         pprob = libsvm.predict_proba(

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -322,6 +322,11 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
                                  "the number of samples at training time" %
                                  (X.shape[1], self.shape_fit_[0]))
 
+        if six.PY3:
+            # In python3 ensure kernel is utf8 unicode to prevent a TypeError
+            if isinstance(kernel, bytes):
+                kernel = str(kernel, 'utf8')
+
         svm_type = LIBSVM_IMPL.index(self._impl)
 
         return libsvm.predict(

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -639,13 +639,13 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
             kernel = 'precomputed'
         
         if six.PY2:
-	        # In python2 ensure kernel is ascii bytes to prevent a TypeError
-	        if isinstance(kernel, six.types.UnicodeType):
-	            kernel = str(kernel)
+            # In python2 ensure kernel is ascii bytes to prevent a TypeError
+            if isinstance(kernel, six.types.UnicodeType):
+                kernel = str(kernel)
         if six.PY3:
             # In python3 ensure kernel is utf8 unicode to prevent a TypeError
             if isinstance(kernel, bytes):
-	            kernel = str(kernel, 'utf8')
+                kernel = str(kernel, 'utf8')
 
         svm_type = LIBSVM_IMPL.index(self._impl)
         pprob = libsvm.predict_proba(

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -503,29 +503,38 @@ def test_bad_input():
     clf.fit(X, Y)
     assert_raises(ValueError, clf.predict, Xt)
 
-
 def test_unicode_kernel():
-    # Test that a unicode kernel name does not cause a TypeError on clf.fit
+    # Test that a unicode kernel name does not cause a TypeError
     if six.PY2:
         # Test unicode (same as str on python3)
-        clf = svm.SVC(kernel=unicode('linear'))
+        clf = svm.SVC(kernel=unicode('linear'), probability=True)
         clf.fit(X, Y)
+        clf.predict(T)
+        clf.predict_proba(T)
 
         # Test ascii bytes (str is bytes in python2)
-        clf = svm.SVC(kernel=str('linear'))
+        clf = svm.SVC(kernel=str('linear'), probability=True)
         clf.fit(X, Y)
+        clf.predict(T)
+        clf.predict_proba(T)
     else:
         # Test unicode (str is unicode in python3)
-        clf = svm.SVC(kernel=str('linear'))
+        clf = svm.SVC(kernel=str('linear'), probability=True)
         clf.fit(X, Y)
+        clf.predict(T)
+        clf.predict_proba(T)
 
         # Test ascii bytes (same as str on python2)
-        clf = svm.SVC(kernel=bytes('linear', 'ascii'))
+        clf = svm.SVC(kernel=bytes('linear', 'ascii'), probability=True)
         clf.fit(X, Y)
+        clf.predict(T)
+        clf.predict_proba(T)
 
     # Test default behavior on both versions
-    clf = svm.SVC(kernel='linear')
+    clf = svm.SVC(kernel='linear', probability=True)
     clf.fit(X, Y)
+    clf.predict(T)
+    clf.predict_proba(T)
 
 
 def test_sparse_precomputed():

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -512,30 +512,35 @@ def test_unicode_kernel():
         clf.fit(X, Y)
         clf.predict(T)
         clf.predict_proba(T)
+        clf.decision_function(T)
 
         # Test ascii bytes (str is bytes in python2)
         clf = svm.SVC(kernel=str('linear'), probability=True)
         clf.fit(X, Y)
         clf.predict(T)
         clf.predict_proba(T)
+        clf.decision_function(T)
     else:
         # Test unicode (str is unicode in python3)
         clf = svm.SVC(kernel=str('linear'), probability=True)
         clf.fit(X, Y)
         clf.predict(T)
         clf.predict_proba(T)
+        clf.decision_function(T)
 
         # Test ascii bytes (same as str on python2)
         clf = svm.SVC(kernel=bytes('linear', 'ascii'), probability=True)
         clf.fit(X, Y)
         clf.predict(T)
         clf.predict_proba(T)
+        clf.decision_function(T)
 
     # Test default behavior on both versions
     clf = svm.SVC(kernel='linear', probability=True)
     clf.fit(X, Y)
     clf.predict(T)
     clf.predict_proba(T)
+    clf.decision_function(T)
 
 
 def test_sparse_precomputed():

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -503,6 +503,7 @@ def test_bad_input():
     clf.fit(X, Y)
     assert_raises(ValueError, clf.predict, Xt)
 
+
 def test_unicode_kernel():
     # Test that a unicode kernel name does not cause a TypeError
     if six.PY2:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Adds mixed object type handling (unicode/string) to the `kernel` parameter of SVM models.
This was present for the `predict` function, but neglected for `predict_proba`
For a recreation of the error, see https://github.com/EducationalTestingService/skll/issues/87
