### PR TITLE
[MRG] Fix collections.abc deprecations with Python 3.7 (0.19.X backport)

### DIFF
--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -19,11 +19,11 @@ from .empirical_covariance_ import (empirical_covariance, EmpiricalCovariance,
 from ..exceptions import ConvergenceWarning
 from ..utils.validation import check_random_state, check_array
 from ..utils import deprecated
+from ..utils.fixes import _Sequence as Sequence
 from ..linear_model import lars_path
 from ..linear_model import cd_fast
 from ..model_selection import check_cv, cross_val_score
 from ..externals.joblib import Parallel, delayed
-import collections
 
 
 # Helper functions to compute the objective and dual objective functions
@@ -595,7 +595,7 @@ class GraphLassoCV(GraphLasso):
         n_alphas = self.alphas
         inner_verbose = max(0, self.verbose - 1)
 
-        if isinstance(n_alphas, collections.Sequence):
+        if isinstance(n_alphas, Sequence):
             alphas = self.alphas
             n_refinements = 1
         else:
@@ -670,7 +670,7 @@ class GraphLassoCV(GraphLasso):
                 alpha_1 = path[best_index - 1][0]
                 alpha_0 = path[best_index + 1][0]
 
-            if not isinstance(n_alphas, collections.Sequence):
+            if not isinstance(n_alphas, Sequence):
                 alphas = np.logspace(np.log10(alpha_1), np.log10(alpha_0),
                                      n_alphas + 2)
                 alphas = alphas[1:-1]

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -15,7 +15,6 @@ import scipy.sparse as sp
 from ..preprocessing import MultiLabelBinarizer
 from ..utils import check_array, check_random_state
 from ..utils import shuffle as util_shuffle
-from ..utils.fixes import _Iterable as Iterable
 from ..utils.random import sample_without_replacement
 from ..externals import six
 map = six.moves.map

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -15,6 +15,7 @@ import scipy.sparse as sp
 from ..preprocessing import MultiLabelBinarizer
 from ..utils import check_array, check_random_state
 from ..utils import shuffle as util_shuffle
+from ..utils.fixes import _Iterable as Iterable
 from ..utils.random import sample_without_replacement
 from ..externals import six
 map = six.moves.map

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -3,7 +3,6 @@
 # License: BSD 3 clause
 
 from array import array
-from collections import Mapping
 from operator import itemgetter
 
 import numpy as np
@@ -13,6 +12,7 @@ from ..base import BaseEstimator, TransformerMixin
 from ..externals import six
 from ..externals.six.moves import xrange
 from ..utils import check_array, tosequence
+from ..utils.fixes import _Mapping as Mapping
 
 
 def _tosequence(X):

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -31,7 +31,8 @@ from sklearn.utils.testing import (assert_equal, assert_false, assert_true,
                                    clean_warning_registry, ignore_warnings,
                                    SkipTest)
 
-from collections import defaultdict, Mapping
+from collections import defaultdict
+from sklearn.utils.fixes import _Mapping as Mapping
 from functools import partial
 import pickle
 from io import StringIO

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -13,7 +13,7 @@ from __future__ import division
 # License: BSD 3 clause
 
 from abc import ABCMeta, abstractmethod
-from collections import Mapping, namedtuple, defaultdict, Sequence
+from collections import namedtuple, defaultdict
 from functools import partial, reduce
 from itertools import product
 import operator
@@ -33,6 +33,7 @@ from ..externals import six
 from ..utils import check_random_state
 from ..utils.fixes import sp_version
 from ..utils.fixes import MaskedArray
+from ..utils.fixes import _Mapping as Mapping, _Sequence as Sequence
 from ..utils.random import sample_without_replacement
 from ..utils.validation import indexable, check_is_fitted
 from ..utils.metaestimators import if_delegate_has_method

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -15,7 +15,6 @@ from __future__ import division
 
 import warnings
 from itertools import chain, combinations
-from collections import Iterable
 from math import ceil, floor
 import numbers
 from abc import ABCMeta, abstractmethod
@@ -29,6 +28,7 @@ from ..utils.multiclass import type_of_target
 from ..externals.six import with_metaclass
 from ..externals.six.moves import zip
 from ..utils.fixes import signature, comb
+from ..utils.fixes import _Iterable as Iterable
 from ..base import _pprint
 
 __all__ = ['BaseCrossValidator',

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1,6 +1,5 @@
 """Test the search module"""
 
-from collections import Iterable, Sized
 from sklearn.externals.six.moves import cStringIO as StringIO
 from sklearn.externals.six.moves import xrange
 from sklearn.externals.joblib._compat import PY3_OR_LATER
@@ -14,6 +13,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from sklearn.utils.fixes import sp_version
+from sklearn.utils.fixes import _Iterable as Iterable, _Sized as Sized
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_raises

--- a/sklearn/tests/test_init.py
+++ b/sklearn/tests/test_init.py
@@ -48,9 +48,7 @@ def test_import_sklearn_no_warnings():
                                      "pytest" in line or
                                      # ignore DeprecationWarnings due to
                                      # numpy.oldnumeric
-                                     "oldnumeric" in line or
-                                     # ignore FutureWarnings
-                                     "FutureWarning" in line
+                                     "oldnumeric" in line
                                      )])
         assert 'Warning' not in message
         assert 'Error' not in message

--- a/sklearn/tests/test_init.py
+++ b/sklearn/tests/test_init.py
@@ -1,10 +1,17 @@
 # Basic unittests to test functioning of module's top-level
 
+import subprocess
+
+import pkgutil
+
+import pytest
+
+import sklearn
+from sklearn.utils.testing import assert_equal
+
 __author__ = 'Yaroslav Halchenko'
 __license__ = 'BSD'
 
-
-from sklearn.utils.testing import assert_equal
 
 try:
     from sklearn import *  # noqa
@@ -18,3 +25,35 @@ def test_import_skl():
     # "import *" is discouraged outside of the module level, hence we
     # rely on setting up the variable above
     assert_equal(_top_import_error, None)
+
+
+def test_import_sklearn_no_warnings():
+    # Test that importing scikit-learn main modules doesn't raise any warnings.
+
+    try:
+        pkgs = pkgutil.iter_modules(path=sklearn.__path__, prefix='sklearn.')
+        import_modules = '; '.join(['import ' + modname
+                                    for _, modname, _ in pkgs
+                                    if not modname.startswith('_')])
+
+        message = subprocess.check_output(['python', '-Wdefault',
+                                           '-c', import_modules],
+                                          stderr=subprocess.STDOUT)
+        message = message.decode("utf-8")
+        message = '\n'.join([line for line in message.splitlines()
+                             if not (  # ignore ImportWarning
+                                     "ImportWarning" in line or
+                                     # ignore DeprecationWarning due to pytest
+                                     "pytest" in line or
+                                     # ignore DeprecationWarnings due to
+                                     # numpy.oldnumeric
+                                     "oldnumeric" in line or
+                                     # ignore FutureWarnings
+                                     "FutureWarning" in line
+                                     )])
+        assert 'Warning' not in message
+        assert 'Error' not in message
+
+    except Exception as e:
+        pytest.skip('soft-failed test_import_sklearn_no_warnings.\n'
+                    ' %s' % e)

--- a/sklearn/tests/test_init.py
+++ b/sklearn/tests/test_init.py
@@ -42,7 +42,8 @@ def test_import_sklearn_no_warnings():
                                           stderr=subprocess.STDOUT)
         message = message.decode("utf-8")
         message = '\n'.join([line for line in message.splitlines()
-                             if not (  # ignore ImportWarning
+                             if not (
+                                     # ignore ImportWarning due to Cython
                                      "ImportWarning" in line or
                                      # ignore DeprecationWarning due to pytest
                                      "pytest" in line or
@@ -55,4 +56,4 @@ def test_import_sklearn_no_warnings():
 
     except Exception as e:
         raise SkipTest('soft-failed test_import_sklearn_no_warnings.\n'
-                       ' %s' % e)
+                       ' %s, \n %s' % (e, message))

--- a/sklearn/tests/test_init.py
+++ b/sklearn/tests/test_init.py
@@ -32,7 +32,10 @@ def test_import_sklearn_no_warnings():
         pkgs = pkgutil.iter_modules(path=sklearn.__path__, prefix='sklearn.')
         import_modules = '; '.join(['import ' + modname
                                     for _, modname, _ in pkgs
-                                    if not modname.startswith('_')])
+                                    if (not modname.startswith('_') and
+                                        # add deprecated top level modules
+                                        # below to ignore them
+                                        modname not in [])])
 
         message = subprocess.check_output(['python', '-Wdefault',
                                            '-c', import_modules],

--- a/sklearn/tests/test_init.py
+++ b/sklearn/tests/test_init.py
@@ -4,10 +4,8 @@ import subprocess
 
 import pkgutil
 
-import pytest
-
 import sklearn
-from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_equal, SkipTest
 
 __author__ = 'Yaroslav Halchenko'
 __license__ = 'BSD'
@@ -55,5 +53,5 @@ def test_import_sklearn_no_warnings():
         assert 'Error' not in message
 
     except Exception as e:
-        pytest.skip('soft-failed test_import_sklearn_no_warnings.\n'
-                    ' %s' % e)
+        raise SkipTest('soft-failed test_import_sklearn_no_warnings.\n'
+                       ' %s' % e)

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -1,7 +1,6 @@
 """
 The :mod:`sklearn.utils` module includes various utilities.
 """
-from collections import Sequence
 
 import numpy as np
 from scipy.sparse import issparse
@@ -16,6 +15,7 @@ from .validation import (as_float_array,
 from .class_weight import compute_class_weight, compute_sample_weight
 from ..externals.joblib import cpu_count
 from ..exceptions import DataConversionWarning
+from ..utils.fixes import _Sequence as Sequence
 from .deprecation import deprecated
 
 

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -194,7 +194,6 @@ if np_version < (1, 12):
 else:
     from numpy.ma import MaskedArray    # noqa
 
-
 # To be removed once this fix is included in six
 try:
     from collections.abc import Sequence as _Sequence  # noqa

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -193,3 +193,16 @@ if np_version < (1, 12):
                                  self._fill_value)
 else:
     from numpy.ma import MaskedArray    # noqa
+
+
+# To be removed once this fix is included in six
+try:
+    from collections.abc import Sequence as _Sequence  # noqa
+    from collections.abc import Iterable as _Iterable  # noqa
+    from collections.abc import Mapping as _Mapping  # noqa
+    from collections.abc import Sized as _Sized  # noqa
+except ImportError:  # python <3.3
+    from collections import Sequence as _Sequence  # noqa
+    from collections import Iterable as _Iterable  # noqa
+    from collections import Mapping as _Mapping  # noqa
+    from collections import Sized as _Sized  # noqa

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -7,7 +7,6 @@ Multi-class / multi-label utility function
 
 """
 from __future__ import division
-from collections import Sequence
 from itertools import chain
 
 from scipy.sparse import issparse
@@ -18,8 +17,8 @@ from scipy.sparse import lil_matrix
 import numpy as np
 
 from ..externals.six import string_types
+from ..utils.fixes import _Sequence as Sequence
 from .validation import check_array
-
 
 
 def _unique_multiclass(y):


### PR DESCRIPTION
Backport of https://github.com/scikit-learn/scikit-learn/pull/11431 to 0.19.X that removes the deprecation warning about ABC being moved from collections to collections.abc when importing scikit-learn in Python 3.7.

~~**Do not merge** while the parent PR is not merged.~~ Done as part of https://github.com/scikit-learn/scikit-learn/pull/11422