### PR TITLE
WIP: Migrate to Cython memoryviews in sklearn.utils

### DIFF
--- a/sklearn/utils/_logistic_sigmoid.pyx
+++ b/sklearn/utils/_logistic_sigmoid.pyx
@@ -10,7 +10,7 @@ cimport numpy as np
 ctypedef np.float64_t DTYPE_t
 
 
-cdef DTYPE_t _inner_log_logistic_sigmoid(DTYPE_t x):
+cdef inline DTYPE_t _inner_log_logistic_sigmoid(DTYPE_t x) nogil:
     """Log of the logistic sigmoid function log(1 / (1 + e ** -x))"""
     if x > 0:
         return -log(1 + exp(-x))

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -157,11 +157,11 @@ def csc_mean_variance_axis0(X):
     return means, variances
 
 
-def _csc_mean_variance_axis0(floating[::1] X_data,
+def _csc_mean_variance_axis0(floating[:] X_data,
                              unsigned long long n_samples,
                              unsigned long long n_features,
-                             integral[::1] X_indices,
-                             integral[::1] X_indptr):
+                             integral[:] X_indices,
+                             integral[:] X_indptr):
     # Implement the function here since variables using fused types
     # cannot be declared directly and can only be passed as function arguments
     cdef:
@@ -262,39 +262,34 @@ def incr_mean_variance_axis0(X, last_mean, last_var, last_n):
                                      last_n)
 
 
-def _incr_mean_variance_axis0(np.ndarray[floating, ndim=1] X_data,
+def _incr_mean_variance_axis0(floating[:] X_data,
                               unsigned long long n_samples,
                               unsigned long long n_features,
-                              np.ndarray[integral, ndim=1] X_indices,
-                              np.ndarray[integral, ndim=1] X_indptr,
+                              integral[:] X_indices,
+                              integral[:] X_indptr,
                               str X_format,
-                              np.ndarray[floating, ndim=1] last_mean,
-                              np.ndarray[floating, ndim=1] last_var,
-                              np.ndarray[np.int64_t, ndim=1] last_n):
+                              floating[:] last_mean,
+                              floating[:] last_var,
+                              np.int64_t[:] last_n):
     # Implement the function here since variables using fused types
     # cannot be declared directly and can only be passed as function arguments
-    cdef:
-        np.npy_intp i
-
-    # last = stats until now
-    # new = the current increment
-    # updated = the aggregated stats
-    # when arrays, they are indexed by i per-feature
-    cdef:
-        np.ndarray[floating, ndim=1] new_mean
-        np.ndarray[floating, ndim=1] new_var
-        np.ndarray[floating, ndim=1] updated_mean
-        np.ndarray[floating, ndim=1] updated_var
 
     if floating is float:
         dtype = np.float32
     else:
         dtype = np.float64
 
-    new_mean = np.zeros(n_features, dtype=dtype)
-    new_var = np.zeros_like(new_mean, dtype=dtype)
-    updated_mean = np.zeros_like(new_mean, dtype=dtype)
-    updated_var = np.zeros_like(new_mean, dtype=dtype)
+    # last = stats until now
+    # new = the current increment
+    # updated = the aggregated stats
+    # when arrays, they are indexed by i per-feature
+    cdef:
+        np.npy_intp i
+
+        floating[::1] new_mean = np.zeros(n_features, dtype=dtype)
+        floating[::1] new_var = np.zeros_like(new_mean, dtype=dtype)
+        floating[::1] updated_mean = np.zeros_like(new_mean, dtype=dtype)
+        floating[::1] updated_var = np.zeros_like(new_mean, dtype=dtype)
 
     cdef:
         np.ndarray[np.int64_t, ndim=1] new_n

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -709,11 +709,13 @@ def data_csc_mmap(request):
 
 @pytest.mark.parametrize(
         'func, array_format',
-        itertools.chain.from_iterable([
-                itertools.product([row_norms], ['dense', 'csr', 'csc']),
-                [(csc_mean_variance_axis0, 'csc'),
-                 (csr_mean_variance_axis0, 'csr')]
-        ]))
+        [
+          (row_norms, 'dense'),
+          (row_norms, 'csr'),
+          (row_norms, 'csc'),
+          (csc_mean_variance_axis0, 'csc'),
+          (csr_mean_variance_axis0, 'csr')
+        ])
 def test_read_only_memmap(func, array_format, data_dense_mmap, data_csr_mmap,
                           data_csc_mmap):
     data = {'dense': data_dense_mmap, 'csr': data_csr_mmap,

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -3,8 +3,6 @@
 #          Denis Engemann <denis-alexander.engemann@inria.fr>
 #
 # License: BSD 3 clause
-import itertools
-
 import numpy as np
 from scipy import sparse
 from scipy import linalg


### PR DESCRIPTION
This aims migrate `sklearn.utils` from the numpy buffer interface in cython to memoryviews.

Addresses part of https://github.com/scikit-learn/scikit-learn/issues/10624
Also added a tests make sure we are not in the case https://github.com/scikit-learn/scikit-learn/issues/10624#issuecomment-371864278

WDYT @lesteve ?