### PR TITLE
[MRG] Fixed bug in _log_reg_scoring_path for multinomial case

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -593,7 +593,6 @@ Classifiers and regressors
   incorrect results in :class:`logistic.LogisticRegressionCV`. :issue:`11724`
   by :user:`Nicolas Hug <NicolasHug>`.
 
-
 Decomposition, manifold learning and clustering
 
 - Fix for uninformative error in :class:`decomposition.IncrementalPCA`:

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -587,6 +587,13 @@ Classifiers and regressors
   considered all samples to be of equal weight importance.
   :issue:`11464` by :user:`John Stott <JohnStott>`.
 
+- Fixed a bug in :func:`logistic.logistic_regression_path` to ensure that the
+  returned coefficients are correct when ``multiclass='multinomial'``.
+  Previously, some of the coefficients would override each other, leading to
+  incorrect results in :class:`logistic.LogisticRegressionCV`. :issue:`11724`
+  by :user:`Nicolas Hug <NicolasHug>`.
+
+
 Decomposition, manifold learning and clustering
 
 - Fix for uninformative error in :class:`decomposition.IncrementalPCA`:

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -762,13 +762,13 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
             multi_w0 = np.reshape(w0, (classes.size, -1))
             if classes.size == 2:
                 multi_w0 = multi_w0[1][np.newaxis, :]
-            coefs.append(multi_w0)
+            coefs.append(multi_w0.copy())
         else:
             coefs.append(w0.copy())
 
         n_iter[i] = n_iter_i
 
-    return coefs, np.array(Cs), n_iter
+    return np.array(coefs), np.array(Cs), n_iter
 
 
 # helper function for LogisticCV

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -572,7 +572,9 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
     coefs : ndarray, shape (n_cs, n_features) or (n_cs, n_features + 1)
         List of coefficients for the Logistic Regression model. If
         fit_intercept is set to True then the second dimension will be
-        n_features + 1, where the last item represents the intercept.
+        n_features + 1, where the last item represents the intercept. For
+        ``multiclass='multinomial'``, the shape is (n_classes, n_cs,
+        n_features) or (n_classes, n_cs, n_features + 1).
 
     Cs : ndarray
         Grid of Cs used for cross-validation.

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1310,7 +1310,7 @@ def test_warm_start_converge_LR():
 
 
 def test_log_reg_scoring_path_multinomial():
-    # Make sure that the scores are all differents when C is different
+    # Make sure that the scores are all different for different C values
     X, y = make_classification(n_samples=200, n_classes=3, n_informative=3,
                                random_state=0)
     train, test = next(StratifiedKFold(n_splits=5).split(X, y))
@@ -1320,5 +1320,5 @@ def test_log_reg_scoring_path_multinomial():
                                 solver='saga', random_state=0,
                                 multi_class='multinomial')
 
-    coefs, Cs, scores, n_iter = res
+    _, _, scores, _ = res
     assert len(set(scores)) != 1

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1307,3 +1307,18 @@ def test_warm_start_converge_LR():
         lr_ws.fit(X, y)
     lr_ws_loss = log_loss(y, lr_ws.predict_proba(X))
     assert_allclose(lr_no_ws_loss, lr_ws_loss, rtol=1e-5)
+
+
+def test_log_reg_scoring_path_multinomial():
+    # Make sure that the scores are all differents when C is different
+    X, y = make_classification(n_samples=200, n_classes=3, n_informative=3,
+                               random_state=0)
+    train, test = next(StratifiedKFold(n_splits=5).split(X, y))
+
+    Cs = np.logspace(-4, 4, 5)
+    res = _log_reg_scoring_path(X, y, train, test, penalty='l1', Cs=Cs,
+                                solver='saga', random_state=0,
+                                multi_class='multinomial')
+
+    coefs, Cs, scores, n_iter = res
+    assert len(set(scores)) != 1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This PR fixes a weird bug in `logistic_regression_path` that makes `_log_reg_scoring_path` give an incorrect output. Prior to this change, all the scores (from the different C values) would have been the same.

#### Any other comments?

I stumbled upon this while working on #11646.

To be fair I suspect that there are other bugs.

Related but not part of this PR: the doc of `logistic_regression_path` says that the `coefs` attribute is of shape `(n_cs, n_features)` but that's not true when `multiclass=multinomial`. Should I update the doc? Or is the actual code that is wrong?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
