### PR TITLE
Fixes #4632: Add weighted_test_score option to sklearn model selection module

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1476,7 +1476,7 @@ def _check_is_partition(locs, n):
 
 
 def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
-                    verbose=0, fit_params=None, pre_dispatch='2*n_jobs', weighted_test_score=True):
+                    verbose=0, fit_params=None, pre_dispatch='2*n_jobs', weighted_test_score=False):
     """Evaluate a score by cross-validation
 
     .. deprecated:: 0.18
@@ -1586,7 +1586,7 @@ def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
 
 def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
                    parameters, fit_params, return_train_score=False,
-                   return_parameters=False, error_score='raise', weighted_test_score=True):
+                   return_parameters=False, error_score='raise', weighted_test_score=False):
     """Fit estimator and compute scores for a given dataset split.
 
     Parameters
@@ -1632,7 +1632,7 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     return_parameters : boolean, optional, default: False
         Return parameters that has been used for the estimator.
 
-    weighted_test_score : boolean, optional, default: True.
+    weighted_test_score : boolean, optional, default: False.
         Test score is weigthed by sample weights.
 
     Returns
@@ -1771,10 +1771,11 @@ def _safe_split(estimator, X, y, indices, train_indices=None):
 
 def _score(estimator, X_test, y_test, scorer, sample_weight=None):
     """Compute the score of an estimator on a given test set."""
+    scorer_kwargs = {'sample_weight': sample_weight} if sample_weight is not None else {}
     if y_test is None:
-        score = scorer(estimator, X_test, sample_weight=sample_weight)
+        score = scorer(estimator, X_test, **scorer_kwargs)
     else:
-        score = scorer(estimator, X_test, y_test, sample_weight=sample_weight)
+        score = scorer(estimator, X_test, y_test, **scorer_kwargs)
     if hasattr(score, 'item'):
         try:
             # e.g. unwrap memmapped scalars

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1717,7 +1717,7 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
                              )
 
     else:
-        test_scores = _score(estimator, X_test, y_test, scorer, sample_weight=test_sample_weight)
+        test_score = _score(estimator, X_test, y_test, scorer, sample_weight=test_sample_weight)
         if return_train_score:
             train_score = _score(estimator, X_train, y_train, scorer, sample_weight=train_sample_weight)
 

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -273,7 +273,7 @@ class ParameterSampler(object):
 
 
 def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
-                   verbose, error_score='raise', **fit_params):
+                   verbose, error_score='raise', weighted_test_score=True, **fit_params):
     """Run fit on one set of parameters.
 
     .. deprecated:: 0.18
@@ -319,6 +319,9 @@ def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
         FitFailedWarning is raised. This parameter does not affect the refit
         step, which will always raise the error.
 
+    weighted_test_score : boolean, optional, default: True
+        Whether test score is weighted.
+
     Returns
     -------
     score : float
@@ -332,7 +335,7 @@ def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
     """
     score, n_samples_test, _ = _fit_and_score(estimator, X, y, scorer, train,
                                               test, verbose, parameters,
-                                              fit_params, error_score)
+                                              fit_params, error_score, weighted_test_score=weighted_test_score)
     return score, parameters, n_samples_test
 
 
@@ -385,7 +388,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
     def __init__(self, estimator, scoring=None,
                  fit_params=None, n_jobs=1, iid=True,
                  refit=True, cv=None, verbose=0, pre_dispatch='2*n_jobs',
-                 error_score='raise'):
+                 error_score='raise', weighted_test_score=True):
 
         self.scoring = scoring
         self.estimator = estimator
@@ -397,6 +400,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         self.verbose = verbose
         self.pre_dispatch = pre_dispatch
         self.error_score = error_score
+        self.weighted_test_score = weighted_test_score
 
     @property
     def _estimator_type(self):
@@ -570,7 +574,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             delayed(_fit_and_score)(clone(base_estimator), X, y, self.scorer_,
                                     train, test, self.verbose, parameters,
                                     self.fit_params, return_parameters=True,
-                                    error_score=self.error_score)
+                                    error_score=self.error_score, weighted_test_score=self.weighted_test_score)
                 for parameters in parameter_iterable
                 for train, test in cv)
 
@@ -812,11 +816,11 @@ class GridSearchCV(BaseSearchCV):
 
     def __init__(self, estimator, param_grid, scoring=None, fit_params=None,
                  n_jobs=1, iid=True, refit=True, cv=None, verbose=0,
-                 pre_dispatch='2*n_jobs', error_score='raise'):
+                 pre_dispatch='2*n_jobs', error_score='raise', weighted_test_score=True):
 
         super(GridSearchCV, self).__init__(
             estimator, scoring, fit_params, n_jobs, iid,
-            refit, cv, verbose, pre_dispatch, error_score)
+            refit, cv, verbose, pre_dispatch, error_score, weighted_test_score=weighted_test_score)
         self.param_grid = param_grid
         _check_param_grid(param_grid)
 
@@ -1016,7 +1020,7 @@ class RandomizedSearchCV(BaseSearchCV):
     def __init__(self, estimator, param_distributions, n_iter=10, scoring=None,
                  fit_params=None, n_jobs=1, iid=True, refit=True, cv=None,
                  verbose=0, pre_dispatch='2*n_jobs', random_state=None,
-                 error_score='raise'):
+                 error_score='raise', weighted_test_score=True):
 
         self.param_distributions = param_distributions
         self.n_iter = n_iter
@@ -1024,7 +1028,7 @@ class RandomizedSearchCV(BaseSearchCV):
         super(RandomizedSearchCV, self).__init__(
             estimator=estimator, scoring=scoring, fit_params=fit_params,
             n_jobs=n_jobs, iid=iid, refit=refit, cv=cv, verbose=verbose,
-            pre_dispatch=pre_dispatch, error_score=error_score)
+            pre_dispatch=pre_dispatch, error_score=error_score, weighted_test_score=weighted_test_score)
 
     def fit(self, X, y=None):
         """Run fit on the estimator with randomly drawn parameters.

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -273,7 +273,7 @@ class ParameterSampler(object):
 
 
 def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
-                   verbose, error_score='raise', weighted_test_score=True, **fit_params):
+                   verbose, error_score='raise', weighted_test_score=False, **fit_params):
     """Run fit on one set of parameters.
 
     .. deprecated:: 0.18
@@ -319,7 +319,7 @@ def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
         FitFailedWarning is raised. This parameter does not affect the refit
         step, which will always raise the error.
 
-    weighted_test_score : boolean, optional, default: True
+    weighted_test_score : boolean, optional, default: False
         Whether test score is weighted.
 
     Returns
@@ -388,7 +388,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
     def __init__(self, estimator, scoring=None,
                  fit_params=None, n_jobs=1, iid=True,
                  refit=True, cv=None, verbose=0, pre_dispatch='2*n_jobs',
-                 error_score='raise', weighted_test_score=True):
+                 error_score='raise', weighted_test_score=False):
 
         self.scoring = scoring
         self.estimator = estimator
@@ -410,7 +410,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
     def classes_(self):
         return self.best_estimator_.classes_
 
-    def score(self, X, y=None):
+    def score(self, X, y=None, sample_weight=None):
         """Returns the score on the given data, if the estimator has been refit.
 
         This uses the score defined by ``scoring`` where provided, and the
@@ -425,6 +425,9 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         y : array-like, shape = [n_samples] or [n_samples, n_output], optional
             Target relative to X for classification or regression;
             None for unsupervised learning.
+
+        sample_weight : array-like of shape = (n_samples), optional
+            Sample weights.
 
         Returns
         -------
@@ -441,7 +444,8 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             raise ValueError("No score function explicitly defined, "
                              "and the estimator doesn't provide one %s"
                              % self.best_estimator_)
-        return self.scorer_(self.best_estimator_, X, y)
+        score_kwargs = {'sample_weight': sample_weight} if sample_weight is not None else {}
+        return self.scorer_(self.best_estimator_, X, y, **score_kwargs)
 
     @if_delegate_has_method(delegate=('best_estimator_', 'estimator'))
     def predict(self, X):
@@ -816,7 +820,7 @@ class GridSearchCV(BaseSearchCV):
 
     def __init__(self, estimator, param_grid, scoring=None, fit_params=None,
                  n_jobs=1, iid=True, refit=True, cv=None, verbose=0,
-                 pre_dispatch='2*n_jobs', error_score='raise', weighted_test_score=True):
+                 pre_dispatch='2*n_jobs', error_score='raise', weighted_test_score=False):
 
         super(GridSearchCV, self).__init__(
             estimator, scoring, fit_params, n_jobs, iid,
@@ -1020,7 +1024,7 @@ class RandomizedSearchCV(BaseSearchCV):
     def __init__(self, estimator, param_distributions, n_iter=10, scoring=None,
                  fit_params=None, n_jobs=1, iid=True, refit=True, cv=None,
                  verbose=0, pre_dispatch='2*n_jobs', random_state=None,
-                 error_score='raise', weighted_test_score=True):
+                 error_score='raise', weighted_test_score=False):
 
         self.param_distributions = param_distributions
         self.n_iter = n_iter

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -392,7 +392,8 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
     def __init__(self, estimator, scoring=None,
                  fit_params=None, n_jobs=1, iid='warn',
                  refit=True, cv=None, verbose=0, pre_dispatch='2*n_jobs',
-                 error_score='raise-deprecating', return_train_score=True):
+                 error_score='raise-deprecating', return_train_score=True,
+                 weighted_test_score=True):
 
         self.scoring = scoring
         self.estimator = estimator
@@ -405,12 +406,13 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         self.pre_dispatch = pre_dispatch
         self.error_score = error_score
         self.return_train_score = return_train_score
+        self.weighted_test_score = weighted_test_score
 
     @property
     def _estimator_type(self):
         return self.estimator._estimator_type
 
-    def score(self, X, y=None):
+    def score(self, X, y=None, sample_weight=None):
         """Returns the score on the given data, if the estimator has been refit.
 
         This uses the score defined by ``scoring`` where provided, and the
@@ -426,6 +428,8 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             Target relative to X for classification or regression;
             None for unsupervised learning.
 
+        sample_weight : array-like of shape = (n_samples), optional
+            Sample weights.
         Returns
         -------
         score : float
@@ -436,7 +440,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                              "and the estimator doesn't provide one %s"
                              % self.best_estimator_)
         score = self.scorer_[self.refit] if self.multimetric_ else self.scorer_
-        return score(self.best_estimator_, X, y)
+        return score(self.best_estimator_, X, y, sample_weight=sample_weight)
 
     def _check_is_fitted(self, method_name):
         if not self.refit:
@@ -636,7 +640,8 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                                   return_train_score=self.return_train_score,
                                   return_n_test_samples=True,
                                   return_times=True, return_parameters=False,
-                                  error_score=self.error_score)
+                                  error_score=self.error_score,
+                                  weighted_test_score=self.weighted_test_score)
           for parameters, (train, test) in product(candidate_params,
                                                    cv.split(X, y, groups)))
 
@@ -1088,12 +1093,12 @@ class GridSearchCV(BaseSearchCV):
     def __init__(self, estimator, param_grid, scoring=None, fit_params=None,
                  n_jobs=1, iid='warn', refit=True, cv=None, verbose=0,
                  pre_dispatch='2*n_jobs', error_score='raise-deprecating',
-                 return_train_score="warn"):
+                 return_train_score="warn", weighted_test_score=True):
         super(GridSearchCV, self).__init__(
             estimator=estimator, scoring=scoring, fit_params=fit_params,
             n_jobs=n_jobs, iid=iid, refit=refit, cv=cv, verbose=verbose,
             pre_dispatch=pre_dispatch, error_score=error_score,
-            return_train_score=return_train_score)
+            return_train_score=return_train_score, weighted_test_score=weighted_test_score)
         self.param_grid = param_grid
         _check_param_grid(param_grid)
 
@@ -1389,7 +1394,7 @@ class RandomizedSearchCV(BaseSearchCV):
     def __init__(self, estimator, param_distributions, n_iter=10, scoring=None,
                  fit_params=None, n_jobs=1, iid='warn', refit=True, cv=None,
                  verbose=0, pre_dispatch='2*n_jobs', random_state=None,
-                 error_score='raise-deprecating', return_train_score="warn"):
+                 error_score='raise-deprecating', return_train_score="warn", weighted_test_score=True):
         self.param_distributions = param_distributions
         self.n_iter = n_iter
         self.random_state = random_state
@@ -1397,7 +1402,7 @@ class RandomizedSearchCV(BaseSearchCV):
             estimator=estimator, scoring=scoring, fit_params=fit_params,
             n_jobs=n_jobs, iid=iid, refit=refit, cv=cv, verbose=verbose,
             pre_dispatch=pre_dispatch, error_score=error_score,
-            return_train_score=return_train_score)
+            return_train_score=return_train_score, weighted_test_score=weighted_test_score)
 
     def _get_param_iterator(self):
         """Return ParameterSampler instance for the given distributions"""

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -273,7 +273,7 @@ class ParameterSampler(object):
 
 
 def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
-                   verbose, error_score='raise-deprecating', weighted_test_score=True, **fit_params):
+                   verbose, error_score='raise-deprecating', weighted_test_score=False, **fit_params):
     """Run fit on one set of parameters.
 
     Parameters
@@ -318,7 +318,7 @@ def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
         step, which will always raise the error. Default is 'raise' but from
         version 0.22 it will change to np.nan.
 
-    weighted_test_score : boolean, optional, default: True
+    weighted_test_score : boolean, optional, default: False
         Whether test score is weighted.
     Returns
     -------
@@ -396,7 +396,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                  fit_params=None, n_jobs=1, iid='warn',
                  refit=True, cv=None, verbose=0, pre_dispatch='2*n_jobs',
                  error_score='raise-deprecating', return_train_score=True,
-                 weighted_test_score=True):
+                 weighted_test_score=False):
 
         self.scoring = scoring
         self.estimator = estimator
@@ -443,7 +443,8 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                              "and the estimator doesn't provide one %s"
                              % self.best_estimator_)
         score = self.scorer_[self.refit] if self.multimetric_ else self.scorer_
-        return score(self.best_estimator_, X, y, sample_weight=sample_weight)
+        score_kwargs = {'sample_weight': sample_weight} if sample_weight is not None else {}
+        return score(self.best_estimator_, X, y, **score_kwargs)
 
     def _check_is_fitted(self, method_name):
         if not self.refit:
@@ -1096,7 +1097,7 @@ class GridSearchCV(BaseSearchCV):
     def __init__(self, estimator, param_grid, scoring=None, fit_params=None,
                  n_jobs=1, iid='warn', refit=True, cv=None, verbose=0,
                  pre_dispatch='2*n_jobs', error_score='raise-deprecating',
-                 return_train_score="warn", weighted_test_score=True):
+                 return_train_score="warn", weighted_test_score=False):
         super(GridSearchCV, self).__init__(
             estimator=estimator, scoring=scoring, fit_params=fit_params,
             n_jobs=n_jobs, iid=iid, refit=refit, cv=cv, verbose=verbose,
@@ -1397,7 +1398,7 @@ class RandomizedSearchCV(BaseSearchCV):
     def __init__(self, estimator, param_distributions, n_iter=10, scoring=None,
                  fit_params=None, n_jobs=1, iid='warn', refit=True, cv=None,
                  verbose=0, pre_dispatch='2*n_jobs', random_state=None,
-                 error_score='raise-deprecating', return_train_score="warn", weighted_test_score=True):
+                 error_score='raise-deprecating', return_train_score="warn", weighted_test_score=False):
         self.param_distributions = param_distributions
         self.n_iter = n_iter
         self.random_state = random_state

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -273,7 +273,7 @@ class ParameterSampler(object):
 
 
 def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
-                   verbose, error_score='raise-deprecating', **fit_params):
+                   verbose, error_score='raise-deprecating', weighted_test_score=True, **fit_params):
     """Run fit on one set of parameters.
 
     Parameters
@@ -318,6 +318,8 @@ def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
         step, which will always raise the error. Default is 'raise' but from
         version 0.22 it will change to np.nan.
 
+    weighted_test_score : boolean, optional, default: True
+        Whether test score is weighted.
     Returns
     -------
     score : float
@@ -337,7 +339,8 @@ def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
                                             test, verbose, parameters,
                                             fit_params=fit_params,
                                             return_n_test_samples=True,
-                                            error_score=error_score)
+                                            error_score=error_score,
+                                            weighted_test_score=weighted_test_score)
     return scores, parameters, n_samples_test
 
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -40,7 +40,7 @@ __all__ = ['cross_validate', 'cross_val_score', 'cross_val_predict',
 def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv=None,
                    n_jobs=1, verbose=0, fit_params=None,
                    pre_dispatch='2*n_jobs', return_train_score="warn",
-                   return_estimator=False):
+                   return_estimator=False, weighted_test_score=True):
     """Evaluate metric(s) by cross-validation and also record fit/score times.
 
     Read more in the :ref:`User Guide <multimetric_cross_validation>`.
@@ -133,6 +133,9 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv=None,
     return_estimator : boolean, default False
         Whether to return the estimators fitted on each split.
 
+    weighted_test_score : boolean, optional, default: True.
+        Test score is weigthed by sample weights.
+
     Returns
     -------
     scores : dict of float arrays of shape=(n_splits,)
@@ -211,7 +214,7 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv=None,
         delayed(_fit_and_score)(
             clone(estimator), X, y, scorers, train, test, verbose, None,
             fit_params, return_train_score=return_train_score,
-            return_times=True, return_estimator=return_estimator)
+            return_times=True, return_estimator=return_estimator, weighted_test_score=weighted_test_score)
         for train, test in cv.split(X, y, groups))
 
     zipped_scores = list(zip(*scores))
@@ -250,7 +253,7 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv=None,
 
 def cross_val_score(estimator, X, y=None, groups=None, scoring=None, cv=None,
                     n_jobs=1, verbose=0, fit_params=None,
-                    pre_dispatch='2*n_jobs'):
+                    pre_dispatch='2*n_jobs', weighted_test_score=True):
     """Evaluate a score by cross-validation
 
     Read more in the :ref:`User Guide <cross_validation>`.
@@ -319,6 +322,9 @@ def cross_val_score(estimator, X, y=None, groups=None, scoring=None, cv=None,
             - A string, giving an expression as a function of n_jobs,
               as in '2*n_jobs'
 
+    weighted_test_score : boolean, optional, default: True.
+        Test score is weigthed by sample weights.
+
     Returns
     -------
     scores : array of float, shape=(len(list(cv)),)
@@ -353,7 +359,7 @@ def cross_val_score(estimator, X, y=None, groups=None, scoring=None, cv=None,
                                 return_train_score=False,
                                 n_jobs=n_jobs, verbose=verbose,
                                 fit_params=fit_params,
-                                pre_dispatch=pre_dispatch)
+                                pre_dispatch=pre_dispatch, weighted_test_score=weighted_test_score)
     return cv_results['test_score']
 
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -366,7 +366,8 @@ def cross_val_score(estimator, X, y=None, groups=None, scoring=None, cv=None,
 def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
                    parameters, fit_params, return_train_score=False,
                    return_parameters=False, return_n_test_samples=False,
-                   return_times=False, error_score='raise', weighted_test_score=False):
+                   return_times=False, return_estimator=False,
+                   error_score='raise', weighted_test_score=False):
     """Fit estimator and compute scores for a given dataset split.
 
     Parameters
@@ -447,6 +448,9 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
 
     parameters : dict or None, optional
         The parameters that have been evaluated.
+
+    return_estimator : boolean, optional, default: False
+        Whether to return the fitted estimator.
     """
     if verbose > 1:
         if parameters is None:
@@ -554,6 +558,8 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         ret.extend([fit_time, score_time])
     if return_parameters:
         ret.append(parameters)
+    if return_estimator:
+        ret.append(estimator)
     return ret
 
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -360,8 +360,7 @@ def cross_val_score(estimator, X, y=None, groups=None, scoring=None, cv=None,
 def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
                    parameters, fit_params, return_train_score=False,
                    return_parameters=False, return_n_test_samples=False,
-                   return_times=False, return_estimator=False,
-                   error_score='raise-deprecating'):
+                   return_times=False, error_score='raise', weighted_test_score=True):
     """Fit estimator and compute scores for a given dataset split.
 
     Parameters
@@ -395,12 +394,11 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     verbose : integer
         The verbosity level.
 
-    error_score : 'raise' or numeric
+    error_score : 'raise' (default) or numeric
         Value to assign to the score if an error occurs in estimator fitting.
         If set to 'raise', the error is raised. If a numeric value is given,
         FitFailedWarning is raised. This parameter does not affect the refit
-        step, which will always raise the error. Default is 'raise' but from
-        version 0.22 it will change to np.nan.
+        step, which will always raise the error.
 
     parameters : dict or None
         Parameters to be set on the estimator.
@@ -420,8 +418,8 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     return_times : boolean, optional, default: False
         Whether to return the fit/score times.
 
-    return_estimator : boolean, optional, default: False
-        Whether to return the fitted estimator.
+    weighted_test_score : boolean, optional, default: True.
+        Test score is weigthed by sample weights.
 
     Returns
     -------
@@ -443,9 +441,6 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
 
     parameters : dict or None, optional
         The parameters that have been evaluated.
-
-    estimator : estimator object
-        The fitted estimator
     """
     if verbose > 1:
         if parameters is None:
@@ -455,11 +450,33 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
                           for k, v in parameters.items()))
         print("[CV] %s %s" % (msg, (64 - len(msg)) * '.'))
 
-    # Adjust length of sample weights
     fit_params = fit_params if fit_params is not None else {}
+
+    if 'sample_weight' in fit_params:
+        sample_weight_key = 'sample_weight'     # standard estimator
+    else:
+        # didn't find 'sample_weight' key, maybe a Pipeline object?
+        maybe_pipeline_sample_weights = list(filter(lambda x: x.endswith('__sample_weight'), fit_params))
+        if len(maybe_pipeline_sample_weights) > 1:
+            raise ValueError("Multiple pipeline weights found in fit_params: %s" % ', '.join(maybe_pipeline_sample_weights))
+        elif len(maybe_pipeline_sample_weights) == 1:
+            sample_weight_key = maybe_pipeline_sample_weights[0]
+        else:
+            # No sample weight passed. Set it to None.
+            sample_weight_key = None
+
+    if sample_weight_key is not None and weighted_test_score:
+        train_sample_weight = _index_param_value(X, fit_params[sample_weight_key], train)
+        test_sample_weight = _index_param_value(X, fit_params[sample_weight_key], test)
+    else:
+        train_sample_weight = None
+        test_sample_weight = None
+
+    # Adjust length of sample weights
     fit_params = dict([(k, _index_param_value(X, v, train))
                       for k, v in fit_params.items()])
 
+    test_scores = {}
     train_scores = {}
     if parameters is not None:
         estimator.set_params(**parameters)
@@ -484,14 +501,6 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         score_time = 0.0
         if error_score == 'raise':
             raise
-        elif error_score == 'raise-deprecating':
-            warnings.warn("From version 0.22, errors during fit will result "
-                          "in a cross validation score of NaN by default. Use "
-                          "error_score='raise' if you want an exception "
-                          "raised or error_score=np.nan to adopt the "
-                          "behavior from version 0.22.",
-                          FutureWarning)
-            raise
         elif isinstance(error_score, numbers.Number):
             if is_multimetric:
                 test_scores = dict(zip(scorer.keys(),
@@ -503,11 +512,9 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
                 test_scores = error_score
                 if return_train_score:
                     train_scores = error_score
-            warnings.warn("Estimator fit failed. The score on this train-test"
+            warnings.warn("Classifier fit failed. The score on this train-test"
                           " partition for these parameters will be set to %f. "
-                          "Details: \n%s" %
-                          (error_score, format_exception_only(type(e), e)[0]),
-                          FitFailedWarning)
+                          "Details: \n%r" % (error_score, e), FitFailedWarning)
         else:
             raise ValueError("error_score must be the string 'raise' or a"
                              " numeric value. (Hint: if using 'raise', please"
@@ -516,11 +523,11 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     else:
         fit_time = time.time() - start_time
         # _score will return dict if is_multimetric is True
-        test_scores = _score(estimator, X_test, y_test, scorer, is_multimetric)
+        test_scores = _score(estimator, X_test, y_test, scorer, is_multimetric, sample_weight=test_sample_weight)
         score_time = time.time() - start_time - fit_time
         if return_train_score:
             train_scores = _score(estimator, X_train, y_train, scorer,
-                                  is_multimetric)
+                                  is_multimetric, sample_weight=train_sample_weight)
 
     if verbose > 2:
         if is_multimetric:
@@ -541,24 +548,17 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         ret.extend([fit_time, score_time])
     if return_parameters:
         ret.append(parameters)
-    if return_estimator:
-        ret.append(estimator)
     return ret
 
 
-def _score(estimator, X_test, y_test, scorer, is_multimetric=False):
-    """Compute the score(s) of an estimator on a given test set.
-
-    Will return a single float if is_multimetric is False and a dict of floats,
-    if is_multimetric is True
-    """
+def _score(estimator, X_test, y_test, scorer, is_multimetric=False, sample_weight=None):
     if is_multimetric:
-        return _multimetric_score(estimator, X_test, y_test, scorer)
+        return _multimetric_score(estimator, X_test, y_test, scorer, sample_weight=sample_weight)
     else:
         if y_test is None:
-            score = scorer(estimator, X_test)
+            score = scorer(estimator, X_test, sample_weight=sample_weight)
         else:
-            score = scorer(estimator, X_test, y_test)
+            score = scorer(estimator, X_test, y_test, sample_weight=sample_weight)
 
         if hasattr(score, 'item'):
             try:
@@ -572,18 +572,17 @@ def _score(estimator, X_test, y_test, scorer, is_multimetric=False):
             raise ValueError("scoring must return a number, got %s (%s) "
                              "instead. (scorer=%r)"
                              % (str(score), type(score), scorer))
-    return score
 
 
-def _multimetric_score(estimator, X_test, y_test, scorers):
+def _multimetric_score(estimator, X_test, y_test, scorers, sample_weight=None):
     """Return a dict of score for multimetric scoring"""
     scores = {}
 
     for name, scorer in scorers.items():
         if y_test is None:
-            score = scorer(estimator, X_test)
+            score = scorer(estimator, X_test, sample_weight=sample_weight)
         else:
-            score = scorer(estimator, X_test, y_test)
+            score = scorer(estimator, X_test, y_test, sample_weight=sample_weight)
 
         if hasattr(score, 'item'):
             try:

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -366,7 +366,7 @@ def cross_val_score(estimator, X, y=None, groups=None, scoring=None, cv=None,
 def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
                    parameters, fit_params, return_train_score=False,
                    return_parameters=False, return_n_test_samples=False,
-                   return_times=False, error_score='raise', weighted_test_score=True):
+                   return_times=False, error_score='raise', weighted_test_score=False):
     """Fit estimator and compute scores for a given dataset split.
 
     Parameters
@@ -424,7 +424,7 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     return_times : boolean, optional, default: False
         Whether to return the fit/score times.
 
-    weighted_test_score : boolean, optional, default: True.
+    weighted_test_score : boolean, optional, default: False.
         Test score is weigthed by sample weights.
 
     Returns
@@ -561,10 +561,11 @@ def _score(estimator, X_test, y_test, scorer, is_multimetric=False, sample_weigh
     if is_multimetric:
         return _multimetric_score(estimator, X_test, y_test, scorer, sample_weight=sample_weight)
     else:
+        scorer_kwargs = {'sample_weight': sample_weight} if sample_weight is not None else {}
         if y_test is None:
-            score = scorer(estimator, X_test, sample_weight=sample_weight)
+            score = scorer(estimator, X_test, **scorer_kwargs)
         else:
-            score = scorer(estimator, X_test, y_test, sample_weight=sample_weight)
+            score = scorer(estimator, X_test, y_test, **scorer_kwargs)
 
         if hasattr(score, 'item'):
             try:
@@ -583,12 +584,12 @@ def _score(estimator, X_test, y_test, scorer, is_multimetric=False, sample_weigh
 def _multimetric_score(estimator, X_test, y_test, scorers, sample_weight=None):
     """Return a dict of score for multimetric scoring"""
     scores = {}
-
+    scorer_kwargs = {'sample_weight': sample_weight} if sample_weight is not None else {}
     for name, scorer in scorers.items():
         if y_test is None:
-            score = scorer(estimator, X_test, sample_weight=sample_weight)
+            score = scorer(estimator, X_test, **scorer_kwargs)
         else:
-            score = scorer(estimator, X_test, y_test, sample_weight=sample_weight)
+            score = scorer(estimator, X_test, y_test, **scorer_kwargs)
 
         if hasattr(score, 'item'):
             try:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #4632


#### What does this implement/fix? Explain your changes.
Add weighted_test_score option so that user can choose to specify whether CV score is weighted or un-weighted. This is very important to certain fields of research, e.g. finance. For now, it is silently default to un-weighted, which is a little undesirable. 

#### Any other comments?
The current fix deals with pipeline as well as regular sklearn estimators. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
