### PR TITLE
Changed references to renamed examples

### DIFF
--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -1011,8 +1011,8 @@ features or samples. For instance Ward clustering
 (:ref:`hierarchical_clustering`) can cluster together only neighboring pixels
 of an image, thus forming contiguous patches:
 
-.. figure:: ../auto_examples/cluster/images/sphx_glr_plot_face_ward_segmentation_001.png
-   :target: ../auto_examples/cluster/plot_face_ward_segmentation.html
+.. figure:: ../auto_examples/cluster/images/sphx_glr_plot_coin_ward_segmentation_001.png
+   :target: ../auto_examples/cluster/plot_coin_ward_segmentation.html
    :align: center
    :scale: 40
 
@@ -1030,7 +1030,7 @@ or similarity matrices.
 
 .. note:: **Examples**
 
-   * :ref:`sphx_glr_auto_examples_cluster_plot_face_ward_segmentation.py`
+   * :ref:`sphx_glr_auto_examples_cluster_plot_coin_ward_segmentation.py`
 
    * :ref:`sphx_glr_auto_examples_cluster_plot_segmentation_toy.py`
 

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -180,8 +180,8 @@
 		      <img src="_images/sphx_glr_plot_gmm_pdf_thumb.png"></a>
 		  </div>
 		  <div class="item">
-		    <a href="{{ pathto('auto_examples/cluster/plot_face_ward_segmentation') }}">
-		      <img src="_images/sphx_glr_plot_face_ward_segmentation_thumb.png"></a>
+		    <a href="{{ pathto('auto_examples/cluster/plot_coin_ward_segmentation') }}">
+		      <img src="_images/sphx_glr_plot_coin_ward_segmentation_thumb.png"></a>
 		  </div>
 		</div>
 		<!-- Carousel nav -->

--- a/doc/tutorial/statistical_inference/unsupervised_learning.rst
+++ b/doc/tutorial/statistical_inference/unsupervised_learning.rst
@@ -177,12 +177,12 @@ This can be useful, for instance, to retrieve connected regions (sometimes
 also referred to as connected components) when
 clustering an image:
 
-.. image:: /auto_examples/cluster/images/sphx_glr_plot_face_ward_segmentation_001.png
-    :target: ../../auto_examples/cluster/plot_face_ward_segmentation.html
+.. image:: /auto_examples/cluster/images/sphx_glr_plot_coin_ward_segmentation_001.png
+    :target: ../../auto_examples/cluster/plot_coin_ward_segmentation.html
     :scale: 40
     :align: right
 
-.. literalinclude:: ../../auto_examples/cluster/plot_face_ward_segmentation.py
+.. literalinclude:: ../../auto_examples/cluster/plot_coin_ward_segmentation.py
     :lines: 21-45
 
 ..


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes breakage caused by #10647


#### What does this implement/fix? Explain your changes.
In #10647, I failed to find all references to the original images. This PR now changes the missing ones to the new file names.


#### Any other comments?
`doc/tutorial/statistical_inference/unsupervised_learning.rst`'s section about Ward-clustering includes these two lines directly below the now changed example images. Should I change the data used there to `skimage.data.coins()` as well?
```
..
    >>> from sklearn.feature_extraction.image import grid_to_graph
    >>> connectivity = grid_to_graph(*face.shape)
```