### PR TITLE
[MRG] TST: fix scipy-dev-wheels build

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1059,20 +1059,27 @@ def test_tfidf_transformer_sparse():
 
 
 @pytest.mark.parametrize(
-    "vectorizer_dtype, output_dtype, expected_warning, msg_warning",
-    [(np.int32, np.float64, UserWarning, "'dtype' should be used."),
-     (np.int64, np.float64, UserWarning, "'dtype' should be used."),
-     (np.float32, np.float32, None, None),
-     (np.float64, np.float64, None, None)]
+    "vectorizer_dtype, output_dtype, warning_expected",
+    [(np.int32, np.float64, True),
+     (np.int64, np.float64, True),
+     (np.float32, np.float32, False),
+     (np.float64, np.float64, False)]
 )
 def test_tfidf_vectorizer_type(vectorizer_dtype, output_dtype,
-                               expected_warning, msg_warning):
+                               warning_expected):
     X = np.array(["numpy", "scipy", "sklearn"])
     vectorizer = TfidfVectorizer(dtype=vectorizer_dtype)
-    with pytest.warns(expected_warning, match=msg_warning) as record:
+
+    warning_msg_match = "'dtype' should be used."
+    warning_cls = UserWarning
+    expected_warning_cls = warning_cls if warning_expected else None
+    with pytest.warns(expected_warning_cls,
+                      match=warning_msg_match) as record:
             X_idf = vectorizer.fit_transform(X)
-    if expected_warning is None:
-        assert len(record) == 0
+    if expected_warning_cls is None:
+        relevant_warnings = [w for w in record
+                             if isinstance(w, warning_cls)]
+        assert len(relevant_warnings) == 0
     assert X_idf.dtype == output_dtype
 
 


### PR DESCRIPTION
Fix #11194 one more time ...

If this keeps happening I think we will need to have a better way of dealing with these.

I was expecting that `pytest.warns` would respect `warnings.filters` (`the matrix subclass is not the recommended way` is included in `warnings.filters` I double-checked) in contrary to `sklearn.utils.testing.assert_no_warnings` which internally does `warnings.simplefilter('always')` (+some custom ignoring of np.VisibleDeprecationWarning). Apparently my expectation about the interaction of `pytest.warns` and `warnings.filters` is not correct ...
