### PR TITLE
[MRG] Improve linear_model.rst : error on Huber function

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -1137,13 +1137,13 @@ The loss function that :class:`HuberRegressor` minimizes is given by
 
 .. math::
 
-  \underset{w, \sigma}{\min\,} {\sum_{i=1}^n\left(\sigma + H_m\left(\frac{X_{i}w - y_{i}}{\sigma}\right)\sigma\right) + \alpha {||w||_2}^2}
+  \underset{w, \sigma}{\min\,} {\sum_{i=1}^n\left(\sigma + H_{\epsilon}\left(\frac{X_{i}w - y_{i}}{\sigma}\right)\sigma\right) + \alpha {||w||_2}^2}
 
 where
 
 .. math::
 
-  H_m(z) = \begin{cases}
+  H_{\epsilon}(z) = \begin{cases}
          z^2, & \text {if } |z| < \epsilon, \\
          2\epsilon|z| - \epsilon^2, & \text{otherwise}
   \end{cases}


### PR DESCRIPTION
The subscript of the Huber function (H_m) was not relevant in linear_model.rst. 
It was written H_m but the index m was nowhere used later on;
it should have been epsilon instead.

#### Changes.
The occurrences of m have been removed and replaced by epsilon.

@agramfort 
@rth 