### PR TITLE
[MRG] fix offset value in docstring of IsolationForest

### DIFF
--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -109,10 +109,12 @@ class IsolationForest(BaseBagging):
     offset_ : float
         Offset used to define the decision function from the raw scores.
         We have the relation: decision_function = score_samples - offset_.
-        The offset is set to 0.5 as in the original paper, except when a
-        contamination parameter different than "auto" is provided. In that
-        case, the offset is defined in such a way we obtain the expected
-        number of outliers (samples with decision function < 0) in training.
+        When the contamination parameter is set to "auto", the offset is equal
+        to -0.5 as the scores of inliers are close to 0 and the scores of
+        outliers are close to -1. When a contamination parameter different
+        than "auto" is provided, the offset is defined in such a way we obtain
+        the expected number of outliers (samples with decision function < 0)
+        in training.
 
     References
     ----------


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
When `contamination` is set to `'auto'`, `offset_` is equal to -0.5 and not 0.5. The code is correct

```python
        if self.contamination == "auto":
            # 0.5 plays a special role as described in the original paper.
            # we take the opposite as we consider the opposite of their score.
            self.offset_ = -0.5
```

but not the docstring

```python
    offset_ : float
        Offset used to define the decision function from the raw scores.
        We have the relation: decision_function = score_samples - offset_.
        The offset is set to 0.5 as in the original paper
```

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
