### PR TITLE
[MRG] Update ValueError msg to address pandas' deprecated reshape()

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -503,16 +503,18 @@ def check_array(array, accept_sparse=False, dtype="numeric", order=None,
             if array.ndim == 0:
                 raise ValueError(
                     "Expected 2D array, got scalar array instead:\narray={}.\n"
-                    "Reshape your data either using array.reshape(-1, 1) if "
-                    "your data has a single feature or array.reshape(1, -1) "
-                    "if it contains a single sample.".format(array))
+                    "Reshape your data either using "
+                    "np.reshape(array, (-1, 1)) if your data has a single "
+                    "feature or np.reshape(array, (1, -1)) if it contains "
+                    "a single sample.".format(array))
             # If input is 1D raise error
             if array.ndim == 1:
                 raise ValueError(
                     "Expected 2D array, got 1D array instead:\narray={}.\n"
-                    "Reshape your data either using array.reshape(-1, 1) if "
-                    "your data has a single feature or array.reshape(1, -1) "
-                    "if it contains a single sample.".format(array))
+                    "Reshape your data either using "
+                    "np.reshape(array, (-1, 1)) if your data has a single "
+                    "feature or np.reshape(array, (1, -1)) if it contains "
+                    "a single sample.".format(array))
             # To ensure that array flags are maintained
             array = np.array(array, dtype=dtype, order=order, copy=copy)
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10935


#### What does this implement/fix? Explain your changes.

Pandas' array.reshape() is deprecated (see [here](http://pandas.pydata.org/pandas-docs/version/0.19.0/generated/pandas.Series.reshape.html)) and is being replaced by array.values.reshape(). The ValueError message in utils/validation.py has been updated to reflect this change. 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
