### PR TITLE
Fix FeatureAgglomeration pooling_func default to "deprecated"

### DIFF
--- a/sklearn/cluster/bicluster.py
+++ b/sklearn/cluster/bicluster.py
@@ -258,6 +258,23 @@ class SpectralCoclustering(BaseSpectral):
     column_labels_ : array-like, shape (n_cols,)
         The bicluster label of each column.
 
+    Examples
+    --------
+    >>> from sklearn.cluster import SpectralCoclustering
+    >>> import numpy as np
+    >>> X = np.array([[1, 2], [1, 4], [1, 0],
+    ...               [4, 2], [4, 4], [4, 0]])
+    >>> clustering = SpectralCoclustering(n_clusters=2).fit(X)
+    >>> clustering.row_labels_
+    array([1, 1, 0, 0, 1, 0], dtype=int32)
+    >>> clustering.column_labels_
+    array([0, 1], dtype=int32)
+    >>> clustering
+    ... # doctest: +NORMALIZE_WHITESPACE
+    SpectralCoclustering(init='k-means++', mini_batch=False, n_clusters=2,
+               n_init=10, n_jobs=1, n_svd_vecs=None, random_state=None,
+               svd_method='randomized')
+
     References
     ----------
 
@@ -388,6 +405,23 @@ class SpectralBiclustering(BaseSpectral):
 
     column_labels_ : array-like, shape (n_cols,)
         Column partition labels.
+
+    Examples
+    --------
+    >>> from sklearn.cluster import SpectralBiclustering
+    >>> import numpy as np
+    >>> X = np.array([[1, 2], [1, 4], [1, 0],
+    ...               [4, 2], [4, 4], [4, 0]])
+    >>> clustering = SpectralBiclustering(n_clusters=2).fit(X)
+    >>> clustering.row_labels_
+    array([0, 0, 1, 1, 0, 1], dtype=int32)
+    >>> clustering.column_labels_
+    array([1, 0], dtype=int32)
+    >>> clustering
+    SpectralBiclustering(init='k-means++', method='bistochastic',
+               mini_batch=False, n_best=3, n_clusters=2, n_components=6,
+               n_init=10, n_jobs=1, n_svd_vecs=None, random_state=None,
+               svd_method='randomized')
 
     References
     ----------

--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -395,6 +395,7 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
     >>> brc = Birch(branching_factor=50, n_clusters=None, threshold=0.5,
     ... compute_labels=True)
     >>> brc.fit(X)
+    ... # doctest: +NORMALIZE_WHITESPACE
     Birch(branching_factor=50, compute_labels=True, copy=True, n_clusters=None,
        threshold=0.5)
     >>> brc.predict(X)

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -233,6 +233,20 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         Cluster labels for each point in the dataset given to fit().
         Noisy samples are given the label -1.
 
+    Examples
+    --------
+    >>> from sklearn.cluster import DBSCAN
+    >>> import numpy as np
+    >>> X = np.array([[1, 2], [2, 2], [2, 3],
+    ...               [8, 7], [8, 8], [9, 8]])
+    >>> clustering = DBSCAN(eps=3, min_samples=2).fit(X)
+    >>> clustering.labels_
+    array([0, 0, 0, 1, 1, 1])
+    >>> clustering
+    ... # doctest: +NORMALIZE_WHITESPACE
+    DBSCAN(algorithm='auto', eps=3, leaf_size=30, metric='euclidean',
+        metric_params=None, min_samples=2, n_jobs=1, p=None)
+
     Notes
     -----
     For an example, see :ref:`examples/cluster/plot_dbscan.py

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -907,7 +907,7 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
     def __init__(self, n_clusters=2, affinity="euclidean",
                  memory=None,
                  connectivity=None, compute_full_tree='auto',
-                 linkage='ward', pooling_func=np.mean):
+                 linkage='ward', pooling_func="deprecated"):
         super(FeatureAgglomeration, self).__init__(
             n_clusters=n_clusters, memory=memory, connectivity=connectivity,
             compute_full_tree=compute_full_tree, linkage=linkage,


### PR DESCRIPTION
`FeatureAgglomeration` subclasses `AgglomerativeClustering` which ignores the value of the `pooling_func` and and shows a warning if it has any value other than `deprecated`.

Therefore the default value of the `pooling_func` in the `__init__` of `FeatureAgglomeration` should also be `deprecated`. This PR does that.