### PR TITLE
[MRG] TST: skip test requiring internet using --skip-network

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,14 +19,8 @@ if LooseVersion(pytest.__version__) < PYTEST_MIN_VERSION:
 
 
 def pytest_addoption(parser):
-    parser.addoption("--skip-network", action="store_true",
+    parser.addoption("--skip-network", action="store_true", default=False,
                      help="skip network tests")
-
-
-def pytest_runtest_setup(item):
-    if 'network' in item.keywords and item.config.getoption("--skip-network"):
-        pytest.skip("skipping due to --skip-network")
-
 
 
 def pytest_collection_modifyitems(config, items):
@@ -38,6 +32,13 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if item.name == 'sklearn.feature_extraction.hashing.FeatureHasher':
                 item.add_marker(skip_marker)
+
+    # Skip test which required internet if the flag is provided
+    if config.getoption("--skip-network"):
+        skip_network = pytest.mark.skip(reason="test required internet")
+        for item in items:
+            if "network" in item.keywords:
+                item.add_marker(skip_network)
 
     # numpy changed the str/repr formatting of numpy arrays in 1.14. We want to
     # run doctests only for numpy >= 1.14.

--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,18 @@ if LooseVersion(pytest.__version__) < PYTEST_MIN_VERSION:
     raise('Your version of pytest is too old, you should have at least '
           'pytest >= {} installed.'.format(PYTEST_MIN_VERSION))
 
+
+def pytest_addoption(parser):
+    parser.addoption("--skip-network", action="store_true",
+                     help="skip network tests")
+
+
+def pytest_runtest_setup(item):
+    if 'network' in item.keywords and item.config.getoption("--skip-network"):
+        pytest.skip("skipping due to --skip-network")
+
+
+
 def pytest_collection_modifyitems(config, items):
 
     # FeatureHasher is not compatible with PyPy

--- a/conftest.py
+++ b/conftest.py
@@ -33,9 +33,10 @@ def pytest_collection_modifyitems(config, items):
             if item.name == 'sklearn.feature_extraction.hashing.FeatureHasher':
                 item.add_marker(skip_marker)
 
-    # Skip test which required internet if the flag is provided
+    # Skip tests which require internet if the flag is provided
     if config.getoption("--skip-network"):
-        skip_network = pytest.mark.skip(reason="test required internet")
+        skip_network = pytest.mark.skip(
+            reason="test requires internet connectivity")
         for item in items:
             if "network" in item.keywords:
                 item.add_marker(skip_network)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -2,6 +2,7 @@
 Testing for the gradient boosting module (sklearn.ensemble.gradient_boosting).
 """
 import warnings
+from test.support import transient_internet
 import numpy as np
 
 from scipy.sparse import csr_matrix
@@ -460,24 +461,28 @@ def test_feature_importance_regression():
     .. [1] Friedman, J., Hastie, T., & Tibshirani, R. (2001). The elements
        of statistical learning. New York: Springer series in statistics.
     """
-    california = fetch_california_housing()
-    X, y = california.data, california.target
-    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+    from sklearn.datasets.california_housing import ARCHIVE
+    with transient_internet(ARCHIVE.url):
+        california = fetch_california_housing()
+        X, y = california.data, california.target
+        X_train, X_test, y_train, y_test = train_test_split(X, y,
+                                                            random_state=0)
 
-    reg = GradientBoostingRegressor(loss='huber', learning_rate=0.1,
-                                    max_leaf_nodes=6, n_estimators=100,
-                                    random_state=0)
-    reg.fit(X_train, y_train)
-    sorted_idx = np.argsort(reg.feature_importances_)[::-1]
-    sorted_features = [california.feature_names[s] for s in sorted_idx]
+        reg = GradientBoostingRegressor(loss='huber', learning_rate=0.1,
+                                        max_leaf_nodes=6, n_estimators=100,
+                                        random_state=0)
+        reg.fit(X_train, y_train)
+        sorted_idx = np.argsort(reg.feature_importances_)[::-1]
+        sorted_features = [california.feature_names[s] for s in sorted_idx]
 
-    # The most important feature is the median income by far.
-    assert sorted_features[0] == 'MedInc'
+        # The most important feature is the median income by far.
+        assert sorted_features[0] == 'MedInc'
 
-    # The three subsequent features are the following. Their relative ordering
-    # might change a bit depending on the randomness of the trees and the
-    # train / test split.
-    assert set(sorted_features[1:4]) == {'Longitude', 'AveOccup', 'Latitude'}
+        # The three subsequent features are the following. Their relative ordering
+        # might change a bit depending on the randomness of the trees and the
+        # train / test split.
+        assert set(sorted_features[1:4]) == {'Longitude', 'AveOccup',
+                                             'Latitude'}
 
 
 def test_max_feature_auto():

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -2,7 +2,6 @@
 Testing for the gradient boosting module (sklearn.ensemble.gradient_boosting).
 """
 import warnings
-from test.support import transient_internet
 import numpy as np
 
 from scipy.sparse import csr_matrix
@@ -453,6 +452,7 @@ def test_max_feature_regression():
     assert_true(deviance < 0.5, "GB failed with deviance %.4f" % deviance)
 
 
+@pytest.mark.network
 def test_feature_importance_regression():
     """Test that Gini importance is calculated correctly.
 
@@ -461,28 +461,24 @@ def test_feature_importance_regression():
     .. [1] Friedman, J., Hastie, T., & Tibshirani, R. (2001). The elements
        of statistical learning. New York: Springer series in statistics.
     """
-    from sklearn.datasets.california_housing import ARCHIVE
-    with transient_internet(ARCHIVE.url):
-        california = fetch_california_housing()
-        X, y = california.data, california.target
-        X_train, X_test, y_train, y_test = train_test_split(X, y,
-                                                            random_state=0)
+    california = fetch_california_housing()
+    X, y = california.data, california.target
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
-        reg = GradientBoostingRegressor(loss='huber', learning_rate=0.1,
-                                        max_leaf_nodes=6, n_estimators=100,
-                                        random_state=0)
-        reg.fit(X_train, y_train)
-        sorted_idx = np.argsort(reg.feature_importances_)[::-1]
-        sorted_features = [california.feature_names[s] for s in sorted_idx]
+    reg = GradientBoostingRegressor(loss='huber', learning_rate=0.1,
+                                    max_leaf_nodes=6, n_estimators=100,
+                                    random_state=0)
+    reg.fit(X_train, y_train)
+    sorted_idx = np.argsort(reg.feature_importances_)[::-1]
+    sorted_features = [california.feature_names[s] for s in sorted_idx]
 
-        # The most important feature is the median income by far.
-        assert sorted_features[0] == 'MedInc'
+    # The most important feature is the median income by far.
+    assert sorted_features[0] == 'MedInc'
 
-        # The three subsequent features are the following. Their relative ordering
-        # might change a bit depending on the randomness of the trees and the
-        # train / test split.
-        assert set(sorted_features[1:4]) == {'Longitude', 'AveOccup',
-                                             'Latitude'}
+    # The three subsequent features are the following. Their relative ordering
+    # might change a bit depending on the randomness of the trees and the
+    # train / test split.
+    assert set(sorted_features[1:4]) == {'Longitude', 'AveOccup', 'Latitude'}
 
 
 def test_max_feature_auto():


### PR DESCRIPTION
closes #12013 

This should skip the test in gradient boosting if we have an issue with internet.
The flag `--skip-network` should be passed when running the test with `pytest`.