### PR TITLE
[MRG] Shape of `coef_` wrong for linear_model.Lasso when using `fit_intercept=False`

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -1,7 +1,0 @@
-import numpy as np
-from sklearn import linear_model
-
-est_no_intercept = linear_model.Lasso(fit_intercept=False)
-est_no_intercept.fit([ [0] ], [1])
-#print(est_no_intercept.coef_.shape)
-assert est_no_intercept.coef_.shape  == (1,)

--- a/sample.py
+++ b/sample.py
@@ -1,0 +1,7 @@
+import numpy as np
+from sklearn import linear_model
+
+est_no_intercept = linear_model.Lasso(fit_intercept=False)
+est_no_intercept.fit([ [0] ], [1])
+#print(est_no_intercept.coef_.shape)
+assert est_no_intercept.coef_.shape  == (1,)

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -264,6 +264,9 @@ class LinearModel(six.with_metaclass(ABCMeta, BaseEstimator)):
             self.coef_ = self.coef_ / X_scale
             self.intercept_ = y_offset - np.dot(X_offset, self.coef_.T)
         else:
+            if(len(self.coef_.shape) == 0):
+                self.coef_ = np.expand_dims(self.coef_, axis=0)
+            self.coef_ = np.array(self.coef_)
             self.intercept_ = 0.
 
 

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -759,7 +759,8 @@ class ElasticNet(LinearModel, RegressorMixin):
         if n_targets == 1:
             self.n_iter_ = self.n_iter_[0]
 
-        self.coef_, self.dual_gap_ = map(np.squeeze, [coef_, dual_gaps_])
+        self.coef_ = map(np.squeeze, coef_)
+        self.dual_gap_ = map(np.squeeze, dual_gaps_)
         self._set_intercept(X_offset, y_offset, X_scale)
 
         # workaround since _set_intercept will cast self.coef_ into X.dtype

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -761,6 +761,7 @@ class ElasticNet(LinearModel, RegressorMixin):
 
         self.coef_ = map(np.squeeze, coef_)
         self.dual_gap_ = map(np.squeeze, dual_gaps_)
+        
         self._set_intercept(X_offset, y_offset, X_scale)
 
         # workaround since _set_intercept will cast self.coef_ into X.dtype

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -759,9 +759,8 @@ class ElasticNet(LinearModel, RegressorMixin):
         if n_targets == 1:
             self.n_iter_ = self.n_iter_[0]
 
-        self.coef_ = map(np.squeeze, coef_)
-        self.dual_gap_ = map(np.squeeze, dual_gaps_)
-        
+        self.coef_, self.dual_gap_ = map(np.squeeze, [coef_, dual_gaps_])
+
         self._set_intercept(X_offset, y_offset, X_scale)
 
         # workaround since _set_intercept will cast self.coef_ into X.dtype

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -318,6 +318,17 @@ def test_lasso_alpha_warning():
     clf = Lasso(alpha=0)
     assert_warns(UserWarning, clf.fit, X, Y)
 
+def test_lasso_fit_intercept():
+    X = [[-1], [0], [1]]
+    Y = [-1, 0, 1]
+
+    clf = Lasso(fit_intercept=False)
+    clf.fit(X, Y)
+    assert_equal(clf.coef_.shape, (1,))
+
+    clf2 = Lasso(fit_intercept=True)
+    clf2.fit(X, Y)
+    assert_equal(clf.coef_.shape, (1,))
 
 def test_lasso_positive_constraint():
     X = [[-1], [0], [1]]

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -318,6 +318,7 @@ def test_lasso_alpha_warning():
     clf = Lasso(alpha=0)
     assert_warns(UserWarning, clf.fit, X, Y)
 
+
 def test_lasso_fit_intercept():
     X = [[-1], [0], [1]]
     Y = [-1, 0, 1]
@@ -329,6 +330,7 @@ def test_lasso_fit_intercept():
     clf2 = Lasso(fit_intercept=True)
     clf2.fit(X, Y)
     assert_equal(clf.coef_.shape, (1,))
+
 
 def test_lasso_positive_constraint():
     X = [[-1], [0], [1]]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
Fixes #10571 