### PR TITLE
[MRG] Fixes #11164 DOC: added cross-referencing of factory functions with their class counterparts

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -106,6 +106,12 @@ boolean mask array
     in the `passthrough` keyword. Those columns specified with `passthrough`
     are added at the right to the output of the transformers.
 
+    See also
+    --------
+    sklearn.compose.make_column_transformer : factory function for
+        combining the output of multiple transformer objects applied to
+        subsets of the original feature space.
+
     Examples
     --------
     >>> from sklearn.compose import ColumnTransformer
@@ -595,6 +601,12 @@ def make_column_transformer(*transformers, **kwargs):
     Returns
     -------
     ct : ColumnTransformer
+
+    See also
+    --------
+    sklearn.compose.ColumnTransformer : Class that allows combining the
+        output of multiple transformer objects used on subsets of the
+        data into a single feature space.
 
     Examples
     --------

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -108,7 +108,7 @@ boolean mask array
 
     See also
     --------
-    sklearn.compose.make_column_transformer : factory function for
+    sklearn.compose.make_column_transformer : convenience function for
         combining the output of multiple transformer objects applied to
         subsets of the original feature space.
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -109,8 +109,8 @@ boolean mask array
     See also
     --------
     sklearn.compose.make_column_transformer : convenience function for
-        combining the output of multiple transformer objects applied to
-        subsets of the original feature space.
+        combining the outputs of multiple transformer objects applied to
+        column subsets of the original feature space.
 
     Examples
     --------
@@ -605,8 +605,8 @@ def make_column_transformer(*transformers, **kwargs):
     See also
     --------
     sklearn.compose.ColumnTransformer : Class that allows combining the
-        output of multiple transformer objects used on subsets of the
-        data into a single feature space.
+        outputs of multiple transformer objects used on column subsets
+        of the data into a single feature space.
 
     Examples
     --------

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -70,8 +70,8 @@ class Pipeline(_BaseComposition):
 
     See also
     --------
-    sklearn.pipeline.make_pipeline : Factory function for generating
-        pipelines.
+    sklearn.pipeline.make_pipeline : convenience function for simplified
+        pipeline construction.
 
     Examples
     --------
@@ -637,8 +637,8 @@ class FeatureUnion(_BaseComposition, TransformerMixin):
 
     See also
     --------
-    sklearn.pipeline.make_union : Factory function for generating
-        feature unions.
+    sklearn.pipeline.make_union : convenience function for simplified
+        feature union construction.
 
     Examples
     --------

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -68,6 +68,11 @@ class Pipeline(_BaseComposition):
         Read-only attribute to access any step parameter by user given name.
         Keys are step names and values are steps parameters.
 
+    See also
+    --------
+    sklearn.pipeline.make_pipeline : Factory function for generating
+        pipelines.
+
     Examples
     --------
     >>> from sklearn import svm
@@ -549,6 +554,11 @@ def make_pipeline(*steps, **kwargs):
         inspect estimators within the pipeline. Caching the
         transformers is advantageous when fitting is time consuming.
 
+    See also
+    --------
+    sklearn.pipeline.Pipeline : Class for creating a pipeline of
+        transforms with a final estimator.
+
     Examples
     --------
     >>> from sklearn.naive_bayes import GaussianNB
@@ -624,6 +634,11 @@ class FeatureUnion(_BaseComposition, TransformerMixin):
     transformer_weights : dict, optional
         Multiplicative weights for features per transformer.
         Keys are transformer names, values the weights.
+
+    See also
+    --------
+    sklearn.pipeline.make_union : Factory function for generating
+        feature unions.
 
     Examples
     --------
@@ -822,6 +837,11 @@ def make_union(*transformers, **kwargs):
     Returns
     -------
     f : FeatureUnion
+
+    See also
+    --------
+    sklearn.pipeline.FeatureUnion : Class for concatenating the results
+        of multiple transformer objects.
 
     Examples
     --------


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #11164.



#### What does this implement/fix? Explain your changes.
Added `See also` to docs for `FeatureUnion`, `Pipeline` and `ColumnTransformer` referencing their factory functions (`make_union`, `make_pipeline` and `make_column_transformer`) as well as referencing the original classes from their factory functions.
