### PR TITLE
[MRG+1] Parallel radius neighbors

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -142,12 +142,21 @@ Classifiers and regressors
   only require X to be an object with finite length or shape.
   :issue:`9832` by :user:`Vrishank Bhardwaj <vrishank97>`.
 
+- :class:`neighbors.RadiusNeighborsRegressor` and 
+  :class:`neighbors.RadiusNeighborsClassifier` are now
+  parallelized according to ``n_jobs`` regardless of ``algorithm``.
+  :issue:`8003` by :user:`Joël Billaud <recamshak>`.
+
 Cluster
 
 - :class:`cluster.KMeans`, :class:`cluster.MiniBatchKMeans` and
   :func:`cluster.k_means` passed with ``algorithm='full'`` now enforces
   row-major ordering, improving runtime.
   :issue:`10471` by :user:`Gaurav Dhingra <gxyd>`.
+
+- :class:`cluster.DBSCAN` now is parallelized according to ``n_jobs``
+  regardless of ``algorithm``.
+  :issue:`8003` by :user:`Joël Billaud <recamshak>`.
 
 Datasets
 

--- a/sklearn/neighbors/ball_tree.pyx
+++ b/sklearn/neighbors/ball_tree.pyx
@@ -105,7 +105,7 @@ cdef inline DTYPE_t max_dist(BinaryTree tree, ITYPE_t i_node,
 
 
 cdef inline int min_max_dist(BinaryTree tree, ITYPE_t i_node, DTYPE_t* pt,
-                             DTYPE_t* min_dist, DTYPE_t* max_dist) except -1:
+                             DTYPE_t* min_dist, DTYPE_t* max_dist) nogil except -1:
     """Compute the minimum and maximum distance between a point and a node"""
     cdef DTYPE_t dist_pt = tree.dist(pt, &tree.node_bounds[0, i_node, 0],
                                      tree.data.shape[1])

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -1503,9 +1503,9 @@ cdef class BinaryTree:
                 distances_npy = np.zeros(Xarr.shape[0], dtype='object')
                 for i in range(Xarr.shape[0]):
                     indices_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_INTP, indices[i])
-                    #indices_npy[i].flags |= np.NPY_ARRAY_OWNDATA
+                    np.PyArray_UpdateFlags(indices_npy[i], indices_npy[i].flags.num | np.NPY_OWNDATA)
                     distances_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_DOUBLE, distances[i])
-                    #distances_npy[i].flags |= np.NPY_ARRAY_OWNDATA
+                    np.PyArray_UpdateFlags(distances_npy[i], distances_npy[i].flags.num | np.NPY_OWNDATA)
 
                 return (indices_npy.reshape(X.shape[:X.ndim - 1]),
                         distances_npy.reshape(X.shape[:X.ndim - 1]))
@@ -1513,7 +1513,7 @@ cdef class BinaryTree:
                 indices_npy = np.zeros(Xarr.shape[0], dtype='object')
                 for i in range(Xarr.shape[0]):
                     indices_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_INTP, indices[i])
-                    #indices_npy[i].flags |= np.NPY_ARRAY_OWNDATA
+                    np.PyArray_UpdateFlags(indices_npy[i], indices_npy[i].flags.num | np.NPY_OWNDATA)
 
                 return indices_npy.reshape(X.shape[:X.ndim - 1])
         finally:

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -1502,7 +1502,7 @@ cdef class BinaryTree:
                 indices_npy = np.zeros(Xarr.shape[0], dtype='object')
                 distances_npy = np.zeros(Xarr.shape[0], dtype='object')
                 for i in range(Xarr.shape[0]):
-                    indices_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_INT64, indices[i])
+                    indices_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_LONG, indices[i])
                     #indices_npy[i].flags |= np.NPY_ARRAY_OWNDATA
                     distances_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_DOUBLE, distances[i])
                     #distances_npy[i].flags |= np.NPY_ARRAY_OWNDATA
@@ -1512,7 +1512,7 @@ cdef class BinaryTree:
             else:
                 indices_npy = np.zeros(Xarr.shape[0], dtype='object')
                 for i in range(Xarr.shape[0]):
-                    indices_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_INT64, indices[i])
+                    indices_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_LONG, indices[i])
                     #indices_npy[i].flags |= np.NPY_ARRAY_OWNDATA
 
                 return indices_npy.reshape(X.shape[:X.ndim - 1])

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -1466,7 +1466,7 @@ cdef class BinaryTree:
                 pt += n_features
 
                 if count_only:
-                    pass
+                    continue
 
                 if sort_results:
                     _simultaneous_sort(&dist_arr_i[0], &idx_arr_i[0],

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -144,6 +144,8 @@
 cimport cython
 cimport numpy as np
 from libc.math cimport fabs, sqrt, exp, cos, pow, log
+from libc.stdlib cimport calloc, malloc, free
+from libc.string cimport memcpy
 from sklearn.utils.lgamma cimport lgamma
 
 import numpy as np
@@ -155,6 +157,8 @@ from typedefs import DTYPE, ITYPE
 
 from dist_metrics cimport (DistanceMetric, euclidean_dist, euclidean_rdist,
                            euclidean_dist_to_rdist, euclidean_rdist_to_dist)
+
+np.import_array()
 
 # some handy constants
 cdef DTYPE_t INF = np.inf
@@ -545,7 +549,7 @@ cdef inline void swap(DITYPE_t* arr, ITYPE_t i1, ITYPE_t i2):
 
 
 cdef inline void dual_swap(DTYPE_t* darr, ITYPE_t* iarr,
-                           ITYPE_t i1, ITYPE_t i2):
+                           ITYPE_t i1, ITYPE_t i2) nogil:
     """swap the values at inex i1 and i2 of both darr and iarr"""
     cdef DTYPE_t dtmp = darr[i1]
     darr[i1] = darr[i2]
@@ -670,7 +674,7 @@ cdef class NeighborsHeap:
 
 
 cdef int _simultaneous_sort(DTYPE_t* dist, ITYPE_t* idx,
-                            ITYPE_t size) except -1:
+                            ITYPE_t size) nogil except -1:
     """
     Perform a recursive quicksort on the dist array, simultaneously
     performing the same swaps on the idx array.  The equivalent in
@@ -1341,7 +1345,7 @@ cdef class BinaryTree:
         else:
             return indices.reshape(X.shape[:X.ndim - 1] + (k,))
 
-    def query_radius(self, X, r, return_distance=False,
+    def query_radius(self, X, r, int return_distance=False,
                      int count_only=False, int sort_results=False):
         """
         query_radius(self, X, r, count_only = False):
@@ -1406,6 +1410,8 @@ cdef class BinaryTree:
         cdef DTYPE_t[::1] dist_arr_i
         cdef ITYPE_t[::1] idx_arr_i, counts
         cdef DTYPE_t* pt
+        cdef ITYPE_t** indices = NULL
+        cdef DTYPE_t** distances = NULL
 
         # validate X and prepare for query
         X = check_array(X, dtype=DTYPE, order='C')
@@ -1429,11 +1435,15 @@ cdef class BinaryTree:
         rarr_np = r.reshape(-1)  # store explicitly to keep in scope
         cdef DTYPE_t[::1] rarr = get_memview_DTYPE_1D(rarr_np)
 
-        # prepare variables for iteration
         if not count_only:
-            indices = np.zeros(Xarr.shape[0], dtype='object')
+            indices = <ITYPE_t**>calloc(Xarr.shape[0], sizeof(ITYPE_t*))
+            if indices == NULL:
+                raise MemoryError()
             if return_distance:
-                distances = np.zeros(Xarr.shape[0], dtype='object')
+                distances = <DTYPE_t**>calloc(Xarr.shape[0], sizeof(DTYPE_t*))
+                if distances == NULL:
+                    free(indices)
+                    raise MemoryError()
 
         np_idx_arr = np.zeros(self.data.shape[0], dtype=ITYPE)
         idx_arr_i = get_memview_ITYPE_1D(np_idx_arr)
@@ -1445,33 +1455,73 @@ cdef class BinaryTree:
         counts = get_memview_ITYPE_1D(counts_arr)
 
         pt = &Xarr[0, 0]
-        for i in range(Xarr.shape[0]):
-            counts[i] = self._query_radius_single(0, pt, rarr[i],
-                                                  &idx_arr_i[0],
-                                                  &dist_arr_i[0],
-                                                  0, count_only,
-                                                  return_distance)
-            pt += n_features
+        memory_error = False
+        with nogil:
+            for i in range(Xarr.shape[0]):
+                counts[i] = self._query_radius_single(0, pt, rarr[i],
+                                                      &idx_arr_i[0],
+                                                      &dist_arr_i[0],
+                                                      0, count_only,
+                                                      return_distance)
+                pt += n_features
 
-            if count_only:
-                pass
-            else:
+                if count_only:
+                    pass
+
                 if sort_results:
                     _simultaneous_sort(&dist_arr_i[0], &idx_arr_i[0],
                                        counts[i])
 
-                indices[i] = np_idx_arr[:counts[i]].copy()
+                indices[i] = <ITYPE_t*>malloc(counts[i] * sizeof(ITYPE_t))
+                if indices[i] == NULL:
+                    memory_error = True
+                    break
+                memcpy(indices[i], &idx_arr_i[0], counts[i] * sizeof(ITYPE_t))
+
                 if return_distance:
-                    distances[i] = np_dist_arr[:counts[i]].copy()
+                    distances[i] = <DTYPE_t*>malloc(counts[i] * sizeof(DTYPE_t))
+                    if distances[i] == NULL:
+                        memory_error = True
+                        break
+                    memcpy(distances[i], &dist_arr_i[0], counts[i] * sizeof(DTYPE_t))
+
+        if memory_error:
+            for i in range(Xarr.shape[0]):
+                free(indices[i])
+                if return_distance:
+                    free(distances[i])
+            free(indices)
+            free(distances)
+            raise MemoryError()
 
         # deflatten results
-        if count_only:
-            return counts_arr.reshape(X.shape[:X.ndim - 1])
-        elif return_distance:
-            return (indices.reshape(X.shape[:X.ndim - 1]),
-                    distances.reshape(X.shape[:X.ndim - 1]))
-        else:
-            return indices.reshape(X.shape[:X.ndim - 1])
+        try:
+            if count_only:
+                return counts_arr.reshape(X.shape[:X.ndim - 1])
+            elif return_distance:
+                indices_npy = np.zeros(Xarr.shape[0], dtype='object')
+                distances_npy = np.zeros(Xarr.shape[0], dtype='object')
+                for i in range(Xarr.shape[0]):
+                    indices_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_INT64, indices[i])
+                    #indices_npy[i].flags |= np.NPY_ARRAY_OWNDATA
+                    distances_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_DOUBLE, distances[i])
+                    #distances_npy[i].flags |= np.NPY_ARRAY_OWNDATA
+
+                return (indices_npy.reshape(X.shape[:X.ndim - 1]),
+                        distances_npy.reshape(X.shape[:X.ndim - 1]))
+            else:
+                indices_npy = np.zeros(Xarr.shape[0], dtype='object')
+                for i in range(Xarr.shape[0]):
+                    indices_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_INT64, indices[i])
+                    #indices_npy[i].flags |= np.NPY_ARRAY_OWNDATA
+
+                return indices_npy.reshape(X.shape[:X.ndim - 1])
+        finally:
+            # FIXME: in case of an exception, some of the distances and indices might
+            #       not be owned by a numpy array and will leak.
+            free(indices)
+            free(distances)
+
 
     def kernel_density(self, X, h, kernel='gaussian',
                        atol=0, rtol=1E-8,
@@ -1971,7 +2021,7 @@ cdef class BinaryTree:
                                       DTYPE_t* distances,
                                       ITYPE_t count,
                                       int count_only,
-                                      int return_distance) except -1:
+                                      int return_distance) nogil except -1:
         """recursive single-tree radius query, depth-first"""
         cdef DTYPE_t* data = &self.data[0, 0]
         cdef ITYPE_t* idx_array = &self.idx_array[0]
@@ -1999,8 +2049,7 @@ cdef class BinaryTree:
             else:
                 for i in range(node_info.idx_start, node_info.idx_end):
                     if (count < 0) or (count >= self.data.shape[0]):
-                        raise ValueError("Fatal: count too big: "
-                                         "this should never happen")
+                        return -1
                     indices[count] = idx_array[i]
                     if return_distance:
                         distances[count] = self.dist(pt, (data + n_features
@@ -2019,8 +2068,7 @@ cdef class BinaryTree:
                                      n_features)
                 if dist_pt <= reduced_r:
                     if (count < 0) or (count >= self.data.shape[0]):
-                        raise ValueError("Fatal: count out of range. "
-                                         "This should never happen.")
+                        return -1
                     if count_only:
                         pass
                     else:

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -1502,7 +1502,7 @@ cdef class BinaryTree:
                 indices_npy = np.zeros(Xarr.shape[0], dtype='object')
                 distances_npy = np.zeros(Xarr.shape[0], dtype='object')
                 for i in range(Xarr.shape[0]):
-                    indices_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_LONG, indices[i])
+                    indices_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_INTP, indices[i])
                     #indices_npy[i].flags |= np.NPY_ARRAY_OWNDATA
                     distances_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_DOUBLE, distances[i])
                     #distances_npy[i].flags |= np.NPY_ARRAY_OWNDATA
@@ -1512,7 +1512,7 @@ cdef class BinaryTree:
             else:
                 indices_npy = np.zeros(Xarr.shape[0], dtype='object')
                 for i in range(Xarr.shape[0]):
-                    indices_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_LONG, indices[i])
+                    indices_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_INTP, indices[i])
                     #indices_npy[i].flags |= np.NPY_ARRAY_OWNDATA
 
                 return indices_npy.reshape(X.shape[:X.ndim - 1])

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -2023,7 +2023,7 @@ cdef class BinaryTree:
                                       DTYPE_t* distances,
                                       ITYPE_t count,
                                       int count_only,
-                                      int return_distance) nogil except -1:
+                                      int return_distance) nogil:
         """recursive single-tree radius query, depth-first"""
         cdef DTYPE_t* data = &self.data[0, 0]
         cdef ITYPE_t* idx_array = &self.idx_array[0]

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -289,6 +289,10 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
     metric_params : dict, optional (default = None)
         Additional keyword arguments for the metric function.
 
+    n_jobs : int, optional (default = 1)
+        The number of parallel jobs to run for neighbors search.
+        If ``-1``, then the number of jobs is set to the number of CPU cores.
+
     Examples
     --------
     >>> X = [[0], [1], [2], [3]]

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -317,12 +317,13 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
 
     def __init__(self, radius=1.0, weights='uniform',
                  algorithm='auto', leaf_size=30, p=2, metric='minkowski',
-                 outlier_label=None, metric_params=None, **kwargs):
+                 outlier_label=None, metric_params=None, n_jobs=1, **kwargs):
         super(RadiusNeighborsClassifier, self).__init__(
               radius=radius,
               algorithm=algorithm,
               leaf_size=leaf_size,
-              metric=metric, p=p, metric_params=metric_params, **kwargs)
+              metric=metric, p=p, metric_params=metric_params,
+              n_jobs=n_jobs, **kwargs)
         self.weights = _check_weights(weights)
         self.outlier_label = outlier_label
 

--- a/sklearn/neighbors/dist_metrics.pxd
+++ b/sklearn/neighbors/dist_metrics.pxd
@@ -39,7 +39,7 @@ cdef inline DTYPE_t euclidean_dist_to_rdist(DTYPE_t dist) nogil except -1:
     return dist * dist
 
 
-cdef inline DTYPE_t euclidean_rdist_to_dist(DTYPE_t dist) except -1:
+cdef inline DTYPE_t euclidean_rdist_to_dist(DTYPE_t dist) nogil except -1:
     return sqrt(dist)
 
 
@@ -72,6 +72,6 @@ cdef class DistanceMetric:
     cdef int cdist(self, DTYPE_t[:, ::1] X, DTYPE_t[:, ::1] Y,
                    DTYPE_t[:, ::1] D) except -1
 
-    cdef DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1
+    cdef DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) nogil except -1
 
     cdef DTYPE_t _dist_to_rdist(self, DTYPE_t dist) nogil except -1

--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -330,7 +330,7 @@ cdef class DistanceMetric:
                 D[i1, i2] = self.dist(&X[i1, 0], &Y[i2, 0], X.shape[1])
         return 0
 
-    cdef DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1:
+    cdef DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) nogil except -1:
         """Convert the reduced distance to the distance"""
         return rdist
 
@@ -418,7 +418,7 @@ cdef class EuclideanDistance(DistanceMetric):
                               ITYPE_t size) nogil except -1:
         return euclidean_rdist(x1, x2, size)
 
-    cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1:
+    cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) nogil except -1:
         return sqrt(rdist)
 
     cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) nogil except -1:
@@ -462,7 +462,7 @@ cdef class SEuclideanDistance(DistanceMetric):
                              ITYPE_t size) nogil except -1:
         return sqrt(self.rdist(x1, x2, size))
 
-    cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1:
+    cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) nogil except -1:
         return sqrt(rdist)
 
     cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) nogil except -1:
@@ -551,7 +551,7 @@ cdef class MinkowskiDistance(DistanceMetric):
                              ITYPE_t size) nogil except -1:
         return pow(self.rdist(x1, x2, size), 1. / self.p)
 
-    cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1:
+    cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) nogil except -1:
         return pow(rdist, 1. / self.p)
 
     cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) nogil except -1:
@@ -610,7 +610,7 @@ cdef class WMinkowskiDistance(DistanceMetric):
                              ITYPE_t size) nogil except -1:
         return pow(self.rdist(x1, x2, size), 1. / self.p)
 
-    cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1:
+    cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) nogil except -1:
         return pow(rdist, 1. / self.p)
 
     cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) nogil except -1:
@@ -683,7 +683,7 @@ cdef class MahalanobisDistance(DistanceMetric):
                              ITYPE_t size) nogil except -1:
         return sqrt(self.rdist(x1, x2, size))
 
-    cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1:
+    cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) nogil except -1:
         return sqrt(rdist)
 
     cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) nogil except -1:
@@ -998,7 +998,7 @@ cdef class HaversineDistance(DistanceMetric):
         return 2 * asin(sqrt(sin_0 * sin_0
                              + cos(x1[0]) * cos(x2[0]) * sin_1 * sin_1))
 
-    cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1:
+    cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) nogil except -1:
         return 2 * asin(sqrt(rdist))
 
     cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) nogil except -1:

--- a/sklearn/neighbors/kd_tree.pyx
+++ b/sklearn/neighbors/kd_tree.pyx
@@ -147,7 +147,7 @@ cdef DTYPE_t max_dist(BinaryTree tree, ITYPE_t i_node, DTYPE_t* pt) except -1:
 
 
 cdef inline int min_max_dist(BinaryTree tree, ITYPE_t i_node, DTYPE_t* pt,
-                             DTYPE_t* min_dist, DTYPE_t* max_dist) except -1:
+                             DTYPE_t* min_dist, DTYPE_t* max_dist) nogil except -1:
     """Compute the minimum and maximum distance between a point and a node"""
     cdef ITYPE_t n_features = tree.data.shape[1]
 

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -238,6 +238,10 @@ class RadiusNeighborsRegressor(NeighborsBase, RadiusNeighborsMixin,
     metric_params : dict, optional (default = None)
         Additional keyword arguments for the metric function.
 
+    n_jobs : int, optional (default = 1)
+        The number of parallel jobs to run for neighbors search.
+        If ``-1``, then the number of jobs is set to the number of CPU cores.
+
     Examples
     --------
     >>> X = [[0], [1], [2], [3]]

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -266,12 +266,14 @@ class RadiusNeighborsRegressor(NeighborsBase, RadiusNeighborsMixin,
 
     def __init__(self, radius=1.0, weights='uniform',
                  algorithm='auto', leaf_size=30,
-                 p=2, metric='minkowski', metric_params=None, **kwargs):
+                 p=2, metric='minkowski', metric_params=None, n_jobs=1,
+                 **kwargs):
         super(RadiusNeighborsRegressor, self).__init__(
               radius=radius,
               algorithm=algorithm,
               leaf_size=leaf_size,
-              p=p, metric=metric, metric_params=metric_params, **kwargs)
+              p=p, metric=metric, metric_params=metric_params,
+              n_jobs=n_jobs, **kwargs)
         self.weights = _check_weights(weights)
 
     def predict(self, X):

--- a/sklearn/neighbors/unsupervised.py
+++ b/sklearn/neighbors/unsupervised.py
@@ -77,7 +77,6 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
     n_jobs : int, optional (default = 1)
         The number of parallel jobs to run for neighbors search.
         If ``-1``, then the number of jobs is set to the number of CPU cores.
-        Affects only :meth:`kneighbors` and :meth:`kneighbors_graph` methods.
 
     Examples
     --------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #8003


#### What does this implement/fix? Explain your changes.

This makes `RadiusNeighborsMixin.radius_neighbors` honor the `n_jobs` argument and split the queries among processors. This also makes `query_radius` GIL-free so that it is actually faster than single thread.

TODO:
- [x] fix memory leak by making the indices and distances array own the data
- [x] fix Windows 32bits issue
- [x] write tests
- [x] run some benchmark

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
