### PR TITLE
[MRG] Appveyor version upgrade

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,20 +17,20 @@ environment:
     SKLEARN_SKIP_NETWORK_TESTS: 1
 
   matrix:
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: "3.7.0"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.0"
+      PYTHON_ARCH: "64"
+
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.8"
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.8"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python36"
-      PYTHON_VERSION: "3.6.1"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6.1"
       PYTHON_ARCH: "64"
 
 

--- a/build_tools/appveyor/requirements.txt
+++ b/build_tools/appveyor/requirements.txt
@@ -1,14 +1,5 @@
-# Fetch numpy and scipy wheels from the sklearn rackspace wheelhouse.
-# Those wheels were collected from https://www.lfd.uci.edu/~gohlke/pythonlibs/
-# This is a temporary solution. As soon as numpy and scipy provide official
-# wheel for windows we ca delete this --find-links line.
---find-links http://28daf2247a33ed269873-7b1aad3fab3cc330e1fd9d109892382a.r6.cf2.rackcdn.com/
-
-# fix the versions of numpy to force the use of numpy and scipy to use the whl
-# of the rackspace folder instead of trying to install from more recent
-# source tarball published on PyPI
-numpy==1.13.0
-scipy==0.19.0
+numpy
+scipy
 cython
 pytest
 wheel

--- a/build_tools/appveyor/requirements.txt
+++ b/build_tools/appveyor/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 scipy
-cython
+# Pin Cython to avoid bug with 0.28.x on Python 3.7 
+cython==0.27.3
 pytest
 wheel
 wheelhouse_uploader


### PR DESCRIPTION
- run windows tests with the latest version of Python (namely 3.7)
- run windows tests with the latest versions of numpy and scipy as published on PyPI.