### PR TITLE
WIP # 10598 enet_path does not pass params to coordinate descent solver (Need feedback)

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -379,15 +379,10 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
     MultiTaskElasticNetCV
     ElasticNet
     ElasticNetCV
-    """
-    #checks if arguments in **params are acceptable
-    if not enet_path(params):
-      raise ValueError("One or more parameters is invalid")
-      
+    """      
     # We expect X and y to be already Fortran ordered when bypassing
     # checks
-
-      
+    
     if check_input:
         X = check_array(X, 'csc', dtype=[np.float64, np.float32],
                         order='F', copy=copy_X)
@@ -435,13 +430,13 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         alphas = np.sort(alphas)[::-1]  # make sure alphas are properly ordered
 
     n_alphas = len(alphas)
-    tol = params.get('tol', 1e-4)
-    max_iter = params.get('max_iter', 1000)
+    tol = params.pop('tol', 1e-4)
+    max_iter = params.pop('max_iter', 1000)
     dual_gaps = np.empty(n_alphas)
     n_iters = []
 
-    rng = check_random_state(params.get('random_state', None))
-    selection = params.get('selection', 'cyclic')
+    rng = check_random_state(params.pop('random_state', None))
+    selection = params.pop('selection', 'cyclic')
     if selection not in ['random', 'cyclic']:
         raise ValueError("selection should be either random or cyclic.")
     random = (selection == 'random')
@@ -508,6 +503,14 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         return alphas, coefs, dual_gaps, n_iters
     return alphas, coefs, dual_gaps
 
+  #takes out remaining values in **params, if there are any values left
+  #we know that an error should be raised (because all the parameters that
+  #are supposed to be there should have been taken out by params.pop
+    params.pop('X_offset')
+    params.pop('X_scale')
+    
+    if (len(params) != 0):
+      raise ValueError("One or more parameters are invalid")
 
 ###############################################################################
 # ElasticNet model

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -507,13 +507,13 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
   #we know that an error should be raised (because all the parameters that
   #are supposed to be there should have been taken out by params.pop
     if 'X_offset' in params:
-      params.pop('X_offset')
+        params.pop('X_offset')
     
     if 'X_scale' in params:
-      params.pop('X_scale')
+        params.pop('X_scale')
     
     if (len(params) != 0):
-      raise ValueError("One or more parameters are invalid")
+        raise ValueError("One or more parameters are invalid")
 
 ###############################################################################
 # ElasticNet model

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -380,8 +380,14 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
     ElasticNet
     ElasticNetCV
     """
+    #checks if arguments in **params are acceptable
+    if not enet_path(params):
+      raise ValueError("One or more parameters is invalid")
+      
     # We expect X and y to be already Fortran ordered when bypassing
     # checks
+
+      
     if check_input:
         X = check_array(X, 'csc', dtype=[np.float64, np.float32],
                         order='F', copy=copy_X)

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -498,12 +498,8 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
                 print('Path: %03i out of %03i' % (i, n_alphas))
             else:
                 sys.stderr.write('.')
-
-    if return_n_iter:
-        return alphas, coefs, dual_gaps, n_iters
-    return alphas, coefs, dual_gaps
-
-  #takes out remaining values in **params, if there are any values left
+                
+ #takes out remaining values in **params, if there are any values left
   #we know that an error should be raised (because all the parameters that
   #are supposed to be there should have been taken out by params.pop
     if 'X_offset' in params:
@@ -520,6 +516,12 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         raise ValueError("One or more parameters are invalid")
     else:
         pass
+      
+    if return_n_iter:
+        return alphas, coefs, dual_gaps, n_iters
+    return alphas, coefs, dual_gaps
+
+ 
 
 ###############################################################################
 # ElasticNet model

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -506,7 +506,10 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
   #takes out remaining values in **params, if there are any values left
   #we know that an error should be raised (because all the parameters that
   #are supposed to be there should have been taken out by params.pop
+    if 'X_offset' in params:
     params.pop('X_offset')
+    
+    if 'X_scale' in params:
     params.pop('X_scale')
     
     if (len(params) != 0):

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -507,10 +507,10 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
   #we know that an error should be raised (because all the parameters that
   #are supposed to be there should have been taken out by params.pop
     if 'X_offset' in params:
-    params.pop('X_offset')
+      params.pop('X_offset')
     
     if 'X_scale' in params:
-    params.pop('X_scale')
+      params.pop('X_scale')
     
     if (len(params) != 0):
       raise ValueError("One or more parameters are invalid")

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -508,12 +508,18 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
   #are supposed to be there should have been taken out by params.pop
     if 'X_offset' in params:
         params.pop('X_offset')
+    else:
+        pass
     
     if 'X_scale' in params:
         params.pop('X_scale')
+    else:
+        pass
     
     if (len(params) != 0):
         raise ValueError("One or more parameters are invalid")
+    else:
+        pass
 
 ###############################################################################
 # ElasticNet model


### PR DESCRIPTION
So my cookie cutter code "if params not in func.__code__.co_varnames" is unacceptable, and I tried passing the parameters to the function above. Something I'm struggling with right now is:  How I would pass the arguments to the function so that it would raise errors when an argument is defined but unacceptable? 

I tried to get the function to reference a list of acceptable arguments (hence the __code__.co_varnames thing) and raise an error whenever someone passed in an unrecognized argument. I was (and still am) trying to get the function to catch unrecognized arguments.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
