### PR TITLE
[MRG] DOC covariance doctest examples

### DIFF
--- a/sklearn/covariance/elliptic_envelope.py
+++ b/sklearn/covariance/elliptic_envelope.py
@@ -74,10 +74,11 @@ class EllipticEnvelope(MinCovDet, OutlierMixin):
     >>> from sklearn.covariance import EllipticEnvelope
     >>> real_cov = np.array([[.8, .3],
     ...                      [.3, .4]])
+    >>> np.random.seed(0)
     >>> X = np.random.multivariate_normal(mean=[0, 0],
     ...                                   cov=real_cov,
     ...                                   size=300)
-    >>> cov = EllipticEnvelope().fit(X)
+    >>> cov = EllipticEnvelope(random_state=0).fit(X)
     >>> cov.covariance_ # doctest: +ELLIPSIS
     array([[0.7411..., 0.2535...],
            [0.2535..., 0.3053...]])

--- a/sklearn/covariance/elliptic_envelope.py
+++ b/sklearn/covariance/elliptic_envelope.py
@@ -3,7 +3,6 @@
 # License: BSD 3 clause
 
 import numpy as np
-import scipy as sp
 import warnings
 from . import MinCovDet
 from ..utils.validation import check_is_fitted, check_array
@@ -68,6 +67,24 @@ class EllipticEnvelope(MinCovDet, OutlierMixin):
         The offset depends on the contamination parameter and is defined in
         such a way we obtain the expected number of outliers (samples with
         decision function < 0) in training.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.covariance import EllipticEnvelope
+    >>> real_cov = np.array([[.8, .3],
+    ...                      [.3, .4]])
+    >>> X = np.random.multivariate_normal(mean=[0, 0],
+    ...                                   cov=real_cov,
+    ...                                   size=300)
+    >>> cov = EllipticEnvelope().fit(X)
+    >>> cov.covariance_ # doctest: +ELLIPSIS
+    array([[0.7411..., 0.2535...],
+           [0.2535..., 0.3053...]])
+    >>> cov.location_
+    array([0.0813... , 0.0427...])
+    >>> cov.predict(np.array([[1, 1], [5, 6]]))
+    array([ 1, -1])
 
     See Also
     --------

--- a/sklearn/covariance/elliptic_envelope.py
+++ b/sklearn/covariance/elliptic_envelope.py
@@ -68,25 +68,6 @@ class EllipticEnvelope(MinCovDet, OutlierMixin):
         such a way we obtain the expected number of outliers (samples with
         decision function < 0) in training.
 
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from sklearn.covariance import EllipticEnvelope
-    >>> real_cov = np.array([[.8, .3],
-    ...                      [.3, .4]])
-    >>> np.random.seed(0)
-    >>> X = np.random.multivariate_normal(mean=[0, 0],
-    ...                                   cov=real_cov,
-    ...                                   size=300)
-    >>> cov = EllipticEnvelope(random_state=0).fit(X)
-    >>> cov.covariance_ # doctest: +ELLIPSIS
-    array([[0.7411..., 0.2535...],
-           [0.2535..., 0.3053...]])
-    >>> cov.location_
-    array([0.0813... , 0.0427...])
-    >>> cov.predict(np.array([[1, 1], [5, 6]]))
-    array([ 1, -1])
-
     See Also
     --------
     EmpiricalCovariance, MinCovDet

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -111,6 +111,24 @@ class EmpiricalCovariance(BaseEstimator):
         Estimated pseudo-inverse matrix.
         (stored only if store_precision is True)
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.covariance import EmpiricalCovariance
+    >>> from sklearn.datasets import make_gaussian_quantiles
+    >>> real_cov = np.array([[.8, .3],
+    ...                      [.3, .4]])
+    >>> np.random.seed(0)
+    >>> X = np.random.multivariate_normal(mean=[0, 0],
+    ...                                   cov=real_cov,
+    ...                                   size=500)
+    >>> cov = EmpiricalCovariance().fit(X)
+    >>> cov.covariance_ # doctest: +ELLIPSIS
+    array([[0.7569..., 0.2818...],
+           [0.2818..., 0.3928...]])
+    >>> cov.location_
+    array([0.0622..., 0.0193...])
+
     """
     def __init__(self, store_precision=True, assume_centered=False):
         self.store_precision = store_precision

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -104,6 +104,9 @@ class EmpiricalCovariance(BaseEstimator):
 
     Attributes
     ----------
+    location_ : array-like, shape (n_features,)
+        Estimated location, i.e. the estimated mean.
+
     covariance_ : 2D ndarray, shape (n_features, n_features)
         Estimated covariance matrix
 

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -581,6 +581,24 @@ class MinCovDet(EmpiricalCovariance):
         Mahalanobis distances of the training set (on which `fit` is called)
         observations.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.covariance import MinCovDet
+    >>> from sklearn.datasets import make_gaussian_quantiles
+    >>> real_cov = np.array([[.8, .3],
+    ...                      [.3, .4]])
+    >>> np.random.seed(0)
+    >>> X = np.random.multivariate_normal(mean=[0, 0],
+    ...                                   cov=real_cov,
+    ...                                   size=500)
+    >>> cov = MinCovDet(random_state=0).fit(X)
+    >>> cov.covariance_ # doctest: +ELLIPSIS
+    array([[0.7411..., 0.2535...],
+           [0.2535..., 0.3053...]])
+    >>> cov.location_
+    array([0.0813... , 0.0427...])
+
     References
     ----------
 

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -95,6 +95,24 @@ class ShrunkCovariance(EmpiricalCovariance):
         Coefficient in the convex combination used for the computation
         of the shrunk estimate.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.covariance import ShrunkCovariance
+    >>> from sklearn.datasets import make_gaussian_quantiles
+    >>> real_cov = np.array([[.8, .3],
+    ...                      [.3, .4]])
+    >>> np.random.seed(0)
+    >>> X = np.random.multivariate_normal(mean=[0, 0],
+    ...                                   cov=real_cov,
+    ...                                   size=500)
+    >>> cov = ShrunkCovariance().fit(X)
+    >>> cov.covariance_ # doctest: +ELLIPSIS
+    array([[0.7387..., 0.2536...],
+           [0.2536..., 0.4110...]])
+    >>> cov.location_
+    array([0.0622..., 0.0193...])
+
     Notes
     -----
     The regularized covariance is given by:

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -84,6 +84,9 @@ class ShrunkCovariance(EmpiricalCovariance):
 
     Attributes
     ----------
+    location_ : array-like, shape (n_features,)
+        Estimated location, i.e. the estimated mean.
+
     covariance_ : array-like, shape (n_features, n_features)
         Estimated covariance matrix
 


### PR DESCRIPTION
See #3846 

Adds examples to all `sklearn/covariance` classes except the ones being handled in PR #11732 