### PR TITLE
[MRG+1] Don't use np.nextafter to define eps

### DIFF
--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -93,7 +93,7 @@ def _single_linkage_tree(connectivity, n_samples, n_nodes, n_clusters,
     connectivity = connectivity.astype('float64')
 
     # Ensure zero distances aren't ignored by setting them to "epsilon"
-    epsilon_value = np.nextafter(0, 1, dtype=connectivity.data.dtype)
+    epsilon_value = np.finfo(dtype=connectivity.data.dtype).eps
     connectivity.data[connectivity.data == 0] = epsilon_value
 
     # Use scipy.sparse.csgraph to generate a minimum spanning tree

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -511,7 +511,7 @@ def test_standard_scaler_trasform_with_partial_fit():
         assert_array_almost_equal(X_sofar, right_input)
 
         zero = np.zeros(X.shape[1])
-        epsilon = np.nextafter(0, 1)
+        epsilon = np.finfo(float).eps
         assert_array_less(zero, scaler_incr.var_ + epsilon)  # as less or equal
         assert_array_less(zero, scaler_incr.scale_ + epsilon)
         # (i+1) because the Scaler has been already fitted


### PR DESCRIPTION
Fixes #11608.
Avoids underflows.