### PR TITLE
[MRG] ENH: Add partial fit support to Pipeline

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -97,7 +97,7 @@ class Pipeline(_BaseComposition):
     >>> # and a parameter 'C' of the svm
     >>> anova_svm.set_params(anova__k=10, svc__C=.1).fit(X, y)
     ...                      # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-    Pipeline(memory=None,
+    Pipeline(memory=None, partially_fit=[],
              steps=[('anova', SelectKBest(...)),
                     ('svc', SVC(...))])
     >>> prediction = anova_svm.predict(X)
@@ -632,7 +632,7 @@ def make_pipeline(*steps, **kwargs):
     >>> from sklearn.preprocessing import StandardScaler
     >>> make_pipeline(StandardScaler(), GaussianNB(priors=None))
     ...     # doctest: +NORMALIZE_WHITESPACE
-    Pipeline(memory=None,
+    Pipeline(memory=None, partially_fit=[],
              steps=[('standardscaler',
                      StandardScaler(copy=True, with_mean=True, with_std=True)),
                     ('gaussiannb',

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -272,6 +272,31 @@ class Pipeline(_BaseComposition):
         return self
 
     def partial_fit(self, X, y, **fit_params):
+        """Partially fit the model
+
+        Fit all the transforms one after the other and transform the
+        data, then fit the transformed data using the final estimator.
+
+        Parameters
+        ----------
+        X : iterable
+            Training data. Must fulfill input requirements of first step of the
+            pipeline.
+
+        y : iterable, default=None
+            Training targets. Must fulfill label requirements for all steps of
+            the pipeline.
+
+        **fit_params : dict of string -> object
+            Parameters passed to the ``fit`` method of each step, where
+            each parameter name is prefixed such that parameter ``p`` for step
+            ``s`` has key ``s__p``.
+
+        Returns
+        -------
+        self : Pipeline
+            This estimator
+        """
         if not any(hasattr(step_est, 'partial_fit')
                    for _, step_est in self.steps):
             raise ValueError('At least one estimator must have '
@@ -290,7 +315,8 @@ class Pipeline(_BaseComposition):
         final_partially_fit = (self.partially_fit == [] or
                                final_name in self.partially_fit)
         if self._final_estimator is not None:
-            if (hasattr(self._final_estimator, 'partial_fit') and final_partially_fit):
+            if (hasattr(self._final_estimator, 'partial_fit') and
+                    final_partially_fit):
                 self._final_estimator.partial_fit(Xt, y, **fit_params)
             else:
                 self._final_estimator.fit(Xt, y, **fit_params)

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -1014,7 +1014,7 @@ def test_make_pipeline_memory():
 
 def test_pipeline_partial_fit():
     X, y = make_classification(random_state=0)
-    clf = SGDClassifier()
+    clf = SGDClassifier(random_state=0)
     pipeline = Pipeline([
         ('features', Normalizer()),
         ('clf', clf)
@@ -1037,7 +1037,7 @@ def test_pipeline_partial_fit_partially_fit_misspecified():
     X, y = make_classification(random_state=0)
     pipeline = Pipeline([
         ('features', Normalizer()),
-        ('clf', SGDClassifier())
+        ('clf', SGDClassifier(random_state=0))
     ], partially_fit=['features'])
     with pytest.raises(ValueError, match=('Not all models specified have '
                                           'partial_fit support')):
@@ -1047,8 +1047,8 @@ def test_pipeline_partial_fit_partially_fit_misspecified():
 def test_pipeline_partial_fit_works_middle():
     X, y = make_classification(random_state=0)
     # n_iter specifies number of iterations to run in partial_fit
-    d = MiniBatchDictionaryLearning(n_iter=10)
-    clf = SGDClassifier(max_iter=5, epsilon=0)
+    d = MiniBatchDictionaryLearning(n_iter=10, random_state=0)
+    clf = SGDClassifier(max_iter=5, epsilon=0, random_state=0)
 
     # All 3 of these have partial fit support
     pipeline = Pipeline([
@@ -1064,8 +1064,8 @@ def test_pipeline_partial_fit_works_middle():
 def test_pipeline_partial_fit_works_end():
     X, y = make_classification(random_state=0)
     # n_iter specifies number of iterations to run in partial_fit
-    d = MiniBatchDictionaryLearning(n_iter=10)
-    clf = SGDClassifier(max_iter=5, epsilon=0)
+    d = MiniBatchDictionaryLearning(n_iter=10, random_state=0)
+    clf = SGDClassifier(max_iter=5, epsilon=0, random_state=0)
 
     # All 3 of these have partial fit support
     pipeline = Pipeline([

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -602,6 +602,7 @@ def test_set_pipeline_step_none():
                        'm3': None,
                        'last': mult5,
                        'memory': None,
+                       'partially_fit': [],
                        'm2__mult': 2,
                        'last__mult': 5,
                        })

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -31,7 +31,8 @@ from sklearn.linear_model import LinearRegression
 from sklearn.cluster import KMeans
 from sklearn.feature_selection import SelectKBest, f_classif
 from sklearn.dummy import DummyRegressor
-from sklearn.decomposition import PCA, TruncatedSVD, MiniBatchDictionaryLearning
+from sklearn.decomposition import PCA, TruncatedSVD
+from sklearn.decomposition import MiniBatchDictionaryLearning
 from sklearn.datasets import load_iris, make_classification
 from sklearn.preprocessing import StandardScaler, Normalizer
 from sklearn.feature_extraction.text import CountVectorizer


### PR DESCRIPTION
#### Reference Issues/PRs
I'd like to see implemented for an adaptive parameter selection scheme that depends on `partial_fit`, https://github.com/dask/dask-searchcv/pull/72.

This will also allow pipelines to work with [`dask_ml.Incremental`][1], a class that wraps models that implement `partial_fit`.

[1]:https://dask-ml.readthedocs.io/en/latest/incremental.html

This also resolves https://github.com/scikit-learn/scikit-learn/issues/3299.

#### What does this implement/fix? Explain your changes.
This implements `Pipeline.partial_fit`. It adds a new keyword argument `partially_fit=[]` to `Pipeline.__init__`. If changed from default it should take in a list of names to call `partial_fit` on.
