### PR TITLE
Scikit learn examples as LIVE Jupyter notebooks

### DIFF
--- a/.jupyter/jupyter_notebook_config.py
+++ b/.jupyter/jupyter_notebook_config.py
@@ -1,1 +1,3 @@
 c.NotebookApp.contents_manager_class = 'jupytext.TextFileContentsManager'  # noqa
+c.ContentsManager.preferred_jupytext_formats_read = 'py:sphinx'  # noqa
+c.ContentsManager.sphinx_convert_rst2md = True  # noqa

--- a/.jupyter/jupyter_notebook_config.py
+++ b/.jupyter/jupyter_notebook_config.py
@@ -1,0 +1,1 @@
+c.NotebookApp.contents_manager_class = 'jupytext.TextFileContentsManager'  # noqa

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 .. -*- mode: rst -*-
 
-|Travis|_ |AppVeyor|_ |Codecov|_ |CircleCI|_ |Python27|_ |Python35|_ |PyPi|_ |DOI|_
+|Travis|_ |AppVeyor|_ |Codecov|_ |CircleCI|_ |Python27|_ |Python35|_ |PyPi|_ |DOI|_ |Binder|_
 
 .. |Travis| image:: https://api.travis-ci.org/scikit-learn/scikit-learn.svg?branch=master
 .. _Travis: https://travis-ci.org/scikit-learn/scikit-learn

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,10 @@
 .. |DOI| image:: https://zenodo.org/badge/21369/scikit-learn/scikit-learn.svg
 .. _DOI: https://zenodo.org/badge/latestdoi/21369/scikit-learn/scikit-learn
 
+.. |Binder| image:: https://mybinder.org/badge.svg
+.. _Binder: https://mybinder.org/v2/gh/mwouts/scikit-learn/master?filepath=examples
+
+
 scikit-learn
 ============
 

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@
 .. _DOI: https://zenodo.org/badge/latestdoi/21369/scikit-learn/scikit-learn
 
 .. |Binder| image:: https://mybinder.org/badge.svg
-.. _Binder: https://mybinder.org/v2/gh/mwouts/scikit-learn/master?filepath=examples
+.. _Binder: https://mybinder.org/v2/gh/scikit-learn/scikit-learn/master?filepath=examples
 
 
 scikit-learn

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,6 @@
+jupytext >= 0.6.5
+numpy >= 1.8.2
+scipy >= 0.13.3
+pandas
+matplotlib >= 1.1.1
+scikit-learn

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
-jupytext >= 0.6.5
+jupytext >= 0.7.1
 numpy >= 1.8.2
 scipy >= 0.13.3
 pandas


### PR DESCRIPTION
The [binder project](https://github.com/binder-project) and [Jupytext](https://github.com/mwouts/jupytext/blob/master/README.md) can turn the beautiful scikit-learn example library into a collection of interactive notebooks.

See the proposed change on the [README](https://github.com/mwouts/scikit-learn/blob/master/README.rst), and try it now: [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/mwouts/scikit-learn/master?filepath=examples).

![image](https://user-images.githubusercontent.com/29915202/45546456-a238e480-b81d-11e8-9979-afb242af8532.png)
