### PR TITLE
[MRG+2] Fix sparse simple imputer

### DIFF
--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -56,19 +56,19 @@ that contain the missing values::
 The :class:`SimpleImputer` class also supports sparse matrices::
 
     >>> import scipy.sparse as sp
-    >>> X = sp.csc_matrix([[1, 2], [0, 3], [7, 6]])
-    >>> imp = SimpleImputer(missing_values=0, strategy='mean')
+    >>> X = sp.csc_matrix([[1, 2], [0, -1], [8, 4]])
+    >>> imp = SimpleImputer(missing_values=-1, strategy='mean')
     >>> imp.fit(X)                  # doctest: +NORMALIZE_WHITESPACE
     SimpleImputer(copy=True, fill_value=None, missing_values=0, strategy='mean', verbose=0)
-    >>> X_test = sp.csc_matrix([[0, 2], [6, 0], [7, 6]])
-    >>> print(imp.transform(X_test))      # doctest: +NORMALIZE_WHITESPACE  +ELLIPSIS
-    [[4.          2.        ]
-     [6.          3.666...]
+    >>> X_test = sp.csc_matrix([[-1, 2], [6, -1], [7, 6]])
+    >>> print(imp.transform(X_test))      # doctest: +NORMALIZE_WHITESPACE
+    [[3.          2.        ]
+     [6.          2.        ]
      [7.          6.        ]]
 
-Note that, here, missing values are encoded by 0 and are thus implicitly stored
-in the matrix. This format is thus suitable when there are many more missing
-values than observed values.
+Note that this format is not meant to be used to implicitly store missing values
+in the matrix because it would densify it at transform time. Missing values encoded
+by 0 must be used with dense input.
 
 The :class:`SimpleImputer` class also supports categorical data represented as
 string values or pandas categoricals when using the ``'most_frequent'`` or

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -59,7 +59,7 @@ The :class:`SimpleImputer` class also supports sparse matrices::
     >>> X = sp.csc_matrix([[1, 2], [0, -1], [8, 4]])
     >>> imp = SimpleImputer(missing_values=-1, strategy='mean')
     >>> imp.fit(X)                  # doctest: +NORMALIZE_WHITESPACE
-    SimpleImputer(copy=True, fill_value=None, missing_values=0, strategy='mean', verbose=0)
+    SimpleImputer(copy=True, fill_value=None, missing_values=-1, strategy='mean', verbose=0)
     >>> X_test = sp.csc_matrix([[-1, 2], [6, -1], [7, 6]])
     >>> print(imp.transform(X_test))      # doctest: +NORMALIZE_WHITESPACE
     [[3.          2.        ]

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -62,9 +62,9 @@ The :class:`SimpleImputer` class also supports sparse matrices::
     SimpleImputer(copy=True, fill_value=None, missing_values=-1, strategy='mean', verbose=0)
     >>> X_test = sp.csc_matrix([[-1, 2], [6, -1], [7, 6]])
     >>> print(imp.transform(X_test).toarray())      # doctest: +NORMALIZE_WHITESPACE
-    [[3.          2.        ]
-     [6.          3.        ]
-     [7.          6.        ]]
+    [[3. 2.]
+     [6. 3.]
+     [7. 6.]]
 
 Note that this format is not meant to be used to implicitly store missing values
 in the matrix because it would densify it at transform time. Missing values encoded

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -61,7 +61,7 @@ The :class:`SimpleImputer` class also supports sparse matrices::
     >>> imp.fit(X)                  # doctest: +NORMALIZE_WHITESPACE
     SimpleImputer(copy=True, fill_value=None, missing_values=-1, strategy='mean', verbose=0)
     >>> X_test = sp.csc_matrix([[-1, 2], [6, -1], [7, 6]])
-    >>> print(imp.transform(X_test))      # doctest: +NORMALIZE_WHITESPACE
+    >>> print(imp.transform(X_test).toarray())      # doctest: +NORMALIZE_WHITESPACE
     [[3.          2.        ]
      [6.          2.        ]
      [7.          6.        ]]

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -63,7 +63,7 @@ The :class:`SimpleImputer` class also supports sparse matrices::
     >>> X_test = sp.csc_matrix([[-1, 2], [6, -1], [7, 6]])
     >>> print(imp.transform(X_test).toarray())      # doctest: +NORMALIZE_WHITESPACE
     [[3.          2.        ]
-     [6.          2.        ]
+     [6.          3.        ]
      [7.          6.        ]]
 
 Note that this format is not meant to be used to implicitly store missing values

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -133,7 +133,6 @@ class SimpleImputer(BaseEstimator, TransformerMixin):
         a new copy will always be made, even if `copy=False`:
 
         - If X is not an array of floating values;
-        - If X is sparse and `missing_values=0`;
         - If X is encoded as a CSR matrix.
 
     Attributes

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -705,3 +705,22 @@ def test_chained_imputer_additive_matrix():
                              random_state=rng).fit(X_train)
     X_test_est = imputer.transform(X_test)
     assert_allclose(X_test_filled, X_test_est, atol=0.01)
+
+
+def regression_test_sparse_zeros():
+    # regression test on wrong statistics computation for sparse input with
+    # explicit zeros. (#11495)
+    X = np.array([[0, 0, 0],
+                  [0, 0, 0],
+                  [1, 1, 1]])
+    X = sparse.csc_matrix(X)
+    X[0] = 0
+
+    X_true = np.array([[1, 1, 1],
+                       [1, 1, 1],
+                       [1, 1, 1]])
+
+    imputer = SimpleImputer(missing_values=0, strategy='mean')
+    X_trans = imputer.fit_transform(X)
+
+    assert_array_equal(X_trans, X_true)


### PR DESCRIPTION
Fixes #11495 

Changed the fit in `SimpleImputer` to properly handle sparse input with explicit zeros.
I made it a little more clean also (I guess)

Since the SimpleImputer hasn't been released yet, do I still have do add an entry in the what's new for this bug fix ?