### PR TITLE
[MRG+2] TST Using default rtol in test sample_weight invariance 

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -589,7 +589,7 @@ def check_sample_weights_invariance(name, estimator_orig):
             if hasattr(estimator_orig, method):
                 X_pred1 = getattr(estimator1, method)(X)
                 X_pred2 = getattr(estimator2, method)(X)
-                assert_allclose(X_pred1, X_pred2, rtol=0.5,
+                assert_allclose(X_pred1, X_pred2,
                                 err_msg="For %s sample_weight=None is not"
                                         " equivalent to sample_weight=ones"
                                         % name)


### PR DESCRIPTION
#### Reference Issues/PRs
Changes the `rtol` in #11558 from `0.5` to `default` based on https://github.com/scikit-learn/scikit-learn/pull/11558#issuecomment-405819892

#### What does this implement/fix? Explain your changes.
Makes the test for `sample_weight` invariance more reliable.