### PR TITLE
[MRG] MNT: Drop unneeded stride workaround for NumPy sum

### DIFF
--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -406,7 +406,7 @@ def _update_dict(dictionary, Y, code, verbose=False, return_r2=False,
             R = ger(-1.0, dictionary[:, k], code[k, :], a=R, overwrite_a=True)
     if return_r2:
         R **= 2
-        R = np.sum(R)
+        R = R.sum()
         return dictionary, R
     return dictionary
 

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -12,7 +12,6 @@ from math import sqrt, ceil
 
 import numpy as np
 from scipy import linalg
-from numpy.lib.stride_tricks import as_strided
 
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import Parallel, delayed, effective_n_jobs
@@ -407,11 +406,6 @@ def _update_dict(dictionary, Y, code, verbose=False, return_r2=False,
             R = ger(-1.0, dictionary[:, k], code[k, :], a=R, overwrite_a=True)
     if return_r2:
         R **= 2
-        # R is fortran-ordered. For numpy version < 1.6, sum does not
-        # follow the quick striding first, and is thus inefficient on
-        # fortran ordered data. We take a flat view of the data with no
-        # striding
-        R = as_strided(R, shape=(R.size, ), strides=(R.dtype.itemsize,))
         R = np.sum(R)
         return dictionary, R
     return dictionary


### PR DESCRIPTION
As we are now long past NumPy pre-1.6, this striding workaround to maintain performance of NumPy's `sum` is no longer needed. In fact, it actually comes at a penalty. So go ahead and drop the workaround simplifying the code a bit.

```python
In [1]: import numpy as np

In [2]: a = np.asfortranarray(np.random.random((200, 300)))

In [3]: %timeit np.sum(a)
27.4 µs ± 561 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [4]: %timeit a.sum()
26 µs ± 298 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [5]: %timeit np.lib.stride_tricks.as_strided(a, shape=(a.size, ), strides=(a.dtype.itemsize,))
8.78 µs ± 65.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [6]: %timeit np.sum(np.lib.stride_tricks.as_strided(a, shape=(a.size, ), strides=(a.dtype.itemsize,)))
40 µs ± 270 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```