### PR TITLE
Corrected error with clashing n_components='mle' and svd_solver='auto'

### DIFF
--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -389,6 +389,8 @@ class PCA(_BasePCA):
             n_components = self.n_components
 
         # Handle svd_solver
+        if n_components == 'mle':
+            self.svd_solver = 'full'
         svd_solver = self.svd_solver
         if svd_solver == 'auto':
             # Small problem or n_components == 'mle', just call full PCA


### PR DESCRIPTION
#https://github.com/scikit-learn/scikit-learn/issues/10491

#### What does this implement/fix? Explain your changes.

When using the `sklearn.decomposition.PCA` class with `n_components='mle'` when `svd_solver='auto'` the following line will attempt to evaluate n_components as a numeric type. An additional safety check is necessary.

I added a simple check which sets `svd_solver='full'` if `n_components='mle'`. It looks like the `_fit_truncated` method of PCA does not currently allow for any string based values of `n_components`. If that is ever changed this "fix" would not work.

Best,
Pablo