### PR TITLE
[MRG] Add optional useful_features to output of make_classification

### DIFF
--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -39,7 +39,7 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
                         n_redundant=2, n_repeated=0, n_classes=2,
                         n_clusters_per_class=2, weights=None, flip_y=0.01,
                         class_sep=1.0, hypercube=True, shift=0.0, scale=1.0,
-                        shuffle=True, random_state=None):
+                        shuffle=True, useful_indices=False, random_state=None):
     """Generate a random n-class classification problem.
 
     This initially creates clusters of points normally distributed (std=1)
@@ -120,6 +120,9 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
     shuffle : boolean, optional (default=True)
         Shuffle the samples and the features.
 
+    useful_indices : boolean, optional (default=False)
+        If True, a boolean array indicating useful features is returned
+
     random_state : int, RandomState instance or None, optional (default=None)
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
@@ -133,6 +136,12 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
 
     y : array of shape [n_samples]
         The integer labels for class membership of each sample.
+
+    useful_indices : array of shape [n_features], optional
+        A boolean array indicating the usefulness of each feature. An element
+        in this array is True if the corresponding feature is either
+        informative, redundant, or repeated. It is returned only if indices
+        is True.
 
     Notes
     -----
@@ -239,16 +248,20 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
         scale = 1 + 100 * generator.rand(n_features)
     X *= scale
 
+    indices = np.arange(n_features)
     if shuffle:
         # Randomly permute samples
         X, y = util_shuffle(X, y, random_state=generator)
 
         # Randomly permute features
-        indices = np.arange(n_features)
         generator.shuffle(indices)
         X[:, :] = X[:, indices]
 
-    return X, y
+    if useful_indices:
+        n_useful = n_informative + n_redundant + n_repeated
+        return X, y, indices < n_useful
+    else:
+        return X, y
 
 
 def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -41,8 +41,9 @@ from sklearn.utils.validation import assert_all_finite
 
 def test_make_classification():
     weights = [0.1, 0.25]
-    X, y, i = make_classification(n_samples=100, n_features=20, n_informative=5,
-                                  n_redundant=1, n_repeated=1, n_classes=3,
+    X, y, i = make_classification(n_samples=100, n_features=20,
+                                  n_informative=5, n_redundant=1,
+                                  n_repeated=1, n_classes=3,
                                   n_clusters_per_class=1, hypercube=False,
                                   shift=None, scale=None, weights=weights,
                                   useful_indices=True, random_state=0)

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -41,11 +41,11 @@ from sklearn.utils.validation import assert_all_finite
 
 def test_make_classification():
     weights = [0.1, 0.25]
-    X, y = make_classification(n_samples=100, n_features=20, n_informative=5,
-                               n_redundant=1, n_repeated=1, n_classes=3,
-                               n_clusters_per_class=1, hypercube=False,
-                               shift=None, scale=None, weights=weights,
-                               random_state=0)
+    X, y, i = make_classification(n_samples=100, n_features=20, n_informative=5,
+                                  n_redundant=1, n_repeated=1, n_classes=3,
+                                  n_clusters_per_class=1, hypercube=False,
+                                  shift=None, scale=None, weights=weights,
+                                  useful_indices=True, random_state=0)
 
     assert_equal(weights, [0.1, 0.25])
     assert_equal(X.shape, (100, 20), "X shape mismatch")
@@ -54,6 +54,8 @@ def test_make_classification():
     assert_equal(sum(y == 0), 10, "Unexpected number of samples in class #0")
     assert_equal(sum(y == 1), 25, "Unexpected number of samples in class #1")
     assert_equal(sum(y == 2), 65, "Unexpected number of samples in class #2")
+    assert_equal(i.shape, (20,), "indices shape mismatch")
+    assert_equal(sum(i), 7, "Unexpected number of informative features")
 
     # Test for n_features > 30
     X, y = make_classification(n_samples=2000, n_features=31, n_informative=31,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #10681

#### What does this implement/fix? Explain your changes.
This PR adds an optional `useful_features` argument to `sklearn.datasets.make_classification`. If True, `make_classification` returns a boolean array indicating the importance of the corresponding feature. That is, it is True if the feature is informative, redundant, or repeated.

#### Any other comments?
When testing regression models, I've found `make_regression`'s `coef` argument useful since I can compare the ground truth coefficients with my estimated ones. This PR is intended to add a similar functionality to `make_classification` by letting the user know the "ground truth" of which features are useful.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
