### PR TITLE
[WIP] FIX: use maxiter rather than maxfun in MultiLayerPerceptron with solver='lbfgs'

### DIFF
--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -460,7 +460,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
         optimal_parameters, self.loss_, d = fmin_l_bfgs_b(
             x0=packed_coef_inter,
             func=self._loss_grad_lbfgs,
-            maxfun=self.max_iter,
+            maxiter=self.max_iter,
             iprint=iprint,
             pgtol=self.tol,
             args=(X, y, activations, deltas, coef_grads, intercept_grads))

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -633,3 +633,16 @@ def test_n_iter_no_change_inf():
 
     # validate _update_no_improvement_count() was always triggered
     assert_equal(clf._no_improvement_count, clf.n_iter_ - 1)
+
+
+@ignore_warnings(category=ConvergenceWarning)
+def test_lbfgs_max_iter():
+    # test n_iter_no_change using binary data set
+    # the fitting process should go to max_iter iterations
+    X = X_digits_binary[:100]
+    y = y_digits_binary[:100]
+
+    max_iter = 3000
+    clf = MLPClassifier(max_iter=max_iter, solver='lbfgs')
+    clf.fit(X, y)
+    assert clf.n_iter_ == max_iter


### PR DESCRIPTION
In my limited experience with LBFGS, the number of function calls is greater than the number of iterations.

The impact of this bug is that with solver='lbfgs' is probably not doing as many iterations as it should in master although I am not sure it matters that much in practice.

To get an idea how much funtion calls differ from iterations, I tweaked `examples/neural_networks/plot_mnist_filters.py` to be able to run for a few hundred iterations:

```py
mlp = MLPClassifier(hidden_layer_sizes=(100,), max_iter=1000, alpha=1e-4,
                    solver='lbfgs', verbose=10, tol=1e-16, random_state=1,
                    learning_rate_init=.1)
```

The result: 393 iterations and 414 function calls.

Not sure whether we nest to test this, and how to test it, suggestions more than welcome!

- [ ] add a whats_new entry once there is agreement