### PR TITLE
[MRG] FIX passthrough parameter from make_column_transformer to ColumnTransformer

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -595,6 +595,15 @@ def make_column_transformer(*transformers, **kwargs):
     ----------
     *transformers : tuples of column selections and transformers
 
+    remainder : {'passthrough', 'drop'}, default 'passthrough'
+        By default, all remaining columns that were not specified in
+        `transformers` will be automatically passed through (default of
+        ``'passthrough'``). This subset of columns is concatenated with the
+        output of the transformers.
+        By using ``remainder='drop'``, only the specified columns in
+        `transformers` are transformed and combined in the output, and the
+        non-specified columns are dropped.
+
     n_jobs : int, optional
         Number of jobs to run in parallel (default 1).
 
@@ -627,8 +636,10 @@ def make_column_transformer(*transformers, **kwargs):
 
     """
     n_jobs = kwargs.pop('n_jobs', 1)
+    remainder = kwargs.pop('remainder', 'passthrough')
     if kwargs:
         raise TypeError('Unknown keyword arguments: "{}"'
                         .format(list(kwargs.keys())[0]))
     transformer_list = _get_transformer_list(transformers)
-    return ColumnTransformer(transformer_list, n_jobs=n_jobs)
+    return ColumnTransformer(transformer_list, n_jobs=n_jobs,
+                             remainder=remainder)

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -342,12 +342,13 @@ def test_make_column_transformer_kwargs():
     scaler = StandardScaler()
     norm = Normalizer()
     ct = make_column_transformer(('first', scaler), (['second'], norm),
-                                 n_jobs=3)
+                                 n_jobs=3, remainder='drop')
     assert_equal(
         ct.transformers,
         make_column_transformer(('first', scaler),
                                 (['second'], norm)).transformers)
     assert_equal(ct.n_jobs, 3)
+    assert_equal(ct.remainder, 'drop')
     # invalid keyword parameters should raise an error message
     assert_raise_message(
         TypeError,


### PR DESCRIPTION
Stumble in an issue with the `make_column_transformer` which is missing the remainder parameter.
I added the parameter. I don't think that we need a what's new.