### PR TITLE
[MRG] MAINT divide appveyor work by 2 while still testing old and new python and 32 and 64 bitnesses

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,10 +17,6 @@ environment:
     SKLEARN_SKIP_NETWORK_TESTS: 1
 
   matrix:
-    - PYTHON: "C:\\Python37"
-      PYTHON_VERSION: "3.7.0"
-      PYTHON_ARCH: "32"
-
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.0"
       PYTHON_ARCH: "64"
@@ -28,10 +24,6 @@ environment:
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.8"
       PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.8"
-      PYTHON_ARCH: "64"
 
 
 # Because we only have a single worker, we don't want to waste precious


### PR DESCRIPTION
appveyor is overloaded.

This PR removes 2 out of the 4 builds while continuing to test both 32 and 64-bit python and old and new python versions.

I think this is a pragmatic trade-off between resource usage and test coverage.

If nobody disagrees we can merge this without waiting for CI to catch-up.