### PR TITLE
[MRG] improve check_non_negative for sparse matrices

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -19,6 +19,7 @@ from scipy.sparse import csr_matrix
 from scipy.sparse import issparse
 
 from ..utils.validation import _num_samples
+from ..utils.validation import check_non_negative
 from ..utils import check_array
 from ..utils import gen_even_slices
 from ..utils import gen_batches, get_chunk_n_rows
@@ -1381,6 +1382,10 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=None, **kwds):
 
     if metric == "precomputed":
         X, _ = check_pairwise_arrays(X, Y, precomputed=True)
+
+        whom = ("`pairwise_distances`. Precomputed distance "
+                " need to have non-negative values.")
+        check_non_negative(X, whom=whom)
         return X
     elif metric in PAIRWISE_DISTANCE_FUNCTIONS:
         func = PAIRWISE_DISTANCE_FUNCTIONS[metric]

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -50,8 +50,6 @@ from sklearn.metrics.pairwise import paired_manhattan_distances
 from sklearn.preprocessing import normalize
 from sklearn.exceptions import DataConversionWarning
 
-import pytest
-
 
 def test_pairwise_distances():
     # Test the pairwise_distance helper function.
@@ -176,6 +174,13 @@ def test_pairwise_precomputed(func):
     # Test converts list to array-like
     S = func([[1.]], metric='precomputed')
     assert_true(isinstance(S, np.ndarray))
+
+
+def test_pairwise_precomputed_non_negative():
+    # Test non-negative values
+    assert_raises_regexp(ValueError, '.* non-negative values.*',
+                         pairwise_distances, np.full((5, 5), -1),
+                         metric='precomputed')
 
 
 def check_pairwise_parallel(func, metric, kwds):

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -39,7 +39,8 @@ from sklearn.utils.validation import (
     check_consistent_length,
     assert_all_finite,
     check_memory,
-    LARGE_SPARSE_SUPPORTED
+    check_non_negative,
+    LARGE_SPARSE_SUPPORTED,
 )
 import sklearn
 
@@ -760,3 +761,22 @@ def test_check_array_memmap(copy):
         X_checked = check_array(X_memmap, copy=copy)
         assert np.may_share_memory(X_memmap, X_checked) == (not copy)
         assert X_checked.flags['WRITEABLE'] == copy
+
+
+@pytest.mark.parametrize('retype', [
+    np.asarray, sp.csr_matrix, sp.csc_matrix, sp.coo_matrix, sp.lil_matrix,
+    sp.bsr_matrix, sp.dok_matrix, sp.dia_matrix
+])
+def test_check_non_negative(retype):
+    A = np.array([[1, 1, 0, 0],
+                  [1, 1, 0, 0],
+                  [0, 0, 0, 0],
+                  [0, 0, 0, 0]])
+    X = retype(A)
+    check_non_negative(X, "")
+    X = retype([[0, 0], [0, 0]])
+    check_non_negative(X, "")
+
+    A[0, 0] = -1
+    X = retype(A)
+    assert_raises_regex(ValueError, "Negative ", check_non_negative, X, "")

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -954,6 +954,16 @@ def check_non_negative(X, whom):
     whom : string
         Who passed X to this function.
     """
-    X = X.data if sp.issparse(X) else X
-    if (X < 0).any():
+    # avoid X.min() on sparse matrix since it also sorts the indices
+    if sp.issparse(X):
+        if X.format in ['lil', 'dok']:
+            X = X.tocsr()
+        if X.data.size == 0:
+            X_min = 0
+        else:
+            X_min = X.data.min()
+    else:
+        X_min = X.min()
+
+    if X_min < 0:
         raise ValueError("Negative values in data passed to %s" % whom)


### PR DESCRIPTION
This is a small improvement on `check_non_negative` for sparse matrices.
It also calls `check_non_negative` for precomputed pairwise distances.

This fix is also included in #10482, but I isolated it here to help the reviews.