### PR TITLE
MAINT make pytest collection ignore folders with Python scripts

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,10 @@ test = pytest
 # disable-pytest-warnings should be removed once we rewrite tests
 # using yield with parametrize
 addopts =
+    --ignore build_tools
+    --ignore benchmarks
+    --ignore doc
+    --ignore examples
     --doctest-modules
     --disable-pytest-warnings
     -rs


### PR DESCRIPTION
Some IDEs such as VS Code use the pytest command to collect all the tests of
the workspace in the background. This can cause unexpected execution of
arbitrary Python scripts in the workspace (examples, benchmarks...).

The doc folder is also ignored because it has python scripts for sphinx
along with copies of the examples.

To safely run pytest in the doc folder, we need to use the find command
to find all "*.rst" files as done in the project Makefile.