### PR TITLE
[MRG] Change image in segmentation example

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -469,15 +469,15 @@ function of the gradient of the image.
  * :ref:`sphx_glr_auto_examples_cluster_plot_segmentation_toy.py`: Segmenting objects
    from a noisy background using spectral clustering.
 
- * :ref:`sphx_glr_auto_examples_cluster_plot_face_segmentation.py`: Spectral clustering
-   to split the image of the raccoon face in regions.
+ * :ref:`sphx_glr_auto_examples_cluster_plot_coin_segmentation.py`: Spectral clustering
+   to split the image of coins in regions.
 
-.. |face_kmeans| image:: ../auto_examples/cluster/images/sphx_glr_plot_face_segmentation_001.png
-    :target: ../auto_examples/cluster/plot_face_segmentation.html
+.. |coin_kmeans| image:: ../auto_examples/cluster/images/sphx_glr_plot_coin_segmentation_001.png
+    :target: ../auto_examples/cluster/plot_coin_segmentation.html
     :scale: 65
 
-.. |face_discretize| image:: ../auto_examples/cluster/images/sphx_glr_plot_face_segmentation_002.png
-    :target: ../auto_examples/cluster/plot_face_segmentation.html
+.. |coin_discretize| image:: ../auto_examples/cluster/images/sphx_glr_plot_coin_segmentation_002.png
+    :target: ../auto_examples/cluster/plot_coin_segmentation.html
     :scale: 65
 
 Different label assignment strategies
@@ -495,7 +495,7 @@ geometrical shape.
 =====================================  =====================================
  ``assign_labels="kmeans"``              ``assign_labels="discretize"``
 =====================================  =====================================
-|face_kmeans|                          |face_discretize|
+|coin_kmeans|                          |coin_discretize|
 =====================================  =====================================
 
 Spectral Clustering Graphs
@@ -631,12 +631,12 @@ merging to nearest neighbors as in :ref:`this example
 <sphx_glr_auto_examples_cluster_plot_agglomerative_clustering.py>`, or
 using :func:`sklearn.feature_extraction.image.grid_to_graph` to
 enable only merging of neighboring pixels on an image, as in the
-:ref:`raccoon face <sphx_glr_auto_examples_cluster_plot_face_ward_segmentation.py>` example.
+:ref:`coin <sphx_glr_auto_examples_cluster_plot_coin_ward_segmentation.py>` example.
 
 .. topic:: Examples:
 
- * :ref:`sphx_glr_auto_examples_cluster_plot_face_ward_segmentation.py`: Ward clustering
-   to split the image of a raccoon face in regions.
+ * :ref:`sphx_glr_auto_examples_cluster_plot_coin_ward_segmentation.py`: Ward clustering
+   to split the image of coins in regions.
 
  * :ref:`sphx_glr_auto_examples_cluster_plot_ward_structured_vs_unstructured.py`: Example of
    Ward algorithm on a swiss-roll, comparison of structured approaches

--- a/examples/cluster/plot_coin_segmentation.py
+++ b/examples/cluster/plot_coin_segmentation.py
@@ -25,7 +25,6 @@ print(__doc__)
 import time
 
 import numpy as np
-import scipy as sp
 from scipy.ndimage.filters import gaussian_filter
 import matplotlib.pyplot as plt
 from skimage.data import coins

--- a/examples/cluster/plot_coin_segmentation.py
+++ b/examples/cluster/plot_coin_segmentation.py
@@ -1,7 +1,7 @@
 """
-===================================================
-Segmenting the picture of a raccoon face in regions
-===================================================
+================================================
+Segmenting the picture of greek coins in regions
+================================================
 
 This example uses :ref:`spectral_clustering` on a graph created from
 voxel-to-voxel difference on an image to break this image into multiple
@@ -28,34 +28,30 @@ import numpy as np
 import scipy as sp
 from scipy.ndimage.filters import gaussian_filter
 import matplotlib.pyplot as plt
-from skimage import img_as_float
+from skimage.data import coins
 from skimage.transform import rescale
 
 from sklearn.feature_extraction import image
 from sklearn.cluster import spectral_clustering
 
 
-# load the raccoon face as a numpy array
-try:  # SciPy >= 0.16 have face in misc
-    from scipy.misc import face
-    orig_face = img_as_float(face(gray=True))
-except ImportError:
-    orig_face = img_as_float(sp.face(gray=True))
+# load the coins as a numpy array
+orig_coins = coins()
 
-# Resize it to 10% of the original size to speed up the processing
+# Resize it to 20% of the original size to speed up the processing
 # Applying a Gaussian filter for smoothing prior to down-scaling
 # reduces aliasing artifacts.
-smoothened_face = gaussian_filter(orig_face, sigma=4.5)
-rescaled_face = rescale(smoothened_face, 0.1, mode="reflect")
+smoothened_coins = gaussian_filter(orig_coins, sigma=2)
+rescaled_coins = rescale(smoothened_coins, 0.2, mode="reflect")
 
 # Convert the image into a graph with the value of the gradient on the
 # edges.
-graph = image.img_to_graph(rescaled_face)
+graph = image.img_to_graph(rescaled_coins)
 
 # Take a decreasing function of the gradient: an exponential
 # The smaller beta is, the more independent the segmentation is of the
 # actual image. For beta=1, the segmentation is close to a voronoi
-beta = 5
+beta = 10
 eps = 1e-6
 graph.data = np.exp(-beta * graph.data / graph.data.std()) + eps
 
@@ -71,10 +67,10 @@ for assign_labels in ('kmeans', 'discretize'):
     labels = spectral_clustering(graph, n_clusters=N_REGIONS,
                                  assign_labels=assign_labels, random_state=42)
     t1 = time.time()
-    labels = labels.reshape(rescaled_face.shape)
+    labels = labels.reshape(rescaled_coins.shape)
 
     plt.figure(figsize=(5, 5))
-    plt.imshow(rescaled_face, cmap=plt.cm.gray)
+    plt.imshow(rescaled_coins, cmap=plt.cm.gray)
     for l in range(N_REGIONS):
         plt.contour(labels == l,
                     colors=[plt.cm.spectral(l / float(N_REGIONS))])

--- a/examples/cluster/plot_coin_ward_segmentation.py
+++ b/examples/cluster/plot_coin_ward_segmentation.py
@@ -17,7 +17,6 @@ print(__doc__)
 import time as time
 
 import numpy as np
-import scipy as sp
 from scipy.ndimage.filters import gaussian_filter
 
 import matplotlib.pyplot as plt

--- a/examples/cluster/plot_coin_ward_segmentation.py
+++ b/examples/cluster/plot_coin_ward_segmentation.py
@@ -1,7 +1,7 @@
 """
-=========================================================================
-A demo of structured Ward hierarchical clustering on a raccoon face image
-=========================================================================
+======================================================================
+A demo of structured Ward hierarchical clustering on an image of coins
+======================================================================
 
 Compute the segmentation of a 2D image with Ward hierarchical
 clustering. The clustering is spatially constrained in order
@@ -22,7 +22,7 @@ from scipy.ndimage.filters import gaussian_filter
 
 import matplotlib.pyplot as plt
 
-from skimage import img_as_float
+from skimage.data import coins
 from skimage.transform import rescale
 
 from sklearn.feature_extraction.image import grid_to_graph
@@ -31,33 +31,29 @@ from sklearn.cluster import AgglomerativeClustering
 
 # #############################################################################
 # Generate data
-try:  # SciPy >= 0.16 have face in misc
-    from scipy.misc import face
-    orig_face = img_as_float(face(gray=True))
-except ImportError:
-    orig_face = img_as_float(sp.face(gray=True))
+orig_coins = coins()
 
-# Resize it to 10% of the original size to speed up the processing
+# Resize it to 20% of the original size to speed up the processing
 # Applying a Gaussian filter for smoothing prior to down-scaling
 # reduces aliasing artifacts.
-smoothened_face = gaussian_filter(orig_face, sigma=4.5)
-rescaled_face = rescale(smoothened_face, 0.1, mode="reflect")
+smoothened_coins = gaussian_filter(orig_coins, sigma=2)
+rescaled_coins = rescale(smoothened_coins, 0.2, mode="reflect")
 
-X = np.reshape(rescaled_face, (-1, 1))
+X = np.reshape(rescaled_coins, (-1, 1))
 
 # #############################################################################
 # Define the structure A of the data. Pixels connected to their neighbors.
-connectivity = grid_to_graph(*rescaled_face.shape)
+connectivity = grid_to_graph(*rescaled_coins.shape)
 
 # #############################################################################
 # Compute clustering
 print("Compute structured hierarchical clustering...")
 st = time.time()
-n_clusters = 15  # number of regions
+n_clusters = 27  # number of regions
 ward = AgglomerativeClustering(n_clusters=n_clusters, linkage='ward',
                                connectivity=connectivity)
 ward.fit(X)
-label = np.reshape(ward.labels_, rescaled_face.shape)
+label = np.reshape(ward.labels_, rescaled_coins.shape)
 print("Elapsed time: ", time.time() - st)
 print("Number of pixels: ", label.size)
 print("Number of clusters: ", np.unique(label).size)
@@ -65,7 +61,7 @@ print("Number of clusters: ", np.unique(label).size)
 # #############################################################################
 # Plot the results on an image
 plt.figure(figsize=(5, 5))
-plt.imshow(rescaled_face, cmap=plt.cm.gray)
+plt.imshow(rescaled_coins, cmap=plt.cm.gray)
 for l in range(n_clusters):
     plt.contour(label == l,
                 colors=[plt.cm.spectral(l / float(n_clusters)), ])


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10607


#### What does this implement/fix? Explain your changes.
This replaces the racoon face used in the image segmentation examples. It does not have sharp boundaries and thus the resulting segmentation is not very instructive (see #10607 for images). As scikit-image is already a dependency for these two examples, `skimage.data.coins` is used instead. Due to the sharper boundaries the results correctness can be judged much more intuitively. (I'll add the links to the images as soon as the build is done.)