### PR TITLE
[MRG+1] MAINT Parametrize common estimator tests with pytest

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -304,21 +304,6 @@ rules before submitting a pull request:
 
     $ make
 
-* The full test suite takes fairly long to run. For faster iterations,
-  it is possibly to select a subset of tests to run using pytest selectors.
-  In particular, one can run a `single test based on its node ID
-  <https://docs.pytest.org/en/latest/example/markers.html#selecting-tests-based-on-their-node-id>`_::
-
-    $ pytest -v sklearn/linear_model/tests/test_logistic.py::test_sparsify
-
-  or use the `-k pytest parameter
-  <https://docs.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-tests-based-on-their-name>`_
-  to select tests based on their name. For instance,::
-
-    $ pytest sklearn/tests/test_common.py -v -k LogisticRegression
-
-  will run all common tests for the ``LogisticRegression`` estimator.
-
 * When adding additional functionality, provide at least one example script
   in the ``examples/`` folder. Have a look at other examples for reference.
   Examples should demonstrate why the new functionality is useful in

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -304,6 +304,21 @@ rules before submitting a pull request:
 
     $ make
 
+* The full test suite takes fairly long to run. For faster iterations,
+  it is possibly to select a subset of tests to run using pytest selectors.
+  In particular, one can run a `single test based on its node ID
+  <https://docs.pytest.org/en/latest/example/markers.html#selecting-tests-based-on-their-node-id>`_::
+
+    $ pytest -v sklearn/linear_model/tests/test_logistic.py::test_sparsify
+
+  or use the `-k pytest parameter
+  <https://docs.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-tests-based-on-their-name>`_
+  to select tests based on their name. For instance,::
+
+    $ pytest sklearn/tests/test_common.py -v -k LogisticRegression
+
+  will run all common tests for the ``LogisticRegression`` estimator.
+
 * When adding additional functionality, provide at least one example script
   in the ``examples/`` folder. Have a look at other examples for reference.
   Examples should demonstrate why the new functionality is useful in

--- a/doc/developers/tips.rst
+++ b/doc/developers/tips.rst
@@ -64,8 +64,24 @@ will be displayed as a color background behind the line number.
 Useful pytest aliases and flags
 -------------------------------
 
-We recommend using pytest to run unit tests. When a unit tests fail, the
-following tricks can make debugging easier:
+We recommend using pytest to run unit tests.
+
+The full test suite takes fairly long to run. For faster iterations,
+it is possibly to select a subset of tests using pytest selectors.
+In particular, one can run a `single test based on its node ID
+<https://docs.pytest.org/en/latest/example/markers.html#selecting-tests-based-on-their-node-id>`_::
+
+  pytest -v sklearn/linear_model/tests/test_logistic.py::test_sparsify
+
+or use the `-k pytest parameter
+<https://docs.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-tests-based-on-their-name>`_
+to select tests based on their name. For instance,::
+
+  pytest sklearn/tests/test_common.py -v -k LogisticRegression
+
+will run all common tests for the ``LogisticRegression`` estimator.
+
+When a unit tests fail, the following tricks can make debugging easier:
 
   1. The command line argument ``pytest -l`` instructs pytest to print the local
      variables when a failure occurs.

--- a/doc/developers/tips.rst
+++ b/doc/developers/tips.rst
@@ -64,8 +64,6 @@ will be displayed as a color background behind the line number.
 Useful pytest aliases and flags
 -------------------------------
 
-We recommend using pytest to run unit tests.
-
 The full test suite takes fairly long to run. For faster iterations,
 it is possibly to select a subset of tests using pytest selectors.
 In particular, one can run a `single test based on its node ID
@@ -79,7 +77,7 @@ to select tests based on their name. For instance,::
 
   pytest sklearn/tests/test_common.py -v -k LogisticRegression
 
-will run all common tests for the ``LogisticRegression`` estimator.
+will run all :term:`common tests` for the ``LogisticRegression`` estimator.
 
 When a unit tests fail, the following tricks can make debugging easier:
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -68,7 +68,7 @@ def _tested_non_meta_estimators():
         yield name, Estimator
 
 
-def _cartesian_product_checks(check_generator, estimators):
+def _combine_checks(check_generator, estimators):
     for name, Estimator in estimators:
         estimator = Estimator()
         for check in check_generator(name, estimator):
@@ -77,8 +77,8 @@ def _cartesian_product_checks(check_generator, estimators):
 
 @pytest.mark.parametrize(
         "name, Estimator, check",
-        _cartesian_product_checks(_yield_all_checks,
-                                  _tested_non_meta_estimators())
+        _combine_checks(_yield_all_checks,
+                        _tested_non_meta_estimators())
 )
 def test_non_meta_estimators(name, Estimator, check):
     # Common tests for non-meta estimators

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -68,7 +68,7 @@ def _tested_non_meta_estimators():
         yield name, Estimator
 
 
-def _combine_checks(check_generator, estimators):
+def _generate_checks_per_estimator(check_generator, estimators):
     for name, Estimator in estimators:
         estimator = Estimator()
         for check in check_generator(name, estimator):
@@ -77,8 +77,8 @@ def _combine_checks(check_generator, estimators):
 
 @pytest.mark.parametrize(
         "name, Estimator, check",
-        _combine_checks(_yield_all_checks,
-                        _tested_non_meta_estimators())
+        _generate_checks_per_estimator(_yield_all_checks,
+                                       _tested_non_meta_estimators())
 )
 def test_non_meta_estimators(name, Estimator, check):
     # Common tests for non-meta estimators


### PR DESCRIPTION
#### Reference Issues/PRs

Partially address https://github.com/scikit-learn/scikit-learn/issues/10728, also relevant to https://github.com/scikit-learn/scikit-learn/issues/7319

#### What does this implement/fix? Explain your changes.

This migrates `sklearn/tests/test_common.py` from yield based tests to pytest paramerized ones.

Instead of the approaches proposed in https://github.com/scikit-learn/scikit-learn/issues/7319#issuecomment-323209268 or https://github.com/scikit-learn/scikit-learn/issues/10728#issuecomment-385167331 this simply parametrizes `sklearn/tests/test_common.py::test_non_meta_estimators` with both the estimator  and the check to perform. 

`sklearn/utils/estimator_checks.py` is left unchanged, and the parametrization relies on `_yield_all_checks` to produce a list of valid checks for a given estimator. 

Here is an example of output (in verbose mode),
```
$ pytest sklearn/tests/test_common.py::test_non_meta_estimators -v
sklearn/tests/test_common.py::test_non_meta_estimators[ARDRegression-ARDRegression-check_estimators_dtypes] PASSED                                    [  0%]
sklearn/tests/test_common.py::test_non_meta_estimators[ARDRegression-ARDRegression-check_fit_score_takes_y] PASSED                                    [  0%]
sklearn/tests/test_common.py::test_non_meta_estimators[ARDRegression-ARDRegression-check_dtype_object] PASSED                                         [  0%]
sklearn/tests/test_common.py::test_non_meta_estimators[ARDRegression-ARDRegression-check_sample_weights_pandas_series] PASSED                         [  0%]
[...]
sklearn/tests/test_common.py::test_non_meta_estimators[AdaBoostClassifier-AdaBoostClassifier-check_estimators_dtypes] PASSED                          [  0%]
sklearn/tests/test_common.py::test_non_meta_estimators[AdaBoostClassifier-AdaBoostClassifier-check_fit_score_takes_y] PASSED                          [  0%]
sklearn/tests/test_common.py::test_non_meta_estimators[AdaBoostClassifier-AdaBoostClassifier-check_dtype_object] PASSED
```
it's a bit verbose, but allows to select both common tests specific to an estimator, e.g.,
```
$ pytest sklearn/tests/test_common.py -v -k LogisticRegression
sklearn/tests/test_common.py::test_parameters_default_constructible[LogisticRegression-LogisticRegression] PASSED                                     [  0%]
sklearn/tests/test_common.py::test_parameters_default_constructible[LogisticRegressionCV-LogisticRegressionCV] PASSED                                 [  1%]
sklearn/tests/test_common.py::test_parameters_default_constructible[RandomizedLogisticRegression-RandomizedLogisticRegression] PASSED                 [  2%]
sklearn/tests/test_common.py::test_non_meta_estimators[LogisticRegression-LogisticRegression-check_estimators_dtypes] PASSED                          [  3%]
sklearn/tests/test_common.py::test_non_meta_estimators[LogisticRegression-LogisticRegression-check_fit_score_takes_y] PASSED                          [  4%]
sklearn/tests/test_common.py::test_non_meta_estimators[LogisticRegression-LogisticRegression-check_dtype_object] PASSED 
[...]
================================================ 105 passed, 4717 deselected, 1580 warnings in 8.67 seconds =================================================
```
(specifying the path to the test file is not necessary - it only makes collection faster),

and to select all tests specific to a check, e.g.
```
$ pytest sklearn/tests/test_common.py -v -k check_estimators_nan_inf
sklearn/tests/test_common.py::test_non_meta_estimators[ARDRegression-ARDRegression-check_estimators_nan_inf] PASSED                                   [  0%]
sklearn/tests/test_common.py::test_non_meta_estimators[AdaBoostClassifier-AdaBoostClassifier-check_estimators_nan_inf] PASSED                         [  1%]
sklearn/tests/test_common.py::test_non_meta_estimators[AdaBoostRegressor-AdaBoostRegressor-check_estimators_nan_inf] PASSED                           [  2%]
sklearn/tests/test_common.py::test_non_meta_estimators[AdditiveChi2Sampler-AdditiveChi2Sampler-check_estimators_nan_inf] PASSED                       [  2%]
sklearn/tests/test_common.py::test_non_meta_estimators[AffinityPropagation-AffinityPropagation-check_estimators_nan_inf] PASSED                       [  3%]
[...]
================================================= 148 passed, 4674 deselected, 128 warnings in 4.33 seconds =================================================
```