### PR TITLE
[MRG + 1] Fix cluster coloring in example

### DIFF
--- a/examples/cluster/plot_cluster_comparison.py
+++ b/examples/cluster/plot_cluster_comparison.py
@@ -168,7 +168,9 @@ for i_dataset, (dataset, algo_params) in enumerate(datasets):
         colors = np.array(list(islice(cycle(['#377eb8', '#ff7f00', '#4daf4a',
                                              '#f781bf', '#a65628', '#984ea3',
                                              '#999999', '#e41a1c', '#dede00']),
-                                      int(max(y_pred) + 2))))
+                                      int(max(y_pred) + 1))))
+        # add black color for outliers (if any)
+        colors = np.append(colors, ["#000000"])
         plt.scatter(X[:, 0], X[:, 1], s=10, color=colors[y_pred])
 
         plt.xlim(-2.5, 2.5)

--- a/examples/cluster/plot_cluster_comparison.py
+++ b/examples/cluster/plot_cluster_comparison.py
@@ -168,7 +168,7 @@ for i_dataset, (dataset, algo_params) in enumerate(datasets):
         colors = np.array(list(islice(cycle(['#377eb8', '#ff7f00', '#4daf4a',
                                              '#f781bf', '#a65628', '#984ea3',
                                              '#999999', '#e41a1c', '#dede00']),
-                                      int(max(y_pred) + 1))))
+                                      int(max(y_pred) + 2))))
         plt.scatter(X[:, 0], X[:, 1], s=10, color=colors[y_pred])
 
         plt.xlim(-2.5, 2.5)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10874 

#### What does this implement/fix? Explain your changes.
Increases the size of the colors array by `1` to take outliers labeled `-1` into account and avoid them being labeled as another cluster.