### PR TITLE
[MRG+1] FIX: enforce consistency between dense and sparse cases in StandardScaler

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -504,12 +504,12 @@ Preprocessing
   when returning a sparse matrix output. :issue:`11042` by :user:`Daniel
   Morales <DanielMorales9>`.
 
-- Fix ``fit`` and ``partial_fit`` in :class:`preprocessing.StandardScaler` with
-  `with_mean=False` and `with_std=False` which was crashing by calling ``fit``
-  more than once and giving inconsistent results for ``mean_`` whether the
-  input was a sparse or a dense matrix. ``mean_`` will be set to ``None`` with
-  both sparse and dense inputs. ``n_samples_seen_`` will be also reported for
-  both input types.
+- Fix ``fit`` and ``partial_fit`` in :class:`preprocessing.StandardScaler` in
+  the rare case when `with_mean=False` and `with_std=False` which was crashing
+  by calling ``fit`` more than once and giving inconsistent results for
+  ``mean_`` whether the input was a sparse or a dense matrix. ``mean_`` will be
+  set to ``None`` with both sparse and dense inputs. ``n_samples_seen_`` will
+  be also reported for both input types.
   :issue:`11235` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Feature selection

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -504,11 +504,12 @@ Preprocessing
   when returning a sparse matrix output. :issue:`11042` by :user:`Daniel
   Morales <DanielMorales9>`.
 
-- Fix inconsistencies in :class:`preprocessing.StandardScaler` with
-  `with_mean=False` and `with_std=False`. ``mean_`` will be set to ``None`` with
+- Fix ``fit`` and ``partial_fit`` in :class:`preprocessing.StandardScaler` with
+  `with_mean=False` and `with_std=False` which was crashing by calling ``fit``
+  more than once and giving inconsistent results for ``mean_`` whether the
+  input was a sparse or a dense matrix. ``mean_`` will be set to ``None`` with
   both sparse and dense inputs. ``n_samples_seen_`` will be also reported for
-  both input types avoiding a crash when ``fit`` is called more than once with
-  sparse input.
+  both input types.
   :issue:`11235` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Feature selection

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -504,6 +504,10 @@ Preprocessing
   when returning a sparse matrix output. :issue:`11042` by :user:`Daniel
   Morales <DanielMorales9>`.
 
+- Fix inconsistency between sparse and dense case in
+  :class:`preprocessing.StandardScaler` with ``with_mean=False`` and
+  ``with_std=False``. :issue:`11235` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Feature selection
 
 - Fixed computation of ``n_features_to_compute`` for edge case with tied CV

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -504,9 +504,12 @@ Preprocessing
   when returning a sparse matrix output. :issue:`11042` by :user:`Daniel
   Morales <DanielMorales9>`.
 
-- Fix inconsistency between sparse and dense case in
-  :class:`preprocessing.StandardScaler` with ``with_mean=False`` and
-  ``with_std=False``. :issue:`11235` by :user:`Guillaume Lemaitre <glemaitre>`.
+- Fix inconsistencies in :class:`preprocessing.StandardScaler` with
+  `with_mean=False` and `with_std=False`. ``mean_`` will be set to ``None`` with
+  both sparse and dense inputs. ``n_samples_seen_`` will be also reported for
+  both input types avoiding a crash when ``fit`` is called more than once with
+  sparse input.
+  :issue:`11235` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Feature selection
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -652,6 +652,10 @@ class StandardScaler(BaseEstimator, TransformerMixin):
             else:
                 self.mean_ = None
                 self.var_ = None
+                if not hasattr(self, 'n_samples_seen_'):
+                    self.n_samples_seen_ = X.shape[0]
+                else:
+                    self.n_samples_seen_ += X.shape[0]
         else:
             # First pass
             if not hasattr(self, 'n_samples_seen_'):
@@ -662,9 +666,14 @@ class StandardScaler(BaseEstimator, TransformerMixin):
                 else:
                     self.var_ = None
 
-            self.mean_, self.var_, self.n_samples_seen_ = \
-                _incremental_mean_and_var(X, self.mean_, self.var_,
-                                          self.n_samples_seen_)
+            if not self.with_mean and not self.with_std:
+                self.mean_ = None
+                self.var_ = None
+                self.n_samples_seen_ += X.shape[0]
+            else:
+                self.mean_, self.var_, self.n_samples_seen_ = \
+                    _incremental_mean_and_var(X, self.mean_, self.var_,
+                                              self.n_samples_seen_)
 
         if self.with_std:
             self.scale_ = _handle_zeros_in_scale(np.sqrt(self.var_))

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -709,13 +709,14 @@ def _check_attributes_scalers(scaler_1, scaler_2):
     assert scaler_1.scale_ == scaler_2.scale_
     assert scaler_1.n_samples_seen_ == scaler_2.n_samples_seen_
 
+
 def test_scaler_return_identity():
     # test that the scaler return identity when with_mean and with_std are
     # False
     X_dense = np.array([[0, 1, 3],
                         [5, 6, 0],
                         [8, 0, 10]])
-    X_csr = csr_matrix(X_dense)
+    X_csr = sparse.csr_matrix(X_dense)
     X_csc = X_csr.tocsc()
 
     transformer_dense = StandardScaler(with_mean=False, with_std=False)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -712,9 +712,11 @@ def _check_attributes_scalers(scaler_1, scaler_2):
 def test_scaler_return_identity():
     # test that the scaler return identity when with_mean and with_std are
     # False
-    X_csr = sparse.random(1000, 10).tocsr()
+    X_dense = np.array([[0, 1, 3],
+                        [5, 6, 0],
+                        [8, 0, 10]])
+    X_csr = csr_matrix(X_dense)
     X_csc = X_csr.tocsc()
-    X_dense = X_csr.A
 
     transformer_dense = StandardScaler(with_mean=False, with_std=False)
     X_trans_dense = transformer_dense.fit_transform(X_dense)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -703,10 +703,10 @@ def test_scaler_without_centering():
     assert_array_almost_equal(X_csc_scaled_back.toarray(), X)
 
 
-def _check_attributes_scalers(scaler_1, scaler_2):
-    assert scaler_1.mean_ == scaler_2.mean_
-    assert scaler_1.var_ == scaler_2.var_
-    assert scaler_1.scale_ == scaler_2.scale_
+def _check_identity_scalers_attributes(scaler_1, scaler_2):
+    assert scaler_1.mean_ is scaler_2.mean_ is None
+    assert scaler_1.var_ is scaler_2.var_ is None
+    assert scaler_1.scale_ is scaler_2.scale_ is None
     assert scaler_1.n_samples_seen_ == scaler_2.n_samples_seen_
 
 
@@ -715,7 +715,8 @@ def test_scaler_return_identity():
     # False
     X_dense = np.array([[0, 1, 3],
                         [5, 6, 0],
-                        [8, 0, 10]])
+                        [8, 0, 10]],
+                       dtype=np.float64)
     X_csr = sparse.csr_matrix(X_dense)
     X_csc = X_csr.tocsc()
 
@@ -728,15 +729,15 @@ def test_scaler_return_identity():
     transformer_csc = clone(transformer_dense)
     X_trans_csc = transformer_csc.fit_transform(X_csc)
 
-    assert_array_almost_equal(X_trans_csr.A, X_csr.A)
-    assert_array_almost_equal(X_trans_csc.A, X_csc.A)
-    assert_array_almost_equal(X_trans_dense, X_dense)
+    assert_allclose(X_trans_csr.toarray(), X_csr.toarray())
+    assert_allclose(X_trans_csc.toarray(), X_csc.toarray())
+    assert_allclose(X_trans_dense, X_dense)
 
     for trans_1, trans_2 in itertools.combinations([transformer_dense,
                                                     transformer_csr,
                                                     transformer_csc],
                                                    2):
-        _check_attributes_scalers(trans_1, trans_2)
+        _check_identity_scalers_attributes(trans_1, trans_2)
 
     transformer_dense.partial_fit(X_dense)
     transformer_csr.partial_fit(X_csr)
@@ -746,7 +747,7 @@ def test_scaler_return_identity():
                                                     transformer_csr,
                                                     transformer_csc],
                                                    2):
-        _check_attributes_scalers(trans_1, trans_2)
+        _check_identity_scalers_attributes(trans_1, trans_2)
 
     transformer_dense.fit(X_dense)
     transformer_csr.fit(X_csr)
@@ -756,7 +757,7 @@ def test_scaler_return_identity():
                                                     transformer_csr,
                                                     transformer_csc],
                                                    2):
-        _check_attributes_scalers(trans_1, trans_2)
+        _check_identity_scalers_attributes(trans_1, trans_2)
 
 
 def test_scaler_int():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -703,6 +703,12 @@ def test_scaler_without_centering():
     assert_array_almost_equal(X_csc_scaled_back.toarray(), X)
 
 
+def _check_attributes_scalers(scaler_1, scaler_2):
+    assert scaler_1.mean_ == scaler_2.mean_
+    assert scaler_1.var_ == scaler_2.var_
+    assert scaler_1.scale_ == scaler_2.scale_
+    assert scaler_1.n_samples_seen_ == scaler_2.n_samples_seen_
+
 def test_scaler_return_identity():
     # test that the scaler return identity when with_mean and with_std are
     # False
@@ -719,19 +725,35 @@ def test_scaler_return_identity():
     transformer_csc = clone(transformer_dense)
     X_trans_csc = transformer_csc.fit_transform(X_csc)
 
+    assert_array_almost_equal(X_trans_csr.A, X_csr.A)
+    assert_array_almost_equal(X_trans_csc.A, X_csc.A)
+    assert_array_almost_equal(X_trans_dense, X_dense)
+
     for trans_1, trans_2 in itertools.combinations([transformer_dense,
                                                     transformer_csr,
                                                     transformer_csc],
                                                    2):
+        _check_attributes_scalers(trans_1, trans_2)
 
-        assert trans_1.mean_ == trans_2.mean_
-        assert trans_1.var_ == trans_2.var_
-        assert trans_1.scale_ == trans_2.scale_
-        assert trans_1.n_samples_seen_ == trans_2.n_samples_seen_
+    transformer_dense.partial_fit(X_dense)
+    transformer_csr.partial_fit(X_csr)
+    transformer_csc.partial_fit(X_csc)
 
-    assert_array_almost_equal(X_trans_csr.A, X_csr.A)
-    assert_array_almost_equal(X_trans_csc.A, X_csc.A)
-    assert_array_almost_equal(X_trans_dense, X_dense)
+    for trans_1, trans_2 in itertools.combinations([transformer_dense,
+                                                    transformer_csr,
+                                                    transformer_csc],
+                                                   2):
+        _check_attributes_scalers(trans_1, trans_2)
+
+    transformer_dense.fit(X_dense)
+    transformer_csr.fit(X_csr)
+    transformer_csc.fit(X_csc)
+
+    for trans_1, trans_2 in itertools.combinations([transformer_dense,
+                                                    transformer_csr,
+                                                    transformer_csc],
+                                                   2):
+        _check_attributes_scalers(trans_1, trans_2)
 
 
 def test_scaler_int():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
closes #11234 


#### What does this implement/fix? Explain your changes.

Ensure that the `mean_` attributes and `n_samples_seen_` are the same in the sparse and dense cases with `StandardScaler(with_mean=False, with_std=False)`


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
