### PR TITLE
[MRG]  Implemented assert_deep_almost_equal

### DIFF
--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -140,7 +140,14 @@ def test_classification_report_dictionary_output():
         y_true, y_pred, labels=np.arange(len(iris.target_names)),
         target_names=iris.target_names, output_dict=True)
 
-    assert_dict_equal(report, expected_report)
+    # assert the 2 dicts are equal.
+    assert(report.keys() == expected_report.keys())
+    for key in expected_report:
+        assert report[key].keys() == expected_report[key].keys()
+        for metric in expected_report[key]:
+            assert_almost_equal(expected_report[key][metric],
+                                report[key][metric])
+
     assert type(expected_report['setosa']['precision']) == float
     assert type(expected_report['macro avg']['precision']) == float
     assert type(expected_report['setosa']['support']) == int

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -27,6 +27,7 @@ from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import ignore_warnings
+from sklearn.utils.testing import assert_deep_almost_equal
 from sklearn.utils.mocking import MockDataFrame
 
 from sklearn.metrics import accuracy_score
@@ -140,14 +141,7 @@ def test_classification_report_dictionary_output():
         y_true, y_pred, labels=np.arange(len(iris.target_names)),
         target_names=iris.target_names, output_dict=True)
 
-    # assert the 2 dicts are equal.
-    assert(report.keys() == expected_report.keys())
-    for key in expected_report:
-        assert report[key].keys() == expected_report[key].keys()
-        for metric in expected_report[key]:
-            assert_almost_equal(expected_report[key][metric],
-                                report[key][metric])
-
+    assert_deep_almost_equal(report, expected_report)
     assert type(expected_report['setosa']['precision']) == float
     assert type(expected_report['macro avg']['precision']) == float
     assert type(expected_report['setosa']['support']) == int

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -3,6 +3,7 @@ import unittest
 import sys
 import os
 import atexit
+from copy import deepcopy
 
 import numpy as np
 
@@ -29,7 +30,9 @@ from sklearn.utils.testing import (
     assert_raises_regex,
     TempMemmap,
     create_memmap_backed_data,
-    _delete_folder)
+    _delete_folder,
+    assert_deep_almost_equal)
+
 
 from sklearn.utils.testing import SkipTest
 from sklearn.tree import DecisionTreeClassifier
@@ -557,3 +560,22 @@ def test_create_memmap_backed_data(monkeypatch):
     for input_array, data in zip(input_list, mmap_data_list):
         check_memmap(input_array, data)
     assert registration_counter.nb_calls == 4
+
+
+def test_assert_deep_almost_equal():
+
+    a = [{'a': 3, 'b': 'hello', 'c': {}}, [1, 2, 3]]
+    b = [{'a': 3, 'b': 'hello', 'c': {}}, [1, 2, 3 + 1e-7]]
+    c = [{'a': 3, 'b': 'hello', 'c': {}}, [1, 2, 3 + 1e-6]]
+    d = [{'a': 8, 'b': 'hello', 'c': {}}, [1, 2, 3]]
+    e = deepcopy(a)
+    e[0]['c']['a'] = 0  # just add key to a nested dict
+
+    assert_deep_almost_equal(a, a)
+    assert_deep_almost_equal(a, b, decimal=7)
+    with pytest.raises(AssertionError):
+        assert_deep_almost_equal(a, c, decimal=7)
+    with pytest.raises(AssertionError):
+        assert_deep_almost_equal(a, d)
+    with pytest.raises(AssertionError):
+        assert_deep_almost_equal(a, e)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Partial fix for #11878 

#### What does this implement/fix? Explain your changes.

This PR implements the `assert_deep_almost_equal` that recursively checks nested objects and applies `assert_almost_equal` to numbers instead of strict equality.

It is also used in a test that would fail on 32 bit plateforms () precisely because strict equality is used to check nested dictionaries (see #11878)

#### Any other comments?

Closes #11881 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
