### PR TITLE
[MRG] DOC: fix a return value in the docstring of _intercept_dot

### DIFF
--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -61,8 +61,8 @@ def _intercept_dot(w, X, y):
         Coefficient vector without the intercept weight (w[-1]) if the
         intercept should be fit. Unchanged otherwise.
 
-    X : {array-like, sparse matrix}, shape (n_samples, n_features)
-        Training data. Unchanged.
+    c : float
+        The intercept.
 
     yz : float
         y * np.dot(X, w).


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
the docstring of `_intercept_dot` says the second value it returns is `X` (the training data), but it is `c` (the intercept).