### PR TITLE
[MRG]new metrics added

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -2047,9 +2047,9 @@ def fall_out(y_true, y_pred, labels=None, sample_weight=None):
        negative but they are positive .In
        other word we can say that it is the
        chances of occuring a TYPE-1 error
-    """
 
-    """Parameters
+
+       Parameters
        ----------
        y_true : array, shape = [n_samples]
            True target, consisting of integers of two values.
@@ -2072,7 +2072,7 @@ def fall_out(y_true, y_pred, labels=None, sample_weight=None):
        Returns
        -------
        loss : float"""
-    CM = confusion_matrix(y_true, y_pred, labels=labels, \
+    CM = confusion_matrix(y_true, y_pred, labels=labels,
                           sample_weight=sample_weight)
     return CM[0][1]
 
@@ -2084,9 +2084,8 @@ def miss_rate(y_true, y_pred, labels=None, sample_weight=None):
     but they actually belongs to the positive
     class or we can say that it indicates the
     chances of happening of TYPE-2 error
-    """
 
-    """Parameters
+    Parameters
     ----------
     y_true : array, shape = [n_samples]
         True target, consisting of
@@ -2107,7 +2106,7 @@ def miss_rate(y_true, y_pred, labels=None, sample_weight=None):
     Returns
     -------
     loss : float"""
-    CM = confusion_matrix(y_true, y_pred, labels=labels, \
+    CM = confusion_matrix(y_true, y_pred, labels=labels,
                           sample_weight=sample_weight)
     return CM[1][0]
 
@@ -2120,8 +2119,8 @@ def specificity(y_true, y_pred, labels=None, sample_weight=None):
     to the positive class . It also denotes the
     number of times when null Hypothesis is
     true..
-    """
-    """Parameters
+
+    Parameters
     ----------
     y_true : array, shape = [n_samples]
         True target, consisting of
@@ -2143,6 +2142,6 @@ def specificity(y_true, y_pred, labels=None, sample_weight=None):
     -------
     loss : float"""
 
-    CM = confusion_matrix(y_true, y_pred, labels=labels, \
+    CM = confusion_matrix(y_true, y_pred, labels=labels,
                           sample_weight=sample_weight)
     return CM[1][1]

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -2116,7 +2116,7 @@ def false_negative(y_true, y_pred, labels=None, sample_weight=None):
     Returns
     -------
     score : Integer
-            The number of time yype-2 error has occurred.
+            The number of time type-2 error has occurred.
      """
 
     # Checking the type of class which they belongs to

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -2082,9 +2082,9 @@ def false_positive(y_true, y_pred, labels=None, sample_weight=None):
                                   sample_weight=sample_weight)
             return CM[0][1]
         else:
-            raise ValueError("this metric is supported for only binary class")
+            raise ValueError("This metric is supported for only binary class")
     else:
-        raise ValueError("this metric is supported for only binary class")
+        raise ValueError("This metric is supported for only binary class")
 
 
 def false_negative(y_true, y_pred, labels=None, sample_weight=None):
@@ -2130,9 +2130,9 @@ def false_negative(y_true, y_pred, labels=None, sample_weight=None):
                                   sample_weight=sample_weight)
             return CM[1][0]
         else:
-            raise ValueError("this metric is supported for only binary class")
+            raise ValueError("This metric is supported for only binary class")
     else:
-        raise ValueError("this metric is supported for only binary class")
+        raise ValueError("This metric is supported for only binary class")
 
 
 def ture_positive(y_true, y_pred, labels=None, sample_weight=None):
@@ -2180,6 +2180,6 @@ def ture_positive(y_true, y_pred, labels=None, sample_weight=None):
                                   sample_weight=sample_weight)
             return CM[1][1]
         else:
-            raise ValueError("this metric is supported for only binary class")
+            raise ValueError("This metric is supported for only binary class")
     else:
-        raise ValueError("this metric is supported for only binary class")
+        raise ValueError("This metric is supported for only binary class")

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -2135,7 +2135,7 @@ def false_negative(y_true, y_pred, labels=None, sample_weight=None):
         raise ValueError("This metric is supported for only binary class")
 
 
-def ture_positive(y_true, y_pred, labels=None, sample_weight=None):
+def true_positive(y_true, y_pred, labels=None, sample_weight=None):
     """This function gives the specificity.
 
     Specificity defines the True positive i.e

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -2068,7 +2068,7 @@ def false_positive(y_true, y_pred, labels=None, sample_weight=None):
 
     Returns
     -------
-    score = The number of times type-1 error has occured.
+    score = The number of times type-1 error has occurred.
     """
 
     # Checking the type of class which they belongs to
@@ -2116,7 +2116,7 @@ def false_negative(y_true, y_pred, labels=None, sample_weight=None):
     Returns
     -------
     score : Integer
-            The number of time yype-2 error has occured.
+            The number of time yype-2 error has occurred.
      """
 
     # Checking the type of class which they belongs to

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -2038,3 +2038,19 @@ def brier_score_loss(y_true, y_prob, sample_weight=None, pos_label=None):
     y_true = np.array(y_true == pos_label, int)
     y_true = _check_binary_probabilistic_predictions(y_true, y_prob)
     return np.average((y_true - y_prob) ** 2, weights=sample_weight)
+
+
+def fall_out(y_true, y_pred, labels=None, sample_weight=None):
+
+    CM = confusion_matrix(y_true, y_pred, labels=None, sample_weight=None)
+    return CM[0][1]
+
+
+def Miss_rate(y_true, y_pred, labels=None, sample_weight=None):
+    CM = confusion_matrix(y_true, y_pred, labels=None, sample_weight=None)
+    return CM[1][0]
+
+
+def specificity(y_true, y_pred, labels=None, sample_weight=None):
+    CM = confusion_matrix(y_true, y_pred, labels=None, sample_weight=None)
+    return  CM[1][1]

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -2040,108 +2040,146 @@ def brier_score_loss(y_true, y_prob, sample_weight=None, pos_label=None):
     return np.average((y_true - y_prob) ** 2, weights=sample_weight)
 
 
-def fall_out(y_true, y_pred, labels=None, sample_weight=None):
-    """compute the false positive rate
-       False positive rate indicate the
-       number of sample which are classified as
-       negative but they are positive .In
-       other word we can say that it is the
-       chances of occuring a TYPE-1 error
+def false_positive(y_true, y_pred, labels=None, sample_weight=None):
+    """Compute the false positive rate.
+
+    False positive rate indicate the
+    number of sample which are classified as
+    negative but they are positive.In
+    other word we can say that it is the
+    chances of occuring a TYPE-1 error.
+
+    Parameters
+    ----------
+    y_true : array, shape = [n_samples]
+        Ground truth (correct) target values.
+
+    y_pred : array, shape = [n_samples]
+        Estimated targets as returned by a classifier.
+
+    labels : array, shape = [n_classes], optional
+        List of labels to index the matrix. This may be used to reorder
+        or select a subset of labels.
+        If none is given, those that appear at least once
+        in ``y_true`` or ``y_pred`` are used in sorted order.
+
+    sample_weight : array-like of shape = [n_samples], optional
+        Sample weights.
+
+    Returns
+    -------
+    score = The number of times type-1 error has occured.
+    """
+
+    # Checking the type of class which they belongs to
+    type_true = type_of_target(y_true)
+    type_pred = type_of_target(y_pred)
+
+    y_type = set([type_true, type_pred])
+    if len(y_type) == 1:
+        if y_type == set(["binary"]):
+            CM = confusion_matrix(y_true, y_pred, labels=labels,
+                                  sample_weight=sample_weight)
+            return CM[0][1]
+        else:
+            raise ValueError("this metric is supported for only binary class")
+    else:
+        raise ValueError("this metric is supported for only binary class")
 
 
-       Parameters
-       ----------
-       y_true : array, shape = [n_samples]
-           True target, consisting of integers of two values.
-           The positive label
-           must be greater than the negative label.
+def false_negative(y_true, y_pred, labels=None, sample_weight=None):
+    """It calculates the miss rate.
 
-       pred_decision : array, shape = [n_samples] or
-       [n_samples, n_classes]
-           Predicted decisions, as output
-           by decision_function (floats).
-
-       labels : array, optional, default None
-           Contains all the labels for the problem.
-           Used in multiclass hinge loss.
-
-       sample_weight : array-like of
-       shape = [n_samples], optional
-           Sample weights.
-
-       Returns
-       -------
-       loss : float"""
-    CM = confusion_matrix(y_true, y_pred, labels=labels,
-                          sample_weight=sample_weight)
-    return CM[0][1]
-
-
-def miss_rate(y_true, y_pred, labels=None, sample_weight=None):
-    """it calculates the miss rate
     The miss rate indicates the number of
     samples which are classified as negative class
     but they actually belongs to the positive
     class or we can say that it indicates the
-    chances of happening of TYPE-2 error
+    chances of happening of TYPE-2 error.
 
     Parameters
     ----------
     y_true : array, shape = [n_samples]
-        True target, consisting of
-        integers of two values. The positive label
-        must be greater than the negative label.
+        Ground truth (correct) target values.
 
-    pred_decision : array, shape =
-    [n_samples] or [n_samples, n_classes]
-        Predicted decisions, as output by decision_function (floats).
+    y_pred : array, shape = [n_samples]
+        Estimated targets as returned by a classifier.
 
-    labels : array, optional, default None
-        Contains all the labels for the
-        problem. Used in multiclass hinge loss.
+    labels : array, shape = [n_classes], optional
+        List of labels to index the matrix. This may be used to reorder
+        or select a subset of labels.
+        If none is given, those that appear at least once
+        in ``y_true`` or ``y_pred`` are used in sorted order.
 
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
 
     Returns
     -------
-    loss : float"""
-    CM = confusion_matrix(y_true, y_pred, labels=labels,
-                          sample_weight=sample_weight)
-    return CM[1][0]
+    score : Integer
+            The number of time yype-2 error has occured.
+     """
+
+    # Checking the type of class which they belongs to
+    type_true = type_of_target(y_true)
+    type_pred = type_of_target(y_pred)
+
+    y_type = set([type_true, type_pred])
+    if len(y_type) == 1:
+        if y_type == set(["binary"]):
+            CM = confusion_matrix(y_true, y_pred, labels=labels,
+                                  sample_weight=sample_weight)
+            return CM[1][0]
+        else:
+            raise ValueError("this metric is supported for only binary class")
+    else:
+        raise ValueError("this metric is supported for only binary class")
 
 
-def specificity(y_true, y_pred, labels=None, sample_weight=None):
-    """This function gives the specificity
+def ture_positive(y_true, y_pred, labels=None, sample_weight=None):
+    """This function gives the specificity.
+
     Specificity defines the True positive i.e
     it indicates the number of sample which belongs
     to positive class when they actually belongs
-    to the positive class . It also denotes the
-    number of times when null Hypothesis is
-    true..
+    to the positive class.It also denotes the
+    number of times when null Hypothesis is.
+    true.
 
     Parameters
     ----------
     y_true : array, shape = [n_samples]
-        True target, consisting of
-        integers of two values. The positive label
-        must be greater than the negative label.
+        Ground truth (correct) target values.
 
-    pred_decision : array, shape =
-    [n_samples] or [n_samples, n_classes]
-        Predicted decisions, as output by decision_function (floats).
+    y_pred : array, shape = [n_samples]
+        Estimated targets as returned by a classifier.
 
-    labels : array, optional, default None
-        Contains all the labels for the
-        problem. Used in multiclass hinge loss.
+    labels : array, shape = [n_classes], optional
+        List of labels to index the matrix. This may be used to reorder
+        or select a subset of labels.
+        If none is given, those that appear at least once
+        in ``y_true`` or ``y_pred`` are used in sorted order.
 
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
 
     Returns
     -------
-    loss : float"""
+    score : Integer
+            The number of times when null hypothesis was
+            accepted.
 
-    CM = confusion_matrix(y_true, y_pred, labels=labels,
-                          sample_weight=sample_weight)
-    return CM[1][1]
+    """
+    # Checking the type of class which they belongs to
+    type_true = type_of_target(y_true)
+    type_pred = type_of_target(y_pred)
+
+    y_type = set([type_true, type_pred])
+    if len(y_type) == 1:
+        if y_type == set(["binary"]):
+            CM = confusion_matrix(y_true, y_pred, labels=labels,
+                                  sample_weight=sample_weight)
+            return CM[1][1]
+        else:
+            raise ValueError("this metric is supported for only binary class")
+    else:
+        raise ValueError("this metric is supported for only binary class")

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -2041,40 +2041,65 @@ def brier_score_loss(y_true, y_prob, sample_weight=None, pos_label=None):
 
 
 def fall_out(y_true, y_pred, labels=None, sample_weight=None):
+    """compute the false positive rate
+       False positive rate indicate the
+       number of sample which are classified as
+       negative but they are positive .In
+       other word we can say that it is the
+       chances of occuring a TYPE-1 error
+    """
+
     """Parameters
        ----------
        y_true : array, shape = [n_samples]
-           True target, consisting of integers of two values. The positive label
+           True target, consisting of integers of two values.
+           The positive label
            must be greater than the negative label.
 
-       pred_decision : array, shape = [n_samples] or [n_samples, n_classes]
-           Predicted decisions, as output by decision_function (floats).
+       pred_decision : array, shape = [n_samples] or
+       [n_samples, n_classes]
+           Predicted decisions, as output
+           by decision_function (floats).
 
        labels : array, optional, default None
-           Contains all the labels for the problem. Used in multiclass hinge loss.
+           Contains all the labels for the problem.
+           Used in multiclass hinge loss.
 
-       sample_weight : array-like of shape = [n_samples], optional
+       sample_weight : array-like of
+       shape = [n_samples], optional
            Sample weights.
 
        Returns
        -------
        loss : float"""
-    CM = confusion_matrix(y_true, y_pred, labels=labels, sample_weight=sample_weight)
+    CM = confusion_matrix(y_true, y_pred, labels=labels
+                          , sample_weight=sample_weight)
     return CM[0][1]
 
 
-def Miss_rate(y_true, y_pred, labels=None, sample_weight=None):
+def miss_rate(y_true, y_pred, labels=None, sample_weight=None):
+    """it calculates the miss rate
+    The miss rate indicates the number of
+    samples which are classified as negative class
+    but they actually belongs to the positive
+    class or we can say that it indicates the
+    chances of happening of TYPE-2 error
+    """
+
     """Parameters
     ----------
     y_true : array, shape = [n_samples]
-        True target, consisting of integers of two values. The positive label
+        True target, consisting of
+        integers of two values. The positive label
         must be greater than the negative label.
 
-    pred_decision : array, shape = [n_samples] or [n_samples, n_classes]
+    pred_decision : array, shape =
+    [n_samples] or [n_samples, n_classes]
         Predicted decisions, as output by decision_function (floats).
 
     labels : array, optional, default None
-        Contains all the labels for the problem. Used in multiclass hinge loss.
+        Contains all the labels for the
+        problem. Used in multiclass hinge loss.
 
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
@@ -2082,22 +2107,34 @@ def Miss_rate(y_true, y_pred, labels=None, sample_weight=None):
     Returns
     -------
     loss : float"""
-    CM = confusion_matrix(y_true, y_pred, labels=labels, sample_weight=sample_weight)
+    CM = confusion_matrix(y_true, y_pred, labels=labels,
+                          sample_weight=sample_weight)
     return CM[1][0]
 
 
 def specificity(y_true, y_pred, labels=None, sample_weight=None):
+    """This function gives the specificity
+    Specificity defines the True positive i.e
+    it indicates the number of sample which belongs
+    to positive class when they actually belongs
+    to the positive class . It also denotes the
+    number of times when null Hypothesis is
+    true..
+    """
     """Parameters
     ----------
     y_true : array, shape = [n_samples]
-        True target, consisting of integers of two values. The positive label
+        True target, consisting of
+        integers of two values. The positive label
         must be greater than the negative label.
 
-    pred_decision : array, shape = [n_samples] or [n_samples, n_classes]
+    pred_decision : array, shape =
+    [n_samples] or [n_samples, n_classes]
         Predicted decisions, as output by decision_function (floats).
 
     labels : array, optional, default None
-        Contains all the labels for the problem. Used in multiclass hinge loss.
+        Contains all the labels for the
+        problem. Used in multiclass hinge loss.
 
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
@@ -2106,5 +2143,6 @@ def specificity(y_true, y_pred, labels=None, sample_weight=None):
     -------
     loss : float"""
 
-    CM = confusion_matrix(y_true, y_pred, labels=labels, sample_weight=sample_weight)
+    CM = confusion_matrix(y_true, y_pred, labels=labels,
+                          sample_weight=sample_weight)
     return CM[1][1]

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1109,16 +1109,16 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
         if len(tp_bins):
             tp_sum = np.bincount(tp_bins, weights=tp_bins_weights,
-                              minlength=len(labels))
+                                 minlength=len(labels))
         else:
             # Pathological case
             true_sum = pred_sum = tp_sum = np.zeros(len(labels))
         if len(y_pred):
             pred_sum = np.bincount(y_pred, weights=sample_weight,
-                                minlength=len(labels))
+                                   minlength=len(labels))
         if len(y_true):
             true_sum = np.bincount(y_true, weights=sample_weight,
-                                minlength=len(labels))
+                                   minlength=len(labels))
 
         # Retain only selected labels
         indices = np.searchsorted(sorted_labels, labels[:n_labels])
@@ -1534,7 +1534,7 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
         if labels_given:
             warnings.warn(
                 "labels size, {0}, does not match size of target_names, {1}"
-                .format(len(labels), len(target_names))
+                    .format(len(labels), len(target_names))
             )
         else:
             raise ValueError(
@@ -2041,25 +2041,25 @@ def brier_score_loss(y_true, y_prob, sample_weight=None, pos_label=None):
 
 
 def fall_out(y_true, y_pred, labels=None, sample_weight=None):
- """Parameters
-    ----------
-    y_true : array, shape = [n_samples]
-        True target, consisting of integers of two values. The positive label
-        must be greater than the negative label.
+    """Parameters
+       ----------
+       y_true : array, shape = [n_samples]
+           True target, consisting of integers of two values. The positive label
+           must be greater than the negative label.
 
-    pred_decision : array, shape = [n_samples] or [n_samples, n_classes]
-        Predicted decisions, as output by decision_function (floats).
+       pred_decision : array, shape = [n_samples] or [n_samples, n_classes]
+           Predicted decisions, as output by decision_function (floats).
 
-    labels : array, optional, default None
-        Contains all the labels for the problem. Used in multiclass hinge loss.
+       labels : array, optional, default None
+           Contains all the labels for the problem. Used in multiclass hinge loss.
 
-    sample_weight : array-like of shape = [n_samples], optional
-        Sample weights.
+       sample_weight : array-like of shape = [n_samples], optional
+           Sample weights.
 
-    Returns
-    -------
-    loss : float"""
-    CM = confusion_matrix(y_true, y_pred, labels=None, sample_weight=None)
+       Returns
+       -------
+       loss : float"""
+    CM = confusion_matrix(y_true, y_pred, labels=labels, sample_weight=sample_weight)
     return CM[0][1]
 
 
@@ -2082,7 +2082,7 @@ def Miss_rate(y_true, y_pred, labels=None, sample_weight=None):
     Returns
     -------
     loss : float"""
-    CM = confusion_matrix(y_true, y_pred, labels=None, sample_weight=None)
+    CM = confusion_matrix(y_true, y_pred, labels=labels, sample_weight=sample_weight)
     return CM[1][0]
 
 
@@ -2105,5 +2105,6 @@ def specificity(y_true, y_pred, labels=None, sample_weight=None):
     Returns
     -------
     loss : float"""
-    CM = confusion_matrix(y_true, y_pred, labels=None, sample_weight=None)
+
+    CM = confusion_matrix(y_true, y_pred, labels=labels, sample_weight=sample_weight)
     return CM[1][1]

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -2072,8 +2072,8 @@ def fall_out(y_true, y_pred, labels=None, sample_weight=None):
        Returns
        -------
        loss : float"""
-    CM = confusion_matrix(y_true, y_pred, labels=labels
-                          , sample_weight=sample_weight)
+    CM = confusion_matrix(y_true, y_pred, labels=labels, \
+                          sample_weight=sample_weight)
     return CM[0][1]
 
 
@@ -2107,7 +2107,7 @@ def miss_rate(y_true, y_pred, labels=None, sample_weight=None):
     Returns
     -------
     loss : float"""
-    CM = confusion_matrix(y_true, y_pred, labels=labels,
+    CM = confusion_matrix(y_true, y_pred, labels=labels, \
                           sample_weight=sample_weight)
     return CM[1][0]
 
@@ -2143,6 +2143,6 @@ def specificity(y_true, y_pred, labels=None, sample_weight=None):
     -------
     loss : float"""
 
-    CM = confusion_matrix(y_true, y_pred, labels=labels,
+    CM = confusion_matrix(y_true, y_pred, labels=labels, \
                           sample_weight=sample_weight)
     return CM[1][1]

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -2041,16 +2041,69 @@ def brier_score_loss(y_true, y_prob, sample_weight=None, pos_label=None):
 
 
 def fall_out(y_true, y_pred, labels=None, sample_weight=None):
+ """Parameters
+    ----------
+    y_true : array, shape = [n_samples]
+        True target, consisting of integers of two values. The positive label
+        must be greater than the negative label.
 
+    pred_decision : array, shape = [n_samples] or [n_samples, n_classes]
+        Predicted decisions, as output by decision_function (floats).
+
+    labels : array, optional, default None
+        Contains all the labels for the problem. Used in multiclass hinge loss.
+
+    sample_weight : array-like of shape = [n_samples], optional
+        Sample weights.
+
+    Returns
+    -------
+    loss : float"""
     CM = confusion_matrix(y_true, y_pred, labels=None, sample_weight=None)
     return CM[0][1]
 
 
 def Miss_rate(y_true, y_pred, labels=None, sample_weight=None):
+    """Parameters
+    ----------
+    y_true : array, shape = [n_samples]
+        True target, consisting of integers of two values. The positive label
+        must be greater than the negative label.
+
+    pred_decision : array, shape = [n_samples] or [n_samples, n_classes]
+        Predicted decisions, as output by decision_function (floats).
+
+    labels : array, optional, default None
+        Contains all the labels for the problem. Used in multiclass hinge loss.
+
+    sample_weight : array-like of shape = [n_samples], optional
+        Sample weights.
+
+    Returns
+    -------
+    loss : float"""
     CM = confusion_matrix(y_true, y_pred, labels=None, sample_weight=None)
     return CM[1][0]
 
 
 def specificity(y_true, y_pred, labels=None, sample_weight=None):
+    """Parameters
+    ----------
+    y_true : array, shape = [n_samples]
+        True target, consisting of integers of two values. The positive label
+        must be greater than the negative label.
+
+    pred_decision : array, shape = [n_samples] or [n_samples, n_classes]
+        Predicted decisions, as output by decision_function (floats).
+
+    labels : array, optional, default None
+        Contains all the labels for the problem. Used in multiclass hinge loss.
+
+    sample_weight : array-like of shape = [n_samples], optional
+        Sample weights.
+
+    Returns
+    -------
+    loss : float"""
     CM = confusion_matrix(y_true, y_pred, labels=None, sample_weight=None)
-    return  CM[1][1]
+    return CM[1][1]

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1717,7 +1717,7 @@ def test_false_positive():
 def test_false_negative():
     y_true, y_pred, _ = make_prediction(binary=True)
 
-    rs = sklearn.metrics.classification.false_negative(y_true, y_pred)
+    rs = false_negative(y_true, y_pred)
     assert_equal(rs, 8)
 
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1707,22 +1707,73 @@ def test_balanced_accuracy_score(y_true, y_pred):
     assert adjusted == (balanced - chance) / (1 - chance)
 
 
-def test_false_positive():
+def test_false_positive_binary():
     y_true, y_pred, _ = make_prediction(binary=True)
 
     rs = false_positive(y_true, y_pred)
     assert_equal(rs, 3)
 
 
-def test_false_negative():
+def test_false_negative_binary():
     y_true, y_pred, _ = make_prediction(binary=True)
 
     rs = false_negative(y_true, y_pred)
     assert_equal(rs, 8)
 
 
-def test_true_positive():
+def test_true_positive_binary():
     y_true, y_pred, _ = make_prediction(binary=True)
 
     rs = true_positive(y_true, y_pred)
     assert_equal(rs, 17)
+
+
+
+def test_true_positive_muticlass():
+    y_ture = np.array([1,2,3,1,1,1,1,1,1])
+    y_pred = np.array([1,1,1,1,1,1,1,1,1])
+
+    msg = "This metric is supported for only binary class"
+    assert_raise_message(ValueError,msg,true_positive,y_ture,y_pred)
+
+    y_ture = np.array([1, 2, 3, 1, 1, 1, 1, 1, 1])
+    y_pred = np.array([1, 1, 3, 1, 2, 1, 2, 1, 1])
+
+    msg = "This metric is supported for only binary class"
+    assert_raise_message(ValueError, msg, true_positive, y_ture, y_pred)
+
+
+def test_false_positive_multiclass():
+    y_ture = np.array([1, 2, 3, 1, 1, 1, 1, 1, 1])
+    y_pred = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1])
+
+    msg = "This metric is supported for only binary class"
+    assert_raise_message(ValueError, msg, false_positive, y_ture, y_pred)
+
+    y_ture = np.array([1, 2, 3, 1, 1, 1, 1, 1, 1])
+    y_pred = np.array([1, 1, 3, 1, 2, 1, 2, 1, 1])
+
+    msg = "This metric is supported for only binary class"
+    assert_raise_message(ValueError, msg, false_positive, y_ture, y_pred)
+
+
+def test_false_negative_multiclass():
+    y_ture = np.array([1, 2, 3, 1, 1, 1, 1, 1, 1])
+    y_pred = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1])
+
+    msg = "This metric is supported for only binary class"
+    assert_raise_message(ValueError, msg, false_negative, y_ture, y_pred,labels=None,sample_weight=None)
+
+    y_ture = np.array([1, 2, 3, 1, 1, 1, 1, 1, 1])
+    y_pred = np.array([1, 1, 3, 1, 2, 1, 2, 1, 1])
+
+    msg = "This metric is supported for only binary class"
+    assert_raise_message(ValueError, msg, false_negative, y_ture, y_pred)
+
+
+
+
+
+
+
+

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1718,7 +1718,7 @@ def test_false_positive():
 def test_false_negative():
     y_true, y_pred, _ = make_prediction(binary=True)
 
-    rs = false_negative(y_true, y_pred)
+    rs = sklearn.metrics.classification.false_negative(y_true, y_pred)
     assert_equal(rs, 8)
 
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -47,9 +47,9 @@ from sklearn.metrics import precision_score
 from sklearn.metrics import recall_score
 from sklearn.metrics import zero_one_loss
 from sklearn.metrics import brier_score_loss
-from sklearn.metrics import true_positive
-from sklearn.metrics import false_negative
-from sklearn.metrics import false_positive
+from sklearn.metrics.classification import true_positive
+from sklearn.metrics.classification import false_negative
+from sklearn.metrics.classification import false_positive
 
 
 from sklearn.metrics.classification import _check_targets
@@ -1711,22 +1711,22 @@ def test_balanced_accuracy_score(y_true, y_pred):
 def test_false_positive():
     y_true, y_pred, _ = make_prediction(binary=True)
 
-    CM = confusion_matrix(y_true,y_pred)
-    assert_equal(CM[0][1],3)
+    rs = false_positive(y_true,y_pred)
+    assert_equal(rs,3)
 
 
 def test_false_negative():
     y_true, y_pred, _ = make_prediction(binary=True)
 
-    CM = confusion_matrix(y_true, y_pred)
-    assert_equal(CM[1][0], 8)
+    rs = false_negative(y_true, y_pred)
+    assert_equal(rs, 8)
 
 
 def test_true_positive():
     y_true, y_pred, _ = make_prediction(binary=True)
 
-    CM = confusion_matrix(y_true, y_pred)
-    assert_equal(CM[1][1], 17)
+    rs = true_positive(y_true, y_pred)
+    assert_equal(rs, 17)
 
 
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1753,7 +1753,8 @@ def test_false_positive_multiclass():
     y_pred = np.array([1, 1, 3, 1, 2, 1, 2, 1, 1])
 
     msg = "This metric is supported for only binary class"
-    assert_raise_message(ValueError, msg, false_positive, y_ture, y_pred)
+    assert_raise_message(ValueError, msg, false_positive, y_ture, y_pred,
+                         labels=None, sample_weight=None)
 
 
 def test_false_negative_multiclass():
@@ -1761,10 +1762,12 @@ def test_false_negative_multiclass():
     y_pred = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1])
 
     msg = "This metric is supported for only binary class"
-    assert_raise_message(ValueError, msg, false_negative, y_ture, y_pred, labels=None, sample_weight=None)
+    assert_raise_message(ValueError, msg, false_negative, y_ture, y_pred,
+                         labels=None, sample_weight=None)
 
     y_ture = np.array([1, 2, 3, 1, 1, 1, 1, 1, 1])
     y_pred = np.array([1, 1, 3, 1, 2, 1, 2, 1, 1])
 
     msg = "This metric is supported for only binary class"
-    assert_raise_message(ValueError, msg, false_negative, y_ture, y_pred)
+    assert_raise_message(ValueError, msg, false_negative, y_ture, y_pred,
+                         labels=None, sample_weight=None)

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1728,13 +1728,12 @@ def test_true_positive_binary():
     assert_equal(rs, 17)
 
 
-
 def test_true_positive_muticlass():
-    y_ture = np.array([1,2,3,1,1,1,1,1,1])
-    y_pred = np.array([1,1,1,1,1,1,1,1,1])
+    y_ture = np.array([1, 2, 3, 1, 1, 1, 1, 1, 1])
+    y_pred = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1])
 
     msg = "This metric is supported for only binary class"
-    assert_raise_message(ValueError,msg,true_positive,y_ture,y_pred)
+    assert_raise_message(ValueError, msg, true_positive, y_ture, y_pred)
 
     y_ture = np.array([1, 2, 3, 1, 1, 1, 1, 1, 1])
     y_pred = np.array([1, 1, 3, 1, 2, 1, 2, 1, 1])
@@ -1762,18 +1761,10 @@ def test_false_negative_multiclass():
     y_pred = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1])
 
     msg = "This metric is supported for only binary class"
-    assert_raise_message(ValueError, msg, false_negative, y_ture, y_pred,labels=None,sample_weight=None)
+    assert_raise_message(ValueError, msg, false_negative, y_ture, y_pred, labels=None, sample_weight=None)
 
     y_ture = np.array([1, 2, 3, 1, 1, 1, 1, 1, 1])
     y_pred = np.array([1, 1, 3, 1, 2, 1, 2, 1, 1])
 
     msg = "This metric is supported for only binary class"
     assert_raise_message(ValueError, msg, false_negative, y_ture, y_pred)
-
-
-
-
-
-
-
-

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -51,11 +51,11 @@ from sklearn.metrics.classification import true_positive
 from sklearn.metrics.classification import false_negative
 from sklearn.metrics.classification import false_positive
 
-
 from sklearn.metrics.classification import _check_targets
 from sklearn.exceptions import UndefinedMetricWarning
 
 from scipy.spatial.distance import hamming as sp_hamming
+
 
 ###############################################################################
 # Utilities for testing
@@ -109,7 +109,6 @@ def make_prediction(dataset=None, binary=False):
 # Tests
 
 def test_classification_report_dictionary_output():
-
     # Test performance report with dictionary output
     iris = datasets.load_iris()
     y_true, y_pred, _ = make_prediction(dataset=iris, binary=False)
@@ -145,7 +144,7 @@ def test_classification_report_dictionary_output():
         target_names=iris.target_names, output_dict=True)
 
     # assert the 2 dicts are equal.
-    assert(report.keys() == expected_report.keys())
+    assert (report.keys() == expected_report.keys())
     for key in expected_report:
         assert report[key].keys() == expected_report[key].keys()
         for metric in expected_report[key]:
@@ -563,7 +562,7 @@ def test_matthews_corrcoef_overflow(n_points):
         mcc_denominator = activity * pos_rate * (1 - activity) * (1 - pos_rate)
         return mcc_numerator / np.sqrt(mcc_denominator)
 
-    def random_ys(n_points):    # binary
+    def random_ys(n_points):  # binary
         x_true = rng.random_sample(n_points)
         x_pred = x_true + 0.2 * (rng.random_sample(n_points) - 0.5)
         y_true = (x_true > 0.5)
@@ -995,7 +994,7 @@ def test_multilabel_hamming_loss():
     assert_equal(hamming_loss(y1, np.zeros(y1.shape)), 4 / 6)
     assert_equal(hamming_loss(y2, np.zeros(y1.shape)), 0.5)
     assert_equal(hamming_loss(y1, y2, sample_weight=w), 1. / 12)
-    assert_equal(hamming_loss(y1, 1-y2, sample_weight=w), 11. / 12)
+    assert_equal(hamming_loss(y1, 1 - y2, sample_weight=w), 11. / 12)
     assert_equal(hamming_loss(y1, np.zeros_like(y1), sample_weight=w), 2. / 3)
     # sp_hamming only works with 1-D arrays
     assert_equal(hamming_loss(y1[0], y2[0]), sp_hamming(y1[0], y2[0]))
@@ -1711,8 +1710,8 @@ def test_balanced_accuracy_score(y_true, y_pred):
 def test_false_positive():
     y_true, y_pred, _ = make_prediction(binary=True)
 
-    rs = false_positive(y_true,y_pred)
-    assert_equal(rs,3)
+    rs = false_positive(y_true, y_pred)
+    assert_equal(rs, 3)
 
 
 def test_false_negative():
@@ -1727,9 +1726,3 @@ def test_true_positive():
 
     rs = true_positive(y_true, y_pred)
     assert_equal(rs, 17)
-
-
-
-
-
-

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -47,6 +47,10 @@ from sklearn.metrics import precision_score
 from sklearn.metrics import recall_score
 from sklearn.metrics import zero_one_loss
 from sklearn.metrics import brier_score_loss
+from sklearn.metrics import true_positive
+from sklearn.metrics import false_negative
+from sklearn.metrics import false_positive
+
 
 from sklearn.metrics.classification import _check_targets
 from sklearn.exceptions import UndefinedMetricWarning
@@ -1702,3 +1706,30 @@ def test_balanced_accuracy_score(y_true, y_pred):
     adjusted = balanced_accuracy_score(y_true, y_pred, adjusted=True)
     chance = balanced_accuracy_score(y_true, np.full_like(y_true, y_true[0]))
     assert adjusted == (balanced - chance) / (1 - chance)
+
+
+def test_false_positive():
+    y_true, y_pred, _ = make_prediction(binary=True)
+
+    CM = confusion_matrix(y_true,y_pred)
+    assert_equal(CM[0][1],3)
+
+
+def test_false_negative():
+    y_true, y_pred, _ = make_prediction(binary=True)
+
+    CM = confusion_matrix(y_true, y_pred)
+    assert_equal(CM[1][0], 8)
+
+
+def test_true_positive():
+    y_true, y_pred, _ = make_prediction(binary=True)
+
+    CM = confusion_matrix(y_true, y_pred)
+    assert_equal(CM[1][1], 17)
+
+
+
+
+
+


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!-- Adding Fall-out, Miss rate, specificity as metrics
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
In this commit i  have added three metrics names miss_rate , specificity, fall_out in sklearn.metrics.
It gives user more flexibility to direct get the value for the given metrics..

#### Any other comments?
MY SYSTEM LIBRARY REQUIREMENTS ARE AS GIVE:
Linux-4.15.0-33-generic-x86_64-with-Ubuntu-16.04-xenial
Python 3.6.5 (default, May  3 2018, 10:08:28)
[GCC 5.4.0 20160609]
NumPy 1.15.0
SciPy 1.1.0


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
