### PR TITLE
 Changed the sign before 'logdet_sigma_' in computing score 's'

### DIFF
--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -237,7 +237,7 @@ class BayesianRidge(LinearModel, RegressorMixin):
                 s += 0.5 * (n_features * log(lambda_) +
                             n_samples * log(alpha_) -
                             alpha_ * rmse_ -
-                            (lambda_ * np.sum(coef_ ** 2)) -
+                            (lambda_ * np.sum(coef_ ** 2)) +
                             logdet_sigma_ -
                             n_samples * log(2 * np.pi))
                 self.scores_.append(s)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### What does this implement/fix? Explain your changes.

It fixes the formula for computing score 's' which seems to have an incorrect sign before logdet_sigma_. The reference indicated by the authors (slide 32 of http://www.utstat.toronto.edu/~rsalakhu/sta4273/notes/Lecture2.pdf#page=15)

![image](https://user-images.githubusercontent.com/17442913/36953626-20b8f158-2014-11e8-9df6-d7e97ae8f819.png)

has a + sign before 0.5ln|S_{N}| which is logdet_sigma_ in the code. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
