### PR TITLE
MNT bump to version 0.21.dev0

### DIFF
--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -44,7 +44,7 @@ warnings.filterwarnings('always', category=DeprecationWarning,
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.20.dev0'
+__version__ = '0.21.dev0'
 
 
 try:


### PR DESCRIPTION
I have branched [0.20.X](https://github.com/scikit-learn/scikit-learn/tree/0.20.X) and tagged `0.20rc1`