### PR TITLE
adding scikit-multilearn to related projects list

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -183,7 +183,10 @@ and tasks.
 
 - `multiisotonic <https://github.com/alexfields/multiisotonic>`_ Isotonic
   regression on multidimensional features.
-  
+
+- `scikit-multilearn <https://scikit.ml>`_ Multi-label classification with 
+  focus on label space manipulation.
+
 - `seglearn <https://github.com/dmbee/seglearn>`_ Time series and sequence 
   learning using sliding window segmentation.
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Include scikit-multilearn in related projects list, it is a library dedicated to multi-label classification, has been around for 4 years and has reached a stable release.