### PR TITLE
Documentation for #10772 MultinomialNB alpha>0

### DIFF
--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -127,7 +127,7 @@ in the training set :math:`T`,
 and :math:`N_{y} = \sum_{i=1}^{|T|} N_{yi}` is the total count of
 all features for class :math:`y`.
 
-The smoothing priors :math:`\alpha \ge 0` accounts for
+The smoothing priors :math:`\alpha > 0` accounts for
 features not present in the learning samples and prevents zero probabilities
 in further computations.
 Setting :math:`\alpha = 1` is called Laplace smoothing,


### PR DESCRIPTION
#### Reference Issues/PRs
Documentation for BernoulliNB and MultinomialNB documentation for alpha=0 
Partially fixes issue #10772

#### What does this implement/fix? Explain your changes.
The MultinomialNB cannot have an alpha = 0, it originally set alpha>=0 and i changed it to alpha>0

#### Any other comments?
