### PR TITLE
[WIP] API: allow cross validation to work with partial_fit

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -109,6 +109,11 @@ Model evaluation
   ``'balanced_accuracy'`` scorer for binary classification.
   :issue:`8066` by :user:`xyguo` and :user:`Aman Dalmia <dalmia>`.
 
+- A ``fit`` keyword argument has been added to
+  :func:`model_selection.cross_val_score` and
+  :func:`model_selection.cross_validate` to control calling ``estimator.fit``
+  before scoring. See :issue:`` by :user:`Scott Sievert <stsievert>`.
+
 Decomposition, manifold learning and clustering
 
 - :class:`cluster.AgglomerativeClustering` now supports Single Linkage

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -109,10 +109,11 @@ Model evaluation
   ``'balanced_accuracy'`` scorer for binary classification.
   :issue:`8066` by :user:`xyguo` and :user:`Aman Dalmia <dalmia>`.
 
-- A ``fit`` keyword argument has been added to
-  :func:`model_selection.cross_val_score` and
-  :func:`model_selection.cross_validate` to control calling ``estimator.fit``
-  before scoring. See :issue:`` by :user:`Scott Sievert <stsievert>`.
+- Keyword arguments have been added to :func:`model_selection.cross_validate`
+  to control calling ``estimator.partial_fit`` before scoring and to control
+  the validation set. These are implemented with the keyword arguments
+  ``partial_fit``, ``X_test`` and ``y_test`` in :issue:`11266` by
+  :user:`Scott Sievert <stsievert>`.
 
 Decomposition, manifold learning and clustering
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2058,6 +2058,7 @@ def train_test_split(*arrays, **options):
 # Tell nose that train_test_split is not a test
 train_test_split.__test__ = False
 
+
 def _build_repr(self):
     # XXX This is copied from BaseEstimator's get_params
     cls = self.__class__

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -48,8 +48,10 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv=None,
 
     Parameters
     ----------
-    estimator : estimator object implementing 'fit'
-        The object to use to fit the data.
+    estimator : estimator object implementing 'fit', list of estimators
+        The object to use to fit the data. If a list, do not clone each
+        estimator and it must be the same length as the number of cross
+        validation splits.
 
     X : array-like
         The data to fit. Can be for example a list, or an array.
@@ -139,6 +141,14 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv=None,
         ``estimator.partial_fit`` once.  If an integer, call ``partial_fit``
         times. ``estimator`` is assumed to be pickleable if ``partial_fit``
         is not True.
+
+    X_test : array-like, optional
+        If present, treat this as the validation set and use
+        ``X`` and ``y`` for training as the training set.
+
+    y_test : array-like, optional
+        If present, treat this as the validation set and use
+        ``X`` and ``y`` for training as the training set.
 
 
     Returns

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -659,6 +659,23 @@ def test_cross_validate_fit_kwarg_raises(partial_fit):
                            fit_params={'classes': classes})
 
 
+def test_cross_validate_val_set():
+    n, d = 100, 2
+    X_train, y_train = make_classification(n_samples=n, n_classes=2,
+                                           n_features=d, random_state=0,
+                                           n_redundant=0, n_informative=d)
+    rng = np.random.RandomState(0)
+    X_test = rng.randn(n, d)
+    y_test = (np.sign(rng.randn(n)) + 1) / 2
+
+    clf = SGDClassifier(random_state=0)
+    ret = cross_validate(clf, X_train, y_train, val_data=(X_test, y_test))
+
+    assert_true(ret['test_score'].max() < ret['train_score'].min())
+    assert_true(ret['test_score'].max() < 0.48)
+    assert_true(0.85 < ret['train_score'].min())
+
+
 def test_cross_val_score_score_func():
     clf = MockClassifier()
     _score_func_args = []

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -669,9 +669,9 @@ def test_cross_validate_val_set():
     y_test = (np.sign(rng.randn(n)) + 1) / 2
 
     clf = SGDClassifier(random_state=0)
-    r = cross_validate(clf, X_train, y_train, test_data=(X_test, y_test))
+    r = cross_validate(clf, X_train, y_train, X_test=X_test, y_test=y_test)
 
-    assert_true(r['test_score'].max() < 0.48 < 0.85 < r['train_score'].min())
+    assert_true(r['test_score'].mean() < 0.48 < 0.85 < r['train_score'].mean())
 
 
 def test_cross_validate_repeated_call():
@@ -690,8 +690,8 @@ def test_cross_validate_repeated_call():
     assert isinstance(ret1['estimator'], tuple)
     assert all([isinstance(e, BaseEstimator) for e in ret1['estimator']])
 
-    ret2 = cross_validate(ret1['estimator'], X, y, return_estimator=True, partial_fit=True,
-                          cv=cv)
+    ret2 = cross_validate(ret1['estimator'], X, y, return_estimator=True,
+                          partial_fit=True, cv=cv)
 
     assert set(ret1.keys()) == set(ret2.keys())
     for k, v1 in ret1.items():


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses (but doesn't fix) #1626: "API Proposal: Genearlized Cross-Validation and Early Stopping". This PR only address early stopping on models that have `partial_fit` (https://github.com/scikit-learn/scikit-learn/issues/1626#issuecomment-12739541), not addressing "when more computation doesn't improve the result." (https://github.com/scikit-learn/scikit-learn/issues/1626#issue-10319901).

I will use this in https://github.com/dask/dask-searchcv/pull/72. Briefly, I want to repeatedly use `cross_validate` with a specified number of `partial_fit` calls.

#### What does this implement/fix? Explain your changes.
This PR implements early stopping for cross validation when `partial_fit` is present. This requires that

- `_fit_and_score` have a `partial_fit` keyword argument that can either be a bool or an int that reflects the number of times `est.partial_fit` is called.
  - I also add a `partial_fit` keyword arg to `cross_validate`, which relies on `_fit_and_score`.
- the specification of a different train/validation set if `_fit_and_score` is called repeatedly.
  - yes, it's possible to make sure train/validation are always separated on repeated calls but not really user-friendly and doesn't have the cleanest documentation.

#### TODO
-  ~~make work with pipelines~~
- [x] allow for specification of a separate train and validation set as mentioned in https://github.com/scikit-learn/scikit-learn/issues/1626#issue-10319901
- [x] make sure will as expected when called repeatedly, which comes up in https://github.com/dask/dask-searchcv/pull/72.
-  ~~integrate with GridSearchCV and RandomizedSearchCV~~