### PR TITLE
Fixed the gradient of RBF kernel in gaussian_process

### DIFF
--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1221,7 +1221,7 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
                 return K, np.empty((X.shape[0], X.shape[0], 0))
             elif not self.anisotropic or length_scale.shape[0] == 1:
                 K_gradient = \
-                    (K * squareform(dists) / self.length_scale_bounds)[:, :, np.newaxis]
+                    (K * squareform(dists) / self.length_scale)[:, :, np.newaxis]
                 return K, K_gradient
             elif self.anisotropic:
                 # We need to recompute the pairwise dimension-wise distances

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1221,12 +1221,13 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
                 return K, np.empty((X.shape[0], X.shape[0], 0))
             elif not self.anisotropic or length_scale.shape[0] == 1:
                 K_gradient = \
-                    (K * squareform(dists) / self.length_scale)[:, :, np.newaxis]
+                    (K * squareform(dists) / self.length_scale)
+                K_gradient = K_gradient[:, :, np.newaxis]
                 return K, K_gradient
             elif self.anisotropic:
                 # We need to recompute the pairwise dimension-wise distances
                 K_gradient = (X[:, np.newaxis, :] - X[np.newaxis, :, :]) ** 2 \
-                    / (length_scale ** 2)
+                    / (length_scale ** 3)
                 K_gradient *= K[..., np.newaxis]
                 return K, K_gradient
         else:

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1221,7 +1221,7 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
                 return K, np.empty((X.shape[0], X.shape[0], 0))
             elif not self.anisotropic or length_scale.shape[0] == 1:
                 K_gradient = \
-                    (K * squareform(dists))[:, :, np.newaxis]
+                    (K * squareform(dists) / self.length_scale_bounds)[:, :, np.newaxis]
                 return K, K_gradient
             elif self.anisotropic:
                 # We need to recompute the pairwise dimension-wise distances


### PR DESCRIPTION

Corrected gradient of the RBF kernel

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes https://github.com/scikit-learn/scikit-learn/issues/11113
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Use the correct formula for the gradient of the RBF kernel: 
gradient = k(x_i, x_j) * ( ||x_i - x_j||^2 / length_scale^3)




<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
