### PR TITLE
[MRG] Fix DeprecationWarning due to collections.abc in Python 3.7

### DIFF
--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -19,7 +19,7 @@ from .empirical_covariance_ import (empirical_covariance, EmpiricalCovariance,
 from ..exceptions import ConvergenceWarning
 from ..utils.validation import check_random_state, check_array
 from ..utils import deprecated
-from ..utils.fixes import Sequence
+from ..utils.fixes import _Sequence as Sequence
 from ..linear_model import lars_path
 from ..linear_model import cd_fast
 from ..model_selection import check_cv, cross_val_score

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -19,11 +19,11 @@ from .empirical_covariance_ import (empirical_covariance, EmpiricalCovariance,
 from ..exceptions import ConvergenceWarning
 from ..utils.validation import check_random_state, check_array
 from ..utils import deprecated
+from ..utils.fixes import Sequence
 from ..linear_model import lars_path
 from ..linear_model import cd_fast
 from ..model_selection import check_cv, cross_val_score
 from ..externals.joblib import Parallel, delayed
-import collections
 
 
 # Helper functions to compute the objective and dual objective functions
@@ -608,7 +608,7 @@ class GraphicalLassoCV(GraphicalLasso):
         n_alphas = self.alphas
         inner_verbose = max(0, self.verbose - 1)
 
-        if isinstance(n_alphas, collections.Sequence):
+        if isinstance(n_alphas, Sequence):
             alphas = self.alphas
             n_refinements = 1
         else:
@@ -684,7 +684,7 @@ class GraphicalLassoCV(GraphicalLasso):
                 alpha_1 = path[best_index - 1][0]
                 alpha_0 = path[best_index + 1][0]
 
-            if not isinstance(n_alphas, collections.Sequence):
+            if not isinstance(n_alphas, Sequence):
                 alphas = np.logspace(np.log10(alpha_1), np.log10(alpha_0),
                                      n_alphas + 2)
                 alphas = alphas[1:-1]

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -11,11 +11,11 @@ import array
 import numpy as np
 from scipy import linalg
 import scipy.sparse as sp
-from collections import Iterable
 
 from ..preprocessing import MultiLabelBinarizer
 from ..utils import check_array, check_random_state
 from ..utils import shuffle as util_shuffle
+from ..utils.fixes import Iterable
 from ..utils.random import sample_without_replacement
 from ..externals import six
 map = six.moves.map

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -15,7 +15,7 @@ import scipy.sparse as sp
 from ..preprocessing import MultiLabelBinarizer
 from ..utils import check_array, check_random_state
 from ..utils import shuffle as util_shuffle
-from ..utils.fixes import Iterable
+from ..utils.fixes import _Iterable as Iterable
 from ..utils.random import sample_without_replacement
 from ..externals import six
 map = six.moves.map

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -12,7 +12,7 @@ from ..base import BaseEstimator, TransformerMixin
 from ..externals import six
 from ..externals.six.moves import xrange
 from ..utils import check_array, tosequence
-from ..utils.fixes import Mapping
+from ..utils.fixes import _Mapping as Mapping
 
 
 def _tosequence(X):

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -3,7 +3,6 @@
 # License: BSD 3 clause
 
 from array import array
-from collections import Mapping
 from operator import itemgetter
 
 import numpy as np
@@ -13,6 +12,7 @@ from ..base import BaseEstimator, TransformerMixin
 from ..externals import six
 from ..externals.six.moves import xrange
 from ..utils import check_array, tosequence
+from ..utils.fixes import Mapping
 
 
 def _tosequence(X):

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -33,8 +33,8 @@ from sklearn.utils.testing import (assert_equal, assert_false, assert_true,
                                    clean_warning_registry, ignore_warnings,
                                    SkipTest, assert_raises,
                                    assert_allclose_dense_sparse)
-
-from collections import defaultdict, Mapping
+from sklearn.utils.fixes import Mapping
+from collections import defaultdict
 from functools import partial
 import pickle
 from io import StringIO

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -33,7 +33,7 @@ from sklearn.utils.testing import (assert_equal, assert_false, assert_true,
                                    clean_warning_registry, ignore_warnings,
                                    SkipTest, assert_raises,
                                    assert_allclose_dense_sparse)
-from sklearn.utils.fixes import Mapping
+from sklearn.utils.fixes import _Mapping as Mapping
 from collections import defaultdict
 from functools import partial
 import pickle

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -19,7 +19,6 @@ ground truth labeling (or ``None`` in the case of unsupervised models).
 # License: Simplified BSD
 
 from abc import ABCMeta
-from collections import Iterable
 
 import numpy as np
 
@@ -40,6 +39,7 @@ from .cluster import normalized_mutual_info_score
 from .cluster import fowlkes_mallows_score
 
 from ..utils.multiclass import type_of_target
+from ..utils.fixes import Iterable
 from ..externals import six
 from ..base import is_regressor
 

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -39,7 +39,7 @@ from .cluster import normalized_mutual_info_score
 from .cluster import fowlkes_mallows_score
 
 from ..utils.multiclass import type_of_target
-from ..utils.fixes import Iterable
+from ..utils.fixes import _Iterable as Iterable
 from ..externals import six
 from ..base import is_regressor
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -13,7 +13,7 @@ from __future__ import division
 # License: BSD 3 clause
 
 from abc import ABCMeta, abstractmethod
-from collections import Mapping, namedtuple, defaultdict, Sequence, Iterable
+from collections import namedtuple, defaultdict
 from functools import partial, reduce
 from itertools import product
 import operator
@@ -34,6 +34,7 @@ from ..externals import six
 from ..utils import check_random_state
 from ..utils.fixes import sp_version
 from ..utils.fixes import MaskedArray
+from ..utils.fixes import Mapping, Sequence, Iterable
 from ..utils.random import sample_without_replacement
 from ..utils.validation import indexable, check_is_fitted
 from ..utils.metaestimators import if_delegate_has_method

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -34,7 +34,8 @@ from ..externals import six
 from ..utils import check_random_state
 from ..utils.fixes import sp_version
 from ..utils.fixes import MaskedArray
-from ..utils.fixes import Mapping, Sequence, Iterable
+from ..utils.fixes import _Mapping as Mapping, _Sequence as Sequence
+from ..utils.fixes import _Iterable as Iterable
 from ..utils.random import sample_without_replacement
 from ..utils.validation import indexable, check_is_fitted
 from ..utils.metaestimators import if_delegate_has_method

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -15,7 +15,6 @@ from __future__ import division
 
 import warnings
 from itertools import chain, combinations
-from collections import Iterable
 from math import ceil, floor
 import numbers
 from abc import ABCMeta, abstractmethod
@@ -29,6 +28,7 @@ from ..utils.multiclass import type_of_target
 from ..externals.six import with_metaclass
 from ..externals.six.moves import zip
 from ..utils.fixes import signature, comb
+from ..utils.fixes import Iterable
 from ..base import _pprint
 
 __all__ = ['BaseCrossValidator',

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -28,7 +28,7 @@ from ..utils.multiclass import type_of_target
 from ..externals.six import with_metaclass
 from ..externals.six.moves import zip
 from ..utils.fixes import signature, comb
-from ..utils.fixes import Iterable
+from ..utils.fixes import _Iterable as Iterable
 from ..base import _pprint
 
 __all__ = ['BaseCrossValidator',

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -14,7 +14,7 @@ import pytest
 
 from sklearn.utils.fixes import sp_version
 from sklearn.utils.fixes import PY3_OR_LATER
-from sklearn.utils.fixes import Iterable, Sized
+from sklearn.utils.fixes import _Iterable as Iterable, _Sized as Sized
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_raises

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1,6 +1,5 @@
 """Test the search module"""
 
-from collections import Iterable, Sized
 from sklearn.externals.six.moves import cStringIO as StringIO
 from sklearn.externals.six.moves import xrange
 from itertools import chain, product
@@ -15,6 +14,7 @@ import pytest
 
 from sklearn.utils.fixes import sp_version
 from sklearn.utils.fixes import PY3_OR_LATER
+from sklearn.utils.fixes import Iterable, Sized
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_raises

--- a/sklearn/tests/test_init.py
+++ b/sklearn/tests/test_init.py
@@ -44,7 +44,8 @@ def test_import_sklearn_no_warnings():
                                           stderr=subprocess.STDOUT)
         message = message.decode("utf-8")
         message = '\n'.join([line for line in message.splitlines()
-                             if not (  # ignore ImportWarning
+                             if not (
+                                     # ignore ImportWarning due to Cython
                                      "ImportWarning" in line or
                                      # ignore DeprecationWarning due to pytest
                                      "pytest" in line or
@@ -57,4 +58,4 @@ def test_import_sklearn_no_warnings():
 
     except Exception as e:
         pytest.skip('soft-failed test_import_sklearn_no_warnings.\n'
-                    ' %s' % e)
+                    ' %s, \n %s' % (e, message))

--- a/sklearn/tests/test_init.py
+++ b/sklearn/tests/test_init.py
@@ -34,7 +34,10 @@ def test_import_sklearn_no_warnings():
         pkgs = pkgutil.iter_modules(path=sklearn.__path__, prefix='sklearn.')
         import_modules = '; '.join(['import ' + modname
                                     for _, modname, _ in pkgs
-                                    if not modname.startswith('_')])
+                                    if (not modname.startswith('_') and
+                                        # add deprecated top level modules
+                                        # below to ignore them
+                                        modname not in [])])
 
         message = subprocess.check_output(['python', '-Wdefault',
                                            '-c', import_modules],

--- a/sklearn/tests/test_init.py
+++ b/sklearn/tests/test_init.py
@@ -1,10 +1,12 @@
 # Basic unittests to test functioning of module's top-level
 
+import subprocess
+
+from sklearn.utils.testing import assert_equal
+
 __author__ = 'Yaroslav Halchenko'
 __license__ = 'BSD'
 
-
-from sklearn.utils.testing import assert_equal
 
 try:
     from sklearn import *  # noqa
@@ -18,3 +20,17 @@ def test_import_skl():
     # "import *" is discouraged outside of the module level, hence we
     # rely on setting up the variable above
     assert_equal(_top_import_error, None)
+
+
+def test_import_sklearn_no_warnings():
+    # Test that importing scikit-learn doesn't raise any warnings.
+
+    message = subprocess.check_output(['python', '-Wdefault',
+                                       '-c', 'import sklearn'],
+                                      stderr=subprocess.STDOUT)
+    message = message.decode("utf-8")
+    # ignore the ImportWarning
+    message = '\n'.join([line for line in message.splitlines()
+                         if "ImportWarning" not in line])
+    assert 'Warning' not in message
+    assert 'Error' not in message

--- a/sklearn/tests/test_init.py
+++ b/sklearn/tests/test_init.py
@@ -50,9 +50,7 @@ def test_import_sklearn_no_warnings():
                                      "pytest" in line or
                                      # ignore DeprecationWarnings due to
                                      # numpy.oldnumeric
-                                     "oldnumeric" in line or
-                                     # ignore FutureWarnings
-                                     "FutureWarning" in line
+                                     "oldnumeric" in line
                                      )])
         assert 'Warning' not in message
         assert 'Error' not in message

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -1,7 +1,7 @@
 """
 The :mod:`sklearn.utils` module includes various utilities.
 """
-from collections import Sequence
+
 import numbers
 
 import numpy as np
@@ -17,6 +17,7 @@ from .validation import (as_float_array,
 from .class_weight import compute_class_weight, compute_sample_weight
 from ..externals.joblib import cpu_count
 from ..exceptions import DataConversionWarning
+from ..utils.fixes import collections_abc
 from .deprecation import deprecated
 from .. import get_config
 
@@ -479,7 +480,7 @@ def tosequence(x):
     """
     if isinstance(x, np.ndarray):
         return np.asarray(x)
-    elif isinstance(x, Sequence):
+    elif isinstance(x, collections_abc.Sequence):
         return x
     else:
         return list(x)

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -17,7 +17,7 @@ from .validation import (as_float_array,
 from .class_weight import compute_class_weight, compute_sample_weight
 from ..externals.joblib import cpu_count
 from ..exceptions import DataConversionWarning
-from ..utils.fixes import collections_abc
+from ..utils.fixes import Sequence
 from .deprecation import deprecated
 from .. import get_config
 
@@ -480,7 +480,7 @@ def tosequence(x):
     """
     if isinstance(x, np.ndarray):
         return np.asarray(x)
-    elif isinstance(x, collections_abc.Sequence):
+    elif isinstance(x, Sequence):
         return x
     else:
         return list(x)

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -17,7 +17,7 @@ from .validation import (as_float_array,
 from .class_weight import compute_class_weight, compute_sample_weight
 from ..externals.joblib import cpu_count
 from ..exceptions import DataConversionWarning
-from ..utils.fixes import Sequence
+from ..utils.fixes import _Sequence as Sequence
 from .deprecation import deprecated
 from .. import get_config
 

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -297,3 +297,10 @@ if np.array_equal(_nan_object_mask, np.array([True])):
 else:
     def _object_dtype_isnan(X):
         return np.frompyfunc(lambda x: x != x, 1, 1)(X).astype(bool)
+
+
+# To be removed once this fix is included in six
+try:
+    import collections.abc as collections_abc  # noqa
+except ImportError:  # python <3.3
+    import collections as collections_abc  # noqa

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -301,8 +301,12 @@ else:
 
 # To be removed once this fix is included in six
 try:
-    from collections.abc import Sequence, Iterable  # noqa
-    from collections.abc import Mapping, Sized  # noqa
+    from collections.abc import Sequence as _Sequence  # noqa
+    from collections.abc import Iterable as _Iterable  # noqa
+    from collections.abc import Mapping as _Mapping  # noqa
+    from collections.abc import Sized as _Sized  # noqa
 except ImportError:  # python <3.3
-    from collections import Sequence, Iterable  # noqa
-    from collections import Mapping, Sized  # noqa
+    from collections import Sequence as _Sequence  # noqa
+    from collections import Iterable as _Iterable  # noqa
+    from collections import Mapping as _Mapping  # noqa
+    from collections import Sized as _Sized  # noqa

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -301,6 +301,8 @@ else:
 
 # To be removed once this fix is included in six
 try:
-    import collections.abc as collections_abc  # noqa
+    from collections.abc import Sequence, Iterable  # noqa
+    from collections.abc import Mapping, Sized  # noqa
 except ImportError:  # python <3.3
-    import collections as collections_abc  # noqa
+    from collections import Sequence, Iterable  # noqa
+    from collections import Mapping, Sized  # noqa

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -235,8 +235,8 @@ def type_of_target(y):
     >>> type_of_target(np.array([[0, 1], [1, 1]]))
     'multilabel-indicator'
     """
-    valid = ((isinstance(y, (Sequence, spmatrix))
-              or hasattr(y, '__array__')) and not isinstance(y, string_types))
+    valid = ((isinstance(y, (Sequence, spmatrix)) or hasattr(y, '__array__'))
+             and not isinstance(y, string_types))
 
     if not valid:
         raise ValueError('Expected array-like (array or non-string sequence), '

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -7,7 +7,6 @@ Multi-class / multi-label utility function
 
 """
 from __future__ import division
-from collections import Sequence
 from itertools import chain
 
 from scipy.sparse import issparse
@@ -18,6 +17,7 @@ from scipy.sparse import lil_matrix
 import numpy as np
 
 from ..externals.six import string_types
+from ..utils.fixes import collections_abc
 from .validation import check_array
 
 
@@ -236,8 +236,8 @@ def type_of_target(y):
     >>> type_of_target(np.array([[0, 1], [1, 1]]))
     'multilabel-indicator'
     """
-    valid = ((isinstance(y, (Sequence, spmatrix)) or hasattr(y, '__array__'))
-             and not isinstance(y, string_types))
+    valid = ((isinstance(y, (collections_abc.Sequence, spmatrix))
+              or hasattr(y, '__array__')) and not isinstance(y, string_types))
 
     if not valid:
         raise ValueError('Expected array-like (array or non-string sequence), '
@@ -258,7 +258,8 @@ def type_of_target(y):
 
     # The old sequence of sequences format
     try:
-        if (not hasattr(y[0], '__array__') and isinstance(y[0], Sequence)
+        if (not hasattr(y[0], '__array__')
+                and isinstance(y[0], collections_abc.Sequence)
                 and not isinstance(y[0], string_types)):
             raise ValueError('You appear to be using a legacy multi-label data'
                              ' representation. Sequence of sequences are no'

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -17,9 +17,8 @@ from scipy.sparse import lil_matrix
 import numpy as np
 
 from ..externals.six import string_types
-from ..utils.fixes import collections_abc
+from ..utils.fixes import Sequence
 from .validation import check_array
-
 
 
 def _unique_multiclass(y):
@@ -236,7 +235,7 @@ def type_of_target(y):
     >>> type_of_target(np.array([[0, 1], [1, 1]]))
     'multilabel-indicator'
     """
-    valid = ((isinstance(y, (collections_abc.Sequence, spmatrix))
+    valid = ((isinstance(y, (Sequence, spmatrix))
               or hasattr(y, '__array__')) and not isinstance(y, string_types))
 
     if not valid:
@@ -258,8 +257,7 @@ def type_of_target(y):
 
     # The old sequence of sequences format
     try:
-        if (not hasattr(y[0], '__array__')
-                and isinstance(y[0], collections_abc.Sequence)
+        if (not hasattr(y[0], '__array__') and isinstance(y[0], Sequence)
                 and not isinstance(y[0], string_types)):
             raise ValueError('You appear to be using a legacy multi-label data'
                              ' representation. Sequence of sequences are no'

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -17,7 +17,7 @@ from scipy.sparse import lil_matrix
 import numpy as np
 
 from ..externals.six import string_types
-from ..utils.fixes import Sequence
+from ..utils.fixes import _Sequence as Sequence
 from .validation import check_array
 
 


### PR DESCRIPTION
Closes https://github.com/scikit-learn/scikit-learn/issues/11121

This PR removes the deprecation warning about ABC being moved from `collections` to `collections.abc` when importing scikit-learn in Python 3.7.

In the end, I put `collections.abc.{Sequence, Iterable, Mapping, Sized}` in the namespace of `sklearn.utils.fixes`. This was the simplest way I could find, and while it has the drawback of obfuscating the real module name, other approached appeared more problematic and a similar approach is currently used e.g. for `utils.fixes.signature` which is an alias for `inspect.signature`.

We can't just patch six with https://github.com/benjaminp/six/pull/241, because sklearn uses six from 5 years ago, which would  need updating and I'm not sure if it could have side effects (e.g. for pickling backward compatibility etc).

**Edit**: This adds a test checking that generally no warnings are raised when importing scikit-learn top-level modules.