### PR TITLE
[MRG] MAINT do not run tests in sklearn/externals

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ test = pytest
 addopts =
     --doctest-modules
     --disable-pytest-warnings
+    --ignore sklearn/externals
 
 [wheelhouse_uploader]
 artifact_indexes=


### PR DESCRIPTION
You can easily test this locally doing `pytest --collect-only | grep externals`.

Saw that while reviewing https://github.com/scikit-learn/scikit-learn/pull/10427#issuecomment-358008784.