### PR TITLE
[MRG+2] Add a test for sample weights for estimators

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -556,41 +556,32 @@ def check_sample_weights_list(name, estimator_orig):
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))
 def check_sample_weight_invariance(name, estimator_orig):
+    # check that the estimators yield same results for
+    # unit weights and no weights
     if (has_fit_parameter(estimator_orig, "sample_weight") and
                     name not in ["KMeans", "MiniBatchKMeans"]):
         estimator1 = clone(estimator_orig)
         estimator2 = clone(estimator_orig)
+        set_random_state(estimator1, random_state=42)
+        set_random_state(estimator2, random_state=42)
 
         X = np.array([[1, 3], [1, 3], [1, 3], [1, 3],
                       [2, 1], [2, 1], [2, 1], [2, 1],
                       [3, 3], [3, 3], [3, 3], [3, 3],
                       [4, 1], [4, 1], [4, 1], [4, 1]], dtype=np.dtype('float'))
         y = np.array([1, 1, 1, 1, 2, 2, 2, 2,
-                      1, 1, 1, 1, 2, 2, 2, 2], dtype=np.dtype('float'))
+                      1, 1, 1, 1, 2, 2, 2, 2], dtype=np.dtype('int'))
 
-        if has_fit_parameter(estimator_orig, "random_state"):
-            estimator1.fit(X, y=y, sample_weight=np.ones(shape=len(y)), random_state=0)
-            estimator2.fit(X, y=y, sample_weight=None, random_state=0)
-        else:
-            estimator1.fit(X, y=y, sample_weight=np.ones(shape=len(y)))
-            estimator2.fit(X, y=y, sample_weight=None)
+        estimator1.fit(X, y=y, sample_weight=np.ones(shape=len(y)))
+        estimator2.fit(X, y=y, sample_weight=None)
 
-        if hasattr(estimator_orig, "predict"):
-            X_pred1 = estimator1.predict(X)
-            X_pred2 = estimator2.predict(X)
-            try:
-                assert_allclose(X_pred1, X_pred2, rtol=0.5)
-            except ValueError:
-                raise ValueError("For %s sample_weight=None is not equivalent to "
-                                 "sample_weight=ones" % name)
-        if hasattr(estimator_orig, "transform"):
-            X_trans1 = estimator1.transform(X)
-            X_trans2 = estimator2.transform(X)
-            try:
-                assert_allclose(X_trans1, X_trans2, rtol=0.5)
-            except ValueError:
-                raise ValueError("For %s sample_weight=None is not equivalent to "
-                                 "sample_weight=ones" % name)
+        for method in ["predict", "transform"]:
+            if hasattr(estimator_orig, method):
+                X_pred1 = getattr(estimator1, method)(X)
+                X_pred2 = getattr(estimator2, method)(X)
+                assert_allclose(X_pred1, X_pred2, rtol=0.5,
+                                err_msg="For %s sample_weight=None is not equivalent to "
+                                "sample_weight=ones" % name)
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning, UserWarning))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -556,7 +556,6 @@ def check_sample_weights_list(name, estimator_orig):
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))
 def check_sample_weight_invariance(name, estimator_orig):
-<<<<<<< HEAD
     if (has_fit_parameter(estimator_orig, "sample_weight") and
                     name not in ["KMeans", "MiniBatchKMeans"]):
         estimator1 = clone(estimator_orig)
@@ -592,7 +591,7 @@ def check_sample_weight_invariance(name, estimator_orig):
             except ValueError:
                 raise ValueError("For %s sample_weight=None is not equivalent to "
                                  "sample_weight=ones" % name)
-            
+
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning, UserWarning))
 def check_dtype_object(name, estimator_orig):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -88,7 +88,7 @@ def _yield_non_meta_checks(name, estimator):
     yield check_dtype_object
     yield check_sample_weights_pandas_series
     yield check_sample_weights_list
-    yield check_sample_weight_invariance
+    yield check_sample_weights_invariance
     yield check_estimators_fit_returns_self
     yield partial(check_estimators_fit_returns_self, readonly_memmap=True)
     yield check_complex_data
@@ -556,10 +556,12 @@ def check_sample_weights_list(name, estimator_orig):
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))
-def check_sample_weight_invariance(name, estimator_orig):
+def check_sample_weights_invariance(name, estimator_orig):
     # check that the estimators yield same results for
     # unit weights and no weights
     if (has_fit_parameter(estimator_orig, "sample_weight") and
+            not (hasattr(estimator_orig, "_pairwise")
+                 and estimator_orig._pairwise) and
             name not in ["KMeans", "MiniBatchKMeans"]):
         estimator1 = clone(estimator_orig)
         estimator2 = clone(estimator_orig)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -583,8 +583,8 @@ def check_sample_weights_invariance(name, estimator_orig):
                 X_pred1 = getattr(estimator1, method)(X)
                 X_pred2 = getattr(estimator2, method)(X)
                 assert_allclose(X_pred1, X_pred2, rtol=0.5,
-                                err_msg="For %s sample_weight=None is not equivalent"
-                                        " to sample_weight=ones" % name)
+                    err_msg="For %s sample_weight=None is not equivalent"
+                            " to sample_weight=ones" % name)
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning, UserWarning))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -559,7 +559,7 @@ def check_sample_weight_invariance(name, estimator_orig):
     # check that the estimators yield same results for
     # unit weights and no weights
     if (has_fit_parameter(estimator_orig, "sample_weight") and
-                    name not in ["KMeans", "MiniBatchKMeans"]):
+            name not in ["KMeans", "MiniBatchKMeans"]):
         estimator1 = clone(estimator_orig)
         estimator2 = clone(estimator_orig)
         set_random_state(estimator1, random_state=42)
@@ -580,8 +580,8 @@ def check_sample_weight_invariance(name, estimator_orig):
                 X_pred1 = getattr(estimator1, method)(X)
                 X_pred2 = getattr(estimator2, method)(X)
                 assert_allclose(X_pred1, X_pred2, rtol=0.5,
-                                err_msg="For %s sample_weight=None is not equivalent to "
-                                "sample_weight=ones" % name)
+                                err_msg="For %s sample_weight=None is not equivalent"
+                                        " to sample_weight=ones" % name)
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning, UserWarning))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -564,9 +564,9 @@ def check_sample_weight_invariance(name, estimator_orig):
         X = np.array([[1, 3], [1, 3], [1, 3], [1, 3],
                       [2, 1], [2, 1], [2, 1], [2, 1],
                       [3, 3], [3, 3], [3, 3], [3, 3],
-                      [4, 1], [4, 1], [4, 1], [4, 1]])
+                      [4, 1], [4, 1], [4, 1], [4, 1]], dtype=np.dtype('float'))
         y = np.array([1, 1, 1, 1, 2, 2, 2, 2,
-                      1, 1, 1, 1, 2, 2, 2, 2])
+                      1, 1, 1, 1, 2, 2, 2, 2], dtype=np.dtype('float'))
 
         if has_fit_parameter(estimator_orig, "random_state"):
             estimator1.fit(X, y=y, sample_weight=np.ones(shape=len(y)), random_state=0)
@@ -584,10 +584,10 @@ def check_sample_weight_invariance(name, estimator_orig):
                 raise ValueError("For %s sample_weight=None is not equivalent to "
                                  "sample_weight=ones" % name)
         if hasattr(estimator_orig, "transform"):
-            X_pred1 = estimator1.transform(X)
-            X_pred2 = estimator2.transform(X)
+            X_trans1 = estimator1.transform(X)
+            X_trans2 = estimator2.transform(X)
             try:
-                assert_allclose(X_pred1, X_pred2, rtol=0.5)
+                assert_allclose(X_trans1, X_trans2, rtol=0.5)
             except ValueError:
                 raise ValueError("For %s sample_weight=None is not equivalent to "
                                  "sample_weight=ones" % name)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -561,14 +561,13 @@ def check_sample_weights_invariance(name, estimator_orig):
     # unit weights and no weights
     if (has_fit_parameter(estimator_orig, "sample_weight") and
             not (hasattr(estimator_orig, "_pairwise")
-                 and estimator_orig._pairwise) and
-            name not in ["KMeans", "MiniBatchKMeans"]):
+                 and estimator_orig._pairwise)):
         # We skip pairwise because the data is not pairwise
-        # KMeans and MiniBatchKMeans were unstable; hence skipped.
+
         estimator1 = clone(estimator_orig)
         estimator2 = clone(estimator_orig)
-        set_random_state(estimator1, random_state=42)
-        set_random_state(estimator2, random_state=42)
+        set_random_state(estimator1, random_state=0)
+        set_random_state(estimator2, random_state=0)
 
         X = np.array([[1, 3], [1, 3], [1, 3], [1, 3],
                       [2, 1], [2, 1], [2, 1], [2, 1],

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -563,6 +563,8 @@ def check_sample_weights_invariance(name, estimator_orig):
             not (hasattr(estimator_orig, "_pairwise")
                  and estimator_orig._pairwise) and
             name not in ["KMeans", "MiniBatchKMeans"]):
+        # We skip pairwise because the data is not pairwise
+        # KMeans and MiniBatchKMeans were unstable; hence skipped.
         estimator1 = clone(estimator_orig)
         estimator2 = clone(estimator_orig)
         set_random_state(estimator1, random_state=42)
@@ -583,8 +585,9 @@ def check_sample_weights_invariance(name, estimator_orig):
                 X_pred1 = getattr(estimator1, method)(X)
                 X_pred2 = getattr(estimator2, method)(X)
                 assert_allclose(X_pred1, X_pred2, rtol=0.5,
-                    err_msg="For %s sample_weight=None is not equivalent"
-                            " to sample_weight=ones" % name)
+                                err_msg="For %s sample_weight=None is not"
+                                        " equivalent to sample_weight=ones"
+                                        % name)
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning, UserWarning))


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes the invariant test for sample weights as mentioned in issue #11316 (Refactor tests for sample weights).

#### What is new?
This is a generic test for estimators that makes sure the sample weights yield consistent results. 

#### What does this implement/fix? Explain your changes.
The test checks if the output of the estimators are the same for `sample_weight = None` and `sample_weight=np.ones()`. 

#### Any other comments?
Pairwise methods are skipped as they require pairwise data.