### PR TITLE
COSMIT remove unnecessary _TreeNode methods

### DIFF
--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -612,12 +612,6 @@ class _TreeNode(object):
         self.children = []
         self.split_point = -1
 
-    def assign_split_point(self, split_point):
-        self.split_point = split_point
-
-    def add_child(self, child):
-        self.children.append(child)
-
 
 def _is_local_maxima(index, reachability_plot, neighborhood_size):
     right_idx = slice(index + 1, index + neighborhood_size + 1)
@@ -661,7 +655,7 @@ def _cluster_tree(node, parent_node, local_maxima_points,
 
     # take largest local maximum as possible separation between clusters
     s = local_maxima_points[0]
-    node.assign_split_point(s)
+    node.split_point = s
     local_maxima_points = local_maxima_points[1:]
 
     # create two new nodes and add to list of nodes
@@ -683,7 +677,7 @@ def _cluster_tree(node, parent_node, local_maxima_points,
     node_list.append((node_2, local_max_2))
 
     if reachability_plot[s] < significant_min:
-        node.assign_split_point(-1)
+        node.split_point = -1
         # if split_point is not significant, ignore this split and continue
         _cluster_tree(node, parent_node, local_maxima_points,
                       reachability_plot, reachability_ordering,
@@ -715,7 +709,7 @@ def _cluster_tree(node, parent_node, local_maxima_points,
                 (avg_reach2 / reachability_plot[s]) >= rejection_ratio):
             # since split_point is not significant,
             # ignore this split and continue (reject both child nodes)
-            node.assign_split_point(-1)
+            node.split_point = -1
             _cluster_tree(node, parent_node, local_maxima_points,
                           reachability_plot, reachability_ordering,
                           min_cluster_size, maxima_ratio, rejection_ratio,
@@ -733,7 +727,7 @@ def _cluster_tree(node, parent_node, local_maxima_points,
         node_list.remove((node_2, local_max_2))
     if not node_list:
         # parent_node will be a leaf
-        node.assign_split_point(-1)
+        node.split_point = -1
         return
 
     # Check if nodes can be moved up one level - the new cluster created
@@ -748,13 +742,13 @@ def _cluster_tree(node, parent_node, local_maxima_points,
 
     for nl in node_list:
         if bypass_node == 1:
-            parent_node.add_child(nl[0])
+            parent_node.children.append(nl[0])
             _cluster_tree(nl[0], parent_node, nl[1],
                           reachability_plot, reachability_ordering,
                           min_cluster_size, maxima_ratio, rejection_ratio,
                           similarity_threshold, significant_min)
         else:
-            node.add_child(nl[0])
+            node.children.append(nl[0])
             _cluster_tree(nl[0], node, nl[1], reachability_plot,
                           reachability_ordering, min_cluster_size,
                           maxima_ratio, rejection_ratio,


### PR DESCRIPTION
These methods are trivial.

I note that `_TreeNode.points` is only really used in a test, and `parent_node` is not used at all. Should we remove them?