### PR TITLE
[MRG] Improve multi-metric scorer speed

### DIFF
--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -79,7 +79,7 @@ class _PredictScorer(_BaseScorer):
         Parameters
         ----------
         estimator : object
-            Trained estimator to use for scoring. Must have a predict_proba
+            Trained estimator to use for scoring. Must have a predict
             method; the output of that is used to compute the score.
 
         X : array-like or sparse matrix


### PR DESCRIPTION
#### Reference Issues/PRs

Works on improving #10802

#### What does this implement/fix? Explain your changes.

Previously multi metric scoring called the `predict` method of an
estimator once for each scorer, this could lead to drastic increases in
costs.

This change avoids calling the scorers directly and instead allows to
call the scorer with the predicted results.

This is only done for `_PredictScorer` and `_ProbaScorer` generated with
`make_scorer`, this means that `_ThresholdScorer` and scorers not
generated with `make_scorer` do not benefit from this change

#### Any other comments?

This implements a solution proposed by @jimmywan and the demarch seemed ok to @jnothman another solution would have been to force the estimator to cache its `predict`, `predict_proba` and `decision_function` methods.