### PR TITLE
[MRG+1] idf_ setter for TfidfTransformer.

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -968,7 +968,7 @@ def test_tfidfvectorizer_invalid_idf_attr():
     copy = TfidfVectorizer(vocabulary=vect.vocabulary_, use_idf=True)
     expected_idf_len = len(vect.idf_)
     invalid_idf = [1.0] * (expected_idf_len + 1)
-    assert_raises(ValueError, copy.__setattr__, 'idf_', invalid_idf)
+    assert_raises(ValueError, setattr, copy, 'idf_', invalid_idf)
 
 
 def test_non_unique_vocab():

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -948,8 +948,8 @@ def test_transformer_idf_setter():
     copy = TfidfTransformer()
     copy.idf_ = orig.idf_
     assert_array_equal(
-        copy.fit_transform(X).toarray(),
-        orig.fit_transform(X).toarray())
+        copy.transform(X).toarray(),
+        orig.transform(X).toarray())
 
 
 def test_non_unique_vocab():

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -942,6 +942,16 @@ def test_pickling_transformer():
         orig.fit_transform(X).toarray())
 
 
+def test_transformer_idf_setter():
+    X = CountVectorizer().fit_transform(JUNK_FOOD_DOCS)
+    orig = TfidfTransformer().fit(X)
+    copy = TfidfTransformer()
+    copy.idf_ = orig.idf_
+    assert_array_equal(
+        copy.fit_transform(X).toarray(),
+        orig.fit_transform(X).toarray())
+
+
 def test_non_unique_vocab():
     vocab = ['a', 'b', 'c', 'a', 'a']
     vect = CountVectorizer(vocabulary=vocab)

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -952,6 +952,25 @@ def test_transformer_idf_setter():
         orig.transform(X).toarray())
 
 
+def test_tfidf_vectorizer_setter():
+    orig = TfidfVectorizer(use_idf=True)
+    orig.fit(JUNK_FOOD_DOCS)
+    copy = TfidfVectorizer(vocabulary=orig.vocabulary_, use_idf=True)
+    copy.idf_ = orig.idf_
+    assert_array_equal(
+        copy.transform(JUNK_FOOD_DOCS).toarray(),
+        orig.transform(JUNK_FOOD_DOCS).toarray())
+
+
+def test_tfidfvectorizer_invalid_idf_attr():
+    vect = TfidfVectorizer(use_idf=True)
+    vect.fit(JUNK_FOOD_DOCS)
+    copy = TfidfVectorizer(vocabulary=vect.vocabulary_, use_idf=True)
+    expected_idf_len = len(vect.idf_)
+    invalid_idf = [1.0] * (expected_idf_len + 1)
+    assert_raises(ValueError, copy.__setattr__, 'idf_', invalid_idf)
+
+
 def test_non_unique_vocab():
     vocab = ['a', 'b', 'c', 'a', 'a']
     vect = CountVectorizer(vocabulary=vocab)

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1064,9 +1064,9 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    idf_ : array, shape = [n_features], or None
+    idf_ : array, shape = [n_features], or not defined
         The learned idf vector (global term weights)
-        when ``use_idf`` is set to True, None otherwise.
+        when ``use_idf`` is set to True, not defined otherwise.
 
     References
     ----------
@@ -1308,9 +1308,9 @@ class TfidfVectorizer(CountVectorizer):
     vocabulary_ : dict
         A mapping of terms to feature indices.
 
-    idf_ : array, shape = [n_features], or None
+    idf_ : array, shape = [n_features], or not defined
         The learned idf vector (global term weights)
-        when ``use_idf`` is set to True, None otherwise.
+        when ``use_idf`` is set to True, not defined otherwise.
 
     stop_words_ : set
         Terms that were ignored because they either:

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1399,6 +1399,14 @@ class TfidfVectorizer(CountVectorizer):
     def idf_(self):
         return self._tfidf.idf_
 
+    @idf_.setter
+    def idf_(self, value):
+        self._validate_vocabulary()
+        if hasattr(self, 'vocabulary_'):
+            if len(self.vocabulary_) != len(value):
+                raise ValueError("idf length = %d must be equal to vocabulary size = %d" % (len(value), len(self.vocabulary)))
+        self._tfidf.idf_ = value
+
     def fit(self, raw_documents, y=None):
         """Learn vocabulary and idf from training set.
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1404,7 +1404,8 @@ class TfidfVectorizer(CountVectorizer):
         self._validate_vocabulary()
         if hasattr(self, 'vocabulary_'):
             if len(self.vocabulary_) != len(value):
-                raise ValueError("idf length = %d must be equal to vocabulary size = %d" %
+                raise ValueError("idf length = %d must be equal "
+                                 "to vocabulary size = %d" %
                                  (len(value), len(self.vocabulary)))
         self._tfidf.idf_ = value
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1064,9 +1064,9 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    idf_ : array, shape = [n_features], or not defined
-        The learned idf vector (global term weights)
-        when ``use_idf`` is set to True, not defined otherwise.
+    idf_ : array, shape (n_features)
+        The inverse document frequency (IDF) vector; only defined
+        if  ``use_idf`` is True.
 
     References
     ----------
@@ -1308,9 +1308,9 @@ class TfidfVectorizer(CountVectorizer):
     vocabulary_ : dict
         A mapping of terms to feature indices.
 
-    idf_ : array, shape = [n_features], or not defined
-        The learned idf vector (global term weights)
-        when ``use_idf`` is set to True, not defined otherwise.
+    idf_ : array, shape (n_features)
+        The inverse document frequency (IDF) vector; only defined
+        if  ``use_idf`` is True.
 
     stop_words_ : set
         Terms that were ignored because they either:

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1404,7 +1404,8 @@ class TfidfVectorizer(CountVectorizer):
         self._validate_vocabulary()
         if hasattr(self, 'vocabulary_'):
             if len(self.vocabulary_) != len(value):
-                raise ValueError("idf length = %d must be equal to vocabulary size = %d" % (len(value), len(self.vocabulary)))
+                raise ValueError("idf length = %d must be equal to vocabulary size = %d" %
+                                 (len(value), len(self.vocabulary)))
         self._tfidf.idf_ = value
 
     def fit(self, raw_documents, y=None):

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1062,6 +1062,12 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
     sublinear_tf : boolean, default=False
         Apply sublinear tf scaling, i.e. replace tf with 1 + log(tf).
 
+    Attributes
+    ----------
+    idf_ : array, shape = [n_features], or None
+        The learned idf vector (global term weights)
+        when ``use_idf`` is set to True, None otherwise.
+
     References
     ----------
 
@@ -1156,6 +1162,13 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
         # if _idf_diag is not set, this will raise an attribute error,
         # which means hasattr(self, "idf_") is False
         return np.ravel(self._idf_diag.sum(axis=0))
+
+    @idf_.setter
+    def idf_(self, value):
+        value = np.asarray(value, dtype=np.float64)
+        n_features = value.shape[0]
+        self._idf_diag = sp.spdiags(value, diags=0, m=n_features,
+                                    n=n_features, format='csr')
 
 
 class TfidfVectorizer(CountVectorizer):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

Fixes #7102. 

#### What does this implement/fix? Explain your changes.
The existing property `idf_`, which returns array of learned idf values does not have the corresponding setter.  Internally, idf vector is stored in diagonal matrix.
The change transforms the setter value into the diaganal matrix using `spdiags`.  The setter allows to restore the state of fitted TfidfTransformer using idf vector stored elsewhere. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
