### PR TITLE
[MRG + 1] BUG: Uses self.scoring for score function

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -326,6 +326,11 @@ Classifiers and regressors
   returning incorrect probabilities in the case of binary outcomes.
   :issue:`9939` by :user:`Roger Westover <rwolst>`.
 
+- Fixed a bug in :class:`linear_model.LogisticRegressionCV` where the
+  ``score`` method always computes accuracy, not the metric given by
+  the ``scoring`` parameter.
+  :issue:`10998` by :user:`Thomas Fan <thomasjpfan>`.
+
 - Fixed a bug in :class:`linear_model.OrthogonalMatchingPursuit` that was
   broken when setting ``normalize=False``.
   :issue:`10071` by `Alexandre Gramfort`_.

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1817,6 +1817,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
             scoring = get_scorer(scoring)
 
         if scoring is None:
-            return super().score(X, y, sample_weight=sample_weight)
+            return (super(LogisticRegressionCV, self)
+                    .score(X, y, sample_weight=sample_weight))
 
         return scoring(self, X, y, sample_weight=sample_weight)

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1816,7 +1816,8 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         if self.scoring is not None:
             warnings.warn("The long-standing behavior to use the "
                           "accuracy score has changed. The scoring "
-                          "parameter is now used",
+                          "parameter is now used. "
+                          "This warning will disappear in version 0.22.",
                           ChangedBehaviorWarning)
         scoring = self.scoring or 'accuracy'
         if isinstance(scoring, six.string_types):

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1800,7 +1800,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         X : array-like, shape = (n_samples, n_features)
             Test samples.
 
-        y : array-like, shape = (n_samples) or (n_samples, n_outputs)
+        y : array-like, shape = (n_samples,)
             True labels for X.
 
         sample_weight : array-like, shape = [n_samples], optional

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1789,3 +1789,34 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
 
         self.C_ = np.asarray(self.C_)
         return self
+
+    def score(self, X, y, sample_weight=None):
+        """Returns the score using the `scoring` option on the given
+        test data and labels.
+
+        Parameters
+        ----------
+        X : array-like, shape = (n_samples, n_features)
+            Test samples.
+
+        y : array-like, shape = (n_samples) or (n_samples, n_outputs)
+            True labels for X.
+
+        sample_weight : array-like, shape = [n_samples], optional
+            Sample weights.
+
+        Returns
+        -------
+        score : float
+            Score of self.predict(X) wrt. y.
+
+       """
+
+        scoring = self.scoring
+        if isinstance(scoring, six.string_types):
+            scoring = get_scorer(scoring)
+
+        if scoring is None:
+            return super().score(X, y, sample_weight=sample_weight)
+
+        return scoring(self, X, y, sample_weight=sample_weight)

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -29,7 +29,8 @@ from ..utils.extmath import row_norms
 from ..utils.fixes import logsumexp
 from ..utils.optimize import newton_cg
 from ..utils.validation import check_X_y
-from ..exceptions import NotFittedError, ConvergenceWarning
+from..exceptions import (NotFittedError, ConvergenceWarning,
+                         ChangedBehaviorWarning)
 from ..utils.multiclass import check_classification_targets
 from ..externals.joblib import Parallel, delayed
 from ..model_selection import check_cv
@@ -1810,8 +1811,13 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         score : float
             Score of self.predict(X) wrt. y.
 
-       """
+        """
 
+        if self.scoring is not None:
+            warnings.warn("The long-standing behavior to use the "
+                          "accuracy score has changed. The scoring "
+                          "parameter is now used",
+                          ChangedBehaviorWarning)
         scoring = self.scoring
         if isinstance(scoring, six.string_types):
             scoring = get_scorer(scoring)

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1818,12 +1818,8 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
                           "accuracy score has changed. The scoring "
                           "parameter is now used",
                           ChangedBehaviorWarning)
-        scoring = self.scoring
+        scoring = self.scoring or 'accuracy'
         if isinstance(scoring, six.string_types):
             scoring = get_scorer(scoring)
-
-        if scoring is None:
-            return (super(LogisticRegressionCV, self)
-                    .score(X, y, sample_weight=sample_weight))
 
         return scoring(self, X, y, sample_weight=sample_weight)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -113,18 +113,18 @@ def test_logistic_cv_mock_scorer():
     lr.fit(X, Y1)
 
     # Cs[2] has the highest score (0.8) from MockScorer
-    assert_equal(lr.C_[0], [Cs[2]])
+    assert lr.C_[0] == Cs[2]
 
     # scorer called 8 times (cv*len(Cs))
-    assert_equal(mock_scorer.calls, cv*len(Cs))
+    assert mock_scorer.calls == cv * len(Cs)
 
     # reset mock_scorer
     mock_scorer.calls = 0
     with pytest.warns(ChangedBehaviorWarning):
         custom_score = lr.score(X, lr.predict(X))
 
-    assert_equal(custom_score, mock_scorer.scores[0])
-    assert_equal(mock_scorer.calls, 1)
+    assert custom_score == mock_scorer.scores[0]
+    assert mock_scorer.calls == 1
 
 
 def test_logistic_cv_score_does_not_warn_by_default():

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1,6 +1,9 @@
 import numpy as np
 import scipy.sparse as sp
 from scipy import linalg, optimize, sparse
+
+import pytest
+
 from sklearn.datasets import load_iris, make_classification
 from sklearn.metrics import log_loss
 from sklearn.model_selection import StratifiedKFold
@@ -117,11 +120,20 @@ def test_logistic_cv_mock_scorer():
 
     # reset mock_scorer
     mock_scorer.calls = 0
-    pred = lr.predict(X)
-    custom_score = assert_warns(ChangedBehaviorWarning, lr.score, X, pred)
+    with pytest.warns(ChangedBehaviorWarning):
+        custom_score = lr.score(X, lr.predict(X))
 
     assert_equal(custom_score, mock_scorer.scores[0])
     assert_equal(mock_scorer.calls, 1)
+
+
+def test_logistic_cv_score_does_not_warn_by_default():
+    lr = LogisticRegressionCV(cv=2)
+    lr.fit(X, Y1)
+
+    with pytest.warns(None) as record:
+        lr.score(X, lr.predict(X))
+    assert len(record) == 0
 
 
 def test_lr_liblinear_warning():


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes https://github.com/scikit-learn/scikit-learn/issues/10998.

#### What does this implement/fix? Explain your changes.
Adds a `score` function to `LogisticRegressionCV` that uses `self.scoring`.