### PR TITLE
[MRG] Use pairwise_distance to compute mahalanobis distance in EmpiricalCovariance

### DIFF
--- a/sklearn/covariance/elliptic_envelope.py
+++ b/sklearn/covariance/elliptic_envelope.py
@@ -161,7 +161,6 @@ class EllipticEnvelope(MinCovDet, OutlierMixin):
             Opposite of the Mahalanobis distances.
         """
         check_is_fitted(self, 'offset_')
-        X = check_array(X)
         return -self.mahalanobis(X)
 
     def predict(self, X):

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -18,6 +18,7 @@ from scipy import linalg
 from ..base import BaseEstimator
 from ..utils import check_array
 from ..utils.extmath import fast_logdet
+from ..metrics.pairwise import pairwise_distances
 
 
 def log_likelihood(emp_cov, precision):
@@ -275,14 +276,13 @@ class EmpiricalCovariance(BaseEstimator):
 
         Returns
         -------
-        mahalanobis_distance : array, shape = [n_observations,]
+        dist : array, shape = [n_observations,]
             Squared Mahalanobis distances of the observations.
 
         """
         precision = self.get_precision()
         # compute mahalanobis distances
-        centered_obs = observations - self.location_
-        mahalanobis_dist = np.sum(
-            np.dot(centered_obs, precision) * centered_obs, 1)
+        dist = pairwise_distances(observations, self.location_[np.newaxis, :],
+                                  metric='mahalanobis', VI=precision)
 
-        return mahalanobis_dist
+        return np.reshape(dist, (len(observations),)) ** 2

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -264,25 +264,25 @@ class EmpiricalCovariance(BaseEstimator):
 
         return result
 
-    def mahalanobis(self, observations):
+    def mahalanobis(self, X):
         """Computes the squared Mahalanobis distances of given observations.
 
         Parameters
         ----------
-        observations : array-like, shape = [n_observations, n_features]
+        X : array-like, shape = [n_samples, n_features]
             The observations, the Mahalanobis distances of the which we
             compute. Observations are assumed to be drawn from the same
             distribution than the data used in fit.
 
         Returns
         -------
-        dist : array, shape = [n_observations,]
+        dist : array, shape = [n_samples,]
             Squared Mahalanobis distances of the observations.
 
         """
         precision = self.get_precision()
         # compute mahalanobis distances
-        dist = pairwise_distances(observations, self.location_[np.newaxis, :],
+        dist = pairwise_distances(X, self.location_[np.newaxis, :],
                                   metric='mahalanobis', VI=precision)
 
-        return np.reshape(dist, (len(observations),)) ** 2
+        return np.reshape(dist, (len(X),)) ** 2


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The Mahalanobis distance is implemented from scratch in `EmpiricalCovariance`. I suggest using pairwise_distance.