### PR TITLE
Fix typo in LDA documentation

### DIFF
--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -848,7 +848,7 @@ a corpus with :math:`D` documents and :math:`K` topics:
   3. For each word :math:`i` in document :math:`d`:
 
     a. Draw a topic index :math:`z_{di} \sim \mathrm{Multinomial}(\theta_d)`
-    b. Draw the observed word :math:`w_{ij} \sim \mathrm{Multinomial}(beta_{z_{di}}.)`
+    b. Draw the observed word :math:`w_{ij} \sim \mathrm{Multinomial}(\beta_{z_{di}})`
 
 For parameter estimation, the posterior distribution is:
 


### PR DESCRIPTION
This PR fixes a typo in the documentation.