### PR TITLE
[MRG+2] Fix SVC predict_proba fails with new-style kernel strings

### DIFF
--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -327,8 +327,8 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
 
         return libsvm.predict(
             X, self.support_, self.support_vectors_, self.n_support_,
-            self._dual_coef_, self._intercept_,
-            self.probA_, self.probB_, svm_type=svm_type, kernel_type=kernel_type,
+            self._dual_coef_, self._intercept_, self.probA_, self.probB_,
+            svm_type=svm_type, kernel_type=kernel_type,
             degree=self.degree, coef0=self.coef0, gamma=self._gamma,
             cache_size=self.cache_size)
 
@@ -409,8 +409,8 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
             X, self.support_, self.support_vectors_, self.n_support_,
             self._dual_coef_, self._intercept_,
             self.probA_, self.probB_,
-            svm_type=LIBSVM_IMPL.index(self._impl),
-            kernel_type=kernel_type, degree=self.degree, cache_size=self.cache_size,
+            svm_type=LIBSVM_IMPL.index(self._impl), kernel_type=kernel_type,
+            degree=self.degree, cache_size=self.cache_size,
             coef0=self.coef0, gamma=self._gamma)
 
     def _sparse_decision_function(self, X):

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -68,7 +68,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
     # The order of these must match the integer values in LibSVM.
     # XXX These are actually the same in the dense case. Need to factor
     # this out.
-    _sparse_kernels = ["linear", "poly", "rbf", "sigmoid", "precomputed"]
+    _kernels = ["linear", "poly", "rbf", "sigmoid", "precomputed"]
 
     @abstractmethod
     def __init__(self, kernel, degree, gamma, coef0,
@@ -259,7 +259,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
         X.data = np.asarray(X.data, dtype=np.float64, order='C')
         X.sort_indices()
 
-        kernel_type = self._sparse_kernels.index(kernel)
+        kernel_type = self._kernels.index(kernel)
 
         libsvm_sparse.set_verbosity_wrap(self.verbose)
 
@@ -323,11 +323,12 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
                                  (X.shape[1], self.shape_fit_[0]))
 
         svm_type = LIBSVM_IMPL.index(self._impl)
+        kernel_type = self._kernels.index(kernel)
 
         return libsvm.predict(
             X, self.support_, self.support_vectors_, self.n_support_,
             self._dual_coef_, self._intercept_,
-            self.probA_, self.probB_, svm_type=svm_type, kernel=kernel,
+            self.probA_, self.probB_, svm_type=svm_type, kernel_type=kernel_type,
             degree=self.degree, coef0=self.coef0, gamma=self._gamma,
             cache_size=self.cache_size)
 
@@ -337,7 +338,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
         if callable(kernel):
             kernel = 'precomputed'
 
-        kernel_type = self._sparse_kernels.index(kernel)
+        kernel_type = self._kernels.index(kernel)
 
         C = 0.0  # C is not useful here
 
@@ -402,12 +403,14 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
         if callable(kernel):
             kernel = 'precomputed'
 
+        kernel_type = self._kernels.index(kernel)
+
         return libsvm.decision_function(
             X, self.support_, self.support_vectors_, self.n_support_,
             self._dual_coef_, self._intercept_,
             self.probA_, self.probB_,
             svm_type=LIBSVM_IMPL.index(self._impl),
-            kernel=kernel, degree=self.degree, cache_size=self.cache_size,
+            kernel_type=kernel_type, degree=self.degree, cache_size=self.cache_size,
             coef0=self.coef0, gamma=self._gamma)
 
     def _sparse_decision_function(self, X):
@@ -417,7 +420,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
         if hasattr(kernel, '__call__'):
             kernel = 'precomputed'
 
-        kernel_type = self._sparse_kernels.index(kernel)
+        kernel_type = self._kernels.index(kernel)
 
         return libsvm_sparse.libsvm_sparse_decision_function(
             X.data, X.indices, X.indptr,
@@ -639,11 +642,12 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
             kernel = 'precomputed'
 
         svm_type = LIBSVM_IMPL.index(self._impl)
+        kernel_type = self._kernels.index(kernel)
         pprob = libsvm.predict_proba(
             X, self.support_, self.support_vectors_, self.n_support_,
             self._dual_coef_, self._intercept_,
             self.probA_, self.probB_,
-            svm_type=svm_type, kernel=kernel, degree=self.degree,
+            svm_type=svm_type, kernel_type=kernel_type, degree=self.degree,
             cache_size=self.cache_size, coef0=self.coef0, gamma=self._gamma)
 
         return pprob
@@ -655,7 +659,7 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
         if callable(kernel):
             kernel = 'precomputed'
 
-        kernel_type = self._sparse_kernels.index(kernel)
+        kernel_type = self._kernels.index(kernel)
 
         return libsvm_sparse.libsvm_sparse_predict_proba(
             X.data, X.indices, X.indptr,

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -229,15 +229,6 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
 
         libsvm.set_verbosity_wrap(self.verbose)
 
-        if six.PY2:
-            # In python2 ensure kernel is ascii bytes to prevent a TypeError
-            if isinstance(kernel, six.types.UnicodeType):
-                kernel = str(kernel)
-        if six.PY3:
-            # In python3 ensure kernel is utf8 unicode to prevent a TypeError
-            if isinstance(kernel, bytes):
-                kernel = str(kernel, 'utf8')
-
         # we don't pass **self.get_params() to allow subclasses to
         # add other parameters to __init__
         self.support_, self.support_vectors_, self.n_support_, \

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -68,7 +68,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
     # The order of these must match the integer values in LibSVM.
     # XXX These are actually the same in the dense case. Need to factor
     # this out.
-    _kernels = ["linear", "poly", "rbf", "sigmoid", "precomputed"]
+    _sparse_kernels = ["linear", "poly", "rbf", "sigmoid", "precomputed"]
 
     @abstractmethod
     def __init__(self, kernel, degree, gamma, coef0,
@@ -259,7 +259,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
         X.data = np.asarray(X.data, dtype=np.float64, order='C')
         X.sort_indices()
 
-        kernel_type = self._kernels.index(kernel)
+        kernel_type = self._sparse_kernels.index(kernel)
 
         libsvm_sparse.set_verbosity_wrap(self.verbose)
 
@@ -323,12 +323,11 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
                                  (X.shape[1], self.shape_fit_[0]))
 
         svm_type = LIBSVM_IMPL.index(self._impl)
-        kernel_type = self._kernels.index(kernel)
 
         return libsvm.predict(
             X, self.support_, self.support_vectors_, self.n_support_,
-            self._dual_coef_, self._intercept_, self.probA_, self.probB_,
-            svm_type=svm_type, kernel_type=kernel_type,
+            self._dual_coef_, self._intercept_,
+            self.probA_, self.probB_, svm_type=svm_type, kernel=kernel,
             degree=self.degree, coef0=self.coef0, gamma=self._gamma,
             cache_size=self.cache_size)
 
@@ -338,7 +337,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
         if callable(kernel):
             kernel = 'precomputed'
 
-        kernel_type = self._kernels.index(kernel)
+        kernel_type = self._sparse_kernels.index(kernel)
 
         C = 0.0  # C is not useful here
 
@@ -403,14 +402,12 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
         if callable(kernel):
             kernel = 'precomputed'
 
-        kernel_type = self._kernels.index(kernel)
-
         return libsvm.decision_function(
             X, self.support_, self.support_vectors_, self.n_support_,
             self._dual_coef_, self._intercept_,
             self.probA_, self.probB_,
-            svm_type=LIBSVM_IMPL.index(self._impl), kernel_type=kernel_type,
-            degree=self.degree, cache_size=self.cache_size,
+            svm_type=LIBSVM_IMPL.index(self._impl),
+            kernel=kernel, degree=self.degree, cache_size=self.cache_size,
             coef0=self.coef0, gamma=self._gamma)
 
     def _sparse_decision_function(self, X):
@@ -420,7 +417,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
         if hasattr(kernel, '__call__'):
             kernel = 'precomputed'
 
-        kernel_type = self._kernels.index(kernel)
+        kernel_type = self._sparse_kernels.index(kernel)
 
         return libsvm_sparse.libsvm_sparse_decision_function(
             X.data, X.indices, X.indptr,
@@ -642,12 +639,11 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
             kernel = 'precomputed'
 
         svm_type = LIBSVM_IMPL.index(self._impl)
-        kernel_type = self._kernels.index(kernel)
         pprob = libsvm.predict_proba(
             X, self.support_, self.support_vectors_, self.n_support_,
             self._dual_coef_, self._intercept_,
             self.probA_, self.probB_,
-            svm_type=svm_type, kernel_type=kernel_type, degree=self.degree,
+            svm_type=svm_type, kernel=kernel, degree=self.degree,
             cache_size=self.cache_size, coef0=self.coef0, gamma=self._gamma)
 
         return pprob
@@ -659,7 +655,7 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
         if callable(kernel):
             kernel = 'precomputed'
 
-        kernel_type = self._kernels.index(kernel)
+        kernel_type = self._sparse_kernels.index(kernel)
 
         return libsvm_sparse.libsvm_sparse_predict_proba(
             X.data, X.indices, X.indptr,

--- a/sklearn/svm/libsvm.pyx
+++ b/sklearn/svm/libsvm.pyx
@@ -462,7 +462,7 @@ def decision_function(
 def cross_validation(
     np.ndarray[np.float64_t, ndim=2, mode='c'] X,
     np.ndarray[np.float64_t, ndim=1, mode='c'] Y,
-    int n_fold, svm_type=0, str kernel='rbf', int degree=3,
+    int n_fold, svm_type=0, kernel='rbf', int degree=3,
     double gamma=0.1, double coef0=0., double tol=1e-3,
     double C=1., double nu=0.5, double epsilon=0.1,
     np.ndarray[np.float64_t, ndim=1, mode='c']

--- a/sklearn/svm/libsvm.pyx
+++ b/sklearn/svm/libsvm.pyx
@@ -288,7 +288,7 @@ def predict(np.ndarray[np.float64_t, ndim=2, mode='c'] X,
     X : array-like, dtype=float, size=[n_samples, n_features]
     svm_type : {0, 1, 2, 3, 4}
         Type of SVM: C SVC, nu SVC, one class, epsilon SVR, nu SVR
-    kernel_type : index of ['linear', 'rbf', 'poly', 'sigmoid', 'precomputed']
+    kernel_type : index of ['linear', 'poly', 'rbf', 'sigmoid', 'precomputed']
         Type of kernel.
     degree : int
         Degree of the polynomial kernel.
@@ -363,7 +363,7 @@ def predict_proba(
     Parameters
     ----------
     X : array-like, dtype=float
-    kernel_type : index of ['linear', 'rbf', 'poly', 'sigmoid', 'precomputed']
+    kernel_type : index of ['linear', 'poly', 'rbf', 'sigmoid', 'precomputed']
 
     Returns
     -------

--- a/sklearn/svm/libsvm.pyx
+++ b/sklearn/svm/libsvm.pyx
@@ -273,7 +273,7 @@ def predict(np.ndarray[np.float64_t, ndim=2, mode='c'] X,
             np.ndarray[np.float64_t, ndim=1, mode='c'] intercept,
             np.ndarray[np.float64_t, ndim=1, mode='c'] probA=np.empty(0),
             np.ndarray[np.float64_t, ndim=1, mode='c'] probB=np.empty(0),
-            int svm_type=0, int kernel_type=1, int degree=3,
+            int svm_type=0, int kernel_type=2, int degree=3,
             double gamma=0.1, double coef0=0.,
             np.ndarray[np.float64_t, ndim=1, mode='c']
                 class_weight=np.empty(0),
@@ -340,7 +340,7 @@ def predict_proba(
     np.ndarray[np.float64_t, ndim=1, mode='c'] intercept,
     np.ndarray[np.float64_t, ndim=1, mode='c'] probA=np.empty(0),
     np.ndarray[np.float64_t, ndim=1, mode='c'] probB=np.empty(0),
-    int svm_type=0, int kernel_type=1, int degree=3,
+    int svm_type=0, int kernel_type=2, int degree=3,
     double gamma=0.1, double coef0=0.,
     np.ndarray[np.float64_t, ndim=1, mode='c']
         class_weight=np.empty(0),
@@ -407,7 +407,7 @@ def decision_function(
     np.ndarray[np.float64_t, ndim=1, mode='c'] intercept,
     np.ndarray[np.float64_t, ndim=1, mode='c'] probA=np.empty(0),
     np.ndarray[np.float64_t, ndim=1, mode='c'] probB=np.empty(0),
-    int svm_type=0, int kernel_type=1, int degree=3,
+    int svm_type=0, int kernel_type=2, int degree=3,
     double gamma=0.1, double coef0=0.,
     np.ndarray[np.float64_t, ndim=1, mode='c']
         class_weight=np.empty(0),

--- a/sklearn/svm/libsvm.pyx
+++ b/sklearn/svm/libsvm.pyx
@@ -273,7 +273,7 @@ def predict(np.ndarray[np.float64_t, ndim=2, mode='c'] X,
             np.ndarray[np.float64_t, ndim=1, mode='c'] intercept,
             np.ndarray[np.float64_t, ndim=1, mode='c'] probA=np.empty(0),
             np.ndarray[np.float64_t, ndim=1, mode='c'] probB=np.empty(0),
-            int svm_type=0, int kernel_type=2, int degree=3,
+            int svm_type=0, int kernel_type=1, int degree=3,
             double gamma=0.1, double coef0=0.,
             np.ndarray[np.float64_t, ndim=1, mode='c']
                 class_weight=np.empty(0),
@@ -288,7 +288,7 @@ def predict(np.ndarray[np.float64_t, ndim=2, mode='c'] X,
     X : array-like, dtype=float, size=[n_samples, n_features]
     svm_type : {0, 1, 2, 3, 4}
         Type of SVM: C SVC, nu SVC, one class, epsilon SVR, nu SVR
-    kernel : {'linear', 'rbf', 'poly', 'sigmoid', 'precomputed'}
+    kernel_type : index of ['linear', 'rbf', 'poly', 'sigmoid', 'precomputed']
         Type of kernel.
     degree : int
         Degree of the polynomial kernel.
@@ -340,7 +340,7 @@ def predict_proba(
     np.ndarray[np.float64_t, ndim=1, mode='c'] intercept,
     np.ndarray[np.float64_t, ndim=1, mode='c'] probA=np.empty(0),
     np.ndarray[np.float64_t, ndim=1, mode='c'] probB=np.empty(0),
-    int svm_type=0, int kernel_type=2, int degree=3,
+    int svm_type=0, int kernel_type=1, int degree=3,
     double gamma=0.1, double coef0=0.,
     np.ndarray[np.float64_t, ndim=1, mode='c']
         class_weight=np.empty(0),
@@ -363,7 +363,7 @@ def predict_proba(
     Parameters
     ----------
     X : array-like, dtype=float
-    kernel : {'linear', 'rbf', 'poly', 'sigmoid', 'precomputed'}
+    kernel_type : index of ['linear', 'rbf', 'poly', 'sigmoid', 'precomputed']
 
     Returns
     -------
@@ -407,7 +407,7 @@ def decision_function(
     np.ndarray[np.float64_t, ndim=1, mode='c'] intercept,
     np.ndarray[np.float64_t, ndim=1, mode='c'] probA=np.empty(0),
     np.ndarray[np.float64_t, ndim=1, mode='c'] probB=np.empty(0),
-    int svm_type=0, int kernel_type=2, int degree=3,
+    int svm_type=0, int kernel_type=1, int degree=3,
     double gamma=0.1, double coef0=0.,
     np.ndarray[np.float64_t, ndim=1, mode='c']
         class_weight=np.empty(0),

--- a/sklearn/svm/libsvm.pyx
+++ b/sklearn/svm/libsvm.pyx
@@ -246,7 +246,7 @@ def fit(
 
 
 cdef void set_predict_params(
-    svm_parameter *param, int svm_type, kernel, int degree, double gamma,
+    svm_parameter *param, int svm_type, int kernel_type, int degree, double gamma,
     double coef0, double cache_size, int probability, int nr_weight,
     char *weight_label, char *weight) except *:
     """Fill param with prediction time-only parameters."""
@@ -260,9 +260,7 @@ cdef void set_predict_params(
     cdef double tol = .1
     cdef int random_seed = -1
 
-    kernel_index = LIBSVM_KERNEL_TYPES.index(kernel)
-
-    set_parameter(param, svm_type, kernel_index, degree, gamma, coef0, nu,
+    set_parameter(param, svm_type, kernel_type, degree, gamma, coef0, nu,
                          cache_size, C, tol, epsilon, shrinking, probability,
                          nr_weight, weight_label, weight, max_iter, random_seed)
 
@@ -275,7 +273,7 @@ def predict(np.ndarray[np.float64_t, ndim=2, mode='c'] X,
             np.ndarray[np.float64_t, ndim=1, mode='c'] intercept,
             np.ndarray[np.float64_t, ndim=1, mode='c'] probA=np.empty(0),
             np.ndarray[np.float64_t, ndim=1, mode='c'] probB=np.empty(0),
-            int svm_type=0, kernel='rbf', int degree=3,
+            int svm_type=0, int kernel_type=2, int degree=3,
             double gamma=0.1, double coef0=0.,
             np.ndarray[np.float64_t, ndim=1, mode='c']
                 class_weight=np.empty(0),
@@ -313,7 +311,7 @@ def predict(np.ndarray[np.float64_t, ndim=2, mode='c'] X,
     cdef np.ndarray[np.int32_t, ndim=1, mode='c'] \
         class_weight_label = np.arange(class_weight.shape[0], dtype=np.int32)
 
-    set_predict_params(&param, svm_type, kernel, degree, gamma, coef0,
+    set_predict_params(&param, svm_type, kernel_type, degree, gamma, coef0,
                        cache_size, 0, <int>class_weight.shape[0],
                        class_weight_label.data, class_weight.data)
     model = set_model(&param, <int> nSV.shape[0], SV.data, SV.shape,
@@ -342,7 +340,7 @@ def predict_proba(
     np.ndarray[np.float64_t, ndim=1, mode='c'] intercept,
     np.ndarray[np.float64_t, ndim=1, mode='c'] probA=np.empty(0),
     np.ndarray[np.float64_t, ndim=1, mode='c'] probB=np.empty(0),
-    int svm_type=0, str kernel='rbf', int degree=3,
+    int svm_type=0, int kernel_type=2, int degree=3,
     double gamma=0.1, double coef0=0.,
     np.ndarray[np.float64_t, ndim=1, mode='c']
         class_weight=np.empty(0),
@@ -379,7 +377,7 @@ def predict_proba(
         class_weight_label = np.arange(class_weight.shape[0], dtype=np.int32)
     cdef int rv
 
-    set_predict_params(&param, svm_type, kernel, degree, gamma, coef0,
+    set_predict_params(&param, svm_type, kernel_type, degree, gamma, coef0,
                        cache_size, 1, <int>class_weight.shape[0],
                        class_weight_label.data, class_weight.data)
     model = set_model(&param, <int> nSV.shape[0], SV.data, SV.shape,
@@ -409,7 +407,7 @@ def decision_function(
     np.ndarray[np.float64_t, ndim=1, mode='c'] intercept,
     np.ndarray[np.float64_t, ndim=1, mode='c'] probA=np.empty(0),
     np.ndarray[np.float64_t, ndim=1, mode='c'] probB=np.empty(0),
-    int svm_type=0, kernel='rbf', int degree=3,
+    int svm_type=0, int kernel_type=2, int degree=3,
     double gamma=0.1, double coef0=0.,
     np.ndarray[np.float64_t, ndim=1, mode='c']
         class_weight=np.empty(0),
@@ -432,7 +430,7 @@ def decision_function(
 
     cdef int rv
 
-    set_predict_params(&param, svm_type, kernel, degree, gamma, coef0,
+    set_predict_params(&param, svm_type, kernel_type, degree, gamma, coef0,
                        cache_size, 0, <int>class_weight.shape[0],
                        class_weight_label.data, class_weight.data)
 

--- a/sklearn/svm/libsvm.pyx
+++ b/sklearn/svm/libsvm.pyx
@@ -54,7 +54,7 @@ LIBSVM_KERNEL_TYPES = ['linear', 'poly', 'rbf', 'sigmoid', 'precomputed']
 def fit(
     np.ndarray[np.float64_t, ndim=2, mode='c'] X,
     np.ndarray[np.float64_t, ndim=1, mode='c'] Y,
-    int svm_type=0, str kernel='rbf', int degree=3,
+    int svm_type=0, kernel='rbf', int degree=3,
     double gamma=0.1, double coef0=0., double tol=1e-3,
     double C=1., double nu=0.5, double epsilon=0.1,
     np.ndarray[np.float64_t, ndim=1, mode='c']
@@ -342,7 +342,7 @@ def predict_proba(
     np.ndarray[np.float64_t, ndim=1, mode='c'] intercept,
     np.ndarray[np.float64_t, ndim=1, mode='c'] probA=np.empty(0),
     np.ndarray[np.float64_t, ndim=1, mode='c'] probB=np.empty(0),
-    int svm_type=0, str kernel='rbf', int degree=3,
+    int svm_type=0, kernel='rbf', int degree=3,
     double gamma=0.1, double coef0=0.,
     np.ndarray[np.float64_t, ndim=1, mode='c']
         class_weight=np.empty(0),

--- a/sklearn/svm/libsvm.pyx
+++ b/sklearn/svm/libsvm.pyx
@@ -246,7 +246,7 @@ def fit(
 
 
 cdef void set_predict_params(
-    svm_parameter *param, int svm_type, int kernel_type, int degree, double gamma,
+    svm_parameter *param, int svm_type, kernel, int degree, double gamma,
     double coef0, double cache_size, int probability, int nr_weight,
     char *weight_label, char *weight) except *:
     """Fill param with prediction time-only parameters."""
@@ -260,7 +260,9 @@ cdef void set_predict_params(
     cdef double tol = .1
     cdef int random_seed = -1
 
-    set_parameter(param, svm_type, kernel_type, degree, gamma, coef0, nu,
+    kernel_index = LIBSVM_KERNEL_TYPES.index(kernel)
+
+    set_parameter(param, svm_type, kernel_index, degree, gamma, coef0, nu,
                          cache_size, C, tol, epsilon, shrinking, probability,
                          nr_weight, weight_label, weight, max_iter, random_seed)
 
@@ -273,7 +275,7 @@ def predict(np.ndarray[np.float64_t, ndim=2, mode='c'] X,
             np.ndarray[np.float64_t, ndim=1, mode='c'] intercept,
             np.ndarray[np.float64_t, ndim=1, mode='c'] probA=np.empty(0),
             np.ndarray[np.float64_t, ndim=1, mode='c'] probB=np.empty(0),
-            int svm_type=0, int kernel_type=2, int degree=3,
+            int svm_type=0, kernel='rbf', int degree=3,
             double gamma=0.1, double coef0=0.,
             np.ndarray[np.float64_t, ndim=1, mode='c']
                 class_weight=np.empty(0),
@@ -288,7 +290,7 @@ def predict(np.ndarray[np.float64_t, ndim=2, mode='c'] X,
     X : array-like, dtype=float, size=[n_samples, n_features]
     svm_type : {0, 1, 2, 3, 4}
         Type of SVM: C SVC, nu SVC, one class, epsilon SVR, nu SVR
-    kernel_type : index of ['linear', 'poly', 'rbf', 'sigmoid', 'precomputed']
+    kernel : {'linear', 'rbf', 'poly', 'sigmoid', 'precomputed'}
         Type of kernel.
     degree : int
         Degree of the polynomial kernel.
@@ -311,7 +313,7 @@ def predict(np.ndarray[np.float64_t, ndim=2, mode='c'] X,
     cdef np.ndarray[np.int32_t, ndim=1, mode='c'] \
         class_weight_label = np.arange(class_weight.shape[0], dtype=np.int32)
 
-    set_predict_params(&param, svm_type, kernel_type, degree, gamma, coef0,
+    set_predict_params(&param, svm_type, kernel, degree, gamma, coef0,
                        cache_size, 0, <int>class_weight.shape[0],
                        class_weight_label.data, class_weight.data)
     model = set_model(&param, <int> nSV.shape[0], SV.data, SV.shape,
@@ -340,7 +342,7 @@ def predict_proba(
     np.ndarray[np.float64_t, ndim=1, mode='c'] intercept,
     np.ndarray[np.float64_t, ndim=1, mode='c'] probA=np.empty(0),
     np.ndarray[np.float64_t, ndim=1, mode='c'] probB=np.empty(0),
-    int svm_type=0, int kernel_type=2, int degree=3,
+    int svm_type=0, str kernel='rbf', int degree=3,
     double gamma=0.1, double coef0=0.,
     np.ndarray[np.float64_t, ndim=1, mode='c']
         class_weight=np.empty(0),
@@ -363,7 +365,7 @@ def predict_proba(
     Parameters
     ----------
     X : array-like, dtype=float
-    kernel_type : index of ['linear', 'poly', 'rbf', 'sigmoid', 'precomputed']
+    kernel : {'linear', 'rbf', 'poly', 'sigmoid', 'precomputed'}
 
     Returns
     -------
@@ -377,7 +379,7 @@ def predict_proba(
         class_weight_label = np.arange(class_weight.shape[0], dtype=np.int32)
     cdef int rv
 
-    set_predict_params(&param, svm_type, kernel_type, degree, gamma, coef0,
+    set_predict_params(&param, svm_type, kernel, degree, gamma, coef0,
                        cache_size, 1, <int>class_weight.shape[0],
                        class_weight_label.data, class_weight.data)
     model = set_model(&param, <int> nSV.shape[0], SV.data, SV.shape,
@@ -407,7 +409,7 @@ def decision_function(
     np.ndarray[np.float64_t, ndim=1, mode='c'] intercept,
     np.ndarray[np.float64_t, ndim=1, mode='c'] probA=np.empty(0),
     np.ndarray[np.float64_t, ndim=1, mode='c'] probB=np.empty(0),
-    int svm_type=0, int kernel_type=2, int degree=3,
+    int svm_type=0, kernel='rbf', int degree=3,
     double gamma=0.1, double coef0=0.,
     np.ndarray[np.float64_t, ndim=1, mode='c']
         class_weight=np.empty(0),
@@ -430,7 +432,7 @@ def decision_function(
 
     cdef int rv
 
-    set_predict_params(&param, svm_type, kernel_type, degree, gamma, coef0,
+    set_predict_params(&param, svm_type, kernel, degree, gamma, coef0,
                        cache_size, 0, <int>class_weight.shape[0],
                        class_weight_label.data, class_weight.data)
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -505,27 +505,27 @@ def test_bad_input():
 
 
 def test_unicode_kernel():
-    # Test that a unicode kernel name does not cause a TypeError on clf.fit
+    # Test that a unicode kernel name does not cause a TypeError
     if six.PY2:
         # Test unicode (same as str on python3)
-        clf = svm.SVC(kernel=unicode('linear'))
+        clf = svm.SVC(kernel=u'linear', probability=True)
         clf.fit(X, Y)
+        clf.predict_proba(T)
 
         # Test ascii bytes (str is bytes in python2)
-        clf = svm.SVC(kernel=str('linear'))
+        clf = svm.SVC(kernel=str('linear'), probability=True)
         clf.fit(X, Y)
+        clf.predict_proba(T)
     else:
         # Test unicode (str is unicode in python3)
-        clf = svm.SVC(kernel=str('linear'))
+        clf = svm.SVC(kernel=str('linear'), probability=True)
         clf.fit(X, Y)
-
-        # Test ascii bytes (same as str on python2)
-        clf = svm.SVC(kernel=bytes('linear', 'ascii'))
-        clf.fit(X, Y)
+        clf.predict_proba(T)
 
     # Test default behavior on both versions
-    clf = svm.SVC(kernel='linear')
+    clf = svm.SVC(kernel='linear', probability=True)
     clf.fit(X, Y)
+    clf.predict_proba(T)
 
 
 def test_sparse_precomputed():

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -508,7 +508,7 @@ def test_unicode_kernel():
     # Test that a unicode kernel name does not cause a TypeError
     if six.PY2:
         # Test unicode (same as str on python3)
-        clf = svm.SVC(kernel=unicode('linear'), probability=True)
+        clf = svm.SVC(kernel=u'linear', probability=True)
         clf.fit(X, Y)
         clf.predict(T)
         clf.predict_proba(T)
@@ -538,6 +538,7 @@ def test_unicode_kernel():
     clf.predict(T)
     clf.predict_proba(T)
     clf.decision_function(T)
+
 
 def test_sparse_precomputed():
     clf = svm.SVC(kernel='precomputed')

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -511,21 +511,37 @@ def test_unicode_kernel():
         clf = svm.SVC(kernel=u'linear', probability=True)
         clf.fit(X, Y)
         clf.predict_proba(T)
+        svm.libsvm.cross_validation(iris.data,
+                                    iris.target.astype(np.float64), 5,
+                                    kernel=u'linear',
+                                    random_seed=0)
 
         # Test ascii bytes (str is bytes in python2)
         clf = svm.SVC(kernel=str('linear'), probability=True)
         clf.fit(X, Y)
         clf.predict_proba(T)
+        svm.libsvm.cross_validation(iris.data,
+                                    iris.target.astype(np.float64), 5,
+                                    kernel=str('linear'),
+                                    random_seed=0)
     else:
         # Test unicode (str is unicode in python3)
         clf = svm.SVC(kernel=str('linear'), probability=True)
         clf.fit(X, Y)
         clf.predict_proba(T)
+        svm.libsvm.cross_validation(iris.data,
+                                    iris.target.astype(np.float64), 5,
+                                    kernel=str('linear'),
+                                    random_seed=0)
 
     # Test default behavior on both versions
     clf = svm.SVC(kernel='linear', probability=True)
     clf.fit(X, Y)
     clf.predict_proba(T)
+    svm.libsvm.cross_validation(iris.data,
+                                iris.target.astype(np.float64), 5,
+                                kernel='linear',
+                                random_seed=0)
 
 
 def test_sparse_precomputed():

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -67,7 +67,7 @@ def test_libsvm_iris():
 
     model = svm.libsvm.fit(iris.data, iris.target.astype(np.float64),
                            kernel='linear')
-    pred = svm.libsvm.predict(iris.data, *model, kernel='linear')
+    pred = svm.libsvm.predict(iris.data, *model, kernel_type=0)
     assert_greater(np.mean(pred == iris.target), .95)
 
     pred = svm.libsvm.cross_validation(iris.data,
@@ -505,28 +505,39 @@ def test_bad_input():
 
 
 def test_unicode_kernel():
-    # Test that a unicode kernel name does not cause a TypeError on clf.fit
+    # Test that a unicode kernel name does not cause a TypeError
     if six.PY2:
         # Test unicode (same as str on python3)
-        clf = svm.SVC(kernel=unicode('linear'))
+        clf = svm.SVC(kernel=unicode('linear'), probability=True)
         clf.fit(X, Y)
+        clf.predict(T)
+        clf.predict_proba(T)
+        clf.decision_function(T)
 
         # Test ascii bytes (str is bytes in python2)
-        clf = svm.SVC(kernel=str('linear'))
+        clf = svm.SVC(kernel=str('linear'), probability=True)
         clf.fit(X, Y)
+        clf.predict(T)
+        clf.predict_proba(T)
+        clf.decision_function(T)
     else:
         # Test unicode (str is unicode in python3)
-        clf = svm.SVC(kernel=str('linear'))
+        clf = svm.SVC(kernel=str('linear'), probability=True)
         clf.fit(X, Y)
+        clf.predict(T)
+        clf.predict_proba(T)
+        clf.decision_function(T)
 
         # Test ascii bytes (same as str on python2)
         clf = svm.SVC(kernel=bytes('linear', 'ascii'))
         clf.fit(X, Y)
 
     # Test default behavior on both versions
-    clf = svm.SVC(kernel='linear')
+    clf = svm.SVC(kernel='linear', probability=True)
     clf.fit(X, Y)
-
+    clf.predict(T)
+    clf.predict_proba(T)
+    clf.decision_function(T)
 
 def test_sparse_precomputed():
     clf = svm.SVC(kernel='precomputed')

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -67,7 +67,7 @@ def test_libsvm_iris():
 
     model = svm.libsvm.fit(iris.data, iris.target.astype(np.float64),
                            kernel='linear')
-    pred = svm.libsvm.predict(iris.data, *model, kernel_type=0)
+    pred = svm.libsvm.predict(iris.data, *model, kernel='linear')
     assert_greater(np.mean(pred == iris.target), .95)
 
     pred = svm.libsvm.cross_validation(iris.data,
@@ -505,39 +505,27 @@ def test_bad_input():
 
 
 def test_unicode_kernel():
-    # Test that a unicode kernel name does not cause a TypeError
+    # Test that a unicode kernel name does not cause a TypeError on clf.fit
     if six.PY2:
         # Test unicode (same as str on python3)
-        clf = svm.SVC(kernel=u'linear', probability=True)
+        clf = svm.SVC(kernel=unicode('linear'))
         clf.fit(X, Y)
-        clf.predict(T)
-        clf.predict_proba(T)
-        clf.decision_function(T)
 
         # Test ascii bytes (str is bytes in python2)
-        clf = svm.SVC(kernel=str('linear'), probability=True)
+        clf = svm.SVC(kernel=str('linear'))
         clf.fit(X, Y)
-        clf.predict(T)
-        clf.predict_proba(T)
-        clf.decision_function(T)
     else:
         # Test unicode (str is unicode in python3)
-        clf = svm.SVC(kernel=str('linear'), probability=True)
+        clf = svm.SVC(kernel=str('linear'))
         clf.fit(X, Y)
-        clf.predict(T)
-        clf.predict_proba(T)
-        clf.decision_function(T)
 
         # Test ascii bytes (same as str on python2)
         clf = svm.SVC(kernel=bytes('linear', 'ascii'))
         clf.fit(X, Y)
 
     # Test default behavior on both versions
-    clf = svm.SVC(kernel='linear', probability=True)
+    clf = svm.SVC(kernel='linear')
     clf.fit(X, Y)
-    clf.predict(T)
-    clf.predict_proba(T)
-    clf.decision_function(T)
 
 
 def test_sparse_precomputed():

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -516,24 +516,6 @@ def test_unicode_kernel():
                                     kernel=u'linear',
                                     random_seed=0)
 
-        # Test ascii bytes (str is bytes in python2)
-        clf = svm.SVC(kernel=str('linear'), probability=True)
-        clf.fit(X, Y)
-        clf.predict_proba(T)
-        svm.libsvm.cross_validation(iris.data,
-                                    iris.target.astype(np.float64), 5,
-                                    kernel=str('linear'),
-                                    random_seed=0)
-    else:
-        # Test unicode (str is unicode in python3)
-        clf = svm.SVC(kernel=str('linear'), probability=True)
-        clf.fit(X, Y)
-        clf.predict_proba(T)
-        svm.libsvm.cross_validation(iris.data,
-                                    iris.target.astype(np.float64), 5,
-                                    kernel=str('linear'),
-                                    random_seed=0)
-
     # Test default behavior on both versions
     clf = svm.SVC(kernel='linear', probability=True)
     clf.fit(X, Y)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10374. Closes #10338


#### What does this implement/fix? Explain your changes.
This fixes SVC predict_proba fails. As discussion in #10338, I change dense case to be like sparse case, that is passing int kernel_type instead of str kernel. 

It is done by moving `kernel_index = LIBSVM_KERNEL_TYPES.index(kernel)` from cypthon code(`svm/libsvm.pyx`) to python code(`svm/base.py`)


#### Any other comments?
Q1: Since both `predict()` and `decision_function()` in `svm/libsvm.pyx` also use `set_predict_params()`, where `kernel_index = LIBSVM_KERNEL_TYPES.index(kernel)` locates in, I modify `predict()` and `decision_function()` for consistency. Is it what we want?

Q2: Should we make a change to `fit()` in `svm/libsvm.pyx` as well?

Q3: Both dense and sparse predict fail when `kernel=b'linear'` is given under Python3. In fact, only `_dense_fit()` handles this case. Should we handle this case?

NOTE: I reuse the test code from #10338, thanks @JoshuaMeyers for the great work!

  