### PR TITLE
DOC API change entry for n_jobs=1 -> n_jobs=None

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -1107,7 +1107,7 @@ Miscellaneous
 
 - |API| The default value of ``n_jobs`` is changed from ``1`` to ``None`` in
   all related functions and classes. ``n_jobs=None`` means ``unset``. It will
-  generally be interpreted as ``n_jobs=1``, unless the current 
+  generally be interpreted as ``n_jobs=1``, unless the current
   ``joblib.Parallel`` backend context specifies otherwise. Note that this
   change happens immediately (i.e., without a deprecation cycle).
   :issue:`11741` by `Olivier Grisel`_.

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -1108,8 +1108,9 @@ Miscellaneous
 - |API| The default value of ``n_jobs`` is changed from ``1`` to ``None`` in
   all related functions and classes. ``n_jobs=None`` means ``unset``. It will
   generally be interpreted as ``n_jobs=1``, unless the current
-  ``joblib.Parallel`` backend context specifies otherwise. Note that this
-  change happens immediately (i.e., without a deprecation cycle).
+  ``joblib.Parallel`` backend context specifies otherwise (See
+  :term:`Glossary <n_jobs>` for additional information). Note that this change
+  happens immediately (i.e., without a deprecation cycle).
   :issue:`11741` by `Olivier Grisel`_.
 
 Changes to estimator checks

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -1105,6 +1105,13 @@ Miscellaneous
   safe and could result in a "pop from empty list" error. :issue:`9569`
   by `Andreas Müller`_.
 
+- |API| The default value of ``n_jobs`` is changed from ``1`` to ``None`` in
+  all related functions and classes. ``n_jobs=None`` means ``unset``. It will
+  generally be interpreted as ``n_jobs=1``, unless the current 
+  ``joblib.Parallel`` backend context specifies otherwise. Note that this
+  change happens immediately (i.e., without a deprecation cycle).
+  :issue:`11741` by `Olivier Grisel`_.
+
 Changes to estimator checks
 ---------------------------
 


### PR DESCRIPTION
Add API change entry to emphasize that we change the default value of n_jobs (part of it is copied from the glossary)
ping @jnothman @rth 