### PR TITLE
[MRG+1] SPCA centering and fixing scaling issue

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -74,6 +74,7 @@ random sampling procedures.
 - The v0.19.0 release notes failed to mention a backwards incompatibility with
   :class:`model_selection.StratifiedKFold` when ``shuffle=True`` due to
   :issue:`7823`.
+- :class:`decomposition.SparsePCA` (bug fix)
 
 Details are listed in the changelog below.
 
@@ -181,6 +182,14 @@ Decomposition, manifold learning and clustering
 - :mod:`dict_learning` functions and models now support positivity constraints.
   This applies to the dictionary and sparse code.
   :issue:`6374` by :user:`John Kirkham <jakirkham>`.
+
+- :class:`decomposition.SparsePCA` now exposes ``normalize_components``. When
+  set to True, the train and test data are centered with the train mean 
+  repsectively during the fit phase and the transform phase. This fixes the
+  behavior of SparsePCA. When set to False, which is the default, the previous
+  abnormal behaviour still holds. The False value is for backward
+  compatibility and should not be used.
+  :issue:`11585` by :user:`Ivan Panico <FollowKenny>`.
 
 Metrics
 

--- a/examples/decomposition/plot_faces_decomposition.py
+++ b/examples/decomposition/plot_faces_decomposition.py
@@ -81,7 +81,8 @@ estimators = [
     ('Sparse comp. - MiniBatchSparsePCA',
      decomposition.MiniBatchSparsePCA(n_components=n_components, alpha=0.8,
                                       n_iter=100, batch_size=3,
-                                      random_state=rng),
+                                      random_state=rng,
+                                      normalize_components=True),
      True),
 
     ('MiniBatchDictionaryLearning',

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -66,6 +66,13 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
+    normalize_components : boolean
+        False : Use a version of Sparse PCA without components normalization
+        and without data centring. This is likely a bug and eventhough it's
+        the default for backward compatibility, this should not be used
+        True : Use a version of Sparse PCA with components normalization
+        and data centring
+
     Attributes
     ----------
     components_ : array, [n_components, n_features]
@@ -77,6 +84,11 @@ class SparsePCA(BaseEstimator, TransformerMixin):
     n_iter_ : int
         Number of iterations run.
 
+    mean_ : array, shape (n_features,)
+        Per-feature empirical mean, estimated from the training set.
+
+        Equal to `X.mean(axis=0)`.
+
     See also
     --------
     PCA
@@ -85,7 +97,8 @@ class SparsePCA(BaseEstimator, TransformerMixin):
     """
     def __init__(self, n_components=None, alpha=1, ridge_alpha=0.01,
                  max_iter=1000, tol=1e-8, method='lars', n_jobs=1, U_init=None,
-                 V_init=None, verbose=False, random_state=None):
+                 V_init=None, verbose=False, random_state=None,
+                 normalize_components=False):
         self.n_components = n_components
         self.alpha = alpha
         self.ridge_alpha = ridge_alpha
@@ -97,6 +110,7 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         self.V_init = V_init
         self.verbose = verbose
         self.random_state = random_state
+        self.normalize_components = normalize_components
 
     def fit(self, X, y=None):
         """Fit the model from data in X.
@@ -116,15 +130,22 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         """
         random_state = check_random_state(self.random_state)
         X = check_array(X)
-        self.mean_ = np.mean(X, axis=0)
-        X -= self.mean_
+
+        if self.normalize_components:
+            self.mean_ = np.mean(X, axis=0)
+            X = X - self.mean_
+        else:
+            warnings.warn("normalize_components should be set to True. "
+                          "This parameter exists for backward compatibility "
+                          "and will be removed in 0.22.", DeprecationWarning)
+
         if self.n_components is None:
             n_components = X.shape[1]
         else:
             n_components = self.n_components
         code_init = self.V_init.T if self.V_init is not None else None
         dict_init = self.U_init.T if self.U_init is not None else None
-        Vt, _, E, self.n_iter_ = dict_learning(X.T, n_components, self.alpha,
+        Vt, U, E, self.n_iter_ = dict_learning(X.T, n_components, self.alpha,
                                                tol=self.tol,
                                                max_iter=self.max_iter,
                                                method=self.method,
@@ -136,9 +157,13 @@ class SparsePCA(BaseEstimator, TransformerMixin):
                                                return_n_iter=True
                                                )
         self.components_ = Vt.T
-        components_norm = np.sqrt((self.components_ ** 2).sum(axis=1))[:, np.newaxis]
-        components_norm[components_norm == 0] = 1
-        self.components_ /= components_norm
+
+        if self.normalize_components:
+            components_norm = \
+                    np.linalg.norm(self.components_, axis=1)[:, np.newaxis]
+            components_norm[components_norm == 0] = 1
+            self.components_ /= components_norm
+
         self.error_ = E
         return self
 
@@ -183,9 +208,18 @@ class SparsePCA(BaseEstimator, TransformerMixin):
                 ridge_alpha = self.ridge_alpha
         else:
             ridge_alpha = self.ridge_alpha
-        X -= self.mean_
+
+        if self.normalize_components:
+            X = X - self.mean_
+
         U = ridge_regression(self.components_.T, X.T, ridge_alpha,
                              solver='cholesky')
+
+        if not self.normalize_components:
+            s = np.sqrt((U ** 2).sum(axis=0))
+            s[s == 0] = 1
+            U /= s
+
         return U
 
 
@@ -242,6 +276,13 @@ class MiniBatchSparsePCA(SparsePCA):
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
+    normalize_components : boolean
+        False : Use a version of Sparse PCA without components normalization
+        and without data centring. This is likely a bug and eventhough it's
+        the default for backward compatibility, this should not be used
+        True : Use a version of Sparse PCA with components normalization
+        and data centring
+
     Attributes
     ----------
     components_ : array, [n_components, n_features]
@@ -249,6 +290,11 @@ class MiniBatchSparsePCA(SparsePCA):
 
     n_iter_ : int
         Number of iterations run.
+
+    mean_ : array, shape (n_features,)
+        Per-feature empirical mean, estimated from the training set.
+
+        Equal to `X.mean(axis=0)`.
 
     See also
     --------
@@ -258,11 +304,13 @@ class MiniBatchSparsePCA(SparsePCA):
     """
     def __init__(self, n_components=None, alpha=1, ridge_alpha=0.01,
                  n_iter=100, callback=None, batch_size=3, verbose=False,
-                 shuffle=True, n_jobs=1, method='lars', random_state=None):
+                 shuffle=True, n_jobs=1, method='lars', random_state=None,
+                 normalize_components=False):
         super(MiniBatchSparsePCA, self).__init__(
             n_components=n_components, alpha=alpha, verbose=verbose,
             ridge_alpha=ridge_alpha, n_jobs=n_jobs, method=method,
-            random_state=random_state)
+            random_state=random_state,
+            normalize_components=normalize_components)
         self.n_iter = n_iter
         self.callback = callback
         self.batch_size = batch_size
@@ -286,6 +334,15 @@ class MiniBatchSparsePCA(SparsePCA):
         """
         random_state = check_random_state(self.random_state)
         X = check_array(X)
+
+        if self.normalize_components:
+            self.mean_ = np.mean(X, axis=0)
+            X = X - self.mean_
+        else:
+            warnings.warn("normalize_components should be set to True. "
+                          "This parameter exists for backward compatibility "
+                          "and will be removed in 0.22.", DeprecationWarning)
+
         if self.n_components is None:
             n_components = X.shape[1]
         else:
@@ -301,4 +358,11 @@ class MiniBatchSparsePCA(SparsePCA):
             random_state=random_state,
             return_n_iter=True)
         self.components_ = Vt.T
+
+        if self.normalize_components:
+            components_norm = \
+                    np.linalg.norm(self.components_, axis=1)[:, np.newaxis]
+            components_norm[components_norm == 0] = 1
+            self.components_ /= components_norm
+
         return self

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -116,6 +116,8 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         """
         random_state = check_random_state(self.random_state)
         X = check_array(X)
+        self.mean_ = np.mean(X, axis=0)
+        X -= self.mean_
         if self.n_components is None:
             n_components = X.shape[1]
         else:
@@ -134,6 +136,9 @@ class SparsePCA(BaseEstimator, TransformerMixin):
                                                return_n_iter=True
                                                )
         self.components_ = Vt.T
+        components_norm = np.sqrt((self.components_ ** 2).sum(axis=1))[:, np.newaxis]
+        components_norm[components_norm == 0] = 1
+        self.components_ /= components_norm
         self.error_ = E
         return self
 
@@ -178,11 +183,9 @@ class SparsePCA(BaseEstimator, TransformerMixin):
                 ridge_alpha = self.ridge_alpha
         else:
             ridge_alpha = self.ridge_alpha
+        X -= self.mean_
         U = ridge_regression(self.components_.T, X.T, ridge_alpha,
                              solver='cholesky')
-        s = np.sqrt((U ** 2).sum(axis=0))
-        s[s == 0] = 1
-        U /= s
         return U
 
 

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -66,12 +66,19 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    normalize_components : boolean
-        False : Use a version of Sparse PCA without components normalization
-        and without data centring. This is likely a bug and eventhough it's
-        the default for backward compatibility, this should not be used
-        True : Use a version of Sparse PCA with components normalization
-        and data centring
+    normalize_components : boolean, optional (default=False)
+        - if False, Use a version of Sparse PCA without components
+          normalization and without data centering. This is likely a bug and
+          even though it's the default for backward compatibility,
+          this should not be used.
+        - if True, Use a version of Sparse PCA with components normalization
+          and data centering.
+
+        .. versionadded:: 0.20
+        .. deprecated:: 0.22
+                ``normalize_components`` was added and set to ``False`` for
+                backward compatibility. It would be set to ``True`` from 0.22
+                onwards.
 
     Attributes
     ----------
@@ -86,8 +93,7 @@ class SparsePCA(BaseEstimator, TransformerMixin):
 
     mean_ : array, shape (n_features,)
         Per-feature empirical mean, estimated from the training set.
-
-        Equal to `X.mean(axis=0)`.
+        Equal to ``X.mean(axis=0)``.
 
     See also
     --------
@@ -135,9 +141,11 @@ class SparsePCA(BaseEstimator, TransformerMixin):
             self.mean_ = np.mean(X, axis=0)
             X = X - self.mean_
         else:
-            warnings.warn("normalize_components should be set to True. "
-                          "This parameter exists for backward compatibility "
-                          "and will be removed in 0.22.", DeprecationWarning)
+            warnings.warn("normalize_components=False is a "
+                          "backward-compatible setting that implements a "
+                          "non-standard definition of sparse PCA. This "
+                          "compatibility mode will be removed in 0.22.",
+                          DeprecationWarning)
 
         if self.n_components is None:
             n_components = X.shape[1]
@@ -277,11 +285,18 @@ class MiniBatchSparsePCA(SparsePCA):
         by `np.random`.
 
     normalize_components : boolean
-        False : Use a version of Sparse PCA without components normalization
-        and without data centring. This is likely a bug and eventhough it's
-        the default for backward compatibility, this should not be used
-        True : Use a version of Sparse PCA with components normalization
-        and data centring
+        - if False, Use a version of Sparse PCA without components
+          normalization and without data centering. This is likely a bug
+          and even though it's the default for backward compatibility,
+          this should not be used.
+        - if True, Use a version of Sparse PCA with components normalization
+          and data centering.
+
+        .. versionadded:: 0.20
+        .. deprecated:: 0.22
+                ``normalize_components`` was added and set to ``False`` for
+                backward compatibility. It would be set to ``True`` from 0.22
+                onwards.
 
     Attributes
     ----------
@@ -293,8 +308,7 @@ class MiniBatchSparsePCA(SparsePCA):
 
     mean_ : array, shape (n_features,)
         Per-feature empirical mean, estimated from the training set.
-
-        Equal to `X.mean(axis=0)`.
+        Equal to ``X.mean(axis=0)``.
 
     See also
     --------
@@ -339,9 +353,11 @@ class MiniBatchSparsePCA(SparsePCA):
             self.mean_ = np.mean(X, axis=0)
             X = X - self.mean_
         else:
-            warnings.warn("normalize_components should be set to True. "
-                          "This parameter exists for backward compatibility "
-                          "and will be removed in 0.22.", DeprecationWarning)
+            warnings.warn("normalize_components=False is a "
+                          "backward-compatible setting that implements a "
+                          "non-standard definition of sparse PCA. This "
+                          "compatibility mode will be removed in 0.22.",
+                          DeprecationWarning)
 
         if self.n_components is None:
             n_components = X.shape[1]

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -145,7 +145,7 @@ class SparsePCA(BaseEstimator, TransformerMixin):
             n_components = self.n_components
         code_init = self.V_init.T if self.V_init is not None else None
         dict_init = self.U_init.T if self.U_init is not None else None
-        Vt, U, E, self.n_iter_ = dict_learning(X.T, n_components, self.alpha,
+        Vt, _, E, self.n_iter_ = dict_learning(X.T, n_components, self.alpha,
                                                tol=self.tol,
                                                max_iter=self.max_iter,
                                                method=self.method,

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -67,18 +67,19 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         by `np.random`.
 
     normalize_components : boolean, optional (default=False)
-        - if False, Use a version of Sparse PCA without components
+        - if False, use a version of Sparse PCA without components
           normalization and without data centering. This is likely a bug and
           even though it's the default for backward compatibility,
           this should not be used.
-        - if True, Use a version of Sparse PCA with components normalization
+        - if True, use a version of Sparse PCA with components normalization
           and data centering.
 
         .. versionadded:: 0.20
+
         .. deprecated:: 0.22
-                ``normalize_components`` was added and set to ``False`` for
-                backward compatibility. It would be set to ``True`` from 0.22
-                onwards.
+           ``normalize_components`` was added and set to ``False`` for
+           backward compatibility. It would be set to ``True`` from 0.22
+           onwards.
 
     Attributes
     ----------
@@ -138,7 +139,7 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         X = check_array(X)
 
         if self.normalize_components:
-            self.mean_ = np.mean(X, axis=0)
+            self.mean_ = X.mean(axis=0)
             X = X - self.mean_
         else:
             warnings.warn("normalize_components=False is a "
@@ -284,19 +285,20 @@ class MiniBatchSparsePCA(SparsePCA):
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    normalize_components : boolean
-        - if False, Use a version of Sparse PCA without components
-          normalization and without data centering. This is likely a bug
-          and even though it's the default for backward compatibility,
+    normalize_components : boolean, optional (default=False)
+        - if False, use a version of Sparse PCA without components
+          normalization and without data centering. This is likely a bug and
+          even though it's the default for backward compatibility,
           this should not be used.
-        - if True, Use a version of Sparse PCA with components normalization
+        - if True, use a version of Sparse PCA with components normalization
           and data centering.
 
         .. versionadded:: 0.20
+
         .. deprecated:: 0.22
-                ``normalize_components`` was added and set to ``False`` for
-                backward compatibility. It would be set to ``True`` from 0.22
-                onwards.
+           ``normalize_components`` was added and set to ``False`` for
+           backward compatibility. It would be set to ``True`` from 0.22
+           onwards.
 
     Attributes
     ----------
@@ -350,7 +352,7 @@ class MiniBatchSparsePCA(SparsePCA):
         X = check_array(X)
 
         if self.normalize_components:
-            self.mean_ = np.mean(X, axis=0)
+            self.mean_ = X.mean(axis=0)
             X = X - self.mean_
         else:
             warnings.warn("normalize_components=False is a "

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -46,6 +46,7 @@ def generate_toy_data(n_components, n_samples, image_size, random_state=None):
 # test different aspects of the code in the same test
 
 
+@pytest.mark.filterwarnings("ignore:normalize_components")
 @pytest.mark.parametrize("norm_comp", [False, True])
 def test_correct_shapes(norm_comp):
     rng = np.random.RandomState(0)
@@ -63,6 +64,7 @@ def test_correct_shapes(norm_comp):
     assert_equal(U.shape, (12, 13))
 
 
+@pytest.mark.filterwarnings("ignore:normalize_components")
 @pytest.mark.parametrize("norm_comp", [False, True])
 def test_fit_transform(norm_comp):
     alpha = 1
@@ -86,6 +88,7 @@ def test_fit_transform(norm_comp):
                          Y, ridge_alpha=None)
 
 
+@pytest.mark.filterwarnings("ignore:normalize_components")
 @pytest.mark.parametrize("norm_comp", [False, True])
 @if_safe_multiprocessing_with_blas
 def test_fit_transform_parallel(norm_comp):
@@ -104,6 +107,7 @@ def test_fit_transform_parallel(norm_comp):
     assert_array_almost_equal(U1, U2)
 
 
+@pytest.mark.filterwarnings("ignore:normalize_components")
 @pytest.mark.parametrize("norm_comp", [False, True])
 def test_transform_nan(norm_comp):
     # Test that SparsePCA won't return NaN when there is 0 feature in all
@@ -115,6 +119,7 @@ def test_transform_nan(norm_comp):
     assert_false(np.any(np.isnan(estimator.fit_transform(Y))))
 
 
+@pytest.mark.filterwarnings("ignore:normalize_components")
 @pytest.mark.parametrize("norm_comp", [False, True])
 def test_fit_transform_tall(norm_comp):
     rng = np.random.RandomState(0)
@@ -128,6 +133,7 @@ def test_fit_transform_tall(norm_comp):
     assert_array_almost_equal(U1, U2)
 
 
+@pytest.mark.filterwarnings("ignore:normalize_components")
 @pytest.mark.parametrize("norm_comp", [False, True])
 def test_initialization(norm_comp):
     rng = np.random.RandomState(0)
@@ -143,6 +149,7 @@ def test_initialization(norm_comp):
         assert_array_equal(model.components_, V_init)
 
 
+@pytest.mark.filterwarnings("ignore:normalize_components")
 @pytest.mark.parametrize("norm_comp", [False, True])
 def test_mini_batch_correct_shapes(norm_comp):
     rng = np.random.RandomState(0)
@@ -160,6 +167,7 @@ def test_mini_batch_correct_shapes(norm_comp):
     assert_equal(U.shape, (12, 13))
 
 
+@pytest.mark.filterwarnings("ignore:normalize_components")
 @pytest.mark.parametrize("norm_comp", [False, True])
 def test_mini_batch_fit_transform(norm_comp):
     raise SkipTest("skipping mini_batch_fit_transform.")
@@ -230,4 +238,4 @@ def test_spca_deprecation_warning(spca):
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)
     with pytest.warns(DeprecationWarning, match="normalize_components"):
-        spca().fit(Y)
+        spca(normalize_components=False).fit(Y)

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -237,6 +237,6 @@ def test_pca_vs_spca():
 def test_spca_deprecation_warning(spca):
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)
-    warn_message ="normalize_components"
+    warn_message = "normalize_components"
     assert_warns_message(DeprecationWarning, warn_message,
                          spca(normalize_components=False).fit, Y)

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -204,7 +204,7 @@ def test_scaling_fit_transform():
                           random_state=rng, normalize_components=True)
     results_train = spca_lars.fit_transform(Y)
     results_test = spca_lars.transform(Y[:10])
-    assert_array_equal(results_train[0], results_test[0])
+    assert_allclose(results_train[0], results_test[0])
 
 
 def test_pca_vs_spca():

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -237,5 +237,6 @@ def test_pca_vs_spca():
 def test_spca_deprecation_warning(spca):
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)
-    with pytest.warns(DeprecationWarning, match="normalize_components"):
-        spca(normalize_components=False).fit(Y)
+    warn_message ="normalize_components"
+    assert_warns_message(DeprecationWarning, warn_message,
+                         spca(normalize_components=False).fit, Y)

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -123,7 +123,7 @@ def test_fit_transform_tall(norm_comp):
                           random_state=rng, normalize_components=norm_comp)
     U1 = spca_lars.fit_transform(Y)
     spca_lasso = SparsePCA(n_components=3, method='cd',
-                          random_state=rng, normalize_components=norm_comp)
+                           random_state=rng, normalize_components=norm_comp)
     U2 = spca_lasso.fit(Y).transform(Y)
     assert_array_almost_equal(U1, U2)
 
@@ -138,7 +138,7 @@ def test_initialization(norm_comp):
     model.fit(rng.randn(5, 4))
     if norm_comp:
         assert_array_equal(model.components_,
-                V_init / np.linalg.norm(V_init, axis=1)[:, np.newaxis])
+                           V_init / np.linalg.norm(V_init, axis=1)[:, None])
     else:
         assert_array_equal(model.components_, V_init)
 
@@ -167,7 +167,8 @@ def test_mini_batch_fit_transform(norm_comp):
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)  # wide array
     spca_lars = MiniBatchSparsePCA(n_components=3, random_state=0,
-            alpha=alpha, normalize_components=norm_comp).fit(Y)
+                                   alpha=alpha,
+                                   normalize_components=norm_comp).fit(Y)
     U1 = spca_lars.transform(Y)
     # Test multiple CPUs
     if sys.platform == 'win32':  # fake parallelism for win32
@@ -178,14 +179,14 @@ def test_mini_batch_fit_transform(norm_comp):
             U2 = MiniBatchSparsePCA(n_components=3, n_jobs=2, alpha=alpha,
                                     random_state=0,
                                     normalize_components=norm_comp)\
-            .fit(Y).transform(Y)
+                .fit(Y).transform(Y)
         finally:
             joblib_par.multiprocessing = _mp
     else:  # we can efficiently use parallelism
         U2 = MiniBatchSparsePCA(n_components=3, n_jobs=2, alpha=alpha,
                                 random_state=0,
                                 normalize_components=norm_comp)\
-        .fit(Y).transform(Y)
+            .fit(Y).transform(Y)
     assert_true(not np.all(spca_lars.components_ == 0))
     assert_array_almost_equal(U1, U2)
     # Test that CD gives similar results
@@ -198,7 +199,7 @@ def test_mini_batch_fit_transform(norm_comp):
 def test_scaling_fit_transform():
     alpha = 1
     rng = np.random.RandomState(0)
-    Y, _, _ = generate_toy_data(3, 1000, (8, 8), random_state=rng)  # wide array
+    Y, _, _ = generate_toy_data(3, 1000, (8, 8), random_state=rng)
     spca_lars = SparsePCA(n_components=3, method='lars', alpha=alpha,
                           random_state=rng, normalize_components=True)
     results_train = spca_lars.fit_transform(Y)
@@ -207,18 +208,18 @@ def test_scaling_fit_transform():
 
 
 def test_pca_vs_spca():
-    alpha = 0
-    ridge_alpha = 0
     rng = np.random.RandomState(0)
-    Y, _, _ = generate_toy_data(3, 1000, (8, 8), random_state=rng)  # wide array
-    Z, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)  # wide array
-    spca = SparsePCA(alpha=0, ridge_alpha=0, n_components=2, normalize_components=True)
+    Y, _, _ = generate_toy_data(3, 1000, (8, 8), random_state=rng)
+    Z, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)
+    spca = SparsePCA(alpha=0, ridge_alpha=0, n_components=2,
+                     normalize_components=True)
     pca = PCA(n_components=2)
-    results_train_pca = pca.fit_transform(Y)
+    pca.fit(Y)
+    spca.fit(Y)
     results_test_pca = pca.transform(Z)
-    results_train_spca = spca.fit_transform(Y)
     results_test_spca = spca.transform(Z)
-    assert_allclose(np.abs(spca.components_.dot(pca.components_.T)), np.eye(2), atol=1e-5)
+    assert_allclose(np.abs(spca.components_.dot(pca.components_.T)),
+                    np.eye(2), atol=1e-5)
     results_test_pca *= np.sign(results_test_pca[0, :])
     results_test_spca *= np.sign(results_test_spca[0, :])
     assert_allclose(results_test_pca, results_test_spca)

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -8,14 +8,17 @@ import numpy as np
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import SkipTest
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import if_safe_multiprocessing_with_blas
 
-from sklearn.decomposition import SparsePCA, MiniBatchSparsePCA
+from sklearn.decomposition import SparsePCA, MiniBatchSparsePCA, PCA
 from sklearn.utils import check_random_state
+
+import pytest
 
 
 def generate_toy_data(n_components, n_samples, image_size, random_state=None):
@@ -43,31 +46,35 @@ def generate_toy_data(n_components, n_samples, image_size, random_state=None):
 # test different aspects of the code in the same test
 
 
-def test_correct_shapes():
+@pytest.mark.parametrize("norm_comp", [False, True])
+def test_correct_shapes(norm_comp):
     rng = np.random.RandomState(0)
     X = rng.randn(12, 10)
-    spca = SparsePCA(n_components=8, random_state=rng)
+    spca = SparsePCA(n_components=8, random_state=rng,
+                     normalize_components=norm_comp)
     U = spca.fit_transform(X)
     assert_equal(spca.components_.shape, (8, 10))
     assert_equal(U.shape, (12, 8))
     # test overcomplete decomposition
-    spca = SparsePCA(n_components=13, random_state=rng)
+    spca = SparsePCA(n_components=13, random_state=rng,
+                     normalize_components=norm_comp)
     U = spca.fit_transform(X)
     assert_equal(spca.components_.shape, (13, 10))
     assert_equal(U.shape, (12, 13))
 
 
-def test_fit_transform():
+@pytest.mark.parametrize("norm_comp", [False, True])
+def test_fit_transform(norm_comp):
     alpha = 1
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)  # wide array
     spca_lars = SparsePCA(n_components=3, method='lars', alpha=alpha,
-                          random_state=0)
+                          random_state=0, normalize_components=norm_comp)
     spca_lars.fit(Y)
 
     # Test that CD gives similar results
     spca_lasso = SparsePCA(n_components=3, method='cd', random_state=0,
-                           alpha=alpha)
+                           alpha=alpha, normalize_components=norm_comp)
     spca_lasso.fit(Y)
     assert_array_almost_equal(spca_lasso.components_, spca_lars.components_)
 
@@ -79,75 +86,88 @@ def test_fit_transform():
                          Y, ridge_alpha=None)
 
 
+@pytest.mark.parametrize("norm_comp", [False, True])
 @if_safe_multiprocessing_with_blas
-def test_fit_transform_parallel():
+def test_fit_transform_parallel(norm_comp):
     alpha = 1
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)  # wide array
     spca_lars = SparsePCA(n_components=3, method='lars', alpha=alpha,
-                          random_state=0)
+                          random_state=0, normalize_components=norm_comp)
     spca_lars.fit(Y)
     U1 = spca_lars.transform(Y)
     # Test multiple CPUs
     spca = SparsePCA(n_components=3, n_jobs=2, method='lars', alpha=alpha,
-                     random_state=0).fit(Y)
+                     random_state=0, normalize_components=norm_comp).fit(Y)
     U2 = spca.transform(Y)
     assert_true(not np.all(spca_lars.components_ == 0))
     assert_array_almost_equal(U1, U2)
 
 
-def test_transform_nan():
+@pytest.mark.parametrize("norm_comp", [False, True])
+def test_transform_nan(norm_comp):
     # Test that SparsePCA won't return NaN when there is 0 feature in all
     # samples.
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)  # wide array
     Y[:, 0] = 0
-    estimator = SparsePCA(n_components=8)
+    estimator = SparsePCA(n_components=8, normalize_components=norm_comp)
     assert_false(np.any(np.isnan(estimator.fit_transform(Y))))
 
 
-def test_fit_transform_tall():
+@pytest.mark.parametrize("norm_comp", [False, True])
+def test_fit_transform_tall(norm_comp):
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 65, (8, 8), random_state=rng)  # tall array
     spca_lars = SparsePCA(n_components=3, method='lars',
-                          random_state=rng)
+                          random_state=rng, normalize_components=norm_comp)
     U1 = spca_lars.fit_transform(Y)
-    spca_lasso = SparsePCA(n_components=3, method='cd', random_state=rng)
+    spca_lasso = SparsePCA(n_components=3, method='cd',
+                          random_state=rng, normalize_components=norm_comp)
     U2 = spca_lasso.fit(Y).transform(Y)
     assert_array_almost_equal(U1, U2)
 
 
-def test_initialization():
+@pytest.mark.parametrize("norm_comp", [False, True])
+def test_initialization(norm_comp):
     rng = np.random.RandomState(0)
     U_init = rng.randn(5, 3)
     V_init = rng.randn(3, 4)
     model = SparsePCA(n_components=3, U_init=U_init, V_init=V_init, max_iter=0,
-                      random_state=rng)
+                      random_state=rng, normalize_components=norm_comp)
     model.fit(rng.randn(5, 4))
-    assert_array_equal(model.components_, V_init)
+    if norm_comp:
+        assert_array_equal(model.components_,
+                V_init / np.linalg.norm(V_init, axis=1)[:, np.newaxis])
+    else:
+        assert_array_equal(model.components_, V_init)
 
 
-def test_mini_batch_correct_shapes():
+@pytest.mark.parametrize("norm_comp", [False, True])
+def test_mini_batch_correct_shapes(norm_comp):
     rng = np.random.RandomState(0)
     X = rng.randn(12, 10)
-    pca = MiniBatchSparsePCA(n_components=8, random_state=rng)
+    pca = MiniBatchSparsePCA(n_components=8, random_state=rng,
+                             normalize_components=norm_comp)
     U = pca.fit_transform(X)
     assert_equal(pca.components_.shape, (8, 10))
     assert_equal(U.shape, (12, 8))
     # test overcomplete decomposition
-    pca = MiniBatchSparsePCA(n_components=13, random_state=rng)
+    pca = MiniBatchSparsePCA(n_components=13, random_state=rng,
+                             normalize_components=norm_comp)
     U = pca.fit_transform(X)
     assert_equal(pca.components_.shape, (13, 10))
     assert_equal(U.shape, (12, 13))
 
 
-def test_mini_batch_fit_transform():
+@pytest.mark.parametrize("norm_comp", [False, True])
+def test_mini_batch_fit_transform(norm_comp):
     raise SkipTest("skipping mini_batch_fit_transform.")
     alpha = 1
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)  # wide array
     spca_lars = MiniBatchSparsePCA(n_components=3, random_state=0,
-                                   alpha=alpha).fit(Y)
+            alpha=alpha, normalize_components=norm_comp).fit(Y)
     U1 = spca_lars.transform(Y)
     # Test multiple CPUs
     if sys.platform == 'win32':  # fake parallelism for win32
@@ -156,15 +176,49 @@ def test_mini_batch_fit_transform():
         joblib_par.multiprocessing = None
         try:
             U2 = MiniBatchSparsePCA(n_components=3, n_jobs=2, alpha=alpha,
-                                    random_state=0).fit(Y).transform(Y)
+                                    random_state=0,
+                                    normalize_components=norm_comp)\
+            .fit(Y).transform(Y)
         finally:
             joblib_par.multiprocessing = _mp
     else:  # we can efficiently use parallelism
         U2 = MiniBatchSparsePCA(n_components=3, n_jobs=2, alpha=alpha,
-                                random_state=0).fit(Y).transform(Y)
+                                random_state=0,
+                                normalize_components=norm_comp)\
+        .fit(Y).transform(Y)
     assert_true(not np.all(spca_lars.components_ == 0))
     assert_array_almost_equal(U1, U2)
     # Test that CD gives similar results
     spca_lasso = MiniBatchSparsePCA(n_components=3, method='cd', alpha=alpha,
-                                    random_state=0).fit(Y)
+                                    random_state=0,
+                                    normalize_components=norm_comp).fit(Y)
     assert_array_almost_equal(spca_lasso.components_, spca_lars.components_)
+
+
+def test_scaling_fit_transform():
+    alpha = 1
+    rng = np.random.RandomState(0)
+    Y, _, _ = generate_toy_data(3, 1000, (8, 8), random_state=rng)  # wide array
+    spca_lars = SparsePCA(n_components=3, method='lars', alpha=alpha,
+                          random_state=rng, normalize_components=True)
+    results_train = spca_lars.fit_transform(Y)
+    results_test = spca_lars.transform(Y[:10])
+    assert_array_equal(results_train[0], results_test[0])
+
+
+def test_pca_vs_spca():
+    alpha = 0
+    ridge_alpha = 0
+    rng = np.random.RandomState(0)
+    Y, _, _ = generate_toy_data(3, 1000, (8, 8), random_state=rng)  # wide array
+    Z, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)  # wide array
+    spca = SparsePCA(alpha=0, ridge_alpha=0, n_components=2, normalize_components=True)
+    pca = PCA(n_components=2)
+    results_train_pca = pca.fit_transform(Y)
+    results_test_pca = pca.transform(Z)
+    results_train_spca = spca.fit_transform(Y)
+    results_test_spca = spca.transform(Z)
+    assert_allclose(np.abs(spca.components_.dot(pca.components_.T)), np.eye(2), atol=1e-5)
+    results_test_pca *= np.sign(results_test_pca[0, :])
+    results_test_spca *= np.sign(results_test_spca[0, :])
+    assert_allclose(results_test_pca, results_test_spca)

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -2,12 +2,12 @@
 # License: BSD 3 clause
 
 import sys
+import pytest
 
 import numpy as np
 
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import SkipTest
 from sklearn.utils.testing import assert_true
@@ -17,8 +17,6 @@ from sklearn.utils.testing import if_safe_multiprocessing_with_blas
 
 from sklearn.decomposition import SparsePCA, MiniBatchSparsePCA, PCA
 from sklearn.utils import check_random_state
-
-import pytest
 
 
 def generate_toy_data(n_components, n_samples, image_size, random_state=None):
@@ -143,10 +141,10 @@ def test_initialization(norm_comp):
                       random_state=rng, normalize_components=norm_comp)
     model.fit(rng.randn(5, 4))
     if norm_comp:
-        assert_array_equal(model.components_,
-                           V_init / np.linalg.norm(V_init, axis=1)[:, None])
+        assert_allclose(model.components_,
+                        V_init / np.linalg.norm(V_init, axis=1)[:, None])
     else:
-        assert_array_equal(model.components_, V_init)
+        assert_allclose(model.components_, V_init)
 
 
 @pytest.mark.filterwarnings("ignore:normalize_components")
@@ -184,17 +182,17 @@ def test_mini_batch_fit_transform(norm_comp):
         _mp = joblib_par.multiprocessing
         joblib_par.multiprocessing = None
         try:
-            U2 = MiniBatchSparsePCA(n_components=3, n_jobs=2, alpha=alpha,
-                                    random_state=0,
-                                    normalize_components=norm_comp)\
-                .fit(Y).transform(Y)
+            spca = MiniBatchSparsePCA(n_components=3, n_jobs=2, alpha=alpha,
+                                      random_state=0,
+                                      normalize_components=norm_comp)
+            U2 = spca.fit(Y).transform(Y)
         finally:
             joblib_par.multiprocessing = _mp
     else:  # we can efficiently use parallelism
-        U2 = MiniBatchSparsePCA(n_components=3, n_jobs=2, alpha=alpha,
-                                random_state=0,
-                                normalize_components=norm_comp)\
-            .fit(Y).transform(Y)
+        spca = MiniBatchSparsePCA(n_components=3, n_jobs=2, alpha=alpha,
+                                  random_state=0,
+                                  normalize_components=norm_comp)
+        U2 = spca.fit(Y).transform(Y)
     assert_true(not np.all(spca_lars.components_ == 0))
     assert_array_almost_equal(U1, U2)
     # Test that CD gives similar results

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -223,3 +223,11 @@ def test_pca_vs_spca():
     results_test_pca *= np.sign(results_test_pca[0, :])
     results_test_spca *= np.sign(results_test_spca[0, :])
     assert_allclose(results_test_pca, results_test_spca)
+
+
+@pytest.mark.parametrize("spca", [SparsePCA, MiniBatchSparsePCA])
+def test_spca_deprecation_warning(spca):
+    rng = np.random.RandomState(0)
+    Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)
+    with pytest.warns(DeprecationWarning, match="normalize_components"):
+        spca().fit(Y)


### PR DESCRIPTION
#### Reference Issues/PRs
fixes #9394

#### What does this implement/fix? Explain your changes.
@andrewww reported a scaling issue with SPCA : the transform scaling was depending on the number of samples. Investigating this issue we found several things that were disturbing :
- In the transform of SPCA the last lines were consisting in a peculiar normalization sequence. These lines were the cause of the issue.
- The SPCA with alpha=0 and alpha_ridge=0 and the standard PCA were giving inconsistent results.
- The data were not centred during the fit.
- The data were not centred either during the transform.
- The components were not normalized. I'm still not sure that they should be but from what I saw in this [paper](http://www.stanford.edu/~hastie/Papers/spc_jcgs.pdf) I'm inclined to say yes but I did not read it thoroughly yet and I did not cross sources.

This PR aims to fix all that. With all the fixes implemented, the scaling issue disappear and the transform from PCA and SPCA(alpha=0, ridge_alpha=0) gives exactly the same results.

#### Any other comments?
TODO :
- [x] Decide on the normalization strategy (read more thoroughly)
- [x] Implement the fixes inside a deprecation path
- [x] Implement the fixes for MiniBatchSparsePCA
- [x] Implement scaling test (from the bug report)
- [x] Implement PCA vs SPCA(0, 0) test (to check the new behaviour is correct)


