### PR TITLE
[MRG] fix issue "check_X_y raises uninformative error message" (#11257)

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -709,7 +709,10 @@ def column_or_1d(y, warn=False):
                           DataConversionWarning, stacklevel=2)
         return np.ravel(y)
 
-    raise ValueError("The value of y cannot be None")
+	if(y == None):
+		raise ValueError("The value of y cannot be None")
+	else:	
+		raise ValueError("bad input shape {0}".format(shape))
 
 
 def check_random_state(seed):

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -709,7 +709,7 @@ def column_or_1d(y, warn=False):
                           DataConversionWarning, stacklevel=2)
         return np.ravel(y)
 
-    raise ValueError("bad input shape {0}".format(shape))
+    raise ValueError("The value of y cannot be None")
 
 
 def check_random_state(seed):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Fixes  #11257 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### fixes the issue of getting an uninformative message when y = None in the check_X_y() function. displays appropriate message when y has bad shape. 


#### Fixed the issue of displaying an error message when y = None and when y has a bad shape. 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
