### PR TITLE
COSMIT Use comb2(x) instead of comb(x, 2)

### DIFF
--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -209,7 +209,7 @@ def adjusted_rand_score(labels_true, labels_pred):
     sum_comb_k = sum(comb2(n_k) for n_k in np.ravel(contingency.sum(axis=0)))
     sum_comb = sum(comb2(n_ij) for n_ij in contingency.data)
 
-    prod_comb = (sum_comb_c * sum_comb_k) / comb(n_samples, 2)
+    prod_comb = (sum_comb_c * sum_comb_k) / comb2(n_samples)
     mean_comb = (sum_comb_k + sum_comb_c) / 2.
     return (sum_comb - prod_comb) / (mean_comb - prod_comb)
 


### PR DESCRIPTION
There is a comment
```
    # the exact version is faster for k == 2: use it by default globally in
    # this module instead of the float approximate variant
```
but we didn't. This fixes that.

Merge when green