### PR TITLE
Fix (attempt) LDA dimension reduction

### DIFF
--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -443,11 +443,9 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
             self.priors_ = self.priors_ / self.priors_.sum()
 
         # Get the maximum number of components
-        if self.n_components is None:
-            self._max_components = X.shape[1]
-        else:
-            self._max_components = min(X.shape[1],
-                                       self.n_components)
+        self._max_components = X.shape[1]
+        if self.n_components is not None:
+            self._max_components = self.n_components
 
         if self.solver == 'svd':
             if self.shrinkage is not None:

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -444,9 +444,9 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
 
         # Get the maximum number of components
         if self.n_components is None:
-            self._max_components = len(self.classes_) - 1
+            self._max_components = X.shape[1]
         else:
-            self._max_components = min(len(self.classes_) - 1,
+            self._max_components = min(X.shape[1],
                                        self.n_components)
 
         if self.solver == 'svd':


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #10375 

#### What does this implement/fix? Explain your changes.
LDA, non concerning the classifier Fisher-LDA, is a supervised dimension reduction technique. The current code on scikit-learn is not correct, for it calculates the minimum between the number of classes and n_components. This is wrong, for the dimensionality of the data is related to the number of collumns of X. And so, X.shape[1] should give the correct dimensionality of the data. Even more, if no n_components is given, the number of classes will be used, which is again wrong.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
