### PR TITLE
WIP: Adjust checks of coef_init in enet_path

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -449,7 +449,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
     coef_ = coef_init
     if coef_ is None:
         coef_ = np.zeros(coefs.shape[:-1], dtype=X.dtype, order='F')
-    else:
+    elif check_input:
         coef_ = np.asfortranarray(coef_, dtype=X.dtype)
 
     for i, alpha in enumerate(alphas):

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -446,10 +446,11 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         coefs = np.empty((n_outputs, n_features, n_alphas),
                          dtype=X.dtype)
 
-    if coef_init is None:
+    coef_ = coef_init
+    if coef_ is None:
         coef_ = np.zeros(coefs.shape[:-1], dtype=X.dtype, order='F')
     else:
-        coef_ = np.asfortranarray(coef_init, dtype=X.dtype)
+        coef_ = np.asfortranarray(coef_, dtype=X.dtype)
 
     for i, alpha in enumerate(alphas):
         l1_reg = alpha * l1_ratio * n_samples


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

There was a call to `asfortranarray` on a C-ordered array that was recently allocated. It's better to just allocate the array as F-ordered to bypass this unneeded copy. Also skip a F-order and type check on `coef_init` if called by `ElasticNet` as we already guarantee both of these properties are met then.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
