### PR TITLE
[MRG + 1] Quick fix for test_classification_report_dictionary_output on 32 bits

### DIFF
--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -140,7 +140,14 @@ def test_classification_report_dictionary_output():
         y_true, y_pred, labels=np.arange(len(iris.target_names)),
         target_names=iris.target_names, output_dict=True)
 
-    assert_dict_equal(report, expected_report)
+    # assert the 2 dicts are equal.
+    assert(report.keys() == expected_report.keys())
+    for key in expected_report:
+        assert report[key].keys() == expected_report[key].keys()
+        for metric in expected_report[key]:
+            assert_almost_equal(expected_report[key][metric],
+                                report[key][metric])
+
     assert type(expected_report['setosa']['precision']) == float
     assert type(expected_report['macro avg']['precision']) == float
     assert type(expected_report['setosa']['support']) == int


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Partial fix for #11878 

#### What does this implement/fix? Explain your changes.

Float values are compared with almost_equal instead of strict equality

#### Any other comments?
This is just a quick fix. As mentioned by @amueller  it would be best to have a `assert_deep_almost_equal` helper. I'll work on that soon. EDIT: implemented this in #11882.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
