### PR TITLE
DOC Remove random_state note from TimeSeriesSplit, and add where needed

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1967,12 +1967,6 @@ def train_test_split(*arrays, **options):
             If the input is sparse, the output will be a
             ``scipy.sparse.csr_matrix``. Else, output type is the same as the
             input type.
-            
-    Notes
-    -----
-    Randomized CV splitters may return different results for each call of
-    split. You can make the results identical by setting ``random_state``
-    to an integer.
 
     Examples
     --------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -749,12 +749,6 @@ class TimeSeriesSplit(_BaseKFold):
 
         test : ndarray
             The testing set indices for that split.
-
-        Notes
-        -----
-        Randomized CV splitters may return different results for each call of
-        split. You can make the results identical by setting ``random_state``
-        to an integer.
         """
         X, y, groups = indexable(X, y, groups)
         n_samples = _num_samples(X)

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -83,12 +83,6 @@ class BaseCrossValidator(with_metaclass(ABCMeta)):
 
         test : ndarray
             The testing set indices for that split.
-
-        Notes
-        -----
-        Randomized CV splitters may return different results for each call of
-        split. You can make the results identical by setting ``random_state``
-        to an integer.
         """
         X, y, groups = indexable(X, y, groups)
         indices = np.arange(_num_samples(X))
@@ -314,12 +308,6 @@ class _BaseKFold(with_metaclass(ABCMeta, BaseCrossValidator)):
 
         test : ndarray
             The testing set indices for that split.
-
-        Notes
-        -----
-        Randomized CV splitters may return different results for each call of
-        split. You can make the results identical by setting ``random_state``
-        to an integer.
         """
         X, y, groups = indexable(X, y, groups)
         n_samples = _num_samples(X)
@@ -401,6 +389,10 @@ class KFold(_BaseKFold):
     The first ``n_samples % n_splits`` folds have size
     ``n_samples // n_splits + 1``, other folds have size
     ``n_samples // n_splits``, where ``n_samples`` is the number of samples.
+
+    Randomized CV splitters may return different results for each call of
+    split. You can make the results identical by setting ``random_state``
+    to an integer.
 
     See also
     --------
@@ -1096,6 +1088,11 @@ class RepeatedKFold(_RepeatedSplits):
     TRAIN: [1 2] TEST: [0 3]
     TRAIN: [0 3] TEST: [1 2]
 
+    Notes
+    -----
+    Randomized CV splitters may return different results for each call of
+    split. You can make the results identical by setting ``random_state``
+    to an integer.
 
     See also
     --------
@@ -1143,6 +1140,11 @@ class RepeatedStratifiedKFold(_RepeatedSplits):
     TRAIN: [1 3] TEST: [0 2]
     TRAIN: [0 2] TEST: [1 3]
 
+    Notes
+    -----
+    Randomized CV splitters may return different results for each call of
+    split. You can make the results identical by setting ``random_state``
+    to an integer.
 
     See also
     --------
@@ -1965,6 +1967,12 @@ def train_test_split(*arrays, **options):
             If the input is sparse, the output will be a
             ``scipy.sparse.csr_matrix``. Else, output type is the same as the
             input type.
+            
+    Notes
+    -----
+    Randomized CV splitters may return different results for each call of
+    split. You can make the results identical by setting ``random_state``
+    to an integer.
 
     Examples
     --------


### PR DESCRIPTION
TimeSeriesSplit does not use a randomized CV splitter and therefore should not include a note regarding "random state". This issue also occurs in the following classes: LeavePOut, LeaveOneOut, LeavePGroupsOut, LeaveOneGroupOut, and GroupKFold. Lastly, a note regarding randomized CV splitters should be added to: RepeatedStratifiedKFold and RepeatedKFold.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
