### PR TITLE
[MRG+1] Fix FutureWarning in CategoricalEncoder due to np.issubdtype (#10507)

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2996,7 +2996,7 @@ class CategoricalEncoder(BaseEstimator, TransformerMixin):
                                      "supported")
 
         X_temp = check_array(X, dtype=None)
-        if not hasattr(X, 'dtype') and np.issubdtype(X_temp.dtype, str):
+        if not hasattr(X, 'dtype') and np.issubdtype(X_temp.dtype, np.str_):
             X = check_array(X, dtype=np.object)
         else:
             X = X_temp
@@ -3039,7 +3039,7 @@ class CategoricalEncoder(BaseEstimator, TransformerMixin):
 
         """
         X_temp = check_array(X, dtype=None)
-        if not hasattr(X, 'dtype') and np.issubdtype(X_temp.dtype, str):
+        if not hasattr(X, 'dtype') and np.issubdtype(X_temp.dtype, np.str_):
             X = check_array(X, dtype=np.object)
         else:
             X = X_temp

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2111,7 +2111,7 @@ def test_categorical_encoder_specified_categories():
     assert_array_equal(enc.fit_transform(X).toarray(), exp)
     assert enc.categories[0] == ['a', 'b', 'c']
     assert enc.categories_[0].tolist() == ['a', 'b', 'c']
-    assert np.issubdtype(enc.categories_[0].dtype, str)
+    assert np.issubdtype(enc.categories_[0].dtype, np.str_)
 
     # unsorted passed categories raises for now
     enc = CategoricalEncoder(categories=[['c', 'b', 'a']])
@@ -2125,7 +2125,7 @@ def test_categorical_encoder_specified_categories():
                     [0., 1., 0., 0., 0., 1.]])
     assert_array_equal(enc.fit_transform(X).toarray(), exp)
     assert enc.categories_[0].tolist() == ['a', 'b', 'c']
-    assert np.issubdtype(enc.categories_[0].dtype, str)
+    assert np.issubdtype(enc.categories_[0].dtype, np.str_)
     assert enc.categories_[1].tolist() == [0, 1, 2]
     assert np.issubdtype(enc.categories_[1].dtype, np.integer)
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2230,10 +2230,7 @@ def test_categorical_encoder_dtypes_pandas():
 def test_categorical_encoder_warning():
     enc = CategoricalEncoder()
     X = [['Male', 1], ['Female', 3]]
-    with warnings.catch_warnings(record=True) as w:
-        enc.fit_transform(X)
-    # check that no warning is raised
-    assert len(w) == 0
+    np.testing.assert_no_warnings(enc.fit_transform, X)
 
 
 def test_fit_cold_start():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2228,11 +2228,11 @@ def test_categorical_encoder_dtypes_pandas():
 
 
 def test_categorical_encoder_warning():
-    # check no warning is raised
+    enc = CategoricalEncoder()
+    X = [['Male', 1], ['Female', 3]]
     with warnings.catch_warnings(record=True) as w:
-        enc = CategoricalEncoder()
-        X = [['Male', 1], ['Female', 3], ['Female', 2]]
         enc.fit_transform(X)
+    # check that no warning is raised
     assert len(w) == 0
 
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2227,6 +2227,15 @@ def test_categorical_encoder_dtypes_pandas():
     assert_array_equal(enc.transform(X).toarray(), exp)
 
 
+def test_categorical_encoder_warning():
+    # check no warning is raised
+    with warnings.catch_warnings(record=True) as w:
+        enc = CategoricalEncoder()
+        X = [['Male', 1], ['Female', 3], ['Female', 2]]
+        enc.fit_transform(X)
+    assert len(w) == 0
+
+
 def test_fit_cold_start():
     X = iris.data
     X_2d = X[:, :2]


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10507 


#### What does this implement/fix? Explain your changes.
To silence the FutureWarning in `CategoricalEncoder`, I replace `str` with `np.str_` in calls to `np.issubdtype` as @rth proposed.

#### Any other comments?
N/A
