### PR TITLE
[MRG+2] Add parameter to linear_kernel for dense_output

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -212,6 +212,10 @@ Metrics
 - :func:`metrics.label_ranking_average_precision_score` now supports vector ``sample_weight``.
   :issue:`10845` by :user:`Jose Perez-Parras Toledano <jopepato>`.
 
+- Add ``dense_output`` parameter to :func:`metrics.pairwise.linear_kernel`. When
+  False and both inputs are sparse, will return a sparse matrix.
+  :issue:`10980` by :user:`Taylor G Smith <tgsmith61591>`.
+
 Linear, kernelized and related models
 
 - Deprecate ``random_state`` parameter in :class:`svm.OneClassSVM` as the

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -214,7 +214,7 @@ Metrics
 
 - Add ``dense_output`` parameter to :func:`metrics.pairwise.linear_kernel`. When
   False and both inputs are sparse, will return a sparse matrix.
-  :issue:`10980` by :user:`Taylor G Smith <tgsmith61591>`.
+  :issue:`10999` by :user:`Taylor G Smith <tgsmith61591>`.
 
 Linear, kernelized and related models
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -722,7 +722,7 @@ def paired_distances(X, Y, metric="euclidean", **kwds):
 
 
 # Kernels
-def linear_kernel(X, Y=None):
+def linear_kernel(X, Y=None, dense_output=True):
     """
     Compute the linear kernel between X and Y.
 
@@ -734,12 +734,19 @@ def linear_kernel(X, Y=None):
 
     Y : array of shape (n_samples_2, n_features)
 
+    dense_output : boolean (optional), default True
+        Whether to return dense output even when the input is sparse. If
+        ``False``, the output is sparse if both input arrays are sparse.
+
+        .. versionadded:: 0.20
+           parameter ``dense_output`` for dense output.
+
     Returns
     -------
     Gram matrix : array of shape (n_samples_1, n_samples_2)
     """
     X, Y = check_pairwise_arrays(X, Y)
-    return safe_sparse_dot(X, Y.T, dense_output=True)
+    return safe_sparse_dot(X, Y.T, dense_output=dense_output)
 
 
 def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1):

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -739,7 +739,6 @@ def linear_kernel(X, Y=None, dense_output=True):
         ``False``, the output is sparse if both input arrays are sparse.
 
         .. versionadded:: 0.20
-           parameter ``dense_output`` for dense output.
 
     Returns
     -------

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -56,7 +56,8 @@ def assert_sparse_pairwise_equals_dense(X_dense, Y_dense, pairwise_func):
     K1 = pairwise_func(Xcsr, Ycsr, dense_output=False)
     assert_true(issparse(K1))
 
-    K2 = pairwise_func(X_dense, Y_dense, dense_output=False)
+    K2 = pairwise_func(X_dense, Y_dense, dense_output=True)
+    assert not issparse(K2)
     assert_array_almost_equal(K1.todense(), K2)
 
     # return for other assertions if needed

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -540,6 +540,18 @@ def test_linear_kernel():
     assert_array_almost_equal(K.flat[::6], [linalg.norm(x) ** 2 for x in X])
 
 
+def test_linear_kernel_sparse_output():
+    rng = np.random.RandomState(0)
+    X = rng.random_sample((5, 4))
+    X_sparse = csr_matrix(X)
+    K = linear_kernel(X_sparse, X_sparse, dense_output=False)
+    assert_true(issparse(K))  # output will be sparse
+
+    # assert the sparse array is equal elementally to the dense array
+    K_dense = linear_kernel(X, X, dense_output=True)
+    assert_array_almost_equal(K.toarray(), K_dense)
+
+
 def test_rbf_kernel():
     rng = np.random.RandomState(0)
     X = rng.random_sample((5, 4))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

This PR references #10980.


#### What does this implement/fix? Explain your changes.

This adds an optional `dense_output=True` parameter to the `metrics.pairwise.linear_kernel`, similar to that in `metrics.pairwise.cosine_similarity`. I've also added the parameter into the docstring, updated the versionadded, and written a unit test that asserts the output is sparse and equal to the expected dense output.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->