### PR TITLE
[WIP] Fix #10410 add ignore_unseen parameter to MultilabelBinarizer

### DIFF
--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -291,6 +291,12 @@ def test_multilabel_binarizer_empty_sample():
 
 def test_multilabel_binarizer_unknown_class():
     mlb = MultiLabelBinarizer()
+    y = [[1, 3], [1, 2, 3], [3]]
+
+    assert_array_equal(mlb.fit(y).transform([[1], [4], [2]]), np.array([[1, 0, 0], [0, 0, 0], [0, 0, 1]]))
+    assert_array_equal(mlb.fit(y).transform([[1], [1, 4], [1, 2, 3]]), np.array([[1, 0, 0], [1, 0, 0], [1, 1, 1]]))
+
+    mlb = MultiLabelBinarizer(ignore_unseen=False)
     y = [[1, 2]]
     assert_raises(KeyError, mlb.fit(y).transform, [[0]])
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fix #10410

#### What does this implement/fix? Explain your changes.
Add `ignore_unseen` parameter to MultilabelBinarizer so that `transform` does not raise `KeyValueError Exception` when labels have not been seen during fitting. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
