### PR TITLE
[MRG] MAINT: remove old scipy LBFGS scipy related code

### DIFF
--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -264,12 +264,6 @@ class SimpleImputer(BaseEstimator, TransformerMixin):
 
         # Median
         elif strategy == "median":
-            if tuple(int(v) for v in np.__version__.split('.')[:2]) < (1, 5):
-                # In old versions of numpy, calling a median on an array
-                # containing nans returns nan. This is different is
-                # recent versions of numpy, which we want to mimic
-                masked_X.mask = np.logical_or(masked_X.mask,
-                                              np.isnan(X))
             median_masked = np.ma.median(masked_X, axis=axis)
             # Avoid the warning "Warning: converting a masked element to nan."
             median = np.ma.getdata(median_masked)

--- a/sklearn/linear_model/huber.py
+++ b/sklearn/linear_model/huber.py
@@ -255,24 +255,16 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
         bounds = np.tile([-np.inf, np.inf], (parameters.shape[0], 1))
         bounds[-1][0] = np.finfo(np.float64).eps * 10
 
-        # Type Error caused in old versions of SciPy because of no
-        # maxiter argument ( <= 0.9).
-        try:
-            parameters, f, dict_ = optimize.fmin_l_bfgs_b(
-                _huber_loss_and_gradient, parameters,
-                args=(X, y, self.epsilon, self.alpha, sample_weight),
-                maxiter=self.max_iter, pgtol=self.tol, bounds=bounds,
-                iprint=0)
-        except TypeError:
-            parameters, f, dict_ = optimize.fmin_l_bfgs_b(
-                _huber_loss_and_gradient, parameters,
-                args=(X, y, self.epsilon, self.alpha, sample_weight),
-                bounds=bounds)
+        parameters, f, dict_ = optimize.fmin_l_bfgs_b(
+            _huber_loss_and_gradient, parameters,
+            args=(X, y, self.epsilon, self.alpha, sample_weight),
+            maxiter=self.max_iter, pgtol=self.tol, bounds=bounds,
+            iprint=0)
         if dict_['warnflag'] == 2:
             raise ValueError("HuberRegressor convergence failed:"
                              " l-BFGS-b solver terminated with %s"
                              % dict_['task'].decode('ascii'))
-        self.n_iter_ = dict_.get('nit', None)
+        self.n_iter_ = dict_['nit']
         self.scale_ = parameters[-1]
         if self.fit_intercept:
             self.intercept_ = parameters[-2]

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -244,8 +244,8 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
           (possibility to set `tol` and `max_iter`).
 
         - 'lsqr' uses the dedicated regularized least-squares routine
-          scipy.sparse.linalg.lsqr. It is the fastest but may not be available
-          in old scipy versions. It also uses an iterative procedure.
+          scipy.sparse.linalg.lsqr. It is the fastest and uses an iterative
+          procedure.
 
         - 'sag' uses a Stochastic Average Gradient descent, and 'saga' uses
           its improved, unbiased version named SAGA. Both methods also use an
@@ -359,11 +359,6 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
             solver = 'cholesky'
         else:
             solver = 'sparse_cg'
-
-    elif solver == 'lsqr' and not hasattr(sp_linalg, 'lsqr'):
-        warnings.warn("""lsqr not available on this machine, falling back
-                      to sparse_cg.""")
-        solver = 'sparse_cg'
 
     if has_sw:
         if np.atleast_1d(sample_weight).ndim > 1:
@@ -578,8 +573,8 @@ class Ridge(_BaseRidge, RegressorMixin):
           (possibility to set `tol` and `max_iter`).
 
         - 'lsqr' uses the dedicated regularized least-squares routine
-          scipy.sparse.linalg.lsqr. It is the fastest but may not be available
-          in old scipy versions. It also uses an iterative procedure.
+          scipy.sparse.linalg.lsqr. It is the fastest and uses an iterative
+          procedure.
 
         - 'sag' uses a Stochastic Average Gradient descent, and 'saga' uses
           its improved, unbiased version named SAGA. Both methods also use an
@@ -736,8 +731,8 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
           (possibility to set `tol` and `max_iter`).
 
         - 'lsqr' uses the dedicated regularized least-squares routine
-          scipy.sparse.linalg.lsqr. It is the fastest but may not be available
-          in old scipy versions. It also uses an iterative procedure.
+          scipy.sparse.linalg.lsqr. It is the fastest and uses an iterative
+          procedure.
 
         - 'sag' uses a Stochastic Average Gradient descent, and 'saga' uses
           its unbiased and more flexible version named SAGA. Both methods

--- a/sklearn/neighbors/tests/test_approximate.py
+++ b/sklearn/neighbors/tests/test_approximate.py
@@ -474,10 +474,8 @@ def test_graphs():
 
 
 def test_sparse_input():
-    # note: Fixed random state in sp.rand is not supported in older scipy.
-    #       The test should succeed regardless.
-    X1 = sp.rand(50, 100)
-    X2 = sp.rand(10, 100)
+    X1 = sp.rand(50, 100, random_state=0)
+    X2 = sp.rand(10, 100, random_state=1)
     forest_sparse = ignore_warnings(LSHForest, category=DeprecationWarning)(
         radius=1, random_state=0).fit(X1)
     forest_dense = ignore_warnings(LSHForest, category=DeprecationWarning)(

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -267,12 +267,6 @@ class Imputer(BaseEstimator, TransformerMixin):
 
         # Median
         elif strategy == "median":
-            if tuple(int(v) for v in np.__version__.split('.')[:2]) < (1, 5):
-                # In old versions of numpy, calling a median on an array
-                # containing nans returns nan. This is different is
-                # recent versions of numpy, which we want to mimic
-                masked_X.mask = np.logical_or(masked_X.mask,
-                                              np.isnan(X))
             median_masked = np.ma.median(masked_X, axis=axis)
             # Avoid the warning "Warning: converting a masked element to nan."
             median = np.ma.getdata(median_masked)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1094,9 +1094,7 @@ def test_quantile_transform_subsampling():
 
     # sparse support
 
-    # TODO: rng should be seeded once we drop support for older versions of
-    # scipy (< 0.13) that don't support seeding.
-    X = sparse.rand(n_samples, 1, density=.99, format='csc')
+    X = sparse.rand(n_samples, 1, density=.99, format='csc', random_state=0)
     inf_norm_arr = []
     for random_state in range(ROUND):
         transformer = QuantileTransformer(random_state=random_state,


### PR DESCRIPTION
Very similar to https://github.com/scikit-learn/scikit-learn/pull/10704.

maxiter parameter and nit in returned info dict have been available in LBFGS starting in scipy 0.12.