### PR TITLE
Fix plot tomography l1 reconstruction

### DIFF
--- a/examples/applications/plot_tomography_l1_reconstruction.py
+++ b/examples/applications/plot_tomography_l1_reconstruction.py
@@ -34,6 +34,7 @@ reconstructed image, contrary to the L1 penalization. Note in particular
 the circular artifact separating the pixels in the corners, that have
 contributed to fewer projections than the central disk.
 """
+from __future__ import division
 
 print(__doc__)
 
@@ -112,7 +113,7 @@ def generate_synthetic_data():
 
 # Generate synthetic images, and projections
 l = 128
-proj_operator = build_projection_operator(l, l / 7.)
+proj_operator = build_projection_operator(l, l // 7)
 data = generate_synthetic_data()
 proj = proj_operator * data.ravel()[:, np.newaxis]
 proj += 0.15 * np.random.randn(*proj.shape)

--- a/examples/applications/plot_tomography_l1_reconstruction.py
+++ b/examples/applications/plot_tomography_l1_reconstruction.py
@@ -51,7 +51,7 @@ import matplotlib.pyplot as plt
 
 def _weights(x, dx=1, orig=0):
     x = np.ravel(x)
-    floor_x = np.floor((x - orig) / dx)
+    floor_x = np.floor((x - orig) / dx).astype(np.int64)
     alpha = (x - orig - floor_x * dx) / dx
     return np.hstack((floor_x, floor_x + 1)), np.hstack((1 - alpha, alpha))
 


### PR DESCRIPTION
Fix part of #11089.

Here is the plot from the dev doc for comparison:
![](http://scikit-learn.org/dev/_images/sphx_glr_plot_tomography_l1_reconstruction_001.png)