### PR TITLE
FIX #11215 : Changing return in docstring to yields for generator functions

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -77,7 +77,7 @@ class BaseCrossValidator(with_metaclass(ABCMeta)):
             train/test set.
 
         Yields
-        -------
+        ------
         train : ndarray
             The training set indices for that split.
 
@@ -302,7 +302,7 @@ class _BaseKFold(with_metaclass(ABCMeta, BaseCrossValidator)):
             train/test set.
 
         Yields
-        -------
+        ------
         train : ndarray
             The training set indices for that split.
 
@@ -735,7 +735,7 @@ class TimeSeriesSplit(_BaseKFold):
             Always ignored, exists for compatibility.
 
         Yields
-        -------
+        ------
         train : ndarray
             The training set indices for that split.
 
@@ -1007,7 +1007,7 @@ class _RepeatedSplits(with_metaclass(ABCMeta)):
             train/test set.
 
         Yields
-        -------
+        ------
         train : ndarray
             The training set indices for that split.
 
@@ -1183,7 +1183,7 @@ class BaseShuffleSplit(with_metaclass(ABCMeta)):
             train/test set.
 
         Yields
-        -------
+        ------
         train : ndarray
             The training set indices for that split.
 
@@ -1764,7 +1764,7 @@ class PredefinedSplit(BaseCrossValidator):
             Always ignored, exists for compatibility.
 
         Yields
-        -------
+        ------
         train : ndarray
             The training set indices for that split.
 
@@ -1848,7 +1848,7 @@ class _CVIterableWrapper(BaseCrossValidator):
             Always ignored, exists for compatibility.
 
         Yields
-        -------
+        ------
         train : ndarray
             The training set indices for that split.
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -647,7 +647,7 @@ class StratifiedKFold(_BaseKFold):
         groups : object
             Always ignored, exists for compatibility.
 
-        Returns
+        Yields
         -------
         train : ndarray
             The training set indices for that split.
@@ -1603,7 +1603,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
         groups : object
             Always ignored, exists for compatibility.
 
-        Returns
+        Yields
         -------
         train : ndarray
             The training set indices for that split.

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -76,7 +76,7 @@ class BaseCrossValidator(with_metaclass(ABCMeta)):
             Group labels for the samples used while splitting the dataset into
             train/test set.
 
-        Returns
+        Yields
         -------
         train : ndarray
             The training set indices for that split.
@@ -301,7 +301,7 @@ class _BaseKFold(with_metaclass(ABCMeta, BaseCrossValidator)):
             Group labels for the samples used while splitting the dataset into
             train/test set.
 
-        Returns
+        Yields
         -------
         train : ndarray
             The training set indices for that split.
@@ -734,7 +734,7 @@ class TimeSeriesSplit(_BaseKFold):
         groups : array-like, with shape (n_samples,), optional
             Always ignored, exists for compatibility.
 
-        Returns
+        Yields
         -------
         train : ndarray
             The training set indices for that split.
@@ -1006,7 +1006,7 @@ class _RepeatedSplits(with_metaclass(ABCMeta)):
             Group labels for the samples used while splitting the dataset into
             train/test set.
 
-        Returns
+        Yields
         -------
         train : ndarray
             The training set indices for that split.
@@ -1182,7 +1182,7 @@ class BaseShuffleSplit(with_metaclass(ABCMeta)):
             Group labels for the samples used while splitting the dataset into
             train/test set.
 
-        Returns
+        Yields
         -------
         train : ndarray
             The training set indices for that split.
@@ -1763,7 +1763,7 @@ class PredefinedSplit(BaseCrossValidator):
         groups : object
             Always ignored, exists for compatibility.
 
-        Returns
+        Yields
         -------
         train : ndarray
             The training set indices for that split.
@@ -1847,7 +1847,7 @@ class _CVIterableWrapper(BaseCrossValidator):
         groups : object
             Always ignored, exists for compatibility.
 
-        Returns
+        Yields
         -------
         train : ndarray
             The training set indices for that split.

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -648,7 +648,7 @@ class StratifiedKFold(_BaseKFold):
             Always ignored, exists for compatibility.
 
         Yields
-        -------
+        ------
         train : ndarray
             The training set indices for that split.
 
@@ -1604,7 +1604,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
             Always ignored, exists for compatibility.
 
         Yields
-        -------
+        ------
         train : ndarray
             The training set indices for that split.
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #11215. 

#### What does this implement/fix? Explain your changes.

I changed all the docstrings for generator functions to say `Yields` instead `Returns`. 

#### Any other comments?

First OSS contribution :) 🥇 
