### PR TITLE
[MRG+1] Fixes #10571: Shape of `coef_` wrong for linear_model.Lasso when using `fit_interce…

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -247,8 +247,8 @@ Classifiers and regressors
   :issue:`10581` by :user:`Yacine Mazari <ymazari>`.
 
 - Fixed a bug in :class:`sklearn.linear_model.Lasso`
-  where the coefficient had wrong shape :issue:`10687`
-  by :user:`Martin Hahn <martin-hahn>`.
+  where the coefficient had wrong shape when ``fit_intercept=False``.
+  :issue:`10687` by :user:`Martin Hahn <martin-hahn>`.
 
 Decomposition, manifold learning and clustering
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -246,6 +246,10 @@ Classifiers and regressors
   overridden when using parameter ``copy_X=True`` and ``check_input=False``.
   :issue:`10581` by :user:`Yacine Mazari <ymazari>`.
 
+- Fixed a bug in :class:`sklearn.linear_model.Lasso`
+  where the coefficient had wrong shape :issue:`10687`
+  by :user:`Martin Hahn <martin-hahn>`.
+
 Decomposition, manifold learning and clustering
 
 - Fix for uninformative error in :class:`decomposition.IncrementalPCA`:

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -764,6 +764,9 @@ class ElasticNet(LinearModel, RegressorMixin):
             self.n_iter_ = self.n_iter_[0]
             self.coef_ = coef_[0]
             self.dual_gap_ = dual_gaps_[0]
+        else:
+            self.coef_ = coef_
+            self.dual_gap_ = dual_gaps_
 
         self._set_intercept(X_offset, y_offset, X_scale)
 

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -762,8 +762,9 @@ class ElasticNet(LinearModel, RegressorMixin):
 
         if n_targets == 1:
             self.n_iter_ = self.n_iter_[0]
+            self.coef_ = coef_[0]
+            self.dual_gap_ = dual_gaps_[0]
 
-        self.coef_, self.dual_gap_ = map(np.squeeze, [coef_, dual_gaps_])
         self._set_intercept(X_offset, y_offset, X_scale)
 
         # workaround since _set_intercept will cast self.coef_ into X.dtype

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -803,3 +803,9 @@ def test_enet_l1_ratio():
         est.fit(X, y[:, None])
         est_desired.fit(X, y[:, None])
     assert_array_almost_equal(est.coef_, est_desired.coef_, decimal=5)
+
+
+def test_coef_shape_not_zero():
+    est_no_intercept = Lasso(fit_intercept=False)
+    est_no_intercept.fit(np.c_[np.ones(3)], np.ones(3))
+    assert est_no_intercept.coef_.shape  == (1,)

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -808,4 +808,4 @@ def test_enet_l1_ratio():
 def test_coef_shape_not_zero():
     est_no_intercept = Lasso(fit_intercept=False)
     est_no_intercept.fit(np.c_[np.ones(3)], np.ones(3))
-    assert est_no_intercept.coef_.shape  == (1,)
+    assert est_no_intercept.coef_.shape == (1,)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10571 
Resolves #10616
Shape of `coef_` wrong for linear_model.Lasso when using `fit_intercept=False`

#### What does this implement/fix? Explain your changes.

np.squeeze was misused and returned zero shaped arrays.