### PR TITLE
miniscule spacing issue fixed in the iris dataset description

### DIFF
--- a/sklearn/datasets/descr/iris.rst
+++ b/sklearn/datasets/descr/iris.rst
@@ -25,7 +25,7 @@ Iris plants dataset
     sepal length:   4.3  7.9   5.84   0.83    0.7826
     sepal width:    2.0  4.4   3.05   0.43   -0.4194
     petal length:   1.0  6.9   3.76   1.76    0.9490  (high!)
-    petal width:    0.1  2.5   1.20  0.76     0.9565  (high!)
+    petal width:    0.1  2.5   1.20   0.76    0.9565  (high!)
     ============== ==== ==== ======= ===== ====================
 
     :Missing Attribute Values: None


### PR DESCRIPTION
It's just a spacing misalignment in the iris.DESCR which I felt compelled to fix