### PR TITLE
[WIP] Detect precision issues in euclidean distance calculations

### DIFF
--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -96,6 +96,17 @@ class EfficiencyWarning(UserWarning):
     """
 
 
+class NumericalPrecisionWarning(UserWarning):
+    """Warning used to notify the user of possibly inaccurate computation.
+
+    This warning notifies the user that the numerical accuracy may not be
+    optimal due to some reason which may be included as a part of the warning
+    message.
+
+    .. versionadded:: 0.21
+    """
+
+
 class FitFailedWarning(RuntimeWarning):
     """Warning class used if there is an error while fitting the estimator.
 

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -8,7 +8,6 @@ from scipy.spatial.distance import cosine, cityblock, minkowski, wminkowski
 
 import pytest
 
-import sklearn
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_allclose
@@ -896,13 +895,16 @@ def test_euclidean_distance_precision(dtype):
         with pytest.raises(AssertionError):
             assert pairwise_distances(XA, XB)[0, 0] == 1.
 
-    with pytest.warns(None) as record:
-        assert euclidean_distances(XA, XB, algorithm='exact')[0, 0] == 1
+    # Note: this needs https://github.com/scikit-learn/scikit-learn/pull/12136
+    # to be merged first.
+    #
+    #  with pytest.warns(None) as record:
+    #      assert euclidean_distances(XA, XB, algorithm='exact')[0, 0] == 1
 
-        with sklearn.config_context(euclidean_distances_algorithm='exact'):
-            assert euclidean_distances(XA, XB)[0, 0] == 1
-            assert pairwise_distances(XA, XB)[0, 0] == 1.
-    assert len(record) == 0
+    #      with sklearn.config_context(euclidean_distances_algorithm='exact'):
+    #          assert euclidean_distances(XA, XB)[0, 0] == 1
+    #          assert pairwise_distances(XA, XB)[0, 0] == 1.
+    #  assert len(record) == 0
 
 
 @pytest.mark.parametrize('dtype', ('float32', 'float64'))

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -874,3 +874,15 @@ def test_check_preserve_type():
                                                    XB.astype(np.float))
     assert_equal(XA_checked.dtype, np.float)
     assert_equal(XB_checked.dtype, np.float)
+
+def test_euclidean_precision32():
+    """dot(x,x) - 2 dot(x,y) + dot(y,y) has catastrophic precision"""
+    XA = np.array([[10000]], np.float32)
+    XB = np.array([[10001]], np.float32)
+    assert_equal(euclidean_distances(XA, XB)[0,0], 1)
+
+def test_euclidean_precision64():
+    """dot(x,x) - 2 dot(x,y) + dot(y,y) has catastrophic precision"""
+    XA = np.array([[100000000]])
+    XB = np.array([[100000001]])
+    assert_equal(euclidean_distances(XA, XB)[0,0], 1)


### PR DESCRIPTION
Following the discussion in https://github.com/scikit-learn/scikit-learn/issues/9354
this is an attempt to  warn the user when numerical precision issues may occur in the euclidean distances computed with quadratic expansion. This affects both 32 bit and 64bit.

The overall idea is that we need to detect when the distance between two vectors is much less then the vector norms (by a factor of 1e7 in 64bit).

Here we take a more simplified approach and instead only consider the global distribution of compared vectors. If all considered vectors are within a very thin shell such a the shell thinkness divided by the mean vector norm is below a given threshold, a warning is raised (cf image below).

![euclidean_distances_accuracy_illustration](https://user-images.githubusercontent.com/630936/45945444-db2b4300-bfed-11e8-9f02-0e3a43b8fe2b.png)

 - If all vectors are within the cluster A, a warning is raised as it should. For instance, an example of this would `[[100000001, 100000000]]` and `[[100000000, 100000001]]`, as reported by @kno10  in https://github.com/scikit-learn/scikit-learn/issues/9354#issuecomment-423475591
 - If points belong to both cluster A and B (e.g. by adding a minus sign to one of the above vectors), a warning will be raised while it's shouldn't be (false postive)
 - if points belong to very tight clusters A and C, no warning will be raised even though it should be.


 Here the cost of checking for precision issues is only `O(n_samples_a + n_samples_b)` which is negligible to the cost of computing pairwise distances `O(n_samples_a*n_samples_b*n_features)`.

This it's more a proof of concept, more work would be needed to make this useful.

TODO
 - [ ] check how this solution is addressed in other libraries. It seem to be a common issue, e.g. from [pytorch discussion forum](https://discuss.pytorch.org/t/efficient-distance-matrix-computation/9065),
   > This seems to be a well documented issue with this approach and existing libraries will use thresholding to default to the direct computation when needed.
 - [ ] contact the scipy community about it
 - [ ] generalize the above approach. I think, it might be possible to get an exhaustive list of problematic points fairly efficiently (possibly either with one pass through sorted vectors of ‖A‖₂, ‖B‖₂, or using e.g. `BallTree.query_radius`), then compute them accurately. The main idea is that comparing only vector norms, may give an idea when precision is problematic, with low computational effort, even though there are false positives.

