### PR TITLE
ENH Fix unfriendly error message for documentation checks

### DIFF
--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -122,9 +122,10 @@ def test_docstring_parameters():
             if (not any(d in name_ for d in _DOCSTRING_IGNORES) and
                     not _is_deprecated(func)):
                 incorrect += check_docstring_parameters(func)
-    msg = '\n' + '\n'.join(sorted(list(set(incorrect))))
+
+    msg = '\n'.join(incorrect)
     if len(incorrect) > 0:
-        raise AssertionError("Docstring Error: " + msg)
+        raise AssertionError("Docstring Error:\n" + msg)
 
 
 @ignore_warnings(category=DeprecationWarning)

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -24,7 +24,6 @@ PUBLIC_MODULES = set([pckg[1] for pckg in walk_packages(prefix='sklearn.',
                                                         path=sklearn.__path__)
                       if not ("._" in pckg[1] or ".tests." in pckg[1])])
 
-
 # functions to ignore args / docstring of
 _DOCSTRING_IGNORES = [
     'sklearn.utils.deprecation.load_mlcomp',
@@ -76,7 +75,7 @@ def test_docstring_parameters():
             this_incorrect = []
             if cname in _DOCSTRING_IGNORES or cname.startswith('_'):
                 continue
-            if isabstract(cls):
+            if inspect.isabstract(cls):
                 continue
             with warnings.catch_warnings(record=True) as w:
                 cdoc = docscrape.ClassDoc(cls)
@@ -88,10 +87,10 @@ def test_docstring_parameters():
 
             if _is_deprecated(cls_init):
                 continue
-
             elif cls_init is not None:
                 this_incorrect += check_docstring_parameters(
                     cls.__init__, cdoc, class_name=cname)
+
             for method_name in cdoc.methods:
                 method = getattr(cls, method_name)
                 if _is_deprecated(method):
@@ -141,7 +140,7 @@ def test_tabs():
         # because we don't import
         mod = importlib.import_module(modname)
         try:
-            source = getsource(mod)
+            source = inspect.getsource(mod)
         except IOError:  # user probably should have run "make clean"
             continue
         assert '\t' not in source, ('"%s" has tabs, please remove them ',

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -89,7 +89,7 @@ def test_docstring_parameters():
                 continue
             elif cls_init is not None:
                 this_incorrect += check_docstring_parameters(
-                    cls.__init__, cdoc, class_name=cname)
+                    cls.__init__, cdoc)
 
             for method_name in cdoc.methods:
                 method = getattr(cls, method_name)
@@ -104,7 +104,7 @@ def test_docstring_parameters():
                             sig.parameters['y'].default is None):
                         param_ignore = ['y']  # ignore y for fit and score
                 result = check_docstring_parameters(
-                    method, ignore=param_ignore, class_name=cname)
+                    method, ignore=param_ignore)
                 this_incorrect += result
 
             incorrect += this_incorrect

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -902,14 +902,9 @@ def _get_func_name(func):
     if module:
         parts.append(module.__name__)
 
-    try:
-        # Python 3
-        qualname = func.__qualname__
-        if qualname != func.__name__:
-            parts.append(qualname[:qualname.find('.')])
-    except AttributeError:
-        # Python 2
-        parts.append(func.im_class.__name__)
+    qualname = func.__qualname__
+    if qualname != func.__name__:
+        parts.append(qualname[:qualname.find('.')])
 
     parts.append(func.__name__)
     return '.'.join(parts)

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -1027,4 +1027,8 @@ def check_docstring_parameters(func, doc=None, ignore=None, class_name=None):
     )
 
     incorrect.extend(message)
-    return '\n'.join(incorrect)
+
+    # Prepend function name
+    incorrect = ['In :' + str(func)] + incorrect
+
+    return incorrect

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -993,6 +993,10 @@ def check_docstring_parameters(func, doc=None, ignore=None, class_name=None):
     # Remove the parameters that should be ignored from list
     param_docs = list(filter(lambda x: x not in ignore, param_docs))
 
+    # The following is derived from pytest, Copyright (c) 2004-2017 Holger
+    # Krekel and others, Licensed under MIT License. See
+    # https://github.com/pytest-dev/pytest
+
     message = []
     for i in range(min(len(param_docs), len(param_signature))):
         if param_signature[i] != param_docs[i]:

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -994,15 +994,28 @@ def check_docstring_parameters(func, doc=None, ignore=None, class_name=None):
     if (len(complete_params) != len(args) or len(complete_params) !=
             len(param_names)):
         missing_from_func = param_doc.difference(param_func)
+        missing_func = [x for x in param_names if x in missing_from_func]
         missing_from_doc = param_func.difference(param_doc)
-        message = func_name + ' contains a parameter mismatch between the function signature and its docstring.\n'
-        if missing_from_doc:
-            message += 'Parameters defined in the function signature and not defined in its docstring: {}\n'.format(missing_from_doc)
-        if missing_from_func:
-            message += 'Parameters defined in the function docstring and not defined in its signature: {}\n'.format(missing_from_func)
+        missing_doc = [x for x in args if x in missing_from_doc]
+
+        message = "There's a difference in the number of parameters in " \
+                  + func_name + "'s signature and its docstring.\n"
+        if missing_doc:
+            message += 'Parameters defined in the function signature and not' \
+                       + ' defined in its docstring: {}\n'.format(missing_doc)
+        if missing_func:
+            message += 'Parameters defined in the function docstring and not' \
+                       + ' defined in its signature: {}\n'.format(missing_func)
         incorrect += [message]
     else:
-        for n1, n2 in zip(param_names, args):
-            if n1 != n2:
-                incorrect += [func_name + ' ' + n1 + ' != ' + n2]
+        message = None
+        for doc_param, func_param in zip(param_names, args):
+            if doc_param != func_param:
+                message = "There's a difference in the order of the" \
+                          + " parameters in " + func_name + "'s signature" \
+                          + " and its docstring.\nAccording to the function" \
+                          + " signature the parameter in this place of the" \
+                          + " docstring should be: \"" + func_param + "\"" \
+                          + " but instead is \"" + doc_param + "\""
+                incorrect += [message]
     return incorrect

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -999,16 +999,20 @@ def check_docstring_parameters(func, doc=None, ignore=None):
     message = []
     for i in range(min(len(param_docs), len(param_signature))):
         if param_signature[i] != param_docs[i]:
-            message += ["At index %s diff: %r != %r" % (i, param_signature[i],
-                                                        param_docs[i])]
+            message += ["There's a parameter name mismatch in function"
+                        " docstring w.r.t. function signature, at index %s"
+                        " diff: %r != %r" %
+                        (i, param_signature[i], param_docs[i])]
             break
     if len(param_signature) > len(param_docs):
-        message += ["Parameters in function signature have more items,"
-                    " first extra item: %s" % param_signature[len(param_docs)]]
+        message += ["Parameters in function docstring have less items w.r.t."
+                    " function signature, first missing item: %s" %
+                    param_signature[len(param_docs)]]
 
     elif len(param_signature) < len(param_docs):
-        message += ["Parameters in function docstring have more items,"
-                    " first extra item: %s" % param_docs[len(param_signature)]]
+        message += ["Parameters in function docstring have more items w.r.t."
+                    " function signature, first extra item: %s" %
+                    param_docs[len(param_signature)]]
 
     # If there wasn't any difference in the parameters themselves between
     # docstring and signature including having the same length then return

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -956,7 +956,7 @@ def check_docstring_parameters(func, doc=None, ignore=None, class_name=None):
     if len(param_signature) > 0 and param_signature[0] == 'self':
         param_signature.remove('self')
 
-    # Analize function's docstring
+    # Analyze function's docstring
     if doc is None:
         with warnings.catch_warnings(record=True) as w:
             try:
@@ -1029,6 +1029,6 @@ def check_docstring_parameters(func, doc=None, ignore=None, class_name=None):
     incorrect.extend(message)
 
     # Prepend function name
-    incorrect = ['In :' + str(func)] + incorrect
+    incorrect = ['In : ' + str(func)] + incorrect
 
     return incorrect

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -503,54 +503,68 @@ def test_check_docstring_parameters():
         ])
 
     messages = [
-            "At index 0 diff: 'b' != 'a'\n"
-            + "Full diff:\n"
-            + "- ['b', 'a']\n"
-            + "+ ['a', 'b']",
+            ["In function: sklearn.utils.tests.test_testing.f_bad_order",
+             "At index 0 diff: 'b' != 'a'",
+             "Full diff:",
+             "- ['b', 'a']",
+             "+ ['a', 'b']"],
 
-            "Parameters in function docstring have more items, first extra"
-            + " item: c\n"
-            + "Full diff:\n"
-            + "- ['a', 'b']\n"
-            + "+ ['a', 'b', 'c']\n"
-            + "?          +++++",
+            ["In function: " +
+                "sklearn.utils.tests.test_testing.f_too_many_param_docstring",
+             "Parameters in function docstring have more items, first extra"
+             + " item: c",
+             "Full diff:",
+             "- ['a', 'b']",
+             "+ ['a', 'b', 'c']",
+             "?          +++++"],
 
-            "Parameters in function signature have more items, first extra"
-            + " item: b\n"
-            + "Full diff:\n"
-            + "- ['a', 'b']\n"
-            + "+ ['a']",
+            ["In function: sklearn.utils.tests.test_testing.f_missing",
+             "Parameters in function signature have more items, first extra"
+             + " item: b",
+             "Full diff:",
+             "- ['a', 'b']",
+             "+ ['a']"],
 
-            "Parameters in function signature have more items, first extra"
-            + " item: X\n"
-            + "Full diff:\n"
-            + "- ['X', 'y']\n"
-            + "+ []",
+            ["In function: sklearn.utils.tests.test_testing.Klass.f_missing",
+             "Parameters in function signature have more items, first extra"
+             + " item: X",
+             "Full diff:",
+             "- ['X', 'y']",
+             "+ []"],
 
-            "At index 0 diff: 'X' != 'y'\n"
-            + "Full diff:\n"
-            + "- ['X']\n"
-            + "?   ^\n"
-            + "+ ['y']\n"
-            + "?   ^",
+            ["In function: " +
+                "sklearn.utils.tests.test_testing.MockMetaEstimator.predict",
+             "At index 0 diff: 'X' != 'y'",
+             "Full diff:",
+             "- ['X']",
+             "?   ^",
+             "+ ['y']",
+             "?   ^"],
 
-            "Parameters in function signature have more items, first extra"
-            + " item: X\n"
-            + "Full diff:\n"
-            + "- ['X']\n"
-            + "+ []",
+            ["In function: " +
+                "sklearn.utils.tests.test_testing.MockMetaEstimator."
+                + "predict_proba",
+             "Parameters in function signature have more items, first extra"
+             + " item: X",
+             "Full diff:",
+             "- ['X']",
+             "+ []"],
 
-            "Parameters in function signature have more items, first extra"
-            + " item: X\n"
-            + "Full diff:\n"
-            + "- ['X']\n"
-            + "+ []",
+            ["In function: " +
+                "sklearn.utils.tests.test_testing.MockMetaEstimator.score",
+             "Parameters in function signature have more items, first extra"
+             + " item: X",
+             "Full diff:",
+             "- ['X']",
+             "+ []"],
 
-            "Parameters in function signature have more items, first extra"
-            + " item: X\n"
-            + "Full diff:\n"
-            + "- ['X', 'y']\n"
-            + "+ []",
+            ["In function: " +
+                "sklearn.utils.tests.test_testing.MockMetaEstimator.fit",
+             "Parameters in function signature have more items, first extra"
+             + " item: X",
+             "Full diff:",
+             "- ['X', 'y']",
+             "+ []"],
 
             ]
 

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -323,6 +323,27 @@ def f_bad_order(b, a):
     return c
 
 
+def f_too_many_param_docstring(a, b):
+    """Function f
+
+    Parameters
+    ----------
+    a : int
+        Parameter a
+    b : int
+        Parameter b
+    c : int
+        Parameter c
+
+    Returns
+    -------
+    d : list
+        Parameter c
+    """
+    d = a + b
+    return d
+
+
 def f_missing(a, b):
     """Function f
 
@@ -482,73 +503,70 @@ def test_check_docstring_parameters():
         ])
 
     messages = [
-            [
-                "There's a difference in the order of the parameters in"
-                + " sklearn.utils.tests.test_testing.f_bad_order's signature"
-                + " and its docstring.\nAccording to the function signature"
-                + " the parameter in this place of the docstring should be:"
-                + " \"b\" but instead is \"a\"",
+            "At index 0 diff: 'b' != 'a'\n"
+            + "Full diff:\n"
+            + "- ['b', 'a']\n"
+            + "+ ['a', 'b']",
 
-                "There's a difference in the order of the parameters in"
-                + " sklearn.utils.tests.test_testing.f_bad_order's signature"
-                + " and its docstring.\nAccording to the function signature"
-                + " the parameter in this place of the docstring should be:"
-                + " \"a\" but instead is \"b\""
-            ],
+            "Parameters in function docstring have more items, first extra"
+            + " item: c\n"
+            + "Full diff:\n"
+            + "- ['a', 'b']\n"
+            + "+ ['a', 'b', 'c']\n"
+            + "?          +++++",
 
-            "There's a difference in the number of parameters in"
-            + " sklearn.utils.tests.test_testing.f_missing's signature and its"
-            + " docstring.\nParameters defined in the function signature and"
-            + " not defined in its docstring: ['b']\n",
+            "Parameters in function signature have more items, first extra"
+            + " item: b\n"
+            + "Full diff:\n"
+            + "- ['a', 'b']\n"
+            + "+ ['a']",
 
-            "There's a difference in the number of parameters in"
-            + " sklearn.utils.tests.test_testing.f_missing's signature and its"
-            + " docstring.\nParameters defined in the function signature and"
-            + " not defined in its docstring: ['X', 'y']\n",
+            "Parameters in function signature have more items, first extra"
+            + " item: X\n"
+            + "Full diff:\n"
+            + "- ['X', 'y']\n"
+            + "+ []",
 
-            "There's a difference in the number of parameters in"
-            + " sklearn.utils.tests.test_testing.predict's signature and its"
+            "At index 0 diff: 'X' != 'y'\n"
+            + "Full diff:\n"
+            + "- ['X']\n"
+            + "?   ^\n"
+            + "+ ['y']\n"
+            + "?   ^",
 
-            + " docstring.\nParameters defined in the function signature and"
-            + " not defined in its docstring: ['X']\nParameters defined in the"
-            + " function docstring and not defined in its signature: ['y']\n",
+            "Parameters in function signature have more items, first extra"
+            + " item: X\n"
+            + "Full diff:\n"
+            + "- ['X']\n"
+            + "+ []",
 
-            "There's a difference in the number of parameters in"
-            + " sklearn.utils.tests.test_testing.predict_proba's signature and"
-            + " its docstring.\nParameters defined in the function signature"
-            + " and not defined in its docstring: ['X']\n",
+            "Parameters in function signature have more items, first extra"
+            + " item: X\n"
+            + "Full diff:\n"
+            + "- ['X']\n"
+            + "+ []",
 
-            "There's a difference in the number of parameters in"
-            + " sklearn.utils.tests.test_testing.score's signature and its"
-            + " docstring.\nParameters defined in the function signature and"
-            + " not defined in its docstring: ['X']\n",
+            "Parameters in function signature have more items, first extra"
+            + " item: X\n"
+            + "Full diff:\n"
+            + "- ['X', 'y']\n"
+            + "+ []",
 
-            "There's a difference in the number of parameters in"
-            + " sklearn.utils.tests.test_testing.fit's signature and its"
-            + " docstring.\nParameters defined in the function signature and"
-            + " not defined in its docstring: ['X', 'y']\n",
             ]
 
     mock_meta = MockMetaEstimator(delegate=MockEst())
 
-    for mess, f in zip(messages,
-                       [f_bad_order,
-                        f_missing,
-                        Klass.f_missing,
-                        mock_meta.predict,
-                        mock_meta.predict_proba,
-                        mock_meta.score,
-                        mock_meta.fit]):
+    for msg, f in zip(messages,
+                      [f_bad_order,
+                       f_too_many_param_docstring,
+                       f_missing,
+                       Klass.f_missing,
+                       mock_meta.predict,
+                       mock_meta.predict_proba,
+                       mock_meta.score,
+                       mock_meta.fit]):
         incorrect = check_docstring_parameters(f)
-        if isinstance(mess, list):
-            for i, _ in enumerate(mess):
-                assert len(incorrect[i]) >= 1
-                assert mess[i] in incorrect[i], '\n"%s"\n not in \n"%s"' \
-                    % (mess[i], incorrect[i])
-        else:
-            assert len(incorrect) >= 1
-            assert mess in incorrect[0], '\n"%s"\n not in \n"%s"' \
-                % (mess, incorrect[i])
+        assert msg == incorrect, ('\n"%s"\n not in \n"%s"' % (msg, incorrect))
 
 
 class RegistrationCounter(object):

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -504,37 +504,39 @@ def test_check_docstring_parameters():
 
     messages = [
             ["In function: sklearn.utils.tests.test_testing.f_bad_order",
-             "At index 0 diff: 'b' != 'a'",
+             "There's a parameter name mismatch in function docstring w.r.t."
+             " function signature, at index 0 diff: 'b' != 'a'",
              "Full diff:",
              "- ['b', 'a']",
              "+ ['a', 'b']"],
 
             ["In function: " +
                 "sklearn.utils.tests.test_testing.f_too_many_param_docstring",
-             "Parameters in function docstring have more items, first extra"
-             + " item: c",
+             "Parameters in function docstring have more items w.r.t. function"
+             " signature, first extra item: c",
              "Full diff:",
              "- ['a', 'b']",
              "+ ['a', 'b', 'c']",
              "?          +++++"],
 
             ["In function: sklearn.utils.tests.test_testing.f_missing",
-             "Parameters in function signature have more items, first extra"
-             + " item: b",
+             "Parameters in function docstring have less items w.r.t. function"
+             " signature, first missing item: b",
              "Full diff:",
              "- ['a', 'b']",
              "+ ['a']"],
 
             ["In function: sklearn.utils.tests.test_testing.Klass.f_missing",
-             "Parameters in function signature have more items, first extra"
-             + " item: X",
+             "Parameters in function docstring have less items w.r.t. function"
+             " signature, first missing item: X",
              "Full diff:",
              "- ['X', 'y']",
              "+ []"],
 
             ["In function: " +
-                "sklearn.utils.tests.test_testing.MockMetaEstimator.predict",
-             "At index 0 diff: 'X' != 'y'",
+             "sklearn.utils.tests.test_testing.MockMetaEstimator.predict",
+             "There's a parameter name mismatch in function docstring w.r.t."
+             " function signature, at index 0 diff: 'X' != 'y'",
              "Full diff:",
              "- ['X']",
              "?   ^",
@@ -542,26 +544,26 @@ def test_check_docstring_parameters():
              "?   ^"],
 
             ["In function: " +
-                "sklearn.utils.tests.test_testing.MockMetaEstimator."
-                + "predict_proba",
-             "Parameters in function signature have more items, first extra"
-             + " item: X",
+             "sklearn.utils.tests.test_testing.MockMetaEstimator."
+             + "predict_proba",
+             "Parameters in function docstring have less items w.r.t. function"
+             " signature, first missing item: X",
              "Full diff:",
              "- ['X']",
              "+ []"],
 
             ["In function: " +
                 "sklearn.utils.tests.test_testing.MockMetaEstimator.score",
-             "Parameters in function signature have more items, first extra"
-             + " item: X",
+             "Parameters in function docstring have less items w.r.t. function"
+             " signature, first missing item: X",
              "Full diff:",
              "- ['X']",
              "+ []"],
 
             ["In function: " +
                 "sklearn.utils.tests.test_testing.MockMetaEstimator.fit",
-             "Parameters in function signature have more items, first extra"
-             + " item: X",
+             "Parameters in function docstring have less items w.r.t. function"
+             " signature, first missing item: X",
              "Full diff:",
              "- ['X', 'y']",
              "+ []"],

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -470,29 +470,85 @@ def test_check_docstring_parameters():
         incorrect == [
             "sklearn.utils.tests.test_testing.f_check_param_definition There "
             "was no space between the param name and colon ('a: int')",
+
             "sklearn.utils.tests.test_testing.f_check_param_definition There "
             "was no space between the param name and colon ('b:')",
+
             "sklearn.utils.tests.test_testing.f_check_param_definition "
             "Parameter 'c :' has an empty type spec. Remove the colon",
+
             "sklearn.utils.tests.test_testing.f_check_param_definition There "
             "was no space between the param name and colon ('d:int')",
         ])
 
-    messages = ["a != b", "arg mismatch: ['b']", "arg mismatch: ['X', 'y']",
-                "predict y != X",
-                "predict_proba arg mismatch: ['X']",
-                "score arg mismatch: ['X']",
-                ".fit arg mismatch: ['X', 'y']"]
+    messages = [
+            [
+                "There's a difference in the order of the parameters in"
+                + " sklearn.utils.tests.test_testing.f_bad_order's signature"
+                + " and its docstring.\nAccording to the function signature"
+                + " the parameter in this place of the docstring should be:"
+                + " \"b\" but instead is \"a\"",
+
+                "There's a difference in the order of the parameters in"
+                + " sklearn.utils.tests.test_testing.f_bad_order's signature"
+                + " and its docstring.\nAccording to the function signature"
+                + " the parameter in this place of the docstring should be:"
+                + " \"a\" but instead is \"b\""
+            ],
+
+            "There's a difference in the number of parameters in"
+            + " sklearn.utils.tests.test_testing.f_missing's signature and its"
+            + " docstring.\nParameters defined in the function signature and"
+            + " not defined in its docstring: ['b']\n",
+
+            "There's a difference in the number of parameters in"
+            + " sklearn.utils.tests.test_testing.f_missing's signature and its"
+            + " docstring.\nParameters defined in the function signature and"
+            + " not defined in its docstring: ['X', 'y']\n",
+
+            "There's a difference in the number of parameters in"
+            + " sklearn.utils.tests.test_testing.predict's signature and its"
+
+            + " docstring.\nParameters defined in the function signature and"
+            + " not defined in its docstring: ['X']\nParameters defined in the"
+            + " function docstring and not defined in its signature: ['y']\n",
+
+            "There's a difference in the number of parameters in"
+            + " sklearn.utils.tests.test_testing.predict_proba's signature and"
+            + " its docstring.\nParameters defined in the function signature"
+            + " and not defined in its docstring: ['X']\n",
+
+            "There's a difference in the number of parameters in"
+            + " sklearn.utils.tests.test_testing.score's signature and its"
+            + " docstring.\nParameters defined in the function signature and"
+            + " not defined in its docstring: ['X']\n",
+
+            "There's a difference in the number of parameters in"
+            + " sklearn.utils.tests.test_testing.fit's signature and its"
+            + " docstring.\nParameters defined in the function signature and"
+            + " not defined in its docstring: ['X', 'y']\n",
+            ]
 
     mock_meta = MockMetaEstimator(delegate=MockEst())
 
     for mess, f in zip(messages,
-                       [f_bad_order, f_missing, Klass.f_missing,
-                        mock_meta.predict, mock_meta.predict_proba,
-                        mock_meta.score, mock_meta.fit]):
+                       [f_bad_order,
+                        f_missing,
+                        Klass.f_missing,
+                        mock_meta.predict,
+                        mock_meta.predict_proba,
+                        mock_meta.score,
+                        mock_meta.fit]):
         incorrect = check_docstring_parameters(f)
-        assert len(incorrect) >= 1
-        assert mess in incorrect[0], '"%s" not in "%s"' % (mess, incorrect[0])
+        if isinstance(mess, list):
+            for i, _ in enumerate(mess):
+                assert len(incorrect[i]) >= 1
+                assert mess[i] in incorrect[i], '\n"%s"\n not in \n"%s"' \
+                    % (mess[i], incorrect[i])
+        else:
+            assert len(incorrect) >= 1
+            assert mess in incorrect[0], '\n"%s"\n not in \n"%s"' \
+                % (mess, incorrect[i])
 
 
 class RegistrationCounter(object):


### PR DESCRIPTION
Fixes: https://github.com/scikit-learn/scikit-learn/issues/11673


Previously error messages for mismatches parameters on function/method
signatures and docstrings were not explicit or user-friendly. This
changes provides a more explicit error message and in addition notifies
the relation of missing/mismatching parameters from signature to
docstring and from docstring to signature.


Signed-off-by: Antonio Gutierrez <chibby0ne@gmail.com>

