### PR TITLE
[MRG] Check dataframe columns names for StandardScaler methods

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -268,7 +268,7 @@ class BaseEstimator(object):
                 "{}. If you are sure your dataframe is correct, you may "
                 "instead pass 'df.values' to explicitely convert the "
                 "dataframe to a numpy array.".format(self._column_names,
-                list(X.columns))
+                                                     list(X.columns))
             )
 
     def __repr__(self):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -223,6 +223,54 @@ class BaseEstimator(object):
 
         return self
 
+    def _check_column_names(self, X, set_names=False):
+        """
+        Check that the columns of X are as expected when X is a pandas
+        dataframe, else silently exits.
+
+        This function is aimed to be called in fit() with set_names=True
+        (before check_array()), and then in subsequent methods like predict()
+        or transform() with set_names=False (defaut).
+
+        Parameters
+        ----------
+        X : {pandas dataframe, object}
+            The input to check. If X is not a pandas dataframe, the function
+            silently exits.
+        set_names: bool, optional (default=False)
+            If True, the column names of X are those that will be expected in
+            the subsequent calls to _check_column_names.
+
+        Raises
+        ------
+        RuntimeError
+            When _check_column_names has not been called with set_names to True
+            before.
+        ValueError
+            When the column names of X are not as expected.
+        """
+
+        if not hasattr(X, 'iloc'):  # X is not a dataframe, ignore
+            return
+
+        if set_names:
+            self._column_names = list(X.columns)
+        elif not hasattr(self, '_column_names'):
+            raise RuntimeError(
+                "You should first call _check_column_names() with "
+                "set_names=True (most likely in fit())."
+            )
+
+        if self._column_names != list(X.columns):
+            raise ValueError(
+                "This estimator was fitted with a pandas dataframe with "
+                "different columns: expected column names are {} but got "
+                "{}. If you are sure your dataframe is correct, you may "
+                "instead pass 'df.values' to explicitely convert the "
+                "dataframe to a numpy array.".format(self._column_names,
+                list(X.columns))
+            )
+
     def __repr__(self):
         class_name = self.__class__.__name__
         return '%s(%s)' % (class_name, _pprint(self.get_params(deep=False),

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -635,6 +635,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         y
             Ignored
         """
+        self._check_column_names(X, set_names=True)
         X = check_array(X, accept_sparse=('csr', 'csc'), copy=self.copy,
                         warn_on_dtype=True, estimator=self, dtype=FLOAT_DTYPES,
                         force_all_finite='allow-nan')
@@ -735,6 +736,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
                           "deprecated since 0.19 and will be removed in 0.21",
                           DeprecationWarning)
 
+        self._check_column_names(X)
         check_is_fitted(self, 'scale_')
 
         copy = copy if copy is not None else self.copy
@@ -771,6 +773,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         X_tr : array-like, shape [n_samples, n_features]
             Transformed array.
         """
+        self._check_column_names(X)
         check_is_fitted(self, 'scale_')
 
         copy = copy if copy is not None else self.copy

--- a/sklearn/tests/test_dataframe_column_names.py
+++ b/sklearn/tests/test_dataframe_column_names.py
@@ -1,0 +1,74 @@
+# Author: Nicolas Hug
+# License: BSD 3 clause
+
+import numpy as np
+import pytest
+
+from sklearn.base import BaseEstimator
+from sklearn.preprocessing import StandardScaler
+from sklearn.utils.testing import SkipTest
+try:
+    import pandas as pd
+except ImportError:
+    raise SkipTest("Pandas not found")
+
+
+def test_check_column_names():
+
+    class CustomEstimator(BaseEstimator):
+
+        def fit(self, X, y=None):
+            # forgot to call _check_column_names
+            return self
+
+        def transform(self, X):
+
+            self._check_column_names(X)
+            return X
+
+        def predict(self, X):
+
+            self._check_column_names(X)
+            return np.zeros(shape=X.shape[0])
+
+    df = pd.DataFrame({'a': np.arange(-1, 1, .1),
+                       'b': np.arange(-1, 1, .1)})
+
+    est = CustomEstimator()
+    est.fit(df)
+    with pytest.raises(RuntimeError):
+        est.transform(df)
+    with pytest.raises(RuntimeError):
+        est.predict(df)
+
+
+def test_column_names_standard_scaler():
+    df = pd.DataFrame({'a': np.arange(-1, 1, .1),
+                       'b': np.arange(-1, 1, .1)})
+    df2 = pd.DataFrame({'c': np.arange(-1, 1, .1),
+                        'd': np.arange(-1, 1, .1)})
+
+    ss = StandardScaler()
+
+    for function in (ss.fit, ss.partial_fit):
+        function(df)
+        ss.transform(df)  # all is fine
+        ss.inverse_transform(df)  # all is fine
+
+        # different column order
+        with pytest.raises(ValueError):
+            ss.transform(df[['b', 'a']])
+        with pytest.raises(ValueError):
+            ss.inverse_transform(df[['b', 'a']])
+
+        # completely different names
+        with pytest.raises(ValueError):
+            ss.transform(df2)
+        with pytest.raises(ValueError):
+            ss.inverse_transform(df2)
+
+        # column order OK but unknown columns
+        with pytest.raises(ValueError):
+            ss.transform(pd.concat([df, df2]))
+        with pytest.raises(ValueError):
+            ss.inverse_transform(pd.concat([df, df2]))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

This addresses #7242 for the StandardScaler class. This goal of this PR is to evaluate how many changes would be needed to completely fix #7242.

#### What does this implement/fix? Explain your changes.

This PR adds the `_check_column_names` method to `BaseEstimator` and uses it in `StandardScaler`.

`_check_column_names` is a helper to verify that the dataframes passed as input to fit(), predict(), transform() (etc.) have the same column names. This prevents user issues (#7242) 

#### Any other comments?

I definitely don't have a sufficiently clear overview of the whole project to be certain, but the changes to the estimators code seem relatively small: only a line here and there.

cc @amueller 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
