### PR TITLE
[MRG] MAINT: Always import signature from sklearn.utils.fixes

### DIFF
--- a/examples/model_selection/plot_precision_recall.py
+++ b/examples/model_selection/plot_precision_recall.py
@@ -137,7 +137,7 @@ print('Average precision-recall score: {0:0.2f}'.format(
 # ................................
 from sklearn.metrics import precision_recall_curve
 import matplotlib.pyplot as plt
-from sklearn.externals.funcsigs import signature
+from sklearn.utils.fixes import signature
 
 precision, recall, _ = precision_recall_curve(y_test, y_score)
 

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -30,7 +30,7 @@ from scipy.spatial.distance import pdist, cdist, squareform
 from ..metrics.pairwise import pairwise_kernels
 from ..externals import six
 from ..base import clone
-from sklearn.externals.funcsigs import signature
+from ..utils.fixes import signature
 
 
 def _check_length_scale(X, length_scale):

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -3,10 +3,9 @@
 # Author: Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
 # License: BSD 3 clause
 
-from sklearn.externals.funcsigs import signature
-
 import numpy as np
 
+from sklearn.utils.fixes import signature
 from sklearn.gaussian_process.kernels import _approx_fprime
 
 from sklearn.metrics.pairwise \

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -45,7 +45,7 @@ except NameError:
 import sklearn
 from sklearn.base import BaseEstimator
 from sklearn.externals import joblib
-from sklearn.externals.funcsigs import signature
+from sklearn.utils.fixes import signature
 from sklearn.utils import deprecated
 
 additional_names_in_all = []


### PR DESCRIPTION

#### Reference Issues/PRs

(partially?) address https://github.com/scikit-learn/scikit-learn/issues/11016


#### What does this implement/fix? Explain your changes.

On Python 3.4+ always use `inspect.signature` via `sklearn.utils.fixes` instead of the Python 3.3 backported version bundled in `sklearn.externals.funcsigs` 

#### Any other comments?

This is also needed for PyPY 3 compatibility
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
