### PR TITLE
[MRG] DOC: fix typos in the docstring of normalized_mutual_info_score

### DIFF
--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -767,14 +767,14 @@ def normalized_mutual_info_score(labels_true, labels_pred,
                                  average_method='warn'):
     """Normalized Mutual Information between two clusterings.
 
-    Normalized Mutual Information (NMI) is an normalization of the Mutual
+    Normalized Mutual Information (NMI) is a normalization of the Mutual
     Information (MI) score to scale the results between 0 (no mutual
     information) and 1 (perfect correlation). In this function, mutual
     information is normalized by some generalized mean of ``H(labels_true)``
     and ``H(labels_pred))``, defined by the `average_method`.
 
     This measure is not adjusted for chance. Therefore
-    :func:`adjusted_mustual_info_score` might be preferred.
+    :func:`adjusted_mutual_info_score` might be preferred.
 
     This metric is independent of the absolute values of the labels:
     a permutation of the class or cluster label values won't change the


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
two typos in the docstring of `normalized_mutual_info_score`.