### PR TITLE
simplifying column transformer example by removing default values

### DIFF
--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -61,13 +61,12 @@ numeric_transformer = Pipeline(steps=[
 categorical_features = ['embarked', 'sex', 'pclass']
 categorical_transformer = Pipeline(steps=[
     ('imputer', SimpleImputer(strategy='constant', fill_value='missing')),
-    ('onehot', OneHotEncoder(sparse=False, handle_unknown='ignore'))])
+    ('onehot', OneHotEncoder(handle_unknown='ignore'))])
 
 preprocessor = ColumnTransformer(
     transformers=[
         ('num', numeric_transformer, numeric_features),
-        ('cat', categorical_transformer, categorical_features)],
-    remainder='drop')
+        ('cat', categorical_transformer, categorical_features)])
 
 # Append classifier to preprocessing pipeline.
 # Now we have a full prediction pipeline.
@@ -77,8 +76,7 @@ clf = Pipeline(steps=[('preprocessor', preprocessor),
 X = data.drop('survived', axis=1)
 y = data['survived']
 
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2,
-                                                    shuffle=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
 
 clf.fit(X_train, y_train)
 print("model score: %.3f" % clf.score(X_test, y_test))


### PR DESCRIPTION
Remove default values, make use of sparse_threshold.
This is an example that will be copy & pasted a lot, I think, and so we should keep it simple.