### PR TITLE
[MRG] Fix DBSCAN is missing _pairwise property

### DIFF
--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -327,3 +327,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         """
         self.fit(X, sample_weight=sample_weight)
         return self.labels_
+
+    @property
+    def _pairwise(self):
+        return self.metric == "precomputed"

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -910,3 +910,7 @@ class TSNE(BaseEstimator):
         """
         self.fit_transform(X)
         return self
+
+    @property
+    def _pairwise(self):
+        return self.metric == "precomputed"

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1194,7 +1194,6 @@ def check_estimators_pickle(name, estimator_orig):
 
 def check_pairwise_estimator_tag(name, estimator_orig):
     attributes_to_check = ['metric', 'affinity', 'kernel']
-    attribute_value = 'precomputed'
 
     # Check if _pairwise attribute is present - will be used later
     has_pairwise_tag = (False
@@ -1213,7 +1212,7 @@ def check_pairwise_estimator_tag(name, estimator_orig):
         try:
             # Construct new object of estimator with desired attribute value
             modified_estimator = clone(estimator_orig).set_params(
-                                                **{attribute: attribute_value})
+                                                **{attribute: 'precomputed'})
             # Estimators may validate parameters in fit if not in set_params
             modified_estimator.fit(distance_matrix, y_)
         except Exception:
@@ -1234,9 +1233,9 @@ def check_pairwise_estimator_tag(name, estimator_orig):
                     modified_estimator.predict(X)
         except ValueError:
             # Check if estimator defines _pairwise attribute
-            error_message = ("{0} implements {1}={2} but does"
+            error_message = ("{0} implements {1}='precomputed' but does"
                              " not implement '_pairwise' estimator tag"
-                             "".format(name, attribute, attribute_value))
+                             "".format(name, attribute))
             assert has_pairwise_tag is True, error_message
         else:
             # Estimator does not raise an error - skip

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1216,7 +1216,7 @@ def check_pairwise_estimator_tag(name, estimator_orig):
                                                 **{attribute: attribute_value})
             # Estimators may validate parameters in fit if not in set_params
             modified_estimator.fit(distance_matrix, y_)
-        except (TypeError, ValueError, KeyError):
+        except Exception:
             # Estimator does not support given attribute value
             continue
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1223,7 +1223,8 @@ def check_pairwise_estimator_tag(name, estimator_orig):
             non_square_distance = distance_matrix[:, :-1]
             if getattr(modified_estimator, 'fit_predict', None) is not None:
                 modified_estimator.fit_predict(X=non_square_distance, y=y_)
-            elif getattr(modified_estimator, 'fit_transform', None) is not None:
+            elif (getattr(modified_estimator, 'fit_transform', None)
+                    is not None):
                 modified_estimator.fit_transform(X=non_square_distance, y=y_)
             elif getattr(modified_estimator, 'fit', None) is not None:
                 modified_estimator.fit(X=non_square_distance, y=y_)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #11432 

#### What does this implement/fix? Explain your changes.
Adds the `_pairwise` attribute to `cluster/dbscan_.py`, returning `True` if a `precomputed` distance metric is indicated.

Also adds a common heuristic test for checking if an estimator should have the `_pairwise` property, but isn't. The test is based on the idea that if an estimator had a `metric`, `affinity` or `kernel` parameter which supports 'precomputed', and if the estimator was then able to fit on pairwise data, but raised an error on non-square training data, a `_pairwise` attribute should exist.