### PR TITLE
[MRG] from_model.py: hasattr->getattr on coef_ [Fixes #7491]

### DIFF
--- a/sklearn/feature_selection/from_model.py
+++ b/sklearn/feature_selection/from_model.py
@@ -16,12 +16,13 @@ def _get_feature_importances(estimator, norm_order=1):
     """Retrieve or aggregate feature importances from estimator"""
     importances = getattr(estimator, "feature_importances_", None)
 
-    if importances is None and hasattr(estimator, "coef_"):
+    coef_ = getattr(estimator, "coef_", None)
+    if importances is None and coef_ is not None:
         if estimator.coef_.ndim == 1:
-            importances = np.abs(estimator.coef_)
+            importances = np.abs(coef_)
 
         else:
-            importances = np.linalg.norm(estimator.coef_, axis=0,
+            importances = np.linalg.norm(coef_, axis=0,
                                          ord=norm_order)
 
     elif importances is None:


### PR DESCRIPTION
Fixes #7491

It seems out of the properties identified in #7491, `coef_` is the only one which needs to be corrected. These are places where a `hasattr(..., 'coef_')` occurs:

    sklearn/svm/tests/test_svm.py:60:        assert_true(hasattr(clf, "coef_") == (k == 'linear'))

Which I ignored since it's a test.

```
sklearn/multiclass.py-386-        check_is_fitted(self, 'estimators_')
sklearn/multiclass.py:387:        if not hasattr(self.estimators_[0], "coef_"):
sklearn/multiclass.py-388-            raise AttributeError(
sklearn/multiclass.py-389-                "Base estimator doesn't have a coef_ attribute.")
sklearn/multiclass.py-390-        coefs = [e.coef_ for e in self.estimators_]
sklearn/multiclass.py-391-        if sp.issparse(coefs[0]):
sklearn/multiclass.py-392-            return sp.vstack(coefs)
sklearn/multiclass.py-393-        return np.vstack(coefs)
```
which I've ignored (for now, unless a reviewer disagrees), since it's impact is not so significant as long as there are more than 2 classes (I know, _significant_ here is not so clear, and you may disagree, in which case I'm happy to fix it).

    sklearn/linear_model/tests/test_sgd.py:926:        assert_true(hasattr(clf, "coef_"))

again a test, so ignored.

```
sklearn/linear_model/coordinate_descent.py:732:        if not self.warm_start or not hasattr(self, "coef_"):
sklearn/linear_model/coordinate_descent.py-733-            coef_ = np.zeros((n_targets, n_features), dtype=X.dtype,
sklearn/linear_model/coordinate_descent.py-734-                             order='F')
sklearn/linear_model/coordinate_descent.py-735-        else:
sklearn/linear_model/coordinate_descent.py-736-            coef_ = self.coef_
sklearn/linear_model/coordinate_descent.py-737-            if coef_.ndim == 1:
sklearn/linear_model/coordinate_descent.py-738-                coef_ = coef_[np.newaxis, :]
```
The `coef_` here is a simple attribute, therefore it doesn't need a fix.

```
sklearn/linear_model/logistic.py:1342:        if not hasattr(self, "coef_"):
sklearn/linear_model/logistic.py-1343-            raise NotFittedError("Call fit before prediction")
sklearn/linear_model/logistic.py-1344-        if self.multi_class == "ovr":
sklearn/linear_model/logistic.py-1345-            return super(LogisticRegression, self)._predict_proba_lr(X)
sklearn/linear_model/logistic.py-1346-        else:
sklearn/linear_model/logistic.py-1347-            decision = self.decision_function(X)
sklearn/linear_model/logistic.py-1348-            if decision.ndim == 1:
sklearn/linear_model/logistic.py-1349-                # Workaround for multi_class="multinomial" and binary outcomes
sklearn/linear_model/logistic.py-1350-                # which requires softmax prediction with only a 1D decision.
sklearn/linear_model/logistic.py-1351-                decision_2d = np.c_[-decision, decision]
sklearn/linear_model/logistic.py-1352-            else:
sklearn/linear_model/logistic.py-1353-                decision_2d = decision
sklearn/linear_model/logistic.py-1354-            return softmax(decision_2d, copy=False)
```
Here `coef_` is again a simple variable, so it doesn't need fixing.

```
sklearn/linear_model/stochastic_gradient.py:553:        if self.warm_start and hasattr(self, "coef_"):
sklearn/linear_model/stochastic_gradient.py-554-            if coef_init is None:
sklearn/linear_model/stochastic_gradient.py-555-                coef_init = self.coef_
sklearn/linear_model/stochastic_gradient.py-556-            if intercept_init is None:
sklearn/linear_model/stochastic_gradient.py-557-                intercept_init = self.intercept_
sklearn/linear_model/stochastic_gradient.py-558-        else:
sklearn/linear_model/stochastic_gradient.py-559-            self.coef_ = None
sklearn/linear_model/stochastic_gradient.py-560-            self.intercept_ = None
```
Also a simple variable.

```
sklearn/feature_selection/from_model.py:19:    if importances is None and hasattr(estimator, "coef_"):
sklearn/feature_selection/from_model.py-20-        if estimator.coef_.ndim == 1:
sklearn/feature_selection/from_model.py-21-            importances = np.abs(estimator.coef_)
sklearn/feature_selection/from_model.py-22-
sklearn/feature_selection/from_model.py-23-        else:
sklearn/feature_selection/from_model.py-24-            importances = np.linalg.norm(estimator.coef_, axis=0,
sklearn/feature_selection/from_model.py-25-                                         ord=norm_order)
```
This could use the fix, which is in this PR.