### PR TITLE
[WIP] added a perplexity value-check and error

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -486,7 +486,8 @@ class TSNE(BaseEstimator):
         is used in other manifold learning algorithms. Larger datasets
         usually require a larger perplexity. Consider selecting a value
         between 5 and 50. The choice is not extremely critical since t-SNE
-        is quite insensitive to this parameter.
+        is quite insensitive to this parameter, however you should never
+        use a value larger than the number of samples in your data.
 
     early_exaggeration : float, optional (default: 12.0)
         Controls how tight natural clusters in the original space are in
@@ -693,6 +694,9 @@ class TSNE(BaseEstimator):
             raise ValueError("n_iter should be at least 250")
 
         n_samples = X.shape[0]
+        
+        if self.perplexity >= n_samples:
+            raise ValueError("perplexity must be less than n_samples")
 
         neighbors_nn = None
         if self.method == "exact":

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -328,7 +328,7 @@ def test_non_positive_computed_distances():
     def metric(x, y):
         return -1
 
-    tsne = TSNE(metric=metric, method='exact')
+    tsne = TSNE(metric=metric, method='exact', perplexity=1)
     X = np.array([[0.0, 0.0], [1.0, 1.0]])
     assert_raises_regexp(ValueError, "All distances .*metric given.*",
                          tsne.fit_transform, X)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
As per the t-sne implementation, any perplexity value larger than the number of samples is mathematically incorrect and should result in an error. Current behavior when perplexity is larger than n_sample results in a seemingly structured, but in reality broken, output. 

See SO link for examples, discussion and references: https://stats.stackexchange.com/questions/332370/why-do-i-get-weird-results-when-using-high-perpexity-in-t-sne

#### Any other comments?
extended description of perplexity parameter as well.