### PR TITLE
Fixes #4632: Allow cross validation to have weighted test scores

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -273,7 +273,8 @@ class ParameterSampler(object):
 
 
 def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
-                   verbose, error_score='raise-deprecating', test_score_weight=None, **fit_params):
+                   verbose, error_score='raise-deprecating',
+                   test_score_weight=None, **fit_params):
     """Run fit on one set of parameters.
 
     Parameters
@@ -342,7 +343,8 @@ def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
                                             fit_params=fit_params,
                                             return_n_test_samples=True,
                                             error_score=error_score,
-                                            test_score_weight=test_score_weight)
+                                            test_score_weight=test_score_weight
+                                            )
     return scores, parameters, n_samples_test
 
 
@@ -446,7 +448,8 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                              "and the estimator doesn't provide one %s"
                              % self.best_estimator_)
         score = self.scorer_[self.refit] if self.multimetric_ else self.scorer_
-        score_kwgs = {} if sample_weight is None else {'sample_weight': sample_weight}
+        score_kwgs = {} if sample_weight is None else \
+            {'sample_weight': sample_weight}
         return score(self.best_estimator_, X, y, **score_kwgs)
 
     def _check_is_fitted(self, method_name):
@@ -1105,7 +1108,8 @@ class GridSearchCV(BaseSearchCV):
             estimator=estimator, scoring=scoring, fit_params=fit_params,
             n_jobs=n_jobs, iid=iid, refit=refit, cv=cv, verbose=verbose,
             pre_dispatch=pre_dispatch, error_score=error_score,
-            return_train_score=return_train_score, test_score_weight=test_score_weight)
+            return_train_score=return_train_score,
+            test_score_weight=test_score_weight)
         self.param_grid = param_grid
         _check_param_grid(param_grid)
 
@@ -1401,7 +1405,8 @@ class RandomizedSearchCV(BaseSearchCV):
     def __init__(self, estimator, param_distributions, n_iter=10, scoring=None,
                  fit_params=None, n_jobs=1, iid='warn', refit=True, cv=None,
                  verbose=0, pre_dispatch='2*n_jobs', random_state=None,
-                 error_score='raise-deprecating', return_train_score="warn", test_score_weight=None):
+                 error_score='raise-deprecating', return_train_score="warn",
+                 test_score_weight=None):
         self.param_distributions = param_distributions
         self.n_iter = n_iter
         self.random_state = random_state
@@ -1409,7 +1414,8 @@ class RandomizedSearchCV(BaseSearchCV):
             estimator=estimator, scoring=scoring, fit_params=fit_params,
             n_jobs=n_jobs, iid=iid, refit=refit, cv=cv, verbose=verbose,
             pre_dispatch=pre_dispatch, error_score=error_score,
-            return_train_score=return_train_score, test_score_weight=test_score_weight)
+            return_train_score=return_train_score,
+            test_score_weight=test_score_weight)
 
     def _get_param_iterator(self):
         """Return ParameterSampler instance for the given distributions"""

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -273,7 +273,7 @@ class ParameterSampler(object):
 
 
 def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
-                   verbose, error_score='raise-deprecating', **fit_params):
+                   verbose, error_score='raise-deprecating', test_score_weight=None, **fit_params):
     """Run fit on one set of parameters.
 
     Parameters
@@ -318,6 +318,10 @@ def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
         step, which will always raise the error. Default is 'raise' but from
         version 0.22 it will change to np.nan.
 
+    test_score_weight : string, optional, default: None
+        If specified, this is the sample weight key in the `fit_params` dict.
+        If there's no such key found, we will assume unweighted test score.
+
     Returns
     -------
     score : float
@@ -337,7 +341,8 @@ def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
                                             test, verbose, parameters,
                                             fit_params=fit_params,
                                             return_n_test_samples=True,
-                                            error_score=error_score)
+                                            error_score=error_score,
+                                            test_score_weight=test_score_weight)
     return scores, parameters, n_samples_test
 
 
@@ -392,7 +397,8 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
     def __init__(self, estimator, scoring=None,
                  fit_params=None, n_jobs=1, iid='warn',
                  refit=True, cv=None, verbose=0, pre_dispatch='2*n_jobs',
-                 error_score='raise-deprecating', return_train_score=True):
+                 error_score='raise-deprecating', return_train_score=True,
+                 test_score_weight=None):
 
         self.scoring = scoring
         self.estimator = estimator
@@ -405,12 +411,13 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         self.pre_dispatch = pre_dispatch
         self.error_score = error_score
         self.return_train_score = return_train_score
+        self.test_score_weight = test_score_weight
 
     @property
     def _estimator_type(self):
         return self.estimator._estimator_type
 
-    def score(self, X, y=None):
+    def score(self, X, y=None, sample_weight=None):
         """Returns the score on the given data, if the estimator has been refit.
 
         This uses the score defined by ``scoring`` where provided, and the
@@ -426,6 +433,9 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             Target relative to X for classification or regression;
             None for unsupervised learning.
 
+        sample_weight : array-like of shape = (n_samples), optional
+            Sample weights.
+
         Returns
         -------
         score : float
@@ -436,7 +446,8 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                              "and the estimator doesn't provide one %s"
                              % self.best_estimator_)
         score = self.scorer_[self.refit] if self.multimetric_ else self.scorer_
-        return score(self.best_estimator_, X, y)
+        score_kwgs = {} if sample_weight is None else {'sample_weight': sample_weight}
+        return score(self.best_estimator_, X, y, **score_kwgs)
 
     def _check_is_fitted(self, method_name):
         if not self.refit:
@@ -636,7 +647,8 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                                   return_train_score=self.return_train_score,
                                   return_n_test_samples=True,
                                   return_times=True, return_parameters=False,
-                                  error_score=self.error_score)
+                                  error_score=self.error_score,
+                                  test_score_weight=self.test_score_weight)
           for parameters, (train, test) in product(candidate_params,
                                                    cv.split(X, y, groups)))
 
@@ -1088,12 +1100,12 @@ class GridSearchCV(BaseSearchCV):
     def __init__(self, estimator, param_grid, scoring=None, fit_params=None,
                  n_jobs=1, iid='warn', refit=True, cv=None, verbose=0,
                  pre_dispatch='2*n_jobs', error_score='raise-deprecating',
-                 return_train_score="warn"):
+                 return_train_score="warn", test_score_weight=None):
         super(GridSearchCV, self).__init__(
             estimator=estimator, scoring=scoring, fit_params=fit_params,
             n_jobs=n_jobs, iid=iid, refit=refit, cv=cv, verbose=verbose,
             pre_dispatch=pre_dispatch, error_score=error_score,
-            return_train_score=return_train_score)
+            return_train_score=return_train_score, test_score_weight=test_score_weight)
         self.param_grid = param_grid
         _check_param_grid(param_grid)
 
@@ -1389,7 +1401,7 @@ class RandomizedSearchCV(BaseSearchCV):
     def __init__(self, estimator, param_distributions, n_iter=10, scoring=None,
                  fit_params=None, n_jobs=1, iid='warn', refit=True, cv=None,
                  verbose=0, pre_dispatch='2*n_jobs', random_state=None,
-                 error_score='raise-deprecating', return_train_score="warn"):
+                 error_score='raise-deprecating', return_train_score="warn", test_score_weight=None):
         self.param_distributions = param_distributions
         self.n_iter = n_iter
         self.random_state = random_state
@@ -1397,7 +1409,7 @@ class RandomizedSearchCV(BaseSearchCV):
             estimator=estimator, scoring=scoring, fit_params=fit_params,
             n_jobs=n_jobs, iid=iid, refit=refit, cv=cv, verbose=verbose,
             pre_dispatch=pre_dispatch, error_score=error_score,
-            return_train_score=return_train_score)
+            return_train_score=return_train_score, test_score_weight=test_score_weight)
 
     def _get_param_iterator(self):
         """Return ParameterSampler instance for the given distributions"""

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -468,8 +468,12 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         sample_weight_key, weighted_test_score = test_score_weight, True
 
     if weighted_test_score:
-        train_sample_weight = _index_param_value(X, fit_params[sample_weight_key], train)
-        test_sample_weight = _index_param_value(X, fit_params[sample_weight_key], test)
+        train_sample_weight = _index_param_value(X,
+                                                 fit_params[sample_weight_key],
+                                                 train)
+        test_sample_weight = _index_param_value(X,
+                                                fit_params[sample_weight_key],
+                                                test)
     else:
         train_sample_weight = None
         test_sample_weight = None
@@ -534,11 +538,13 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     else:
         fit_time = time.time() - start_time
         # _score will return dict if is_multimetric is True
-        test_scores = _score(estimator, X_test, y_test, scorer, is_multimetric, sample_weight=test_sample_weight)
+        test_scores = _score(estimator, X_test, y_test, scorer, is_multimetric,
+                             sample_weight=test_sample_weight)
         score_time = time.time() - start_time - fit_time
         if return_train_score:
             train_scores = _score(estimator, X_train, y_train, scorer,
-                                  is_multimetric, sample_weight=train_sample_weight)
+                                  is_multimetric,
+                                  sample_weight=train_sample_weight)
 
     if verbose > 2:
         if is_multimetric:
@@ -564,16 +570,19 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     return ret
 
 
-def _score(estimator, X_test, y_test, scorer, is_multimetric=False, sample_weight=None):
+def _score(estimator, X_test, y_test, scorer, is_multimetric=False,
+           sample_weight=None):
     """Compute the score(s) of an estimator on a given test set.
 
     Will return a single float if is_multimetric is False and a dict of floats,
     if is_multimetric is True
     """
     if is_multimetric:
-        return _multimetric_score(estimator, X_test, y_test, scorer, sample_weight=sample_weight)
+        return _multimetric_score(estimator, X_test, y_test, scorer,
+                                  sample_weight=sample_weight)
     else:
-        score_kwgs = {} if sample_weight is None else {'sample_weight': sample_weight}
+        score_kwgs = {} if sample_weight is None else \
+            {'sample_weight': sample_weight}
         if y_test is None:
             score = scorer(estimator, X_test, **score_kwgs)
         else:
@@ -594,10 +603,12 @@ def _score(estimator, X_test, y_test, scorer, is_multimetric=False, sample_weigh
     return score
 
 
-def _multimetric_score(estimator, X_test, y_test, scorers, sample_weight=None):
+def _multimetric_score(estimator, X_test, y_test, scorers,
+                       sample_weight=None):
     """Return a dict of score for multimetric scoring"""
     scores = {}
-    score_kwgs = {} if sample_weight is None else {'sample_weight': sample_weight}
+    score_kwgs = {} if sample_weight is None else \
+        {'sample_weight': sample_weight}
     for name, scorer in scorers.items():
         if y_test is None:
             score = scorer(estimator, X_test, **score_kwgs)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #4632. Highly relevant to #4497. 


#### What does this implement/fix? Explain your changes.
Add `test_score_weight` option so that user can choose to pass in a sample weight string that is used in `fit_params` dictionary if user intends to get weighted cv test scores, or do nothing if user wants un-weighted test scores. This is very important to certain fields of research, e.g. finance. For now, it is silently default to un-weighted, which is a little undesirable.

#### Any other comments?
This supersedes #10800, which is closed. 