### PR TITLE
[WIP] Add partial_fit() method to DictVectorizer 

### DIFF
--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -8,6 +8,7 @@ from operator import itemgetter
 
 import numpy as np
 import scipy.sparse as sp
+import numbers
 
 from ..base import BaseEstimator, TransformerMixin
 from ..externals import six

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -116,11 +116,13 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
             raise ValueError("Invalid number of features (%d)." % n_features)
     
     @staticmethod
-    def _validate_feature_name(feature,x):
+    def _validate_feature_name(feature, x):
         # strangely, np.int16 instances are not instances of Integral,
         # while np.int64 instances are...
         if feature.isdigit():
-            raise ValueError("For fixed size features must be nondigit, got %s on %s." % (feature,x))
+            raise ValueError('For fixed size features must be nondigit, ' 
+                             'got %s on %s.'
+                              % (feature, x))
 
     def fit(self, X, y=None):
         """Learn a list of feature name -> indices mappings.
@@ -144,7 +146,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
     def _partial_fit(self, X, y=None):
         if getattr(self, "feature_names_", None) is None:
             self.feature_names_ = []
-            
+
         if getattr(self, "vocabulary_", None) is None:
             self.vocabulary_ = {}
             
@@ -156,9 +158,10 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
                 if isinstance(v, six.string_types):
                     f = "%s%s%s" % (f, self.separator, v)
                 if f not in vocab:
-                    self._validate_feature_name(f,x)
+                    self._validate_feature_name(f, x)
                     if len(feature_names) == self.n_features:
-                        raise ValueError("The size of vocab is larger than n_features.")
+                        raise ValueError("The size of vocab is "
+                                         "larger than n_features.")
                     feature_names.append(f)
                     vocab[f] = len(vocab)
                     

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -135,11 +135,10 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         -------
         self
         """
-        return self._partial_fit(X,y)
+        return self._partial_fit(X)
 
     def partial_fit(self, X, y=None):
-        self._partial_fit(X, y)
-        return self.transform(X)
+        return self._partial_fit(X).self.transform(X)
 
     def _partial_fit(self, X, y=None):
         if getattr(self, "feature_names_", None) is None:
@@ -167,8 +166,9 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
             feature_names.sort()
             vocab = dict((f, i) for i, f in enumerate(feature_names))
         
-        for k in range(len(feature_names),self.n_features):
-            vocab[str(k)] = None
+        if getattr(self, "n_features", None) is not None:
+            for k in range(len(feature_names), self.n_features):
+                vocab[str(k)] = None
 
         self.feature_names_ = feature_names
         self.vocabulary_ = vocab
@@ -221,6 +221,16 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         result_matrix = sp.csr_matrix((values, indices, indptr),
                                       shape=shape, dtype=dtype)
 
+        # Sort everything if asked
+        #[TODO] Check if this still works with new n_features parameter
+        if self.sort:
+            feature_names.sort()
+            map_index = np.empty(len(feature_names), dtype=np.int32)
+            for new_val, f in enumerate(feature_names):
+                map_index[new_val] = vocab[f]
+                vocab[f] = new_val
+            result_matrix = result_matrix[:, map_index]
+
         if self.sparse:
             result_matrix.sort_indices()
         else:
@@ -246,8 +256,8 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         Xa : {array, sparse matrix}
             Feature vectors; always 2-d.
         """
-        self._partial_fit(X,y)
-        return self.transform(X)
+        #[TODO] Not working because of iterator being exchausted
+        return self._partial_fit(X)._transform(X)
 
     def inverse_transform(self, X, dict_type=dict):
         """Transform array or sparse matrix X back to feature mappings.
@@ -307,26 +317,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         Xa : {array, sparse matrix}
             Feature vectors; always 2-d.
         """
-        if self.sparse:
-            return self._transform(X)
-
-        else:
-            dtype = self.dtype
-            vocab = self.vocabulary_
-            X = _tosequence(X)
-            Xa = np.zeros((len(X), len(vocab)), dtype=dtype)
-
-            for i, x in enumerate(X):
-                for f, v in six.iteritems(x):
-                    if isinstance(v, six.string_types):
-                        f = "%s%s%s" % (f, self.separator, v)
-                        v = 1
-                    try:
-                        Xa[i, vocab[f]] = dtype(v)
-                    except KeyError:
-                        pass
-
-            return Xa
+        return self._transform(X)
 
     def get_feature_names(self):
         """Returns a list of feature names, ordered by their indices.

--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -26,7 +26,11 @@ def test_dictvectorizer(sparse, dtype, sort, iterable):
          {"bar": 1, "quux": 1, "quuux": 2}]
 
     v = DictVectorizer(sparse=sparse, dtype=dtype, sort=sort)
-    X = v.fit_transform(iter(D) if iterable else D)
+    #[TODO] check how to deal with not materializing X in memory calling fit_transform()
+    #X = v.fit_transform(iter(D) if iterable else D)
+ 
+    v.fit(iter(D) if iterable else D)
+    X = v.transform(iter(D) if iterable else D)
 
     assert_equal(sp.issparse(X), sparse)
     assert_equal(X.shape, (3, 5))
@@ -102,7 +106,7 @@ def test_unseen_or_no_features():
 
 def test_deterministic_vocabulary():
     # Generate equal dictionaries with different memory layouts
-    items = [("%03d" % i, i) for i in range(1000)]
+    items = [("%03dfeature_name" % i, i) for i in range(1000)]
     rng = Random(42)
     d_sorted = dict(items)
     rng.shuffle(items)

--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -26,7 +26,8 @@ def test_dictvectorizer(sparse, dtype, sort, iterable):
          {"bar": 1, "quux": 1, "quuux": 2}]
 
     v = DictVectorizer(sparse=sparse, dtype=dtype, sort=sort)
-    #[TODO] check how to deal with not materializing X in memory calling fit_transform()
+    #[TODO] check how to deal with not materializing 
+    # X in memory calling fit_transform()
     #X = v.fit_transform(iter(D) if iterable else D)
  
     v.fit(iter(D) if iterable else D)


### PR DESCRIPTION
#### Reference Issues/PRs
Closes [#11267](https://github.com/scikit-learn/scikit-learn/issues/11267)

#### What does this implement/fix? 
Adds a `n_features` parameter and a `partial_fit() `method to `DictVectorizer`. Useful when we are learning a `vocab` on the fly and still need a fixed size output.

TODO:

- [x] Ask for feedback on implementation decision 

- [ ] Decide how/if `fit_transform()` will deal without materializing X in memory

- [ ] The code follow the code guidelines

- [ ] Check for common programming errors

- [ ] The new implementation doesn't break current `DictVectorizer` tests

- [ ] The new implementation doesn't break all library tests

- [ ] Create new test cases for `n_features != None`

- [ ] Add a script to `/examples`

- [ ] Update documentation

