### PR TITLE
[MRG] Use imgconverter sphinx extension for SVG support in latex

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -220,7 +220,7 @@ The 2013 Paris international sprint
    :target: https://www.tinyclues.com/
 
 
-.. |afpy| image:: https://www.afpy.org/logo.png
+.. |afpy| image:: https://www.afpy.org/static/images/logo.svg
    :width: 120pt
    :target: https://www.afpy.org
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,6 +35,7 @@ extensions = [
     'numpydoc',
     'sphinx.ext.linkcode', 'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
+    'sphinx.ext.imgconverter',
     'sphinx_gallery.gen_gallery',
     'sphinx_issues',
 ]


### PR DESCRIPTION
And use SVG afpy logo in about.rst.

Should fix #11089. I tested it locally but there is no good way of knowing before merging into master where the `make latexpdf` will be run.