### PR TITLE
[MRG] ENH Simplify error message of get_scorer

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -105,7 +105,7 @@ Usage examples:
     >>> model = svm.SVC()
     >>> cross_val_score(model, X, y, cv=5, scoring='wrong_choice')
     Traceback (most recent call last):
-    ValueError: 'wrong_choice' is not a valid scoring value. Valid options are ['accuracy', 'adjusted_mutual_info_score', 'adjusted_rand_score', 'average_precision', 'balanced_accuracy', 'brier_score_loss', 'completeness_score', 'explained_variance', 'f1', 'f1_macro', 'f1_micro', 'f1_samples', 'f1_weighted', 'fowlkes_mallows_score', 'homogeneity_score', 'mutual_info_score', 'neg_log_loss', 'neg_mean_absolute_error', 'neg_mean_squared_error', 'neg_mean_squared_log_error', 'neg_median_absolute_error', 'normalized_mutual_info_score', 'precision', 'precision_macro', 'precision_micro', 'precision_samples', 'precision_weighted', 'r2', 'recall', 'recall_macro', 'recall_micro', 'recall_samples', 'recall_weighted', 'roc_auc', 'v_measure_score']
+    ValueError: 'wrong_choice' is not a valid scoring value. Use sorted(sklearn.metrics.SCORERS.keys()) to get valid options.
 
 .. note::
 

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -216,8 +216,8 @@ def get_scorer(scoring):
             scorer = SCORERS[scoring]
         except KeyError:
             raise ValueError('%r is not a valid scoring value. '
-                             'Valid options are %s'
-                             % (scoring, sorted(SCORERS.keys())))
+                             'Use sorted(sklearn.metrics.SCORERS.keys()) '
+                             'to get valid options.' % (scoring))
     else:
         scorer = scoring
     return scorer


### PR DESCRIPTION
Closes #11062
Closes #10712 
We have more and more scorers, so it seems reasonable to simplify the error message.
What's more, the new error message tells users how to list all the available scorers. (though actually users need to first ``from sklearn import metrics`` then ``sorted(metrics.SCORERS.keys())``)