### PR TITLE
[MRG+1] Fix scipy-dev-wheels build because numpy.core.umath_tests has been renamed

### DIFF
--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -26,7 +26,6 @@ The module structure is the following:
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
-from numpy.core.umath_tests import inner1d
 
 from .base import BaseEnsemble
 from ..base import ClassifierMixin, RegressorMixin, is_regressor, is_classifier
@@ -522,8 +521,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
 
         # Boost weight using multi-class AdaBoost SAMME.R alg
         estimator_weight = (-1. * self.learning_rate
-                                * (((n_classes - 1.) / n_classes) *
-                                   inner1d(y_coding, np.log(y_predict_proba))))
+                            * ((n_classes - 1.) / n_classes)
+                            * (y_coding * np.log(y_predict_proba)).sum(axis=1))
 
         # Only boost the weights if it will fit again
         if not iboost == self.n_estimators - 1:


### PR DESCRIPTION
Our scipy-dev-wheels has been broken for 2 days, see for example this [one](https://travis-ci.org/scikit-learn/scikit-learn/builds/358788542#L2020). 

numpy.core.umath_tests has been moved to private modules in numpy dev. See https://github.com/numpy/numpy/issues/10815 where I added more details.

It seems like inner1d can be replaced by using standard constructs. I ran the tests to make sure that the results from inner1d were matching the ones in this PR (they do match according to assert_allclose not assert_array_equal).

Travis Cron [job](https://travis-ci.org/lesteve/scikit-learn/builds/359323576) running on my fork, which is the only way to make sure that the Cron job will get fixed by this PR (the CI statuses in this PR just make sure that I did not break anything but do not test that I fixed the scipy-dev-wheels build). 