### PR TITLE
[MRG] Normalization fix for gbm ensemble feature importances

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -782,7 +782,7 @@ accessed via the ``feature_importances_`` property::
     >>> clf = GradientBoostingClassifier(n_estimators=100, learning_rate=1.0,
     ...     max_depth=1, random_state=0).fit(X, y)
     >>> clf.feature_importances_  # doctest: +ELLIPSIS
-    array([0.10684213, 0.10461707, 0.11265447, ...
+    array([0.10..., 0.10..., 0.11..., ...
 
 .. topic:: Examples:
 

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -782,7 +782,7 @@ accessed via the ``feature_importances_`` property::
     >>> clf = GradientBoostingClassifier(n_estimators=100, learning_rate=1.0,
     ...     max_depth=1, random_state=0).fit(X, y)
     >>> clf.feature_importances_  # doctest: +ELLIPSIS
-    array([0.11, 0.1 , 0.11, ...
+    array([0.10684213, 0.10461707, 0.11265447, ...
 
 .. topic:: Examples:
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -29,6 +29,7 @@ random sampling procedures.
 - :class:`neural_network.MLPRegressor` (bug fix)
 - :class:`neural_network.MLPClassifier` (bug fix)
 - :class:`neural_network.BaseMultilayerPerceptron` (bug fix)
+- :class:`tree.DecisionTreeRegressor` (bug fix)
 - The v0.19.0 release notes failed to mention a backwards incompatibility with
   :class:`model_selection.StratifiedKFold` when ``shuffle=True`` due to
   :issue:`7823`.
@@ -377,6 +378,12 @@ Classifiers and regressors
 - Fixed condition triggering gap computation in :class:`linear_model.Lasso`
   and :class:`linear_model.ElasticNet` when working with sparse matrices.
   :issue:`10992` by `Alexandre Gramfort`_.
+
+- Fixed a bug in :class:`tree.DecisionTreeRegressor` and added a ``kwarg`` to
+  :class:`tree.BaseDecisionTree` to allow user to skip feature importance
+  normalization on a per-tree basis. The previous behavior over-weighted the GINI
+  importance of features that appear in later stages.
+  :issue:`11176` by :user:`Gil Forsyth <gforsyth>`.
 
 Decomposition, manifold learning and clustering
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -29,7 +29,7 @@ random sampling procedures.
 - :class:`neural_network.MLPRegressor` (bug fix)
 - :class:`neural_network.MLPClassifier` (bug fix)
 - :class:`neural_network.BaseMultilayerPerceptron` (bug fix)
-- :class:`tree.DecisionTreeRegressor` (bug fix)
+- :class:`ensemble.gradient_boosting.BaseGradientBoosting` (bug fix)
 - The v0.19.0 release notes failed to mention a backwards incompatibility with
   :class:`model_selection.StratifiedKFold` when ``shuffle=True`` due to
   :issue:`7823`.
@@ -379,11 +379,11 @@ Classifiers and regressors
   and :class:`linear_model.ElasticNet` when working with sparse matrices.
   :issue:`10992` by `Alexandre Gramfort`_.
 
-- Fixed a bug in :class:`tree.DecisionTreeRegressor` and added a ``kwarg`` to
-  :class:`tree.BaseDecisionTree` to allow user to skip feature importance
-  normalization on a per-tree basis. The previous behavior over-weighted the GINI
-  importance of features that appear in later stages.
-  :issue:`11176` by :user:`Gil Forsyth <gforsyth>`.
+- Fixed a bug in :class:`ensemble.gradient_boosting.BaseGradientBoosting` to
+  have feature importances summed and then normalized, rather than normalizing
+  on a per-tree basis. The previous behavior over-weighted the GINI importance
+  of features that appear in later stages. :issue:`11176` by :user:`Gil Forsyth
+  <gforsyth>`.
 
 Decomposition, manifold learning and clustering
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -381,7 +381,7 @@ Classifiers and regressors
 
 - Fixed a bug in :class:`ensemble.gradient_boosting.BaseGradientBoosting` to
   have feature importances summed and then normalized, rather than normalizing
-  on a per-tree basis. The previous behavior over-weighted the GINI importance
+  on a per-tree basis. The previous behavior over-weighted the Gini importance
   of features that appear in later stages. :issue:`11176` by :user:`Gil Forsyth
   <gforsyth>`.
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -29,7 +29,7 @@ random sampling procedures.
 - :class:`neural_network.MLPRegressor` (bug fix)
 - :class:`neural_network.MLPClassifier` (bug fix)
 - :class:`neural_network.BaseMultilayerPerceptron` (bug fix)
-- :class:`ensemble.gradient_boosting.BaseGradientBoosting` (bug fix)
+- :class:`ensemble.gradient_boosting.GradientBoostingClassifier` (bug fix affecting feature importances)
 - The v0.19.0 release notes failed to mention a backwards incompatibility with
   :class:`model_selection.StratifiedKFold` when ``shuffle=True`` due to
   :issue:`7823`.
@@ -379,11 +379,12 @@ Classifiers and regressors
   and :class:`linear_model.ElasticNet` when working with sparse matrices.
   :issue:`10992` by `Alexandre Gramfort`_.
 
-- Fixed a bug in :class:`ensemble.gradient_boosting.BaseGradientBoosting` to
-  have feature importances summed and then normalized, rather than normalizing
-  on a per-tree basis. The previous behavior over-weighted the Gini importance
-  of features that appear in later stages. :issue:`11176` by :user:`Gil Forsyth
-  <gforsyth>`.
+- Fixed a bug in :class:`ensemble.gradient_boosting.GradientBoostingRegressor`
+  and :class:`ensemble.gradient_boosting.GradientBoostingClassifier` to have
+  feature importances summed and then normalized, rather than normalizing on a
+  per-tree basis. The previous behavior over-weighted the Gini importance of
+  features that appear in later stages. This issue only affected feature
+  importances. :issue:`11176` by :user:`Gil Forsyth <gforsyth>`.
 
 Decomposition, manifold learning and clustering
 

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1229,7 +1229,7 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         total_sum = np.zeros((self.n_features_, ), dtype=np.float64)
         for stage in self.estimators_:
-            stage_sum = sum(tree.tree_.compute_feature_importances_(normalize=False)
+            stage_sum = sum(tree.tree_.compute_feature_importances(normalize=False)
                             for tree in stage) / len(stage)
             total_sum += stage_sum
 

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1229,8 +1229,8 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         total_sum = np.zeros((self.n_features_, ), dtype=np.float64)
         for stage in self.estimators_:
-            stage_sum = sum(tree.tree_.compute_feature_importances(normalize=False)
-                            for tree in stage) / len(stage)
+            stage_sum = sum(tree.tree_.compute_feature_importances(
+                normalize=False) for tree in stage) / len(stage)
             total_sum += stage_sum
 
         importances = total_sum / len(self.estimators_)

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -779,7 +779,8 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
                 max_features=self.max_features,
                 max_leaf_nodes=self.max_leaf_nodes,
                 random_state=random_state,
-                presort=self.presort)
+                presort=self.presort,
+                normalize_feature_importances=False)
 
             if self.subsample < 1.0:
                 # no inplace multiplication!
@@ -1234,6 +1235,7 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             total_sum += stage_sum
 
         importances = total_sum / len(self.estimators_)
+        importances /= importances.sum()
         return importances
 
     def _validate_y(self, y, sample_weight):

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -779,8 +779,7 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
                 max_features=self.max_features,
                 max_leaf_nodes=self.max_leaf_nodes,
                 random_state=random_state,
-                presort=self.presort,
-                normalize_feature_importances=False)
+                presort=self.presort)
 
             if self.subsample < 1.0:
                 # no inplace multiplication!
@@ -1230,7 +1229,7 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         total_sum = np.zeros((self.n_features_, ), dtype=np.float64)
         for stage in self.estimators_:
-            stage_sum = sum(tree.feature_importances_
+            stage_sum = sum(tree.tree_.compute_feature_importances_(normalize=False)
                             for tree in stage) / len(stage)
             total_sum += stage_sum
 

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -457,8 +457,8 @@ def test_feature_importance_regression():
     # Make sure that results are summed, then normalized to avoid
     # over-weighting features from later stages
     boston = datasets.load_boston()
-    X, y = shuffle(boston.data, boston.target, random_state=13)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, shuffle=False,
+    X, y = boston.data, boston.target
+    X_train, X_test, y_train, y_test = train_test_split(X, y, shuffle=True,
                                                         random_state=1)
 
     clf = GradientBoostingRegressor(n_estimators=500, min_samples_split=2,
@@ -471,8 +471,8 @@ def test_feature_importance_regression():
                                   feature_importance.max())
     sorted_idx = np.argsort(feature_importance)
 
-    ordered_features = ['ZN', 'CHAS', 'RAD', 'INDUS', 'B', 'AGE', 'TAX',
-                        'PTRATIO', 'NOX', 'CRIM', 'DIS', 'RM', 'LSTAT']
+    ordered_features = ['ZN', 'CHAS', 'RAD', 'INDUS', 'B', 'TAX', 'AGE',
+                        'CRIM', 'NOX', 'PTRATIO', 'DIS', 'RM', 'LSTAT']
 
     assert boston.feature_names[sorted_idx].tolist() == ordered_features
 

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -19,7 +19,7 @@ from sklearn.ensemble.gradient_boosting import ZeroEstimator
 from sklearn.ensemble._gradient_boosting import predict_stages
 from sklearn.metrics import mean_squared_error
 from sklearn.model_selection import train_test_split
-from sklearn.utils import check_random_state, tosequence, shuffle
+from sklearn.utils import check_random_state, tosequence
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -453,14 +453,13 @@ def test_max_feature_regression():
 
 
 def test_feature_importance_regression():
-    # Test to make sure GINI importance is calculated correctly
+    # Test to make sure Gini importance is calculated correctly
     # Make sure that results are summed, then normalized to avoid
     # over-weighting features from later stages
     boston = datasets.load_boston()
     X, y = shuffle(boston.data, boston.target, random_state=13)
-    X = X.astype(np.float32)
-    offset = int(X.shape[0] * 0.9)
-    X_train, y_train = X[:offset], y[:offset]
+    X_train, X_test, y_train, y_test = train_test_split(X, y, shuffle=False,
+                                                        random_state=1)
 
     clf = GradientBoostingRegressor(n_estimators=500, min_samples_split=2,
                                     max_depth=4, learning_rate=0.01, loss='ls',
@@ -472,10 +471,10 @@ def test_feature_importance_regression():
                                   feature_importance.max())
     sorted_idx = np.argsort(feature_importance)
 
-    feature_order = ['CHAS', 'ZN', 'RAD', 'INDUS', 'B', 'AGE', 'TAX',
-                     'PTRATIO', 'CRIM', 'NOX', 'DIS', 'RM', 'LSTAT']
+    ordered_features = ['ZN', 'CHAS', 'RAD', 'INDUS', 'B', 'AGE', 'TAX',
+                        'PTRATIO', 'NOX', 'CRIM', 'DIS', 'RM', 'LSTAT']
 
-    assert_equal(list(boston.feature_names[sorted_idx]), feature_order)
+    assert boston.feature_names[sorted_idx].tolist() == ordered_features
 
 
 def test_max_feature_auto():

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -453,18 +453,17 @@ def test_max_feature_regression():
 
 
 def test_feature_importance_regression():
-    """Test that Gini importance is calculated correctly
+    """Test that Gini importance is calculated correctly.
 
-    This test is follows an example from [1] (pg. 373).
+    This test follows the example from [1]_ (pg. 373).
 
-    [1]: Friedman, J., Hastie, T., & Tibshirani, R. (2001). The elements of
-    statistical learning. New York: Springer series in statistics.
+    .. [1] Friedman, J., Hastie, T., & Tibshirani, R. (2001). The elements
+       of statistical learning. New York: Springer series in statistics.
     """
     california = fetch_california_housing()
     X, y = california.data, california.target
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
-    # Gradient boosting
     reg = GradientBoostingRegressor(loss='huber', learning_rate=0.1,
                                     max_leaf_nodes=6, n_estimators=100,
                                     random_state=0)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -466,14 +466,19 @@ def test_feature_importance_regression():
 
     # Gradient boosting
     reg = GradientBoostingRegressor(loss='huber', learning_rate=0.1,
-                                    max_leaf_nodes=6, n_estimators=200,
+                                    max_leaf_nodes=6, n_estimators=100,
                                     random_state=0)
     reg.fit(X_train, y_train)
     sorted_idx = np.argsort(reg.feature_importances_)[::-1]
-    feature_names_sorted = [california.feature_names[s] for s in sorted_idx]
+    sorted_features = [california.feature_names[s] for s in sorted_idx]
 
-    assert feature_names_sorted[:4] == ['MedInc', 'Longitude',
-                                        'AveOccup', 'Latitude']
+    # The most important feature is the median income by far.
+    assert sorted_features[0] == 'MedInc'
+
+    # The three subsequent features are the following. Their relative ordering
+    # might change a bit depending on the randomness of the trees and the
+    # train / test split.
+    assert set(sorted_features[1:4]) == {'Longitude', 'AveOccup', 'Latitude'}
 
 
 def test_max_feature_auto():

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -93,7 +93,8 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
                  min_impurity_decrease,
                  min_impurity_split,
                  class_weight=None,
-                 presort=False):
+                 presort=False,
+                 normalize_feature_importances=True):
         self.criterion = criterion
         self.splitter = splitter
         self.max_depth = max_depth
@@ -107,6 +108,7 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
         self.min_impurity_split = min_impurity_split
         self.class_weight = class_weight
         self.presort = presort
+        self.normalize_feature_importances = normalize_feature_importances
 
     def fit(self, X, y, sample_weight=None, check_input=True,
             X_idx_sorted=None):
@@ -508,7 +510,9 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
         """
         check_is_fitted(self, 'tree_')
 
-        return self.tree_.compute_feature_importances()
+        return self.tree_.compute_feature_importances(
+            normalize=self.normalize_feature_importances
+        )
 
 
 # =============================================================================
@@ -989,6 +993,14 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
         When using either a smaller dataset or a restricted depth, this may
         speed up the training.
 
+    normalize_feature_importances : bool, optional (default=True)
+        For RandomForests, it is often beneficial to normalize before summing
+        as each stage has roughly the same amount of beginning entropy.
+
+        However, when computing feature importance for GBM ensembles,
+        normalization before summing will overweight the importance of features
+        from later stages, so it is recommended to set this to ``False``.
+
     Attributes
     ----------
     feature_importances_ : array of shape = [n_features]
@@ -1068,7 +1080,8 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
                  max_leaf_nodes=None,
                  min_impurity_decrease=0.,
                  min_impurity_split=None,
-                 presort=False):
+                 presort=False,
+                 normalize_feature_importances=True):
         super(DecisionTreeRegressor, self).__init__(
             criterion=criterion,
             splitter=splitter,
@@ -1081,7 +1094,8 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
             random_state=random_state,
             min_impurity_decrease=min_impurity_decrease,
             min_impurity_split=min_impurity_split,
-            presort=presort)
+            presort=presort,
+            normalize_feature_importances=normalize_feature_importances)
 
     def fit(self, X, y, sample_weight=None, check_input=True,
             X_idx_sorted=None):

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -93,8 +93,7 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
                  min_impurity_decrease,
                  min_impurity_split,
                  class_weight=None,
-                 presort=False,
-                 normalize_feature_importances=True):
+                 presort=False):
         self.criterion = criterion
         self.splitter = splitter
         self.max_depth = max_depth
@@ -108,7 +107,6 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
         self.min_impurity_split = min_impurity_split
         self.class_weight = class_weight
         self.presort = presort
-        self.normalize_feature_importances = normalize_feature_importances
 
     def fit(self, X, y, sample_weight=None, check_input=True,
             X_idx_sorted=None):
@@ -510,9 +508,7 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
         """
         check_is_fitted(self, 'tree_')
 
-        return self.tree_.compute_feature_importances(
-            normalize=self.normalize_feature_importances
-        )
+        return self.tree_.compute_feature_importances()
 
 
 # =============================================================================
@@ -993,14 +989,6 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
         When using either a smaller dataset or a restricted depth, this may
         speed up the training.
 
-    normalize_feature_importances : bool, optional (default=True)
-        For RandomForests, it is often beneficial to normalize before summing
-        as each stage has roughly the same amount of beginning entropy.
-
-        However, when computing feature importance for GBM ensembles,
-        normalization before summing will overweight the importance of features
-        from later stages, so it is recommended to set this to ``False``.
-
     Attributes
     ----------
     feature_importances_ : array of shape = [n_features]
@@ -1080,8 +1068,7 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
                  max_leaf_nodes=None,
                  min_impurity_decrease=0.,
                  min_impurity_split=None,
-                 presort=False,
-                 normalize_feature_importances=True):
+                 presort=False):
         super(DecisionTreeRegressor, self).__init__(
             criterion=criterion,
             splitter=splitter,
@@ -1094,8 +1081,7 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
             random_state=random_state,
             min_impurity_decrease=min_impurity_decrease,
             min_impurity_split=min_impurity_split,
-            presort=presort,
-            normalize_feature_importances=normalize_feature_importances)
+            presort=presort)
 
     def fit(self, X, y, sample_weight=None, check_input=True,
             X_idx_sorted=None):


### PR DESCRIPTION


#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This makes a small change to the ``BaseDecisionTree`` and
``DecisionTreeRegressor``, adding a ``normalize_feature_importances`` ``kwarg``
that defaults to ``True`` (matching current behavior) but is set to ``False``
for GBMs.

Tree-level feature importances are calculated as the proportional reduction of
that tree's root node entropy (see [_tree.pyx](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/tree/_tree.pyx#L1056)) and ensemble-level importances are
averaged across trees.

Because the feature importances are (currently, by default) normalized and then
averaged, feature importances from later stages are overweighted.

GBMs now defer the normalization step until after the per-tree importances have
been calculated (for the ``DecisionTreeRegressor`` used in
``ensemble.gradient_boosting.BaseGradientBoosting``).


#### Any other comments?
h/t to Joel Danke for spotting this and writing up the issue.

