### PR TITLE
[MRG] DOC fix indication of manifold.MDS.embedding_ array shape

### DIFF
--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -332,7 +332,7 @@ class MDS(BaseEstimator):
 
     Attributes
     ----------
-    embedding_ : array-like, shape (n_components, n_samples)
+    embedding_ : array-like, shape (n_samples, n_components)
         Stores the position of the dataset in the embedding space.
 
     stress_ : float


### PR DESCRIPTION
#### Reference Issues/PRs

None.

#### What does this implement/fix? Explain your changes.

Fixes a documentation typo: the `manifold.MDS.embedding_` attribute currently says it has a shape of `(n_components, n_samples)`, when it actually has a shape of `(n_samples, n_components)`.

#### Any other comments?

No.