### PR TITLE
[MRG] FIX Access Memory's location as a positional arg

### DIFF
--- a/benchmarks/bench_plot_nmf.py
+++ b/benchmarks/bench_plot_nmf.py
@@ -29,7 +29,7 @@ from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted, check_non_negative
 
 
-mem = Memory(cachedir='.', verbose=0)
+mem = Memory('.', verbose=0)
 
 ###################
 # Start of _PGNMF #

--- a/benchmarks/bench_rcv1_logreg_convergence.py
+++ b/benchmarks/bench_rcv1_logreg_convergence.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     lightning_clf = None
 
-m = Memory(cachedir='.', verbose=0)
+m = Memory('.', verbose=0)
 
 
 # compute logistic loss

--- a/benchmarks/bench_saga.py
+++ b/benchmarks/bench_saga.py
@@ -108,7 +108,7 @@ def _predict_proba(lr, X):
 
 def exp(solvers, penalties, single_target, n_samples=30000, max_iter=20,
         dataset='rcv1', n_jobs=1, skip_slow=False):
-    mem = Memory(cachedir=expanduser('~/cache'), verbose=0)
+    mem = Memory(expanduser('~/cache'), verbose=0)
 
     if dataset == 'rcv1':
         rcv1 = fetch_rcv1()

--- a/doc/developers/utilities.rst
+++ b/doc/developers/utilities.rst
@@ -46,7 +46,7 @@ should be used when applicable.
 - :func:`validation.check_memory` checks that input is ``joblib.Memory``-like,
   which means that it can be converted into a
   ``sklearn.utils.Memory`` instance (typically a str denoting
-  the ``cachedir``) or has the same interface.
+  the cache directory ``location``) or has the same interface.
 
 If your code relies on a random number generator, it should never use
 functions like ``numpy.random.random`` or ``numpy.random.normal``.  This

--- a/examples/applications/wikipedia_principal_eigenvector.py
+++ b/examples/applications/wikipedia_principal_eigenvector.py
@@ -76,7 +76,7 @@ for url, filename in resources:
 # #############################################################################
 # Loading the redirect files
 
-memory = Memory(cachedir=".")
+memory = Memory(".")
 
 
 def index(redirects, index_map, k):

--- a/examples/cluster/plot_feature_agglomeration_vs_univariate_selection.py
+++ b/examples/cluster/plot_feature_agglomeration_vs_univariate_selection.py
@@ -63,7 +63,7 @@ y += noise_coef * noise  # add noise
 cv = KFold(2)  # cross-validation generator for model selection
 ridge = BayesianRidge()
 cachedir = tempfile.mkdtemp()
-mem = Memory(cachedir=cachedir, verbose=1)
+mem = Memory(cachedir, verbose=1)
 
 # Ward agglomeration followed by BayesianRidge
 connectivity = grid_to_graph(n_x=size, n_y=size)

--- a/examples/compose/plot_compare_reduction.py
+++ b/examples/compose/plot_compare_reduction.py
@@ -108,7 +108,7 @@ from sklearn.utils import Memory
 
 # Create a temporary folder to store the transformers of the pipeline
 cachedir = mkdtemp()
-memory = Memory(cachedir=cachedir, verbose=10)
+memory = Memory(cachedir, verbose=10)
 cached_pipe = Pipeline([('reduce_dim', PCA()),
                         ('classify', LinearSVC())],
                        memory=memory)

--- a/sklearn/datasets/lfw.py
+++ b/sklearn/datasets/lfw.py
@@ -330,7 +330,7 @@ def fetch_lfw_people(data_home=None, funneled=True, resize=0.5,
     # arrays for optimal memory usage
     if LooseVersion(joblib_version) < LooseVersion('0.12'):
         # Deal with change of API in joblib
-        m = Memory(cachedir=lfw_home, compress=6, verbose=0)
+        m = Memory(lfw_home, compress=6, verbose=0)
     else:
         m = Memory(location=lfw_home, compress=6, verbose=0)
     load_func = m.cache(_fetch_lfw_people)
@@ -499,11 +499,7 @@ def fetch_lfw_pairs(subset='train', data_home=None, funneled=True, resize=0.5,
 
     # wrap the loader in a memoizing function that will return memmaped data
     # arrays for optimal memory usage
-    if LooseVersion(joblib_version) < LooseVersion('0.12'):
-        # Deal with change of API in joblib
-        m = Memory(cachedir=lfw_home, compress=6, verbose=0)
-    else:
-        m = Memory(location=lfw_home, compress=6, verbose=0)
+    m = Memory(lfw_home, compress=6, verbose=0)
     load_func = m.cache(_fetch_lfw_pairs)
 
     # select the right metadata file according to the requested subset

--- a/sklearn/linear_model/randomized_l1.py
+++ b/sklearn/linear_model/randomized_l1.py
@@ -104,9 +104,9 @@ class BaseRandomizedLinearModel(six.with_metaclass(ABCMeta, BaseEstimator,
         estimator_func, params = self._make_estimator_and_params(X, y)
         memory = self.memory
         if memory is None:
-            memory = Memory(cachedir=None, verbose=0)
+            memory = Memory(None, verbose=0)
         elif isinstance(memory, six.string_types):
-            memory = Memory(cachedir=memory, verbose=0)
+            memory = Memory(memory, verbose=0)
         elif not isinstance(memory, Memory):
             raise ValueError("'memory' should either be a string or"
                              " a sklearn.utils.Memory"

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -206,22 +206,12 @@ class Pipeline(_BaseComposition):
             if transformer is None:
                 pass
             else:
-                if hasattr(memory, 'location'):
-                    # joblib >= 0.12
-                    if memory.location is None:
-                        # we do not clone when caching is disabled to
-                        # preserve backward compatibility
-                        cloned_transformer = transformer
-                    else:
-                        cloned_transformer = clone(transformer)
-                elif hasattr(memory, 'cachedir'):
-                    # joblib < 0.11
-                    if memory.cachedir is None:
-                        # we do not clone when caching is disabled to
-                        # preserve backward compatibility
-                        cloned_transformer = transformer
-                    else:
-                        cloned_transformer = clone(transformer)
+                # XXX: cachedir was renamed to location in joblib 0.12
+                if getattr(memory, 'location',
+                           getattr(memory, 'cachedir', None)) is None:
+                    # we do not clone when caching is disabled to
+                    # preserve backward compatibility
+                    cloned_transformer = transformer
                 else:
                     cloned_transformer = clone(transformer)
                 # Fit or load from cache the current transfomer

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -942,11 +942,7 @@ def test_pipeline_memory():
     y = iris.target
     cachedir = mkdtemp()
     try:
-        if LooseVersion(joblib_version) < LooseVersion('0.12'):
-            # Deal with change of API in joblib
-            memory = Memory(cachedir=cachedir, verbose=10)
-        else:
-            memory = Memory(location=cachedir, verbose=10)
+        memory = Memory(cachedir, verbose=10)
         # Test with Transformer + SVC
         clf = SVC(gamma='scale', probability=True, random_state=0)
         transf = DummyTransf()
@@ -1004,11 +1000,7 @@ def test_pipeline_memory():
 
 def test_make_pipeline_memory():
     cachedir = mkdtemp()
-    if LooseVersion(joblib_version) < LooseVersion('0.12'):
-        # Deal with change of API in joblib
-        memory = Memory(cachedir=cachedir, verbose=10)
-    else:
-        memory = Memory(location=cachedir, verbose=10)
+    memory = Memory(cachedir, verbose=10)
     pipeline = make_pipeline(DummyTransf(), SVC(), memory=memory)
     assert_true(pipeline.memory is memory)
     pipeline = make_pipeline(DummyTransf(), SVC())

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -184,7 +184,7 @@ def check_memory(memory):
 
     joblib.Memory-like means that ``memory`` can be converted into a
     sklearn.utils.Memory instance (typically a str denoting the
-    ``cachedir``) or has the same interface (has a ``cache`` method).
+    cache directory) or has the same interface (has a ``cache`` method).
 
     Parameters
     ----------
@@ -201,10 +201,7 @@ def check_memory(memory):
     """
 
     if memory is None or isinstance(memory, six.string_types):
-        if LooseVersion(joblib_version) < '0.12':
-            memory = Memory(cachedir=memory, verbose=0)
-        else:
-            memory = Memory(location=memory, verbose=0)
+        memory = Memory(memory, verbose=0)
     elif not hasattr(memory, 'cache'):
         raise ValueError("'memory' should be None, a string or have the same"
                          " interface as sklearn.utils.Memory."


### PR DESCRIPTION
I'm not sure why circle was failing claiming that `location` and `cachedir` were both set. As far as I can tell, we never set both.

However, we can set `cachedir` in old versions and `location` in 0.12 by passing them as the first positional argument, rather than a named arg (which is slightly harder to read, but I think that it's still okay). Their semantics are identical as long as `backend` is the default.

I have also avoided/changed some if-elses currently handling support of multiple joblib versions around this API change.

?Partial fix for #11771