### PR TITLE
[MRG] Removed ref. to deprecated imread/imresize in docs

### DIFF
--- a/doc/datasets/index.rst
+++ b/doc/datasets/index.rst
@@ -290,10 +290,6 @@ refer to:
 * `skimage.io <http://scikit-image.org/docs/dev/api/skimage.io.html>`_ or
   `Imageio <https://imageio.readthedocs.io/en/latest/userapi.html>`_ 
   for loading images and videos to numpy arrays
-* `scipy.misc.imread <https://docs.scipy.org/doc/scipy/reference/generated/scipy.
-  misc.imread.html#scipy.misc.imread>`_ (requires the `Pillow
-  <https://pypi.python.org/pypi/Pillow>`_ package) to load pixel intensities
-  data from various image file formats
 * `scipy.io.wavfile.read 
   <https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.io.wavfile.read.html>`_ 
   for reading WAV files into a numpy array

--- a/doc/datasets/index.rst
+++ b/doc/datasets/index.rst
@@ -289,7 +289,7 @@ refer to:
 
 * `skimage.io <http://scikit-image.org/docs/dev/api/skimage.io.html>`_ or
   `Imageio <https://imageio.readthedocs.io/en/latest/userapi.html>`_ 
-  for loading images and videos to numpy arrays
+  for loading images and videos into numpy arrays
 * `scipy.io.wavfile.read 
   <https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.io.wavfile.read.html>`_ 
   for reading WAV files into a numpy array

--- a/examples/cluster/plot_face_segmentation.py
+++ b/examples/cluster/plot_face_segmentation.py
@@ -30,6 +30,7 @@ import matplotlib.pyplot as plt
 
 from sklearn.feature_extraction import image
 from sklearn.cluster import spectral_clustering
+from sklearn.externals._pilutil import imresize
 
 
 # load the raccoon face as a numpy array
@@ -40,7 +41,7 @@ except ImportError:
     face = sp.face(gray=True)
 
 # Resize it to 10% of the original size to speed up the processing
-face = sp.misc.imresize(face, 0.10) / 255.
+face = imresize(face, 0.10) / 255.
 
 # Convert the image into a graph with the value of the gradient on the
 # edges.

--- a/examples/cluster/plot_face_ward_segmentation.py
+++ b/examples/cluster/plot_face_ward_segmentation.py
@@ -23,6 +23,7 @@ import matplotlib.pyplot as plt
 
 from sklearn.feature_extraction.image import grid_to_graph
 from sklearn.cluster import AgglomerativeClustering
+from sklearn.externals._pilutil import imresize
 
 
 # #############################################################################
@@ -34,7 +35,7 @@ except ImportError:
     face = sp.face(gray=True)
 
 # Resize it to 10% of the original size to speed up the processing
-face = sp.misc.imresize(face, 0.10) / 255.
+face = imresize(face, 0.10) / 255.
 
 X = np.reshape(face, (-1, 1))
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes:  #10499 
See also:  #10427 

#### What does this implement/fix? Explain your changes.
This removes all occurrences of `scipy.misc.imread` and `scipy.misc.imresize` from the docs and examples as these functions are deprecated and will be removed. In the examples they were replaced by `sklearn.externals._pilutil.imresize`. The mention in the docs was simply removed as they already point to the correct alternatives (`skimage` and `imageio`).

#### Any other comments?
If thats preferred, instead of using `sklearn.externals._pilutil.imresize` in the two examples `examples/cluster/plot_face_segmentation.py` and `examples/cluster/plot_face_ward_segmentation.py` one could also use [`skimage.transform.rescale`](http://scikit-image.org/docs/dev/api/skimage.transform.html#skimage.transform.rescale).
