### PR TITLE
[MRG] Issue 7867: Install numpy and scipy using "install_requires"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,7 @@ def configuration(parent_package='', top_path=None):
         os.remove('MANIFEST')
 
     from numpy.distutils.misc_util import Configuration
+
     config = Configuration(None, parent_package, top_path)
 
     # Avoid non-useful msg:
@@ -135,26 +136,6 @@ def configuration(parent_package='', top_path=None):
     config.add_subpackage('sklearn')
 
     return config
-
-
-def get_scipy_status():
-    """
-    Returns a dictionary containing a boolean specifying whether SciPy
-    is up-to-date, along with the version string (empty string if
-    not installed).
-    """
-    scipy_status = {}
-    try:
-        import scipy
-        scipy_version = scipy.__version__
-        scipy_status['up_to_date'] = parse_version(
-            scipy_version) >= parse_version(SCIPY_MIN_VERSION)
-        scipy_status['version'] = scipy_version
-    except ImportError:
-        traceback.print_exc()
-        scipy_status['up_to_date'] = False
-        scipy_status['version'] = ""
-    return scipy_status
 
 
 def get_numpy_status():
@@ -206,6 +187,10 @@ def setup_package():
                                  'Programming Language :: Python :: 3.6',
                                  ],
                     cmdclass=cmdclass,
+                    install_requires=[
+                        'numpy>={0}'.format(NUMPY_MIN_VERSION),
+                        'scipy>={0}'.format(SCIPY_MIN_VERSION)
+                    ],
                     **extra_setuptools_args)
 
     if len(sys.argv) == 1 or (
@@ -229,9 +214,6 @@ def setup_package():
         numpy_status = get_numpy_status()
         numpy_req_str = "scikit-learn requires NumPy >= {0}.\n".format(
             NUMPY_MIN_VERSION)
-        scipy_status = get_scipy_status()
-        scipy_req_str = "scikit-learn requires SciPy >= {0}.\n".format(
-            SCIPY_MIN_VERSION)
 
         instructions = ("Installation instructions are available on the "
                         "scikit-learn website: "
@@ -247,16 +229,6 @@ def setup_package():
                 raise ImportError("Numerical Python (NumPy) is not "
                                   "installed.\n{0}{1}"
                                   .format(numpy_req_str, instructions))
-        if scipy_status['up_to_date'] is False:
-            if scipy_status['version']:
-                raise ImportError("Your installation of Scientific Python "
-                                  "(SciPy) {0} is out-of-date.\n{1}{2}"
-                                  .format(scipy_status['version'],
-                                          scipy_req_str, instructions))
-            else:
-                raise ImportError("Scientific Python (SciPy) is not "
-                                  "installed.\n{0}{1}"
-                                  .format(scipy_req_str, instructions))
 
         from numpy.distutils.core import setup
 


### PR DESCRIPTION
Alternate, simpler PR after feedback on https://github.com/scikit-learn/scikit-learn/pull/10398. We can iterate on this one but possibly fall back to the other one if this doesn't work out.

In my testing, installing from a `.tar.gz` appears to work (i.e. I can import the `sklearn` module afterwards) but there are some errors displayed during installation. I don't know if those are a concern or not. Full output below.

Installing from a wheel worked smoothly.

Installing from source tarball (Mac OS X Sierra, Python 2.7.13):
```
$ pip install scikit-learn/dist/scikit-learn-0.20.dev0.tar.gz
Processing ./scikit-learn/dist/scikit-learn-0.20.dev0.tar.gz
Collecting numpy>=1.8.2 (from scikit-learn==0.20.dev0)
  Downloading https://artifactory.rsglab.com/artifactory/api/pypi/pypi/packages/ea/df/f0671353e3d2eab4c87df014ad09505268561f6b09d0dc257d1b32653cfe/numpy-1.13.3-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl (4.6MB)
Collecting scipy>=0.13.3 (from scikit-learn==0.20.dev0)
  Downloading https://artifactory.rsglab.com/artifactory/api/pypi/pypi/packages/4d/e4/e92135b070c0913cbee59849b61f57076ac33d8a754be0fef581a28676f9/scipy-1.0.0-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl (16.8MB)
Building wheels for collected packages: scikit-learn
  Running setup.py bdist_wheel for scikit-learn: started
  Running setup.py bdist_wheel for scikit-learn: finished with status 'error'
  Complete output from command /Users/bhart/.pyenv/versions/2.7.13/envs/scikit-learn-2.7.13/bin/python2.7 -u -c "import setuptools, tokenize;__file__='/private/var/folders/vd/j7yv3l2x0tb2t_7pvwrvhr2r0000gq/T/pip-GZj9kO-build/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /var/folders/vd/j7yv3l2x0tb2t_7pvwrvhr2r0000gq/T/tmp5WQUMIpip-wheel- --python-tag cp27:
  Partial import of sklearn during the build process.
  Traceback (most recent call last):
    File "/private/var/folders/vd/j7yv3l2x0tb2t_7pvwrvhr2r0000gq/T/pip-GZj9kO-build/setup.py", line 149, in get_numpy_status
      import numpy
  ImportError: No module named numpy
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/private/var/folders/vd/j7yv3l2x0tb2t_7pvwrvhr2r0000gq/T/pip-GZj9kO-build/setup.py", line 241, in <module>
      setup_package()
    File "/private/var/folders/vd/j7yv3l2x0tb2t_7pvwrvhr2r0000gq/T/pip-GZj9kO-build/setup.py", line 231, in setup_package
      .format(numpy_req_str, instructions))
  ImportError: Numerical Python (NumPy) is not installed.
  scikit-learn requires NumPy >= 1.8.2.
  Installation instructions are available on the scikit-learn website: http://scikit-learn.org/stable/install.html
  
  
  ----------------------------------------
  Running setup.py clean for scikit-learn
Failed to build scikit-learn
Installing collected packages: numpy, scipy, scikit-learn
  Running setup.py install for scikit-learn: started
    Running setup.py install for scikit-learn: still running...
    Running setup.py install for scikit-learn: finished with status 'done'
Successfully installed numpy-1.13.3 scikit-learn-0.20.dev0 scipy-1.0.0
$ python
Python 2.7.13 (default, Jun  8 2017, 17:00:51)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import sklearn
>>> import numpy
>>> import scipy
>>>
```

Fixes #10398, fix #7867.
  