### PR TITLE
DOC  HashingVectorizer.fit_transform docstring

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -548,6 +548,14 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin, TransformerMixin):
                              non_negative=self.non_negative)
 
 
+if six.PY3:
+    HashingVectorizer.fit_transform.__doc__ = \
+           HashingVectorizer.transform.__doc__
+else:
+    HashingVectorizer.fit_transform.__func__.__doc__ = \
+            HashingVectorizer.transform.__doc__
+
+
 def _document_frequency(X):
     """Count the number of non-zero values for each feature in sparse X."""
     if sp.isspmatrix_csr(X):

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -541,19 +541,31 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin, TransformerMixin):
             X = normalize(X, norm=self.norm, copy=False)
         return X
 
+    def fit_transform(self, X, y=None):
+        """Transform a sequence of documents to a document-term matrix.
+
+        Parameters
+        ----------
+        X : iterable over raw text documents, length = n_samples
+            Samples. Each sample must be a text document (either bytes or
+            unicode strings, file name or file object depending on the
+            constructor argument) which will be tokenized and hashed.
+        y : any
+            Ignored. This parameter exists only for compatibility with
+            sklearn.pipeline.Pipeline.
+
+        Returns
+        -------
+        X : scipy.sparse matrix, shape = (n_samples, self.n_features)
+            Document-term matrix.
+        """
+        return self.fit(X, y).transform(X)
+
     def _get_hasher(self):
         return FeatureHasher(n_features=self.n_features,
                              input_type='string', dtype=self.dtype,
                              alternate_sign=self.alternate_sign,
                              non_negative=self.non_negative)
-
-
-if six.PY3:
-    HashingVectorizer.fit_transform.__doc__ = \
-           HashingVectorizer.transform.__doc__
-else:
-    HashingVectorizer.fit_transform.__func__.__doc__ = \
-            HashingVectorizer.transform.__doc__
 
 
 def _document_frequency(X):


### PR DESCRIPTION
[`HashingVectorizer.fit_transform`](https://20989-843222-gh.circle-artifacts.com/0/doc/modules/generated/sklearn.feature_extraction.text.HashingVectorizer.html#sklearn.feature_extraction.text.HashingVectorizer.fit_transform) docstring currently gets inherited from the `TransformerMixin`; it is fairly generic and not very suitable for text vectorization.

This copies it from [`HashingVectorizer.transform`](https://20989-843222-gh.circle-artifacts.com/0/doc/modules/generated/sklearn.feature_extraction.text.HashingVectorizer.html#sklearn.feature_extraction.text.HashingVectorizer.transform) instead (since `fit` doesn't do anything anyway).

The issue is that `class.method.__doc__` [is read-only for Python 2.7](https://stackoverflow.com/a/4835557/1791279), hence the workaround...