### PR TITLE
[MRG] comb2(n) is n*(n-1)//2

### DIFF
--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -22,13 +22,14 @@ from scipy import sparse as sp
 
 from .expected_mutual_info_fast import expected_mutual_information
 from ...utils.validation import check_array
-from ...utils.fixes import comb
 
 
 def comb2(n):
-    # the exact version is faster for k == 2: use it by default globally in
-    # this module instead of the float approximate variant
-    return comb(n, 2, exact=1)
+    # returns (n choose 2)
+    if n < 2:
+        return 0
+    else:
+        return n*(n-1)//2
 
 
 def check_clusterings(labels_true, labels_pred):


### PR DESCRIPTION
#### Reference Issues/PRs

none


#### What does this implement/fix? Explain your changes.

comb2(n) is essentially n*(n-1)//2

#### Any other comments?

Tests & benchmarks:

```python
from scipy.special import comb
def comb2_old(n):
    # the exact version is faster for k == 2: use it by default globally in
    # this module instead of the float approximate variant
    return comb(n, 2, exact=1)

def comb2(n):
    # returns (n choose 2)
    if n < 2:
        return 0
    else:
        return n*(n-1)//2

print(all([comb2_old(n) == comb2(n) for n in range(-1, 100000)]))
## True

%timeit [comb2_old(n) for n in range(-1, 100000)]
## 27.2 ms ± 168 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
%timeit [comb2(n) for n in range(-1, 100000)]
## 18.3 ms ± 20.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

```