### PR TITLE
[WIP] Column selector functions for ColumnTransformer

### DIFF
--- a/examples/compose/column_selector_callables.py
+++ b/examples/compose/column_selector_callables.py
@@ -1,0 +1,61 @@
+# Author: Pedro Morales <part.morales@gmail.com>
+#
+# License: BSD 3 clause
+
+from __future__ import print_function
+
+import numpy as np
+import pandas as pd
+
+from sklearn.compose import make_column_transformer, select_types
+from sklearn.pipeline import make_pipeline
+from sklearn.impute import SimpleImputer
+from sklearn.preprocessing import StandardScaler, CategoricalEncoder
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
+
+
+# Read data from Titanic dataset.
+titanic_url = ('https://raw.githubusercontent.com/amueller/'
+               'scipy-2017-sklearn/091d371/notebooks/datasets/titanic3.csv')
+
+data = pd.read_csv(titanic_url)
+
+# Provisionally, use pd.fillna() to impute missing values for categorical
+# features; SimpleImputer will eventually support strategy="constant".
+data[['embarked', 'sex', 'pclass']] = data[
+    ['embarked', 'sex', 'pclass']].fillna(value='missing')
+
+
+# We create the preprocessing pipelines for both numeric and categorical data.
+numeric_transformer = make_pipeline(SimpleImputer(), StandardScaler())
+categorical_transformer = CategoricalEncoder('onehot-dense',
+                                             handle_unknown='ignore')
+
+# We construct a column transformer, using dtype selectors
+preprocessing_pl = make_column_transformer(
+    (select_types([float]), numeric_transformer),
+    (select_types([int, 'object']), categorical_transformer),
+    remainder='drop'
+)
+
+clf = make_pipeline(preprocessing_pl, LogisticRegression())
+
+np.random.seed(0)
+
+# We will train our classifier with the following features:
+# Numeric Features:
+# - age: float.
+# - fare: float.
+# Categorical Features:
+# - embarked: categories encoded as strings {'C', 'S', 'Q'}.
+# - sex: categories encoded as strings {'female', 'male'}.
+# - pclass: ordinal integers {1, 2, 3}.
+X = data[['age', 'fare', 'embarked', 'sex', 'pclass']]
+y = data.survived.values
+
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2,
+                                                    shuffle=True)
+
+clf.fit(X_train, y_train)
+print("model score: %f" % clf.score(X_test, y_test))

--- a/examples/compose/column_selector_callables.py
+++ b/examples/compose/column_selector_callables.py
@@ -1,3 +1,11 @@
+"""
+=======================
+Select Column Functions
+=======================
+
+TODO
+"""
+
 # Author: Pedro Morales <part.morales@gmail.com>
 #
 # License: BSD 3 clause

--- a/sklearn/compose/__init__.py
+++ b/sklearn/compose/__init__.py
@@ -5,12 +5,17 @@ refurbished versions of Pipeline and FeatureUnion.
 
 """
 
-from ._column_transformer import ColumnTransformer, make_column_transformer
+from ._column_transformer import (
+    ColumnTransformer,
+    make_column_transformer,
+    select_types
+)
 from ._target import TransformedTargetRegressor
 
 
 __all__ = [
     'ColumnTransformer',
     'make_column_transformer',
-    'TransformedTargetRegressor',
+    'select_types',
+    'TransformedTargetRegressor'
 ]

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -584,6 +584,11 @@ def _get_column_indices(X, key):
     elif hasattr(key, 'dtype') and np.issubdtype(key.dtype, np.bool_):
         # boolean mask
         return list(np.arange(n_columns)[key])
+    elif callable(key):
+        if not hasattr(X, 'columns'):
+            raise ValueError("Using column selector callables is only "
+                             "supported for pandas DataFrames")
+        return list(np.arange(n_columns)[key(X)])
     else:
         raise ValueError("No valid specification of the columns. Only a "
                          "scalar, list or slice of all integers or all "


### PR DESCRIPTION
#### Reference Issues
Closes #11190 

#### What does this implement?
This PR introduces functions to generate column selector callables that can be passed to `make_column_transformer` and `ColumnTransformer` in place of the actual column selections.

For now, I have implemented a selector for dtypes. I am working on a name selector.
(As discussed in #11190)

#### Other comments:

This PR is still incomplete. I have created it early in order to receive feedback.
The example I have included is just a quick refactorization of #11197. I will care further about the formatting when we are happy with the functions.
