### PR TITLE
Fix radius neighbors memory leak.

### DIFF
--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -158,6 +158,9 @@ from typedefs import DTYPE, ITYPE
 from dist_metrics cimport (DistanceMetric, euclidean_dist, euclidean_rdist,
                            euclidean_dist_to_rdist, euclidean_rdist_to_dist)
 
+cdef extern from "numpy/arrayobject.h":
+    void PyArray_ENABLEFLAGS(np.ndarray arr, int flags)
+
 np.import_array()
 
 # some handy constants
@@ -1501,14 +1504,14 @@ cdef class BinaryTree:
                     # make a new numpy array that wraps the existing data
                     indices_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_INTP, indices[i])
                     # make sure the data will be freed when the numpy array is garbage collected
-                    np.PyArray_UpdateFlags(indices_npy[i], indices_npy[i].flags.num | np.NPY_OWNDATA)
+                    PyArray_ENABLEFLAGS(indices_npy[i], np.NPY_OWNDATA)
                     # make sure the data is not freed twice
                     indices[i] = NULL
 
                     # make a new numpy array that wraps the existing data
                     distances_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_DOUBLE, distances[i])
                     # make sure the data will be freed when the numpy array is garbage collected
-                    np.PyArray_UpdateFlags(distances_npy[i], distances_npy[i].flags.num | np.NPY_OWNDATA)
+                    PyArray_ENABLEFLAGS(distances_npy[i], np.NPY_OWNDATA)
                     # make sure the data is not freed twice
                     distances[i] = NULL
 
@@ -1521,7 +1524,7 @@ cdef class BinaryTree:
                     # make a new numpy array that wraps the existing data
                     indices_npy[i] = np.PyArray_SimpleNewFromData(1, &counts[i], np.NPY_INTP, indices[i])
                     # make sure the data will be freed when the numpy array is garbage collected
-                    np.PyArray_UpdateFlags(indices_npy[i], indices_npy[i].flags.num | np.NPY_OWNDATA)
+                    PyArray_ENABLEFLAGS(indices_npy[i], np.NPY_OWNDATA)
                     # make sure the data is not freed twice
                     indices[i] = NULL
 


### PR DESCRIPTION
PyArray_UpdateFlags silently ignores the NPY_OWNDATA flag.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #11051 

#### What does this implement/fix? Explain your changes.

Replace the call to [PyArray_UpdateFlags](https://docs.scipy.org/doc/numpy-1.14.0/reference/c-api.array.html#c.PyArray_UpdateFlags) that silently ignores the `NPY_OWNDATA` flag with [PyArray_ENABLEFLAGS](https://docs.scipy.org/doc/numpy-1.14.0/reference/c-api.array.html#c.PyArray_ENABLEFLAGS).

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
