### PR TITLE
[MRG+2] EXA Get rid of warnings in plot_svm_anova.py

### DIFF
--- a/examples/svm/plot_svm_anova.py
+++ b/examples/svm/plot_svm_anova.py
@@ -10,17 +10,19 @@ print(__doc__)
 
 import numpy as np
 import matplotlib.pyplot as plt
-from sklearn import svm, datasets, feature_selection
+from sklearn.datasets import load_digits
+from sklearn.feature_selection import SelectPercentile, chi2
 from sklearn.model_selection import cross_val_score
 from sklearn.pipeline import Pipeline
+from sklearn.svm import SVC
+
 
 # #############################################################################
 # Import some data to play with
-digits = datasets.load_digits()
-y = digits.target
+X, y = load_digits(return_X_y=True)
 # Throw away data, to be in the curse of dimension settings
+X = X[:200]
 y = y[:200]
-X = digits.data[:200]
 n_samples = len(y)
 X = X.reshape((n_samples, -1))
 # add 200 non-informative features
@@ -30,9 +32,9 @@ X = np.hstack((X, 2 * np.random.random((n_samples, 200))))
 # Create a feature-selection transform and an instance of SVM that we
 # combine together to have an full-blown estimator
 
-transform = feature_selection.SelectPercentile(feature_selection.f_classif)
+transform = SelectPercentile(chi2)
 
-clf = Pipeline([('anova', transform), ('svc', svm.SVC(C=1.0))])
+clf = Pipeline([('anova', transform), ('svc', SVC(gamma="auto"))])
 
 # #############################################################################
 # Plot the cross-validation score as a function of percentile of features


### PR DESCRIPTION
Fixes #11565
old example(master):
![sphx_glr_plot_svm_anova_001](https://user-images.githubusercontent.com/12003569/42813987-57e65ca6-89f5-11e8-9713-8088f051c2b8.png)
new example(my PC):
![default](https://user-images.githubusercontent.com/12003569/42813996-600997e0-89f5-11e8-89ce-17d5477e7906.png)
But I fail to understand the example. The example claims that "This example shows how to perform univariate feature selection ... to improve the classification scores", but we actually get highest accuracy with all the features (including the non-informative features added to the datasets)? If we select number of features equal to the original dataset, we only get 20%-30% accuracy through cross validation?