### PR TITLE
[MRG+2] Fix Support sample_weight in label_ranking_average_precision_score

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -195,6 +195,9 @@ Metrics
 - :func:`metrics.roc_auc_score` now supports binary ``y_true`` other than
   ``{0, 1}`` or ``{-1, 1}``. :issue:`9828` by :user:`Hanmin Qin <qinhanmin2014>`.
 
+- :func:`label_ranking_average_precision_score` now supports vector ``sample_weight``
+  :issue:`10845` by :user:`Jose Perez-Parras Toledano <jopepato>`.
+
 Linear, kernelized and related models
 
 - Deprecate ``random_state`` parameter in :class:`svm.OneClassSVM` as the

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -195,7 +195,7 @@ Metrics
 - :func:`metrics.roc_auc_score` now supports binary ``y_true`` other than
   ``{0, 1}`` or ``{-1, 1}``. :issue:`9828` by :user:`Hanmin Qin <qinhanmin2014>`.
 
-- :func:`label_ranking_average_precision_score` now supports vector ``sample_weight``
+- :func:`metrics.label_ranking_average_precision_score` now supports vector ``sample_weight``.
   :issue:`10845` by :user:`Jose Perez-Parras Toledano <jopepato>`.
 
 Linear, kernelized and related models

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -725,7 +725,7 @@ def label_ranking_average_precision_score(y_true, y_score, sample_weight=None):
         out /= n_samples
     else:
         out /= np.sum(sample_weight)
-    
+
     return out
 
 

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -715,11 +715,9 @@ def label_ranking_average_precision_score(y_true, y_score, sample_weight=None):
         rank = rankdata(scores_i, 'max')[relevant]
         L = rankdata(scores_i[relevant], 'max')
         aux = (L / rank).mean()
-        if sample_weight is None:
-            out += aux
-        else:
-            aux = aux * sample_weight[i]
-            out += aux
+        if sample_weight is not None:
+            aux = aux * sample_weight[i]    
+        out += aux
 
     if sample_weight is None:
         out /= n_samples

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -714,15 +714,17 @@ def label_ranking_average_precision_score(y_true, y_score, sample_weight=None):
         scores_i = y_score[i]
         rank = rankdata(scores_i, 'max')[relevant]
         L = rankdata(scores_i[relevant], 'max')
-        out += (L / rank).mean()
-    
-    out /= n_samples
-    if sample_weight != None:
-        aux = 0.0
-        for weight in sample_weight:
-            aux += weight
-            out = out*weight
-        out /= aux
+        aux = (L / rank).mean()
+        if sample_weight is None:
+            out += aux
+        else:
+            aux = aux * sample_weight[i]
+            out += aux
+
+    if sample_weight is None:
+        out /= n_samples
+    else:
+        out /= np.sum(sample_weight)
     
     return out
 

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -639,7 +639,7 @@ def roc_curve(y_true, y_score, pos_label=None, sample_weight=None,
     return fpr, tpr, thresholds
 
 
-def label_ranking_average_precision_score(y_true, y_score):
+def label_ranking_average_precision_score(y_true, y_score, sample_weight=None):
     """Compute ranking-based average precision
 
     Label ranking average precision (LRAP) is the average over each ground
@@ -664,6 +664,9 @@ def label_ranking_average_precision_score(y_true, y_score):
         class, confidence values, or non-thresholded measure of decisions
         (as returned by "decision_function" on some classifiers).
 
+    sample_weight : array-like of shape = [n_samples], optional
+        Sample weights.
+
     Returns
     -------
     score : float
@@ -682,6 +685,7 @@ def label_ranking_average_precision_score(y_true, y_score):
     check_consistent_length(y_true, y_score)
     y_true = check_array(y_true, ensure_2d=False)
     y_score = check_array(y_score, ensure_2d=False)
+    check_consistent_length(y_true, y_score, sample_weight)
 
     if y_true.shape != y_score.shape:
         raise ValueError("y_true and y_score have different shape")
@@ -712,7 +716,7 @@ def label_ranking_average_precision_score(y_true, y_score):
         L = rankdata(scores_i[relevant], 'max')
         out += (L / rank).mean()
 
-    return out / n_samples
+    return np.average(out / n_samples, weights=sample_weight)
 
 
 def coverage_error(y_true, y_score, sample_weight=None):

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -715,8 +715,16 @@ def label_ranking_average_precision_score(y_true, y_score, sample_weight=None):
         rank = rankdata(scores_i, 'max')[relevant]
         L = rankdata(scores_i[relevant], 'max')
         out += (L / rank).mean()
-
-    return np.average(out / n_samples, weights=sample_weight)
+    
+    out /= n_samples
+    if sample_weight != None:
+        aux = 0.0
+        for weight in sample_weight:
+            aux += weight
+            out = out*weight
+        out /= aux
+    
+    return out
 
 
 def coverage_error(y_true, y_score, sample_weight=None):

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -716,7 +716,7 @@ def label_ranking_average_precision_score(y_true, y_score, sample_weight=None):
         L = rankdata(scores_i[relevant], 'max')
         aux = (L / rank).mean()
         if sample_weight is not None:
-            aux = aux * sample_weight[i]    
+            aux = aux * sample_weight[i]
         out += aux
 
     if sample_weight is None:

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -682,10 +682,9 @@ def label_ranking_average_precision_score(y_true, y_score, sample_weight=None):
     0.416...
 
     """
-    check_consistent_length(y_true, y_score)
+    check_consistent_length(y_true, y_score, sample_weight)
     y_true = check_array(y_true, ensure_2d=False)
     y_score = check_array(y_score, ensure_2d=False)
-    check_consistent_length(y_true, y_score, sample_weight)
 
     if y_true.shape != y_score.shape:
         raise ValueError("y_true and y_score have different shape")

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -306,6 +306,7 @@ THRESHOLDED_MULTILABEL_METRICS = [
     "macro_average_precision_score",
 
     "coverage_error", "label_ranking_loss",
+    "label_ranking_average_precision_score",
 ]
 
 # Classification metrics with  "multilabel-indicator" format


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #10845 and resolves #10840 

#### What does this implement/fix? Explain your changes.
It adds the sample_weight parameter in the function label_ranking_average_precision_score for metrics

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
