### PR TITLE
CI show full traceback on sphinx-build exception

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -92,7 +92,7 @@ else
     make_args=html
 fi
 
-make_args="-T $make_args"  # show full traceback on exception
+make_args="SPHINXOPTS=-T $make_args"  # show full traceback on exception
 
 # Installing required system packages to support the rendering of math
 # notation in the HTML documentation

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -92,6 +92,8 @@ else
     make_args=html
 fi
 
+make_args="-T $make_args"  # show full traceback on exception
+
 # Installing required system packages to support the rendering of math
 # notation in the HTML documentation
 sudo -E apt-get -yq update


### PR DESCRIPTION
I noticed in #9251 that a sphinx-build exception in Circle CI will currently say:

```
The full traceback has been saved in /tmp/sphinx-err-VqjD4Q.log, if you want to report the issue to the developers.
```

Better to issue the full traceback than an inaccessible log file.