### PR TITLE
[MRG + 1] Add refit_time_ attribute to model selection

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -258,7 +258,7 @@ Model evaluation and meta-estimators
   :class:`model_selection.RandomizedSearchCV` if ``refit`` is set to ``True``.
   This will allow measuring the complete time it takes to perform
   hyperparameter optimization and refitting the best model on the whole
-  dataset.
+  dataset. :issue:`11310` by :user:`Matthias Feurer <mfeurer>`.
 
 Decomposition and manifold learning
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -253,6 +253,13 @@ Model evaluation and meta-estimators
   return estimators fitted on each split. :issue:`9686` by :user:`Aurélien Bellet
   <bellet>`.
 
+- New ``refit_time_`` attribute will be stored in
+  :class:`model_selection.GridSearchCV` and
+  :class:`model_selection.RandomizedSearchCV` if ``refit`` is set to ``True``.
+  This will allow measuring the complete time it takes to perform
+  hyperparameter optimization and refitting the best model on the whole
+  dataset.
+
 Decomposition and manifold learning
 
 - Speed improvements for both 'exact' and 'barnes_hut' methods in

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1083,7 +1083,7 @@ class GridSearchCV(BaseSearchCV):
     refit_time_ : float
         Seconds used for refitting the best model on the whole dataset.
 
-        This is present only if ``refit`` is set to ``True``.
+        This is present only if ``refit`` is not False.
 
     Notes
     ------
@@ -1399,7 +1399,7 @@ class RandomizedSearchCV(BaseSearchCV):
     refit_time_ : float
         Seconds used for refitting the best model on the whole dataset.
 
-        This is present only if ``refit`` is set to ``True``.
+        This is present only if ``refit`` is not False.
 
     Notes
     -----

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -17,6 +17,7 @@ from collections import Mapping, namedtuple, defaultdict, Sequence, Iterable
 from functools import partial, reduce
 from itertools import product
 import operator
+import time
 import warnings
 
 import numpy as np
@@ -766,10 +767,13 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         if self.refit:
             self.best_estimator_ = clone(base_estimator).set_params(
                 **self.best_params_)
+            refit_start_time = time.time()
             if y is not None:
                 self.best_estimator_.fit(X, y, **fit_params)
             else:
                 self.best_estimator_.fit(X, **fit_params)
+            refit_end_time = time.time()
+            self.refit_time_ = refit_end_time - refit_start_time
 
         # Store the only scorer not as a dict for single metric evaluation
         self.scorer_ = scorers if self.multimetric_ else scorers['score']
@@ -1075,6 +1079,11 @@ class GridSearchCV(BaseSearchCV):
 
     n_splits_ : int
         The number of cross-validation splits (folds/iterations).
+
+    refit_time_ : float
+        Seconds used for refitting the best model on the whole dataset.
+
+        This is present only if ``refit`` is set to ``True``.
 
     Notes
     ------
@@ -1386,6 +1395,11 @@ class RandomizedSearchCV(BaseSearchCV):
 
     n_splits_ : int
         The number of cross-validation splits (folds/iterations).
+
+    refit_time_ : float
+        Seconds used for refitting the best model on the whole dataset.
+
+        This is present only if ``refit`` is set to ``True``.
 
     Notes
     -----

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -5,6 +5,7 @@ from sklearn.externals.six.moves import cStringIO as StringIO
 from sklearn.externals.six.moves import xrange
 from sklearn.externals.joblib._compat import PY3_OR_LATER
 from itertools import chain, product
+import os
 import pickle
 import sys
 from types import GeneratorType
@@ -1175,7 +1176,7 @@ def test_search_cv_timing():
 
         assert_true(hasattr(search, "refit_time_"))
         assert_true(isinstance(search.refit_time_, float))
-        if sys.version_info[0] >= 3:
+        if os.name in ('mac', 'posix'):
             assert_greater(search.refit_time_, 0)
 
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -5,7 +5,6 @@ from sklearn.externals.six.moves import cStringIO as StringIO
 from sklearn.externals.six.moves import xrange
 from sklearn.externals.joblib._compat import PY3_OR_LATER
 from itertools import chain, product
-import os
 import pickle
 import sys
 from types import GeneratorType

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -27,7 +27,7 @@ from sklearn.utils.testing import assert_false, assert_true
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_almost_equal
-from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import assert_greater_equal
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.mocking import CheckingClassifier, MockDataFrame
 
@@ -1176,8 +1176,7 @@ def test_search_cv_timing():
 
         assert_true(hasattr(search, "refit_time_"))
         assert_true(isinstance(search.refit_time_, float))
-        if os.name in ('mac', 'posix'):
-            assert_greater(search.refit_time_, 0)
+        assert_greater_equal(search.refit_time_, 0)
 
 
 def test_grid_search_correct_score_results():

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1175,7 +1175,8 @@ def test_search_cv_timing():
 
         assert_true(hasattr(search, "refit_time_"))
         assert_true(isinstance(search.refit_time_, float))
-        assert_greater(search.refit_time_, 0)
+        if sys.version_info[0] >= 3:
+            assert_greater(search.refit_time_, 0)
 
 
 def test_grid_search_correct_score_results():

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -26,6 +26,7 @@ from sklearn.utils.testing import assert_false, assert_true
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.mocking import CheckingClassifier, MockDataFrame
 
@@ -1171,6 +1172,10 @@ def test_search_cv_timing():
             assert_true(search.cv_results_[key][1] >= 0)
             assert_true(search.cv_results_[key][0] == 0.0)
             assert_true(np.all(search.cv_results_[key] < 1))
+
+        assert_true(hasattr(search, "refit_time_"))
+        assert_true(isinstance(search.refit_time_, float))
+        assert_greater(search.refit_time_, 0)
 
 
 def test_grid_search_correct_score_results():


### PR DESCRIPTION
#### Reference Issues/PRs

Resolves #8833.

#### What does this implement/fix? Explain your changes.

This PR implements a new `refit_time_` attribute which will be stored in GridSearchCV and RandomizedSearchCV if `refit` is set to `True`. This will allow measuring the complete time it takes to perform +  hyperparameter optimization and refitting the best model on the whole dataset and will be particularly helpful if the hyperparameter optimization is carried out in parallel.