### PR TITLE
[MRG] TST Use fixed random state to avoid test failure of test_weighted_vs_repeated

### DIFF
--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -917,7 +917,8 @@ def _sort_centers(centers):
 def test_weighted_vs_repeated():
     # a sample weight of N should yield the same result as an N-fold
     # repetition of the sample
-    sample_weight = np.random.randint(1, 5, size=n_samples)
+    rng = np.random.RandomState(0)
+    sample_weight = rng.randint(1, 5, size=n_samples)
     X_repeat = np.repeat(X, sample_weight, axis=0)
     estimators = [KMeans(init="k-means++", n_clusters=n_clusters,
                          random_state=42),


### PR DESCRIPTION
Fixes #11236 

Implement the solution proposed by @jnothman and @ogrisel (I also agree with it)

> an alternative is to check that it passes for a reasonable percentage of random_states

I tried seed from 0 to 999, the test only fails when using ``np.random.seed(973)``

> I would rather fix the random seed and maybe relax the condition to have a v_measure over 0.9 for the MiniBatchKMeans case.

Since we've used a fixed random state, I keep the check for v_measure.