### PR TITLE
[MRG] Document `length_scale_bounds="fixed"` in GP kernels #8358

### DIFF
--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1152,10 +1152,10 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
         used. If an array, an anisotropic kernel is used where each dimension
         of l defines the length-scale of the respective feature dimension.
 
-    length_scale_bounds : pair of floats >= 0 or string "fixed",
-        default: (1e-5, 1e5)
-        The lower and upper bound on length_scale. If set to "fixed",
-        length_scale cannot be changed during hyperparameter tuning.
+    length_scale_bounds : pair of floats >= 0 or string "fixed"
+        The lower and upper bound on length_scale (default: (1e-5, 1e5)).
+        If set to "fixed", length_scale cannot be changed during
+        hyperparameter tuning.
 
     """
     def __init__(self, length_scale=1.0, length_scale_bounds=(1e-5, 1e5)):
@@ -1267,10 +1267,10 @@ class Matern(RBF):
         used. If an array, an anisotropic kernel is used where each dimension
         of l defines the length-scale of the respective feature dimension.
 
-    length_scale_bounds : pair of floats >= 0 or string "fixed",
-        default: (1e-5, 1e5)
-        The lower and upper bound on length_scale. If set to "fixed",
-        length_scale cannot be changed during hyperparameter tuning.
+    length_scale_bounds : pair of floats >= 0 or string "fixed"
+        The lower and upper bound on length_scale (default: (1e-5, 1e5)).
+        If set to "fixed", length_scale cannot be changed during
+        hyperparameter tuning.
 
     nu: float, default: 1.5
         The parameter nu controlling the smoothness of the learned function.
@@ -1417,10 +1417,10 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
     alpha : float > 0, default: 1.0
         Scale mixture parameter
 
-    length_scale_bounds : pair of floats >= 0 or string "fixed",
-        default: (1e-5, 1e5)
-        The lower and upper bound on length_scale. If set to "fixed",
-        length_scale cannot be changed during hyperparameter tuning.
+    length_scale_bounds : pair of floats >= 0 or string "fixed"
+        The lower and upper bound on length_scale (default: (1e-5, 1e5)).
+        If set to "fixed", length_scale cannot be changed during
+        hyperparameter tuning.
 
     alpha_bounds : pair of floats >= 0, default: (1e-5, 1e5)
         The lower and upper bound on alpha
@@ -1531,10 +1531,10 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
     periodicity : float > 0, default: 1.0
         The periodicity of the kernel.
 
-    length_scale_bounds : pair of floats >= 0 or string "fixed",
-        default: (1e-5, 1e5)
-        The lower and upper bound on length_scale. If set to "fixed",
-        length_scale cannot be changed during hyperparameter tuning.
+    length_scale_bounds : pair of floats >= 0 or string "fixed"
+        The lower and upper bound on length_scale (default: (1e-5, 1e5)).
+        If set to "fixed", length_scale cannot be changed during
+        hyperparameter tuning.
 
     periodicity_bounds : pair of floats >= 0, default: (1e-5, 1e5)
         The lower and upper bound on periodicity

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1152,8 +1152,10 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
         used. If an array, an anisotropic kernel is used where each dimension
         of l defines the length-scale of the respective feature dimension.
 
-    length_scale_bounds : pair of floats >= 0, default: (1e-5, 1e5)
-        The lower and upper bound on length_scale
+    length_scale_bounds : pair of floats >= 0 or string "fixed",
+        default: (1e-5, 1e5)
+        The lower and upper bound on length_scale. If set to "fixed",
+        length_scale cannot be changed during hyperparameter tuning.
 
     """
     def __init__(self, length_scale=1.0, length_scale_bounds=(1e-5, 1e5)):
@@ -1265,8 +1267,10 @@ class Matern(RBF):
         used. If an array, an anisotropic kernel is used where each dimension
         of l defines the length-scale of the respective feature dimension.
 
-    length_scale_bounds : pair of floats >= 0, default: (1e-5, 1e5)
-        The lower and upper bound on length_scale
+    length_scale_bounds : pair of floats >= 0 or string "fixed",
+        default: (1e-5, 1e5)
+        The lower and upper bound on length_scale. If set to "fixed",
+        length_scale cannot be changed during hyperparameter tuning.
 
     nu: float, default: 1.5
         The parameter nu controlling the smoothness of the learned function.
@@ -1413,8 +1417,10 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
     alpha : float > 0, default: 1.0
         Scale mixture parameter
 
-    length_scale_bounds : pair of floats >= 0, default: (1e-5, 1e5)
-        The lower and upper bound on length_scale
+    length_scale_bounds : pair of floats >= 0 or string "fixed",
+        default: (1e-5, 1e5)
+        The lower and upper bound on length_scale. If set to "fixed",
+        length_scale cannot be changed during hyperparameter tuning.
 
     alpha_bounds : pair of floats >= 0, default: (1e-5, 1e5)
         The lower and upper bound on alpha
@@ -1525,8 +1531,10 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
     periodicity : float > 0, default: 1.0
         The periodicity of the kernel.
 
-    length_scale_bounds : pair of floats >= 0, default: (1e-5, 1e5)
-        The lower and upper bound on length_scale
+    length_scale_bounds : pair of floats >= 0 or string "fixed",
+        default: (1e-5, 1e5)
+        The lower and upper bound on length_scale. If set to "fixed",
+        length_scale cannot be changed during hyperparameter tuning.
 
     periodicity_bounds : pair of floats >= 0, default: (1e-5, 1e5)
         The lower and upper bound on periodicity


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #8358. See also PR #8391.

#### What does this implement/fix? Explain your changes.
Documents more clearly that if length_scale_bounds is set to "fixed", the hyperparameter length_scale cannot be changed during tuning. 

#### Any other comments?
Put the default values in the description line as suggested here [https://github.com/scikit-learn/scikit-learn/pull/8391/files](url), since adding default values to the type specification line exceeds the maximum line limit.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
