### PR TITLE
[MRG] TST: avoid DeprecationWarning on latest joblib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="3.6.2" INSTALL_MKL="true"
            NUMPY_VERSION="1.14.2" SCIPY_VERSION="1.0.0" PANDAS_VERSION="0.20.3"
            CYTHON_VERSION="0.26.1" PYAMG_VERSION="3.3.2" PILLOW_VERSION="4.3.0"
-           JOBLIB_VERSION="0.11" COVERAGE=true
+           JOBLIB_VERSION="0.12" COVERAGE=true
            CHECK_PYTEST_SOFT_DEPENDENCY="true" TEST_DOCSTRINGS="true"
            SKLEARN_SITE_JOBLIB=1
       if: type != cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="3.6.2" INSTALL_MKL="true"
            NUMPY_VERSION="1.14.2" SCIPY_VERSION="1.0.0" PANDAS_VERSION="0.20.3"
            CYTHON_VERSION="0.26.1" PYAMG_VERSION="3.3.2" PILLOW_VERSION="4.3.0"
-           JOBLIB_VERSION="0.12" COVERAGE=true
+           JOBLIB_VERSION="0.12.1" COVERAGE=true
            CHECK_PYTEST_SOFT_DEPENDENCY="true" TEST_DOCSTRINGS="true"
            SKLEARN_SITE_JOBLIB=1
       if: type != cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="3.6.2" INSTALL_MKL="true"
            NUMPY_VERSION="1.14.2" SCIPY_VERSION="1.0.0" PANDAS_VERSION="0.20.3"
            CYTHON_VERSION="0.26.1" PYAMG_VERSION="3.3.2" PILLOW_VERSION="4.3.0"
-           JOBLIB_VERSION="0.12.1" COVERAGE=true
+           JOBLIB_VERSION="0.12" COVERAGE=true
            CHECK_PYTEST_SOFT_DEPENDENCY="true" TEST_DOCSTRINGS="true"
            SKLEARN_SITE_JOBLIB=1
       if: type != cron

--- a/sklearn/datasets/lfw.py
+++ b/sklearn/datasets/lfw.py
@@ -34,7 +34,7 @@ import numpy as np
 from .base import get_data_home, _fetch_remote, RemoteFileMetadata
 from ..utils import Bunch
 from ..utils import Memory
-from ..utils._joblib import version as joblib_version
+from ..utils._joblib import __version__ as joblib_version
 from ..externals.six import b
 
 logger = logging.getLogger(__name__)

--- a/sklearn/datasets/lfw.py
+++ b/sklearn/datasets/lfw.py
@@ -27,11 +27,14 @@ from os import listdir, makedirs, remove
 from os.path import join, exists, isdir
 
 import logging
+from distutils.version import LooseVersion
+
 import numpy as np
 
 from .base import get_data_home, _fetch_remote, RemoteFileMetadata
 from ..utils import Bunch
 from ..utils import Memory
+from ..utils._joblib import version as joblib_version
 from ..externals.six import b
 
 logger = logging.getLogger(__name__)
@@ -327,7 +330,11 @@ def fetch_lfw_people(data_home=None, funneled=True, resize=0.5,
 
     # wrap the loader in a memoizing function that will return memmaped data
     # arrays for optimal memory usage
-    m = Memory(cachedir=lfw_home, compress=6, verbose=0)
+    if LooseVersion(joblib_version) < LooseVersion('0.12'):
+        # Deal with change of API in joblib
+        m = Memory(cachedir=lfw_home, compress=6, verbose=0)
+    else:
+        m = Memory(location=lfw_home, compress=6, verbose=0)
     load_func = m.cache(_fetch_lfw_people)
 
     # load and memoize the pairs as np arrays
@@ -494,7 +501,11 @@ def fetch_lfw_pairs(subset='train', data_home=None, funneled=True, resize=0.5,
 
     # wrap the loader in a memoizing function that will return memmaped data
     # arrays for optimal memory usage
-    m = Memory(cachedir=lfw_home, compress=6, verbose=0)
+    if LooseVersion(joblib_version) < LooseVersion('0.12'):
+        # Deal with change of API in joblib
+        m = Memory(cachedir=lfw_home, compress=6, verbose=0)
+    else:
+        m = Memory(location=lfw_home, compress=6, verbose=0)
     load_func = m.cache(_fetch_lfw_pairs)
 
     # select the right metadata file according to the requested subset

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -7,6 +7,7 @@
 #
 # License: BSD 3 clause (C) INRIA, University of Amsterdam
 from functools import partial
+from distutils.version import LooseVersion
 
 import warnings
 from abc import ABCMeta, abstractmethod
@@ -24,6 +25,7 @@ from ..utils.multiclass import check_classification_targets
 from ..utils.validation import check_is_fitted
 from ..externals import six
 from ..utils import Parallel, delayed
+from ..utils._joblib import __version__ as joblib_version
 from ..exceptions import NotFittedError
 from ..exceptions import DataConversionWarning
 
@@ -422,8 +424,14 @@ class KNeighborsMixin(object):
                 raise ValueError(
                     "%s does not work with sparse matrices. Densify the data, "
                     "or set algorithm='brute'" % self._fit_method)
+            if LooseVersion(joblib_version) < '0.12':
+                # Deal with change of API in joblib
+                delayed_query = delayed(self._tree.query,
+                                        check_pickle=False)
+            else:
+                delayed_query = delayed(self._tree.query)
             result = Parallel(n_jobs, backend='threading')(
-                delayed(self._tree.query, check_pickle=False)(
+                delayed_query(
                     X[s], n_neighbors, return_distance)
                 for s in gen_even_slices(X.shape[0], n_jobs)
             )

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -706,9 +706,15 @@ class RadiusNeighborsMixin(object):
                     "or set algorithm='brute'" % self._fit_method)
 
             n_jobs = _get_n_jobs(self.n_jobs)
+
+            if LooseVersion(joblib_version) < LooseVersion('0.12'):
+                # Deal with change of API in joblib
+                delayed_query = delayed(self._tree.query_radius,
+                                        check_pickle=False)
+            else:
+                delayed_query = delayed(self._tree.query_radius)
             results = Parallel(n_jobs, backend='threading')(
-                delayed(self._tree.query_radius, check_pickle=False)(
-                    X[s], radius, return_distance)
+                delayed_query(X[s], radius, return_distance)
                 for s in gen_even_slices(X.shape[0], n_jobs)
             )
             if return_distance:

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -424,7 +424,7 @@ class KNeighborsMixin(object):
                 raise ValueError(
                     "%s does not work with sparse matrices. Densify the data, "
                     "or set algorithm='brute'" % self._fit_method)
-            if LooseVersion(joblib_version) < '0.12':
+            if LooseVersion(joblib_version) < LooseVersion('0.12'):
                 # Deal with change of API in joblib
                 delayed_query = delayed(self._tree.query,
                                         check_pickle=False)

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -206,10 +206,22 @@ class Pipeline(_BaseComposition):
             if transformer is None:
                 pass
             else:
-                if hasattr(memory, 'cachedir') and memory.cachedir is None:
-                    # we do not clone when caching is disabled to preserve
-                    # backward compatibility
-                    cloned_transformer = transformer
+                if hasattr(memory, 'location'):
+                    # joblib >= 0.12
+                    if memory.location is None:
+                        # we do not clone when caching is disabled to
+                        # preserve backward compatibility
+                        cloned_transformer = transformer
+                    else:
+                        cloned_transformer = clone(transformer)
+                elif hasattr(memory, 'cachedir'):
+                    # joblib < 0.11
+                    if memory.cachedir is None:
+                        # we do not clone when caching is disabled to
+                        # preserve backward compatibility
+                        cloned_transformer = transformer
+                    else:
+                        cloned_transformer = clone(transformer)
                 else:
                     cloned_transformer = clone(transformer)
                 # Fit or load from cache the current transfomer

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -1,7 +1,7 @@
 """
 Test the pipeline module.
 """
-
+from distutils.version import LooseVersion
 from tempfile import mkdtemp
 import shutil
 import time
@@ -34,6 +34,7 @@ from sklearn.datasets import load_iris
 from sklearn.preprocessing import StandardScaler
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.utils import Memory
+from sklearn.utils._joblib import version as joblib_version
 
 
 JUNK_FOOD_DOCS = (
@@ -941,7 +942,11 @@ def test_pipeline_memory():
     y = iris.target
     cachedir = mkdtemp()
     try:
-        memory = Memory(cachedir=cachedir, verbose=10)
+        if LooseVersion(joblib_version) < LooseVersion('0.12'):
+            # Deal with change of API in joblib
+            memory = Memory(cachedir=cachedir, verbose=10)
+        else:
+            memory = Memory(location=cachedir, verbose=10)
         # Test with Transformer + SVC
         clf = SVC(gamma='scale', probability=True, random_state=0)
         transf = DummyTransf()
@@ -999,7 +1004,11 @@ def test_pipeline_memory():
 
 def test_make_pipeline_memory():
     cachedir = mkdtemp()
-    memory = Memory(cachedir=cachedir)
+    if LooseVersion(joblib_version) < LooseVersion('0.12'):
+        # Deal with change of API in joblib
+        memory = Memory(cachedir=cachedir, verbose=10)
+    else:
+        memory = Memory(location=cachedir, verbose=10)
     pipeline = make_pipeline(DummyTransf(), SVC(), memory=memory)
     assert_true(pipeline.memory is memory)
     pipeline = make_pipeline(DummyTransf(), SVC())

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -34,7 +34,7 @@ from sklearn.datasets import load_iris
 from sklearn.preprocessing import StandardScaler
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.utils import Memory
-from sklearn.utils._joblib import version as joblib_version
+from sklearn.utils._joblib import __version__ as joblib_version
 
 
 JUNK_FOOD_DOCS = (

--- a/sklearn/utils/_joblib.py
+++ b/sklearn/utils/_joblib.py
@@ -2,9 +2,12 @@
 # site one
 from __future__ import absolute_import
 import os as _os
+import warnings as _warnings
 
 # An environment variable to use the site joblib
 if _os.environ.get('SKLEARN_SITE_JOBLIB', False):
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("ignore")
     from joblib import __all__
     from joblib import *  # noqa
     from joblib import __version__

--- a/sklearn/utils/_joblib.py
+++ b/sklearn/utils/_joblib.py
@@ -8,6 +8,8 @@ import warnings as _warnings
 if _os.environ.get('SKLEARN_SITE_JOBLIB', False):
     with _warnings.catch_warnings():
         _warnings.simplefilter("ignore")
+        # joblib imports may raise DeprecationWarning on certain Python
+        # versions
         from joblib import __all__
         from joblib import *  # noqa
         from joblib import __version__

--- a/sklearn/utils/_joblib.py
+++ b/sklearn/utils/_joblib.py
@@ -8,10 +8,10 @@ import warnings as _warnings
 if _os.environ.get('SKLEARN_SITE_JOBLIB', False):
     with _warnings.catch_warnings():
         _warnings.simplefilter("ignore")
-    from joblib import __all__
-    from joblib import *  # noqa
-    from joblib import __version__
-    from joblib import logger
+        from joblib import __all__
+        from joblib import *  # noqa
+        from joblib import __version__
+        from joblib import logger
 else:
     from ..externals.joblib import __all__   # noqa
     from ..externals.joblib import *  # noqa

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -733,7 +733,7 @@ class WrongDummyMemory(object):
     pass
 
 
-@pytest.mark.filterwarnings("'cachedir' attribute has been deprecated")
+@pytest.mark.filterwarnings("ignore:The 'cachedir' attribute")
 def test_check_memory():
     memory = check_memory("cache_directory")
     assert_equal(memory.cachedir, os.path.join('cache_directory', 'joblib'))

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -733,6 +733,7 @@ class WrongDummyMemory(object):
     pass
 
 
+@pytest.mark.filterwarnings("'cachedir' attribute has been deprecated")
 def test_check_memory():
     memory = check_memory("cache_directory")
     assert_equal(memory.cachedir, os.path.join('cache_directory', 'joblib'))

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -25,7 +25,7 @@ from ..exceptions import NonBLASDotWarning
 from ..exceptions import NotFittedError
 from ..exceptions import DataConversionWarning
 from ..utils._joblib import Memory
-
+from ..utils._joblib import __version__ as joblib_version
 
 FLOAT_DTYPES = (np.float64, np.float32, np.float16)
 
@@ -201,7 +201,10 @@ def check_memory(memory):
     """
 
     if memory is None or isinstance(memory, six.string_types):
-        memory = Memory(cachedir=memory, verbose=0)
+        if LooseVersion(joblib_version) < '0.12':
+            memory = Memory(cachedir=memory, verbose=0)
+        else:
+            memory = Memory(location=memory, verbose=0)
     elif not hasattr(memory, 'cache'):
         raise ValueError("'memory' should be None, a string or have the same"
                          " interface as sklearn.utils.Memory."


### PR DESCRIPTION
On one of the travis worker, we use the latest release of joblib, in which "check_pickle" is deprecated.

This is creating failures on travis:
https://travis-ci.org/scikit-learn/scikit-learn/jobs/405093001

