### PR TITLE
[MRG+2] Fix problematic caveat in ignore_warnings

### DIFF
--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -319,7 +319,7 @@ class CommonTest(object):
 
         assert_array_equal(clf1.coef_, clf2.coef_)
 
-    @ignore_warnings(ConvergenceWarning)
+    @ignore_warnings(category=ConvergenceWarning)
     def test_n_iter_no_change(self):
         # test that n_iter_ increases monotonically with n_iter_no_change
         for early_stopping in [True, False]:

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -295,11 +295,13 @@ def ignore_warnings(obj=None, category=Warning):
     if isinstance(obj, type) and issubclass(obj, Warning):
         # Avoid common pitfall of passing category as the first positional
         # argument which result in the test not being run
+        warning_name = obj.__name__
         raise ValueError(
             "'obj' should be a callable where you want to ignore warnings. "
-            "You passed a warning class instead: 'obj={obj}'. If you want "
-            "to pass a warning class to ignore_warnings, you should use "
-            "'category={obj}'".format(obj=obj))
+            "You passed a warning class instead: 'obj={warning_name}'. "
+            "If you want to pass a warning class to ignore_warnings, "
+            "you should use 'category={warning_name}'".format(
+                warning_name=warning_name))
     elif callable(obj):
         return _IgnoreWarnings(category=category)(obj)
     else:

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -275,6 +275,8 @@ def ignore_warnings(obj=None, category=Warning):
 
     Parameters
     ----------
+    obj : callable or None
+        callable where you want to ignore the warnings.
     category : warning class, defaults to Warning.
         The category to filter. If Warning, all categories will be muted.
 
@@ -290,7 +292,15 @@ def ignore_warnings(obj=None, category=Warning):
     >>> ignore_warnings(nasty_warn)()
     42
     """
-    if callable(obj):
+    if isinstance(obj, type) and issubclass(obj, Warning):
+        # Avoid common pitfall of passing category as the first positional
+        # argument which result in the test not being run
+        raise ValueError(
+            "'obj' should be a callable where you want to ignore warnings. "
+            "You passed a warning class instead: 'obj={obj}'. If you want "
+            "to pass a warning class to ignore_warnings, you should use "
+            "'category={obj}'".format(obj=obj))
+    elif callable(obj):
         return _IgnoreWarnings(category=category)(obj)
     else:
         return _IgnoreWarnings(category=category)

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -214,8 +214,7 @@ def test_ignore_warning():
 
     # Check that passing warning class as first positional argument
     warning_class = UserWarning
-    match = "'obj' should be a callable.+you should use 'category={}'".format(
-        warning_class)
+    match = "'obj' should be a callable.+you should use 'category=UserWarning'"
 
     with pytest.raises(ValueError, match=match):
         silence_warnings_func = ignore_warnings(warning_class)(

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -8,6 +8,8 @@ import numpy as np
 
 from scipy import sparse
 
+import pytest
+
 from sklearn.utils.deprecation import deprecated
 from sklearn.utils.metaestimators import if_delegate_has_method
 from sklearn.utils.testing import (
@@ -209,6 +211,21 @@ def test_ignore_warning():
     assert_warns(DeprecationWarning, context_manager_no_user_warning)
     assert_warns(UserWarning, context_manager_no_deprecation_multiple_warning)
     assert_warns(DeprecationWarning, context_manager_no_user_multiple_warning)
+
+    # Check that passing warning class as first positional argument
+    warning_class = UserWarning
+    match = "'obj' should be a callable.+you should use 'category={}'".format(
+        warning_class)
+
+    with pytest.raises(ValueError, match=match):
+        silence_warnings_func = ignore_warnings(warning_class)(
+            _warning_function)
+        silence_warnings_func()
+
+    with pytest.raises(ValueError, match=match):
+        @ignore_warnings(warning_class)
+        def test():
+            pass
 
 
 class TestWarns(unittest.TestCase):


### PR DESCRIPTION
When the warning class is passed as a positional argument, the function is not called.

This is a slightly dangerous caveat of ignore_warnings in a test settings: basically the test is not run.

```py
from sklearn.utils.testing import ignore_warnings

@ignore_warnings(UserWarning)
def test():
    1/0
```

```
❯ pytest /tmp/test.py
======================================================== test session starts ========================================================
platform linux -- Python 3.6.5, pytest-3.6.0, py-1.5.3, pluggy-0.6.0
rootdir: /tmp, inifile:
plugins: cov-2.5.1, hypothesis-3.56.0
collected 0 items                                                                                                                   

=================================================== no tests ran in 0.14 seconds ====================================================
```
