### PR TITLE
modify test_sparse_oneclasssvm to be parametrized(#11880)

### DIFF
--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -268,7 +268,7 @@ def test_sparse_liblinear_intercept_handling():
 
 @pytest.mark.parametrize("datasets_index", range(4))
 @pytest.mark.parametrize("kernel", ["linear", "poly", "rbf", "sigmoid"])
-def test_sparse_oneclasssvm(datasets_index,kernel):
+def test_sparse_oneclasssvm(datasets_index, kernel):
     # Check that sparse OneClassSVM gives the same result as dense OneClassSVM
     # many class dataset:
     X_blobs, _ = make_blobs(n_samples=100, centers=10, random_state=0)

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -10,10 +10,9 @@ from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils.extmath import safe_sparse_dot
 from sklearn.utils.testing import (assert_raises, assert_true, assert_false,
                                    assert_warns, assert_raise_message,
-                                   ignore_warnings, skip_if_32bit)                                
+                                   ignore_warnings, skip_if_32bit)
 import pytest
 
-                                   
 
 # test sample 1
 X = np.array([[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]])
@@ -267,7 +266,6 @@ def test_sample_weights():
 def test_sparse_liblinear_intercept_handling():
     # Test that sparse liblinear honours intercept_scaling param
     test_svm.test_dense_liblinear_intercept_handling(svm.LinearSVC)
-
 
 
 @pytest.mark.parametrize("datasets_index", range(4))

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -11,6 +11,7 @@ from sklearn.utils.extmath import safe_sparse_dot
 from sklearn.utils.testing import (assert_raises, assert_true, assert_false,
                                    assert_warns, assert_raise_message,
                                    ignore_warnings)
+import pytest
 
 # test sample 1
 X = np.array([[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]])
@@ -265,21 +266,20 @@ def test_sparse_liblinear_intercept_handling():
     test_svm.test_dense_liblinear_intercept_handling(svm.LinearSVC)
 
 
-def test_sparse_oneclasssvm():
+@pytest.mark.parametrize("datasets_index", range(4))
+@pytest.mark.parametrize("kernel", ["linear", "poly", "rbf", "sigmoid"])
+def test_sparse_oneclasssvm(datasets_index,kernel):
     # Check that sparse OneClassSVM gives the same result as dense OneClassSVM
     # many class dataset:
     X_blobs, _ = make_blobs(n_samples=100, centers=10, random_state=0)
     X_blobs = sparse.csr_matrix(X_blobs)
-
     datasets = [[X_sp, None, T], [X2_sp, None, T2],
                 [X_blobs[:80], None, X_blobs[80:]],
                 [iris.data, None, iris.data]]
-    kernels = ["linear", "poly", "rbf", "sigmoid"]
-    for dataset in datasets:
-        for kernel in kernels:
-            clf = svm.OneClassSVM(gamma='scale', kernel=kernel)
-            sp_clf = svm.OneClassSVM(gamma='scale', kernel=kernel)
-            check_svm_model_equal(clf, sp_clf, *dataset)
+    dataset = datasets[datasets_index]
+    clf = svm.OneClassSVM(gamma='scale', kernel=kernel)
+    sp_clf = svm.OneClassSVM(gamma='scale', kernel=kernel)
+    check_svm_model_equal(clf, sp_clf, *dataset)
 
 
 def test_sparse_realdata():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
this modify the test_sparse_oneclasssvm to be parametrized using the list of possible kernels and
datasets so that each test is being run separately instead of stopping at a single failed test at referenced in (#11880) 

#### Any other comments?
The current change will cause the initialization to be rerun multiple time and I use a magic number to change the input parameter by using a index instead of the datasets. I am not that familiar with pytest, but I believe there is a way to parametrize without using magic number. But right now this will do.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
