### PR TITLE
[MRG] Fix numpy.int overflow in make_classification

### DIFF
--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -161,6 +161,7 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
         raise ValueError("Number of informative, redundant and repeated "
                          "features must sum to less than the number of total"
                          " features")
+    # Use log2 to avoid overflow errors
     if n_informative < np.log2(n_classes * n_clusters_per_class):
         raise ValueError("n_classes * n_clusters_per_class must"
                          " be smaller or equal 2 ** n_informative")

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -161,7 +161,7 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
         raise ValueError("Number of informative, redundant and repeated "
                          "features must sum to less than the number of total"
                          " features")
-    if 2 ** int(n_informative) < n_classes * n_clusters_per_class:
+    if n_informative < np.log2(n_classes * n_clusters_per_class):
         raise ValueError("n_classes * n_clusters_per_class must"
                          " be smaller or equal 2 ** n_informative")
     if weights and len(weights) not in [n_classes, n_classes - 1]:

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -161,7 +161,7 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
         raise ValueError("Number of informative, redundant and repeated "
                          "features must sum to less than the number of total"
                          " features")
-    if 2 ** n_informative < n_classes * n_clusters_per_class:
+    if 2 ** int(n_informative) < n_classes * n_clusters_per_class:
         raise ValueError("n_classes * n_clusters_per_class must"
                          " be smaller or equal 2 ** n_informative")
     if weights and len(weights) not in [n_classes, n_classes - 1]:

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -85,7 +85,7 @@ def test_make_classification_informative_features():
                                                          (2, [1/2] * 2, 2),
                                                          (2, [3/4, 1/4], 2),
                                                          (10, [1/3] * 3, 10),
-                                                         (np.array(64), [1], 1)
+                                                         (np.int(64), [1], 1)
                                                          ]:
         n_classes = len(weights)
         n_clusters = n_classes * n_clusters_per_class
@@ -129,9 +129,10 @@ def test_make_classification_informative_features():
             for cluster in range(len(unique_signs)):
                 centroid = X[cluster_index == cluster].mean(axis=0)
                 if hypercube:
-                    assert_array_almost_equal(np.abs(centroid),
-                                              [class_sep] * n_informative,
-                                              decimal=0,
+                    assert_array_almost_equal(np.abs(centroid) / class_sep,
+                                              np.array([class_sep] \
+                                              * n_informative) / class_sep,
+                                              decimal=5,
                                               err_msg="Clusters are not "
                                                       "centered on hypercube "
                                                       "vertices")

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -84,7 +84,8 @@ def test_make_classification_informative_features():
                                                          (2, [1/4] * 4, 1),
                                                          (2, [1/2] * 2, 2),
                                                          (2, [3/4, 1/4], 2),
-                                                         (10, [1/3] * 3, 10)
+                                                         (10, [1/3] * 3, 10),
+                                                         (np.array(64), [1], 1)
                                                          ]:
         n_classes = len(weights)
         n_clusters = n_classes * n_clusters_per_class

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -130,7 +130,7 @@ def test_make_classification_informative_features():
                 centroid = X[cluster_index == cluster].mean(axis=0)
                 if hypercube:
                     assert_array_almost_equal(np.abs(centroid) / class_sep,
-                                              np.array([class_sep] \
+                                              np.array([class_sep]
                                               * n_informative) / class_sep,
                                               decimal=5,
                                               err_msg="Clusters are not "

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -130,8 +130,7 @@ def test_make_classification_informative_features():
                 centroid = X[cluster_index == cluster].mean(axis=0)
                 if hypercube:
                     assert_array_almost_equal(np.abs(centroid) / class_sep,
-                                              np.array([class_sep]
-                                              * n_informative) / class_sep,
+                                              np.ones(n_informative),
                                               decimal=5,
                                               err_msg="Clusters are not "
                                                       "centered on hypercube "
@@ -139,10 +138,10 @@ def test_make_classification_informative_features():
                 else:
                     assert_raises(AssertionError,
                                   assert_array_almost_equal,
-                                  np.abs(centroid),
-                                  [class_sep] * n_informative,
-                                  decimal=0,
-                                  err_msg="Clusters should not be cenetered "
+                                  np.abs(centroid) / class_sep,
+                                  np.ones(n_informative),
+                                  decimal=5,
+                                  err_msg="Clusters should not be centered "
                                           "on hypercube vertices")
 
     assert_raises(ValueError, make, n_features=2, n_informative=2, n_classes=5,


### PR DESCRIPTION
The sample generator `make_classification()` raises misleading errors on certain valid inputs.

#### What does this implement/fix? Explain your changes.

The sample generator `make_classification()` checks its parameters,
e.g. `2 ** n_informative < n_classes * n_clusters_per_class`.

If `n_informative` is given as numpy.int with a value of 64 or larger,
`2 ** n_informative` evaluates to 0, and the check fails with a misleading error message.

Casting to Python int() avoids this issue.

#### Reproduce the error
```python
>>> import numpy as np
>>> from sklearn.datasets import make_classification 
>>> N_INFORMATIVE = np.arange(31, 65)
>>> for n_informative in N_INFORMATIVE:
>>>      print(f'n_informative = {n_informative}, 2 ** n_informative = {2 ** n_informative}')
>>>      make_classification(n_features=100, 
>>>          n_informative=n_informative, n_classes=2, n_clusters_per_class=1)
```

#### Any other comments?
`2. ** n_informative` would also do the trick.