### PR TITLE
[MRG+2] AffinityPropagation example added to its class's docstring [See #3846]

### DIFF
--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -297,8 +297,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
     >>> X = np.array([[1, 2], [1, 4], [1, 0],
     ...               [4, 2], [4, 4], [4, 0]])
     >>> clustering = AffinityPropagation().fit(X)
-    >>> clustering
-    ... # doctest: +NORMALIZE_WHITESPACE
+    >>> clustering # doctest: +NORMALIZE_WHITESPACE
     AffinityPropagation(affinity='euclidean', convergence_iter=15, copy=True,
               damping=0.5, max_iter=200, preference=None, verbose=False)
     >>> clustering.labels_

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -290,6 +290,25 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
     n_iter_ : int
         Number of iterations taken to converge.
 
+    Examples
+    --------
+    >>> from sklearn.cluster import AffinityPropagation
+    >>> import numpy as np
+    >>> X = np.array([[1, 2], [1, 4], [1, 0],
+    ...               [4, 2], [4, 4], [4, 0]])
+    >>> clustering = AffinityPropagation().fit(X)
+    >>> clustering
+    ... # doctest: +NORMALIZE_WHITESPACE
+    AffinityPropagation(affinity='euclidean', convergence_iter=15, copy=True,
+              damping=0.5, max_iter=200, preference=None, verbose=False)
+    >>> clustering.labels_
+    array([0, 0, 0, 1, 1, 1])
+    >>> clustering.predict([[0, 0], [4, 4]])
+    array([0, 1])
+    >>> clustering.cluster_centers_
+    array([[1, 2],
+           [4, 2]])
+
     Notes
     -----
     For an example, see :ref:`examples/cluster/plot_affinity_propagation.py


### PR DESCRIPTION
See #3846 

This PR adds an example to the `AffinityPropagation`'s docstring.