### PR TITLE
[MRG+1] TST fix: X_sparse_mix was not dense

### DIFF
--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -137,6 +137,7 @@ X_multilabel, y_multilabel = datasets.make_multilabel_classification(
 
 X_sparse_pos = random_state.uniform(size=(20, 5))
 X_sparse_pos[X_sparse_pos <= 0.8] = 0.
+X_sparse_pos = csr_matrix(X_sparse_pos)
 y_random = random_state.randint(0, 4, size=(20, ))
 X_sparse_mix = sparse_random_matrix(20, 10, density=0.25, random_state=0)
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -135,11 +135,12 @@ random_state = check_random_state(0)
 X_multilabel, y_multilabel = datasets.make_multilabel_classification(
     random_state=0, n_samples=30, n_features=10)
 
-# NB: these are sparse in nature, but X is still ndarray (and X_sparse is CSC)
+# NB: despite their names X_sparse_* are numpy arrays (and not sparse matrices)
 X_sparse_pos = random_state.uniform(size=(20, 5))
 X_sparse_pos[X_sparse_pos <= 0.8] = 0.
 y_random = random_state.randint(0, 4, size=(20, ))
-X_sparse_mix = sparse_random_matrix(20, 10, density=0.25, random_state=0).A
+X_sparse_mix = sparse_random_matrix(20, 10, density=0.25,
+                                    random_state=0).toarray()
 
 
 DATASETS = {

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -135,11 +135,11 @@ random_state = check_random_state(0)
 X_multilabel, y_multilabel = datasets.make_multilabel_classification(
     random_state=0, n_samples=30, n_features=10)
 
+# NB: these are sparse in nature, but X is still ndarray (and X_sparse is CSC)
 X_sparse_pos = random_state.uniform(size=(20, 5))
 X_sparse_pos[X_sparse_pos <= 0.8] = 0.
-X_sparse_pos = csr_matrix(X_sparse_pos)
 y_random = random_state.randint(0, 4, size=(20, ))
-X_sparse_mix = sparse_random_matrix(20, 10, density=0.25, random_state=0)
+X_sparse_mix = sparse_random_matrix(20, 10, density=0.25, random_state=0).A
 
 
 DATASETS = {


### PR DESCRIPTION
~I found that naming in tree tests implied input was sparse, but it was an ndarray!~

Turning this on its head.