### PR TITLE
[WIP] OPTICS include split points in clusters if not noise

### DIFF
--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -25,7 +25,7 @@ def optics(X, min_samples=5, max_eps=np.inf, metric='euclidean',
            p=2, metric_params=None, maxima_ratio=.75,
            rejection_ratio=.7, similarity_threshold=0.4,
            significant_min=.003, min_cluster_size=.005,
-           min_maxima_ratio=0.001, xi=0.8, algorithm='ball_tree',
+           min_maxima_ratio=0.001, xi=0.9, algorithm='ball_tree',
            leaf_size=30, n_jobs=None):
     """Perform OPTICS clustering from vector array
 
@@ -294,7 +294,7 @@ class OPTICS(BaseEstimator, ClusterMixin):
                  p=2, metric_params=None, maxima_ratio=.75,
                  rejection_ratio=.7, similarity_threshold=0.4,
                  significant_min=.003, min_cluster_size=.005,
-                 min_maxima_ratio=0.001, xi=.8, algorithm='ball_tree',
+                 min_maxima_ratio=0.001, xi=.9, algorithm='ball_tree',
                  leaf_size=30, n_jobs=None):
 
         self.max_eps = max_eps
@@ -510,7 +510,7 @@ def _extract_dbscan(ordering, core_distances, reachability, eps):
 def _extract_optics(ordering, reachability, maxima_ratio=.75,
                     rejection_ratio=.7, similarity_threshold=0.4,
                     significant_min=.003, min_cluster_size=.005,
-                    min_maxima_ratio=0.001, xi=0.8):
+                    min_maxima_ratio=0.001, xi=0.9):
     """Performs automatic cluster extraction for variable density data.
 
     Parameters
@@ -583,12 +583,6 @@ def _extract_optics(ordering, reachability, maxima_ratio=.75,
         labels[index] = clustid
         is_core[index] = 1
         clustid += 1
-
-    # check if the last point is xi-steep upward
-    last_point = ordering[-1]
-    if reachability_plot[-2] <= reachability_plot[-1] * (1 - xi):
-        labels[last_point] = -1
-        is_core[last_point] = 0
 
     return np.arange(n_samples)[is_core], labels
 
@@ -692,8 +686,15 @@ def _cluster_tree(node, parent_node, local_maxima_points,
         node_2_start = s
     else:
         node_2_start = s + 1
-    node_2 = _TreeNode(reachability_ordering[node_2_start:node.end],
-                       node_2_start, node.end, node)
+
+    # check if the last point is xi-steep upward
+    node_2_end = node.end
+    if (reachability_plot[node.end - 1] * (1 - xi)
+        >= reachability_plot[node.end - 2]):
+        node_2_end = node.end - 1
+
+    node_2 = _TreeNode(reachability_ordering[node_2_start:node_2_end],
+                       node_2_start, node_2_end, node)
     local_max_1 = []
     local_max_2 = []
 

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -103,6 +103,11 @@ def optics(X, min_samples=5, max_eps=np.inf, metric='euclidean',
         Each local maxima should be a largest value in a neighborhood
         of the `size min_maxima_ratio * len(X)` from left and right.
 
+    xi : float between 0 and 1, optional (default=.9)
+        Defines the steepness used to include/explude a split point and
+        the last point of a split in that cluster. Setting `xi` to 1
+        would always exclude those split points. 
+
     algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:
 
@@ -232,6 +237,11 @@ class OPTICS(BaseEstimator, ClusterMixin):
         Used to determine neighborhood size for minimum cluster membership.
         Each local maxima should be a largest value in a neighborhood
         of the `size min_maxima_ratio * len(X)` from left and right.
+
+    xi : float between 0 and 1, optional (default=.9)
+        Defines the steepness used to include/explude a split point and
+        the last point of a split in that cluster. Setting `xi` to 1
+        would always exclude those split points.
 
     algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -106,7 +106,7 @@ def optics(X, min_samples=5, max_eps=np.inf, metric='euclidean',
     xi : float between 0 and 1, optional (default=.9)
         Defines the steepness used to include/explude a split point and
         the last point of a split in that cluster. Setting `xi` to 1
-        would always exclude those split points. 
+        would always exclude those split points.
 
     algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:
@@ -700,7 +700,7 @@ def _cluster_tree(node, parent_node, local_maxima_points,
     # check if the last point is xi-steep upward
     node_2_end = node.end
     if (reachability_plot[node.end - 1] * (1 - xi)
-        >= reachability_plot[node.end - 2]):
+            >= reachability_plot[node.end - 2]):
         node_2_end = node.end - 1
 
     node_2 = _TreeNode(reachability_ordering[node_2_start:node_2_end],

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -179,6 +179,26 @@ def test_min_cluster_size_invalid2():
         clust.fit(X)
 
 
+def test_auto_extract_outlier():
+    np.random.seed(0)
+
+    n_points_per_cluster = 4
+
+    C1 = [-5, -2] + .8 * np.random.randn(n_points_per_cluster, 2)
+    C2 = [4, -1] + .1 * np.random.randn(n_points_per_cluster, 2)
+    X = np.vstack((C1, C2, np.array([[100, 200]])))
+    clust = OPTICS(min_samples=3).fit(X)
+
+    assert_array_equal(clust.labels_, np.r_[[0] * 4, [1] * 4, -1])
+
+    C1 = [-5, -2] + .8 * np.random.randn(n_points_per_cluster, 2)
+    C2 = [4, -1] + .1 * np.random.randn(n_points_per_cluster, 2)
+    X = np.vstack((C1, np.array([[100, 200], [200, 300]]), C2))
+    clust = OPTICS(min_samples=3).fit(X)
+
+    assert_array_equal(clust.labels_, np.r_[[0] * 4, -1, -1, [1] * 4])
+
+
 @pytest.mark.parametrize("reach, n_child, members", [
     (np.array([np.inf, 0.9, 0.9, 1.0, 0.89, 0.88, 10, .9, .9, .9, 10, 0.9,
                0.9, 0.89, 0.88, 10, .9, .9, .9, .9]), 2, np.r_[0:6]),
@@ -199,7 +219,7 @@ def test_cluster_sigmin_pruning(reach, n_child, members):
 
     # Build cluster tree inplace on root node
     _cluster_tree(root, None, cluster_boundaries, reach, ordering,
-                  5, .75, .7, .4, .3)
+                  5, .75, .7, .4, .3, 1)
     assert_equal(root.split_point, cluster_boundaries[0])
     assert_equal(n_child, len(root.children))
     assert_array_equal(members, root.children[0].points)


### PR DESCRIPTION
Fixes #11677 (OPTICS detecting the wrong outlier)
See PR #11857 (related discussions)

Borrowing the concept of `Xi`-steep points and the parameter, this PR suggests to include a split point in a cluster if it's a steep downward point. It also checks if the last point of a cluster is a noise.