### PR TITLE
[MRG] Make pip install numpy and scipy for us

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -231,7 +231,7 @@ def setup_package():
 
     build_requires = []
     try:
-        import scipy
+        import scipy  # noqa: F401
     except ImportError:  # We do not have scipy installed
         build_requires += ['scipy>={0}'.format(SCIPY_MIN_VERSION)]
     else:

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ if SETUPTOOLS_COMMANDS.intersection(sys.argv):
 else:
     extra_setuptools_args = dict()
 
-
 # Custom clean command to remove build artifacts
 
 class CleanCommand(Clean):


### PR DESCRIPTION
This PR modifies `setup.py` to include `numpy` and `scipy` as setup dependencies. Thus, running `pip install scikit-learn` will automatically install these libraries if needed. This code was adapted from `scipy`.

Fix #7867.