### PR TITLE
[MRG] Consistent shape indications in contributing.rst

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -698,7 +698,7 @@ Here's a simple example of code using some of the above guidelines::
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
+        X : array-like, shape (n_samples, n_features)
             array representing the data
         random_state : RandomState or an int seed (0 by default)
             A random number generator instance to define the state of the
@@ -706,7 +706,7 @@ Here's a simple example of code using some of the above guidelines::
 
         Returns
         -------
-        x : numpy array, shape = [n_features,]
+        x : numpy array, shape (n_features,)
             A random point selected from X
         """
         X = check_array(X)
@@ -1037,9 +1037,9 @@ the predict method.
 ============= ======================================================
 Parameters
 ============= ======================================================
-X             array-like, shape = [n_samples, n_features]
+X             array-like, shape (n_samples, n_features)
 
-y             array, shape = [n_samples]
+y             array, shape (n_samples,)
 
 kwargs        optional data-dependent parameters.
 ============= ======================================================

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -698,7 +698,7 @@ Here's a simple example of code using some of the above guidelines::
 
         Parameters
         ----------
-        X : array-like, shape = (n_samples, n_features)
+        X : array-like, shape = [n_samples, n_features]
             array representing the data
         random_state : RandomState or an int seed (0 by default)
             A random number generator instance to define the state of the
@@ -706,7 +706,7 @@ Here's a simple example of code using some of the above guidelines::
 
         Returns
         -------
-        x : numpy array, shape = (n_features,)
+        x : numpy array, shape = [n_features,]
             A random point selected from X
         """
         X = check_array(X)
@@ -1037,11 +1037,9 @@ the predict method.
 ============= ======================================================
 Parameters
 ============= ======================================================
-X             array-like, with shape = [N, D], where N is the number
-              of samples and D is the number of features.
+X             array-like, shape = [n_samples, n_features]
 
-y             array, with shape = [N], where N is the number of
-              samples.
+y             array, shape = [n_samples]
 
 kwargs        optional data-dependent parameters.
 ============= ======================================================


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Use of `shape = [...]` instead of `shape = (...)` (both were being used).

I chose brackets over parenthesis because it seems to be the most common, but could easily change:
```
~/dev/scikit-learn(branch:master) » ag "shape = \[" | wc -w  
5025
~/dev/scikit-learn(branch:master) » ag "shape = \(" | wc -w  
1278
```

#### Any other comments?

I also proposed in #11450 to fix the inconsistency issues everywhere, but the contributors guide maybe the most critical place as it dictates what new contributors will base on.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
