### PR TITLE
[MRG] DOC replace 'interesting' with 'better' for model_persistence

### DIFF
--- a/doc/modules/model_persistence.rst
+++ b/doc/modules/model_persistence.rst
@@ -35,7 +35,7 @@ persistence model, namely `pickle <https://docs.python.org/2/library/pickle.html
   >>> y[0]
   0
 
-In the specific case of scikit-learn, it may be more interesting to use
+In the specific case of scikit-learn, it may be better to use
 joblib's replacement of pickle (``joblib.dump`` & ``joblib.load``),
 which is more efficient on objects that carry large numpy arrays internally as
 is often the case for fitted scikit-learn estimators, but can only pickle to the


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
The following language can be found [here](http://scikit-learn.org/stable/modules/model_persistence.html#persistence-example):
> In the specific case of the scikit, it may be more interesting to use joblib’s replacement of pickle (`joblib.dump` & `joblib.load`), which is more efficient on objects that carry large numpy arrays internally as is often the case for fitted scikit-learn estimators, but can only pickle to the disk and not to a string

But "more interesting" isn't directly supported by the following claim (i.e., that joblib can be more efficient than pickle), and also describing this as interesting isn't very useful to the user in my opinion. I think "better" or "more efficient" is more suitable here.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
