### PR TITLE
[MRG + 1] Fix Sign mistake in the RBM doc #11153

### DIFF
--- a/doc/modules/neural_networks_unsupervised.rst
+++ b/doc/modules/neural_networks_unsupervised.rst
@@ -59,8 +59,8 @@ The energy function measures the quality of a joint assignment:
 
 .. math:: 
 
-   E(\mathbf{v}, \mathbf{h}) = \sum_i \sum_j w_{ij}v_ih_j + \sum_i b_iv_i
-     + \sum_j c_jh_j
+   E(\mathbf{v}, \mathbf{h}) = -\sum_i \sum_j w_{ij}v_ih_j - \sum_i b_iv_i
+     - \sum_j c_jh_j
 
 In the formula above, :math:`\mathbf{b}` and :math:`\mathbf{c}` are the
 intercept vectors for the visible and hidden layers, respectively. The


### PR DESCRIPTION
The signs in the definition should be negative as in the referenced paper by Tieleman. If not,then the logits in the conditional probabiities further down would need a '-'

#### Reference Issues/PRs
Fixes #11153 

#### What does this implement/fix? Explain your changes.
The signs in the definition should be negative as in the referenced paper by Tieleman. If not,then the logits in the conditional probabiities further down would need a '-'