### PR TITLE
[MRG+2] Tree MAE fix to ensure sample_weights are used during impurity calculation

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -514,7 +514,7 @@ Classifiers and regressors
   features that appear in later stages. This issue only affected feature
   importances. :issue:`11176` by :user:`Gil Forsyth <gforsyth>`.
   
-- Fixed a bug in :class:`tree.MAE` to ensure sample_weights are being used 
+- Fixed a bug in :class:`tree.MAE` to ensure sample weights are being used 
   during the calculation of tree MAE impurity. Previous behaviour could 
   cause suboptimal splits to be chosen since the impurity calculation 
   considered all samples to be of equal weight importance.

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -513,6 +513,12 @@ Classifiers and regressors
   per-tree basis. The previous behavior over-weighted the Gini importance of
   features that appear in later stages. This issue only affected feature
   importances. :issue:`11176` by :user:`Gil Forsyth <gforsyth>`.
+  
+- Fixed a bug in :class:`tree.MAE` to ensure sample_weights are being used 
+  during the calculation of tree MAE impurity. Previous behaviour could 
+  cause suboptimal splits to be chosen since the impurity calculation 
+  considered all samples to be of equal weight importance.
+  :issue:`11464` by :user:`John Stott <JohnStott>`.  
 
 Decomposition, manifold learning and clustering
 

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1238,7 +1238,7 @@ cdef class MAE(RegressionCriterion):
         cdef SIZE_t* samples = self.samples
         cdef SIZE_t i, p, k
         cdef DOUBLE_t y_ik
-        cdef DOUBLE_t w_y_ik
+        cdef double w = 1.0
 
         cdef double impurity = 0.0
 
@@ -1248,7 +1248,11 @@ cdef class MAE(RegressionCriterion):
 
                 y_ik = y[i * self.y_stride + k]
 
-                impurity += <double> fabs((<double> y_ik) - <double> self.node_medians[k])
+                if sample_weight != NULL:
+                    w = sample_weight[i]
+
+                impurity += (<double> fabs((<double> y_ik) - 
+							<double> self.node_medians[k])) * w
         return impurity / (self.weighted_n_node_samples * self.n_outputs)
 
     cdef void children_impurity(self, double* impurity_left,
@@ -1269,6 +1273,7 @@ cdef class MAE(RegressionCriterion):
         cdef SIZE_t i, p, k
         cdef DOUBLE_t y_ik
         cdef DOUBLE_t median
+        cdef double w = 1.0
 
         cdef void** left_child = <void**> self.left_child.data
         cdef void** right_child = <void**> self.right_child.data
@@ -1283,8 +1288,11 @@ cdef class MAE(RegressionCriterion):
 
                 y_ik = y[i * self.y_stride + k]
 
-                impurity_left[0] += <double>fabs((<double> y_ik) -
-                                                 <double> median)
+                if sample_weight != NULL:
+                    w = sample_weight[i]
+
+                impurity_left[0] += (<double> fabs((<double> y_ik) -
+                                                 <double> median)) * w
         impurity_left[0] /= <double>((self.weighted_n_left) * self.n_outputs)
 
         for k in range(self.n_outputs):
@@ -1294,8 +1302,11 @@ cdef class MAE(RegressionCriterion):
 
                 y_ik = y[i * self.y_stride + k]
 
-                impurity_right[0] += <double>fabs((<double> y_ik) -
-                                                  <double> median)
+                if sample_weight != NULL:
+                    w = sample_weight[i]
+
+                impurity_right[0] += (<double>fabs((<double> y_ik) -
+                                                  <double> median)) * w
         impurity_right[0] /= <double>((self.weighted_n_right) *
                                       self.n_outputs)
 

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1291,7 +1291,7 @@ cdef class MAE(RegressionCriterion):
 
                 impurity_left += fabs(y_ik - median) * w
         p_impurity_left[0] = impurity_left / (self.weighted_n_left * 
-                                         self.n_outputs)
+                                              self.n_outputs)
 
         for k in range(self.n_outputs):
             median = (<WeightedMedianCalculator> right_child[k]).get_median()
@@ -1305,7 +1305,7 @@ cdef class MAE(RegressionCriterion):
 
                 impurity_right += fabs(y_ik - median) * w
         p_impurity_right[0] = impurity_right / (self.weighted_n_right * 
-                                           self.n_outputs)
+                                                self.n_outputs)
 
 
 cdef class FriedmanMSE(MSE):

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1290,7 +1290,7 @@ cdef class MAE(RegressionCriterion):
                     w = sample_weight[i]
 
                 impurity_left += fabs(y_ik - median) * w
-        p_impurity_left[0] = imp_left / (self.weighted_n_left * 
+        p_impurity_left[0] = impurity_left / (self.weighted_n_left * 
                                          self.n_outputs)
 
         for k in range(self.n_outputs):
@@ -1304,7 +1304,7 @@ cdef class MAE(RegressionCriterion):
                     w = sample_weight[i]
 
                 impurity_right += fabs(y_ik - median) * w
-        p_impurity_right[0] = imp_right / (self.weighted_n_right * 
+        p_impurity_right[0] = impurity_right / (self.weighted_n_right * 
                                            self.n_outputs)
 
 

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1252,8 +1252,7 @@ cdef class MAE(RegressionCriterion):
 
                 impurity += fabs(y_ik - self.node_medians[k]) * w
 
-        return <double>(impurity / (self.weighted_n_node_samples *
-                                    self.n_outputs))
+        return impurity / (self.weighted_n_node_samples * self.n_outputs)
 
     cdef void children_impurity(self, double* impurity_left,
                                 double* impurity_right) nogil:

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1252,7 +1252,8 @@ cdef class MAE(RegressionCriterion):
 
                 impurity += fabs(y_ik - self.node_medians[k]) * w
 
-        return <double>(impurity / (self.weighted_n_node_samples *                              self.n_outputs))
+        return <double>(impurity / (self.weighted_n_node_samples *
+                                    self.n_outputs))
 
     cdef void children_impurity(self, double* impurity_left,
                                 double* impurity_right) nogil:

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1254,8 +1254,8 @@ cdef class MAE(RegressionCriterion):
 
         return impurity / (self.weighted_n_node_samples * self.n_outputs)
 
-    cdef void children_impurity(self, double* impurity_left,
-                                double* impurity_right) nogil:
+    cdef void children_impurity(self, double* p_impurity_left,
+                                double* p_impurity_right) nogil:
         """Evaluate the impurity in children nodes, i.e. the impurity of the
            left child (samples[start:pos]) and the impurity the right child
            (samples[pos:end]).
@@ -1273,14 +1273,11 @@ cdef class MAE(RegressionCriterion):
         cdef DOUBLE_t y_ik
         cdef DOUBLE_t median
         cdef DOUBLE_t w = 1.0
-        cdef DOUBLE_t imp_left = 0.0
-        cdef DOUBLE_t imp_right = 0.0
+        cdef DOUBLE_t impurity_left = 0.0
+        cdef DOUBLE_t impurity_right = 0.0
 
         cdef void** left_child = <void**> self.left_child.data
         cdef void** right_child = <void**> self.right_child.data
-
-        impurity_left[0] = 0.0
-        impurity_right[0] = 0.0
 
         for k in range(self.n_outputs):
             median = (<WeightedMedianCalculator> left_child[k]).get_median()
@@ -1292,8 +1289,9 @@ cdef class MAE(RegressionCriterion):
                 if sample_weight != NULL:
                     w = sample_weight[i]
 
-                imp_left += fabs(y_ik - median) * w
-        impurity_left[0] = imp_left / (self.weighted_n_left * self.n_outputs)
+                impurity_left += fabs(y_ik - median) * w
+        p_impurity_left[0] = imp_left / (self.weighted_n_left * 
+                                         self.n_outputs)
 
         for k in range(self.n_outputs):
             median = (<WeightedMedianCalculator> right_child[k]).get_median()
@@ -1305,8 +1303,9 @@ cdef class MAE(RegressionCriterion):
                 if sample_weight != NULL:
                     w = sample_weight[i]
 
-                imp_right += fabs(y_ik - median) * w
-        impurity_right[0] = imp_right / (self.weighted_n_right * self.n_outputs)
+                impurity_right += fabs(y_ik - median) * w
+        p_impurity_right[0] = imp_right / (self.weighted_n_right * 
+                                           self.n_outputs)
 
 
 cdef class FriedmanMSE(MSE):

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1293,8 +1293,8 @@ cdef class MAE(RegressionCriterion):
                     w = sample_weight[i]
 
                 imp_left += fabs(y_ik - median) * w
-        impurity_left[0] = <double> (imp_left / (self.weighted_n_left *
-                                     self.n_outputs))
+        impurity_left[0] = (imp_left / (self.weighted_n_left *
+                                        self.n_outputs))
 
         for k in range(self.n_outputs):
             median = (<WeightedMedianCalculator> right_child[k]).get_median()
@@ -1307,8 +1307,8 @@ cdef class MAE(RegressionCriterion):
                     w = sample_weight[i]
 
                 imp_right += fabs(y_ik - median) * w
-        impurity_right[0] = <double> (imp_right / (self.weighted_n_right *
-                                      self.n_outputs))
+        impurity_right[0] = (imp_right / (self.weighted_n_right *
+                                          self.n_outputs))
 
 
 cdef class FriedmanMSE(MSE):

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1252,7 +1252,7 @@ cdef class MAE(RegressionCriterion):
 
                 impurity += fabs(y_ik - self.node_medians[k]) * w
 
-        return impurity / (self.weighted_n_node_samples * self.n_outputs)
+        return <double>(impurity / (self.weighted_n_node_samples * self.n_outputs))
 
     cdef void children_impurity(self, double* impurity_left,
                                 double* impurity_right) nogil:
@@ -1293,7 +1293,7 @@ cdef class MAE(RegressionCriterion):
                     w = sample_weight[i]
 
                 imp_left += fabs(y_ik - median) * w
-        impurity_left[0] = (imp_left / (self.weighted_n_left *
+        impurity_left[0] = <double>(imp_left / (self.weighted_n_left *
                                         self.n_outputs))
 
         for k in range(self.n_outputs):
@@ -1307,7 +1307,7 @@ cdef class MAE(RegressionCriterion):
                     w = sample_weight[i]
 
                 imp_right += fabs(y_ik - median) * w
-        impurity_right[0] = (imp_right / (self.weighted_n_right *
+        impurity_right[0] = <double>(imp_right / (self.weighted_n_right *
                                           self.n_outputs))
 
 

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1293,8 +1293,7 @@ cdef class MAE(RegressionCriterion):
                     w = sample_weight[i]
 
                 imp_left += fabs(y_ik - median) * w
-        impurity_left[0] = <double> (imp_left / (self.weighted_n_left *
-                                     self.n_outputs))
+        impurity_left[0] = imp_left / (self.weighted_n_left * self.n_outputs)
 
         for k in range(self.n_outputs):
             median = (<WeightedMedianCalculator> right_child[k]).get_median()
@@ -1307,8 +1306,7 @@ cdef class MAE(RegressionCriterion):
                     w = sample_weight[i]
 
                 imp_right += fabs(y_ik - median) * w
-        impurity_right[0] = <double> (imp_right / (self.weighted_n_right *
-                                      self.n_outputs))
+        impurity_right[0] = imp_right / (self.weighted_n_right * self.n_outputs)
 
 
 cdef class FriedmanMSE(MSE):

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1698,13 +1698,13 @@ def test_mae():
     dt_mae = DecisionTreeRegressor(random_state=0, criterion="mae",
                                    max_leaf_nodes=2)
     dt_mae.fit([[3], [5], [3], [8], [5]], [6, 7, 3, 4, 3])
-    assert_array_equal(dt_mae.tree_.impurity, [1.4, 1.5, 4.0/3.0])
+    assert_array_equal(dt_mae.tree_.impurity, [1.4, 1.5, 4.0 / 3.0])
     assert_array_equal(dt_mae.tree_.value.flat, [4, 4.5, 4.0])
 
     dt_mae.fit([[3], [5], [3], [8], [5]], [6, 7, 3, 4, 3],
                [0.6, 0.3, 0.1, 1.0, 0.3])
     assert_array_almost_equal(dt_mae.tree_.impurity,
-                              [2.5/2.3, 0.3/0.7, 1.2/1.6])
+                              [2.5 / 2.3, 0.3 / 0.7, 1.2 / 1.6])
     assert_array_equal(dt_mae.tree_.value.flat, [4.0, 6.0, 4.0])
 
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1780,7 +1780,7 @@ def test_mae():
 
     # Test MAE where all sample weights are uniform:
     dt_mae.fit(X=[[3], [5], [3], [8], [5]], y=[6, 7, 3, 4, 3], 
-               sample_weight = np.ones(5))
+               sample_weight=np.ones(5))
     assert_array_equal(dt_mae.tree_.impurity, [1.4, 1.5, 4.0 / 3.0])
     assert_array_equal(dt_mae.tree_.value.flat, [4, 4.5, 4.0])
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1697,7 +1697,7 @@ def test_mae():
     # on small toy dataset
     dt_mae = DecisionTreeRegressor(random_state=0, criterion="mae",
                                    max_leaf_nodes=2)
- 
+
     # Test MAE where all sample weights are uniform:
     dt_mae.fit([[3], [5], [3], [8], [5]], [6, 7, 3, 4, 3], np.ones(5))
     assert_array_equal(dt_mae.tree_.impurity, [1.4, 1.5, 4.0 / 3.0])

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1777,7 +1777,7 @@ def test_mae():
     assert_array_equal(dt_mae.tree_.value.flat, [4.0, 6.0, 4.0])
 
     # Test MAE where all sample weights are uniform:
-    dt_mae.fit(X=[[3], [5], [3], [8], [5]], y=[6, 7, 3, 4, 3], 
+    dt_mae.fit(X=[[3], [5], [3], [8], [5]], y=[6, 7, 3, 4, 3],
                sample_weight=np.ones(5))
     assert_array_equal(dt_mae.tree_.impurity, [1.4, 1.5, 4.0 / 3.0])
     assert_array_equal(dt_mae.tree_.value.flat, [4, 4.5, 4.0])

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1708,17 +1708,17 @@ def test_mae():
     |sum wt:|  2.3   |
     ------------------
 
-    Because we are dealing with sample weights, we cannot find the median by 
-    simply choosing/averaging the centre value(s), instead we consider the 
+    Because we are dealing with sample weights, we cannot find the median by
+    simply choosing/averaging the centre value(s), instead we consider the
     median where 50% of the cumulative weight is found (in a y sorted data set)
-    . Therefore with regards to this test data, the cumulative weight is >= 50% 
+    . Therefore with regards to this test data, the cumulative weight is >= 50%
     when y = 4.  Therefore:
     Median = 4
 
     For all the samples, we can get the total error by summing:
     Absolute(Median - y) * weight
 
-    I.e., total error = (Absolute(4 - 3) * 0.1) 
+    I.e., total error = (Absolute(4 - 3) * 0.1)
                       + (Absolute(4 - 3) * 0.3)
                       + (Absolute(4 - 4) * 1.0)
                       + (Absolute(4 - 6) * 0.6)
@@ -1746,7 +1746,7 @@ def test_mae():
 
     Impurity is found in the same way:
     Left node Median = 6
-    Total error = (Absolute(6 - 3) * 0.1) 
+    Total error = (Absolute(6 - 3) * 0.1)
                 + (Absolute(6 - 6) * 0.6)
                 = 0.3
 
@@ -1760,7 +1760,7 @@ def test_mae():
     Total error = (Absolute(4 - 3) * 0.3)
                 + (Absolute(4 - 4) * 1.0)
                 + (Absolute(4 - 7) * 0.3)
-                = 1.2 
+                = 1.2
 
     Right Impurity = Total error / total weight
             = 1.2 / 1.6

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1703,7 +1703,8 @@ def test_mae():
 
     dt_mae.fit([[3], [5], [3], [8], [5]], [6, 7, 3, 4, 3],
                [0.6, 0.3, 0.1, 1.0, 0.3])
-    assert_array_equal(dt_mae.tree_.impurity, [7.0/2.3, 3.0/0.7, 4.0/1.6])
+    #check equal to at least 6 decimal places:
+    assert_array_almost_equal((dt_mae.tree_.impurity, [2.5/2.3, 0.3/0.7, 1.2/1.6])
     assert_array_equal(dt_mae.tree_.value.flat, [4.0, 6.0, 4.0])
 
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1697,6 +1697,14 @@ def test_mae():
     # on small toy dataset
     dt_mae = DecisionTreeRegressor(random_state=0, criterion="mae",
                                    max_leaf_nodes=2)
+
+    dt_mae.fit([[3], [5], [3], [8], [5]], [6, 7, 3, 4, 3], np.ones(5))
+    assert_array_equal(dt_mae.tree_.impurity, [1.4, 1.5, 4.0 / 3.0])
+    assert_array_equal(dt_mae.tree_.value.flat, [4, 4.5, 4.0])
+
+    # Not providing a `sample_weight` should create a tree equivalent
+    # to having a `sample_weight` where all weights are 1 i.e.,
+    # we should get the same tree created as the above test:  
     dt_mae.fit([[3], [5], [3], [8], [5]], [6, 7, 3, 4, 3])
     assert_array_equal(dt_mae.tree_.impurity, [1.4, 1.5, 4.0 / 3.0])
     assert_array_equal(dt_mae.tree_.value.flat, [4, 4.5, 4.0])

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1703,7 +1703,8 @@ def test_mae():
 
     dt_mae.fit([[3], [5], [3], [8], [5]], [6, 7, 3, 4, 3],
                [0.6, 0.3, 0.1, 1.0, 0.3])
-    assert_array_almost_equal((dt_mae.tree_.impurity, [2.5/2.3, 0.3/0.7, 1.2/1.6])
+    assert_array_almost_equal((dt_mae.tree_.impurity,
+                               [2.5/2.3, 0.3/0.7, 1.2/1.6])
     assert_array_equal(dt_mae.tree_.value.flat, [4.0, 6.0, 4.0])
 
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1693,29 +1693,103 @@ def test_no_sparse_y_support(name):
 
 
 def test_mae():
-    # Check MAE criterion produces correct results
-    # on small toy dataset
+    ''' 
+    Check MAE criterion produces correct results on small toy dataset:
+
+    ------------------
+    | X | y | weight |
+    ------------------
+    | 3 | 3 |  0.1   |
+    | 5 | 3 |  0.3   |
+    | 8 | 4 |  1.0   |
+    | 3 | 6 |  0.6   |
+    | 5 | 7 |  0.3   |
+    ------------------
+    |sum wt:|  2.3   |
+    ------------------
+
+    Because we are dealing with sample weights, we cannot find the median by 
+    simply choosing/averaging the centre value(s), instead we consider the 
+    median where 50% of the cumulative weight is found (in a y sorted data set)
+    . Therefore with regards to this test data, the cumulative weight is >= 50% 
+    when y = 4.  Therefore:
+    Median = 4
+
+    For all the samples, we can get the total error by summing:
+    Absolute(Median – y) * weight
+
+    I.e., total error = (Absolute(4 - 3) * 0.1) 
+                      + (Absolute(4 - 3) * 0.3)
+                      + (Absolute(4 - 4) * 1.0)
+                      + (Absolute(4 - 6) * 0.6)
+                      + (Absolute(4 - 7) * 0.3)
+                      = 2.5
+
+    Impurity = Total error / total weight
+             = 2.5 / 2.3
+             = 1.08695652173913
+             ------------------
+
+    From this root node, the next best split is between X values of 3 and 5.
+    Thus, we have left and right child nodes:
+
+    LEFT                    RIGHT
+    ------------------      ------------------
+    | X | y | weight |      | X | y | weight |
+    ------------------      ------------------
+    | 3 | 3 |  0.1   |      | 5 | 3 |  0.3   |
+    | 3 | 6 |  0.6   |      | 8 | 4 |  1.0   |
+    ------------------      | 5 | 7 |  0.3   |
+    |sum wt:|  0.7   |      ------------------
+    ------------------      |sum wt:|  1.6   |
+                            ------------------
+
+    Impurity is found in the same way:
+    Left node Median = 6
+    Total error = (Absolute(6 - 3) * 0.1) 
+                + (Absolute(6 - 6) * 0.6)
+                = 0.3
+
+    Left Impurity = Total error / total weight
+            = 0.3 / 0.7
+            = 0.428571428571429
+            -------------------
+
+    Likewise for Right node:
+    Right node Median = 4
+    Total error = (Absolute(4 - 3) * 0.3)
+                + (Absolute(4 - 4) * 1.0)
+                + (Absolute(4 - 7) * 0.3)
+                = 1.2 
+
+    Right Impurity = Total error / total weight
+            = 1.2 / 1.6
+            = 0.75
+            ------
+    '''
+
     dt_mae = DecisionTreeRegressor(random_state=0, criterion="mae",
                                    max_leaf_nodes=2)
 
+    # Test MAE where sample weights are non-uniform (as illustrated above):
+    dt_mae.fit(X=[[3], [5], [3], [8], [5]], y=[6, 7, 3, 4, 3],
+               sample_weight=[0.6, 0.3, 0.1, 1.0, 0.3])
+    assert_array_almost_equal(dt_mae.tree_.impurity,
+                              [2.5 / 2.3, 0.3 / 0.7, 1.2 / 1.6])
+    assert_array_equal(dt_mae.tree_.value.flat, [4.0, 6.0, 4.0])
+
     # Test MAE where all sample weights are uniform:
-    dt_mae.fit([[3], [5], [3], [8], [5]], [6, 7, 3, 4, 3], np.ones(5))
+    dt_mae.fit(X=[[3], [5], [3], [8], [5]], y=[6, 7, 3, 4, 3], 
+               sample_weight = np.ones(5))
     assert_array_equal(dt_mae.tree_.impurity, [1.4, 1.5, 4.0 / 3.0])
     assert_array_equal(dt_mae.tree_.value.flat, [4, 4.5, 4.0])
 
     # Test MAE where a `sample_weight` is not explicitly provided.
     # This is equivalent to providing uniform sample weights, though
     # the internal logic is different:
-    dt_mae.fit([[3], [5], [3], [8], [5]], [6, 7, 3, 4, 3])
+    dt_mae.fit(X=[[3], [5], [3], [8], [5]], y=[6, 7, 3, 4, 3])
     assert_array_equal(dt_mae.tree_.impurity, [1.4, 1.5, 4.0 / 3.0])
     assert_array_equal(dt_mae.tree_.value.flat, [4, 4.5, 4.0])
-
-    # Test MAE where sample weights are non-uniform:
-    dt_mae.fit([[3], [5], [3], [8], [5]], [6, 7, 3, 4, 3],
-               [0.6, 0.3, 0.1, 1.0, 0.3])
-    assert_array_almost_equal(dt_mae.tree_.impurity,
-                              [2.5 / 2.3, 0.3 / 0.7, 1.2 / 1.6])
-    assert_array_equal(dt_mae.tree_.value.flat, [4.0, 6.0, 4.0])
 
 
 def test_criterion_copy():

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1765,8 +1765,8 @@ def test_mae():
     Right Impurity = Total error / total weight
             = 1.2 / 1.6
             = 0.75
-            ------"""
-
+            ------
+    """
     dt_mae = DecisionTreeRegressor(random_state=0, criterion="mae",
                                    max_leaf_nodes=2)
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1703,8 +1703,8 @@ def test_mae():
 
     dt_mae.fit([[3], [5], [3], [8], [5]], [6, 7, 3, 4, 3],
                [0.6, 0.3, 0.1, 1.0, 0.3])
-    assert_array_almost_equal((dt_mae.tree_.impurity,
-                               [2.5/2.3, 0.3/0.7, 1.2/1.6])
+    assert_array_almost_equal(dt_mae.tree_.impurity,
+                              [2.5/2.3, 0.3/0.7, 1.2/1.6])
     assert_array_equal(dt_mae.tree_.value.flat, [4.0, 6.0, 4.0])
 
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -18,6 +18,7 @@ from sklearn.random_projection import sparse_random_matrix
 from sklearn.metrics import accuracy_score
 from sklearn.metrics import mean_squared_error
 
+from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_almost_equal
@@ -1693,8 +1694,7 @@ def test_no_sparse_y_support(name):
 
 
 def test_mae():
-    ''' 
-    Check MAE criterion produces correct results on small toy dataset:
+    """Check MAE criterion produces correct results on small toy dataset:
 
     ------------------
     | X | y | weight |
@@ -1716,7 +1716,7 @@ def test_mae():
     Median = 4
 
     For all the samples, we can get the total error by summing:
-    Absolute(Median – y) * weight
+    Absolute(Median - y) * weight
 
     I.e., total error = (Absolute(4 - 3) * 0.1) 
                       + (Absolute(4 - 3) * 0.3)
@@ -1765,8 +1765,7 @@ def test_mae():
     Right Impurity = Total error / total weight
             = 1.2 / 1.6
             = 0.75
-            ------
-    '''
+            ------"""
 
     dt_mae = DecisionTreeRegressor(random_state=0, criterion="mae",
                                    max_leaf_nodes=2)
@@ -1774,8 +1773,7 @@ def test_mae():
     # Test MAE where sample weights are non-uniform (as illustrated above):
     dt_mae.fit(X=[[3], [5], [3], [8], [5]], y=[6, 7, 3, 4, 3],
                sample_weight=[0.6, 0.3, 0.1, 1.0, 0.3])
-    assert_array_almost_equal(dt_mae.tree_.impurity,
-                              [2.5 / 2.3, 0.3 / 0.7, 1.2 / 1.6])
+    assert_allclose(dt_mae.tree_.impurity, [2.5 / 2.3, 0.3 / 0.7, 1.2 / 1.6])
     assert_array_equal(dt_mae.tree_.value.flat, [4.0, 6.0, 4.0])
 
     # Test MAE where all sample weights are uniform:

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1693,22 +1693,24 @@ def test_no_sparse_y_support(name):
 
 
 def test_mae():
-    # check MAE criterion produces correct results
+    # Check MAE criterion produces correct results
     # on small toy dataset
     dt_mae = DecisionTreeRegressor(random_state=0, criterion="mae",
                                    max_leaf_nodes=2)
-
+ 
+    # Test MAE where all sample weights are uniform:
     dt_mae.fit([[3], [5], [3], [8], [5]], [6, 7, 3, 4, 3], np.ones(5))
     assert_array_equal(dt_mae.tree_.impurity, [1.4, 1.5, 4.0 / 3.0])
     assert_array_equal(dt_mae.tree_.value.flat, [4, 4.5, 4.0])
 
-    # Not providing a `sample_weight` should create a tree equivalent
-    # to having a `sample_weight` where all weights are 1 i.e.,
-    # we should get the same tree created as the above test:  
+    # Test MAE where a `sample_weight` is not explicitly provided.
+    # This is equivalent to providing uniform sample weights, though
+    # the internal logic is different:
     dt_mae.fit([[3], [5], [3], [8], [5]], [6, 7, 3, 4, 3])
     assert_array_equal(dt_mae.tree_.impurity, [1.4, 1.5, 4.0 / 3.0])
     assert_array_equal(dt_mae.tree_.value.flat, [4, 4.5, 4.0])
 
+    # Test MAE where sample weights are non-uniform:
     dt_mae.fit([[3], [5], [3], [8], [5]], [6, 7, 3, 4, 3],
                [0.6, 0.3, 0.1, 1.0, 0.3])
     assert_array_almost_equal(dt_mae.tree_.impurity,

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1703,7 +1703,6 @@ def test_mae():
 
     dt_mae.fit([[3], [5], [3], [8], [5]], [6, 7, 3, 4, 3],
                [0.6, 0.3, 0.1, 1.0, 0.3])
-    #check equal to at least 6 decimal places:
     assert_array_almost_equal((dt_mae.tree_.impurity, [2.5/2.3, 0.3/0.7, 1.2/1.6])
     assert_array_equal(dt_mae.tree_.value.flat, [4.0, 6.0, 4.0])
 


### PR DESCRIPTION
Tree MAE is not considering sample_weights when calculating impurity!

In the proposed fix, you will see I have multiplied by the sample weight after applying the absolute to the difference (not before). This is in line with the consensus / discussion found here, where negative sample weights are considered: #3774 (and also because during initialisation, self.weighted_n_node_samples is a summation of the sample weights with no "absolute" applied (this is used in the impurity division calc)).

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes: #11460 (Tree MAE is not considering sample_weights when calculating impurity!)
