### PR TITLE
[MRG] MAINT Use explicit relative imports instead of absolute ones

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -14,7 +14,7 @@ from math import log
 import numpy as np
 
 from scipy.optimize import fmin_bfgs
-from sklearn.preprocessing import LabelEncoder
+from .preprocessing import LabelEncoder
 
 from .base import BaseEstimator, ClassifierMixin, RegressorMixin, clone
 from .preprocessing import label_binarize, LabelBinarizer

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -8,7 +8,7 @@
 import numpy as np
 import warnings
 
-from sklearn.exceptions import ConvergenceWarning
+from ..exceptions import ConvergenceWarning
 from ..base import BaseEstimator, ClusterMixin
 from ..utils import as_float_array, check_array
 from ..utils.validation import check_is_fitted

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -22,7 +22,7 @@ from ..utils import check_random_state
 
 import numpy as np
 
-from sklearn.externals.six.moves.urllib.request import urlretrieve
+from ..externals.six.moves.urllib.request import urlretrieve
 
 RemoteFileMetadata = namedtuple('RemoteFileMetadata',
                                 ['filename', 'url', 'checksum'])

--- a/sklearn/datasets/mlcomp.py
+++ b/sklearn/datasets/mlcomp.py
@@ -5,7 +5,7 @@
 import os
 import numbers
 
-from ..datasets.base import load_files
+from .base import load_files
 from ..utils import deprecated
 
 

--- a/sklearn/datasets/mlcomp.py
+++ b/sklearn/datasets/mlcomp.py
@@ -4,8 +4,9 @@
 
 import os
 import numbers
-from sklearn.datasets.base import load_files
-from sklearn.utils import deprecated
+
+from ..datasets.base import load_files
+from ..utils import deprecated
 
 
 def _load_document_classification(dataset_path, metadata, set_=None, **kwargs):

--- a/sklearn/datasets/species_distributions.py
+++ b/sklearn/datasets/species_distributions.py
@@ -49,9 +49,9 @@ import numpy as np
 from .base import get_data_home
 from .base import _fetch_remote
 from .base import RemoteFileMetadata
+from .base import _pkl_filepath
 from ..utils import Bunch
-from sklearn.datasets.base import _pkl_filepath
-from sklearn.externals import joblib
+from ..externals import joblib
 
 PY3_OR_LATER = sys.version_info[0] >= 3
 

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -8,7 +8,6 @@ import numpy as np
 import scipy as sp
 import warnings
 from warnings import warn
-from sklearn.utils.fixes import euler_gamma
 
 from scipy.sparse import issparse
 
@@ -16,6 +15,7 @@ import numbers
 from ..externals import six
 from ..tree import ExtraTreeRegressor
 from ..utils import check_random_state, check_array
+from ..utils.fixes import euler_gamma
 from ..utils.validation import check_is_fitted
 from ..base import OutlierMixin
 

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -39,7 +39,7 @@ from ..tree._tree import DTYPE
 from ..utils import check_array, check_X_y, check_random_state
 from ..utils.extmath import stable_cumsum
 from ..metrics import accuracy_score, r2_score
-from sklearn.utils.validation import has_fit_parameter, check_is_fitted
+from ..utils.validation import has_fit_parameter, check_is_fitted
 
 __all__ = [
     'AdaBoostClassifier',

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -12,14 +12,13 @@ from scipy.linalg import cholesky, cho_solve, solve
 from scipy.optimize import fmin_l_bfgs_b
 from scipy.special import erf, expit
 
-from sklearn.base import BaseEstimator, ClassifierMixin, clone
-from sklearn.gaussian_process.kernels \
-    import RBF, CompoundKernel, ConstantKernel as C
-from sklearn.utils.validation import check_X_y, check_is_fitted, check_array
-from sklearn.utils import check_random_state
-from sklearn.preprocessing import LabelEncoder
-from sklearn.multiclass import OneVsRestClassifier, OneVsOneClassifier
-from sklearn.exceptions import ConvergenceWarning
+from ..base import BaseEstimator, ClassifierMixin, clone
+from .kernels import RBF, CompoundKernel, ConstantKernel as C
+from ..utils.validation import check_X_y, check_is_fitted, check_array
+from ..utils import check_random_state
+from ..preprocessing import LabelEncoder
+from ..multiclass import OneVsRestClassifier, OneVsOneClassifier
+from ..exceptions import ConvergenceWarning
 
 
 # Values required for approximating the logistic sigmoid by

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -11,12 +11,12 @@ import numpy as np
 from scipy.linalg import cholesky, cho_solve, solve_triangular
 from scipy.optimize import fmin_l_bfgs_b
 
-from sklearn.base import BaseEstimator, RegressorMixin, clone
-from sklearn.gaussian_process.kernels import RBF, ConstantKernel as C
-from sklearn.utils import check_random_state
-from sklearn.utils.validation import check_X_y, check_array
-from sklearn.utils.deprecation import deprecated
-from sklearn.exceptions import ConvergenceWarning
+from ..base import BaseEstimator, RegressorMixin, clone
+from .kernels import RBF, ConstantKernel as C
+from ..utils import check_random_state
+from ..utils.validation import check_X_y, check_array
+from ..utils.deprecation import deprecated
+from ..exceptions import ConvergenceWarning
 
 
 class GaussianProcessRegressor(BaseEstimator, RegressorMixin):

--- a/sklearn/metrics/cluster/bicluster.py
+++ b/sklearn/metrics/cluster/bicluster.py
@@ -2,8 +2,8 @@ from __future__ import division
 
 import numpy as np
 
-from sklearn.utils.linear_assignment_ import linear_assignment
-from sklearn.utils.validation import check_consistent_length, check_array
+from ...utils.linear_assignment_ import linear_assignment
+from ...utils.validation import check_consistent_length, check_array
 
 __all__ = ["consensus_score"]
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -13,57 +13,57 @@ import numpy as np
 from scipy import sparse
 from scipy.stats import rankdata
 
-from sklearn.externals.six.moves import zip
-from sklearn.utils import IS_PYPY
-from sklearn.utils._joblib import hash, Memory
-from sklearn.utils.testing import assert_raises, _get_args
-from sklearn.utils.testing import assert_raises_regex
-from sklearn.utils.testing import assert_raise_message
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_not_equal
-from sklearn.utils.testing import assert_almost_equal
-from sklearn.utils.testing import assert_true
-from sklearn.utils.testing import assert_false
-from sklearn.utils.testing import assert_in
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_allclose
-from sklearn.utils.testing import assert_allclose_dense_sparse
-from sklearn.utils.testing import assert_warns_message
-from sklearn.utils.testing import META_ESTIMATORS
-from sklearn.utils.testing import set_random_state
-from sklearn.utils.testing import assert_greater
-from sklearn.utils.testing import assert_greater_equal
-from sklearn.utils.testing import SkipTest
-from sklearn.utils.testing import ignore_warnings
-from sklearn.utils.testing import assert_dict_equal
-from sklearn.utils.testing import create_memmap_backed_data
-from sklearn.utils import is_scalar_nan
-from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
+from ..externals.six.moves import zip
+from . import IS_PYPY
+from ._joblib import hash, Memory
+from .testing import assert_raises, _get_args
+from .testing import assert_raises_regex
+from .testing import assert_raise_message
+from .testing import assert_equal
+from .testing import assert_not_equal
+from .testing import assert_almost_equal
+from .testing import assert_true
+from .testing import assert_false
+from .testing import assert_in
+from .testing import assert_array_equal
+from .testing import assert_allclose
+from .testing import assert_allclose_dense_sparse
+from .testing import assert_warns_message
+from .testing import META_ESTIMATORS
+from .testing import set_random_state
+from .testing import assert_greater
+from .testing import assert_greater_equal
+from .testing import SkipTest
+from .testing import ignore_warnings
+from .testing import assert_dict_equal
+from .testing import create_memmap_backed_data
+from . import is_scalar_nan
+from ..discriminant_analysis import LinearDiscriminantAnalysis
 
 
-from sklearn.base import (clone, ClusterMixin,
-                          BaseEstimator, is_classifier, is_regressor,
-                          is_outlier_detector)
+from ..base import (clone, ClusterMixin,
+                    BaseEstimator, is_classifier, is_regressor,
+                    is_outlier_detector)
 
-from sklearn.metrics import accuracy_score, adjusted_rand_score, f1_score
+from ..metrics import accuracy_score, adjusted_rand_score, f1_score
 
-from sklearn.random_projection import BaseRandomProjection
-from sklearn.feature_selection import SelectKBest
-from sklearn.svm.base import BaseLibSVM
-from sklearn.linear_model.stochastic_gradient import BaseSGD
-from sklearn.pipeline import make_pipeline
-from sklearn.exceptions import DataConversionWarning
-from sklearn.exceptions import SkipTestWarning
-from sklearn.model_selection import train_test_split
-from sklearn.metrics.pairwise import (rbf_kernel, linear_kernel,
-                                      pairwise_distances)
+from ..random_projection import BaseRandomProjection
+from ..feature_selection import SelectKBest
+from ..svm.base import BaseLibSVM
+from ..linear_model.stochastic_gradient import BaseSGD
+from ..pipeline import make_pipeline
+from ..exceptions import DataConversionWarning
+from ..exceptions import SkipTestWarning
+from ..model_selection import train_test_split
+from ..metrics.pairwise import (rbf_kernel, linear_kernel,
+                                pairwise_distances)
 
-from sklearn.utils import shuffle
-from sklearn.utils.fixes import signature
-from sklearn.utils.validation import (has_fit_parameter, _num_samples,
-                                      LARGE_SPARSE_SUPPORTED)
-from sklearn.preprocessing import StandardScaler
-from sklearn.datasets import load_iris, load_boston, make_blobs
+from . import shuffle
+from .fixes import signature
+from .validation import (has_fit_parameter, _num_samples,
+                         LARGE_SPARSE_SUPPORTED)
+from ..preprocessing import StandardScaler
+from ..datasets import load_iris, load_boston, make_blobs
 
 
 BOSTON = None

--- a/sklearn/utils/random.py
+++ b/sklearn/utils/random.py
@@ -6,7 +6,7 @@ import numpy as np
 import scipy.sparse as sp
 import array
 
-from sklearn.utils import check_random_state
+from . import check_random_state
 from ._random import sample_without_replacement
 from .deprecation import deprecated
 

--- a/sklearn/utils/sparsetools/__init__.py
+++ b/sklearn/utils/sparsetools/__init__.py
@@ -3,7 +3,7 @@
 from scipy.sparse.csgraph import connected_components as \
      scipy_connected_components
 
-from sklearn.utils.deprecation import deprecated
+from ..deprecation import deprecated
 
 
 @deprecated("sklearn.utils.sparsetools.connected_components was deprecated in "

--- a/sklearn/utils/stats.py
+++ b/sklearn/utils/stats.py
@@ -1,8 +1,8 @@
 import numpy as np
 from scipy.stats import rankdata as scipy_rankdata
 
-from sklearn.utils.extmath import stable_cumsum
-from sklearn.utils.deprecation import deprecated
+from .extmath import stable_cumsum
+from .deprecation import deprecated
 
 
 # Remove in sklearn 0.21


### PR DESCRIPTION
For the sake of code consistency, use explicit relative imports instead of the absolute ones in Python files (excluding tests). Most of the code base (excluding tests and Cython files) already currently uses them.

This would also help with the issue reported in https://github.com/scikit-learn/scikit-learn/issues/11656  (even if I don't believe we want to support such use case in general).

