### PR TITLE
[MRG] Fix confusion_matrix documentation example

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -245,19 +245,19 @@ permitted and will require a wrapper to return a single metric::
     >>> # A sample toy binary classification dataset
     >>> X, y = datasets.make_classification(n_classes=2, random_state=0)
     >>> svm = LinearSVC(random_state=0)
-    >>> def tp(y_true, y_pred): return confusion_matrix(y_true, y_pred)[0, 0]
     >>> def tn(y_true, y_pred): return confusion_matrix(y_true, y_pred)[0, 0]
-    >>> def fp(y_true, y_pred): return confusion_matrix(y_true, y_pred)[1, 0]
-    >>> def fn(y_true, y_pred): return confusion_matrix(y_true, y_pred)[0, 1]
+    >>> def fp(y_true, y_pred): return confusion_matrix(y_true, y_pred)[0, 1]
+    >>> def fn(y_true, y_pred): return confusion_matrix(y_true, y_pred)[1, 0]
+    >>> def tp(y_true, y_pred): return confusion_matrix(y_true, y_pred)[1, 1]
     >>> scoring = {'tp' : make_scorer(tp), 'tn' : make_scorer(tn),
     ...            'fp' : make_scorer(fp), 'fn' : make_scorer(fn)}
     >>> cv_results = cross_validate(svm.fit(X, y), X, y, scoring=scoring)
     >>> # Getting the test set true positive scores
     >>> print(cv_results['test_tp'])          # doctest: +NORMALIZE_WHITESPACE
-    [12 13 15]
+    [16 14  9]
     >>> # Getting the test set false negative scores
     >>> print(cv_results['test_fn'])          # doctest: +NORMALIZE_WHITESPACE
-    [5 4 1]
+    [1 3 7]
 
 .. _classification_metrics:
 


### PR DESCRIPTION
Fixes confusion_matrix example in http://scikit-learn.org/stable/modules/model_evaluation.html#using-multiple-metric-evaluation where the index references of output matrix are not correct.

#### Reference Issues/PRs
Have not found one


#### What does this implement/fix? Explain your changes.
I believe this fixes mistake in docs. According to the docstring of the function https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/metrics/classification.py#L246 it should be like this.
Please remember the labels are returned sorted by unique_labels() in order (0, 1)

#### Any other comments?
```
In [41]: truth = [0,0,1,1,0,1,1,0]

In [42]: prediction = [1,1,0,1,0,1,1,0]

In [43]: cm = confusion_matrix(truth, prediction)

In [44]: cm
Out[44]: 
array([[2, 2],   # tn fp
       [1, 3]])  # fn tp
```