### PR TITLE
MAINT Fix invalid escape sequence

### DIFF
--- a/sklearn/datasets/mlcomp.py
+++ b/sklearn/datasets/mlcomp.py
@@ -24,7 +24,7 @@ LOADERS = {
             "in March 2017, the load_mlcomp function was deprecated "
             "in version 0.19 and will be removed in 0.21.")
 def load_mlcomp(name_or_id, set_="raw", mlcomp_root=None, **kwargs):
-    """Load a datasets as downloaded from http://mlcomp.org
+    r"""Load a datasets as downloaded from http://mlcomp.org
 
     Read more in the :ref:`User Guide <datasets>`.
 


### PR DESCRIPTION
`"\_"` is not allowed in Python 3.7.0. See failing build at https://travis-ci.org/scikit-learn/scikit-learn/builds/427618911?utm_source=email&utm_medium=notification