### PR TITLE
[MRG+1] COSMIT Make it easier to add config settings

### DIFF
--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -15,83 +15,13 @@ See http://scikit-learn.org for complete documentation.
 import sys
 import re
 import warnings
-import os
-from contextlib import contextmanager as _contextmanager
 import logging
+
+from ._config import get_config, set_config, config_context
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 logger.setLevel(logging.INFO)
-
-_ASSUME_FINITE = bool(os.environ.get('SKLEARN_ASSUME_FINITE', False))
-
-
-def get_config():
-    """Retrieve current values for configuration set by :func:`set_config`
-
-    Returns
-    -------
-    config : dict
-        Keys are parameter names that can be passed to :func:`set_config`.
-    """
-    return {'assume_finite': _ASSUME_FINITE}
-
-
-def set_config(assume_finite=None):
-    """Set global scikit-learn configuration
-
-    Parameters
-    ----------
-    assume_finite : bool, optional
-        If True, validation for finiteness will be skipped,
-        saving time, but leading to potential crashes. If
-        False, validation for finiteness will be performed,
-        avoiding error.
-    """
-    global _ASSUME_FINITE
-    if assume_finite is not None:
-        _ASSUME_FINITE = assume_finite
-
-
-@_contextmanager
-def config_context(**new_config):
-    """Context manager for global scikit-learn configuration
-
-    Parameters
-    ----------
-    assume_finite : bool, optional
-        If True, validation for finiteness will be skipped,
-        saving time, but leading to potential crashes. If
-        False, validation for finiteness will be performed,
-        avoiding error.
-
-    Notes
-    -----
-    All settings, not just those presently modified, will be returned to
-    their previous values when the context manager is exited. This is not
-    thread-safe.
-
-    Examples
-    --------
-    >>> import sklearn
-    >>> from sklearn.utils.validation import assert_all_finite
-    >>> with sklearn.config_context(assume_finite=True):
-    ...     assert_all_finite([float('nan')])
-    >>> with sklearn.config_context(assume_finite=True):
-    ...     with sklearn.config_context(assume_finite=False):
-    ...         assert_all_finite([float('nan')])
-    ... # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-    ...
-    ValueError: Input contains NaN, ...
-    """
-    old_config = get_config().copy()
-    set_config(**new_config)
-
-    try:
-        yield
-    finally:
-        set_config(**old_config)
 
 
 # Make sure that DeprecationWarning within this package always gets printed
@@ -145,7 +75,7 @@ else:
                'preprocessing', 'random_projection', 'semi_supervised',
                'svm', 'tree', 'discriminant_analysis',
                # Non-modules:
-               'clone']
+               'clone', 'get_config', 'set_config', 'config_context']
 
 
 def setup_module(module):

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -1,0 +1,75 @@
+"""Global configuration state and functions for management
+"""
+import os
+from contextlib import contextmanager as contextmanager
+
+_global_config = {
+    'assume_finite': bool(os.environ.get('SKLEARN_ASSUME_FINITE', False)),
+}
+
+
+def get_config():
+    """Retrieve current values for configuration set by :func:`set_config`
+
+    Returns
+    -------
+    config : dict
+        Keys are parameter names that can be passed to :func:`set_config`.
+    """
+    return _global_config.copy()
+
+
+def set_config(assume_finite=None):
+    """Set global scikit-learn configuration
+
+    Parameters
+    ----------
+    assume_finite : bool, optional
+        If True, validation for finiteness will be skipped,
+        saving time, but leading to potential crashes. If
+        False, validation for finiteness will be performed,
+        avoiding error.  Global default: False.
+    """
+    if assume_finite is not None:
+        _global_config['assume_finite'] = assume_finite
+
+
+@contextmanager
+def config_context(**new_config):
+    """Context manager for global scikit-learn configuration
+
+    Parameters
+    ----------
+    assume_finite : bool, optional
+        If True, validation for finiteness will be skipped,
+        saving time, but leading to potential crashes. If
+        False, validation for finiteness will be performed,
+        avoiding error.  Global default: False.
+
+    Notes
+    -----
+    All settings, not just those presently modified, will be returned to
+    their previous values when the context manager is exited. This is not
+    thread-safe.
+
+    Examples
+    --------
+    >>> import sklearn
+    >>> from sklearn.utils.validation import assert_all_finite
+    >>> with sklearn.config_context(assume_finite=True):
+    ...     assert_all_finite([float('nan')])
+    >>> with sklearn.config_context(assume_finite=True):
+    ...     with sklearn.config_context(assume_finite=False):
+    ...         assert_all_finite([float('nan')])
+    ... # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    ValueError: Input contains NaN, ...
+    """
+    old_config = get_config().copy()
+    set_config(**new_config)
+
+    try:
+        yield
+    finally:
+        set_config(**old_config)

--- a/sklearn/tests/test_config.py
+++ b/sklearn/tests/test_config.py
@@ -1,5 +1,5 @@
 from sklearn import get_config, set_config, config_context
-from sklearn.utils.testing import assert_equal, assert_raises
+from sklearn.utils.testing import assert_raises
 
 
 def test_config_context():
@@ -10,7 +10,7 @@ def test_config_context():
     assert get_config()['assume_finite'] is False
 
     with config_context(assume_finite=True):
-        assert get_config() is {'assume_finite': True}
+        assert get_config() == {'assume_finite': True}
     assert get_config()['assume_finite'] is False
 
     with config_context(assume_finite=True):
@@ -34,7 +34,7 @@ def test_config_context():
 
         assert get_config()['assume_finite'] is True
 
-    assert get_config() is {'assume_finite': False}
+    assert get_config() == {'assume_finite': False}
 
     # No positional arguments
     assert_raises(TypeError, config_context, True)

--- a/sklearn/tests/test_config.py
+++ b/sklearn/tests/test_config.py
@@ -10,7 +10,7 @@ def test_config_context():
     assert get_config()['assume_finite'] is False
 
     with config_context(assume_finite=True):
-        assert get_config() is {'assume_finite': True}
+        assert get_config() == {'assume_finite': True}
     assert get_config()['assume_finite'] is False
 
     with config_context(assume_finite=True):
@@ -34,7 +34,7 @@ def test_config_context():
 
         assert get_config()['assume_finite'] is True
 
-    assert get_config() is {'assume_finite': False}
+    assert get_config() == {'assume_finite': False}
 
     # No positional arguments
     assert_raises(TypeError, config_context, True)

--- a/sklearn/tests/test_config.py
+++ b/sklearn/tests/test_config.py
@@ -3,36 +3,37 @@ from sklearn.utils.testing import assert_equal, assert_raises
 
 
 def test_config_context():
-    assert_equal(get_config(), {'assume_finite': False})
+    assert_equal(get_config(),
+                 {'assume_finite': False})
 
     # Not using as a context manager affects nothing
     config_context(assume_finite=True)
-    assert_equal(get_config(), {'assume_finite': False})
+    assert_equal(get_config()['assume_finite'], False)
 
     with config_context(assume_finite=True):
         assert_equal(get_config(), {'assume_finite': True})
-    assert_equal(get_config(), {'assume_finite': False})
+    assert_equal(get_config()['assume_finite'], False)
 
     with config_context(assume_finite=True):
         with config_context(assume_finite=None):
-            assert_equal(get_config(), {'assume_finite': True})
+            assert_equal(get_config()['assume_finite'], True)
 
-        assert_equal(get_config(), {'assume_finite': True})
+        assert_equal(get_config()['assume_finite'], True)
 
         with config_context(assume_finite=False):
-            assert_equal(get_config(), {'assume_finite': False})
+            assert_equal(get_config()['assume_finite'], False)
 
             with config_context(assume_finite=None):
-                assert_equal(get_config(), {'assume_finite': False})
+                assert_equal(get_config()['assume_finite'], False)
 
                 # global setting will not be retained outside of context that
                 # did not modify this setting
                 set_config(assume_finite=True)
-                assert_equal(get_config(), {'assume_finite': True})
+                assert_equal(get_config()['assume_finite'], True)
 
-            assert_equal(get_config(), {'assume_finite': False})
+            assert_equal(get_config()['assume_finite'], False)
 
-        assert_equal(get_config(), {'assume_finite': True})
+        assert_equal(get_config()['assume_finite'], True)
 
     assert_equal(get_config(), {'assume_finite': False})
 
@@ -43,26 +44,26 @@ def test_config_context():
 
 
 def test_config_context_exception():
-    assert_equal(get_config(), {'assume_finite': False})
+    assert_equal(get_config()['assume_finite'], False)
     try:
         with config_context(assume_finite=True):
-            assert_equal(get_config(), {'assume_finite': True})
+            assert_equal(get_config()['assume_finite'], True)
             raise ValueError()
     except ValueError:
         pass
-    assert_equal(get_config(), {'assume_finite': False})
+    assert_equal(get_config()['assume_finite'], False)
 
 
 def test_set_config():
-    assert_equal(get_config(), {'assume_finite': False})
+    assert_equal(get_config()['assume_finite'], False)
     set_config(assume_finite=None)
-    assert_equal(get_config(), {'assume_finite': False})
+    assert_equal(get_config()['assume_finite'], False)
     set_config(assume_finite=True)
-    assert_equal(get_config(), {'assume_finite': True})
+    assert_equal(get_config()['assume_finite'], True)
     set_config(assume_finite=None)
-    assert_equal(get_config(), {'assume_finite': True})
+    assert_equal(get_config()['assume_finite'], True)
     set_config(assume_finite=False)
-    assert_equal(get_config(), {'assume_finite': False})
+    assert_equal(get_config()['assume_finite'], False)
 
     # No unknown arguments
     assert_raises(TypeError, set_config, do_something_else=True)

--- a/sklearn/tests/test_config.py
+++ b/sklearn/tests/test_config.py
@@ -3,39 +3,38 @@ from sklearn.utils.testing import assert_equal, assert_raises
 
 
 def test_config_context():
-    assert_equal(get_config(),
-                 {'assume_finite': False})
+    assert get_config() == {'assume_finite': False}
 
     # Not using as a context manager affects nothing
     config_context(assume_finite=True)
-    assert_equal(get_config()['assume_finite'], False)
+    assert get_config()['assume_finite'] is False
 
     with config_context(assume_finite=True):
-        assert_equal(get_config(), {'assume_finite': True})
-    assert_equal(get_config()['assume_finite'], False)
+        assert get_config() is {'assume_finite': True}
+    assert get_config()['assume_finite'] is False
 
     with config_context(assume_finite=True):
         with config_context(assume_finite=None):
-            assert_equal(get_config()['assume_finite'], True)
+            assert get_config()['assume_finite'] is True
 
-        assert_equal(get_config()['assume_finite'], True)
+        assert get_config()['assume_finite'] is True
 
         with config_context(assume_finite=False):
-            assert_equal(get_config()['assume_finite'], False)
+            assert get_config()['assume_finite'] is False
 
             with config_context(assume_finite=None):
-                assert_equal(get_config()['assume_finite'], False)
+                assert get_config()['assume_finite'] is False
 
                 # global setting will not be retained outside of context that
                 # did not modify this setting
                 set_config(assume_finite=True)
-                assert_equal(get_config()['assume_finite'], True)
+                assert get_config()['assume_finite'] is True
 
-            assert_equal(get_config()['assume_finite'], False)
+            assert get_config()['assume_finite'] is False
 
-        assert_equal(get_config()['assume_finite'], True)
+        assert get_config()['assume_finite'] is True
 
-    assert_equal(get_config(), {'assume_finite': False})
+    assert get_config() is {'assume_finite': False}
 
     # No positional arguments
     assert_raises(TypeError, config_context, True)
@@ -44,26 +43,26 @@ def test_config_context():
 
 
 def test_config_context_exception():
-    assert_equal(get_config()['assume_finite'], False)
+    assert get_config()['assume_finite'] is False
     try:
         with config_context(assume_finite=True):
-            assert_equal(get_config()['assume_finite'], True)
+            assert get_config()['assume_finite'] is True
             raise ValueError()
     except ValueError:
         pass
-    assert_equal(get_config()['assume_finite'], False)
+    assert get_config()['assume_finite'] is False
 
 
 def test_set_config():
-    assert_equal(get_config()['assume_finite'], False)
+    assert get_config()['assume_finite'] is False
     set_config(assume_finite=None)
-    assert_equal(get_config()['assume_finite'], False)
+    assert get_config()['assume_finite'] is False
     set_config(assume_finite=True)
-    assert_equal(get_config()['assume_finite'], True)
+    assert get_config()['assume_finite'] is True
     set_config(assume_finite=None)
-    assert_equal(get_config()['assume_finite'], True)
+    assert get_config()['assume_finite'] is True
     set_config(assume_finite=False)
-    assert_equal(get_config()['assume_finite'], False)
+    assert get_config()['assume_finite'] is False
 
     # No unknown arguments
     assert_raises(TypeError, set_config, do_something_else=True)


### PR DESCRIPTION
Towards making #10280 easier to review, this:

* moves configuration functions from `sklearn/__init__.py` to `sklearn/_config.py`
* makes tests and implementation better oriented to having more than one setting through use of collections/loops

ping @rth