### PR TITLE
[MRG] DOCS: Incorrect variable description

### DIFF
--- a/sklearn/datasets/descr/linnerud.rst
+++ b/sklearn/datasets/descr/linnerud.rst
@@ -12,10 +12,11 @@ Linnerrud dataset
 The Linnerud dataset constains two small dataset:
 
 - *exercise*: A list containing the following components: exercise data with
-  20 observations on 3 exercise variables: Weight, Waist and Pulse.
+  20 observations on 3 exercise variables:
+  Chins, Situps and Jumps. 
 
 - *physiological*: Data frame with 20 observations on 3 physiological variables:
-   Chins, Situps and Jumps.
+   Weight, Waist and Pulse.
 
 .. topic:: References
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Fixes incorrect documentation. The variables list for the two `linerudd` datasets should be swapped.
Actual datasets can be found here: [exercise](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/datasets/data/linnerud_exercise.csv) and [physiological](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/datasets/data/linnerud_physiological.csv)

#### Any other comments?
None

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
