### PR TITLE
[MRG] Fix typo in Multinomial Naive Bayes online guide

### DIFF
--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -125,7 +125,7 @@ version of maximum likelihood, i.e. relative frequency counting:
 where :math:`N_{yi} = \sum_{x \in T} x_i` is
 the number of times feature :math:`i` appears in a sample of class :math:`y`
 in the training set :math:`T`,
-and :math:`N_{y} = \sum_{i=1}^{|T|} N_{yi}` is the total count of
+and :math:`N_{y} = \sum_{i=1}^{n} N_{yi}` is the total count of
 all features for class :math:`y`.
 
 The smoothing priors :math:`\alpha \ge 0` accounts for


### PR DESCRIPTION
I found a typo in the [Multinomial Naive Bayes](http://scikit-learn.org/stable/modules/naive_bayes.html#multinomial-naive-bayes) guide: `N_y` is the sum of `N_yi` for `i` from 1 to `n`, not `|T|` as it currently says.
Hopefully this should be straightforward (that's why I haven't opened an issue and am directly submitting the fix) but let me know if I need to do anything else.
