### PR TITLE
DOC: AdaBoostClassifier default value for base_estimator argument

### DIFF
--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -308,10 +308,11 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
 
     Parameters
     ----------
-    base_estimator : object, optional (default=DecisionTreeClassifier)
+    base_estimator : object, optional (default=see below)
         The base estimator from which the boosted ensemble is built.
         Support for sample weighting is required, as well as proper `classes_`
         and `n_classes_` attributes.
+        Default value: DecisionTreeClassifier(max_depth=1)
 
     n_estimators : integer, optional (default=50)
         The maximum number of estimators at which boosting is terminated.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

The default value used for 'base_estimator' is not correctly documented.


#### Any other comments?

I spent hours trying to understand what was going on on my code until I looked at the source code of AdaBoostClassifier and I realized the documentation for the default value of  'base_estimator' is incomplete

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
