### PR TITLE
BUG: fix KD Tree node construction

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -655,6 +655,9 @@ Neighbors
   warning when no neighbors are found for samples.  :issue:`9655` by
   :user:`Andreas Bjerre-Nielsen <abjer>`.
 
+- Fixed a bug in ``KDTree`` construction that results in faster construction
+  and querying times. :issue:`11556` by :user:`Jake VanderPlas <jakevdp>`
+
 Feature Extraction
 
 - Fixed a bug in :func:`feature_extraction.image.extract_patches_2d` which would

--- a/sklearn/neighbors/kd_tree.pyx
+++ b/sklearn/neighbors/kd_tree.pyx
@@ -69,6 +69,8 @@ cdef int init_node(BinaryTree tree, ITYPE_t i_node,
         for j in range(n_features):
             lower_bounds[j] = fmin(lower_bounds[j], data_row[j])
             upper_bounds[j] = fmax(upper_bounds[j], data_row[j])
+
+    for j in range(n_features):
         if tree.dist_metric.p == INF:
             rad = fmax(rad, 0.5 * (upper_bounds[j] - lower_bounds[j]))
         else:


### PR DESCRIPTION
 Fixes #11313

The issue is in pre-computation of KD Tree node radii, which are used during querying to rank the queue of nodes to be split & explored. As such, I think the main effect of this bug will be related to performance – this is why our tests didn't catch it.