### PR TITLE
FIX: warn for invalid n_components in LinearDiscriminantAnalysis

### DIFF
--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -19,11 +19,11 @@ from .empirical_covariance_ import (empirical_covariance, EmpiricalCovariance,
 from ..exceptions import ConvergenceWarning
 from ..utils.validation import check_random_state, check_array
 from ..utils import deprecated
+from ..utils.fixes import _Sequence as Sequence
 from ..linear_model import lars_path
 from ..linear_model import cd_fast
 from ..model_selection import check_cv, cross_val_score
 from ..externals.joblib import Parallel, delayed
-import collections
 
 
 # Helper functions to compute the objective and dual objective functions
@@ -608,7 +608,7 @@ class GraphicalLassoCV(GraphicalLasso):
         n_alphas = self.alphas
         inner_verbose = max(0, self.verbose - 1)
 
-        if isinstance(n_alphas, collections.Sequence):
+        if isinstance(n_alphas, Sequence):
             alphas = self.alphas
             n_refinements = 1
         else:
@@ -684,7 +684,7 @@ class GraphicalLassoCV(GraphicalLasso):
                 alpha_1 = path[best_index - 1][0]
                 alpha_0 = path[best_index + 1][0]
 
-            if not isinstance(n_alphas, collections.Sequence):
+            if not isinstance(n_alphas, Sequence):
                 alphas = np.logspace(np.log10(alpha_1), np.log10(alpha_0),
                                      n_alphas + 2)
                 alphas = alphas[1:-1]

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -11,11 +11,11 @@ import array
 import numpy as np
 from scipy import linalg
 import scipy.sparse as sp
-from collections import Iterable
 
 from ..preprocessing import MultiLabelBinarizer
 from ..utils import check_array, check_random_state
 from ..utils import shuffle as util_shuffle
+from ..utils.fixes import _Iterable as Iterable
 from ..utils.random import sample_without_replacement
 from ..externals import six
 map = six.moves.map

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -12,6 +12,8 @@ Linear Discriminant Analysis and Quadratic Discriminant Analysis
 from __future__ import print_function
 import warnings
 import numpy as np
+
+from sklearn.exceptions import ChangedBehaviorWarning
 from .utils import deprecated
 from scipy import linalg
 from .externals.six import string_types
@@ -166,8 +168,10 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
     priors : array, optional, shape (n_classes,)
         Class priors.
 
-    n_components : int, optional
-        Number of components (< n_classes - 1) for dimensionality reduction.
+    n_components : int, optional (default=None)
+        Number of components (< min(n_classes - 1, n_features)) for
+        dimensionality reduction. If None, will be set to
+        min(n_classes - 1, n_features).
 
     store_covariance : bool, optional
         Additionally compute class covariance matrix (default False), used
@@ -443,11 +447,24 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
             self.priors_ = self.priors_ / self.priors_.sum()
 
         # Get the maximum number of components
+
+        # Maximum number of components no matter what n_components is
+        # specified:
+        max_components = min(len(self.classes_) - 1, X.shape[1])
+
         if self.n_components is None:
-            self._max_components = len(self.classes_) - 1
+            self._max_components = max_components
         else:
-            self._max_components = min(len(self.classes_) - 1,
-                                       self.n_components)
+            if self.n_components > max_components:
+                warnings.warn(
+                    "n_components cannot be superior to min(n_features, "
+                    "n_classes - 1). Using min(n_features, "
+                    "n_classes - 1) = min(%d, %d - 1) = %d components."
+                    % (X.shape[1], len(self.classes_), max_components) ,
+                    ChangedBehaviorWarning)
+                self._max_components = max_components
+            else:
+                self._max_components = self.n_components
 
         if self.solver == 'svd':
             if self.shrinkage is not None:

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -3,7 +3,6 @@
 # License: BSD 3 clause
 
 from array import array
-from collections import Mapping
 from operator import itemgetter
 
 import numpy as np
@@ -13,6 +12,7 @@ from ..base import BaseEstimator, TransformerMixin
 from ..externals import six
 from ..externals.six.moves import xrange
 from ..utils import check_array, tosequence
+from ..utils.fixes import _Mapping as Mapping
 
 
 def _tosequence(X):

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -33,8 +33,8 @@ from sklearn.utils.testing import (assert_equal, assert_false, assert_true,
                                    clean_warning_registry, ignore_warnings,
                                    SkipTest, assert_raises,
                                    assert_allclose_dense_sparse)
-
-from collections import defaultdict, Mapping
+from sklearn.utils.fixes import _Mapping as Mapping
+from collections import defaultdict
 from functools import partial
 import pickle
 from io import StringIO

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -19,7 +19,6 @@ ground truth labeling (or ``None`` in the case of unsupervised models).
 # License: Simplified BSD
 
 from abc import ABCMeta
-from collections import Iterable
 
 import numpy as np
 
@@ -40,6 +39,7 @@ from .cluster import normalized_mutual_info_score
 from .cluster import fowlkes_mallows_score
 
 from ..utils.multiclass import type_of_target
+from ..utils.fixes import _Iterable as Iterable
 from ..externals import six
 from ..base import is_regressor
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -13,7 +13,7 @@ from __future__ import division
 # License: BSD 3 clause
 
 from abc import ABCMeta, abstractmethod
-from collections import Mapping, namedtuple, defaultdict, Sequence, Iterable
+from collections import namedtuple, defaultdict
 from functools import partial, reduce
 from itertools import product
 import operator
@@ -34,6 +34,8 @@ from ..externals import six
 from ..utils import check_random_state
 from ..utils.fixes import sp_version
 from ..utils.fixes import MaskedArray
+from ..utils.fixes import _Mapping as Mapping, _Sequence as Sequence
+from ..utils.fixes import _Iterable as Iterable
 from ..utils.random import sample_without_replacement
 from ..utils.validation import indexable, check_is_fitted
 from ..utils.metaestimators import if_delegate_has_method

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -15,7 +15,6 @@ from __future__ import division
 
 import warnings
 from itertools import chain, combinations
-from collections import Iterable
 from math import ceil, floor
 import numbers
 from abc import ABCMeta, abstractmethod
@@ -29,6 +28,7 @@ from ..utils.multiclass import type_of_target
 from ..externals.six import with_metaclass
 from ..externals.six.moves import zip
 from ..utils.fixes import signature, comb
+from ..utils.fixes import _Iterable as Iterable
 from ..base import _pprint
 
 __all__ = ['BaseCrossValidator',

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1,6 +1,5 @@
 """Test the search module"""
 
-from collections import Iterable, Sized
 from sklearn.externals.six.moves import cStringIO as StringIO
 from sklearn.externals.six.moves import xrange
 from itertools import chain, product
@@ -15,6 +14,7 @@ import pytest
 
 from sklearn.utils.fixes import sp_version
 from sklearn.utils.fixes import PY3_OR_LATER
+from sklearn.utils.fixes import _Iterable as Iterable, _Sized as Sized
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_raises

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -15,9 +15,8 @@ from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import ignore_warnings
-from pytest import warns
 
-from sklearn.datasets import make_blobs, make_classification
+from sklearn.datasets import make_blobs
 from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
 from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis
 from sklearn.discriminant_analysis import _cov

--- a/sklearn/tests/test_init.py
+++ b/sklearn/tests/test_init.py
@@ -1,10 +1,17 @@
 # Basic unittests to test functioning of module's top-level
 
+import subprocess
+
+import pkgutil
+
+import pytest
+
+import sklearn
+from sklearn.utils.testing import assert_equal
+
 __author__ = 'Yaroslav Halchenko'
 __license__ = 'BSD'
 
-
-from sklearn.utils.testing import assert_equal
 
 try:
     from sklearn import *  # noqa
@@ -18,3 +25,37 @@ def test_import_skl():
     # "import *" is discouraged outside of the module level, hence we
     # rely on setting up the variable above
     assert_equal(_top_import_error, None)
+
+
+def test_import_sklearn_no_warnings():
+    # Test that importing scikit-learn main modules doesn't raise any warnings.
+
+    try:
+        pkgs = pkgutil.iter_modules(path=sklearn.__path__, prefix='sklearn.')
+        import_modules = '; '.join(['import ' + modname
+                                    for _, modname, _ in pkgs
+                                    if (not modname.startswith('_') and
+                                        # add deprecated top level modules
+                                        # below to ignore them
+                                        modname not in [])])
+
+        message = subprocess.check_output(['python', '-Wdefault',
+                                           '-c', import_modules],
+                                          stderr=subprocess.STDOUT)
+        message = message.decode("utf-8")
+        message = '\n'.join([line for line in message.splitlines()
+                             if not (
+                                     # ignore ImportWarning due to Cython
+                                     "ImportWarning" in line or
+                                     # ignore DeprecationWarning due to pytest
+                                     "pytest" in line or
+                                     # ignore DeprecationWarnings due to
+                                     # numpy.oldnumeric
+                                     "oldnumeric" in line
+                                     )])
+        assert 'Warning' not in message
+        assert 'Error' not in message
+
+    except Exception as e:
+        pytest.skip('soft-failed test_import_sklearn_no_warnings.\n'
+                    ' %s, \n %s' % (e, message))

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -1,7 +1,7 @@
 """
 The :mod:`sklearn.utils` module includes various utilities.
 """
-from collections import Sequence
+
 import numbers
 
 import numpy as np
@@ -17,6 +17,7 @@ from .validation import (as_float_array,
 from .class_weight import compute_class_weight, compute_sample_weight
 from ..externals.joblib import cpu_count
 from ..exceptions import DataConversionWarning
+from ..utils.fixes import _Sequence as Sequence
 from .deprecation import deprecated
 from .. import get_config
 

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -310,3 +310,16 @@ if np.array_equal(_nan_object_mask, np.array([True])):
 else:
     def _object_dtype_isnan(X):
         return np.frompyfunc(lambda x: x != x, 1, 1)(X).astype(bool)
+
+
+# To be removed once this fix is included in six
+try:
+    from collections.abc import Sequence as _Sequence  # noqa
+    from collections.abc import Iterable as _Iterable  # noqa
+    from collections.abc import Mapping as _Mapping  # noqa
+    from collections.abc import Sized as _Sized  # noqa
+except ImportError:  # python <3.3
+    from collections import Sequence as _Sequence  # noqa
+    from collections import Iterable as _Iterable  # noqa
+    from collections import Mapping as _Mapping  # noqa
+    from collections import Sized as _Sized  # noqa

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -7,7 +7,6 @@ Multi-class / multi-label utility function
 
 """
 from __future__ import division
-from collections import Sequence
 from itertools import chain
 
 from scipy.sparse import issparse
@@ -18,8 +17,8 @@ from scipy.sparse import lil_matrix
 import numpy as np
 
 from ..externals.six import string_types
+from ..utils.fixes import _Sequence as Sequence
 from .validation import check_array
-
 
 
 def _unique_multiclass(y):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10048.
Fixes #8956. (The second dimension of scalings will always be thresholded (not only for svd, (see https://github.com/scikit-learn/scikit-learn/issues/8956#issuecomment-376881805)))

#### What does this implement/fix? Explain your changes.
This PR: 
 - Raises a `ChangedBehaviourWarning` when the user sets `n_components` > `min(n_features, n_classes - 1)`. In this case it sets the `max_features` (the number of first components to take) to `min(n_features, n_classes - 1)` (and this way it doesn't take the `n_components` into account anymore). It does not throws an error like PCA not to break user code (cf comment: https://github.com/scikit-learn/scikit-learn/issues/6355#issuecomment-340855091). I should maybe provide a `FutureWarning` and throw an error in the future ? 
- Changes the docstring, saying that we should have `n_components < min(n_features, n_classes - 1)` (and not just `n_components` < `n_classes - 1`)
- Tests that if the condition is verified no warning is thrown otherwise a warning is thrown

I did not check explicitly the dimension (just the presence/absence of warnings) because it can still happen that the dimension is unexpected if input points are colinear. I was thinking to tackle this in another PR (raise a warning in that case and/or return the whole `scalings_` (including zeros) without truncation)