### PR TITLE
OPTIM remove useless overhead caused by nested parallelism in mean_shift

### DIFF
--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -193,7 +193,11 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
             seeds = X
     n_samples, n_features = X.shape
     center_intensity_dict = {}
-    nbrs = NearestNeighbors(radius=bandwidth, n_jobs=n_jobs).fit(X)
+
+    # We use n_jobs=1 because this will be used in nested calls under
+    # parallel calls to _mean_shift_single_seed so there is no need for
+    # for further parallelism.
+    nbrs = NearestNeighbors(radius=bandwidth, n_jobs=1).fit(X)
 
     # execute iterations on all seeds in parallel
     all_res = Parallel(n_jobs=n_jobs)(


### PR DESCRIPTION
When trying to debug the random joblib deadlock reported for Python 2 in https://github.com/joblib/joblib/issues/779 , I found out that doing nested parallel neighbors queries in mean_shift introduces a lot of useless overhead for nothing. Therefore I disable nested parallelism in this section of the mean shift algorithm.

Note that this optim is very likely to hide the original deadlock problem.