### PR TITLE
[MRG] EHN ignore nan in minmax_scale

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -225,12 +225,11 @@ Preprocessing
 - :class:`preprocessing.QuantileTransformer` handles and ignores NaN values.
   :issue:`10404` by :user:`Guillaume Lemaitre <glemaitre>`.
 
-- Updated :class:`preprocessing.MinMaxScaler` to pass through NaN values.
-  :issue:`10404` by :user:`Lucija Gregov <LucijaGregov>`.
+- Updated :class:`preprocessing.MinMaxScaler` and
+  :func:`preprocessing.minmax_scale` to pass through NaN values.
+  :issue:`10404` and :issue:`11243` by :user:`Lucija Gregov <LucijaGregov>` and
+  :user:`Guillaume Lemaitre <glemaitre>`.
 
-- Updated :func:`preprocessing.minmax_scale` to pass through NaN values.
-  :issue:`11243` by :user:`Guillaume Lemaitre <glemaitre>`.
-         
 Model evaluation and meta-estimators
 
 - A scorer based on :func:`metrics.brier_score_loss` is also available.

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -229,7 +229,7 @@ Preprocessing
   :issue:`10404` by :user:`Lucija Gregov <LucijaGregov>`.
 
 - Updated :func:`preprocessing.minmax_scale` to pass through NaN values.
-  :issue:`` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :issue:`11243` by :user:`Guillaume Lemaitre <glemaitre>`.
          
 Model evaluation and meta-estimators
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -228,6 +228,9 @@ Preprocessing
 - Updated :class:`preprocessing.MinMaxScaler` to pass through NaN values.
   :issue:`10404` by :user:`Lucija Gregov <LucijaGregov>`.
 
+- Updated :func:`preprocessing.minmax_scale` to pass through NaN values.
+  :issue:`` by :user:`Guillaume Lemaitre <glemaitre>`.
+         
 Model evaluation and meta-estimators
 
 - A scorer based on :func:`metrics.brier_score_loss` is also available.

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -455,7 +455,7 @@ def minmax_scale(X, feature_range=(0, 1), axis=0, copy=True):
     # Unlike the scaler object, this function allows 1d input.
     # If copy is required, it will be done inside the scaler object.
     X = check_array(X, copy=False, ensure_2d=False, warn_on_dtype=True,
-                    dtype=FLOAT_DTYPES)
+                    dtype=FLOAT_DTYPES, force_all_finite='allow-nan')
     original_ndim = X.ndim
 
     if original_ndim == 1:

--- a/sklearn/preprocessing/tests/test_common.py
+++ b/sklearn/preprocessing/tests/test_common.py
@@ -8,8 +8,11 @@ from sklearn.model_selection import train_test_split
 
 from sklearn.base import clone
 
-from sklearn.preprocessing import QuantileTransformer
+from sklearn.preprocessing import minmax_scale
+from sklearn.preprocessing import quantile_transform
+
 from sklearn.preprocessing import MinMaxScaler
+from sklearn.preprocessing import QuantileTransformer
 
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_allclose
@@ -23,11 +26,11 @@ def _get_valid_samples_by_column(X, col):
 
 
 @pytest.mark.parametrize(
-    "est, support_sparse",
-    [(MinMaxScaler(), False),
-     (QuantileTransformer(n_quantiles=10, random_state=42), True)]
+    "est, func, support_sparse",
+    [(MinMaxScaler(), minmax_scale, False),
+     (QuantileTransformer(n_quantiles=10), quantile_transform, True)]
 )
-def test_missing_value_handling(est, support_sparse):
+def test_missing_value_handling(est, func, support_sparse):
     # check that the preprocessing method let pass nan
     rng = np.random.RandomState(42)
     X = iris.data.copy()
@@ -44,6 +47,12 @@ def test_missing_value_handling(est, support_sparse):
     Xt = est.fit(X_train).transform(X_test)
     # missing values should still be missing, and only them
     assert_array_equal(np.isnan(Xt), np.isnan(X_test))
+
+    # check that the function lead to the same results than the class
+    Xt_class = est.transform(X_train)
+    Xt_func = func(X_train, **est.get_params())
+    assert_array_equal(np.isnan(Xt_func), np.isnan(Xt_class))
+    assert_allclose(Xt_func[~np.isnan(Xt_func)], Xt_class[~np.isnan(Xt_class)])
 
     # check that the inverse transform keep NaN
     Xt_inv = est.inverse_transform(Xt)

--- a/sklearn/preprocessing/tests/test_common.py
+++ b/sklearn/preprocessing/tests/test_common.py
@@ -48,7 +48,7 @@ def test_missing_value_handling(est, func, support_sparse):
     # missing values should still be missing, and only them
     assert_array_equal(np.isnan(Xt), np.isnan(X_test))
 
-    # check that the function lead to the same results than the class
+    # check that the function leads to the same results as the class
     Xt_class = est.transform(X_train)
     Xt_func = func(X_train, **est.get_params())
     assert_array_equal(np.isnan(Xt_func), np.isnan(Xt_class))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

closes #11239 


#### What does this implement/fix? Explain your changes.

* ignore NaN in `minmax_scale` function.
* add additional test to check that the results between `minmax_scale` and `MinMaxScaler` will be the same.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
