### PR TITLE
[MRG+2] change tol in test ridge

### DIFF
--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -172,7 +172,8 @@ def test_ridge_sample_weights():
         for (alpha, intercept, solver) in param_grid:
 
             # Ridge with explicit sample_weight
-            est = Ridge(alpha=alpha, fit_intercept=intercept, solver=solver, tol=1e-6)
+            est = Ridge(alpha=alpha, fit_intercept=intercept,
+                        solver=solver, tol=1e-6)
             est.fit(X, y, sample_weight=sample_weight)
             coefs = est.coef_
             inter = est.intercept_

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -172,7 +172,7 @@ def test_ridge_sample_weights():
         for (alpha, intercept, solver) in param_grid:
 
             # Ridge with explicit sample_weight
-            est = Ridge(alpha=alpha, fit_intercept=intercept, solver=solver)
+            est = Ridge(alpha=alpha, fit_intercept=intercept, solver=solver, tol=1e-6)
             est.fit(X, y, sample_weight=sample_weight)
             coefs = est.coef_
             inter = est.intercept_


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #11200 (Instability in test_ridge.py::test_ridge_sample_weights ). The test was failing for some random states. We observed 26 failures for 100 runs.

#### What does this implement/fix? Explain your changes.
The problem was that the default tolerance in `Ridge` was `1e-3` and `assert_almost_equal` uses a tolerance of `1e-6`. Adding `tol=1e-6` to `Ridge` fixes the issue.

#### Any other comments?
The run time takes  approximately 1.3 times of previous.
See more details at https://github.com/scikit-learn/scikit-learn/issues/11200#issuecomment-405531112