### PR TITLE
[MRG] MAINT: skip doctest for Python 2

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,11 +6,12 @@
 # the one from site-packages.
 
 import platform
-import sys
 from distutils.version import LooseVersion
 
 import pytest
 from _pytest.doctest import DoctestItem
+
+from sklearn.utils.fixes import PY3_OR_LATER
 
 PYTEST_MIN_VERSION = '3.3.0'
 
@@ -31,13 +32,13 @@ def pytest_collection_modifyitems(config, items):
     # numpy changed the str/repr formatting of numpy arrays in 1.14. We want to
     # run doctests only for numpy >= 1.14. We want to skip the doctest for
     # python 2 due to unicode.
-    skip_doctests = True
-    if sys.version_info[:1] >= (3,):
-        skip_doctests = False
+    skip_doctests = False
+    if not PY3_OR_LATER:
+        skip_doctests = True
     try:
         import numpy as np
-        if LooseVersion(np.__version__) >= LooseVersion('1.14'):
-            skip_doctests = False
+        if LooseVersion(np.__version__) < LooseVersion('1.14'):
+            skip_doctests = True
     except ImportError:
         pass
 

--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,7 @@
 # the one from site-packages.
 
 import platform
+import sys
 from distutils.version import LooseVersion
 
 import pytest
@@ -32,14 +33,15 @@ def pytest_collection_modifyitems(config, items):
     skip_doctests = True
     try:
         import numpy as np
-        if LooseVersion(np.__version__) >= LooseVersion('1.14'):
+        if (LooseVersion(np.__version__) >= LooseVersion('1.14') or
+                sys.version_info[:1] >= (3,)):
             skip_doctests = False
     except ImportError:
         pass
 
     if skip_doctests:
         skip_marker = pytest.mark.skip(
-            reason='doctests are only run for numpy >= 1.14')
+            reason='doctests are only run for numpy >= 1.14 and python >= 3')
 
         for item in items:
             if isinstance(item, DoctestItem):

--- a/conftest.py
+++ b/conftest.py
@@ -31,10 +31,11 @@ def pytest_collection_modifyitems(config, items):
     # numpy changed the str/repr formatting of numpy arrays in 1.14. We want to
     # run doctests only for numpy >= 1.14.
     skip_doctests = True
+    if sys.version_info[:1] >= (3,):
+        skip_doctests = False
     try:
         import numpy as np
-        if (LooseVersion(np.__version__) >= LooseVersion('1.14') or
-                sys.version_info[:1] >= (3,)):
+        if LooseVersion(np.__version__) >= LooseVersion('1.14'):
             skip_doctests = False
     except ImportError:
         pass

--- a/conftest.py
+++ b/conftest.py
@@ -29,7 +29,8 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(skip_marker)
 
     # numpy changed the str/repr formatting of numpy arrays in 1.14. We want to
-    # run doctests only for numpy >= 1.14.
+    # run doctests only for numpy >= 1.14. We want to skip the doctest for
+    # python 2 due to unicode.
     skip_doctests = True
     if sys.version_info[:1] >= (3,):
         skip_doctests = False


### PR DESCRIPTION
closes #12015 

Skip doctest for python < 3