### PR TITLE
BUG: always raise on NaN in OneHotEncoder for object dtype data

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -52,8 +52,8 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
             X = X_temp
 
         if X.dtype == np.dtype('object'):
-           if _object_dtype_isnan(X).any():
-               raise ValueError("Input contains NaN")
+            if _object_dtype_isnan(X).any():
+                raise ValueError("Input contains NaN")
 
         return X
 

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -10,6 +10,7 @@ import warnings
 import numpy as np
 from scipy import sparse
 
+from .. import get_config as _get_config
 from ..base import BaseEstimator, TransformerMixin
 from ..externals import six
 from ..utils import check_array
@@ -52,8 +53,9 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
             X = X_temp
 
         if X.dtype == np.dtype('object'):
-            if _object_dtype_isnan(X).any():
-                raise ValueError("Input contains NaN")
+            if not _get_config()['assume_finite']:
+                if _object_dtype_isnan(X).any():
+                    raise ValueError("Input contains NaN")
 
         return X
 

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -504,15 +504,15 @@ def test_one_hot_encoder_feature_names_unicode():
 def test_one_hot_encoder_raise_missing(X, handle_unknown):
     ohe = OneHotEncoder(categories='auto', handle_unknown=handle_unknown)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Input contains NaN"):
         ohe.fit(X)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Input contains NaN"):
         ohe.fit_transform(X)
 
     ohe.fit(X[:1, :])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Input contains NaN"):
         ohe.transform(X)
 
 
@@ -549,15 +549,15 @@ def test_ordinal_encoder_inverse():
 def test_ordinal_encoder_raise_missing(X):
     ohe = OrdinalEncoder()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Input contains NaN"):
         ohe.fit(X)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Input contains NaN"):
         ohe.fit_transform(X)
 
     ohe.fit(X[:1, :])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Input contains NaN"):
         ohe.transform(X)
 
 

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -497,6 +497,25 @@ def test_one_hot_encoder_feature_names_unicode():
     assert_array_equal([u'n👍me_c❤t1', u'n👍me_dat2'], feature_names)
 
 
+@pytest.mark.parametrize("X", [np.array([[1, np.nan]]).T,
+                               np.array([['a', np.nan]], dtype=object).T],
+                         ids=['numeric', 'object'])
+@pytest.mark.parametrize("handle_unknown", ['error', 'ignore'])
+def test_one_hot_encoder_raise_missing(X, handle_unknown):
+    ohe = OneHotEncoder(categories='auto', handle_unknown=handle_unknown)
+
+    with pytest.raises(ValueError):
+        ohe.fit(X)
+
+    with pytest.raises(ValueError):
+        ohe.fit_transform(X)
+
+    ohe.fit(X[:1, :])
+
+    with pytest.raises(ValueError):
+        ohe.transform(X)
+
+
 @pytest.mark.parametrize("X", [
     [['abc', 2, 55], ['def', 1, 55]],
     np.array([[10, 2, 55], [20, 1, 55]]),
@@ -522,6 +541,24 @@ def test_ordinal_encoder_inverse():
     X_tr = np.array([[0, 1, 1, 2], [1, 0, 1, 0]])
     msg = re.escape('Shape of the passed X data is not correct')
     assert_raises_regex(ValueError, msg, enc.inverse_transform, X_tr)
+
+
+@pytest.mark.parametrize("X", [np.array([[1, np.nan]]).T,
+                               np.array([['a', np.nan]], dtype=object).T],
+                         ids=['numeric', 'object'])
+def test_ordinal_encoder_raise_missing(X):
+    ohe = OrdinalEncoder()
+
+    with pytest.raises(ValueError):
+        ohe.fit(X)
+
+    with pytest.raises(ValueError):
+        ohe.fit_transform(X)
+
+    ohe.fit(X[:1, :])
+
+    with pytest.raises(ValueError):
+        ohe.transform(X)
 
 
 def test_encoder_dtypes():


### PR DESCRIPTION
Closes #12018

This does not really solve the underlying issue that the `valid_mask` logic (for handling unknown categories) needs to become NaN-aware, but this PR (by checking for NaNs and then raising) will prevent that we get to that point if there are NaNs in the data. 

When we change the default of raising to passing through the NaNs, the masking logic will need to be reworked anyway. 