### PR TITLE
[MRG + 1] Properly handle corner case in sort.

### DIFF
--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -535,6 +535,8 @@ cdef class BestSplitter(BaseDenseSplitter):
 # Sort n-element arrays pointed to by Xf and samples, simultaneously,
 # by the values in Xf. Algorithm: Introsort (Musser, SP&E, 1997).
 cdef inline void sort(DTYPE_t* Xf, SIZE_t* samples, SIZE_t n) nogil:
+    if n == 0:
+      return
     cdef int maxd = 2 * <int>log(n)
     introsort(Xf, samples, n, maxd)
 


### PR DESCRIPTION
There is one test case that fails undefined behavior test. This happens
when n is 0, which resutls in log(n) evalutes to -inf. And to convert
-inf to integer is undefined behavior and causes exception when
undefined behavior check is turned on.

Properly handle this by early return when sorting array is zero length.

I agree this might be an usage error instead of a bug, but to leave it
vulnerable to undefined behavior exception might not a good idea.

Undefined behavior check is happy after this fix.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
