### PR TITLE
replacing period with comma to improve readability

### DIFF
--- a/doc/modules/calibration.rst
+++ b/doc/modules/calibration.rst
@@ -105,7 +105,7 @@ in the middle, i.e., 0.5.
 .. currentmodule:: sklearn.metrics
 
 The following experiment is performed on an artificial dataset for binary
-classification with 100.000 samples (1.000 of them are used for model fitting)
+classification with 100,000 samples (1,000 of them are used for model fitting)
 with 20 features. Of the 20 features, only 2 are informative and 10 are
 redundant. The figure shows the estimated probabilities obtained with
 logistic regression, a linear support-vector classifier (SVC), and linear SVC with

--- a/examples/calibration/plot_calibration_curve.py
+++ b/examples/calibration/plot_calibration_curve.py
@@ -10,7 +10,7 @@ how well calibrated the predicted probabilities are and how to calibrate an
 uncalibrated classifier.
 
 The experiment is performed on an artificial dataset for binary classification
-with 100.000 samples (1.000 of them are used for model fitting) with 20
+with 100,000 samples (1,000 of them are used for model fitting) with 20
 features. Of the 20 features, only 2 are informative and 10 are redundant. The
 first figure shows the estimated probabilities obtained with logistic
 regression, Gaussian naive Bayes, and Gaussian naive Bayes with both isotonic


### PR DESCRIPTION
Number One thousand is written as 1.000 which can misinterpreted with one point zero zero zero.
To improve the readability period is replaced with comma

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
