### PR TITLE
Doc fix: default value for fill_value in SimpleImputer

### DIFF
--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -118,7 +118,7 @@ class SimpleImputer(BaseEstimator, TransformerMixin):
         .. versionadded:: 0.20
            strategy="constant" for fixed value imputation.
 
-    fill_value : string or numerical value, optional
+    fill_value : string or numerical value, optional (default=None)
         When strategy == "constant", fill_value is used to replace all
         occurrences of missing_values.
         If left to the default, fill_value will be 0 when imputing numerical


### PR DESCRIPTION
Added the default value of `fill_value` parameter in the `SimpleImputer` docstring. See #11380