### PR TITLE
[WIP] Fix FeatureAgglomeration deprecated func_pool param

### DIFF
--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -907,7 +907,7 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
     def __init__(self, n_clusters=2, affinity="euclidean",
                  memory=None,
                  connectivity=None, compute_full_tree='auto',
-                 linkage='ward', pooling_func=np.mean):
+                 linkage='ward', pooling_func="deprecated"):
         super(FeatureAgglomeration, self).__init__(
             n_clusters=n_clusters, memory=memory, connectivity=connectivity,
             compute_full_tree=compute_full_tree, linkage=linkage,


### PR DESCRIPTION
`FeatureAgglomeration` subclasses `AgglomerativeClustering` which ignores the value of the `pooling_func` and and shows a warning if it has any value other than `deprecated`.

Therefore the default value of the `pooling_func` in the `__init__` of `FeatureAgglomeration` should also be `deprecated`. This PR does that.