### PR TITLE
[MRG+1] Fix [RandomizedSearchCV] Do not enforce that n_iter is less than or equal to size of search space

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -53,7 +53,7 @@ Classifiers and regressors
   via ``n_iter_no_change``, ``validation_fraction`` and ``tol``. :issue:`7071`
   by `Raghav RV`_
 
-- :class:`dummy.DummyRegressor` now has a ``return_std`` option in its 
+- :class:`dummy.DummyRegressor` now has a ``return_std`` option in its
   ``predict`` method. The returned standard deviations will be zeros.
 
 - Added :class:`naive_bayes.ComplementNB`, which implements the Complement
@@ -142,7 +142,7 @@ Classifiers and regressors
   only require X to be an object with finite length or shape.
   :issue:`9832` by :user:`Vrishank Bhardwaj <vrishank97>`.
 
-- :class:`neighbors.RadiusNeighborsRegressor` and 
+- :class:`neighbors.RadiusNeighborsRegressor` and
   :class:`neighbors.RadiusNeighborsClassifier` are now
   parallelized according to ``n_jobs`` regardless of ``algorithm``.
   :issue:`8003` by :user:`Joël Billaud <recamshak>`.
@@ -268,9 +268,9 @@ Classifiers and regressors
 - Fixed a bug in :class:`linear_model.RidgeClassifierCV` where
   the parameter ``store_cv_values`` was not implemented though
   it was documented in ``cv_values`` as a way to set up the storage
-  of cross-validation values for different alphas. :issue:`10297` by 
+  of cross-validation values for different alphas. :issue:`10297` by
   :user:`Mabel Villalba-Jiménez <mabelvj>`.
-  
+
 - Fixed a bug in :class:`naive_bayes.MultinomialNB` which did not accept vector
   valued pseudocounts (alpha).
   :issue:`10346` by :user:`Tobias Madsen <TobiasMadsen>`
@@ -481,8 +481,8 @@ Outlier Detection models
 
 Covariance
 
-- The :func:`covariance.graph_lasso`, :class:`covariance.GraphLasso` and 
-  :class:`covariance.GraphLassoCV` have been renamed to 
+- The :func:`covariance.graph_lasso`, :class:`covariance.GraphLasso` and
+  :class:`covariance.GraphLassoCV` have been renamed to
   :func:`covariance.graphical_lasso`, :class:`covariance.GraphicalLasso` and
   :class:`covariance.GraphicalLassoCV` respectively and will be removed in version 0.22.
   :issue:`9993` by :user:`Artiem Krinitsyn <artiemq>`
@@ -497,6 +497,12 @@ Misc
   :func:`decomposition.fastica`, :class:`cross_decomposition.PLSCanonical`,
   :class:`cluster.AffinityPropagation`, and :class:`cluster.Birch`.
   :issue:`#10306` by :user:`Jonathan Siebert <jotasi>`.
+
+- Changed ValueError exception raised in :class:`model_selection.ParameterSampler`
+  to a UserWarning for case where the class is instantiated with a greater value of
+  ``n_iter`` than the total space of parameters in the parameter grid. ``n_iter`` now
+  acts as an upper bound on iterations.
+  :issue:`#10982` by :user:`Juliet Lawton <julietcl>`
 
 Changes to estimator checks
 ---------------------------

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -249,7 +249,7 @@ class ParameterSampler(object):
                     'The total space of parameters %d is smaller '
                     'than n_iter=%d. Running %d iterations. For exhaustive '
                     'searches, use GridSearchCV.'
-                    % (grid_size, self.n_iter, grid_size), RuntimeWarning)
+                    % (grid_size, self.n_iter, grid_size), UserWarning)
                 n_iter = grid_size
             for i in sample_without_replacement(grid_size, n_iter,
                                                 random_state=rnd):

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -248,7 +248,7 @@ class ParameterSampler(object):
                 warnings.warn(
                     'The total space of parameters %d is smaller '
                     'than n_iter=%d. Running %d iterations. For exhaustive '
-                    'searches, use GridSearchCV.' 
+                    'searches, use GridSearchCV.'
                     % (grid_size, self.n_iter, grid_size), RuntimeWarning)
                 n_iter = grid_size
             for i in sample_without_replacement(grid_size, n_iter,

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -242,14 +242,16 @@ class ParameterSampler(object):
             # look up sampled parameter settings in parameter grid
             param_grid = ParameterGrid(self.param_distributions)
             grid_size = len(param_grid)
+            n_iter = self.n_iter
 
-            if grid_size < self.n_iter:
+            if grid_size < n_iter:
                 warnings.warn(
                     'The total space of parameters %d is smaller '
-                    'than n_iter=%d. For exhaustive searches, use '
-                    'GridSearchCV.' % (grid_size, self.n_iter), RuntimeWarning)
-                self.n_iter = grid_size
-            for i in sample_without_replacement(grid_size, self.n_iter,
+                    'than n_iter=%d. Running %d iterations. For exhaustive searches, '
+                    'use GridSearchCV.' % (grid_size, self.n_iter, grid_size),
+                     RuntimeWarning)
+                n_iter = grid_size
+            for i in sample_without_replacement(grid_size, n_iter,
                                                 random_state=rnd):
                 yield param_grid[i]
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -244,10 +244,11 @@ class ParameterSampler(object):
             grid_size = len(param_grid)
 
             if grid_size < self.n_iter:
-                raise ValueError(
-                    "The total space of parameters %d is smaller "
-                    "than n_iter=%d. For exhaustive searches, use "
-                    "GridSearchCV." % (grid_size, self.n_iter))
+                warnings.warn(
+                    'The total space of parameters %d is smaller '
+                    'than n_iter=%d. For exhaustive searches, use '
+                    'GridSearchCV.' % (grid_size, self.n_iter), RuntimeWarning)
+                self.n_iter = grid_size
             for i in sample_without_replacement(grid_size, self.n_iter,
                                                 random_state=rnd):
                 yield param_grid[i]

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -247,9 +247,9 @@ class ParameterSampler(object):
             if grid_size < n_iter:
                 warnings.warn(
                     'The total space of parameters %d is smaller '
-                    'than n_iter=%d. Running %d iterations. For exhaustive searches, '
-                    'use GridSearchCV.' % (grid_size, self.n_iter, grid_size),
-                     RuntimeWarning)
+                    'than n_iter=%d. Running %d iterations. For exhaustive '
+                    'searches, use GridSearchCV.' 
+                    % (grid_size, self.n_iter, grid_size), RuntimeWarning)
                 n_iter = grid_size
             for i in sample_without_replacement(grid_size, n_iter,
                                                 random_state=rnd):

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1394,7 +1394,7 @@ def test_parameters_sampler_replacement():
                         'than n_iter=%d. Running %d iterations. For '
                         'exhaustive searches, use GridSearchCV.'
                         % (grid_size, n_iter, grid_size))
-    assert_warns_message(RuntimeWarning, expected_warning,
+    assert_warns_message(UserWarning, expected_warning,
                          list, sampler)
 
     # degenerates to GridSearchCV if n_iter the same as grid_size

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1391,9 +1391,9 @@ def test_parameters_sampler_replacement():
     n_iter = 7
     grid_size = 6
     expected_warning = ('The total space of parameters %d is smaller '
-                    'than n_iter=%d. Running %d iterations. For '
-                    'exhaustive searches, use GridSearchCV.'
-                    % (grid_size, n_iter, grid_size))
+                        'than n_iter=%d. Running %d iterations. For '
+                        'exhaustive searches, use GridSearchCV.'
+                        % (grid_size, n_iter, grid_size))
     assert_warns_message(RuntimeWarning, expected_warning,
                          list, sampler)
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1385,10 +1385,18 @@ def test_grid_search_failing_classifier_raise():
 
 
 def test_parameters_sampler_replacement():
-    # raise error if n_iter too large
+    # raise warning if n_iter is bigger than total parameter space
     params = {'first': [0, 1], 'second': ['a', 'b', 'c']}
     sampler = ParameterSampler(params, n_iter=7)
-    assert_raises(ValueError, list, sampler)
+    n_iter=7
+    grid_size=6
+    expected_warning = ('The total space of parameters %d is smaller '
+                        'than n_iter=%d. Running %d iterations. For exhaustive '
+                        'searches, use GridSearchCV.' 
+                        % (grid_size, n_iter, grid_size))
+    assert_warns_message(RuntimeWarning, expected_warning,
+                         list, sampler)
+
     # degenerates to GridSearchCV if n_iter the same as grid_size
     sampler = ParameterSampler(params, n_iter=6)
     samples = list(sampler)

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1391,9 +1391,9 @@ def test_parameters_sampler_replacement():
     n_iter = 7
     grid_size = 6
     expected_warning = ('The total space of parameters %d is smaller '
-                        'than n_iter=%d. Running %d iterations. '
-                        'For exhaustive searches, use GridSearchCV. '
-                        % (grid_size, n_iter, grid_size))
+                    'than n_iter=%d. Running %d iterations. For '
+                    'exhaustive searches, use GridSearchCV.'
+                    % (grid_size, n_iter, grid_size))
     assert_warns_message(RuntimeWarning, expected_warning,
                          list, sampler)
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1388,11 +1388,11 @@ def test_parameters_sampler_replacement():
     # raise warning if n_iter is bigger than total parameter space
     params = {'first': [0, 1], 'second': ['a', 'b', 'c']}
     sampler = ParameterSampler(params, n_iter=7)
-    n_iter=7
-    grid_size=6
+    n_iter = 7
+    grid_size = 6
     expected_warning = ('The total space of parameters %d is smaller '
-                        'than n_iter=%d. Running %d iterations. For exhaustive '
-                        'searches, use GridSearchCV.' 
+                        'than n_iter=%d. Running %d iterations. '
+                        'For exhaustive searches, use GridSearchCV. '
                         % (grid_size, n_iter, grid_size))
     assert_warns_message(RuntimeWarning, expected_warning,
                          list, sampler)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #10900
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Changed exception raised if ParameterSampler is instantiated with a greater value of n_iter than the total space of parameters in the parameter grid to a warning. n_iter now acts as an upper bound.

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
