### PR TITLE
[MRG] DOC Demote *Release History* heading to promote *New Features* heading

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,13 +1,12 @@
 .. currentmodule:: sklearn
 .. include:: includes/big_toc_css.rst
 .. include:: whats_new/_contributors.rst
-===============
+
 Release History
 ===============
 .. include:: whats_new/v0.20.rst
 .. include:: whats_new/v0.19.rst
 
-=================
 Previous Releases
 =================
 .. toctree::

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -4,8 +4,14 @@
 
 Release History
 ===============
+
+Release notes for current and recent releases are detailed on this page, with
+:ref:`previous releases <previous_releases_whats_new>` linked below.
+
 .. include:: whats_new/v0.20.rst
 .. include:: whats_new/v0.19.rst
+
+.. _previous_releases_whats_new:
 
 Previous Releases
 =================


### PR DESCRIPTION
I noticed that the section headings in what's new were not as big as they used to be. http://scikit-learn.org/dev/whats_new.html. Compare http://scikit-learn.org/dev/whats_new/v0.20.html

This is because Release History at the top level demotes all the headings under it. Let's see if this improves it.