### PR TITLE
[MRG+1] TST apply transformer checks to any estimator supporting 'transform'

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -219,12 +219,13 @@ def _yield_all_checks(name, estimator):
     if is_regressor(estimator):
         for check in _yield_regressor_checks(name, estimator):
             yield check
-    if isinstance(estimator, TransformerMixin):
+    if hasattr(estimator, 'transform'):
         for check in _yield_transformer_checks(name, estimator):
             yield check
     if isinstance(estimator, ClusterMixin):
         for check in _yield_clustering_checks(name, estimator):
             yield check
+    if hasattr():
     yield check_fit2d_predict1d
     if name != 'GaussianProcess':  # FIXME
         # XXX GaussianProcess deprecated in 0.20

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -225,7 +225,6 @@ def _yield_all_checks(name, estimator):
     if isinstance(estimator, ClusterMixin):
         for check in _yield_clustering_checks(name, estimator):
             yield check
-    if hasattr():
     yield check_fit2d_predict1d
     if name != 'GaussianProcess':  # FIXME
         # XXX GaussianProcess deprecated in 0.20

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -134,28 +134,14 @@ class NoSampleWeightPandasSeriesType(BaseEstimator):
         return np.ones(X.shape[0])
 
 
-class BadTransformerWithoutMixin1(BaseEstimator):
+class BadTransformerWithoutMixin(BaseEstimator):
     def fit(self, X, y=None):
+        X = check_array(X)
         return self
 
     def transform(self, X):
+        X = check_array(X)
         return X
-
-
-class BadTransformerWithoutMixin2(BaseEstimator):
-
-    def fit(self, X, y=None):
-        try:
-            self.count_ += 1
-        except AttributeError:
-            self.count_ = 0
-        return self
-
-    def fit_transform(self, X, y=None):
-        return self.fit(X).transform(X)
-
-    def transform(self, X):
-        return np.array([self.count_] * len(X))
 
 
 def test_check_estimator():
@@ -235,9 +221,7 @@ def test_check_estimator():
 def test_check_estimator_transformer_no_mixin():
     # check that TransformerMixin is not required for transformer tests to run
     assert_raises_regex(AttributeError, '.*fit_transform.*',
-                        check_estimator, BadTransformerWithoutMixin1())
-    assert_raises_regex(AssertionError, 'consecutive fit_transform outcomes',
-                        check_estimator, BadTransformerWithoutMixin2())
+                        check_estimator, BadTransformerWithoutMixin())
 
 
 def test_check_estimator_clones():


### PR DESCRIPTION
I found that we were only applying common tests for transformers to  those inheriting TransformerMixin. This seems strange to me. Let's try ducktyping it.

TODO:
* [x] see if tests pass and/or decide if `fit_transform` would be a better duck typing check
* [x] test case