### PR TITLE
[MRG + 1] Remove  pilutil from examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
       - CONDA_ENV_NAME: testenv
       - PYTHON_VERSION: 2
       - MATPLOTLIB_VERSION: "1.3"
+      - SCIKITIMAGE_VERSION: "0.9.3"
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - CONDA_ENV_NAME: testenv
       - PYTHON_VERSION: 2
       - MATPLOTLIB_VERSION: "1.3"
-      - SCIKITIMAGE_VERSION: "0.9.3"
+      - SCIKIT_IMAGE_VERSION: "0.9.3"
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,8 @@ scikit-learn requires:
 - NumPy (>= 1.8.2)
 - SciPy (>= 0.13.3)
 
-For running the examples Matplotlib >= 1.1.1 is required.
+For running the examples Matplotlib >= 1.1.1 and scikit-image >= 0.9.3 are
+required.
 
 scikit-learn also uses CBLAS, the C interface to the Basic Linear Algebra
 Subprograms library. scikit-learn comes with a reference implementation, but

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,8 @@ scikit-learn requires:
 - NumPy (>= 1.8.2)
 - SciPy (>= 0.13.3)
 
-For running the examples Matplotlib >= 1.3.1 is required. A few examples require scikit-image >= 0.9.3 as well.
+For running the examples Matplotlib >= 1.3.1 is required. A few examples
+require scikit-image >= 0.9.3 as well.
 
 scikit-learn also uses CBLAS, the C interface to the Basic Linear Algebra
 Subprograms library. scikit-learn comes with a reference implementation, but

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -117,7 +117,7 @@ conda update --yes --quiet conda
 # provided versions
 conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" numpy scipy \
   cython pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=1.6.2 pillow \
-  scikit-image="${SCIKITIMAGE_VERSION:-*}"
+  scikit-image="${SCIKIT_IMAGE_VERSION:-*}"
 
 source activate testenv
 pip install sphinx-gallery

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -116,7 +116,8 @@ conda update --yes --quiet conda
 # Configure the conda environment and put it in the path using the
 # provided versions
 conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" numpy scipy \
-  cython pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=1.6.2 pillow
+  cython pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=1.6.2 pillow \
+  scikit-image="${SCIKITIMAGE_VERSION:-*}"
 
 source activate testenv
 pip install sphinx-gallery

--- a/examples/cluster/plot_face_segmentation.py
+++ b/examples/cluster/plot_face_segmentation.py
@@ -28,6 +28,7 @@ import numpy as np
 import scipy as sp
 from scipy.ndimage.filters import gaussian_filter
 import matplotlib.pyplot as plt
+from skimage import img_as_float
 from skimage.transform import rescale
 
 from sklearn.feature_extraction import image
@@ -37,15 +38,15 @@ from sklearn.cluster import spectral_clustering
 # load the raccoon face as a numpy array
 try:  # SciPy >= 0.16 have face in misc
     from scipy.misc import face
-    orig_face = face(gray=True)
+    orig_face = img_as_float(face(gray=True))
 except ImportError:
-    orig_face = sp.face(gray=True)
+    orig_face = img_as_float(sp.face(gray=True))
 
 # Resize it to 10% of the original size to speed up the processing
 # Applying a Gaussian filter for smoothing prior to down-scaling
 # reduces aliasing artifacts.
-smoothened_face = gaussian_filter(orig_face/255., sigma=(1/0.10-1)/2.)
-rescaled_face = rescale(smoothened_face, 0.10, mode="reflect")
+smoothened_face = gaussian_filter(orig_face, sigma=4.5)
+rescaled_face = rescale(smoothened_face, 0.1, mode="reflect")
 
 # Convert the image into a graph with the value of the gradient on the
 # edges.

--- a/examples/cluster/plot_face_segmentation.py
+++ b/examples/cluster/plot_face_segmentation.py
@@ -44,8 +44,8 @@ except ImportError:
 # Resize it to 10% of the original size to speed up the processing
 # Applying a Gaussian filter for smoothing prior to down-scaling
 # reduces aliasing artifacts.
-smoothened_face = gaussian_filter(orig_face, sigma=(1/0.10-1)/2.)
-rescaled_face = rescale(smoothened_face, 0.10, mode="reflect")/255.
+smoothened_face = gaussian_filter(orig_face/255., sigma=(1/0.10-1)/2.)
+rescaled_face = rescale(smoothened_face, 0.10, mode="reflect")
 
 # Convert the image into a graph with the value of the gradient on the
 # edges.

--- a/examples/cluster/plot_face_ward_segmentation.py
+++ b/examples/cluster/plot_face_ward_segmentation.py
@@ -39,8 +39,8 @@ except ImportError:
 # Resize it to 10% of the original size to speed up the processing
 # Applying a Gaussian filter for smoothing prior to down-scaling
 # reduces aliasing artifacts.
-smoothened_face = gaussian_filter(orig_face, sigma=(1/0.10-1)/2.)
-rescaled_face = rescale(smoothened_face, 0.10, mode="reflect")/255.
+smoothened_face = gaussian_filter(orig_face/255., sigma=(1/0.10-1)/2.)
+rescaled_face = rescale(smoothened_face, 0.10, mode="reflect")
 
 X = np.reshape(rescaled_face, (-1, 1))
 

--- a/examples/cluster/plot_face_ward_segmentation.py
+++ b/examples/cluster/plot_face_ward_segmentation.py
@@ -18,30 +18,35 @@ import time as time
 
 import numpy as np
 import scipy as sp
+from scipy.ndimage.filters import gaussian_filter
 
 import matplotlib.pyplot as plt
 
+from skimage.transform import rescale
+
 from sklearn.feature_extraction.image import grid_to_graph
 from sklearn.cluster import AgglomerativeClustering
-from sklearn.externals._pilutil import imresize
 
 
 # #############################################################################
 # Generate data
 try:  # SciPy >= 0.16 have face in misc
     from scipy.misc import face
-    face = face(gray=True)
+    orig_face = face(gray=True)
 except ImportError:
-    face = sp.face(gray=True)
+    orig_face = sp.face(gray=True)
 
 # Resize it to 10% of the original size to speed up the processing
-face = imresize(face, 0.10) / 255.
+# Applying a Gaussian filter for smoothing prior to down-scaling
+# reduces aliasing artifacts.
+smoothened_face = gaussian_filter(orig_face, sigma=(1/0.10-1)/2.)
+rescaled_face = rescale(smoothened_face, 0.10, mode="reflect")/255.
 
-X = np.reshape(face, (-1, 1))
+X = np.reshape(rescaled_face, (-1, 1))
 
 # #############################################################################
 # Define the structure A of the data. Pixels connected to their neighbors.
-connectivity = grid_to_graph(*face.shape)
+connectivity = grid_to_graph(*rescaled_face.shape)
 
 # #############################################################################
 # Compute clustering
@@ -51,7 +56,7 @@ n_clusters = 15  # number of regions
 ward = AgglomerativeClustering(n_clusters=n_clusters, linkage='ward',
                                connectivity=connectivity)
 ward.fit(X)
-label = np.reshape(ward.labels_, face.shape)
+label = np.reshape(ward.labels_, rescaled_face.shape)
 print("Elapsed time: ", time.time() - st)
 print("Number of pixels: ", label.size)
 print("Number of clusters: ", np.unique(label).size)
@@ -59,7 +64,7 @@ print("Number of clusters: ", np.unique(label).size)
 # #############################################################################
 # Plot the results on an image
 plt.figure(figsize=(5, 5))
-plt.imshow(face, cmap=plt.cm.gray)
+plt.imshow(rescaled_face, cmap=plt.cm.gray)
 for l in range(n_clusters):
     plt.contour(label == l, contours=1,
                 colors=[plt.cm.spectral(l / float(n_clusters)), ])

--- a/examples/cluster/plot_face_ward_segmentation.py
+++ b/examples/cluster/plot_face_ward_segmentation.py
@@ -22,6 +22,7 @@ from scipy.ndimage.filters import gaussian_filter
 
 import matplotlib.pyplot as plt
 
+from skimage import img_as_float
 from skimage.transform import rescale
 
 from sklearn.feature_extraction.image import grid_to_graph
@@ -32,15 +33,15 @@ from sklearn.cluster import AgglomerativeClustering
 # Generate data
 try:  # SciPy >= 0.16 have face in misc
     from scipy.misc import face
-    orig_face = face(gray=True)
+    orig_face = img_as_float(face(gray=True))
 except ImportError:
-    orig_face = sp.face(gray=True)
+    orig_face = img_as_float(sp.face(gray=True))
 
 # Resize it to 10% of the original size to speed up the processing
 # Applying a Gaussian filter for smoothing prior to down-scaling
 # reduces aliasing artifacts.
-smoothened_face = gaussian_filter(orig_face/255., sigma=(1/0.10-1)/2.)
-rescaled_face = rescale(smoothened_face, 0.10, mode="reflect")
+smoothened_face = gaussian_filter(orig_face, sigma=4.5)
+rescaled_face = rescale(smoothened_face, 0.1, mode="reflect")
 
 X = np.reshape(rescaled_face, (-1, 1))
 


### PR DESCRIPTION
#### Reference Issues/PRs
See discussion in #10502 


#### What does this implement/fix?
#10502 replaced `scipy.misc.imresize`, which was deprecated by SciPy, with the local copy `sklearn.externals._pilutil.imresize`. As pointed out by @jnothman and agreed on in the linked discussion, this usage of a private module in an example is non-ideal. So this PR replaces it again by a combination of `scipy.ndimage.filters.gaussian_filter` and `skimage.image.rescale`. The new dependency (scikit-image) is added to the README and to circleCI as pointed out by @lesteve in his instructions on how to proceed (Thank you for these, btw).


#### Any other comments?
 - The results differ slightly from the older version. I'll post a comparison later (or tomorrow).
 - To avoid the overwriting of `face` from a function to images of different resolution, I introduced new variables `orig_face`, `smoothened_face`, and `rescaled_face`. If preferred, I can also change it back, though.
 - Different from what was discussed in #10502, I did not use `skimage.filters.gaussian`. This wrapper around `scipy.ndimage.filters.gaussian_filter` changed names from `skimage.filter.gaussian_filter` to `skimage.filters.gaussian_filter` in version 0.11 and then to `skimage.filters.gaussian` in 0.12, while `skimage.filters.gaussian_filter` was deprecated and is removed in the current dev version 0.14. As the resulting convolution of `try: except ImportError:` blocks did not seem right for a minor part of a simple example, I went with `scipy.ndimage.filters.gaussian_filter` instead.
 - So far I have checked compatibility with the minimum scikit-image version (0.9.3) in the README only in a local docker container. I'll add a link to the circleCI-artifacts as soon as the builds are done.
 - BTW, while adding scikit-image I saw that the versions in circleCI (SciPy=0.14, Matplotlib=1.3) do not match the minima in the README (SciPy>=0.13.3, Matplotlib>=1.1.1). Is this difference intentional or should this be updated in the README at some point?
 - Finally, both examples raise a warning on my machine:
`matplotlib/contour.py:967: UserWarning: The following kwargs were not used by contour: 'contours'`
`plot_face_segmentation.py` also raises:
`sklearn/utils/graph.py:115: FutureWarning: Conversion of the second argument of issubdtype from int to np.signedinteger is deprecated. In future, it will be treated as np.int64 == np.dtype(int).type.`
Should I remove the offending parts as well?