### PR TITLE
[MRG+1] DOC changed plotting of SGD penalties to improve clarity

### DIFF
--- a/examples/linear_model/plot_sgd_penalties.py
+++ b/examples/linear_model/plot_sgd_penalties.py
@@ -15,9 +15,9 @@ print(__doc__)
 import numpy as np
 import matplotlib.pyplot as plt
 
-l1_color = 'C0'
-l2_color = 'C1'
-elastic_net_color = 'C2'
+l1_color = "navy"
+l2_color = "c"
+elastic_net_color = "darkorange"
 
 line = np.linspace(-1.5, 1.5, 1001)
 xx, yy = np.meshgrid(line, line)
@@ -25,15 +25,15 @@ xx, yy = np.meshgrid(line, line)
 l2 = xx ** 2 + yy ** 2
 l1 = np.abs(xx) + np.abs(yy)
 rho = 0.5
-elastic_net = rho * l1 + (1-rho)/2 * l2
+elastic_net = rho * l1 + (1 - rho) * l2
 
 plt.figure(figsize=(10, 10), dpi=100)
 ax = plt.gca()
 
-elastic_net_contour = plt.contour(xx, yy, elastic_net, levels="1",
+elastic_net_contour = plt.contour(xx, yy, elastic_net, levels=[1],
                                   colors=elastic_net_color)
-l2_contour = plt.contour(xx, yy, l2, levels="1", colors=l2_color)
-l1_contour = plt.contour(xx, yy, l1, levels="1", colors=l1_color)
+l2_contour = plt.contour(xx, yy, l2, levels=[1], colors=l2_color)
+l1_contour = plt.contour(xx, yy, l1, levels=[1], colors=l1_color)
 ax.set_aspect("equal")
 ax.spines['left'].set_position('center')
 ax.spines['right'].set_color('none')

--- a/examples/linear_model/plot_sgd_penalties.py
+++ b/examples/linear_model/plot_sgd_penalties.py
@@ -3,70 +3,43 @@
 SGD: Penalties
 ==============
 
-Plot the contours of the three penalties.
+Contours of where the penalty is equal to 1 for the three penalties L1, L2 and elastic-net.
 
 All of the above are supported by
 :class:`sklearn.linear_model.stochastic_gradient`.
 
 """
-from __future__ import division
 print(__doc__)
 
 import numpy as np
 import matplotlib.pyplot as plt
 
+l1_color = 'C0'
+l2_color = 'C1'
+elastic_net_color = 'C2'
 
-def l1(xs):
-    return np.array([np.sqrt((1 - np.sqrt(x ** 2.0)) ** 2.0) for x in xs])
+line = np.linspace(-1.5, 1.5, 1001)
+xx, yy = np.meshgrid(line, line)
 
+l2 = xx ** 2 + yy ** 2
+l1 = np.abs(xx) + np.abs(yy)
+rho = 0.5
+elastic_net = rho * l1 + (1-rho)/2 * l2
 
-def l2(xs):
-    return np.array([np.sqrt(1.0 - x ** 2.0) for x in xs])
+plt.figure(figsize=(10, 10), dpi=100)
+ax = plt.gca()
 
+elastic_net_contour = plt.contour(xx, yy, elastic_net, levels="1", colors=elastic_net_color)
+l2_contour = plt.contour(xx, yy, l2, levels="1", colors=l2_color)
+l1_contour = plt.contour(xx, yy, l1, levels="1", colors=l1_color)
+ax.set_aspect("equal")
+ax.spines['left'].set_position('center')
+ax.spines['right'].set_color('none')
+ax.spines['bottom'].set_position('center')
+ax.spines['top'].set_color('none')
 
-def el(xs, z):
-    return np.array([(2 - 2 * x - 2 * z + 4 * x * z -
-                      (4 * z ** 2
-                       - 8 * x * z ** 2
-                       + 8 * x ** 2 * z ** 2
-                       - 16 * x ** 2 * z ** 3
-                       + 8 * x * z ** 3 + 4 * x ** 2 * z ** 4) ** (1. / 2)
-                      - 2 * x * z ** 2) / (2 - 4 * z) for x in xs])
+plt.clabel(elastic_net_contour, inline=1, fontsize=10, fmt={1.0: 'elastic-net'}, manual=[(-1, -1)])
+plt.clabel(l2_contour, inline=1, fontsize=10, fmt={1.0: 'L2'}, manual=[(-1, -1)])
+plt.clabel(l1_contour, inline=1, fontsize=10, fmt={1.0: 'L1'}, manual=[(-1, -1)])
 
-
-def cross(ext):
-    plt.plot([-ext, ext], [0, 0], "k-")
-    plt.plot([0, 0], [-ext, ext], "k-")
-
-xs = np.linspace(0, 1, 100)
-
-alpha = 0.501  # 0.5 division throuh zero
-
-cross(1.2)
-
-l1_color = "navy"
-l2_color = "c"
-elastic_net_color = "darkorange"
-lw = 2
-
-plt.plot(xs, l1(xs), color=l1_color, label="L1", lw=lw)
-plt.plot(xs, -1.0 * l1(xs), color=l1_color, lw=lw)
-plt.plot(-1 * xs, l1(xs), color=l1_color, lw=lw)
-plt.plot(-1 * xs, -1.0 * l1(xs), color=l1_color, lw=lw)
-
-plt.plot(xs, l2(xs), color=l2_color, label="L2", lw=lw)
-plt.plot(xs, -1.0 * l2(xs), color=l2_color, lw=lw)
-plt.plot(-1 * xs, l2(xs), color=l2_color, lw=lw)
-plt.plot(-1 * xs, -1.0 * l2(xs), color=l2_color, lw=lw)
-
-plt.plot(xs, el(xs, alpha), color=elastic_net_color, label="Elastic Net", lw=lw)
-plt.plot(xs, -1.0 * el(xs, alpha), color=elastic_net_color, lw=lw)
-plt.plot(-1 * xs, el(xs, alpha), color=elastic_net_color, lw=lw)
-plt.plot(-1 * xs, -1.0 * el(xs, alpha), color=elastic_net_color, lw=lw)
-
-plt.xlabel(r"$w_0$")
-plt.ylabel(r"$w_1$")
-plt.legend()
-
-plt.axis("equal")
 plt.show()

--- a/examples/linear_model/plot_sgd_penalties.py
+++ b/examples/linear_model/plot_sgd_penalties.py
@@ -40,11 +40,12 @@ ax.spines['right'].set_color('none')
 ax.spines['bottom'].set_position('center')
 ax.spines['top'].set_color('none')
 
-plt.clabel(elastic_net_contour, inline=1, fontsize=10,
+plt.clabel(elastic_net_contour, inline=1, fontsize=18,
            fmt={1.0: 'elastic-net'}, manual=[(-1, -1)])
-plt.clabel(l2_contour, inline=1, fontsize=10,
+plt.clabel(l2_contour, inline=1, fontsize=18,
            fmt={1.0: 'L2'}, manual=[(-1, -1)])
-plt.clabel(l1_contour, inline=1, fontsize=10,
+plt.clabel(l1_contour, inline=1, fontsize=18,
            fmt={1.0: 'L1'}, manual=[(-1, -1)])
 
+plt.tight_layout()
 plt.show()

--- a/examples/linear_model/plot_sgd_penalties.py
+++ b/examples/linear_model/plot_sgd_penalties.py
@@ -3,7 +3,8 @@
 SGD: Penalties
 ==============
 
-Contours of where the penalty is equal to 1 for the three penalties L1, L2 and elastic-net.
+Contours of where the penalty is equal to 1
+for the three penalties L1, L2 and elastic-net.
 
 All of the above are supported by
 :class:`sklearn.linear_model.stochastic_gradient`.
@@ -29,7 +30,8 @@ elastic_net = rho * l1 + (1-rho)/2 * l2
 plt.figure(figsize=(10, 10), dpi=100)
 ax = plt.gca()
 
-elastic_net_contour = plt.contour(xx, yy, elastic_net, levels="1", colors=elastic_net_color)
+elastic_net_contour = plt.contour(xx, yy, elastic_net, levels="1",
+                                  colors=elastic_net_color)
 l2_contour = plt.contour(xx, yy, l2, levels="1", colors=l2_color)
 l1_contour = plt.contour(xx, yy, l1, levels="1", colors=l1_color)
 ax.set_aspect("equal")
@@ -38,8 +40,11 @@ ax.spines['right'].set_color('none')
 ax.spines['bottom'].set_position('center')
 ax.spines['top'].set_color('none')
 
-plt.clabel(elastic_net_contour, inline=1, fontsize=10, fmt={1.0: 'elastic-net'}, manual=[(-1, -1)])
-plt.clabel(l2_contour, inline=1, fontsize=10, fmt={1.0: 'L2'}, manual=[(-1, -1)])
-plt.clabel(l1_contour, inline=1, fontsize=10, fmt={1.0: 'L1'}, manual=[(-1, -1)])
+plt.clabel(elastic_net_contour, inline=1, fontsize=10,
+           fmt={1.0: 'elastic-net'}, manual=[(-1, -1)])
+plt.clabel(l2_contour, inline=1, fontsize=10,
+           fmt={1.0: 'L2'}, manual=[(-1, -1)])
+plt.clabel(l1_contour, inline=1, fontsize=10,
+           fmt={1.0: 'L1'}, manual=[(-1, -1)])
 
 plt.show()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #10554 nitpick: SGD penalty demo should use spines


#### What does this implement/fix? Explain your changes.
The plotting of the SGD penalties is much clearer and easier to read now.
Each penalty is calculated on a 2D mesh, and then the contour when the penalty is equal to 1is plotted.
Axes are also centered similarly to https://matplotlib.org/examples/pylab_examples/spine_placement_demo.html further improving readability.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
