### PR TITLE
[MRG] Add the ability to gel all predictions from all n_estimators of the forest

### DIFF
--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1221,3 +1221,27 @@ def test_min_impurity_decrease():
             # Simply check if the parameter is passed on correctly. Tree tests
             # will suffice for the actual working of this param
             assert_equal(tree.min_impurity_decrease, 0.1)
+
+
+def test_all_predictions_attribute():
+    n_targets = 2
+    n_estimators = 10
+    X_reg, y_reg = datasets.make_regression(n_samples=100, n_targets=n_targets)
+    X_cls, y_cls = datasets.make_classification(n_samples=100, n_classes=n_targets)
+    regressors = [RandomForestClassifier, RandomForestRegressor,
+                      ExtraTreesClassifier, ExtraTreesRegressor]
+
+    for Estimator in regressors:
+        est = Estimator(n_estimators=10)
+        assert_equal(est.all_predictions_, None)
+        if est._estimator_type == 'classifier':
+            est.fit(X_cls, y_cls)
+            X_test = X_cls[-10:]
+        else:
+            est.fit(X_reg, y_reg)
+            X_test = X_reg[-10:]
+        est.predict(X_test)
+        all_pred_shape = est.all_predictions_.shape
+        assert_equal(all_pred_shape[0], X_test.shape[0])
+        assert_equal(all_pred_shape[1], n_estimators)
+        assert_equal(all_pred_shape[2], n_targets)


### PR DESCRIPTION
Hi,

This commit solves the problem of inability to see the n_estimators predictions. which the only way to solve in the current version is to rebuild each tree using `apply()` and check the output yourself. I saw someone else asking this question in this [stackoverflow](https://stackoverflow.com/questions/20615750/how-do-i-output-the-regression-prediction-from-each-tree-in-a-random-forest-in-p) as well.

What I have done is that upon calling `predict` of any forest estimator, a new attribute `all_predictions_` is introduce that holds the predictions of all n_estimators with shape of (X_test.shape[0], n_estimators, n_outpus/n_classes). I have also wrote a test function to test the shape of the all_prediction attribute.

I hope I have the contribution in right manner. Please do forgive my ignorance.

Cheers.

