### PR TITLE
[WIP] Ravel voting classifier predict

### DIFF
--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -348,4 +348,4 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
 
     def _predict(self, X):
         """Collect results from clf.predict calls. """
-        return np.asarray([clf.predict(X) for clf in self.estimators_]).T
+        return np.asarray([np.ravel(clf.predict(X)) for clf in self.estimators_]).T


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #11031 

#### What does this implement/fix? Explain your changes.
It fixes a special case where a keras classifier and sklearn classifier are combined. Keras seems to return a 2d array (dim, 1) for y when making prediction which is problematic for sklearn since it expects a 1d array from the sklearn classifier. 

To overcome the problem I am raveling the output of each classifier to flatten the arrays before making combinging them with weight to make predictions.

#### Any other comments?
As mentioned in the issue, I am not sure whether this should be fixed in sklearn end or keras end. Keras has an sklearn wrapper that should follow the sklearn convention of y being 1 dimensional when there not multiple outputs.

