### PR TITLE
[MRG+1]  Doc: complete PR #11180 for the reorganization of the dataset loading utilities section

### DIFF
--- a/doc/datasets/index.rst
+++ b/doc/datasets/index.rst
@@ -10,7 +10,7 @@ The ``sklearn.datasets`` package embeds some small toy datasets
 as introduced in the :ref:`Getting Started <loading_example_dataset>` section.
 
 This package also features helpers to fetch larger datasets commonly
-used by the machine learning community to benchmark algorithm on data
+used by the machine learning community to benchmark algorithms on data
 that comes from the 'real world'.
 
 To evaluate the impact of the scale of the dataset (``n_samples`` and
@@ -43,7 +43,7 @@ The datasets also contain a full description in their ``DESCR`` attribute and
 some contain ``feature_names`` and ``target_names``. See the dataset 
 descriptions below for details.  
 
-**The dataset generation functions.** They can be used to generate controled 
+**The dataset generation functions.** They can be used to generate controlled 
 synthetic datasets, described in the :ref:`generated_datasets` section.
 
 These functions return a tuple ``(X, y)`` consisting of a ``n_samples`` *
@@ -60,10 +60,9 @@ Toy datasets
 ============
 
 scikit-learn comes with a few small standard datasets that do not require to 
-download any file from some external website. A description of each dataset is
-available below.
+download any file from some external website. 
 
-They can be loaded using the following functions :
+They can be loaded using the following functions:
 
 .. autosummary::
 
@@ -114,9 +113,9 @@ Real world datasets
 ===================
 
 scikit-learn provides tools to load larger datasets, downloading them if
-necessary. A description of each dataset is available below.
+necessary.
 
-They can be loaded using the following functions :
+They can be loaded using the following functions:
 
 .. autosummary::
 
@@ -131,7 +130,6 @@ They can be loaded using the following functions :
    fetch_covtype
    fetch_rcv1
    fetch_kddcup99
-
 
 .. toctree::
     :maxdepth: 2
@@ -276,8 +274,6 @@ Generators for decomposition
 
 Loading other datasets
 ======================
-
-This section gathers different tools to load other kinds of datasets.
 
 .. _sample_images:
 

--- a/doc/datasets/index.rst
+++ b/doc/datasets/index.rst
@@ -32,7 +32,7 @@ described in the :ref:`real_world_datasets` section.
 
 Both loaders and fetchers functions return a dictionary-like object holding 
 at least two items: an array of shape ``n_samples`` * ``n_features`` with 
-key ``data``(except for 20newsgroups) and a numpy array of 
+key ``data`` (except for 20newsgroups) and a numpy array of 
 length ``n_samples``, containing the target values, with key ``target``.
 
 It's also possible for almost all of these function to constrain the output

--- a/doc/datasets/index.rst
+++ b/doc/datasets/index.rst
@@ -9,49 +9,61 @@ Dataset loading utilities
 The ``sklearn.datasets`` package embeds some small toy datasets
 as introduced in the :ref:`Getting Started <loading_example_dataset>` section.
 
+This package also features helpers to fetch larger datasets commonly
+used by the machine learning community to benchmark algorithm on data
+that comes from the 'real world'.
+
 To evaluate the impact of the scale of the dataset (``n_samples`` and
 ``n_features``) while controlling the statistical properties of the data
 (typically the correlation and informativeness of the features), it is
 also possible to generate synthetic data.
 
-This package also features helpers to fetch larger datasets commonly
-used by the machine learning community to benchmark algorithm on data
-that comes from the 'real world'.
-
 General dataset API
 ===================
 
-There are three distinct kinds of dataset interfaces for different types
-of datasets.
-The simplest one is the interface for sample images, which is described
-below in the :ref:`sample_images` section.
+There are three main kinds of dataset interfaces that can be used to get 
+datasets depending on the desired type of dataset.
+  
+**The dataset loaders.** They can be used to load small standard datasets, 
+described in the :ref:`toy_datasets` section.  
 
-The dataset generation functions and the svmlight loader share a simplistic
-interface, returning a tuple ``(X, y)`` consisting of a ``n_samples`` *
+**The dataset fetchers.** They can be used to download and load larger datasets,
+described in the :ref:`real_world_datasets` section.
+
+Both loaders and fetchers functions return a dictionary-like object holding 
+at least two items: an array of shape ``n_samples`` * ``n_features`` with 
+key ``data``(except for 20newsgroups) and a numpy array of 
+length ``n_samples``, containing the target values, with key ``target``.
+
+It's also possible for almost all of these function to constrain the output
+to be a tuple containing only the data and the target, by setting the 
+``return_X_y`` parameter to ``True``.
+
+The datasets also contain a full description in their ``DESCR`` attribute and 
+some contain ``feature_names`` and ``target_names``. See the dataset 
+descriptions below for details.  
+
+**The dataset generation functions.** They can be used to generate controled 
+synthetic datasets, described in the :ref:`generated_datasets` section.
+
+These functions return a tuple ``(X, y)`` consisting of a ``n_samples`` *
 ``n_features`` numpy array ``X`` and an array of length ``n_samples``
 containing the targets ``y``.
 
-The toy datasets as well as the 'real world' datasets and the datasets
-fetched from mldata.org have more sophisticated structure.
-These functions return a dictionary-like object holding at least two items:
-an array of shape ``n_samples`` * ``n_features`` with key ``data``
-(except for 20newsgroups)
-and a numpy array of length ``n_samples``, containing the target values,
-with key ``target``.
-
-The datasets also contain a description in ``DESCR`` and some contain
-``feature_names`` and ``target_names``.
-See the dataset descriptions below for details.
+In addition, there are also miscellanous tools to load datasets of other 
+formats or from other locations, described in the :ref:`loading_other_datasets`
+section. 
 
 .. _toy_datasets:
 
 Toy datasets
 ============
 
-scikit-learn comes with a few small standard datasets that do not
-require to download any file from some external website. 
+scikit-learn comes with a few small standard datasets that do not require to 
+download any file from some external website. A description of each dataset is
+available below.
 
-*desc*
+They can be loaded using the following functions :
 
 .. autosummary::
 
@@ -101,7 +113,10 @@ small to be representative of real world machine learning tasks.
 Real world datasets
 ===================
 
-*Add desc*
+scikit-learn provides tools to load larger datasets, downloading them if
+necessary. A description of each dataset is available below.
+
+They can be loaded using the following functions :
 
 .. autosummary::
 
@@ -261,6 +276,8 @@ Generators for decomposition
 
 Loading other datasets
 ======================
+
+This section gathers different tools to load other kinds of datasets.
 
 .. _sample_images:
 


### PR DESCRIPTION
This PR is just the continued work started in #11180 for the reorganization of the datasets loading utilities
section in the doc discussed in #11083.

There were TODOs left out in #11180 that this PR aims to fill. It's essentially adding/reworking introductions of the new datasets loading utilities sections.