### PR TITLE
[MRG] ENH Return int/float instead of np.int/np.float in classification_report

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1549,9 +1549,11 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
         report_dict = {label[0]: label[1:] for label in rows}
 
         for label, scores in report_dict.items():
-            report_dict[label] = dict(zip(headers, scores))
+            report_dict[label] = dict(zip(headers,
+                                          [i.item() for i in scores]))
 
-        report_dict['avg / total'] = dict(zip(headers, avg_total))
+        report_dict['avg / total'] = dict(zip(headers,
+                                              [i.item() for i in avg_total]))
 
         return report_dict
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -132,6 +132,10 @@ def test_classification_report_dictionary_output():
         target_names=iris.target_names, output_dict=True)
 
     assert_dict_equal(report, expected_report)
+    assert type(expected_report['setosa']['precision']) == float
+    assert type(expected_report['avg / total']['precision']) == float
+    assert type(expected_report['setosa']['support']) == int
+    assert type(expected_report['avg / total']['support']) == int
 
 
 def test_multilabel_accuracy_score_subset_accuracy():


### PR DESCRIPTION
See https://github.com/scikit-learn/scikit-learn/pull/11160#issuecomment-406865707
We've decided to return int/float instead of np.int/np.float in classification_report
cc @jnothman 