### PR TITLE
Fixed adapting tolerance value according to data type in manifold MDS

### DIFF
--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -67,8 +67,8 @@ def _smacof_single(dissimilarities, metric=True, n_components=2, init=None,
     n_iter : int
         The number of iterations corresponding to the best stress.
     """
-    if dissimilarities.dtype is np.float16 \
-            or dissimilarities.dtype is np.float32:
+    if dissimilarities.dtype == np.float16 \
+            or dissimilarities.dtype == np.float32:
         _tol = np.finfo(dissimilarities.dtype).eps
     else:
         _tol = 1E-10

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -67,7 +67,10 @@ def _smacof_single(dissimilarities, metric=True, n_components=2, init=None,
     n_iter : int
         The number of iterations corresponding to the best stress.
     """
-    _tol = np.finfo(dissimilarities.dtype).eps
+    if dissimilarities.dtype is np.float16 or np.float32:
+        _tol = np.finfo(dissimilarities.dtype).eps
+    else:
+        _tol = 1E-10
 
     dissimilarities = check_symmetric(dissimilarities, tol=_tol,
                                       raise_exception=True)

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -67,7 +67,8 @@ def _smacof_single(dissimilarities, metric=True, n_components=2, init=None,
     n_iter : int
         The number of iterations corresponding to the best stress.
     """
-    if dissimilarities.dtype is np.float16 or np.float32:
+    if dissimilarities.dtype is np.float16 \
+            or dissimilarities.dtype is np.float32:
         _tol = np.finfo(dissimilarities.dtype).eps
     else:
         _tol = 1E-10

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -67,12 +67,7 @@ def _smacof_single(dissimilarities, metric=True, n_components=2, init=None,
     n_iter : int
         The number of iterations corresponding to the best stress.
     """
-    if dissimilarities.dtype == np.float16:
-        _tol = 1E-2
-    elif dissimilarities.dtype == np.float32:
-        _tol = 1E-4
-    else:
-        _tol = 1E-10
+    _tol = np.finfo(dissimilarities.dtype).eps
 
     dissimilarities = check_symmetric(dissimilarities, tol=_tol,
                                       raise_exception=True)

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -67,7 +67,15 @@ def _smacof_single(dissimilarities, metric=True, n_components=2, init=None,
     n_iter : int
         The number of iterations corresponding to the best stress.
     """
-    dissimilarities = check_symmetric(dissimilarities, raise_exception=True)
+    if dissimilarities.dtype == np.float16:
+        _tol = 1E-2
+    elif dissimilarities.dtype == np.float32:
+        _tol = 1E-4
+    else:
+        _tol = 1E-10
+
+    dissimilarities = check_symmetric(dissimilarities, tol=_tol,
+                                      raise_exception=True)
 
     n_samples = dissimilarities.shape[0]
     random_state = check_random_state(random_state)

--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -64,5 +64,5 @@ def test_MDS():
     mat = np.random.rand(1000, 2).astype(np.float32)
     mds.MDS().fit_transform(mat)
 
-    mat = np.random.rand(1000, 2).astype(np.float16)
-    mds.MDS().fit_transform(mat)
+    _mat = mat.astype(np.float16)
+    mds.MDS().fit_transform(_mat)

--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -59,3 +59,10 @@ def test_MDS():
                     [4, 2, 1, 0]])
     mds_clf = mds.MDS(metric=False, n_jobs=3, dissimilarity="precomputed")
     mds_clf.fit(sim)
+
+    # Test to check the adaptive tol value
+    mat = np.random.rand(1000, 2).astype(np.float32)
+    mds.MDS().fit_transform(mat)
+
+    mat = np.random.rand(1000, 2).astype(np.float16)
+    mds.MDS().fit_transform(mat)

--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -64,5 +64,5 @@ def test_MDS():
     mat = np.random.rand(1000, 2).astype(np.float32)
     mds.MDS().fit_transform(mat)
 
-    _mat = mat.astype(np.float16)
+    _mat = np.float16(mat)
     mds.MDS().fit_transform(_mat)


### PR DESCRIPTION
**#### Reference Issues**
Fixes #11159 .
check_symmetric: adapt tolerance to data type


**#### What does this implement/fix? Explain your changes.**
In manifold MDS set the tolerance values for the check_symmetric function as per the data type of input.


**#### Any other comments?**
Added a test.
