### PR TITLE
[MRG+1] MNT Use std math lib log1p instead of np.log1p in cython inner loops

### DIFF
--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -143,7 +143,7 @@
 
 cimport cython
 cimport numpy as np
-from libc.math cimport fabs, sqrt, exp, cos, pow, log
+from libc.math cimport fabs, sqrt, exp, cos, pow, log, log1p
 from libc.stdlib cimport calloc, malloc, free
 from libc.string cimport memcpy
 from sklearn.utils.lgamma cimport lgamma
@@ -486,7 +486,7 @@ cdef DTYPE_t _log_kernel_norm(DTYPE_t h, ITYPE_t d,
     elif kernel == EXPONENTIAL_KERNEL:
         factor = logSn(d - 1) + lgamma(d)
     elif kernel == LINEAR_KERNEL:
-        factor = logVn(d) - np.log1p(d)
+        factor = logVn(d) - log1p(d)
     elif kernel == COSINE_KERNEL:
         # this is derived from a chain rule integration
         factor = 0

--- a/sklearn/utils/_logistic_sigmoid.pyx
+++ b/sklearn/utils/_logistic_sigmoid.pyx
@@ -2,7 +2,7 @@
 #cython: cdivision=True
 #cython: wraparound=False
 
-from libc.math cimport log, exp
+from libc.math cimport log1p, exp
 
 import numpy as np
 cimport numpy as np
@@ -13,9 +13,9 @@ ctypedef np.float64_t DTYPE_t
 cdef DTYPE_t _inner_log_logistic_sigmoid(DTYPE_t x):
     """Log of the logistic sigmoid function log(1 / (1 + e ** -x))"""
     if x > 0:
-        return -np.log1p(exp(-x))
+        return -log1p(exp(-x))
     else:
-        return x - np.log1p(exp(x))
+        return x - log1p(exp(x))
 
 
 def _log_logistic_sigmoid(int n_samples, int n_features, 


### PR DESCRIPTION


#### Reference Issues/PRs
Fixes performance regressions introduced in #11428 as discussed in https://github.com/scikit-learn/scikit-learn/pull/11476#issuecomment-413958478

We should be using low level C functions in inner loops, not numpy functions.