### PR TITLE
TST: display reason of skipping by default with pytest

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -61,6 +61,8 @@ if [[ "$DISTRIB" == "conda" ]]; then
 
     conda create -n testenv --yes $TO_INSTALL
     source activate testenv
+    conda install pip --yes
+    pip install -U pytest
 
 elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # At the time of writing numpy 1.9.1 is included in the travis

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -61,8 +61,11 @@ if [[ "$DISTRIB" == "conda" ]]; then
 
     conda create -n testenv --yes $TO_INSTALL
     source activate testenv
-    conda install pip --yes
-    pip install -U pytest
+
+    # for python 3.4, conda does not have recent pytest packages
+    if [[ "$PYTHON_VERSION" == "3.4" ]]; then
+        pip install --upgrade --no-deps pytest
+    fi
 
 elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # At the time of writing numpy 1.9.1 is included in the travis

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -64,7 +64,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
 
     # for python 3.4, conda does not have recent pytest packages
     if [[ "$PYTHON_VERSION" == "3.4" ]]; then
-        pip install --upgrade --no-deps pytest
+        pip install pytest==3.5
     fi
 
 elif [[ "$DISTRIB" == "ubuntu" ]]; then

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ test = pytest
 addopts =
     --doctest-modules
     --disable-pytest-warnings
+    -r s
 
 [wheelhouse_uploader]
 artifact_indexes=

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ test = pytest
 addopts =
     --doctest-modules
     --disable-pytest-warnings
-    -r s
+    -r skipped
 
 [wheelhouse_uploader]
 artifact_indexes=


### PR DESCRIPTION
#### Reference Issues/PRs

See discussion in https://github.com/scikit-learn/scikit-learn/pull/10835#issuecomment-380029784 
Actually doing this change, will make it easier to see how it looks on Travis to decide if this is too verbose or not.

With this change, `pytest` will show the reason that a test is skipped by default. This can be especially useful to not be surprised why your doctests are skipping because you don't have numpy 1.14.