### PR TITLE
[MRG] FIX: raise error with inconsistent dtype X and missing_values

### DIFF
--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -45,10 +45,10 @@ def _check_inputs_dtype(X, missing_values):
     missing_values."""
     if (X.dtype.kind in ("f", "i", "u") and
             not isinstance(missing_values, numbers.Real)):
-        raise TypeError("The data type of 'missing_values' and 'X' are "
-                        "not compatible. 'missing_values' data type is "
-                        "{} and 'X' is {}."
-                        .format(type(missing_values), X.dtype))
+        raise ValueError("The data type of 'missing_values' and 'X' are "
+                         "not compatible. 'missing_values' data type is "
+                         "{} and 'X' is {}."
+                         .format(type(missing_values), X.dtype))
 
 
 def _get_mask(X, value_to_mask):

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -43,10 +43,10 @@ __all__ = [
 def _check_inputs_dtype(X, missing_values):
     if (X.dtype.kind in ("f", "i", "u") and
             not isinstance(missing_values, numbers.Real)):
-        raise ValueError("The data type of 'missing_values' and 'X' are "
-                         "not compatible. 'missing_values' data type is "
-                         "{} and 'X' is {}. Both type should be numerical."
-                         .format(type(missing_values), X.dtype))
+        raise ValueError("'X' and 'missing_values' types are expected to be"
+                         " both numerical. Got X.dtype={} and "
+                         " type(missing_values)={}."
+                         .format(X.dtype, type(missing_values)))
 
 
 def _get_mask(X, value_to_mask):

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -40,6 +40,17 @@ __all__ = [
 ]
 
 
+def _check_inputs_dtype(X, missing_values):
+    """Check that the dtype of X is in accordance with the one of
+    missing_values."""
+    if (X.dtype.kind in ("f", "i", "u") and
+            not isinstance(missing_values, numbers.Real)):
+        raise TypeError("The data type of 'missing_values' and 'X' are "
+                        "not compatible. 'missing_values' data type is "
+                        "{} and 'X' is {}."
+                        .format(type(missing_values), X.dtype))
+
+
 def _get_mask(X, value_to_mask):
     """Compute the boolean mask X == missing_values."""
     if value_to_mask is np.nan:
@@ -51,7 +62,6 @@ def _get_mask(X, value_to_mask):
         else:
             # np.isnan does not work on object dtypes.
             return _object_dtype_isnan(X)
-
     else:
         # X == value_to_mask with object dytpes does not always perform
         # element-wise for old versions of numpy
@@ -183,6 +193,7 @@ class SimpleImputer(BaseEstimator, TransformerMixin):
             else:
                 raise ve
 
+        _check_inputs_dtype(X, self.missing_values)
         if X.dtype.kind not in ("i", "u", "f", "O"):
             raise ValueError("SimpleImputer does not support data with dtype "
                              "{0}. Please provide either a numeric array (with"
@@ -788,6 +799,7 @@ class ChainedImputer(BaseEstimator, TransformerMixin):
 
         X = check_array(X, dtype=FLOAT_DTYPES, order="F",
                         force_all_finite=force_all_finite)
+        _check_inputs_dtype(X, self.missing_values)
 
         mask_missing_values = _get_mask(X, self.missing_values)
         if self.initial_imputer_ is None:

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -41,8 +41,9 @@ __all__ = [
 
 
 def _check_inputs_dtype(X, missing_values):
-    """Check that the dtype of X is in accordance with the one of
-    missing_values."""
+    """Check that the type of missing_values is in accordance with the
+    dtype of X.
+    """
     if (X.dtype.kind in ("f", "i", "u") and
             not isinstance(missing_values, numbers.Real)):
         raise ValueError("The data type of 'missing_values' and 'X' are "

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -41,14 +41,11 @@ __all__ = [
 
 
 def _check_inputs_dtype(X, missing_values):
-    """Check that the type of missing_values is in accordance with the
-    dtype of X.
-    """
     if (X.dtype.kind in ("f", "i", "u") and
             not isinstance(missing_values, numbers.Real)):
         raise ValueError("The data type of 'missing_values' and 'X' are "
                          "not compatible. 'missing_values' data type is "
-                         "{} and 'X' is {}."
+                         "{} and 'X' is {}. Both type should be numerical."
                          .format(type(missing_values), X.dtype))
 
 

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -711,8 +711,9 @@ def test_chained_imputer_additive_matrix():
                          [SimpleImputer, ChainedImputer])
 @pytest.mark.parametrize(
     "missing_values, X_missing_value, err_msg",
-    [("NaN", np.nan, "contains"),
-     ("-1", -1, "not compatible")])
+    [("NaN", np.nan, "Input contains NaN"),
+     ("-1", -1, "The data type of 'missing_values' and 'X' are not compatible")
+    ])
 def test_inconsistent_dtype_X_missing_values(imputer_constructor,
                                              missing_values, X_missing_value,
                                              err_msg):

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -712,7 +712,7 @@ def test_chained_imputer_additive_matrix():
 @pytest.mark.parametrize(
     "imputer_missing_values, missing_value, err_msg",
     [("NaN", np.nan, "Input contains NaN"),
-     ("-1", -1, "data type of 'missing_values' and 'X' are not compatible")])
+     ("-1", -1, "types are expected to be both numerical.")])
 def test_inconsistent_dtype_X_missing_values(imputer_constructor,
                                              imputer_missing_values,
                                              missing_value,

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -710,18 +710,18 @@ def test_chained_imputer_additive_matrix():
 @pytest.mark.parametrize("imputer_constructor",
                          [SimpleImputer, ChainedImputer])
 @pytest.mark.parametrize(
-    "missing_values, X_missing_value, err_type, err_msg",
-    [("NaN", np.nan, ValueError, "contains"),
-     ("-1", -1, TypeError, "not compatible")])
+    "missing_values, X_missing_value, err_msg",
+    [("NaN", np.nan, "contains"),
+     ("-1", -1, "not compatible")])
 def test_inconsistent_dtype_X_missing_values(imputer_constructor,
                                              missing_values, X_missing_value,
-                                             err_type, err_msg):
+                                             err_msg):
     # regression test for issue #11390. Comparison between incoherent dtype
     # for X and missing_values was not raising a proper error.
-    X = np.random.randn(1000, 10)
+    X = np.random.randn(10, 10)
     X[0, 0] = X_missing_value
 
     imputer = imputer_constructor(missing_values=missing_values)
 
-    with pytest.raises(err_type, match=err_msg):
+    with pytest.raises(ValueError, match=err_msg):
         imputer.fit_transform(X)

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -710,19 +710,20 @@ def test_chained_imputer_additive_matrix():
 @pytest.mark.parametrize("imputer_constructor",
                          [SimpleImputer, ChainedImputer])
 @pytest.mark.parametrize(
-    "missing_values, X_missing_value, err_msg",
+    "imputer_missing_values, missing_value, err_msg",
     [("NaN", np.nan, "Input contains NaN"),
      ("-1", -1, "data type of 'missing_values' and 'X' are not compatible")])
 def test_inconsistent_dtype_X_missing_values(imputer_constructor,
-                                             missing_values, X_missing_value,
+                                             imputer_missing_values,
+                                             missing_value,
                                              err_msg):
     # regression test for issue #11390. Comparison between incoherent dtype
     # for X and missing_values was not raising a proper error.
     rng = np.random.RandomState(42)
     X = rng.randn(10, 10)
-    X[0, 0] = X_missing_value
+    X[0, 0] = missing_value
 
-    imputer = imputer_constructor(missing_values=missing_values)
+    imputer = imputer_constructor(missing_values=imputer_missing_values)
 
     with pytest.raises(ValueError, match=err_msg):
         imputer.fit_transform(X)

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -718,7 +718,8 @@ def test_inconsistent_dtype_X_missing_values(imputer_constructor,
                                              err_msg):
     # regression test for issue #11390. Comparison between incoherent dtype
     # for X and missing_values was not raising a proper error.
-    X = np.random.randn(10, 10)
+    rng = np.random.RandomState(42)
+    X = rng.randn(10, 10)
     X[0, 0] = X_missing_value
 
     imputer = imputer_constructor(missing_values=missing_values)

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -712,8 +712,7 @@ def test_chained_imputer_additive_matrix():
 @pytest.mark.parametrize(
     "missing_values, X_missing_value, err_msg",
     [("NaN", np.nan, "Input contains NaN"),
-     ("-1", -1, "The data type of 'missing_values' and 'X' are not compatible")
-    ])
+     ("-1", -1, "data type of 'missing_values' and 'X' are not compatible")])
 def test_inconsistent_dtype_X_missing_values(imputer_constructor,
                                              missing_values, X_missing_value,
                                              err_msg):

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -705,3 +705,23 @@ def test_chained_imputer_additive_matrix():
                              random_state=rng).fit(X_train)
     X_test_est = imputer.transform(X_test)
     assert_allclose(X_test_filled, X_test_est, atol=0.01)
+
+
+@pytest.mark.parametrize("imputer_constructor",
+                         [SimpleImputer, ChainedImputer])
+@pytest.mark.parametrize(
+    "missing_values, X_missing_value, err_type, err_msg",
+    [("NaN", np.nan, ValueError, "contains"),
+     ("-1", -1, TypeError, "not compatible")])
+def test_inconsistent_dtype_X_missing_values(imputer_constructor,
+                                             missing_values, X_missing_value,
+                                             err_type, err_msg):
+    # regression test for issue #11390. Comparison between incoherent dtype
+    # for X and missing_values was not raising a proper error.
+    X = np.random.randn(1000, 10)
+    X[0, 0] = X_missing_value
+
+    imputer = imputer_constructor(missing_values=missing_values)
+
+    with pytest.raises(err_type, match=err_msg):
+        imputer.fit_transform(X)


### PR DESCRIPTION
closes #11390 

Implement an additional check to avoid raising `NotImplemented` from `np.equal` when the dtype of `X` and `missing_values` are inconsistent for a comparison.
