### PR TITLE
[MRG] Fixed the float parameter validation for n_neighbors in Neighbors Estimator (#11024)

### DIFF
--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -258,6 +258,10 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
                     "Expected n_neighbors > 0. Got %d" %
                     self.n_neighbors
                 )
+            else:
+            	if isinstance(self.n_neighbors,float):
+            		raise ValueError(
+            			"Expected integer value for n_neighbors")
 
         return self
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -62,6 +62,13 @@ def _weight_func(dist):
     return retval ** 2
 
 
+def test_float_n_neighbors():
+    # Test float values for parameter n_neighbors
+    neigh = neighbors.NearestNeighbors(n_neighbors=3.)
+    X = [[1,0],[0,1]]
+    assert_raises(ValueError,neigh.fit, X )
+
+
 def test_unsupervised_kneighbors(n_samples=20, n_features=5,
                                  n_query_pts=2, n_neighbors=5):
     # Test unsupervised neighbors methods


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #11024 

#### What does this implement/fix? Explain your changes.
Validates that n_neighbors should be an integer, throwing a ValueError if not.

#### Any other comments?
One test was added. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
