### PR TITLE
Reenable SSL checks on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -90,9 +90,7 @@ artifacts:
 
 on_success:
   # Upload the generated wheel package to Rackspace
-  # On Windows, Apache Libcloud cannot find a standard CA cert bundle so we
-  # disable the ssl checks.
-  - "python -m wheelhouse_uploader upload --no-ssl-check --local-folder=dist sklearn-windows-wheels"
+  - "python -m wheelhouse_uploader upload --local-folder=dist sklearn-windows-wheels"
 
 notifications:
   - provider: Webhook


### PR DESCRIPTION
See: https://github.com/ogrisel/wheelhouse-uploader/issues/26

wheelhouse-uploader 0.9.7 now depends on certifi that should provide the necessary certificate to successfully upload the resulting windows wheels to rackspace.