### PR TITLE
Update plot_compare_reduction.py

### DIFF
--- a/examples/plot_compare_reduction.py
+++ b/examples/plot_compare_reduction.py
@@ -87,6 +87,8 @@ plt.ylabel('Digit classification accuracy')
 plt.ylim((0, 1))
 plt.legend(loc='upper left')
 
+plt.show()
+
 ###############################################################################
 # Caching transformers within a ``Pipeline``
 ###############################################################################
@@ -126,5 +128,3 @@ rmtree(cachedir)
 # estimator data, leading to save processing time. Therefore, the use of
 # caching the pipeline using ``memory`` is highly beneficial when fitting
 # a transformer is costly.
-
-plt.show()


### PR DESCRIPTION
Misplaced plt.show(), fixed.

Like me a few scikit-learn newbies might be wondering where is the graph :grin: .

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
A graph is supposed to be showen in the example: [of Selecting dimensionality reduction with Pipeline and GridSearchCV](http://scikit-learn.org/stable/auto_examples/plot_compare_reduction.html). But it does not show due to misplaced `plt.show()`



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

  