### PR TITLE
[MRG] Fix small typo in documentation

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1125,7 +1125,7 @@ the correct interface more easily.
 
 .. topic:: ``BaseEstimator`` and mixins:
 
-    We tend to use use "duck typing", so building an estimator which follows
+    We tend to use "duck typing", so building an estimator which follows
     the API suffices for compatibility, without needing to inherit from or
     even import any scikit-learn classes.
 


### PR DESCRIPTION
#### Reference Issues/PRs
fixes a small typo introduced in #8440


#### What does this implement/fix? Explain your changes.
This fixes a small typo in the "Rolling your own estimator" documentation.
