### PR TITLE
[MRG] Mentioned that Calinski-Harabasz score is also known as Variance Rati…

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -1527,8 +1527,8 @@ Calinski-Harabaz Index
 ----------------------
 
 If the ground truth labels are not known, the Calinski-Harabaz index
-(:func:`sklearn.metrics.calinski_harabaz_score`), also known as the Variance 
-Ratio Criterion, can be used to evaluate the model, where a higher 
+(:func:`sklearn.metrics.calinski_harabaz_score`) - also known as the Variance 
+Ratio Criterion - can be used to evaluate the model, where a higher 
 Calinski-Harabaz score relates to a model with better defined clusters.
 
 For :math:`k` clusters, the Calinski-Harabaz score :math:`s` is given as the

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -1527,9 +1527,9 @@ Calinski-Harabaz Index
 ----------------------
 
 If the ground truth labels are not known, the Calinski-Harabaz index
-(:func:`sklearn.metrics.calinski_harabaz_score`) can be used to evaluate the
-model, where a higher Calinski-Harabaz score relates to a model with better
-defined clusters.
+(:func:`sklearn.metrics.calinski_harabaz_score`), also known as the Variance 
+Ratio Criterion, can be used to evaluate the model, where a higher 
+Calinski-Harabaz score relates to a model with better defined clusters.
 
 For :math:`k` clusters, the Calinski-Harabaz score :math:`s` is given as the
 ratio of the between-clusters dispersion mean and the within-cluster

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -209,7 +209,8 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
 
 
 def calinski_harabaz_score(X, labels):
-    """Compute the Calinski and Harabaz score, also known as the Variance Ratio Criterion.
+    """Compute the Calinski and Harabaz score, also known as the Variance Ratio
+    Criterion.
 
     The score is defined as ratio between the within-cluster dispersion and
     the between-cluster dispersion.

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -209,8 +209,8 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
 
 
 def calinski_harabaz_score(X, labels):
-    """Compute the Calinski and Harabaz score, also known as the Variance Ratio
-    Criterion.
+    """Compute the Calinski and Harabaz score.
+    It is also known as the Variance Ratio Criterion.
 
     The score is defined as ratio between the within-cluster dispersion and
     the between-cluster dispersion.

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -209,7 +209,7 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
 
 
 def calinski_harabaz_score(X, labels):
-    """Compute the Calinski and Harabaz score.
+    """Compute the Calinski and Harabaz score, also known as the Variance Ratio Criterion.
 
     The score is defined as ratio between the within-cluster dispersion and
     the between-cluster dispersion.

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -210,6 +210,7 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
 
 def calinski_harabaz_score(X, labels):
     """Compute the Calinski and Harabaz score.
+
     It is also known as the Variance Ratio Criterion.
 
     The score is defined as ratio between the within-cluster dispersion and


### PR DESCRIPTION
…o Criterion in unsupervised.py and clustering.rst

#### Reference Issues/PRs
Fixes documentation #10879 

#### What does this implement/fix? Explain your changes.
Mentioned that Calinski-Harabasz is also known as Variance Ratio Criterion. Modified 2 files, the changes will appear in [sklearn/metrics/cluster/unsupervised.py](http://scikit-learn.org/stable/modules/generated/sklearn.metrics.calinski_harabaz_score.html#sklearn.metrics.calinski_harabaz_score) and in [doc/modules/clustering.rst](http://scikit-learn.org/stable/modules/clustering.html#calinski-harabaz-index)

#### Any other comments?
[SoonaMata](https://github.com/SoonaMata) is also working on mentioning this in other lessons.