### PR TITLE
[MRG+1] Fix minor FastICA bugs

### DIFF
--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -285,7 +285,8 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
         g = _cube
     elif callable(fun):
         def g(x, fun_args):
-            return fun(x, **fun_args)
+            f, f_prime = fun(x, **fun_args)
+            return f, f_prime.mean(axis=-1)
     else:
         exc = ValueError if isinstance(fun, six.string_types) else TypeError
         raise exc("Unknown function %r;"

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -75,7 +75,6 @@ def _ica_def(X, tol, g, fun_args, max_iter, w_init):
     for j in range(n_components):
         w = w_init[j, :].copy()
         w /= np.sqrt((w ** 2).sum())
-        i = -1
         for i in moves.xrange(max_iter):
             gwtx, g_wtx = g(np.dot(w.T, X), fun_args)
 
@@ -105,7 +104,6 @@ def _ica_par(X, tol, g, fun_args, max_iter, w_init):
     W = _sym_decorrelation(w_init)
     del w_init
     p_ = float(X.shape[1])
-    ii = -1
     for ii in moves.xrange(max_iter):
         gwtx, g_wtx = g(np.dot(W, X), fun_args)
         W1 = _sym_decorrelation(np.dot(gwtx, X.T) / p_
@@ -456,6 +454,8 @@ class FastICA(BaseEstimator, TransformerMixin):
                  fun='logcosh', fun_args=None, max_iter=200, tol=1e-4,
                  w_init=None, random_state=None):
         super(FastICA, self).__init__()
+        if max_iter < 1:
+            raise (ValueError, "max_iter should be greater than 1")
         self.n_components = n_components
         self.algorithm = algorithm
         self.whiten = whiten

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -183,10 +183,11 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
         or 'cube'.
         You can also provide your own function. It should return a tuple
         containing the value of the function, and of its derivative, in the
-        point. Example:
+        point. The derivative should be averaged along its last dimension.
+        Example:
 
         def my_g(x):
-            return x ** 3, 3 * x ** 2
+            return x ** 3, np.mean(3 * x ** 2, axis=-1)
 
     fun_args : dictionary, optional
         Arguments to send to the functional form.
@@ -285,8 +286,7 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
         g = _cube
     elif callable(fun):
         def g(x, fun_args):
-            f, f_prime = fun(x, **fun_args)
-            return f, f_prime.mean(axis=-1)
+            return fun(x, **fun_args)
     else:
         exc = ValueError if isinstance(fun, six.string_types) else TypeError
         raise exc("Unknown function %r;"

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -70,10 +70,12 @@ def _ica_def(X, tol, g, fun_args, max_iter, w_init):
     n_components = w_init.shape[0]
     W = np.zeros((n_components, n_components), dtype=X.dtype)
     n_iter = []
+
     # j is the index of the extracted component
     for j in range(n_components):
         w = w_init[j, :].copy()
         w /= np.sqrt((w ** 2).sum())
+
         for i in moves.xrange(max_iter):
             gwtx, g_wtx = g(np.dot(w.T, X), fun_args)
 

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -75,7 +75,7 @@ def _ica_def(X, tol, g, fun_args, max_iter, w_init):
     for j in range(n_components):
         w = w_init[j, :].copy()
         w /= np.sqrt((w ** 2).sum())
-
+        i = -1
         for i in moves.xrange(max_iter):
             gwtx, g_wtx = g(np.dot(w.T, X), fun_args)
 
@@ -105,6 +105,7 @@ def _ica_par(X, tol, g, fun_args, max_iter, w_init):
     W = _sym_decorrelation(w_init)
     del w_init
     p_ = float(X.shape[1])
+    ii = -1
     for ii in moves.xrange(max_iter):
         gwtx, g_wtx = g(np.dot(W, X), fun_args)
         W1 = _sym_decorrelation(np.dot(gwtx, X.T) / p_

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -457,7 +457,7 @@ class FastICA(BaseEstimator, TransformerMixin):
         super(FastICA, self).__init__()
         if max_iter < 1:
             raise ValueError("max_iter should be greater than 1, got "
-                             "(max_iter=%d)" % max_iter)
+                             "(max_iter={})".format(max_iter))
         self.n_components = n_components
         self.algorithm = algorithm
         self.whiten = whiten

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -70,7 +70,6 @@ def _ica_def(X, tol, g, fun_args, max_iter, w_init):
     n_components = w_init.shape[0]
     W = np.zeros((n_components, n_components), dtype=X.dtype)
     n_iter = []
-
     # j is the index of the extracted component
     for j in range(n_components):
         w = w_init[j, :].copy()

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -456,7 +456,7 @@ class FastICA(BaseEstimator, TransformerMixin):
                  w_init=None, random_state=None):
         super(FastICA, self).__init__()
         if max_iter < 1:
-            raise (ValueError, "max_iter should be greater than 1")
+            raise ValueError("max_iter should be greater than 1")
         self.n_components = n_components
         self.algorithm = algorithm
         self.whiten = whiten

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -456,7 +456,8 @@ class FastICA(BaseEstimator, TransformerMixin):
                  w_init=None, random_state=None):
         super(FastICA, self).__init__()
         if max_iter < 1:
-            raise ValueError("max_iter should be greater than 1")
+            raise ValueError("max_iter should be greater than 1, got "
+                             "(max_iter=%d)" % max_iter)
         self.n_components = n_components
         self.algorithm = algorithm
         self.whiten = whiten

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -14,6 +14,7 @@ from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raises_regex
 
 from sklearn.decomposition import FastICA, fastica, PCA
 from sklearn.decomposition.fastica_ import _gs_decorrelation
@@ -267,7 +268,12 @@ def test_fastica_errors():
     rng = np.random.RandomState(0)
     X = rng.random_sample((n_samples, n_features))
     w_init = rng.randn(n_features + 1, n_features + 1)
-    assert_raises(ValueError, FastICA, max_iter=0)
-    assert_raises(ValueError, fastica, X, fun_args={'alpha': 0})
-    assert_raises(ValueError, fastica, X, w_init=w_init)
-    assert_raises(ValueError, fastica, X, algorithm='pizza')
+    assert_raises_regex(ValueError, 'max_iter should be greater than 1',
+                        FastICA, max_iter=0)
+    assert_raises_regex(ValueError, r'alpha must be in \[1,2\]',
+                        fastica, X, fun_args={'alpha': 0})
+    assert_raises_regex(ValueError, 'w_init has invalid shape.+\(3, 3\)',
+                        fastica, X, w_init=w_init)
+    assert_raises_regex(ValueError,
+                        'Invalid algorithm.+must be.+parallel.+or.+deflation',
+                        fastica, X, algorithm='pizza')

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -272,7 +272,8 @@ def test_fastica_errors():
                         FastICA, max_iter=0)
     assert_raises_regex(ValueError, r'alpha must be in \[1,2\]',
                         fastica, X, fun_args={'alpha': 0})
-    assert_raises_regex(ValueError, 'w_init has invalid shape.+\(3, 3\)',
+    assert_raises_regex(ValueError, 'w_init has invalid shape.+'
+                        r'should be \(3L?, 3L?\)',
                         fastica, X, w_init=w_init)
     assert_raises_regex(ValueError,
                         'Invalid algorithm.+must be.+parallel.+or.+deflation',

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -77,21 +77,21 @@ def test_fastica_simple(add_noise=False):
 
     # function as fun arg
     def g_test(x):
-        return x ** 3, (3 * x ** 2).mean(axis=-1)
+        return x ** 3, 3 * x ** 2
 
     algos = ['parallel', 'deflation']
     nls = ['logcosh', 'exp', 'cube', g_test]
     whitening = [True, False]
+    assert_raises(IndexError, fastica, m.T, fun=np.tanh,
+                  algorithm='parallel')
+    assert_raises(ValueError, fastica, m.T, fun=np.tanh,
+                  algorithm='deflation')
     for algo, nl, whiten in itertools.product(algos, nls, whitening):
         if whiten:
             k_, mixing_, s_ = fastica(m.T, fun=nl, algorithm=algo)
-            assert_raises(ValueError, fastica, m.T, fun=np.tanh,
-                          algorithm=algo)
         else:
             X = PCA(n_components=2, whiten=True).fit_transform(m.T)
             k_, mixing_, s_ = fastica(X, fun=nl, algorithm=algo, whiten=False)
-            assert_raises(ValueError, fastica, X, fun=np.tanh,
-                          algorithm=algo)
         s_ = s_.T
         # Check that the mixing model described in the docstring holds:
         if whiten:

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -259,3 +259,15 @@ def test_inverse_transform():
             # reversibility test in non-reduction case
             if n_components == X.shape[1]:
                 assert_array_almost_equal(X, X2)
+
+
+def test_fastica_errors():
+    n_features = 3
+    n_samples = 10
+    rng = np.random.RandomState(0)
+    X = rng.random_sample((n_samples, n_features))
+    w_init = rng.randn(n_features + 1, n_features + 1)
+    assert_raises(ValueError, FastICA, max_iter=0)
+    assert_raises(ValueError, fastica, X, fun_args={'alpha': 0})
+    assert_raises(ValueError, fastica, X, w_init=w_init)
+    assert_raises(ValueError, fastica, X, algorithm='pizza')

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -77,21 +77,21 @@ def test_fastica_simple(add_noise=False):
 
     # function as fun arg
     def g_test(x):
-        return x ** 3, 3 * x ** 2
+        return x ** 3, (3 * x ** 2).mean(axis=-1)
 
     algos = ['parallel', 'deflation']
     nls = ['logcosh', 'exp', 'cube', g_test]
     whitening = [True, False]
-    assert_raises(IndexError, fastica, m.T, fun=np.tanh,
-                  algorithm='parallel')
-    assert_raises(ValueError, fastica, m.T, fun=np.tanh,
-                  algorithm='deflation')
     for algo, nl, whiten in itertools.product(algos, nls, whitening):
         if whiten:
             k_, mixing_, s_ = fastica(m.T, fun=nl, algorithm=algo)
+            assert_raises(ValueError, fastica, m.T, fun=np.tanh,
+                          algorithm=algo)
         else:
             X = PCA(n_components=2, whiten=True).fit_transform(m.T)
             k_, mixing_, s_ = fastica(X, fun=nl, algorithm=algo, whiten=False)
+            assert_raises(ValueError, fastica, X, fun=np.tanh,
+                          algorithm=algo)
         s_ = s_.T
         # Check that the mixing model described in the docstring holds:
         if whiten:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Hi,

Two minor changes:

-Using FastICA with max_iter=0 returns an obfuscated error. I think that either one should be allowed to set max_iter=0 (my first commit allows this), or should get a proper error (I can also code this :) )

-The way user provide custom functions (e.g. `def my_g(x): return x ** 3, 3 * x ** 2`) is currently broken, because the algorithm actually expects something like `def my_g(x): return x ** 3, np.mean(3 * x ** 2, axis=-1)`.

The second commit fixes this.

Thanks !
