### PR TITLE
[MRG] DOC: Add Link to existing Label Propagation Example

### DIFF
--- a/doc/modules/label_propagation.rst
+++ b/doc/modules/label_propagation.rst
@@ -86,6 +86,7 @@ which can drastically reduce running times.
 
   * :ref:`sphx_glr_auto_examples_semi_supervised_plot_label_propagation_versus_svm_iris.py`
   * :ref:`sphx_glr_auto_examples_semi_supervised_plot_label_propagation_structure.py`
+  * :ref:`sphx_glr_auto_examples_semi_supervised_plot_label_propagation_digits.py`
   * :ref:`sphx_glr_auto_examples_semi_supervised_plot_label_propagation_digits_active_learning.py`
 
 .. topic:: References


### PR DESCRIPTION
In https://github.com/scikit-learn/scikit-learn/tree/master/examples/semi_supervised , there are four example files, but in http://scikit-learn.org/stable/modules/label_propagation.html#label-propagation , only three of them are mentioned in *Examples*. 

We should add the missing example file [plot_label_propagation_digits.py](examples/semi_supervised/plot_label_propagation_digits.py) to the list of examples.