### PR TITLE
[MRG] Force scores with 0 weights to be 0 in _average_binary_score.

### DIFF
--- a/sklearn/metrics/base.py
+++ b/sklearn/metrics/base.py
@@ -119,6 +119,9 @@ def _average_binary_score(binary_metric, y_true, y_score, average,
 
     # Average the results
     if average is not None:
+        # Scores with 0 weights are forced to be 0, preventing the average score from being affected by...
+        # 0-weighted NaN elements.
+        score[average_weight == 0] = 0
         return np.average(score, weights=average_weight)
     else:
         return score

--- a/sklearn/metrics/base.py
+++ b/sklearn/metrics/base.py
@@ -119,8 +119,8 @@ def _average_binary_score(binary_metric, y_true, y_score, average,
 
     # Average the results
     if average is not None:
-        # Scores with 0 weights are forced to be 0, preventing the average score from being affected by...
-        # 0-weighted NaN elements.
+        # Scores with 0 weights are forced to be 0, preventing the average
+        # score from being affected by 0-weighted NaN elements.
         score[average_weight == 0] = 0
         return np.average(score, weights=average_weight)
     else:


### PR DESCRIPTION
Some metrics can produce NaN scores which are however 0-weighted (e.g. PR curve score calculated on class with no positive ground truth samples in the batch). When directly taking weighted average of them, the NaN scores can cause the average score to be NaN, even if they are 0-weighted.

To prevent this, before taking the average, we force the scores with 0 weight to be 0, so that they will not pose effect on the final average score.