### PR TITLE
DOCS: noting y is present in one-class fit methods merely for API consistency

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -342,9 +342,12 @@ class ClusterMixin(object):
         X : ndarray, shape (n_samples, n_features)
             Input data.
 
+        y : Ignored
+            not used, present for API consistency by convention.
+
         Returns
         -------
-        y : ndarray, shape (n_samples,)
+        labels : ndarray, shape (n_samples,)
             cluster labels
         """
         # non-optimized default implementation; override when a better

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -494,6 +494,9 @@ class OutlierMixin(object):
         X : ndarray, shape (n_samples, n_features)
             Input data.
 
+        y : Ignored
+            not used, present for API consistency by convention.
+
         Returns
         -------
         y : ndarray, shape (n_samples,)

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -948,6 +948,7 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
             copy if the given data is not C-contiguous.
 
         y : Ignored
+            not used, present here for API consistency by convention.
 
         sample_weight : array-like, shape (n_samples,), optional
             The weights for each observation in X. If None, all observations
@@ -979,6 +980,7 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
             New data to transform.
 
         y : Ignored
+            not used, present here for API consistency by convention.
 
         sample_weight : array-like, shape (n_samples,), optional
             The weights for each observation in X. If None, all observations
@@ -1002,6 +1004,7 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
             New data to transform.
 
         y : Ignored
+            not used, present here for API consistency by convention.
 
         sample_weight : array-like, shape (n_samples,), optional
             The weights for each observation in X. If None, all observations
@@ -1081,6 +1084,7 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
             New data.
 
         y : Ignored
+            not used, present here for API consistency by convention.
 
         sample_weight : array-like, shape (n_samples,), optional
             The weights for each observation in X. If None, all observations
@@ -1473,6 +1477,7 @@ class MiniBatchKMeans(KMeans):
             if the given data is not C-contiguous.
 
         y : Ignored
+            not used, present here for API consistency by convention.
 
         sample_weight : array-like, shape (n_samples,), optional
             The weights for each observation in X. If None, all observations
@@ -1654,6 +1659,7 @@ class MiniBatchKMeans(KMeans):
             X will be copied if it is not C-contiguous.
 
         y : Ignored
+            not used, present here for API consistency by convention.
 
         sample_weight : array-like, shape (n_samples,), optional
             The weights for each observation in X. If None, all observations

--- a/sklearn/covariance/elliptic_envelope.py
+++ b/sklearn/covariance/elliptic_envelope.py
@@ -103,7 +103,10 @@ class EllipticEnvelope(MinCovDet, OutlierMixin):
         ----------
         X : numpy array or sparse matrix, shape (n_samples, n_features).
             Training data
-        y : (ignored)
+
+        y : Ignored
+            not used, present for API consistency by convention.
+
         """
         super(EllipticEnvelope, self).fit(X)
         self.offset_ = np.percentile(-self.dist_, 100. * self.contamination)

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -200,6 +200,9 @@ class IsolationForest(BaseBagging, OutlierMixin):
         sample_weight : array-like, shape = [n_samples] or None
             Sample weights. If None, then samples are equally weighted.
 
+        y : Ignored
+            not used, present for API consistency by convention.
+
         Returns
         -------
         self : object

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -139,9 +139,9 @@ def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
     Returns
     -------
     score : float
-        If ``normalize == True``, return the correctly classified samples
-        (float), else it returns the number of correctly classified samples
-        (int).
+        If ``normalize == True``, return the fraction of correctly
+        classified samples (float), else returns the number of correctly
+        classified samples (int).
 
         The best performance is 1 with ``normalize == True`` and the number
         of samples with ``normalize == False``.

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -171,6 +171,9 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin,
             The query sample or samples to compute the Local Outlier Factor
             w.r.t. to the training samples.
 
+        y : Ignored
+            not used, present for API consistency by convention.
+
         Returns
         -------
         is_inlier : array, shape (n_samples,)
@@ -218,6 +221,9 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin,
         X : {array-like, sparse matrix, BallTree, KDTree}
             Training data. If array or matrix, shape [n_samples, n_features],
             or [n_samples, n_samples] if metric='precomputed'.
+
+        y : Ignored
+            not used, present for API consistency by convention.
 
         Returns
         -------

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -1122,6 +1122,9 @@ class OneClassSVM(BaseLibSVM, OutlierMixin):
             Per-sample weights. Rescale C per sample. Higher weights
             force the classifier to put more emphasis on these points.
 
+        y : Ignored
+            not used, present for API consistency by convention.
+
         Returns
         -------
         self : object


### PR DESCRIPTION
This is a continuation of and closes #11933 