### PR TITLE
[MRG] contours is no kwarg of matplotlib.pyplot.contour

### DIFF
--- a/examples/cluster/plot_face_segmentation.py
+++ b/examples/cluster/plot_face_segmentation.py
@@ -71,7 +71,7 @@ for assign_labels in ('kmeans', 'discretize'):
     plt.figure(figsize=(5, 5))
     plt.imshow(face, cmap=plt.cm.gray)
     for l in range(N_REGIONS):
-        plt.contour(labels == l, contours=1,
+        plt.contour(labels == l,
                     colors=[plt.cm.spectral(l / float(N_REGIONS))])
     plt.xticks(())
     plt.yticks(())

--- a/examples/cluster/plot_face_ward_segmentation.py
+++ b/examples/cluster/plot_face_ward_segmentation.py
@@ -61,7 +61,7 @@ print("Number of clusters: ", np.unique(label).size)
 plt.figure(figsize=(5, 5))
 plt.imshow(face, cmap=plt.cm.gray)
 for l in range(n_clusters):
-    plt.contour(label == l, contours=1,
+    plt.contour(label == l,
                 colors=[plt.cm.spectral(l / float(n_clusters)), ])
 plt.xticks(())
 plt.yticks(())


### PR DESCRIPTION
#### Reference Issues/PRs
See discussion of #10527 


#### What does this implement/fix? Explain your changes.
The examples `plot_face_segmentation.py` and `plot_face_ward_segmentation.py` raise the warning:
`matplotlib/contour.py:967: UserWarning: The following kwargs were not used by contour: 'contours'` as `matplotlib.pyplot.contour` is called with the kwarg `contours`, which is not part of its API (neither for version [1.3](https://matplotlib.org/1.3.0/api/pyplot_api.html#matplotlib.pyplot.contour) nor for the current version [2.1.1](https://matplotlib.org/api/_as_gen/matplotlib.pyplot.contour.html#matplotlib.pyplot.contour)) and is thus removed here.