### PR TITLE
changes in svm.rst - issue 10939

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -336,6 +336,9 @@ floating point values instead of integer values::
 Density estimation, novelty detection
 =======================================
 
+One-class SVM is used for novelty detection, that is, given a set of samples, it will detect the soft boundary of that set so as to classify new points as belonging to that set or not. The class that implements this is called OneClassSVM.
+
+
 See, section :ref:`outlier_detection` for more details on this usage.
 
 .. figure:: ../auto_examples/svm/images/sphx_glr_plot_oneclass_001.png

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -1,4 +1,4 @@
-.. _svm:
+﻿.. _svm:
 
 =======================
 Support Vector Machines
@@ -335,14 +335,6 @@ floating point values instead of integer values::
 
 Density estimation, novelty detection
 =======================================
-
-One-class SVM is used for novelty detection, that is, given a set of
-samples, it will detect the soft boundary of that set so as to
-classify new points as belonging to that set or not. The class that
-implements this is called :class:`OneClassSVM`.
-
-In this case, as it is a type of unsupervised learning, the fit method
-will only take as input an array X, as there are no class labels.
 
 See, section :ref:`outlier_detection` for more details on this usage.
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fix #10923.

#### What does this implement/fix? Explain your changes.

The link that goes from OneClassSVM to the guide page, i.e on the SVM.rst , now has the link to the Novelty Detection and Outlier page without the contents i.e to the outlier_detection.rst

#### Any other comments?
