### PR TITLE
[MRG+1] Fix scipy-dev-wheels build

### DIFF
--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -6,6 +6,8 @@ Testing for Isolation Forest algorithm (sklearn.ensemble.iforest).
 #          Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 # License: BSD 3 clause
 
+import pytest
+
 import numpy as np
 
 from sklearn.utils.fixes import euler_gamma
@@ -15,7 +17,6 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import ignore_warnings
 
@@ -105,8 +106,17 @@ def test_iforest_error():
     assert_warns_message(UserWarning,
                          "max_samples will be set to n_samples for estimation",
                          IsolationForest(max_samples=1000).fit, X)
-    assert_no_warnings(IsolationForest(max_samples='auto').fit, X)
-    assert_no_warnings(IsolationForest(max_samples=np.int64(2)).fit, X)
+    with pytest.warns(None) as record:
+        IsolationForest(max_samples='auto').fit(X)
+    user_warnings = [each for each in record
+                     if issubclass(each.category, UserWarning)]
+    assert len(user_warnings) == 0
+    with pytest.warns(None) as record:
+        IsolationForest(max_samples=np.int64(2)).fit(X)
+    user_warnings = [each for each in record
+                     if issubclass(each.category, UserWarning)]
+    assert len(user_warnings) == 0
+
     assert_raises(ValueError, IsolationForest(max_samples='foobar').fit, X)
     assert_raises(ValueError, IsolationForest(max_samples=1.5).fit, X)
 

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -106,6 +106,9 @@ def test_iforest_error():
     assert_warns_message(UserWarning,
                          "max_samples will be set to n_samples for estimation",
                          IsolationForest(max_samples=1000).fit, X)
+    # note that assert_no_warnings does not apply since it enables a
+    # PendingDeprecationWarning triggered by scipy.sparse's use of
+    # np.matrix. See issue #11251.
     with pytest.warns(None) as record:
         IsolationForest(max_samples='auto').fit(X)
     user_warnings = [each for each in record


### PR DESCRIPTION
scipy-dev-wheels Cron daily build has been failing for a while. One error was due to a regression in numpy and has been recently fixed in numpy (see https://github.com/numpy/numpy/issues/11305 for more details) and another one is fixed by this PR. Fix #11194.

https://travis-ci.org/scikit-learn/scikit-learn/builds/391183710#L2385
```
AssertionError: Got warnings when calling fit: [{message : PendingDeprecationWarning('the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.',)
```

assert_no_warnings is getting plenty of new PendingDeprecationWarning about
using numpy arrays rather than matrices.

If you can think of a better way of tackling this, better suggestions would be more than welcome!