### PR TITLE
[MRG] RBFSampler example added to its class docstring [See #3846]

### DIFF
--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -55,11 +55,12 @@ class RBFSampler(BaseEstimator, TransformerMixin):
     >>> clf = SGDClassifier(max_iter=5)
     >>> clf.fit(X_features, y)
     ... # doctest: +NORMALIZE_WHITESPACE
-    SGDClassifier(alpha=0.0001, average=False, class_weight=None, epsilon=0.1,
-           eta0=0.0, fit_intercept=True, l1_ratio=0.15,
-           learning_rate='optimal', loss='hinge', max_iter=5, n_iter=None,
-           n_jobs=1, penalty='l2', power_t=0.5, random_state=None,
-           shuffle=True, tol=None, verbose=0, warm_start=False)
+    SGDClassifier(alpha=0.0001, average=False, class_weight=None,
+           early_stopping=False, epsilon=0.1, eta0=0.0, fit_intercept=True,
+           l1_ratio=0.15, learning_rate='optimal', loss='hinge', max_iter=5,
+           n_iter=None, n_iter_no_change=5, n_jobs=1, penalty='l2',
+           power_t=0.5, random_state=None, shuffle=True, tol=None,
+           validation_fraction=0.1, verbose=0, warm_start=False)
     >>> clf.score(X_features, y)
     1.0
 

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -44,6 +44,25 @@ class RBFSampler(BaseEstimator, TransformerMixin):
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
+    Examples
+    --------
+    >>> from sklearn.kernel_approximation import RBFSampler
+    >>> from sklearn.linear_model import SGDClassifier
+    >>> X = [[0, 0], [1, 1], [1, 0], [0, 1]]
+    >>> y = [0, 0, 1, 1]
+    >>> rbf_feature = RBFSampler(gamma=1, random_state=1)
+    >>> X_features = rbf_feature.fit_transform(X)
+    >>> clf = SGDClassifier(max_iter=5)
+    >>> clf.fit(X_features, y)
+    ... # doctest: +NORMALIZE_WHITESPACE
+    SGDClassifier(alpha=0.0001, average=False, class_weight=None, epsilon=0.1,
+           eta0=0.0, fit_intercept=True, l1_ratio=0.15,
+           learning_rate='optimal', loss='hinge', max_iter=5, n_iter=None,
+           n_jobs=1, penalty='l2', power_t=0.5, random_state=None,
+           shuffle=True, tol=None, verbose=0, warm_start=False)
+    >>> clf.score(X_features, y)
+    1.0
+
     Notes
     -----
     See "Random Features for Large-Scale Kernel Machines" by A. Rahimi and


### PR DESCRIPTION
See #3846 

This PR adds an example to the `RBFSampler`'s docstring.