### PR TITLE
[WIP] Add param `default_value` to Imputer to keep and control unknown data

### DIFF
--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -95,6 +95,10 @@ class Imputer(BaseEstimator, TransformerMixin):
     verbose : integer, optional (default=0)
         Controls the verbosity of the imputer.
 
+    default_value : numeric or boolean, optional (default=None)
+        The default_value for columns where all elements are NaN.
+        If `default_value` is None the column will be dropped.
+
     copy : boolean, optional (default=True)
         If True, a copy of X will be created. If False, imputation will
         be done in-place whenever possible. Note that, in the following cases,

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -119,11 +119,11 @@ class Imputer(BaseEstimator, TransformerMixin):
       contain missing values).
     """
     def __init__(self, missing_values="NaN", strategy="mean",
-                 axis=0, handle_unknown=None, verbose=0, copy=True):
+                 axis=0, default_value=None, verbose=0, copy=True):
         self.missing_values = missing_values
         self.strategy = strategy
         self.axis = axis
-        self.handle_unknown = handle_unknown
+        self.default_value = default_value
         self.verbose = verbose
         self.copy = copy
 
@@ -158,15 +158,15 @@ class Imputer(BaseEstimator, TransformerMixin):
             X = check_array(X, accept_sparse='csc', dtype=np.float64,
                             force_all_finite=False)
 
-            # Replace nan columns with handle_unknown.
-            if self.handle_unknown is not None:
+            # Replace nan columns with the passed `default_value`.
+            if self.default_value is not None:
                 _isnan = lambda x: np.isnan(x) if \
                     isinstance(x, type(np.nan)) else False
                 _isnan = np.vectorize(_isnan)
                 is_col_nan = np.all(_isnan(X), axis=0)
                 if np.any(is_col_nan):
                     nan_indexes = np.where(is_col_nan)[0]
-                    X[:, nan_indexes] = self.handle_unknown
+                    X[:, nan_indexes] = self.default_value
 
             if sparse.issparse(X):
                 self.statistics_ = self._sparse_fit(X,

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -160,9 +160,7 @@ class Imputer(BaseEstimator, TransformerMixin):
 
             # Replace nan columns with the passed `default_value`.
             if self.default_value is not None:
-                _isnan = lambda x: np.isnan(x) if \
-                    isinstance(x, type(np.nan)) else False
-                _isnan = np.vectorize(_isnan)
+                _isnan = np.vectorize(Imputer._isnan)
                 is_col_nan = np.all(_isnan(X), axis=0)
                 if np.any(is_col_nan):
                     nan_indexes = np.where(is_col_nan)[0]
@@ -388,3 +386,8 @@ class Imputer(BaseEstimator, TransformerMixin):
             X[coordinates] = values
 
         return X
+
+    @staticmethod
+    def _isnan(x):
+        """Check whether x is nan or not."""
+        return np.isnan(x) if isinstance(x, type(np.nan)) else False

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -147,21 +147,21 @@ def test_handle_unknown():
         [5, 1],
         [5, 1]
     ]
-    inputer = Imputer(handle_unknown=1)
+    inputer = Imputer(default_value=1)
     assert_array_almost_equal(inputer.fit_transform(X), X_replaced)
 
     X_replaced = [
         [5, True],
         [5, True]
     ]
-    inputer = Imputer(handle_unknown=True)
+    inputer = Imputer(default_value=True)
     assert_array_almost_equal(inputer.fit_transform(X), X_replaced)
 
     X_replaced = [
         [5, False],
         [5, False]
     ]
-    inputer = Imputer(handle_unknown=False)
+    inputer = Imputer(default_value=False)
     assert_array_almost_equal(inputer.fit_transform(X), X_replaced)
 
     X_complex = [
@@ -172,7 +172,7 @@ def test_handle_unknown():
         [5, 1, 15, 1],
         [5, 1, 15, 1]
     ]
-    inputer = Imputer(handle_unknown=1)
+    inputer = Imputer(default_value=1)
     assert_array_almost_equal(inputer.fit_transform(X_complex), X_replaced)
 
     X_complex = [
@@ -183,7 +183,7 @@ def test_handle_unknown():
         [5, False, 15, 10],
         [5, False, 15, 10]
     ]
-    inputer = Imputer(handle_unknown=False)
+    inputer = Imputer(default_value=False)
     assert_array_almost_equal(inputer.fit_transform(X_complex), X_replaced)
 
 

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -130,6 +130,63 @@ def test_imputation_mean_median_only_zero():
                       statistics_median, 0)
 
 
+def test_handle_unknown():
+    # Test replacing nan columns.
+    X = [
+        [5, np.NaN],
+        [5, np.NaN]
+    ]
+    X_default = [
+        [5],
+        [5]
+    ]
+    inputer = Imputer()
+    assert_array_almost_equal(inputer.fit_transform(X), X_default)
+
+    X_replaced = [
+        [5, 1],
+        [5, 1]
+    ]
+    inputer = Imputer(handle_unknown=1)
+    assert_array_almost_equal(inputer.fit_transform(X), X_replaced)
+
+    X_replaced = [
+        [5, True],
+        [5, True]
+    ]
+    inputer = Imputer(handle_unknown=True)
+    assert_array_almost_equal(inputer.fit_transform(X), X_replaced)
+
+    X_replaced = [
+        [5, False],
+        [5, False]
+    ]
+    inputer = Imputer(handle_unknown=False)
+    assert_array_almost_equal(inputer.fit_transform(X), X_replaced)
+
+    X_complex = [
+        [5, np.NaN, 15, np.NaN],
+        [5, np.NaN, 15, np.NaN]
+    ]
+    X_replaced = [
+        [5, 1, 15, 1],
+        [5, 1, 15, 1]
+    ]
+    inputer = Imputer(handle_unknown=1)
+    assert_array_almost_equal(inputer.fit_transform(X_complex), X_replaced)
+
+    X_complex = [
+        [5, np.NaN, 15, np.NaN],
+        [5, np.NaN, 15, 10]
+    ]
+    X_replaced = [
+        [5, False, 15, 10],
+        [5, False, 15, 10]
+    ]
+    inputer = Imputer(handle_unknown=False)
+    assert_array_almost_equal(inputer.fit_transform(X_complex), X_replaced)
+
+
 def safe_median(arr, *args, **kwargs):
     # np.median([]) raises a TypeError for numpy >= 1.10.1
     length = arr.size if hasattr(arr, 'size') else len(arr)

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -140,29 +140,36 @@ def test_handle_unknown():
         [5],
         [5]
     ]
-    inputer = Imputer()
-    assert_array_almost_equal(inputer.fit_transform(X), X_default)
+    imputer = Imputer()
+    assert_array_almost_equal(imputer.fit_transform(X), X_default)
 
     X_replaced = [
         [5, 1],
         [5, 1]
     ]
-    inputer = Imputer(default_value=1)
-    assert_array_almost_equal(inputer.fit_transform(X), X_replaced)
+    imputer = Imputer(default_value=1)
+    assert_array_almost_equal(imputer.fit_transform(X), X_replaced)
+
+    X_replaced = [
+        [5, 1.],
+        [5, 1.]
+    ]
+    imputer = Imputer(default_value=1.)
+    assert_array_almost_equal(imputer.fit_transform(X), X_replaced)
 
     X_replaced = [
         [5, True],
         [5, True]
     ]
-    inputer = Imputer(default_value=True)
-    assert_array_almost_equal(inputer.fit_transform(X), X_replaced)
+    imputer = Imputer(default_value=True)
+    assert_array_almost_equal(imputer.fit_transform(X), X_replaced)
 
     X_replaced = [
         [5, False],
         [5, False]
     ]
-    inputer = Imputer(default_value=False)
-    assert_array_almost_equal(inputer.fit_transform(X), X_replaced)
+    imputer = Imputer(default_value=False)
+    assert_array_almost_equal(imputer.fit_transform(X), X_replaced)
 
     X_complex = [
         [5, np.NaN, 15, np.NaN],
@@ -172,8 +179,8 @@ def test_handle_unknown():
         [5, 1, 15, 1],
         [5, 1, 15, 1]
     ]
-    inputer = Imputer(default_value=1)
-    assert_array_almost_equal(inputer.fit_transform(X_complex), X_replaced)
+    imputer = Imputer(default_value=1)
+    assert_array_almost_equal(imputer.fit_transform(X_complex), X_replaced)
 
     X_complex = [
         [5, np.NaN, 15, np.NaN],
@@ -183,8 +190,19 @@ def test_handle_unknown():
         [5, False, 15, 10],
         [5, False, 15, 10]
     ]
-    inputer = Imputer(default_value=False)
-    assert_array_almost_equal(inputer.fit_transform(X_complex), X_replaced)
+    imputer = Imputer(default_value=False)
+    assert_array_almost_equal(imputer.fit_transform(X_complex), X_replaced)
+
+    X_complex = [
+        [-1, np.NaN, -1, 5],
+        [-1, np.NaN, -1, np.NaN]
+    ]
+    X_replaced = [
+        [False, np.nan, 0, 5],
+        [False, np.nan, 0, np.nan]
+    ]
+    imputer = Imputer(missing_values=-1, default_value=False)
+    assert_array_almost_equal(imputer.fit_transform(X_complex), X_replaced)
 
 
 def safe_median(arr, *args, **kwargs):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #10671.

#### What does this implement/fix? Explain your changes.

It added a new param `handle_unknown` to the [Imputer](http://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.Imputer.html) to enhance the possibilities to handle unknown data, because today unknown data in matrices will be dropped.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

It's still in progress and just a suggestion to discuss.