### PR TITLE
Fix for #10372: partial_dependence.py _grid_from_X ignores percentile specification for small numbers of unique feature values

### DIFF
--- a/sklearn/ensemble/partial_dependence.py
+++ b/sklearn/ensemble/partial_dependence.py
@@ -55,8 +55,8 @@ def _grid_from_X(X, percentiles=(0.05, 0.95), grid_resolution=100):
     axes = []
     emp_percentiles = mquantiles(X, prob=percentiles, axis=0)
     for col in range(X.shape[1]):
-        X_interior = X[(X[:, col] >= emp_percentiles[0, col]) & 
-                       (X[:, col] <= emp_percentiles[1, col]), 
+        X_interior = X[(X[:, col] >= emp_percentiles[0, col]) &
+                       (X[:, col] <= emp_percentiles[1, col]),
                        col]
         uniques = np.unique(X_interior)
 

--- a/sklearn/ensemble/partial_dependence.py
+++ b/sklearn/ensemble/partial_dependence.py
@@ -43,7 +43,7 @@ def _grid_from_X(X, percentiles=(0.05, 0.95), grid_resolution=100):
     -------
     grid : ndarray
         All data points on the grid; ``grid.shape[1] == X.shape[1]``
-        and ``grid.shape[0] == grid_resolution * X.shape[1]``.
+        and ``grid.shape[0] == grid_resolution ** X.shape[1]``.
     axes : seq of ndarray
         The axes with which the grid has been created.
     """
@@ -55,9 +55,14 @@ def _grid_from_X(X, percentiles=(0.05, 0.95), grid_resolution=100):
     axes = []
     emp_percentiles = mquantiles(X, prob=percentiles, axis=0)
     for col in range(X.shape[1]):
-        uniques = np.unique(X[:, col])
+        X_interior = X[(X[:, col] >= emp_percentiles[0, col]) & 
+                       (X[:, col] <= emp_percentiles[1, col]), 
+                       col]
+        uniques = np.unique(X_interior)
+
         if uniques.shape[0] < grid_resolution:
-            # feature has low resolution use unique vals
+            # feature has low resolution inside the extremal vals,
+            # use unique vals
             axis = uniques
         else:
             # create axis based on percentiles and grid resolution

--- a/sklearn/ensemble/tests/test_partial_dependence.py
+++ b/sklearn/ensemble/tests/test_partial_dependence.py
@@ -32,15 +32,17 @@ def test_partial_dependence_classifier():
     clf = GradientBoostingClassifier(n_estimators=10, random_state=1)
     clf.fit(X, y)
 
-    pdp, axes = partial_dependence(clf, [0], X=X, grid_resolution=5)
+    pdp, axes = partial_dependence(clf, [0], X=X, grid_resolution=5,
+                                   percentiles=(0.2, 0.8))
 
-    # only 4 grid points instead of 5 because only 4 unique X[:,0] vals
-    assert pdp.shape == (1, 4)
-    assert axes[0].shape[0] == 4
+    # only 2 grid points instead of 5 because only 2 unique X[:,0] vals
+    # inside the percentile range
+    assert pdp.shape == (1, 2)
+    assert axes[0].shape[0] == 2
 
     # now with our own grid
     X_ = np.asarray(X)
-    grid = np.unique(X_[:, 0])
+    grid = np.unique(X_[(X_[:, 0] >= -1) & (X_[:, 0] <= 1), 0])
     pdp_2, axes = partial_dependence(clf, [0], grid=grid)
 
     assert axes is None


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10372

#### What does this implement/fix? Explain your changes.
We should accept the recommended idea.

When there are a small number of unique values along a particular dimension, we could build a smaller grid by just picking those unique values.
This PR can make this grid slightly more efficient by just considering the unique values inside the specified percentile range.