### PR TITLE
DOC Update joblib what's new

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -1107,13 +1107,13 @@ Miscellaneous
   :func:`metrics.pairwise_distances_chunked`. See :ref:`working_memory`.
   :issue:`10280` by `Joel Nothman`_ and :user:`Aman Dalmia <dalmia>`.
 
-- |Feature| The version of :mod:`joblib` bundled with Scikit-learn is now 0.12.
-  This uses a new default multiprocessing implementation, named `loky
+- |Feature| The version of :mod:`joblib` bundled with Scikit-learn is now
+  0.12.3. This uses a new default multiprocessing implementation, named `loky
   <https://github.com/tomMoral/loky>`_. While this may incur some memory and
   communication overhead, it should provide greater cross-platform stability
-  than relying on Python standard library multiprocessing. :issue:`11741` by
-  the Joblib developers, especially :user:`Thomas Moreau <tomMoral>` and
-  `Olivier Grisel`_.
+  than relying on Python standard library multiprocessing. :issue:`11741` and
+  :issue:`11923` by the Joblib developers, especially
+  :user:`Thomas Moreau <tomMoral>` and `Olivier Grisel`_.
 
 - |Feature| An environment variable to use the site joblib instead of the
   vendored one was added (:ref:`environment_variable`). The main API of joblib


### PR DESCRIPTION
Clearly state that we're using joblib 0.12.3