### PR TITLE
[MRG] MNT Use `clip` to make dictionary and/or code positive

### DIFF
--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -160,7 +160,7 @@ def _sparse_encode(X, dictionary, gram, cov=None, algorithm='lasso_lars',
         new_code = ((np.sign(cov) *
                     np.maximum(np.abs(cov) - regularization, 0)).T)
         if positive:
-            new_code[new_code < 0] = 0
+            np.clip(new_code, 0, None, out=new_code)
 
     elif algorithm == 'omp':
         # TODO: Should verbose argument be passed to this?

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -383,7 +383,7 @@ def _update_dict(dictionary, Y, code, verbose=False, return_r2=False,
         R = ger(1.0, dictionary[:, k], code[k, :], a=R, overwrite_a=True)
         dictionary[:, k] = np.dot(R, code[k, :].T)
         if positive:
-            dictionary[:, k][dictionary[:, k] < 0] = 0.0
+            np.clip(dictionary[:, k], 0, None, out=dictionary[:, k])
         # Scale k'th atom
         atom_norm_square = np.dot(dictionary[:, k], dictionary[:, k])
         if atom_norm_square < 1e-20:
@@ -394,7 +394,7 @@ def _update_dict(dictionary, Y, code, verbose=False, return_r2=False,
                 print("Adding new random atom")
             dictionary[:, k] = random_state.randn(n_features)
             if positive:
-                dictionary[:, k][dictionary[:, k] < 0] = 0.0
+                np.clip(dictionary[:, k], 0, None, out=dictionary[:, k])
             # Setting corresponding coefs to 0
             code[k, :] = 0.0
             dictionary[:, k] /= sqrt(np.dot(dictionary[:, k],


### PR DESCRIPTION
Instead of finding a mask of negative values and setting them to zero, use NumPy's `clip` to replace all values less than zero with zero. These have the same effect other than `clip` is a bit faster as it avoids creating an intermediate bool array for setting values instead doing this in-place.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
