### PR TITLE
[MRG] DOC: Add pytest version in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,8 +119,6 @@ contribute to scikit-learn: https://github.com/scikit-learn/scikit-learn/blob/ma
 Testing
 ~~~~~~~
 
-.. if you change pytest min version here, also change it in conftest.py
-
 After installation, you can launch the test suite from outside the
 source directory (you will need to have ``pytest`` >= 3.3.0 installed)::
 

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,8 @@ Testing
 ~~~~~~~
 
 After installation, you can launch the test suite from outside the
-source directory (you will need to have the ``pytest`` package installed)::
+source directory (you will need to have the ``pytest`` package installed
+(version >= 3.3.0))::
 
     pytest sklearn
 

--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,8 @@ contribute to scikit-learn: https://github.com/scikit-learn/scikit-learn/blob/ma
 Testing
 ~~~~~~~
 
+.. if you change pytest min version here, also change it in conftest.py
+
 After installation, you can launch the test suite from outside the
 source directory (you will need to have ``pytest`` >= 3.3.0 installed)::
 

--- a/README.rst
+++ b/README.rst
@@ -120,8 +120,7 @@ Testing
 ~~~~~~~
 
 After installation, you can launch the test suite from outside the
-source directory (you will need to have the ``pytest`` package installed
-(version >= 3.3.0))::
+source directory (you will need to have ``pytest`` >= 3.3.0 installed)::
 
     pytest sklearn
 

--- a/conftest.py
+++ b/conftest.py
@@ -11,10 +11,12 @@ from distutils.version import LooseVersion
 import pytest
 from _pytest.doctest import DoctestItem
 
+# if you change pytest min version here, also change it in README.rst
+PYTEST_MIN_VERSION = '3.3.0'
 
-if LooseVersion(pytest.__version__) < '3.3.0':
+if LooseVersion(pytest.__version__) < PYTEST_MIN_VERSION:
     raise('Your version of pytest is too old, you should have at least '
-          'pytest >= 3.3.0 installed.')
+          'pytest >= {} installed.'.format(PYTEST_MIN_VERSION))
 
 def pytest_collection_modifyitems(config, items):
 

--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,10 @@ import pytest
 from _pytest.doctest import DoctestItem
 
 
+if LooseVersion(pytest.__version__) < '3.3.0':
+    raise('Your version of pytest is too old, you should have at least '
+          'pytest >= 3.3.0 installed.')
+
 def pytest_collection_modifyitems(config, items):
 
     # FeatureHasher is not compatible with PyPy

--- a/conftest.py
+++ b/conftest.py
@@ -11,7 +11,6 @@ from distutils.version import LooseVersion
 import pytest
 from _pytest.doctest import DoctestItem
 
-# if you change pytest min version here, also change it in README.rst
 PYTEST_MIN_VERSION = '3.3.0'
 
 if LooseVersion(pytest.__version__) < PYTEST_MIN_VERSION:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -122,6 +122,7 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  Major themes that come with

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -122,18 +122,6 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
-## Substitutions to be used in all documents:
-
-# loading variables
-conftest_vars = {}
-with open(os.path.join('..', 'conftest.py')) as fp:
-    exec(fp.read(), conftest_vars)
-
-# using variables in substitutions
-rst_prolog = """
-.. |PytestMinVersion| replace:: {pytest_min_version}
-""".format(pytest_min_version=conftest_vars['PYTEST_MIN_VERSION'])
-
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  Major themes that come with

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -122,6 +122,17 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
+## Substitutions to be used in all documents:
+
+# loading variables
+conftest_vars = {}
+with open(os.path.join('..', 'conftest.py')) as fp:
+    exec(fp.read(), conftest_vars)
+
+# using variables in substitutions
+rst_prolog = """
+.. |Pytest| replace:: {pytest_min_version}
+""".format(pytest_min_version=conftest_vars['PYTEST_MIN_VERSION'])
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -131,7 +131,7 @@ with open(os.path.join('..', 'conftest.py')) as fp:
 
 # using variables in substitutions
 rst_prolog = """
-.. |Pytest| replace:: {pytest_min_version}
+.. |PytestMinVersion| replace:: {pytest_min_version}
 """.format(pytest_min_version=conftest_vars['PYTEST_MIN_VERSION'])
 
 # -- Options for HTML output -------------------------------------------------

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -50,7 +50,7 @@ Building Scikit-learn also requires
 
 Running tests requires
 
-- pytest >=\ |Pytest|
+- pytest >=\ |PytestMinVersion|
 
 Some tests also require `pandas <https://pandas.pydata.org>`_.
 
@@ -276,7 +276,7 @@ Testing
 Testing scikit-learn once installed
 -----------------------------------
 
-Testing requires having `pytest <https://docs.pytest.org>`_ >=\ |Pytest|\ .
+Testing requires having `pytest <https://docs.pytest.org>`_ >=\ |PytestMinVersion|\ .
 Some tests also require having `pandas <https://pandas.pydata.org/>` installed.
 After installation, the package can be tested by executing *from outside* the
 source directory::

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -50,7 +50,7 @@ Building Scikit-learn also requires
 
 Running tests requires
 
-- pytest >=3.3.0
+- pytest >=\ |Pytest|
 
 Some tests also require `pandas <https://pandas.pydata.org>`_.
 
@@ -276,8 +276,8 @@ Testing
 Testing scikit-learn once installed
 -----------------------------------
 
-Testing requires having `pytest <https://docs.pytest.org>`_ >= 3.3.0. Some
-tests also require having `pandas <https://pandas.pydata.org/>` installed.
+Testing requires having `pytest <https://docs.pytest.org>`_ >=\ |Pytest|\ .
+Some tests also require having `pandas <https://pandas.pydata.org/>` installed.
 After installation, the package can be tested by executing *from outside* the
 source directory::
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -50,7 +50,7 @@ Building Scikit-learn also requires
 
 Running tests requires
 
-- pytest
+- pytest >=3.3.0
 
 Some tests also require `pandas <https://pandas.pydata.org>`_.
 
@@ -277,8 +277,8 @@ Testing scikit-learn once installed
 -----------------------------------
 
 Testing requires having the `pytest
-<https://docs.pytest.org>`_ library. Some tests also require having
-`pandas <https://pandas.pydata.org/>` installed.
+<https://docs.pytest.org>`_ library (version >= 3.3.0). Some tests also require
+having `pandas <https://pandas.pydata.org/>` installed.
 After installation, the package can be tested by executing *from outside* the
 source directory::
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -276,9 +276,8 @@ Testing
 Testing scikit-learn once installed
 -----------------------------------
 
-Testing requires having the `pytest
-<https://docs.pytest.org>`_ library (version >= 3.3.0). Some tests also require
-having `pandas <https://pandas.pydata.org/>` installed.
+Testing requires having `pytest <https://docs.pytest.org>`_ >= 3.3.0. Some
+tests also require having `pandas <https://pandas.pydata.org/>` installed.
 After installation, the package can be tested by executing *from outside* the
 source directory::
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -50,6 +50,8 @@ Building Scikit-learn also requires
 
 Running tests requires
 
+.. |PytestMinVersion| replace:: 3.3.0
+
 - pytest >=\ |PytestMinVersion|
 
 Some tests also require `pandas <https://pandas.pydata.org>`_.


### PR DESCRIPTION
This PR adds the minimal pytest version needed in order to avoid arguments like `match` (as in `with pytest.raises(SomeError, match='some error message'):`) to fail silently (see #12001)