### PR TITLE
MAINT: don't display passed tests in pytest summary 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ test = pytest
 addopts =
     --doctest-modules
     --disable-pytest-warnings
-    -r skipped
+    -rs
 
 [wheelhouse_uploader]
 artifact_indexes=


### PR DESCRIPTION
This PR removes the list of passing tests from the pytest summary, only keeping the skipped tests there as intended in https://github.com/scikit-learn/scikit-learn/pull/10946  ; 

See https://github.com/scikit-learn/scikit-learn/pull/10946#issuecomment-383412040 for more context.