### PR TITLE
[MRG] FIX-#11257 raise exception when parameter y is None in validation/column_or_1d

### DIFF
--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -181,7 +181,7 @@ def test_label_encoder():
     assert_raises(ValueError, le.transform, [0, 6])
 
     le.fit(["apple", "orange"])
-    msg = "bad input shape"
+    msg = "Array size must bigger than zero"
     assert_raise_message(ValueError, msg, le.transform, "apple")
 
 
@@ -210,7 +210,7 @@ def test_label_encoder_errors():
     assert_raise_message(ValueError, msg, le.inverse_transform, [-2, -3, -4])
 
     # Fail on inverse_transform("")
-    msg = "bad input shape ()"
+    msg = "Array size must bigger than zero"
     assert_raise_message(ValueError, msg, le.inverse_transform, "")
 
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -669,8 +669,6 @@ def check_X_y(X, y, accept_sparse=False, dtype="numeric", order=None,
     X = check_array(X, accept_sparse, dtype, order, copy, force_all_finite,
                     ensure_2d, allow_nd, ensure_min_samples,
                     ensure_min_features, warn_on_dtype, estimator)
-    if y is None:
-        raise  ValueError('Parameter y cannot be None')
     if multi_output:
         y = check_array(y, 'csr', force_all_finite=True, ensure_2d=False,
                         dtype=None)
@@ -700,6 +698,8 @@ def column_or_1d(y, warn=False):
     y : array
 
     """
+    if y is None:
+        raise ValueError('Parameter y cannot be None')
     shape = np.shape(y)
     if len(shape) == 1:
         return np.ravel(y)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -669,6 +669,8 @@ def check_X_y(X, y, accept_sparse=False, dtype="numeric", order=None,
     X = check_array(X, accept_sparse, dtype, order, copy, force_all_finite,
                     ensure_2d, allow_nd, ensure_min_samples,
                     ensure_min_features, warn_on_dtype, estimator)
+    if y is None:
+        raise  ValueError('Parameter y cannot be None')
     if multi_output:
         y = check_array(y, 'csr', force_all_finite=True, ensure_2d=False,
                         dtype=None)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -698,9 +698,10 @@ def column_or_1d(y, warn=False):
     y : array
 
     """
-    if y is None:
-        raise ValueError('Parameter y cannot be None')
+
     shape = np.shape(y)
+    if len(shape) == 0:
+        raise ValueError('Array size must bigger than zero')
     if len(shape) == 1:
         return np.ravel(y)
     if len(shape) == 2 and shape[1] == 1:


### PR DESCRIPTION
Fixes #11257 

### What does this implement/fix? Explain your changes.

Raise an value exception when parameter y is None or has zero element

### Any other comments?

