### PR TITLE
MAINT skip joblib vendor test on debian

### DIFF
--- a/sklearn/tests/test_site_joblib.py
+++ b/sklearn/tests/test_site_joblib.py
@@ -1,4 +1,6 @@
 import os
+import pytest
+from sklearn import externals
 from sklearn.externals import joblib as joblib_vendored
 from sklearn.utils import Parallel, delayed, Memory, parallel_backend
 
@@ -9,6 +11,11 @@ else:
 
 
 def test_old_pickle(tmpdir):
+    vendored_joblib_home = os.path.dirname(joblib_vendored.__file__)
+    sklearn_externals_home = os.path.dirname(externals.__file__)
+    if not vendored_joblib_home.startswith(sklearn_externals_home):
+        pytest.skip("joblib is physically unvendored (e.g. as in debian)")
+
     # Check that a pickle that references sklearn.external.joblib can load
     f = tmpdir.join('foo.pkl')
     f.write(b'\x80\x02csklearn.externals.joblib.numpy_pickle\nNumpyArrayWrappe'


### PR DESCRIPTION
This should fix #12016 reported when preparing debian packages.