### PR TITLE
[WIP] No longer use SVD for fastica

### DIFF
--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -309,10 +309,13 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
         X -= X_mean[:, np.newaxis]
 
         # Whitening and preprocessing by PCA
-        u, d, _ = linalg.svd(X, full_matrices=False)
+        d, u = linalg.eigh(X.dot(X.T))
 
-        del _
-        K = (u / d).T[:n_components]  # see (6.33) p.140
+        eps = np.finfo(float).eps  # For numerical precision
+        d[d < eps] = eps
+
+        K = (u / np.sqrt(d)).T[:n_components]  # see (6.33) p.140
+
         del u, d
         X1 = np.dot(K, X)
         # see (13.6) p.267 Here X1 is white and data

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -150,8 +150,8 @@ def _cube(x, fun_args):
 
 def fastica(X, n_components=None, algorithm="parallel", whiten=True,
             fun="logcosh", fun_args=None, max_iter=200, tol=1e-04, w_init=None,
-            random_state=None, return_X_mean=False, compute_sources=True,
-            return_n_iter=False, svd_solver='svd'):
+            svd_solver='svd', random_state=None, return_X_mean=False,
+            compute_sources=True, return_n_iter=False):
     """Perform Fast Independent Component Analysis.
 
     Read more in the :ref:`User Guide <ICA>`.

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -309,13 +309,15 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
         X -= X_mean[:, np.newaxis]
 
         # Whitening and preprocessing by PCA
-        d, u = linalg.eigh(X.dot(X.T))
-
-        eps = np.finfo(float).eps  # For numerical precision
-        d[d < eps] = eps
-
-        K = (u / np.sqrt(d)).T[:n_components]  # see (6.33) p.140
-
+        if n > p:
+            u, d, _ = linalg.svd(X, full_matrices=False)
+        else:
+            D, u = linalg.eigh(X.dot(X.T))  # Faster when n < p
+            eps = np.finfo(np.double).eps
+            D[D < eps] = eps  # For numerical issues
+            d = np.sqrt(D)
+            del D
+        K = (u / d).T[:n_components]  # see (6.33) p.140
         del u, d
         X1 = np.dot(K, X)
         # see (13.6) p.267 Here X1 is white and data

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -115,8 +115,10 @@ def test_fastica_simple(add_noise=False):
             assert_almost_equal(np.dot(s2_, s2) / n_samples, 1, decimal=1)
 
     # Test FastICA class
-    _, _, sources_fun = fastica(m.T, fun=nl, algorithm=algo, random_state=0)
-    ica = FastICA(fun=nl, algorithm=algo, random_state=0)
+    _, _, sources_fun = fastica(m.T, fun=nl, algorithm=algo, random_state=0,
+                                svd_solver='eigh')
+    ica = FastICA(fun=nl, algorithm=algo, random_state=0,
+                  svd_solver='eigh')
     sources = ica.fit_transform(m.T)
     assert_equal(ica.components_.shape, (2, 2))
     assert_equal(sources.shape, (1000, 2))


### PR DESCRIPTION
In most use cases, ICA is performed on arrays with `p << n` . In this case, using `linalg.svd` can be order of magnitude slower than just computing the eigen decompostion of `X.dot(X.T)`:


    In [1]: import numpy as np

    In [2]: X = np.random.randn(10, 1000)

    In [3]: %timeit np.linalg.svd(X)
    36.9 ms ± 1.39 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

    In [4]: %timeit np.linalg.eigh(X.dot(X.T))
    73.7 µs ± 4.25 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)


And then, SVD becomes the bottleneck of ICA!


Now, this PR breaks one test because of numerical issues (where the problem is degenerate), and I don't really know how to fix this. I do not think that this problem is likely to happen on any real case application though.



(Note that does not slow things down when `p` and `n` are similar, and is only slower when `p` is much larger than `n`. This hardly ever occurs in practice.)