### PR TITLE
[MRG] FIX Support cv=None in *CV

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -988,8 +988,8 @@ Model selection
 
 - The default number of cross-validation folds ``cv`` and the default number of
   splits ``n_splits`` in the :class:`model_selection.KFold`-like splitters will change
-  from 3 to 5 in 0.22 as 3-fold has a lot of variance.
-  :issue:`11557` by :user:`Alexandre Boucaud <aboucaud>`.
+  from 3 to 5 in 0.22 as 3-fold has a lot of variance. :issue:`11557` and
+  :issue:`11761` by :user:`Alexandre Boucaud <aboucaud>` and `Hanmin Qin`_.
 
 Changes to estimator checks
 ---------------------------

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -988,8 +988,8 @@ Model selection
 
 - The default number of cross-validation folds ``cv`` and the default number of
   splits ``n_splits`` in the :class:`model_selection.KFold`-like splitters will change
-  from 3 to 5 in 0.22 as 3-fold has a lot of variance. :issue:`11557` and
-  :issue:`11761` by :user:`Alexandre Boucaud <aboucaud>` and `Hanmin Qin`_.
+  from 3 to 5 in 0.22 as 3-fold has a lot of variance.
+  :issue:`11557` by :user:`Alexandre Boucaud <aboucaud>`.
 
 Changes to estimator checks
 ---------------------------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1939,7 +1939,7 @@ def check_cv(cv='warn', y=None, classifier=False):
         The return value is a cross-validator which generates the train/test
         splits via the ``split`` method.
     """
-    if cv is 'warn':
+    if cv is None or cv is 'warn':
         warnings.warn(CV_WARNING, FutureWarning)
         cv = 3
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1444,7 +1444,7 @@ def test_nsplit_default_warn():
 def test_check_cv_default_warn():
     # Test that warnings are raised. Will be removed in 0.22
     assert_warns_message(FutureWarning, CV_WARNING, check_cv)
-
+    assert_warns_message(FutureWarning, CV_WARNING, check_cv, None)
     assert_no_warnings(check_cv, cv=5)
 
 


### PR DESCRIPTION
Fixes #11760
Script to reproduce the regression:
```
from sklearn.datasets import load_iris
from sklearn.linear_model import LogisticRegressionCV
X, y = load_iris(return_X_y=True)
clf = LogisticRegressionCV(cv=None)
clf.fit(X, y)
```