### PR TITLE
[MRG+1] FIX Pickled sample_weights in BinaryTree

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -719,6 +719,10 @@ Support for Python 3.3 has been officially dropped.
   faster construction and querying times.
   :issue:`11556` by :user:`Jake VanderPlas <jakevdp>`
 
+- |Fix| Fixed a bug in `neighbors.KDTree` and `neighbors.BallTree` where
+  pickled tree objects would change their type to the super class `BinaryTree`.
+  :issue:`11774` by :user:`Nicolas Hug <NicolasHug>`.
+
 .. rubric:: :mod:`sklearn.neural_network`:
 
 - |Feature| Add `n_iter_no_change` parameter in

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -1119,7 +1119,7 @@ cdef class BinaryTree:
         """
         reduce method used for pickling
         """
-        return (newObj, (BinaryTree,), self.__getstate__())
+        return (newObj, (type(self),), self.__getstate__())
 
     def __getstate__(self):
         """

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -1136,7 +1136,8 @@ cdef class BinaryTree:
                 int(self.n_leaves),
                 int(self.n_splits),
                 int(self.n_calls),
-                self.dist_metric)
+                self.dist_metric,
+                self.sample_weight)
 
     def __setstate__(self, state):
         """
@@ -1162,6 +1163,7 @@ cdef class BinaryTree:
         self.dist_metric = state[11]
         self.euclidean = (self.dist_metric.__class__.__name__
                           == 'EuclideanDistance')
+        self.sample_weight = state[12]
 
     def get_tree_stats(self):
         return (self.n_trims, self.n_leaves, self.n_splits)

--- a/sklearn/neighbors/tests/test_ball_tree.py
+++ b/sklearn/neighbors/tests/test_ball_tree.py
@@ -10,6 +10,7 @@ from sklearn.neighbors.ball_tree import (BallTree, NeighborsHeap,
 from sklearn.neighbors.dist_metrics import DistanceMetric
 from sklearn.utils import check_random_state
 from sklearn.utils.testing import assert_allclose
+from sklearn.externals import joblib
 
 rng = np.random.RandomState(10)
 V_mahalanobis = rng.rand(3, 3)
@@ -290,3 +291,17 @@ def test_query_haversine():
 
     assert_array_almost_equal(dist1, dist2)
     assert_array_almost_equal(ind1, ind2)
+
+
+def test_pickling(tmpdir):
+    # make sure pickled tree keeps its class. Prior to a fix, it would be
+    # BinaryTree
+
+    data = np.reshape([1., 2., 3.], (-1, 1))
+    tree = BallTree(data)
+
+    assert isinstance(tree, BallTree)
+    file_path = str(tmpdir.join('dump.pkl'))
+    joblib.dump(tree, file_path)
+    tree = joblib.load(file_path)
+    assert isinstance(tree, BallTree)

--- a/sklearn/neighbors/tests/test_ball_tree.py
+++ b/sklearn/neighbors/tests/test_ball_tree.py
@@ -10,7 +10,6 @@ from sklearn.neighbors.ball_tree import (BallTree, NeighborsHeap,
 from sklearn.neighbors.dist_metrics import DistanceMetric
 from sklearn.utils import check_random_state
 from sklearn.utils.testing import assert_allclose
-from sklearn.externals import joblib
 
 rng = np.random.RandomState(10)
 V_mahalanobis = rng.rand(3, 3)
@@ -229,6 +228,8 @@ def test_ball_tree_pickle():
         assert_array_almost_equal(ind1_pyfunc, ind2_pyfunc)
         assert_array_almost_equal(dist1_pyfunc, dist2_pyfunc)
 
+        assert isinstance(bt2, BallTree)
+
     for protocol in (0, 1, 2):
         check_pickle_protocol(protocol)
 
@@ -291,17 +292,3 @@ def test_query_haversine():
 
     assert_array_almost_equal(dist1, dist2)
     assert_array_almost_equal(ind1, ind2)
-
-
-def test_pickling(tmpdir):
-    # make sure pickled tree keeps its class. Prior to a fix, it would be
-    # BinaryTree
-
-    data = np.reshape([1., 2., 3.], (-1, 1))
-    tree = BallTree(data)
-
-    assert isinstance(tree, BallTree)
-    file_path = str(tmpdir.join('dump.pkl'))
-    joblib.dump(tree, file_path)
-    tree = joblib.load(file_path)
-    assert isinstance(tree, BallTree)

--- a/sklearn/neighbors/tests/test_kd_tree.py
+++ b/sklearn/neighbors/tests/test_kd_tree.py
@@ -9,6 +9,7 @@ from sklearn.neighbors.kd_tree import (KDTree, NeighborsHeap,
 from sklearn.neighbors.dist_metrics import DistanceMetric
 from sklearn.utils import check_random_state
 from sklearn.utils.testing import SkipTest, assert_allclose
+from sklearn.externals import joblib
 
 rng = np.random.RandomState(42)
 V = rng.random_sample((3, 3))
@@ -238,3 +239,17 @@ def test_simultaneous_sort(n_rows=10, n_pts=201):
 
     assert_array_almost_equal(dist, dist2)
     assert_array_almost_equal(ind, ind2)
+
+
+def test_pickling(tmpdir):
+    # make sure pickled tree keeps its class. Prior to a fix, it would be
+    # BinaryTree
+
+    data = np.reshape([1., 2., 3.], (-1, 1))
+    tree = KDTree(data)
+
+    assert isinstance(tree, KDTree)
+    file_path = str(tmpdir.join('dump.pkl'))
+    joblib.dump(tree, file_path)
+    tree = joblib.load(file_path)
+    assert isinstance(tree, KDTree)

--- a/sklearn/neighbors/tests/test_kd_tree.py
+++ b/sklearn/neighbors/tests/test_kd_tree.py
@@ -9,7 +9,6 @@ from sklearn.neighbors.kd_tree import (KDTree, NeighborsHeap,
 from sklearn.neighbors.dist_metrics import DistanceMetric
 from sklearn.utils import check_random_state
 from sklearn.utils.testing import SkipTest, assert_allclose
-from sklearn.externals import joblib
 
 rng = np.random.RandomState(42)
 V = rng.random_sample((3, 3))
@@ -188,6 +187,7 @@ def test_kd_tree_pickle(protocol):
         ind2, dist2 = kdt2.query(X)
         assert_array_almost_equal(ind1, ind2)
         assert_array_almost_equal(dist1, dist2)
+        assert isinstance(kdt2, KDTree)
 
     check_pickle_protocol(protocol)
 
@@ -239,17 +239,3 @@ def test_simultaneous_sort(n_rows=10, n_pts=201):
 
     assert_array_almost_equal(dist, dist2)
     assert_array_almost_equal(ind, ind2)
-
-
-def test_pickling(tmpdir):
-    # make sure pickled tree keeps its class. Prior to a fix, it would be
-    # BinaryTree
-
-    data = np.reshape([1., 2., 3.], (-1, 1))
-    tree = KDTree(data)
-
-    assert isinstance(tree, KDTree)
-    file_path = str(tmpdir.join('dump.pkl'))
-    joblib.dump(tree, file_path)
-    tree = joblib.load(file_path)
-    assert isinstance(tree, KDTree)

--- a/sklearn/neighbors/tests/test_kde.py
+++ b/sklearn/neighbors/tests/test_kde.py
@@ -10,6 +10,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.datasets import make_blobs
 from sklearn.model_selection import GridSearchCV
 from sklearn.preprocessing import StandardScaler
+from sklearn.externals import joblib
 
 
 def compute_kernel_slow(Y, X, kernel, h):
@@ -202,3 +203,23 @@ def test_kde_sample_weights():
                     kde.fit(X, sample_weight=(scale_factor * weights))
                     scores_scaled_weight = kde.score_samples(test_points)
                     assert_allclose(scores_scaled_weight, scores_weight)
+
+
+def test_pickling(tmpdir):
+    # Make sure that predictions are the same before and after pickling. Used
+    # to be a bug because sample_weights wasn't pickled and the resulting tree
+    # would miss some info.
+
+    kde = KernelDensity()
+    data = np.reshape([1., 2., 3.], (-1, 1))
+    kde.fit(data)
+
+    X = np.reshape([1.1, 2.1], (-1, 1))
+    scores = kde.score_samples(X)
+
+    file_path = str(tmpdir.join('dump.pkl'))
+    joblib.dump(kde, file_path)
+    kde = joblib.load(file_path)
+    scores_pickled = kde.score_samples(X)
+
+    assert_allclose(scores, scores_pickled)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes  #11769

#### What does this implement/fix? Explain your changes.

This PR adds the `sample_weight` attribute to the list of pickled attributes of `BinaryTree`, which fixes bugs such as the one in #11769.

Also, pickled KDTree and BallTree instances now keep their classes. Before, they would become BinaryTree objects.

#### Any other comments?

I added a basic test which is basically the sample code in  #11769, but this is only testing a side effect of the changes. I'm not sure what could be more relevant here.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
