### PR TITLE
MAINT: fix to enable Cython 0.28 to build extended_mutual_info.pyx

### DIFF
--- a/sklearn/metrics/cluster/setup.py
+++ b/sklearn/metrics/cluster/setup.py
@@ -1,3 +1,4 @@
+
 import os
 
 import numpy
@@ -5,7 +6,7 @@ from numpy.distutils.misc_util import Configuration
 
 
 def configuration(parent_package="", top_path=None):
-    config = Configuration("metrics.cluster", parent_package, top_path)
+    config = Configuration("cluster", parent_package, top_path)
     libraries = []
     if os.name == 'posix':
         libraries.append('m')

--- a/sklearn/metrics/cluster/setup.py
+++ b/sklearn/metrics/cluster/setup.py
@@ -1,4 +1,3 @@
-
 import os
 
 import numpy

--- a/sklearn/metrics/setup.py
+++ b/sklearn/metrics/setup.py
@@ -14,6 +14,7 @@ def configuration(parent_package="", top_path=None):
     if os.name == 'posix':
         cblas_libs.append('m')
 
+    config.add_subpackage('cluster')
     config.add_extension("pairwise_fast",
                          sources=["pairwise_fast.pyx"],
                          include_dirs=[os.path.join('..', 'src', 'cblas'),

--- a/sklearn/setup.py
+++ b/sklearn/setup.py
@@ -53,7 +53,6 @@ def configuration(parent_package='', top_path=None):
     config.add_subpackage('feature_extraction')
     config.add_subpackage('manifold')
     config.add_subpackage('metrics')
-    config.add_subpackage('metrics/cluster')
     config.add_subpackage('neighbors')
     config.add_subpackage('tree')
     config.add_subpackage('svm')


### PR DESCRIPTION
With update of Cython from 0.27.3 to 0.28 compiling cythonized source of `extended_mutual_info.pyx` in 1.0.0 sources started failing with the error that the module with name `sklearn.metrics/cluster.` in it could not be found.

Applying the proposed fix allowed the compilation to proceed as expected.

