### PR TITLE
[WIP] Information Gain Ratio for decision trees (Issue #6821)

### DIFF
--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -52,7 +52,7 @@ from sklearn import datasets
 
 from sklearn.utils import compute_sample_weight
 
-CLF_CRITERIONS = ("gini", "entropy")
+CLF_CRITERIONS = ("gini", "entropy", "gain_ratio")
 REG_CRITERIONS = ("mse", "mae", "friedman_mse")
 
 CLF_TREES = {

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -57,7 +57,8 @@ __all__ = ["DecisionTreeClassifier",
 DTYPE = _tree.DTYPE
 DOUBLE = _tree.DOUBLE
 
-CRITERIA_CLF = {"gini": _criterion.Gini, "entropy": _criterion.Entropy}
+CRITERIA_CLF = {"gini": _criterion.Gini, "entropy": _criterion.Entropy,
+                "gain_ratio": _criterion.GainRatio}
 CRITERIA_REG = {"mse": _criterion.MSE, "friedman_mse": _criterion.FriedmanMSE,
                 "mae": _criterion.MAE}
 


### PR DESCRIPTION
Treats #6821

Class GainRatio inherits from Entropy and only overwrites the impurity_improvements functions
of the Criterion super class

Adds gain_ratio as parameters to the respective test file.

TODO's

[X] Provide Code for GainRatio
[X] Extend criteria in tests_tree.py by gain_ratio
[ ] Documentation in _criterion.pyx, tree.py 
[ ] Provide example in examples folder
[ ] Add content to documentation 
[X] Provide a performance analysis, specifically since the criterion does not and can not use a real proxy_impurity_improvement function

Specifically I implemented balanced gain ratio. Code removes some edge cases and makes it to be coded easier
Sources:
http://hunch.net/~coms-4771/quinlan.pdf
https://arxiv.org/pdf/1801.08310.pdf


#### Reference Issues/PRs
Fixes #6821 


#### What does this implement/fix? Explain your changes.
Implements the (balanced) gain ratio criterion for decision trees

#### Any other comments?
It might be also possible, to modify the Criterion class and passing a ratio keyword. Then, one could would directly get a gini gain ratio. I did not create a class on the same level as Entropy to avoid duplicate code. Essentially, the impurity improvement is all that needs to be changed.
Any feedback is welcome