### PR TITLE
Add a test for numeric precision (see #9354)

### DIFF
--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -874,3 +874,15 @@ def test_check_preserve_type():
                                                    XB.astype(np.float))
     assert_equal(XA_checked.dtype, np.float)
     assert_equal(XB_checked.dtype, np.float)
+
+def test_euclidean_precision32():
+    """dot(x,x) - 2 dot(x,y) + dot(y,y) has catastrophic precision"""
+    XA = np.array([[10000]], np.float32)
+    XB = np.array([[10001]], np.float32)
+    assert_equal(euclidean_distances(XA, XB)[0,0], 1)
+
+def test_euclidean_precision64():
+    """dot(x,x) - 2 dot(x,y) + dot(y,y) has catastrophic precision"""
+    XA = np.array([[100000000]])
+    XB = np.array([[100000001]])
+    assert_equal(euclidean_distances(XA, XB)[0,0], 1)


### PR DESCRIPTION
Surprisingly bad precision, isn't it?

Note that the traditional computation sqrt(sum((x-y)**2)) gets the results exact.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
