### PR TITLE
[MRG+1] Fix "We probably shouldn't recommend autopep8" (#10645)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,11 +143,11 @@ tools:
   $ pytest --cov sklearn path/to/tests_for_package
   ```
 
--  No pyflakes warnings, check with:
+-  No flake8 warnings, check with:
 
   ```bash
-  $ pip install pyflakes
-  $ pyflakes path/to/module.py
+  $ pip install flake8
+  $ flake8 path/to/module.py
   ```
 
 Bonus points for contributions that include a performance analysis with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,20 +150,6 @@ tools:
   $ pyflakes path/to/module.py
   ```
 
--  No PEP8 warnings, check with:
-
-  ```bash
-  $ pip install pep8
-  $ pep8 path/to/module.py
-  ```
-
--  AutoPEP8 can help you fix some of the easy redundant errors:
-
-  ```bash
-  $ pip install autopep8
-  $ autopep8 path/to/pep8.py
-  ```
-
 Bonus points for contributions that include a performance analysis with
 a benchmark script and profiling output (please report on the mailing
 list or on the GitHub issue).

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -285,10 +285,10 @@ You can also check for common programming errors with the following tools:
 
   see also :ref:`testing_coverage`
 
-* No pyflakes warnings, check with::
+* No flake8 warnings, check with::
 
-    $ pip install pyflakes
-    $ pyflakes path/to/module.py
+    $ pip install flake8
+    $ flake8 path/to/module.py
 
 Bonus points for contributions that include a performance analysis with
 a benchmark script and profiling output (please report on the mailing

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -290,16 +290,6 @@ You can also check for common programming errors with the following tools:
     $ pip install pyflakes
     $ pyflakes path/to/module.py
 
-* No PEP8 warnings, check with::
-
-    $ pip install pep8
-    $ pep8 path/to/module.py
-
-* AutoPEP8 can help you fix some of the easy redundant errors::
-
-    $ pip install autopep8
-    $ autopep8 path/to/pep8.py
-
 Bonus points for contributions that include a performance analysis with
 a benchmark script and profiling output (please report on the mailing
 list or on the GitHub wiki).


### PR DESCRIPTION
Fixes #10645 
Removed recommendation of pep8 and autopep8 from both `CONTRIBUTING.md` and `doc/developers/contributing.rst` 