### PR TITLE
[MRG] revert #10558 Deprecate axis parameter in imputer

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -614,10 +614,9 @@ that contain the missing values::
 
     >>> import numpy as np
     >>> from sklearn.preprocessing import Imputer
-    >>> imp = Imputer(missing_values='NaN', strategy='mean')
+    >>> imp = Imputer(missing_values='NaN', strategy='mean', axis=0)
     >>> imp.fit([[1, 2], [np.nan, 3], [7, 6]])
-    Imputer(axis=None, copy=True, missing_values='NaN', strategy='mean',
-        verbose=0)
+    Imputer(axis=0, copy=True, missing_values='NaN', strategy='mean', verbose=0)
     >>> X = [[np.nan, 2], [6, np.nan], [7, 6]]
     >>> print(imp.transform(X))                           # doctest: +ELLIPSIS
     [[ 4.          2.        ]
@@ -628,9 +627,9 @@ The :class:`Imputer` class also supports sparse matrices::
 
     >>> import scipy.sparse as sp
     >>> X = sp.csc_matrix([[1, 2], [0, 3], [7, 6]])
-    >>> imp = Imputer(missing_values=0, strategy='mean')
+    >>> imp = Imputer(missing_values=0, strategy='mean', axis=0)
     >>> imp.fit(X)
-    Imputer(axis=None, copy=True, missing_values=0, strategy='mean', verbose=0)
+    Imputer(axis=0, copy=True, missing_values=0, strategy='mean', verbose=0)
     >>> X_test = sp.csc_matrix([[0, 2], [6, 0], [7, 6]])
     >>> print(imp.transform(X_test))                      # doctest: +ELLIPSIS
     [[ 4.          2.        ]

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -382,12 +382,6 @@ Outlier Detection models
   ``raw_values`` parameter is deprecated as the shifted Mahalanobis distance
   will be always returned in 0.22. :issue:`9015` by `Nicolas Goix`_.
 
-Preprocessing
-
-- Deprecate ``axis`` parameter in :func:`preprocessing.Imputer`.
-  :issue:`10558` by :user:`Baze Petrushev <petrushev>` and
-  :user:`Hanmin Qin <qinhanmin2014>`.
-
 Misc
 
 - Changed warning type from UserWarning to ConvergenceWarning for failing

--- a/examples/plot_missing_values.py
+++ b/examples/plot_missing_values.py
@@ -65,7 +65,8 @@ X_missing = X_full.copy()
 X_missing[np.where(missing_samples)[0], missing_features] = 0
 y_missing = y_full.copy()
 estimator = Pipeline([("imputer", Imputer(missing_values=0,
-                                          strategy="mean")),
+                                          strategy="mean",
+                                          axis=0)),
                       ("forest", RandomForestRegressor(random_state=0,
                                                        n_estimators=100))])
 score = cross_val_score(estimator, X_missing, y_missing).mean()

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -7,8 +7,6 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_false
-from sklearn.utils.testing import assert_warns_message
-from sklearn.utils.testing import ignore_warnings
 
 from sklearn.preprocessing.imputation import Imputer
 from sklearn.pipeline import Pipeline
@@ -17,7 +15,6 @@ from sklearn import tree
 from sklearn.random_projection import sparse_random_matrix
 
 
-@ignore_warnings(category=DeprecationWarning)  # To be removed in 0.22
 def _check_statistics(X, X_true,
                       strategy, statistics, missing_values):
     """Utility function for testing imputation for a given strategy.
@@ -301,7 +298,6 @@ def test_imputation_pickle():
         )
 
 
-@ignore_warnings(category=DeprecationWarning)  # To be removed in 0.22
 def test_imputation_copy():
     # Test imputation with copy
     X_orig = sparse_random_matrix(5, 5, density=0.75, random_state=0)
@@ -368,15 +364,3 @@ def test_imputation_copy():
 
     # Note: If X is sparse and if missing_values=0, then a (dense) copy of X is
     # made, even if copy=False.
-
-
-def test_deprecated_imputer_axis():
-    depr_message = ("Parameter 'axis' has been deprecated in 0.20 and will "
-                    "be removed in 0.22. Future (and default) behavior is "
-                    "equivalent to 'axis=0' (impute along columns). Row-wise "
-                    "imputation can be performed with FunctionTransformer.")
-    X = sparse_random_matrix(5, 5, density=0.75, random_state=0)
-    imputer = Imputer(missing_values=0, axis=0)
-    assert_warns_message(DeprecationWarning, depr_message, imputer.fit, X)
-    imputer = Imputer(missing_values=0, axis=1)
-    assert_warns_message(DeprecationWarning, depr_message, imputer.fit, X)


### PR DESCRIPTION
See https://github.com/scikit-learn/scikit-learn/pull/10483#issuecomment-365485168
Will drop the parameter directly in ``impute.SimpleImputer``
ping @jnothman 