### PR TITLE
[MRG] MNT: Drop boilerplate fused type `typedef`s

### DIFF
--- a/sklearn/cluster/_k_means.pyx
+++ b/sklearn/cluster/_k_means.pyx
@@ -20,9 +20,6 @@ from sklearn.utils.sparsefuncs_fast import assign_rows_csr
 ctypedef np.float64_t DOUBLE
 ctypedef np.int32_t INT
 
-ctypedef floating (*DOT)(int N, floating *X, int incX, floating *Y,
-                         int incY)
-
 cdef extern from "cblas.h":
     double ddot "cblas_ddot"(int N, double *X, int incX, double *Y, int incY)
     float sdot "cblas_sdot"(int N, float *X, int incX, float *Y, int incY)
@@ -58,7 +55,6 @@ cpdef DOUBLE _assign_labels_array(np.ndarray[floating, ndim=2] X,
         DOUBLE inertia = 0.0
         DOUBLE min_dist
         DOUBLE dist
-        DOT dot
 
     if floating is float:
         center_squared_norms = np.zeros(n_clusters, dtype=np.float32)
@@ -130,7 +126,6 @@ cpdef DOUBLE _assign_labels_csr(X, np.ndarray[floating, ndim=1] sample_weight,
         DOUBLE inertia = 0.0
         DOUBLE min_dist
         DOUBLE dist
-        DOT dot
 
     if floating is float:
         center_squared_norms = np.zeros(n_clusters, dtype=np.float32)

--- a/sklearn/linear_model/cd_fast.pyx
+++ b/sklearn/linear_model/cd_fast.pyx
@@ -18,11 +18,6 @@ import warnings
 
 ctypedef np.float64_t DOUBLE
 ctypedef np.uint32_t UINT32_t
-ctypedef floating (*DOT)(int N, floating *X, int incX, floating *Y,
-                         int incY) nogil
-ctypedef void (*AXPY)(int N, floating alpha, floating *X, int incX,
-                      floating *Y, int incY) nogil
-ctypedef floating (*ASUM)(int N, floating *X, int incX) nogil
 
 np.import_array()
 
@@ -162,10 +157,6 @@ def enet_coordinate_descent(np.ndarray[floating, ndim=1] w,
     """
 
     # fused types version of BLAS functions
-    cdef DOT dot
-    cdef AXPY axpy
-    cdef ASUM asum
-
     if floating is float:
         dtype = np.float32
         dot = sdot
@@ -355,9 +346,6 @@ def sparse_enet_coordinate_descent(floating [:] w,
     cdef floating[:] XtA
 
     # fused types version of BLAS functions
-    cdef DOT dot
-    cdef ASUM asum
-
     if floating is float:
         dtype = np.float32
         n_tasks = y.strides[0] / sizeof(float)
@@ -559,10 +547,6 @@ def enet_coordinate_descent_gram(floating[:] w, floating alpha, floating beta,
     """
 
     # fused types version of BLAS functions
-    cdef DOT dot
-    cdef AXPY axpy
-    cdef ASUM asum
-
     if floating is float:
         dtype = np.float32
         dot = sdot
@@ -713,10 +697,6 @@ def enet_coordinate_descent_multi_task(floating[::1, :] W, floating l1_reg,
 
     """
     # fused types version of BLAS functions
-    cdef DOT dot
-    cdef AXPY axpy
-    cdef ASUM asum
-
     if floating is float:
         dtype = np.float32
         dot = sdot


### PR DESCRIPTION
When generating C code from Cython without this code, Cython seems able to figure out that function pointers are needed and what kinds within each function where we assign them. So going through the effort of forward declaring fused type versions of them and declaring the function pointers in each function is unneeded. Not to mention that some of the fused types that were used later are not declared with `cdef`s nor are `ctypedef`s for them above using fused types. Given all of this, it makes more sense to remove this unneeded boilerplate instead of updating it to include the missing definitions and declarations.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
