### PR TITLE
DOC: Clarify splitting behavior of fit_params

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -598,7 +598,15 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             train/test set.
 
         **fit_params : dict of string -> object
-            Parameters passed to the ``fit`` method of the estimator
+            Parameters passed to the ``fit`` method of the estimator.
+
+            Depending on the value, a fit parameter may be split into multiple
+            CV groups along with `X` and `y`. For example, the `sample_weight`
+            parameter to :meth:`sklearn.linear_model.SGDClassifier.fit`
+            is split becuase it's an array-like with the same number of
+            samples as `X` and `y`. On the other hand, the `coef_init`
+            parameter is not split along with `X` and `y`, because it's
+            shape is ``[n_features, n_classes]``.
         """
 
         if self.fit_params is not None:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

(hopefully) clarifies how BaseSearchCV.fit handles fit_params. From the docs, it wasn't clear to me if / how these would be split.

IIUC, it comes down to the behavior of https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/model_selection/_validation.py#L919-L926. Parameters are split along with `X` and `y` when they are array-like and have the same number of samples.