### PR TITLE
[MRG] MAINT test joblib master with unvendoring

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -89,6 +89,9 @@ elif [[ "$DISTRIB" == "scipy-dev" ]]; then
     echo "Installing numpy and scipy master wheels"
     dev_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
     pip install --pre --upgrade --timeout=60 -f $dev_url numpy scipy pandas cython
+    echo "Installing joblib master"
+    pip install https://github.com/joblib/joblib/archive/master.zip
+    export SKLEARN_SITE_JOBLIB=1
     pip install pytest pytest-cov
 fi
 


### PR DESCRIPTION
Use the scipy-dev built to also test unvendor joblib (master version)