### PR TITLE
[MRG] FIX IndexError due to imprecision in KMeans++

### DIFF
--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -112,7 +112,7 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
         candidate_ids = np.searchsorted(stable_cumsum(closest_dist_sq),
                                         rand_vals)
         # XXX: numerical imprecision can result in a candidate_id out of range
-        np.clip(candidate_ids, None, len(closest_dist_sq) - 1,
+        np.clip(candidate_ids, None, closest_dist_sq.size - 1,
                 out=candidate_ids)
 
         # Compute distances to center candidates

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -111,6 +111,9 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
         rand_vals = random_state.random_sample(n_local_trials) * current_pot
         candidate_ids = np.searchsorted(stable_cumsum(closest_dist_sq),
                                         rand_vals)
+        # XXX: numerical imprecision can result in a candidate_id out of range
+        np.clip(candidate_ids, None, len(closest_dist_sq) - 1,
+                out=candidate_ids)
 
         # Compute distances to center candidates
         distance_to_candidates = euclidean_distances(


### PR DESCRIPTION
I'm not sure how to test this.

As noted in https://github.com/scikit-learn/scikit-learn/issues/8583#issuecomment-410568283 we could instead switch to using `random_state.choice` but will probably lose backwards compatibility.