### PR TITLE
[MRG+1] FIX: change warning type and validation location for contamination in LOF

### DIFF
--- a/sklearn/neighbors/tests/test_lof.py
+++ b/sklearn/neighbors/tests/test_lof.py
@@ -3,6 +3,8 @@
 # License: BSD 3 clause
 
 from math import sqrt
+
+import pytest
 import numpy as np
 from sklearn import neighbors
 
@@ -32,8 +34,7 @@ iris.data = iris.data[perm]
 iris.target = iris.target[perm]
 
 
-@ignore_warnings(category=DeprecationWarning)
-# contamination changed to 'auto' 0.22
+@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
 def test_lof():
     # Toy sample (the last two samples are outliers):
     X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [5, 3], [-4, 2]]
@@ -53,8 +54,7 @@ def test_lof():
     assert_array_equal(clf.fit_predict(X), 6 * [1] + 2 * [-1])
 
 
-@ignore_warnings(category=DeprecationWarning)
-# contamination changed to 'auto' 0.22
+@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
 def test_lof_performance():
     # Generate train/test data
     rng = check_random_state(2)
@@ -76,8 +76,7 @@ def test_lof_performance():
     assert_greater(roc_auc_score(y_test, y_pred), .99)
 
 
-@ignore_warnings(category=DeprecationWarning)
-# contamination changed to 'auto' 0.22
+@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
 def test_lof_values():
     # toy samples:
     X_train = [[1, 1], [1, 2], [2, 1]]
@@ -99,8 +98,7 @@ def test_lof_values():
     assert_array_almost_equal(-clf2.score_samples([[1., 1.]]), [s_1])
 
 
-@ignore_warnings(category=DeprecationWarning)
-# contamination changed to 'auto' 0.22
+@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
 def test_lof_precomputed(random_state=42):
     """Tests LOF with a distance matrix."""
     # Note: smaller samples may result in spurious test success
@@ -126,8 +124,7 @@ def test_lof_precomputed(random_state=42):
     assert_array_almost_equal(pred_X_Y, pred_D_Y)
 
 
-@ignore_warnings(category=DeprecationWarning)
-# contamination changed to 'auto' 0.22
+@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
 def test_n_neighbors_attribute():
     X = iris.data
     clf = neighbors.LocalOutlierFactor(n_neighbors=500).fit(X)
@@ -140,8 +137,7 @@ def test_n_neighbors_attribute():
     assert_equal(clf.n_neighbors_, X.shape[0] - 1)
 
 
-@ignore_warnings(category=DeprecationWarning)
-# contamination changed to 'auto' 0.22
+@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
 def test_score_samples():
     X_train = [[1, 1], [1, 2], [2, 1]]
     clf1 = neighbors.LocalOutlierFactor(n_neighbors=2,
@@ -163,8 +159,7 @@ def test_contamination():
     assert_raises(ValueError, clf.fit, X)
 
 
-@ignore_warnings(category=DeprecationWarning)
-# contamination changed to 'auto' 0.22
+@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
 def test_novelty_errors():
     X = iris.data
 
@@ -182,8 +177,7 @@ def test_novelty_errors():
     assert_raises_regex(AttributeError, msg, getattr, clf, 'fit_predict')
 
 
-@ignore_warnings(category=DeprecationWarning)
-# contamination changed to 'auto' 0.22
+@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
 def test_novelty_training_scores():
     # check that the scores of the training samples are still accessible
     # when novelty=True through the negative_outlier_factor_ attribute
@@ -202,8 +196,7 @@ def test_novelty_training_scores():
     assert_array_almost_equal(scores_1, scores_2)
 
 
-@ignore_warnings(category=DeprecationWarning)
-# contamination changed to 'auto' 0.22
+@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
 def test_hasattr_prediction():
     # check availability of prediction methods depending on novelty value.
     X = [[1, 1], [1, 2], [2, 1]]
@@ -225,16 +218,16 @@ def test_hasattr_prediction():
     assert not hasattr(clf, 'score_samples')
 
 
-@ignore_warnings(category=DeprecationWarning)
-# contamination changed to 'auto' 0.22
+@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
 def test_novelty_true_common_tests():
     # the common tests are run for the default LOF (novelty=False).
     # here we run these common tests for LOF when novelty=True
     check_estimator(neighbors.LocalOutlierFactor(novelty=True))
 
 
-def test_deprecation():
-    assert_warns_message(DeprecationWarning,
+def test_contamination_future_warning():
+    X = [[1, 1], [1, 2], [2, 1]]
+    assert_warns_message(FutureWarning,
                          'default contamination parameter 0.1 will change '
                          'in version 0.22 to "auto"',
-                         neighbors.LocalOutlierFactor, )
+                         neighbors.LocalOutlierFactor().fit, X)

--- a/sklearn/neighbors/tests/test_lof.py
+++ b/sklearn/neighbors/tests/test_lof.py
@@ -34,7 +34,9 @@ iris.data = iris.data[perm]
 iris.target = iris.target[perm]
 
 
-@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
+@pytest.mark.filterwarnings(
+    'ignore:default contamination parameter 0.1:FutureWarning')
+# XXX: Remove in 0.22
 def test_lof():
     # Toy sample (the last two samples are outliers):
     X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [5, 3], [-4, 2]]
@@ -54,7 +56,9 @@ def test_lof():
     assert_array_equal(clf.fit_predict(X), 6 * [1] + 2 * [-1])
 
 
-@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
+@pytest.mark.filterwarnings(
+    'ignore:default contamination parameter 0.1:FutureWarning')
+# XXX: Remove in 0.22
 def test_lof_performance():
     # Generate train/test data
     rng = check_random_state(2)
@@ -76,7 +80,9 @@ def test_lof_performance():
     assert_greater(roc_auc_score(y_test, y_pred), .99)
 
 
-@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
+@pytest.mark.filterwarnings(
+    'ignore:default contamination parameter 0.1:FutureWarning')
+# XXX: Remove in 0.22
 def test_lof_values():
     # toy samples:
     X_train = [[1, 1], [1, 2], [2, 1]]
@@ -98,7 +104,9 @@ def test_lof_values():
     assert_array_almost_equal(-clf2.score_samples([[1., 1.]]), [s_1])
 
 
-@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
+@pytest.mark.filterwarnings(
+    'ignore:default contamination parameter 0.1:FutureWarning')
+# XXX: Remove in 0.22
 def test_lof_precomputed(random_state=42):
     """Tests LOF with a distance matrix."""
     # Note: smaller samples may result in spurious test success
@@ -124,7 +132,9 @@ def test_lof_precomputed(random_state=42):
     assert_array_almost_equal(pred_X_Y, pred_D_Y)
 
 
-@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
+@pytest.mark.filterwarnings(
+    'ignore:default contamination parameter 0.1:FutureWarning')
+# XXX: Remove in 0.22
 def test_n_neighbors_attribute():
     X = iris.data
     clf = neighbors.LocalOutlierFactor(n_neighbors=500).fit(X)
@@ -137,7 +147,9 @@ def test_n_neighbors_attribute():
     assert_equal(clf.n_neighbors_, X.shape[0] - 1)
 
 
-@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
+@pytest.mark.filterwarnings(
+    'ignore:default contamination parameter 0.1:FutureWarning')
+# XXX: Remove in 0.22
 def test_score_samples():
     X_train = [[1, 1], [1, 2], [2, 1]]
     clf1 = neighbors.LocalOutlierFactor(n_neighbors=2,
@@ -159,7 +171,9 @@ def test_contamination():
     assert_raises(ValueError, clf.fit, X)
 
 
-@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
+@pytest.mark.filterwarnings(
+    'ignore:default contamination parameter 0.1:FutureWarning')
+# XXX: Remove in 0.22
 def test_novelty_errors():
     X = iris.data
 
@@ -177,7 +191,9 @@ def test_novelty_errors():
     assert_raises_regex(AttributeError, msg, getattr, clf, 'fit_predict')
 
 
-@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
+@pytest.mark.filterwarnings(
+    'ignore:default contamination parameter 0.1:FutureWarning')
+# XXX: Remove in 0.22
 def test_novelty_training_scores():
     # check that the scores of the training samples are still accessible
     # when novelty=True through the negative_outlier_factor_ attribute
@@ -196,7 +212,9 @@ def test_novelty_training_scores():
     assert_array_almost_equal(scores_1, scores_2)
 
 
-@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
+@pytest.mark.filterwarnings(
+    'ignore:default contamination parameter 0.1:FutureWarning')
+# XXX: Remove in 0.22
 def test_hasattr_prediction():
     # check availability of prediction methods depending on novelty value.
     X = [[1, 1], [1, 2], [2, 1]]
@@ -218,8 +236,11 @@ def test_hasattr_prediction():
     assert not hasattr(clf, 'score_samples')
 
 
-@pytest.mark.filterwarnings('ignore:default contamination parameter 0.1')
+@pytest.mark.filterwarnings(
+    'ignore:default contamination parameter 0.1:FutureWarning')
+# XXX: Remove in 0.22
 def test_novelty_true_common_tests():
+
     # the common tests are run for the default LOF (novelty=False).
     # here we run these common tests for LOF when novelty=True
     check_estimator(neighbors.LocalOutlierFactor(novelty=True))


### PR DESCRIPTION
Follow user guide for parameter change:

- Use a FutureWarning
- Make the check in fit