### PR TITLE
Fix code typo in plot_unveil_tree_structure.py

### DIFF
--- a/examples/tree/plot_unveil_tree_structure.py
+++ b/examples/tree/plot_unveil_tree_structure.py
@@ -106,7 +106,7 @@ node_index = node_indicator.indices[node_indicator.indptr[sample_id]:
 
 print('Rules used to predict sample %s: ' % sample_id)
 for node_id in node_index:
-    if leave_id[sample_id] != node_id:
+    if leave_id[sample_id] == node_id:
         continue
 
     if (X_test[sample_id, feature[node_id]] <= threshold[node_id]):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #10921.

#### What does this implement/fix? Explain your changes.

This branch fixes one code typo in `plot_unveil__tree_structure.py`. To show the decision path for samples, only leaves rules are displayed, previous nodes are skipped. This is done by changing `if leave_id[sample_id] != node_id` to `if leave_id[sample_id] == node_id`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->