### PR TITLE
[WIP] Stable and fast float32 implementation of euclidean_distances

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -169,25 +169,14 @@ def _euclidean_distances_float64(X, Y, Y_norm_squared=None, squared=False,
     float64.
     """
     if X_norm_squared is not None:
-        XX = check_array(X_norm_squared)
-        if XX.shape == (1, X.shape[0]):
-            XX = XX.T
-        elif XX.shape != (X.shape[0], 1):
-            raise ValueError(
-                "Incompatible dimensions for X and X_norm_squared")
-
+        XX = X_norm_squared
     else:
         XX = row_norms(X, squared=True)[:, np.newaxis]
 
     if X is Y:  # shortcut in the common case euclidean_distances(X, X)
         YY = XX.T
     elif Y_norm_squared is not None:
-        YY = np.atleast_2d(Y_norm_squared)
-
-        if YY.shape != (1, Y.shape[0]):
-            raise ValueError(
-                "Incompatible dimensions for Y and Y_norm_squared")
-
+        YY = Y_norm_squared
     else:
         YY = row_norms(Y, squared=True)[np.newaxis, :]
 
@@ -307,6 +296,22 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
 
     if Y_norm_squared is not None and Y_norm_squared.dtype != Y.dtype:
         warnings.warn("Y_norm_squared has a different dtype than Y")
+
+    if X_norm_squared is not None:
+        X_norm_squared = np.atleast_2d(X_norm_squared)
+        X_norm_squared = check_array(X_norm_squared)
+        if X_norm_squared.shape == (1, X.shape[0]):
+            X_norm_squared = X_norm_squared.T
+        elif X_norm_squared.shape != (X.shape[0], 1):
+            raise ValueError(
+                    "Incompatible dimensions between X and X_norm_squared")
+
+    if Y_norm_squared is not None:
+        Y_norm_squared = np.atleast_2d(Y_norm_squared)
+        Y_norm_squared = check_array(Y_norm_squared)
+        if Y_norm_squared.shape != (1, Y.shape[0]):
+            raise ValueError(
+                    "Incompatible dimensions between Y and Y_norm_squared")
 
     if X is Y:
         if X_norm_squared is None and Y_norm_squared is not None:

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -202,6 +202,15 @@ def _euclidean_distances_cast(X, Y, outdtype, Y_norm_squared=None,
 
     The computation is done by blocks to limit additional memory usage.
     """
+    # For performance reasons, swap X and Y if I got X_norm_squared but not
+    # Y_norm_squared
+    if X_norm_squared is not None and Y_norm_squared is None:
+        swap = True
+        X, Y = Y, X
+        X_norm_squared, Y_norm_squared = None, X_norm_squared.T
+    else:
+        swap = False
+
     # No more than 10MB of additional memory will be used to cast X and Y to
     # float64 and to get the float64 result.
     maxmem = 10*1024*1024
@@ -261,6 +270,9 @@ def _euclidean_distances_cast(X, Y, outdtype, Y_norm_squared=None,
 
             if X is Y and j > i:
                 distances[j:jpbs, i:ipbs] = d.T
+
+    if swap:
+        distances = distances.T
 
     return distances if squared else np.sqrt(distances, out=distances)
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -214,8 +214,8 @@ def _euclidean_distances_cast(X, Y, outdtype, Y_norm_squared=None,
     # - a float64 copy of a block of the rows of X if needed;
     # - a float64 copy of a block of the rows of Y if needed;
     # - the float64 block result;
-    # - a block of X_norm_squared if needed;
-    # - a block of Y_norm_squared if needed.
+    # - a float64 copy of a block of X_norm_squared if needed;
+    # - a float64 copy of a block of Y_norm_squared if needed.
     # This is a quadratic equation that we solve to compute the block size that
     # would use maxmem bytes.
     XYmem = 0
@@ -223,9 +223,9 @@ def _euclidean_distances_cast(X, Y, outdtype, Y_norm_squared=None,
         XYmem += X.shape[1]
     if Y.dtype != np.float64:
         XYmem += Y.shape[1]  # Note that Y.shape[1] == X.shape[1]
-    if X_norm_squared is None:
+    if X_norm_squared is None or X_norm_squared.dtype != np.float64:
         XYmem += 1
-    if Y_norm_squared is None:
+    if Y_norm_squared is None or Y_norm_squared.dtype != np.float64:
         XYmem += 1
 
     delta = XYmem ** 2 + 4 * maxmem
@@ -239,7 +239,7 @@ def _euclidean_distances_cast(X, Y, outdtype, Y_norm_squared=None,
         Xc = _cast_if_needed(X[i:ipbs, :], np.float64)
 
         if X_norm_squared is not None:
-            Xnc = X_norm_squared[i:ipbs, :]
+            Xnc = _cast_if_needed(X_norm_squared[i:ipbs, :], np.float64)
         else:
             Xnc = None
 
@@ -251,7 +251,7 @@ def _euclidean_distances_cast(X, Y, outdtype, Y_norm_squared=None,
                 Yc = _cast_if_needed(Y[j:jpbs, :], np.float64)
 
             if Y_norm_squared is not None:
-                Ync = Y_norm_squared[:, j:jpbs]
+                Ync = _cast_if_needed(Y_norm_squared[:, j:jpbs], np.float64)
             else:
                 Ync = None
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -308,6 +308,12 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
     if Y_norm_squared is not None and Y_norm_squared.dtype != Y.dtype:
         warnings.warn("Y_norm_squared has a different dtype than Y")
 
+    if X is Y:
+        if X_norm_squared is None and Y_norm_squared is not None:
+            X_norm_squared = Y_norm_squared.T
+        if X_norm_squared is not None and Y_norm_squared is None:
+            Y_norm_squared = X_norm_squared.T
+
     outdtype = (X[0, 0] + Y[0, 0]).dtype
 
     if X.dtype == np.float64 and Y.dtype == np.float64:

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -235,11 +235,11 @@ def _euclidean_distances_cast(X, Y, outdtype, Y_norm_squared=None,
     distances = np.empty((X.shape[0], Y.shape[0]), dtype=outdtype)
 
     for i in range(0, X.shape[0], bs):
-        for j in range(i, Y.shape[0], bs):
-            ipbs = min(i + bs, X.shape[0])
-            jpbs = min(j + bs, Y.shape[0])
+        ipbs = min(i + bs, X.shape[0])
+        Xc = _cast_if_needed(X[i:ipbs, :], np.float64)
 
-            Xc = _cast_if_needed(X[i:ipbs, :], np.float64)
+        for j in range(i, Y.shape[0], bs):
+            jpbs = min(j + bs, Y.shape[0])
             if X is Y and i == j:
                 Yc = Xc
             else:

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -238,6 +238,11 @@ def _euclidean_distances_cast(X, Y, outdtype, Y_norm_squared=None,
         ipbs = min(i + bs, X.shape[0])
         Xc = _cast_if_needed(X[i:ipbs, :], np.float64)
 
+        if X_norm_squared is not None:
+            Xnc = X_norm_squared[i:ipbs, :]
+        else:
+            Xnc = None
+
         for j in range(i, Y.shape[0], bs):
             jpbs = min(j + bs, Y.shape[0])
             if X is Y and i == j:
@@ -245,8 +250,13 @@ def _euclidean_distances_cast(X, Y, outdtype, Y_norm_squared=None,
             else:
                 Yc = _cast_if_needed(Y[j:jpbs, :], np.float64)
 
-            d = _euclidean_distances_float64(Xc, Yc, Y_norm_squared=None,
-                                             squared=True, X_norm_squared=None)
+            if Y_norm_squared is not None:
+                Ync = Y_norm_squared[:, j:jpbs]
+            else:
+                Ync = None
+
+            d = _euclidean_distances_float64(Xc, Yc, Y_norm_squared=Ync,
+                                             squared=True, X_norm_squared=Xnc)
             distances[i:ipbs, j:jpbs] = d
 
             if X is Y and j > i:

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -241,7 +241,7 @@ def _euclidean_distances_cast(X, Y, outdtype, Y_norm_squared=None,
         if X_norm_squared is not None:
             Xnc = _cast_if_needed(X_norm_squared[i:ipbs, :], np.float64)
         else:
-            Xnc = None
+            Xnc = row_norms(Xc, squared=True)[:, np.newaxis]
 
         for j in range(i, Y.shape[0], bs):
             jpbs = min(j + bs, Y.shape[0])

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -570,6 +570,17 @@ def test_euclidean_distances():
     assert_array_almost_equal(D32_64, D64)
     assert_array_almost_equal(D32_32, D64)
 
+    # Check that {X,Y}_norm_squared are used with float32 arguments
+    X32_norm_sq = 0.5 * (X32 ** 2).sum(axis=1).reshape(1, -1)
+    Y32_norm_sq = 0.5 * (Y32 ** 2).sum(axis=1).reshape(1, -1)
+    DYN = euclidean_distances(X32, Y32, Y_norm_squared=Y32_norm_sq)
+    DXN = euclidean_distances(X32, Y32, X_norm_squared=X32_norm_sq)
+    DXYN = euclidean_distances(X32, Y32, X_norm_squared=X32_norm_sq,
+                               Y_norm_squared=Y32_norm_sq)
+    assert_greater(np.max(np.abs(DYN - D64)), .01)
+    assert_greater(np.max(np.abs(DXN - D64)), .01)
+    assert_greater(np.max(np.abs(DXYN - D64)), .01)
+
     # Check that the accuracy with float32 is not too bad
     X = np.array([[0.9215765222065525, 0.9682577158572608],
                   [0.9221151778782808, 0.9681831844652774]])

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -570,6 +570,13 @@ def test_euclidean_distances():
     assert_array_almost_equal(D32_64, D64)
     assert_array_almost_equal(D32_32, D64)
 
+    # Check that the accuracy with float32 is not too bad
+    X = np.array([[0.9215765222065525, 0.9682577158572608],
+                  [0.9221151778782808, 0.9681831844652774]])
+    D64 = euclidean_distances(X)
+    D32 = euclidean_distances(X.astype(np.float32))
+    assert_array_almost_equal(D32, D64)
+
 
 def test_cosine_distances():
     # Check the pairwise Cosine distances computation

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -556,6 +556,20 @@ def test_euclidean_distances():
                                   Y_norm_squared=np.zeros_like(Y_norm_sq))
     assert_greater(np.max(np.abs(wrong_D - D1)), .01)
 
+    # Check euclidean_distances when using float32 for one or both arguments
+    X32 = X.astype(np.float32)
+    Y32 = Y.astype(np.float32)
+    D64 = euclidean_distances(X, Y)
+    D64_32 = euclidean_distances(X, Y32)
+    D32_64 = euclidean_distances(X32, Y)
+    D32_32 = euclidean_distances(X32, Y32)
+    assert_equal(D64_32.dtype, np.float64)
+    assert_equal(D32_64.dtype, np.float64)
+    assert_equal(D32_32.dtype, np.float32)
+    assert_array_almost_equal(D64_32, D64)
+    assert_array_almost_equal(D32_64, D64)
+    assert_array_almost_equal(D32_32, D64)
+
 
 def test_cosine_distances():
     # Check the pairwise Cosine distances computation

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -295,3 +295,15 @@ if np.array_equal(_nan_object_mask, np.array([True])):
 else:
     def _object_dtype_isnan(X):
         return np.frompyfunc(lambda x: x != x, 1, 1)(X).astype(bool)
+
+
+if sp_version < (1, 0):
+    # Before scipy 1.0, sp.sparse.csr_matrix.astype didn't have a 'copy'
+    # argument.
+    def _cast_if_needed(arr, dtype):
+        if arr.dtype == dtype:
+            return arr
+        return arr.astype(dtype)
+else:
+    def _cast_if_needed(arr, dtype):
+        return arr.astype(dtype, copy=False)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9354
Superseds PR #10069

#### What does this implement/fix? Explain your changes.
These commits implement a block-wise casting to float64 and uses the older code to compute the euclidean distance matrix on the blocks. This is done useing only a fixed amount of additional (temporary) memory.

#### Any other comments?
This code implements several optimizations:

* since the distance matrix is symmetric when `X is Y`, copy the blocks of the upper triangle to the lower triangle;
* compute the optimal block size that would use most of the allowed additional memory;
* cast blocks of `{X,Y}_norm_squared` to float64;
* precompute blocks of `X_norm_squared` if not given so it gets reused through the iterations over `Y`;
* swap `X` and `Y` when `X_norm_squared` is given, but not `Y_norm_squared`.

Note that all the optimizations listed here have proven useful in a benchmark. The hardcoded amount of additional memory of 10MB is also derived from a benchmark.

As a side bonus, this implementation should also support float16 out of the box, should scikit-learn support it at some point.