### PR TITLE
FIXES typo in description of noise variance

### DIFF
--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -243,7 +243,7 @@ class PCA(_BasePCA):
         from Tipping and Bishop 1999. See "Pattern Recognition and
         Machine Learning" by C. Bishop, 12.2.1 p. 574 or
         http://www.miketipping.com/papers/met-mppca.pdf. It is required to
-        computed the estimated data covariance and score samples.
+        compute the estimated data covariance and score samples.
 
         Equal to the average of (min(n_features, n_samples) - n_components)
         smallest eigenvalues of the covariance matrix of X.


### PR DESCRIPTION
FIXES documentation of the description of [noise_variance_](https://github.com/ericd34n/scikit-learn/blob/4e87d93ce6fae938aa366742732b59a730724c73/sklearn/decomposition/pca.py#L246) within the PCA class.

I believe the line:

"It is required to **computed** the estimated data covariance and score samples..."

Should read:

"It is required to **compute** the estimated data covariance and score samples."