### PR TITLE
BUG: ColumnTransformer with remainder='passthrough' and array-like of strings as columns

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -502,7 +502,7 @@ def _get_column(X, key):
         column_names = False
     elif _check_key_type(key, six.string_types):
         column_names = True
-    elif hasattr(key, 'dtype') and np.issubdtype(key.dtype, np.bool):
+    elif hasattr(key, 'dtype') and np.issubdtype(key.dtype, np.bool_):
         # boolean mask
         column_names = False
         if hasattr(X, 'loc'):
@@ -569,7 +569,7 @@ def _get_column_indices(X, key):
 
         return [all_columns.index(col) for col in columns]
 
-    elif hasattr(key, 'dtype') and np.issubdtype(key.dtype, np.bool):
+    elif hasattr(key, 'dtype') and np.issubdtype(key.dtype, np.bool_):
         # boolean mask
         return list(np.arange(n_columns)[key])
     else:

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -459,7 +459,10 @@ def _check_key_type(key, superclass):
     if isinstance(key, list):
         return all(isinstance(x, superclass) for x in key)
     if hasattr(key, 'dtype'):
-        return key.dtype.kind == 'i'
+        if superclass is int:
+            return key.dtype.kind == 'i'
+        else:
+            return key.dtype.kind in ('O', 'U', 'S')
     return False
 
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -448,7 +448,17 @@ boolean mask array
 
 def _check_key_type(key, superclass):
     """
-    Check that scalar, list or slice is of certain type.
+    Check that scalar, list or slice is of a certain type.
+
+    This is only used in _get_column and _get_column_indices to check
+    if the `key` (column specification) is fully integer or fully string-like.
+
+    Parameters
+    ----------
+    key : scalar, list, slice, array-like
+        The column specification to check
+    superclass : int or six.string_types
+        The type for which to check the `key`
 
     """
     if isinstance(key, superclass):
@@ -462,6 +472,7 @@ def _check_key_type(key, superclass):
         if superclass is int:
             return key.dtype.kind == 'i'
         else:
+            # superclass = six.string_types
             return key.dtype.kind in ('O', 'U', 'S')
     return False
 

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -551,9 +551,10 @@ def test_column_transformer_remainder_numpy(key):
     assert_array_equal(ct.fit(X_array).transform(X_array), X_res_both)
 
 
-@pytest.mark.parametrize("key", [[0], slice(0, 1), np.array([True, False]),
-                                 ['first'], slice(None, 'first'),
-                                 slice('first', 'first')])
+@pytest.mark.parametrize(
+    "key", [[0], slice(0, 1), np.array([True, False]), ['first'],
+            np.array(['first']), np.array(['first'], dtype=object),
+            slice(None, 'first'), slice('first', 'first')])
 def test_column_transformer_remainder_pandas(key):
     # test different ways that columns are specified with passthrough
     pd = pytest.importorskip('pandas')

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -302,7 +302,7 @@ def test_column_transformer_invalid_columns(remainder):
     X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
 
     # general invalid
-    for col in [1.5, ['string', 1], slice(1, 's')]:
+    for col in [1.5, ['string', 1], slice(1, 's'), np.array([1.])]:
         ct = ColumnTransformer([('trans', Trans(), col)], remainder=remainder)
         assert_raise_message(ValueError, "No valid specification",
                              ct.fit, X_array)

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -16,6 +16,7 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_allclose_dense_sparse
 
 from sklearn.base import BaseEstimator
+from sklearn.externals import six
 from sklearn.compose import ColumnTransformer, make_column_transformer
 from sklearn.exceptions import NotFittedError
 from sklearn.preprocessing import StandardScaler, Normalizer
@@ -552,12 +553,14 @@ def test_column_transformer_remainder_numpy(key):
 
 
 @pytest.mark.parametrize(
-    "key", [[0], slice(0, 1), np.array([True, False]), ['first'],
+    "key", [[0], slice(0, 1), np.array([True, False]), ['first'], 'pd-index',
             np.array(['first']), np.array(['first'], dtype=object),
             slice(None, 'first'), slice('first', 'first')])
 def test_column_transformer_remainder_pandas(key):
     # test different ways that columns are specified with passthrough
     pd = pytest.importorskip('pandas')
+    if isinstance(key, six.string_types) and key == 'pd-index':
+        key = pd.Index(['first'])
 
     X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
     X_df = pd.DataFrame(X_array, columns=['first', 'second'])


### PR DESCRIPTION
So in the tests I missed the case where the column specification is an array-like of strings (-> array, pandas Series or Index object) in combination with `passthrough='remainder'`.

Eg that caused this to fail:

```
In [19]: X_df = pd.DataFrame(np.arange(30).reshape(10, 3), columns=['a', 'b', 'c'])

In [20]: ct = ColumnTransformer([('trans1', StandardScaler(), X_df.columns)], remainder='passthrough')

In [21]: ct.fit_transform(X_df)
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-21-b9746449300d> in <module>()
----> 1 ct.fit_transform(X_df)

~/scipy/scikit-learn/sklearn/compose/_column_transformer.py in fit_transform(self, X, y)
    383         """
    384         self._validate_transformers()
--> 385         self._validate_remainder(X)
    386 
    387         result = self._fit_transform(X, y, _fit_transform_one)

~/scipy/scikit-learn/sklearn/compose/_column_transformer.py in _validate_remainder(self, X)
    232             cols = []
    233             for _, _, columns in self.transformers:
--> 234                 cols.extend(_get_column_indices(X, columns))
    235             self._passthrough = sorted(list(set(range(n_columns)) - set(cols)))
    236             if not self._passthrough:

~/scipy/scikit-learn/sklearn/compose/_column_transformer.py in _get_column_indices(X, key)
    558     elif hasattr(key, 'dtype') and np.issubdtype(key.dtype, np.bool):
    559         # boolean mask
--> 560         return list(np.arange(n_columns)[key])
    561     else:
    562         raise ValueError("No valid specification of the columns. Only a "

IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices

In [22]: ct = ColumnTransformer([('trans1', StandardScaler(), X_df.columns[1:])], remainder='drop')

In [23]: ct.fit_transform(X_df)
Out[23]: 
array([[-1.5666989 , -1.5666989 ],
       [-1.21854359, -1.21854359],
       [-0.87038828, -0.87038828],
       [-0.52223297, -0.52223297],
       [-0.17407766, -0.17407766],
       [ 0.17407766,  0.17407766],
       [ 0.52223297,  0.52223297],
       [ 0.87038828,  0.87038828],
       [ 1.21854359,  1.21854359],
       [ 1.5666989 ,  1.5666989 ]])
```

The reason this was missed is because now this took the code path for boolean masks because this is apparently true:

```
In [14]: key = X_df.columns

In [15]: key.dtype
Out[15]: dtype('O')

In [16]: np.issubdtype(key.dtype, np.bool)
Out[16]: True
```

and in many cases the code path for boolean masks also worked for arrays/index of strings for pandas dataframes, but not for the passthrough case.