### PR TITLE
[MRG] DOC add random_projection examples to docstrings

### DIFF
--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -591,11 +591,15 @@ class SparseRandomProjection(BaseRandomProjection):
     --------
     >>> import numpy as np
     >>> from sklearn.random_projection import SparseRandomProjection
+    >>> np.random.seed(42)
     >>> X = np.random.rand(100, 10000)
     >>> transformer = SparseRandomProjection()
     >>> X_new = transformer.fit_transform(X)
     >>> X_new.shape
     (100, 3947)
+    >>> # very few components are non-zero
+    >>> np.mean(transformer.components_ != 0) # doctest: +ELLIPSIS
+    0.0100...
 
     See Also
     --------

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -465,6 +465,16 @@ class GaussianRandomProjection(BaseRandomProjection):
     components_ : numpy array of shape [n_components, n_features]
         Random matrix used for the projection.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.random_projection import GaussianRandomProjection
+    >>> X = np.random.rand(100, 10000)
+    >>> transformer = GaussianRandomProjection()
+    >>> X_new = transformer.fit_transform(X)
+    >>> X_new.shape
+    (100, 3947)
+
     See Also
     --------
     SparseRandomProjection
@@ -576,6 +586,16 @@ class SparseRandomProjection(BaseRandomProjection):
 
     density_ : float in range 0.0 - 1.0
         Concrete density computed from when density = "auto".
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.random_projection import SparseRandomProjection
+    >>> X = np.random.rand(100, 10000)
+    >>> transformer = SparseRandomProjection()
+    >>> X_new = transformer.fit_transform(X)
+    >>> X_new.shape
+    (100, 3947)
 
     See Also
     --------


### PR DESCRIPTION
See #3846 

examples added to two classes in `random_projection.py`. The example template is taken from http://scikit-learn.org/stable/modules/random_projection.html#gaussian-random-matrix
