### PR TITLE
[MRG] Class weight imprecision

### DIFF
--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -66,7 +66,8 @@ def compute_class_weight(class_weight, classes, y):
             while not np.all(np.equal(true_order, weighted_order)):
                 # add jitter until weighted order = true order.
                 jitter += _jitter_transform(true_order, weighted_order)
-                recip_freq = (len(y) + jitter * 1e-7) / (len(le.classes_) * freq)
+                recip_freq = (len(y) + jitter * 1e-7) / (len(le.classes_) *
+                                                         freq)
                 weight = recip_freq[le.transform(classes)]
                 weighted_order = np.argsort(ordered_freq * weight)[::-1]
 

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -59,7 +59,7 @@ def compute_class_weight(class_weight, classes, y):
             # Just in case, we will add a little eps in order to prefer
             # true class distribution.
             jitter = np.zeros(len(freq))
-            jitter[np.argmax(freq)] = 1e-8
+            jitter[np.argsort(freq)] = np.arange(len(freq)) * 1e-8
             recip_freq = (len(y) + jitter) / (len(le.classes_) * freq)
             weight = recip_freq[le.transform(classes)]
     else:

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -58,8 +58,10 @@ def compute_class_weight(class_weight, classes, y):
             # Numerical imprecision issues.
             # Just in case, we will add a little eps in order to prefer
             # true class distribution.
-            order = np.argsort(freq)
-            weight[order] += np.arange(len(freq)) * 1e-8
+            jitter = np.zeros(len(freq))
+            jitter[np.argmax(freq)] = 1e-8
+            recip_freq = (len(y) + jitter) / (len(le.classes_) * freq)
+            weight = recip_freq[le.transform(classes)]
     else:
         # user-defined dictionary
         weight = np.ones(classes.shape[0], dtype=np.float64, order='C')

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -51,9 +51,15 @@ def compute_class_weight(class_weight, classes, y):
         if not all(np.in1d(classes, le.classes_)):
             raise ValueError("classes should have valid labels that are in y")
 
-        recip_freq = len(y) / (len(le.classes_) *
-                               np.bincount(y_ind).astype(np.float64))
+        freq = np.bincount(y_ind).astype(np.float64)
+        recip_freq = len(y) / (len(le.classes_) * freq)
         weight = recip_freq[le.transform(classes)]
+        if np.any(np.diff(freq)):
+            # Numerical imprecision issues.
+            # Just in case, we will add a little eps in order to prefer
+            # true class distribution.
+            order = np.argsort(freq)
+            weight[order] += np.arange(len(freq)) * 1e-8
     else:
         # user-defined dictionary
         weight = np.ones(classes.shape[0], dtype=np.float64, order='C')

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -54,7 +54,7 @@ def compute_class_weight(class_weight, classes, y):
         freq = np.bincount(y_ind).astype(np.float64)
         recip_freq = len(y) / (len(le.classes_) * freq)
         weight = recip_freq[le.transform(classes)]
-        if np.any(np.diff(freq)):
+        if np.any(np.diff(freq * weight)):
             # Numerical imprecision issues.
             # Just in case, we will add a little eps in order to prefer
             # true class distribution.

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -8,6 +8,7 @@ from sklearn.utils.class_weight import compute_class_weight
 from sklearn.utils.class_weight import compute_sample_weight
 
 from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raise_message
@@ -132,7 +133,7 @@ def test_balanced_class_weight_numerical_precision(freq):
     diff = np.diff(wfreq.reshape((k,1)) - wfreq.reshape((1,k)))
     assert np.all(np.abs(diff) < 1e-6)  # we want to be very close to true balance
     # sum of frequence should be close to the weighted sum
-    assert_almost_equal(np.sum(wfreq), np.sum(freq))
+    assert_allclose(np.sum(wfreq), np.sum(freq))
     # but in case of ambiguity, deterministically prefer original distribution
     assert np.all(diff == 0) or np.all(np.equal(np.argsort(freq), np.argsort(wfreq)))
 

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -126,6 +126,8 @@ def test_balanced_class_weight_numerical_precision(freq0, freq1):
     wfreq = w * [freq0, freq1]
     diff = np.diff(wfreq)
     assert np.abs(diff) < 1e-6  # we want to be very close to true balance
+    # sum of frequence should be close to the weighted sum
+    assert_almost_equal(np.sum(wfreq), np.sum([freq0, freq1]))
     # but in case of ambiguity, deterministically prefer original distribution
     assert diff == 0 or np.sign(diff) == np.sign(np.diff([freq0, freq1]))
 

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -130,12 +130,14 @@ def test_balanced_class_weight_numerical_precision(freq):
     # make sure we do comparisons as numpy floats to maintain imprecision
     w = compute_class_weight('balanced', np.arange(k), y)
     wfreq = w * freq
-    diff = np.diff(wfreq.reshape((k,1)) - wfreq.reshape((1,k)))
-    assert np.all(np.abs(diff) < 1e-6)  # we want to be very close to true balance
+    diff = np.diff(wfreq.reshape((k, 1)) - wfreq.reshape((1, k)))
+    # we want to be very close to true balance
+    assert np.all(np.abs(diff) < 1e-6)
     # sum of frequence should be close to the weighted sum
     assert_allclose(np.sum(wfreq), np.sum(freq))
     # but in case of ambiguity, deterministically prefer original distribution
-    assert np.all(diff == 0) or np.all(np.equal(np.argsort(freq), np.argsort(wfreq)))
+    assert (np.all(diff == 0) or np.all(np.equal(np.argsort(freq),
+                                                 np.argsort(wfreq))))
 
 
 def test_compute_class_weight_balanced_unordered():


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes  #10233
Continue the work of #10249

#### What does this implement/fix? Explain your changes.
add epsilon to favour the true distribution in case when class_weight 'balanced' is used and float imprecision does not allow the sum of weights to be equal (float vs rational).

#### Any other comments?
Not sure if this is necessary.