### PR TITLE
allow kmeans centroids to be sparse if original input was sparse

### DIFF
--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -68,6 +68,11 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
         Set to None to make the number of trials depend logarithmically
         on the number of seeds (2+log(k)); this is the default.
 
+    Returns
+    -------
+    centers : array or sparse matrix, shape (n_clusters, n_features
+        Coordinates of cluster centers
+
     Notes
     -----
     Selects initial cluster centers for k-mean clustering in a smart way
@@ -80,7 +85,10 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
     """
     n_samples, n_features = X.shape
 
-    centers = np.empty((n_clusters, n_features), dtype=X.dtype)
+    if sp.issparse(X):
+        centers = sp.csr_matrix((n_clusters, n_features), dtype=X.dtype)
+    else:
+        centers = np.empty((n_clusters, n_features), dtype=X.dtype)
 
     assert x_squared_norms is not None, 'x_squared_norms None in _k_init'
 
@@ -93,10 +101,7 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
 
     # Pick first center randomly
     center_id = random_state.randint(n_samples)
-    if sp.issparse(X):
-        centers[0] = X[center_id].toarray()
-    else:
-        centers[0] = X[center_id]
+    centers[0] = X[center_id]
 
     # Initialize list of closest distances and calculate current potential
     closest_dist_sq = euclidean_distances(
@@ -133,10 +138,7 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
                 best_dist_sq = new_dist_sq
 
         # Permanently add best center candidate found in local tries
-        if sp.issparse(X):
-            centers[c] = X[best_candidate].toarray()
-        else:
-            centers[c] = X[best_candidate]
+        centers[c] = X[best_candidate]
         current_pot = best_pot
         closest_dist_sq = best_dist_sq
 
@@ -851,7 +853,7 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
 
     Attributes
     ----------
-    cluster_centers_ : array, [n_clusters, n_features]
+    cluster_centers_ : array or sparse matrix, [n_clusters, n_features]
         Coordinates of cluster centers
 
     labels_ :
@@ -1393,7 +1395,7 @@ class MiniBatchKMeans(KMeans):
     Attributes
     ----------
 
-    cluster_centers_ : array, [n_clusters, n_features]
+    cluster_centers_ : array or sparse matrix, [n_clusters, n_features]
         Coordinates of cluster centers
 
     labels_ :


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #11786

#### What does this implement/fix? Explain your changes.
If the centroids are in sparse format it does not convert them to dense format.
