### PR TITLE
Update learning_curve.py

### DIFF
--- a/sklearn/learning_curve.py
+++ b/sklearn/learning_curve.py
@@ -28,7 +28,7 @@ __all__ = ['learning_curve', 'validation_curve']
 def learning_curve(estimator, X, y, train_sizes=np.linspace(0.1, 1.0, 5),
                    cv=None, scoring=None, exploit_incremental_learning=False,
                    n_jobs=1, pre_dispatch="all", verbose=0,
-                   error_score='raise'):
+                   error_score='raise', safe=True):
     """Learning curve.
 
     .. deprecated:: 0.18
@@ -111,6 +111,10 @@ def learning_curve(estimator, X, y, train_sizes=np.linspace(0.1, 1.0, 5),
         If set to 'raise', the error is raised. If a numeric value is given,
         FitFailedWarning is raised. This parameter does not affect the refit
         step, which will always raise the error.
+        
+    safe : boolean, optional, default: True
+        If safe is false, clone will fall back to a deep copy on objects that
+        are not estimators.
 
     Returns
     -------
@@ -161,11 +165,11 @@ def learning_curve(estimator, X, y, train_sizes=np.linspace(0.1, 1.0, 5),
     if exploit_incremental_learning:
         classes = np.unique(y) if is_classifier(estimator) else None
         out = parallel(delayed(_incremental_fit_estimator)(
-            clone(estimator), X, y, classes, train, test, train_sizes_abs,
+            clone(estimator, safe=safe), X, y, classes, train, test, train_sizes_abs,
             scorer, verbose) for train, test in cv)
     else:
         out = parallel(delayed(_fit_and_score)(
-            clone(estimator), X, y, scorer, train[:n_train_samples], test,
+            clone(estimator, safe=safe), X, y, scorer, train[:n_train_samples], test,
             verbose, parameters=None, fit_params=None, return_train_score=True,
             error_score=error_score)
             for train, test in cv for n_train_samples in train_sizes_abs)


### PR DESCRIPTION
This allows setting the argument `safe` in the function `clone()` when using `learning_curve()`.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

According to the documentation the `estimator` in `learning_curve()` has to be a object that implements the `fit` and `predict` methods. Nevertheless, the function `clone()` expects this object to provide other methods like `get_params`. This breaks `learning_curve()` when using custom estimators.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
