### PR TITLE
[MRG] MNT Remove redundant metrics in test_common.py

### DIFF
--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -202,7 +202,6 @@ THRESHOLDED_METRICS = {
     "weighted_roc_auc": partial(roc_auc_score, average="weighted"),
     "samples_roc_auc": partial(roc_auc_score, average="samples"),
     "micro_roc_auc": partial(roc_auc_score, average="micro"),
-    "macro_roc_auc": partial(roc_auc_score, average="macro"),
     "partial_roc_auc": partial(roc_auc_score, max_fpr=0.5),
 
     "average_precision_score": average_precision_score,
@@ -212,8 +211,6 @@ THRESHOLDED_METRICS = {
     partial(average_precision_score, average="samples"),
     "micro_average_precision_score":
     partial(average_precision_score, average="micro"),
-    "macro_average_precision_score":
-    partial(average_precision_score, average="macro"),
     "label_ranking_average_precision_score":
     label_ranking_average_precision_score,
 }
@@ -253,14 +250,12 @@ METRIC_UNDEFINED_MULTICLASS = {
     "roc_auc_score",
     "micro_roc_auc",
     "weighted_roc_auc",
-    "macro_roc_auc",
     "samples_roc_auc",
     "partial_roc_auc",
 
     "average_precision_score",
     "weighted_average_precision_score",
     "micro_average_precision_score",
-    "macro_average_precision_score",
     "samples_average_precision_score",
 
     # with default average='binary', multiclass is prohibited
@@ -301,7 +296,6 @@ METRICS_WITH_POS_LABEL = {
     "average_precision_score",
     "weighted_average_precision_score",
     "micro_average_precision_score",
-    "macro_average_precision_score",
     "samples_average_precision_score",
 
     # pos_label support deprecated; to be removed in 0.18:
@@ -353,11 +347,10 @@ THRESHOLDED_MULTILABEL_METRICS = {
     "unnormalized_log_loss",
 
     "roc_auc_score", "weighted_roc_auc", "samples_roc_auc",
-    "micro_roc_auc", "macro_roc_auc", "partial_roc_auc",
+    "micro_roc_auc", "partial_roc_auc",
 
     "average_precision_score", "weighted_average_precision_score",
     "samples_average_precision_score", "micro_average_precision_score",
-    "macro_average_precision_score",
 
     "coverage_error", "label_ranking_loss",
     "label_ranking_average_precision_score",

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -198,13 +198,14 @@ THRESHOLDED_METRICS = {
 
     "brier_score_loss": brier_score_loss,
 
-    "roc_auc_score": roc_auc_score,
+    "roc_auc_score": roc_auc_score,  # default: average="macro"
     "weighted_roc_auc": partial(roc_auc_score, average="weighted"),
     "samples_roc_auc": partial(roc_auc_score, average="samples"),
     "micro_roc_auc": partial(roc_auc_score, average="micro"),
     "partial_roc_auc": partial(roc_auc_score, max_fpr=0.5),
 
-    "average_precision_score": average_precision_score,
+    "average_precision_score":
+    average_precision_score,  # default: average="macro"
     "weighted_average_precision_score":
     partial(average_precision_score, average="weighted"),
     "samples_average_precision_score":


### PR DESCRIPTION
Not sure if others like it so feel free to close it if someone has enough confidence.
The core idea is that ``"macro_roc_auc": partial(roc_auc_score, average="macro")`` is the same as ``"roc_auc_score": roc_auc_score``. What's more, when ``"macro_roc_auc"`` appears in a list, ``"roc_auc_score"`` also appears. So we can remove ``"macro_roc_auc"``.
Same for ``"macro_average_precision_score"``.
This will get rid of 8 redundant tests but won't save too much time.