### PR TITLE
[MRG] Fix typo in pipeline user guide

### DIFF
--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -14,7 +14,7 @@ Pipeline: chaining estimators
 :class:`Pipeline` can be used to chain multiple estimators
 into one. This is useful as there is often a fixed sequence
 of steps in processing the data, for example feature selection, normalization
-and classification. :class:`Pipeline` serves two purposes here:
+and classification. :class:`Pipeline` serves multiple purposes here:
 
 Convenience and encapsulation
     You only have to call ``fit`` and ``predict`` once on your


### PR DESCRIPTION
#### Reference Issues/PRs
This fixes an inconsistency in documentation introduced in #9510.

#### What does this implement/fix? Explain your changes.
This fixes a typo in the pipeline user guide.  It reads "`Pipeline` serves two purposes here:" and then lists three advantages of using `Pipeline`.  I replaced the word "two" with "multiple".
