### PR TITLE
[MRG] warning class should be passed to ignore_warnings as the category parameter.

### DIFF
--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -319,7 +319,7 @@ class CommonTest(object):
 
         assert_array_equal(clf1.coef_, clf2.coef_)
 
-    @ignore_warnings(ConvergenceWarning)
+    @ignore_warnings(category=ConvergenceWarning)
     def test_n_iter_no_change(self):
         # test that n_iter_ increases monotonically with n_iter_no_change
         for early_stopping in [True, False]:


### PR DESCRIPTION
I found this one while commenting in https://github.com/scikit-learn/scikit-learn/pull/11580#issuecomment-405614445:

This is a slightly dangerous caveat of ignore_warnings: if you pass the warning class as the first argument, then the test is not run:

```py
from sklearn.utils.testing import ignore_warnings

@ignore_warnings(UserWarning)
def test():
    1/0
```

```
❯ pytest /tmp/test.py
======================================================== test session starts ========================================================
platform linux -- Python 3.6.5, pytest-3.6.0, py-1.5.3, pluggy-0.6.0
rootdir: /tmp, inifile:
plugins: cov-2.5.1, hypothesis-3.56.0
collected 0 items                                                                                                                   

=================================================== no tests ran in 0.14 seconds ====================================================
```

The reason is that the first argument is the test callable. Maybe that could be fixed not sure.