### PR TITLE
[MRG+1] Change default error_score to raise_deprecating

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -273,7 +273,7 @@ class ParameterSampler(object):
 
 
 def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
-                   verbose, error_score='raise', **fit_params):
+                   verbose, error_score='raise-deprecating', **fit_params):
     """Run fit on one set of parameters.
 
     Parameters
@@ -311,11 +311,12 @@ def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
     **fit_params : kwargs
         Additional parameter passed to the fit function of the estimator.
 
-    error_score : 'raise' (default) or numeric
+    error_score : 'raise' or numeric
         Value to assign to the score if an error occurs in estimator fitting.
         If set to 'raise', the error is raised. If a numeric value is given,
         FitFailedWarning is raised. This parameter does not affect the refit
-        step, which will always raise the error.
+        step, which will always raise the error. From version 0.22 the default
+        will be np.nan
 
     Returns
     -------
@@ -391,7 +392,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
     def __init__(self, estimator, scoring=None,
                  fit_params=None, n_jobs=1, iid='warn',
                  refit=True, cv=None, verbose=0, pre_dispatch='2*n_jobs',
-                 error_score='raise', return_train_score=True):
+                 error_score='raise-deprecating', return_train_score=True):
 
         self.scoring = scoring
         self.estimator = estimator
@@ -909,11 +910,12 @@ class GridSearchCV(BaseSearchCV):
     verbose : integer
         Controls the verbosity: the higher, the more messages.
 
-    error_score : 'raise' (default) or numeric
+    error_score : 'raise' or numeric
         Value to assign to the score if an error occurs in estimator fitting.
         If set to 'raise', the error is raised. If a numeric value is given,
         FitFailedWarning is raised. This parameter does not affect the refit
-        step, which will always raise the error.
+        step, which will always raise the error. From version 0.22 the default
+        will be np.nan
 
     return_train_score : boolean, optional
         If ``False``, the ``cv_results_`` attribute will not include training
@@ -1085,7 +1087,7 @@ class GridSearchCV(BaseSearchCV):
 
     def __init__(self, estimator, param_grid, scoring=None, fit_params=None,
                  n_jobs=1, iid='warn', refit=True, cv=None, verbose=0,
-                 pre_dispatch='2*n_jobs', error_score='raise',
+                 pre_dispatch='2*n_jobs', error_score='raise-deprecating',
                  return_train_score="warn"):
         super(GridSearchCV, self).__init__(
             estimator=estimator, scoring=scoring, fit_params=fit_params,
@@ -1244,11 +1246,12 @@ class RandomizedSearchCV(BaseSearchCV):
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    error_score : 'raise' (default) or numeric
+    error_score : 'raise' or numeric
         Value to assign to the score if an error occurs in estimator fitting.
         If set to 'raise', the error is raised. If a numeric value is given,
         FitFailedWarning is raised. This parameter does not affect the refit
-        step, which will always raise the error.
+        step, which will always raise the error. From version 0.22 the default
+        will be np.nan
 
     return_train_score : boolean, optional
         If ``False``, the ``cv_results_`` attribute will not include training
@@ -1386,7 +1389,7 @@ class RandomizedSearchCV(BaseSearchCV):
     def __init__(self, estimator, param_distributions, n_iter=10, scoring=None,
                  fit_params=None, n_jobs=1, iid='warn', refit=True, cv=None,
                  verbose=0, pre_dispatch='2*n_jobs', random_state=None,
-                 error_score='raise', return_train_score="warn"):
+                 error_score='raise-deprecating', return_train_score="warn"):
         self.param_distributions = param_distributions
         self.n_iter = n_iter
         self.random_state = random_state

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -315,8 +315,8 @@ def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
         Value to assign to the score if an error occurs in estimator fitting.
         If set to 'raise', the error is raised. If a numeric value is given,
         FitFailedWarning is raised. This parameter does not affect the refit
-        step, which will always raise the error. From version 0.22 the default
-        will be np.nan
+        step, which will always raise the error. Default is 'raise' but from
+        version 0.22 it will change to np.nan.
 
     Returns
     -------

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -914,8 +914,8 @@ class GridSearchCV(BaseSearchCV):
         Value to assign to the score if an error occurs in estimator fitting.
         If set to 'raise', the error is raised. If a numeric value is given,
         FitFailedWarning is raised. This parameter does not affect the refit
-        step, which will always raise the error. From version 0.22 the default
-        will be np.nan
+        step, which will always raise the error. Default is 'raise' but from
+        version 0.22 it will change to np.nan.
 
     return_train_score : boolean, optional
         If ``False``, the ``cv_results_`` attribute will not include training
@@ -1250,8 +1250,8 @@ class RandomizedSearchCV(BaseSearchCV):
         Value to assign to the score if an error occurs in estimator fitting.
         If set to 'raise', the error is raised. If a numeric value is given,
         FitFailedWarning is raised. This parameter does not affect the refit
-        step, which will always raise the error. From version 0.22 the default
-        will be np.nan
+        step, which will always raise the error. Default is 'raise' but from
+        version 0.22 it will change to np.nan.
 
     return_train_score : boolean, optional
         If ``False``, the ``cv_results_`` attribute will not include training

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -361,7 +361,7 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
                    parameters, fit_params, return_train_score=False,
                    return_parameters=False, return_n_test_samples=False,
                    return_times=False, return_estimator=False,
-                   error_score='raise'):
+                   error_score='raise-deprecating'):
     """Fit estimator and compute scores for a given dataset split.
 
     Parameters
@@ -395,11 +395,12 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     verbose : integer
         The verbosity level.
 
-    error_score : 'raise' (default) or numeric
+    error_score : 'raise' or numeric
         Value to assign to the score if an error occurs in estimator fitting.
         If set to 'raise', the error is raised. If a numeric value is given,
         FitFailedWarning is raised. This parameter does not affect the refit
-        step, which will always raise the error.
+        step, which will always raise the error. From version 0.22 the default
+        will be np.nan
 
     parameters : dict or None
         Parameters to be set on the estimator.
@@ -459,7 +460,6 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     fit_params = dict([(k, _index_param_value(X, v, train))
                       for k, v in fit_params.items()])
 
-    test_scores = {}
     train_scores = {}
     if parameters is not None:
         estimator.set_params(**parameters)
@@ -483,6 +483,11 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         fit_time = time.time() - start_time
         score_time = 0.0
         if error_score == 'raise':
+            raise
+        elif error_score == 'raise-deprecating':
+            warnings.warn("Estimator fit failed. From version 0.22 "
+                          "the default value will be error_score=np.nan",
+                          FutureWarning)
             raise
         elif isinstance(error_score, numbers.Number):
             if is_multimetric:

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -485,11 +485,11 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         if error_score == 'raise':
             raise
         elif error_score == 'raise-deprecating':
-            warnings.warn("Estimator failed to fit for these parameters; the "
-                          "error will be raised. If you want a value to be "
-                          "assigned to the score in such cases, then specify "
-                          "error_score parameter. Default is 'raise' but from "
-                          "version 0.22 it will change to np.nan.",
+            warnings.warn("From version 0.22, errors during fit will result "
+                          "in a cross validation score of NaN by default. Use "
+                          "error_score='raise' if you want an exception "
+                          "raised or error_score=np.nan to adopt the "
+                          "behavior from version 0.22.",
                           FutureWarning)
             raise
         elif isinstance(error_score, numbers.Number):

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -485,11 +485,11 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         if error_score == 'raise':
             raise
         elif error_score == 'raise-deprecating':
-            warnings.warn("Estimator failed to fit train-test for this "
-                          "parameters, the error will be raised. If you want "
-                          "value to be assigned to the score in such case, "
-                          "then specify error_score parameter. From version "
-                          "0.22 the default value will be error_score=np.nan",
+            warnings.warn("Estimator failed to fit for these parameters; the "
+                          "error will be raised. If you want value to be "
+                          "assigned to the score in such case, then specify "
+                          "error_score parameter. From version 0.22 the "
+                          "default value will be error_score=np.nan",
                           FutureWarning)
             raise
         elif isinstance(error_score, numbers.Number):

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -399,8 +399,8 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         Value to assign to the score if an error occurs in estimator fitting.
         If set to 'raise', the error is raised. If a numeric value is given,
         FitFailedWarning is raised. This parameter does not affect the refit
-        step, which will always raise the error. From version 0.22 the default
-        will be np.nan
+        step, which will always raise the error. Default is 'raise' but from
+        version 0.22 it will change to np.nan.
 
     parameters : dict or None
         Parameters to be set on the estimator.
@@ -488,8 +488,8 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
             warnings.warn("Estimator failed to fit for these parameters; the "
                           "error will be raised. If you want a value to be "
                           "assigned to the score in such cases, then specify "
-                          "error_score parameter. From version 0.22 the "
-                          "default value will be error_score=np.nan",
+                          "error_score parameter. Default is 'raise' but from "
+                          "version 0.22 it will change to np.nan.",
                           FutureWarning)
             raise
         elif isinstance(error_score, numbers.Number):

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -486,8 +486,8 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
             raise
         elif error_score == 'raise-deprecating':
             warnings.warn("Estimator failed to fit for these parameters; the "
-                          "error will be raised. If you want value to be "
-                          "assigned to the score in such case, then specify "
+                          "error will be raised. If you want a value to be "
+                          "assigned to the score in such cases, then specify "
                           "error_score parameter. From version 0.22 the "
                           "default value will be error_score=np.nan",
                           FutureWarning)

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -485,8 +485,11 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         if error_score == 'raise':
             raise
         elif error_score == 'raise-deprecating':
-            warnings.warn("Estimator fit failed. From version 0.22 "
-                          "the default value will be error_score=np.nan",
+            warnings.warn("Estimator failed to fit train-test for this "
+                          "parameters, the error will be raised. If you want "
+                          "value to be assigned to the score in such case, "
+                          "then specify error_score parameter. From version "
+                          "0.22 the default value will be error_score=np.nan",
                           FutureWarning)
             raise
         elif isinstance(error_score, numbers.Number):

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1468,11 +1468,11 @@ def test_fit_and_score():
                          _fit_and_score, *fit_and_score_args)
 
     # check if warning was raised, with default error_score argument
-    warning_message = ("Estimator failed to fit for these parameters; the "
-                       "error will be raised. If you want a value to be "
-                       "assigned to the score in such cases, then specify "
-                       "error_score parameter. Default is 'raise' but from "
-                       "version 0.22 it will change to np.nan.")
+    warning_message = ("From version 0.22, errors during fit will result "
+                       "in a cross validation score of NaN by default. Use "
+                       "error_score='raise' if you want an exception "
+                       "raised or error_score=np.nan to adopt the "
+                       "behavior from version 0.22.")
     with pytest.raises(ValueError):
         assert_warns_message(FutureWarning, warning_message, _fit_and_score,
                              *fit_and_score_args)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1471,8 +1471,8 @@ def test_fit_and_score():
     warning_message = ("Estimator failed to fit for these parameters; the "
                        "error will be raised. If you want a value to be "
                        "assigned to the score in such cases, then specify "
-                       "error_score parameter. From version 0.22 the "
-                       "default value will be error_score=np.nan")
+                       "error_score parameter. Default is 'raise' but from "
+                       "version 0.22 it will change to np.nan.")
     with pytest.raises(ValueError):
         assert_warns_message(FutureWarning, warning_message, _fit_and_score,
                              *fit_and_score_args)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1468,8 +1468,8 @@ def test_fit_and_score():
 
     # check if warning was raised, with default error_score argument
     warning_message = ("Estimator failed to fit for these parameters; the "
-                       "error will be raised. If you want value to be "
-                       "assigned to the score in such case, then specify "
+                       "error will be raised. If you want a value to be "
+                       "assigned to the score in such cases, then specify "
                        "error_score parameter. From version 0.22 the "
                        "default value will be error_score=np.nan")
     try:

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1467,11 +1467,11 @@ def test_fit_and_score():
                          _fit_and_score, *fit_and_score_args)
 
     # check if warning was raised, with default error_score argument
-    warning_message = ("Estimator failed to fit train-test for this "
-                       "parameters, the error will be raised. If you want "
-                       "value to be assigned to the score in such case, "
-                       "then specify error_score parameter. From version "
-                       "0.22 the default value will be error_score=np.nan")
+    warning_message = ("Estimator failed to fit for these parameters; the "
+                       "error will be raised. If you want value to be "
+                       "assigned to the score in such case, then specify "
+                       "error_score parameter. From version 0.22 the "
+                       "default value will be error_score=np.nan")
     try:
         assert_warns_message(FutureWarning, warning_message, _fit_and_score,
                              *fit_and_score_args)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -7,6 +7,7 @@ import tempfile
 import os
 from time import sleep
 
+import pytest
 import numpy as np
 from scipy.sparse import coo_matrix, csr_matrix
 from sklearn.exceptions import FitFailedWarning
@@ -1462,7 +1463,7 @@ def test_fit_and_score():
     assert_warns_message(FitFailedWarning, warning_message, _fit_and_score,
                          *fit_and_score_args, **fit_and_score_kwargs)
 
-    # check if exception was raised, with default error_score argument
+    # check if exception is raised, with default error_score argument
     assert_raise_message(ValueError, "Failing classifier failed as required",
                          _fit_and_score, *fit_and_score_args)
 
@@ -1472,11 +1473,9 @@ def test_fit_and_score():
                        "assigned to the score in such cases, then specify "
                        "error_score parameter. From version 0.22 the "
                        "default value will be error_score=np.nan")
-    try:
+    with pytest.raises(ValueError):
         assert_warns_message(FutureWarning, warning_message, _fit_and_score,
                              *fit_and_score_args)
-    except ValueError:
-        pass
 
     fit_and_score_kwargs = {'error_score': 'raise'}
     # check if exception was raised, with default error_score='raise'

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1467,8 +1467,11 @@ def test_fit_and_score():
                          _fit_and_score, *fit_and_score_args)
 
     # check if warning was raised, with default error_score argument
-    warning_message = ("Estimator fit failed. From version 0.22 "
-                       "the default value will be error_score=np.nan")
+    warning_message = ("Estimator failed to fit train-test for this "
+                       "parameters, the error will be raised. If you want "
+                       "value to be assigned to the score in such case, "
+                       "then specify error_score parameter. From version "
+                       "0.22 the default value will be error_score=np.nan")
     try:
         assert_warns_message(FutureWarning, warning_message, _fit_and_score,
                              *fit_and_score_args)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1461,3 +1461,22 @@ def test_fit_and_score():
     # check if the same warning is triggered
     assert_warns_message(FitFailedWarning, warning_message, _fit_and_score,
                          *fit_and_score_args, **fit_and_score_kwargs)
+
+    # check if exception was raised, with default error_score argument
+    assert_raise_message(ValueError, "Failing classifier failed as required",
+                         _fit_and_score, *fit_and_score_args)
+
+    # check if warning was raised, with default error_score argument
+    warning_message = ("Estimator fit failed. From version 0.22 "
+                       "the default value will be error_score=np.nan")
+    try:
+        assert_warns_message(FutureWarning, warning_message, _fit_and_score,
+                             *fit_and_score_args)
+    except ValueError:
+        pass
+
+    fit_and_score_kwargs = {'error_score': 'raise'}
+    # check if exception was raised, with default error_score='raise'
+    assert_raise_message(ValueError, "Failing classifier failed as required",
+                         _fit_and_score, *fit_and_score_args,
+                         **fit_and_score_kwargs)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10309.

#### What does this implement/fix? Explain your changes.
Changes default parameter of error_score to raise-deprecating

#### Any other comments?
Should be method _fit_and_score(cross_validation.py) be updated in the same way?