### PR TITLE
[MRG] MNT Only checks warnings on latest depedendencies versions in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
     # installed from their CI wheels in a virtualenv with the Python
     # interpreter provided by travis.
     -  python: 3.6
-       env: DISTRIB="scipy-dev"
+       env: DISTRIB="scipy-dev" CHECK_WARNINGS="true"
        if: type = cron OR commit_message =~ /\[scipy-dev\]/
 
 install: source build_tools/travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
            CYTHON_VERSION="*" PYAMG_VERSION="*" PILLOW_VERSION="*"
            JOBLIB_VERSION="*" COVERAGE=true
            CHECK_PYTEST_SOFT_DEPENDENCY="true" TEST_DOCSTRINGS="true"
-           SKLEARN_SITE_JOBLIB=1
+           SKLEARN_SITE_JOBLIB=1 CHECK_WARNINGS="true"
       if: type != cron
     # flake8 linting on diff wrt common ancestor with upstream/master
     - env: RUN_FLAKE8="true" SKIP_TESTS="true"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,9 +75,9 @@ test_script:
   - cd "../empty_folder"
   - ps: >-
         if (Test-Path variable:global:CHECK_WARNINGS) {
-            $env.PYTEST_ARGS = "-Werror::DeprecationWarning -Werror::FutureWarning"
+            $env:PYTEST_ARGS = "-Werror::DeprecationWarning -Werror::FutureWarning"
         } else {
-            $env.PYTEST_ARGS = ""
+            $env:PYTEST_ARGS = ""
         }
   - "pytest --showlocals --durations=20 %PYTEST_ARGS% --pyargs sklearn"
   # Move back to the project folder

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ environment:
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.0"
       PYTHON_ARCH: "64"
+      CHECK_WARNINGS: "true"
 
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.8"
@@ -72,7 +73,13 @@ test_script:
   # installed library.
   - mkdir "../empty_folder"
   - cd "../empty_folder"
-  - pytest --showlocals --durations=20 --pyargs sklearn
+  - ps: >-
+        if (Test-Path variable:global:CHECK_WARNINGS) {
+            $env.PYTEST_ARGS = "-Werror::DeprecationWarning -Werror::FutureWarning"
+        } else {
+            $env.PYTEST_ARGS = ""
+        }
+  - "pytest --showlocals --durations=20 %PYTEST_ARGS% --pyargs sklearn"
   # Move back to the project folder
   - cd "../scikit-learn"
 

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -84,11 +84,7 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # and scipy
     virtualenv --system-site-packages testvenv
     source testvenv/bin/activate
-    # FIXME: Importing scipy.sparse with numpy 1.8.2 and scipy 0.13.3 produces
-    # a deprecation warning and the test suite fails on such warnings.
-    # To test these numpy/scipy versions, we use pytest<3.8 as it has
-    # a known limitation/bug of not capturing warnings during test collection.
-    pip install pytest==3.7.4 pytest-cov cython==$CYTHON_VERSION
+    pip install pytest pytest-cov cython==$CYTHON_VERSION
 
 elif [[ "$DISTRIB" == "scipy-dev" ]]; then
     make_conda python=3.7

--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -38,6 +38,11 @@ run_tests() {
     if [[ "$COVERAGE" == "true" ]]; then
         TEST_CMD="$TEST_CMD --cov sklearn"
     fi
+
+    if [[ -n "$CHECK_WARNINGS" ]]; then
+        TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning"
+    fi
+
     $TEST_CMD sklearn
 
     # Going back to git checkout folder needed to test documentation

--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -43,6 +43,8 @@ run_tests() {
         TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning"
     fi
 
+    set -x  # print executed commands to the terminal
+
     $TEST_CMD sklearn
 
     # Going back to git checkout folder needed to test documentation

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,6 @@ addopts =
     --doctest-modules
     --disable-pytest-warnings
     -rs
-filterwarnings =
-    error::DeprecationWarning
-    error::FutureWarning
 
 [wheelhouse_uploader]
 artifact_indexes=


### PR DESCRIPTION
Closes #12043 

This removes error on warning from `setup.cfg` adds it explicitly to the CI builds that use the latest dependencies.

This ~~is blocker~~ would be nice to have  for #12039  

cc @amueller who might be opposed to this change.