### PR TITLE
[MRG+1] Use almost minimal dependencies in Python 2 build on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,8 @@ jobs:
       - MINICONDA_PATH: ~/miniconda
       - CONDA_ENV_NAME: testenv
       - PYTHON_VERSION: 2
+      - NUMPY_VERSION: 1.8.2
+      - SCIPY_VERSION: 0.13.3
       - MATPLOTLIB_VERSION: "1.3"
       - SCIKIT_IMAGE_VERSION: "0.9.3"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
       # PYTHON_VERSION environment variable.
       - image: circleci/python:3.6.1
     environment:
+      # Test examples run with minimal dependencies.
       - MINICONDA_PATH: ~/miniconda
       - CONDA_ENV_NAME: testenv
       - PYTHON_VERSION: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,14 +38,15 @@ jobs:
       # PYTHON_VERSION environment variable.
       - image: circleci/python:3.6.1
     environment:
-      # Test examples run with minimal dependencies.
+      # Test examples run with minimal dependencies
       - MINICONDA_PATH: ~/miniconda
       - CONDA_ENV_NAME: testenv
       - PYTHON_VERSION: 2
       - NUMPY_VERSION: 1.8.2
-      - SCIPY_VERSION: 0.13.3
-      - MATPLOTLIB_VERSION: "1.3"
-      - SCIKIT_IMAGE_VERSION: "0.9.3"
+      # XXX: plot_gpc_xor.py fails with scipy 0.13.3
+      - SCIPY_VERSION: 0.14
+      - MATPLOTLIB_VERSION: 1.3
+      - SCIKIT_IMAGE_VERSION: 0.9.3
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -118,7 +118,7 @@ conda update --yes --quiet conda
 conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
   numpy="${NUMPY_VERSION:-*}" scipy="${SCIPY_VERSION:-*}" cython \
   pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=1.6.2 pillow \
-  scikit-image="${SCIKIT_IMAGE_VERSION:-*}
+  scikit-image="${SCIKIT_IMAGE_VERSION:-*}"
 
 source activate testenv
 pip install sphinx-gallery

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -115,9 +115,10 @@ conda update --yes --quiet conda
 
 # Configure the conda environment and put it in the path using the
 # provided versions
-conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" numpy scipy \
-  cython pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=1.6.2 pillow \
-  scikit-image="${SCIKIT_IMAGE_VERSION:-*}"
+conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
+  numpy="${NUMPY_VERSION:-*}" scipy="${SCIPY_VERSION:-*}" cython \
+  pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=1.6.2 pillow \
+  scikit-image="${SCIKIT_IMAGE_VERSION:-*}
 
 source activate testenv
 pip install sphinx-gallery


### PR DESCRIPTION
This is a continuation of #10557 (that was reverted because examples/gaussian_process/plot_gpc_xor.py fails on scipy 0.13.3) so that we run the examples with versions that are as close as possible to the minimal required versions.