### PR TITLE
[MRG + 1] DOC Add permalink icons to glossary terms

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -282,6 +282,7 @@ issues_user_uri = 'https://github.com/{user}'
 def setup(app):
     # to hide/show the prompt in code examples:
     app.add_javascript('js/copybutton.js')
+    app.add_javascript('js/extra.js')
     app.connect('build-finished', make_carousel_thumbs)
 
 

--- a/doc/themes/scikit-learn/static/js/extra.js
+++ b/doc/themes/scikit-learn/static/js/extra.js
@@ -1,0 +1,12 @@
+// Miscellaneous enhancements to doc display
+
+
+$(document).ready(function() {
+	/*** Add permalink buttons next to glossary terms ***/
+
+	$('dl.glossary > dt[id]').append(function() {
+		return ('<a class="headerlink" href="#' +
+			    this.getAttribute('id') +
+			    '" title="Permalink to this term">¶</a>');
+	})
+});


### PR DESCRIPTION
This inserts permalink buttons -- like those for headings -- next to glossary terms in HTML documentation