### PR TITLE
Fix typo in sparsfuncs.py and sparsfuncs_fast.pyx

### DIFF
--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -104,7 +104,7 @@ def incr_mean_variance_axis(X, axis, last_mean, last_var, last_n):
     CSC matrix.
 
     last_mean, last_var are the statistics computed at the last step by this
-    function. Both must be initilized to 0-arrays of the proper size, i.e.
+    function. Both must be initialized to 0-arrays of the proper size, i.e.
     the number of features in X. last_n is the number of samples encountered
     until now.
 

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -201,7 +201,7 @@ def incr_mean_variance_axis0(X, last_mean, last_var, unsigned long last_n):
     """Compute mean and variance along axis 0 on a CSR or CSC matrix.
 
     last_mean, last_var are the statistics computed at the last step by this
-    function. Both must be initilized to 0.0. last_n is the
+    function. Both must be initialized to 0.0. last_n is the
     number of samples encountered until now and is initialized at 0.
 
     Parameters


### PR DESCRIPTION
Spelling correction: 'initialized' instead of 'initilized'

