### PR TITLE
[MRG] Adding min. req. for numpy and scipy to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,8 @@ jobs:
       - MINICONDA_PATH: ~/miniconda
       - CONDA_ENV_NAME: testenv
       - PYTHON_VERSION: 2
+      - NUMPY_VERSION: 1.8.2
+      - SCIPY_VERSION: 0.13.3
       - MATPLOTLIB_VERSION: "1.3"
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
       # PYTHON_VERSION environment variable.
       - image: circleci/python:3.6.1
     environment:
+      # Test examples run with minimal dependencies.
       - MINICONDA_PATH: ~/miniconda
       - CONDA_ENV_NAME: testenv
       - PYTHON_VERSION: 2

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -115,8 +115,9 @@ conda update --yes --quiet conda
 
 # Configure the conda environment and put it in the path using the
 # provided versions
-conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" numpy scipy \
-  cython pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=1.6.2 pillow
+conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
+  numpy="${NUMPY_VERSION:-*}" scipy="${SCIPY_VERSION:-*}" cython \
+  pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=1.6.2 pillow
 
 source activate testenv
 pip install sphinx-gallery


### PR DESCRIPTION
#### Reference Issues/PRs
See discussion in #10527


#### What does this implement/fix? Explain your changes.
As suggested by @lesteve in [his comment](https://github.com/scikit-learn/scikit-learn/pull/10527#issuecomment-361209397) in the discussion about #10527, this PR specifies the numpy and scipy versions installed in the python 2 build of circleCI. They are set to the minimum requirements (numpy>=1.8.2, scipy>=0.13.3) to verify that the examples all run with those minimum requirements as well.