### PR TITLE
[MRG] DOC: add binder links to examples 

### DIFF
--- a/build_tools/circle/push_doc.sh
+++ b/build_tools/circle/push_doc.sh
@@ -59,7 +59,14 @@ cp -R $GENERATED_DOC_DIR $dir
 git config user.email "olivier.grisel+sklearn-ci@gmail.com"
 git config user.name $USERNAME
 git config push.default matching
-git add -f $dir/
+
+# binder folder for requirements needs to be at the root of the repo
+if [ -d dev/binder ]; then
+    rm -f binder
+    ln -s dev/binder
+    git add binder
+fi
+
 git commit -m "$MSG" $dir
 git push
-echo $MSG 
+echo $MSG

--- a/build_tools/circle/push_doc.sh
+++ b/build_tools/circle/push_doc.sh
@@ -60,13 +60,6 @@ git config user.email "olivier.grisel+sklearn-ci@gmail.com"
 git config user.name $USERNAME
 git config push.default matching
 
-# binder folder for requirements needs to be at the root of the repo
-if [ -d dev/binder ]; then
-    rm -f binder
-    ln -s dev/binder
-    git add binder
-fi
-
 git commit -m "$MSG" $dir
 git push
 echo $MSG

--- a/build_tools/circle/push_doc.sh
+++ b/build_tools/circle/push_doc.sh
@@ -59,7 +59,7 @@ cp -R $GENERATED_DOC_DIR $dir
 git config user.email "olivier.grisel+sklearn-ci@gmail.com"
 git config user.name $USERNAME
 git config push.default matching
-
+git add -f $dir/
 git commit -m "$MSG" $dir
 git push
-echo $MSG
+echo $MSG 

--- a/doc/binder/requirements.txt
+++ b/doc/binder/requirements.txt
@@ -1,7 +1,4 @@
-# Requirements for running the examples
-numpy
-scipy
-scikit-learn
-matplotlib
-pandas
-scikit-image
+# This is required by sphinx-gallery 0.4 but not needed since the examples are
+# not in the scikit-learn.github.io repo that comes from the scikit-learn doc
+# build but on a separate repo. This file can be removed if 'dependencies' key
+# is made an optional key for binder in sphinx-gallery.

--- a/doc/binder/requirements.txt
+++ b/doc/binder/requirements.txt
@@ -1,0 +1,7 @@
+# Requirements for running the examples
+numpy
+scipy
+scikit-learn
+matplotlib
+pandas
+scikit-image

--- a/doc/binder/requirements.txt
+++ b/doc/binder/requirements.txt
@@ -1,4 +1,5 @@
-# This is required by sphinx-gallery 0.4 but not needed since the examples are
-# not in the scikit-learn.github.io repo that comes from the scikit-learn doc
-# build but on a separate repo. This file can be removed if 'dependencies' key
-# is made an optional key for binder in sphinx-gallery.
+# A binder requirement file is required by sphinx-gallery. We don't really need
+# one since the binder requirement files live in the
+# scikit-learn/binder-examples repo and not in the scikit-learn.github.io repo
+# that comes from the scikit-learn doc build. This file can be removed if
+# 'dependencies' is made an optional key for binder in sphinx-gallery.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -261,7 +261,6 @@ else:
     major, minor = match.groups()
     binder_branch = '{}.{}.X'.format(major, minor)
 
-print('binder_branch:', binder_branch)
 sphinx_gallery_conf = {
     'doc_module': 'sklearn',
     'backreferences_dir': os.path.join('modules', 'generated'),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,6 +15,7 @@
 import sys
 import os
 import warnings
+import re
 
 # If extensions (or modules to document with autodoc) are in another
 # directory, add these directories to sys.path here. If the directory
@@ -247,6 +248,20 @@ intersphinx_mapping = {
     'joblib': ('https://joblib.readthedocs.io/en/latest/', None),
 }
 
+if 'dev' in version:
+    binder_branch = 'master'
+else:
+    match = re.search(r'^(\d+)\.(\d+)\.', version)
+    if match is None:
+        raise ValueError(
+            'Ill-formed version: {!r}. Expected either '
+            'a version containing dev '
+            'or something like major_version.minor_version.'.format(version))
+
+    major, minor = match.groups()
+    binder_branch = '{}.{}.X'.format(major, minor)
+
+print('binder_branch:', binder_branch)
 sphinx_gallery_conf = {
     'doc_module': 'sklearn',
     'backreferences_dir': os.path.join('modules', 'generated'),
@@ -256,10 +271,10 @@ sphinx_gallery_conf = {
     'examples_dirs': ['../examples'],
     'gallery_dirs': ['auto_examples'],
     'binder': {
-        'org': 'lesteve',
-        'repo': 'test-binder-scikit-learn',
-        'url': 'https://mybinder.org',
-        'branch': 'master',
+        'org': 'scikit-learn',
+        'repo': 'binder-examples',
+        'binderhub_url': 'https://mybinder.org',
+        'branch': binder_branch,
         'dependencies': './binder/requirements.txt',
         'use_jupyter_lab': True
     }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -256,9 +256,9 @@ sphinx_gallery_conf = {
     'examples_dirs': ['../examples'],
     'gallery_dirs': ['auto_examples'],
     'binder': {
-        'org': 'scikit-learn',
-        'repo': 'scikit-learn.github.io',
-        'url': 'https://mybinder.org',
+        'org': 'lesteve',
+        'repo': 'test-binder-scikit-learn',
+        'binderhub_url': 'https://mybinder.org',
         'branch': 'master',
         'dependencies': './binder/requirements.txt',
         'use_jupyter_lab': True

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -258,7 +258,7 @@ sphinx_gallery_conf = {
     'binder': {
         'org': 'lesteve',
         'repo': 'test-binder-scikit-learn',
-        'binderhub_url': 'https://mybinder.org',
+        'url': 'https://mybinder.org',
         'branch': 'master',
         'dependencies': './binder/requirements.txt',
         'use_jupyter_lab': True

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -251,12 +251,12 @@ intersphinx_mapping = {
 if 'dev' in version:
     binder_branch = 'master'
 else:
-    match = re.search(r'^(\d+)\.(\d+)\.', version)
+    match = re.match(r'^(\d+)\.(\d+)(?:\.\d)?$', version)
     if match is None:
         raise ValueError(
             'Ill-formed version: {!r}. Expected either '
             'a version containing dev '
-            'or something like major_version.minor_version.'.format(version))
+            'or a version like X.Y or X.Y.Z.'.format(version))
 
     major, minor = match.groups()
     binder_branch = '{}.{}.X'.format(major, minor)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -252,7 +252,17 @@ sphinx_gallery_conf = {
     'backreferences_dir': os.path.join('modules', 'generated'),
     'show_memory': True,
     'reference_url': {
-        'sklearn': None}
+        'sklearn': None},
+    'examples_dirs': ['../examples'],
+    'gallery_dirs': ['auto_examples'],
+    'binder': {
+        'org': 'scikit-learn',
+        'repo': 'scikit-learn.github.io',
+        'url': 'https://mybinder.org',
+        'branch': 'master',
+        'dependencies': './binder/requirements.txt',
+        'use_jupyter_lab': True
+    }
 }
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -251,11 +251,11 @@ intersphinx_mapping = {
 if 'dev' in version:
     binder_branch = 'master'
 else:
-    match = re.match(r'^(\d+)\.(\d+)(?:\.\d)?$', version)
+    match = re.match(r'^(\d+)\.(\d+)(?:\.\d+)?$', version)
     if match is None:
         raise ValueError(
             'Ill-formed version: {!r}. Expected either '
-            'a version containing dev '
+            "a version containing 'dev' "
             'or a version like X.Y or X.Y.Z.'.format(version))
 
     major, minor = match.groups()


### PR DESCRIPTION
This is using the binder feature in the recent 0.2 sphinx-gallery release.

Summary of the changes:
- conf.py needs to configure sphinx-gallery to create binder links
- binder/requirements.txt: requirements for the docker image created on binder
- build_tools/circle/push_doc.sh: binder needs the `binder` repo to be at the root of the repo and the `binder` folder is in `dev/binder`.

At the moment the latest scikit-learn release is installed so some examples may not work if they use some features from master.
Maybe a question for @choldgraf: if I add `-f git+https://github.com/scikit-learn/scikit-learn.git` to `requirements.txt` will it ensure that the docker image is rebuilt on each push and that I have always scikit-learn master in the docker image?

I have to say I haven't thought too much about how stable doc vs dev doc is going to work yet. For now the binder links are only visible on the dev doc anyway.