### PR TITLE
[MRG] Remove redundant validation from BaseMultilayerPerceptron

### DIFF
--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -300,17 +300,14 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
                 self.best_loss_ = np.inf
 
     def _init_coef(self, fan_in, fan_out):
+        # Use the initialization method recommended by
+        # Glorot et al.
+        factor = 6.
         if self.activation == 'logistic':
-            # Use the initialization method recommended by
-            # Glorot et al.
-            init_bound = np.sqrt(2. / (fan_in + fan_out))
-        elif self.activation in ('identity', 'tanh', 'relu'):
-            init_bound = np.sqrt(6. / (fan_in + fan_out))
-        else:
-            # this was caught earlier, just to make sure
-            raise ValueError("Unknown activation function %s" %
-                             self.activation)
+            factor = 2.
+        init_bound = np.sqrt(factor / (fan_in + fan_out))
 
+        # Generate weights and bias:
         coef_init = self._random_state.uniform(-init_bound, init_bound,
                                                (fan_in, fan_out))
         intercept_init = self._random_state.uniform(-init_bound, init_bound,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

<!--
#### Reference Issues/PRs
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

Remove the redundant validation in method `_init_coef ` and refactor the used conditions:

From:

```python
def _init_coef(self, fan_in, fan_out):
    if self.activation == 'logistic':
        # Use the initialization method recommended by
        # Glorot et al.
        init_bound = np.sqrt(2. / (fan_in + fan_out))
    elif self.activation in ('identity', 'tanh', 'relu'):
        init_bound = np.sqrt(6. / (fan_in + fan_out))
    else:
        # this was caught earlier, just to make sure
        raise ValueError("Unknown activation function %s" %
                         self.activation)
    # ...
```

To:

```python
def _init_coef(self, fan_in, fan_out):
    # Use the initialization method recommended by
    # Glorot et al.
    factor = 6.
    if self.activation == 'logistic':
        factor = 2.
    init_bound = np.sqrt(factor / (fan_in + fan_out))
    # ...
```

The method `_validate_hyperparameters` does always the validation before the method `_initialize` with `_init_coef` will be called:

```python
supported_activations = ('identity', 'logistic', 'tanh', 'relu')
if self.activation not in supported_activations:
    raise ValueError("The activation '%s' is not supported. Supported "
                     "activations are %s." % (self.activation,
                                              supported_activations))
# ...
```
(`def _validate_hyperparameters()` in [multilayer_perceptron.py#L425-L429](https://github.com/nok/scikit-learn/blob/master/sklearn/neural_network/multilayer_perceptron.py#L425-L429))

---

Additional links:

- `_validate_hyperparameters()` call in [multilayer_perceptron.py#L325](https://github.com/nok/scikit-learn/blob/feature/remove-redundant-validation/sklearn/neural_network/multilayer_perceptron.py#L325)
- `self._initialize()` call in [multilayer_perceptron.py#L348](https://github.com/nok/scikit-learn/blob/feature/remove-redundant-validation/sklearn/neural_network/multilayer_perceptron.py#L348)
- `self._init_coef()` call in [multilayer_perceptron.py#L288-L289](https://github.com/nok/scikit-learn/blob/feature/remove-redundant-validation/sklearn/neural_network/multilayer_perceptron.py#L288-L289)

<!--
#### Any other comments?

Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->