### PR TITLE
[MRG] DOC: prevent confusion matrix example images xlabel cut off

### DIFF
--- a/examples/model_selection/plot_confusion_matrix.py
+++ b/examples/model_selection/plot_confusion_matrix.py
@@ -79,9 +79,10 @@ def plot_confusion_matrix(cm, classes,
                  horizontalalignment="center",
                  color="white" if cm[i, j] > thresh else "black")
 
-    plt.tight_layout()
     plt.ylabel('True label')
     plt.xlabel('Predicted label')
+    plt.tight_layout()
+
 
 # Compute confusion matrix
 cnf_matrix = confusion_matrix(y_test, y_pred)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
example images for confusion matrix are showing partial xlabel on http://scikit-learn.org/stable/auto_examples/model_selection/plot_confusion_matrix.html

this PR fixes this issue by moving plt.tight_layout after plt.xlabel and plt.ylabel. New example images are attached.

![sphx_glr_plot_confusion_matrix_001](https://user-images.githubusercontent.com/14131823/39633414-d79bfe4a-4faf-11e8-999c-cc2bb5eb372d.png)
![sphx_glr_plot_confusion_matrix_002](https://user-images.githubusercontent.com/14131823/39633415-d7cab898-4faf-11e8-81cf-90c1efca776b.png)

