### PR TITLE
[MRG] MNT: Skip array check in dict_learning_online

### DIFF
--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -797,6 +797,7 @@ def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
 
         this_code = sparse_encode(this_X, dictionary.T, algorithm=method,
                                   alpha=alpha, n_jobs=n_jobs,
+                                  check_input=False,
                                   positive=positive_code).T
 
         # Update the auxiliary variables


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes https://github.com/scikit-learn/scikit-learn/issues/11688

#### What does this implement/fix? Explain your changes.

Already `dict_learning_online` has ensured that `this_X` is a double precision, C-ordered array and `dictionary` is a double precision, F-ordered array (so `dictionary.T` is C-ordered). The array checks in `sparse_encode` only apply to `lasso_cd` where this constraint is met. The other checks are merely to validate the input data has reasonable values, which again was already checked in `dict_learning_online`. So these checks in `sparse_encode` can be bypassed in `dict_learning_online`.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
