### PR TITLE
MNT add durations=20 to makefile to show test runtimes locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code: in
-	$(PYTEST) --showlocals -v sklearn
+	$(PYTEST) --showlocals -v sklearn --durations=20
 test-sphinxext:
 	$(PYTEST) --showlocals -v doc/sphinxext/
 test-doc:


### PR DESCRIPTION
This is already happening on travis. Times on travis and locally are quite different sometimes, though.