### PR TITLE
ENH Remember predecessor in OPTICS

### DIFF
--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -6,6 +6,7 @@ cluster extraction methods of the ordered list.
 
 Authors: Shane Grigsby <refuge@rocktalus.com>
          Amy X. Zhang <axz@mit.edu>
+         Erich Schubert <erich@debian.org>
 License: BSD 3 clause
 """
 
@@ -317,6 +318,10 @@ class OPTICS(BaseEstimator, ClusterMixin):
         Distance at which each sample becomes a core point.
         Points which will never be core have a distance of inf.
 
+    predecessor_ : array, shape (n_samples,)
+        Point that a sample was reached from.
+        Seed points have a predecessor of -1.
+
     See also
     --------
 
@@ -329,6 +334,10 @@ class OPTICS(BaseEstimator, ClusterMixin):
     Ankerst, Mihael, Markus M. Breunig, Hans-Peter Kriegel, and Jörg Sander.
     "OPTICS: ordering points to identify the clustering structure." ACM SIGMOD
     Record 28, no. 2 (1999): 49-60.
+
+    Schubert, Erich, Michael Gertz.
+    "Improving the Cluster Structure Extracted from OPTICS Plots." Proc. of
+    the Conference "Lernen, Wissen, Daten, Analysen" (LWDA) (2018): 318-329.
     """
 
     def __init__(self, min_samples=5, max_eps=np.inf, metric='euclidean',
@@ -396,6 +405,8 @@ class OPTICS(BaseEstimator, ClusterMixin):
         # Start all points as 'unprocessed' ##
         self.reachability_ = np.empty(n_samples)
         self.reachability_.fill(np.inf)
+        self.predecessor_ = np.empty(n_samples, dtype=int)
+        self.predecessor_.fill(-1)
         # Start all points as noise ##
         self.labels_ = np.full(n_samples, -1, dtype=int)
 
@@ -499,8 +510,9 @@ class OPTICS(BaseEstimator, ClusterMixin):
                                        self.metric, n_jobs=None).ravel()
 
         rdists = np.maximum(dists, self.core_distances_[point_index])
-        new_reach = np.minimum(np.take(self.reachability_, unproc), rdists)
-        self.reachability_[unproc] = new_reach
+        improved = np.where(rdists < np.take(self.reachability_, unproc))
+        self.reachability_[unproc[improved]] = rdists[improved]
+        self.predecessor_[unproc[improved]] = point_index
 
         # Define return order based on reachability distance
         return (unproc[quick_scan(np.take(self.reachability_, unproc),


### PR DESCRIPTION
This will allow filtering the extracted clusters,
in order to improve quality (see Schubert and Gertz, LWDA 2018)

#### Reference Issues/PRs
Predecessor information was requested in #12049

#### What does this implement/fix? Explain your changes.
Store the predecessor of each point, which is useful information to filter certain difficult points when extracting clusters (see Schubert and Gertz, LWDA 2018).

#### Any other comments?
The extraction methods still need to be modified to use this.
