### PR TITLE
[MRG+1] Usage examples added to sklearn.cluster classes [See #3846] 

### DIFF
--- a/sklearn/cluster/bicluster.py
+++ b/sklearn/cluster/bicluster.py
@@ -262,17 +262,17 @@ class SpectralCoclustering(BaseSpectral):
     --------
     >>> from sklearn.cluster import SpectralCoclustering
     >>> import numpy as np
-    >>> X = np.array([[1, 2], [1, 4], [1, 0],
-    ...               [4, 2], [4, 4], [4, 0]])
-    >>> clustering = SpectralCoclustering(n_clusters=2).fit(X)
+    >>> X = np.array([[1, 1], [2, 1], [1, 0],
+    ...               [4, 7], [3, 5], [3, 6]])
+    >>> clustering = SpectralCoclustering(n_clusters=2, random_state=0).fit(X)
     >>> clustering.row_labels_
-    array([1, 1, 0, 0, 1, 0], dtype=int32)
+    array([0, 1, 1, 0, 0, 0], dtype=int32)
     >>> clustering.column_labels_
-    array([0, 1], dtype=int32)
+    array([0, 0], dtype=int32)
     >>> clustering
     ... # doctest: +NORMALIZE_WHITESPACE
     SpectralCoclustering(init='k-means++', mini_batch=False, n_clusters=2,
-               n_init=10, n_jobs=1, n_svd_vecs=None, random_state=None,
+               n_init=10, n_jobs=1, n_svd_vecs=None, random_state=0,
                svd_method='randomized')
 
     References

--- a/sklearn/cluster/bicluster.py
+++ b/sklearn/cluster/bicluster.py
@@ -410,17 +410,18 @@ class SpectralBiclustering(BaseSpectral):
     --------
     >>> from sklearn.cluster import SpectralBiclustering
     >>> import numpy as np
-    >>> X = np.array([[1, 2], [1, 4], [1, 0],
-    ...               [4, 2], [4, 4], [4, 0]])
-    >>> clustering = SpectralBiclustering(n_clusters=2).fit(X)
+    >>> X = np.array([[1, 1], [2, 1], [1, 0],
+    ...               [4, 7], [3, 5], [3, 6]])
+    >>> clustering = SpectralBiclustering(n_clusters=2, random_state=0).fit(X)
     >>> clustering.row_labels_
-    array([0, 0, 1, 1, 0, 1], dtype=int32)
+    array([1, 1, 1, 0, 0, 0], dtype=int32)
     >>> clustering.column_labels_
-    array([1, 0], dtype=int32)
+    array([0, 1], dtype=int32)
     >>> clustering
+    ... # doctest: +NORMALIZE_WHITESPACE
     SpectralBiclustering(init='k-means++', method='bistochastic',
                mini_batch=False, n_best=3, n_clusters=2, n_components=6,
-               n_init=10, n_jobs=1, n_svd_vecs=None, random_state=None,
+               n_init=10, n_jobs=1, n_svd_vecs=None, random_state=0,
                svd_method='randomized')
 
     References

--- a/sklearn/cluster/bicluster.py
+++ b/sklearn/cluster/bicluster.py
@@ -269,8 +269,7 @@ class SpectralCoclustering(BaseSpectral):
     array([0, 1, 1, 0, 0, 0], dtype=int32)
     >>> clustering.column_labels_
     array([0, 0], dtype=int32)
-    >>> clustering
-    ... # doctest: +NORMALIZE_WHITESPACE
+    >>> clustering # doctest: +NORMALIZE_WHITESPACE
     SpectralCoclustering(init='k-means++', mini_batch=False, n_clusters=2,
                n_init=10, n_jobs=1, n_svd_vecs=None, random_state=0,
                svd_method='randomized')
@@ -417,8 +416,7 @@ class SpectralBiclustering(BaseSpectral):
     array([1, 1, 1, 0, 0, 0], dtype=int32)
     >>> clustering.column_labels_
     array([0, 1], dtype=int32)
-    >>> clustering
-    ... # doctest: +NORMALIZE_WHITESPACE
+    >>> clustering # doctest: +NORMALIZE_WHITESPACE
     SpectralBiclustering(init='k-means++', method='bistochastic',
                mini_batch=False, n_best=3, n_clusters=2, n_components=6,
                n_init=10, n_jobs=1, n_svd_vecs=None, random_state=0,

--- a/sklearn/cluster/bicluster.py
+++ b/sklearn/cluster/bicluster.py
@@ -258,6 +258,23 @@ class SpectralCoclustering(BaseSpectral):
     column_labels_ : array-like, shape (n_cols,)
         The bicluster label of each column.
 
+    Examples
+    --------
+    >>> from sklearn.cluster import SpectralCoclustering
+    >>> import numpy as np
+    >>> X = np.array([[1, 2], [1, 4], [1, 0],
+    ...               [4, 2], [4, 4], [4, 0]])
+    >>> clustering = SpectralCoclustering(n_clusters=2).fit(X)
+    >>> clustering.row_labels_
+    array([1, 1, 0, 0, 1, 0], dtype=int32)
+    >>> clustering.column_labels_
+    array([0, 1], dtype=int32)
+    >>> clustering
+    ... # doctest: +NORMALIZE_WHITESPACE
+    SpectralCoclustering(init='k-means++', mini_batch=False, n_clusters=2,
+               n_init=10, n_jobs=1, n_svd_vecs=None, random_state=None,
+               svd_method='randomized')
+
     References
     ----------
 
@@ -388,6 +405,23 @@ class SpectralBiclustering(BaseSpectral):
 
     column_labels_ : array-like, shape (n_cols,)
         Column partition labels.
+
+    Examples
+    --------
+    >>> from sklearn.cluster import SpectralBiclustering
+    >>> import numpy as np
+    >>> X = np.array([[1, 2], [1, 4], [1, 0],
+    ...               [4, 2], [4, 4], [4, 0]])
+    >>> clustering = SpectralBiclustering(n_clusters=2).fit(X)
+    >>> clustering.row_labels_
+    array([0, 0, 1, 1, 0, 1], dtype=int32)
+    >>> clustering.column_labels_
+    array([1, 0], dtype=int32)
+    >>> clustering
+    SpectralBiclustering(init='k-means++', method='bistochastic',
+               mini_batch=False, n_best=3, n_clusters=2, n_components=6,
+               n_init=10, n_jobs=1, n_svd_vecs=None, random_state=None,
+               svd_method='randomized')
 
     References
     ----------

--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -394,8 +394,7 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
     >>> X = [[0, 1], [0.3, 1], [-0.3, 1], [0, -1], [0.3, -1], [-0.3, -1]]
     >>> brc = Birch(branching_factor=50, n_clusters=None, threshold=0.5,
     ... compute_labels=True)
-    >>> brc.fit(X)
-    ... # doctest: +NORMALIZE_WHITESPACE
+    >>> brc.fit(X) # doctest: +NORMALIZE_WHITESPACE
     Birch(branching_factor=50, compute_labels=True, copy=True, n_clusters=None,
        threshold=0.5)
     >>> brc.predict(X)

--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -395,6 +395,7 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
     >>> brc = Birch(branching_factor=50, n_clusters=None, threshold=0.5,
     ... compute_labels=True)
     >>> brc.fit(X)
+    ... # doctest: +NORMALIZE_WHITESPACE
     Birch(branching_factor=50, compute_labels=True, copy=True, n_clusters=None,
        threshold=0.5)
     >>> brc.predict(X)

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -253,8 +253,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
     >>> clustering = DBSCAN(eps=3, min_samples=2).fit(X)
     >>> clustering.labels_
     array([0, 0, 0, 1, 1, 1])
-    >>> clustering
-    ... # doctest: +NORMALIZE_WHITESPACE
+    >>> clustering # doctest: +NORMALIZE_WHITESPACE
     DBSCAN(algorithm='auto', eps=3, leaf_size=30, metric='euclidean',
         metric_params=None, min_samples=2, n_jobs=1, p=None)
 

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -244,6 +244,20 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         Cluster labels for each point in the dataset given to fit().
         Noisy samples are given the label -1.
 
+    Examples
+    --------
+    >>> from sklearn.cluster import DBSCAN
+    >>> import numpy as np
+    >>> X = np.array([[1, 2], [2, 2], [2, 3],
+    ...               [8, 7], [8, 8], [9, 8]])
+    >>> clustering = DBSCAN(eps=3, min_samples=2).fit(X)
+    >>> clustering.labels_
+    array([0, 0, 0, 1, 1, 1])
+    >>> clustering
+    ... # doctest: +NORMALIZE_WHITESPACE
+    DBSCAN(algorithm='auto', eps=3, leaf_size=30, metric='euclidean',
+        metric_params=None, min_samples=2, n_jobs=1, p=None)
+
     See also
     --------
     OPTICS

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -249,10 +249,10 @@ class DBSCAN(BaseEstimator, ClusterMixin):
     >>> from sklearn.cluster import DBSCAN
     >>> import numpy as np
     >>> X = np.array([[1, 2], [2, 2], [2, 3],
-    ...               [8, 7], [8, 8], [9, 8]])
+    ...               [8, 7], [8, 8], [25, 80]])
     >>> clustering = DBSCAN(eps=3, min_samples=2).fit(X)
     >>> clustering.labels_
-    array([0, 0, 0, 1, 1, 1])
+    array([ 0,  0,  0,  1,  1, -1])
     >>> clustering # doctest: +NORMALIZE_WHITESPACE
     DBSCAN(algorithm='auto', eps=3, leaf_size=30, metric='euclidean',
         metric_params=None, min_samples=2, n_jobs=1, p=None)

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -927,10 +927,10 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
     >>> images = digits.images
     >>> X = np.reshape(images, (len(images), -1))
     >>> agglo = cluster.FeatureAgglomeration(n_clusters=32)
-    >>> agglo.fit(X)
+    >>> agglo.fit(X) # doctest: +ELLIPSIS
     FeatureAgglomeration(affinity='euclidean', compute_full_tree='auto',
                connectivity=None, linkage='ward', memory=None, n_clusters=32,
-               pooling_func=<function mean at 0x7f5aa2e6e158>)
+               pooling_func=...)
     >>> X_reduced = agglo.transform(X)
     >>> clf = SGDClassifier(max_iter=5, random_state=0)
     >>> clf.fit(X_reduced, digits.target) # doctest: +NORMALIZE_WHITESPACE

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -920,13 +920,29 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
 
     Examples
     --------
-    >>> from sklearn.cluster import FeatureAgglomeration
     >>> import numpy as np
-    >>> X = np.array([[1, 5], [2, 4], [2, 4],
-    ...               [1, 7], [2, 8], [3, 8]])
-    >>> clustering = FeatureAgglomeration(n_clusters=2).fit(X)
-    >>> clustering.labels_
-    array([1, 0])
+    >>> from sklearn import datasets, cluster
+    >>> from sklearn.linear_model import SGDClassifier
+    >>> #from sklearn.feature_extraction.image import grid_to_graph
+    >>> digits = datasets.load_digits()
+    >>> images = digits.images
+    >>> X = np.reshape(images, (len(images), -1))
+    >>> agglo = cluster.FeatureAgglomeration(n_clusters=32)
+    >>> agglo.fit(X)
+    FeatureAgglomeration(affinity='euclidean', compute_full_tree='auto',
+               connectivity=None, linkage='ward', memory=None, n_clusters=32,
+               pooling_func=<function mean at 0x7f5aa2e6e158>)
+    >>> X_reduced = agglo.transform(X)
+    >>> clf = SGDClassifier(max_iter=5, random_state=0)
+    >>> clf.fit(X_reduced, digits.target) # doctest: +NORMALIZE_WHITESPACE
+    SGDClassifier(alpha=0.0001, average=False, class_weight=None,
+           early_stopping=False, epsilon=0.1, eta0=0.0, fit_intercept=True,
+           l1_ratio=0.15, learning_rate='optimal', loss='hinge', max_iter=5,
+           n_iter=None, n_iter_no_change=5, n_jobs=1, penalty='l2',
+           power_t=0.5, random_state=0, shuffle=True, tol=None,
+           validation_fraction=0.1, verbose=0, warm_start=False)
+    >>> clf.score(X_reduced, digits.target) # doctest: +ELLIPSIS
+    0.9226...
     """
 
     def __init__(self, n_clusters=2, affinity="euclidean",

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -923,7 +923,6 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
     >>> import numpy as np
     >>> from sklearn import datasets, cluster
     >>> from sklearn.linear_model import SGDClassifier
-    >>> #from sklearn.feature_extraction.image import grid_to_graph
     >>> digits = datasets.load_digits()
     >>> images = digits.images
     >>> X = np.reshape(images, (len(images), -1))

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -922,7 +922,6 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
     --------
     >>> import numpy as np
     >>> from sklearn import datasets, cluster
-    >>> from sklearn.linear_model import SGDClassifier
     >>> digits = datasets.load_digits()
     >>> images = digits.images
     >>> X = np.reshape(images, (len(images), -1))
@@ -932,16 +931,8 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
                connectivity=None, linkage='ward', memory=None, n_clusters=32,
                pooling_func=...)
     >>> X_reduced = agglo.transform(X)
-    >>> clf = SGDClassifier(max_iter=5, random_state=0)
-    >>> clf.fit(X_reduced, digits.target) # doctest: +NORMALIZE_WHITESPACE
-    SGDClassifier(alpha=0.0001, average=False, class_weight=None,
-           early_stopping=False, epsilon=0.1, eta0=0.0, fit_intercept=True,
-           l1_ratio=0.15, learning_rate='optimal', loss='hinge', max_iter=5,
-           n_iter=None, n_iter_no_change=5, n_jobs=1, penalty='l2',
-           power_t=0.5, random_state=0, shuffle=True, tol=None,
-           validation_fraction=0.1, verbose=0, warm_start=False)
-    >>> clf.score(X_reduced, digits.target) # doctest: +ELLIPSIS
-    0.9226...
+    >>> X_reduced.shape
+    (1797, 32)
     """
 
     def __init__(self, n_clusters=2, affinity="euclidean",

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -917,12 +917,27 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
         node and has children `children_[i - n_features]`. Alternatively
         at the i-th iteration, children[i][0] and children[i][1]
         are merged to form node `n_features + i`
+
+    Examples
+    --------
+    >>> from sklearn.cluster import FeatureAgglomeration
+    >>> import numpy as np
+    >>> X = np.array([[1, 5], [2, 4], [2, 4],
+    ...               [1, 7], [2, 8], [3, 8]])
+    >>> clustering = FeatureAgglomeration(n_clusters=2).fit(X)
+    >>> clustering.labels_
+    array([1, 0])
+    >>> clustering
+    ... # doctest: +NORMALIZE_WHITESPACE
+    FeatureAgglomeration(affinity='euclidean', compute_full_tree='auto',
+               connectivity=None, linkage='ward', memory=None, n_clusters=2,
+               pooling_func='deprecated')
     """
 
     def __init__(self, n_clusters=2, affinity="euclidean",
                  memory=None,
                  connectivity=None, compute_full_tree='auto',
-                 linkage='ward', pooling_func=np.mean):
+                 linkage='ward', pooling_func="deprecated"):
         super(FeatureAgglomeration, self).__init__(
             n_clusters=n_clusters, memory=memory, connectivity=connectivity,
             compute_full_tree=compute_full_tree, linkage=linkage,

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -937,7 +937,7 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
     def __init__(self, n_clusters=2, affinity="euclidean",
                  memory=None,
                  connectivity=None, compute_full_tree='auto',
-                 linkage='ward', pooling_func="deprecated"):
+                 linkage='ward', pooling_func=np.mean):
         super(FeatureAgglomeration, self).__init__(
             n_clusters=n_clusters, memory=memory, connectivity=connectivity,
             compute_full_tree=compute_full_tree, linkage=linkage,

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -927,11 +927,6 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
     >>> clustering = FeatureAgglomeration(n_clusters=2).fit(X)
     >>> clustering.labels_
     array([1, 0])
-    >>> clustering
-    ... # doctest: +NORMALIZE_WHITESPACE
-    FeatureAgglomeration(affinity='euclidean', compute_full_tree='auto',
-               connectivity=None, linkage='ward', memory=None, n_clusters=2,
-               pooling_func='deprecated')
     """
 
     def __init__(self, n_clusters=2, affinity="euclidean",

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -1404,6 +1404,21 @@ class MiniBatchKMeans(KMeans):
         defined as the sum of square distances of samples to their nearest
         neighbor.
 
+    Examples
+    --------
+    >>> from sklearn.cluster import MiniBatchKMeans
+    >>> import numpy as np
+    >>> X = np.array([[1, 2], [1, 4], [1, 0],
+    ...               [4, 2], [4, 4], [4, 0]])
+    >>> kmeans = MiniBatchKMeans(n_clusters=2, random_state=0).fit(X)
+    >>> kmeans.labels_
+    array([0, 0, 0, 1, 1, 1], dtype=int32)
+    >>> kmeans.predict([[0, 0], [4, 4]])
+    array([0, 1], dtype=int32)
+    >>> kmeans.cluster_centers_
+    array([[1.        , 2.01023891],
+           [4.        , 1.96451613]])
+
     See also
     --------
 

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -1436,7 +1436,6 @@ class MiniBatchKMeans(KMeans):
            [3, 4]])
     >>> kmeans.predict([[0, 0], [4, 4]])
     array([0, 1], dtype=int32)
-    >>> 
     >>> # fit on the whole data
     >>> kmeans = MiniBatchKMeans(n_clusters=2, random_state=0)
     >>> kmeans.fit(X) # doctest: +ELLIPSIS

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -1413,41 +1413,24 @@ class MiniBatchKMeans(KMeans):
     ...               [4, 5], [0, 1], [2, 2],
     ...               [3, 2], [5, 5], [1, -1]])
     >>> # manually fit on batches
-    >>> kmeans = MiniBatchKMeans(n_clusters=2, random_state=0)
-    >>> kmeans.partial_fit(X[0:6,:]) # doctest: +ELLIPSIS
-    MiniBatchKMeans(batch_size=100, compute_labels=True, init='k-means++',
-            init_size=None, max_iter=100, max_no_improvement=10, n_clusters=2,
-            n_init=3, random_state=0, reassignment_ratio=0.01, tol=0.0,
-            verbose=0)
-    >>> kmeans.labels_
-    array([0, 1, 0, 0, 0, 1], dtype=int32)
-    >>> kmeans.cluster_centers_
-    array([[2, 1],
-           [2, 4]])
-    >>> kmeans.partial_fit(X[6:12,:]) # doctest: +ELLIPSIS
-    MiniBatchKMeans(batch_size=100, compute_labels=True, init='k-means++',
-            init_size=None, max_iter=100, max_no_improvement=10, n_clusters=2,
-            n_init=3, random_state=0, reassignment_ratio=0.01, tol=0.0,
-            verbose=0)
-    >>> kmeans.labels_
-    array([1, 0, 0, 1, 1, 0], dtype=int32)
+    >>> kmeans = MiniBatchKMeans(n_clusters=2,
+    ...         random_state=0,
+    ...         batch_size=6)
+    >>> kmeans = kmeans.partial_fit(X[0:6,:])
+    >>> kmeans = kmeans.partial_fit(X[6:12,:])
     >>> kmeans.cluster_centers_
     array([[1, 1],
            [3, 4]])
     >>> kmeans.predict([[0, 0], [4, 4]])
     array([0, 1], dtype=int32)
     >>> # fit on the whole data
-    >>> kmeans = MiniBatchKMeans(n_clusters=2, random_state=0)
-    >>> kmeans.fit(X) # doctest: +ELLIPSIS
-    MiniBatchKMeans(batch_size=100, compute_labels=True, init='k-means++',
-            init_size=None, max_iter=100, max_no_improvement=10, n_clusters=2,
-            n_init=3, random_state=0, reassignment_ratio=0.01, tol=0.0,
-            verbose=0)
-    >>> kmeans.labels_
-    array([1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1], dtype=int32)
+    >>> kmeans = MiniBatchKMeans(n_clusters=2,
+    ...         random_state=0,
+    ...         batch_size=6,
+    ...         max_iter=10).fit(X)
     >>> kmeans.cluster_centers_
-    array([[3.52195122, 3.58699187],
-           [1.5041876 , 0.65661642]])
+    array([[3.95918367, 2.40816327],
+           [1.12195122, 1.3902439 ]])
     >>> kmeans.predict([[0, 0], [4, 4]])
     array([1, 0], dtype=int32)
 

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -1409,15 +1409,48 @@ class MiniBatchKMeans(KMeans):
     >>> from sklearn.cluster import MiniBatchKMeans
     >>> import numpy as np
     >>> X = np.array([[1, 2], [1, 4], [1, 0],
-    ...               [4, 2], [4, 4], [4, 0]])
-    >>> kmeans = MiniBatchKMeans(n_clusters=2, random_state=0).fit(X)
+    ...               [4, 2], [4, 0], [4, 4],
+    ...               [4, 5], [0, 1], [2, 2],
+    ...               [3, 2], [5, 5], [1, -1]])
+    >>> # manually fit on batches
+    >>> kmeans = MiniBatchKMeans(n_clusters=2, random_state=0)
+    >>> kmeans.partial_fit(X[0:6,:]) # doctest: +ELLIPSIS
+    MiniBatchKMeans(batch_size=100, compute_labels=True, init='k-means++',
+            init_size=None, max_iter=100, max_no_improvement=10, n_clusters=2,
+            n_init=3, random_state=0, reassignment_ratio=0.01, tol=0.0,
+            verbose=0)
     >>> kmeans.labels_
-    array([0, 0, 0, 1, 1, 1], dtype=int32)
+    array([0, 1, 0, 0, 0, 1], dtype=int32)
+    >>> kmeans.cluster_centers_
+    array([[2, 1],
+           [2, 4]])
+    >>> kmeans.partial_fit(X[6:12,:]) # doctest: +ELLIPSIS
+    MiniBatchKMeans(batch_size=100, compute_labels=True, init='k-means++',
+            init_size=None, max_iter=100, max_no_improvement=10, n_clusters=2,
+            n_init=3, random_state=0, reassignment_ratio=0.01, tol=0.0,
+            verbose=0)
+    >>> kmeans.labels_
+    array([1, 0, 0, 1, 1, 0], dtype=int32)
+    >>> kmeans.cluster_centers_
+    array([[1, 1],
+           [3, 4]])
     >>> kmeans.predict([[0, 0], [4, 4]])
     array([0, 1], dtype=int32)
+    >>> 
+    >>> # fit on the whole data
+    >>> kmeans = MiniBatchKMeans(n_clusters=2, random_state=0)
+    >>> kmeans.fit(X) # doctest: +ELLIPSIS
+    MiniBatchKMeans(batch_size=100, compute_labels=True, init='k-means++',
+            init_size=None, max_iter=100, max_no_improvement=10, n_clusters=2,
+            n_init=3, random_state=0, reassignment_ratio=0.01, tol=0.0,
+            verbose=0)
+    >>> kmeans.labels_
+    array([1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1], dtype=int32)
     >>> kmeans.cluster_centers_
-    array([[1.        , 2.01023891],
-           [4.        , 1.96451613]])
+    array([[3.52195122, 3.58699187],
+           [1.5041876 , 0.65661642]])
+    >>> kmeans.predict([[0, 0], [4, 4]])
+    array([1, 0], dtype=int32)
 
     See also
     --------

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -351,6 +351,22 @@ class MeanShift(BaseEstimator, ClusterMixin):
     labels_ :
         Labels of each point.
 
+    Examples
+    --------
+    >>> from sklearn.cluster import MeanShift
+    >>> import numpy as np
+    >>> X = np.array([[1, 1], [2, 1], [1, 0],
+    ...               [4, 7], [3, 5], [3, 6]])
+    >>> clustering = MeanShift(bandwidth=2).fit(X)
+    >>> clustering.labels_
+    array([0, 0, 0, 1, 1, 1])
+    >>> clustering.predict([[0, 0], [5, 5]])
+    array([0, 1])
+    >>> clustering
+    ... # doctest: +NORMALIZE_WHITESPACE
+    MeanShift(bandwidth=2, bin_seeding=False, cluster_all=True, min_bin_freq=1,
+         n_jobs=1, seeds=None)
+
     Notes
     -----
 

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -362,8 +362,7 @@ class MeanShift(BaseEstimator, ClusterMixin):
     array([0, 0, 0, 1, 1, 1])
     >>> clustering.predict([[0, 0], [5, 5]])
     array([0, 1])
-    >>> clustering
-    ... # doctest: +NORMALIZE_WHITESPACE
+    >>> clustering # doctest: +NORMALIZE_WHITESPACE
     MeanShift(bandwidth=2, bin_seeding=False, cluster_all=True, min_bin_freq=1,
          n_jobs=1, seeds=None)
 

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -371,6 +371,22 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
     labels_ :
         Labels of each point
 
+    Examples
+    --------
+    >>> from sklearn.cluster import SpectralClustering
+    >>> import numpy as np
+    >>> X = np.array([[1, 1], [2, 1], [1, 0],
+    ...               [4, 7], [3, 5], [3, 6]])
+    >>> clustering = SpectralClustering(n_clusters=2).fit(X)
+    >>> clustering.labels_
+    array([0, 0, 0, 1, 1, 1], dtype=int32)
+    >>> clustering
+    ... # doctest: +NORMALIZE_WHITESPACE
+    SpectralClustering(affinity='rbf', assign_labels='kmeans', coef0=1, degree=3,
+              eigen_solver=None, eigen_tol=0.0, gamma=1.0, kernel_params=None,
+              n_clusters=2, n_init=10, n_jobs=1, n_neighbors=10,
+              random_state=None)
+
     Notes
     -----
     If you have an affinity matrix, such as a distance matrix,

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -377,15 +377,17 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
     >>> import numpy as np
     >>> X = np.array([[1, 1], [2, 1], [1, 0],
     ...               [4, 7], [3, 5], [3, 6]])
-    >>> clustering = SpectralClustering(n_clusters=2).fit(X)
+    >>> clustering = SpectralClustering(n_clusters=2,
+    ...         assign_labels="discretize",
+    ...         random_state=0).fit(X)
     >>> clustering.labels_
-    array([0, 0, 0, 1, 1, 1], dtype=int32)
+    array([1, 1, 1, 0, 0, 0])
     >>> clustering
     ... # doctest: +NORMALIZE_WHITESPACE
-    SpectralClustering(affinity='rbf', assign_labels='kmeans', coef0=1, degree=3,
-              eigen_solver=None, eigen_tol=0.0, gamma=1.0, kernel_params=None,
-              n_clusters=2, n_init=10, n_jobs=1, n_neighbors=10,
-              random_state=None)
+    SpectralClustering(affinity='rbf', assign_labels='discretize', coef0=1,
+              degree=3, eigen_solver=None, eigen_tol=0.0, gamma=1.0,
+              kernel_params=None, n_clusters=2, n_init=10, n_jobs=1,
+              n_neighbors=10, random_state=0)
 
     Notes
     -----

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -382,8 +382,7 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
     ...         random_state=0).fit(X)
     >>> clustering.labels_
     array([1, 1, 1, 0, 0, 0])
-    >>> clustering
-    ... # doctest: +NORMALIZE_WHITESPACE
+    >>> clustering # doctest: +NORMALIZE_WHITESPACE
     SpectralClustering(affinity='rbf', assign_labels='discretize', coef0=1,
               degree=3, eigen_solver=None, eigen_tol=0.0, gamma=1.0,
               kernel_params=None, n_clusters=2, n_init=10, n_jobs=1,


### PR DESCRIPTION
See #3846

Usage examples added to:

 - SpectralBiclustering
 - SpectralCoclustering
 - DBSCAN
 - FeatureAgglomeration
 - MiniBatchKMeans
 - MeanShift
 - SpectralClustering

Please note that the example for `FeatureAgglomeration` would result in a `warning` thrown from `AgglomerativeClustering` due to deprecated `pooling_func` which is set by `FeatureAgglomeration`. The warning would automatically go away in version 0.22, but I'm not sure if a note atout the warning should be added to that example or not.