### PR TITLE
[MRG] Clone estimator between fits in sklearn/utils/estimator_checks.py::check_supervised_y_2d

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1505,6 +1505,8 @@ def check_supervised_y_2d(name, estimator_orig):
     estimator.fit(X, y)
     y_pred = estimator.predict(X)
 
+    # Clone original estimator again before setting random state
+    estimator = clone(estimator_orig)
     set_random_state(estimator)
     # Check that when a 2D y is given, a DataConversionWarning is
     # raised


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10977 

#### What does this implement/fix? Explain your changes.
Test function `check_supervised_y_2d` reuses an already fitted estimator which could leave potential side effects. This PR clones the estimator between fits to prevent any potential side effects from affecting the results of this test.

#### Any other comments?
Please see #10977 for a sample estimator that would fail this test, even though it correctly handles what `check_supervised_y_2d` should be testing for. 
