### PR TITLE
[MRG+1] MultiLabelBinarizer ignore unkown class in transform

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -53,7 +53,7 @@ Classifiers and regressors
   via ``n_iter_no_change``, ``validation_fraction`` and ``tol``. :issue:`7071`
   by `Raghav RV`_
 
-- :class:`dummy.DummyRegressor` now has a ``return_std`` option in its 
+- :class:`dummy.DummyRegressor` now has a ``return_std`` option in its
   ``predict`` method. The returned standard deviations will be zeros.
 
 - Added :class:`naive_bayes.ComplementNB`, which implements the Complement
@@ -161,6 +161,11 @@ Preprocessing
 - :class:`preprocessing.PolynomialFeatures` now supports sparse input.
   :issue:`10452` by :user:`Aman Dalmia <dalmia>` and `Joel Nothman`_.
 
+- The ``transform`` method of :class:`sklearn.preprocessing.MultiLabelBinarizer`
+  now ignores any unknown classes. A warning is raised stating the unknown classes
+  classes found which are ignored.
+  :issue:`10913` by :user:`Rodrigo Agundez <rragundez>`.
+
 Model evaluation and meta-estimators
 
 - A scorer based on :func:`metrics.brier_score_loss` is also available.
@@ -259,9 +264,9 @@ Classifiers and regressors
 - Fixed a bug in :class:`linear_model.RidgeClassifierCV` where
   the parameter ``store_cv_values`` was not implemented though
   it was documented in ``cv_values`` as a way to set up the storage
-  of cross-validation values for different alphas. :issue:`10297` by 
+  of cross-validation values for different alphas. :issue:`10297` by
   :user:`Mabel Villalba-Jiménez <mabelvj>`.
-  
+
 - Fixed a bug in :class:`naive_bayes.MultinomialNB` which did not accept vector
   valued pseudocounts (alpha).
   :issue:`10346` by :user:`Tobias Madsen <TobiasMadsen>`
@@ -472,8 +477,8 @@ Outlier Detection models
 
 Covariance
 
-- The :func:`covariance.graph_lasso`, :class:`covariance.GraphLasso` and 
-  :class:`covariance.GraphLassoCV` have been renamed to 
+- The :func:`covariance.graph_lasso`, :class:`covariance.GraphLasso` and
+  :class:`covariance.GraphLassoCV` have been renamed to
   :func:`covariance.graphical_lasso`, :class:`covariance.GraphicalLasso` and
   :class:`covariance.GraphicalLassoCV` respectively and will be removed in version 0.22.
   :issue:`9993` by :user:`Artiem Krinitsyn <artiemq>`

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -798,6 +798,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         empty_mapping = False if class_mapping else True
         for labels in y:
             if not empty_mapping:
+                # use only known classes in self.classes_
                 labels = filter(class_mapping.__contains__, labels)
             indices.extend(set(class_mapping[label] for label in labels))
             indptr.append(len(indices))

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -797,15 +797,17 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         indices = array.array('i')
         indptr = array.array('i', [0])
         for labels in y:
-            index = set()
+            index, unknown = set(), set()
             for label in labels:
                 try:
                     index.add(class_mapping[label])
                 except KeyError:
-                    warnings.warn("Unkown class {0!r} will be ignored"
-                                  .format(label))
+                    unknown.add(label)
             indices.extend(index)
             indptr.append(len(indices))
+        if unknown:
+            warnings.warn("Unkown class(es) {0} will be ignored"
+                          .format(unknown))
         data = np.ones(len(indices), dtype=int)
 
         return sp.csr_matrix((data, indices, indptr),

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -797,14 +797,9 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         indptr = array.array('i', [0])
         empty_mapping = False if class_mapping else True
         for labels in y:
-            if empty_mapping:
-                # use all labels
-                index = set(class_mapping[label] for label in labels)
-            else:
-                # only use labels in self.classes_
-                index = set(class_mapping[label] for label in labels
-                            if label in class_mapping)
-            indices.extend(index)
+            if not empty_mapping:
+                labels = filter(class_mapping.__contains__, labels)
+            indices.extend(set(class_mapping[label] for label in labels))
             indptr.append(len(indices))
         data = np.ones(len(indices), dtype=int)
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -9,7 +9,7 @@
 from collections import defaultdict
 import itertools
 import array
-import logging
+import warnings
 
 import numpy as np
 import scipy.sparse as sp
@@ -35,9 +35,6 @@ __all__ = [
     'LabelEncoder',
     'MultiLabelBinarizer',
 ]
-
-
-logger = logging.getLogger(__name__)
 
 
 class LabelEncoder(BaseEstimator, TransformerMixin):
@@ -799,19 +796,15 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         """
         indices = array.array('i')
         indptr = array.array('i', [0])
-        empty_mapping = False if class_mapping else True
-
         for labels in y:
-            if not empty_mapping:
-                # use only known classes in self.classes_
-                labels = set(labels)  # in case labels is a generator
-                missing = labels - set(class_mapping)
-                if missing:
-                    logger.warning("Unkown class(es) found %s will be ignored",
-                                   missing)
-                labels = filter(class_mapping.__contains__, labels)
-
-            indices.extend(set(class_mapping[label] for label in labels))
+            index = set()
+            for label in labels:
+                try:
+                    index.add(class_mapping[label])
+                except KeyError:
+                    warnings.warn("Unkown class {0} found and will be ignored"
+                                  .format(label))
+            indices.extend(index)
             indptr.append(len(indices))
         data = np.ones(len(indices), dtype=int)
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -9,6 +9,7 @@
 from collections import defaultdict
 import itertools
 import array
+import logging
 
 import numpy as np
 import scipy.sparse as sp
@@ -34,6 +35,9 @@ __all__ = [
     'LabelEncoder',
     'MultiLabelBinarizer',
 ]
+
+
+logger = logging.getLogger(__name__)
 
 
 class LabelEncoder(BaseEstimator, TransformerMixin):
@@ -803,9 +807,8 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
                 labels = set(labels)  # in case labels is a generator
                 missing = labels - set(class_mapping)
                 if missing:
-                    raise Warning("Unkown class(es) found '{0}' "
-                                  "will be ignored."
-                                  .format("', '".join(missing)))
+                    logger.warning("Unkown class(es) found %s will be ignored",
+                                   missing)
                 labels = filter(class_mapping.__contains__, labels)
 
             indices.extend(set(class_mapping[label] for label in labels))

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -807,8 +807,8 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
             indices.extend(index)
             indptr.append(len(indices))
         if unknown:
-            warnings.warn("Unkown class(es) {0} will be ignored"
-                          .format(unknown))
+            warnings.warn('unknown class(es) {0} will be ignored'
+                          .format(sorted(unknown, key=str)))
         data = np.ones(len(indices), dtype=int)
 
         return sp.csr_matrix((data, indices, indptr),

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -796,8 +796,9 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         """
         indices = array.array('i')
         indptr = array.array('i', [0])
+        unknown = set()
         for labels in y:
-            index, unknown = set(), set()
+            index = set()
             for label in labels:
                 try:
                     index.add(class_mapping[label])

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -796,10 +796,18 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         indices = array.array('i')
         indptr = array.array('i', [0])
         empty_mapping = False if class_mapping else True
+
         for labels in y:
             if not empty_mapping:
                 # use only known classes in self.classes_
+                labels = set(labels)  # in case labels is a generator
+                missing = labels - set(class_mapping)
+                if missing:
+                    raise Warning("Unkown class(es) found '{0}' "
+                                  "will be ignored."
+                                  .format("', '".join(missing)))
                 labels = filter(class_mapping.__contains__, labels)
+
             indices.extend(set(class_mapping[label] for label in labels))
             indptr.append(len(indices))
         data = np.ones(len(indices), dtype=int)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -802,7 +802,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
                 try:
                     index.add(class_mapping[label])
                 except KeyError:
-                    warnings.warn("Unkown class {0} found and will be ignored"
+                    warnings.warn("Unkown class {0!r} will be ignored"
                                   .format(label))
             indices.extend(index)
             indptr.append(len(indices))

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -684,6 +684,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
     sklearn.preprocessing.OneHotEncoder : encode categorical integer features
         using a one-hot aka one-of-K scheme.
     """
+
     def __init__(self, classes=None, sparse_output=False):
         self.classes = classes
         self.sparse_output = sparse_output
@@ -794,8 +795,16 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         """
         indices = array.array('i')
         indptr = array.array('i', [0])
+        empty_mapping = False if class_mapping else True
         for labels in y:
-            indices.extend(set(class_mapping[label] for label in labels))
+            if empty_mapping:
+                # use all labels
+                index = set(class_mapping[label] for label in labels)
+            else:
+                # only use labels in self.classes_
+                index = set(class_mapping[label] for label in labels
+                            if label in class_mapping)
+            indices.extend(index)
             indptr.append(len(indices))
         data = np.ones(len(indices), dtype=int)
 

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -309,11 +309,12 @@ def test_multilabel_binarizer_unknown_class():
     mlb = MultiLabelBinarizer()
     y = [[1, 2]]
     Y = np.array([[0, 0]])
-    assert_warns(UserWarning, mlb.fit(y).transform, [[0]])
-    assert_array_equal(mlb.fit(y).transform([[0]]), Y)
+    matrix = assert_warns(UserWarning, mlb.fit(y).transform, [[0]])
+    assert_array_equal(matrix, Y)
 
     mlb = MultiLabelBinarizer(classes=[1, 2])
-    assert_array_equal(mlb.fit(y).transform([[0]]), Y)
+    matrix = assert_warns(UserWarning, mlb.fit(y).transform, [[0]])
+    assert_array_equal(matrix, Y)
 
 
 def test_multilabel_binarizer_given_classes():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -308,15 +308,16 @@ def test_multilabel_binarizer_empty_sample():
 def test_multilabel_binarizer_unknown_class():
     mlb = MultiLabelBinarizer()
     y = [[1, 2]]
-    Y = np.array([[0, 0]])
-    w = 'unknown class(es) [0] will be ignored'
+    Y = np.array([[1, 0], [0, 1]])
+    w = 'unknown class(es) [0, 4] will be ignored'
     matrix = assert_warns_message(UserWarning, w,
-                                  mlb.fit(y).transform, [[0]])
+                                  mlb.fit(y).transform, [[4, 1], [2, 0]])
     assert_array_equal(matrix, Y)
 
-    mlb = MultiLabelBinarizer(classes=[1, 2])
+    Y = np.array([[1, 0, 0], [0, 1, 0]])
+    mlb = MultiLabelBinarizer(classes=[1, 2, 3])
     matrix = assert_warns_message(UserWarning, w,
-                                  mlb.fit(y).transform, [[0]])
+                                  mlb.fit(y).transform, [[4, 1], [2, 0]])
     assert_array_equal(matrix, Y)
 
 

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -14,7 +14,6 @@ from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raise_message
-from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import ignore_warnings
 

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -307,10 +307,11 @@ def test_multilabel_binarizer_empty_sample():
 def test_multilabel_binarizer_unknown_class():
     mlb = MultiLabelBinarizer()
     y = [[1, 2]]
-    assert_raises(KeyError, mlb.fit(y).transform, [[0]])
+    Y = np.array([[0, 0]])
+    assert_array_equal(mlb.fit(y).transform([[0]]), Y)
 
     mlb = MultiLabelBinarizer(classes=[1, 2])
-    assert_raises(KeyError, mlb.fit_transform, [[0]])
+    assert_array_equal(mlb.fit(y).transform([[0]]), Y)
 
 
 def test_multilabel_binarizer_given_classes():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -15,6 +15,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import ignore_warnings
 
 from sklearn.preprocessing.label import LabelBinarizer
@@ -309,11 +310,14 @@ def test_multilabel_binarizer_unknown_class():
     mlb = MultiLabelBinarizer()
     y = [[1, 2]]
     Y = np.array([[0, 0]])
-    matrix = assert_warns(UserWarning, mlb.fit(y).transform, [[0]])
+    w = 'unknown class(es) [0] will be ignored'
+    matrix = assert_warns_message(UserWarning, w,
+                                  mlb.fit(y).transform, [[0]])
     assert_array_equal(matrix, Y)
 
     mlb = MultiLabelBinarizer(classes=[1, 2])
-    matrix = assert_warns(UserWarning, mlb.fit(y).transform, [[0]])
+    matrix = assert_warns_message(UserWarning, w,
+                                  mlb.fit(y).transform, [[0]])
     assert_array_equal(matrix, Y)
 
 

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -14,6 +14,7 @@ from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raise_message
+from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import ignore_warnings
 
 from sklearn.preprocessing.label import LabelBinarizer
@@ -308,6 +309,7 @@ def test_multilabel_binarizer_unknown_class():
     mlb = MultiLabelBinarizer()
     y = [[1, 2]]
     Y = np.array([[0, 0]])
+    assert_warns(UserWarning, mlb.fit(y).transform, [[0]])
     assert_array_equal(mlb.fit(y).transform([[0]]), Y)
 
     mlb = MultiLabelBinarizer(classes=[1, 2])


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10410 

#### What does this implement/fix? Explain your changes.
Like with other transformers I would expect that `transform` uses what is picked up/learned during `fit` (e.g. `sklearn.preprocessing.StandardScaler` uses the mean and variance learned during `fit`), to my surprise this was not the case with `MultiLabelBinarizer`.

Example:
```python
from sklearn.preprocessing import MultiLabelBinarizer
mlb = MultiLabelBinarizer()
y_train = [['a'],['a', 'b'], ['a', 'b', 'c']]
mlb.fit(y_train)
y_test = [['a'],['b', 'c'],['d']]
mlb.transform(y_test)
>>> KeyError: 'd'
```
My case was that I used a container to train the model with a pre-processing step that uses `MultiLabelBinarizer`, build pipeline and output the pipeline as pkl file. Another container picks it up and `predicts` on new data. To my surprise the pre-processing pipeline breaks if an unseen label is received. To fix this I had to write an ugly hack using `MultiLabelBinarizer`'s `classes_` attribute.

This change addresses that problem. Now `transform` only uses the seen during `fit`. If the parameter `classes` was given on initialization it will use that. If `fit_transform`  is used it respects the optimization already in place.

Example with change:
```python
from sklearn.preprocessing import MultiLabelBinarizer
mlb = MultiLabelBinarizer()
y_train = [['a'],['a', 'b'], ['a', 'b', 'c']]
mlb.fit(y_train)
y_test = [['a'],['b', 'c'],['d']]
mlb.transform(y_test)
>>> array([[1, 0, 0],
       [0, 1, 1],
       [0, 0, 0]])
```
#### Any other comments?
The Issue 10410 that this change fixes, mentions the idea of adding an argument `ignore_unseen`. In my opinion this is not the a good solution:
- It does not respect the pattern of other transformers, scalers, etc.
- It is not intuitive
- It adds unnecessary complexity
