### PR TITLE
[MRG] Add verbose option to VotingClassifier

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -158,6 +158,10 @@ Classifiers and regressors
   parallelized according to ``n_jobs`` regardless of ``algorithm``.
   :issue:`8003` by :user:`Joël Billaud <recamshak>`.
 
+- Add `verbose` parameter in :class:`ensemble.VotingClassifier` to enable the
+  progress messages of ``fit`` calls.
+  :issue:`10360` by :user:`Martin Gubri <framartin>`.
+
 Cluster
 
 - :class:`cluster.KMeans`, :class:`cluster.MiniBatchKMeans` and

--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -428,3 +428,30 @@ def test_transform():
             eclf3.transform(X).swapaxes(0, 1).reshape((4, 6)),
             eclf2.transform(X)
     )
+
+
+def test_verbose(capfd):
+    """Check verbose option."""
+    clf1 = LogisticRegression(random_state=123)
+    clf2 = RandomForestClassifier(random_state=123)
+    clf3 = GaussianNB()
+    X = np.array([[-1.1, -1.5], [-1.2, -1.4], [-3.4, -2.2], [1.1, 1.2]])
+    y = np.array([1, 1, 2, 2])
+
+    VotingClassifier(estimators=[
+        ('lr', clf1), ('rf', clf2), ('gnb', clf3)],
+        voting='soft').fit(X, y)
+    out, err = capfd.readouterr()
+    assert out == err == ''
+
+    VotingClassifier(estimators=[
+        ('lr', clf1), ('rf', clf2), ('gnb', clf3)],
+        voting='soft', verbose=49).fit(X, y)
+    out, err = capfd.readouterr()
+    assert out == '' and err != ''
+
+    VotingClassifier(estimators=[
+        ('lr', clf1), ('rf', clf2), ('gnb', clf3)],
+        voting='soft', verbose=51).fit(X, y)
+    out, err = capfd.readouterr()
+    assert out != '' and err == ''

--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -446,12 +446,12 @@ def test_verbose(capfd):
 
     VotingClassifier(estimators=[
         ('lr', clf1), ('rf', clf2), ('gnb', clf3)],
-        voting='soft', verbose=49).fit(X, y)
+        voting='soft', verbose=False).fit(X, y)
     out, err = capfd.readouterr()
-    assert out == '' and err != ''
+    assert out == err == ''
 
     VotingClassifier(estimators=[
         ('lr', clf1), ('rf', clf2), ('gnb', clf3)],
-        voting='soft', verbose=51).fit(X, y)
+        voting='soft', verbose=True).fit(X, y)
     out, err = capfd.readouterr()
     assert out != '' and err == ''

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -54,6 +54,12 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
         the sums of the predicted probabilities, which is recommended for
         an ensemble of well-calibrated classifiers.
 
+    verbose: int, optional
+        The verbosity level: if non zero, progress messages are printed.
+        Above 50, the output is sent to stdout. The frequency of the messages
+        increases with the verbosity level. If it more than 10, all iterations
+        are reported.
+
     weights : array-like, shape = [n_classifiers], optional (default=`None`)
         Sequence of weights (`float` or `int`) to weight the occurrences of
         predicted class labels (`hard` voting) or class probabilities
@@ -121,10 +127,11 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
     >>>
     """
 
-    def __init__(self, estimators, voting='hard', weights=None, n_jobs=1,
-                 flatten_transform=None):
+    def __init__(self, estimators, voting='hard', verbose=0, weights=None,
+                 n_jobs=1, flatten_transform=None):
         self.estimators = estimators
         self.voting = voting
+        self.verbose = verbose
         self.weights = weights
         self.n_jobs = n_jobs
         self.flatten_transform = flatten_transform
@@ -192,7 +199,7 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
 
         transformed_y = self.le_.transform(y)
 
-        self.estimators_ = Parallel(n_jobs=self.n_jobs)(
+        self.estimators_ = Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
                 delayed(_parallel_fit_estimator)(clone(clf), X, transformed_y,
                                                  sample_weight=sample_weight)
                 for clf in clfs if clf is not None)

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -57,8 +57,8 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
     verbose: int, optional
         The verbosity level: if non zero, progress messages are printed.
         Above 50, the output is sent to stdout. The frequency of the messages
-        increases with the verbosity level. If it more than 10, all iterations
-        are reported.
+        increases with the verbosity level. If it more than 10, all ``fit``
+        calls are reported.
 
     weights : array-like, shape = [n_classifiers], optional (default=`None`)
         Sequence of weights (`float` or `int`) to weight the occurrences of

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -54,11 +54,8 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
         the sums of the predicted probabilities, which is recommended for
         an ensemble of well-calibrated classifiers.
 
-    verbose: int, optional
-        The verbosity level: if non zero, progress messages are printed.
-        Above 50, the output is sent to stdout. The frequency of the messages
-        increases with the verbosity level. If it more than 10, all ``fit``
-        calls are reported.
+    verbose : bool, optional (default=False)
+        Enable progress messages of ``fit`` calls.
 
     weights : array-like, shape = [n_classifiers], optional (default=`None`)
         Sequence of weights (`float` or `int`) to weight the occurrences of
@@ -127,7 +124,7 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
     >>>
     """
 
-    def __init__(self, estimators, voting='hard', verbose=0, weights=None,
+    def __init__(self, estimators, voting='hard', verbose=False, weights=None,
                  n_jobs=1, flatten_transform=None):
         self.estimators = estimators
         self.voting = voting
@@ -199,7 +196,12 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
 
         transformed_y = self.le_.transform(y)
 
-        self.estimators_ = Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
+        if not self.verbose:
+            verbose_int = 0
+        else:
+            verbose_int = 100
+
+        self.estimators_ = Parallel(n_jobs=self.n_jobs, verbose=verbose_int)(
                 delayed(_parallel_fit_estimator)(clone(clf), X, transformed_y,
                                                  sample_weight=sample_weight)
                 for clf in clfs if clf is not None)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

Fixes #10360
Closes #10367 #10365 

#### What does this implement/fix? Explain your changes.

- Add a boolean `verbose` option to `VotingClassifier`. If True, `100` is passed to the `verbose` option of `Parallel` in order to print all progress messages to stdout.
- Update the docstring of `VotingClassifier`.
- Add a unit test to check stdout and stderr with the default value of the verbose option, `False`, and `True`.

#### Any other comments?

I used the [`capfd` pytest fixture](https://docs.pytest.org/en/latest/capture.html#accessing-captured-output-from-a-test-function) in my unit test. Is it ok? Is there a particular reason for not using it in other verbose tests (found with `git grep test_.*verbose`)? Because it seems quite convenient.