### PR TITLE
[MRG] TST Remove metrics from METRICS_WITH_POS_LABEL

### DIFF
--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -303,16 +303,6 @@ METRICS_WITH_POS_LABEL = {
     "micro_average_precision_score",
     "macro_average_precision_score",
     "samples_average_precision_score",
-
-    # pos_label support deprecated; to be removed in 0.18:
-    "weighted_f0.5_score", "weighted_f1_score", "weighted_f2_score",
-    "weighted_precision_score", "weighted_recall_score",
-
-    "micro_f0.5_score", "micro_f1_score", "micro_f2_score",
-    "micro_precision_score", "micro_recall_score",
-
-    "macro_f0.5_score", "macro_f1_score", "macro_f2_score",
-    "macro_precision_score", "macro_recall_score",
 }
 
 # Metrics with a "labels" argument


### PR DESCRIPTION
Fixes #11148 
When ``average != 'binary'``, pos_label of P/R/F won't make sense. Instead, users with get a warning (We already have a test to ensure that the warning is raised).
```
if average == 'binary':
      ......
elif pos_label not in (None, 1):
     warnings.warn("Note that pos_label (set to %r) is ignored when average != 'binary' ......
```
So it's natural to remove these metrics from METRICS_WITH_POS_LABEL
