### PR TITLE
CI Handle new branch in scikit-learn.github.io

### DIFF
--- a/build_tools/circle/push_doc.sh
+++ b/build_tools/circle/push_doc.sh
@@ -42,7 +42,10 @@ git config core.sparseCheckout true
 echo $dir > .git/info/sparse-checkout
 git checkout $CIRCLE_BRANCH
 git reset --hard origin/$CIRCLE_BRANCH
-git rm -rf $dir/ && rm -rf $dir/
+if [ -d $dir ]
+then
+	git rm -rf $dir/ && rm -rf $dir/
+fi
 cp -R $GENERATED_DOC_DIR $dir
 git config user.email "olivier.grisel+sklearn-ci@gmail.com"
 git config user.name $USERNAME

--- a/build_tools/circle/push_doc.sh
+++ b/build_tools/circle/push_doc.sh
@@ -40,8 +40,8 @@ fi
 cd $DOC_REPO
 git config core.sparseCheckout true
 echo $dir > .git/info/sparse-checkout
-git checkout $CIRCLE_BRANCH
-git reset --hard origin/$CIRCLE_BRANCH
+git checkout master
+git reset --hard origin/master
 if [ -d $dir ]
 then
 	git rm -rf $dir/ && rm -rf $dir/

--- a/build_tools/circle/push_doc.sh
+++ b/build_tools/circle/push_doc.sh
@@ -38,8 +38,17 @@ if [ ! -d $DOC_REPO ];
 then git clone --depth 1 --no-checkout "git@github.com:scikit-learn/"$DOC_REPO".git";
 fi
 cd $DOC_REPO
-git config core.sparseCheckout true
+
+# check if it's a new branch
+
 echo $dir > .git/info/sparse-checkout
+if ! git show HEAD:$dir >/dev/null
+then
+	# directory does not exist. Need to make it so sparse checkout works
+	mkdir $dir
+	touch $dir/index.html
+	git add $dir
+fi
 git checkout master
 git reset --hard origin/master
 if [ -d $dir ]

--- a/build_tools/circle/push_doc.sh
+++ b/build_tools/circle/push_doc.sh
@@ -4,7 +4,7 @@
 # The behavior of the script is controlled by environment variable defined
 # in the circle.yml in the top level folder of the project.
 
-set -e
+set -ex
 
 if [ -z $CIRCLE_PROJECT_USERNAME ];
 then USERNAME="sklearn-ci";


### PR DESCRIPTION
I've made this change to push_doc.sh in 0.20.X because Circle failed to deploy to the 0.20/ directory because it did not yet exist. If https://circleci.com/workflow-run/422516b7-60f3-418c-bdd8-b3cb1acd00df goes green, this should be good to merge.