### PR TITLE
[MRG+1] Fix bad fp-comparisons

### DIFF
--- a/examples/applications/wikipedia_principal_eigenvector.py
+++ b/examples/applications/wikipedia_principal_eigenvector.py
@@ -205,8 +205,7 @@ def centrality_scores(X, alpha=0.85, max_iter=100, tol=1e-10):
     for i in incoming_counts.nonzero()[0]:
         X.data[X.indptr[i]:X.indptr[i + 1]] *= 1.0 / incoming_counts[i]
     dangle = np.asarray(np.where(np.isclose(X.sum(axis=1), 0),
-                                 1.0 / n,
-                                 0)).ravel()
+                                 1.0 / n, 0)).ravel()
 
     scores = np.ones(n, dtype=np.float32) / n  # initial guess
     for i in range(max_iter):

--- a/examples/applications/wikipedia_principal_eigenvector.py
+++ b/examples/applications/wikipedia_principal_eigenvector.py
@@ -127,7 +127,7 @@ def get_redirects(redirects_filename):
 
 
 # disabling joblib as the pickling of large dicts seems much too slow
-#@memory.cache
+# @memory.cache
 def get_adjacency_matrix(redirects_filename, page_links_filename, limit=None):
     """Extract the adjacency graph as a scipy sparse matrix
 
@@ -204,7 +204,9 @@ def centrality_scores(X, alpha=0.85, max_iter=100, tol=1e-10):
     print("Normalizing the graph")
     for i in incoming_counts.nonzero()[0]:
         X.data[X.indptr[i]:X.indptr[i + 1]] *= 1.0 / incoming_counts[i]
-    dangle = np.asarray(np.where(X.sum(axis=1) == 0, 1.0 / n, 0)).ravel()
+    dangle = np.asarray(np.where(np.isclose(X.sum(axis=1), 0),
+                                 1.0 / n,
+                                 0)).ravel()
 
     scores = np.ones(n, dtype=np.float32) / n  # initial guess
     for i in range(max_iter):
@@ -222,6 +224,7 @@ def centrality_scores(X, alpha=0.85, max_iter=100, tol=1e-10):
             return scores
 
     return scores
+
 
 print("Computing principal eigenvector score using a power iteration method")
 t0 = time()

--- a/examples/applications/wikipedia_principal_eigenvector.py
+++ b/examples/applications/wikipedia_principal_eigenvector.py
@@ -127,7 +127,7 @@ def get_redirects(redirects_filename):
 
 
 # disabling joblib as the pickling of large dicts seems much too slow
-# @memory.cache
+#@memory.cache
 def get_adjacency_matrix(redirects_filename, page_links_filename, limit=None):
     """Extract the adjacency graph as a scipy sparse matrix
 
@@ -224,7 +224,6 @@ def centrality_scores(X, alpha=0.85, max_iter=100, tol=1e-10):
             return scores
 
     return scores
-
 
 print("Computing principal eigenvector score using a power iteration method")
 t0 = time()

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -437,7 +437,7 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
 
         if (self.priors_ < 0).any():
             raise ValueError("priors must be non-negative")
-        if self.priors_.sum() != 1:
+        if not np.isclose(self.priors_.sum(), 1.0):
             warnings.warn("The priors do not sum to 1. Renormalizing",
                           UserWarning)
             self.priors_ = self.priors_ / self.priors_.sum()

--- a/sklearn/metrics/base.py
+++ b/sklearn/metrics/base.py
@@ -94,7 +94,7 @@ def _average_binary_score(binary_metric, y_true, y_score, average,
                 y_true, np.reshape(score_weight, (-1, 1))), axis=0)
         else:
             average_weight = np.sum(y_true, axis=0)
-        if average_weight.sum() == 0:
+        if np.isclose(average_weight.sum(), 0.0):
             return 0
 
     elif average == 'samples':

--- a/sklearn/utils/random.py
+++ b/sklearn/utils/random.py
@@ -158,7 +158,7 @@ def random_choice_csc(n_samples, classes, class_probability=None,
         else:
             class_prob_j = np.asarray(class_probability[j])
 
-        if np.sum(class_prob_j) != 1.0:
+        if not np.isclose(np.sum(class_prob_j), 1.0):
             raise ValueError("Probability array at index {0} does not sum to "
                              "one".format(j))
 


### PR DESCRIPTION
Fixes #11551

changed exact comparison with between float values by np.isclose where needed.
- [x] sklearn/discriminant_analysis.py -> if self.priors_.sum() != 1
- [x] sklearn/utils/random.py -> if np.sum(class_prob_j) != 1.0:
- [x] examples/applications/wikipedia_principal_eigenvector.py
                                         -> np.asarray(np.where(X.sum(axis=1) == 0, 1.0 / n, 0)).ravel()
- [x] sklearn/metrics/base.py -> if average_weight.sum() == 0:

edit: removed 2. They were in cython functions, within nogil statement.