### PR TITLE
[MRG+1] Add reference to the glossary in the warm_start parameter description of public APIs 

### DIFF
--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -480,7 +480,7 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
     warm_start : bool, optional (default=False)
         When set to True, reuse the solution of the previous call to fit
         and add more estimators to the ensemble, otherwise, just fit
-        a whole new ensemble.
+        a whole new ensemble. See :term:`the Glossary <warm_start>`.
 
         .. versionadded:: 0.17
            *warm_start* constructor parameter.
@@ -850,7 +850,7 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
     warm_start : bool, optional (default=False)
         When set to True, reuse the solution of the previous call to fit
         and add more estimators to the ensemble, otherwise, just fit
-        a whole new ensemble.
+        a whole new ensemble. See :term:`the Glossary <warm_start>`.
 
     n_jobs : int, optional (default=1)
         The number of jobs to run in parallel for both `fit` and `predict`.

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -866,7 +866,7 @@ class RandomForestClassifier(ForestClassifier):
     warm_start : bool, optional (default=False)
         When set to ``True``, reuse the solution of the previous call to fit
         and add more estimators to the ensemble, otherwise, just fit a whole
-        new forest.
+        new forest. See :term:`the Glossary <warm_start>`.
 
     class_weight : dict, list of dicts, "balanced",
         "balanced_subsample" or None, optional (default=None)
@@ -1144,7 +1144,7 @@ class RandomForestRegressor(ForestRegressor):
     warm_start : bool, optional (default=False)
         When set to ``True``, reuse the solution of the previous call to fit
         and add more estimators to the ensemble, otherwise, just fit a whole
-        new forest.
+        new forest. See :term:`the Glossary <warm_start>`.
 
     Attributes
     ----------
@@ -1375,7 +1375,7 @@ class ExtraTreesClassifier(ForestClassifier):
     warm_start : bool, optional (default=False)
         When set to ``True``, reuse the solution of the previous call to fit
         and add more estimators to the ensemble, otherwise, just fit a whole
-        new forest.
+        new forest. See :term:`the Glossary <warm_start>`.
 
     class_weight : dict, list of dicts, "balanced", "balanced_subsample" or None, optional (default=None)
         Weights associated with classes in the form ``{class_label: weight}``.
@@ -1623,7 +1623,7 @@ class ExtraTreesRegressor(ForestRegressor):
     warm_start : bool, optional (default=False)
         When set to ``True``, reuse the solution of the previous call to fit
         and add more estimators to the ensemble, otherwise, just fit a whole
-        new forest.
+        new forest. See :term:`the Glossary <warm_start>`.
 
     Attributes
     ----------
@@ -1814,7 +1814,7 @@ class RandomTreesEmbedding(BaseForest):
     warm_start : bool, optional (default=False)
         When set to ``True``, reuse the solution of the previous call to fit
         and add more estimators to the ensemble, otherwise, just fit a whole
-        new forest.
+        new forest. See :term:`the Glossary <warm_start>`.
 
     Attributes
     ----------

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1424,7 +1424,7 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
     warm_start : bool, default: False
         When set to ``True``, reuse the solution of the previous call to fit
         and add more estimators to the ensemble, otherwise, just erase the
-        previous solution.
+        previous solution. See :term:`the Glossary <warm_start>`.
 
     random_state : int, RandomState instance or None, optional (default=None)
         If int, random_state is the seed used by the random number generator;
@@ -1882,7 +1882,7 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
     warm_start : bool, default: False
         When set to ``True``, reuse the solution of the previous call to fit
         and add more estimators to the ensemble, otherwise, just erase the
-        previous solution.
+        previous solution. See :term:`the Glossary <warm_start>`.
 
     random_state : int, RandomState instance or None, optional (default=None)
         If int, random_state is the seed used by the random number generator;

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -100,6 +100,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         initialization for the next call of _posterior_mode(). This can speed
         up convergence when _posterior_mode is called several times on similar
         problems as in hyperparameter optimization. 
+        
         See :term:`the Glossary <warm_start>`.
 
     copy_X_train : bool, optional (default: True)

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -99,9 +99,8 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         on the Laplace approximation of the posterior mode is used as
         initialization for the next call of _posterior_mode(). This can speed
         up convergence when _posterior_mode is called several times on similar
-        problems as in hyperparameter optimization.
-
-        See :term:`the Glossary <warm_start>`.
+        problems as in hyperparameter optimization. See :term:`the Glossary
+        <warm_start>`.
 
     copy_X_train : bool, optional (default: True)
         If True, a persistent copy of the training data is stored in the
@@ -508,9 +507,8 @@ class GaussianProcessClassifier(BaseEstimator, ClassifierMixin):
         on the Laplace approximation of the posterior mode is used as
         initialization for the next call of _posterior_mode(). This can speed
         up convergence when _posterior_mode is called several times on similar
-        problems as in hyperparameter optimization.
-
-        See :term:`the Glossary <warm_start>`.
+        problems as in hyperparameter optimization. See :term:`the Glossary
+        <warm_start>`.
 
     copy_X_train : bool, optional (default: True)
         If True, a persistent copy of the training data is stored in the

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -99,7 +99,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         on the Laplace approximation of the posterior mode is used as
         initialization for the next call of _posterior_mode(). This can speed
         up convergence when _posterior_mode is called several times on similar
-        problems as in hyperparameter optimization. 
+        problems as in hyperparameter optimization.
         
         See :term:`the Glossary <warm_start>`.
 

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -99,7 +99,8 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         on the Laplace approximation of the posterior mode is used as
         initialization for the next call of _posterior_mode(). This can speed
         up convergence when _posterior_mode is called several times on similar
-        problems as in hyperparameter optimization.
+        problems as in hyperparameter optimization. 
+        See :term:`the Glossary <warm_start>`.
 
     copy_X_train : bool, optional (default: True)
         If True, a persistent copy of the training data is stored in the
@@ -507,6 +508,7 @@ class GaussianProcessClassifier(BaseEstimator, ClassifierMixin):
         initialization for the next call of _posterior_mode(). This can speed
         up convergence when _posterior_mode is called several times on similar
         problems as in hyperparameter optimization.
+        See :term:`the Glossary <warm_start>`.
 
     copy_X_train : bool, optional (default: True)
         If True, a persistent copy of the training data is stored in the

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -509,6 +509,7 @@ class GaussianProcessClassifier(BaseEstimator, ClassifierMixin):
         initialization for the next call of _posterior_mode(). This can speed
         up convergence when _posterior_mode is called several times on similar
         problems as in hyperparameter optimization.
+        
         See :term:`the Glossary <warm_start>`.
 
     copy_X_train : bool, optional (default: True)

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -100,7 +100,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         initialization for the next call of _posterior_mode(). This can speed
         up convergence when _posterior_mode is called several times on similar
         problems as in hyperparameter optimization.
-        
+
         See :term:`the Glossary <warm_start>`.
 
     copy_X_train : bool, optional (default: True)

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -509,7 +509,7 @@ class GaussianProcessClassifier(BaseEstimator, ClassifierMixin):
         initialization for the next call of _posterior_mode(). This can speed
         up convergence when _posterior_mode is called several times on similar
         problems as in hyperparameter optimization.
-        
+
         See :term:`the Glossary <warm_start>`.
 
     copy_X_train : bool, optional (default: True)

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -579,7 +579,8 @@ class ElasticNet(LinearModel, RegressorMixin):
 
     warm_start : bool, optional
         When set to ``True``, reuse the solution of the previous call to fit as
-        initialization, otherwise, just erase the previous solution.
+        initialization, otherwise, just erase the previous solution. 
+        See :term:`the Glossary <warm_start>`.
 
     positive : bool, optional
         When set to ``True``, forces the coefficients to be positive.
@@ -855,6 +856,7 @@ class Lasso(ElasticNet):
     warm_start : bool, optional
         When set to True, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
+        See :term:`the Glossary <warm_start>`.
 
     positive : bool, optional
         When set to ``True``, forces the coefficients to be positive.
@@ -1648,6 +1650,7 @@ class MultiTaskElasticNet(Lasso):
     warm_start : bool, optional
         When set to ``True``, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
+        See :term:`the Glossary <warm_start>`.
 
     random_state : int, RandomState instance or None, optional, default None
         The seed of the pseudo random number generator that selects a random
@@ -1838,6 +1841,7 @@ class MultiTaskLasso(MultiTaskElasticNet):
     warm_start : bool, optional
         When set to ``True``, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
+        See :term:`the Glossary <warm_start>`.
 
     random_state : int, RandomState instance or None, optional, default None
         The seed of the pseudo random number generator that selects a random

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -579,7 +579,7 @@ class ElasticNet(LinearModel, RegressorMixin):
 
     warm_start : bool, optional
         When set to ``True``, reuse the solution of the previous call to fit as
-        initialization, otherwise, just erase the previous solution. 
+        initialization, otherwise, just erase the previous solution.
         See :term:`the Glossary <warm_start>`.
 
     positive : bool, optional

--- a/sklearn/linear_model/huber.py
+++ b/sklearn/linear_model/huber.py
@@ -158,7 +158,6 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
         This is useful if the stored attributes of a previously used model
         has to be reused. If set to False, then the coefficients will
         be rewritten for every call to fit.
-        
         See :term:`the Glossary <warm_start>`.
 
     fit_intercept : bool, default True

--- a/sklearn/linear_model/huber.py
+++ b/sklearn/linear_model/huber.py
@@ -158,6 +158,7 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
         This is useful if the stored attributes of a previously used model
         has to be reused. If set to False, then the coefficients will
         be rewritten for every call to fit.
+        
         See :term:`the Glossary <warm_start>`.
 
     fit_intercept : bool, default True

--- a/sklearn/linear_model/huber.py
+++ b/sklearn/linear_model/huber.py
@@ -158,6 +158,7 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
         This is useful if the stored attributes of a previously used model
         has to be reused. If set to False, then the coefficients will
         be rewritten for every call to fit.
+        See :term:`the Glossary <warm_start>`.
 
     fit_intercept : bool, default True
         Whether or not to fit the intercept. This can be set to False

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1084,7 +1084,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
     warm_start : bool, default: False
         When set to True, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
-        Useless for liblinear solver.
+        Useless for liblinear solver. See :term:`the Glossary <warm_start>`.
 
         .. versionadded:: 0.17
            *warm_start* to support *lbfgs*, *newton-cg*, *sag*, *saga* solvers.

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -62,12 +62,11 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
     warm_start : bool, optional
         When set to True, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
+        See :term:`the Glossary <warm_start>`.
 
         Repeatedly calling fit or partial_fit when warm_start is True can
         result in a different solution than when calling fit a single time
         because of the way the data is shuffled.
-        
-        See :term:`the Glossary <warm_start>`.
 
     class_weight : dict, {class_label: weight} or "balanced" or None, optional
         Preset for the class_weight fit parameter.
@@ -287,12 +286,11 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
     warm_start : bool, optional
         When set to True, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
+        See :term:`the Glossary <warm_start>`.
 
         Repeatedly calling fit or partial_fit when warm_start is True can
         result in a different solution than when calling fit a single time
         because of the way the data is shuffled.
-        
-        See :term:`the Glossary <warm_start>`.
 
     average : bool or int, optional
         When set to True, computes the averaged SGD weights and stores the

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -66,6 +66,8 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
         Repeatedly calling fit or partial_fit when warm_start is True can
         result in a different solution than when calling fit a single time
         because of the way the data is shuffled.
+        
+        See :term:`the Glossary <warm_start>`.
 
     class_weight : dict, {class_label: weight} or "balanced" or None, optional
         Preset for the class_weight fit parameter.
@@ -289,6 +291,8 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
         Repeatedly calling fit or partial_fit when warm_start is True can
         result in a different solution than when calling fit a single time
         because of the way the data is shuffled.
+        
+        See :term:`the Glossary <warm_start>`.
 
     average : bool or int, optional
         When set to True, computes the averaged SGD weights and stores the

--- a/sklearn/linear_model/perceptron.py
+++ b/sklearn/linear_model/perceptron.py
@@ -72,7 +72,7 @@ class Perceptron(BaseSGDClassifier):
     warm_start : bool, optional
         When set to True, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
-        
+
         See :term:`the Glossary <warm_start>`.
 
     n_iter : int, optional

--- a/sklearn/linear_model/perceptron.py
+++ b/sklearn/linear_model/perceptron.py
@@ -71,9 +71,8 @@ class Perceptron(BaseSGDClassifier):
 
     warm_start : bool, optional
         When set to True, reuse the solution of the previous call to fit as
-        initialization, otherwise, just erase the previous solution.
-
-        See :term:`the Glossary <warm_start>`.
+        initialization, otherwise, just erase the previous solution. See
+        :term:`the Glossary <warm_start>`.
 
     n_iter : int, optional
         The number of passes over the training data (aka epochs).

--- a/sklearn/linear_model/perceptron.py
+++ b/sklearn/linear_model/perceptron.py
@@ -72,6 +72,8 @@ class Perceptron(BaseSGDClassifier):
     warm_start : bool, optional
         When set to True, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
+        
+        See :term:`the Glossary <warm_start>`.
 
     n_iter : int, optional
         The number of passes over the training data (aka epochs).

--- a/sklearn/linear_model/sag.py
+++ b/sklearn/linear_model/sag.py
@@ -178,8 +178,6 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1., beta=0.,
                 samples, for the intercept.
             - 'seen': array of boolean describing the seen samples.
             - 'num_seen': the number of seen samples.
-        
-        See :term:`the Glossary <warm_start>`. 
 
     is_saga : boolean, optional
         Whether to use the SAGA algorithm or the SAG algorithm. SAGA behaves

--- a/sklearn/linear_model/sag.py
+++ b/sklearn/linear_model/sag.py
@@ -178,6 +178,8 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1., beta=0.,
                 samples, for the intercept.
             - 'seen': array of boolean describing the seen samples.
             - 'num_seen': the number of seen samples.
+        
+        See :term:`the Glossary <warm_start>`. 
 
     is_saga : boolean, optional
         Whether to use the SAGA algorithm or the SAG algorithm. SAGA behaves

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -732,6 +732,8 @@ class SGDClassifier(BaseSGDClassifier):
         depending on the number of samples already seen. Calling ``fit`` resets
         this counter, while ``partial_fit`` will result in increasing the
         existing counter.
+        
+        See :term:`the Glossary <warm_start>`.
 
     average : bool or int, optional
         When set to True, computes the averaged SGD weights and stores the
@@ -1289,6 +1291,8 @@ class SGDRegressor(BaseSGDRegressor):
         depending on the number of samples already seen. Calling ``fit`` resets
         this counter, while ``partial_fit``  will result in increasing the
         existing counter.
+        
+        See :term:`the Glossary <warm_start>`.
 
     average : bool or int, optional
         When set to True, computes the averaged SGD weights and stores the

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -724,6 +724,7 @@ class SGDClassifier(BaseSGDClassifier):
     warm_start : bool, optional
         When set to True, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
+        See :term:`the Glossary <warm_start>`.
 
         Repeatedly calling fit or partial_fit when warm_start is True can
         result in a different solution than when calling fit a single time
@@ -732,8 +733,6 @@ class SGDClassifier(BaseSGDClassifier):
         depending on the number of samples already seen. Calling ``fit`` resets
         this counter, while ``partial_fit`` will result in increasing the
         existing counter.
-        
-        See :term:`the Glossary <warm_start>`.
 
     average : bool or int, optional
         When set to True, computes the averaged SGD weights and stores the
@@ -1283,6 +1282,7 @@ class SGDRegressor(BaseSGDRegressor):
     warm_start : bool, optional
         When set to True, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
+        See :term:`the Glossary <warm_start>`.
 
         Repeatedly calling fit or partial_fit when warm_start is True can
         result in a different solution than when calling fit a single time
@@ -1291,8 +1291,6 @@ class SGDRegressor(BaseSGDRegressor):
         depending on the number of samples already seen. Calling ``fit`` resets
         this counter, while ``partial_fit``  will result in increasing the
         existing counter.
-        
-        See :term:`the Glossary <warm_start>`.
 
     average : bool or int, optional
         When set to True, computes the averaged SGD weights and stores the

--- a/sklearn/mixture/bayesian_mixture.py
+++ b/sklearn/mixture/bayesian_mixture.py
@@ -173,7 +173,6 @@ class BayesianGaussianMixture(BaseMixture):
         If 'warm_start' is True, the solution of the last fitting is used as
         initialization for the next call of fit(). This can speed up
         convergence when fit is called several times on similar problems.
-
         See :term:`the Glossary <warm_start>`.
 
     verbose : int, default to 0.

--- a/sklearn/mixture/bayesian_mixture.py
+++ b/sklearn/mixture/bayesian_mixture.py
@@ -172,7 +172,9 @@ class BayesianGaussianMixture(BaseMixture):
     warm_start : bool, default to False.
         If 'warm_start' is True, the solution of the last fitting is used as
         initialization for the next call of fit(). This can speed up
-        convergence when fit is called several time on similar problems.
+        convergence when fit is called several times on similar problems.
+        
+        See :term:`the Glossary <warm_start>`.
 
     verbose : int, default to 0.
         Enable verbose output. If 1 then it prints the current

--- a/sklearn/mixture/bayesian_mixture.py
+++ b/sklearn/mixture/bayesian_mixture.py
@@ -173,7 +173,7 @@ class BayesianGaussianMixture(BaseMixture):
         If 'warm_start' is True, the solution of the last fitting is used as
         initialization for the next call of fit(). This can speed up
         convergence when fit is called several times on similar problems.
-        
+
         See :term:`the Glossary <warm_start>`.
 
     verbose : int, default to 0.

--- a/sklearn/mixture/gaussian_mixture.py
+++ b/sklearn/mixture/gaussian_mixture.py
@@ -508,7 +508,9 @@ class GaussianMixture(BaseMixture):
     warm_start : bool, default to False.
         If 'warm_start' is True, the solution of the last fitting is used as
         initialization for the next call of fit(). This can speed up
-        convergence when fit is called several time on similar problems.
+        convergence when fit is called several times on similar problems.
+        
+        See :term:`the Glossary <warm_start>`.
 
     verbose : int, default to 0.
         Enable verbose output. If 1 then it prints the current

--- a/sklearn/mixture/gaussian_mixture.py
+++ b/sklearn/mixture/gaussian_mixture.py
@@ -509,7 +509,6 @@ class GaussianMixture(BaseMixture):
         If 'warm_start' is True, the solution of the last fitting is used as
         initialization for the next call of fit(). This can speed up
         convergence when fit is called several times on similar problems.
-
         See :term:`the Glossary <warm_start>`.
 
     verbose : int, default to 0.

--- a/sklearn/mixture/gaussian_mixture.py
+++ b/sklearn/mixture/gaussian_mixture.py
@@ -509,7 +509,7 @@ class GaussianMixture(BaseMixture):
         If 'warm_start' is True, the solution of the last fitting is used as
         initialization for the next call of fit(). This can speed up
         convergence when fit is called several times on similar problems.
-        
+
         See :term:`the Glossary <warm_start>`.
 
     verbose : int, default to 0.

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -788,7 +788,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
     warm_start : bool, optional, default False
         When set to True, reuse the solution of the previous
         call to fit as initialization, otherwise, just erase the
-        previous solution.
+        previous solution. See :term:`the Glossary <warm_start>`.
 
     momentum : float, default 0.9
         Momentum for gradient descent update. Should be between 0 and 1. Only
@@ -1171,7 +1171,7 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
     warm_start : bool, optional, default False
         When set to True, reuse the solution of the previous
         call to fit as initialization, otherwise, just erase the
-        previous solution.
+        previous solution. See :term:`the Glossary <warm_start>`.
 
     momentum : float, default 0.9
         Momentum for gradient descent update.  Should be between 0 and 1. Only


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10659


#### What does this implement/fix? Explain your changes.
This answers the issue raised by @jnothman in #10659, where as explained in his own words: 

> users seem to be confused with the application of warm_start (#10658), particularly not realising that one should usually use it when re-fitting the model with the same or a super-sample of data, but with different parameters. 

So, as suggested, referencing the glossary may help reduce the confusion. 

Concretely, this pull request adds a reference to the glossary within the definitions of `warm_start` parameter of all public APIs, where applicable. The changes in most cases are restricted to a simple addition of  ``See :term:`the Glossary <warm_start>`.`` to the existent definition. 

#### Any other comments?

In two occurrences, I fixed a small typo within the same definition of warm_start in which I changed _several time_ to _several time**s**_. 

In one occasion, I added the `warm_start` glossary's reference within the definition of the parameter `warm_start_mem` because, since this parameter is related to `warm_start`, I think adding the reference can make it clearer. 
