### PR TITLE
[MRG] Fix some example refs due to renaming examples

### DIFF
--- a/doc/datasets/twenty_newsgroups.rst
+++ b/doc/datasets/twenty_newsgroups.rst
@@ -135,7 +135,7 @@ which is fast to train and achieves a decent F-score::
   >>> metrics.f1_score(newsgroups_test.target, pred, average='macro')
   0.88213592402729568
 
-(The example :ref:`sphx_glr_auto_examples_text_document_classification_20newsgroups.py` shuffles
+(The example :ref:`sphx_glr_auto_examples_text_plot_document_classification_20newsgroups.py` shuffles
 the training and test data, instead of segmenting by time, and in that case
 multinomial Naive Bayes gets a much higher F-score of 0.88. Are you suspicious
 yet of what's going on inside this classifier?)
@@ -215,4 +215,4 @@ the ``--filter`` option to compare the results.
 
    * :ref:`sphx_glr_auto_examples_model_selection_grid_search_text_feature_extraction.py`
 
-   * :ref:`sphx_glr_auto_examples_text_document_classification_20newsgroups.py`
+   * :ref:`sphx_glr_auto_examples_text_plot_document_classification_20newsgroups.py`

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -271,7 +271,7 @@ small, as shown in the example and cited reference.
  * :ref:`sphx_glr_auto_examples_cluster_plot_mini_batch_kmeans.py`: Comparison of KMeans and
    MiniBatchKMeans
 
- * :ref:`sphx_glr_auto_examples_text_document_clustering.py`: Document clustering using sparse
+ * :ref:`sphx_glr_auto_examples_text_plot_document_clustering.py`: Document clustering using sparse
    MiniBatchKMeans
 
  * :ref:`sphx_glr_auto_examples_cluster_plot_dict_face_patches.py`

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -347,7 +347,7 @@ compensating for LSA's erroneous assumptions about textual data.
 
 .. topic:: Examples:
 
-   * :ref:`sphx_glr_auto_examples_text_document_clustering.py`
+   * :ref:`sphx_glr_auto_examples_text_plot_document_clustering.py`
 
 .. topic:: References:
 

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -657,12 +657,12 @@ In particular in a **supervised setting** it can be successfully combined
 with fast and scalable linear models to train **document classifiers**,
 for instance:
 
- * :ref:`sphx_glr_auto_examples_text_document_classification_20newsgroups.py`
+ * :ref:`sphx_glr_auto_examples_text_plot_document_classification_20newsgroups.py`
 
 In an **unsupervised setting** it can be used to group similar documents
 together by applying clustering algorithms such as :ref:`k_means`:
 
-  * :ref:`sphx_glr_auto_examples_text_document_clustering.py`
+  * :ref:`sphx_glr_auto_examples_text_plot_document_clustering.py`
 
 Finally it is possible to discover the main topics of a corpus by
 relaxing the hard assignment constraint of clustering, for instance by

--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -198,7 +198,7 @@ alpha parameter, the fewer features selected.
 
 .. topic:: Examples:
 
-    * :ref:`sphx_glr_auto_examples_text_document_classification_20newsgroups.py`: Comparison
+    * :ref:`sphx_glr_auto_examples_text_plot_document_classification_20newsgroups.py`: Comparison
       of different algorithms for document classification including L1-based
       feature selection.
 

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -114,7 +114,7 @@ its ``coef_`` member::
 .. topic:: Examples:
 
    * :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_path.py`
-   * :ref:`sphx_glr_auto_examples_text_document_classification_20newsgroups.py`
+   * :ref:`sphx_glr_auto_examples_text_plot_document_classification_20newsgroups.py`
 
 
 Ridge Complexity

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -565,7 +565,7 @@ false negatives and true positives as follows::
     for an example of using a confusion matrix to classify
     hand-written digits.
 
-  * See :ref:`sphx_glr_auto_examples_text_document_classification_20newsgroups.py`
+  * See :ref:`sphx_glr_auto_examples_text_plot_document_classification_20newsgroups.py`
     for an example of using a confusion matrix to classify text
     documents.
 
@@ -598,7 +598,7 @@ and inferred labels::
     for an example of classification report usage for
     hand-written digits.
 
-  * See :ref:`sphx_glr_auto_examples_text_document_classification_20newsgroups.py`
+  * See :ref:`sphx_glr_auto_examples_text_plot_document_classification_20newsgroups.py`
     for an example of classification report usage for text
     documents.
 
@@ -749,7 +749,7 @@ binary classification and multilabel indicator format.
 
 .. topic:: Examples:
 
-  * See :ref:`sphx_glr_auto_examples_text_document_classification_20newsgroups.py`
+  * See :ref:`sphx_glr_auto_examples_text_plot_document_classification_20newsgroups.py`
     for an example of :func:`f1_score` usage to classify  text
     documents.
 

--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -218,7 +218,7 @@ matrix format as defined in `scipy.sparse.csr_matrix
 
 .. topic:: Examples:
 
- - :ref:`sphx_glr_auto_examples_text_document_classification_20newsgroups.py`
+ - :ref:`sphx_glr_auto_examples_text_plot_document_classification_20newsgroups.py`
 
 Complexity
 ==========

--- a/doc/tutorial/text_analytics/working_with_text_data.rst
+++ b/doc/tutorial/text_analytics/working_with_text_data.rst
@@ -554,7 +554,7 @@ upon the completion of this tutorial:
   :class:`CountVectorizer`.
 
 * If you don't have labels, try using
-  :ref:`Clustering <sphx_glr_auto_examples_text_document_clustering.py>`
+  :ref:`Clustering <sphx_glr_auto_examples_text_plot_document_clustering.py>`
   on your problem.
 
 * If you have multiple labels per document, e.g categories, have a look

--- a/doc/whats_new/older_versions.rst
+++ b/doc/whats_new/older_versions.rst
@@ -1273,7 +1273,7 @@ Examples
 
 - new examples using some of the mlcomp datasets:
   ``sphx_glr_auto_examples_mlcomp_sparse_document_classification.py`` (since removed) and
-  :ref:`sphx_glr_auto_examples_text_document_classification_20newsgroups.py`
+  :ref:`sphx_glr_auto_examples_text_plot_document_classification_20newsgroups.py`
 
 - Many more examples. `See here
   <http://scikit-learn.org/stable/auto_examples/index.html>`_


### PR DESCRIPTION
An [example](http://scikit-learn.org/dev/datasets/twenty_newsgroups.html#filtering-text-for-more-realistic-training) of broken link that can be seen on the dev doc (search for `sphx_glr`).

It's really hard to remember to check for sphinx references when moving around the examples ...

Another [broken link](http://scikit-learn.org/dev/faq.html#why-do-categorical-variables-need-preprocessing-in-scikit-learn-compared-to-other-tools) I found in the FAQ. Not sure what the proper replacement link is because the example does not exist anymore ...