### PR TITLE
ENH: add oob support to CalibratedClassifier

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -402,7 +402,6 @@ class _CalibratedClassifier(object):
         return proba
 
     def _transform_proba(self, df, idx_pos_class, n_classes):
-        n_classes = n_classes
         proba = np.zeros(shape=(df.shape[0], n_classes))
         for k, this_df, calibrator in \
                 zip(idx_pos_class, df.T, self.calibrators_):

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -204,8 +204,8 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
             if hasattr(self.base_estimator, 'oob_score') and \
                     self.base_estimator.oob_score:
                 # average over all oob for each sample
-                self.oob_decision_function_ = \
-                    np.nanmean(np.array(oob_decision_function_), axis=0)
+                setattr(self, 'oob_decision_function_',
+                        np.nanmean(np.array(oob_decision_function_), axis=0))
 
         return self
 
@@ -371,7 +371,7 @@ class _CalibratedClassifier(object):
         if hasattr(self.base_estimator, 'oob_decision_function_'):
             oob_df = self.base_estimator.oob_decision_function_
             self._transform_proba(oob_df, idx_pos_class, len(self.classes))
-            self.oob_decision_function_= oob_df
+            setattr(self, 'oob_decision_function_', oob_df)
             delattr(self.base_estimator, 'oob_decision_function_')
 
         return self

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -200,7 +200,7 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
                         # save memory: remove the oob from the estimator
                         delattr(calibrated_classifier,
                                 'oob_decision_function_')
-                    self.calibrated_classifiers_.append(calibrated_classifier)
+                self.calibrated_classifiers_.append(calibrated_classifier)
             if hasattr(self.base_estimator, 'oob_score') and \
                     self.base_estimator.oob_score:
                 # average over all oob for each sample
@@ -370,7 +370,7 @@ class _CalibratedClassifier(object):
             self.calibrators_.append(calibrator)
         if hasattr(self.base_estimator, 'oob_decision_function_'):
             oob_df = self.base_estimator.oob_decision_function_
-            self._transform_proba(oob_df, idx_pos_class, len(self.classes))
+            self._transform_proba(oob_df, idx_pos_class, (X.shape[0], len(self.classes)))
             setattr(self, 'oob_decision_function_', oob_df)
             delattr(self.base_estimator, 'oob_decision_function_')
 
@@ -393,16 +393,16 @@ class _CalibratedClassifier(object):
             The predicted probas. Can be exact zeros.
         """
         n_classes = len(self.classes_)
-        proba = np.zeros((X.shape[0], n_classes))
 
         df, idx_pos_class = self._preproc(X)
 
-        proba = self._transform_proba(df, idx_pos_class, n_classes)
+        proba = self._transform_proba(df, idx_pos_class, (X.shape[0], n_classes))
 
         return proba
 
-    def _transform_proba(self, df, idx_pos_class, n_classes):
-        proba = np.empty(shape=(df.shape[0], n_classes))
+    def _transform_proba(self, df, idx_pos_class, shape):
+        _, n_classes = shape
+        proba = np.zeros(shape=shape)
         for k, this_df, calibrator in \
                 zip(idx_pos_class, df.T, self.calibrators_):
             if n_classes == 2:

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -195,7 +195,8 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
                     # out-of-bag (oob) requires special treatment
                     if hasattr(calibrated_classifier,
                                'oob_decision_function_'):
-                        oob[train] = calibrated_classifier.oob_decision_function_
+                        oob[train] = \
+                            calibrated_classifier.oob_decision_function_
                         oob_decision_function_.append(oob)
                         # save memory: remove the oob from the estimator
                         delattr(calibrated_classifier,
@@ -370,7 +371,8 @@ class _CalibratedClassifier(object):
             self.calibrators_.append(calibrator)
         if hasattr(self.base_estimator, 'oob_decision_function_'):
             oob_df = self.base_estimator.oob_decision_function_
-            self._transform_proba(oob_df, idx_pos_class, (X.shape[0], len(self.classes)))
+            self._transform_proba(
+                oob_df, idx_pos_class, (X.shape[0], len(self.classes)))
             setattr(self, 'oob_decision_function_', oob_df)
             delattr(self.base_estimator, 'oob_decision_function_')
 
@@ -396,7 +398,8 @@ class _CalibratedClassifier(object):
 
         df, idx_pos_class = self._preproc(X)
 
-        proba = self._transform_proba(df, idx_pos_class, (X.shape[0], n_classes))
+        proba = self._transform_proba(df, idx_pos_class,
+                                      (X.shape[0], n_classes))
 
         return proba
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -371,8 +371,7 @@ class _CalibratedClassifier(object):
             self.calibrators_.append(calibrator)
         if hasattr(self.base_estimator, 'oob_decision_function_'):
             oob_df = self.base_estimator.oob_decision_function_
-            self._transform_proba(
-                oob_df, idx_pos_class, (X.shape[0], len(self.classes)))
+            self._transform_proba(oob_df, idx_pos_class, len(self.classes))
             setattr(self, 'oob_decision_function_', oob_df)
             delattr(self.base_estimator, 'oob_decision_function_')
 
@@ -398,14 +397,13 @@ class _CalibratedClassifier(object):
 
         df, idx_pos_class = self._preproc(X)
 
-        proba = self._transform_proba(df, idx_pos_class,
-                                      (X.shape[0], n_classes))
+        proba = self._transform_proba(df, idx_pos_class, n_classes)
 
         return proba
 
-    def _transform_proba(self, df, idx_pos_class, shape):
-        _, n_classes = shape
-        proba = np.zeros(shape=shape)
+    def _transform_proba(self, df, idx_pos_class, n_classes):
+        n_classes = n_classes
+        proba = np.zeros(shape=(df.shape[0], n_classes))
         for k, this_df, calibrator in \
                 zip(idx_pos_class, df.T, self.calibrators_):
             if n_classes == 2:

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -312,7 +312,8 @@ def test_oob():
                                random_state=42)
 
     for method in ['sigmoid', 'isotonic']:
-        base_estimator = RandomForestClassifier(oob_score=True, n_estimators=150)
+        base_estimator = RandomForestClassifier(
+            oob_score=True, n_estimators=150)
         calibrated_clf = CalibratedClassifierCV(base_estimator, method=method)
         calibrated_clf.fit(X, y)
         assert hasattr(calibrated_clf, 'oob_decision_function_')

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -8,7 +8,7 @@ from sklearn.model_selection import LeaveOneOut
 
 from sklearn.utils.testing import (assert_array_almost_equal, assert_equal,
                                    assert_greater, assert_almost_equal,
-                                   assert_greater_equal,
+                                   assert_greater_equal, assert_allclose,
                                    assert_array_equal,
                                    assert_raises,
                                    ignore_warnings)
@@ -304,3 +304,19 @@ def test_calibration_less_classes():
         assert_array_equal(proba[:, i], np.zeros(len(y)))
         assert_equal(np.all(np.hstack([proba[:, :i],
                                        proba[:, i + 1:]])), True)
+
+
+def test_oob():
+    n_samples = 100
+    X, y = make_classification(n_samples=n_samples, n_features=6,
+                               random_state=42)
+
+    for method in ['sigmoid', 'isotonic']:
+        base_estimator = RandomForestClassifier(oob_score=True, n_estimators=150)
+        calibrated_clf = CalibratedClassifierCV(base_estimator, method=method)
+        calibrated_clf.fit(X, y)
+        assert hasattr(calibrated_clf, 'oob_decision_function_')
+        oob = calibrated_clf.oob_decision_function_
+        pred = calibrated_clf.predict_proba(X)
+        assert_array_equal(oob.shape, pred.shape)
+        assert_allclose(np.sum(oob, axis=1), 1)


### PR DESCRIPTION
## Enhances: CalibratedClassifierCV
This pull request implements out-of-bag (oob) support for `CalibratedClassifierCV` when using a base_classifier that uses out-of-bag (e.g. `RandomForestClassifier`).

If the base_classifier has the attribute `oob_decision_function_` after training (which means that the base classifier was trained with `oob=True`) the calibrated classifier uses the fitted calibration to transform the out-of-bag predictions using that fit. 

Importantly, since the oob prediction is calculated for each fold, the model holds a matrix of the oob predictions for all samples in each fold and embeds the predictions for the fold (leaving nan values for the left-out fold). After the cross-validation the matrix is averaged (ignoring nan values) to obtain an oob prediction for all the samples.

Finally, the `oob` attribute is set to True

###note:
I could not find a specific issue that this resolves.