### PR TITLE
FIX towards disregarding multi_class in the case of binary y

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -440,10 +440,11 @@ Support for Python 3.3 has been officially dropped.
   incorrect results in :class:`linear_model.LogisticRegressionCV`.
   :issue:`11724` by :user:`Nicolas Hug <NicolasHug>`.
 
-- |Fix| Fixed a bug in :class:`linear_model.LogisticRegression` where when using
-  the parameter ``multi_class='multinomial'``, the ``predict_proba`` method was
-  returning incorrect probabilities in the case of binary outcomes.
-  :issue:`9939` by :user:`Roger Westover <rwolst>`.
+- |Fix| Fixed a bug in :class:`linear_model.LogisticRegression` where incorrect
+  coefficients and probabilities were reported for binary targets if
+  ``multi_class='multinomial'``.
+  ``multi_class`` is now disregarded for binary targets.
+  :issue:`XXX` by :user:`Roger Westover <rwolst>` and `Joel Nothman`_.
 
 - |Fix| Fixed a bug in :class:`linear_model.LogisticRegressionCV` where the
   ``score`` method always computes accuracy, not the metric given by
@@ -764,7 +765,6 @@ Support for Python 3.3 has been officially dropped.
 - |Fix| Fixed a bug in :class:`naive_bayes.MultinomialNB` which did not accept
   vector valued pseudocounts (alpha).
   :issue:`10346` by :user:`Tobias Madsen <TobiasMadsen>`
-
 
 :mod:`sklearn.neighbors`
 ........................

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -608,7 +608,8 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
     if classes.size <= 2:
         multi_class = 'ovr'
         # np.unique(y) gives labels in sorted order.
-        pos_class = classes[1]
+        if pos_class is None:
+            pos_class = classes[1]
     elif multi_class == 'ovr' and pos_class is None:
         raise ValueError('To fit OvR, use the pos_class argument')
 

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -247,23 +247,6 @@ def test_multinomial_binary(solver):
     assert_greater(np.mean(pred == target), .9)
 
 
-def test_multinomial_binary_probabilities():
-    # Test multinomial LR gives expected probabilities based on the
-    # decision function, for a binary problem.
-    X, y = make_classification()
-    clf = LogisticRegression(multi_class='multinomial', solver='saga')
-    clf.fit(X, y)
-
-    decision = clf.decision_function(X)
-    proba = clf.predict_proba(X)
-
-    expected_proba_class_1 = (np.exp(decision) /
-                              (np.exp(decision) + np.exp(-decision)))
-    expected_proba = np.c_[1-expected_proba_class_1, expected_proba_class_1]
-
-    assert_almost_equal(proba, expected_proba)
-
-
 def test_sparsify():
     # Test sparsify and densify members.
     n_samples, n_features = iris.data.shape
@@ -1327,3 +1310,22 @@ def test_logistic_regression_path_coefs_multinomial():
         assert_array_almost_equal(coefs[0], coefs[2], decimal=1)
     with pytest.raises(AssertionError):
         assert_array_almost_equal(coefs[1], coefs[2], decimal=1)
+
+
+@pytest.mark.parametrize('est', [LogisticRegression(),
+                                 LogisticRegressionCV(cv=3)])
+@pytest.mark.parametrize('solver', ['newton-cg', 'lbfgs', 'sag', 'saga'])
+def test_logistic_binary_invariant_to_multi_class(est, solver):
+    # Make sure that multi_class does not affect binary classification
+    X, y = make_classification(n_samples=200, n_classes=2, n_informative=2,
+                               n_redundant=0, n_clusters_per_class=1,
+                               random_state=0, n_features=2)
+    est.set_params(multi_class='ovr', solver=solver, max_iter=10000)
+    est.fit(X, y)
+    model_ovr = np.hstack([np.squeeze(est.coef_), est.intercept_])
+    assert est.coef_.shape == (1, X.shape[1])
+    est.set_params(multi_class='multinomial')
+    est.fit(X, y)
+    assert est.coef_.shape == (1, X.shape[1])
+    model_multi = np.hstack([np.squeeze(est.coef_), est.intercept_])
+    assert_allclose(model_ovr, model_multi, rtol=0.01)


### PR DESCRIPTION
This is not quite ready. Apparently just changing `:` to `...` wasn't the quick fix I needed.