### PR TITLE
[MRG+1] DOC more warnings about cross_val_predict misuse

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -614,7 +614,7 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv=None, n_jobs=1,
                       method='predict'):
     """Generate cross-validated estimates for each input data point
 
-    NB: It is not appropriate to pass these predictions into an evaluation
+    It is not appropriate to pass these predictions into an evaluation
     metric. Use :func:`cross_validate` to measure generalization error.
 
     Read more in the :ref:`User Guide <cross_validation>`.

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -194,6 +194,10 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv=None,
     :func:`sklearn.model_selection.cross_val_score`:
         Run cross-validation for single metric evaluation.
 
+    :func:`sklearn.model_selection.cross_val_predict`:
+        Get predictions from each split of cross-validation for diagnostic
+        purposes.
+
     :func:`sklearn.metrics.make_scorer`:
         Make a scorer from a performance metric or loss function.
 
@@ -340,6 +344,10 @@ def cross_val_score(estimator, X, y=None, groups=None, scoring=None, cv=None,
     :func:`sklearn.model_selection.cross_validate`:
         To run cross-validation on multiple metrics and also to return
         train scores, fit times and score times.
+
+    :func:`sklearn.model_selection.cross_val_predict`:
+        Get predictions from each split of cross-validation for diagnostic
+        purposes.
 
     :func:`sklearn.metrics.make_scorer`:
         Make a scorer from a performance metric or loss function.
@@ -606,6 +614,9 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv=None, n_jobs=1,
                       method='predict'):
     """Generate cross-validated estimates for each input data point
 
+    NB: It is not appropriate to pass these predictions into an evaluation
+    metric. Use :func:`cross_validate` to measure generalization error.
+
     Read more in the :ref:`User Guide <cross_validation>`.
 
     Parameters
@@ -676,6 +687,12 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv=None, n_jobs=1,
     -------
     predictions : ndarray
         This is the result of calling ``method``
+
+    See also
+    --------
+    cross_val_score : calculate score for each CV split
+
+    cross_validate : calculate one or more scores and timings for each CV split
 
     Notes
     -----


### PR DESCRIPTION
Following on from #9883, I feel like users are still led astray by `cross_val_predict`. `precision_recall_fscore_support(y, cross_val_predict(est, X, y), average='binary')` can be quite different from `cross_validate(est, X, y, scoring=['precision', 'recall', 'f1'])`, particularly because of the brittleness of precision to changes in its denominator. I've got a collection of assignments to mark, and can see that students are misled by `cross_val_predict`.