### PR TITLE
[MRG + 1] Fix #9350: Enable has_fit_parameter() and fit_score_takes_y() to work with @deprecated in Python 2

### DIFF
--- a/sklearn/utils/deprecation.py
+++ b/sklearn/utils/deprecation.py
@@ -78,6 +78,9 @@ class deprecated(object):
             return fun(*args, **kwargs)
 
         wrapped.__doc__ = self._update_doc(wrapped.__doc__)
+        # Add a reference to the wrapped function so that we can introspect
+        # on function arguments in Python 2 (already works in Python 3)
+        wrapped.__wrapped__ = fun
 
         return wrapped
 

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -9,12 +9,14 @@ from sklearn.externals.six.moves import cStringIO as StringIO
 from sklearn.externals import joblib
 
 from sklearn.base import BaseEstimator, ClassifierMixin
+from sklearn.utils import deprecated
 from sklearn.utils.testing import (assert_raises_regex, assert_true,
                                    assert_equal, ignore_warnings)
 from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.estimator_checks import set_random_state
 from sklearn.utils.estimator_checks import set_checking_parameters
 from sklearn.utils.estimator_checks import check_estimators_unfitted
+from sklearn.utils.estimator_checks import check_fit_score_takes_y
 from sklearn.utils.estimator_checks import check_no_attributes_set_in_init
 from sklearn.ensemble import AdaBoostClassifier, RandomForestClassifier
 from sklearn.linear_model import LinearRegression, SGDClassifier
@@ -174,6 +176,18 @@ class SparseTransformer(BaseEstimator):
         if X.shape[1] != self.X_shape_[1]:
             raise ValueError('Bad number of features')
         return sp.csr_matrix(X)
+
+
+def test_check_fit_score_takes_y_works_on_deprecated_fit():
+    # Tests that check_fit_score_takes_y works on a class with
+    # a deprecated fit method
+
+    class TestEstimatorWithDeprecatedFitMethod(BaseEstimator):
+        @deprecated("Deprecated for the purpose of testing check_fit_score_takes_y")
+        def fit(self, X, y):
+            return self
+
+    check_fit_score_takes_y("test", TestEstimatorWithDeprecatedFitMethod())
 
 
 def test_check_estimator():

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -183,7 +183,8 @@ def test_check_fit_score_takes_y_works_on_deprecated_fit():
     # a deprecated fit method
 
     class TestEstimatorWithDeprecatedFitMethod(BaseEstimator):
-        @deprecated("Deprecated for the purpose of testing check_fit_score_takes_y")
+        @deprecated("Deprecated for the purpose of testing "
+                    "check_fit_score_takes_y")
         def fit(self, X, y):
             return self
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -22,6 +22,7 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_allclose_dense_sparse
 from sklearn.utils import as_float_array, check_array, check_symmetric
 from sklearn.utils import check_X_y
+from sklearn.utils import deprecated
 from sklearn.utils.mocking import MockDataFrame
 from sklearn.utils.estimator_checks import NotAnArray
 from sklearn.random_projection import sparse_random_matrix
@@ -562,6 +563,13 @@ def test_has_fit_parameter():
     assert_true(has_fit_parameter(RandomForestRegressor, "sample_weight"))
     assert_true(has_fit_parameter(SVR, "sample_weight"))
     assert_true(has_fit_parameter(SVR(), "sample_weight"))
+
+    class TestClassWithDeprecatedFitMethod:
+        @deprecated("Deprecated for the purpose of testing has_fit_parameter")
+        def fit(self, X, y, sample_weight=None):
+            pass
+
+    assert_true(has_fit_parameter(TestClassWithDeprecatedFitMethod, "sample_weight"))
 
 
 def test_check_symmetric():

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -569,7 +569,8 @@ def test_has_fit_parameter():
         def fit(self, X, y, sample_weight=None):
             pass
 
-    assert_true(has_fit_parameter(TestClassWithDeprecatedFitMethod, "sample_weight"))
+    assert_true(has_fit_parameter(TestClassWithDeprecatedFitMethod,
+                                  "sample_weight"))
 
 
 def test_check_symmetric():

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -569,8 +569,9 @@ def test_has_fit_parameter():
         def fit(self, X, y, sample_weight=None):
             pass
 
-    assert_true(has_fit_parameter(TestClassWithDeprecatedFitMethod,
-                                  "sample_weight"))
+    assert has_fit_parameter(TestClassWithDeprecatedFitMethod,
+                             "sample_weight"), \
+        "has_fit_parameter fails for class with deprecated fit method."
 
 
 def test_check_symmetric():


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9350: Bug in common tests: should use utils.testing._get_args 

#### What does this implement/fix? Explain your changes.
This fix does not use `utils.testing._get_args()` but rather adds two new unit tests confirm that #9350 is no longer an issue. I walked through this with @amueller during a sprint and he agrees these tests are the right ones to confirm the issue is resolved.

Specifically:

1. I've added a test in `test_validation.py` that ensures `has_fit_parameter()` works for classes with a deprecated `fit()` method.

2. This issue was referenced in PR #9290 where `check_fit_score_takes_y()` was returning a "list index out of range" when a method in `naive_bayes.py` was marked as `@deprecated`, but succeeding when not deprecated. To ensure `check_fit_score_takes_y()` behaves correctly in this scenario, I've added another test to ensure `check_fit_score_takes_y()` works on a class that has a deprecated `fit()` method.

#### Any other comments?

These tests were discussed with @amueller during Two Sigma's "TS Open" 2018 sprint.
