### PR TITLE
Correcting OneClassSVM.fit() Signature

### DIFF
--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -1108,7 +1108,7 @@ class OneClassSVM(BaseLibSVM, OutlierMixin):
             shrinking, False, cache_size, None, verbose, max_iter,
             random_state)
 
-    def fit(self, X, y=None, sample_weight=None, **params):
+    def fit(self, X, sample_weight=None, **params):
         """
         Detects the soft boundary of the set of samples X.
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -1108,7 +1108,7 @@ class OneClassSVM(BaseLibSVM, OutlierMixin):
             shrinking, False, cache_size, None, verbose, max_iter,
             random_state)
 
-    def fit(self, X, sample_weight=None, **params):
+    def fit(self, X, sample_weight=None):
         """
         Detects the soft boundary of the set of samples X.
 
@@ -1137,7 +1137,7 @@ class OneClassSVM(BaseLibSVM, OutlierMixin):
                           " be removed in version 0.22.", DeprecationWarning)
 
         super(OneClassSVM, self).fit(X, np.ones(_num_samples(X)),
-                                     sample_weight=sample_weight, **params)
+                                     sample_weight=sample_weight)
         self.offset_ = -self._intercept_
         return self
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -1176,8 +1176,7 @@ class OneClassSVM(BaseLibSVM, OutlierMixin):
         """
         Perform classification on samples in X.
 
-        For an one-class model, +1 or -1 is returned.
-        Label +1 implies that the sample predicted to be an outlier (or novel).
+        For an one-class model, +1 (inlier) or -1 (outlier) is returned.
 
         Parameters
         ----------

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -1177,6 +1177,7 @@ class OneClassSVM(BaseLibSVM, OutlierMixin):
         Perform classification on samples in X.
 
         For an one-class model, +1 or -1 is returned.
+        Label +1 implies that the sample predicted to be an outlier (or novel).
 
         Parameters
         ----------


### PR DESCRIPTION


#### What does this implement/fix? Explain your changes.

The signature of `OneClassSVM.fit()` method has an unexpected `y=None` in its signature, although its not being used or documented under Parameters. Moreover `kwargs` capturing is unncessary as its not documented or expected, and super-class method doesn't take them anyways.

#### Any other comments?

Perhaps this was a design decision to try match the signatures in `BaseLibSVM` class, but I don't think this is a good idea. 

