### PR TITLE
[MRG] DOC Links to anchors of svm.rst from index.rst

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,7 +22,7 @@
         <strong>Applications</strong>: Spam detection, Image recognition.</br>
         <strong>Algorithms</strong>:&nbsp;
 
-    :ref:`SVM<svm>`, :ref:`nearest neighbors<classification>`, :ref:`random forest<forest>`, ...
+    :ref:`SVM<svm_classification>`, :ref:`nearest neighbors<classification>`, :ref:`random forest<forest>`, ...
 
     .. raw:: html
 
@@ -52,7 +52,7 @@
         <strong>Applications</strong>: Drug response, Stock prices.</br>
         <strong>Algorithms</strong>:&nbsp;
 
-    :ref:`SVR<svm>`, :ref:`ridge regression<ridge_regression>`, :ref:`Lasso<lasso>`, ...
+    :ref:`SVR<svm_regression>`, :ref:`ridge regression<ridge_regression>`, :ref:`Lasso<lasso>`, ...
 
     .. raw:: html
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Links to the sections of the `svm.rst` from `index.rst` for consistency. On the `Algorithms` parts of the `index.rst`, only SVM are linked to the top of the page, but others are linked to specific sections. For example, nearest neighbors for Classification is linked to `neighbors.html#classification`.
