### PR TITLE
[MRG] fixes multinomial scoring for LogisticRegressionCV

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -71,6 +71,7 @@ random sampling procedures.
 - :class:`linear_model.PassiveAggressiveRegressor` (bug fix)
 - :class:`linear_model.Perceptron` (bug fix)
 - :class:`ensemble.gradient_boosting.GradientBoostingClassifier` (bug fix affecting feature importances)
+- :class:`linear_model.LogisticRegressionCV` (bug fix)
 - The v0.19.0 release notes failed to mention a backwards incompatibility with
   :class:`model_selection.StratifiedKFold` when ``shuffle=True`` due to
   :issue:`7823`.
@@ -441,6 +442,11 @@ Classifiers and regressors
   ``score`` method always computes accuracy, not the metric given by
   the ``scoring`` parameter.
   :issue:`10998` by :user:`Thomas Fan <thomasjpfan>`.
+
+- Fixed a bug in :class:`linear_model.LogisticRegressionCV` where the 'ovr'
+  strategy was always used to compute cross-validation scores in the
+  multiclass setting, even if 'multinomial' was set.
+  :issue:`8720` by :user:`William de Vazelhes <wdevazelhes>`.
 
 - Fixed a bug in :class:`linear_model.OrthogonalMatchingPursuit` that was
   broken when setting ``normalize=False``.

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -922,7 +922,7 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
         check_input=False, max_squared_sum=max_squared_sum,
         sample_weight=sample_weight)
 
-    log_reg = LogisticRegression(fit_intercept=fit_intercept)
+    log_reg = LogisticRegression(multi_class=multi_class)
 
     # The score method of Logistic Regression has a classes_ attribute.
     if multi_class == 'ovr':

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -6,6 +6,7 @@ import pytest
 
 from sklearn.datasets import load_iris, make_classification
 from sklearn.metrics import log_loss
+from sklearn.metrics.scorer import get_scorer
 from sklearn.model_selection import StratifiedKFold
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import compute_class_weight
@@ -29,7 +30,7 @@ from sklearn.linear_model.logistic import (
     logistic_regression_path, LogisticRegressionCV,
     _logistic_loss_and_grad, _logistic_grad_hess,
     _multinomial_grad_hess, _logistic_loss,
-)
+    _log_reg_scoring_path)
 
 X = [[-1, 0], [0, 1], [1, 1]]
 X_sp = sp.csr_matrix(X)
@@ -490,6 +491,37 @@ def test_logistic_cv():
     assert_array_equal(lr_cv.Cs_.shape, (1,))
     scores = np.asarray(list(lr_cv.scores_.values()))
     assert_array_equal(scores.shape, (1, 3, 1))
+
+
+@pytest.mark.parametrize('scoring', ['accuracy', 'f1', 'neg_log_loss',
+                                     'precision', 'recall'])
+def test_logistic_cv_multinomial_score(scoring):
+    # test that LogisticRegressionCV uses the right score to compute its
+    # cross-validation scores when using a multinomial scoring
+    # see https://github.com/scikit-learn/scikit-learn/issues/8720
+    X, y = make_classification(n_samples=100, random_state=0, n_classes=3,
+                               n_informative=6)
+    train, test = np.arange(80), np.arange(80, 100)
+    lr = LogisticRegression(C=1., solver='lbfgs', multi_class='multinomial')
+    # we use lbfgs to support multinomial
+    params = lr.get_params()
+    # we store the params to set them further in _log_reg_scoring_path
+    for key in ['C', 'n_jobs', 'warm_start']:
+        del(params[key])
+    lr.fit(X[train], y[train])
+    if scoring in ['f1', 'precision', 'recall']:
+        for averaging in ['micro', 'macro', 'weighted']:
+            scorer = get_scorer('{0}_{1}'.format(scoring, averaging))
+            np.testing.assert_array_almost_equal(
+                _log_reg_scoring_path(X, y, train, test, Cs=[1.], **params,
+                                      scoring=scorer)[2][0],
+                scorer(lr, X[test], y[test]))
+    else:
+        scorer = get_scorer(scoring)
+        np.testing.assert_array_almost_equal(
+            _log_reg_scoring_path(X, y, train, test, Cs=[1.], **params,
+                                  scoring=scorer)[2][0],
+            scorer(lr, X[test], y[test]))
 
 
 def test_multinomial_logistic_regression_string_inputs():

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -493,9 +493,18 @@ def test_logistic_cv():
     assert_array_equal(scores.shape, (1, 3, 1))
 
 
-@pytest.mark.parametrize('scoring', ['accuracy', 'f1', 'neg_log_loss',
-                                     'precision', 'recall'])
-def test_logistic_cv_multinomial_score(scoring):
+@pytest.mark.parametrize('scoring, multiclass_agg_list',
+                         [('accuracy', ['']),
+                          ('precision', ['_macro', '_weighted']),
+                          # no need to test for micro averaging because it
+                          # is the same as accuracy for f1, precision,
+                          # and recall (see https://github.com/
+                          # scikit-learn/scikit-learn/pull/
+                          # 11578#discussion_r203250062)
+                          ('f1', ['_macro', '_weighted']),
+                          ('neg_log_loss', ['']),
+                          ('recall', ['_macro', '_weighted'])])
+def test_logistic_cv_multinomial_score(scoring, multiclass_agg_list):
     # test that LogisticRegressionCV uses the right score to compute its
     # cross-validation scores when using a multinomial scoring
     # see https://github.com/scikit-learn/scikit-learn/issues/8720
@@ -507,17 +516,10 @@ def test_logistic_cv_multinomial_score(scoring):
     params = lr.get_params()
     # we store the params to set them further in _log_reg_scoring_path
     for key in ['C', 'n_jobs', 'warm_start']:
-        del(params[key])
+        del params[key]
     lr.fit(X[train], y[train])
-    if scoring in ['f1', 'precision', 'recall']:
-        for averaging in ['micro', 'macro', 'weighted']:
-            scorer = get_scorer('{0}_{1}'.format(scoring, averaging))
-            assert_array_almost_equal(
-                _log_reg_scoring_path(X, y, train, test, Cs=[1.],
-                                      scoring=scorer, **params)[2][0],
-                scorer(lr, X[test], y[test]))
-    else:
-        scorer = get_scorer(scoring)
+    for averaging in multiclass_agg_list:
+        scorer = get_scorer(scoring + averaging)
         assert_array_almost_equal(
             _log_reg_scoring_path(X, y, train, test, Cs=[1.],
                                   scoring=scorer, **params)[2][0],

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -512,15 +512,15 @@ def test_logistic_cv_multinomial_score(scoring):
     if scoring in ['f1', 'precision', 'recall']:
         for averaging in ['micro', 'macro', 'weighted']:
             scorer = get_scorer('{0}_{1}'.format(scoring, averaging))
-            np.testing.assert_array_almost_equal(
-                _log_reg_scoring_path(X, y, train, test, Cs=[1.], **params,
-                                      scoring=scorer)[2][0],
+            assert_array_almost_equal(
+                _log_reg_scoring_path(X, y, train, test, Cs=[1.],
+                                      scoring=scorer, **params)[2][0],
                 scorer(lr, X[test], y[test]))
     else:
         scorer = get_scorer(scoring)
-        np.testing.assert_array_almost_equal(
-            _log_reg_scoring_path(X, y, train, test, Cs=[1.], **params,
-                                  scoring=scorer)[2][0],
+        assert_array_almost_equal(
+            _log_reg_scoring_path(X, y, train, test, Cs=[1.],
+                                  scoring=scorer, **params)[2][0],
             scorer(lr, X[test], y[test]))
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #8720.
Closes #8760.

#### What does this implement/fix? Explain your changes.
The change is described in the issue (see https://github.com/scikit-learn/scikit-learn/issues/8720#issuecomment-405349408)

#### Any other comments?

On master, the test fails for param scoring='neg_log_loss', whereas it passes on this branch.

For the test, note that `_log_reg_scoring_path` has different defaults than `LogisticRegression` (for instance `fit_intercept` is True for one, False for the other), so I took the get_params from the `LogisticRegression` to put them in `_log_reg_scoring_path`.

When doing that, I deleted the ones that do not exist in `_log_reg_scoring_path` removing explicitely 'C' ,'n_jobs' and 'warm_start'. This way, if some new arguments are added to both `LogisticRegression` and `_log_reg_scoring_path`, they would be transmitted. On the other hand, if a new argument is created only in `LogisticRegression`, it would break the test (but then someone would just update it). 
Another option would be to have the list of arguments that we keep (instead of a list of the ones we throw). But doing that if we added a new parameter to both `LogisticRegression` and `_log_reg_scoring_path`, we would have a weird behaviour with params that are not transmitted and this could not raise any error.	


I also tested the function not only for `neg_log_loss` but also for other metrics for classification with the 'multinomial' option (see http://scikit-learn.org/stable/modules/model_evaluation.html#common-cases-predefined-values). `average_precision` and `roc_auc` returned "multiclass format is not supported" so as they are not applicable for this test I didn't include them. For `f1`, `precision` and `recall`, I test all averagings methods except `samples`, since it is only applicable for multilabel classification (``ValueError: Sample-based precision, recall, fscore is not meaningful outside multilabel classification. See the accuracy_score instead.``)

As it only tests the `multinomial` case, it is rather tailored for the previous particular issue. Should I include also a test for the multiclass + ovr case (this test would be a bit more complicated because when using 'ovr', `_log_reg_scoring_path` should be called with a pos_class argument and returns only a 1 vs rest score, so it must be done for every class and mixed together for having a single ovr score), and the binary case ? 



