### PR TITLE
Document use of Fast HALS in NMF's cd solver

### DIFF
--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -817,7 +817,7 @@ stored components::
     .. [5] `"Fast local algorithms for large scale nonnegative matrix and tensor
       factorizations."
       <http://www.bsp.brain.riken.jp/publications/2009/Cichocki-Phan-IEICE_col.pdf>`_
-      A. Cichocki, P. Anh-Huy, 2009
+      A. Cichocki, A. Phan, 2009
 
     .. [6] `"Algorithms for nonnegative matrix factorization with the beta-divergence"
       <https://arxiv.org/pdf/1010.1763.pdf>`_

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -891,7 +891,8 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
 
     solver : 'cd' | 'mu'
         Numerical solver to use:
-        'cd' is a Coordinate Descent solver.
+        'cd' is a Coordinate Descent solver that uses Fast Hierarchical
+            Alternating Least Squares (Fast HALS).
         'mu' is a Multiplicative Update solver.
 
         .. versionadded:: 0.17

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -467,7 +467,7 @@ def _fit_coordinate_descent(X, W, H, tol=1e-4, max_iter=200, l1_reg_W=0,
 
     References
     ----------
-    Cichocki, Andrzej, and P. H. A. N. Anh-Huy. "Fast local algorithms for
+    Cichocki, Andrzej, and Phan, Anh-Huy. "Fast local algorithms for
     large scale nonnegative matrix and tensor factorizations."
     IEICE transactions on fundamentals of electronics, communications and
     computer sciences 92.3: 708-721, 2009.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Closes #10235


#### What does this implement/fix? Explain your changes.
This PR adds a simple small update to the documentation in `sklearn/decomposition/nmf.py` to point out that the `cd` solver in NMF uses Fast Hierarchical Alternating Least Squares (Fast HALS). This doc update is meant to help prevent others from reimplementing a Fast HALS solver for Scikit-Learn [[see comment offering PR](https://github.com/scikit-learn/scikit-learn/issues/10235#issue-278370111)].


#### Any other comments?

Thanks for all the great work! I often point researchers in Yale's Digital Humanities Lab to Scikit's NMF as an intuitive approach to topic modeling.