### PR TITLE
[MRG] FIX: Force `w` to be a contiguous vector

### DIFF
--- a/sklearn/linear_model/cd_fast.pyx
+++ b/sklearn/linear_model/cd_fast.pyx
@@ -308,7 +308,7 @@ def enet_coordinate_descent(np.ndarray[floating, ndim=1, mode='c'] w,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-def sparse_enet_coordinate_descent(floating [:] w,
+def sparse_enet_coordinate_descent(floating [::1] w,
                             floating alpha, floating beta,
                             np.ndarray[floating, ndim=1, mode='c'] X_data,
                             np.ndarray[int, ndim=1, mode='c'] X_indices,
@@ -528,7 +528,8 @@ def sparse_enet_coordinate_descent(floating [:] w,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-def enet_coordinate_descent_gram(floating[:] w, floating alpha, floating beta,
+def enet_coordinate_descent_gram(floating[::1] w,
+                                 floating alpha, floating beta,
                                  np.ndarray[floating, ndim=2, mode='c'] Q,
                                  np.ndarray[floating, ndim=1, mode='c'] q,
                                  np.ndarray[floating, ndim=1] y,

--- a/sklearn/linear_model/cd_fast.pyx
+++ b/sklearn/linear_model/cd_fast.pyx
@@ -141,7 +141,7 @@ cdef extern from "cblas.h":
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-def enet_coordinate_descent(np.ndarray[floating, ndim=1] w,
+def enet_coordinate_descent(np.ndarray[floating, ndim=1, mode='c'] w,
                             floating alpha, floating beta,
                             np.ndarray[floating, ndim=2, mode='fortran'] X,
                             np.ndarray[floating, ndim=1, mode='c'] y,


### PR DESCRIPTION
Seems that all other arrays and all other instances of `w` (or `W`) in different functions in `cd_fast.pyx` are required to be contiguous. A few functions in `cd_fast.pyx` are not enforcing that `w` meet this constraint. This in spite of the fact that they implicitly assume that `w` is contiguous internally (e.g. when calling BLAS functions). This explicitly requires `w` to be contiguous when calling into these functions. Cython will error out if this constraint is not met.