### PR TITLE
[MRG+1] Fixes #10458: Make LabelEncoder work with empty list/array

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -279,7 +279,7 @@ Feature Extraction
 Preprocessing
 
 - Fixed bugs in :class:`preprocessing.LabelEncoder` which would sometimes throw
-  errors when `transform` or `inverse_transform` was called with empty arrays
+  errors when `transform` or `inverse_transform` was called with empty arrays.
   :issue:`10458` by :user:`Mayur Kulkarni <maykulkarni>`.
 
 API changes summary

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -280,7 +280,7 @@ Preprocessing
 
 - Fixed bugs in :class:`preprocessing.LabelEncoder` which would throw
   errors when `transform` or `inverse_transform` was called with empty arrays
-  :issue:`10458` by :user:`Mayur Kulkarni <maykulkarni>`
+  :issue:`10458` by :user:`Mayur Kulkarni <maykulkarni>`.
 
 API changes summary
 -------------------

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -278,7 +278,7 @@ Feature Extraction
 
 Preprocessing
 
-- Fixed bugs in :class:`preprocessing.LabelEncoder` which would throw
+- Fixed bugs in :class:`preprocessing.LabelEncoder` which would sometimes throw
   errors when `transform` or `inverse_transform` was called with empty arrays
   :issue:`10458` by :user:`Mayur Kulkarni <maykulkarni>`.
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -279,7 +279,7 @@ Feature Extraction
 Preprocessing
 
 - Fixed bugs in :class:`preprocessing.LabelEncoder` which would sometimes throw
-  errors when `transform` or `inverse_transform` was called with empty arrays.
+  errors when ``transform`` or ``inverse_transform`` was called with empty arrays.
   :issue:`10458` by :user:`Mayur Kulkarni <maykulkarni>`.
 
 API changes summary

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -276,6 +276,12 @@ Feature Extraction
   (words or n-grams). :issue:`9147` by :user:`Claes-Fredrik Mannby <mannby>`
   and `Roman Yurchak`_.
 
+Preprocessing
+
+- Fixed bugs in :class:`preprocessing.LabelEncoder` which would throw
+  errors when `transform` or `inverse_transform` was called with empty arrays
+  :issue:`10458` by :user:`Mayur Kulkarni <maykulkarni>`
+
 API changes summary
 -------------------
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -125,15 +125,16 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y : array-like of shape [n_samples]
         """
         check_is_fitted(self, 'classes_')
+        y = column_or_1d(y, warn=True)
+
         if _num_samples(y) == 0:
             return np.array([])
-        y = column_or_1d(y, warn=True)
 
         classes = np.unique(y)
         if len(np.intersect1d(classes, self.classes_)) < len(classes):
             diff = np.setdiff1d(classes, self.classes_)
             raise ValueError(
-                    "y contains previously unseen labels: %s" % str(diff))
+                "y contains previously unseen labels: %s" % str(diff))
         return np.searchsorted(self.classes_, y)
 
     def inverse_transform(self, y):

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -128,6 +128,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
             return np.array([])
         check_is_fitted(self, 'classes_')
         y = column_or_1d(y, warn=True)
+
         classes = np.unique(y)
         if len(np.intersect1d(classes, self.classes_)) < len(classes):
             diff = np.setdiff1d(classes, self.classes_)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -124,9 +124,10 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         -------
         y : array-like of shape [n_samples]
         """
+        if _num_samples(y) == 0:
+            return np.array([])
         check_is_fitted(self, 'classes_')
-        y = np.array(column_or_1d(y, warn=True), dtype=self.classes_.dtype)
-
+        y = column_or_1d(y, warn=True)
         classes = np.unique(y)
         if len(np.intersect1d(classes, self.classes_)) < len(classes):
             diff = np.setdiff1d(classes, self.classes_)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -148,7 +148,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         """
         check_is_fitted(self, 'classes_')
         # inverse transform of empty array is empty array
-        if len(y) == 0:
+        if _num_samples(y) == 0:
             return np.array([])
 
         diff = np.setdiff1d(y, np.arange(len(self.classes_)))

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -126,7 +126,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         """
         check_is_fitted(self, 'classes_')
         y = column_or_1d(y, warn=True)
-
+        # transform of empty array is empty array
         if _num_samples(y) == 0:
             return np.array([])
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -150,6 +150,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y : numpy array of shape [n_samples]
         """
         check_is_fitted(self, 'classes_')
+        y = column_or_1d(y, warn=True)
         # inverse transform of empty array is empty array
         if _num_samples(y) == 0:
             return np.array([])

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -125,7 +125,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y : array-like of shape [n_samples]
         """
         check_is_fitted(self, 'classes_')
-        y = column_or_1d(y, warn=True)
+        y = np.array(column_or_1d(y, warn=True), dtype=self.classes_.dtype)
 
         classes = np.unique(y)
         if len(np.intersect1d(classes, self.classes_)) < len(classes):
@@ -147,6 +147,9 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y : numpy array of shape [n_samples]
         """
         check_is_fitted(self, 'classes_')
+        # inverse transform of empty array is empty array
+        if len(y) == 0:
+            return np.array([])
 
         diff = np.setdiff1d(y, np.arange(len(self.classes_)))
         if len(diff):

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -124,9 +124,9 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         -------
         y : array-like of shape [n_samples]
         """
+        check_is_fitted(self, 'classes_')
         if _num_samples(y) == 0:
             return np.array([])
-        check_is_fitted(self, 'classes_')
         y = column_or_1d(y, warn=True)
 
         classes = np.unique(y)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -134,7 +134,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         if len(np.intersect1d(classes, self.classes_)) < len(classes):
             diff = np.setdiff1d(classes, self.classes_)
             raise ValueError(
-                "y contains previously unseen labels: %s" % str(diff))
+                    "y contains previously unseen labels: %s" % str(diff))
         return np.searchsorted(self.classes_, y)
 
     def inverse_transform(self, y):

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -211,7 +211,7 @@ def test_label_encoder_errors():
 
 def test_label_encoder_empty_array():
     le = LabelEncoder()
-    le.fit(np.array(["1", "2", "1", "2", "2"], dtype=np.float64))
+    le.fit(np.array(["1", "2", "1", "2", "2"]))
     # test empty transform
     transformed = le.transform([])
     assert_array_equal(np.array([]), transformed)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -196,11 +196,6 @@ def test_label_encoder_fit_transform():
 
 
 def test_label_encoder_errors():
-    # Check that invalid arguments yield ValueError
-    le = LabelEncoder()
-    assert_raises(ValueError, le.transform, [])
-    assert_raises(ValueError, le.inverse_transform, [])
-
     # Fail on unseen labels
     le = LabelEncoder()
     le.fit([1, 2, 3, -1, 1])

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -210,7 +210,6 @@ def test_label_encoder_errors():
 
     # Fail on inverse_transform("")
     msg = "bad input shape ()"
-    assert_raises(ValueError, le.inverse_transform, "")
     assert_raise_message(ValueError, msg, le.inverse_transform, "")
 
 

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -515,15 +515,12 @@ def test_inverse_binarize_multiclass():
     assert_array_equal(got, np.array([1, 1, 0]))
 
 
-def test_empty_labels_transform():
+def test_empty_labels():
     le = LabelEncoder()
-    le.fit(np.array([1, 2, 1, 2, 2], dtype=np.float64))
+    le.fit(np.array(["1", "2", "1", "2", "2"], dtype=np.float64))
+    # test empty transform
     transformed = le.transform([])
     assert_array_equal(np.array([]), transformed)
-
-
-def test_empty_labels_inverse_transform():
-    le = LabelEncoder()
-    le.fit(np.array([1, 2, 1, 2, 2], dtype=np.float64))
+    # test empty inverse transform
     inverse_transformed = le.inverse_transform([])
     assert_array_equal(np.array([]), inverse_transformed)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -209,6 +209,17 @@ def test_label_encoder_errors():
     assert_raise_message(ValueError, msg, le.inverse_transform, [-2, -3, -4])
 
 
+def test_label_encoder_empty_array():
+    le = LabelEncoder()
+    le.fit(np.array(["1", "2", "1", "2", "2"], dtype=np.float64))
+    # test empty transform
+    transformed = le.transform([])
+    assert_array_equal(np.array([]), transformed)
+    # test empty inverse transform
+    inverse_transformed = le.inverse_transform([])
+    assert_array_equal(np.array([]), inverse_transformed)
+
+
 def test_sparse_output_multilabel_binarizer():
     # test input as iterable of iterables
     inputs = [
@@ -513,14 +524,3 @@ def test_inverse_binarize_multiclass():
                                                    [0, 0, 0]]),
                                        np.arange(3))
     assert_array_equal(got, np.array([1, 1, 0]))
-
-
-def test_empty_labels():
-    le = LabelEncoder()
-    le.fit(np.array(["1", "2", "1", "2", "2"], dtype=np.float64))
-    # test empty transform
-    transformed = le.transform([])
-    assert_array_equal(np.array([]), transformed)
-    # test empty inverse transform
-    inverse_transformed = le.inverse_transform([])
-    assert_array_equal(np.array([]), inverse_transformed)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -513,3 +513,17 @@ def test_inverse_binarize_multiclass():
                                                    [0, 0, 0]]),
                                        np.arange(3))
     assert_array_equal(got, np.array([1, 1, 0]))
+
+
+def test_empty_labels_transform():
+    le = LabelEncoder()
+    le.fit(np.array([1, 2, 1, 2, 2], dtype=np.float64))
+    transformed = le.transform([])
+    assert_array_equal(np.array([]), transformed)
+
+
+def test_empty_labels_inverse_transform():
+    le = LabelEncoder()
+    le.fit(np.array([1, 2, 1, 2, 2], dtype=np.float64))
+    inverse_transformed = le.inverse_transform([])
+    assert_array_equal(np.array([]), inverse_transformed)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -196,6 +196,11 @@ def test_label_encoder_fit_transform():
 
 
 def test_label_encoder_errors():
+    # Check that invalid arguments yield ValueError
+    le = LabelEncoder()
+    assert_raises(ValueError, le.transform, [])
+    assert_raises(ValueError, le.inverse_transform, [])
+
     # Fail on unseen labels
     le = LabelEncoder()
     le.fit([1, 2, 3, -1, 1])

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -208,6 +208,11 @@ def test_label_encoder_errors():
     assert_raise_message(ValueError, msg, le.inverse_transform, [-2])
     assert_raise_message(ValueError, msg, le.inverse_transform, [-2, -3, -4])
 
+    # Fail on inverse_transform("")
+    msg = "bad input shape ()"
+    assert_raises(ValueError, le.inverse_transform, "")
+    assert_raise_message(ValueError, msg, le.inverse_transform, "")
+
 
 def test_label_encoder_empty_array():
     le = LabelEncoder()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #10458 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
- [x] LabelEncoder transforms empty list without raising error
- [x] LabelEncoder inverse transforms empty list without raising error
- [x] test cases to test the changes

#### Any other comments?
The original issue reported transform only. The same issue was with `inverse_transform` calling `inverse_transform([])` used to return a strange error which is now fixed. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
