### PR TITLE
Changed the description of init='random' #10849

### DIFF
--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -191,8 +191,8 @@ def k_means(X, n_clusters, init='k-means++', precompute_distances='auto',
         clustering in a smart way to speed up convergence. See section
         Notes in k_init for more details.
 
-        'random': generate k centroids from a Gaussian with mean and
-        variance estimated from the data.
+        'random': choose k observations (rows) at random from data for
+        the initial centroids.
 
         If an ndarray is passed, it should be of shape (n_clusters, n_features)
         and gives the initial centers.
@@ -445,8 +445,8 @@ def _kmeans_single_lloyd(X, n_clusters, max_iter=300, init='k-means++',
         clustering in a smart way to speed up convergence. See section
         Notes in k_init for more details.
 
-        'random': generate k centroids from a Gaussian with mean and
-        variance estimated from the data.
+        'random': choose k observations (rows) at random from data for
+        the initial centroids.
 
         If an ndarray is passed, it should be of shape (k, p) and gives
         the initial centers.


### PR DESCRIPTION
Fixes #10849 
The description of init='random' is consistent across `KMeans`, `MiniBatchKMeans`, `k_means` and `_kmeans_single_lloyd`. This fixes issue #10849 

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
