### PR TITLE
[MRG] Make imputers picklable

### DIFF
--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -42,7 +42,7 @@ __all__ = [
 
 def _get_mask(X, value_to_mask):
     """Compute the boolean mask X == missing_values."""
-    if value_to_mask is np.nan:
+    if isinstance(value_to_mask, float) and np.isnan(value_to_mask):
         if X.dtype.kind == "f":
             return np.isnan(X)
         elif X.dtype.kind in ("i", "u"):

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -42,7 +42,7 @@ __all__ = [
 
 def _get_mask(X, value_to_mask):
     """Compute the boolean mask X == missing_values."""
-    if isinstance(value_to_mask, float) and np.isnan(value_to_mask):
+    if is_scalar_nan(value_to_mask):
         if X.dtype.kind == "f":
             return np.isnan(X)
         elif X.dtype.kind in ("i", "u"):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -51,7 +51,6 @@ from sklearn.feature_selection import SelectKBest
 from sklearn.svm.base import BaseLibSVM
 from sklearn.linear_model.stochastic_gradient import BaseSGD
 from sklearn.pipeline import make_pipeline
-from sklearn.exceptions import ConvergenceWarning
 from sklearn.exceptions import DataConversionWarning
 from sklearn.exceptions import SkipTestWarning
 from sklearn.model_selection import train_test_split

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1193,7 +1193,7 @@ def check_estimators_pickle(name, estimator_orig):
     if name in ALLOW_NAN:
         # set random 10 elements to be np.nan
         rng = np.random.RandomState(42)
-        mask = rng.choice(X.size, 10, replace=True)
+        mask = rng.choice(X.size, 10, replace=False)
         X.reshape(-1)[mask] = np.nan
         estimator.fit(X, y)
 
@@ -1209,12 +1209,11 @@ def check_estimators_pickle(name, estimator_orig):
         for method in nan_result:
             unpickled_nan_result = getattr(unpickled_estimator, method)(X)
             if name == 'ChainedImputer':
-                assert_allclose_dense_sparse(nan_result[method],
-                                             unpickled_nan_result,
-                                             rtol=1e-5, atol=0.1)
+                tol = {'rtol': 1e-5, 'atol': 0.1}
             else:
+                tol = {}
                 assert_allclose_dense_sparse(nan_result[method],
-                                             unpickled_nan_result)
+                                             unpickled_nan_result, **tol)
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1209,9 +1209,12 @@ def check_estimators_pickle(name, estimator_orig):
         for method in nan_result:
             unpickled_nan_result = getattr(unpickled_estimator, method)(X)
             if name == 'ChainedImputer':
-                assert_allclose_dense_sparse(nan_result[method], unpickled_nan_result, rtol=1e-5, atol=0.1)
+                assert_allclose_dense_sparse(nan_result[method],
+                                             unpickled_nan_result,
+                                             rtol=1e-5, atol=0.1)
             else:
-                assert_allclose_dense_sparse(nan_result[method], unpickled_nan_result)
+                assert_allclose_dense_sparse(nan_result[method],
+                                             unpickled_nan_result)
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1166,9 +1166,9 @@ def check_estimators_pickle(name, estimator_orig):
         X += 1
     X = pairwise_estimator_convert_X(X, estimator_orig, kernel=rbf_kernel)
 
-    # check if input with nans pickles properly
+    # include NaN values when the estimator should deal with them
     if name in ALLOW_NAN:
-        # set random 10 elements to be np.nan
+        # set randomly 10 elements to np.nan
         rng = np.random.RandomState(42)
         mask = rng.choice(X.size, 10, replace=False)
         X.reshape(-1)[mask] = np.nan

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1194,7 +1194,7 @@ def check_estimators_pickle(name, estimator_orig):
         # set random 10 elements to be np.nan
         rng = np.random.RandomState(42)
         mask = rng.choice(X.size, 10, replace=True)
-        X[mask] = np.nan
+        X.reshape(-1)[mask] = np.nan
         estimator.fit(X, y)
 
         nan_result = dict()

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1192,8 +1192,10 @@ def check_estimators_pickle(name, estimator_orig):
 
     # check if input with nans pickles properly
     if name in ALLOW_NAN:
-        # set random 10 elements to be corrupted
-        X.ravel()[np.random.choice(X.size, 10, replace=False)] = np.nan
+        # set random 10 elements to be np.nan
+        rng = np.random.RandomState(42)
+        mask = rng.choice(X.size, 10, replace=True)
+        X[mask] = np.nan
         estimator.fit(X, y)
 
         nan_result = dict()
@@ -1203,8 +1205,6 @@ def check_estimators_pickle(name, estimator_orig):
 
         # pickle and unpickle!
         pickled_estimator = pickle.dumps(estimator)
-        if estimator.__module__.startswith('sklearn.'):
-            assert_true(b"version" in pickled_estimator)
         unpickled_estimator = pickle.loads(pickled_estimator)
 
         for method in nan_result:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1181,25 +1181,20 @@ def check_estimators_pickle(name, estimator_orig):
     set_random_state(estimator)
     estimator.fit(X, y)
 
-    result = dict()
-    for method in check_methods:
-        if hasattr(estimator, method):
-            result[method] = getattr(estimator, method)(X)
-
     # pickle and unpickle!
     pickled_estimator = pickle.dumps(estimator)
     if estimator.__module__.startswith('sklearn.'):
         assert_true(b"version" in pickled_estimator)
     unpickled_estimator = pickle.loads(pickled_estimator)
 
+    result = dict()
+    for method in check_methods:
+        if hasattr(estimator, method):
+            result[method] = getattr(estimator, method)(X)
+
     for method in result:
         unpickled_result = getattr(unpickled_estimator, method)(X)
-        if name == 'ChainedImputer':
-            tol = {'rtol': 1e-5, 'atol': 0.1}
-        else:
-            tol = {}
-        assert_allclose_dense_sparse(result[method],
-                                     unpickled_result, **tol)
+        assert_allclose_dense_sparse(result[method], unpickled_result)
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1212,8 +1212,8 @@ def check_estimators_pickle(name, estimator_orig):
                 tol = {'rtol': 1e-5, 'atol': 0.1}
             else:
                 tol = {}
-                assert_allclose_dense_sparse(nan_result[method],
-                                             unpickled_nan_result, **tol)
+            assert_allclose_dense_sparse(nan_result[method],
+                                         unpickled_nan_result, **tol)
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #11462 


#### What does this implement/fix? Explain your changes.

Changes the problematic line (identified in the issue) to properly identify `np.nan`s after pickling. 

Test added to `util.estimator_checks` to check that all estimators that allow `np.nan`s properly pickle models that are fitted with data containing `np.nan`s
