### PR TITLE
[MRG+1] Make _hstack a staticmethod on ColumnTransformer

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -480,9 +480,8 @@ boolean mask array or callable
         Supports input types (X): list of
             numpy arrays, sparse arrays and DataFrames
 
-        This is implemented as a staticmethod to enable subclasses to control
-        the stacking behavior, while reusing everything else from
-        ColumnTransformer.
+        This allows subclasses to control the stacking behavior, while reusing
+        everything else from ColumnTransformer.
         """
         if sparse_:
             return sparse.hstack(X).tocsr()

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -443,7 +443,7 @@ boolean mask array or callable
         self._update_fitted_transformers(transformers)
         self._validate_output(Xs)
 
-        return self._hstack(list(Xs), self.sparse_output_)
+        return self._hstack(list(Xs))
 
     def transform(self, X):
         """Transform X separately by each transformer, concatenate results.
@@ -471,23 +471,23 @@ boolean mask array or callable
             # All transformers are None
             return np.zeros((X.shape[0], 0))
 
-        return self._hstack(list(Xs), self.sparse_output_)
+        return self._hstack(list(Xs))
 
-    def _hstack(self, X, sparse_):
-        """
-        Stacks X horizontally.
-
-        Supports input types (X): list of
-            numpy arrays, sparse arrays and DataFrames
+    def _hstack(self, Xs):
+        """Stacks Xs horizontally.
 
         This allows subclasses to control the stacking behavior, while reusing
         everything else from ColumnTransformer.
+
+        Parameters
+        ----------
+        Xs : List of numpy arrays, sparse arrays, or DataFrames
         """
-        if sparse_:
-            return sparse.hstack(X).tocsr()
+        if self.sparse_output_:
+            return sparse.hstack(Xs).tocsr()
         else:
-            X = [f.toarray() if sparse.issparse(f) else f for f in X]
-            return np.hstack(X)
+            Xs = [f.toarray() if sparse.issparse(f) else f for f in Xs]
+            return np.hstack(Xs)
 
 
 def _check_key_type(key, superclass):

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -473,8 +473,7 @@ boolean mask array or callable
 
         return self._hstack(list(Xs), self.sparse_output_)
 
-    @staticmethod
-    def _hstack(X, sparse_):
+    def _hstack(self, X, sparse_):
         """
         Stacks X horizontally.
 


### PR DESCRIPTION
This lets subclasses re-use more of sklearn.compose._column_transformer.

The `dask_ml` implementation went from 170 lines of code to 30 by being able to override just `_hstack`.

xref https://github.com/dask/dask-ml/pull/315

cc @ogrisel 