### PR TITLE
[MRG] EHN: Change default value of n_init to 1 in KMeans

### DIFF
--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -300,6 +300,7 @@ n_init=10
     if n_init == 'warn':
         warnings.warn("The default value of n_init will change from "
                       "10 to 1 in 0.22", FutureWarning)
+        n_init = 10
 
     if n_init <= 0:
         raise ValueError("Invalid number of initializations."
@@ -914,11 +915,6 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
                  verbose=0, random_state=None, copy_x=True,
                  n_jobs=1, algorithm='auto'):
 
-        if n_init == 'warn':
-            warnings.warn("The default value of n_init will change from "
-                          "10 to 1 in 0.22", FutureWarning)
-            n_init = 10
-
         self.n_clusters = n_clusters
         self.init = init
         self.max_iter = max_iter
@@ -930,6 +926,10 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         self.copy_x = copy_x
         self.n_jobs = n_jobs
         self.algorithm = algorithm
+        if n_init == 'warn':
+            warnings.warn("The default value of n_init will change from "
+                          "10 to 1 in 0.22", FutureWarning)
+            n_init = 10
 
     def _check_test_data(self, X):
         X = check_array(X, accept_sparse='csr', dtype=FLOAT_DTYPES)

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -183,7 +183,7 @@ def _check_sample_weight(X, sample_weight):
 
 
 def k_means(X, n_clusters, sample_weight=None, init='k-means++',
-            precompute_distances='auto', n_init=10, max_iter=300,
+            precompute_distances='auto', n_init='warn', max_iter=300,
             verbose=False, tol=1e-4, random_state=None, copy_x=True, n_jobs=1,
             algorithm="auto", return_n_iter=False):
     """K-means clustering algorithm.
@@ -235,14 +235,15 @@ def k_means(X, n_clusters, sample_weight=None, init='k-means++',
     n_init : int, optional, default: 10
         Number of time the k-means algorithm will be run with different
         centroid seeds. The final results will be the best output of
-        n_init consecutive runs in terms of inertia.
+        n_init consecutive runs in terms of inertia. Note the defaul value will
+        be changed to 1 in 0.22.
 
     max_iter : int, optional, default 300
         Maximum number of iterations of the k-means algorithm to run.
 
     verbose : boolean, optional
         Verbosity mode.
-
+n_init=10
     tol : float, optional
         The relative increment in the results before declaring convergence.
 
@@ -296,6 +297,10 @@ def k_means(X, n_clusters, sample_weight=None, init='k-means++',
         Returned only if `return_n_iter` is set to True.
 
     """
+    if n_init == 'warn':
+        warnings.warn("The default value of n_init will change from "
+                      "10 to 1 in 0.22", FutureWarning)
+
     if n_init <= 0:
         raise ValueError("Invalid number of initializations."
                          " n_init=%d must be bigger than zero." % n_init)
@@ -904,10 +909,15 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
 
     """
 
-    def __init__(self, n_clusters=8, init='k-means++', n_init=10,
+    def __init__(self, n_clusters=8, init='k-means++', n_init='warn',
                  max_iter=300, tol=1e-4, precompute_distances='auto',
                  verbose=0, random_state=None, copy_x=True,
                  n_jobs=1, algorithm='auto'):
+
+        if n_init == 'warn':
+            warnings.warn("The default value of n_init will change from "
+                          "10 to 1 in 0.22", FutureWarning)
+            n_init = 10
 
         self.n_clusters = n_clusters
         self.init = init

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -233,17 +233,19 @@ def k_means(X, n_clusters, sample_weight=None, init='k-means++',
         False : never precompute distances
 
     n_init : int, optional, default: 10
+        .. versionchanged:: 0.22
+           n_init default version changed from 10 to 1
+
         Number of time the k-means algorithm will be run with different
         centroid seeds. The final results will be the best output of
-        n_init consecutive runs in terms of inertia. Note the defaul value will
-        be changed to 1 in 0.22.
+        n_init consecutive runs in terms of inertia.
 
     max_iter : int, optional, default 300
         Maximum number of iterations of the k-means algorithm to run.
 
     verbose : boolean, optional
         Verbosity mode.
-n_init=10
+
     tol : float, optional
         The relative increment in the results before declaring convergence.
 
@@ -914,7 +916,6 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
                  max_iter=300, tol=1e-4, precompute_distances='auto',
                  verbose=0, random_state=None, copy_x=True,
                  n_jobs=1, algorithm='auto'):
-
         self.n_clusters = n_clusters
         self.init = init
         self.max_iter = max_iter
@@ -926,10 +927,7 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         self.copy_x = copy_x
         self.n_jobs = n_jobs
         self.algorithm = algorithm
-        if n_init == 'warn':
-            warnings.warn("The default value of n_init will change from "
-                          "10 to 1 in 0.22", FutureWarning)
-            n_init = 10
+
 
     def _check_test_data(self, X):
         X = check_array(X, accept_sparse='csr', dtype=FLOAT_DTYPES)
@@ -959,6 +957,11 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
             are assigned equal weight (default: None)
 
         """
+        if self.n_init == 'warn':
+            warnings.warn("The default value of n_init will change from "
+                          "10 to 1 in 0.22", FutureWarning)
+            self.n_init = 10
+
         random_state = check_random_state(self.random_state)
 
         self.cluster_centers_, self.labels_, self.inertia_, self.n_iter_ = \

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -18,6 +18,7 @@ from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
+from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import if_safe_multiprocessing_with_blas
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.validation import _num_samples
@@ -987,3 +988,16 @@ def test_iter_attribute():
     estimator = KMeans(algorithm="elkan", max_iter=1)
     estimator.fit(np.random.rand(10, 10))
     assert estimator.n_iter_ == 1
+
+
+def test_deprecation_warnings():
+    # Test that warnings are raised. Will be removed in 0.22
+
+    # When n_init is specified (no warning)
+    km = KMeans(n_init=1)
+    assert_no_warnings(km.fit, X)
+
+    # When n_init is not specified (warns)
+    msg_future = "The default value of n_init will change from 10 to 1 in 0.22"
+    km = KMeans()
+    assert_warns_message(FutureWarning, msg_future, km.fit, X)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -990,14 +990,12 @@ def test_iter_attribute():
     assert estimator.n_iter_ == 1
 
 
-def test_deprecation_warnings():
-    # Test that warnings are raised. Will be removed in 0.22
+def test_change_n_init_future_warning():
+    # FIXME: Remove this test in 0.22
 
-    # When n_init is specified (no warning)
     km = KMeans(n_init=1)
     assert_no_warnings(km.fit, X)
 
-    # When n_init is not specified (warns)
     msg_future = "The default value of n_init will change from 10 to 1 in 0.22"
     km = KMeans()
     assert_warns_message(FutureWarning, msg_future, km.fit, X)


### PR DESCRIPTION
closes #9729 Change KMeans n_init default value to 1.

#### What does this implement/fix? Explain your changes.
Creates a warning message when the user does not specify a value for n_init. The warning message tells the user that the default value will change from 10 to 1 in 0.22 

#### Any other comments?
Thanks for helping us contribute at SciPy 2018!