### PR TITLE
[MRG] MAINT remove redundant code in test_search.py

### DIFF
--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -919,9 +919,6 @@ def test_search_iid_param():
         test_cv_scores = np.array(list(search.cv_results_['split%d_test_score'
                                                           % s_i][0]
                                        for s_i in range(search.n_splits_)))
-        train_cv_scores = np.array(list(search.cv_results_['split%d_train_'
-                                                           'score' % s_i][0]
-                                        for s_i in range(search.n_splits_)))
         test_mean = search.cv_results_['mean_test_score'][0]
         test_std = search.cv_results_['std_test_score'][0]
 


### PR DESCRIPTION
This statement seems redundant, See
https://github.com/scikit-learn/scikit-learn/blob/6bd1cf594b05fdf16f827077e719a4ab0c0bd7ab/sklearn/model_selection/tests/test_search.py#L922-L930
Not sure whether it's appropriate for such thing but I think it's not harmful.