### PR TITLE
[MRG] MAINT: remove even more old scipy related code

### DIFF
--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -169,13 +169,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
 
     # will hold the cholesky factorization. Only lower part is
     # referenced.
-    # We are initializing this to "zeros" and not empty, because
-    # it is passed to scipy linalg functions and thus if it has NaNs,
-    # even if they are in the upper part that it not used, we
-    # get errors raised.
-    # Once we support only scipy > 0.12 we can use check_finite=False and
-    # go back to "empty"
-    L = np.zeros((max_features, max_features), dtype=X.dtype)
+    L = np.empty((max_features, max_features), dtype=X.dtype)
     swap, nrm2 = linalg.get_blas_funcs(('swap', 'nrm2'), (X,))
     solve_cholesky, = get_lapack_funcs(('potrs',), (X,))
 

--- a/sklearn/linear_model/tests/test_huber.py
+++ b/sklearn/linear_model/tests/test_huber.py
@@ -168,9 +168,7 @@ def test_huber_warm_start():
     # these would be almost same but not equal.
     assert_array_almost_equal(huber_warm.coef_, huber_warm_coef, 1)
 
-    # No n_iter_ in old SciPy (<=0.9)
-    if huber_warm.n_iter_ is not None:
-        assert_equal(0, huber_warm.n_iter_)
+    assert_equal(0, huber_warm.n_iter_)
 
 
 def test_huber_better_r2_score():

--- a/sklearn/linear_model/tests/test_huber.py
+++ b/sklearn/linear_model/tests/test_huber.py
@@ -168,7 +168,7 @@ def test_huber_warm_start():
     # these would be almost same but not equal.
     assert_array_almost_equal(huber_warm.coef_, huber_warm_coef, 1)
 
-    assert_equal(0, huber_warm.n_iter_)
+    assert huber_warm.n_iter_ == 0
 
 
 def test_huber_better_r2_score():

--- a/sklearn/neighbors/tests/test_ball_tree.py
+++ b/sklearn/neighbors/tests/test_ball_tree.py
@@ -192,11 +192,7 @@ def test_gaussian_kde(n_samples=1000):
 
     for h in [0.01, 0.1, 1]:
         bt = BallTree(x_in[:, None])
-        try:
-            gkde = gaussian_kde(x_in, bw_method=h / np.std(x_in))
-        except TypeError:
-            raise SkipTest("Old version of scipy, doesn't accept "
-                           "explicit bandwidth.")
+        gkde = gaussian_kde(x_in, bw_method=h / np.std(x_in))
 
         dens_bt = bt.kernel_density(x_out[:, None], h) / n_samples
         dens_gkde = gkde.evaluate(x_out)

--- a/sklearn/neighbors/tests/test_kd_tree.py
+++ b/sklearn/neighbors/tests/test_kd_tree.py
@@ -145,10 +145,7 @@ def test_gaussian_kde(n_samples=1000):
 
     for h in [0.01, 0.1, 1]:
         kdt = KDTree(x_in[:, None])
-        try:
-            gkde = gaussian_kde(x_in, bw_method=h / np.std(x_in))
-        except TypeError:
-            raise SkipTest("Old scipy, does not accept explicit bandwidth.")
+        gkde = gaussian_kde(x_in, bw_method=h / np.std(x_in))
 
         dens_kdt = kdt.kernel_density(x_out[:, None], h) / n_samples
         dens_gkde = gkde.evaluate(x_out)

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2333,8 +2333,6 @@ class QuantileTransformer(BaseEstimator, TransformerMixin):
             output_distribution = self.output_distribution
         output_distribution = getattr(stats, output_distribution)
 
-        # older version of scipy do not handle tuple as fill_value
-        # clipping the value before transform solve the issue
         if not inverse:
             lower_bound_x = quantiles[0]
             upper_bound_x = quantiles[-1]

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -13,6 +13,7 @@ from itertools import chain, combinations
 import numbers
 import warnings
 from itertools import combinations_with_replacement as combinations_w_r
+from distutils.version import LooseVersion
 
 import numpy as np
 from scipy import sparse
@@ -2222,9 +2223,11 @@ class QuantileTransformer(BaseEstimator, TransformerMixin):
                           " sparse matrix. This parameter has no effect.")
 
         n_samples, n_features = X.shape
-        # for compatibility issue with numpy<=1.8.X, references
-        # need to be a list scaled between 0 and 100
-        references = (self.references_ * 100).tolist()
+        references = self.references_ * 100
+        # numpy < 1.9 bug: np.percentile 2nd argument needs to be a list
+        if LooseVersion(np.__version__) < '1.9':
+            references = references.tolist()
+
         self.quantiles_ = []
         for col in X.T:
             if self.subsample < n_samples:
@@ -2245,10 +2248,11 @@ class QuantileTransformer(BaseEstimator, TransformerMixin):
             needs to be nonnegative.
         """
         n_samples, n_features = X.shape
+        references = self.references_ * 100
+        # numpy < 1.9 bug: np.percentile 2nd argument needs to be a list
+        if LooseVersion(np.__version__) < '1.9':
+            references = references.tolist()
 
-        # for compatibility issue with numpy<=1.8.X, references
-        # need to be a list scaled between 0 and 100
-        references = list(map(lambda x: x * 100, self.references_))
         self.quantiles_ = []
         for feature_idx in range(n_features):
             column_nnz_data = X.data[X.indptr[feature_idx]:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2036,7 +2036,7 @@ def check_non_transformer_estimators_n_iter(name, estimator_orig):
         else:
             estimator.fit(X, y_)
 
-        assert_greater_equal(estimator.n_iter_, 1)
+        assert estimator.n_iter_ >= 1
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2036,10 +2036,7 @@ def check_non_transformer_estimators_n_iter(name, estimator_orig):
         else:
             estimator.fit(X, y_)
 
-        # HuberRegressor depends on scipy.optimize.fmin_l_bfgs_b
-        # which doesn't return a n_iter for old versions of SciPy.
-        if not (name == 'HuberRegressor' and estimator.n_iter_ is None):
-            assert_greater_equal(estimator.n_iter_, 1)
+        assert_greater_equal(estimator.n_iter_, 1)
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))


### PR DESCRIPTION
* one is from https://github.com/scikit-learn/scikit-learn/pull/8363/files#r170995592 with @glemaitre's guidance
* others are because I tweaked my hacky git grep command to be case insensitive and found more old code

Here is my hacky git grep in case it is useful:
```
git grep -inP '(np|numpy|scipy|sp).__version__|np_version|sp_version|\bold.+(numpy|scipy)|(scipy|numpy) ?[<>]'
```