### PR TITLE
[MRG] Minor doc improvement in tutorial

### DIFF
--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -318,7 +318,7 @@ Refitting and updating parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Hyper-parameters of an estimator can be updated after it has been constructed
-via the ``set_params()``  method. Calling ``fit()`` more than once will
+via the :term:`set_params` method. Calling ``fit()`` more than once will
 overwrite what was learned by any previous ``fit()``::
 
   >>> import numpy as np

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -318,8 +318,8 @@ Refitting and updating parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Hyper-parameters of an estimator can be updated after it has been constructed
-via the :func:`sklearn.pipeline.Pipeline.set_params` method. Calling ``fit()``
-more than once will overwrite what was learned by any previous ``fit()``::
+via the ``set_params()``  method. Calling ``fit()`` more than once will
+overwrite what was learned by any previous ``fit()``::
 
   >>> import numpy as np
   >>> from sklearn.svm import SVC
@@ -346,9 +346,10 @@ more than once will overwrite what was learned by any previous ``fit()``::
   >>> clf.predict(X_test)
   array([1, 0, 1, 1, 0])
 
-Here, the default kernel ``rbf`` is first changed to ``linear`` after the
-estimator has been constructed via ``SVC()``, and changed back to ``rbf`` to
-refit the estimator and to make a second prediction.
+Here, the default kernel ``rbf`` is first changed to ``linear`` via
+:func:`SVC.set_params()<sklearn.svm.SVC.set_params>` after the estimator has
+been constructed, and changed back to ``rbf`` to refit the estimator and to
+make a second prediction.
 
 Multiclass vs. multilabel fitting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -318,8 +318,8 @@ Refitting and updating parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Hyper-parameters of an estimator can be updated after it has been constructed
-via the :term:`set_params()<set_params>` method. Calling ``fit()`` more than once will
-overwrite what was learned by any previous ``fit()``::
+via the :term:`set_params()<set_params>` method. Calling ``fit()`` more than
+once will overwrite what was learned by any previous ``fit()``::
 
   >>> import numpy as np
   >>> from sklearn.svm import SVC

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -318,7 +318,7 @@ Refitting and updating parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Hyper-parameters of an estimator can be updated after it has been constructed
-via the :term:`set_params` method. Calling ``fit()`` more than once will
+via the :term:`set_params()<set_params>` method. Calling ``fit()`` more than once will
 overwrite what was learned by any previous ``fit()``::
 
   >>> import numpy as np


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
The tutorial section on `set_params` currently links to `sklearn.pipeline.Pipeline.set_params` which pretty misleading.

This PR makes clear that `set_params()` exists for any estimator and links to `SVC.set_params` which is the estimator used in the example.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
