### PR TITLE
[MRG] Remove error_ in MiniBatchSparsePCA docstring

### DIFF
--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -244,9 +244,6 @@ class MiniBatchSparsePCA(SparsePCA):
     components_ : array, [n_components, n_features]
         Sparse components extracted from the data.
 
-    error_ : array
-        Vector of errors at each iteration.
-
     n_iter_ : int
         Number of iterations run.
 


### PR DESCRIPTION
`self.error_` is never actually defined in `MiniBatchSparsePCA`, so it shouldn't say that it is in the docstring.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
The attribute is not defined so the docstring shouldn't say that is is.

#### Any other comments?
Thanks!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
