### PR TITLE
BF: Define "message" since exception might happen in initial import

### DIFF
--- a/sklearn/tests/test_init.py
+++ b/sklearn/tests/test_init.py
@@ -28,6 +28,7 @@ def test_import_skl():
 def test_import_sklearn_no_warnings():
     # Test that importing scikit-learn main modules doesn't raise any warnings.
 
+    message = "No message yet"
     try:
         pkgs = pkgutil.iter_modules(path=sklearn.__path__, prefix='sklearn.')
         import_modules = '; '.join(['import ' + modname


### PR DESCRIPTION
Unless really intended to error out (not to "Fail") if initial import fails for some reason (didn't figure out yet why), then code might end up in exception handling without `message` variable been defined.