### PR TITLE
MNT: Use NumPy clip's instead of assigning mask

### DIFF
--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -278,7 +278,7 @@ def test_beta_divergence():
     # initialization
     rng = np.random.mtrand.RandomState(42)
     X = rng.randn(n_samples, n_features)
-    X[X < 0] = 0.
+    np.clip(X, 0, None, out=X)
     X_csr = sp.csr_matrix(X)
     W, H = nmf._initialize_nmf(X, n_components, init='random', random_state=42)
 
@@ -298,7 +298,7 @@ def test_special_sparse_dot():
     n_components = 3
     rng = np.random.mtrand.RandomState(42)
     X = rng.randn(n_samples, n_features)
-    X[X < 0] = 0.
+    np.clip(X, 0, None, out=X)
     X_csr = sp.csr_matrix(X)
 
     W = np.abs(rng.randn(n_samples, n_components))
@@ -377,7 +377,7 @@ def test_nmf_negative_beta_loss():
 
     rng = np.random.mtrand.RandomState(42)
     X = rng.randn(n_samples, n_features)
-    X[X < 0] = 0
+    np.clip(X, 0, None, out=X)
     X_csr = sp.csr_matrix(X)
 
     def _assert_nmf_no_nan(X, beta_loss):

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -285,7 +285,7 @@ def _samme_proba(estimator, n_classes, X):
     # Displace zero probabilities so the log is defined.
     # Also fix negative elements which may occur with
     # negative sample weights.
-    proba[proba < np.finfo(proba.dtype).eps] = np.finfo(proba.dtype).eps
+    np.clip(proba, np.finfo(proba.dtype).eps, None, out=proba)
     log_proba = np.log(proba)
 
     return (n_classes - 1) * (log_proba - (1. / n_classes)
@@ -517,7 +517,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         # Also fix negative elements which may occur with
         # negative sample weights.
         proba = y_predict_proba  # alias for readability
-        proba[proba < np.finfo(proba.dtype).eps] = np.finfo(proba.dtype).eps
+        np.clip(proba, np.finfo(proba.dtype).eps, None, out=proba)
 
         # Boost weight using multi-class AdaBoost SAMME.R alg
         estimator_weight = (-1. * self.learning_rate

--- a/sklearn/gaussian_process/correlation_models.py
+++ b/sklearn/gaussian_process/correlation_models.py
@@ -238,7 +238,7 @@ def cubic(theta, d):
     else:
         td = np.abs(d) * theta.reshape(1, n_features)
 
-    td[td > 1.] = 1.
+    np.clip(td, None, 1., out=td)
     ss = 1. - td ** 2. * (3. - 2. * td)
     r = np.prod(ss, 1)
 
@@ -290,7 +290,7 @@ def linear(theta, d):
     else:
         td = np.abs(d) * theta.reshape(1, n_features)
 
-    td[td > 1.] = 1.
+    np.clip(td, None, 1., out=td)
     ss = 1. - td
     r = np.prod(ss, 1)
 

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -752,7 +752,7 @@ class ChainedImputer(BaseEstimator, TransformerMixin):
         # np.corrcoef is not defined for features with zero std
         abs_corr_mat[np.isnan(abs_corr_mat)] = tolerance
         # ensures exploration, i.e. at least some probability of sampling
-        abs_corr_mat[abs_corr_mat < tolerance] = tolerance
+        np.clip(abs_corr_mat, tolerance, None, out=abs_corr_mat)
         # features are not their own neighbors
         np.fill_diagonal(abs_corr_mat, 0)
         # needs to sum to 1 for np.random.choice sampling

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1910,7 +1910,7 @@ def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None):
 
     losses = 1 - margin
     # The hinge_loss doesn't penalize good enough predictions.
-    losses[losses <= 0] = 0
+    np.clip(losses, 0, None, out=losses)
     return np.average(losses, weights=sample_weight)
 
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1460,7 +1460,7 @@ def test_hinge_loss_multiclass():
         1 - pred_decision[4][3] + pred_decision[4][2],
         1 - pred_decision[5][2] + pred_decision[5][3]
     ])
-    dummy_losses[dummy_losses <= 0] = 0
+    np.clip(dummy_losses, 0, None, out=dummy_losses)
     dummy_hinge_loss = np.mean(dummy_losses)
     assert_equal(hinge_loss(y_true, pred_decision),
                  dummy_hinge_loss)
@@ -1498,7 +1498,7 @@ def test_hinge_loss_multiclass_with_missing_labels():
         1 - pred_decision[3][1] + pred_decision[3][2],
         1 - pred_decision[4][2] + pred_decision[4][3]
     ])
-    dummy_losses[dummy_losses <= 0] = 0
+    np.clip(dummy_losses, 0, None, out=dummy_losses)
     dummy_hinge_loss = np.mean(dummy_losses)
     assert_equal(hinge_loss(y_true, pred_decision, labels=labels),
                  dummy_hinge_loss)
@@ -1525,7 +1525,7 @@ def test_hinge_loss_multiclass_invariance_lists():
         1 - pred_decision[4][3] + pred_decision[4][2],
         1 - pred_decision[5][2] + pred_decision[5][3]
     ])
-    dummy_losses[dummy_losses <= 0] = 0
+    np.clip(dummy_losses, 0, None, out=dummy_losses)
     dummy_hinge_loss = np.mean(dummy_losses)
     assert_equal(hinge_loss(y_true, pred_decision),
                  dummy_hinge_loss)

--- a/sklearn/neighbors/nearest_centroid.py
+++ b/sklearn/neighbors/nearest_centroid.py
@@ -161,7 +161,7 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
             # it becomes zero.
             signs = np.sign(deviation)
             deviation = (np.abs(deviation) - self.shrink_threshold)
-            deviation[deviation < 0] = 0
+            np.clip(deviation, 0, None, out=deviation)
             deviation *= signs
             # Now adjust the centroids using the deviation
             msd = ms * deviation


### PR DESCRIPTION
Instead of finding a mask of values above/below a threshold and setting them to that threshold, use NumPy's `clip` to replace all values beyond the threshold with the threshold. Using `clip` here has the same effect as using the mask and assigning except that `clip` is a bit faster as it avoids creating an intermediate bool array for setting values and it does the operation in-place.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Follow-up to [this comment]( https://github.com/scikit-learn/scikit-learn/pull/11468#issuecomment-403849880 ).

#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
