### PR TITLE
FIX: attempt to fix pickling backward compat

### DIFF
--- a/sklearn/externals/joblib.py
+++ b/sklearn/externals/joblib.py
@@ -8,8 +8,10 @@ if _os.environ.get('SKLEARN_SITE_JOBLIB', False):
     from joblib import *
     from joblib import __version__
     from joblib import logger
+    from joblib import numpy_pickle
 else:
     from ._joblib import *
     from ._joblib import __version__
     from ._joblib import logger
+    from ._joblib import numpy_pickle
 


### PR DESCRIPTION
The import path of numpy_pickle should be unchanged for backward
compatibility.

This attempts to fix a regression introduced in https://github.com/scikit-learn/scikit-learn/pull/11166