### PR TITLE
[MRG +1] MNT TST Use assert_raises instead of legacy constructions

### DIFF
--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -203,17 +203,13 @@ def test_predict_proba_on_toy_problem():
     assert_almost_equal(t21, eclf_res[2][1], decimal=1)
     assert_almost_equal(t31, eclf_res[3][1], decimal=1)
 
-    try:
+    with pytest.raises(
+            AttributeError,
+            match="predict_proba is not available when voting='hard'"):
         eclf = VotingClassifier(estimators=[
                                 ('lr', clf1), ('rf', clf2), ('gnb', clf3)],
                                 voting='hard')
         eclf.fit(X, y).predict_proba(X)
-
-    except AttributeError:
-        pass
-    else:
-        raise AssertionError('AttributeError for voting == "hard"'
-                             ' and with predict_proba not raised')
 
 
 def test_multilabel():

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -482,13 +482,10 @@ def test_shuffle_kfold_stratifiedkfold_reproducibility():
                                                 cv.split(*data)):
                 # cv.split(...) returns an array of tuples, each tuple
                 # consisting of an array with train indices and test indices
-                try:
+                with pytest.raises(AssertionError,
+                                   message="The splits for data, are same even"
+                                           " when random state is not set"):
                     np.testing.assert_array_equal(test_a, test_b)
-                except AssertionError:
-                    pass
-                else:
-                    raise AssertionError("The splits for data, are same even "
-                                         "when random state is not set")
 
 
 def test_shuffle_stratifiedkfold():


### PR DESCRIPTION
Minor maintenance fix that replaces,
```py
try:
   something
except ExceptedException:
   pass
else:
   raise AssertionError(error_message)
```
with `pytest.raises` which is more readable and helps increase coverage (by a few lines). Using `assert_raises` would have also worked.