### PR TITLE
[MRG] FIX: Ensure dictionary is writeable

### DIFF
--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -749,6 +749,8 @@ def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
 
     dictionary = check_array(dictionary.T, order='F', dtype=np.float64,
                              copy=False)
+    dictionary = np.require(dictionary, requirements='W')
+
     X_train = check_array(X_train, order='C', dtype=np.float64, copy=False)
 
     batches = gen_batches(n_samples, batch_size)

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -264,6 +264,15 @@ def test_dict_learning_online_initialization():
     assert_array_equal(dico.components_, V)
 
 
+def test_dict_learning_online_readonly_initialization():
+    n_components = 12
+    rng = np.random.RandomState(0)
+    V = rng.randn(n_components, n_features)
+    V.setflags(write=False)
+    MiniBatchDictionaryLearning(n_components, n_iter=1, dict_init=V,
+                                random_state=0, shuffle=False).fit(X)
+
+
 def test_dict_learning_online_partial_fit():
     n_components = 12
     rng = np.random.RandomState(0)


### PR DESCRIPTION
As the `dictionary` in `dict_learning_online` can be supplied by the user and we intend to write to it, ensure that it is writable before proceeding. This is needed as `dict_learning_online` will overwrite data in `dictionary` as it runs. Tweak an existing test to initialize `dict_learning_online` with a read-only `dictionary` and ensure it will reach code that tries to write to the read-only `dictionary` (unless we ensure it is writeable).