### PR TITLE
DOC move labelencoder what's new from 0.19 to 0.20

### DIFF
--- a/doc/whats_new/v0.19.rst
+++ b/doc/whats_new/v0.19.rst
@@ -48,10 +48,6 @@ Bug fixes
 - Avoid integer overflows in :func:`metrics.matthews_corrcoef`.
   :issue:`9693` by :user:`Sam Steingold <sam-s>`.
 
-- Fix ValueError in :class:`preprocessing.LabelEncoder` when using
-  ``inverse_transform`` on unseen labels. :issue:`9816` by :user:`Charlie Newey
-  <newey01c>`.
-
 - Fixed a bug in the objective function for :class:`manifold.TSNE` (both exact
   and with the Barnes-Hut approximation) when ``n_components >= 3``.
   :issue:`9711` by :user:`goncalo-rodrigues`.

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -311,6 +311,10 @@ Preprocessing
   errors when ``transform`` or ``inverse_transform`` was called with empty arrays.
   :issue:`10458` by :user:`Mayur Kulkarni <maykulkarni>`.
 
+- Fix ValueError in :class:`preprocessing.LabelEncoder` when using
+  ``inverse_transform`` on unseen labels. :issue:`9816` by :user:`Charlie Newey
+  <newey01c>`.
+
 API changes summary
 -------------------
 


### PR DESCRIPTION
Fixes #10552 Will self-check and merge.
See https://github.com/scikit-learn/scikit-learn/issues/10552#issuecomment-361616109
#9816 is supposed to be in 0.19.1(See #9816 (comment) by jnothman ) but somehow missing.
The problem is that we have a what's new entry in 0.19.1 but the code is not there, So let's move the entry.
