### PR TITLE
[WIP] fixes OPTICS split_points detected as NOISE and last point not detected as outlier.

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -838,9 +838,9 @@ algorithm builds a *reachability* graph, which assigns each sample both a
 ``reachability_`` distance, and a spot within the cluster ``ordering_``
 attribute; these two attributes are assigned when the model is fitted, and are
 used to determine cluster membership. If OPTICS is run with the default value
-of *inf* set for ``max_bound``, then DBSCAN style cluster extraction can be
+of *inf* set for ``max_eps``, then DBSCAN style cluster extraction can be
 performed in linear time for any given ``eps`` value using the
-``extract_dbscan`` method. Setting ``max_bound`` to a lower value will result
+``extract_dbscan`` method. Setting ``max_eps`` to a lower value will result
 in shorter run times, and can be thought of as the maximum cluster object size
 (in diameter) that OPTICS will be able to extract.
 
@@ -892,10 +892,10 @@ larger parent cluster.
     shorter run time than OPTICS; however, for repeated runs at varying ``eps``
     values, a single run of OPTICS may require less cumulative runtime than
     DBSCAN. It is also important to note that OPTICS output can be unstable at
-    ``eps`` values very close to the initial ``max_bound`` value. OPTICS seems
+    ``eps`` values very close to the initial ``max_eps`` value. OPTICS seems
     to produce near identical results to DBSCAN provided that ``eps`` passed to
     ``extract_dbscan`` is a half order of magnitude less than the inital
-    ``max_bound`` that was used to fit; using a value close to ``max_bound``
+    ``max_eps`` that was used to fit; using a value close to ``max_eps``
     will throw a warning, and using a value larger will result in an exception. 
 
 .. topic:: Computational Complexity
@@ -909,7 +909,7 @@ larger parent cluster.
     multithreaded, and has better algorithmic runtime complexity than OPTICS--
     at the cost of worse memory scaling. For extremely large datasets that
     exhaust system memory using HDBSCAN, OPTICS will maintain *n* (as opposed
-    to *n^2* memory scaling); however, tuning of the ``max_bound`` parameter
+    to *n^2* memory scaling); however, tuning of the ``max_eps`` parameter
     will likely need to be used to give a solution in a reasonable amount of
     wall time.
 

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -246,6 +246,8 @@ class OPTICS(BaseEstimator, ClusterMixin):
 
     min_maxima_ratio : float, optional (default=.001)
         Used to determine neighborhood size for minimum cluster membership.
+        Each local maxima should be a largest value in a neighborhood
+        of the `size min_maxima_ratio * len(X)` from left and right.
 
     algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -573,7 +573,8 @@ def _extract_optics(ordering, reachability, core_distances, maxima_ratio=.75,
         labels[index] = clustid
         is_core[index] = 1
         clustid += 1
-    
+
+    # check if the last point in the ordering is a NOISE
     last_point = ordering[-1]
     if (core_distances_plot[last_point] * 1.5
             >= reachability_plot[last_point]):
@@ -695,7 +696,6 @@ def _cluster_tree(node, parent_node, local_maxima_points,
     local_max_1 = []
     local_max_2 = []
 
-    # wouldn't list expansion be faster? -> realloc
     for i in local_maxima_points:
         if i < s:
             local_max_1.append(i)

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -690,7 +690,8 @@ def _find_local_maxima(reachability_plot, neighborhood_size):
         # if the point is a local maxima on the reachability plot with
         # regard to neighborhood_size, insert it into priority queue and
         # maxima list
-        if (reachability_plot[i] > reachability_plot[i - 1] and
+        # all inf values are local maxima.
+        if (reachability_plot[i] >= reachability_plot[i - 1] and
             reachability_plot[i] >= reachability_plot[i + 1] and
             _is_local_maxima(i, np.array(reachability_plot),
                              neighborhood_size) == 1):

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -168,9 +168,6 @@ class OPTICS(BaseEstimator, ClusterMixin):
 
     Parameters
     ----------
-    NOTE: should we call this parameter min_neighbors, or n_neighbors,
-    to be more consistent with the NearestNeighbors API, which this parameter
-    is used for?
     min_samples : int (default=5)
         The number of samples in a neighborhood for a point to be considered
         as a core point.
@@ -197,21 +194,6 @@ class OPTICS(BaseEstimator, ClusterMixin):
         equivalent to using manhattan_distance (l1), and euclidean_distance
         (l2) for p = 2. For arbitrary p, minkowski_distance (l_p) is used.
 
-    NOTE: the API doesn't seem to be consistent with regard to metric_params,
-    i.e. in some cases it's taken as input, in some cases only a `metric`
-    is accepted and no `metric_params`
-    also, regarding metric, why is it not like t-sne for instance?
-        metric : string or callable, optional
-            The metric to use when calculating distance between instances in a
-            feature array. If metric is a string, it must be one of the options
-            allowed by scipy.spatial.distance.pdist for its metric parameter, or
-            a metric listed in pairwise.PAIRWISE_DISTANCE_FUNCTIONS.
-            If metric is "precomputed", X is assumed to be a distance matrix.
-            Alternatively, if metric is a callable function, it is called on each
-            pair of instances (rows) and the resulting value recorded. The callable
-            should take two arrays from X as input and return a value indicating
-            the distance between them. The default is "euclidean" which is
-            interpreted as squared euclidean distance.
     metric_params : dict, optional (default=None)
         Additional keyword arguments for the metric function.
 

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -570,26 +570,16 @@ def _extract_optics(ordering, reachability, core_distances, maxima_ratio=.75,
     labels = np.full(n_samples, -1, dtype=int)
     # Start all points as non-core noise
     for leaf in leaves:
-        """
-        print("leaf: ", leaf)
-        start = leaf.start
-        print("====checking leaf")
-        print(leaf.parent_node)
-        if leaf.parent_node is not None:
-            print(leaf.start == leaf.parent_node.split_point + 1)
-            print(core_distances_plot[leaf.parent_node.split_point])
-            print(core_distances_plot[leaf.start:leaf.end])
-            if leaf.start == leaf.parent_node.split_point + 1 \
-               and core_distances_plot[leaf.parent_node.split_point] \
-               <= np.max(core_distances_plot[leaf.start:leaf.end]):
-                start = leaf.start - 1
-        print("start: %s" % start)
-        index = ordering[start:leaf.end]
-        """
         index = ordering[leaf.start:leaf.end]
         labels[index] = clustid
         is_core[index] = 1
         clustid += 1
+    
+    last_point = ordering[-1]
+    if (core_distances_plot[last_point] * 1.5
+        >= reachability_plot[last_point]):
+        labels[last_point] = -1
+        is_core[last_point] = 0
     return np.arange(n_samples)[is_core], labels
 
 
@@ -665,8 +655,6 @@ def _find_local_maxima(reachability_plot, neighborhood_size):
     local_maxima_points = {}
     # 1st and last points on Reachability Plot are not taken
     # as local maxima points
-    # why? The first one is always INF?
-    # but the last one can be a NOISE
     for i in range(1, len(reachability_plot) - 1):
         # if the point is a local maxima on the reachability plot with
         # regard to neighborhood_size, insert it into priority queue and

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -171,20 +171,20 @@ class OPTICS(BaseEstimator, ClusterMixin):
     NOTE: should we call this parameter min_neighbors, or n_neighbors,
     to be more consistent with the NearestNeighbors API, which this parameter
     is used for?
-    min_samples : int
+    min_samples : int (default=5)
         The number of samples in a neighborhood for a point to be considered
         as a core point.
 
     NOTE: max_radius (similar to NearestNeighbors API)
     or max_eps (to follow paper's jargon)
-    max_bound : float, optional
+    max_bound : float, optional (default=np.inf)
         The maximum distance between two samples for them to be considered
         as in the same neighborhood. This is also the largest object size
         expected within the dataset. Default value of "np.inf" will identify
         clusters across all scales; reducing `max_bound` will result in
         shorter run times.
 
-    metric : string or callable, optional
+    metric : string or callable, optional (default='euclidean')
         The distance metric to use for neighborhood lookups. Default is
         "minkowski". Other options include "euclidean", "manhattan",
         "chebyshev", "haversine", "seuclidean", "hamming", "canberra",
@@ -215,20 +215,20 @@ class OPTICS(BaseEstimator, ClusterMixin):
     metric_params : dict, optional (default=None)
         Additional keyword arguments for the metric function.
 
-    maxima_ratio : float, optional
+    maxima_ratio : float, optional (default=.75)
         The maximum ratio we allow of average height of clusters on the
         right and left to the local maxima in question. The higher the
         ratio, the more generous the algorithm is to preserving local
         minima, and the more cuts the resulting tree will have.
 
-    rejection_ratio : float, optional
+    rejection_ratio : float, optional (default=.7)
         Adjusts the fitness of the clustering. When the maxima_ratio is
         exceeded, determine which of the clusters to the left and right to
         reject based on rejection_ratio. Higher values will result in points
         being more readily classified as noise; conversely, lower values will
         result in more points being clustered.
 
-    similarity_threshold : float, optional
+    similarity_threshold : float, optional (default=.4)
         Used to check if nodes can be moved up one level, that is, if the
         new cluster created is too "similar" to its parent, given the
         similarity threshold. Similarity can be determined by 1) the size
@@ -238,19 +238,19 @@ class OPTICS(BaseEstimator, ClusterMixin):
         node. A lower value for the similarity threshold means less levels
         in the tree.
 
-    significant_min : float, optional
+    significant_min : float, optional (default=.003)
         Sets a lower threshold on how small a significant maxima can be.
 
-    min_cluster_size_ratio : float, optional
+    min_cluster_size_ratio : float, optional (default=.005)
         Minimum percentage of dataset expected for cluster membership.
 
-    min_maxima_ratio : float, optional
+    min_maxima_ratio : float, optional (default=.001)
         Used to determine neighborhood size for minimum cluster membership.
 
     algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:
 
-        - 'ball_tree' will use :class:`BallTree`
+        - 'ball_tree' will use :class:`BallTree` (default)
         - 'kd_tree' will use :class:`KDTree`
         - 'brute' will use a brute-force search.
         - 'auto' will attempt to decide the most appropriate algorithm

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -746,11 +746,11 @@ def _cluster_tree(node, parent_node, local_maxima_points,
     if reachability_plot[s] < significant_min:
         node.assign_split_point(-1)
         # if split_point is not significant, ignore this split and continue
-        _cluster_tree(node, parent_node, local_maxima_points,
-                      reachability_plot, core_distances_plot,
-                      reachability_ordering,
-                      min_cluster_size, maxima_ratio, rejection_ratio,
-                      similarity_threshold, significant_min)
+        #_cluster_tree(node, parent_node, local_maxima_points,
+        #              reachability_plot, core_distances_plot,
+        #              reachability_ordering,
+        #              min_cluster_size, maxima_ratio, rejection_ratio,
+        #              similarity_threshold, significant_min)
         return
 
     # only check a certain ratio of points in the child

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -41,18 +41,17 @@ def optics(X, min_samples=5, max_eps=np.inf, metric='euclidean',
     X : array, shape (n_samples, n_features)
         The data.
 
-    min_samples : int
+    min_samples : int (default=5)
         The number of samples in a neighborhood for a point to be considered
         as a core point.
 
-    max_eps : float, optional
+    max_eps : float, optional (default=np.inf)
         The maximum distance between two samples for them to be considered
-        as in the same neighborhood. This is also the largest object size
-        expected within the dataset. Default value of "np.inf" will identify
+        as in the same neighborhood. Default value of "np.inf" will identify
         clusters across all scales; reducing `max_eps` will result in
         shorter run times.
 
-    metric : string or callable, optional
+    metric : string or callable, optional (default='euclidean')
         The distance metric to use for neighborhood lookups. Default is
         "minkowski". Other options include "euclidean", "manhattan",
         "chebyshev", "haversine", "seuclidean", "hamming", "canberra",
@@ -68,20 +67,20 @@ def optics(X, min_samples=5, max_eps=np.inf, metric='euclidean',
     metric_params : dict, optional (default=None)
         Additional keyword arguments for the metric function.
 
-    maxima_ratio : float, optional
+    maxima_ratio : float, optional (default=.75)
         The maximum ratio we allow of average height of clusters on the
         right and left to the local maxima in question. The higher the
         ratio, the more generous the algorithm is to preserving local
         minima, and the more cuts the resulting tree will have.
 
-    rejection_ratio : float, optional
+    rejection_ratio : float, optional (default=.7)
         Adjusts the fitness of the clustering. When the maxima_ratio is
         exceeded, determine which of the clusters to the left and right to
         reject based on rejection_ratio. Higher values will result in points
         being more readily classified as noise; conversely, lower values will
         result in more points being clustered.
 
-    similarity_threshold : float, optional
+    similarity_threshold : float, optional (default=.4)
         Used to check if nodes can be moved up one level, that is, if the
         new cluster created is too "similar" to its parent, given the
         similarity threshold. Similarity can be determined by 1) the size
@@ -91,19 +90,21 @@ def optics(X, min_samples=5, max_eps=np.inf, metric='euclidean',
         node. A lower value for the similarity threshold means less levels
         in the tree.
 
-    significant_min : float, optional
+    significant_min : float, optional (default=.003)
         Sets a lower threshold on how small a significant maxima can be.
 
-    min_cluster_size_ratio : float, optional
+    min_cluster_size_ratio : float, optional (default=.005)
         Minimum percentage of dataset expected for cluster membership.
 
-    min_maxima_ratio : float, optional
+    min_maxima_ratio : float, optional (default=.001)
         Used to determine neighborhood size for minimum cluster membership.
+        Each local maxima should be a largest value in a neighborhood
+        of the `size min_maxima_ratio * len(X)` from left and right.
 
     algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:
 
-        - 'ball_tree' will use :class:`BallTree`
+        - 'ball_tree' will use :class:`BallTree` (default)
         - 'kd_tree' will use :class:`KDTree`
         - 'brute' will use a brute-force search.
         - 'auto' will attempt to decide the most appropriate algorithm

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -168,6 +168,9 @@ class OPTICS(BaseEstimator, ClusterMixin):
 
     Parameters
     ----------
+    NOTE: should we call this parameter min_neighbors, or n_neighbors,
+    to be more consistent with the NearestNeighbors API, which this parameter
+    is used for?
     min_samples : int
         The number of samples in a neighborhood for a point to be considered
         as a core point.
@@ -269,6 +272,19 @@ class OPTICS(BaseEstimator, ClusterMixin):
     core_distances_ : array, shape (n_samples,)
         Distance at which each sample becomes a core point.
         Points which will never be core have a distance of inf.
+
+    Examples
+    --------
+    >>> from sklearn.cluster import OPTICS
+    >>> import numpy as np
+    >>> np.random.seed(0)
+    >>> n_points_per_cluster = 3
+    >>> C1 = [-5, -2] + .8 * np.random.randn(n_points_per_cluster, 2)
+    >>> C2 = [4, -1] + .1 * np.random.randn(n_points_per_cluster, 2)
+    >>> X = np.vstack((C1, np.array([[100, 200]]), C2))
+    >>> clust = OPTICS(min_samples=2).fit(X)
+    >>> clust.labels_
+    array([ 0,  0,  0, -1,  1,  1,  1])
 
     See also
     --------

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -21,7 +21,7 @@ from ..metrics import pairwise_distances
 from ._optics_inner import quick_scan
 
 
-def optics(X, min_samples=5, max_bound=np.inf, metric='euclidean',
+def optics(X, min_samples=5, max_eps=np.inf, metric='euclidean',
            p=2, metric_params=None, maxima_ratio=.75,
            rejection_ratio=.7, similarity_threshold=0.4,
            significant_min=.003, min_cluster_size_ratio=.005,
@@ -45,11 +45,11 @@ def optics(X, min_samples=5, max_bound=np.inf, metric='euclidean',
         The number of samples in a neighborhood for a point to be considered
         as a core point.
 
-    max_bound : float, optional
+    max_eps : float, optional
         The maximum distance between two samples for them to be considered
         as in the same neighborhood. This is also the largest object size
         expected within the dataset. Default value of "np.inf" will identify
-        clusters across all scales; reducing `max_bound` will result in
+        clusters across all scales; reducing `max_eps` will result in
         shorter run times.
 
     metric : string or callable, optional
@@ -147,7 +147,7 @@ def optics(X, min_samples=5, max_bound=np.inf, metric='euclidean',
     Record 28, no. 2 (1999): 49-60.
     """
 
-    clust = OPTICS(min_samples, max_bound, metric, p, metric_params,
+    clust = OPTICS(min_samples, max_eps, metric, p, metric_params,
                    maxima_ratio, rejection_ratio,
                    similarity_threshold, significant_min,
                    min_cluster_size_ratio, min_maxima_ratio,
@@ -172,13 +172,10 @@ class OPTICS(BaseEstimator, ClusterMixin):
         The number of samples in a neighborhood for a point to be considered
         as a core point.
 
-    NOTE: max_radius (similar to NearestNeighbors API)
-    or max_eps (to follow paper's jargon)
-    max_bound : float, optional (default=np.inf)
+    max_eps : float, optional (default=np.inf)
         The maximum distance between two samples for them to be considered
-        as in the same neighborhood. This is also the largest object size
-        expected within the dataset. Default value of "np.inf" will identify
-        clusters across all scales; reducing `max_bound` will result in
+        as in the same neighborhood. Default value of "np.inf" will identify
+        clusters across all scales; reducing `max_eps` will result in
         shorter run times.
 
     metric : string or callable, optional (default='euclidean')
@@ -301,14 +298,14 @@ class OPTICS(BaseEstimator, ClusterMixin):
     Record 28, no. 2 (1999): 49-60.
     """
 
-    def __init__(self, min_samples=5, max_bound=np.inf, metric='euclidean',
+    def __init__(self, min_samples=5, max_eps=np.inf, metric='euclidean',
                  p=2, metric_params=None, maxima_ratio=.75,
                  rejection_ratio=.7, similarity_threshold=0.4,
                  significant_min=.003, min_cluster_size_ratio=.005,
                  min_maxima_ratio=0.001, algorithm='ball_tree',
                  leaf_size=30, n_jobs=None):
 
-        self.max_bound = max_bound
+        self.max_eps = max_eps
         self.min_samples = min_samples
         self.maxima_ratio = maxima_ratio
         self.rejection_ratio = rejection_ratio
@@ -327,7 +324,7 @@ class OPTICS(BaseEstimator, ClusterMixin):
         """Perform OPTICS clustering
 
         Extracts an ordered list of points and reachability distances, and
-        performs initial clustering using `max_bound` distance specified at
+        performs initial clustering using `max_eps` distance specified at
         OPTICS object instantiation.
 
         Parameters
@@ -396,7 +393,7 @@ class OPTICS(BaseEstimator, ClusterMixin):
     def _expand_cluster_order(self, point, X, nbrs):
         # As above, not parallelizable. Parallelizing would allow items in
         # the 'unprocessed' list to switch to 'processed'
-        if self.core_distances_[point] <= self.max_bound:
+        if self.core_distances_[point] <= self.max_eps:
             while not self._processed[point]:
                 self._processed[point] = True
                 self.ordering_.append(point)
@@ -407,7 +404,7 @@ class OPTICS(BaseEstimator, ClusterMixin):
 
     def _set_reach_dist(self, point_index, X, nbrs):
         P = np.array(X[point_index]).reshape(1, -1)
-        indices = nbrs.radius_neighbors(P, radius=self.max_bound,
+        indices = nbrs.radius_neighbors(P, radius=self.max_eps,
                                         return_distance=False)[0]
 
         # Getting indices of neighbors that have not been processed
@@ -434,17 +431,17 @@ class OPTICS(BaseEstimator, ClusterMixin):
     def extract_dbscan(self, eps):
         """Performs DBSCAN extraction for an arbitrary epsilon.
 
-        Extraction runs in linear time. Note that if the `max_bound` OPTICS
+        Extraction runs in linear time. Note that if the `max_eps` OPTICS
         parameter was set to < inf for extracting reachability and ordering
         arrays, DBSCAN extractions will be unstable for `eps` values close to
-        `max_bound`. Setting `eps` < (`max_bound` / 5.0) will guarantee
+        `max_eps`. Setting `eps` < (`max_eps` / 5.0) will guarantee
         extraction parity with DBSCAN.
 
         Parameters
         ----------
         eps : float or int, required
-            DBSCAN `eps` parameter. Must be set to < `max_bound`. Equivalence
-            with DBSCAN algorithm is achieved if `eps` is < (`max_bound` / 5)
+            DBSCAN `eps` parameter. Must be set to < `max_eps`. Equivalence
+            with DBSCAN algorithm is achieved if `eps` is < (`max_eps` / 5)
 
         Returns
         -------
@@ -456,14 +453,14 @@ class OPTICS(BaseEstimator, ClusterMixin):
         """
         check_is_fitted(self, 'reachability_')
 
-        if eps > self.max_bound:
+        if eps > self.max_eps:
             raise ValueError('Specify an epsilon smaller than %s. Got %s.'
-                             % (self.max_bound, eps))
+                             % (self.max_eps, eps))
 
-        if eps * 5.0 > (self.max_bound * 1.05):
+        if eps * 5.0 > (self.max_eps * 1.05):
             warnings.warn(
-                "Warning, max_bound (%s) is close to eps (%s): "
-                "Output may be unstable." % (self.max_bound, eps),
+                "Warning, max_eps (%s) is close to eps (%s): "
+                "Output may be unstable." % (self.max_eps, eps),
                 RuntimeWarning, stacklevel=2)
         # Stability warning is documented in _extract_dbscan method...
 
@@ -569,7 +566,7 @@ def _extract_optics(ordering, reachability, core_distances, maxima_ratio=.75,
     # epsilong, there should be more than one INF.
     if np.all(np.isinf(reachability)):
         raise ValueError("All reachability values are inf. Set a larger"
-                         " max_bound.")
+                         " max_eps.")
     normalization_factor = np.max(reachability[reachability < np.inf])
     reachability = reachability / normalization_factor
     reachability_plot = reachability[ordering].tolist()

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -576,8 +576,8 @@ def _extract_optics(ordering, reachability, core_distances, maxima_ratio=.75,
 
     # check if the last point in the ordering is a NOISE
     last_point = ordering[-1]
-    if (core_distances_plot[last_point] * 1.5
-            >= reachability_plot[last_point]):
+    if (core_distances_plot[-1] * 5 >= reachability_plot[-1]
+            and reachability_plot[-1] > reachability_plot[-2] * 5):
         labels[last_point] = -1
         is_core[last_point] = 0
 
@@ -689,7 +689,7 @@ def _cluster_tree(node, parent_node, local_maxima_points,
     node_1 = _TreeNode(reachability_ordering[node.start:s],
                        node.start, s, node)
     node_2_start = s + 1
-    if core_distances_plot[s] * 1.5 < reachability_plot[s]:
+    if core_distances_plot[s] * 5 < reachability_plot[s]:
         node_2_start = s
     node_2 = _TreeNode(reachability_ordering[node_2_start:node.end],
                        node_2_start, node.end, node)

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -361,6 +361,8 @@ class OPTICS(BaseEstimator, ClusterMixin):
             if not self._processed[point]:
                 self._expand_cluster_order(point, X, nbrs)
 
+        print("ordering\n%s" % self.ordering_)
+        print("reachability_\n%s" % self.reachability_) 
         indices_, self.labels_ = _extract_optics(self.ordering_,
                                                  self.reachability_,
                                                  self.maxima_ratio,
@@ -550,7 +552,9 @@ def _extract_optics(ordering, reachability, maxima_ratio=.75,
                                    maxima_ratio, rejection_ratio,
                                    similarity_threshold, significant_min,
                                    min_cluster_size_ratio, min_maxima_ratio)
+    print("root_node\n%s" % root_node.__dict__)
     leaves = _get_leaves(root_node, [])
+    print("leaves\n%s" % [l.__dict__ for l in leaves])
     # Start cluster id's at 0
     clustid = 0
     n_samples = len(reachability)

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -553,8 +553,10 @@ def _extract_optics(ordering, reachability, core_distances, maxima_ratio=.75,
     # why are we generating only 1 (the first one) INF in the reachability?
     # according to the paper (p. 5), for a small enough generative distance
     # epsilong, there should be more than one INF.
-    reachability = reachability / np.max(reachability[1:])
+    normalization_factor = np.max(reachability[1:])
+    reachability = reachability / normalization_factor
     reachability_plot = reachability[ordering].tolist()
+    core_distances = core_distances / normalization_factor
     core_distances_plot = core_distances[ordering].tolist()
     root_node = _automatic_cluster(reachability_plot, core_distances_plot,
                                    ordering,
@@ -580,6 +582,7 @@ def _extract_optics(ordering, reachability, core_distances, maxima_ratio=.75,
         >= reachability_plot[last_point]):
         labels[last_point] = -1
         is_core[last_point] = 0
+
     return np.arange(n_samples)[is_core], labels
 
 
@@ -700,6 +703,12 @@ def _cluster_tree(node, parent_node, local_maxima_points,
     node_1 = _TreeNode(reachability_ordering[node.start:s],
                        node.start, s, node)
     node_2_start = s + 1
+    print("add split point?")
+    print(s)
+    print(core_distances_plot[s])
+    print(reachability_plot[s])
+    print(core_distances_plot[s] * 1.5 < reachability_plot[s])
+    print("---------------")
     if core_distances_plot[s] * 1.5 < reachability_plot[s]:
         node_2_start = s
     node_2 = _TreeNode(reachability_ordering[node_2_start:node.end],

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -702,8 +702,7 @@ def _find_local_maxima(reachability_plot, neighborhood_size):
 
 
 def _cluster_tree(node, parent_node, local_maxima_points,
-                  reachability_plot, core_distances_plot,
-                  reachability_ordering,
+                  reachability_plot, core_distances_plot, ordering,
                   min_cluster_size, maxima_ratio, rejection_ratio,
                   similarity_threshold, significant_min):
     """Recursively builds cluster tree to hold hierarchical cluster structure
@@ -722,12 +721,12 @@ def _cluster_tree(node, parent_node, local_maxima_points,
     local_maxima_points = local_maxima_points[1:]
 
     # create two new nodes and add to list of nodes
-    node_1 = _TreeNode(reachability_ordering[node.start:s],
+    node_1 = _TreeNode(ordering[node.start:s],
                        node.start, s, node)
     node_2_start = s + 1
     if core_distances_plot[s] * 5 < reachability_plot[s]:
         node_2_start = s
-    node_2 = _TreeNode(reachability_ordering[node_2_start:node.end],
+    node_2 = _TreeNode(ordering[node_2_start:node.end],
                        node_2_start, node.end, node)
     local_max_1 = []
     local_max_2 = []
@@ -749,7 +748,7 @@ def _cluster_tree(node, parent_node, local_maxima_points,
         # if split_point is not significant, ignore this split and continue
         #_cluster_tree(node, parent_node, local_maxima_points,
         #              reachability_plot, core_distances_plot,
-        #              reachability_ordering,
+        #              ordering,
         #              min_cluster_size, maxima_ratio, rejection_ratio,
         #              similarity_threshold, significant_min)
         return
@@ -782,8 +781,7 @@ def _cluster_tree(node, parent_node, local_maxima_points,
             # ignore this split and continue (reject both child nodes)
             node.assign_split_point(-1)
             _cluster_tree(node, parent_node, local_maxima_points,
-                          reachability_plot, core_distances_plot,
-                          reachability_ordering,
+                          reachability_plot, core_distances_plot, ordering,
                           min_cluster_size, maxima_ratio, rejection_ratio,
                           similarity_threshold, significant_min)
             return
@@ -816,15 +814,13 @@ def _cluster_tree(node, parent_node, local_maxima_points,
         if bypass_node == 1:
             parent_node.add_child(nl[0])
             _cluster_tree(nl[0], parent_node, nl[1],
-                          reachability_plot, core_distances_plot,
-                          reachability_ordering,
+                          reachability_plot, core_distances_plot, ordering,
                           min_cluster_size, maxima_ratio, rejection_ratio,
                           similarity_threshold, significant_min)
         else:
             node.add_child(nl[0])
             _cluster_tree(nl[0], node, nl[1], reachability_plot,
-                          core_distances_plot,
-                          reachability_ordering, min_cluster_size,
+                          core_distances_plot, ordering, min_cluster_size,
                           maxima_ratio, rejection_ratio,
                           similarity_threshold, significant_min)
 

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -728,7 +728,7 @@ def _cluster_tree(node, parent_node, local_maxima_points,
     if reachability_plot[s] < significant_min:
         node.assign_split_point(-1)
         # if split_point is not significant, ignore this split and continue
-        #_cluster_tree(node, parent_node, local_maxima_points,
+        # _cluster_tree(node, parent_node, local_maxima_points,
         #              reachability_plot, core_distances_plot,
         #              ordering,
         #              min_cluster_size, maxima_ratio, rejection_ratio,

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -576,7 +576,7 @@ def _extract_optics(ordering, reachability, core_distances, maxima_ratio=.75,
     
     last_point = ordering[-1]
     if (core_distances_plot[last_point] * 1.5
-        >= reachability_plot[last_point]):
+            >= reachability_plot[last_point]):
         labels[last_point] = -1
         is_core[last_point] = 0
 

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -564,10 +564,9 @@ def _extract_optics(ordering, reachability, core_distances, maxima_ratio=.75,
     """
 
     # Extraction wrapper
-    # why are we generating only 1 (the first one) INF in the reachability?
     # according to the paper (p. 5), for a small enough generative distance
     # epsilong, there should be more than one INF.
-    normalization_factor = np.max(reachability[1:])
+    normalization_factor = np.max(reachability[reachability < np.inf])
     reachability = reachability / normalization_factor
     reachability_plot = reachability[ordering].tolist()
     core_distances = core_distances / normalization_factor

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -620,9 +620,8 @@ def _automatic_cluster(reachability_plot, core_distances_plot, ordering,
     neighborhood_size = int(min_maxima_ratio * len(ordering))
 
     # Should this check for < min_samples? Should this be public?
-    # why 5? shouldn't it be 2?
-    if min_cluster_size < 2:
-        min_cluster_size = 2
+    if min_cluster_size < 5:
+        min_cluster_size = 5
 
     # Again, should this check < min_samples, should the parameter be public?
     if neighborhood_size < min_neighborhood_size:
@@ -717,16 +716,13 @@ def _cluster_tree(node, parent_node, local_maxima_points,
     node_list.append((node_1, local_max_1))
     node_list.append((node_2, local_max_2))
 
-    # if local maxima are sorted by their reachability, doesn't it
-    # mean we can stop? Why do we continue?
     if reachability_plot[s] < significant_min:
         node.split_point = -1
         # if split_point is not significant, ignore this split and continue
-        # _cluster_tree(node, parent_node, local_maxima_points,
-        #              reachability_plot, core_distances_plot,
-        #              ordering,
-        #              min_cluster_size, maxima_ratio, rejection_ratio,
-        #              similarity_threshold, significant_min)
+        _cluster_tree(node, parent_node, local_maxima_points,
+                      reachability_plot, reachability_ordering,
+                      min_cluster_size, maxima_ratio, rejection_ratio,
+                      similarity_threshold, significant_min)
         return
 
     # only check a certain ratio of points in the child

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -361,8 +361,6 @@ class OPTICS(BaseEstimator, ClusterMixin):
             if not self._processed[point]:
                 self._expand_cluster_order(point, X, nbrs)
 
-        print("ordering\n%s" % self.ordering_)
-        print("reachability_\n%s" % self.reachability_) 
         indices_, self.labels_ = _extract_optics(self.ordering_,
                                                  self.reachability_,
                                                  self.core_distances_,
@@ -564,7 +562,6 @@ def _extract_optics(ordering, reachability, core_distances, maxima_ratio=.75,
                                    similarity_threshold, significant_min,
                                    min_cluster_size_ratio, min_maxima_ratio)
     leaves = _get_leaves(root_node, [])
-    print("leaves\n%s" % [l for l in leaves])
     # Start cluster id's at 0
     clustid = 0
     n_samples = len(reachability)
@@ -641,11 +638,6 @@ class _TreeNode(object):
     def add_child(self, child):
         self.children.append(child)
 
-    def __str__(self):
-        return ("\tpoints: %s\n\tstart: %s\n\tend: %s\n\tchildren: %s\n\tsplit_point: %s" %
-                (self.points, self.start, self.end, len(self.children),
-                 self.split_point))
-
 
 def _is_local_maxima(index, reachability_plot, neighborhood_size):
     right_idx = slice(index + 1, index + neighborhood_size + 1)
@@ -684,13 +676,6 @@ def _cluster_tree(node, parent_node, local_maxima_points,
     local_maxima_points is list of local maxima points sorted in
     descending order of reachability
     """
-    print("======_cluster_tree=====")
-    print("node", node)
-    print("parent_node", parent_node)
-    print("local_maxima_points", local_maxima_points)
-    print("reachability_plot", reachability_plot)
-    print("reachability_ordering", reachability_ordering)
-
     if len(local_maxima_points) == 0:
         return  # parent_node is a leaf
 
@@ -703,12 +688,6 @@ def _cluster_tree(node, parent_node, local_maxima_points,
     node_1 = _TreeNode(reachability_ordering[node.start:s],
                        node.start, s, node)
     node_2_start = s + 1
-    print("add split point?")
-    print(s)
-    print(core_distances_plot[s])
-    print(reachability_plot[s])
-    print(core_distances_plot[s] * 1.5 < reachability_plot[s])
-    print("---------------")
     if core_distances_plot[s] * 1.5 < reachability_plot[s]:
         node_2_start = s
     node_2 = _TreeNode(reachability_ordering[node_2_start:node.end],
@@ -755,11 +734,9 @@ def _cluster_tree(node, parent_node, local_maxima_points,
 
         if (avg_reach1 / reachability_plot[s]) < rejection_ratio:
             # reject node 2
-            print("reject node 2")
             node_list.remove((node_2, local_max_2))
         if (avg_reach2 / reachability_plot[s]) < rejection_ratio:
             # reject node 1
-            print("reject node 1")
             node_list.remove((node_1, local_max_1))
         if ((avg_reach1 / reachability_plot[s]) >= rejection_ratio and
                 (avg_reach2 / reachability_plot[s]) >= rejection_ratio):
@@ -777,12 +754,10 @@ def _cluster_tree(node, parent_node, local_maxima_points,
     if (len(node_1.points) < min_cluster_size and
             node_list.count((node_1, local_max_1)) > 0):
         # cluster 1 is too small
-        print("cluster 1 too small")
         node_list.remove((node_1, local_max_1))
     if (len(node_2.points) < min_cluster_size and
             node_list.count((node_2, local_max_2)) > 0):
         # cluster 2 is too small
-        print("cluster 2 too small")
         node_list.remove((node_2, local_max_2))
     if not node_list:
         # parent_node will be a leaf
@@ -818,7 +793,6 @@ def _cluster_tree(node, parent_node, local_maxima_points,
 
 def _get_leaves(node, arr):
     if node is not None:
-        print("_get_leaves node\n%s" % str(node))
         if node.split_point == -1:
             arr.append(node)
         for n in node.children:

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -140,12 +140,16 @@ def test_auto_extract_hier():
     assert_equal(len(set(clust.labels_)), 6)
 
 
-@pytest.mark.parametrize("reach, n_child, members", [
+@pytest.mark.parametrize("reach, core_dist, n_child, members", [
     (np.array([np.inf, 0.9, 0.9, 1.0, 0.89, 0.88, 10, .9, .9, .9, 10, 0.9,
-               0.9, 0.89, 0.88, 10, .9, .9, .9, .9]), 2, np.r_[0:6]),
+               0.9, 0.89, 0.88, 10, .9, .9, .9, .9]),
+     np.array([np.inf, 0.9, 0.9, 1.0, 0.89, 0.88, 1, .9, .9, .9, 1, 0.9,
+               0.9, 0.89, 0.88, 1, .9, .9, .9, .9]), 2, np.r_[0:6]),
     (np.array([np.inf, 0.9, 0.9, 0.9, 0.89, 0.88, 10, .9, .9, .9, 10, 0.9,
-               0.9, 0.89, 0.88, 100, .9, .9, .9, .9]), 1, np.r_[0:15])])
-def test_cluster_sigmin_pruning(reach, n_child, members):
+               0.9, 0.89, 0.88, 100, .9, .9, .9, .9]),
+     np.array([np.inf, 0.9, 0.9, 0.9, 0.89, 0.88, 1, .9, .9, .9, 1, 0.9,
+               0.9, 0.89, 0.88, 1, .9, .9, .9, .9]), 1, np.r_[0:15])])
+def test_cluster_sigmin_pruning(reach, core_dist, n_child, members):
     # Tests pruning left and right, insignificant splitpoints, empty nodelists
     # Parameters chosen specifically for this task
 
@@ -159,7 +163,7 @@ def test_cluster_sigmin_pruning(reach, n_child, members):
     root = _TreeNode(ordering, 0, 20, None)
 
     # Build cluster tree inplace on root node
-    _cluster_tree(root, None, cluster_boundaries, reach, ordering,
+    _cluster_tree(root, None, cluster_boundaries, reach, core_dist, ordering,
                   5, .75, .7, .4, .3)
     assert_equal(root.split_point, cluster_boundaries[0])
     assert_equal(n_child, len(root.children))

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -57,15 +57,25 @@ def test_empty_extract():
 
 def test_bad_extract():
     # Test an extraction of eps too close to original eps
-    msg = "Specify an epsilon smaller than 0.015. Got 0.3."
+    msg = "Specify an epsilon smaller than 0.15. Got 0.3."
     centers = [[1, 1], [-1, -1], [1, -1]]
     X, labels_true = make_blobs(n_samples=750, centers=centers,
                                 cluster_std=0.4, random_state=0)
 
     # Compute OPTICS
-    clust = OPTICS(max_bound=5.0 * 0.003, min_samples=10)
+    clust = OPTICS(max_bound=5.0 * 0.03, min_samples=10)
     clust2 = clust.fit(X)
     assert_raise_message(ValueError, msg, clust2.extract_dbscan, 0.3)
+
+
+def test_bad_reachability():
+    msg = "All reachability values are inf. Set a larger max_bound."
+    centers = [[1, 1], [-1, -1], [1, -1]]
+    X, labels_true = make_blobs(n_samples=750, centers=centers,
+                                cluster_std=0.4, random_state=0)
+
+    clust = OPTICS(max_bound=5.0 * 0.003, min_samples=10)
+    assert_raise_message(ValueError, msg, clust.fit, X)
 
 
 def test_close_extract():

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -27,7 +27,7 @@ def test_correct_number_of_clusters():
     X = generate_clustered_data(n_clusters=n_clusters)
     # Parameters chosen specifically for this task.
     # Compute OPTICS
-    clust = OPTICS(max_bound=5.0 * 6.0, min_samples=4, metric='euclidean')
+    clust = OPTICS(max_eps=5.0 * 6.0, min_samples=4, metric='euclidean')
     clust.fit(X)
     # number of clusters, ignoring noise if present
     n_clusters_1 = len(set(clust.labels_)) - int(-1 in clust.labels_)
@@ -41,7 +41,7 @@ def test_minimum_number_of_sample_check():
 
     # Compute OPTICS
     X = [[1, 1]]
-    clust = OPTICS(max_bound=5.0 * 0.3, min_samples=10)
+    clust = OPTICS(max_eps=5.0 * 0.3, min_samples=10)
 
     # Run the fit
     assert_raise_message(ValueError, msg, clust.fit, X)
@@ -51,7 +51,7 @@ def test_empty_extract():
     # Test extract where fit() has not yet been run.
     msg = ("This OPTICS instance is not fitted yet. Call 'fit' with "
            "appropriate arguments before using this method.")
-    clust = OPTICS(max_bound=5.0 * 0.3, min_samples=10)
+    clust = OPTICS(max_eps=5.0 * 0.3, min_samples=10)
     assert_raise_message(ValueError, msg, clust.extract_dbscan, 0.01)
 
 
@@ -63,18 +63,18 @@ def test_bad_extract():
                                 cluster_std=0.4, random_state=0)
 
     # Compute OPTICS
-    clust = OPTICS(max_bound=5.0 * 0.03, min_samples=10)
+    clust = OPTICS(max_eps=5.0 * 0.03, min_samples=10)
     clust2 = clust.fit(X)
     assert_raise_message(ValueError, msg, clust2.extract_dbscan, 0.3)
 
 
 def test_bad_reachability():
-    msg = "All reachability values are inf. Set a larger max_bound."
+    msg = "All reachability values are inf. Set a larger max_eps."
     centers = [[1, 1], [-1, -1], [1, -1]]
     X, labels_true = make_blobs(n_samples=750, centers=centers,
                                 cluster_std=0.4, random_state=0)
 
-    clust = OPTICS(max_bound=5.0 * 0.003, min_samples=10)
+    clust = OPTICS(max_eps=5.0 * 0.003, min_samples=10)
     assert_raise_message(ValueError, msg, clust.fit, X)
 
 
@@ -86,7 +86,7 @@ def test_close_extract():
                                 cluster_std=0.4, random_state=0)
 
     # Compute OPTICS
-    clust = OPTICS(max_bound=1.0, min_samples=10)
+    clust = OPTICS(max_eps=1.0, min_samples=10)
     clust3 = clust.fit(X)
     # check warning when centers are passed
     assert_warns(RuntimeWarning, clust3.extract_dbscan, .3)
@@ -177,7 +177,7 @@ def test_multi_inf_in_reachability():
     C2 = [4, -1] + .1 * np.random.randn(n_points_per_cluster, 2)
     X = np.vstack((C1, np.array([[100, 200], [200, 300]]), C2))
 
-    clust = OPTICS(min_samples=2, max_bound=2).fit(X)
+    clust = OPTICS(min_samples=2, max_eps=2).fit(X)
 
     assert_array_equal(clust.labels_, np.r_[[0] * 3, -1, -1, [1] * 3])
     assert_array_equal(clust.reachability_[[0, 3, 4, 5]], [np.inf] * 4)

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -169,6 +169,20 @@ def test_auto_extract_no_outlier():
     assert_equal(set(clust.labels_), set([0, 1, 2, 3, 4, 5]))
 
 
+def test_multi_inf_in_reachability():
+    np.random.seed(0)
+    n_points_per_cluster = 3
+
+    C1 = [-5, -2] + .8 * np.random.randn(n_points_per_cluster, 2)
+    C2 = [4, -1] + .1 * np.random.randn(n_points_per_cluster, 2)
+    X = np.vstack((C1, np.array([[100, 200], [200, 300]]), C2))
+
+    clust = OPTICS(min_samples=2, max_bound=2).fit(X)
+
+    assert_array_equal(clust.labels_, np.r_[[0]*3, -1, -1, [1]*3])
+    assert_array_equal(clust.reachability_[[0, 3, 4, 5]], [np.inf] * 4)
+
+
 def test_auto_extract_outlier():
     np.random.seed(0)
     n_points_per_cluster = 4
@@ -183,11 +197,11 @@ def test_auto_extract_outlier():
 
     C1 = [-5, -2] + .8 * np.random.randn(n_points_per_cluster, 2)
     C2 = [4, -1] + .1 * np.random.randn(n_points_per_cluster, 2)
-    X = np.vstack((C1, np.array([[100, 200]]), C2))
+    X = np.vstack((C1, np.array([[100, 200], [200, 300]]), C2))
 
     clust = OPTICS(min_samples=3).fit(X)
 
-    assert_array_equal(clust.labels_, np.r_[[0]*4, -1, [1]*4])
+    assert_array_equal(clust.labels_, np.r_[[0]*4, -1, -1, [1]*4])
 
 
 @pytest.mark.parametrize("reach, core_dist, n_child, members", [

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -137,7 +137,47 @@ def test_auto_extract_hier():
     # Run the fit
     clust.fit(X)
 
-    assert_equal(len(set(clust.labels_)), 6)
+    assert_equal(set(clust.labels_), set([-1, 0, 1, 2, 3, 4]))
+
+
+def test_auto_extract_no_outlier():
+    np.random.seed(0)
+    n_points_per_cluster = 100
+    C1 = [-50, -20] + .08 * np.random.randn(n_points_per_cluster, 2)
+    C2 = [40, -10] + .01 * np.random.randn(n_points_per_cluster, 2)
+    C3 = [10, -20] + .02 * np.random.randn(n_points_per_cluster, 2)
+    C4 = [-20, 30] + .03 * np.random.randn(n_points_per_cluster, 2)
+    C5 = [30, -20] + .06 * np.random.randn(n_points_per_cluster, 2)
+    C6 = [50, 60] + .02 * np.random.randn(n_points_per_cluster, 2)
+    X = np.vstack((C1, C2, C3, C4, C5, C6))
+
+    clust = OPTICS(min_samples=4)
+
+    clust.fit(X)
+
+    # there should be no outliers detected
+    assert_equal(set(clust.labels_), set([0, 1, 2, 3, 4, 5]))
+
+
+def test_auto_extract_outlier():
+    np.random.seed(0)
+    n_points_per_cluster = 4
+
+    C1 = [-5, -2] + .8 * np.random.randn(n_points_per_cluster, 2)
+    C2 = [4, -1] + .1 * np.random.randn(n_points_per_cluster, 2)
+    X = np.vstack((C1, C2, np.array([[100, 200]])))
+
+    clust = OPTICS(min_samples=3).fit(X)
+
+    assert_array_equal(clust.labels_, np.r_[[0]*4, [1]*4, -1])
+
+    C1 = [-5, -2] + .8 * np.random.randn(n_points_per_cluster, 2)
+    C2 = [4, -1] + .1 * np.random.randn(n_points_per_cluster, 2)
+    X = np.vstack((C1, np.array([[100, 200]]), C2))
+
+    clust = OPTICS(min_samples=3).fit(X)
+
+    assert_array_equal(clust.labels_, np.r_[[0]*4, -1, [1]*4])
 
 
 @pytest.mark.parametrize("reach, core_dist, n_child, members", [

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -179,7 +179,7 @@ def test_multi_inf_in_reachability():
 
     clust = OPTICS(min_samples=2, max_bound=2).fit(X)
 
-    assert_array_equal(clust.labels_, np.r_[[0]*3, -1, -1, [1]*3])
+    assert_array_equal(clust.labels_, np.r_[[0] * 3, -1, -1, [1] * 3])
     assert_array_equal(clust.reachability_[[0, 3, 4, 5]], [np.inf] * 4)
 
 
@@ -193,7 +193,7 @@ def test_auto_extract_outlier():
 
     clust = OPTICS(min_samples=3).fit(X)
 
-    assert_array_equal(clust.labels_, np.r_[[0]*4, [1]*4, -1])
+    assert_array_equal(clust.labels_, np.r_[[0] * 4, [1] * 4, -1])
 
     C1 = [-5, -2] + .8 * np.random.randn(n_points_per_cluster, 2)
     C2 = [4, -1] + .1 * np.random.randn(n_points_per_cluster, 2)
@@ -201,7 +201,7 @@ def test_auto_extract_outlier():
 
     clust = OPTICS(min_samples=3).fit(X)
 
-    assert_array_equal(clust.labels_, np.r_[[0]*4, -1, -1, [1]*4])
+    assert_array_equal(clust.labels_, np.r_[[0] * 4, -1, -1, [1] * 4])
 
 
 @pytest.mark.parametrize("reach, core_dist, n_child, members", [


### PR DESCRIPTION
Fixes #11677, i.e.

- Count split points as a member of the cluster if they're not far from the cluster 
- Detect the single outlier if it's the last point in `ordering_`

Adds an example to the docstring (See #3846)

Fixes the numerical warnings when there's more than one `np.inf` present in `reachability_`, which happens if `max_bound` is small (default is `np.inf`).