### PR TITLE
[MGR] Fix absolute imports on sklear.attribute and add test

### DIFF
--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -60,22 +60,29 @@ if __SKLEARN_SETUP__:
     # We are not importing the rest of scikit-learn during the build
     # process, as it may not be compiled yet
 else:
+    import importlib
     from . import __check_build
     from .base import clone
+
     __check_build  # avoid flakes unused variable error
 
-    __all__ = ['calibration', 'cluster', 'covariance', 'cross_decomposition',
-               'cross_validation', 'datasets', 'decomposition', 'dummy',
-               'ensemble', 'exceptions', 'externals', 'feature_extraction',
-               'feature_selection', 'gaussian_process', 'grid_search',
-               'isotonic', 'kernel_approximation', 'kernel_ridge',
-               'learning_curve', 'linear_model', 'manifold', 'metrics',
-               'mixture', 'model_selection', 'multiclass', 'multioutput',
-               'naive_bayes', 'neighbors', 'neural_network', 'pipeline',
-               'preprocessing', 'random_projection', 'semi_supervised',
-               'svm', 'tree', 'discriminant_analysis', 'impute',
-               # Non-modules:
-               'clone', 'get_config', 'set_config', 'config_context']
+    visible_modules = ['calibration', 'cluster', 'covariance', 'cross_decomposition',
+                       'cross_validation', 'datasets', 'decomposition', 'dummy',
+                       'ensemble', 'exceptions', 'externals', 'feature_extraction',
+                       'feature_selection', 'gaussian_process', 'grid_search',
+                       'isotonic', 'kernel_approximation', 'kernel_ridge',
+                       'learning_curve', 'linear_model', 'manifold', 'metrics',
+                       'mixture', 'model_selection', 'multiclass', 'multioutput',
+                       'naive_bayes', 'neighbors', 'neural_network', 'pipeline',
+                       'preprocessing', 'random_projection', 'semi_supervised',
+                       'svm', 'tree', 'discriminant_analysis', 'impute']
+    # import all the modules specified in __all__
+    for module in visible_modules:
+        importlib.import_module('.' + module, package='sklearn')
+
+    # Non-modules:
+    visible_non_modules = ['clone', 'get_config', 'set_config', 'config_context']
+    __all__ = visible_modules + visible_non_modules
 
 
 def setup_module(module):

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -66,7 +66,7 @@ else:
 
     __check_build  # avoid flakes unused variable error
 
-    visible_modules = ['calibration', 'cluster', 'covariance', 'cross_decomposition',
+    _visible_modules = ['calibration', 'cluster', 'covariance', 'cross_decomposition',
                        'cross_validation', 'datasets', 'decomposition', 'dummy',
                        'ensemble', 'exceptions', 'externals', 'feature_extraction',
                        'feature_selection', 'gaussian_process', 'grid_search',
@@ -77,12 +77,12 @@ else:
                        'preprocessing', 'random_projection', 'semi_supervised',
                        'svm', 'tree', 'discriminant_analysis', 'impute']
     # import all the modules specified in __all__
-    for module in visible_modules:
+    for module in _visible_modules:
         importlib.import_module('.' + module, package='sklearn')
 
     # Non-modules:
-    visible_non_modules = ['clone', 'get_config', 'set_config', 'config_context']
-    __all__ = visible_modules + visible_non_modules
+    _visible_non_modules = ['clone', 'get_config', 'set_config', 'config_context']
+    __all__ = _visible_modules + _visible_non_modules
 
 
 def setup_module(module):

--- a/sklearn/tests/test_abs_import.py
+++ b/sklearn/tests/test_abs_import.py
@@ -1,0 +1,14 @@
+# Author: Jonas Eschle 'Mayou36@jonas.eschle.com'
+# License: BSD 3 clause
+# Testing the absolute import of attributes like sklearn.module or sklearn.attribute
+
+
+from sklearn.utils.testing import assert_equal
+
+
+def test_abs_import_skl():
+    # Test if the modules/attributes have been imported correctly
+    import sklearn
+
+    failed_attributes = [att for att in sklearn.__all__ if not hasattr(sklearn, att)]
+    assert_equal(failed_attributes, [])


### PR DESCRIPTION

#### Reference Issues/PRs
Fixes #10694 

#### Fix
In `sklearn.__init__` the `__all__` was defined but the modules were not imported inside (as in other modules), so sklearn.module failed.

#### Implementation
I've split the `__all__` list into two (`visible_modules` and `visible_non_modules`  and automatically import all `'visible_modules'. Then, `__all__` is the concatenation of the two lists.

Unittest is added (**not** in the existing `test_init.py` as this *needs* to import modules on a module level and therefore "pollutes" the namespace making the tests to pass anyway (by importing all the modules in another way).

