### PR TITLE
[MRG+1] more explicit error message when multiple scores passed

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -204,10 +204,6 @@ Model evaluation and meta-estimators
   return estimators fitted on each split. :issue:`9686` by :user:`Aurélien Bellet
   <bellet>`.
 
-- Add improved error message in :func:`model_selection.cross_val_score` when
-  multiple metrics are passed in ``scoring`` keyword.
-  :issue:`11006` by :user:`Ming Li <minggli>`.
-
 Decomposition and manifold learning
 
 - Speed improvements for both 'exact' and 'barnes_hut' methods in
@@ -417,6 +413,10 @@ Preprocessing
 - Fix ValueError in :class:`preprocessing.LabelEncoder` when using
   ``inverse_transform`` on unseen labels. :issue:`9816` by :user:`Charlie Newey
   <newey01c>`.
+
+- Add improved error message in :func:`model_selection.cross_val_score` when
+  multiple metrics are passed in ``scoring`` keyword.
+  :issue:`11006` by :user:`Ming Li <minggli>`.
 
 Datasets
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -91,11 +91,11 @@ Preprocessing
 
 - Added :class:`MICEImputer`, which is a strategy for imputing missing
   values by modeling each feature with missing values as a function of
-  other features in a round-robin fashion. :issue:`8478` by 
+  other features in a round-robin fashion. :issue:`8478` by
   :user:`Sergey Feldman <sergeyf>`.
 
-- Updated :class:`preprocessing.MinMaxScaler` to pass through NaN values. :issue:`10404` 
-  by :user:`Lucija Gregov <LucijaGregov>`. 
+- Updated :class:`preprocessing.MinMaxScaler` to pass through NaN values. :issue:`10404`
+  by :user:`Lucija Gregov <LucijaGregov>`.
 
 Model evaluation
 
@@ -203,6 +203,10 @@ Model evaluation and meta-estimators
 - Add `return_estimator` parameter in :func:`model_selection.cross_validate` to
   return estimators fitted on each split. :issue:`9686` by :user:`Aurélien Bellet
   <bellet>`.
+
+- Add improved error message in :func:`model_selection.cross_val_score` when
+  multiple metrics are passed in ``scoring`` keyword.
+  :issue:`11006` by :user:`Ming Li <minggli>`.
 
 Decomposition and manifold learning
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -414,6 +414,8 @@ Preprocessing
   ``inverse_transform`` on unseen labels. :issue:`9816` by :user:`Charlie Newey
   <newey01c>`.
 
+Model evaluation and meta-estimators
+
 - Add improved error message in :func:`model_selection.cross_val_score` when
   multiple metrics are passed in ``scoring`` keyword.
   :issue:`11006` by :user:`Ming Li <minggli>`.

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -300,6 +300,10 @@ def check_scoring(estimator, scoring=None, allow_none=False):
                 "If no scoring is specified, the estimator passed should "
                 "have a 'score' method. The estimator %r does not."
                 % estimator)
+    elif isinstance(scoring, (list, tuple, set, dict)):
+        raise ValueError("For evaluating multiple scores, use "
+                         "sklearn.model_selection.cross_validate instead. "
+                         "{0} was passed.".format(scoring))
     else:
         raise ValueError("scoring value should either be a callable, string or"
                          " None. %r was passed" % scoring)

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -19,6 +19,7 @@ ground truth labeling (or ``None`` in the case of unsupervised models).
 # License: Simplified BSD
 
 from abc import ABCMeta, abstractmethod
+from collections import Iterable
 import warnings
 
 import numpy as np
@@ -300,7 +301,7 @@ def check_scoring(estimator, scoring=None, allow_none=False):
                 "If no scoring is specified, the estimator passed should "
                 "have a 'score' method. The estimator %r does not."
                 % estimator)
-    elif isinstance(scoring, (list, tuple, set, dict)):
+    elif isinstance(scoring, Iterable):
         raise ValueError("For evaluating multiple scores, use "
                          "sklearn.model_selection.cross_validate instead. "
                          "{0} was passed.".format(scoring))

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1217,10 +1217,10 @@ def test_fit_grid_point():
             assert_equal(n_test_samples, test.size)
 
     # Should raise an error upon multimetric scorer
-    assert_raise_message(ValueError, "scoring value should either be a "
-                         "callable, string or None.", fit_grid_point, X, y,
-                         svc, params, train, test, {'score': scorer},
-                         verbose=True)
+    assert_raise_message(ValueError, "For evaluating multiple scores, use "
+                         "sklearn.model_selection.cross_validate instead.",
+                         fit_grid_point, X, y, svc, params, train, test,
+                         {'score': scorer}, verbose=True)
 
 
 def test_pickle():


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes https://github.com/scikit-learn/scikit-learn/issues/11006. See also #3456.

#### What does this implement/fix? Explain your changes.
Add a more explicit message when one of below is passed to `scoring=` keyword in cross_val_score: list, set, tuple, dict. It prompts user to use cross_validate for multiple metrics evaluation.

#### Any other comments?
