### PR TITLE
Fixed parameter validation in Neighbors Estimator for n_neighbors(#11024)

### DIFF
--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -258,6 +258,11 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
                     "Expected n_neighbors > 0. Got %d" %
                     self.n_neighbors
                 )
+            if type(self.n_neighbors) is not int:
+                raise TypeError(
+                    "n_neighbors does not take %s value, "
+                    "enter integer value" %
+                    type(self.n_neighbors))
 
         return self
 

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -263,7 +263,7 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
                     raise TypeError(
                         "n_neighbors does not take %s value, "
                         "enter integer value" %
-                        str(type(self.n_neighbors)).split("'")[1])
+                        type(self.n_neighbors))
 
         return self
 

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -333,6 +333,17 @@ class KNeighborsMixin(object):
 
         if n_neighbors is None:
             n_neighbors = self.n_neighbors
+        elif n_neighbors <= 0:
+            raise ValueError(
+                "Expected n_neighbors > 0. Got %d" %
+                n_neighbors
+            )
+        else:
+            if not np.issubdtype(type(n_neighbors), np.integer):
+                raise TypeError(
+                    "n_neighbors does not take %s value, "
+                    "enter integer value" %
+                    type(n_neighbors))
 
         if X is not None:
             query_is_train = False

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -258,11 +258,12 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
                     "Expected n_neighbors > 0. Got %d" %
                     self.n_neighbors
                 )
-            if type(self.n_neighbors) is not int:
-                raise TypeError(
-                    "n_neighbors does not take %s value, "
-                    "enter integer value" %
-                    type(self.n_neighbors))
+            else:
+                if not np.issubdtype(type(self.n_neighbors), int):
+                    raise TypeError(
+                        "n_neighbors does not take %s value, "
+                        "enter integer value" %
+                        type(self.n_neighbors))
 
         return self
 

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -259,7 +259,7 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
                     self.n_neighbors
                 )
             else:
-                if not np.issubdtype(type(self.n_neighbors), int):
+                if not np.issubdtype(type(self.n_neighbors), np.integer):
                     raise TypeError(
                         "n_neighbors does not take %s value, "
                         "enter integer value" %

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -263,7 +263,7 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
                     raise TypeError(
                         "n_neighbors does not take %s value, "
                         "enter integer value" %
-                        type(self.n_neighbors))
+                        str(type(self.n_neighbors)).split("'")[1])
 
         return self
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -111,7 +111,7 @@ def test_unsupervised_inputs():
 
 def test_n_neighbors_datatype():
     # Test to check whether n_neighbors is integer
-    x = [[1, 1], [1, 1]]
+    x = [[1, 1], [1, 1], [1, 1]]
     n = 3.
     expected_msg = "n_neighbors does not take .*float.* " \
                    "value, enter integer value"

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -113,7 +113,9 @@ def test_n_neighbors_datatype():
     # Test to check whether n_neighbors is integer
     x = [[1, 1], [1, 1]]
     n = 3.
-    expected_msg = "n_neighbors does not take " + str(type(n)) + " value, enter integer value"
+    expected_msg = "n_neighbors does not take " \
+                   + str(type(n)) \
+                   + " value, enter integer value"
 
     neighbors_ = neighbors.NearestNeighbors(n_neighbors=n)
     assert_raises_regex(TypeError, expected_msg, neighbors_.fit, x)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -18,6 +18,7 @@ from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_in
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
@@ -111,8 +112,10 @@ def test_unsupervised_inputs():
 def test_n_neighbors_datatype():
     # Test to check whether n_neighbors is integer
     x = [[1, 1], [1, 1]]
+    expected_msg = "n_neighbors does not take <class 'float'> value, enter integer value"
+
     neighbors_ = neighbors.NearestNeighbors(n_neighbors=3.)
-    assert_raises(TypeError, neighbors_.fit, x)
+    assert_raises_regex(TypeError, expected_msg, neighbors_.fit, x)
 
 
 def test_precomputed(random_state=42):

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -113,7 +113,7 @@ def test_n_neighbors_datatype():
     # Test to check whether n_neighbors is integer
     x = [[1, 1], [1, 1]]
     n = 3.
-    expected_msg = "n_neighbors does not take <type 'float'> " \
+    expected_msg = "n_neighbors does not take float " \
                    "value, enter integer value"
 
     neighbors_ = neighbors.NearestNeighbors(n_neighbors=n)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -113,9 +113,8 @@ def test_n_neighbors_datatype():
     # Test to check whether n_neighbors is integer
     x = [[1, 1], [1, 1]]
     n = 3.
-    expected_msg = "n_neighbors does not take " \
-                   + str(type(n)) \
-                   + " value, enter integer value"
+    expected_msg = "n_neighbors does not take <type 'float'> " \
+                   "value, enter integer value"
 
     neighbors_ = neighbors.NearestNeighbors(n_neighbors=n)
     assert_raises_regex(TypeError, expected_msg, neighbors_.fit, x)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -118,6 +118,7 @@ def test_n_neighbors_datatype():
 
     neighbors_ = neighbors.NearestNeighbors(n_neighbors=n)
     assert_raises_regex(TypeError, expected_msg, neighbors_.fit, x)
+    assert_raises_regex(TypeError, expected_msg, neighbors_.kneighbors, x, n)
 
 
 def test_precomputed(random_state=42):

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -118,7 +118,7 @@ def test_n_neighbors_datatype():
 
     neighbors_ = neighbors.NearestNeighbors(n_neighbors=n)
     assert_raises_regex(TypeError, expected_msg, neighbors_.fit, x)
-    assert_raises_regex(TypeError, expected_msg, neighbors_.kneighbors, x, n)
+    assert_raises_regex(TypeError, expected_msg, neighbors_.kneighbors, X = x, n_neighbors = n)
 
 
 def test_precomputed(random_state=42):

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -112,9 +112,10 @@ def test_unsupervised_inputs():
 def test_n_neighbors_datatype():
     # Test to check whether n_neighbors is integer
     x = [[1, 1], [1, 1]]
-    expected_msg = "n_neighbors does not take <class 'float'> value, enter integer value"
+    n = 3.
+    expected_msg = "n_neighbors does not take " + str(type(n)) + " value, enter integer value"
 
-    neighbors_ = neighbors.NearestNeighbors(n_neighbors=3.)
+    neighbors_ = neighbors.NearestNeighbors(n_neighbors=n)
     assert_raises_regex(TypeError, expected_msg, neighbors_.fit, x)
 
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -119,8 +119,10 @@ def test_n_neighbors_datatype():
 
     neighbors_ = neighbors.NearestNeighbors(n_neighbors=n)
     assert_raises_regex(TypeError, expected_msg, neighbors_.fit, x)
-    assert_raises_regex(ValueError, msg, neighbors_.kneighbors, X=x, n_neighbors=-3)
-    assert_raises_regex(TypeError, expected_msg, neighbors_.kneighbors, X=x, n_neighbors=n)
+    assert_raises_regex(ValueError, msg,
+                        neighbors_.kneighbors, X=x, n_neighbors=-3)
+    assert_raises_regex(TypeError, expected_msg,
+                        neighbors_.kneighbors, X=x, n_neighbors=n)
 
 
 def test_precomputed(random_state=42):

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -115,9 +115,11 @@ def test_n_neighbors_datatype():
     n = 3.
     expected_msg = "n_neighbors does not take .*float.* " \
                    "value, enter integer value"
+    msg = "Expected n_neighbors > 0. Got -3"
 
     neighbors_ = neighbors.NearestNeighbors(n_neighbors=n)
     assert_raises_regex(TypeError, expected_msg, neighbors_.fit, x)
+    assert_raises_regex(ValueError, msg, neighbors_.kneighbors, X=x, n_neighbors=-3)
     assert_raises_regex(TypeError, expected_msg, neighbors_.kneighbors, X=x, n_neighbors=n)
 
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -111,18 +111,17 @@ def test_unsupervised_inputs():
 
 def test_n_neighbors_datatype():
     # Test to check whether n_neighbors is integer
-    x = [[1, 1], [1, 1], [1, 1]]
-    n = 3.
+    X = [[1, 1], [1, 1], [1, 1]]
     expected_msg = "n_neighbors does not take .*float.* " \
                    "value, enter integer value"
     msg = "Expected n_neighbors > 0. Got -3"
 
-    neighbors_ = neighbors.NearestNeighbors(n_neighbors=n)
-    assert_raises_regex(TypeError, expected_msg, neighbors_.fit, x)
+    neighbors_ = neighbors.NearestNeighbors(n_neighbors=3.)
+    assert_raises_regex(TypeError, expected_msg, neighbors_.fit, X)
     assert_raises_regex(ValueError, msg,
-                        neighbors_.kneighbors, X=x, n_neighbors=-3)
+                        neighbors_.kneighbors, X=X, n_neighbors=-3)
     assert_raises_regex(TypeError, expected_msg,
-                        neighbors_.kneighbors, X=x, n_neighbors=n)
+                        neighbors_.kneighbors, X=X, n_neighbors=3.)
 
 
 def test_precomputed(random_state=42):

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -118,7 +118,7 @@ def test_n_neighbors_datatype():
 
     neighbors_ = neighbors.NearestNeighbors(n_neighbors=n)
     assert_raises_regex(TypeError, expected_msg, neighbors_.fit, x)
-    assert_raises_regex(TypeError, expected_msg, neighbors_.kneighbors, X = x, n_neighbors = n)
+    assert_raises_regex(TypeError, expected_msg, neighbors_.kneighbors, X=x, n_neighbors=n)
 
 
 def test_precomputed(random_state=42):

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -113,7 +113,7 @@ def test_n_neighbors_datatype():
     # Test to check whether n_neighbors is integer
     x = [[1, 1], [1, 1]]
     n = 3.
-    expected_msg = "n_neighbors does not take float " \
+    expected_msg = "n_neighbors does not take .*float.* " \
                    "value, enter integer value"
 
     neighbors_ = neighbors.NearestNeighbors(n_neighbors=n)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -108,6 +108,13 @@ def test_unsupervised_inputs():
         assert_array_almost_equal(ind1, ind2)
 
 
+def test_n_neighbors_datatype():
+    # Test to check whether n_neighbors is integer
+    x = [[1, 1], [1, 1]]
+    neighbors_ = neighbors.NearestNeighbors(n_neighbors=3.)
+    assert_raises(TypeError, neighbors_.fit, x)
+
+
 def test_precomputed(random_state=42):
     """Tests unsupervised NearestNeighbors with a distance matrix."""
     # Note: smaller samples may result in spurious test success


### PR DESCRIPTION
## Reference Issues/PRs
Fixes #11024 
Missing parameter validation in Neighbors estimator for float n_neighbors

## What does this implement/fix? Explain your changes.
Validates that n_neighbors should be an integer, throwing a TypeError if not.

## Any other comments?
Also checks for other data types.
One test was added.