### PR TITLE
[MRG+1] OPTICS remove redundant recursion

### DIFF
--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -685,10 +685,6 @@ def _cluster_tree(node, parent_node, local_maxima_points,
     if reachability_plot[s] < significant_min:
         node.assign_split_point(-1)
         # if split_point is not significant, ignore this split and continue
-        _cluster_tree(node, parent_node, local_maxima_points,
-                      reachability_plot, reachability_ordering,
-                      min_cluster_size, maxima_ratio, rejection_ratio,
-                      similarity_threshold, significant_min)
         return
 
     # only check a certain ratio of points in the child


### PR DESCRIPTION
See https://github.com/scikit-learn/scikit-learn/pull/11857#discussion_r214556247

This recursion will continue on `local_maxima_points`, which is sorted by their `reachability_`. Therefore all the following recursions will also fall into this condition. As a result it's redundant and not necessary to continue the recursion at the point where it falls into this condition.