### PR TITLE
[MRG+2] Implement two non-uniform strategies for KBinsDiscretizer (discrete branch)

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -547,7 +547,7 @@ K-bins discretization
   >>> X = np.array([[ -3., 5., 15 ],
   ...               [  0., 6., 14 ],
   ...               [  6., 3., 11 ]])
-  >>> est = preprocessing.KBinsDiscretizer(n_bins=[3, 4, 2], encode='ordinal').fit(X)
+  >>> est = preprocessing.KBinsDiscretizer(n_bins=[3, 2, 2], encode='ordinal').fit(X)
 
 By default the output is one-hot encoded into a sparse matrix
 (See :ref:`preprocessing_categorical_features`)
@@ -557,14 +557,14 @@ the number of bins, they will define the intervals. Therefore, for the current
 example, these intervals are defined as:
 
  - feature 1: :math:`{[-\infty, -1), [-1, 2), [2, \infty)}`
- - feature 2: :math:`{[-\infty, 4), [4, 5), [5, 5.5), [5.5, \infty)}`
+ - feature 2: :math:`{[-\infty, 5), [5, \infty)}`
  - feature 3: :math:`{[-\infty, 14), [14, \infty)}`
 
  Based on these bin intervals, ``X`` is transformed as follows::
 
   >>> est.transform(X)                      # doctest: +SKIP
-  array([[ 0., 2., 1.],
-         [ 1., 3., 1.],
+  array([[ 0., 1., 1.],
+         [ 1., 1., 1.],
          [ 2., 0., 0.]])
 
 The resulting dataset contains ordinal attributes which can be further used

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -576,6 +576,18 @@ Discretization is similar to constructing histograms for continuous data.
 However, histograms focus on counting features which fall into particular
 bins, whereas discretization focuses on assigning feature values to these bins.
 
+:class:`KBinsDiscretizer` implement different binning strategies, which can be
+selected with the ``strategy`` parameter. The 'uniform' strategy uses
+constant-width bins. The 'quantile' strategy uses the quantiles values to have
+equally populated bins in each feature. The 'kmeans' strategy defines bins based
+on a k-means clustering procedure performed on each feature independently.
+
+.. topic:: Examples:
+
+  * :ref:`sphx_glr_auto_examples_plot_discretization.py`
+  * :ref:`sphx_glr_auto_examples_plot_discretization_classification.py`
+  * :ref:`sphx_glr_auto_examples_plot_discretization_strategies.py`
+
 .. _preprocessing_binarization:
 
 Feature binarization

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -576,7 +576,7 @@ Discretization is similar to constructing histograms for continuous data.
 However, histograms focus on counting features which fall into particular
 bins, whereas discretization focuses on assigning feature values to these bins.
 
-:class:`KBinsDiscretizer` implement different binning strategies, which can be
+:class:`KBinsDiscretizer` implements different binning strategies, which can be
 selected with the ``strategy`` parameter. The 'uniform' strategy uses
 constant-width bins. The 'quantile' strategy uses the quantiles values to have
 equally populated bins in each feature. The 'kmeans' strategy defines bins based

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -547,24 +547,24 @@ K-bins discretization
   >>> X = np.array([[ -3., 5., 15 ],
   ...               [  0., 6., 14 ],
   ...               [  6., 3., 11 ]])
-  >>> est = preprocessing.KBinsDiscretizer(n_bins=[3, 3, 2], encode='ordinal').fit(X)
+  >>> est = preprocessing.KBinsDiscretizer(n_bins=[3, 4, 2], encode='ordinal').fit(X)
 
 By default the output is one-hot encoded into a sparse matrix
 (See :ref:`preprocessing_categorical_features`)
 and this can be configured with the ``encode`` parameter.
-For each feature, the bin width is computed during ``fit`` and together with
+For each feature, the bin edges are computed during ``fit`` and together with
 the number of bins, they will define the intervals. Therefore, for the current
 example, these intervals are defined as:
 
- - feature 1: :math:`{[-\infty, 0), [0, 3), [3, \infty)}`
- - feature 2: :math:`{[-\infty, 4), [4, 5), [5, \infty)}`
- - feature 3: :math:`{[-\infty, 13), [13, \infty)}`
+ - feature 1: :math:`{[-\infty, -1), [-1, 2), [2, \infty)}`
+ - feature 2: :math:`{[-\infty, 4), [4, 5), [5, 5.5), [5.5, \infty)}`
+ - feature 3: :math:`{[-\infty, 14), [14, \infty)}`
 
  Based on these bin intervals, ``X`` is transformed as follows::
 
   >>> est.transform(X)                      # doctest: +SKIP
-  array([[ 0., 1., 1.],
-         [ 1., 2., 1.],
+  array([[ 0., 2., 1.],
+         [ 1., 3., 1.],
          [ 2., 0., 0.]])
 
 The resulting dataset contains ordinal attributes which can be further used

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -548,8 +548,6 @@ K-bins discretization
   ...               [  0., 6., 14 ],
   ...               [  6., 3., 11 ]])
   >>> est = preprocessing.KBinsDiscretizer(n_bins=[3, 3, 2], encode='ordinal').fit(X)
-  >>> est.bin_width_
-  array([3., 1., 2.])
 
 By default the output is one-hot encoded into a sparse matrix
 (See :ref:`preprocessing_categorical_features`)
@@ -565,7 +563,7 @@ example, these intervals are defined as:
  Based on these bin intervals, ``X`` is transformed as follows::
 
   >>> est.transform(X)                      # doctest: +SKIP
-  array([[ 0., 2., 1.],
+  array([[ 0., 1., 1.],
          [ 1., 2., 1.],
          [ 2., 0., 0.]])
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -81,8 +81,9 @@ Preprocessing
 
 - Added :class:`preprocessing.KBinsDiscretizer` for turning
   continuous features into categorical or one-hot encoded
-  features. :issue:`7668`, :issue:`9647`, :issue:`10195` and
-  :issue:`10192` by :user:`Henry Lin <hlin117>`, `Hanmin Qin`_
+  features. :issue:`7668`, :issue:`9647`, :issue:`10195`,
+  :issue:`10192` and :issue:`11272`
+  by :user:`Henry Lin <hlin117>`, `Hanmin Qin`_
   and `Tom Dupre la Tour`_.
 
 - Added :class:`compose.ColumnTransformer`, which allows to apply

--- a/examples/preprocessing/plot_discretization.py
+++ b/examples/preprocessing/plot_discretization.py
@@ -77,8 +77,7 @@ reg = DecisionTreeRegressor(min_samples_split=3,
 ax2.plot(line, reg.predict(line_binned), linewidth=2, color='red',
          linestyle=':', label='decision tree')
 ax2.plot(X[:, 0], y, 'o', c='k')
-bins = enc.offset_[0] + enc.bin_width_[0] * np.arange(1, enc.n_bins_[0])
-ax2.vlines(bins, *plt.gca().get_ylim(), linewidth=1, alpha=.2)
+ax2.vlines(enc.bin_edges_[0], *plt.gca().get_ylim(), linewidth=1, alpha=.2)
 ax2.legend(loc="best")
 ax2.set_xlabel("Input feature")
 ax2.set_title("Result after discretization")

--- a/examples/preprocessing/plot_discretization_classification.py
+++ b/examples/preprocessing/plot_discretization_classification.py
@@ -28,8 +28,6 @@ The plots show training points in solid colors and testing points
 semi-transparent. The lower right shows the classification accuracy on the test
 set.
 """
-print(__doc__)
-
 # Code source: Tom Dupré la Tour
 # Adapted from plot_classifier_comparison by Gaël Varoquaux and Andreas Müller
 #
@@ -47,6 +45,8 @@ from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import KBinsDiscretizer
 from sklearn.svm import SVC, LinearSVC
 from sklearn.ensemble import GradientBoostingClassifier
+
+print(__doc__)
 
 h = .02  # step size in the mesh
 

--- a/examples/preprocessing/plot_discretization_strategies.py
+++ b/examples/preprocessing/plot_discretization_strategies.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""
+==========================================================
+Demonstrating the different strategies of KBinsDiscretizer
+==========================================================
+
+This example presents the different strategies implemented in KBinsDiscretizer:
+- 'uniform': The discretization is uniform in each feature, which means that
+  the bin widths are constant in each dimension.
+- quantile': The discretization is done on the quantiled values, which means
+  that each bin has approximately the same number of samples.
+- 'kmeans': The discretization is based on the centroids of a KMeans clustering
+  procedure.
+
+The plot shows the regions where the discretized encoding is constant.
+"""
+
+# Author: Tom Dupré la Tour
+# License: BSD 3 clause
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from sklearn.preprocessing import KBinsDiscretizer
+from sklearn.datasets import make_blobs
+
+print(__doc__)
+
+strategies = ['uniform', 'quantile', 'kmeans']
+
+n_samples = 200
+centers_0 = np.array([[0, 0], [0, 5], [2, 4], [8, 8]])
+centers_1 = np.array([[0, 0], [3, 1]])
+
+# construct the datasets
+random_state = 42
+X_list = [
+    np.random.RandomState(random_state).uniform(-3, 3, size=(n_samples, 2)),
+    make_blobs(n_samples=[n_samples // 10, n_samples * 4 // 10,
+                          n_samples // 10, n_samples * 4 // 10],
+               cluster_std=0.5, centers=centers_0,
+               random_state=random_state)[0],
+    make_blobs(n_samples=[n_samples // 5, n_samples * 4 // 5],
+               cluster_std=0.5, centers=centers_1,
+               random_state=random_state)[0],
+]
+
+figure = plt.figure(figsize=(14, 9))
+cm = plt.cm.viridis
+i = 1
+for ds_cnt, X in enumerate(X_list):
+
+    ax = plt.subplot(len(X_list), len(strategies) + 1, i)
+    ax.scatter(X[:, 0], X[:, 1], edgecolors='k')
+    if ds_cnt == 0:
+        ax.set_title("Input data", size=14)
+
+    xx, yy = np.meshgrid(
+        np.linspace(X[:, 0].min(), X[:, 0].max(), 300),
+        np.linspace(X[:, 1].min(), X[:, 1].max(), 300))
+    grid = np.c_[xx.ravel(), yy.ravel()]
+
+    ax.set_xlim(xx.min(), xx.max())
+    ax.set_ylim(yy.min(), yy.max())
+    ax.set_xticks(())
+    ax.set_yticks(())
+
+    i += 1
+    # transform the dataset with KBinsDiscretizer
+    for strategy in strategies:
+        enc = KBinsDiscretizer(n_bins=4, encode='ordinal', strategy=strategy,
+                               random_state=random_state)
+        enc.fit(X)
+        grid_encoded = enc.transform(grid)
+
+        ax = plt.subplot(len(X_list), len(strategies) + 1, i)
+
+        # horizontal stripes
+        horizontal = grid_encoded[:, 0].reshape(xx.shape)
+        ax.contourf(xx, yy, horizontal, cmap=cm, alpha=.5)
+        # vertical stripes
+        vertical = grid_encoded[:, 1].reshape(xx.shape)
+        ax.contourf(xx, yy, vertical, cmap=cm, alpha=.5)
+
+        ax.scatter(X[:, 0], X[:, 1], edgecolors='k')
+        ax.set_xlim(xx.min(), xx.max())
+        ax.set_ylim(yy.min(), yy.max())
+        ax.set_xticks(())
+        ax.set_yticks(())
+        if ds_cnt == 0:
+            ax.set_title("strategy='%s'" % (strategy, ), size=14)
+
+        i += 1
+
+plt.tight_layout()
+plt.show()

--- a/examples/preprocessing/plot_discretization_strategies.py
+++ b/examples/preprocessing/plot_discretization_strategies.py
@@ -67,8 +67,7 @@ for ds_cnt, X in enumerate(X_list):
     i += 1
     # transform the dataset with KBinsDiscretizer
     for strategy in strategies:
-        enc = KBinsDiscretizer(n_bins=4, encode='ordinal', strategy=strategy,
-                               random_state=random_state)
+        enc = KBinsDiscretizer(n_bins=4, encode='ordinal', strategy=strategy)
         enc.fit(X)
         grid_encoded = enc.transform(grid)
 

--- a/examples/preprocessing/plot_discretization_strategies.py
+++ b/examples/preprocessing/plot_discretization_strategies.py
@@ -46,7 +46,6 @@ X_list = [
 ]
 
 figure = plt.figure(figsize=(14, 9))
-cm = plt.cm.viridis
 i = 1
 for ds_cnt, X in enumerate(X_list):
 
@@ -77,10 +76,10 @@ for ds_cnt, X in enumerate(X_list):
 
         # horizontal stripes
         horizontal = grid_encoded[:, 0].reshape(xx.shape)
-        ax.contourf(xx, yy, horizontal, cmap=cm, alpha=.5)
+        ax.contourf(xx, yy, horizontal, alpha=.5)
         # vertical stripes
         vertical = grid_encoded[:, 1].reshape(xx.shape)
-        ax.contourf(xx, yy, vertical, cmap=cm, alpha=.5)
+        ax.contourf(xx, yy, vertical, alpha=.5)
 
         ax.scatter(X[:, 0], X[:, 1], edgecolors='k')
         ax.set_xlim(xx.min(), xx.max())

--- a/examples/preprocessing/plot_discretization_strategies.py
+++ b/examples/preprocessing/plot_discretization_strategies.py
@@ -5,6 +5,7 @@ Demonstrating the different strategies of KBinsDiscretizer
 ==========================================================
 
 This example presents the different strategies implemented in KBinsDiscretizer:
+
 - 'uniform': The discretization is uniform in each feature, which means that
   the bin widths are constant in each dimension.
 - quantile': The discretization is done on the quantiled values, which means

--- a/sklearn/preprocessing/__init__.py
+++ b/sklearn/preprocessing/__init__.py
@@ -26,12 +26,13 @@ from .data import OneHotEncoder
 from .data import PowerTransformer
 from .data import CategoricalEncoder
 from .data import PolynomialFeatures
-from .discretization import KBinsDiscretizer
 
 from .label import label_binarize
 from .label import LabelBinarizer
 from .label import LabelEncoder
 from .label import MultiLabelBinarizer
+
+from .discretization import KBinsDiscretizer
 
 from .imputation import Imputer
 

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -22,13 +22,13 @@ from ..utils.fixes import np_version
 
 
 class KBinsDiscretizer(BaseEstimator, TransformerMixin):
-    """Bins continuous data into k equal width intervals.
+    """Bin continuous data into intervals.
 
     Read more in the :ref:`User Guide <preprocessing_discretization>`.
 
     Parameters
     ----------
-    n_bins : int or array-like, shape (n_features,) (default=2)
+    n_bins : int or array-like, shape (n_features,) (default=5)
         The number of bins to produce. The intervals for the bins are
         determined by the minimum and maximum of the input data.
         Raises ValueError if ``n_bins < 2``.
@@ -123,7 +123,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
         ``1`` based on a parameter ``threshold``.
     """
 
-    def __init__(self, n_bins=2, ignored_features=None, encode='onehot',
+    def __init__(self, n_bins=5, ignored_features=None, encode='onehot',
                  dtype=np.float64, strategy='quantile'):
         self.n_bins = n_bins
         self.ignored_features = ignored_features
@@ -182,7 +182,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
                 bin_edges[jj] = np.asarray(np.percentile(column, quantiles))
 
             elif self.strategy == 'kmeans':
-                from ..cluster import KMeans
+                from ..cluster import KMeans  # fixes import loops
                 # Deterministic initialization with uniform spacing
                 col_min, col_max = column.min(), column.max()
                 uniform_edges = np.linspace(col_min, col_max, n_bins[jj] + 1)

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -148,12 +148,12 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
         valid_encode = ('onehot', 'onehot-dense', 'ordinal')
         if self.encode not in valid_encode:
             raise ValueError("Valid options for 'encode' are {}. "
-                             "Got 'encode = {}' instead."
+                             "Got encode={!r} instead."
                              .format(valid_encode, self.encode))
         valid_strategy = ('uniform', 'quantile', 'kmeans')
         if self.strategy not in valid_strategy:
             raise ValueError("Valid options for 'strategy' are {}. "
-                             "Got 'strategy = {}' instead."
+                             "Got strategy={!r} instead."
                              .format(valid_strategy, self.strategy))
 
         n_features = X.shape[1]
@@ -356,8 +356,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
         # Currently, OneHotEncoder doesn't support inverse_transform
         if self.encode != 'ordinal':
             raise ValueError("inverse_transform only supports "
-                             "'encode = ordinal'. "
-                             "Got 'encode = {}' instead."
+                             "'encode = ordinal'. Got encode={!r} instead."
                              .format(self.encode))
 
         Xt = self._validate_X_post_fit(Xt)

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -13,10 +13,12 @@ import warnings
 
 from . import OneHotEncoder
 from .data import _transform_selected
+
 from ..base import BaseEstimator, TransformerMixin
 from ..utils.validation import check_array
 from ..utils.validation import check_is_fitted
 from ..utils.validation import column_or_1d
+from ..utils.fixes import np_version
 
 
 class KBinsDiscretizer(BaseEstimator, TransformerMixin):
@@ -173,8 +175,10 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
                 edges = np.linspace(col.min(), col.max(), self.n_bins_[jj] + 1)
 
             elif self.strategy == 'quantile':
-                edges = np.percentile(
-                    col, np.linspace(0, 100, self.n_bins_[jj] + 1))
+                quantiles = np.linspace(0, 100, self.n_bins_[jj] + 1)
+                if np_version < (1, 9):
+                    quantiles = list(quantiles)
+                edges = np.asarray(np.percentile(col, quantiles))
 
             elif self.strategy == 'kmeans':
                 from ..cluster import KMeans

--- a/sklearn/preprocessing/discretization.py
+++ b/sklearn/preprocessing/discretization.py
@@ -61,10 +61,10 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
         uniform
             All bins in each feature have identical widths.
         quantile
-            Widths are defined by a quantile transform, to have a uniform
-            number of samples in each bin.
+            All bins in each feature have the same number of points.
         kmeans
-            Widths are defined by a k-means on each features.
+            Values in each bin have the same nearest center of a 1D k-means
+            cluster.
 
     Attributes
     ----------
@@ -170,8 +170,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
             col = X[:, jj][:, None]
 
             if self.strategy == 'uniform':
-                edges = np.linspace(col.min(), col.max(),
-                                    self.n_bins_[jj] + 1)
+                edges = np.linspace(col.min(), col.max(), self.n_bins_[jj] + 1)
 
             elif self.strategy == 'quantile':
                 edges = np.percentile(
@@ -194,7 +193,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
                 edges = np.r_[col.min(), edges, col.max()]
 
             if edges[0] == edges[-1] and self.n_bins_[jj] > 2:
-                warnings.warn("Features %d is constant and will be "
+                warnings.warn("Feature %d is constant and will be "
                               "replaced with 0." % jj)
                 self.n_bins_[jj] = 1
                 edges = np.array([-np.inf, np.inf])
@@ -307,10 +306,10 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
 
         bin_edges = self.bin_edges_[trans]
         for jj in range(X.shape[1]):
-            # Values which are a multiple of the bin width are susceptible to
-            # numeric instability. Add eps to X so these values are binned
-            # correctly. See documentation for numpy.isclose for an explanation
-            # of ``rtol`` and ``atol``.
+            # Values which are close to a bin edge are susceptible to numeric
+            # instability. Add eps to X so these values are binned correctly
+            # with respect to their decimal truncation. See documentation of
+            # numpy.isclose for an explanation of ``rtol`` and ``atol``.
             rtol = 1.e-5
             atol = 1.e-8
             eps = atol + rtol * np.abs(X[:, jj])

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -151,7 +151,7 @@ def test_same_min_max():
                   [1, 0],
                   [1, 1]])
     est = assert_warns_message(UserWarning,
-                               "Features 0 is constant and will be replaced "
+                               "Feature 0 is constant and will be replaced "
                                "with 0.", KBinsDiscretizer
                                (n_bins=3, encode='ordinal').fit, X)
     Xt = est.transform(X)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -139,7 +139,7 @@ def test_same_min_max():
                   [1, 0],
                   [1, 1]])
     est = assert_warns_message(UserWarning,
-                               "Features 0 are constant and will be replaced "
+                               "Features 0 is constant and will be replaced "
                                "with 0.", KBinsDiscretizer
                                (n_bins=3, encode='ordinal').fit, X)
     Xt = est.transform(X)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -5,7 +5,6 @@ import numpy as np
 import scipy.sparse as sp
 import warnings
 
-from sklearn.datasets import make_blobs
 from sklearn.externals.six.moves import xrange as range
 from sklearn.preprocessing import KBinsDiscretizer
 from sklearn.preprocessing import OneHotEncoder
@@ -270,14 +269,6 @@ def test_nonuniform_strategies(strategy, expected_2bins, expected_3bins):
     est = KBinsDiscretizer(n_bins=3, strategy=strategy, encode='ordinal')
     Xt = est.fit_transform(X)
     assert_array_equal(expected_3bins, Xt.ravel())
-
-
-def test_kmeans_strategy():
-    X, y = make_blobs(cluster_std=0.2, centers=np.array([0, 5, 8, 8])[:, None])
-    y[y == 3] = 2
-    Xt = KBinsDiscretizer(n_bins=3, strategy='kmeans',
-                          encode='ordinal').fit_transform(X)
-    assert_array_equal(Xt.ravel(), y)
 
 
 @pytest.mark.parametrize('strategy', ['uniform', 'kmeans', 'quantile'])

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -95,6 +95,12 @@ def test_fit_transform_n_bins_array(strategy, expected):
                            strategy=strategy).fit(X)
     assert_array_equal(expected, est.transform(X))
 
+    # test the shape of bin_edges_
+    n_features = np.array(X).shape[1]
+    assert est.bin_edges_.shape == (n_features, )
+    for bin_edges, n_bins in zip(est.bin_edges_, est.n_bins_):
+        assert bin_edges.shape == (n_bins + 1, )
+
 
 def test_invalid_n_features():
     est = KBinsDiscretizer(n_bins=3).fit(X)
@@ -199,7 +205,7 @@ def test_invalid_encode_option():
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], encode='invalid-encode')
     assert_raise_message(ValueError, "Valid options for 'encode' are "
                          "('onehot', 'onehot-dense', 'ordinal'). "
-                         "Got 'encode = invalid-encode' instead.",
+                         "Got encode='invalid-encode' instead.",
                          est.fit, X)
 
 
@@ -214,7 +220,7 @@ def test_encode_options():
     assert_array_equal(OneHotEncoder(n_values=[2, 3, 3, 3], sparse=False)
                        .fit_transform(Xt_1), Xt_2)
     assert_raise_message(ValueError, "inverse_transform only supports "
-                         "'encode = ordinal'. Got 'encode = onehot-dense' "
+                         "'encode = ordinal'. Got encode='onehot-dense' "
                          "instead.", est.inverse_transform, Xt_2)
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3],
                            encode='onehot').fit(X)
@@ -224,7 +230,7 @@ def test_encode_options():
                        .fit_transform(Xt_1).toarray(),
                        Xt_3.toarray())
     assert_raise_message(ValueError, "inverse_transform only supports "
-                         "'encode = ordinal'. Got 'encode = onehot' "
+                         "'encode = ordinal'. Got encode='onehot' "
                          "instead.", est.inverse_transform, Xt_2)
 
 
@@ -243,7 +249,7 @@ def test_invalid_strategy_option():
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], strategy='invalid-strategy')
     assert_raise_message(ValueError, "Valid options for 'strategy' are "
                          "('uniform', 'quantile', 'kmeans'). "
-                         "Got 'strategy = invalid-strategy' instead.",
+                         "Got strategy='invalid-strategy' instead.",
                          est.fit, X)
 
 

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -144,17 +144,17 @@ def test_ignored_invalid():
 
 
 @pytest.mark.parametrize('strategy', ['uniform', 'kmeans', 'quantile'])
-@pytest.mark.parametrize('n_bins', [2, 3])
-def test_same_min_max(strategy, n_bins):
+def test_same_min_max(strategy):
     warnings.simplefilter("always")
     X = np.array([[1, -2],
                   [1, -1],
                   [1, 0],
                   [1, 1]])
-    est = KBinsDiscretizer(strategy=strategy, n_bins=n_bins, encode='ordinal')
+    est = KBinsDiscretizer(strategy=strategy, n_bins=3, encode='ordinal')
     assert_warns_message(UserWarning,
                          "Feature 0 is constant and will be replaced "
                          "with 0.", est.fit, X)
+    assert est.n_bins_[0] == 1
     # replace the feature with zeros
     Xt = est.transform(X)
     assert_array_equal(Xt[:, 0], np.zeros(X.shape[0]))

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -143,23 +143,21 @@ def test_ignored_invalid():
         assert_raises(ValueError, est.fit, X)
 
 
-def test_same_min_max():
+@pytest.mark.parametrize('strategy', ['uniform', 'kmeans', 'quantile'])
+@pytest.mark.parametrize('n_bins', [2, 3])
+def test_same_min_max(strategy, n_bins):
     warnings.simplefilter("always")
     X = np.array([[1, -2],
                   [1, -1],
                   [1, 0],
                   [1, 1]])
-    est = assert_warns_message(UserWarning,
-                               "Feature 0 is constant and will be replaced "
-                               "with 0.", KBinsDiscretizer
-                               (n_bins=3, encode='ordinal').fit, X)
+    est = KBinsDiscretizer(strategy=strategy, n_bins=n_bins, encode='ordinal')
+    assert_warns_message(UserWarning,
+                         "Feature 0 is constant and will be replaced "
+                         "with 0.", est.fit, X)
+    # replace the feature with zeros
     Xt = est.transform(X)
-
-    expected = [[0, 0],
-                [0, 1],
-                [0, 2],
-                [0, 2]]
-    assert_array_equal(expected, Xt)
+    assert_array_equal(Xt[:, 0], np.zeros(X.shape[0]))
 
 
 def test_transform_1d_behavior():


### PR DESCRIPTION
Fixes #9338.

This PR implements two non-uniform strategies for KBinsDiscretizer (in discrete branch #9342), adding a parameter `strategy`:
- `KBinsDiscretizer(strategy='uniform')`: previous behavior, constant width bins.
- `KBinsDiscretizer(strategy='quantile')`: new behavior (default), based on `np.percentile`.
- `KBinsDiscretizer(strategy='kmeans')`: new behavior, based on `KMeans`.

It adds the following example:
![figure_1](https://user-images.githubusercontent.com/11065596/41465630-3534fa88-709f-11e8-96bc-19541342a877.png)
