### PR TITLE
[MRG] Better convergence warnings for lbfgs solver in LogisticRegression

### DIFF
--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -718,12 +718,20 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
                 func, w0, fprime=None,
                 args=(X, target, 1. / C, sample_weight),
                 iprint=iprint, pgtol=tol, maxiter=max_iter)
-            if info["warnflag"] == 1:
-                warnings.warn("lbfgs failed to converge. Increase the number "
-                              "of iterations.", ConvergenceWarning)
+
             # In scipy <= 1.0.0, nit may exceed maxiter.
             # See https://github.com/scipy/scipy/issues/7854.
             n_iter_i = min(info['nit'], max_iter)
+
+            if info["warnflag"] == 1:
+                warnings.warn("lbfgs failed to converge with max_iter={}. "
+                              "max(|grad|) = {:.3e} while pgtol={:.3e} (see "
+                              "scipy.optimize.fmin_l_bfgs_b documentation for "
+                              "more information). Increase the number of "
+                              "iterations."
+                              .format(n_iter_i,
+                                      np.abs(info['grad']).max(), tol),
+                              ConvergenceWarning)
         elif solver == 'newton-cg':
             args = (X, target, 1. / C, sample_weight)
             w0, n_iter_i = newton_cg(hess, func, grad, w0, args=args,


### PR DESCRIPTION
When the `lbfgs` solver in `LogisticRegression` fails to converge, the resulting ConvergenceWarning is not very informative. This PR increases it's verbosity so we have a better estimation of how bad the convergence is. 
This is particularly relevant if `lbfgs` is to become the default solver (https://github.com/scikit-learn/scikit-learn/pull/11476)

The tricky part is that, as far as I understood, `scipy.optimize.fmin_l_bfgs_b` only returns the evaluated gradient at the minimum, while the convergence criterion is the max |projected gradient|. Still IMO providing at least some information about the final gradient is better than nothing.. 

**Example**
```py
from sklearn.linear_model import LogisticRegression
from sklearn.datasets import load_iris


iris = load_iris()

estimator = LogisticRegression(solver='lbfgs', multi_class='ovr', max_iter=20)
estimator.fit(iris.data, iris.target)
```

**Output on master**
```
sklearn/linear_model/logistic.py:723: ConvergenceWarning: lbfgs failed to converge. Increase the number of iterations.
  "of iterations.", ConvergenceWarning)
sklearn/linear_model/logistic.py:723: ConvergenceWarning: lbfgs failed to converge. Increase the number of iterations.
  "of iterations.", ConvergenceWarning)
sklearn/linear_model/logistic.py:723: ConvergenceWarning: lbfgs failed to converge. Increase the number of iterations.
  "of iterations.", ConvergenceWarning)
```

**Output with this PR**
```
sklearn/linear_model/logistic.py:734: ConvergenceWarning: lbfgs failed to converge with max_iter=20. max(|grad|) = 1.610e+00 while pgtol=1.000e-04 (see scipy.optimize.fmin_l_bfgs_b documentation for more information). Increase the number of iterations.
  ConvergenceWarning)
sklearn/linear_model/logistic.py:734: ConvergenceWarning: lbfgs failed to converge with max_iter=20. max(|grad|) = 4.764e+00 while pgtol=1.000e-04 (see scipy.optimize.fmin_l_bfgs_b documentation for more information). Increase the number of iterations.
  ConvergenceWarning)
sklearn/linear_model/logistic.py:734: ConvergenceWarning: lbfgs failed to converge with max_iter=20. max(|grad|) = 4.413e-01 while pgtol=1.000e-04 (see scipy.optimize.fmin_l_bfgs_b documentation for more information). Increase the number of iterations.
```