### PR TITLE
[MRG] MNT: Use GEMV in enet_coordinate_descent

### DIFF
--- a/sklearn/linear_model/cd_fast.pyx
+++ b/sklearn/linear_model/cd_fast.pyx
@@ -211,9 +211,11 @@ def enet_coordinate_descent(floating[::1] w,
                 # stopping criterion
 
                 # XtA = np.dot(X.T, R) - beta * w
-                for i in range(n_features):
-                    XtA[i] = (_dot(n_samples, &X[0, i], 1, &R[0], 1)
-                              - beta * w[i])
+                _copy(n_features, &w[0], 1, &XtA[0], 1)
+                _gemv(ColMajor, Trans,
+                      n_samples, n_features, 1.0, &X[0, 0], n_samples,
+                      &R[0], 1,
+                      -beta, &XtA[0], 1)
 
                 if positive:
                     dual_norm_XtA = max(n_features, &XtA[0])


### PR DESCRIPTION
Make use of the BLAS GEMV operation in `enet_coordinate_descent` instead of using DOT in a `for`-loop. They are both semantically equivalent, but the former is likely multithreaded in BLAS implementations while here it is merely a serial loop.