### PR TITLE
make notation for regression criterion more uniform and better looking

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -490,17 +490,17 @@ Mean Squared Error:
 
 .. math::
 
-    c_m = \frac{1}{N_m} \sum_{i \in N_m} y_i
+    \bar{y}_m = \frac{1}{N_m} \sum_{i \in N_m} y_i
 
-    H(X_m) = \frac{1}{N_m} \sum_{i \in N_m} (y_i - c_m)^2
+    H(X_m) = \frac{1}{N_m} \sum_{i \in N_m} (y_i - \bar{y}_m)^2
 
 Mean Absolute Error:
 
 .. math::
 
-    \bar{y_m} = \frac{1}{N_m} \sum_{i \in N_m} y_i
+    \bar{y}_m = \frac{1}{N_m} \sum_{i \in N_m} y_i
 
-    H(X_m) = \frac{1}{N_m} \sum_{i \in N_m} |y_i - \bar{y_m}|
+    H(X_m) = \frac{1}{N_m} \sum_{i \in N_m} |y_i - \bar{y}_m|
 
 where :math:`X_m` is the training data in node :math:`m`
 


### PR DESCRIPTION
Fixes notation inconsistency in decision tree regression criteria.
The mean in a leaf is called `c_m` and `\bar{y_m}` right next to each other. I picked `\bar{y_m}` because it seemed more semantic. Only I changed it to `\bar{y}_m` because the bar was rendering over the center of ``y_m`` and not over the y.

before:
![image](https://user-images.githubusercontent.com/449558/36281263-0ec54de0-126b-11e8-8f81-5d904bdb34e0.png)

(waiting for circle for after)
