### PR TITLE
Fixed: check_cv correctly assigns cv=3 when cv=None

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1939,7 +1939,7 @@ def check_cv(cv='warn', y=None, classifier=False):
         The return value is a cross-validator which generates the train/test
         splits via the ``split`` method.
     """
-    if cv is 'warn':
+    if cv is 'warn' or cv is None:
         warnings.warn(CV_WARNING, FutureWarning)
         cv = 3
 


### PR DESCRIPTION
Fixes Issue #11760 
