### PR TITLE
[MRG+1] Reference glossary in random_state docstring entries in datasets module

### DIFF
--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -144,7 +144,7 @@ def load_files(container_path, description=None, categories=None,
         contains characters not of the given `encoding`. Passed as keyword
         argument 'errors' to bytes.decode.
 
-    random_state : int, RandomState instance or None (default)
+    random_state : int, RandomState instance or None (default = 0)
         Determines random number generation for dataset shuffling. Pass an int
         for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -144,7 +144,7 @@ def load_files(container_path, description=None, categories=None,
         contains characters not of the given `encoding`. Passed as keyword
         argument 'errors' to bytes.decode.
 
-    random_state : int, RandomState instance or None (default = 0)
+    random_state : int, RandomState instance or None (default=0)
         Determines random number generation for dataset shuffling. Pass an int
         for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -147,7 +147,7 @@ def load_files(container_path, description=None, categories=None,
     random_state : int, RandomState instance or None (default=0)
         Determines random number generation for dataset shuffling. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -144,11 +144,9 @@ def load_files(container_path, description=None, categories=None,
         contains characters not of the given `encoding`. Passed as keyword
         argument 'errors' to bytes.decode.
 
-    random_state : int, RandomState instance or None, optional (default=0)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset shuffling.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -145,7 +145,8 @@ def load_files(container_path, description=None, categories=None,
         argument 'errors' to bytes.decode.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset shuffling.
+        Determines random number generation for dataset shuffling. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns

--- a/sklearn/datasets/covtype.py
+++ b/sklearn/datasets/covtype.py
@@ -58,7 +58,8 @@ def fetch_covtype(data_home=None, download_if_missing=True,
         instead of trying to download the data from the source site.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset shuffling.
+        Determines random number generation for dataset shuffling. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     shuffle : bool, default=False

--- a/sklearn/datasets/covtype.py
+++ b/sklearn/datasets/covtype.py
@@ -60,7 +60,7 @@ def fetch_covtype(data_home=None, download_if_missing=True,
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset shuffling. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     shuffle : bool, default=False
         Whether to shuffle dataset.

--- a/sklearn/datasets/covtype.py
+++ b/sklearn/datasets/covtype.py
@@ -57,12 +57,9 @@ def fetch_covtype(data_home=None, download_if_missing=True,
         If False, raise a IOError if the data is not locally available
         instead of trying to download the data from the source site.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        Random state for shuffling the dataset.
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset shuffling.
+        See :term:`random_state <Glossary>`.
 
     shuffle : bool, default=False
         Whether to shuffle dataset.

--- a/sklearn/datasets/kddcup99.py
+++ b/sklearn/datasets/kddcup99.py
@@ -139,14 +139,10 @@ def fetch_kddcup99(subset=None, data_home=None, shuffle=False,
     shuffle : bool, default=False
         Whether to shuffle dataset.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        Random state for shuffling the dataset. If subset='SA', this random
-        state is also used to randomly select the small proportion of abnormal
-        samples.
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset shuffling and for
+        selection of abnormal samples if `subset='SA'`.
+        See :term:`random_state <Glossary>`.
 
     percent10 : bool, default=True
         Whether to load only 10 percent of the data.

--- a/sklearn/datasets/kddcup99.py
+++ b/sklearn/datasets/kddcup99.py
@@ -141,7 +141,8 @@ def fetch_kddcup99(subset=None, data_home=None, shuffle=False,
 
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset shuffling and for
-        selection of abnormal samples if `subset='SA'`.
+        selection of abnormal samples if `subset='SA'`. Pass an int for
+        reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     percent10 : bool, default=True

--- a/sklearn/datasets/kddcup99.py
+++ b/sklearn/datasets/kddcup99.py
@@ -143,7 +143,7 @@ def fetch_kddcup99(subset=None, data_home=None, shuffle=False,
         Determines random number generation for dataset shuffling and for
         selection of abnormal samples if `subset='SA'`. Pass an int for
         reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     percent10 : bool, default=True
         Whether to load only 10 percent of the data.

--- a/sklearn/datasets/olivetti_faces.py
+++ b/sklearn/datasets/olivetti_faces.py
@@ -64,7 +64,7 @@ def fetch_olivetti_faces(data_home=None, shuffle=False, random_state=0,
         If True the order of the dataset is shuffled to avoid having
         images of the same person grouped.
 
-    random_state : int, RandomState instance or None (default = 0)
+    random_state : int, RandomState instance or None (default=0)
         Determines random number generation for dataset shuffling. Pass an int
         for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.

--- a/sklearn/datasets/olivetti_faces.py
+++ b/sklearn/datasets/olivetti_faces.py
@@ -64,7 +64,7 @@ def fetch_olivetti_faces(data_home=None, shuffle=False, random_state=0,
         If True the order of the dataset is shuffled to avoid having
         images of the same person grouped.
 
-    random_state : int, RandomState instance or None (default)
+    random_state : int, RandomState instance or None (default = 0)
         Determines random number generation for dataset shuffling. Pass an int
         for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.

--- a/sklearn/datasets/olivetti_faces.py
+++ b/sklearn/datasets/olivetti_faces.py
@@ -67,7 +67,7 @@ def fetch_olivetti_faces(data_home=None, shuffle=False, random_state=0,
     random_state : int, RandomState instance or None (default=0)
         Determines random number generation for dataset shuffling. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     download_if_missing : optional, True by default
         If False, raise a IOError if the data is not locally available

--- a/sklearn/datasets/olivetti_faces.py
+++ b/sklearn/datasets/olivetti_faces.py
@@ -64,11 +64,9 @@ def fetch_olivetti_faces(data_home=None, shuffle=False, random_state=0,
         If True the order of the dataset is shuffled to avoid having
         images of the same person grouped.
 
-    random_state : int, RandomState instance or None, optional (default=0)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset shuffling.
+        See :term:`random_state <Glossary>`.
 
     download_if_missing : optional, True by default
         If False, raise a IOError if the data is not locally available

--- a/sklearn/datasets/olivetti_faces.py
+++ b/sklearn/datasets/olivetti_faces.py
@@ -65,7 +65,8 @@ def fetch_olivetti_faces(data_home=None, shuffle=False, random_state=0,
         images of the same person grouped.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset shuffling.
+        Determines random number generation for dataset shuffling. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     download_if_missing : optional, True by default

--- a/sklearn/datasets/rcv1.py
+++ b/sklearn/datasets/rcv1.py
@@ -103,7 +103,8 @@ def fetch_rcv1(data_home=None, subset='all', download_if_missing=True,
         instead of trying to download the data from the source site.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset shuffling.
+        Determines random number generation for dataset shuffling. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     shuffle : bool, default=False
@@ -178,7 +179,6 @@ def fetch_rcv1(data_home=None, subset='all', download_if_missing=True,
     else:
         X = joblib.load(samples_path)
         sample_id = joblib.load(sample_id_path)
-
 
     # load target (y), categories, and sample_id_bis
     if download_if_missing and (not exists(sample_topics_path) or

--- a/sklearn/datasets/rcv1.py
+++ b/sklearn/datasets/rcv1.py
@@ -102,12 +102,9 @@ def fetch_rcv1(data_home=None, subset='all', download_if_missing=True,
         If False, raise a IOError if the data is not locally available
         instead of trying to download the data from the source site.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        Random state for shuffling the dataset.
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset shuffling.
+        See :term:`random_state <Glossary>`.
 
     shuffle : bool, default=False
         Whether to shuffle dataset.

--- a/sklearn/datasets/rcv1.py
+++ b/sklearn/datasets/rcv1.py
@@ -105,7 +105,7 @@ def fetch_rcv1(data_home=None, subset='all', download_if_missing=True,
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset shuffling. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     shuffle : bool, default=False
         Whether to shuffle dataset.

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -120,11 +120,9 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
     shuffle : boolean, optional (default=True)
         Shuffle the samples and the features.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset creation.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -311,11 +309,9 @@ def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
         probabilities of features given classes, from which the data was
         drawn.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset creation.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -418,11 +414,9 @@ def make_hastie_10_2(n_samples=12000, random_state=None):
     n_samples : int, optional (default=12000)
         The number of samples.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset creation.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -510,11 +504,9 @@ def make_regression(n_samples=100, n_features=100, n_informative=10,
     coef : boolean, optional (default=False)
         If True, the coefficients of the underlying linear model are returned.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset creation.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -595,11 +587,9 @@ def make_circles(n_samples=100, shuffle=True, noise=None, random_state=None,
     noise : double or None (default=None)
         Standard deviation of Gaussian noise added to the data.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset shuffling and noise.
+        See :term:`random_state <Glossary>`.
 
     factor : 0 < double < 1 (default=.8)
         Scale factor between inner and outer circle.
@@ -658,11 +648,9 @@ def make_moons(n_samples=100, shuffle=True, noise=None, random_state=None):
     noise : double or None (default=None)
         Standard deviation of Gaussian noise added to the data.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset shuffling and noise.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -731,11 +719,9 @@ def make_blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
     shuffle : boolean, optional (default=True)
         Shuffle the samples.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset creation.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -869,11 +855,9 @@ def make_friedman1(n_samples=100, n_features=10, noise=0.0, random_state=None):
     noise : float, optional (default=0.0)
         The standard deviation of the gaussian noise applied to the output.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset noise.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -931,11 +915,9 @@ def make_friedman2(n_samples=100, noise=0.0, random_state=None):
     noise : float, optional (default=0.0)
         The standard deviation of the gaussian noise applied to the output.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset noise.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -997,11 +979,9 @@ def make_friedman3(n_samples=100, noise=0.0, random_state=None):
     noise : float, optional (default=0.0)
         The standard deviation of the gaussian noise applied to the output.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset noise.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -1074,11 +1054,9 @@ def make_low_rank_matrix(n_samples=100, n_features=100, effective_rank=10,
         The relative importance of the fat noisy tail of the singular values
         profile.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset creation.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -1128,11 +1106,9 @@ def make_sparse_coded_signal(n_samples, n_components, n_features,
     n_nonzero_coefs : int
         number of active (non-zero) coefficients in each sample
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset creation.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -1188,11 +1164,9 @@ def make_sparse_uncorrelated(n_samples=100, n_features=10, random_state=None):
     n_features : int, optional (default=10)
         The number of features.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset creation.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -1229,11 +1203,9 @@ def make_spd_matrix(n_dim, random_state=None):
     n_dim : int
         The matrix dimension.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset creation.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -1279,11 +1251,9 @@ def make_sparse_spd_matrix(dim=1, alpha=0.95, norm_diag=False,
     largest_coef : float between 0 and 1, optional (default=0.9)
         The value of the largest coefficient.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset creation.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -1341,11 +1311,9 @@ def make_swiss_roll(n_samples=100, noise=0.0, random_state=None):
     noise : float, optional (default=0.0)
         The standard deviation of the gaussian noise.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset creation.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -1394,11 +1362,9 @@ def make_s_curve(n_samples=100, noise=0.0, random_state=None):
     noise : float, optional (default=0.0)
         The standard deviation of the gaussian noise.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset creation.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -1458,11 +1424,9 @@ def make_gaussian_quantiles(mean=None, cov=1., n_samples=100,
     shuffle : boolean, optional (default=True)
         Shuffle the samples.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset creation.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -1547,11 +1511,9 @@ def make_biclusters(shape, n_clusters, noise=0.0, minval=10,
     shuffle : boolean, optional (default=True)
         Shuffle the samples.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset creation.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------
@@ -1614,7 +1576,6 @@ def make_biclusters(shape, n_clusters, noise=0.0, minval=10,
 
 def make_checkerboard(shape, n_clusters, noise=0.0, minval=10,
                       maxval=100, shuffle=True, random_state=None):
-
     """Generate an array with block checkerboard structure for
     biclustering.
 
@@ -1640,11 +1601,9 @@ def make_checkerboard(shape, n_clusters, noise=0.0, minval=10,
     shuffle : boolean, optional (default=True)
         Shuffle the samples.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset creation.
+        See :term:`random_state <Glossary>`.
 
     Returns
     -------

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -128,7 +128,7 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -318,7 +318,7 @@ def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -424,7 +424,7 @@ def make_hastie_10_2(n_samples=12000, random_state=None):
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -515,7 +515,7 @@ def make_regression(n_samples=100, n_features=100, n_informative=10,
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -599,7 +599,7 @@ def make_circles(n_samples=100, shuffle=True, noise=None, random_state=None,
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset shuffling and noise.
         Pass an int for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     factor : 0 < double < 1 (default=.8)
         Scale factor between inner and outer circle.
@@ -661,7 +661,7 @@ def make_moons(n_samples=100, shuffle=True, noise=None, random_state=None):
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset shuffling and noise.
         Pass an int for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -733,7 +733,7 @@ def make_blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -870,7 +870,7 @@ def make_friedman1(n_samples=100, n_features=10, noise=0.0, random_state=None):
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset noise. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -931,7 +931,7 @@ def make_friedman2(n_samples=100, noise=0.0, random_state=None):
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset noise. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -996,7 +996,7 @@ def make_friedman3(n_samples=100, noise=0.0, random_state=None):
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset noise. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -1072,7 +1072,7 @@ def make_low_rank_matrix(n_samples=100, n_features=100, effective_rank=10,
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -1125,7 +1125,7 @@ def make_sparse_coded_signal(n_samples, n_components, n_features,
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -1184,7 +1184,7 @@ def make_sparse_uncorrelated(n_samples=100, n_features=10, random_state=None):
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -1224,7 +1224,7 @@ def make_spd_matrix(n_dim, random_state=None):
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -1273,7 +1273,7 @@ def make_sparse_spd_matrix(dim=1, alpha=0.95, norm_diag=False,
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -1334,7 +1334,7 @@ def make_swiss_roll(n_samples=100, noise=0.0, random_state=None):
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -1386,7 +1386,7 @@ def make_s_curve(n_samples=100, noise=0.0, random_state=None):
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -1449,7 +1449,7 @@ def make_gaussian_quantiles(mean=None, cov=1., n_samples=100,
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -1537,7 +1537,7 @@ def make_biclusters(shape, n_clusters, noise=0.0, minval=10,
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -1628,7 +1628,7 @@ def make_checkerboard(shape, n_clusters, noise=0.0, minval=10,
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -121,7 +121,8 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
         Shuffle the samples and the features.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset creation.
+        Determines random number generation for dataset creation. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -310,7 +311,8 @@ def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
         drawn.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset creation.
+        Determines random number generation for dataset creation. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -415,7 +417,8 @@ def make_hastie_10_2(n_samples=12000, random_state=None):
         The number of samples.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset creation.
+        Determines random number generation for dataset creation. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -505,7 +508,8 @@ def make_regression(n_samples=100, n_features=100, n_informative=10,
         If True, the coefficients of the underlying linear model are returned.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset creation.
+        Determines random number generation for dataset creation. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -589,6 +593,7 @@ def make_circles(n_samples=100, shuffle=True, noise=None, random_state=None,
 
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset shuffling and noise.
+        Pass an int for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     factor : 0 < double < 1 (default=.8)
@@ -650,6 +655,7 @@ def make_moons(n_samples=100, shuffle=True, noise=None, random_state=None):
 
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset shuffling and noise.
+        Pass an int for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -720,7 +726,8 @@ def make_blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
         Shuffle the samples.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset creation.
+        Determines random number generation for dataset creation. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -856,7 +863,8 @@ def make_friedman1(n_samples=100, n_features=10, noise=0.0, random_state=None):
         The standard deviation of the gaussian noise applied to the output.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset noise.
+        Determines random number generation for dataset noise. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -916,7 +924,8 @@ def make_friedman2(n_samples=100, noise=0.0, random_state=None):
         The standard deviation of the gaussian noise applied to the output.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset noise.
+        Determines random number generation for dataset noise. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -980,7 +989,8 @@ def make_friedman3(n_samples=100, noise=0.0, random_state=None):
         The standard deviation of the gaussian noise applied to the output.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset noise.
+        Determines random number generation for dataset noise. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -1055,7 +1065,8 @@ def make_low_rank_matrix(n_samples=100, n_features=100, effective_rank=10,
         profile.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset creation.
+        Determines random number generation for dataset creation. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -1107,7 +1118,8 @@ def make_sparse_coded_signal(n_samples, n_components, n_features,
         number of active (non-zero) coefficients in each sample
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset creation.
+        Determines random number generation for dataset creation. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -1165,7 +1177,8 @@ def make_sparse_uncorrelated(n_samples=100, n_features=10, random_state=None):
         The number of features.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset creation.
+        Determines random number generation for dataset creation. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -1204,7 +1217,8 @@ def make_spd_matrix(n_dim, random_state=None):
         The matrix dimension.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset creation.
+        Determines random number generation for dataset creation. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -1252,7 +1266,8 @@ def make_sparse_spd_matrix(dim=1, alpha=0.95, norm_diag=False,
         The value of the largest coefficient.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset creation.
+        Determines random number generation for dataset creation. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -1312,7 +1327,8 @@ def make_swiss_roll(n_samples=100, noise=0.0, random_state=None):
         The standard deviation of the gaussian noise.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset creation.
+        Determines random number generation for dataset creation. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -1363,7 +1379,8 @@ def make_s_curve(n_samples=100, noise=0.0, random_state=None):
         The standard deviation of the gaussian noise.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset creation.
+        Determines random number generation for dataset creation. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -1425,7 +1442,8 @@ def make_gaussian_quantiles(mean=None, cov=1., n_samples=100,
         Shuffle the samples.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset creation.
+        Determines random number generation for dataset creation. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -1512,7 +1530,8 @@ def make_biclusters(shape, n_clusters, noise=0.0, minval=10,
         Shuffle the samples.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset creation.
+        Determines random number generation for dataset creation. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns
@@ -1602,7 +1621,8 @@ def make_checkerboard(shape, n_clusters, noise=0.0, minval=10,
         Shuffle the samples.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset creation.
+        Determines random number generation for dataset creation. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     Returns

--- a/sklearn/datasets/svmlight_format.py
+++ b/sklearn/datasets/svmlight_format.py
@@ -446,8 +446,8 @@ def dump_svmlight_file(X, y, f,  zero_based=True, comment=None, query_id=None,
 
     Xval = check_array(X, accept_sparse='csr')
     if Xval.shape[0] != yval.shape[0]:
-        raise ValueError("X.shape[0] and y.shape[0] should be the same, got "
-                         "%r and %r instead." % (Xval.shape[0], yval.shape[0]))
+        raise ValueError("X.shape[0] and y.shape[0] should be the same, got"
+                         " %r and %r instead." % (Xval.shape[0], yval.shape[0]))
 
     # We had some issues with CSR matrices with unsorted indices (e.g. #1501),
     # so sort them here, but first make sure we don't modify the user's X.

--- a/sklearn/datasets/svmlight_format.py
+++ b/sklearn/datasets/svmlight_format.py
@@ -446,8 +446,8 @@ def dump_svmlight_file(X, y, f,  zero_based=True, comment=None, query_id=None,
 
     Xval = check_array(X, accept_sparse='csr')
     if Xval.shape[0] != yval.shape[0]:
-        raise ValueError("X.shape[0] and y.shape[0] should be the same, got"
-                         " %r and %r instead." % (Xval.shape[0], yval.shape[0]))
+        raise ValueError("X.shape[0] and y.shape[0] should be the same, got "
+                         "%r and %r instead." % (Xval.shape[0], yval.shape[0]))
 
     # We had some issues with CSR matrices with unsorted indices (e.g. #1501),
     # so sort them here, but first make sure we don't modify the user's X.

--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -169,8 +169,9 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
         make the assumption that the samples are independent and identically
         distributed (i.i.d.), such as stochastic gradient descent.
 
-    random_state : numpy random number generator or seed integer
-        Used to shuffle the dataset.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset shuffling.
+        See :term:`random_state <Glossary>`.
 
     remove : tuple
         May contain any subset of ('headers', 'footers', 'quotes'). Each of

--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -172,7 +172,7 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
     random_state : int, RandomState instance or None (default)
         Determines random number generation for dataset shuffling. Pass an int
         for reproducible output across multiple function calls.
-        See :term:`random_state <Glossary>`.
+        See :term:`Glossary <random_state>`.
 
     remove : tuple
         May contain any subset of ('headers', 'footers', 'quotes'). Each of

--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -170,7 +170,8 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
         distributed (i.i.d.), such as stochastic gradient descent.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation for dataset shuffling.
+        Determines random number generation for dataset shuffling. Pass an int
+        for reproducible output across multiple function calls.
         See :term:`random_state <Glossary>`.
 
     remove : tuple


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Partially addresses #10548 

#### What does this implement/fix? Explain your changes.
This PR updates the `random_state` docstring descriptions in all `sklearn.datasets` docstrings. The descriptions now refer to the glossary and, in some cases, provide some detail on what exactly the random number generation is used for.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
