### PR TITLE
[MRG] Improve data handling in BaseMultilayerPerceptron

### DIFF
--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -315,6 +315,8 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
         return coef_init, intercept_init
 
     def _fit(self, X, y, incremental=False):
+        X, y = self._validate_input(X, y, incremental)
+
         # Make sure self.hidden_layer_sizes is a list
         hidden_layer_sizes = self.hidden_layer_sizes
         if not hasattr(hidden_layer_sizes, "__iter__"):
@@ -327,7 +329,6 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
             raise ValueError("hidden_layer_sizes must be > 0, got %s." %
                              hidden_layer_sizes)
 
-        X, y = self._validate_input(X, y, incremental)
         n_samples, n_features = X.shape
 
         # Ensure y is 2D

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -862,8 +862,8 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
     n_outputs_ : int
         Number of outputs.
 
-    layers_ : list, length >= 3
-        List of all layers with used neurons, e.g. [10, 30, 3].
+    layers_ : list, length n_layers (>=3)
+        List of all layers with number of used neurons, e.g. [10, 30, 3].
 
     out_activation_ : string
         Name of the output activation function.
@@ -1243,8 +1243,14 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
     n_layers_ : int
         Number of layers.
 
+    n_inputs_ : int
+        Number of inputs.
+
     n_outputs_ : int
         Number of outputs.
+
+    layers_ : list, length n_layers (>=3)
+        List of all layers with number of used neurons, e.g. [10, 30, 3].
 
     out_activation_ : string
         Name of the output activation function.

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -667,6 +667,12 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
         """
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])
 
+        if X.shape[1] != self.n_inputs_:
+            raise ValueError("The size of the passed feature vector does not "
+                             "match the number of neurons of the input layer, "
+                             "got %s instead of %s." % (X.shape[1],
+                                                        self.n_inputs_))
+
         # Initialize layers:
         activations = [X]
         for i in range(self.n_layers_ - 1):

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -440,6 +440,7 @@ def test_params_errors():
 
 
 def test_predict_errors():
+    # Test invalid input data length.
     X = [[3, 2], [1, 6]]
     y = [1, 0]
     X_mismatch = [[1, 2, 3], [4, 5, 6]]

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -427,6 +427,13 @@ def test_params_errors():
     assert_raises(ValueError, clf(activation='cloak').fit, X, y)
 
 
+def test_predict_errors():
+    X = [[3, 2], [1, 6]]
+    y = [1, 0]
+    X_mismatch = [[1, 2, 3], [4, 5, 6]]
+    assert_raises(ValueError, MLPClassifier().fit(X, y).predict, X_mismatch)
+
+
 def test_predict_proba_binary():
     # Test that predict_proba works as expected for binary class.
     X = X_digits_binary[:50]

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -398,6 +398,18 @@ def test_partial_fit_errors():
     assert_false(hasattr(MLPClassifier(solver='lbfgs'), 'partial_fit'))
 
 
+def test_layer_units():
+    # Test the compound layers of the fitted network.
+    X = iris.data
+    y = iris.target
+    clf = MLPClassifier(hidden_layer_sizes=[5, 10]).fit(X, y)
+
+    assert_equal(clf.n_inputs_, 4)
+    assert_equal(clf.n_outputs_, 3)
+    assert_equal(len(clf.layers_), 4)
+    assert_equal(clf.layers_, [4, 5, 10, 3])
+
+
 def test_params_errors():
     # Test that invalid parameters raise value error
     X = [[3, 2], [1, 6]]


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
\-

#### What does this implement/fix? Explain your changes.

This PR improves different data handling related sections. In most cases the `fit` method will be called once and the `predict` method multiple times I guess. So I improved the prediction part by removing redundant code and adding a lightweight validation. I hope that such kind of improvements are welcome.

The original `_fit` method:

```python
def _fit(self, X, y, incremental=False):
    X, y = self._validate_input(X, y, incremental)

    # Make sure self.hidden_layer_sizes is a list
    hidden_layer_sizes = self.hidden_layer_sizes       # <--- `hidden_layer_sizes` is a hyperparameter
    if not hasattr(hidden_layer_sizes, "__iter__"):
        hidden_layer_sizes = [hidden_layer_sizes]
    hidden_layer_sizes = list(hidden_layer_sizes)

    # Validate input parameters.
    self._validate_hyperparameters()                   # <--- run other hyperparameter validations
    if np.any(np.array(hidden_layer_sizes) <= 0):      # <--- check the `hidden_layer_sizes` after all
        raise ValueError("hidden_layer_sizes must be > 0, got %s." %
                         hidden_layer_sizes)
    # ...
```

The improved version run all validations in the method `_validate_hyperparameters`: [multilayer_perceptron.py#L385-L391](https://github.com/nok/scikit-learn/blob/c7acb5b0446af723617950160a76a17e8ea14ea9/sklearn/neural_network/multilayer_perceptron.py#L385-L391).

Furthermore I changed it, because the `_predict` method does exactly the same, because the variable `layer_units` is required for the initialization of weights: [multilayer_perceptron.py#L679-L681](https://github.com/scikit-learn/scikit-learn/blob/d840ad3dec539f1b6314efb7d9299da18d34ac1e/sklearn/neural_network/multilayer_perceptron.py#L679-L681).

```python
def _predict(self, X):
    X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])

    # Make sure self.hidden_layer_sizes is a list
    hidden_layer_sizes = self.hidden_layer_sizes       # <--- redundant code and validation
    if not hasattr(hidden_layer_sizes, "__iter__"):
        hidden_layer_sizes = [hidden_layer_sizes]
    hidden_layer_sizes = list(hidden_layer_sizes)

    layer_units = [X.shape[1]] + hidden_layer_sizes + \ 
        [self.n_outputs_]                              # <--- b/c layer_units is required

    # Initialize layers
    activations = [X]

    for i in range(self.n_layers_ - 1):
        activations.append(np.empty((X.shape[0],
                                     layer_units[i + 1])))  # <--- usage of layer_units

    # ...
```

The improved method uses the new attribute `layers_`:

```python
def _predict(self, X):
    X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])

    if X.shape[1] != self.n_inputs_:
        raise ValueError("The size of the passed feature vector does not "
                         "match the number of neurons of the input layer, "
                         "got %s instead of %s." % (X.shape[1],
                                                    self.n_inputs_))

    # Initialize layers:
    activations = [X]
    for i in range(self.n_layers_ - 1):
        activations.append(np.empty((X.shape[0], self.layers_[i + 1])))
    # ...
```

The new attributes `n_inputs_` and `layers_` are useful like `n_outputs_`:

```python
# Extract meta data:
n_samples, n_features = X.shape
self.n_inputs_ = n_features
self.n_outputs_ = y.shape[1]
self.layers_ = [self.n_inputs_] + layers + [self.n_outputs_]

is_initialized = hasattr(self, 'coefs_')
if not is_initialized or (not self.warm_start and not incremental):
    # First time training the model:
    self._initialize(y, self.layers_)                  # <--- e.g. usage of `self.layers_`
```

The new tests:

- Test for the new attributes: [test_mlp.py#L401-L410](https://github.com/nok/scikit-learn/blob/c7acb5b0446af723617950160a76a17e8ea14ea9/sklearn/neural_network/tests/test_mlp.py#L401-L410).
- Test for the new lightweight validation: [test_mlp.py#L442-L447](https://github.com/nok/scikit-learn/blob/c7acb5b0446af723617950160a76a17e8ea14ea9/sklearn/neural_network/tests/test_mlp.py#L442-L447).

#### Any other comments?

\-