### PR TITLE
[WIP] Disregard nan fix

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -651,7 +651,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
                                                 last_mean=self.mean_,
                                                 last_var=self.var_,
                                                 last_n=0,
-                                                last_n_feat= \
+                                                last_n_feat=
                                                 self.n_samples_seen_)
             else:
                 self.mean_ = None

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -660,7 +660,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
             # First pass
             if not hasattr(self, 'n_samples_seen_'):
                 self.mean_ = .0
-                self.n_samples_seen_ = 0
+                self.n_samples_seen_ = np.zeros(X.shape[1])
                 if self.with_std:
                     self.var_ = .0
                 else:

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -636,10 +636,13 @@ class StandardScaler(BaseEstimator, TransformerMixin):
                 # First pass
                 if not hasattr(self, 'n_samples_seen_'):
                     self.mean_, self.var_ = mean_variance_axis(X, axis=0)
-                    if isinstance (X, sparse.csc_matrix):
-                        self.n_samples_seen_ = n_samples_count_csc(X.data, X.shape, X.indices, X.indptr)
+                    if isinstance(X, sparse.csc_matrix):
+                        self.n_samples_seen_ = \
+                            n_samples_count_csc(X.data, X.shape,
+                                                X.indices, X.indptr)
                     else:
-                        self.n_samples_seen_ = n_samples_count_csr(X.data, X.shape, X.indices)
+                        self.n_samples_seen_ = \
+                            n_samples_count_csr(X.data, X.shape, X.indices)
 
                 # Next passes
                 else:
@@ -648,7 +651,8 @@ class StandardScaler(BaseEstimator, TransformerMixin):
                                                 last_mean=self.mean_,
                                                 last_var=self.var_,
                                                 last_n=0,
-                                                last_n_feat=self.n_samples_seen_)
+                                                last_n_feat= \
+                                                self.n_samples_seen_)
             else:
                 self.mean_ = None
                 self.var_ = None

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -647,12 +647,12 @@ class StandardScaler(BaseEstimator, TransformerMixin):
                 # Next passes
                 else:
                     self.mean_, self.var_, self.n_samples_seen_ = \
-                        incr_mean_variance_axis(X, axis=0,
-                                                last_mean=self.mean_,
-                                                last_var=self.var_,
-                                                last_n=0,
-                                                last_n_feat=
-                                                self.n_samples_seen_)
+                        incr_mean_variance_axis(
+                            X, axis=0,
+                            last_mean=self.mean_,
+                            last_var=self.var_,
+                            last_n=0,
+                            last_n_feat=self.n_samples_seen_)
             else:
                 self.mean_ = None
                 self.var_ = None

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -26,7 +26,8 @@ from ..utils.extmath import row_norms
 from ..utils.extmath import _incremental_mean_and_var
 from ..utils.fixes import _argmax
 from ..utils.sparsefuncs_fast import (inplace_csr_row_normalize_l1,
-                                      inplace_csr_row_normalize_l2)
+                                      inplace_csr_row_normalize_l2,
+                                      n_samples_count_csc, n_samples_count_csr)
 from ..utils.sparsefuncs import (inplace_column_scale,
                                  mean_variance_axis, incr_mean_variance_axis,
                                  min_max_axis)
@@ -619,7 +620,8 @@ class StandardScaler(BaseEstimator, TransformerMixin):
             Ignored
         """
         X = check_array(X, accept_sparse=('csr', 'csc'), copy=self.copy,
-                        warn_on_dtype=True, estimator=self, dtype=FLOAT_DTYPES)
+                        warn_on_dtype=True, estimator=self,
+                        force_all_finite='allow-nan', dtype=FLOAT_DTYPES)
 
         # Even in the case of `with_mean=False`, we update the mean anyway
         # This is needed for the incremental computation of the var
@@ -634,14 +636,19 @@ class StandardScaler(BaseEstimator, TransformerMixin):
                 # First pass
                 if not hasattr(self, 'n_samples_seen_'):
                     self.mean_, self.var_ = mean_variance_axis(X, axis=0)
-                    self.n_samples_seen_ = X.shape[0]
+                    if isinstance (X, sparse.csc_matrix):
+                        self.n_samples_seen_ = n_samples_count_csc(X.data, X.shape, X.indices, X.indptr)
+                    else:
+                        self.n_samples_seen_ = n_samples_count_csr(X.data, X.shape, X.indices)
+
                 # Next passes
                 else:
                     self.mean_, self.var_, self.n_samples_seen_ = \
                         incr_mean_variance_axis(X, axis=0,
                                                 last_mean=self.mean_,
                                                 last_var=self.var_,
-                                                last_n=self.n_samples_seen_)
+                                                last_n=0,
+                                                last_n_feat=self.n_samples_seen_)
             else:
                 self.mean_ = None
                 self.var_ = None
@@ -688,7 +695,8 @@ class StandardScaler(BaseEstimator, TransformerMixin):
 
         copy = copy if copy is not None else self.copy
         X = check_array(X, accept_sparse='csr', copy=copy, warn_on_dtype=True,
-                        estimator=self, dtype=FLOAT_DTYPES)
+                        estimator=self, dtype=FLOAT_DTYPES,
+                        force_all_finite='allow-nan')
 
         if sparse.issparse(X):
             if self.with_mean:

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -203,7 +203,7 @@ def test_standard_scaler_1d():
                                       np.zeros_like(n_features))
             assert_array_almost_equal(X_scaled.mean(axis=0), .0)
             assert_array_almost_equal(X_scaled.std(axis=0), 1.)
-        assert_equal(scaler.n_samples_seen_, X.shape[0])
+        assert_equal(scaler.n_samples_seen_[0], X.shape[0])
 
         # check inverse transform
         X_scaled_back = scaler.inverse_transform(X_scaled)
@@ -283,7 +283,7 @@ def test_scaler_2d_arrays():
     scaler = StandardScaler()
     X_scaled = scaler.fit(X).transform(X, copy=True)
     assert_false(np.any(np.isnan(X_scaled)))
-    assert_equal(scaler.n_samples_seen_, n_samples)
+    assert_equal(scaler.n_samples_seen_[0], n_samples)
 
     assert_array_almost_equal(X_scaled.mean(axis=0), n_features * [0.0])
     assert_array_almost_equal(X_scaled.std(axis=0), [0., 1., 1., 1., 1.])
@@ -399,7 +399,7 @@ def test_standard_scaler_partial_fit():
 
         assert_array_almost_equal(scaler_batch.mean_, scaler_incr.mean_)
         assert_equal(scaler_batch.var_, scaler_incr.var_)  # Nones
-        assert_equal(scaler_batch.n_samples_seen_, scaler_incr.n_samples_seen_)
+        assert_equal(scaler_batch.n_samples_seen_[0], scaler_incr.n_samples_seen_[0])
 
         # Test std after 1 step
         batch0 = slice(0, chunk_size)
@@ -423,10 +423,10 @@ def test_standard_scaler_partial_fit():
             assert_correct_incr(i, batch_start=batch.start,
                                 batch_stop=batch.stop, n=n,
                                 chunk_size=chunk_size,
-                                n_samples_seen=scaler_incr.n_samples_seen_)
+                                n_samples_seen=scaler_incr.n_samples_seen_[0])
 
         assert_array_almost_equal(scaler_batch.var_, scaler_incr.var_)
-        assert_equal(scaler_batch.n_samples_seen_, scaler_incr.n_samples_seen_)
+        assert_equal(scaler_batch.n_samples_seen_[0], scaler_incr.n_samples_seen_[0])
 
 
 def test_standard_scaler_partial_fit_numerical_stability():
@@ -515,7 +515,7 @@ def test_standard_scaler_trasform_with_partial_fit():
         assert_array_less(zero, scaler_incr.var_ + epsilon)  # as less or equal
         assert_array_less(zero, scaler_incr.scale_ + epsilon)
         # (i+1) because the Scaler has been already fitted
-        assert_equal((i + 1), scaler_incr.n_samples_seen_)
+        assert_equal((i + 1), scaler_incr.n_samples_seen_[0])
 
 
 def test_min_max_scaler_iris():

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -70,6 +70,7 @@ MULTI_OUTPUT = ['CCA', 'DecisionTreeRegressor', 'ElasticNet',
                 'OrthogonalMatchingPursuit', 'PLSCanonical', 'PLSRegression',
                 'RANSACRegressor', 'RadiusNeighborsRegressor',
                 'RandomForestRegressor', 'Ridge', 'RidgeCV']
+ALLOW_NAN = ['StandardScaler']
 
 
 def _yield_non_meta_checks(name, estimator):
@@ -1024,6 +1025,8 @@ def check_estimators_nan_inf(name, estimator_orig):
     error_string_transform = ("Estimator doesn't check for NaN and inf in"
                               " transform.")
     for X_train in [X_train_nan, X_train_inf]:
+        if np.any(np.isnan(X_train)) and name in ALLOW_NAN:
+            continue
         # catch deprecation warnings
         with ignore_warnings(category=(DeprecationWarning, FutureWarning)):
             estimator = clone(estimator_orig)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -715,23 +715,26 @@ def _incremental_mean_and_var(X, last_mean=.0, last_variance=None,
         new_unnormalized_variance = (new_unnormalized_variance *
                                      new_sample_count)
         for i in xrange(n_features):
-            if updated_sample_count[i] == 0:  # Avoid division by 0
-                continue
-            # Avoid division by 0
-            elif last_sample_count[i] == 0 or new_sample_count[i] == 0:
-                updated_unnormalized_variance = new_unnormalized_variance[i]
-            else:
-                last_over_new_count = (last_sample_count[i] /
-                                       new_sample_count[i])
-                last_unnormalized_variance = (last_variance[i] *
-                                              last_sample_count[i])
-                updated_unnormalized_variance = (
-                    last_unnormalized_variance +
-                    new_unnormalized_variance[i] +
-                    last_over_new_count / updated_sample_count[i] *
-                    (last_sum[i] / last_over_new_count - new_sum[i]) ** 2)
-            updated_variance[i] = (updated_unnormalized_variance /
-                                   updated_sample_count[i])
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                if updated_sample_count[i] == 0:  # Avoid division by 0
+                    continue
+                # Avoid division by 0
+                elif last_sample_count[i] == 0 or new_sample_count[i] == 0:
+                    updated_unnormalized_variance = \
+                        new_unnormalized_variance[i]
+                else:
+                    last_over_new_count = (last_sample_count[i] /
+                                           new_sample_count[i])
+                    last_unnormalized_variance = (last_variance[i] *
+                                                  last_sample_count[i])
+                    updated_unnormalized_variance = (
+                        last_unnormalized_variance +
+                        new_unnormalized_variance[i] +
+                        last_over_new_count / updated_sample_count[i] *
+                        (last_sum[i] / last_over_new_count - new_sum[i]) ** 2)
+                updated_variance[i] = (updated_unnormalized_variance /
+                                       updated_sample_count[i])
 
     if flag == 0:  # If n_sample_count was not an array
         updated_sample_count = updated_sample_count[0]

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -643,7 +643,7 @@ def make_nonnegative(X, min_value=0):
 
 
 def _incremental_mean_and_var(X, last_mean=.0, last_variance=None,
-                              last_sample_count=0):
+                              last_sample_count=0, ignore_nan=True):
     """Calculate mean update and a Youngs and Cramer variance update.
 
     last_mean and last_variance are statistics computed at the last step by the
@@ -688,29 +688,53 @@ def _incremental_mean_and_var(X, last_mean=.0, last_variance=None,
     # old = stats until now
     # new = the current increment
     # updated = the aggregated stats
-    last_sum = last_mean * last_sample_count
-    new_sum = X.sum(axis=0)
+    flag = 0  # if flag == 1 then last_sample_count was an array
+    n_features = X.shape[1]
+    if isinstance(last_sample_count, np.ndarray):
+        flag = 1
+    else:
+        last_sample_count *= np.ones(n_features)
 
-    new_sample_count = X.shape[0]
+    last_sum = last_mean * last_sample_count
+    sum_func = np.nansum if ignore_nan else np.sum
+    new_sum = sum_func(X, axis=0)
+    new_sum[np.isnan(new_sum)] = 0
+
+    new_sample_count = np.count_nonzero(~np.isnan(X), axis=0)
     updated_sample_count = last_sample_count + new_sample_count
 
     updated_mean = (last_sum + new_sum) / updated_sample_count
+    updated_variance = np.zeros(n_features)
 
     if last_variance is None:
         updated_variance = None
     else:
-        new_unnormalized_variance = X.var(axis=0) * new_sample_count
-        if last_sample_count == 0:  # Avoid division by 0
-            updated_unnormalized_variance = new_unnormalized_variance
-        else:
-            last_over_new_count = last_sample_count / new_sample_count
-            last_unnormalized_variance = last_variance * last_sample_count
-            updated_unnormalized_variance = (
-                last_unnormalized_variance +
-                new_unnormalized_variance +
-                last_over_new_count / updated_sample_count *
-                (last_sum / last_over_new_count - new_sum) ** 2)
-        updated_variance = updated_unnormalized_variance / updated_sample_count
+        var_func = np.nanvar if ignore_nan else np.var
+        new_unnormalized_variance = var_func(X, axis=0)
+        new_unnormalized_variance[np.isnan(new_unnormalized_variance)] = 0
+        new_unnormalized_variance = (new_unnormalized_variance *
+                                     new_sample_count)
+        for i in xrange(n_features):
+            if updated_sample_count[i] == 0:  # Avoid division by 0
+                continue
+            # Avoid division by 0
+            elif last_sample_count[i] == 0 or new_sample_count[i] == 0:
+                updated_unnormalized_variance = new_unnormalized_variance[i]
+            else:
+                last_over_new_count = (last_sample_count[i] /
+                                       new_sample_count[i])
+                last_unnormalized_variance = (last_variance[i] *
+                                              last_sample_count[i])
+                updated_unnormalized_variance = (
+                    last_unnormalized_variance +
+                    new_unnormalized_variance[i] +
+                    last_over_new_count / updated_sample_count[i] *
+                    (last_sum[i] / last_over_new_count - new_sum[i]) ** 2)
+            updated_variance[i] = (updated_unnormalized_variance /
+                                   updated_sample_count[i])
+
+    if flag == 0:  # If n_sample_count was not an array
+        updated_sample_count = updated_sample_count[0]
 
     return updated_mean, updated_variance, updated_sample_count
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -701,6 +701,8 @@ def _incremental_mean_and_var(X, last_mean=.0, last_variance=None,
     new_sum[np.isnan(new_sum)] = 0
 
     new_sample_count = np.count_nonzero(~np.isnan(X), axis=0)
+    if not isinstance(new_sample_count, np.ndarray):
+        new_sample_count *= np.ones(n_features)
     updated_sample_count = last_sample_count + new_sample_count
 
     updated_mean = (last_sum + new_sum) / updated_sample_count

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -715,26 +715,23 @@ def _incremental_mean_and_var(X, last_mean=.0, last_variance=None,
         new_unnormalized_variance = (new_unnormalized_variance *
                                      new_sample_count)
         for i in xrange(n_features):
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                if updated_sample_count[i] == 0:  # Avoid division by 0
-                    continue
-                # Avoid division by 0
-                elif last_sample_count[i] == 0 or new_sample_count[i] == 0:
-                    updated_unnormalized_variance = \
-                        new_unnormalized_variance[i]
-                else:
-                    last_over_new_count = (last_sample_count[i] /
-                                           new_sample_count[i])
-                    last_unnormalized_variance = (last_variance[i] *
-                                                  last_sample_count[i])
-                    updated_unnormalized_variance = (
-                        last_unnormalized_variance +
-                        new_unnormalized_variance[i] +
-                        last_over_new_count / updated_sample_count[i] *
-                        (last_sum[i] / last_over_new_count - new_sum[i]) ** 2)
-                updated_variance[i] = (updated_unnormalized_variance /
-                                       updated_sample_count[i])
+            if updated_sample_count[i] == 0:  # Avoid division by 0
+                continue
+            # Avoid division by 0
+            elif last_sample_count[i] == 0 or new_sample_count[i] == 0:
+                updated_unnormalized_variance = new_unnormalized_variance[i]
+            else:
+                last_over_new_count = (last_sample_count[i] /
+                                       new_sample_count[i])
+                last_unnormalized_variance = (last_variance[i] *
+                                              last_sample_count[i])
+                updated_unnormalized_variance = (
+                    last_unnormalized_variance +
+                    new_unnormalized_variance[i] +
+                    last_over_new_count / updated_sample_count[i] *
+                    (last_sum[i] / last_over_new_count - new_sum[i]) ** 2)
+            updated_variance[i] = (updated_unnormalized_variance /
+                                   updated_sample_count[i])
 
     if flag == 0:  # If n_sample_count was not an array
         updated_sample_count = updated_sample_count[0]

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -99,7 +99,8 @@ def mean_variance_axis(X, axis):
         _raise_typeerror(X)
 
 
-def incr_mean_variance_axis(X, axis, last_mean, last_var, last_n):
+def incr_mean_variance_axis(X, axis, last_mean, last_var, last_n,
+                            last_n_feat=np.array([0], dtype=np.uint32)):
     """Compute incremental mean and variance along an axix on a CSR or
     CSC matrix.
 
@@ -143,17 +144,21 @@ def incr_mean_variance_axis(X, axis, last_mean, last_var, last_n):
     if isinstance(X, sp.csr_matrix):
         if axis == 0:
             return _incr_mean_var_axis0(X, last_mean=last_mean,
-                                        last_var=last_var, last_n=last_n)
+                                        last_var=last_var, last_n=last_n,
+                                        last_n_feat=last_n_feat)
         else:
             return _incr_mean_var_axis0(X.T, last_mean=last_mean,
-                                        last_var=last_var, last_n=last_n)
+                                        last_var=last_var, last_n=last_n,
+                                        last_n_feat=last_n_feat)
     elif isinstance(X, sp.csc_matrix):
         if axis == 0:
             return _incr_mean_var_axis0(X, last_mean=last_mean,
-                                        last_var=last_var, last_n=last_n)
+                                        last_var=last_var, last_n=last_n,
+                                        last_n_feat=last_n_feat)
         else:
             return _incr_mean_var_axis0(X.T, last_mean=last_mean,
-                                        last_var=last_var, last_n=last_n)
+                                        last_var=last_var, last_n=last_n,
+                                        last_n_feat=last_n_feat)
     else:
         _raise_typeerror(X)
 

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -136,8 +136,9 @@ def _csr_mean_variance_axis0(np.ndarray[floating, ndim=1, mode="c"] X_data,
         counts[col_ind] += 1
 
     for i in xrange(n_features):
-        variances[i] += (n_samples_feat[i] - counts[i]) * means[i] ** 2
-        variances[i] /= n_samples_feat[i]
+        if n_samples_feat[i]:
+            variances[i] += (n_samples_feat[i] - counts[i]) * means[i] ** 2
+            variances[i] /= n_samples_feat[i]
 
     return means, variances
 
@@ -203,14 +204,19 @@ def _csc_mean_variance_axis0(np.ndarray[floating, ndim=1] X_data,
         n_samples_feat = n_samples
 
         for j in xrange(startptr, endptr):
+            if isnan(X_data[j]) and ignore_nan:
+                n_samples_feat -= 1
+                counts -= 1
+        if n_samples_feat == 0: # Avoid division by Zero
+            continue
+
+        for j in xrange(startptr, endptr):
             x_i = X_data[j]
             if isnan(x_i) and ignore_nan:
-                n_samples_feat -= 1
                 continue
             means[i] += x_i
-        # Avoid division by Zero in case where all values are NaN in feature i
-        if n_samples_feat:
-            means[i] /= n_samples_feat
+
+        means[i] /= n_samples_feat
 
         for j in xrange(startptr, endptr):
             x_i = X_data[j]

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -222,10 +222,11 @@ def _csc_mean_variance_axis0(np.ndarray[floating, ndim=1] X_data,
 
     return means, variances
 
+
 def n_samples_count_csc(np.ndarray[floating, ndim=1] X_data,
-                             shape,
-                             np.ndarray[int, ndim=1] X_indices,
-                             np.ndarray[int, ndim=1] X_indptr):
+                        shape,
+                        np.ndarray[int, ndim=1] X_indices,
+                        np.ndarray[int, ndim=1] X_indptr):
     cdef unsigned int n_samples = shape[0]
     cdef unsigned int n_features = shape[1]
     cdef unsigned int startptr
@@ -247,9 +248,10 @@ def n_samples_count_csc(np.ndarray[floating, ndim=1] X_data,
 
     return n_samples_feat
 
+
 def n_samples_count_csr(np.ndarray[floating, ndim=1, mode="c"] X_data,
-                             shape,
-                             np.ndarray[int, ndim=1] X_indices):
+                        shape,
+                        np.ndarray[int, ndim=1] X_indices):
     cdef unsigned int n_samples = shape[0]
     cdef unsigned int n_features = shape[1]
 
@@ -410,7 +412,6 @@ def _incr_mean_variance_axis0(np.ndarray[floating, ndim=1] X_data,
             updated_var[i] = updated_var[i] / updated_n_feat[i]
 
         return updated_mean, updated_var, updated_n_feat
-
 
     # Where updated_n is a scaler
     else:

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -9,14 +9,14 @@
 #!python
 #cython: boundscheck=False, wraparound=False, cdivision=True
 
-from libc.math cimport fabs, sqrt, pow, isnan
+from libc.math cimport fabs, sqrt, pow
 cimport numpy as np
 import numpy as np
 import scipy.sparse as sp
 cimport cython
 from cython cimport floating
-cdef extern from "numpy/npy_math.h" nogil:
-    bint isnan "npy_isnan"(long double)
+
+from numpy.math cimport isnan
 
 np.import_array()
 

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -15,6 +15,8 @@ import numpy as np
 import scipy.sparse as sp
 cimport cython
 from cython cimport floating
+cdef extern from "numpy/npy_math.h" nogil:
+    bint isnan "npy_isnan"(long double)
 
 np.import_array()
 

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -5,6 +5,7 @@
 # License: BSD 3 clause
 
 import numpy as np
+from numpy.testing import assert_allclose
 from scipy import sparse
 from scipy import linalg
 from scipy import stats
@@ -465,6 +466,31 @@ def test_logistic_sigmoid():
 
     extreme_x = np.array([-100., 100.])
     assert_array_almost_equal(log_logistic(extreme_x), [-100, 0])
+
+
+def test_incremental_mean_and_var_nan():
+    # Test mean and variance when an array has floating NaN values
+    A = np.array([[600, 470, 170, 430, np.nan],
+                   [600, np.nan, 170, 430, 300],
+                   [np.nan, np.nan, np.nan, np.nan, np.nan],
+                   [np.nan, np.nan, np.nan, np.nan, np.nan]])
+    X1 = A[:2, :]
+    X2 = A[2:, :]
+    X_means = np.nanmean(X1, axis=0)
+    X_variances = np.nanvar(X1, axis=0)
+    X_count = np.count_nonzero(~np.isnan(X1), axis=0)
+    A_means = np.nanmean(A, axis=0)
+    A_variances = np.nanvar(A, axis=0)
+    A_count = np.count_nonzero(~np.isnan(A), axis=0)
+
+    final_means, final_variances, final_count = \
+        _incremental_mean_and_var(X2, X_means, X_variances, X_count)
+    assert_allclose(A_means, final_means, equal_nan=True)
+    print A_variances
+    print X_variances
+    print final_variances
+    assert_allclose(A_variances, final_variances, equal_nan=True)
+    assert_allclose(A_count, final_count, equal_nan=True)
 
 
 def test_incremental_variance_update_formulas():

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -32,9 +32,7 @@ def test_mean_variance_axis0_nan():
     X_csc = sp.csc_matrix(A)
 
     expected_dtypes = [(np.float32, np.float32),
-                       (np.float64, np.float64),
-                       (np.int32, np.float64),
-                       (np.int64, np.float64)]
+                       (np.float64, np.float64)]
 
     for input_dtype, output_dtype in expected_dtypes:
 

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -22,8 +22,8 @@ from sklearn.utils.testing import assert_raises
 
 
 def test_mean_variance_axis0_nan():
-    X = np.zeros(10).reshape(5,2) * np.nan
-    X[0,0] = 1
+    X = np.zeros(10).reshape(5, 2) * np.nan
+    X[0, 0] = 1
     X_csr = sp.csr_matrix(X)
     X_csc = sp.csc_matrix(X)
 
@@ -104,12 +104,13 @@ def test_mean_variance_axis1():
             assert_array_almost_equal(X_means, np.mean(X_test, axis=0))
             assert_array_almost_equal(X_vars, np.var(X_test, axis=0))
 
+
 def test_incr_mean_variance_axis_nan():
     for axis in [0, 1]:
         n_features = 50
-        data_chunk = np.random.randint(0,2, size=500).reshape(50,10)
+        data_chunk = np.random.randint(0, 2, size=500).reshape(50, 10)
         data_chunk = np.array(data_chunk, dtype=np.float)
-        data_chunk[0,0] = np.nan
+        data_chunk[0, 0] = np.nan
 
         # default params for incr_mean_variance
         last_mean = np.zeros(n_features)
@@ -228,6 +229,7 @@ def test_incr_mean_variance_axis():
                 assert_array_almost_equal(X_means, X_means_incr)
                 assert_array_almost_equal(X_vars, X_vars_incr)
                 assert_equal(X.shape[axis], n_incr)
+
 
 def test_mean_variance_illegal_axis():
     X, _ = make_classification(5, 4, random_state=0)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Partially Addressed : #10404

#### What does this implement/fix? Explain your changes.
- [x] StandardScaler -> Sparse Matrix ignore NaN
- [x] Add more thorough test in **test_sparsefunctions.py**
- [x] StandardScaler -> **_incremental_mean_var** ignores NaN
- [x] Add thorough test in **test_extmath.py**
#### Any other comments?
now various functions which previously took **last_n** to get the previous number of samples while computing the updated mean and variance now takes additional argument: **last_n_feat**

**last_n** is a scaler. This is not optional
**last_n_feat** is optional and takes a vector. Useful in cases when different features have different values because some of them had NaN values which needs to be ignored.

**Instruction** to use **last_n_feat** instead of **last_n**:
function_name(................., last_n=0, last_n_feat=self.n_samples_seen_)
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
