### PR TITLE
[MRG] Fix typo in model_evaluation.rst

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1737,7 +1737,7 @@ implements several such simple strategies for classification:
   set class distribution.
 - ``most_frequent`` always predicts the most frequent label in the training set.
 - ``prior`` always predicts the class that maximizes the class prior
-  (like ``most_frequent`) and ``predict_proba`` returns the class prior.
+  (like ``most_frequent``) and ``predict_proba`` returns the class prior.
 - ``uniform`` generates predictions uniformly at random.
 - ``constant`` always predicts a constant label that is provided by the user.
    A major motivation of this method is F1-scoring, when the positive class


### PR DESCRIPTION
In the section "3.3.6. Dummy estimators" in the User Guide, a backtick was added to fix a Markdown error.

#### Reference Issues/PRs

None

#### What does this implement/fix? Explain your changes.

A typo was fixed in the User Guide.

#### Any other comments?

None