### PR TITLE
[MRG] EXA Use fetch_openml(returnX_y=True) in examples

### DIFF
--- a/examples/linear_model/plot_sparse_logistic_regression_mnist.py
+++ b/examples/linear_model/plot_sparse_logistic_regression_mnist.py
@@ -36,9 +36,7 @@ t0 = time.time()
 train_samples = 5000
 
 # Load data from https://www.openml.org/d/554
-mnist = fetch_openml('mnist_784', version=1)
-X = mnist.data
-y = mnist.target
+X, y = fetch_openml('mnist_784', version=1, return_X_y=True)
 
 random_state = check_random_state(0)
 permutation = random_state.permutation(X.shape[0])

--- a/examples/multioutput/plot_classifier_chain_yeast.py
+++ b/examples/multioutput/plot_classifier_chain_yeast.py
@@ -47,9 +47,8 @@ from sklearn.linear_model import LogisticRegression
 print(__doc__)
 
 # Load a multi-label dataset from https://www.openml.org/d/40597
-yeast = fetch_openml('yeast', version=4)
-X = yeast.data
-Y = yeast.target == 'TRUE'
+X, Y = fetch_openml('yeast', version=4, return_X_y=True)
+Y = Y == 'TRUE'
 X_train, X_test, Y_train, Y_test = train_test_split(X, Y, test_size=.2,
                                                     random_state=0)
 

--- a/examples/neural_networks/plot_mnist_filters.py
+++ b/examples/neural_networks/plot_mnist_filters.py
@@ -27,9 +27,7 @@ from sklearn.neural_network import MLPClassifier
 print(__doc__)
 
 # Load data from https://www.openml.org/d/554
-mnist = fetch_openml('mnist_784', version=1)
-X = mnist.data
-y = mnist.target
+X, y = fetch_openml('mnist_784', version=1, return_X_y=True)
 
 # rescale the data, use the traditional train/test split
 X_train, X_test = X[:60000], X[60000:]


### PR DESCRIPTION
Remaining things to do in #11840.
I leave [examples/linear_model/plot_sgd_early_stopping.py](https://github.com/scikit-learn/scikit-learn/blob/master/examples/linear_model/plot_sgd_early_stopping.py) as it is because it seems reasonable not to use return_X_y=True there.