### PR TITLE
FIX _binary_clf_curve no longer supports multilabel-indicator type

### DIFF
--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -341,6 +341,7 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     # Check to make sure y_true is valid
     y_type = type_of_target(y_true)
     if not (y_type == "binary" or
+            y_type == "multilabel-indicator" or
             (y_type == "multiclass" and pos_label is not None)):
         raise ValueError("{0} format is not supported".format(y_type))
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #10690

#### What does this implement/fix? Explain your changes.
This fixes issue #10690 by adding a check for `multilabel-indicator` type for `y_true`.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
