### PR TITLE
[MRG] Fix FeatureUnion numerically unstable doctest

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -644,12 +644,12 @@ class FeatureUnion(_BaseComposition, TransformerMixin):
     --------
     >>> from sklearn.pipeline import FeatureUnion
     >>> from sklearn.decomposition import PCA, TruncatedSVD
-    >>> union = FeatureUnion([("pca", PCA(n_components=2)),
+    >>> union = FeatureUnion([("pca", PCA(n_components=1)),
     ...                       ("svd", TruncatedSVD(n_components=2))])
     >>> X = [[0., 1., 3], [2., 2., 5]]
     >>> union.fit_transform(X)    # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    array([[ 1.5       ,  0.        ,  3.0...,  0.8...],
-           [-1.5       ,  0.        ,  5.7..., -0.4...]])
+    array([[ 1.5       ,  3.0...,  0.8...],
+           [-1.5       ,  5.7..., -0.4...]])
     """
     def __init__(self, transformer_list, n_jobs=1, transformer_weights=None):
         self.transformer_list = transformer_list


### PR DESCRIPTION
To reproduce (at least on my machine):
```
conda remove --all -n tmp -y -q
conda create -n tmp numpy scipy pytest cython -y
. activate tmp
make clean in
pytest ~/dev/scikit-learn/sklearn/pipeline.py
. deactivate
```

Excerpt of the output:
```
======================================================== test session starts ========================================================
platform linux -- Python 3.6.5, pytest-3.6.0, py-1.5.3, pluggy-0.6.0
rootdir: /home/ROCQ/sed/lesteve/dev/scikit-learn, inifile: setup.cfg
collected 4 items                                                                                                                   

../../../../ROCQ/sed/lesteve/dev/scikit-learn/sklearn/pipeline.py F...                                                        [100%]

============================================================= FAILURES ==============================================================
______________________________________________ [doctest] sklearn.pipeline.FeatureUnion ______________________________________________
641         feature union construction.
642 
643     Examples
644     --------
645     >>> from sklearn.pipeline import FeatureUnion
646     >>> from sklearn.decomposition import PCA, TruncatedSVD
647     >>> union = FeatureUnion([("pca", PCA(n_components=2)),
648     ...                       ("svd", TruncatedSVD(n_components=2))])
649     >>> X = [[0., 1., 3], [2., 2., 5]]
650     >>> union.fit_transform(X)    # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
Expected:
    array([[ 1.5       ,  0.        ,  3.0...,  0.8...],
           [-1.5       ,  0.        ,  5.7..., -0.4...]])
Got:
    array([[ 1.50000000e+00,  3.10316769e-17,  3.03954967e+00,
             8.72432133e-01],
           [-1.50000000e+00,  3.10316769e-17,  5.72586357e+00,
            -4.63126787e-01]])

/home/ROCQ/sed/lesteve/dev/scikit-learn/sklearn/pipeline.py:650: DocTestFailure
================================================ 1 failed, 3 passed in 0.95 seconds =================================================
```

I don't know why this does not fail on Travis but all I can say is that this doctest does not seem to be numerically stable: I do not get a failure on my machine by adding `nomkl` to the environment (`conda create -n tmp numpy scipy pytest cython nomkl -y`).

I don't think there is a good way to fix it using doctest features, so I used only one component for the PCA, let me know if you can think of a better fix.