### PR TITLE
Fix error in SVC documentation

### DIFF
--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -431,7 +431,7 @@ class SVC(BaseSVC):
     is more than quadratic with the number of samples which makes it hard
     to scale to dataset with more than a couple of 10000 samples.
 
-    The multiclass support is handled according to a one-vs-one scheme.
+    The multiclass support is handled according to a one-vs-rest scheme.
 
     For details on the precise mathematical formulation of the provided
     kernel functions and how `gamma`, `coef0` and `degree` affect each


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This doesn't have an issue submitted yet

#### What does this implement/fix? Explain your changes.
The default SVC uses the one-vs-rest multiclass extension, however documentation states otherwise.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
