### PR TITLE
[MRG] FIX remove duplicated code and handle 0 seed for our_rand_r (#5…

### DIFF
--- a/sklearn/linear_model/cd_fast.pyx
+++ b/sklearn/linear_model/cd_fast.pyx
@@ -16,6 +16,8 @@ from cpython cimport bool
 from cython cimport floating
 import warnings
 
+from sklearn.utils cimport _random 
+
 ctypedef np.float64_t DOUBLE
 ctypedef np.uint32_t UINT32_t
 ctypedef floating (*DOT)(int N, floating *X, int incX, floating *Y,
@@ -35,17 +37,9 @@ cdef enum:
     RAND_R_MAX = 0x7FFFFFFF
 
 
-cdef inline UINT32_t our_rand_r(UINT32_t* seed) nogil:
-    seed[0] ^= <UINT32_t>(seed[0] << 13)
-    seed[0] ^= <UINT32_t>(seed[0] >> 17)
-    seed[0] ^= <UINT32_t>(seed[0] << 5)
-
-    return seed[0] % (<UINT32_t>RAND_R_MAX + 1)
-
-
 cdef inline UINT32_t rand_int(UINT32_t end, UINT32_t* random_state) nogil:
     """Generate a random integer in [0; end)."""
-    return our_rand_r(random_state) % end
+    return _random.our_rand_r(random_state) % end
 
 
 cdef inline floating fmax(floating x, floating y) nogil:

--- a/sklearn/tree/_utils.pxd
+++ b/sklearn/tree/_utils.pxd
@@ -19,6 +19,7 @@ ctypedef np.npy_intp SIZE_t              # Type for indices and counters
 ctypedef np.npy_int32 INT32_t            # Signed 32 bit integer
 ctypedef np.npy_uint32 UINT32_t          # Unsigned 32 bit integer
 
+
 cdef enum:
     # Max value for our rand_r replacement (near the bottom).
     # We don't use RAND_MAX because it's different across platforms and

--- a/sklearn/tree/_utils.pyx
+++ b/sklearn/tree/_utils.pyx
@@ -20,6 +20,8 @@ import numpy as np
 cimport numpy as np
 np.import_array()
 
+from sklearn.utils cimport _random 
+
 # =============================================================================
 # Helper functions
 # =============================================================================
@@ -52,16 +54,6 @@ def _realloc_test():
         assert False
 
 
-# rand_r replacement using a 32bit XorShift generator
-# See http://www.jstatsoft.org/v08/i14/paper for details
-cdef inline UINT32_t our_rand_r(UINT32_t* seed) nogil:
-    seed[0] ^= <UINT32_t>(seed[0] << 13)
-    seed[0] ^= <UINT32_t>(seed[0] >> 17)
-    seed[0] ^= <UINT32_t>(seed[0] << 5)
-
-    return seed[0] % (<UINT32_t>RAND_R_MAX + 1)
-
-
 cdef inline np.ndarray sizet_ptr_to_ndarray(SIZE_t* data, SIZE_t size):
     """Return copied data as 1D numpy array of intp's."""
     cdef np.npy_intp shape[1]
@@ -72,13 +64,13 @@ cdef inline np.ndarray sizet_ptr_to_ndarray(SIZE_t* data, SIZE_t size):
 cdef inline SIZE_t rand_int(SIZE_t low, SIZE_t high,
                             UINT32_t* random_state) nogil:
     """Generate a random integer in [low; end)."""
-    return low + our_rand_r(random_state) % (high - low)
+    return low + _random.our_rand_r(random_state) % (high - low)
 
 
 cdef inline double rand_uniform(double low, double high,
                                 UINT32_t* random_state) nogil:
     """Generate a random double in [low; high)."""
-    return ((high - low) * <double> our_rand_r(random_state) /
+    return ((high - low) * <double> _random.our_rand_r(random_state) /
             <double> RAND_R_MAX) + low
 
 

--- a/sklearn/utils/_random.pxd
+++ b/sklearn/utils/_random.pxd
@@ -5,10 +5,17 @@
 
 import numpy as np
 cimport numpy as np
+ctypedef np.npy_uint32 UINT32_t 
 
+cdef enum:
+    # Max value for our rand_r replacement (near the bottom).
+    # We don't use RAND_MAX because it's different across platforms and
+    # particularly tiny on Windows/MSVC.
+    RAND_R_MAX = 0x7FFFFFFF
 
 cpdef sample_without_replacement(np.int_t n_population,
                                  np.int_t n_samples,
                                  method=*,
                                  random_state=*)
 
+cdef UINT32_t our_rand_r(UINT32_t* seed) nogil

--- a/sklearn/utils/_random.pyx
+++ b/sklearn/utils/_random.pyx
@@ -11,7 +11,7 @@ This module complements missing features of ``numpy.random``.
 
 The module contains:
     * Several algorithms to sample integers without replacement.
-
+    * Fast rand_r alternative based on xor shifts
 """
 from __future__ import division
 
@@ -22,6 +22,8 @@ cimport numpy as np
 np.import_array()
 
 from sklearn.utils import check_random_state
+
+cdef UINT32_t DEFAULT_SEED = 1
 
 
 cpdef _sample_without_replacement_check_input(np.int_t n_population,
@@ -310,3 +312,16 @@ cpdef sample_without_replacement(np.int_t n_population,
     else:
         raise ValueError('Expected a method name in %s, got %s. '
                          % (all_methods, method))
+
+
+
+# rand_r replacement using a 32bit XorShift generator
+# See http://www.jstatsoft.org/v08/i14/paper for details
+cdef inline UINT32_t our_rand_r(UINT32_t* seed) nogil:
+    # seed shouldn't ever be 0.
+    if (seed[0] == 0): seed[0] = DEFAULT_SEED
+    seed[0] ^= <UINT32_t>(seed[0] << 13)
+    seed[0] ^= <UINT32_t>(seed[0] >> 17)
+    seed[0] ^= <UINT32_t>(seed[0] << 5)
+
+    return seed[0] % (<UINT32_t>RAND_R_MAX + 1)

--- a/sklearn/utils/seq_dataset.pyx
+++ b/sklearn/utils/seq_dataset.pyx
@@ -13,6 +13,7 @@ import numpy as np
 
 np.import_array()
 
+from sklearn.utils cimport _random
 
 cdef class SequentialDataset:
     """Base class for datasets with sequential data access. """
@@ -86,7 +87,7 @@ cdef class SequentialDataset:
         cdef int n = self.n_samples
         cdef unsigned i, j
         for i in range(n - 1):
-            j = i + our_rand_r(&seed) % (n - i)
+            j = i + _random.our_rand_r(&seed) % (n - i)
             ind[i], ind[j] = ind[j], ind[i]
 
     cdef int _get_next_index(self) nogil:
@@ -100,7 +101,7 @@ cdef class SequentialDataset:
 
     cdef int _get_random_index(self) nogil:
         cdef int n = self.n_samples
-        cdef int current_index = our_rand_r(&self.seed) % n
+        cdef int current_index = _random.our_rand_r(&self.seed) % n
         self.current_index = current_index
         return current_index
 
@@ -287,14 +288,3 @@ cdef class CSRDataset(SequentialDataset):
 
 cdef enum:
     RAND_R_MAX = 0x7FFFFFFF
-
-
-# rand_r replacement using a 32bit XorShift generator
-# See http://www.jstatsoft.org/v08/i14/paper for details
-# XXX copied over from sklearn/tree/_tree.pyx, should refactor
-cdef inline np.uint32_t our_rand_r(np.uint32_t* seed) nogil:
-    seed[0] ^= <np.uint32_t>(seed[0] << 13)
-    seed[0] ^= <np.uint32_t>(seed[0] >> 17)
-    seed[0] ^= <np.uint32_t>(seed[0] << 5)
-
-    return seed[0] % (<np.uint32_t>RAND_R_MAX + 1)


### PR DESCRIPTION
…015)

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fix #5015 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This PR makes 2 contributions:
1. code blocks similar to our_rand_r are duplicated at multiple places. This refactors these to use the single definition of the function which is now available via sklearn.utils._random.pyx
2. Currently the function would always generate 0 if the seed was 0. This fixes this behavior to now fallback to a default seed, whenever the seed parameter is 0. Currently it used the default seed value of 1.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
