### PR TITLE
[MRG] Added 'l2' as acceptable input for loss in l1_min_c()

### DIFF
--- a/sklearn/svm/bounds.py
+++ b/sklearn/svm/bounds.py
@@ -51,8 +51,8 @@ def l1_min_c(X, y, loss='squared_hinge', fit_intercept=True,
     l1_min_c : float
         minimum value for C
     """
-    if loss not in ('squared_hinge', 'log', 'l2'):
-        raise ValueError('loss type not in ("squared_hinge", "log", "l2")')
+    if loss not in ('squared_hinge', 'log'):
+        raise ValueError('loss type not in ("squared_hinge", "log")')
 
     X = check_array(X, accept_sparse='csc')
     check_consistent_length(X, y)

--- a/sklearn/svm/bounds.py
+++ b/sklearn/svm/bounds.py
@@ -51,7 +51,7 @@ def l1_min_c(X, y, loss='squared_hinge', fit_intercept=True,
     l1_min_c : float
         minimum value for C
     """
-    if loss not in ('squared_hinge', 'log'):
+    if loss not in ('squared_hinge', 'log', 'l2'):
         raise ValueError('loss type not in ("squared_hinge", "log", "l2")')
 
     X = check_array(X, accept_sparse='csc')


### PR DESCRIPTION
Fixes #11851

Currently, passing `"l2"` to `loss` parameter raises `ValueError` in `l1_min_c()`.
Added `"l2"` as acceptable input for `loss`.
