### PR TITLE
add warning about Python2.7 support drop

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,9 @@ scikit-learn requires:
 - NumPy (>= 1.8.2)
 - SciPy (>= 0.13.3)
 
+**Scikit-learn 0.20 is the last version to support Python2.7.**
+Scikit-learn 0.21 and later will require Python 3.5 or newer.
+
 For running the examples Matplotlib >= 1.3.1 is required. A few examples
 require scikit-image >= 0.9.3 and a few examples require pandas >= 0.13.1.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -207,6 +207,10 @@
                     <li><em>On-going development:</em>
                     <a href="/dev/whats_new.html"><em>What's new</em> (Changelog)</a>
                     </li>
+                    <li>Scikit-learn 0.21 will drop support for Python 2.7 and Python 3.4.
+                    </li>
+                    <li><em>July 2018.</em> scikit-learn 0.20 is available for download (<a href="whats_new.html#version-0-20">Changelog</a>).
+                    </li> 
                     <li><em>July 2018.</em> scikit-learn 0.19.2 is available for download (<a href="whats_new.html#version-0-19">Changelog</a>).
                     </li>
                     <li><em>October 2017.</em> scikit-learn 0.19.1 is available for download (<a href="whats_new.html#version-0-19">Changelog</a>).
@@ -214,12 +218,6 @@
                     <li><em>July 2017.</em> scikit-learn 0.19.0 is available for download (<a href="whats_new/v0.19.html#version-0-19">Changelog</a>).
                     </li>
                     <li><em>June 2017.</em> scikit-learn 0.18.2 is available for download (<a href="whats_new/v0.18.html#version-0-18-2">Changelog</a>).
-                    </li>
-                    <li><em>September 2016.</em> scikit-learn 0.18.0 is available for download (<a href="whats_new/v0.18.html#version-0-18">Changelog</a>).
-                    </li>
-                    <li><em>November 2015.</em> scikit-learn 0.17.0 is available for download (<a href="whats_new/v0.17.html">Changelog</a>).
-                    </li>
-                    <li><em>March 2015.</em> scikit-learn 0.16.0 is available for download (<a href="whats_new/v0.16.html">Changelog</a>).
                     </li>
                     </ul>
                 </div>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -207,10 +207,10 @@
                     <li><em>On-going development:</em>
                     <a href="/dev/whats_new.html"><em>What's new</em> (Changelog)</a>
                     </li>
-                    <li>Scikit-learn 0.21 will drop support for Python 2.7 and Python 3.4.
+                    <li><strong>Scikit-learn 0.21 will drop support for Python 2.7 and Python 3.4.</strong>
                     </li>
                     <li><em>July 2018.</em> scikit-learn 0.20 is available for download (<a href="whats_new.html#version-0-20">Changelog</a>).
-                    </li> 
+                    </li>
                     <li><em>July 2018.</em> scikit-learn 0.19.2 is available for download (<a href="whats_new.html#version-0-19">Changelog</a>).
                     </li>
                     <li><em>October 2017.</em> scikit-learn 0.19.1 is available for download (<a href="whats_new.html#version-0-19">Changelog</a>).

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -21,6 +21,12 @@ Scikit-learn requires:
 - NumPy (>= 1.8.2),
 - SciPy (>= 0.13.3).
 
+
+.. warning::
+
+    Scikit-learn 0.20 is the last version to support Python2.7. Scikit-learn
+    0.21 will require Python 3.5 or newer.
+
 If you already have a working installation of numpy and scipy,
 the easiest way to install scikit-learn is using ``pip`` ::
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -24,7 +24,7 @@ Scikit-learn requires:
 
 .. warning::
 
-    Scikit-learn 0.20 is the last version to support Python 2.7 and Python 3.5.
+    Scikit-learn 0.20 is the last version to support Python 2.7 and Python 3.4.
     Scikit-learn 0.21 will require Python 3.5 or newer.
 
 If you already have a working installation of numpy and scipy,

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -24,8 +24,8 @@ Scikit-learn requires:
 
 .. warning::
 
-    Scikit-learn 0.20 is the last version to support Python2.7. Scikit-learn
-    0.21 will require Python 3.5 or newer.
+    Scikit-learn 0.20 is the last version to support Python 2.7 and Python 3.5.
+    Scikit-learn 0.21 will require Python 3.5 or newer.
 
 If you already have a working installation of numpy and scipy,
 the easiest way to install scikit-learn is using ``pip`` ::

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -14,8 +14,7 @@ Thanks to our many contributors!
 .. warning::
 
     Version 0.20 will be the last version of scikit-learn to support Python2.7.
-    From scikit-learn 0.21 onwards, only Python 3.x will be supported.
-    Scikit-learn 0.21 will also drop support for Python 3.4.
+    Scikit-learn 0.21 will require Python 3.5 or higher.
 
 Highlights
 ----------

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -13,7 +13,7 @@ Thanks to our many contributors!
 
 .. warning::
 
-    Version 0.20 will be the last version of scikit-learn to support Python2.7.
+    Version 0.20 is the last version of scikit-learn to support Python 2.7 and Python 3.4.
     Scikit-learn 0.21 will require Python 3.5 or higher.
 
 Highlights

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -11,6 +11,12 @@ This release packs in a mountain of bug fixes, features and enhancements for
 the Scikit-learn library, and improvements to the documentation and examples.
 Thanks to our many contributors!
 
+.. warning::
+
+    Version 0.20 will be the last version of scikit-learn to support Python2.7.
+    From scikit-learn 0.21 onwards, only Python 3.x will be supported.
+    Scikit-learn 0.21 will also drop support for Python 3.4.
+
 Highlights
 ----------
 


### PR DESCRIPTION
Fixes #11115.

Says we'll drop 2.7 and 3.4 for sklearn 0.21