### PR TITLE
[MRG+1] test method subset invariance (Fixes #10420)

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -322,3 +322,7 @@ Changes to estimator checks
 - Allow :func:`estimator_checks.check_estimator` to check that there is no
   private settings apart from parameters during estimator initialization.
   :issue:`9378` by :user:`Herilalaina Rakotoarison <herilalaina>`
+
+- Add test :func:`estimator_checks.check_methods_subset_invariance` to check
+  that estimators methods are invariant if applied to a data subset.
+  :issue:`10420` by :user:`Jonathan Ohayon <Johayon>`

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -677,13 +677,13 @@ def check_methods_subset_invariance(name, estimator_orig):
                 res_all = res_all[0]
                 res_one = list(map(lambda x: x[0], res_one))
             # TODO remove cases when corrected
-            if [name, method] in [['SVC', 'decision_function'],
-                                  ['SparsePCA', 'transform'],
-                                  ['MiniBatchSparsePCA', 'transform'],
-                                  ['BernoulliRBM', 'score_samples']]:
+            if (name, method) in [('SVC', 'decision_function'),
+                                  ('SparsePCA', 'transform'),
+                                  ('MiniBatchSparsePCA', 'transform'),
+                                  ('BernoulliRBM', 'score_samples')]:
                 raise SkipTest(msg)
             assert_allclose(np.ravel(res_all), np.ravel(res_one),
-                            atol=1e-8, err_msg=msg)
+                            atol=1e-7, err_msg=msg)
 
 
 @ignore_warnings

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -644,10 +644,24 @@ def check_fit2d_predict1d(name, estimator_orig):
                                  getattr(estimator, method), X[0])
 
 
+def _apply_func(func, X):
+    # apply function on the whole set and on mini batches
+    result_full = func(X)
+    n_features = X.shape[1]
+    result_by_batch = [func(batch.reshape(1, n_features))
+                       for batch in X]
+    # func can output tuple (e.g. score_samples)
+    if type(result_full) == tuple:
+        result_full = result_full[0]
+        result_by_batch = list(map(lambda x: x[0], result_by_batch))
+
+    return np.ravel(result_full), np.ravel(result_by_batch)
+
+
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))
 def check_methods_subset_invariance(name, estimator_orig):
     # check that method gives invariant results if applied
-    # one by one or on all elements together.
+    # on mini bathes or the whole set
     rnd = np.random.RandomState(0)
     X = 3 * rnd.uniform(size=(20, 3))
     X = pairwise_estimator_convert_X(X, estimator_orig)
@@ -665,24 +679,20 @@ def check_methods_subset_invariance(name, estimator_orig):
 
     for method in ["predict", "transform", "decision_function",
                    "score_samples", "predict_proba"]:
+
+        msg = ("{method} of {name} is not invariant when applied "
+               "to a subset.").format(method=method, name=name)
+        # TODO remove cases when corrected
+        if (name, method) in [('SVC', 'decision_function'),
+                              ('SparsePCA', 'transform'),
+                              ('MiniBatchSparsePCA', 'transform'),
+                              ('BernoulliRBM', 'score_samples')]:
+            raise SkipTest(msg)
+
         if hasattr(estimator, method):
-            msg = ("{method} of {name} is not invariant when applied "
-                   "to a subset.").format(method=method, name=name)
-            func = getattr(estimator, method)
-            res_all = func(X)
-            res_one = [func(X[i].reshape(1, X.shape[1]))
-                       for i in range(X.shape[0])]
-            # func can output tuple (e.g. score_samples)
-            if type(res_all) == tuple:
-                res_all = res_all[0]
-                res_one = list(map(lambda x: x[0], res_one))
-            # TODO remove cases when corrected
-            if (name, method) in [('SVC', 'decision_function'),
-                                  ('SparsePCA', 'transform'),
-                                  ('MiniBatchSparsePCA', 'transform'),
-                                  ('BernoulliRBM', 'score_samples')]:
-                raise SkipTest(msg)
-            assert_allclose(np.ravel(res_all), np.ravel(res_one),
+            result_full, result_by_batch = _apply_func(getattr(estimator,
+                                                               method), X)
+            assert_allclose(result_full, result_by_batch,
                             atol=1e-7, err_msg=msg)
 
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -690,8 +690,8 @@ def check_methods_subset_invariance(name, estimator_orig):
             raise SkipTest(msg)
 
         if hasattr(estimator, method):
-            result_full, result_by_batch = _apply_func(getattr(estimator,
-                                                               method), X)
+            result_full, result_by_batch = _apply_func(
+                getattr(estimator, method), X)
             assert_allclose(result_full, result_by_batch,
                             atol=1e-7, err_msg=msg)
 

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -134,6 +134,23 @@ class NoSampleWeightPandasSeriesType(BaseEstimator):
         return np.ones(X.shape[0])
 
 
+class NotInvariantPredict(BaseEstimator):
+    def fit(self, X, y):
+        # Convert data
+        X, y = check_X_y(X, y,
+                         accept_sparse=("csr", "csc"),
+                         multi_output=True,
+                         y_numeric=True)
+        return self
+
+    def predict(self, X):
+        # return 1 if X has more than one element else return 0
+        X = check_array(X)
+        if X.shape[0] > 1:
+            return np.ones(X.shape[0])
+        return np.zeros(X.shape[0])
+
+
 def test_check_estimator():
     # tests that the estimator actually fails on "bad" estimators.
     # not a complete test of all checks, which are very extensive.
@@ -184,6 +201,13 @@ def test_check_estimator():
            ' with _ but wrong_attribute added')
     assert_raises_regex(AssertionError, msg,
                         check_estimator, SetsWrongAttribute)
+    # check for invariant method
+    name = NotInvariantPredict.__name__
+    method = 'predict'
+    msg = ("{method} of {name} is not invariant when applied "
+           "to a subset.").format(method=method, name=name)
+    assert_raises_regex(AssertionError, msg,
+                        check_estimator, NotInvariantPredict)
     # check for sparse matrix input handling
     name = NoSparseClassifier.__name__
     msg = "Estimator %s doesn't seem to fail gracefully on sparse data" % name


### PR DESCRIPTION
Fixes #10420
- added a test for all estimators to check if any of the methods {`predict`, `predict_proba`, `decision_function`, `score_samples`, `transform`} produces a different result if applied on all the data or a subset (in this case all the elements one by one).

- the test currently fails in 4 cases
1.  `SVC` with `decision_function` (#9174)
2. `SparsePCA` with `transform` (#10431)
3. `MiniBatchSparsePCA` with `transform` (#10431)
4. `BernoulliRBM` with `score_samples` (due to stochasticity; can't easily fix)


  