### PR TITLE
Added support for not normalising OneVsRestClassifier predict_proba result

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -143,6 +143,14 @@ Preprocessing
 
 Model evaluation and meta-estimators
 
+- When estimators of :class:`multiclass.OneVsRestClassifier` have a 
+  `predict_proba` but no `decision_function`, 
+  `OneVsRestClassifier.decision_function` returns the individual 
+  `predict_proba` results scaled to [-1,1]. This is different from 
+  `OneVsRestClassifier.predict_proba` which normalizes the individual 
+  probabilities so that they sum up to 1. :issue:`10612` by 
+  :user:`Emre Ates <EmreAtes>`.
+
 - A scorer based on :func:`metrics.brier_score_loss` is also available.
   :issue:`9521` by :user:`Hanmin Qin <qinhanmin2014>`.
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -163,6 +163,10 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         useful for debugging. For n_jobs below -1, (n_cpus + 1 + n_jobs) are
         used. Thus for n_jobs = -2, all CPUs but one are used.
 
+    normalize_proba : bool, optional, default: True
+        Normalizes the predict_proba result so that the sum of the returned
+        matrix is 1.
+
     Attributes
     ----------
     estimators_ : list of `n_classes` estimators
@@ -176,9 +180,10 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
     multilabel_ : boolean
         Whether a OneVsRestClassifier is a multilabel classifier.
     """
-    def __init__(self, estimator, n_jobs=1):
+    def __init__(self, estimator, n_jobs=1, normalize_proba=True):
         self.estimator = estimator
         self.n_jobs = n_jobs
+        self.normalize_proba = normalize_proba
 
     def fit(self, X, y):
         """Fit underlying estimators.
@@ -325,7 +330,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         labels both have a 90% probability of applying to a given sample.
 
         In the single label multiclass case, the rows of the returned matrix
-        sum to 1.
+        sum to 1 if normalize_proba is True in __init__.
 
         Parameters
         ----------
@@ -347,7 +352,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             # for two classes.
             Y = np.concatenate(((1 - Y), Y), axis=1)
 
-        if not self.multilabel_:
+        if not self.multilabel_ and self.normalize_proba:
             # Then, probabilities should be normalized to 1.
             Y /= np.sum(Y, axis=1)[:, np.newaxis]
         return Y

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -50,7 +50,8 @@ from .utils.validation import check_X_y, check_array
 from .utils.multiclass import (_check_partial_fit_first_call,
                                check_classification_targets,
                                _ovr_decision_function)
-from .utils.metaestimators import _safe_split, if_delegate_has_method
+from .utils.metaestimators import (_safe_split, if_delegate_has_method,
+                                   if_delegate_has_methods)
 
 from .externals.joblib import Parallel
 from .externals.joblib import delayed
@@ -352,8 +353,8 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             Y /= np.sum(Y, axis=1)[:, np.newaxis]
         return Y
 
-    @if_delegate_has_method(['_first_estimator', 'estimator'],
-                            backup_method='predict_proba')
+    @if_delegate_has_methods(['_first_estimator', 'estimator'],
+                             ['decision_function', 'predict_proba'])
     def decision_function(self, X):
         """Returns the distance of each sample from the decision boundary for
         each class. If decision_function is not implemented in the estimator,

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -365,15 +365,22 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
 
         Returns
         -------
-        T : array-like, shape = [n_samples, n_classes]
+        T : array-like, shape = [n_samples, n_classes] or [n_samples] if
+            n_classes == 1
         """
         check_is_fitted(self, 'estimators_')
-        try:
-            T = np.array([est.decision_function(X).ravel()
-                          for est in self.estimators_]).T
-        except AttributeError:
-            T = np.array([e.predict_proba(X)[:, 1] * 2 - 1
-                          for e in self.estimators_]).T
+        if len(self.estimators_) == 1:
+            try:
+                T = self.estimators_[0].decision_function(X)
+            except AttributeError:
+                T = self.estimators_[0].predict_proba(X)[:, 1] * 2 - 1
+        else:
+            try:
+                T = np.array([est.decision_function(X).ravel()
+                              for est in self.estimators_]).T
+            except AttributeError:
+                T = np.array([e.predict_proba(X)[:, 1] * 2 - 1
+                              for e in self.estimators_]).T
         return T
 
     @property

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -369,18 +369,14 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             n_classes == 1
         """
         check_is_fitted(self, 'estimators_')
+        try:
+            T = np.array([est.decision_function(X).ravel()
+                          for est in self.estimators_]).T
+        except AttributeError:
+            T = np.array([e.predict_proba(X)[:, 1] * 2 - 1
+                          for e in self.estimators_]).T
         if len(self.estimators_) == 1:
-            try:
-                T = self.estimators_[0].decision_function(X)
-            except AttributeError:
-                T = self.estimators_[0].predict_proba(X)[:, 1] * 2 - 1
-        else:
-            try:
-                T = np.array([est.decision_function(X).ravel()
-                              for est in self.estimators_]).T
-            except AttributeError:
-                T = np.array([e.predict_proba(X)[:, 1] * 2 - 1
-                              for e in self.estimators_]).T
+            T = T.ravel()
         return T
 
     @property

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -352,7 +352,8 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             Y /= np.sum(Y, axis=1)[:, np.newaxis]
         return Y
 
-    @if_delegate_has_method(['_first_estimator', 'estimator'], backup_method='predict_proba')
+    @if_delegate_has_method(['_first_estimator', 'estimator'],
+                            backup_method='predict_proba')
     def decision_function(self, X):
         """Returns the distance of each sample from the decision boundary for
         each class. If decision_function is not implemented in the estimator,
@@ -371,7 +372,8 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             T = np.array([est.decision_function(X).ravel()
                           for est in self.estimators_]).T
         except AttributeError:
-            T = np.array([e.predict_proba(X)[:, 1] * 2 - 1 for e in self.estimators_]).T
+            T = np.array([e.predict_proba(X)[:, 1] * 2 - 1
+                          for e in self.estimators_]).T
         return T
 
     @property

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -50,8 +50,7 @@ from .utils.validation import check_X_y, check_array
 from .utils.multiclass import (_check_partial_fit_first_call,
                                check_classification_targets,
                                _ovr_decision_function)
-from .utils.metaestimators import (_safe_split, if_delegate_has_method,
-                                   if_delegate_has_methods)
+from .utils.metaestimators import _safe_split, if_delegate_has_method
 
 from .externals.joblib import Parallel
 from .externals.joblib import delayed
@@ -353,8 +352,8 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             Y /= np.sum(Y, axis=1)[:, np.newaxis]
         return Y
 
-    @if_delegate_has_methods(['_first_estimator', 'estimator'],
-                             ['decision_function', 'predict_proba'])
+    @if_delegate_has_method(['_first_estimator', 'estimator'],
+                            backup_method='predict_proba')
     def decision_function(self, X):
         """Returns the distance of each sample from the decision boundary for
         each class. If decision_function is not implemented in the estimator,

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -256,7 +256,7 @@ def test_ovr_binary():
         assert_equal(set(y_pred), set("eggs"))
         if hasattr(base_clf, 'decision_function'):
             dec = clf.decision_function(X)
-            assert_equal(dec.shape, (5, 1))
+            assert_equal(dec.shape, (5,))
 
         if test_predict_proba:
             X_test = np.array([[0, 0, 4]])
@@ -405,6 +405,12 @@ def test_ovr_multilabel_decision_function():
     assert_array_equal((clf.decision_function(X_test) > 0).astype(int),
                        clf.predict(X_test))
 
+    # Test fallback to predict_proba
+    clf = OneVsRestClassifier(DecisionTreeClassifier(min_samples_split=10))
+    clf.fit(X_train, Y_train)
+    assert_array_equal((clf.decision_function(X_test) > 0).astype(int),
+                       clf.predict(X_test))
+
 
 def test_ovr_single_label_decision_function():
     X, Y = datasets.make_classification(n_samples=100,
@@ -417,7 +423,8 @@ def test_ovr_single_label_decision_function():
                        clf.predict(X_test))
 
     # Test fallback to predict_proba
-    clf = OneVsRestClassifier(DecisionTreeClassifier()).fit(X_train, Y_train)
+    clf = OneVsRestClassifier(DecisionTreeClassifier(min_samples_split=10))
+    clf.fit(X_train, Y_train)
     assert_array_equal(clf.decision_function(X_test).ravel() > 0,
                        clf.predict(X_test))
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -256,7 +256,7 @@ def test_ovr_binary():
         assert_equal(set(y_pred), set("eggs"))
         if hasattr(base_clf, 'decision_function'):
             dec = clf.decision_function(X)
-            assert_equal(dec.shape, (5,1))
+            assert_equal(dec.shape, (5, 1))
 
         if test_predict_proba:
             X_test = np.array([[0, 0, 4]])

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -256,7 +256,7 @@ def test_ovr_binary():
         assert_equal(set(y_pred), set("eggs"))
         if hasattr(base_clf, 'decision_function'):
             dec = clf.decision_function(X)
-            assert_equal(dec.shape, (5,))
+            assert_equal(dec.shape, (5,1))
 
         if test_predict_proba:
             X_test = np.array([[0, 0, 4]])
@@ -413,6 +413,11 @@ def test_ovr_single_label_decision_function():
     X_train, Y_train = X[:80], Y[:80]
     X_test = X[80:]
     clf = OneVsRestClassifier(svm.SVC()).fit(X_train, Y_train)
+    assert_array_equal(clf.decision_function(X_test).ravel() > 0,
+                       clf.predict(X_test))
+
+    # Test fallback to predict_proba
+    clf = OneVsRestClassifier(DecisionTreeClassifier()).fit(X_train, Y_train)
     assert_array_equal(clf.decision_function(X_test).ravel() > 0,
                        clf.predict(X_test))
 

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -12,7 +12,7 @@ from ..utils import safe_indexing
 from ..externals import six
 from ..base import BaseEstimator
 
-__all__ = ['if_delegate_has_method', 'if_delegate_has_methods']
+__all__ = ['if_delegate_has_method']
 
 
 class _BaseComposition(six.with_metaclass(ABCMeta, BaseEstimator)):
@@ -132,7 +132,7 @@ class _IffHasAttrDescriptor(object):
         return out
 
 
-def if_delegate_has_method(delegate):
+def if_delegate_has_method(delegate, backup_method=''):
     """Create a decorator for methods that are delegated to a sub-estimator
 
     This enables ducktyping by hasattr returning True according to the
@@ -145,31 +145,9 @@ def if_delegate_has_method(delegate):
         base object. If a list or a tuple of names are provided, the first
         sub-estimator that is an attribute of the base object will be used.
 
-    """
-    if isinstance(delegate, list):
-        delegate = tuple(delegate)
-    if not isinstance(delegate, tuple):
-        delegate = (delegate,)
-
-    return lambda fn: _IffHasAttrDescriptor(fn, delegate, fn.__name__)
-
-
-def if_delegate_has_methods(delegate, methods):
-    """Create a decorator for checking the existance of multiple methods
-
-    This enables ducktyping by hasattr returning True according to the
-    sub-estimator and supports multiple methods.
-
-    Parameters
-    ----------
-    delegate : string, list of strings or tuple of strings
-        Name of the sub-estimator that can be accessed as an attribute of the
-        base object. If a list or a tuple of names are provided, the first
-        sub-estimator that is an attribute of the base object will be used.
-
-    methods : iterable of strings
-        Name of the methods that will be looked up. fn.__name__ is not used,
-        and should be included in methods.
+    backup_method : string
+        Name of the method that will be looked up, in case the function with
+        the same name is not found.
 
     """
     if isinstance(delegate, list):
@@ -178,7 +156,7 @@ def if_delegate_has_methods(delegate, methods):
         delegate = (delegate,)
 
     return lambda fn: _IffHasAttrDescriptor(
-        fn, delegate, methods)
+        fn, delegate, (fn.__name__, backup_method))
 
 
 def _safe_split(estimator, X, y, indices, train_indices=None):

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -90,7 +90,10 @@ class _IffHasAttrDescriptor(object):
     def __init__(self, fn, delegate_names, attribute_names):
         self.fn = fn
         self.delegate_names = delegate_names
-        self.attribute_names = attribute_names
+        if isinstance(attribute_names, str):
+            self.attribute_names = (attribute_names,)
+        else:
+            self.attribute_names = attribute_names
 
         # update the docstring of the descriptor
         update_wrapper(self, fn)
@@ -148,8 +151,7 @@ def if_delegate_has_method(delegate):
     if not isinstance(delegate, tuple):
         delegate = (delegate,)
 
-    return lambda fn: _IffHasAttrDescriptor(
-        fn, delegate, (fn.__name__,))
+    return lambda fn: _IffHasAttrDescriptor(fn, delegate, fn.__name__)
 
 
 def if_delegate_has_methods(delegate, methods):


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
I added support for not normalizing the predict_proba result, and returning it as it is, even if the data is not multilabel. This is useful for implementing a rejection threshold.

#### Any other comments?
I can also add thresholding in ovrclassifier or somewhere else to reject classifications results, but I didn't see anything else like that in scikit, so I don't know if it's a wanted feature.
