### PR TITLE
DOC BaggingRegressor missing default value for oob_score in docstring

### DIFF
--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -472,7 +472,7 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
     bootstrap_features : boolean, optional (default=False)
         Whether features are drawn with replacement.
 
-    oob_score : bool
+    oob_score : bool, optional (default=False)
         Whether to use out-of-bag samples to estimate
         the generalization error.
 


### PR DESCRIPTION
Adds the default value (False) to the docstring.

We have many missing default values in the docstring, but seems fixing all of them would conflict with many existing PRs. I just fixed this one since all the other parameters do have the default value there.