### PR TITLE
[MRG] CI Add commit flag [nightly] to run travis with SciPy nightly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
     # interpreter provided by travis.
     -  python: 3.6
        env: DISTRIB="scipy-dev-wheels"
-       if: type = cron OR commit_message ~ /\[nightly\]/
+       if: type = cron OR commit_message ~ /\[scipy-dev\]/
 
 install: source build_tools/travis/install.sh
 script: bash build_tools/travis/test_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
     # interpreter provided by travis.
     -  python: 3.6
        env: DISTRIB="scipy-dev-wheels"
-       if: type = cron
+       if: type = cron OR commit_message ~ /\[nightly\]/
 
 install: source build_tools/travis/install.sh
 script: bash build_tools/travis/test_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
     # installed from their CI wheels in a virtualenv with the Python
     # interpreter provided by travis.
     -  python: 3.6
-       env: DISTRIB="scipy-dev-wheels"
+       env: DISTRIB="scipy-dev"
        if: type = cron OR commit_message ~ /\[scipy-dev\]/
 
 install: source build_tools/travis/install.sh

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -78,7 +78,7 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     source testvenv/bin/activate
     pip install pytest pytest-cov cython==$CYTHON_VERSION
 
-elif [[ "$DISTRIB" == "scipy-dev-wheels" ]]; then
+elif [[ "$DISTRIB" == "scipy-dev" ]]; then
     # Set up our own virtualenv environment to avoid travis' numpy.
     # This venv points to the python interpreter of the travis build
     # matrix.

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -400,6 +400,7 @@ and Cython optimizations.
      ====================== ===================
      Commit Message Marker  Action Taken by CI
      ---------------------- -------------------
+     [nightly]              Add a Travis build with SciPy/NumPy nightly builds
      [ci skip]              CI is skipped completely
      [doc skip]             Docs are not built
      [doc quick]            Docs built, but excludes example gallery plots

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -400,7 +400,7 @@ and Cython optimizations.
      ====================== ===================
      Commit Message Marker  Action Taken by CI
      ---------------------- -------------------
-     [nightly]              Add a Travis build with SciPy/NumPy nightly builds
+     [scipy-dev]            Add a Travis build with SciPy/NumPy nightly builds
      [ci skip]              CI is skipped completely
      [doc skip]             Docs are not built
      [doc quick]            Docs built, but excludes example gallery plots

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -400,7 +400,7 @@ and Cython optimizations.
      ====================== ===================
      Commit Message Marker  Action Taken by CI
      ---------------------- -------------------
-     [scipy-dev]            Add a Travis build with SciPy/NumPy nightly builds
+     [scipy-dev]            Add a Travis build with our dependencies (numpy, scipy, etc ...) development builds
      [ci skip]              CI is skipped completely
      [doc skip]             Docs are not built
      [doc quick]            Docs built, but excludes example gallery plots

--- a/sklearn/preprocessing/tests/test_common.py
+++ b/sklearn/preprocessing/tests/test_common.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 import numpy as np
 
@@ -110,10 +112,12 @@ def test_missing_value_handling(est, func, support_sparse, strictly_positive):
             X_train_sp = sparse_constructor(X_train)
             X_test_sp = sparse_constructor(X_test)
             with pytest.warns(None) as records:
+                warnings.simplefilter('ignore', PendingDeprecationWarning)
                 Xt_sp = est_sparse.fit(X_train_sp).transform(X_test_sp)
             assert len(records) == 0
             assert_allclose(Xt_sp.A, Xt_dense)
             with pytest.warns(None) as records:
+                warnings.simplefilter('ignore', PendingDeprecationWarning)
                 Xt_inv_sp = est_sparse.inverse_transform(Xt_sp)
             assert len(records) == 0
             assert_allclose(Xt_inv_sp.A, Xt_inv_dense)


### PR DESCRIPTION
Unfortunately #11359 still didn't fix our builds on scipy nightly wheels (#11194).

This PR adds a commit message flag, `[nightly]` to trigger the Travis build otherwise only run on cron. I'll try to fix the remaining issues in this PR also.