### PR TITLE
[MRG+1] fix the path of html files in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,7 +217,7 @@ You can edit the documentation using any text editor and then generate
 the HTML output by typing ``make html`` from the doc/ directory.
 Alternatively, ``make`` can be used to quickly generate the
 documentation without the example gallery. The resulting HTML files will
-be placed in ``_build/html/`` and are viewable in a web browser. See the
+be placed in ``_build/html/stable`` and are viewable in a web browser. See the
 ``README`` file in the ``doc/`` directory for more information.
 
 For building the documentation, you will need


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
When building the documentation, the resulting html files are located in _build/html/stable as indicated in the contributing section of the user guide. This PR fixes the path in CONTRIBUTING.md


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
