### PR TITLE
Add (failing) test for OPTICS

### DIFF
--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -63,6 +63,8 @@ def test_correct_number_of_clusters():
     assert clust.ordering_.shape == (len(X),)
     assert clust.ordering_.dtype.kind == 'i'
     assert set(clust.ordering_) == set(range(len(X)))
+    
+    assert clust.reachability_[1] == clust.core_distances_[0]
 
 
 def test_minimum_number_of_sample_check():


### PR DESCRIPTION
The reachability of the second point *must* be the core-distance of the first point.
Either that point was reached from the first, or both have core distance infinity.

Therefore, the current OPTICS code is incorrect. See also: #11677

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
