### PR TITLE
Allow NaN in y of TransformedTargetRegressor

### DIFF
--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -162,7 +162,8 @@ class TransformedTargetRegressor(BaseEstimator, RegressorMixin):
         -------
         self : object
         """
-        y = check_array(y, accept_sparse=False, force_all_finite=True,
+        
+        y = check_array(y, accept_sparse=False, force_all_finite=False,
                         ensure_2d=False, dtype='numeric')
 
         # store the number of dimension of the target to predict an array of
@@ -194,7 +195,7 @@ class TransformedTargetRegressor(BaseEstimator, RegressorMixin):
             self.regressor_.fit(X, y_trans)
         else:
             self.regressor_.fit(X, y_trans, sample_weight=sample_weight)
-
+	
         return self
 
     def predict(self, X):

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -100,7 +100,7 @@ class FunctionTransformer(BaseEstimator, TransformerMixin):
             self._validate = self.validate
 
         if self._validate:
-            return check_array(X, accept_sparse=self.accept_sparse)
+            return check_array(X, accept_sparse=self.accept_sparse,force_all_finite=False)
         return X
 
     def _check_inverse_transform(self, X):


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #11339
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This is a fix for the issue allow NaNs for the target values in TransformedTargetRegressor .

#### Any other comments?
None

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
