### PR TITLE
Fixes #11126 Clarified documentation of `X_transformed_fit_` and `dual_coef_`

### DIFF
--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -107,10 +107,10 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         `remove_zero_eig` are not set, then all components are stored.
 
     dual_coef_ : array, (n_samples, n_features)
-        Inverse transform matrix. Set if `fit_inverse_transform` is True.
+        Inverse transform matrix. Only available when `fit_inverse_transform` is True.
 
     X_transformed_fit_ : array, (n_samples, n_components)
-        Projection of the fitted data on the kernel principal components.
+        Projection of the fitted data on the kernel principal components. Only available when `fit_inverse_transform` is True.
 
     X_fit_ : (n_samples, n_features)
         The data used to fit the model. If `copy_X=False`, then `X_fit_` is

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -107,11 +107,11 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         `remove_zero_eig` are not set, then all components are stored.
 
     dual_coef_ : array, (n_samples, n_features)
-        Inverse transform matrix. Only available when ``fit_inverse_transform``
-        is True.
+        Inverse transform matrix. Only available when
+        ``fit_inverse_transform`` is True.
 
     X_transformed_fit_ : array, (n_samples, n_components)
-        Projection of the fitted data on the kernel principal components. 
+        Projection of the fitted data on the kernel principal components.
         Only available when ``fit_inverse_transform`` is True.
 
     X_fit_ : (n_samples, n_features)

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -107,10 +107,12 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         `remove_zero_eig` are not set, then all components are stored.
 
     dual_coef_ : array, (n_samples, n_features)
-        Inverse transform matrix. Only available when `fit_inverse_transform` is True.
+        Inverse transform matrix. Only available when ``fit_inverse_transform``
+        is True.
 
     X_transformed_fit_ : array, (n_samples, n_components)
-        Projection of the fitted data on the kernel principal components. Only available when `fit_inverse_transform` is True.
+        Projection of the fitted data on the kernel principal components. 
+        Only available when ``fit_inverse_transform`` is True.
 
     X_fit_ : (n_samples, n_features)
         The data used to fit the model. If `copy_X=False`, then `X_fit_` is


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #11126 
This updates the documentation in KernelPCA to clarify the presence of attributes `X_transformed_fit_` and `dual_coef_` as discussed in the issue.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
