### PR TITLE
[MRG] Fix failing doctest in statistical inference tutorial

### DIFF
--- a/doc/tutorial/statistical_inference/supervised_learning.rst
+++ b/doc/tutorial/statistical_inference/supervised_learning.rst
@@ -178,8 +178,9 @@ Linear models: :math:`y = X\beta + \epsilon`
     >>> regr.fit(diabetes_X_train, diabetes_y_train)
     LinearRegression(copy_X=True, fit_intercept=True, n_jobs=1, normalize=False)
     >>> print(regr.coef_)
-    [   0.30349955 -237.63931533  510.53060544  327.73698041 -814.13170937
-      492.81458798  102.84845219  184.60648906  743.51961675   76.09517222]
+    [  3.03499549e-01  -2.37639315e+02   5.10530605e+02   3.27736980e+02
+      -8.14131709e+02   4.92814588e+02   1.02848452e+02   1.84606489e+02
+       7.43519617e+02   7.60951722e+01]
 
     >>> # The mean square error
     >>> np.mean((regr.predict(diabetes_X_test)-diabetes_y_test)**2)# doctest: +ELLIPSIS


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->


#### What does this implement/fix? Explain your changes.

Fix failing doctest in statistical inference tutorial.

#### Any other comments?

I am not sure why this isn't picked up in the travis. Any explanation will be appreciated.

Currently locally on my computer:
```bash
gxyd@stallman:~/dev/scikit-learn/doc/tutorial/statistical_inference(svc_gamma)$ pytest supervised_learning.rst 
============================================================= test session starts =============================================================
platform linux2 -- Python 2.7.6, pytest-3.3.1, py-1.5.2, pluggy-0.6.0
rootdir: /home/gxyd/dev/scikit-learn, inifile: setup.cfg
collected 1 item                                                                                                                              

supervised_learning.rst F                                                                                                               [100%]

================================================================== FAILURES ===================================================================
______________________________________________________ [doctest] supervised_learning.rst ______________________________________________________
171  * :math:`\beta`: Coefficients
172  * :math:`\epsilon`: Observation noise
173 
174 ::
175 
176     >>> from sklearn import linear_model
177     >>> regr = linear_model.LinearRegression()
178     >>> regr.fit(diabetes_X_train, diabetes_y_train)
179     LinearRegression(copy_X=True, fit_intercept=True, n_jobs=1, normalize=False)
180     >>> print(regr.coef_)
Expected:
    [   0.30349955 -237.63931533  510.53060544  327.73698041 -814.13170937
      492.81458798  102.84845219  184.60648906  743.51961675   76.09517222]
Got:
    [  3.03499549e-01  -2.37639315e+02   5.10530605e+02   3.27736980e+02
      -8.14131709e+02   4.92814588e+02   1.02848452e+02   1.84606489e+02
       7.43519617e+02   7.60951722e+01]

```