### PR TITLE
[MRG] Fixes tree and forest classification for non-numeric multi-target

### DIFF
--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1337,3 +1337,26 @@ def test_backend_respected():
         clf.predict_proba(X)
 
     assert ba.count == 0
+
+
+def check_multi_target(name, oob_score):
+    ForestClassifier = FOREST_CLASSIFIERS[name]
+
+    clf = ForestClassifier(bootstrap=True, oob_score=oob_score)
+
+    X, y = datasets.make_classification()
+    # Make y have string classes.
+    y = np.array(['foo' if v else 'bar' for v in y]).reshape((y.shape[0], 1))
+
+    # Make multi-target.
+    ys = np.hstack([y, y])
+
+    # Try to fix and predict.
+    clf.fit(X, ys)
+    clf.predict(X)
+
+
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
+@pytest.mark.parametrize('oob_score', (True, False))
+def test_multi_target(name, oob_score):
+    check_multi_target(name, oob_score)

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1339,6 +1339,7 @@ def test_backend_respected():
     assert ba.count == 0
 
 
+@pytest.mark.filterwarnings('ignore:The default value of n_estimators')
 @pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
 @pytest.mark.parametrize('oob_score', (True, False))
 def test_multi_target(name, oob_score):

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1347,13 +1347,15 @@ def test_multi_target(name, oob_score):
 
     clf = ForestClassifier(bootstrap=True, oob_score=oob_score)
 
-    X, y = datasets.make_classification()
-    # Make y have string classes.
-    y = np.array(['foo' if v else 'bar' for v in y]).reshape((y.shape[0], 1))
+    X = iris.data
 
-    # Make multi-target.
-    ys = np.hstack([y, y])
+    # Make multi column mixed type target.
+    y = np.vstack([
+        iris.target.astype(float),
+        iris.target.astype(int),
+        iris.target.astype(str),
+    ]).T
 
-    # Try to fix and predict.
-    clf.fit(X, ys)
+    # Try to fit and predict.
+    clf.fit(X, y)
     clf.predict(X)

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1339,7 +1339,9 @@ def test_backend_respected():
     assert ba.count == 0
 
 
-def check_multi_target(name, oob_score):
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
+@pytest.mark.parametrize('oob_score', (True, False))
+def test_multi_target(name, oob_score):
     ForestClassifier = FOREST_CLASSIFIERS[name]
 
     clf = ForestClassifier(bootstrap=True, oob_score=oob_score)
@@ -1354,9 +1356,3 @@ def check_multi_target(name, oob_score):
     # Try to fix and predict.
     clf.fit(X, ys)
     clf.predict(X)
-
-
-@pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
-@pytest.mark.parametrize('oob_score', (True, False))
-def test_multi_target(name, oob_score):
-    check_multi_target(name, oob_score)

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1836,13 +1836,15 @@ def test_multi_target(name):
 
     clf = Tree()
 
-    X, y = datasets.make_classification()
-    # Make y have string classes.
-    y = np.array(['foo' if v else 'bar' for v in y]).reshape((y.shape[0], 1))
+    X = iris.data
 
-    # Make multi-target.
-    ys = np.hstack([y, y])
+    # Make multi column mixed type target.
+    y = np.vstack([
+        iris.target.astype(float),
+        iris.target.astype(int),
+        iris.target.astype(str),
+    ]).T
 
-    # Try to fix and predict.
-    clf.fit(X, ys)
+    # Try to fit and predict.
+    clf.fit(X, y)
     clf.predict(X)

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1828,3 +1828,25 @@ def test_empty_leaf_infinite_threshold():
         infinite_threshold = np.where(~np.isfinite(tree.tree_.threshold))[0]
         assert len(infinite_threshold) == 0
         assert len(empty_leaf) == 0
+
+
+def check_multi_target(name):
+    Tree = CLF_TREES[name]
+
+    clf = Tree()
+
+    X, y = datasets.make_classification()
+    # Make y have string classes.
+    y = np.array(['foo' if v else 'bar' for v in y]).reshape((y.shape[0], 1))
+
+    # Make multi-target.
+    ys = np.hstack([y, y])
+
+    # Try to fix and predict.
+    clf.fit(X, ys)
+    clf.predict(X)
+
+
+@pytest.mark.parametrize('name', CLF_TREES)
+def test_multi_target(name):
+    check_multi_target(name)

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1830,7 +1830,8 @@ def test_empty_leaf_infinite_threshold():
         assert len(empty_leaf) == 0
 
 
-def check_multi_target(name):
+@pytest.mark.parametrize('name', CLF_TREES)
+def test_multi_target(name):
     Tree = CLF_TREES[name]
 
     clf = Tree()
@@ -1845,8 +1846,3 @@ def check_multi_target(name):
     # Try to fix and predict.
     clf.fit(X, ys)
     clf.predict(X)
-
-
-@pytest.mark.parametrize('name', CLF_TREES)
-def test_multi_target(name):
-    check_multi_target(name)

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -436,8 +436,8 @@ class BaseDecisionTree(BaseEstimator, metaclass=ABCMeta):
                 return self.classes_.take(np.argmax(proba, axis=1), axis=0)
 
             else:
-                predictions = np.zeros((n_samples, self.n_outputs_))
-
+                class_type = self.classes_[0].dtype
+                predictions = np.zeros((n_samples, self.n_outputs_), dtype=class_type)
                 for k in range(self.n_outputs_):
                     predictions[:, k] = self.classes_[k].take(
                         np.argmax(proba[:, k], axis=1),

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -437,7 +437,8 @@ class BaseDecisionTree(BaseEstimator, metaclass=ABCMeta):
 
             else:
                 class_type = self.classes_[0].dtype
-                predictions = np.zeros((n_samples, self.n_outputs_), dtype=class_type)
+                predictions = np.zeros((n_samples, self.n_outputs_),
+                                       dtype=class_type)
                 for k in range(self.n_outputs_):
                     predictions[:, k] = self.classes_[k].take(
                         np.argmax(proba[:, k], axis=1),


### PR DESCRIPTION
Fixes #11451.

This fixes the issue that trees and forests cannot classify (but they can fit) non-numeric targets, when there are multiple targets.