### PR TITLE
[MRG+1] DOC Fixed Broken Link in boston_housing_dataset.rst

### DIFF
--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -78,7 +78,7 @@ Loading an example dataset
 `iris <https://en.wikipedia.org/wiki/Iris_flower_data_set>`_ and `digits
 <http://archive.ics.uci.edu/ml/datasets/Pen-Based+Recognition+of+Handwritten+Digits>`_
 datasets for classification and the `boston house prices dataset
-<http://archive.ics.uci.edu/ml/datasets/Housing>`_ for regression.
+<https://archive.ics.uci.edu/ml/machine-learning-databases/housing/>`_ for regression.
 
 In the following, we start a Python interpreter from our shell and then
 load the ``iris`` and ``digits`` datasets.  Our notational convention is that

--- a/sklearn/datasets/descr/boston_house_prices.rst
+++ b/sklearn/datasets/descr/boston_house_prices.rst
@@ -34,6 +34,7 @@ Data Set Characteristics:
 This is a copy of UCI ML housing dataset.
 https://archive.ics.uci.edu/ml/machine-learning-databases/housing/
 
+
 This dataset was taken from the StatLib library which is maintained at Carnegie Mellon University.
 
 The Boston house-price data of Harrison, D. and Rubinfeld, D.L. 'Hedonic

--- a/sklearn/datasets/descr/boston_house_prices.rst
+++ b/sklearn/datasets/descr/boston_house_prices.rst
@@ -50,4 +50,3 @@ problems.
 
    - Belsley, Kuh & Welsch, 'Regression diagnostics: Identifying Influential Data and Sources of Collinearity', Wiley, 1980. 244-261.
    - Quinlan,R. (1993). Combining Instance-Based and Model-Based Learning. In Proceedings on the Tenth International Conference of Machine Learning, 236-243, University of Massachusetts, Amherst. Morgan Kaufmann.
-   - many more! (see https://archive.ics.uci.edu/ml/machine-learning-databases/housing/)

--- a/sklearn/datasets/descr/boston_house_prices.rst
+++ b/sklearn/datasets/descr/boston_house_prices.rst
@@ -32,8 +32,7 @@ Data Set Characteristics:
     :Creator: Harrison, D. and Rubinfeld, D.L.
 
 This is a copy of UCI ML housing dataset.
-http://archive.ics.uci.edu/ml/datasets/Housing
-
+https://archive.ics.uci.edu/ml/machine-learning-databases/housing/
 
 This dataset was taken from the StatLib library which is maintained at Carnegie Mellon University.
 

--- a/sklearn/datasets/descr/boston_house_prices.rst
+++ b/sklearn/datasets/descr/boston_house_prices.rst
@@ -49,4 +49,4 @@ problems.
 
    - Belsley, Kuh & Welsch, 'Regression diagnostics: Identifying Influential Data and Sources of Collinearity', Wiley, 1980. 244-261.
    - Quinlan,R. (1993). Combining Instance-Based and Model-Based Learning. In Proceedings on the Tenth International Conference of Machine Learning, 236-243, University of Massachusetts, Amherst. Morgan Kaufmann.
-   - many more! (see http://archive.ics.uci.edu/ml/datasets/Housing)
+   - many more! (see https://archive.ics.uci.edu/ml/machine-learning-databases/housing/)


### PR DESCRIPTION
Fixed the link to the Boston Housing Dataset. Was unable to find the dataset in the UCI website (probably not there). But found them in the Index pages.