### PR TITLE
DOC note controversy on multiclass balanced accuracy definition

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1403,6 +1403,13 @@ def balanced_accuracy_score(y_true, y_pred, sample_weight=None,
     --------
     recall_score, roc_auc_score
 
+    Notes
+    -----
+    Some literature promotes alternative definitions of balanced accuracy. Our
+    definition is equivalent to :func:`accuracy_score` with class-balanced
+    sample weights, and shares desirable properties with the binary case.
+    See the :ref:`User Guide <balanced_accuracy_score>`.
+
     References
     ----------
     .. [1] Brodersen, K.H.; Ong, C.S.; Stephan, K.E.; Buhmann, J.M. (2010).


### PR DESCRIPTION
Further emphasis on disputed meaning of "balanced accuracy" in multiclass case in response to https://github.com/scikit-learn/scikit-learn/issues/6747#issuecomment-417209333. This is already discussed in the [User Guide](http://scikit-learn.org/dev/modules/model_evaluation.html#balanced-accuracy-score), but now has a note in the API reference.

Ping @ledell