### PR TITLE
[MRG] MNT: Use nrm2 to validate and normalize atoms in dictionary learning

### DIFF
--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -399,8 +399,9 @@ def _update_dict(dictionary, Y, code, verbose=False, return_r2=False,
                 np.clip(dictionary[:, k], 0, None, out=dictionary[:, k])
             # Setting corresponding coefs to 0
             code[k, :] = 0.0
-            dictionary[:, k] /= sqrt(np.dot(dictionary[:, k],
-                                            dictionary[:, k]))
+            atom_norm = sqrt(np.dot(dictionary[:, k],
+                                    dictionary[:, k]))
+            dictionary[:, k] /= atom_norm
         else:
             dictionary[:, k] /= atom_norm
             # R <- -1.0 * U_k * V_k^T + R

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -8,7 +8,7 @@ import time
 import sys
 import itertools
 
-from math import sqrt, ceil
+from math import ceil
 
 import numpy as np
 from scipy import linalg
@@ -376,6 +376,7 @@ def _update_dict(dictionary, Y, code, verbose=False, return_r2=False,
     # Get BLAS functions
     gemm, = linalg.get_blas_funcs(('gemm',), (dictionary, code, Y))
     ger, = linalg.get_blas_funcs(('ger',), (dictionary, code))
+    nrm2, = linalg.get_blas_funcs(('nrm2',), (dictionary,))
     # Residuals, computed with BLAS for speed and efficiency
     # R <- -1.0 * U * V^T + 1.0 * Y
     # Outputs R as Fortran array for efficiency
@@ -387,7 +388,8 @@ def _update_dict(dictionary, Y, code, verbose=False, return_r2=False,
         if positive:
             np.clip(dictionary[:, k], 0, None, out=dictionary[:, k])
         # Scale k'th atom
-        atom_norm = sqrt(np.dot(dictionary[:, k], dictionary[:, k]))
+        # (U_k * U_k) ** 0.5
+        atom_norm = nrm2(dictionary[:, k])
         if atom_norm < 1e-10:
             if verbose == 1:
                 sys.stdout.write("+")
@@ -399,8 +401,8 @@ def _update_dict(dictionary, Y, code, verbose=False, return_r2=False,
                 np.clip(dictionary[:, k], 0, None, out=dictionary[:, k])
             # Setting corresponding coefs to 0
             code[k, :] = 0.0
-            atom_norm = sqrt(np.dot(dictionary[:, k],
-                                    dictionary[:, k]))
+            # (U_k * U_k) ** 0.5
+            atom_norm = nrm2(dictionary[:, k])
             dictionary[:, k] /= atom_norm
         else:
             dictionary[:, k] /= atom_norm

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -387,8 +387,8 @@ def _update_dict(dictionary, Y, code, verbose=False, return_r2=False,
         if positive:
             np.clip(dictionary[:, k], 0, None, out=dictionary[:, k])
         # Scale k'th atom
-        atom_norm_square = np.dot(dictionary[:, k], dictionary[:, k])
-        if atom_norm_square < 1e-20:
+        atom_norm = sqrt(np.dot(dictionary[:, k], dictionary[:, k]))
+        if atom_norm < 1e-10:
             if verbose == 1:
                 sys.stdout.write("+")
                 sys.stdout.flush()
@@ -402,7 +402,7 @@ def _update_dict(dictionary, Y, code, verbose=False, return_r2=False,
             dictionary[:, k] /= sqrt(np.dot(dictionary[:, k],
                                             dictionary[:, k]))
         else:
-            dictionary[:, k] /= sqrt(atom_norm_square)
+            dictionary[:, k] /= atom_norm
             # R <- -1.0 * U_k * V_k^T + R
             R = ger(-1.0, dictionary[:, k], code[k, :], a=R, overwrite_a=True)
     if return_r2:


### PR DESCRIPTION
This switches to using the BLAS `nrm2` operation in `_update_dict` instead of rolling our own with `dot`. Note this operation occurs on every iteration of dictionary learning to check whether the atom needs to be replaced. If the atom does need to be replaced, this happens twice. The performance difference between using `dot` vs. using `nrm2` is an order of magnitude. So this is quite significant. Simple benchmark between these two included below.

```python
In [1]: import numpy as np

In [2]: from math import sqrt

In [3]: from scipy import linalg

In [4]: a = np.random.random((200,))

In [5]: %timeit sqrt(np.dot(a, a))
2.69 µs ± 25.7 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [6]: nrm2 = linalg.get_blas_funcs('nrm2', (a,))

In [7]: %timeit nrm2(a)
288 ns ± 5.01 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```