### PR TITLE
[MRG] DOC Examples added to the rest of linear models

### DIFF
--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -399,6 +399,15 @@ class LinearRegression(LinearModel, RegressorMixin):
     intercept_ : array
         Independent term in the linear model.
 
+    Examples
+    --------
+    >>> from sklearn.linear_model import LinearRegression
+    >>> from sklearn.datasets import make_regression
+    >>> X, y = make_regression(n_features=10, noise=4, random_state=0)
+    >>> reg = LinearRegression().fit(X, y)
+    >>> reg.score(X, y) # doctest: +ELLIPSIS
+    0.9997...
+
     Notes
     -----
     From the implementation point of view, this is just plain Ordinary

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -407,6 +407,8 @@ class LinearRegression(LinearModel, RegressorMixin):
     >>> reg = LinearRegression().fit(X, y)
     >>> reg.score(X, y) # doctest: +ELLIPSIS
     0.9997...
+    >>> reg.predict(X[:1,])
+    array([9.8117...])
 
     Notes
     -----

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -401,14 +401,18 @@ class LinearRegression(LinearModel, RegressorMixin):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from sklearn.linear_model import LinearRegression
-    >>> from sklearn.datasets import make_regression
-    >>> X, y = make_regression(n_features=10, noise=4, random_state=0)
+    >>> X = np.array([[1, 1], [1, 2], [2, 2], [2, 3]])
+    >>> # y = 1 * x_0 + 2 * x_1
+    >>> y = np.dot(X, np.array([1, 2]))
     >>> reg = LinearRegression().fit(X, y)
-    >>> reg.score(X, y) # doctest: +ELLIPSIS
-    0.9997...
-    >>> reg.predict(X[:1,])
-    array([9.8117...])
+    >>> reg.score(X, y)
+    1.0
+    >>> reg.coef_
+    array([1., 2.])
+    >>> reg.predict(np.array([[3, 5]]))
+    array([13.])
 
     Notes
     -----

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -404,15 +404,17 @@ class LinearRegression(LinearModel, RegressorMixin):
     >>> import numpy as np
     >>> from sklearn.linear_model import LinearRegression
     >>> X = np.array([[1, 1], [1, 2], [2, 2], [2, 3]])
-    >>> # y = 1 * x_0 + 2 * x_1
-    >>> y = np.dot(X, np.array([1, 2]))
+    >>> # y = 1 * x_0 + 2 * x_1 + 3
+    >>> y = np.dot(X, np.array([1, 2])) + 3
     >>> reg = LinearRegression().fit(X, y)
     >>> reg.score(X, y)
     1.0
     >>> reg.coef_
     array([1., 2.])
+    >>> reg.intercept_ # doctest: +ELLIPSIS
+    3.0000...
     >>> reg.predict(np.array([[3, 5]]))
-    array([13.])
+    array([16.])
 
     Notes
     -----

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1368,6 +1368,15 @@ class LassoCV(LinearModelCV, RegressorMixin):
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance for the optimal alpha.
 
+    Examples
+    --------
+    >>> from sklearn.linear_model import LassoCV
+    >>> from sklearn.datasets import make_regression
+    >>> X, y = make_regression(noise=4, random_state=0)
+    >>> reg = LassoCV(cv=5, random_state=0).fit(X, y)
+    >>> reg.score(X, y) # doctest: +ELLIPSIS
+    0.9993...
+
     Notes
     -----
     For an example, see
@@ -2234,6 +2243,17 @@ class MultiTaskLassoCV(LinearModelCV, RegressorMixin):
     n_iter_ : int
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance for the optimal alpha.
+
+    Examples
+    --------
+    >>> from sklearn.linear_model import MultiTaskLassoCV
+    >>> from sklearn.datasets import make_regression
+    >>> X, y = make_regression(n_targets=2, noise=4, random_state=0)
+    >>> reg = MultiTaskLassoCV(cv=5, random_state=0).fit(X, y)
+    >>> reg.score(X, y) # doctest: +ELLIPSIS
+    0.9994...
+    >>> reg.predict(X[:1,])
+    array([[153.7971...,  94.9015...]])
 
     See also
     --------

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -2254,6 +2254,8 @@ class MultiTaskLassoCV(LinearModelCV, RegressorMixin):
     >>> reg = MultiTaskLassoCV(cv=5, random_state=0).fit(X, y)
     >>> reg.score(X, y) # doctest: +ELLIPSIS
     0.9994...
+    >>> reg.alpha_
+    0.5713...
     >>> reg.predict(X[:1,])
     array([[153.7971...,  94.9015...]])
 

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1376,6 +1376,8 @@ class LassoCV(LinearModelCV, RegressorMixin):
     >>> reg = LassoCV(cv=5, random_state=0).fit(X, y)
     >>> reg.score(X, y) # doctest: +ELLIPSIS
     0.9993...
+    >>> reg.predict(X[:1,])
+    array([-78.4951...])
 
     Notes
     -----

--- a/sklearn/linear_model/huber.py
+++ b/sklearn/linear_model/huber.py
@@ -203,14 +203,16 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
     >>> X[:4] = np.random.uniform(10, 20, (4, 2))
     >>> y[:4] = np.random.uniform(10, 20, 4)
     >>> huber = HuberRegressor().fit(X, y)
-    >>> huber.predict(X[:1,]) # doctest: +ELLIPSIS
+    >>> huber.score(X, y) # doctest: +ELLIPSIS
+    -7.284608623514573
+    >>> huber.predict(X[:1,])
     array([806.7200...])
     >>> linear = LinearRegression().fit(X, y)
-    >>> print("True coefficients: %s\nHuber coefficients: %s\n"
-    ...       "Linear Regression coefficients: %s"
-    ...       % (coef, huber.coef_, linear.coef_))
+    >>> print("True coefficients:", coef)
     True coefficients: [20.4923...  34.1698...]
+    >>> print("Huber coefficients:", huber.coef_)
     Huber coefficients: [17.7906... 31.0106...]
+    >>> print("Linear Regression coefficients:", linear.coef_)
     Linear Regression coefficients: [-1.9221...  7.0226...]
 
     References

--- a/sklearn/linear_model/huber.py
+++ b/sklearn/linear_model/huber.py
@@ -192,6 +192,25 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
         A boolean mask which is set to True where the samples are identified
         as outliers.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.linear_model import HuberRegressor, LinearRegression
+    >>> from sklearn.datasets import make_regression
+    >>> np.random.seed(0)
+    >>> X, y, coef = make_regression(
+    ...     n_samples=200, n_features=2, noise=4.0, coef=True, random_state=0)
+    >>> X[:4] = np.random.uniform(10, 20, (4, 2))
+    >>> y[:4] = np.random.uniform(10, 20, 4)
+    >>> huber = HuberRegressor().fit(X, y)
+    >>> linear = LinearRegression().fit(X, y) # doctest: +ELLIPSIS
+    >>> print("True coefficients: %s\nHuber coefficients: %s\n"
+    ...       "Linear Regression coefficients: %s"
+    ...       % (coef, huber.coef_, linear.coef_))
+    True coefficients: [20.4923...  34.1698...]
+    Huber coefficients: [17.7906... 31.0106...]
+    Linear Regression coefficients: [-1.9221...  7.0226...]
+
     References
     ----------
     .. [1] Peter J. Huber, Elvezio M. Ronchetti, Robust Statistics

--- a/sklearn/linear_model/huber.py
+++ b/sklearn/linear_model/huber.py
@@ -203,7 +203,9 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
     >>> X[:4] = np.random.uniform(10, 20, (4, 2))
     >>> y[:4] = np.random.uniform(10, 20, 4)
     >>> huber = HuberRegressor().fit(X, y)
-    >>> linear = LinearRegression().fit(X, y) # doctest: +ELLIPSIS
+    >>> huber.predict(X[:1,]) # doctest: +ELLIPSIS
+    array([806.7200...])
+    >>> linear = LinearRegression().fit(X, y)
     >>> print("True coefficients: %s\nHuber coefficients: %s\n"
     ...       "Linear Regression coefficients: %s"
     ...       % (coef, huber.coef_, linear.coef_))

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -1074,13 +1074,14 @@ class LarsCV(Lars):
     --------
     >>> from sklearn.linear_model import LarsCV
     >>> from sklearn.datasets import make_regression
-    >>> X, y = make_regression(
-    ...     n_samples=200, n_features=2, noise=4.0, random_state=0)
+    >>> X, y = make_regression(n_samples=200, noise=4.0, random_state=0)
     >>> reg = LarsCV(cv=5).fit(X, y)
     >>> reg.score(X, y) # doctest: +ELLIPSIS
-    0.9885...
+    0.9996...
+    >>> reg.alpha_
+    0.0254...
     >>> reg.predict(X[:1,])
-    array([-31.9417...])
+    array([154.0842...])
 
     See also
     --------
@@ -1306,13 +1307,14 @@ class LassoLarsCV(LarsCV):
     --------
     >>> from sklearn.linear_model import LassoLarsCV
     >>> from sklearn.datasets import make_regression
-    >>> X, y = make_regression(
-    ...     n_samples=200, n_features=2, noise=4.0, random_state=0)
+    >>> X, y = make_regression(noise=4.0, random_state=0)
     >>> reg = LassoLarsCV(cv=5).fit(X, y)
     >>> reg.score(X, y) # doctest: +ELLIPSIS
-    0.9885...
+    0.9992...
+    >>> reg.alpha_
+    0.0484...
     >>> reg.predict(X[:1,])
-    array([-31.9417...])
+    array([-77.8723...])
 
     Notes
     -----

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -1070,6 +1070,16 @@ class LarsCV(Lars):
     n_iter_ : array-like or int
         the number of iterations run by Lars with the optimal alpha.
 
+    Examples
+    --------
+    >>> from sklearn.linear_model import LarsCV
+    >>> from sklearn.datasets import make_regression
+    >>> X, y = make_regression(
+    ...     n_samples=200, n_features=2, noise=4.0 random_state=0)
+    >>> reg = LarsCV(cv=5).fit(X, y)
+    >>> reg.score(X, y) # doctest: +ELLIPSIS
+    0.9885...
+
     See also
     --------
     lars_path, LassoLars, LassoLarsCV
@@ -1289,6 +1299,16 @@ class LassoLarsCV(LarsCV):
 
     n_iter_ : array-like or int
         the number of iterations run by Lars with the optimal alpha.
+
+    Examples
+    --------
+    >>> from sklearn.linear_model import LassoLarsCV
+    >>> from sklearn.datasets import make_regression
+    >>> X, y = make_regression(
+    ...     n_samples=200, n_features=2, noise=4.0, random_state=0)
+    >>> reg = LassoLarsCV(cv=5).fit(X, y)
+    >>> reg.score(X, y) # doctest: +ELLIPSIS
+    0.9885...
 
     Notes
     -----

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -1075,10 +1075,12 @@ class LarsCV(Lars):
     >>> from sklearn.linear_model import LarsCV
     >>> from sklearn.datasets import make_regression
     >>> X, y = make_regression(
-    ...     n_samples=200, n_features=2, noise=4.0 random_state=0)
+    ...     n_samples=200, n_features=2, noise=4.0, random_state=0)
     >>> reg = LarsCV(cv=5).fit(X, y)
     >>> reg.score(X, y) # doctest: +ELLIPSIS
     0.9885...
+    >>> reg.predict(X[:1,])
+    array([-31.9417...])
 
     See also
     --------
@@ -1309,6 +1311,8 @@ class LassoLarsCV(LarsCV):
     >>> reg = LassoLarsCV(cv=5).fit(X, y)
     >>> reg.score(X, y) # doctest: +ELLIPSIS
     0.9885...
+    >>> reg.predict(X[:1,])
+    array([-31.9417...])
 
     Notes
     -----

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -829,10 +829,13 @@ class OrthogonalMatchingPursuitCV(LinearModel, RegressorMixin):
     --------
     >>> from sklearn.linear_model import OrthogonalMatchingPursuitCV
     >>> from sklearn.datasets import make_regression
-    >>> X, y = make_regression(noise=4, random_state=0)
+    >>> X, y = make_regression(n_features=100, n_informative=10,
+    ...                        noise=4, random_state=0)
     >>> reg = OrthogonalMatchingPursuitCV(cv=5).fit(X, y)
     >>> reg.score(X, y) # doctest: +ELLIPSIS
     0.9991...
+    >>> reg.n_nonzero_coefs_
+    10
     >>> reg.predict(X[:1,])
     array([-78.3854...])
 

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -591,6 +591,8 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
     >>> reg = OrthogonalMatchingPursuit().fit(X, y)
     >>> reg.score(X, y) # doctest: +ELLIPSIS
     0.9991...
+    >>> reg.predict(X[:1,])
+    array([-78.3854...])
 
     Notes
     -----
@@ -831,6 +833,8 @@ class OrthogonalMatchingPursuitCV(LinearModel, RegressorMixin):
     >>> reg = OrthogonalMatchingPursuitCV(cv=5).fit(X, y)
     >>> reg.score(X, y) # doctest: +ELLIPSIS
     0.9991...
+    >>> reg.predict(X[:1,])
+    array([-78.3854...])
 
     See also
     --------

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -583,6 +583,15 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
     n_iter_ : int or array-like
         Number of active features across every target.
 
+    Examples
+    --------
+    >>> from sklearn.linear_model import OrthogonalMatchingPursuit
+    >>> from sklearn.datasets import make_regression
+    >>> X, y = make_regression(noise=4, random_state=0)
+    >>> reg = OrthogonalMatchingPursuit().fit(X, y)
+    >>> reg.score(X, y) # doctest: +ELLIPSIS
+    0.9991...
+
     Notes
     -----
     Orthogonal matching pursuit was introduced in G. Mallat, Z. Zhang,
@@ -813,6 +822,15 @@ class OrthogonalMatchingPursuitCV(LinearModel, RegressorMixin):
     n_iter_ : int or array-like
         Number of active features across every target for the model refit with
         the best hyperparameters got by cross-validating across all folds.
+
+    Examples
+    --------
+    >>> from sklearn.linear_model import OrthogonalMatchingPursuitCV
+    >>> from sklearn.datasets import make_regression
+    >>> X, y = make_regression(noise=4, random_state=0)
+    >>> reg = OrthogonalMatchingPursuitCV(cv=5).fit(X, y)
+    >>> reg.score(X, y) # doctest: +ELLIPSIS
+    0.9991...
 
     See also
     --------

--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -186,6 +186,16 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
 
         .. versionadded:: 0.19
 
+    Examples
+    --------
+    >>> from sklearn.linear_model import RANSACRegressor
+    >>> from sklearn.datasets import make_regression
+    >>> X, y = make_regression(
+    ...     n_samples=200, n_features=2, noise=4.0, random_state=0)
+    >>> reg = RANSACRegressor(random_state=0).fit(X, y)
+    >>> reg.score(X, y) # doctest: +ELLIPSIS
+    0.9885...
+
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/RANSAC

--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -195,6 +195,8 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
     >>> reg = RANSACRegressor(random_state=0).fit(X, y)
     >>> reg.score(X, y) # doctest: +ELLIPSIS
     0.9885...
+    >>> reg.predict(X[:1,])
+    array([-31.9417...])
 
     References
     ----------

--- a/sklearn/linear_model/theil_sen.py
+++ b/sklearn/linear_model/theil_sen.py
@@ -285,6 +285,8 @@ class TheilSenRegressor(LinearModel, RegressorMixin):
     >>> reg = TheilSenRegressor(random_state=0).fit(X, y)
     >>> reg.score(X, y) # doctest: +ELLIPSIS
     0.9884...
+    >>> reg.predict(X[:1,])
+    array([-31.5871...])
 
     References
     ----------

--- a/sklearn/linear_model/theil_sen.py
+++ b/sklearn/linear_model/theil_sen.py
@@ -276,6 +276,16 @@ class TheilSenRegressor(LinearModel, RegressorMixin):
         Number of combinations taken into account from 'n choose k', where n is
         the number of samples and k is the number of subsamples.
 
+    Examples
+    --------
+    >>> from sklearn.linear_model import TheilSenRegressor
+    >>> from sklearn.datasets import make_regression
+    >>> X, y = make_regression(
+    ...     n_samples=200, n_features=2, noise=4.0, random_state=0)
+    >>> reg = TheilSenRegressor(random_state=0).fit(X, y)
+    >>> reg.score(X, y) # doctest: +ELLIPSIS
+    0.9884...
+
     References
     ----------
     - Theil-Sen Estimators in a Multiple Linear Regression Model, 2009


### PR DESCRIPTION
See #3846

Examples added to the docstrings of all classes under `linear_model` which didn't already have an example.