### PR TITLE
DOC Release dates for 0.20RC

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -209,11 +209,9 @@
                     </li>
                     <li><strong>Scikit-learn 0.21 will drop support for Python 2.7 and Python 3.4.</strong>
                     </li>
-                    <li><em>July 2018.</em> scikit-learn 0.20 is available for download (<a href="whats_new.html#version-0-20">Changelog</a>).
+                    <li><em>August 2018.</em> scikit-learn 0.20 is available for download (<a href="whats_new.html#version-0-20">Changelog</a>).
                     </li>
                     <li><em>July 2018.</em> scikit-learn 0.19.2 is available for download (<a href="whats_new.html#version-0-19">Changelog</a>).
-                    </li>
-                    <li><em>October 2017.</em> scikit-learn 0.19.1 is available for download (<a href="whats_new.html#version-0-19">Changelog</a>).
                     </li>
                     <li><em>July 2017.</em> scikit-learn 0.19.0 is available for download (<a href="whats_new/v0.19.html#version-0-19">Changelog</a>).
                     </li>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -209,7 +209,7 @@
                     </li>
                     <li><strong>Scikit-learn 0.21 will drop support for Python 2.7 and Python 3.4.</strong>
                     </li>
-                    <li><em>August 2018.</em> scikit-learn 0.20 is available for download (<a href="whats_new.html#version-0-20">Changelog</a>).
+                    <li><em>September 2018.</em> scikit-learn 0.20 is available for download (<a href="whats_new.html#version-0-20">Changelog</a>).
                     </li>
                     <li><em>July 2018.</em> scikit-learn 0.19.2 is available for download (<a href="whats_new.html#version-0-19">Changelog</a>).
                     </li>

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -4,8 +4,10 @@
 
 .. _changes_0_20:
 
-Version 0.20 (under development)
-================================
+Version 0.20.0
+==============
+
+**August, 2018**
 
 This release packs in a mountain of bug fixes, features and enhancements for
 the Scikit-learn library, and improvements to the documentation and examples.

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -7,7 +7,7 @@
 Version 0.20.0
 ==============
 
-**August, 2018**
+**September, 2018**
 
 This release packs in a mountain of bug fixes, features and enhancements for
 the Scikit-learn library, and improvements to the documentation and examples.


### PR DESCRIPTION
We are blocking on a fix to https://github.com/joblib/joblib/issues/741. (See #11837) Otherwise, I think we can release an RC, with this change to release dates.

I'd be keen to add "Release Candidate 17 August 2018" if others are willing to go with this plan.

Note: This is merging to master, not 0.20.X. After merge we should branch to 0.20.X

Before release, we still need to add contributors to the docs. And perhaps we also need to sort out the OPTICS issue #11677 (@espg, any progress?).