### PR TITLE
[MRG+1] Fix validation of ngram_range property in vectorizers

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -35,7 +35,7 @@ from functools import partial
 import pickle
 from io import StringIO
 
-from pytest import mark
+import pytest
 
 JUNK_FOOD_DOCS = (
     "the pizza pizza beer copyright",
@@ -998,27 +998,24 @@ def test_vectorizer_string_object_as_input():
             ValueError, message, vec.transform, "hello world!")
 
 
-@mark.parametrize("vec, index", [
-        (HashingVectorizer(ngram_range=(2, 1)), 0),
-        (CountVectorizer(ngram_range=(2, 1)), 1),
-        (TfidfVectorizer(ngram_range=(2, 1)), 2)
+@pytest.mark.parametrize("vec", [
+        HashingVectorizer(ngram_range=(2, 1)),
+        CountVectorizer(ngram_range=(2, 1)),
+        TfidfVectorizer(ngram_range=(2, 1))
     ])
-def test_vectorizers_invalid_ngram_range(vec, index):
+def test_vectorizers_invalid_ngram_range(vec):
     # vectorizers could be initialized with invalid ngram range
     # test for raising error message
     invalid_range = vec.ngram_range
     message = ("Invalid value for ngram_range=%s "
-               "lower boundary larger than the upper boundary"
+               "lower boundary larger than the upper boundary."
                % str(invalid_range))
 
-    # HashingVectorizer implements fit, transform
-    # CountVectorizer, TfidfVectorizer implement fit, fit_transform
-    if index in [0, 1, 2]:
-        assert_raise_message(
-            ValueError, message, vec.fit, ["good news everyone"])
-    if index in [1, 2]:
-        assert_raise_message(
-            ValueError, message, vec.fit_transform, ["good news everyone"])
-    if index in [0]:
+    assert_raise_message(
+        ValueError, message, vec.fit, ["good news everyone"])
+    assert_raise_message(
+        ValueError, message, vec.fit_transform, ["good news everyone"])
+
+    if isinstance(vec, HashingVectorizer):
         assert_raise_message(
             ValueError, message, vec.transform, ["good news everyone"])

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -995,3 +995,25 @@ def test_vectorizer_string_object_as_input():
             ValueError, message, vec.fit, "hello world!")
         assert_raise_message(
             ValueError, message, vec.transform, "hello world!")
+
+def test_vectorizers_invalid_ngram_range():
+    # vectorizers could be initialized with invalid ngram range
+    # test for raising error message
+    message = ("Invalid value for ngram_range, "
+               "min_n should not be larger than max_m")
+    invalid_range = (2, 1)
+    vecs = [CountVectorizer(ngram_range=invalid_range), 
+            HashingVectorizer(ngram_range=invalid_range)]
+    
+    for i, vec in enumerate(vecs):
+        assert_raise_message(
+            ValueError, message, vec.fit, ["good news everyone"])
+        assert_raise_message(
+            ValueError, message, vec.transform, ["good news everyone"])
+        if i == 1:
+            continue
+        # HashingVectorizer doesn't implement fit_transform   
+        assert_raise_message(
+            ValueError, message, vec.fit_transform, ["good news everyone"])
+
+

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -997,6 +997,7 @@ def test_vectorizer_string_object_as_input():
         assert_raise_message(
             ValueError, message, vec.transform, "hello world!")
 
+
 @mark.parametrize("vec, index", [
         (HashingVectorizer(ngram_range=(2, 1)), 0),
         (CountVectorizer(ngram_range=(2, 1)), 1),
@@ -1007,9 +1008,9 @@ def test_vectorizers_invalid_ngram_range(vec, index):
     # test for raising error message
     invalid_range = vec.ngram_range
     message = ("Invalid value for ngram_range=%s "
-                "lower boundary larger than the upper boundary"
-                % str(invalid_range))
-    
+               "lower boundary larger than the upper boundary"
+               % str(invalid_range))
+
     # HashingVectorizer implements fit, transform
     # CountVectorizer, TfidfVectorizer implement fit, fit_transform
     if index in [0, 1, 2]:
@@ -1017,7 +1018,7 @@ def test_vectorizers_invalid_ngram_range(vec, index):
             ValueError, message, vec.fit, ["good news everyone"])
     if index in [1, 2]:
         assert_raise_message(
-            ValueError, message, vec.fit_transform, ["good news everyone"])  
+            ValueError, message, vec.fit_transform, ["good news everyone"])
     if index in [0]:
         assert_raise_message(
             ValueError, message, vec.transform, ["good news everyone"])

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -306,6 +306,15 @@ class VectorizerMixin(object):
         if len(self.vocabulary_) == 0:
             raise ValueError("Vocabulary is empty")
 
+    def _check_ngram_range(self):
+        """ Check validity of ngram_range parameter, 
+            e.g., ngram_range=(2,1) is invalid
+        """
+        min_n, max_m = self.ngram_range
+        if min_n > max_m:
+            raise ValueError(
+                "Invalid value for ngram_range, "
+                "min_n should not be larger than max_m")
 
 class HashingVectorizer(BaseEstimator, VectorizerMixin, TransformerMixin):
     """Convert a collection of text documents to a matrix of token occurrences
@@ -497,6 +506,8 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin, TransformerMixin):
                 "Iterable over raw text documents expected, "
                 "string object received.")
 
+        self._check_ngram_range()
+
         self._get_hasher().fit(X, y=y)
         return self
 
@@ -519,6 +530,8 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin, TransformerMixin):
             raise ValueError(
                 "Iterable over raw text documents expected, "
                 "string object received.")
+
+        self._check_ngram_range()
 
         analyzer = self.build_analyzer()
         X = self._get_hasher().transform(analyzer(doc) for doc in X)
@@ -882,6 +895,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                 "Iterable over raw text documents expected, "
                 "string object received.")
 
+        self._check_ngram_range()
         self._validate_vocabulary()
         max_df = self.max_df
         min_df = self.min_df
@@ -939,6 +953,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         if not hasattr(self, 'vocabulary_'):
             self._validate_vocabulary()
 
+        self._check_ngram_range()
         self._check_vocabulary()
 
         # use the same matrix-building strategy as fit_transform

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -312,7 +312,7 @@ class VectorizerMixin(object):
         if min_n > max_m:
             raise ValueError(
                 "Invalid value for ngram_range=%s "
-                "lower boundary larger than the upper boundary"
+                "lower boundary larger than the upper boundary."
                 % str(self.ngram_range))
 
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -306,15 +306,14 @@ class VectorizerMixin(object):
         if len(self.vocabulary_) == 0:
             raise ValueError("Vocabulary is empty")
 
-    def _check_ngram_range(self):
-        """Check validity of ngram_range parameter,
-        e.g., ngram_range=(2,1) is invalid
-        """
+    def _validate_params(self):
+        """Check validity of ngram_range parameter"""
         min_n, max_m = self.ngram_range
         if min_n > max_m:
             raise ValueError(
-                "Invalid value for ngram_range, "
-                "min_n should not be larger than max_m")
+                "Invalid value for ngram_range=%s "
+                "lower boundary larger than the upper boundary"
+                % str(self.ngram_range))
 
 
 class HashingVectorizer(BaseEstimator, VectorizerMixin, TransformerMixin):
@@ -507,7 +506,7 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin, TransformerMixin):
                 "Iterable over raw text documents expected, "
                 "string object received.")
 
-        self._check_ngram_range()
+        self._validate_params()
 
         self._get_hasher().fit(X, y=y)
         return self
@@ -532,7 +531,7 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin, TransformerMixin):
                 "Iterable over raw text documents expected, "
                 "string object received.")
 
-        self._check_ngram_range()
+        self._validate_params()
 
         analyzer = self.build_analyzer()
         X = self._get_hasher().transform(analyzer(doc) for doc in X)
@@ -896,7 +895,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                 "Iterable over raw text documents expected, "
                 "string object received.")
 
-        self._check_ngram_range()
+        self._validate_params()
         self._validate_vocabulary()
         max_df = self.max_df
         min_df = self.min_df
@@ -950,8 +949,6 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             raise ValueError(
                 "Iterable over raw text documents expected, "
                 "string object received.")
-
-        self._check_ngram_range()
 
         if not hasattr(self, 'vocabulary_'):
             self._validate_vocabulary()

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -950,10 +950,11 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                 "Iterable over raw text documents expected, "
                 "string object received.")
 
+        self._check_ngram_range()
+
         if not hasattr(self, 'vocabulary_'):
             self._validate_vocabulary()
-
-        self._check_ngram_range()
+        
         self._check_vocabulary()
 
         # use the same matrix-building strategy as fit_transform

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -307,14 +307,15 @@ class VectorizerMixin(object):
             raise ValueError("Vocabulary is empty")
 
     def _check_ngram_range(self):
-        """ Check validity of ngram_range parameter, 
-            e.g., ngram_range=(2,1) is invalid
+        """Check validity of ngram_range parameter,
+        e.g., ngram_range=(2,1) is invalid
         """
         min_n, max_m = self.ngram_range
         if min_n > max_m:
             raise ValueError(
                 "Invalid value for ngram_range, "
                 "min_n should not be larger than max_m")
+
 
 class HashingVectorizer(BaseEstimator, VectorizerMixin, TransformerMixin):
     """Convert a collection of text documents to a matrix of token occurrences
@@ -954,7 +955,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
 
         if not hasattr(self, 'vocabulary_'):
             self._validate_vocabulary()
-        
+
         self._check_vocabulary()
 
         # use the same matrix-building strategy as fit_transform


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #8688. See also #8700 (should be closed).

#### What does this implement/fix? Explain your changes.
In `feature_extraction` (`.text`) module there's no validation of ngram_range property for the following vectorizers :
```python
class HashingVectorizer(BaseEstimator, VectorizerMixin, TransformerMixin)
class CountVectorizer(BaseEstimator, VectorizerMixin)
class TfidfVectorizer(CountVectorizer)
```
For example we can init a vectorizer that extracts n-grams in this range: 2 >= n >= 1, which doesn't make sense.

Following @jnothman guidelines on #8688 I added a private function in `VectorizerMixin` and called it on relevant fit/transform functions of `HashingVectorizer` and `CountVectorizer` (`Tfidf` implements same fit/transform), tested all of the three. 

#### Any other comments?
 The function `VectorizerMixin.build_analyzer()` is the one relying on `ngram_range`. 

Call to it can be found in `HashingVectorizer.transform()`

And on `CountVectorizer.fit_transform()/transform()`
which also uses `VectorizerMixin.build_analyzer()`  through `CountVectorizer._count_vocab()`

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
