### PR TITLE
[MRG] MNT: Use `fmax` when finding the maximum

### DIFF
--- a/sklearn/linear_model/cd_fast.pyx
+++ b/sklearn/linear_model/cd_fast.pyx
@@ -244,11 +244,9 @@ def enet_coordinate_descent(floating[::1] w,
 
                 # update the maximum absolute coefficient update
                 d_w_ii = fabs(w[ii] - w_ii)
-                if d_w_ii > d_w_max:
-                    d_w_max = d_w_ii
+                d_w_max = fmax(d_w_max, d_w_ii)
 
-                if fabs(w[ii]) > w_max:
-                    w_max = fabs(w[ii])
+                w_max = fmax(w_max, fabs(w[ii]))
 
             if (w_max == 0.0 or
                 d_w_max / w_max < d_w_tol or


### PR DESCRIPTION
Instead of adding an `if` to check for values that become the new max, simply use `fmax` to get the maximum and update the value. This improves readability. It may improve performance as `fmax` can be a single assembly instruction. Though most compilers can probably figure this out anyways.