### PR TITLE
DOC: update link to other versions

### DIFF
--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -279,7 +279,7 @@
 
     {%- if pagename != "install" %}
       <p class="doc-version"><b>{{project}} v{{ release|e }}</b><br/>
-      <a href="http://scikit-learn.org/stable/support.html#documentation-resources">Other versions</a></p>
+      <a href="http://scikit-learn.org/dev/versions.html">Other versions</a></p>
     {%- endif %}
     <p class="citing">Please <b><a href="{{ pathto('about').replace('#', '') }}#citing-scikit-learn" style="font-size: 110%;">cite us </a></b>if you use the software.</p>
     {{ toc }}


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/12157 

I used the same link as is used on the home page.