### PR TITLE
[MRG] Functions not rendered as links in developers utilities webpage

### DIFF
--- a/doc/developers/utilities.rst
+++ b/doc/developers/utilities.rst
@@ -97,7 +97,7 @@ Efficient Linear Algebra & Array Operations
   number of components.
 
 - :func:`arrayfuncs.cholesky_delete`:
-  (used in :func:`sklearn.linear_model.least_angle.lars_path`)  Remove an
+  (used in :func:`sklearn.linear_model.lars_path`)  Remove an
   item from a cholesky factorization.
 
 - :func:`arrayfuncs.min_pos`: (used in ``sklearn.linear_model.least_angle``)
@@ -140,10 +140,10 @@ efficiently process ``scipy.sparse`` data.
 - :func:`sparsefuncs.mean_variance_axis`: compute the means and
   variances along a specified axis of a CSR matrix.
   Used for normalizing the tolerance stopping criterion in
-  :class:`sklearn.cluster.k_means_.KMeans`.
+  :class:`sklearn.cluster.KMeans`.
 
-- :func:`sparsefuncs.inplace_csr_row_normalize_l1` and
-  :func:`sparsefuncs.inplace_csr_row_normalize_l2`: can be used to normalize
+- :func:`sparsefuncs_fast.inplace_csr_row_normalize_l1` and
+  :func:`sparsefuncs_fast.inplace_csr_row_normalize_l2`: can be used to normalize
   individual sparse samples to unit L1 or L2 norm as done in
   :class:`sklearn.preprocessing.Normalizer`.
 
@@ -200,9 +200,6 @@ Multiclass and multilabel utility function
 - :func:`multiclass.is_multilabel`: Helper function to check if the task
   is a multi-label classification one.
 
-- :func:`multiclass.is_label_indicator_matrix`: Helper function to check if
-  a classification output is in label indicator matrix format.
-
 - :func:`multiclass.unique_labels`: Helper function to extract an ordered
   array of unique labels from different formats of target.
 
@@ -211,8 +208,8 @@ Helper Functions
 ================
 
 - :class:`gen_even_slices`: generator to create ``n``-packs of slices going up
-  to ``n``.  Used in ``sklearn.decomposition.dict_learning`` and
-  ``sklearn.cluster.k_means``.
+  to ``n``.  Used in :func:`sklearn.decomposition.dict_learning` and
+  :func:`sklearn.cluster.k_means`.
 
 - :func:`safe_mask`: Helper function to convert a mask to the format expected
   by the numpy array or scipy sparse matrix on which to use it (sparse

--- a/doc/developers/utilities.rst
+++ b/doc/developers/utilities.rst
@@ -120,7 +120,7 @@ Efficient Linear Algebra & Array Operations
   used in :func:`shuffle`, below.
 
 - :func:`shuffle`: Shuffle arrays or sparse matrices in a consistent way.
-  Used in ``sklearn.cluster.k_means``.
+  Used in :func:`sklearn.cluster.k_means`.
 
 
 Efficient Random Sampling

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1384,6 +1384,12 @@ Low-level methods
 
 .. autosummary::
    :toctree: generated/
+   :template: class.rst
+
+   utils.testing.mock_mldata_urlopen
+
+.. autosummary::
+   :toctree: generated/
    :template: function.rst
 
    utils.arrayfuncs.cholesky_delete
@@ -1437,7 +1443,6 @@ Low-level methods
    utils.testing.assert_not_in
    utils.testing.assert_raise_message
    utils.testing.all_estimators
-   utils.testing.mock_mldata_urlopen
 
 Recently deprecated
 ===================

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1397,6 +1397,7 @@ Low-level methods
    utils.check_random_state
    utils.class_weight.compute_class_weight
    utils.class_weight.compute_sample_weight
+   utils.deprecated
    utils.estimator_checks.check_estimator
    utils.extmath.safe_sparse_dot
    utils.extmath.randomized_range_finder

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1386,8 +1386,11 @@ Low-level methods
    :toctree: generated/
    :template: function.rst
 
+   utils.arrayfuncs.cholesky_delete
+   utils.arrayfuncs.min_pos
    utils.as_float_array
    utils.assert_all_finite
+   utils.bench.total_seconds
    utils.check_X_y
    utils.check_array
    utils.check_consistent_length
@@ -1396,10 +1399,23 @@ Low-level methods
    utils.class_weight.compute_sample_weight
    utils.estimator_checks.check_estimator
    utils.extmath.safe_sparse_dot
+   utils.extmath.randomized_range_finder
+   utils.extmath.randomized_svd
+   utils.extmath.fast_logdet
+   utils.extmath.density
+   utils.extmath.weighted_mode
+   utils.gen_even_slices
+   utils.graph.single_source_shortest_path_length
+   utils.graph_shortest_path.graph_shortest_path
    utils.indexable
    utils.multiclass.type_of_target
+   utils.multiclass.is_multilabel
+   utils.multiclass.unique_labels
+   utils.murmurhash3_32
    utils.resample
    utils.safe_indexing
+   utils.safe_mask
+   utils.safe_sqr
    utils.shuffle
    utils.sparsefuncs.incr_mean_variance_axis
    utils.sparsefuncs.inplace_column_scale
@@ -1407,11 +1423,20 @@ Low-level methods
    utils.sparsefuncs.inplace_swap_row
    utils.sparsefuncs.inplace_swap_column
    utils.sparsefuncs.mean_variance_axis
+   utils.sparsefuncs.inplace_csr_column_scale
+   utils.sparsefuncs_fast.inplace_csr_row_normalize_l1
+   utils.sparsefuncs_fast.inplace_csr_row_normalize_l2
+   utils.random.sample_without_replacement
    utils.validation.check_is_fitted
    utils.validation.check_memory
    utils.validation.check_symmetric
    utils.validation.column_or_1d
    utils.validation.has_fit_parameter
+   utils.testing.assert_in
+   utils.testing.assert_not_in
+   utils.testing.assert_raise_message
+   utils.testing.all_estimators
+   utils.testing.mock_mldata_urlopen
 
 Recently deprecated
 ===================

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -484,20 +484,22 @@ def fake_mldata(columns_dict, dataname, matfile, ordering=None):
 
 
 class mock_mldata_urlopen(object):
+    """Object that mocks the urlopen function to fake requests to mldata.
 
+    When requesting a dataset with a name that is in mock_datasets, this object
+    creates a fake dataset in a StringIO object and returns it. Otherwise, it
+    raises an HTTPError.
+
+    Parameters
+    ----------
+    mock_datasets : dict
+        A dictionary of {dataset_name: data_dict}, or
+        {dataset_name: (data_dict, ordering). `data_dict` itself is a dictionary
+        of {column_name: data_array}, and `ordering` is a list of column_names
+        to determine the ordering in the data set (see :func:`fake_mldata` for
+        details).
+    """
     def __init__(self, mock_datasets):
-        """Object that mocks the urlopen function to fake requests to mldata.
-
-        `mock_datasets` is a dictionary of {dataset_name: data_dict}, or
-        {dataset_name: (data_dict, ordering).
-        `data_dict` itself is a dictionary of {column_name: data_array},
-        and `ordering` is a list of column_names to determine the ordering
-        in the data set (see `fake_mldata` for details).
-
-        When requesting a dataset with a name that is in mock_datasets,
-        this object creates a fake dataset in a StringIO object and
-        returns it. Otherwise, it raises an HTTPError.
-        """
         self.mock_datasets = mock_datasets
 
     def __call__(self, urlname):

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -494,10 +494,10 @@ class mock_mldata_urlopen(object):
     ----------
     mock_datasets : dict
         A dictionary of {dataset_name: data_dict}, or
-        {dataset_name: (data_dict, ordering). `data_dict` itself is a dictionary
-        of {column_name: data_array}, and `ordering` is a list of column_names
-        to determine the ordering in the data set (see :func:`fake_mldata` for
-        details).
+        {dataset_name: (data_dict, ordering). `data_dict` itself is a
+        dictionary of {column_name: data_array}, and `ordering` is a list of
+        column_names to determine the ordering in the data set (see
+        :func:`fake_mldata` for details).
     """
     def __init__(self, mock_datasets):
         self.mock_datasets = mock_datasets


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #10672 


#### What does this implement/fix? Explain your changes.
- Added missing entries to `doc/modules/classes.rst`
- Removed the description for `sklearn.utils.multiclass.is_label_indicator_matrix` (removed implementation)  from `doc/developers/utilities`
- Fixed misnamed references in `doc/developers/utilities`

#### Any other comments?
The following lack in documentation:
- `utils.sparsefuncs_fast.inplace_csr_row_normalize_l1`
- `utils.sparsefuncs_fast.inplace_csr_row_normalize_l2`
- `utils.arrayfuncs.cholesky_delete`
- `utils.testing.mock_mldata_urlopen`

In particular, `utils.testing.mock_mldata_urlopen` (callable class) doesn't render correctly on the `classes.html` page.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->