### PR TITLE
DOC Fix minor typo in PCA Fit function

### DIFF
--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -326,7 +326,7 @@ class PCA(_BasePCA):
         Parameters
         ----------
         X : array-like, shape (n_samples, n_features)
-            Training data, where n_samples in the number of samples
+            Training data, where n_samples is the number of samples
             and n_features is the number of features.
 
         y : Ignored


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Fixes minor typo in fit function of PCA. `in` change to `is`.

#### Any other comments?
