### PR TITLE
[MRG] Fixes code formatting in TransformedTargetRegressor docstring

### DIFF
--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -22,14 +22,28 @@ class TransformedTargetRegressor(BaseEstimator, RegressorMixin):
     QuantileTransformer or as a function and its inverse such as ``log`` and
     ``exp``.
 
-    The computation during ``fit`` is::
+    The computation during ``fit`` is
+
+    .. code-block:: python
+
         regressor.fit(X, func(y))
-    or::
+
+    or
+
+    .. code-block:: python
+
         regressor.fit(X, transformer.transform(y))
 
-    The computation during ``predict`` is::
+    The computation during ``predict`` is
+
+    .. code-block:: python
+
         inverse_func(regressor.predict(X))
-    or::
+
+    or
+
+    .. code-block:: python
+
         transformer.inverse_transform(regressor.predict(X))
 
     Read more in the :ref:`User Guide <preprocessing_targets>`.

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -22,27 +22,16 @@ class TransformedTargetRegressor(BaseEstimator, RegressorMixin):
     QuantileTransformer or as a function and its inverse such as ``log`` and
     ``exp``.
 
-    The computation during ``fit`` is
-
-    .. code-block:: python
+    The computation during ``fit`` is::
 
         regressor.fit(X, func(y))
-
-    or
-
-    .. code-block:: python
+    or::
 
         regressor.fit(X, transformer.transform(y))
-
-    The computation during ``predict`` is
-
-    .. code-block:: python
+    The computation during ``predict`` is::
 
         inverse_func(regressor.predict(X))
-
-    or
-
-    .. code-block:: python
+    or::
 
         transformer.inverse_transform(regressor.predict(X))
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

This PR fixes code block rendering in the `TransformedTargetRegressor` API documentation. 

Currently several code blocks aren't formatted correctly: 

<img width="1274" alt="screen shot 2018-04-10 at 3 29 03 pm" src="https://user-images.githubusercontent.com/11656932/38582236-ba4799e6-3cd4-11e8-9c71-05b14d62d310.png">

This PR updates the `TransformedTargetRegressor` docstring so that the API documentation looks like:

<img width="1273" alt="screen shot 2018-04-10 at 3 29 17 pm" src="https://user-images.githubusercontent.com/11656932/38582248-c41e2642-3cd4-11e8-86c6-844441c41934.png">



#### Any other comments?

```
Darwin-17.4.0-x86_64-i386-64bit
Python 3.6.4 |Anaconda, Inc.| (default, Mar 12 2018, 20:05:31) 
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)]
NumPy 1.14.2
SciPy 1.0.1
Scikit-Learn 0.20.dev0
```

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
