### PR TITLE
[MRG] improve separator in PolynomialFeatures.get_feature_names

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1308,7 +1308,7 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         for row in powers:
             inds = np.where(row)[0]
             if len(inds):
-                name = " ".join("%s^%d" % (input_features[ind], exp)
+                name = "*".join("%s^%d" % (input_features[ind], exp)
                                 if exp != 1 else input_features[ind]
                                 for ind, exp in zip(inds, row[inds]))
             else:

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -139,16 +139,16 @@ def test_polynomial_feature_names():
     X = np.arange(30).reshape(10, 3)
     poly = PolynomialFeatures(degree=2, include_bias=True).fit(X)
     feature_names = poly.get_feature_names()
-    assert_array_equal(['1', 'x0', 'x1', 'x2', 'x0^2', 'x0 x1',
-                        'x0 x2', 'x1^2', 'x1 x2', 'x2^2'],
+    assert_array_equal(['1', 'x0', 'x1', 'x2', 'x0^2', 'x0*x1',
+                        'x0*x2', 'x1^2', 'x1*x2', 'x2^2'],
                        feature_names)
 
     poly = PolynomialFeatures(degree=3, include_bias=False).fit(X)
     feature_names = poly.get_feature_names(["a", "b", "c"])
-    assert_array_equal(['a', 'b', 'c', 'a^2', 'a b', 'a c', 'b^2',
-                        'b c', 'c^2', 'a^3', 'a^2 b', 'a^2 c',
-                        'a b^2', 'a b c', 'a c^2', 'b^3', 'b^2 c',
-                        'b c^2', 'c^3'], feature_names)
+    assert_array_equal(['a', 'b', 'c', 'a^2', 'a*b', 'a*c', 'b^2',
+                        'b*c', 'c^2', 'a^3', 'a^2*b', 'a^2*c',
+                        'a*b^2', 'a*b*c', 'a*c^2', 'b^3', 'b^2*c',
+                        'b*c^2', 'c^3'], feature_names)
     # test some unicode
     poly = PolynomialFeatures(degree=1, include_bias=True).fit(X)
     feature_names = poly.get_feature_names(


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes  #10742

#### What does this implement/fix? Explain your changes.
When the feature names contain whitespaces, like the column `"A B"` in the example below  the output of the get_feature_names method is ambiguous, e.g `['1', 'A B', 'C', 'D', 'A B^2', 'A B C', 'A B D', 'C^2', 'C D', 'D^2']`, i.e we can't differentiate between whitespaces used to denote multiplication and those within the feature name. 

Here's the full example: 

```
>>> import pandas as pd 
>>> df = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]], columns=["A B", "C", "D"])
>>> df
   A B  C  D
0    1  2  3
1    4  5  6
2    7  8  9
>>> from sklearn.preprocessing import PolynomialFeatures
>>> poly = PolynomialFeatures(2)
>>> poly.fit(df)
PolynomialFeatures(degree=2, include_bias=True, interaction_only=False)
>>> poly.transform(df)
array([[  1.,   1.,   2.,   3.,   1.,   2.,   3.,   4.,   6.,   9.],
       [  1.,   4.,   5.,   6.,  16.,  20.,  24.,  25.,  30.,  36.],
       [  1.,   7.,   8.,   9.,  49.,  56.,  63.,  64.,  72.,  81.]])
>>> poly.get_feature_names() 
['1', 'x0', 'x1', 'x2', 'x0^2', 'x0 x1', 'x0 x2', 'x1^2', 'x1 x2', 'x2^2']
>>> poly.get_feature_names(input_features=df.columns.tolist()) 
['1', 'A B', 'C', 'D', 'A B^2', 'A B C', 'A B D', 'C^2', 'C D', 'D^2']

```

This PR changes the separator to `"*"` instead of a whitespace, thus removing the ambiguity: 
```
>>> poly.get_feature_names(input_features=df.columns.tolist())
['1', 'A B', 'C', 'D', 'A B^2', 'A B*C', 'A B*D', 'C^2', 'C*D', 'D^2']
```