### PR TITLE
Mixture modeling reports wrong number of `n_iter_`

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -358,6 +358,9 @@ Decomposition, manifold learning and clustering
   by :user:`Jan Margeta <jmargeta>`, :user:`Guillaume Lemaitre <glemaitre>`,
   and :user:`Devansh D. <devanshdalal>`.
 
+- Fix `n_iter_` counting 0 to n-1 in `sklearn.mixture.GaussianMixture`.
+  :issue:`10740` by :user:`Erich Schubert <kno10>`.
+
 Metrics
 
 - Fixed a bug in :func:`metrics.precision_precision_recall_fscore_support`

--- a/sklearn/mixture/base.py
+++ b/sklearn/mixture/base.py
@@ -208,7 +208,7 @@ class BaseMixture(six.with_metaclass(ABCMeta, DensityMixin, BaseEstimator)):
                 self._initialize_parameters(X, random_state)
                 self.lower_bound_ = -np.infty
 
-            for n_iter in range(self.max_iter):
+            for n_iter in range(1, self.max_iter + 1):
                 prev_lower_bound = self.lower_bound_
 
                 log_prob_norm, log_resp = self._e_step(X)

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -172,6 +172,18 @@ def test_gaussian_mixture_attributes():
     assert_equal(gmm.n_init, n_init)
     assert_equal(gmm.init_params, init_params)
 
+def test_regression_10740():
+    # Regression test for #10740. Ensure that n_iter_ is the number of iterations done
+    rng = np.random.RandomState(0)
+    X = rng.rand(10, 2)
+
+    n_components, tol, n_init, max_iter, reg_covar = 2, 1e-10, 3, 1, 1e-1
+    covariance_type, init_params = 'full', 'random'
+    gmm = GaussianMixture(n_components=n_components, tol=tol, n_init=n_init,
+                          max_iter=max_iter, reg_covar=reg_covar,
+                          covariance_type=covariance_type,
+                          init_params=init_params).fit(X)
+    assert_equal(gmm.n_iter_, max_iter)
 
 def test_check_X():
     from sklearn.mixture.base import _check_X


### PR DESCRIPTION
If you run mixture modeling with max_iter set to 5, it will report to have finished 4 iterations.

Because it is reporting the last iteration number 0...max_iter-1 in mixture/base.by, not the number of *completed* iterations.

This patch adds + 1 in the appropriate place.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
