### PR TITLE
[MRG+1] Fixes #10393 Fixed error when fitting RidgeCV with integers

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -277,6 +277,10 @@ Classifiers and regressors
   where the coefficient had wrong shape when ``fit_intercept=False``.
   :issue:`10687` by :user:`Martin Hahn <martin-hahn>`.
 
+- Fixed a bug in :class:`linear_model.RidgeCV` where using negative integer 
+  `alphas` raised an error :issue:`10393` 
+  by :user:`Mabel Villalba-Jiménez <mabelvj>`.
+
 Decomposition, manifold learning and clustering
 
 - Fix for uninformative error in :class:`decomposition.IncrementalPCA`:

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -277,8 +277,8 @@ Classifiers and regressors
   where the coefficient had wrong shape when ``fit_intercept=False``.
   :issue:`10687` by :user:`Martin Hahn <martin-hahn>`.
 
-- Fixed a bug in :class:`linear_model.RidgeCV` where using negative integer 
-  `alphas` raised an error :issue:`10393` 
+- Fixed a bug in :class:`linear_model.RidgeCV` where using integer
+  `alphas` raised an error :issue:`10393`
   by :user:`Mabel Villalba-Jiménez <mabelvj>`.
 
 Decomposition, manifold learning and clustering

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -277,9 +277,8 @@ Classifiers and regressors
   where the coefficient had wrong shape when ``fit_intercept=False``.
   :issue:`10687` by :user:`Martin Hahn <martin-hahn>`.
 
-- Fixed a bug in :class:`linear_model.RidgeCV` where using integer
-  `alphas` raised an error :issue:`10393`
-  by :user:`Mabel Villalba-Jiménez <mabelvj>`.
+- Fixed a bug in :class:`linear_model.RidgeCV` where using integer ``alphas``
+  raised an error. :issue:`10393` by :user:`Mabel Villalba-Jiménez <mabelvj>`.
 
 Decomposition, manifold learning and clustering
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1042,6 +1042,8 @@ class _RidgeGCV(LinearModel):
         error = scorer is None
 
         for i, alpha in enumerate(self.alphas):
+            if float(alpha) < 0:
+                raise ValueError("alpha value cannot be negative")
             if error:
                 out, c = _errors(float(alpha), y, v, Q, QT_y)
             else:

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1042,7 +1042,7 @@ class _RidgeGCV(LinearModel):
         error = scorer is None
 
         for i, alpha in enumerate(self.alphas):
-            if float(alpha) < 0:
+            if alpha < 0:
                 raise ValueError("alpha value cannot be negative")
             if error:
                 out, c = _errors(float(alpha), y, v, Q, QT_y)

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -639,7 +639,6 @@ class Ridge(_BaseRidge, RegressorMixin):
           normalize=False, random_state=None, solver='auto', tol=0.001)
 
     """
-
     def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
                  copy_X=True, max_iter=None, tol=1e-3, solver="auto",
                  random_state=None):
@@ -1092,7 +1091,7 @@ class _BaseRidgeCV(LinearModel):
                  fit_intercept=True, normalize=False, scoring=None,
                  cv=None, gcv_mode=None,
                  store_cv_values=False):
-        self.alphas = np.asarray(alphas, dtype=np.float64)
+        self.alphas = np.asarray(alphas)
         self.fit_intercept = fit_intercept
         self.normalize = normalize
         self.scoring = scoring

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -639,6 +639,7 @@ class Ridge(_BaseRidge, RegressorMixin):
           normalize=False, random_state=None, solver='auto', tol=0.001)
 
     """
+
     def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
                  copy_X=True, max_iter=None, tol=1e-3, solver="auto",
                  random_state=None):
@@ -778,6 +779,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
     a one-versus-all approach. Concretely, this is implemented by taking
     advantage of the multi-variate response support in Ridge.
     """
+
     def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
                  copy_X=True, max_iter=None, tol=1e-3, class_weight=None,
                  solver="auto", random_state=None):
@@ -1041,9 +1043,12 @@ class _RidgeGCV(LinearModel):
         scorer = check_scoring(self, scoring=self.scoring, allow_none=True)
         error = scorer is None
 
+        if np.any(self.alphas < 0):
+            raise ValueError("alphas cannot be negative. "
+                             "Got {} containing some "
+                             "negative value instead.".format(self.alphas))
+
         for i, alpha in enumerate(self.alphas):
-            if alpha < 0:
-                raise ValueError("alpha value cannot be negative")
             if error:
                 out, c = _errors(float(alpha), y, v, Q, QT_y)
             else:
@@ -1087,7 +1092,7 @@ class _BaseRidgeCV(LinearModel):
                  fit_intercept=True, normalize=False, scoring=None,
                  cv=None, gcv_mode=None,
                  store_cv_values=False):
-        self.alphas = alphas
+        self.alphas = np.asarray(alphas, dtype=np.float64)
         self.fit_intercept = fit_intercept
         self.normalize = normalize
         self.scoring = scoring
@@ -1330,6 +1335,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
     a one-versus-all approach. Concretely, this is implemented by taking
     advantage of the multi-variate response support in Ridge.
     """
+
     def __init__(self, alphas=(0.1, 1.0, 10.0), fit_intercept=True,
                  normalize=False, scoring=None, cv=None, class_weight=None):
         super(RidgeClassifierCV, self).__init__(

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1043,9 +1043,9 @@ class _RidgeGCV(LinearModel):
 
         for i, alpha in enumerate(self.alphas):
             if error:
-                out, c = _errors(alpha, y, v, Q, QT_y)
+                out, c = _errors(float(alpha), y, v, Q, QT_y)
             else:
-                out, c = _values(alpha, y, v, Q, QT_y)
+                out, c = _values(float(alpha), y, v, Q, QT_y)
             cv_values[:, i] = out.ravel()
             C.append(c)
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -709,29 +709,6 @@ def test_sparse_design_with_sample_weights():
                                       decimal=6)
 
 
-testdata_alpha = [
-    ((1, 10, 100), np.array([1.0, 10.0, 100.0])),
-    ((-1, -10, -100), np.array([-1.0, -10.0, -100.0]))
-]
-
-
-@pytest.mark.parametrize("alpha_input, alpha_expected", testdata_alpha)
-def test_conversion(alpha_input, alpha_expected):
-    assert((RidgeCV(alpha_input).get_params()['alphas'] ==
-            alpha_expected).all())
-
-
-def test_ridgecv_int_alphas():
-
-    X = np.array([[-1.0, -1.0], [-1.0, 0], [-.8, -1.0],
-                  [1.0, 1.0], [1.0, 0.0]])
-    y = [1, 1, 1, -1, -1]
-
-    # Integers
-    ridge = RidgeCV(alphas=(1, 10, 100))
-    ridge.fit(X, y)
-
-
 def test_ridgecv_negative_alphas():
 
     X = np.array([[-1.0, -1.0], [-1.0, 0], [-.8, -1.0],

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -53,10 +53,8 @@ X_iris = sp.csr_matrix(iris.data)
 y_iris = iris.target
 
 
-def DENSE_FILTER(X): return X
-
-
-def SPARSE_FILTER(X): return sp.csr_matrix(X)
+DENSE_FILTER = lambda X: X
+SPARSE_FILTER = lambda X: sp.csr_matrix(X)
 
 
 def test_ridge():
@@ -368,7 +366,7 @@ def _test_ridge_loo(filter_):
     assert_equal(ridge_gcv2.alpha_, alpha_)
 
     # check that we get same best alpha with custom score_func
-    def func(x, y): return -mean_squared_error(x, y)
+    func = lambda x, y: -mean_squared_error(x, y)
     scoring = make_scorer(func)
     ridge_gcv3 = RidgeCV(fit_intercept=False, scoring=scoring)
     f(ridge_gcv3.fit)(filter_(X_diabetes), y_diabetes)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -707,7 +707,6 @@ def test_sparse_design_with_sample_weights():
 
 
 def test_ridgecv_int_alphas():
-
     X = np.array([[-1.0, -1.0], [-1.0, 0], [-.8, -1.0],
                   [1.0, 1.0], [1.0, 0.0]])
     y = [1, 1, 1, -1, -1]
@@ -718,7 +717,6 @@ def test_ridgecv_int_alphas():
 
 
 def test_ridgecv_negative_alphas():
-
     X = np.array([[-1.0, -1.0], [-1.0, 0], [-.8, -1.0],
                   [1.0, 1.0], [1.0, 0.0]])
     y = [1, 1, 1, -1, -1]
@@ -729,7 +727,7 @@ def test_ridgecv_negative_alphas():
                         "alphas cannot be negative.",
                         ridge.fit, X, y)
 
-    # Negative alphas
+    # Negative floats
     ridge = RidgeCV(alphas=(-0.1, -1.0, -10.0))
     assert_raises_regex(ValueError,
                         "alphas cannot be negative.",

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -709,6 +709,17 @@ def test_sparse_design_with_sample_weights():
                                       decimal=6)
 
 
+def test_ridgecv_int_alphas():
+
+    X = np.array([[-1.0, -1.0], [-1.0, 0], [-.8, -1.0],
+                  [1.0, 1.0], [1.0, 0.0]])
+    y = [1, 1, 1, -1, -1]
+
+    # Integers
+    ridge = RidgeCV(alphas=(1, 10, 100))
+    ridge.fit(X, y)
+
+
 def test_ridgecv_negative_alphas():
 
     X = np.array([[-1.0, -1.0], [-1.0, 0], [-.8, -1.0],

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -706,11 +706,22 @@ def test_sparse_design_with_sample_weights():
 
 def test_ridgecv_alphas():
     # Test that no error is raised when fitting RidgeCV
-    # either for positive or negatives alphas
+    # with integer alpha values and also
+    # check that an error is raised for negative alphas
 
     X = np.array([[-1.0, -1.0], [-1.0, 0], [-.8, -1.0],
                   [1.0, 1.0], [1.0, 0.0]])
     y = [1, 1, 1, -1, -1]
+
+    # Integers
+    alphas = (1, 10, 100)
+    ridge = RidgeCV(alphas)
+    ridge.fit(X, y)
+
+    # Negative integers
+    alphas = (-1, -10, -100)
+    ridge = RidgeCV(alphas)
+    assert_raises(ValueError, ridge.fit, X, y)
 
     # Positive alphas
     alphas = (0.1, 1.0, 10.0)
@@ -720,7 +731,7 @@ def test_ridgecv_alphas():
     # Negative alphas
     alphas = (-0.1, -1.0, -10.0)
     ridge = RidgeCV(alphas)
-    ridge.fit(X, y)
+    assert_raises(ValueError, ridge.fit, X, y)
 
 
 def test_raises_value_error_if_solver_not_supported():

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -709,16 +709,16 @@ def test_sparse_design_with_sample_weights():
                                       decimal=6)
 
 
-def test_ridgecv_alpha_conversion_to_array():
+testdata_alpha = [
+    ((1, 10, 100), np.array([1.0, 10.0, 100.0])),
+    ((-1, -10, -100), np.array([-1.0, -10.0, -100.0]))
+]
 
-    testdata_alpha = [
-        ((1, 10, 100), np.array([1.0, 10.0, 100.0])),
-        ((-1, -10, -100), np.array([-1.0, -10.0, -100.0]))
-    ]
 
-    @pytest.mark.parametrize("alpha_input, alpha_expected", testdata_alpha)
-    def test_conversion(alpha_input, alpha_expected):
-        assert(RidgeCV(alpha_input).get_params()['alphas'] == alpha_expected)
+@pytest.mark.parametrize("alpha_input, alpha_expected", testdata_alpha)
+def test_conversion(alpha_input, alpha_expected):
+    assert((RidgeCV(alpha_input).get_params()['alphas'] ==
+            alpha_expected).all())
 
 
 def test_ridgecv_int_alphas():

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -2,7 +2,6 @@ import numpy as np
 import scipy.sparse as sp
 from scipy import linalg
 from itertools import product
-import pytest
 
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_almost_equal

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -704,6 +704,25 @@ def test_sparse_design_with_sample_weights():
                                       decimal=6)
 
 
+def test_ridgecv_alphas():
+    # Test that no error is raised when fitting RidgeCV
+    # either for positive or negatives alphas
+
+    X = np.array([[-1.0, -1.0], [-1.0, 0], [-.8, -1.0],
+                  [1.0, 1.0], [1.0, 0.0]])
+    y = [1, 1, 1, -1, -1]
+
+    # Positive alphas
+    alphas = (0.1, 1.0, 10.0)
+    ridge = RidgeCV(alphas)
+    ridge.fit(X, y)
+
+    # Negative alphas
+    alphas = (-0.1, -1.0, -10.0)
+    ridge = RidgeCV(alphas)
+    ridge.fit(X, y)
+
+
 def test_raises_value_error_if_solver_not_supported():
     # Tests whether a ValueError is raised if a non-identified solver
     # is passed to ridge_regression


### PR DESCRIPTION
fixes #10393 

- [Fix bug]: added support for float alphas in `class _RidgeGCV(LinearModel)`, lines 1050 and 1052.
- [Test]: added a test to check that using negative alphas does not raise an error.