### PR TITLE
[MRG+1] DOC examples added to sklearn.decomposition classes

### DIFF
--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -110,17 +110,12 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
 
     Examples
     --------
-    >>> from sklearn.datasets import load_digits
     >>> from sklearn.decomposition import FactorAnalysis
     >>> X, _ = load_digits(return_X_y=True)
-    >>> transformer = FactorAnalysis(n_components=10, random_state=0)
-    >>> transformer.fit(X)
-    FactorAnalysis(copy=True, iterated_power=3, max_iter=1000, n_components=10,
-            noise_variance_init=None, random_state=0, svd_method='randomized',
-            tol=0.01)
-    >>> X_transformed = transformer.transform(X)
+    >>> transformer = FactorAnalysis(n_components=7, random_state=0)
+    >>> X_transformed = transformer.fit_transform(X)
     >>> X_transformed.shape
-    (1797, 10)
+    (1797, 7)
 
     References
     ----------

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -110,6 +110,7 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
 
     Examples
     --------
+    >>> from sklearn.datasets import load_digits
     >>> from sklearn.decomposition import FactorAnalysis
     >>> X, _ = load_digits(return_X_y=True)
     >>> transformer = FactorAnalysis(n_components=7, random_state=0)

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -108,6 +108,20 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
     n_iter_ : int
         Number of iterations run.
 
+    Examples
+    --------
+    >>> from sklearn.datasets import load_digits
+    >>> from sklearn.decomposition import FactorAnalysis
+    >>> X, _ = load_digits(return_X_y=True)
+    >>> transformer = FactorAnalysis(n_components=10, random_state=0)
+    >>> transformer.fit(X)
+    FactorAnalysis(copy=True, iterated_power=3, max_iter=1000, n_components=10,
+            noise_variance_init=None, random_state=0, svd_method='randomized',
+            tol=0.01)
+    >>> X_transformed = transformer.transform(X)
+    >>> X_transformed.shape
+    (1797, 10)
+
     References
     ----------
     .. David Barber, Bayesian Reasoning and Machine Learning,

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -448,14 +448,11 @@ class FastICA(BaseEstimator, TransformerMixin):
     >>> from sklearn.datasets import load_digits
     >>> from sklearn.decomposition import FastICA
     >>> X, _ = load_digits(return_X_y=True)
-    >>> transformer = FastICA(n_components=10,
+    >>> transformer = FastICA(n_components=7,
     ...         random_state=0)
-    >>> transformer.fit(X)
-    FastICA(algorithm='parallel', fun='logcosh', fun_args=None, max_iter=200,
-        n_components=10, random_state=0, tol=0.0001, w_init=None, whiten=True)
-    >>> X_transformed = transformer.transform(X)
+    >>> X_transformed = transformer.fit_transform(X)
     >>> X_transformed.shape
-    (1797, 10)
+    (1797, 7)
 
     Notes
     -----

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -443,6 +443,20 @@ class FastICA(BaseEstimator, TransformerMixin):
         maximum number of iterations run across all components. Else
         they are just the number of iterations taken to converge.
 
+    Examples
+    --------
+    >>> from sklearn.datasets import load_digits
+    >>> from sklearn.decomposition import FastICA
+    >>> X, _ = load_digits(return_X_y=True)
+    >>> transformer = FastICA(n_components=10,
+    ...         random_state=0)
+    >>> transformer.fit(X)
+    FastICA(algorithm='parallel', fun='logcosh', fun_args=None, max_iter=200,
+        n_components=10, random_state=0, tol=0.0001, w_init=None, whiten=True)
+    >>> X_transformed = transformer.transform(X)
+    >>> X_transformed.shape
+    (1797, 10)
+
     Notes
     -----
     Implementation based on

--- a/sklearn/decomposition/incremental_pca.py
+++ b/sklearn/decomposition/incremental_pca.py
@@ -105,12 +105,10 @@ class IncrementalPCA(_BasePCA):
     >>> from sklearn.datasets import load_digits
     >>> from sklearn.decomposition import IncrementalPCA
     >>> X, _ = load_digits(return_X_y=True)
-    >>> transformer = IncrementalPCA(n_components=10)
-    >>> transformer.fit(X)
-    IncrementalPCA(batch_size=None, copy=True, n_components=10, whiten=False)
-    >>> X_transformed = transformer.transform(X)
+    >>> transformer = IncrementalPCA(n_components=7)
+    >>> X_transformed = transformer.fit_transform(X)
     >>> X_transformed.shape
-    (1797, 10)
+    (1797, 7)
 
     Notes
     -----

--- a/sklearn/decomposition/incremental_pca.py
+++ b/sklearn/decomposition/incremental_pca.py
@@ -100,6 +100,18 @@ class IncrementalPCA(_BasePCA):
         The number of samples processed by the estimator. Will be reset on
         new calls to fit, but increments across ``partial_fit`` calls.
 
+    Examples
+    --------
+    >>> from sklearn.datasets import load_digits
+    >>> from sklearn.decomposition import IncrementalPCA
+    >>> X, _ = load_digits(return_X_y=True)
+    >>> transformer = IncrementalPCA(n_components=10)
+    >>> transformer.fit(X)
+    IncrementalPCA(batch_size=None, copy=True, n_components=10, whiten=False)
+    >>> X_transformed = transformer.transform(X)
+    >>> X_transformed.shape
+    (1797, 10)
+
     Notes
     -----
     Implements the incremental PCA model from:

--- a/sklearn/decomposition/incremental_pca.py
+++ b/sklearn/decomposition/incremental_pca.py
@@ -105,7 +105,11 @@ class IncrementalPCA(_BasePCA):
     >>> from sklearn.datasets import load_digits
     >>> from sklearn.decomposition import IncrementalPCA
     >>> X, _ = load_digits(return_X_y=True)
-    >>> transformer = IncrementalPCA(n_components=7)
+    >>> transformer = IncrementalPCA(n_components=7, batch_size=200)
+    >>> # either partially fit on smaller batches of data
+    >>> transformer.partial_fit(X[:100, :])
+    IncrementalPCA(batch_size=200, copy=True, n_components=7, whiten=False)
+    >>> # or let the fit function itself divide the data into batches
     >>> X_transformed = transformer.fit_transform(X)
     >>> X_transformed.shape
     (1797, 7)

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -123,15 +123,10 @@ class KernelPCA(BaseEstimator, TransformerMixin):
     >>> from sklearn.datasets import load_digits
     >>> from sklearn.decomposition import KernelPCA
     >>> X, _ = load_digits(return_X_y=True)
-    >>> transformer = KernelPCA(n_components=10)
-    >>> transformer.fit(X)
-    KernelPCA(alpha=1.0, coef0=1, copy_X=True, degree=3, eigen_solver='auto',
-         fit_inverse_transform=False, gamma=None, kernel='linear',
-         kernel_params=None, max_iter=None, n_components=10, n_jobs=None,
-         random_state=None, remove_zero_eig=False, tol=0)
-    >>> X_transformed = transformer.transform(X)
+    >>> transformer = KernelPCA(n_components=7)
+    >>> X_transformed = transformer.fit_transform(X)
     >>> X_transformed.shape
-    (1797, 10)
+    (1797, 7)
 
     References
     ----------

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -118,6 +118,21 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         The data used to fit the model. If `copy_X=False`, then `X_fit_` is
         a reference. This attribute is used for the calls to transform.
 
+    Examples
+    --------
+    >>> from sklearn.datasets import load_digits
+    >>> from sklearn.decomposition import KernelPCA
+    >>> X, _ = load_digits(return_X_y=True)
+    >>> transformer = KernelPCA(n_components=10)
+    >>> transformer.fit(X)
+    KernelPCA(alpha=1.0, coef0=1, copy_X=True, degree=3, eigen_solver='auto',
+         fit_inverse_transform=False, gamma=None, kernel='linear',
+         kernel_params=None, max_iter=None, n_components=10, n_jobs=None,
+         random_state=None, remove_zero_eig=False, tol=0)
+    >>> X_transformed = transformer.transform(X)
+    >>> X_transformed.shape
+    (1797, 10)
+
     References
     ----------
     Kernel PCA was introduced in:

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -123,7 +123,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
     >>> from sklearn.datasets import load_digits
     >>> from sklearn.decomposition import KernelPCA
     >>> X, _ = load_digits(return_X_y=True)
-    >>> transformer = KernelPCA(n_components=7)
+    >>> transformer = KernelPCA(n_components=7, kernel='linear')
     >>> X_transformed = transformer.fit_transform(X)
     >>> X_transformed.shape
     (1797, 7)

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -255,8 +255,8 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
     >>> from sklearn.feature_extraction.text import CountVectorizer
     >>> from sklearn.decomposition import LatentDirichletAllocation
     >>> from sklearn.datasets import fetch_20newsgroups
-    >>> n_samples = 1000
-    >>> n_features = 200
+    >>> n_samples = 300
+    >>> n_features = 50
     >>> n_components = 5
     >>> dataset = fetch_20newsgroups(shuffle=True, random_state=1,
     ...                              remove=('headers', 'footers', 'quotes'))
@@ -276,8 +276,8 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
                  total_samples=1000000.0, verbose=0)
     >>> # get topics for some given samples:
     >>> lda.transform(tf_vectorizer.transform(dataset.data[-2:]))
-    array([[0.03509476, 0.86243059, 0.03446344, 0.03405526, 0.03395595],
-           [0.05974169, 0.70750174, 0.08565529, 0.14146641, 0.00563486]])
+    array([[0.0503626 , 0.05039563, 0.79839686, 0.05000126, 0.05084366],
+           [0.01141977, 0.011134  , 0.72786348, 0.01134744, 0.23823531]])
 
     References
     ----------

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -250,6 +250,35 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
     n_iter_ : int
         Number of passes over the dataset.
 
+    Examples
+    --------
+    >>> from sklearn.feature_extraction.text import CountVectorizer
+    >>> from sklearn.decomposition import LatentDirichletAllocation
+    >>> from sklearn.datasets import fetch_20newsgroups
+    >>> n_samples = 1000
+    >>> n_features = 200
+    >>> n_components = 5
+    >>> dataset = fetch_20newsgroups(shuffle=True, random_state=1,
+    ...                              remove=('headers', 'footers', 'quotes'))
+    >>> X = dataset.data[:n_samples]
+    >>> tf_vectorizer = CountVectorizer(max_features=n_features,
+    ...                                 stop_words='english')
+    >>> tf = tf_vectorizer.fit_transform(X)
+    >>> lda = LatentDirichletAllocation(n_components=n_components,
+    ...     random_state=0)
+    >>> lda.fit(tf)
+    LatentDirichletAllocation(batch_size=128, doc_topic_prior=None,
+                 evaluate_every=-1, learning_decay=0.7,
+                 learning_method='batch', learning_offset=10.0,
+                 max_doc_update_iter=100, max_iter=10, mean_change_tol=0.001,
+                 n_components=5, n_jobs=None, n_topics=None, perp_tol=0.1,
+                 random_state=0, topic_word_prior=None,
+                 total_samples=1000000.0, verbose=0)
+    >>> # get topics for some given samples:
+    >>> lda.transform(tf_vectorizer.transform(dataset.data[-2:]))
+    array([[0.03509476, 0.86243059, 0.03446344, 0.03405526, 0.03395595],
+           [0.05974169, 0.70750174, 0.08565529, 0.14146641, 0.00563486]])
+
     References
     ----------
     [1] "Online Learning for Latent Dirichlet Allocation", Matthew D. Hoffman,

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -254,6 +254,8 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
     --------
     >>> from sklearn.decomposition import LatentDirichletAllocation
     >>> from sklearn.datasets import make_multilabel_classification
+    >>> # This produces a feature matrix of token counts, similar to what
+    >>> # CountVectorizer would produce on text.
     >>> X, _ = make_multilabel_classification(random_state=0)
     >>> lda = LatentDirichletAllocation(n_components=5,
     ...     random_state=0)

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -252,32 +252,17 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
 
     Examples
     --------
-    >>> from sklearn.feature_extraction.text import CountVectorizer
     >>> from sklearn.decomposition import LatentDirichletAllocation
-    >>> from sklearn.datasets import fetch_20newsgroups
-    >>> n_samples = 300
-    >>> n_features = 50
-    >>> n_components = 5
-    >>> dataset = fetch_20newsgroups(shuffle=True, random_state=1,
-    ...                              remove=('headers', 'footers', 'quotes'))
-    >>> X = dataset.data[:n_samples]
-    >>> tf_vectorizer = CountVectorizer(max_features=n_features,
-    ...                                 stop_words='english')
-    >>> tf = tf_vectorizer.fit_transform(X)
-    >>> lda = LatentDirichletAllocation(n_components=n_components,
+    >>> from sklearn.datasets import make_multilabel_classification
+    >>> X, _ = make_multilabel_classification(random_state=0)
+    >>> lda = LatentDirichletAllocation(n_components=5,
     ...     random_state=0)
-    >>> lda.fit(tf)
-    LatentDirichletAllocation(batch_size=128, doc_topic_prior=None,
-                 evaluate_every=-1, learning_decay=0.7,
-                 learning_method='batch', learning_offset=10.0,
-                 max_doc_update_iter=100, max_iter=10, mean_change_tol=0.001,
-                 n_components=5, n_jobs=None, n_topics=None, perp_tol=0.1,
-                 random_state=0, topic_word_prior=None,
-                 total_samples=1000000.0, verbose=0)
+    >>> lda.fit(X) # doctest: +ELLIPSIS
+    LatentDirichletAllocation(...)
     >>> # get topics for some given samples:
-    >>> lda.transform(tf_vectorizer.transform(dataset.data[-2:]))
-    array([[0.0503626 , 0.05039563, 0.79839686, 0.05000126, 0.05084366],
-           [0.01141977, 0.011134  , 0.72786348, 0.01134744, 0.23823531]])
+    >>> lda.transform(X[-2:])
+    array([[0.00360392, 0.25499205, 0.0036211 , 0.64236448, 0.09541846],
+           [0.15297572, 0.00362644, 0.44412786, 0.39568399, 0.003586  ]])
 
     References
     ----------

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -98,19 +98,20 @@ class SparsePCA(BaseEstimator, TransformerMixin):
 
     Examples
     --------
-    >>> from sklearn.datasets import load_iris
+    >>> import numpy as np
+    >>> from sklearn.datasets import make_friedman1
     >>> from sklearn.decomposition import SparsePCA
-    >>> X, _ = load_iris(return_X_y=True)
-    >>> transformer = SparsePCA(n_components=2,
+    >>> X, _ = make_friedman1(n_samples=200, n_features=30, random_state=0)
+    >>> transformer = SparsePCA(n_components=5,
     ...         normalize_components=True,
     ...         random_state=0)
-    >>> transformer.fit(X)
-    SparsePCA(U_init=None, V_init=None, alpha=1, max_iter=1000, method='lars',
-         n_components=2, n_jobs=None, normalize_components=True,
-         random_state=0, ridge_alpha=0.01, tol=1e-08, verbose=False)
+    >>> transformer.fit(X) # doctest: +ELLIPSIS
+    SparsePCA(...)
     >>> X_transformed = transformer.transform(X)
     >>> X_transformed.shape
-    (150, 2)
+    (200, 5)
+    >>> np.mean(transformer.components_ == 0) # doctest: +ELLIPSIS
+    0.9666...
 
     See also
     --------
@@ -330,21 +331,21 @@ class MiniBatchSparsePCA(SparsePCA):
 
     Examples
     --------
-    >>> from sklearn.datasets import load_iris
+    >>> import numpy as np
+    >>> from sklearn.datasets import make_friedman1
     >>> from sklearn.decomposition import MiniBatchSparsePCA
-    >>> X, _ = load_iris(return_X_y=True)
-    >>> transformer = MiniBatchSparsePCA(n_components=2,
+    >>> X, _ = make_friedman1(n_samples=200, n_features=30, random_state=0)
+    >>> transformer = MiniBatchSparsePCA(n_components=5,
     ...         batch_size=50,
     ...         normalize_components=True,
     ...         random_state=0)
-    >>> transformer.fit(X)
-    MiniBatchSparsePCA(alpha=1, batch_size=50, callback=None, method='lars',
-              n_components=2, n_iter=100, n_jobs=None,
-              normalize_components=True, random_state=0, ridge_alpha=0.01,
-              shuffle=True, verbose=False)
+    >>> transformer.fit(X) # doctest: +ELLIPSIS
+    MiniBatchSparsePCA(...)
     >>> X_transformed = transformer.transform(X)
     >>> X_transformed.shape
-    (150, 2)
+    (200, 5)
+    >>> np.mean(transformer.components_ == 0)
+    0.94
 
     See also
     --------

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -96,6 +96,24 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         Per-feature empirical mean, estimated from the training set.
         Equal to ``X.mean(axis=0)``.
 
+    Examples
+    --------
+    >>> from sklearn.datasets import load_iris
+    >>> from sklearn.decomposition import SparsePCA
+    >>> 
+    >>> X, _ = load_iris(return_X_y=True)
+    >>> 
+    >>> transformer = SparsePCA(n_components=2,
+    ...         normalize_components=True,
+    ...         random_state=0)
+    >>> transformer.fit(X)
+    SparsePCA(U_init=None, V_init=None, alpha=1, max_iter=1000, method='lars',
+         n_components=2, n_jobs=None, normalize_components=True,
+         random_state=0, ridge_alpha=0.01, tol=1e-08, verbose=False)
+    >>> X_transformed = transformer.transform(X)
+    >>> X_transformed.shape
+    (150, 2)
+
     See also
     --------
     PCA

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -100,9 +100,7 @@ class SparsePCA(BaseEstimator, TransformerMixin):
     --------
     >>> from sklearn.datasets import load_iris
     >>> from sklearn.decomposition import SparsePCA
-    >>> 
     >>> X, _ = load_iris(return_X_y=True)
-    >>> 
     >>> transformer = SparsePCA(n_components=2,
     ...         normalize_components=True,
     ...         random_state=0)
@@ -329,6 +327,24 @@ class MiniBatchSparsePCA(SparsePCA):
     mean_ : array, shape (n_features,)
         Per-feature empirical mean, estimated from the training set.
         Equal to ``X.mean(axis=0)``.
+
+    Examples
+    --------
+    >>> from sklearn.datasets import load_iris
+    >>> from sklearn.decomposition import MiniBatchSparsePCA
+    >>> X, _ = load_iris(return_X_y=True)
+    >>> transformer = MiniBatchSparsePCA(n_components=2,
+    ...         batch_size=50,
+    ...         normalize_components=True,
+    ...         random_state=0)
+    >>> transformer.fit(X)
+    MiniBatchSparsePCA(alpha=1, batch_size=50, callback=None, method='lars',
+              n_components=2, n_iter=100, n_jobs=None,
+              normalize_components=True, random_state=0, ridge_alpha=0.01,
+              shuffle=True, verbose=False)
+    >>> X_transformed = transformer.transform(X)
+    >>> X_transformed.shape
+    (150, 2)
 
     See also
     --------

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -110,6 +110,7 @@ class SparsePCA(BaseEstimator, TransformerMixin):
     >>> X_transformed = transformer.transform(X)
     >>> X_transformed.shape
     (200, 5)
+    >>> # most values in the components_ are zero (sparsity)
     >>> np.mean(transformer.components_ == 0) # doctest: +ELLIPSIS
     0.9666...
 
@@ -344,6 +345,7 @@ class MiniBatchSparsePCA(SparsePCA):
     >>> X_transformed = transformer.transform(X)
     >>> X_transformed.shape
     (200, 5)
+    >>> # most values in the components_ are zero (sparsity)
     >>> np.mean(transformer.components_ == 0)
     0.94
 


### PR DESCRIPTION
See #3846

Added examples to `decomposition` classes except for `SparseCoder`. Haven't figured how to have a short and easy example for that yet.