### PR TITLE
[MRG] Fix plot_stock_market.py after Google finance URL shut-down

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
       - SCIPY_VERSION: 0.14
       - MATPLOTLIB_VERSION: 1.3
       - SCIKIT_IMAGE_VERSION: 0.9.3
+      - PANDAS_VERSION: 0.13.1
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ scikit-learn requires:
 - SciPy (>= 0.13.3)
 
 For running the examples Matplotlib >= 1.3.1 is required. A few examples
-require scikit-image >= 0.9.3 as well.
+require scikit-image >= 0.9.3 and a few examples require pandas >= 0.13.1.
 
 scikit-learn also uses CBLAS, the C interface to the Basic Linear Algebra
 Subprograms library. scikit-learn comes with a reference implementation, but

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -118,7 +118,7 @@ conda update --yes --quiet conda
 conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
   numpy="${NUMPY_VERSION:-*}" scipy="${SCIPY_VERSION:-*}" cython \
   pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=1.6.2 pillow \
-  scikit-image="${SCIKIT_IMAGE_VERSION:-*}"
+  scikit-image="${SCIKIT_IMAGE_VERSION:-*}" pandas="${PANDAS_VERSION:-*}"
 
 source activate testenv
 pip install sphinx-gallery

--- a/examples/applications/plot_stock_market.py
+++ b/examples/applications/plot_stock_market.py
@@ -72,158 +72,90 @@ import matplotlib.pyplot as plt
 from matplotlib.collections import LineCollection
 from six.moves.urllib.request import urlopen
 from six.moves.urllib.parse import urlencode
+
+import pandas as pd
+
 from sklearn import cluster, covariance, manifold
 
 print(__doc__)
 
 
-def retry(f, n_attempts=3):
-    "Wrapper function to retry function calls in case of exceptions"
-    def wrapper(*args, **kwargs):
-        for i in range(n_attempts):
-            try:
-                return f(*args, **kwargs)
-            except Exception:
-                if i == n_attempts - 1:
-                    raise
-    return wrapper
-
-
-def quotes_historical_google(symbol, start_date, end_date):
-    """Get the historical data from Google finance.
-
-    Parameters
-    ----------
-    symbol : str
-        Ticker symbol to query for, for example ``"DELL"``.
-    start_date : datetime.datetime
-        Start date.
-    end_date : datetime.datetime
-        End date.
-
-    Returns
-    -------
-    X : array
-        The columns are ``date`` -- date, ``open``, ``high``,
-        ``low``, ``close`` and ``volume`` of type float.
-    """
-    params = {
-        'q': symbol,
-        'startdate': start_date.strftime('%Y-%m-%d'),
-        'enddate': end_date.strftime('%Y-%m-%d'),
-        'output': 'csv',
-    }
-    url = 'https://finance.google.com/finance/historical?' + urlencode(params)
-    response = urlopen(url)
-    dtype = {
-        'names': ['date', 'open', 'high', 'low', 'close', 'volume'],
-        'formats': ['object', 'f4', 'f4', 'f4', 'f4', 'f4']
-    }
-    converters = {
-        0: lambda s: datetime.strptime(s.decode(), '%d-%b-%y').date()}
-    data = np.genfromtxt(response, delimiter=',', skip_header=1,
-                         dtype=dtype, converters=converters,
-                         missing_values='-', filling_values=-1)
-    min_date = min(data['date']) if len(data) else datetime.min.date()
-    max_date = max(data['date']) if len(data) else datetime.max.date()
-    start_end_diff = (end_date - start_date).days
-    min_max_diff = (max_date - min_date).days
-    data_is_fine = (
-        start_date <= min_date <= end_date and
-        start_date <= max_date <= end_date and
-        start_end_diff - 7 <= min_max_diff <= start_end_diff)
-
-    if not data_is_fine:
-        message = (
-            'Data looks wrong for symbol {}, url {}\n'
-            '  - start_date: {}, end_date: {}\n'
-            '  - min_date:   {}, max_date: {}\n'
-            '  - start_end_diff: {}, min_max_diff: {}'.format(
-                symbol, url,
-                start_date, end_date,
-                min_date, max_date,
-                start_end_diff, min_max_diff))
-        raise RuntimeError(message)
-    return data
-
-
 # #############################################################################
 # Retrieve the data from Internet
 
-# Choose a time period reasonably calm (not too long ago so that we get
-# high-tech firms, and before the 2008 crash)
+# The data is from 2003 - 2008. This is reasonably calm: (not too long ago so that we
+# get high-tech firms, and before the 2008 crash)
 start_date = datetime(2003, 1, 1).date()
 end_date = datetime(2008, 1, 1).date()
 
 symbol_dict = {
-    'NYSE:TOT': 'Total',
-    'NYSE:XOM': 'Exxon',
-    'NYSE:CVX': 'Chevron',
-    'NYSE:COP': 'ConocoPhillips',
-    'NYSE:VLO': 'Valero Energy',
-    'NASDAQ:MSFT': 'Microsoft',
-    'NYSE:IBM': 'IBM',
-    'NYSE:TWX': 'Time Warner',
-    'NASDAQ:CMCSA': 'Comcast',
-    'NYSE:CVC': 'Cablevision',
-    'NASDAQ:YHOO': 'Yahoo',
-    'NASDAQ:DELL': 'Dell',
-    'NYSE:HPQ': 'HP',
-    'NASDAQ:AMZN': 'Amazon',
-    'NYSE:TM': 'Toyota',
-    'NYSE:CAJ': 'Canon',
-    'NYSE:SNE': 'Sony',
-    'NYSE:F': 'Ford',
-    'NYSE:HMC': 'Honda',
-    'NYSE:NAV': 'Navistar',
-    'NYSE:NOC': 'Northrop Grumman',
-    'NYSE:BA': 'Boeing',
-    'NYSE:KO': 'Coca Cola',
-    'NYSE:MMM': '3M',
-    'NYSE:MCD': 'McDonald\'s',
-    'NYSE:PEP': 'Pepsi',
-    'NYSE:K': 'Kellogg',
-    'NYSE:UN': 'Unilever',
-    'NASDAQ:MAR': 'Marriott',
-    'NYSE:PG': 'Procter Gamble',
-    'NYSE:CL': 'Colgate-Palmolive',
-    'NYSE:GE': 'General Electrics',
-    'NYSE:WFC': 'Wells Fargo',
-    'NYSE:JPM': 'JPMorgan Chase',
-    'NYSE:AIG': 'AIG',
-    'NYSE:AXP': 'American express',
-    'NYSE:BAC': 'Bank of America',
-    'NYSE:GS': 'Goldman Sachs',
-    'NASDAQ:AAPL': 'Apple',
-    'NYSE:SAP': 'SAP',
-    'NASDAQ:CSCO': 'Cisco',
-    'NASDAQ:TXN': 'Texas Instruments',
-    'NYSE:XRX': 'Xerox',
-    'NYSE:WMT': 'Wal-Mart',
-    'NYSE:HD': 'Home Depot',
-    'NYSE:GSK': 'GlaxoSmithKline',
-    'NYSE:PFE': 'Pfizer',
-    'NYSE:SNY': 'Sanofi-Aventis',
-    'NYSE:NVS': 'Novartis',
-    'NYSE:KMB': 'Kimberly-Clark',
-    'NYSE:R': 'Ryder',
-    'NYSE:GD': 'General Dynamics',
-    'NYSE:RTN': 'Raytheon',
-    'NYSE:CVS': 'CVS',
-    'NYSE:CAT': 'Caterpillar',
-    'NYSE:DD': 'DuPont de Nemours'}
+    'TOT': 'Total',
+    'XOM': 'Exxon',
+    'CVX': 'Chevron',
+    'COP': 'ConocoPhillips',
+    'VLO': 'Valero Energy',
+    'MSFT': 'Microsoft',
+    'IBM': 'IBM',
+    'TWX': 'Time Warner',
+    'CMCSA': 'Comcast',
+    'CVC': 'Cablevision',
+    'YHOO': 'Yahoo',
+    'DELL': 'Dell',
+    'HPQ': 'HP',
+    'AMZN': 'Amazon',
+    'TM': 'Toyota',
+    'CAJ': 'Canon',
+    'SNE': 'Sony',
+    'F': 'Ford',
+    'HMC': 'Honda',
+    'NAV': 'Navistar',
+    'NOC': 'Northrop Grumman',
+    'BA': 'Boeing',
+    'KO': 'Coca Cola',
+    'MMM': '3M',
+    'MCD': 'McDonald\'s',
+    'PEP': 'Pepsi',
+    'K': 'Kellogg',
+    'UN': 'Unilever',
+    'MAR': 'Marriott',
+    'PG': 'Procter Gamble',
+    'CL': 'Colgate-Palmolive',
+    'GE': 'General Electrics',
+    'WFC': 'Wells Fargo',
+    'JPM': 'JPMorgan Chase',
+    'AIG': 'AIG',
+    'AXP': 'American express',
+    'BAC': 'Bank of America',
+    'GS': 'Goldman Sachs',
+    'AAPL': 'Apple',
+    'SAP': 'SAP',
+    'CSCO': 'Cisco',
+    'TXN': 'Texas Instruments',
+    'XRX': 'Xerox',
+    'WMT': 'Wal-Mart',
+    'HD': 'Home Depot',
+    'GSK': 'GlaxoSmithKline',
+    'PFE': 'Pfizer',
+    'SNY': 'Sanofi-Aventis',
+    'NVS': 'Novartis',
+    'KMB': 'Kimberly-Clark',
+    'R': 'Ryder',
+    'GD': 'General Dynamics',
+    'RTN': 'Raytheon',
+    'CVS': 'CVS',
+    'CAT': 'Caterpillar',
+    'DD': 'DuPont de Nemours'}
 
 
 symbols, names = np.array(sorted(symbol_dict.items())).T
 
-# retry is used because quotes_historical_google can temporarily fail
-# for various reasons (e.g. empty result from Google API).
 quotes = []
 
 for symbol in symbols:
     print('Fetching quote history for %r' % symbol, file=sys.stderr)
-    quotes.append(retry(quotes_historical_google)(
-        symbol, start_date, end_date))
+    url = ('https://raw.githubusercontent.com/scikit-learn/examples-data/master/'
+           'financial-data/{}.csv')
+    quotes.append(pd.read_csv(url.format(symbol)))
 
 close_prices = np.vstack([q['close'] for q in quotes])
 open_prices = np.vstack([q['open'] for q in quotes])

--- a/examples/applications/plot_stock_market.py
+++ b/examples/applications/plot_stock_market.py
@@ -82,7 +82,9 @@ print(__doc__)
 # Retrieve the data from Internet
 
 # The data is from 2003 - 2008. This is reasonably calm: (not too long ago so
-# that we get high-tech firms, and before the 2008 crash)
+# that we get high-tech firms, and before the 2008 crash). This kind of
+# historical data can be obtained for from APIs like the quandl.com and
+# alphavantage.co ones.
 start_date = datetime(2003, 1, 1).date()
 end_date = datetime(2008, 1, 1).date()
 

--- a/examples/applications/plot_stock_market.py
+++ b/examples/applications/plot_stock_market.py
@@ -70,8 +70,6 @@ from datetime import datetime
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.collections import LineCollection
-from six.moves.urllib.request import urlopen
-from six.moves.urllib.parse import urlencode
 
 import pandas as pd
 
@@ -83,8 +81,8 @@ print(__doc__)
 # #############################################################################
 # Retrieve the data from Internet
 
-# The data is from 2003 - 2008. This is reasonably calm: (not too long ago so that we
-# get high-tech firms, and before the 2008 crash)
+# The data is from 2003 - 2008. This is reasonably calm: (not too long ago so
+# that we get high-tech firms, and before the 2008 crash)
 start_date = datetime(2003, 1, 1).date()
 end_date = datetime(2008, 1, 1).date()
 
@@ -153,8 +151,8 @@ quotes = []
 
 for symbol in symbols:
     print('Fetching quote history for %r' % symbol, file=sys.stderr)
-    url = ('https://raw.githubusercontent.com/scikit-learn/examples-data/master/'
-           'financial-data/{}.csv')
+    url = ('https://raw.githubusercontent.com/scikit-learn/examples-data/'
+           'master/financial-data/{}.csv')
     quotes.append(pd.read_csv(url.format(symbol)))
 
 close_prices = np.vstack([q['close'] for q in quotes])


### PR DESCRIPTION
Fix #10858.

I did the simplest thing I could think of, namely put the financial data we need in the scikit-learn/examples-data as mentioned in https://github.com/scikit-learn/scikit-learn/issues/10858#issuecomment-377223026.

I am also using pandas in the example. Again when I was trying to fix the example, this was the simplest thing to do. I seem to remember that using pandas in the examples was acceptable although there is no precedent. If someone strongly insists on using numpy for reading the csv I can do that.