### PR TITLE
DOC add impute.rst to user guide

### DIFF
--- a/doc/data_transforms.rst
+++ b/doc/data_transforms.rst
@@ -28,6 +28,7 @@ scikit-learn.
     modules/pipeline
     modules/feature_extraction
     modules/preprocessing
+    modules/impute
     modules/unsupervised_reduction
     modules/random_projection
     modules/kernel_approximation

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -1,8 +1,10 @@
-
 .. _impute:
 
+============================
 Imputation of missing values
 ============================
+
+.. currentmodule:: sklearn.impute
 
 For various reasons, many real world datasets contain missing values, often
 encoded as blanks, NaNs or other placeholders. Such datasets however are


### PR DESCRIPTION
We recently add module `impute` and doc `impute.rst`, but it's not included in the contents of user guide.
Also resolves some broken links.