### PR TITLE
[MRG] Warning for inf or -inf values in cross-validation

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -652,20 +652,6 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         test_scores = _aggregate_score_dicts(test_score_dicts)
         if self.return_train_score:
             train_scores = _aggregate_score_dicts(train_score_dicts)
-
-        # check for inf or -inf values in the train and test scores.-------------------------
-        
-        if(np.any(np.logical_not(np.isfinite(a))) for a in test_scores.values() ):
-            warnings.warn('Non-finite test scores were'
-                          ' generated during'
-                          ' cross-validation.', RuntimeWarning)
-                          
-        if(np.any(np.logical_not(np.isfinite(a))) for a in train_scores.values() ):
-            warnings.warn('Non-finite train scores were'
-                          ' generated during'
-                          ' cross-validation.', RuntimeWarning)
-        #------------------------------------------------------------------------------------
-      
       
         # TODO: replace by a dict in 0.21
         results = (DeprecationDict() if self.return_train_score == 'warn'
@@ -759,14 +745,6 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             self.best_params_ = candidate_params[self.best_index_]
             self.best_score_ = results["mean_test_%s" % refit_metric][
                 self.best_index_]
-
-        ### my code---
-        print('results[] keys= ')
-        print(str( results.keys() ))
-        print('\n\n\n')
-        print('results[] = ')
-        print(str( results))
-        print('\n\n\n')
 
         if self.refit:
             self.best_estimator_ = clone(base_estimator).set_params(

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -426,6 +426,7 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     parameters : dict or None, optional
         The parameters that have been evaluated.
     """
+    
     if verbose > 1:
         if parameters is None:
             msg = ''
@@ -504,6 +505,21 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         total_time = score_time + fit_time
         end_msg = "%s, total=%s" % (msg, logger.short_format_time(total_time))
         print("[CV] %s %s" % ((64 - len(end_msg)) * '.', end_msg))
+
+    # check for inf or -inf values in the train and test scores   
+    if(np.any(np.logical_not(np.isfinite(a))) for a in test_scores.values() ):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('once', RuntimeWarning)
+            warnings.warn('Non-finite test scores were'
+                          ' generated during'
+                          ' cross-validation.', RuntimeWarning)            
+                          
+    if(np.any(np.logical_not(np.isfinite(a))) for a in train_scores.values() ):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('once', RuntimeWarning)
+            warnings.warn('Non-finite train scores were'
+                          ' generated during'
+                          ' cross-validation.', RuntimeWarning)             
 
     ret = [train_scores, test_scores] if return_train_score else [test_scores]
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10529 

#### What does this implement/fix? Explain your changes.
A warning is displayed when non-finite train or test scores (inf or -inf) are generated from cross-validation. These infinite values cause the `mean` to become infinite and hence are problematic. 



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
