### PR TITLE
[MRG+1] DOC Add libraries.io and changelog links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,15 +84,6 @@ Changelog
 See the `changelog <http://scikit-learn.org/dev/whats_new.html>`__
 for a history of notable changes to scikit-learn.
 
-.. The following two lines are duplicated in doc/whats_new.rst
-   so remember to make any changes in both places.
-   (Can't use an `.. include::` here to be more DRY because
-   GitHub's rst renderer ignores include directives.)
-
-**Tip:** `Subscribe to scikit-learn releases <https://libraries.io/pypi/scikit-learn>`__
-on libraries.io to be notified when new versions are released.
-
-
 Development
 -----------
 

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,21 @@ or ``conda``::
 The documentation includes more detailed `installation instructions <http://scikit-learn.org/stable/install.html>`_.
 
 
+Changelog
+---------
+
+See the `changelog <http://scikit-learn.org/dev/whats_new.html>`__
+for a history of notable changes to scikit-learn.
+
+.. The following two lines are duplicated in doc/whats_new.rst
+   so remember to make any changes in both places.
+   (Can't use an `.. include::` here to be more DRY because
+   GitHub's rst renderer ignores include directives.)
+
+**Tip:** `Subscribe to scikit-learn releases <https://libraries.io/pypi/scikit-learn>`__
+on libraries.io to be notified when new versions are released.
+
+
 Development
 -----------
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -8,6 +8,9 @@ Release History
 Release notes for current and recent releases are detailed on this page, with
 :ref:`previous releases <previous_releases_whats_new>` linked below.
 
+**Tip:** `Subscribe to scikit-learn releases <https://libraries.io/pypi/scikit-learn>`__
+on libraries.io to be notified when new versions are released.
+
 .. include:: whats_new/v0.20.rst
 .. include:: whats_new/v0.19.rst
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -8,11 +8,6 @@ Release History
 Release notes for current and recent releases are detailed on this page, with
 :ref:`previous releases <previous_releases_whats_new>` linked below.
 
-.. The following two lines are duplicated in ../README.rst
-   so remember to make any changes in both places.
-   (Can't use an `.. include::` here to be more DRY because
-   GitHub's rst renderer ignores include directives.)
-
 **Tip:** `Subscribe to scikit-learn releases <https://libraries.io/pypi/scikit-learn>`__
 on libraries.io to be notified when new versions are released.
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -8,6 +8,11 @@ Release History
 Release notes for current and recent releases are detailed on this page, with
 :ref:`previous releases <previous_releases_whats_new>` linked below.
 
+.. The following two lines are duplicated in ../README.rst
+   so remember to make any changes in both places.
+   (Can't use an `.. include::` here to be more DRY because
+   GitHub's rst renderer ignores include directives.)
+
 **Tip:** `Subscribe to scikit-learn releases <https://libraries.io/pypi/scikit-learn>`__
 on libraries.io to be notified when new versions are released.
 


### PR DESCRIPTION
The first commit in this PR closes #11287 by adding a "subscribe to releases on libraries.io" link to the "what's new" page:
![screen shot 2018-06-16 at 12 19 12](https://user-images.githubusercontent.com/40300730/41500595-be25a2e8-7162-11e8-9622-f97a8a77fc7e.png)

I also noticed that there is no link to the changelog/what's new page from the https://github.com/scikit-learn/scikit-learn#readme content on GitHub, but I thought there should be: The "what's new" content is often the one thing that upgrading users are looking for, so I think it should be linked to from every top-level page. So the second commit in this PR adds a changelog link to the README that is displayed on GitHub, as well as another "subscribe to releases" link there as well.