### PR TITLE
[MRG+1] Fixed multilayer_perceptron deprecation error at line no 938

### DIFF
--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -935,7 +935,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
                                  (self.classes_, classes))
         else:
             classes = unique_labels(y)
-            if np.setdiff1d(classes, self.classes_, assume_unique=True):
+            if len(np.setdiff1d(classes, self.classes_, assume_unique=True)):
                 raise ValueError("`y` has classes not in `self.classes_`."
                                  " `self.classes_` has %s. 'y' has %s." %
                                  (self.classes_, classes))


### PR DESCRIPTION
Fixed the deprecation error at line no 938 multilayer_perceptron.py file. The warning is generated due to direct conversion of numpy array to boolean instead of using len() function 