### PR TITLE
[MRG+1] Fix escape sequences that are deprecated in Python 3.6

### DIFF
--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -791,7 +791,7 @@ def make_blobs(n_samples=100, n_features=2, centers=3, cluster_std=1.0,
 
 
 def make_friedman1(n_samples=100, n_features=10, noise=0.0, random_state=None):
-    """Generate the "Friedman \#1" regression problem
+    """Generate the "Friedman #1" regression problem
 
     This dataset is described in Friedman [1] and Breiman [2].
 
@@ -854,7 +854,7 @@ def make_friedman1(n_samples=100, n_features=10, noise=0.0, random_state=None):
 
 
 def make_friedman2(n_samples=100, noise=0.0, random_state=None):
-    """Generate the "Friedman \#2" regression problem
+    """Generate the "Friedman #2" regression problem
 
     This dataset is described in Friedman [1] and Breiman [2].
 
@@ -920,7 +920,7 @@ def make_friedman2(n_samples=100, noise=0.0, random_state=None):
 
 
 def make_friedman3(n_samples=100, noise=0.0, random_state=None):
-    """Generate the "Friedman \#3" regression problem
+    """Generate the "Friedman #3" regression problem
 
     This dataset is described in Friedman [1] and Breiman [2].
 
@@ -1377,7 +1377,7 @@ def make_s_curve(n_samples=100, noise=0.0, random_state=None):
 def make_gaussian_quantiles(mean=None, cov=1., n_samples=100,
                             n_features=2, n_classes=3,
                             shuffle=True, random_state=None):
-    """Generate isotropic Gaussian and label samples by quantile
+    r"""Generate isotropic Gaussian and label samples by quantile
 
     This classification dataset is constructed by taking a multi-dimensional
     standard normal distribution and defining classes separated by nested

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -823,7 +823,7 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
                                max_iter=200, alpha=0., l1_ratio=0.,
                                regularization=None, random_state=None,
                                verbose=0, shuffle=False):
-    """Compute Non-negative Matrix Factorization (NMF)
+    r"""Compute Non-negative Matrix Factorization (NMF)
 
     Find two non-negative matrices (W, H) whose product approximates the non-
     negative matrix X. This factorization can be used for example for
@@ -958,8 +958,8 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
     >>> import numpy as np
     >>> X = np.array([[1,1], [2, 1], [3, 1.2], [4, 1], [5, 0.8], [6, 1]])
     >>> from sklearn.decomposition import non_negative_factorization
-    >>> W, H, n_iter = non_negative_factorization(X, n_components=2, \
-        init='random', random_state=0)
+    >>> W, H, n_iter = non_negative_factorization(X, n_components=2,
+    ... init='random', random_state=0)
 
     References
     ----------
@@ -1039,7 +1039,7 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
 
 
 class NMF(BaseEstimator, TransformerMixin):
-    """Non-Negative Matrix Factorization (NMF)
+    r"""Non-Negative Matrix Factorization (NMF)
 
     Find two non-negative matrices (W, H) whose product approximates the non-
     negative matrix X. This factorization can be used for example for

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -369,7 +369,7 @@ def test_pca_validation():
 
                 assert_raises_regex(ValueError,
                                     "n_components={}L? must be between "
-                                    "{}L? and min\(n_samples, n_features\)="
+                                    r"{}L? and min\(n_samples, n_features\)="
                                     "{}L? with svd_solver=\'{}\'"
                                     .format(n_components,
                                             lower_limit[solver],
@@ -384,7 +384,7 @@ def test_pca_validation():
                 assert_raises_regex(ValueError,
                                     "n_components={}L? must be "
                                     "strictly less than "
-                                    "min\(n_samples, n_features\)={}L?"
+                                    r"min\(n_samples, n_features\)={}L?"
                                     " with svd_solver=\'arpack\'"
                                     .format(n_components, smallest_d),
                                     PCA(n_components, svd_solver=solver)

--- a/sklearn/externals/joblib/_memory_helpers.py
+++ b/sklearn/externals/joblib/_memory_helpers.py
@@ -7,7 +7,7 @@ except ImportError:
     from codecs import lookup, BOM_UTF8
     import re
     from io import TextIOWrapper, open
-    cookie_re = re.compile("coding[:=]\s*([-\w.]+)")
+    cookie_re = re.compile(r"coding[:=]\s*([-\w.]+)")
 
     def _get_normal_name(orig_enc):
         """Imitates get_normal_name in tokenizer.c."""

--- a/sklearn/externals/joblib/func_inspect.py
+++ b/sklearn/externals/joblib/func_inspect.py
@@ -50,7 +50,7 @@ def get_func_code(func):
             line_no = 1
             if source_file.startswith('<doctest '):
                 source_file, line_no = re.match(
-                    '\<doctest (.*\.rst)\[(.*)\]\>', source_file).groups()
+                    r'\<doctest (.*\.rst)\[(.*)\]\>', source_file).groups()
                 line_no = int(line_no)
                 source_file = '<doctest %s>' % source_file
             return source_code, source_file, line_no

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1505,7 +1505,7 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 
 
 class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
-    """Exp-Sine-Squared kernel.
+    r"""Exp-Sine-Squared kernel.
 
     The ExpSineSquared kernel allows modeling periodic functions. It is
     parameterized by a length-scale parameter length_scale>0 and a periodicity
@@ -1618,7 +1618,7 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 
 
 class DotProduct(Kernel):
-    """Dot-Product kernel.
+    r"""Dot-Product kernel.
 
     The DotProduct kernel is non-stationary and can be obtained from linear
     regression by putting N(0, 1) priors on the coefficients of x_d (d = 1, . .

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -126,7 +126,7 @@ def _alpha_grid(X, y, Xy=None, l1_ratio=1.0, fit_intercept=True,
 def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
                precompute='auto', Xy=None, copy_X=True, coef_init=None,
                verbose=False, return_n_iter=False, positive=False, **params):
-    """Compute Lasso path with coordinate descent
+    r"""Compute Lasso path with coordinate descent
 
     The Lasso optimization function varies for mono and multi-outputs.
 
@@ -269,7 +269,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
               precompute='auto', Xy=None, copy_X=True, coef_init=None,
               verbose=False, return_n_iter=False, positive=False,
               check_input=True, **params):
-    """Compute elastic net path with coordinate descent
+    r"""Compute elastic net path with coordinate descent
 
     The elastic net optimization function varies for mono and multi-outputs.
 
@@ -1589,7 +1589,7 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
 
 
 class MultiTaskElasticNet(Lasso):
-    """Multi-task ElasticNet model trained with L1/L2 mixed-norm as regularizer
+    r"""Multi-task ElasticNet model trained with L1/L2 mixed-norm as regularizer
 
     The optimization objective for MultiTaskElasticNet is::
 
@@ -1787,7 +1787,7 @@ class MultiTaskElasticNet(Lasso):
 
 
 class MultiTaskLasso(MultiTaskElasticNet):
-    """Multi-task Lasso model trained with L1/L2 mixed-norm as regularizer
+    r"""Multi-task Lasso model trained with L1/L2 mixed-norm as regularizer
 
     The optimization objective for Lasso is::
 
@@ -1905,7 +1905,7 @@ class MultiTaskLasso(MultiTaskElasticNet):
 
 
 class MultiTaskElasticNetCV(LinearModelCV, RegressorMixin):
-    """Multi-task L1/L2 ElasticNet with built-in cross-validation.
+    r"""Multi-task L1/L2 ElasticNet with built-in cross-validation.
 
     The optimization objective for MultiTaskElasticNet is::
 
@@ -2086,7 +2086,7 @@ class MultiTaskElasticNetCV(LinearModelCV, RegressorMixin):
 
 
 class MultiTaskLassoCV(LinearModelCV, RegressorMixin):
-    """Multi-task L1/L2 Lasso with built-in cross-validation.
+    r"""Multi-task L1/L2 Lasso with built-in cross-validation.
 
     The optimization objective for MultiTaskLasso is::
 

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -274,7 +274,7 @@ def _gram_omp(Gram, Xy, n_nonzero_coefs, tol_0=None, tol=None,
 def orthogonal_mp(X, y, n_nonzero_coefs=None, tol=None, precompute=False,
                   copy_X=True, return_path=False,
                   return_n_iter=False):
-    """Orthogonal Matching Pursuit (OMP)
+    r"""Orthogonal Matching Pursuit (OMP)
 
     Solves n_targets Orthogonal Matching Pursuit problems.
     An instance of the problem has the form:

--- a/sklearn/linear_model/sag_fast.pyx
+++ b/sklearn/linear_model/sag_fast.pyx
@@ -53,7 +53,7 @@ cdef double _logsumexp(double* arr, int n_classes) nogil:
 cdef class MultinomialLogLoss:
     cdef double _loss(self, double* prediction, double y, int n_classes,
                       double sample_weight) nogil:
-        """Multinomial Logistic regression loss.
+        r"""Multinomial Logistic regression loss.
 
         The multinomial logistic loss for one sample is:
         loss = - sw \sum_c \delta_{y,c} (prediction[c] - logsumexp(prediction))
@@ -97,7 +97,7 @@ cdef class MultinomialLogLoss:
 
     cdef void _dloss(self, double* prediction, double y, int n_classes,
                      double sample_weight, double* gradient_ptr) nogil:
-        """Multinomial Logistic regression gradient of the loss.
+        r"""Multinomial Logistic regression gradient of the loss.
 
         The gradient of the multinomial logistic loss with respect to a class c,
         and for one sample is:

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -385,15 +385,16 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
 
     def test_partial_fit_weight_class_balanced(self):
         # partial_fit with class_weight='balanced' not supported"""
+        regex = (r"class_weight 'balanced' is not supported for "
+                 r"partial_fit\. In order to use 'balanced' weights, "
+                 r"use compute_class_weight\('balanced', classes, y\). "
+                 r"In place of y you can us a large enough sample "
+                 r"of the full training set target to properly "
+                 r"estimate the class frequency distributions\. "
+                 r"Pass the resulting weights as the class_weight "
+                 r"parameter\.")
         assert_raises_regexp(ValueError,
-                             "class_weight 'balanced' is not supported for "
-                             "partial_fit. In order to use 'balanced' weights, "
-                             "use compute_class_weight\('balanced', classes, y\). "
-                             "In place of y you can us a large enough sample "
-                             "of the full training set target to properly "
-                             "estimate the class frequency distributions. "
-                             "Pass the resulting weights as the class_weight "
-                             "parameter.",
+                             regex,
                              self.factory(class_weight='balanced').partial_fit,
                              X, Y, classes=np.unique(Y))
 

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -378,7 +378,7 @@ def _gradient_descent(objective, p0, it, n_iter,
 
 
 def trustworthiness(X, X_embedded, n_neighbors=5, precomputed=False):
-    """Expresses to what extent the local structure is retained.
+    r"""Expresses to what extent the local structure is retained.
 
     The trustworthiness is within [0, 1]. It is defined as
 

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -293,7 +293,7 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
 
 
 def cohen_kappa_score(y1, y2, labels=None, weights=None, sample_weight=None):
-    """Cohen's kappa: a statistic that measures inter-annotator agreement.
+    r"""Cohen's kappa: a statistic that measures inter-annotator agreement.
 
     This function computes Cohen's kappa [1]_, a score that expresses the level
     of agreement between two annotators on a classification problem. It is

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -528,7 +528,7 @@ def v_measure_score(labels_true, labels_pred):
 
 
 def mutual_info_score(labels_true, labels_pred, contingency=None):
-    """Mutual Information between two clusterings.
+    r"""Mutual Information between two clusterings.
 
     The Mutual Information is a measure of the similarity between two labels of
     the same data. Where :math:`|U_i|` is the number of the samples

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -136,15 +136,15 @@ def test_correct_labelsize():
     # n_labels = n_samples
     y = np.arange(X.shape[0])
     assert_raises_regexp(ValueError,
-                         'Number of labels is %d\. Valid values are 2 '
-                         'to n_samples - 1 \(inclusive\)' % len(np.unique(y)),
+                         r'Number of labels is %d\. Valid values are 2 '
+                         r'to n_samples - 1 \(inclusive\)' % len(np.unique(y)),
                          silhouette_score, X, y)
 
     # n_labels = 1
     y = np.zeros(X.shape[0])
     assert_raises_regexp(ValueError,
-                         'Number of labels is %d\. Valid values are 2 '
-                         'to n_samples - 1 \(inclusive\)' % len(np.unique(y)),
+                         r'Number of labels is %d\. Valid values are 2 '
+                         r'to n_samples - 1 \(inclusive\)' % len(np.unique(y)),
                          silhouette_score, X, y)
 
 

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -854,8 +854,8 @@ def test_cross_val_predict_decision_function_shape():
     ind = np.argsort(y)
     X, y = X[ind], y[ind]
     assert_raises_regex(ValueError,
-                        'Output shape \(599L?, 21L?\) of decision_function '
-                        'does not match number of classes \(7\) in fold. '
+                        r'Output shape \(599L?, 21L?\) of decision_function '
+                        r'does not match number of classes \(7\) in fold. '
                         'Irregular decision_function .*',
                         cross_val_predict, est, X, y,
                         cv=KFold(n_splits=3), method='decision_function')

--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -402,7 +402,7 @@ cdef class DistanceMetric:
 # Euclidean Distance
 #  d = sqrt(sum(x_i^2 - y_i^2))
 cdef class EuclideanDistance(DistanceMetric):
-    """Euclidean Distance metric
+    r"""Euclidean Distance metric
 
     .. math::
        D(x, y) = \sqrt{ \sum_i (x_i - y_i) ^ 2 }
@@ -435,7 +435,7 @@ cdef class EuclideanDistance(DistanceMetric):
 # SEuclidean Distance
 #  d = sqrt(sum((x_i - y_i2)^2 / v_i))
 cdef class SEuclideanDistance(DistanceMetric):
-    """Standardized Euclidean Distance metric
+    r"""Standardized Euclidean Distance metric
 
     .. math::
        D(x, y) = \sqrt{ \sum_i \frac{ (x_i - y_i) ^ 2}{V_i} }
@@ -479,7 +479,7 @@ cdef class SEuclideanDistance(DistanceMetric):
 # Manhattan Distance
 #  d = sum(abs(x_i - y_i))
 cdef class ManhattanDistance(DistanceMetric):
-    """Manhattan/City-block Distance metric
+    r"""Manhattan/City-block Distance metric
 
     .. math::
        D(x, y) = \sum_i |x_i - y_i|
@@ -521,7 +521,7 @@ cdef class ChebyshevDistance(DistanceMetric):
 # Minkowski Distance
 #  d = sum(x_i^p - y_i^p) ^ (1/p)
 cdef class MinkowskiDistance(DistanceMetric):
-    """Minkowski Distance
+    r"""Minkowski Distance
 
     .. math::
        D(x, y) = [\sum_i (x_i - y_i)^p] ^ (1/p)
@@ -568,7 +568,7 @@ cdef class MinkowskiDistance(DistanceMetric):
 # W-Minkowski Distance
 #  d = sum(w_i^p * (x_i^p - y_i^p)) ^ (1/p)
 cdef class WMinkowskiDistance(DistanceMetric):
-    """Weighted Minkowski Distance
+    r"""Weighted Minkowski Distance
 
     .. math::
        D(x, y) = [\sum_i |w_i * (x_i - y_i)|^p] ^ (1/p)
@@ -700,7 +700,7 @@ cdef class MahalanobisDistance(DistanceMetric):
 # Hamming Distance
 #  d = N_unequal(x, y) / N_tot
 cdef class HammingDistance(DistanceMetric):
-    """Hamming Distance
+    r"""Hamming Distance
 
     Hamming distance is meant for discrete-valued vectors, though it is
     a valid metric for real-valued vectors.
@@ -722,7 +722,7 @@ cdef class HammingDistance(DistanceMetric):
 # Canberra Distance
 #  D(x, y) = sum[ abs(x_i - y_i) / (abs(x_i) + abs(y_i)) ]
 cdef class CanberraDistance(DistanceMetric):
-    """Canberra Distance
+    r"""Canberra Distance
 
     Canberra distance is meant for discrete-valued vectors, though it is
     a valid metric for real-valued vectors.
@@ -745,7 +745,7 @@ cdef class CanberraDistance(DistanceMetric):
 # Bray-Curtis Distance
 #  D(x, y) = sum[abs(x_i - y_i)] / sum[abs(x_i) + abs(y_i)]
 cdef class BrayCurtisDistance(DistanceMetric):
-    """Bray-Curtis Distance
+    r"""Bray-Curtis Distance
 
     Bray-Curtis distance is meant for discrete-valued vectors, though it is
     a valid metric for real-valued vectors.
@@ -770,7 +770,7 @@ cdef class BrayCurtisDistance(DistanceMetric):
 # Jaccard Distance (boolean)
 #  D(x, y) = N_unequal(x, y) / N_nonzero(x, y)
 cdef class JaccardDistance(DistanceMetric):
-    """Jaccard Distance
+    r"""Jaccard Distance
 
     Jaccard Distance is a dissimilarity measure for boolean-valued
     vectors. All nonzero entries will be treated as True, zero entries will
@@ -795,7 +795,7 @@ cdef class JaccardDistance(DistanceMetric):
 # Matching Distance (boolean)
 #  D(x, y) = n_neq / n
 cdef class MatchingDistance(DistanceMetric):
-    """Matching Distance
+    r"""Matching Distance
 
     Matching Distance is a dissimilarity measure for boolean-valued
     vectors. All nonzero entries will be treated as True, zero entries will
@@ -819,7 +819,7 @@ cdef class MatchingDistance(DistanceMetric):
 # Dice Distance (boolean)
 #  D(x, y) = n_neq / (2 * ntt + n_neq)
 cdef class DiceDistance(DistanceMetric):
-    """Dice Distance
+    r"""Dice Distance
 
     Dice Distance is a dissimilarity measure for boolean-valued
     vectors. All nonzero entries will be treated as True, zero entries will
@@ -844,7 +844,7 @@ cdef class DiceDistance(DistanceMetric):
 # Kulsinski Distance (boolean)
 #  D(x, y) = (ntf + nft - ntt + n) / (n_neq + n)
 cdef class KulsinskiDistance(DistanceMetric):
-    """Kulsinski Distance
+    r"""Kulsinski Distance
 
     Kulsinski Distance is a dissimilarity measure for boolean-valued
     vectors. All nonzero entries will be treated as True, zero entries will
@@ -869,7 +869,7 @@ cdef class KulsinskiDistance(DistanceMetric):
 # Rogers-Tanimoto Distance (boolean)
 #  D(x, y) = 2 * n_neq / (n + n_neq)
 cdef class RogersTanimotoDistance(DistanceMetric):
-    """Rogers-Tanimoto Distance
+    r"""Rogers-Tanimoto Distance
 
     Rogers-Tanimoto Distance is a dissimilarity measure for boolean-valued
     vectors. All nonzero entries will be treated as True, zero entries will
@@ -893,7 +893,7 @@ cdef class RogersTanimotoDistance(DistanceMetric):
 # Russell-Rao Distance (boolean)
 #  D(x, y) = (n - ntt) / n
 cdef class RussellRaoDistance(DistanceMetric):
-    """Russell-Rao Distance
+    r"""Russell-Rao Distance
 
     Russell-Rao Distance is a dissimilarity measure for boolean-valued
     vectors. All nonzero entries will be treated as True, zero entries will
@@ -917,7 +917,7 @@ cdef class RussellRaoDistance(DistanceMetric):
 # Sokal-Michener Distance (boolean)
 #  D(x, y) = 2 * n_neq / (n + n_neq)
 cdef class SokalMichenerDistance(DistanceMetric):
-    """Sokal-Michener Distance
+    r"""Sokal-Michener Distance
 
     Sokal-Michener Distance is a dissimilarity measure for boolean-valued
     vectors. All nonzero entries will be treated as True, zero entries will
@@ -941,7 +941,7 @@ cdef class SokalMichenerDistance(DistanceMetric):
 # Sokal-Sneath Distance (boolean)
 #  D(x, y) = n_neq / (0.5 * n_tt + n_neq)
 cdef class SokalSneathDistance(DistanceMetric):
-    """Sokal-Sneath Distance
+    r"""Sokal-Sneath Distance
 
     Sokal-Sneath Distance is a dissimilarity measure for boolean-valued
     vectors. All nonzero entries will be treated as True, zero entries will

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1222,7 +1222,7 @@ def test_robust_scaler_invalid_range():
     ]:
         scaler = RobustScaler(quantile_range=range_)
 
-        assert_raises_regex(ValueError, 'Invalid quantile range: \(',
+        assert_raises_regex(ValueError, r'Invalid quantile range: \(',
                             scaler.fit, iris.data)
 
 
@@ -1858,7 +1858,7 @@ def test_one_hot_encoder_sparse():
     # test that an error is raised when out of bounds:
     X_too_large = [[0, 2, 1], [0, 1, 1]]
     assert_raises(ValueError, enc.transform, X_too_large)
-    error_msg = "unknown categorical feature present \[2\] during transform."
+    error_msg = r"unknown categorical feature present \[2\] during transform."
     assert_raises_regex(ValueError, error_msg, enc.transform, X_too_large)
     assert_raises(ValueError, OneHotEncoder(n_values=2).fit_transform, X)
 

--- a/sklearn/preprocessing/tests/test_target.py
+++ b/sklearn/preprocessing/tests/test_target.py
@@ -37,8 +37,8 @@ def test_transform_target_regressor_error():
     sample_weight = np.ones((y.shape[0],))
     regr = TransformedTargetRegressor(regressor=Lasso(),
                                       transformer=StandardScaler())
-    assert_raises_regex(TypeError, "fit\(\) got an unexpected keyword argument"
-                        " 'sample_weight'", regr.fit, X, y,
+    assert_raises_regex(TypeError, r"fit\(\) got an unexpected keyword "
+                        "argument 'sample_weight'", regr.fit, X, y,
                         sample_weight=sample_weight)
     # func is given but inverse_func is not
     regr = TransformedTargetRegressor(func=np.exp)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -121,8 +121,8 @@ def test_ovr_partial_fit_exceptions():
     # A new class value which was not in the first call of partial_fit
     # It should raise ValueError
     y1 = [5] + y[7:-1]
-    assert_raises_regexp(ValueError, "Mini-batch contains \[.+\] while classes"
-                                     " must be subset of \[.+\]",
+    assert_raises_regexp(ValueError, r"Mini-batch contains \[.+\] while "
+                                     r"classes must be subset of \[.+\]",
                          ovr.partial_fit, X=X[7:], y=y1)
 
 

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -515,7 +515,7 @@ cdef class ClassificationCriterion(Criterion):
 
 
 cdef class Entropy(ClassificationCriterion):
-    """Cross Entropy impurity criterion.
+    r"""Cross Entropy impurity criterion.
 
     This handles cases where the target is a classification taking values
     0, 1, ... K-2, K-1. If node m represents a region Rm with Nm observations,
@@ -596,7 +596,7 @@ cdef class Entropy(ClassificationCriterion):
 
 
 cdef class Gini(ClassificationCriterion):
-    """Gini Index impurity criterion.
+    r"""Gini Index impurity criterion.
 
     This handles cases where the target is a classification taking values
     0, 1, ... K-2, K-1. If node m represents a region Rm with Nm observations,
@@ -690,7 +690,7 @@ cdef class Gini(ClassificationCriterion):
 
 
 cdef class RegressionCriterion(Criterion):
-    """Abstract regression criterion.
+    r"""Abstract regression criterion.
 
     This handles cases where the target is a continuous value, and is
     evaluated by computing the variance of the target values left and right
@@ -989,7 +989,7 @@ cdef class MSE(RegressionCriterion):
         impurity_right[0] /= self.n_outputs
 
 cdef class MAE(RegressionCriterion):
-    """Mean absolute error impurity criterion
+    r"""Mean absolute error impurity criterion
 
        MAE = (1 / n)*(\sum_i |y_i - f_i|), where y_i is the true
        value and f_i is the predicted value."""

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -261,7 +261,7 @@ def test_friedman_mse_in_graphviz():
     for estimator in clf.estimators_:
         export_graphviz(estimator[0], out_file=dot_data)
 
-    for finding in finditer("\[.*?samples.*?\]", dot_data.getvalue()):
+    for finding in finditer(r"\[.*?samples.*?\]", dot_data.getvalue()):
         assert_in("friedman_mse", finding.group())
 
 
@@ -290,21 +290,21 @@ def test_precision():
             # therefore, only a less equal comparison will be done.
 
             # check value
-            for finding in finditer("value = \d+\.\d+", dot_data):
+            for finding in finditer(r"value = \d+\.\d+", dot_data):
                 assert_less_equal(
-                    len(search("\.\d+", finding.group()).group()),
+                    len(search(r"\.\d+", finding.group()).group()),
                     precision + 1)
             # check impurity
             if is_classifier(clf):
-                pattern = "gini = \d+\.\d+"
+                pattern = r"gini = \d+\.\d+"
             else:
-                pattern = "friedman_mse = \d+\.\d+"
+                pattern = r"friedman_mse = \d+\.\d+"
 
             # check impurity
             for finding in finditer(pattern, dot_data):
-                assert_equal(len(search("\.\d+", finding.group()).group()),
+                assert_equal(len(search(r"\.\d+", finding.group()).group()),
                              precision + 1)
             # check threshold
-            for finding in finditer("<= \d+\.\d+", dot_data):
-                assert_equal(len(search("\.\d+", finding.group()).group()),
+            for finding in finditer(r"<= \d+\.\d+", dot_data):
+                assert_equal(len(search(r"\.\d+", finding.group()).group()),
                              precision + 1)

--- a/sklearn/utils/_random.pyx
+++ b/sklearn/utils/_random.pyx
@@ -41,7 +41,7 @@ cpdef _sample_without_replacement_with_tracking_selection(
         np.int_t n_population,
         np.int_t n_samples,
         random_state=None):
-    """Sample integers without replacement.
+    r"""Sample integers without replacement.
 
     Select n_samples integers from the set [0, n_population) without
     replacement.

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1000,7 +1000,7 @@ def check_estimators_empty_data_messages(name, estimator_orig):
     # the following y should be accepted by both classifiers and regressors
     # and ignored by unsupervised models
     y = multioutput_estimator_convert_y_2d(e, np.array([1, 0, 1]))
-    msg = ("0 feature\(s\) \(shape=\(3, 0\)\) while a minimum of \d* "
+    msg = (r"0 feature\(s\) \(shape=\(3, 0\)\) while a minimum of \d* "
            "is required.")
     assert_raises_regex(ValueError, msg, e.fit, X_zero_features, y)
 

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -195,7 +195,7 @@ def test_check_estimator():
                         check_estimator, ChangesWrongAttribute)
     check_estimator(ChangesUnderscoreAttribute)
     # check that `fit` doesn't add any public attribute
-    msg = ('Estimator adds public attribute\(s\) during the fit method.'
+    msg = (r'Estimator adds public attribute\(s\) during the fit method.'
            ' Estimators are only allowed to add private attributes'
            ' either started with _ or ended'
            ' with _ but wrong_attribute added')
@@ -286,7 +286,7 @@ def test_check_no_attributes_set_in_init():
     assert_raises_regex(AssertionError,
                         "Estimator estimator_name should not set any"
                         " attribute apart from parameters during init."
-                        " Found attributes \[\'you_should_not_set_this_\'\].",
+                        r" Found attributes \['you_should_not_set_this_'\].",
                         check_no_attributes_set_in_init,
                         'estimator_name',
                         NonConformantEstimatorPrivateSet())
@@ -294,7 +294,7 @@ def test_check_no_attributes_set_in_init():
                         "Estimator estimator_name should store all "
                         "parameters as an attribute during init. "
                         "Did not find attributes "
-                        "\[\'you_should_set_this_\'\].",
+                        r"\['you_should_set_this_'\].",
                         check_no_attributes_set_in_init,
                         'estimator_name',
                         NonConformantEstimatorNoParamSet())

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -287,7 +287,7 @@ def test_type_of_target():
                               % (example, group, type_of_target(example))))
 
     for example in NON_ARRAY_LIKE_EXAMPLES:
-        msg_regex = 'Expected array-like \(array or non-string sequence\).*'
+        msg_regex = r'Expected array-like \(array or non-string sequence\).*'
         assert_raises_regex(ValueError, msg_regex, type_of_target, example)
 
     for example in MULTILABEL_SEQUENCES:

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -595,9 +595,9 @@ def test_check_consistent_length():
     check_consistent_length([1], (2,), np.array([3]), sp.csr_matrix((1, 2)))
     assert_raises_regex(ValueError, 'inconsistent numbers of samples',
                         check_consistent_length, [1, 2], [1])
-    assert_raises_regex(TypeError, 'got <\w+ \'int\'>',
+    assert_raises_regex(TypeError, r"got <\w+ 'int'>",
                         check_consistent_length, [1, 2], 1)
-    assert_raises_regex(TypeError, 'got <\w+ \'object\'>',
+    assert_raises_regex(TypeError, r"got <\w+ 'object'>",
                         check_consistent_length, [1, 2], object())
 
     assert_raises(TypeError, check_consistent_length, [1, 2], np.array(1))


### PR DESCRIPTION
This PR fixes escape sequences that are deprecated in Python 3.6 by using raw strings/bytes.

https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior