### PR TITLE
[MRG] add whats_new entry for KMeans sample weight support

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -111,6 +111,9 @@ Decomposition, manifold learning and clustering
 - :class:`cluster.AgglomerativeClustering` now supports Single Linkage
   clustering via ``linkage='single'``. :issue:`9372` by
   :user:`Leland McInnes <lmcinnes>` and :user:`Steve Astels <sastels>`.
+- :class:`cluster.KMeans` and :class:`cluster.MiniBatchKMeans` now support
+  sample weights via new parameter ``sample_weight`` in ``fit`` function.
+  :issue:`10933` by :user:`Johannes Hansen <jnhansen>`.
 
 Metrics
 
@@ -160,7 +163,7 @@ Classifiers and regressors
   :class:`neighbors.RadiusNeighborsClassifier` are now
   parallelized according to ``n_jobs`` regardless of ``algorithm``.
   :issue:`8003` by :user:`Joël Billaud <recamshak>`.
-  
+
 - Memory usage improvement for :func:`_class_means` and :func:`_class_cov`
   in :class:`discriminant_analysis`.
   :issue:`10898` by :user:`Nanxin Chen <bobchennan>`.`
@@ -190,7 +193,7 @@ Preprocessing
 
 - :class:`preprocessing.PolynomialFeatures` now supports sparse input.
   :issue:`10452` by :user:`Aman Dalmia <dalmia>` and `Joel Nothman`_.
-  
+
 - Enable the call to :meth:`get_feature_names` in unfitted
   :class:`feature_extraction.text.CountVectorizer` initialized with a
   vocabulary. :issue:`10908` by :user:`Mohamed Maskani <maskani-moh>`.
@@ -611,3 +614,8 @@ Changes to estimator checks
 - Add tests in :func:`estimator_checks.check_estimator` to check that an
   estimator can handle read-only memmap input data. :issue:`10663` by
   :user:`Arthur Mensch <arthurmensch>` and :user:`Loïc Estève <lesteve>`.
+
+- :func:`estimator_checks.check_sample_weights_pandas_series` now uses 8 rather
+  than 6 samples to accommodate for the default number of clusters in
+  :class:`cluster.KMeans`.
+  :issue:`10933` by :user:`Johannes Hansen <jnhansen>`.

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -111,6 +111,7 @@ Decomposition, manifold learning and clustering
 - :class:`cluster.AgglomerativeClustering` now supports Single Linkage
   clustering via ``linkage='single'``. :issue:`9372` by
   :user:`Leland McInnes <lmcinnes>` and :user:`Steve Astels <sastels>`.
+
 - :class:`cluster.KMeans` and :class:`cluster.MiniBatchKMeans` now support
   sample weights via new parameter ``sample_weight`` in ``fit`` function.
   :issue:`10933` by :user:`Johannes Hansen <jnhansen>`.


### PR DESCRIPTION
#### Reference Issues/PRs
See also #10933.

#### What does this implement/fix? Explain your changes.
Adding entry in `doc/whats_new/v0.20.rst` for added sample weight support in `cluster.KMeans`.