### PR TITLE
[MRG] FIX allow non-finite target values in TransformedTargetRegressor

### DIFF
--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -151,7 +151,7 @@ class TransformedTargetRegressor(BaseEstimator, RegressorMixin):
             Training vector, where n_samples is the number of samples and
             n_features is the number of features.
 
-        y : array-like, shape (n_samples,)
+        y : array-like, shape (n_samples,) or (n_samples, n_outputs)
             Target values.
 
         sample_weight : array-like, shape (n_samples,) optional

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -162,7 +162,7 @@ class TransformedTargetRegressor(BaseEstimator, RegressorMixin):
         -------
         self : object
         """
-        y = check_array(y, accept_sparse=False, force_all_finite=True,
+        y = check_array(y, accept_sparse=False, force_all_finite='allow-nan',
                         ensure_2d=False, dtype='numeric')
 
         # store the number of dimension of the target to predict an array of

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -162,7 +162,7 @@ class TransformedTargetRegressor(BaseEstimator, RegressorMixin):
         -------
         self : object
         """
-        y = check_array(y, accept_sparse=False, force_all_finite='allow-nan',
+        y = check_array(y, accept_sparse=False, force_all_finite=False,
                         ensure_2d=False, dtype='numeric')
 
         # store the number of dimension of the target to predict an array of

--- a/sklearn/compose/tests/test_target.py
+++ b/sklearn/compose/tests/test_target.py
@@ -16,6 +16,8 @@ from sklearn.utils.testing import assert_no_warnings
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.preprocessing import StandardScaler
 
+from sklearn.impute import SimpleImputer
+
 from sklearn.linear_model import LinearRegression, Lasso
 
 from sklearn import datasets
@@ -265,3 +267,26 @@ def test_transform_target_regressor_ensure_y_array():
     tt.predict(X.tolist())
     assert_raises(AssertionError, tt.fit, X, y.tolist())
     assert_raises(AssertionError, tt.predict, X)
+
+
+def test_transform_target_regressor_allow_nan():
+    # check if the TransformedTargetRegressor allows missing value in the target array
+
+    X, y = datasets.load_linnerud(return_X_y=True)
+
+    # put some NaN in y
+    y[5, 1] = np.NaN
+
+    class DummyInvertibleImputer(SimpleImputer):
+        """ add a dummy inverse transform to simple impute"""
+        def inverse_transform(self, X):
+            return X
+
+    estimator = TransformedTargetRegressor(
+        regressor=LinearRegression(),
+        transformer=DummyInvertibleImputer(),
+        check_inverse=False
+    )
+
+    estimator.fit(X, y)
+    estimator.predict(X)

--- a/sklearn/compose/tests/test_target.py
+++ b/sklearn/compose/tests/test_target.py
@@ -270,7 +270,8 @@ def test_transform_target_regressor_ensure_y_array():
 
 
 def test_transform_target_regressor_allow_nan():
-    # check if the TransformedTargetRegressor allows missing value in the target array
+    # check if the TransformedTargetRegressor allows missing value in
+    # the target array
 
     X, y = datasets.load_linnerud(return_X_y=True)
 

--- a/sklearn/compose/tests/test_target.py
+++ b/sklearn/compose/tests/test_target.py
@@ -274,7 +274,6 @@ def test_transform_target_regressor_allow_nan():
 
     X, y = datasets.load_linnerud(return_X_y=True)
 
-    # put some NaN in y
     y[5, 1] = np.NaN
 
     class DummyInvertibleImputer(SimpleImputer):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -180,7 +180,8 @@ def _yield_regressor_checks(name, regressor):
     yield check_estimators_partial_fit_n_features
     yield check_regressors_no_decision_function
     yield check_supervised_y_2d
-    yield check_supervised_y_no_nan
+    if name != 'TransformedTargetRegressor':
+        yield check_supervised_y_no_nan
     if name != 'CCA':
         # check that the regressor handles int input
         yield check_regressors_int


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #11339 
simply changed `force_all_finite` to `'False'`

**Update:**
turn off all finiteness checks
#### What does this implement/fix? Explain your changes.
Allow target values to have missing values in `TransformedTargetRegressor`


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
