### PR TITLE
[MRG] SkewedChi2Sampler example added to its class's docstring [See #3846]

### DIFF
--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -132,6 +132,27 @@ class SkewedChi2Sampler(BaseEstimator, TransformerMixin):
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
+    Examples
+    --------
+    >>> from sklearn.kernel_approximation import SkewedChi2Sampler
+    >>> from sklearn.linear_model import SGDClassifier
+    >>> X = [[0, 0], [1, 1], [1, 0], [0, 1]]
+    >>> y = [0, 0, 1, 1]
+    >>> chi2_feature = SkewedChi2Sampler(skewedness=.01,
+    ...                                  n_components=10,
+    ...                                  random_state=0)
+    >>> X_features = chi2_feature.fit_transform(X, y)
+    >>> clf = SGDClassifier(max_iter=10)
+    >>> clf.fit(X_features, y)
+    SGDClassifier(alpha=0.0001, average=False, class_weight=None,
+           early_stopping=False, epsilon=0.1, eta0=0.0, fit_intercept=True,
+           l1_ratio=0.15, learning_rate='optimal', loss='hinge', max_iter=10,
+           n_iter=None, n_iter_no_change=5, n_jobs=1, penalty='l2',
+           power_t=0.5, random_state=None, shuffle=True, tol=None,
+           validation_fraction=0.1, verbose=0, warm_start=False)
+    >>> clf.score(X_features, y)
+    1.0
+
     References
     ----------
     See "Random Fourier Approximations for Skewed Multiplicative Histogram


### PR DESCRIPTION
See #3846 

This PR adds an example to the `SkewedChi2Sampler`'s docstring.