### PR TITLE
[MRG+1] TSNE: only compute error when needed

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -81,11 +81,14 @@ Model evaluation
 - Added :class:`multioutput.RegressorChain` for multi-target
   regression. :issue:`9257` by :user:`Kumar Ashutosh <thechargedneutron>`.
 
-Clustering
+Decomposition, manifold learning and clustering
 
 - :class:`cluster.AgglomerativeClustering` now supports Single Linkage
   clustering via ``linkage='single'``. :issue:`9372` by
   :user:`Leland McInnes <lmcinnes>` and :user:`Steve Astels <sastels>`.
+
+- Speed improvements for both 'exact' and 'barnes_hut' methods in
+  :class:`manifold.TSNE`. :issue:`10593` by `Tom Dupre la Tour`_.
 
 
 Enhancements

--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -53,7 +53,7 @@ cdef float compute_gradient(float[:] val_P,
                             float dof,
                             long start,
                             long stop,
-                            int compute_error) nogil:
+                            bint compute_error) nogil:
     # Having created the tree, calculate the gradient
     # in two components, the positive and negative forces
     cdef:
@@ -110,7 +110,7 @@ cdef float compute_gradient_positive(float[:] val_P,
                                      double sum_Q,
                                      np.int64_t start,
                                      int verbose,
-                                     int compute_error) nogil:
+                                     bint compute_error) nogil:
     # Sum over the following expression for i not equal to j
     # grad_i = p_ij (1 + ||y_i - y_j||^2)^-1 (y_i - y_j)
     # This is equivalent to compute_edge_forces in the authors' code
@@ -238,7 +238,7 @@ def gradient(float[:] val_P,
              int verbose,
              float dof = 1.0,
              long skip_num_points=0,
-             int compute_error=1):
+             bint compute_error=1):
     # This function is designed to be called from external Python
     # it passes the 'forces' array by reference and fills thats array
     # up in-place

--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -272,4 +272,6 @@ def gradient(float[:] val_P,
         printf("[t-SNE] Checking tree consistency\n%s", EMPTY_STRING)
     m = "Tree consistency failed: unexpected number of points on the tree"
     assert qt.cells[0].cumulative_size == qt.n_points, m
+    if not compute_error:
+        C = np.nan
     return C

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -119,7 +119,7 @@ def _joint_probabilities_nn(distances, neighbors, desired_perplexity, verbose):
 
 
 def _kl_divergence(params, P, degrees_of_freedom, n_samples, n_components,
-                   skip_num_points=0):
+                   skip_num_points=0, compute_error=True):
     """t-SNE objective function: gradient of the KL divergence
     of p_ijs and q_ijs and the absolute error.
 
@@ -145,6 +145,9 @@ def _kl_divergence(params, P, degrees_of_freedom, n_samples, n_components,
         `skip_num_points`. This is useful when computing transforms of new
         data where you'd like to keep the old data fixed.
 
+    compute_error: bool (optional, default:True)
+        If False, the kl_divergence is not computed and returns 0.
+
     Returns
     -------
     kl_divergence : float
@@ -167,7 +170,11 @@ def _kl_divergence(params, P, degrees_of_freedom, n_samples, n_components,
     # np.sum(x * y) because it calls BLAS
 
     # Objective: C (Kullback-Leibler divergence of P and Q)
-    kl_divergence = 2.0 * np.dot(P, np.log(np.maximum(P, MACHINE_EPSILON) / Q))
+    if compute_error:
+        kl_divergence = 2.0 * np.dot(
+            P, np.log(np.maximum(P, MACHINE_EPSILON) / Q))
+    else:
+        kl_divergence = 0.
 
     # Gradient: dC/dY
     # pdist always returns double precision distances. Thus we need to take
@@ -184,7 +191,8 @@ def _kl_divergence(params, P, degrees_of_freedom, n_samples, n_components,
 
 
 def _kl_divergence_bh(params, P, degrees_of_freedom, n_samples, n_components,
-                      angle=0.5, skip_num_points=0, verbose=False):
+                      angle=0.5, skip_num_points=0, verbose=False,
+                      compute_error=True):
     """t-SNE objective function: KL divergence of p_ijs and q_ijs.
 
     Uses Barnes-Hut tree methods to calculate the gradient that
@@ -225,6 +233,9 @@ def _kl_divergence_bh(params, P, degrees_of_freedom, n_samples, n_components,
     verbose : int
         Verbosity level.
 
+    compute_error: bool (optional, default:True)
+        If False, the kl_divergence is not computed and returns 0.
+
     Returns
     -------
     kl_divergence : float
@@ -244,7 +255,8 @@ def _kl_divergence_bh(params, P, degrees_of_freedom, n_samples, n_components,
     grad = np.zeros(X_embedded.shape, dtype=np.float32)
     error = _barnes_hut_tsne.gradient(val_P, X_embedded, neighbors, indptr,
                                       grad, angle, n_components, verbose,
-                                      dof=degrees_of_freedom)
+                                      dof=degrees_of_freedom,
+                                      compute_error=compute_error)
     c = 2.0 * (degrees_of_freedom + 1.0) / degrees_of_freedom
     grad = grad.ravel()
     grad *= c
@@ -336,6 +348,10 @@ def _gradient_descent(objective, p0, it, n_iter,
 
     tic = time()
     for i in range(it, n_iter):
+        check_convergence = (i + 1) % n_iter_check == 0
+        # only compute the error when needed
+        kwargs['compute_error'] = check_convergence
+
         error, grad = objective(p, *args, **kwargs)
         grad_norm = linalg.norm(grad)
 
@@ -348,7 +364,7 @@ def _gradient_descent(objective, p0, it, n_iter,
         update = momentum * update - learning_rate * grad
         p += update
 
-        if (i + 1) % n_iter_check == 0:
+        if check_convergence:
             toc = time()
             duration = toc - tic
             tic = toc

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -350,8 +350,7 @@ def _gradient_descent(objective, p0, it, n_iter,
     for i in range(it, n_iter):
         check_convergence = (i + 1) % n_iter_check == 0
         # only compute the error when needed
-        if 'compute_error' in kwargs:
-            kwargs['compute_error'] = check_convergence
+        kwargs['compute_error'] = check_convergence or i == n_iter - 1
 
         error, grad = objective(p, *args, **kwargs)
         grad_norm = linalg.norm(grad)
@@ -812,7 +811,8 @@ class TSNE(BaseEstimator):
             "min_grad_norm": self.min_grad_norm,
             "learning_rate": self.learning_rate,
             "verbose": self.verbose,
-            "kwargs": dict(skip_num_points=skip_num_points),
+            "kwargs": dict(skip_num_points=skip_num_points,
+                           compute_error=True),
             "args": [P, degrees_of_freedom, n_samples, self.n_components],
             "n_iter_without_progress": self._EXPLORATION_N_ITER,
             "n_iter": self._EXPLORATION_N_ITER,
@@ -823,10 +823,8 @@ class TSNE(BaseEstimator):
             opt_args['kwargs']['angle'] = self.angle
             # Repeat verbose argument for _kl_divergence_bh
             opt_args['kwargs']['verbose'] = self.verbose
-            opt_args['kwargs']['compute_error'] = True
         else:
             obj_func = _kl_divergence
-            opt_args['kwargs']['compute_error'] = True
 
         # Learning schedule (part 1): do 250 iteration with lower momentum but
         # higher learning rate controlled via the early exageration parameter

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -350,7 +350,7 @@ def _gradient_descent(objective, p0, it, n_iter,
     for i in range(it, n_iter):
         check_convergence = (i + 1) % n_iter_check == 0
         # only compute the error when needed
-        if hasattr(kwargs, 'compute_error'):
+        if 'compute_error' in kwargs:
             kwargs['compute_error'] = check_convergence
 
         error, grad = objective(p, *args, **kwargs)

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -350,7 +350,8 @@ def _gradient_descent(objective, p0, it, n_iter,
     for i in range(it, n_iter):
         check_convergence = (i + 1) % n_iter_check == 0
         # only compute the error when needed
-        kwargs['compute_error'] = check_convergence
+        if hasattr(kwargs, 'compute_error'):
+            kwargs['compute_error'] = check_convergence
 
         error, grad = objective(p, *args, **kwargs)
         grad_norm = linalg.norm(grad)
@@ -822,8 +823,10 @@ class TSNE(BaseEstimator):
             opt_args['kwargs']['angle'] = self.angle
             # Repeat verbose argument for _kl_divergence_bh
             opt_args['kwargs']['verbose'] = self.verbose
+            opt_args['kwargs']['compute_error'] = True
         else:
             obj_func = _kl_divergence
+            opt_args['kwargs']['compute_error'] = True
 
         # Learning schedule (part 1): do 250 iteration with lower momentum but
         # higher learning rate controlled via the early exageration parameter

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -146,7 +146,7 @@ def _kl_divergence(params, P, degrees_of_freedom, n_samples, n_components,
         data where you'd like to keep the old data fixed.
 
     compute_error: bool (optional, default:True)
-        If False, the kl_divergence is not computed and returns 0.
+        If False, the kl_divergence is not computed and returns NaN.
 
     Returns
     -------
@@ -174,7 +174,7 @@ def _kl_divergence(params, P, degrees_of_freedom, n_samples, n_components,
         kl_divergence = 2.0 * np.dot(
             P, np.log(np.maximum(P, MACHINE_EPSILON) / Q))
     else:
-        kl_divergence = 0.
+        kl_divergence = np.nan
 
     # Gradient: dC/dY
     # pdist always returns double precision distances. Thus we need to take
@@ -234,7 +234,7 @@ def _kl_divergence_bh(params, P, degrees_of_freedom, n_samples, n_components,
         Verbosity level.
 
     compute_error: bool (optional, default:True)
-        If False, the kl_divergence is not computed and returns 0.
+        If False, the kl_divergence is not computed and returns NaN.
 
     Returns
     -------
@@ -811,8 +811,7 @@ class TSNE(BaseEstimator):
             "min_grad_norm": self.min_grad_norm,
             "learning_rate": self.learning_rate,
             "verbose": self.verbose,
-            "kwargs": dict(skip_num_points=skip_num_points,
-                           compute_error=True),
+            "kwargs": dict(skip_num_points=skip_num_points),
             "args": [P, degrees_of_freedom, n_samples, self.n_components],
             "n_iter_without_progress": self._EXPLORATION_N_ITER,
             "n_iter": self._EXPLORATION_N_ITER,

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -48,11 +48,11 @@ def test_gradient_descent_stops():
         def __init__(self):
             self.it = -1
 
-        def __call__(self, _):
+        def __call__(self, _, compute_error=True):
             self.it += 1
             return (10 - self.it) / 10.0, np.array([1e-5])
 
-    def flat_function(_):
+    def flat_function(_, compute_error=True):
         return 0.0, np.ones(1)
 
     # Gradient norm
@@ -581,6 +581,20 @@ def test_64bit():
             # tsne cython code is only single precision, so the output will
             # always be single precision, irrespectively of the input dtype
             assert effective_type == np.float32
+
+
+def test_kl_divergence_non_zero():
+    # Ensure kl_divergence_ is computed at last iteration
+    # even though n_iter % n_iter_check != 0, i.e. 1003 % 50 != 0
+    random_state = check_random_state(0)
+    methods = ['barnes_hut', 'exact']
+    for method in methods:
+        X = random_state.randn(50, 2)
+        tsne = TSNE(n_components=2, perplexity=2, learning_rate=100.0,
+                    random_state=0, method=method, verbose=0, n_iter=1003)
+        tsne.fit_transform(X)
+
+        assert tsne.kl_divergence_ != 0
 
 
 def test_barnes_hut_angle():

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -583,7 +583,7 @@ def test_64bit():
             assert effective_type == np.float32
 
 
-def test_kl_divergence_non_zero():
+def test_kl_divergence_not_nan():
     # Ensure kl_divergence_ is computed at last iteration
     # even though n_iter % n_iter_check != 0, i.e. 1003 % 50 != 0
     random_state = check_random_state(0)
@@ -594,7 +594,7 @@ def test_kl_divergence_non_zero():
                     random_state=0, method=method, verbose=0, n_iter=1003)
         tsne.fit_transform(X)
 
-        assert tsne.kl_divergence_ != 0
+        assert not np.isnan(tsne.kl_divergence_)
 
 
 def test_barnes_hut_angle():


### PR DESCRIPTION
This is a first speed improvement for TSNE with both solvers.
The idea is to compute the KL-divergence only every 50 iterations, when the stopping criterion is actually checked.

With `method='barnes_hut'`, it leads to a **40% speed improvement** on the gradient descent.
```
master_gradient_duration = array([   1.411,    8.815,   18.606,   97.405,  208.401])
branch_gradient_duration = array([   0.836,    4.988,   11.352,   61.483,  136.631])
```

![figure_1](https://user-images.githubusercontent.com/11065596/35859371-17f3ba00-0b40-11e8-8431-64c2fd5ce0f1.png)

The benchmark is available [here](https://github.com/scikit-learn/scikit-learn/blob/master/benchmarks/bench_tsne_mnist.py), where I used `--pca-components 0` and a single CPU.