### PR TITLE
[WIP] use more robust mean online computation in StandardScaler

### DIFF
--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -704,7 +704,8 @@ def _incremental_mean_and_var(X, last_mean, last_variance, last_sample_count):
     new_mean = new_sum / new_sample_count
     delta = new_mean - last_mean
     updated_mean = \
-        last_mean + (delta * new_sample_count) / updated_sample_count
+        last_mean + (delta * new_sample_count) / updated_sample_count  # fixes test
+        # (last_mean * last_sample_count + new_sum) / updated_sample_count  # breaks stability test
 
     if last_variance is None:
         updated_variance = None

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -696,13 +696,15 @@ def _incremental_mean_and_var(X, last_mean, last_variance, last_sample_count):
     # old = stats until now
     # new = the current increment
     # updated = the aggregated stats
-    last_sum = last_mean * last_sample_count
     new_sum = np.nansum(X, axis=0)
 
     new_sample_count = np.sum(~np.isnan(X), axis=0)
     updated_sample_count = last_sample_count + new_sample_count
 
-    updated_mean = (last_sum + new_sum) / updated_sample_count
+    new_mean = new_sum / new_sample_count
+    delta = new_mean - last_mean
+    updated_mean = \
+        last_mean + (delta * new_sample_count) / updated_sample_count
 
     if last_variance is None:
         updated_variance = None
@@ -710,6 +712,7 @@ def _incremental_mean_and_var(X, last_mean, last_variance, last_sample_count):
         new_unnormalized_variance = np.nanvar(X, axis=0) * new_sample_count
         last_unnormalized_variance = last_variance * last_sample_count
 
+        last_sum = last_mean * last_sample_count
         with np.errstate(divide='ignore', invalid='ignore'):
             last_over_new_count = last_sample_count / new_sample_count
             updated_unnormalized_variance = (

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -609,7 +609,7 @@ def test_incremental_variance_numerical_stability():
             _incremental_mean_and_var(A1[i, :].reshape((1, A1.shape[1])),
                                       mean, var, n)
     assert_array_equal(n, A.shape[0])
-    assert_array_almost_equal(A.mean(axis=0), mean)
+    assert_allclose(A.mean(axis=0), mean, rtol=1e-12)
     assert_greater(tol, np.abs(stable_var(A) - var).max())
 
 


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #5602

#### What does this implement/fix? Explain your changes.

use parallel algo from https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm

I still new to check if same problem occurs on sparse matrices and for variance... which I suspect
