### PR TITLE
[MRG] fix PLS predict output shape

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -167,6 +167,10 @@ Bug fixes
 
 Classifiers and regressors
 
+- Fixed a bug in :class:`cross_decomposition.PLSRegression`
+  where predict returns a 2D-array when a 1D-array is expected
+  :issue:`8856` by :user:`Jean-Baptiste Delafosse <jbDelafosse>`.
+
 - Fixed a bug in :class:`isotonic.IsotonicRegression` which incorrectly
   combined weights when fitting a model to data involving points with
   identical X values.

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -190,7 +190,7 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
     y_rotations_ : array, [q, n_components]
         Y block to latents rotations.
 
-    coef_ : array, [p, q]
+    coef_ : array, [p,] or [p, q]
         The coefficients of the linear model: ``Y = X coef_ + Err``
 
     n_iter_ : array-like

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -14,7 +14,7 @@ from scipy.sparse.linalg import svds
 
 from ..base import BaseEstimator, RegressorMixin, TransformerMixin
 from ..utils import check_array, check_consistent_length
-from ..utils.extmath import svd_flip
+from ..utils.extmath import svd_flip, safe_sparse_dot
 from ..utils.validation import check_is_fitted, FLOAT_DTYPES
 from ..externals import six
 
@@ -249,7 +249,9 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
         X = check_array(X, dtype=np.float64, copy=self.copy,
                         ensure_min_samples=2)
         Y = check_array(Y, dtype=np.float64, copy=self.copy, ensure_2d=False)
+        Y_ndim_is_one = False
         if Y.ndim == 1:
+            Y_ndim_is_one = True
             Y = Y.reshape(-1, 1)
 
         n = X.shape[0]
@@ -369,6 +371,11 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
             # => B = W*Q' (p x q)
             self.coef_ = np.dot(self.x_rotations_, self.y_loadings_.T)
             self.coef_ = self.coef_ * self.y_std_
+            if Y_ndim_is_one:
+                self.coef_ = np.ravel(self.coef_)
+                self.y_mean_ = np.ravel(self.y_mean_)
+                self.y_std_ = np.ravel(self.y_std_)
+
         return self
 
     def transform(self, X, Y=None, copy=True):
@@ -431,8 +438,9 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
         # Normalize
         X -= self.x_mean_
         X /= self.x_std_
-        Ypred = np.dot(X, self.coef_)
-        return Ypred + self.y_mean_
+        Ypred = safe_sparse_dot(
+            X, self.coef_, dense_output=True) + self.y_mean_
+        return Ypred
 
     def fit_transform(self, X, y=None):
         """Learn and apply the dimension reduction on the train data.

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -281,6 +281,9 @@ def test_univariate_pls_regression():
 
     clf = pls_.PLSRegression()
     # Compare 1d to column vector
+    model1 = clf.fit(X, Y[:, 0]).coef_
+    model2 = clf.fit(X, Y[:, :1]).coef_
+    assert_array_almost_equal(model1, model2.ravel())
     # issue #8856
     ndim_predict_1d = clf.fit(X, Y[:, 0]).predict(X).ndim
     ndim_predict_2d = clf.fit(X, Y[:, :1]).predict(X).ndim

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -281,9 +281,11 @@ def test_univariate_pls_regression():
 
     clf = pls_.PLSRegression()
     # Compare 1d to column vector
-    model1 = clf.fit(X, Y[:, 0]).coef_
-    model2 = clf.fit(X, Y[:, :1]).coef_
-    assert_array_almost_equal(model1, model2)
+    # issue #8856
+    ndim_predict_1d = clf.fit(X, Y[:, 0]).predict(X).ndim
+    ndim_predict_2d = clf.fit(X, Y[:, :1]).predict(X).ndim
+    assert_equal(ndim_predict_1d, 1)
+    assert_equal(ndim_predict_2d, 2)
 
 
 def test_predict_transform_copy():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
This pull request is based on #8932 but I messed up this one because i'm bad at git.
This fixes the issue #8856.
This issue was closed as "working as intended".

I still disagree (hence the current PR).

#### What does this implement/fix? Explain your changes.

In #8856, I had some trouble using a `BaggingRegressor` with a `PLSRegression`.
It seems the problem comes from the fact the shape of the ouput given by `PLSRegression.predict` should be the same one as the shape of the Y used during the `fit` step. Hence when a 1D array is used during the `fit`, a 1D array is expected when using `predict`

I forced the output of predict to be shaped as `(n_sample,)` if the number of column is 1

#### Any other comments?

All the tests run smoothly 
There are PEP8 errors in the pls_.py files and test_pls.py that are in the master and that I left unedited.

I re-runned the example I gave in #8856 with no problem this time

On my personal project, the BaggingRegressor now works as I expected it to with the PLSRegression

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
