### PR TITLE
[MRG+1] MAINT use numpydoc 0.8 to build docs

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -122,8 +122,7 @@ conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
 
 source activate testenv
 pip install sphinx-gallery
-# Use numpydoc master (for now)
-pip install git+https://github.com/numpy/numpydoc
+pip install numpydoc==0.8
 
 # Build and install scikit-learn in dev mode
 python setup.py develop


### PR DESCRIPTION
Numpydoc 0.8 is released, hopefully with the changes we need to finally depend on it.

I'm not sure if there's any harm in continuing to build with the dev version of numpydoc, but just in case there's volatility there, we can pin it...