### PR TITLE
MNT Remove n_clusters_ in OPTICS

### DIFF
--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -370,7 +370,6 @@ class OPTICS(BaseEstimator, ClusterMixin):
                                                  self.min_cluster_size_ratio,
                                                  self.min_maxima_ratio)
         self.core_sample_indices_ = indices_
-        self.n_clusters_ = np.max(self.labels_)
         return self
 
     # OPTICS helper functions; these should not be public #


### PR DESCRIPTION
Closes #11979 
This attribute is not used & not documented. What's more, seems that it's not very useful. So maybe we can remove it.