### PR TITLE
[MRG] Update test_metaestimators to pass y parameter when calling score

### DIFF
--- a/sklearn/tests/test_metaestimators.py
+++ b/sklearn/tests/test_metaestimators.py
@@ -37,9 +37,9 @@ DELEGATING_METAESTIMATORS = [
                       est, param_distributions={'param': [5]}, cv=2, n_iter=1),
                   skip_methods=['score']),
     DelegatorData('RFE', RFE,
-                  skip_methods=['transform', 'inverse_transform', 'score']),
+                  skip_methods=['transform', 'inverse_transform']),
     DelegatorData('RFECV', RFECV,
-                  skip_methods=['transform', 'inverse_transform', 'score']),
+                  skip_methods=['transform', 'inverse_transform']),
     DelegatorData('BaggingClassifier', BaggingClassifier,
                   skip_methods=['transform', 'inverse_transform', 'score',
                                 'predict_proba', 'predict_log_proba',
@@ -101,7 +101,7 @@ def test_metaestimator_delegation():
             return np.ones(X.shape[0])
 
         @hides
-        def score(self, X, *args, **kwargs):
+        def score(self, X, y, *args, **kwargs):
             self._check_fit()
             return 1.0
 
@@ -120,15 +120,24 @@ def test_metaestimator_delegation():
                         msg="%s does not have method %r when its delegate does"
                             % (delegator_data.name, method))
             # delegation before fit raises a NotFittedError
-            assert_raises(NotFittedError, getattr(delegator, method),
-                          delegator_data.fit_args[0])
+            if method.startswith('score'):
+                assert_raises(NotFittedError, getattr(delegator, method),
+                              delegator_data.fit_args[0],
+                              delegator_data.fit_args[1])
+            else:
+                assert_raises(NotFittedError, getattr(delegator, method),
+                              delegator_data.fit_args[0])
 
         delegator.fit(*delegator_data.fit_args)
         for method in methods:
             if method in delegator_data.skip_methods:
                 continue
             # smoke test delegation
-            getattr(delegator, method)(delegator_data.fit_args[0])
+            if method.startswith('score'):
+                getattr(delegator, method)(delegator_data.fit_args[0],
+                                           delegator_data.fit_args[1])
+            else:
+                getattr(delegator, method)(delegator_data.fit_args[0])
 
         for method in methods:
             if method in delegator_data.skip_methods:

--- a/sklearn/tests/test_metaestimators.py
+++ b/sklearn/tests/test_metaestimators.py
@@ -120,7 +120,7 @@ def test_metaestimator_delegation():
                         msg="%s does not have method %r when its delegate does"
                             % (delegator_data.name, method))
             # delegation before fit raises a NotFittedError
-            if method.startswith('score'):
+            if method == 'score':
                 assert_raises(NotFittedError, getattr(delegator, method),
                               delegator_data.fit_args[0],
                               delegator_data.fit_args[1])
@@ -133,7 +133,7 @@ def test_metaestimator_delegation():
             if method in delegator_data.skip_methods:
                 continue
             # smoke test delegation
-            if method.startswith('score'):
+            if method == 'score':
                 getattr(delegator, method)(delegator_data.fit_args[0],
                                            delegator_data.fit_args[1])
             else:


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #12088.

#### What does this implement/fix? Explain your changes.
Updates `tests/test_metaestimators.py` to pass y as a parameter when calling score on a delegated estimator. This allows `'score'` to be removed from the skipped methods for RFE and RFECV
