### PR TITLE
[MRG] Add sparse efficiency warning to randomized_svd (fixes randomized_svd is slow for dok_matrix and lil_matrix #11262)

### DIFF
--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -306,6 +306,12 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter='auto',
       analysis
       A. Szlam et al. 2014
     """
+    if isinstance(M, (sparse.lil_matrix, sparse.dok_matrix)):
+        warnings.warn("Calculating SVD of a {} is expensive. "
+                      "csr_matrix is more efficient.".format(
+                          type(M).__name__),
+                      sparse.SparseEfficiencyWarning)
+
     random_state = check_random_state(random_state)
     n_random = n_components + n_oversamples
     n_samples, n_features = M.shape
@@ -320,12 +326,6 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter='auto',
     if transpose:
         # this implementation is a bit faster with smaller shape[1]
         M = M.T
-
-    if isinstance(M, (sparse.lil_matrix, sparse.dok_matrix)):
-        warnings.warn("Calculating SVD of a {} is expensive. "
-                      "csr_matrix is more efficient.".format(
-                          type(M).__name__),
-                      sparse.SparseEfficiencyWarning)
 
     Q = randomized_range_finder(M, n_random, n_iter,
                                 power_iteration_normalizer, random_state)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -321,14 +321,10 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter='auto',
         # this implementation is a bit faster with smaller shape[1]
         M = M.T
 
-    if isinstance(M, sparse.lil_matrix):
-        warnings.warn("Calculating SVD of a lil_matrix is expensive. "
-                      "csr_matrix is more efficient.",
-                      sparse.SparseEfficiencyWarning)
-    elif isinstance(M, sparse.dok_matrix):
-        warnings.warn("Calculating SVD of a dok_matrix is expensive. "
-                      "csr_matrix is more efficient.",
-                      sparse.SparseEfficiencyWarning)
+    if isinstance(M, (sparse.lil_matrix, sparse.dok_matrix)):
+        warnings.warn("Calculating SVD of a {} is expensive. "
+                      "csr_matrix is more efficient.".format(
+                          type(M).__name__))
 
     Q = randomized_range_finder(M, n_random, n_iter,
                                 power_iteration_normalizer, random_state)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -324,7 +324,8 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter='auto',
     if isinstance(M, (sparse.lil_matrix, sparse.dok_matrix)):
         warnings.warn("Calculating SVD of a {} is expensive. "
                       "csr_matrix is more efficient.".format(
-                          type(M).__name__))
+                          type(M).__name__),
+                      sparse.SparseEfficiencyWarning)
 
     Q = randomized_range_finder(M, n_random, n_iter,
                                 power_iteration_normalizer, random_state)

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -365,6 +365,21 @@ def test_randomized_svd_power_iteration_normalizer():
             assert_greater(15, np.abs(error_2 - error))
 
 
+def test_randomized_svd_sparse_warnings():
+    # randomized_svd throws a warning for lil and dok matrix
+    rng = np.random.RandomState(42)
+    X = make_low_rank_matrix(100, 500, effective_rank=50, random_state=rng)
+    n_components = 50
+    for cls in (sparse.lil_matrix, sparse.dok_matrix):
+        X = cls(X)
+        assert_warns_message(
+            sparse.SparseEfficiencyWarning,
+            "Calculating SVD of a {} is expensive. "
+            "csr_matrix is more efficient.".format(cls.__name__),
+            randomized_svd, X, n_components, n_iter=1,
+            power_iteration_normalizer='none')
+
+
 def test_svd_flip():
     # Check that svd_flip works in both situations, and reconstructs input.
     rs = np.random.RandomState(1999)

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -368,8 +368,8 @@ def test_randomized_svd_power_iteration_normalizer():
 def test_randomized_svd_sparse_warnings():
     # randomized_svd throws a warning for lil and dok matrix
     rng = np.random.RandomState(42)
-    X = make_low_rank_matrix(100, 500, effective_rank=50, random_state=rng)
-    n_components = 50
+    X = make_low_rank_matrix(50, 20, effective_rank=10, random_state=rng)
+    n_components = 5
     for cls in (sparse.lil_matrix, sparse.dok_matrix):
         X = cls(X)
         assert_warns_message(


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #11262

#### What does this implement/fix? Explain your changes.

Adds a `scipy.sparse.SparseEfficiencyWarning` when `randomized_svd` is run on `lil_matrix` or `dok_matrix`.

#### Any other comments?

`coo_matrix` is about 1.5x slower than `csr_matrix`. Maybe it is worth also warning about this, but that's a judgement call. Also worth considering whether it is better to simply coerce the matrix to a better data type, rather than printing a warning.
