### PR TITLE
[MRG] more informative warning if increasing determinants in EllipticEnvelope/MinCovDet

### DIFF
--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -7,6 +7,8 @@ Here are implemented estimators that are resistant to outliers.
 # Author: Virgile Fritsch <virgile.fritsch@inria.fr>
 #
 # License: BSD 3 clause
+from __future__ import division
+
 import warnings
 import numbers
 import numpy as np

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -144,6 +144,16 @@ def _c_step(X, n_support, random_state, remaining_iterations=30,
         location = X_support.mean(axis=0)
         covariance = cov_computation_method(X_support)
         det = fast_logdet(covariance)
+
+        if det > previous_det:
+            # determinant has increased (should not happen)
+            warnings.warn("Determinant has increased; this should not happen: "
+                          "log(det) > log(previous_det) (%.15f > %.15f). "
+                          "You may want to try with a higher value of "
+                          "support_fraction (current value: %.3f)."
+                          % (det, previous_det, n_support / n_samples),
+                          RuntimeWarning)
+
         # update remaining iterations for early stopping
         remaining_iterations -= 1
 
@@ -161,8 +171,6 @@ def _c_step(X, n_support, random_state, remaining_iterations=30,
         results = location, covariance, det, support, dist
     elif det > previous_det:
         # determinant has increased (should not happen)
-        warnings.warn("Warning! det > previous_det (%.15f > %.15f)"
-                      % (det, previous_det), RuntimeWarning)
         results = previous_location, previous_covariance, \
             previous_det, previous_support, previous_dist
 

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -146,16 +146,6 @@ def _c_step(X, n_support, random_state, remaining_iterations=30,
         location = X_support.mean(axis=0)
         covariance = cov_computation_method(X_support)
         det = fast_logdet(covariance)
-
-        if det > previous_det:
-            # determinant has increased (should not happen)
-            warnings.warn("Determinant has increased; this should not happen: "
-                          "log(det) > log(previous_det) (%.15f > %.15f). "
-                          "You may want to try with a higher value of "
-                          "support_fraction (current value: %.3f)."
-                          % (det, previous_det, n_support / n_samples),
-                          RuntimeWarning)
-
         # update remaining iterations for early stopping
         remaining_iterations -= 1
 
@@ -173,6 +163,12 @@ def _c_step(X, n_support, random_state, remaining_iterations=30,
         results = location, covariance, det, support, dist
     elif det > previous_det:
         # determinant has increased (should not happen)
+        warnings.warn("Determinant has increased; this should not happen: "
+                      "log(det) > log(previous_det) (%.15f > %.15f). "
+                      "You may want to try with a higher value of "
+                      "support_fraction (current value: %.3f)."
+                      % (det, previous_det, n_support / n_samples),
+                      RuntimeWarning)
         results = previous_location, previous_covariance, \
             previous_det, previous_support, previous_dist
 

--- a/sklearn/covariance/tests/test_robust_covariance.py
+++ b/sklearn/covariance/tests/test_robust_covariance.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_raise_message
+from sklearn.utils.testing import assert_warns_message
 
 from sklearn import datasets
 from sklearn.covariance import empirical_covariance, MinCovDet
@@ -133,3 +134,35 @@ def test_mcd_support_covariance_is_zero():
            'increase support_fraction')
     for X in [X_1, X_2]:
         assert_raise_message(ValueError, msg, MinCovDet().fit, X)
+
+
+def test_mcd_increasing_det_warning():
+    # Check that a warning is raised if we observe increasing determinants
+    # during the c_step. In theory the sequence of determinants should be
+    # decreasing. Increasing determinants are likely due to ill-conditioned
+    # covariance matrices that result in poor precision matrices.
+
+    X = [[5.1, 3.5, 1.4, 0.2],
+         [4.9, 3.0, 1.4, 0.2],
+         [4.7, 3.2, 1.3, 0.2],
+         [4.6, 3.1, 1.5, 0.2],
+         [5.0, 3.6, 1.4, 0.2],
+         [4.6, 3.4, 1.4, 0.3],
+         [5.0, 3.4, 1.5, 0.2],
+         [4.4, 2.9, 1.4, 0.2],
+         [4.9, 3.1, 1.5, 0.1],
+         [5.4, 3.7, 1.5, 0.2],
+         [4.8, 3.4, 1.6, 0.2],
+         [4.8, 3.0, 1.4, 0.1],
+         [4.3, 3.0, 1.1, 0.1],
+         [5.1, 3.5, 1.4, 0.3],
+         [5.7, 3.8, 1.7, 0.3],
+         [5.4, 3.4, 1.7, 0.2],
+         [4.6, 3.6, 1.0, 0.2],
+         [5.0, 3.0, 1.6, 0.2],
+         [5.2, 3.5, 1.5, 0.2]]
+
+    mcd = MinCovDet(random_state=1)
+    assert_warns_message(RuntimeWarning,
+                         "Determinant has increased",
+                         mcd.fit, X)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #8811 and possible solution to #11366.

#### What does this implement/fix? Explain your changes.
This gives a more informative warning message in case of increasing determinants when running MinCovDet and EllipticEnvelope. This should not happen in theory. See the issues above for more information and reproducible examples.
~This also changes the location of the warning so that it is raised each time increasing determinants are observed.~
