### PR TITLE
DOC add guideline for choosing a scoring function

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -369,51 +369,11 @@ See also :ref:`TunedThresholdClassifierCV`.
 There are many scoring functions which measure different aspects of such a
 decision, most of them are covered with or derived from the :func:`confusion_matrix`.
 
-Point forecasts and consistent scoring functions
-------------------------------------------------
-
-Let's assume that the target variable :math:`Y` is a random variable, that
-we have observations/realizations :math:`y` and that we make predictions
-:math:`\hat{y}`.
-Scoring functions :math:`S(y, \hat{y})` then rank the prediction
-:math:`\hat{y}` of different models, given the observation :math:`y`.
-The higher the score the better the corresponding model (note that the
-literature uses sometimes the other orientation: smaller values are better).
-For a test or validation set :math:`y_i`, one usually uses
-
-.. math::
-
-    \bar{S} = \frac{1}{n_\text{samples}}
-              \sum_{i=0}^{n_\text{samples}-1} S(y_i, \hat{y}_i).
-
-The optimal point prediction :math:`\hat{y}^\star` under :math:`S` is the
-*Bayes Rule*
-
-.. math::
-
-    \hat{y}^\star = \operatorname{argmax}_x \mathbb{E}[S(Y, x)].
-
-Note that in order to get an unbiased estimate of :math:`\mathbb{E}[S(Y, x)]` for model
-evaluation and model selection, one has to use a test set independen of the training
-set.
-
-If you are free to choose a scoring function, you should first ask yourself,
-which functional of :math:`F(Y)` you want to predict as a point forecast:
-the mean, the mode, the median, a quantile, ...
-Then, **strictly consistent** scoring functions for this functional are to be
-preferred because only they provide that :math:`\hat{y}^\star` is unique and
-equals the desired target functional, see [Gneiting2009]_ for more details.
-Stated otherwise: if the scoring function is (strictly) consistent for the
-functional at interest, this functional is the (unique) optimal point forecast
-under this scoring function.
-
-One could say that consistent scoring functions act as *truth serum* in that
-they guarantee "that truth telling [. . .] is an optimal strategy in
-expectation" [Gneiting2014]_.
-
-Here, we list some of the well known functionals and corresponding scoring
-functions. For further criteria on how to select a specific one, see
-[Fissler2022]_.
+**List of strictly consistent scoring functions**
+Here, we list some of the most well known statistical functionals and corresponding
+stritcly consistent scoring functions. Note that the list is not complete and that
+there are more of them.
+For further criteria on how to select a specific one, see [Fissler2022]_.
 
 ==================  ========================  ================  ==============================
 functional          scoring or loss function  response y        prediction

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -118,24 +118,24 @@ argument names, `quantile` and `alpha`) be it in grid search for finding
 hyperparameters or in comparing to other models like
 `QuantileRegressor(quantile=0.99)`.
 
-.. rubric:: References:
+.. rubric:: References
 
-  .. [Gneiting2007] T. Gneiting and A. E. Raftery. :doi:`Strictly Proper
-     Scoring Rules, Prediction, and Estimation <10.1198/016214506000001437>`
-     In: Journal of the American Statistical Association 102 (2007),
-     pp. 359– 378.
-     `link to pdf <www.stat.washington.edu/people/raftery/Research/PDF/Gneiting2007jasa.pdf>`_
+.. [Gneiting2007] T. Gneiting and A. E. Raftery. :doi:`Strictly Proper
+    Scoring Rules, Prediction, and Estimation <10.1198/016214506000001437>`
+    In: Journal of the American Statistical Association 102 (2007),
+    pp. 359– 378.
+    `link to pdf <www.stat.washington.edu/people/raftery/Research/PDF/Gneiting2007jasa.pdf>`_
 
-  .. [Gneiting2009] T. Gneiting. :arxiv:`Making and Evaluating Point Forecasts
-     <0912.0902>`
-     Journal of the American Statistical Association 106 (2009): 746 - 762.
+.. [Gneiting2009] T. Gneiting. :arxiv:`Making and Evaluating Point Forecasts
+    <0912.0902>`
+    Journal of the American Statistical Association 106 (2009): 746 - 762.
 
-  .. [Gneiting2014] T. Gneiting and M. Katzfuss. :doi:`Probabilistic Forecasting
-     <10.1146/annurev-st atistics-062713-085831>`. In: Annual Review of Statistics and Its Application 1.1 (2014), pp. 125–151.
+.. [Gneiting2014] T. Gneiting and M. Katzfuss. :doi:`Probabilistic Forecasting
+    <10.1146/annurev-st atistics-062713-085831>`. In: Annual Review of Statistics and Its Application 1.1 (2014), pp. 125–151.
 
-  .. [Fissler2022] T. Fissler, C. Lorentzen and M. Mayer. :arxiv:`Model
-     Comparison and Calibration Assessment: User Guide for Consistent Scoring
-     Functions in Machine Learning and Actuarial Practice. <2202.12780>`
+.. [Fissler2022] T. Fissler, C. Lorentzen and M. Mayer. :arxiv:`Model
+    Comparison and Calibration Assessment: User Guide for Consistent Scoring
+    Functions in Machine Learning and Actuarial Practice. <2202.12780>`
 
 .. _scoring_api_overview:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -15,8 +15,8 @@ Before diving into the details of the many scores and metrics, we want
 to give some guidance, inspired by statistical decision theory, on the choice
 of **scoring functions** for **supervised learning**, see [Gneiting2009]_:
 
-  - *Which scoring function should I use?*
-  - *Which scoring function is a good one for my task?*
+- *Which scoring function should I use?*
+- *Which scoring function is a good one for my task?*
 
 In a nutshell, if the scoring function is given, e.g. in a kaggle competition
 or in a business context, use that one.
@@ -28,7 +28,7 @@ of the prediction. It is useful to distinguish two steps:
 
 **Prediction:**
 Usually, the response variable :math:`Y` is a random variable, in the sense that there
-is *no deterministic* function :math:`Y = g(X)`.
+is *no deterministic* function :math:`Y = g(X)` of the features :math:`X`.
 Instead, there is a probability distribution :math:`F` of :math:`Y`.
 One can aim to predict the whole distribution, known as *probabilistic prediction*,
 or---more the focus of scikit-learn---issue a *point prediction* (or point forecast)
@@ -38,12 +38,13 @@ response variable :math:`Y` (conditionally on :math:`X`).
 
 Once that is settled, use a **strictly consistent** scoring function for that
 target functional, see [Gneiting2009]_.
-For classification **stricly proper scoring rules**, see [Gneiting2007]_, conincide
-with strictly consistent scoring functions.
+For classification
+`**strictly proper scoring rules** <https://en.wikipedia.org/wiki/Scoring_rule>`_,
+see [Gneiting2007]_, coincide with strictly consistent scoring functions.
 See the table further below for examples.
 One could say that consistent scoring functions act as *truth serum* in that
-they guarantee "that truth telling [. . .] is an optimal strategy in
-expectation" [Gneiting2014]_.
+they guarantee *"that truth telling [. . .] is an optimal strategy in
+expectation"* [Gneiting2014]_.
 
 Note that for regressors, the prediction is done with :term:`predict` while for
 classifiers it is usually :term:`predict_proba`.
@@ -64,21 +65,21 @@ stritcly consistent scoring functions. Note that the list is not complete and th
 there are more of them.
 For further criteria on how to select a specific one, see [Fissler2022]_.
 
-==================  ===============================================  ================  ==============================
-functional          scoring or loss function                         response y        prediction
-==================  ===============================================  ================  ==============================
+==================  ===============================================  ==================  ==============================
+functional          scoring or loss function                         response :math:`y`  prediction
+==================  ===============================================  ==================  ==============================
 **Classification**
-mean                :ref:`Brier score <brier_score_loss>`            multi-class       ``predict_proba``
-mean                :ref:`log loss <log_loss>`                       multi-class       ``predict_proba``
-mode                :ref:`zero-one loss <zero_one_loss>` :sup:`1`    multi-class       ``predict``, categorical
-**Regression**
-mean                :ref:`squared error <mean_squared_error>`        all reals         ``predict``, all reals
-mean                :ref:`Poisson deviance <mean_tweedie_deviance>`  non-negative      ``predict``, strictly positive
-mean                :ref:`Gamma deviance <mean_tweedie_deviance>`    stricly positive  ``predict``, strictly positive
-median              :ref:`absolute error <mean_absolute_error>`      all reals         ``predict``, all reals
-quantile            :ref:`pinball loss <pinball_loss>`               all reals         ``predict``, all reals
-mode                does not exist
-==================  ===============================================  ================  ==============================
+mean                :ref:`Brier score <brier_score_loss>`            multi-class         ``predict_proba``
+mean                :ref:`log loss <log_loss>`                       multi-class         ``predict_proba``
+mode                :ref:`zero-one loss <zero_one_loss>` :sup:`1`    multi-class         ``predict``, categorical
+**Regression  **
+mean                :ref:`squared error <mean_squared_error>`        all reals           ``predict``, all reals
+mean                :ref:`Poisson deviance <mean_tweedie_deviance>`  non-negative        ``predict``, strictly positive
+mean                  :ref:`Gamma deviance <mean_tweedie_deviance>`  strictly positive   ``predict``, strictly positive
+median              :ref:`absolute error <mean_absolute_error>`      all reals           ``predict``, all reals
+quantile            :ref:`pinball loss <pinball_loss>`               all reals           ``predict``, all reals
+mode                no consistent one exists                         reals
+==================  ===============================================  ==================  ==============================
 
 :sup:`1` The zero-one loss is only consistent but not strictly consistent for the mode.
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -97,6 +97,24 @@ R² gives the same ranking as squared loss.
 Furthermore, the Brier score is just a different name for the squared error
 in case of classification.
 
+**Ficticious Example:**
+Let's make the above arguments more tangible. Consider a setting of reliability
+engineering of network connections, e.g. internet or wifi. As provider of the network,
+you have access to the dataset of log entries of network connection containing network
+load over time and many interesting features. Your goal is to improve the raliability
+of the connections. In fact, you promise your customors that at least on 99% of all
+days there are no connection discontinuities larger 1 minute.
+Therefore, you are interested in a prediction of the 99% quantile (of connections per
+day free of interruptions larger than 1 minute) in order to know in advance when to add
+more bandwidth and thereby satisfy your customers. So the *target functional* is the
+99% quantile. From the table above, you choose the pinball loss as scoring function
+(fair enough, not much choice given), for model training (e.g.
+`HistGradientBoostingRegressor(loss="quantile", quantile=0.99)` as well as model
+evaluation (`mean_pinball_loss(..., alpha=0.9)` - we apoligize for the different
+argument names, `quantile` and `alpha`) be it in grid search for finding
+hyperparameters or in comparing to other models like
+`QuantileRegressor(quantile=0.99)`.
+
 .. topic:: References:
 
   .. [Gneiting2007] T. Gneiting and A. E. Raftery. :doi:`Strictly Proper

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -27,7 +27,7 @@ of the prediction. It is useful to distinguish two steps:
 * Predicting
 * Decision making
 
-**Prediction:**
+**Predicting:**
 Usually, the response variable :math:`Y` is a random variable, in the sense that there
 is *no deterministic* function :math:`Y = g(X)` of the features :math:`X`.
 Instead, there is a probability distribution :math:`F` of :math:`Y`.
@@ -43,14 +43,14 @@ This means using a scoring function that is aligned with *measuring the distance
 between predictions* `y_pred` *and the true target functional using observations of*
 :math:`Y`, i.e. `y_true`.
 For classification **strictly proper scoring rules**, see
-`wikipedia <https://en.wikipedia.org/wiki/Scoring_rule>`_ and [Gneiting2007]_, coincide
-with strictly consistent scoring functions.
+`Wikipedia entry for Scoring rule <https://en.wikipedia.org/wiki/Scoring_rule>`_
+and [Gneiting2007]_, coincide with strictly consistent scoring functions.
 The table further below provides examples.
 One could say that consistent scoring functions act as *truth serum* in that
 they guarantee *"that truth telling [. . .] is an optimal strategy in
 expectation"* [Gneiting2014]_.
 
-Once a strictly consistent scoring functions is chosen, it is best used for both: as
+Once a strictly consistent scoring function is chosen, it is best used for both: as
 loss function for model training and as metric/score in model evaluation and model
 comparison.
 
@@ -68,9 +68,9 @@ There are many scoring functions which measure different aspects of such a
 decision, most of them are covered with or derived from the :func:`confusion_matrix`.
 
 **List of strictly consistent scoring functions:**
-Here, we list some of the most well known statistical functionals and corresponding
-stritcly consistent scoring functions. Note that the list is not complete and that
-there are more of them.
+Here, we list some of the most relevant statistical functionals and corresponding
+strictly consistent scoring functions for tasks in practice. Note that the list is not
+complete and that there are more of them.
 For further criteria on how to select a specific one, see [Fissler2022]_.
 
 ==================  ===================================================  ====================  =================================
@@ -99,25 +99,26 @@ different score values but the same ranking.
 
 :sup:`3` R² gives the same ranking as squared error.
 
-**Ficticious Example:**
-Let's make the above arguments more tangible. Consider a setting of reliability
-engineering of network connections, e.g. internet or wifi. As provider of the network,
-you have access to the dataset of log entries of network connections containing network
-load over time and many interesting features. Your goal is to improve the raliability
-of the connections. In fact, you promise your customers that at least on 99% of all
-days there are no connection discontinuities larger 1 minute.
+**Fictitious Example:**
+Let's make the above arguments more tangible. Consider a setting in network reliability
+engineering, such as maintaining stable internet or Wi-Fi connections.
+As provider of the network, you have access to the dataset of log entries of network
+connections containing network load over time and many interesting features.
+Your goal is to improve the reliability of the connections.
+In fact, you promise your customers that at least on 99% of all days there are no
+connection discontinuities larger than 1 minute.
 Therefore, you are interested in a prediction of the 99% quantile (of longest
 connection interruption duration per day) in order to know in advance when to add
 more bandwidth and thereby satisfy your customers. So the *target functional* is the
 99% quantile. From the table above, you choose the pinball loss as scoring function
 (fair enough, not much choice given), for model training (e.g.
 `HistGradientBoostingRegressor(loss="quantile", quantile=0.99)`) as well as model
-evaluation (`mean_pinball_loss(..., alpha=0.9)` - we apoligize for the different
+evaluation (`mean_pinball_loss(..., alpha=0.99)` - we apologize for the different
 argument names, `quantile` and `alpha`) be it in grid search for finding
 hyperparameters or in comparing to other models like
 `QuantileRegressor(quantile=0.99)`.
 
-.. topic:: References:
+.. rubric:: References:
 
   .. [Gneiting2007] T. Gneiting and A. E. Raftery. :doi:`Strictly Proper
      Scoring Rules, Prediction, and Estimation <10.1198/016214506000001437>`

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -38,10 +38,10 @@ response variable :math:`Y` (conditionally on :math:`X`).
 
 Once that is settled, use a **strictly consistent** scoring function for that
 target functional, see [Gneiting2009]_.
-For classification
-`**strictly proper scoring rules** <https://en.wikipedia.org/wiki/Scoring_rule>`_,
-see [Gneiting2007]_, coincide with strictly consistent scoring functions.
-See the table further below for examples.
+For classification **strictly proper scoring rules**, see
+`wikipedia <https://en.wikipedia.org/wiki/Scoring_rule>`_ and [Gneiting2007]_, coincide
+with strictly consistent scoring functions.
+The table further below provides examples.
 One could say that consistent scoring functions act as *truth serum* in that
 they guarantee *"that truth telling [. . .] is an optimal strategy in
 expectation"* [Gneiting2014]_.

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -324,15 +324,26 @@ Which scoring function should I use?
 
 Before diving into the details of the many scores and metrics, we want
 to give some guidance, inspired by statistical decision theory, on the choice
-of scoring functions for supervised learning:
-*Which scoring function should I use?
-Which scoring function is a good one for my task?*
-In a nutshell, if the scoring function is given, e.g. in a kaggle competition,
-use that one.
-If you are free to choose and you think, your target variable :math:`y` is
-(at least kind of) a random variable, first clarify what it is you actually
-want to predict: the mean, the median or the mode of your target :math:`Y`?
-Then choose a **strictly consistent** scoring function for that.
+of scoring functions for supervized learning, see [Gneiting2009]_ and
+[Fissler2022]_:
+  - *Which scoring function should I use?*
+  - *Which scoring function is a good one for my task?*
+
+In a nutshell, if the scoring function is given, e.g. in a kaggle competition
+or in a business context, use that one.
+If you are free to choose, it starts by considering your ultimate goal of
+prediction. Usually, the response variable :math:`Y` is a random variable, in
+the sense that there is *no deterministic* function :math:`Y = g(X)`.
+Instead, there is a probability distribution :math:`F` of :math:`Y`.
+One can aim to predict the whole distribution, known as *probabilistic
+prediction*, or---more the focus of
+scikit-learn---issue a *point prediction* (or point forecast) by choosing a
+property or functional of that distribution. Typical examples are the mean
+(expected value), the median or the mode of the response variable :math:`Y`
+(conditionally on :math:`X`).
+
+Once that is settled, use a **strictly consistent** scoring function for that
+target functional.
 
 Point forecasts and consistent scoring functions
 ------------------------------------------------
@@ -342,96 +353,120 @@ we have observations/realizations :math:`y` and that we make predictions
 :math:`\hat{y}`.
 Scoring functions :math:`S(y, \hat{y})` then rank the prediction :math:`\hat{y}`
 of different models, given the observation :math:`y`.
-The higher the score the better the corresponding model.
+The higher the score the better the corresponding model (note that the
+literature uses sometimes the other orientation: smaller values are better).
 For a test or validation set :math:`y_i`, one usually uses
 :math:`\bar{S} = \frac{1}{n_\text{samples}}\sum_{i=0}^{n_\text{samples}-1} S(y_i, \hat{y}_i)`.
-The prediction :math:`\hat{y}` is said to be a point forecast.
-The optimal point forecast under :math:`S` is the Bayes Rule
-:math:`\hat{y} = \operatorname{argmax}_x \mathbb{E}[S(Y,x)]` (to get an
-unbiased estimate of :math:`\mathbb{E}[S(Y,x)]` for model evaluation is one
-reason to use a test set independent of the training set).
-Instead of a point forecast, one could try to issue the whole probability
-distribution :math:`F(y)` of the target variable :math:`Y`.
-This is called a probabilistic forecast.
+The optimal point prediction :math:`\hat{y}^\star` under :math:`S` is the
+*Bayes Rule* :math:`\hat{y}^\star = \operatorname{argmax}_x \mathbb{E}[S(Y, x)]`.
+
+Note that in order to get an unbiased estimate of :math:`\mathbb{E}[S(Y, x)]`
+for model evaluation and model selection, one has to use a test set independent
+of the training set.
+
 If you are free to choose a scoring function, you should first ask yourself,
-which functional of :math:`F(y)` you want to predict as a point forecast:
-the mean, the mode, the median, ...
-Then, a **strictly consistent** scoring function for this
-functional is to be preferred, see [G2009]_ for a definition of *strictly
-consistent* and for more details.
-The reasoning goes as follows: If the scoring function is (strictly) consistent
-for the functional at interest, this functional is the (unique) optimal point
-forecast under this scoring function.
+which functional of :math:`F(Y)` you want to predict as a point forecast:
+the mean, the mode, the median, a quantile, ...
+Then, **strictly consistent** scoring functions for this functional are to be
+preferred because only they provide that :math:`\hat{y}^\star` is unique and
+equals the desired target functional, see [Gneiting2009]_ for more details.
+Stated otherwise: if the scoring function is (strictly) consistent for the
+functional at interest, this functional is the (unique) optimal point forecast
+under this scoring function.
 
+One could say that consistent scoring functions act as *truth serum* in that
+they guarantee "that truth telling [. . .] is an optimal strategy in
+expectation" [Gneiting2014]_.
 
-==================    ========================    ===============================================
-functional            scoring or loss function    property
-==================    ========================    ===============================================
+Here, we list some of the well known functionals and corresponding scoring
+functions. For further criteria on how to select a specific one, see
+[Fissler2022]_.
+
+==================    ========================    ===================   ================   ==============================
+functional            scoring or loss function    property              response y         prediction
+==================    ========================    ===================   ================   ==============================
 **Classification**
-mean                  Brier score                 strictly consistent
-mean                  log loss                    strictly consistent
-median                absolute error              strictly consistent
-mode                  zero-one loss               consistent (for binary classification)
+mean                  Brier score                 strictly consistent   multi-class        ``predict_proba``
+mean                  log loss                    strictly consistent   multi-class        ``predict_proba``
+median                absolute error              strictly consistent   binary             ``predict_proba``
+mode                  zero-one loss               strictly consistent   multi-class        ``predict``
 **Regression**
-mean                  squared error               strictly consistent (if finite 2nd moment)
-mean                  Poisson deviance            strictly consistent (for non-negative target y)
-mean                  Gamma deviance              strictly consistent (for positive target y)
-median                absolute error              strictly consistent
-mode                  zero-one loss               asymptotically consistent
-==================    ========================    ===============================================
+mean                  squared error               strictly consistent   all reals          ``predict``, all reals
+mean                  Poisson deviance            strictly consistent   non-negative       ``predict``, stritcly positive
+mean                  Gamma deviance              strictly consistent   stricly positive   ``predict``, stritcly positive
+median                absolute error              strictly consistent   all reals          ``predict``, all reals
+quantile              pinball loss                strictly consistent   all reals          ``predict``, all reals
+==================    ========================    ===================   ================   ==============================
 
-The zero-one loss is equivalent to the accuracy score, meaning it gives
-different score values but the same ranking.
-R² is equivalent to squared loss.
-The Brier score is the squared error for classification.
+The zero-one loss is equivalent to one minus the accuracy score, meaning it
+gives different score values but the same ranking.
+R² gives the same ranking as squared loss.
+Furthermode, the Brier score is just a different name for the squared error
+in case ofclassification.
 
 An example with binary classification
 -------------------------------------
 
 Suppose you want to predict whether an apple blossom in spring becomes an
 eatable apple fruit in autumn.
-This is binary classification for :math:`Y = \text{fruit} = 1` or
+This is a binary classification problem with :math:`Y = \text{fruit} = 1` or
 :math:`Y = \text{no fruit} = 0`.
-The good thing about binary classification is that predicting the mean of
-:math:`Y`, :math:`\operatorname{E}[Y] = p` (a result of setting the values of
-:math:`Y` to 0 and 1), is equivalent to predicting the whole distribution
-:math:`F(Y=\text{fruit}) = \operatorname{Pr}(Y=\text{no fruit}) = p`.
+
+Binary classification is very special in that the mean of :math:`Y` is also
+the full probability distribution, i.e.
+:math:`\mathbb{E}[Y] = p = \operatorname{P}(Y=\text{no fruit}) = F(Y=\text{fruit})`
+(a result of setting the values of :math:`Y` to 0 and 1). This means that
+point predicting the mean is the same as probabilistic prediction of the class
+probability :math:`p`.
 Therefore, a good scoring function is one that is strictly consistent for the
 mean, e.g. log loss or Brier score.
-Note that for binary classification, the mode - the most probable outcome
-(*fruit* if :math:`p>0.5`) -
-is less informative than the mean: To say that we expect a fruit is less
-informative than to say that we expect a fruit with probability :math:`p`.
+They are also called *proper scoring rules*, as they assess predicting the
+whole probability distribution, [Gneiting2007]_.
+Note that for binary classification, the mode---the most probable outcome
+(*fruit* if :math:`p>0.5`)---is much less informative than the mean: To say
+that we expect a fruit is less informative than to say that we expect a fruit
+with probability :math:`p`.
 
-On the other side, depending on the purpose of your prediction, you might
-also be interested in the use of other scoring functions:
+Let's have a look on different purposes of your prediction:
 
 * If you want to optimize the conditions for good blossoms and you therefore
-  cut of blossoms for which you predict *no fruit*, you might want to optimize
+  cut off blossoms for which you predict *no fruit*, you might want to minimize
   the false negative rate (predicting *no fruit* when it actually gives a
   fruit) in order to avoid cutting of too many.
-* If you sell your apples in advance base on the predicted number of fruits,
-  you might want to avoid selling too much and therefore go for the false
-  positive rate (predicting *fruit* when it actually does not give a fruit).
+  If you have calibrated predictions for the probability :math:`p`, this helps
+  a lot. You can start cutting off the blossoms with lowest predicted
+  :math:`p`, which serves as prediction of the (expected) false negative rate.
+* If you sell your apples in advance based on the predicted number of fruits,
+  you might want to avoid selling too many and control your false positive
+  rate (predicting *fruit* when it actually does not give a fruit).
+  Again, having a calibrated prediction for :math:`p` available, one
+  immediately has an estimate of the false positives by :math:`1-p`.
 * Treating the target variable :math:`y` as a random variable may just be an
-  approximation, but the true nature might be deterministic.
-  For example, if there was no bee to pollinate the blossoms, there won't be
-  any fruit--with certainty.
-  Some scoring functions like the log loss have problems at the boundaries
-  :math:`\hat{y}=0` or :math:`\hat{y}=1` (the same might be
+  approximation, but the true nature might be deterministic. For example, if
+  there was no bee to pollinate the blossoms, there won't be any fruit---with
+  certainty! Some scoring functions like the log loss have problems at the
+  boundaries :math:`\hat{y}=0` or :math:`\hat{y}=1` (the same might be
   true for an estimator).
 * Your own use case...
 
 .. topic:: References:
 
-  .. [G2009] T. Gneiting, `Making and Evaluating Point Forecasts
-    <https://arxiv.org/abs/0912.0902>`_, `alternative link
-    <https://www.bundesbank.de/Redaktion/EN/Downloads/Bundesbank/Research_Centre/Conferences/2012/2012_06_01_eltville_11_gneiting_paper.pdf>`_
+  .. [Fissler2022] T. Fissler, C. Lorentzen and M. Mayer. :arxiv:`Model
+     Comparison and Calibration Assessment: User Guide for Consistent Scoring
+    Functions in Machine Learning and Actuarial Practice. <2202.12780>`
 
-  .. [GR2007] T. Gneiting & A. E. Raftery `Strictly Proper Scoring Rules, Prediction,
-    and Estimation
-    <https://doi.org/10.1198/016214506000001437>`_,
-    `alternative link <https://www.stat.washington.edu/raftery/Research/PDF/Gneiting2007jasa.pdf>`_
+  .. [Gneiting2007] T. Gneiting and A. E. Raftery. :doi:`Strictly Proper
+     Scoring Rules, Prediction, and Estimation <10.1198/016214506000001437>`
+     In: Journal of the American Statistical Association 102 (2007),
+     pp. 359– 378.
+     `link to pdf <www.stat.washington.edu/people/raftery/Research/PDF/Gneiting2007jasa.pdf>`_
+
+  .. [Gneiting2009] T. Gneiting. :arxiv:`Making and Evaluating Point Forecasts
+     <0912.0902>`
+     Journal of the American Statistical Association 106 (2009): 746 - 762.
+
+  .. [Gneiting2014] T. Gneiting and M. Katzfuss. :doi:`Probabilistic Forecasting
+     <10.1146/annurev-st atistics-062713-085831>`. In: Annual Review of Statistics and Its Application 1.1 (2014), pp. 125–151.
 
 .. _classification_metrics:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -11,9 +11,10 @@ Metrics and scoring: quantifying the quality of predictions
 Which scoring function should I use?
 ====================================
 
-Before diving into the details of the many scores and metrics, we want
-to give some guidance, inspired by statistical decision theory, on the choice
-of **scoring functions** for **supervised learning**, see [Gneiting2009]_:
+Before we take a closer look into the details of the many scores and
+:term:`evaluation metrics`, we want to give some guidance, inspired by statistical
+decision theory, on the choice of **scoring functions** for **supervised learning**,
+see [Gneiting2009]_:
 
 - *Which scoring function should I use?*
 - *Which scoring function is a good one for my task?*
@@ -37,7 +38,7 @@ Typical examples are the mean (expected value), the median or a quantile of the
 response variable :math:`Y` (conditionally on :math:`X`).
 
 Once that is settled, use a **strictly consistent** scoring function for that
-target functional, see [Gneiting2009]_.
+(target) functional, see [Gneiting2009]_.
 For classification **strictly proper scoring rules**, see
 `wikipedia <https://en.wikipedia.org/wiki/Scoring_rule>`_ and [Gneiting2007]_, coincide
 with strictly consistent scoring functions.
@@ -45,6 +46,10 @@ The table further below provides examples.
 One could say that consistent scoring functions act as *truth serum* in that
 they guarantee *"that truth telling [. . .] is an optimal strategy in
 expectation"* [Gneiting2014]_.
+
+Once a strictly consistent scoring functions is chosen, it is best used for both: as
+loss function for model training and as metric/score in model evaluation and model
+comparison.
 
 Note that for regressors, the prediction is done with :term:`predict` while for
 classifiers it is usually :term:`predict_proba`.

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -324,8 +324,7 @@ Which scoring function should I use?
 
 Before diving into the details of the many scores and metrics, we want
 to give some guidance, inspired by statistical decision theory, on the choice
-of **scoring functions** for **supervised learning**, see [Gneiting2009]_ and
-[Fissler2022]_:
+of **scoring functions** for **supervised learning**, see [Gneiting2009]_:
 
   - *Which scoring function should I use?*
   - *Which scoring function is a good one for my task?*
@@ -338,7 +337,7 @@ of the prediction. It is useful to distinguish two steps:
 * Predicting
 * Decision making
 
-**Prediction**
+**Prediction:**
 Usually, the response variable :math:`Y` is a random variable, in the sense that there
 is *no deterministic* function :math:`Y = g(X)`.
 Instead, there is a probability distribution :math:`F` of :math:`Y`.
@@ -359,7 +358,7 @@ expectation" [Gneiting2014]_.
 Note that for regressors, the prediction ist done with :term:`predict` while for
 classifiers it is usually :term:`predict_proba`.
 
-**Decision Making**
+**Decision Making:**
 The most common decisions are done on binary classification tasks, where the result of
 :term:`predict_proba` is turned into a single outcome, e.g., from the predicted
 probability of rain a decision is made on how to act (whether to take mitigating
@@ -369,7 +368,7 @@ See also :ref:`TunedThresholdClassifierCV`.
 There are many scoring functions which measure different aspects of such a
 decision, most of them are covered with or derived from the :func:`confusion_matrix`.
 
-**List of strictly consistent scoring functions**
+**List of strictly consistent scoring functions:**
 Here, we list some of the most well known statistical functionals and corresponding
 stritcly consistent scoring functions. Note that the list is not complete and that
 there are more of them.
@@ -381,7 +380,7 @@ functional          scoring or loss function  response y        prediction
 **Classification**
 mean                Brier score               multi-class       ``predict_proba``
 mean                log loss                  multi-class       ``predict_proba``
-mode                zero-one loss:sup:`1`     multi-class       ``predict``, categorical
+mode                zero-one loss :sup:`1`    multi-class       ``predict``, categorical
 **Regression**
 mean                squared error             all reals         ``predict``, all reals
 mean                Poisson deviance          non-negative      ``predict``, strictly positive

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -100,12 +100,12 @@ in case of classification.
 **Ficticious Example:**
 Let's make the above arguments more tangible. Consider a setting of reliability
 engineering of network connections, e.g. internet or wifi. As provider of the network,
-you have access to the dataset of log entries of network connection containing network
+you have access to the dataset of log entries of network connections containing network
 load over time and many interesting features. Your goal is to improve the raliability
-of the connections. In fact, you promise your customors that at least on 99% of all
+of the connections. In fact, you promise your customers that at least on 99% of all
 days there are no connection discontinuities larger 1 minute.
-Therefore, you are interested in a prediction of the 99% quantile (of connections per
-day free of interruptions larger than 1 minute) in order to know in advance when to add
+Therefore, you are interested in a prediction of the 99% quantile (of longest
+connection interruption duration per day) in order to know in advance when to add
 more bandwidth and thereby satisfy your customers. So the *target functional* is the
 99% quantile. From the table above, you choose the pinball loss as scoring function
 (fair enough, not much choice given), for model training (e.g.

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -375,21 +375,21 @@ stritcly consistent scoring functions. Note that the list is not complete and th
 there are more of them.
 For further criteria on how to select a specific one, see [Fissler2022]_.
 
-==================  ========================  ================  ==============================
-functional          scoring or loss function  response y        prediction
-==================  ========================  ================  ==============================
+==================  ===============================================  ================  ==============================
+functional          scoring or loss function                         response y        prediction
+==================  ===============================================  ================  ==============================
 **Classification**
-mean                Brier score               multi-class       ``predict_proba``
-mean                log loss                  multi-class       ``predict_proba``
-mode                zero-one loss :sup:`1`    multi-class       ``predict``, categorical
+mean                :ref:`Brier score <brier_score_loss>`            multi-class       ``predict_proba``
+mean                :ref:`log loss <log_loss>`                       multi-class       ``predict_proba``
+mode                :ref:`zero-one loss <zero_one_loss>` :sup:`1`    multi-class       ``predict``, categorical
 **Regression**
-mean                squared error             all reals         ``predict``, all reals
-mean                Poisson deviance          non-negative      ``predict``, strictly positive
-mean                Gamma deviance            stricly positive  ``predict``, strictly positive
-median              absolute error            all reals         ``predict``, all reals
-quantile            pinball loss              all reals         ``predict``, all reals
+mean                :ref:`squared error <mean_squared_error>`        all reals         ``predict``, all reals
+mean                :ref:`Poisson deviance <mean_tweedie_deviance>`  non-negative      ``predict``, strictly positive
+mean                :ref:`Gamma deviance <mean_tweedie_deviance>`    stricly positive  ``predict``, strictly positive
+median              :ref:`absolute error <mean_absolute_error>`      all reals         ``predict``, all reals
+quantile            :ref:`pinball loss <pinball_loss>`               all reals         ``predict``, all reals
 mode                does not exist
-==================  ========================  ================  ==============================
+==================  ===============================================  ================  ==============================
 
 :sup:`1` The zero-one loss is only consistent but not strictly consistent for the mode.
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -317,6 +317,122 @@ parameter:
     >>> print(cv_results['test_fn'])
     [0 1 2 3 2]
 
+.. _which_scoring_function:
+
+Which scoring function should I use?
+====================================
+
+Before diving into the details of the many scores and metrics, we want
+to give some guidance, inspired by statistical decision theory, on the choice
+of scoring functions for supervised learning:
+*Which scoring function should I use?
+Which scoring function is a good one for my task?*
+In a nutshell, if the scoring function is given, e.g. in a kaggle competition,
+use that one.
+If you are free to choose and you think, your target variable :math:`y` is
+(at least kind of) a random variable, first clarify what it is you actually
+want to predict: the mean, the median or the mode of your target :math:`Y`?
+Then choose a **strictly consistent** scoring function for that.
+
+Point forecasts and consistent scoring functions
+------------------------------------------------
+
+Let's assume that the target variable :math:`Y` is a random variable, that
+we have observations/realizations :math:`y` and that we make predictions
+:math:`\hat{y}`.
+Scoring functions :math:`S(\hat{y}, y)` then rank the prediction :math:`\hat{y}`
+of different models, given the observation :math:`y`.
+The higher the score the better the correponding model.
+For a test or validation set :math:`y_i`, one usually uses
+:math:`\bar{S} = \frac{1}{n_\text{samples}}\sum_{i=0}^{n_\text{samples}-1} S(\hat{y}_i, y_i)`.
+The prediction :math:`\hat{y}` is said to be a point forecast.
+The optimal point forecast under :math:`S` is the Bayes Rule
+:math:`\hat{y} = \operatorname{argmin}_x \mathbb{E}[S(x,Y)]` (to get an
+unbiased estimate of :math:`\mathbb{E}[S(x,Y)]` for model evaluation is one
+reason to use a test set independent of the training set).
+Instead of a point forecast, one could try to issue the whole probability
+distribution :math:`F(y)` of the target variable :math:`Y`.
+This is called a probabilistic forecast.
+If you are free to choose a scoring function, you should first ask yourself,
+which functional of :math:`F(y)` you want to predict as a point forecast:
+the mean, the mode, the median, ...
+Then, a **strictly consistent** scoring function for this
+functional is to be preferred, see [G2009]_ for a definition of *strictly
+consistent* and for more details.
+The reasoning goes as follows: If the scoring function is (strictly) consistent
+for the functional at interest, this functional is the (unique) optimal point
+forecast under this scoring function.
+
+
+==================    ================    ===============================================
+functional            scoring function    property
+==================    ================    ===============================================
+**Classification**
+mean                  brier score         strictly consistent
+mean                  log loss            strictly consistent
+median                absolute error      strictly consistent
+mode                  zero-one loss       consistent (for binary classification)
+**Regression**
+mean                  squared error       strictly consistent (if finite 2nd moment)
+mean                  Poisson deviance    strictly consistent (for non-negative target y)
+mean                  Gamma deviance      strictly consistent (for positive target y)
+median                absolute error      strictly consistent
+mode                  zero-one loss       asymptotically consistent
+==================    ================    ===============================================
+
+The zero-one loss is equivalent to the accuracy score, meaning it gives
+different score values but the same ranking.
+R² is equivalent to squared loss.
+The Brier score is the squared error for classification.
+
+An example with binary classification
+-------------------------------------
+
+Suppose you want to predict whether an apple blossom in spring becomes an
+eatable apple fruit in autumn.
+This is binary classification for :math:`Y = \text{fruit} = 1` or
+:math:`Y = \text{no fruit} = 0`.
+The good thing about binary classification is that predicting the mean of
+:math:`Y`, :math:`\operatorname{E}[Y] = p` (a result of setting the values of
+:math:`Y` to 0 and 1), is equivalent to predicting the whole distribution
+:math:`F(Y=\text{fruit}) = \operatorname{Pr}(Y=\text{no fruit}) = p`.
+Therefore, a good scoring function is one that is strictly consistent for the
+mean, e.g. log loss or Brier score.
+Note that for binary classification, the mode - the most probable outcome
+(*fruit* if :math:`p>0.5`) -
+is less informative than the mean: To say that we expect a fruit is less
+informative than to say that we expect a fruit with probability :math:`p`.
+
+On the other side, depending on the purpose of your prediction, you might
+also be interested in the use of other scoring functions:
+
+* If you want to optimize the conditions for good blossoms and you therefore
+  cut of blossoms for which you predict *no fruit*, you might want to optimize
+  the false negative rate (predicting *no fruit* when it actually gives a
+  fruit) in order to avoid cutting of too many.
+* If you sell your apples in advance base on the predicted number of fruits,
+  you might want to avoid selling too much and therefore go for the false
+  positive rate (predicting *fruit* when it actually does not give a fruit).
+* Treating the target variable :math:`y` as a random variable may just be an
+  approximation, but the true nature might be deterministic.
+  For example, if there was no bee to pollinate the blossoms, there won't be
+  any fruit--with certainty.
+  Some scoring functions like the log loss have problems at the boundaries
+  :math:`\hat{y}=0` or :math:`\hat{y}=1` (the same might be
+  true for an estimator).
+* Your own use case...
+
+.. topic:: References:
+
+  .. [G2009] T. Gneiting, `Making and Evaluating Point Forecasts
+    <https://arxiv.org/abs/0912.0902>`_, `alternative link
+    <https://www.bundesbank.de/Redaktion/EN/Downloads/Bundesbank/Research_Centre/Conferences/2012/2012_06_01_eltville_11_gneiting_paper.pdf>`_
+
+  .. [GR2007] T. Gneiting & A. E. Raftery `Strictly Proper Scoring Rules, Prediction,
+    and Estimation
+    <https://doi.org/10.1198/016214506000001437>`_,
+    `alternative link <https://www.stat.washington.edu/raftery/Research/PDF/Gneiting2007jasa.pdf>`_
+
 .. _classification_metrics:
 
 Classification metrics

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -75,7 +75,7 @@ mode                :ref:`zero-one loss <zero_one_loss>` :sup:`1`    multi-class
 **Regression  **
 mean                :ref:`squared error <mean_squared_error>`        all reals           ``predict``, all reals
 mean                :ref:`Poisson deviance <mean_tweedie_deviance>`  non-negative        ``predict``, strictly positive
-mean                  :ref:`Gamma deviance <mean_tweedie_deviance>`  strictly positive   ``predict``, strictly positive
+mean                :ref:`Gamma deviance <mean_tweedie_deviance>`    strictly positive   ``predict``, strictly positive
 median              :ref:`absolute error <mean_absolute_error>`      all reals           ``predict``, all reals
 quantile            :ref:`pinball loss <pinball_loss>`               all reals           ``predict``, all reals
 mode                no consistent one exists                         reals

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -73,29 +73,31 @@ stritcly consistent scoring functions. Note that the list is not complete and th
 there are more of them.
 For further criteria on how to select a specific one, see [Fissler2022]_.
 
-==================  ===============================================  ===================  ==============================
-functional          scoring or loss function                         response `y`         prediction
-==================  ===============================================  ===================  ==============================
+==================  ===================================================  ====================  =================================
+functional          scoring or loss function                             response `y`          prediction
+==================  ===================================================  ====================  =================================
 **Classification**
-mean                :ref:`Brier score <brier_score_loss>`            multi-class          ``predict_proba``
-mean                :ref:`log loss <log_loss>`                       multi-class          ``predict_proba``
-mode                :ref:`zero-one loss <zero_one_loss>` :sup:`1`    multi-class          ``predict``, categorical
+mean                :ref:`Brier score <brier_score_loss>` :sup:`1`       multi-class           ``predict_proba``
+mean                :ref:`log loss <log_loss>`                           multi-class           ``predict_proba``
+mode                :ref:`zero-one loss <zero_one_loss>` :sup:`2`        multi-class           ``predict``, categorical
 **Regression**
-mean                :ref:`squared error <mean_squared_error>`        all reals             ``predict``, all reals
-mean                :ref:`Poisson deviance <mean_tweedie_deviance>`  non-negative          ``predict``, strictly positive
-mean                :ref:`Gamma deviance <mean_tweedie_deviance>`    strictly positive     ``predict``, strictly positive
-median              :ref:`absolute error <mean_absolute_error>`      all reals             ``predict``, all reals
-quantile            :ref:`pinball loss <pinball_loss>`               all reals             ``predict``, all reals
-mode                no consistent one exists                         reals
-==================  ===============================================  ===================  ==============================
+mean                :ref:`squared error <mean_squared_error>` :sup:`3`   all reals             ``predict``, all reals
+mean                :ref:`Poisson deviance <mean_tweedie_deviance>`      non-negative          ``predict``, strictly positive
+mean                :ref:`Gamma deviance <mean_tweedie_deviance>`        strictly positive     ``predict``, strictly positive
+mean                :ref:`Tweedie deviance <mean_tweedie_deviance>`      depends on ``power``  ``predict``, depends on ``power``
+median              :ref:`absolute error <mean_absolute_error>`          all reals             ``predict``, all reals
+quantile            :ref:`pinball loss <pinball_loss>`                   all reals             ``predict``, all reals
+mode                no consistent one exists                             reals
+==================  ===================================================  ====================  =================================
 
-:sup:`1` The zero-one loss is only consistent but not strictly consistent for the mode.
+:sup:`1` The Brier score is just a different name for the squared error in case of
+classification.
 
-The zero-one loss is equivalent to one minus the accuracy score, meaning it
-gives different score values but the same ranking.
-R² gives the same ranking as squared loss.
-Furthermore, the Brier score is just a different name for the squared error
-in case of classification.
+:sup:`2` The zero-one loss is only consistent but not strictly consistent for the mode.
+The zero-one loss is equivalent to one minus the accuracy score, meaning it gives
+different score values but the same ranking.
+
+:sup:`3` R² gives the same ranking as squared error.
 
 **Ficticious Example:**
 Let's make the above arguments more tangible. Consider a setting of reliability

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -351,14 +351,23 @@ Point forecasts and consistent scoring functions
 Let's assume that the target variable :math:`Y` is a random variable, that
 we have observations/realizations :math:`y` and that we make predictions
 :math:`\hat{y}`.
-Scoring functions :math:`S(y, \hat{y})` then rank the prediction :math:`\hat{y}`
-of different models, given the observation :math:`y`.
+Scoring functions :math:`S(y, \hat{y})` then rank the prediction
+:math:`\hat{y}` of different models, given the observation :math:`y`.
 The higher the score the better the corresponding model (note that the
 literature uses sometimes the other orientation: smaller values are better).
 For a test or validation set :math:`y_i`, one usually uses
-:math:`\bar{S} = \frac{1}{n_\text{samples}}\sum_{i=0}^{n_\text{samples}-1} S(y_i, \hat{y}_i)`.
+
+.. :math::
+
+    \bar{S} = \frac{1}{n_\text{samples}}
+              \sum_{i=0}^{n_\text{samples}-1} S(y_i, \hat{y}_i).
+
 The optimal point prediction :math:`\hat{y}^\star` under :math:`S` is the
-*Bayes Rule* :math:`\hat{y}^\star = \operatorname{argmax}_x \mathbb{E}[S(Y, x)]`.
+*Bayes Rule*
+
+.. :math:
+
+    \hat{y}^\star = \operatorname{argmax}_x \mathbb{E}[S(Y, x)].
 
 Note that in order to get an unbiased estimate of :math:`\mathbb{E}[S(Y, x)]`
 for model evaluation and model selection, one has to use a test set independent

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -65,7 +65,8 @@ measures like an umbrella or not).
 For classifiers, this is what :term:`predict` returns.
 See also :ref:`TunedThresholdClassifierCV`.
 There are many scoring functions which measure different aspects of such a
-decision, most of them are covered with or derived from the :func:`confusion_matrix`.
+decision, most of them are covered with or derived from the
+:func:`metrics.confusion_matrix`.
 
 **List of strictly consistent scoring functions:**
 Here, we list some of the most relevant statistical functionals and corresponding
@@ -105,7 +106,7 @@ engineering, such as maintaining stable internet or Wi-Fi connections.
 As provider of the network, you have access to the dataset of log entries of network
 connections containing network load over time and many interesting features.
 Your goal is to improve the reliability of the connections.
-In fact, you promise your customers that at least on 99% of all days there are no
+In fact, you promise your customers that on at least 99% of all days there are no
 connection discontinuities larger than 1 minute.
 Therefore, you are interested in a prediction of the 99% quantile (of longest
 connection interruption duration per day) in order to know in advance when to add

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -432,23 +432,23 @@ mean, e.g. log loss or Brier score.
 They are also called *proper scoring rules*, as they assess predicting the
 whole probability distribution, [Gneiting2007]_.
 Note that for binary classification, the mode---the most probable outcome
-(*fruit* if :math:`p>0.5`)---is much less informative than the mean: To say
-that we expect a fruit is less informative than to say that we expect a fruit
-with probability :math:`p`.
+(:math:`\text{fruit}` if :math:`p>0.5`)---is much less informative than the
+mean: To say that we expect a fruit is less informative than to say that we
+expect a fruit with probability :math:`p`.
 
 Let's have a look on different purposes of your prediction:
 
 * If you want to optimize the conditions for good blossoms and you therefore
-  cut off blossoms for which you predict *no fruit*, you might want to minimize
-  the false negative rate (predicting *no fruit* when it actually gives a
-  fruit) in order to avoid cutting of too many.
+  cut off blossoms for which you predict :math:`\text{no fruit}`, you might
+  want to minimize the false negative rate (predicting :math:`\text{no fruit}`
+  when it actually gives a fruit) in order to avoid cutting of too many.
   If you have calibrated predictions for the probability :math:`p`, this helps
   a lot. You can start cutting off the blossoms with lowest predicted
   :math:`p`, which serves as prediction of the (expected) false negative rate.
 * If you sell your apples in advance based on the predicted number of fruits,
   you might want to avoid selling too many and control your false positive
-  rate (predicting *fruit* when it actually does not give a fruit).
-  Again, having a calibrated prediction for :math:`p` available, one
+  rate (predicting :math:`\text{fruit}` when it actually does not give a
+  fruit). Again, having a calibrated prediction for :math:`p` available, one
   immediately has an estimate of the false positives by :math:`1-p`.
 * Treating the target variable :math:`y` as a random variable may just be an
   approximation, but the true nature might be deterministic. For example, if

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -439,51 +439,6 @@ R² gives the same ranking as squared loss.
 Furthermore, the Brier score is just a different name for the squared error
 in case of classification.
 
-An example with binary classification
--------------------------------------
-
-Suppose you want to predict whether an apple blossom in spring becomes an
-eatable apple fruit in autumn.
-This is a binary classification problem with :math:`Y = \text{fruit} = 1` or
-:math:`Y = \text{no fruit} = 0`.
-
-Binary classification is very special in that the mean of :math:`Y` is also
-the full probability distribution, i.e.
-:math:`\mathbb{E}[Y] = p = \operatorname{P}(Y=\text{fruit}) = F(Y=\text{fruit})`
-(a result of setting the values of :math:`Y` to 0 and 1). This means that
-point predicting the mean is the same as probabilistic prediction of the class
-probability :math:`p`.
-Therefore, a good scoring function is one that is strictly consistent for the
-mean, e.g. log loss or Brier score.
-They are also called *proper scoring rules*, as they assess predicting the
-whole probability distribution, [Gneiting2007]_.
-Note that for binary classification, the mode---the most probable outcome
-(:math:`\text{fruit}` if :math:`p>0.5`)---is much less informative than the
-mean: To say that we expect a fruit is less informative than to say that we
-expect a fruit with probability :math:`p`.
-
-Let's have a look on different purposes of your prediction:
-
-* If you want to optimize the conditions for good blossoms and you therefore
-  cut off blossoms for which you predict :math:`\text{no fruit}`, you might
-  want to minimize the false negative rate (predicting :math:`\text{no fruit}`
-  when it actually gives a fruit) in order to avoid cutting off too many.
-  If you have calibrated predictions for the probability :math:`p`, this helps
-  a lot. You can start cutting off the blossoms with lowest predicted
-  :math:`p`, which serves as prediction of the (expected) false negative rate.
-* If you sell your apples in advance based on the predicted number of fruits,
-  you might want to avoid selling too many and control your false positive
-  rate (predicting :math:`\text{fruit}` when it actually does not give a
-  fruit). Again, having a calibrated prediction for :math:`p` available, one
-  immediately has an estimate of the false positives by :math:`1-p`.
-* Treating the target variable :math:`y` as a random variable may just be an
-  approximation, but the true nature might be deterministic. For example, if
-  there was no bee to pollinate the blossoms, there won't be any fruit---with
-  certainty! Some scoring functions like the log loss have problems at the
-  boundaries :math:`\hat{y}=0` or :math:`\hat{y}=1` (the same might be
-  true for an estimator).
-* Your own use case...
-
 .. topic:: References:
 
   .. [Gneiting2007] T. Gneiting and A. E. Raftery. :doi:`Strictly Proper

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -39,6 +39,9 @@ response variable :math:`Y` (conditionally on :math:`X`).
 
 Once that is settled, use a **strictly consistent** scoring function for that
 (target) functional, see [Gneiting2009]_.
+This means using a scoring function that is aligned with *measuring the distance
+between predictions* `y_pred` *and the true target functional using observations of*
+:math:`Y`, i.e. `y_true`.
 For classification **strictly proper scoring rules**, see
 `wikipedia <https://en.wikipedia.org/wiki/Scoring_rule>`_ and [Gneiting2007]_, coincide
 with strictly consistent scoring functions.

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -109,7 +109,7 @@ day free of interruptions larger than 1 minute) in order to know in advance when
 more bandwidth and thereby satisfy your customers. So the *target functional* is the
 99% quantile. From the table above, you choose the pinball loss as scoring function
 (fair enough, not much choice given), for model training (e.g.
-`HistGradientBoostingRegressor(loss="quantile", quantile=0.99)` as well as model
+`HistGradientBoostingRegressor(loss="quantile", quantile=0.99)`) as well as model
 evaluation (`mean_pinball_loss(..., alpha=0.9)` - we apoligize for the different
 argument names, `quantile` and `alpha`) be it in grid search for finding
 hyperparameters or in comparing to other models like

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -71,7 +71,7 @@ there are more of them.
 For further criteria on how to select a specific one, see [Fissler2022]_.
 
 ==================  ===============================================  ===================  ==============================
-functional          scoring or loss function                         response :math:`y`   prediction
+functional          scoring or loss function                         response `y`         prediction
 ==================  ===============================================  ===================  ==============================
 **Classification**
 mean                :ref:`Brier score <brier_score_loss>`            multi-class          ``predict_proba``

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -351,11 +351,12 @@ Once that is settled, use a **strictly consistent** scoring function for that
 target functional, see [Gneiting2009]_.
 For classification **stricly proper scoring rules**, see [Gneiting2007]_, conincide
 with strictly consistent scoring functions.
+See the table further below for examples.
 One could say that consistent scoring functions act as *truth serum* in that
 they guarantee "that truth telling [. . .] is an optimal strategy in
 expectation" [Gneiting2014]_.
 
-Note that for regressors, the prediction ist done with :term:`predict` while for
+Note that for regressors, the prediction is done with :term:`predict` while for
 classifiers it is usually :term:`predict_proba`.
 
 **Decision Making:**

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -340,15 +340,15 @@ Point forecasts and consistent scoring functions
 Let's assume that the target variable :math:`Y` is a random variable, that
 we have observations/realizations :math:`y` and that we make predictions
 :math:`\hat{y}`.
-Scoring functions :math:`S(\hat{y}, y)` then rank the prediction :math:`\hat{y}`
+Scoring functions :math:`S(y, \hat{y})` then rank the prediction :math:`\hat{y}`
 of different models, given the observation :math:`y`.
-The higher the score the better the correponding model.
+The higher the score the better the corresponding model.
 For a test or validation set :math:`y_i`, one usually uses
-:math:`\bar{S} = \frac{1}{n_\text{samples}}\sum_{i=0}^{n_\text{samples}-1} S(\hat{y}_i, y_i)`.
+:math:`\bar{S} = \frac{1}{n_\text{samples}}\sum_{i=0}^{n_\text{samples}-1} S(y_i, \hat{y}_i)`.
 The prediction :math:`\hat{y}` is said to be a point forecast.
 The optimal point forecast under :math:`S` is the Bayes Rule
-:math:`\hat{y} = \operatorname{argmin}_x \mathbb{E}[S(x,Y)]` (to get an
-unbiased estimate of :math:`\mathbb{E}[S(x,Y)]` for model evaluation is one
+:math:`\hat{y} = \operatorname{argmax}_x \mathbb{E}[S(Y,x)]` (to get an
+unbiased estimate of :math:`\mathbb{E}[S(Y,x)]` for model evaluation is one
 reason to use a test set independent of the training set).
 Instead of a point forecast, one could try to issue the whole probability
 distribution :math:`F(y)` of the target variable :math:`Y`.
@@ -364,21 +364,21 @@ for the functional at interest, this functional is the (unique) optimal point
 forecast under this scoring function.
 
 
-==================    ================    ===============================================
-functional            scoring function    property
-==================    ================    ===============================================
+==================    ========================    ===============================================
+functional            scoring or loss function    property
+==================    ========================    ===============================================
 **Classification**
-mean                  brier score         strictly consistent
-mean                  log loss            strictly consistent
-median                absolute error      strictly consistent
-mode                  zero-one loss       consistent (for binary classification)
+mean                  Brier score                 strictly consistent
+mean                  log loss                    strictly consistent
+median                absolute error              strictly consistent
+mode                  zero-one loss               consistent (for binary classification)
 **Regression**
-mean                  squared error       strictly consistent (if finite 2nd moment)
-mean                  Poisson deviance    strictly consistent (for non-negative target y)
-mean                  Gamma deviance      strictly consistent (for positive target y)
-median                absolute error      strictly consistent
-mode                  zero-one loss       asymptotically consistent
-==================    ================    ===============================================
+mean                  squared error               strictly consistent (if finite 2nd moment)
+mean                  Poisson deviance            strictly consistent (for non-negative target y)
+mean                  Gamma deviance              strictly consistent (for positive target y)
+median                absolute error              strictly consistent
+mode                  zero-one loss               asymptotically consistent
+==================    ========================    ===============================================
 
 The zero-one loss is equivalent to the accuracy score, meaning it gives
 different score values but the same ranking.

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -65,21 +65,21 @@ stritcly consistent scoring functions. Note that the list is not complete and th
 there are more of them.
 For further criteria on how to select a specific one, see [Fissler2022]_.
 
-==================  ===============================================  ==================  ==============================
-functional          scoring or loss function                         response :math:`y`  prediction
-==================  ===============================================  ==================  ==============================
+==================  ===============================================  ===================  ==============================
+functional          scoring or loss function                         response :math:`y`   prediction
+==================  ===============================================  ===================  ==============================
 **Classification**
-mean                :ref:`Brier score <brier_score_loss>`            multi-class         ``predict_proba``
-mean                :ref:`log loss <log_loss>`                       multi-class         ``predict_proba``
-mode                :ref:`zero-one loss <zero_one_loss>` :sup:`1`    multi-class         ``predict``, categorical
-**Regression  **
-mean                :ref:`squared error <mean_squared_error>`        all reals           ``predict``, all reals
-mean                :ref:`Poisson deviance <mean_tweedie_deviance>`  non-negative        ``predict``, strictly positive
-mean                :ref:`Gamma deviance <mean_tweedie_deviance>`    strictly positive   ``predict``, strictly positive
-median              :ref:`absolute error <mean_absolute_error>`      all reals           ``predict``, all reals
-quantile            :ref:`pinball loss <pinball_loss>`               all reals           ``predict``, all reals
+mean                :ref:`Brier score <brier_score_loss>`            multi-class          ``predict_proba``
+mean                :ref:`log loss <log_loss>`                       multi-class          ``predict_proba``
+mode                :ref:`zero-one loss <zero_one_loss>` :sup:`1`    multi-class          ``predict``, categorical
+**Regression**
+mean                :ref:`squared error <mean_squared_error>`        all reals             ``predict``, all reals
+mean                :ref:`Poisson deviance <mean_tweedie_deviance>`  non-negative          ``predict``, strictly positive
+mean                :ref:`Gamma deviance <mean_tweedie_deviance>`    strictly positive     ``predict``, strictly positive
+median              :ref:`absolute error <mean_absolute_error>`      all reals             ``predict``, all reals
+quantile            :ref:`pinball loss <pinball_loss>`               all reals             ``predict``, all reals
 mode                no consistent one exists                         reals
-==================  ===============================================  ==================  ==============================
+==================  ===============================================  ===================  ==============================
 
 :sup:`1` The zero-one loss is only consistent but not strictly consistent for the mode.
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -423,7 +423,7 @@ This is a binary classification problem with :math:`Y = \text{fruit} = 1` or
 
 Binary classification is very special in that the mean of :math:`Y` is also
 the full probability distribution, i.e.
-:math:`\mathbb{E}[Y] = p = \operatorname{P}(Y=\text{no fruit}) = F(Y=\text{fruit})`
+:math:`\mathbb{E}[Y] = p = \operatorname{P}(Y=\text{fruit}) = F(Y=\text{fruit})`
 (a result of setting the values of :math:`Y` to 0 and 1). This means that
 point predicting the mean is the same as probabilistic prediction of the class
 probability :math:`p`.

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -324,8 +324,9 @@ Which scoring function should I use?
 
 Before diving into the details of the many scores and metrics, we want
 to give some guidance, inspired by statistical decision theory, on the choice
-of scoring functions for supervized learning, see [Gneiting2009]_ and
+of scoring functions for supervised learning, see [Gneiting2009]_ and
 [Fissler2022]_:
+
   - *Which scoring function should I use?*
   - *Which scoring function is a good one for my task?*
 
@@ -357,7 +358,7 @@ The higher the score the better the corresponding model (note that the
 literature uses sometimes the other orientation: smaller values are better).
 For a test or validation set :math:`y_i`, one usually uses
 
-.. :math::
+.. math::
 
     \bar{S} = \frac{1}{n_\text{samples}}
               \sum_{i=0}^{n_\text{samples}-1} S(y_i, \hat{y}_i).
@@ -365,7 +366,7 @@ For a test or validation set :math:`y_i`, one usually uses
 The optimal point prediction :math:`\hat{y}^\star` under :math:`S` is the
 *Bayes Rule*
 
-.. :math:
+.. math::
 
     \hat{y}^\star = \operatorname{argmax}_x \mathbb{E}[S(Y, x)].
 
@@ -410,8 +411,8 @@ quantile              pinball loss                strictly consistent   all real
 The zero-one loss is equivalent to one minus the accuracy score, meaning it
 gives different score values but the same ranking.
 R² gives the same ranking as squared loss.
-Furthermode, the Brier score is just a different name for the squared error
-in case ofclassification.
+Furthermore, the Brier score is just a different name for the squared error
+in case of classification.
 
 An example with binary classification
 -------------------------------------
@@ -441,7 +442,7 @@ Let's have a look on different purposes of your prediction:
 * If you want to optimize the conditions for good blossoms and you therefore
   cut off blossoms for which you predict :math:`\text{no fruit}`, you might
   want to minimize the false negative rate (predicting :math:`\text{no fruit}`
-  when it actually gives a fruit) in order to avoid cutting of too many.
+  when it actually gives a fruit) in order to avoid cutting off too many.
   If you have calibrated predictions for the probability :math:`p`, this helps
   a lot. You can start cutting off the blossoms with lowest predicted
   :math:`p`, which serves as prediction of the (expected) false negative rate.
@@ -462,7 +463,7 @@ Let's have a look on different purposes of your prediction:
 
   .. [Fissler2022] T. Fissler, C. Lorentzen and M. Mayer. :arxiv:`Model
      Comparison and Calibration Assessment: User Guide for Consistent Scoring
-    Functions in Machine Learning and Actuarial Practice. <2202.12780>`
+     Functions in Machine Learning and Actuarial Practice. <2202.12780>`
 
   .. [Gneiting2007] T. Gneiting and A. E. Raftery. :doi:`Strictly Proper
      Scoring Rules, Prediction, and Estimation <10.1198/016214506000001437>`


### PR DESCRIPTION
Solves issue #10584.
Adds the new chapter "3.3.2. Which scoring function should I use?" to the user guide.