### PR TITLE
[MRG] Update refences to best_parameters_ in GridSearchCV docs

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -467,7 +467,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                                  'with refit=False. %s is '
                                  'available only after refitting on the best '
                                  'parameters. You can refit an estimator '
-                                 'manually using the ``best_parameters_`` '
+                                 'manually using the ``best_params_`` '
                                  'attribute'
                                  % (type(self).__name__, method_name))
         else:
@@ -969,7 +969,7 @@ class GridSearchCV(BaseSearchCV):
         ``GridSearchCV`` instance.
 
         Also for multiple metric evaluation, the attributes ``best_index_``,
-        ``best_score_`` and ``best_parameters_`` will only be available if
+        ``best_score_`` and ``best_params_`` will only be available if
         ``refit`` is set and all of them will be determined w.r.t this specific
         scorer.
 
@@ -1313,7 +1313,7 @@ class RandomizedSearchCV(BaseSearchCV):
         ``RandomizedSearchCV`` instance.
 
         Also for multiple metric evaluation, the attributes ``best_index_``,
-        ``best_score_`` and ``best_parameters_`` will only be available if
+        ``best_score_`` and ``best_params_`` will only be available if
         ``refit`` is set and all of them will be determined w.r.t this specific
         scorer.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

The GridSearchCV [docs](http://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html) reference a `best_parameters_` attribute.

This doesn't seem to exist, so I've updated the docs to reference `best_params_` instead.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
