### PR TITLE
[MRG] MNT: Use `nrm2` to find the residuals squared

### DIFF
--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -411,8 +411,7 @@ def _update_dict(dictionary, Y, code, verbose=False, return_r2=False,
             # R <- -1.0 * U_k * V_k^T + R
             R = ger(-1.0, dictionary[:, k], code[k, :], a=R, overwrite_a=True)
     if return_r2:
-        R **= 2
-        R = R.sum()
+        R = nrm2(R) ** 2.0
         return dictionary, R
     return dictionary
 


### PR DESCRIPTION
Using BLAS's `nrm2` is a bit faster than squaring the residuals in-place and summing them. So switch to using `nrm2` instead. Interestingly it doesn't appear necessary to flatten the array first as the BLAS function interprets the array as flat under the hood.