### PR TITLE
[MRG+1] Fix optics metric issues (DOC and precomputed)

### DIFF
--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -369,7 +369,7 @@ class OPTICS(BaseEstimator, ClusterMixin):
         self : instance of OPTICS
             The instance.
         """
-        X = check_array(X, dtype=np.float)
+        X = check_array(X, dtype=np.float64)
 
         n_samples = len(X)
 

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -199,11 +199,30 @@ class OPTICS(BaseEstimator, ClusterMixin):
         shorter run times.
 
     metric : string or callable, optional (default='euclidean')
-        The distance metric to use for neighborhood lookups. Default is
-        "euclidean". Other options include "minkowski", "manhattan",
-        "chebyshev", "haversine", "seuclidean", "hamming", "canberra",
-        and "braycurtis". The "wminkowski" and "mahalanobis" metrics are
-        also valid with an additional argument.
+        metric to use for distance computation. Any metric from scikit-learn
+        or scipy.spatial.distance can be used.
+
+        If metric is a callable function, it is called on each
+        pair of instances (rows) and the resulting value recorded. The callable
+        should take two arrays as input and return one value indicating the
+        distance between them. This works for Scipy's metrics, but is less
+        efficient than passing the metric name as a string.
+
+        Distance matrices are not supported.
+
+        Valid values for metric are:
+
+        - from scikit-learn: ['cityblock', 'cosine', 'euclidean', 'l1', 'l2',
+          'manhattan']
+
+        - from scipy.spatial.distance: ['braycurtis', 'canberra', 'chebyshev',
+          'correlation', 'dice', 'hamming', 'jaccard', 'kulsinski',
+          'mahalanobis', 'minkowski', 'rogerstanimoto', 'russellrao',
+          'seuclidean', 'sokalmichener', 'sokalsneath', 'sqeuclidean',
+          'yule']
+
+        See the documentation for scipy.spatial.distance for details on these
+        metrics.
 
     p : integer, optional (default=2)
         Parameter for the Minkowski metric from
@@ -346,7 +365,7 @@ class OPTICS(BaseEstimator, ClusterMixin):
         self : instance of OPTICS
             The instance.
         """
-        X = check_array(X, dtype=np.float)
+        X = check_array(X, dtype=np.float, accept_sparse=True)
 
         n_samples = len(X)
         # Start all points as 'unprocessed' ##

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -457,8 +457,11 @@ class OPTICS(BaseEstimator, ClusterMixin):
             # Everything is already processed. Return to main loop
             return point_index
 
-        dists = pairwise_distances(P, np.take(X, unproc, axis=0),
-                                   self.metric, n_jobs=1).ravel()
+        if self.metric == 'precomputed':
+            dists = X[point_index, unproc]
+        else:
+            dists = pairwise_distances(P, np.take(X, unproc, axis=0),
+                                       self.metric, n_jobs=None).ravel()
 
         rdists = np.maximum(dists, self.core_distances_[point_index])
         new_reach = np.minimum(np.take(self.reachability_, unproc), rdists)

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -369,7 +369,7 @@ class OPTICS(BaseEstimator, ClusterMixin):
         self : instance of OPTICS
             The instance.
         """
-        X = check_array(X, dtype=np.float64)
+        X = check_array(X, dtype=np.float)
 
         n_samples = len(X)
 

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -365,7 +365,7 @@ class OPTICS(BaseEstimator, ClusterMixin):
         self : instance of OPTICS
             The instance.
         """
-        X = check_array(X, dtype=np.float, accept_sparse=True)
+        X = check_array(X, dtype=np.float)
 
         n_samples = len(X)
         # Start all points as 'unprocessed' ##

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -52,11 +52,30 @@ def optics(X, min_samples=5, max_eps=np.inf, metric='euclidean',
         shorter run times.
 
     metric : string or callable, optional (default='euclidean')
-        The distance metric to use for neighborhood lookups. Default is
-        "euclidean". Other options include "minkowski", "manhattan",
-        "chebyshev", "haversine", "seuclidean", "hamming", "canberra",
-        and "braycurtis". The "wminkowski" and "mahalanobis" metrics are
-        also valid with an additional argument.
+        metric to use for distance computation. Any metric from scikit-learn
+        or scipy.spatial.distance can be used.
+
+        If metric is a callable function, it is called on each
+        pair of instances (rows) and the resulting value recorded. The callable
+        should take two arrays as input and return one value indicating the
+        distance between them. This works for Scipy's metrics, but is less
+        efficient than passing the metric name as a string.
+
+        Distance matrices are not supported.
+
+        Valid values for metric are:
+
+        - from scikit-learn: ['cityblock', 'cosine', 'euclidean', 'l1', 'l2',
+          'manhattan']
+
+        - from scipy.spatial.distance: ['braycurtis', 'canberra', 'chebyshev',
+          'correlation', 'dice', 'hamming', 'jaccard', 'kulsinski',
+          'mahalanobis', 'minkowski', 'rogerstanimoto', 'russellrao',
+          'seuclidean', 'sokalmichener', 'sokalsneath', 'sqeuclidean',
+          'yule']
+
+        See the documentation for scipy.spatial.distance for details on these
+        metrics.
 
     p : integer, optional (default=2)
         Parameter for the Minkowski metric from
@@ -398,8 +417,11 @@ class OPTICS(BaseEstimator, ClusterMixin):
                              indices, axis=0)
         # Keep n_jobs = 1 in the following lines...please
         if len(unproc) > 0:
-            dists = pairwise_distances(P, np.take(X, unproc, axis=0),
-                                       self.metric, n_jobs=None).ravel()
+            if self.metric == 'precomputed':
+                dists = X[point_index, unproc]
+            else:
+                dists = pairwise_distances(P, np.take(X, unproc, axis=0),
+                                           self.metric, n_jobs=None).ravel()
 
             rdists = np.maximum(dists, self.core_distances_[point_index])
             new_reach = np.minimum(np.take(self.reachability_, unproc), rdists)

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -440,23 +440,12 @@ def test_reach_dists():
 
 
 def test_precomputed_dists():
-    rng = np.random.RandomState(0)
-    n_points_per_cluster = 50
-
-    C1 = [-5, -2] + .8 * rng.randn(n_points_per_cluster, 2)
-    C2 = [4, -1] + .1 * rng.randn(n_points_per_cluster, 2)
-    C3 = [1, -2] + .2 * rng.randn(n_points_per_cluster, 2)
-    C4 = [-2, 3] + .3 * rng.randn(n_points_per_cluster, 2)
-    C5 = [3, -2] + 1.6 * rng.randn(n_points_per_cluster, 2)
-    C6 = [5, 6] + 2 * rng.randn(n_points_per_cluster, 2)
-    X = np.vstack((C1, C2, C3, C4, C5, C6))
-
-    dists = pairwise_distances(X, metric='euclidean')
+    redX = X[::10]
+    dists = pairwise_distances(redX, metric='euclidean')
     clust1 = OPTICS(min_samples=10, algorithm='brute',
                     metric='precomputed').fit(dists)
     clust2 = OPTICS(min_samples=10, algorithm='brute',
-                    metric='euclidean').fit(X)
+                    metric='euclidean').fit(redX)
 
     assert_allclose(clust1.reachability_, clust2.reachability_)
     assert_array_equal(clust1.labels_, clust2.labels_)
-    assert_array_equal(clust1.ordering_, clust2.ordering_)


### PR DESCRIPTION
Fixes #12009
See #11982

Still doesn't support the output of `radius_neighbors_graph` as input though.

Question: what's the criterion to include one's name in the _authors_ section in the files? Are those only the original authors or do I count as an author in the `optics_.py` and `test_optics.py` now?