### PR TITLE
[MRG] Use rcond value for np.linalg.lstsq depending on numpy version.

### DIFF
--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -1,5 +1,7 @@
 import warnings
 
+from distutils.version import LooseVersion
+
 import numpy as np
 from scipy import linalg
 
@@ -96,7 +98,9 @@ def test_lars_lstsq():
     X1 = 3 * diabetes.data  # use un-normalized dataset
     clf = linear_model.LassoLars(alpha=0.)
     clf.fit(X1, y)
-    coef_lstsq = np.linalg.lstsq(X1, y, rcond=None)[0]
+    # Avoid FutureWarning about default value change when numpy >= 1.14
+    rcond = None if LooseVersion(np.__version__) >= '1.14' else -1
+    coef_lstsq = np.linalg.lstsq(X1, y, rcond=rcond)[0]
     assert_array_almost_equal(clf.coef_, coef_lstsq)
 
 


### PR DESCRIPTION
This avoids a FutureWarning for rcond default value on numpy >= 1.14.

This fixes one of the Python 2 error seen in https://travis-ci.org/scikit-learn/scikit-learn/jobs/405115944.