### PR TITLE
[MRG] proposal to recommend ".joblib" file extension for load/dump

### DIFF
--- a/doc/modules/model_persistence.rst
+++ b/doc/modules/model_persistence.rst
@@ -42,12 +42,12 @@ is often the case for fitted scikit-learn estimators, but can only pickle to the
 disk and not to a string::
 
   >>> from sklearn.externals import joblib
-  >>> joblib.dump(clf, 'filename.pkl') # doctest: +SKIP
+  >>> joblib.dump(clf, 'filename.joblib') # doctest: +SKIP
 
 Later you can load back the pickled model (possibly in another Python process)
 with::
 
-  >>> clf = joblib.load('filename.pkl') # doctest:+SKIP
+  >>> clf = joblib.load('filename.joblib') # doctest:+SKIP
 
 .. note::
 


### PR DESCRIPTION
I'm proposing the use of `filename.joblib` instead of `filename.pkl` for models persisted via the joblib library. This will make it easier for model sharing and reduce confusion when it comes to time load a model, as it will be more clear whether a file was saved using the `pickle` or `joblib` library.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
