### PR TITLE
MRG/REL fixes /skips for 32bit tests

### DIFF
--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -10,7 +10,7 @@ from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils.extmath import safe_sparse_dot
 from sklearn.utils.testing import (assert_raises, assert_true, assert_false,
                                    assert_warns, assert_raise_message,
-                                   ignore_warnings)
+                                   ignore_warnings, skip_if_32bit)
 
 # test sample 1
 X = np.array([[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]])
@@ -71,6 +71,7 @@ def check_svm_model_equal(dense_svm, sparse_svm, X_train, y_train, X_test):
         assert_raise_message(ValueError, msg, dense_svm.predict, X_test)
 
 
+@skip_if_32bit
 def test_svc():
     """Check that sparse SVC gives the same result as SVC"""
     # many class dataset:
@@ -265,6 +266,7 @@ def test_sparse_liblinear_intercept_handling():
     test_svm.test_dense_liblinear_intercept_handling(svm.LinearSVC)
 
 
+@skip_if_32bit
 def test_sparse_oneclasssvm():
     # Check that sparse OneClassSVM gives the same result as dense OneClassSVM
     # many class dataset:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1545,7 +1545,7 @@ def check_outliers_train(name, estimator_orig, readonly_memmap=True):
     y_scores = estimator.score_samples(X)
     assert y_scores.shape == (n_samples,)
     y_dec = y_scores - estimator.offset_
-    assert_array_almost_equal(y_dec, decision)
+    assert_allclose(y_dec, decision)
 
     # raises error on malformed input for score_samples
     assert_raises(ValueError, estimator.score_samples, X.T)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1545,7 +1545,7 @@ def check_outliers_train(name, estimator_orig, readonly_memmap=True):
     y_scores = estimator.score_samples(X)
     assert y_scores.shape == (n_samples,)
     y_dec = y_scores - estimator.offset_
-    assert_array_equal(y_dec, decision)
+    assert_array_almost_equal(y_dec, decision)
 
     # raises error on malformed input for score_samples
     assert_raises(ValueError, estimator.score_samples, X.T)


### PR DESCRIPTION
Fixes part of #11878. Don't use equal on floats. Also skip some tests on 32bit.