### PR TITLE
[MRG] Fixes issue: Verbose VotingClassifier #10360

### DIFF
--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -122,12 +122,13 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
     """
 
     def __init__(self, estimators, voting='hard', weights=None, n_jobs=1,
-                 flatten_transform=None):
+                 flatten_transform=None, verbose=1):
         self.estimators = estimators
         self.voting = voting
         self.weights = weights
         self.n_jobs = n_jobs
         self.flatten_transform = flatten_transform
+        self.verbose = verbose
 
     @property
     def named_estimators(self):
@@ -192,7 +193,7 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
 
         transformed_y = self.le_.transform(y)
 
-        self.estimators_ = Parallel(n_jobs=self.n_jobs)(
+        self.estimators_ = Parallel(n_jobs=self.n_jobs, verbose=1)(
                 delayed(_parallel_fit_estimator)(clone(clf), X, transformed_y,
                                                  sample_weight=sample_weight)
                 for clf in clfs if clf is not None)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
 - Have set `verbose=1` in the call to `Parallel(..)` in line 196 of voting_classifier.py
 - Chose 1 because it will show basic frequency of messages, greater than 10 would have shown all (which might have been too much)
 - Also added the verbose argument to `VotingClassifier.__init__(..)`

#### Any other comments?
This is my first PR :) !

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
