### PR TITLE
[MRG] Deploy doc even if broken on Python2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,4 +91,3 @@ workflows:
       - deploy:
           requires:
             - python3
-            - python2


### PR DESCRIPTION
This changes CircleCI workflow dependencies so that the deploy step only depends on Python3. This means that the doc on master will be deployed even if the doc is broken on Python2.