### PR TITLE
[MRG] TST/FIX stop optics reachability failure on 32bit

### DIFF
--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -408,5 +408,8 @@ def test_reach_dists():
 
     # FIXME: known failure in 32bit Linux; numerical imprecision results in
     # different ordering in quick_scan
-    assert_allclose(clust.reachability_, np.array(v),
-                    rtol=0.01 if _IS_32BIT else 1e-7)
+    if _IS_32BIT:
+        assert_allclose(clust.reachability_, np.array(v), rtol=1e-2)
+    else:
+        # we compare to truncated decimals, so use atol
+        assert_allclose(clust.reachability_, np.array(v), atol=1e-5)

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -12,7 +12,6 @@ from sklearn.cluster.optics_ import _find_local_maxima
 from sklearn.metrics.cluster import contingency_matrix
 from sklearn.cluster.dbscan_ import DBSCAN
 from sklearn.utils.testing import assert_equal, assert_warns
-from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_allclose

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -408,7 +408,7 @@ def test_reach_dists():
 
     # FIXME: known failure in 32bit Linux; numerical imprecision results in
     # different ordering in quick_scan
-    if _IS_32BIT:
+    if _IS_32BIT:  # pragma: no cover
         assert_allclose(clust.reachability_, np.array(v), rtol=1e-2)
     else:
         # we compare to truncated decimals, so use atol

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -15,6 +15,8 @@ from sklearn.utils.testing import assert_equal, assert_warns
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raise_message
+from sklearn.utils.testing import assert_allclose
+from sklearn.utils import _IS_32BIT
 
 from sklearn.cluster.tests.common import generate_clustered_data
 
@@ -405,4 +407,7 @@ def test_reach_dists():
          1.364861, 0.459580, 1.025370, 0.980304, 0.607592, 0.533907, 1.134650,
          0.446161, 0.629962]
 
-    assert_array_almost_equal(clust.reachability_, np.array(v))
+    # FIXME: known failure in 32bit Linux; numerical imprecision results in
+    # different ordering in quick_scan
+    assert_allclose(clust.reachability_, np.array(v),
+                    rtol=0.01 if _IS_32BIT else 1e-7)


### PR DESCRIPTION
`test_reach_dists` is currently failing on 32 bit linux

As per discussion at https://github.com/scikit-learn/scikit-learn/pull/11857#issuecomment-415823094, this is due to numerical imprecision issues.

I'm not convinced that the fix proposed there is correct. I think that if a large succession of rdist entries differed by small amounts, `quick_scan` could return a very incorrect result, whereas now at least the results are arguably valid if platform-dependent.

It would be good to investigate downstream whether there is some point in which we translate the data to machine precision, or whether it is just a matter of ?unavoidable instability.

This should be the last issue to fix before the wheels come clean: https://github.com/MacPython/scikit-learn-wheels/pull/7