### PR TITLE
[MRG] start section for the 0.20.1 bugfix notes

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -2,6 +2,27 @@
 
 .. currentmodule:: sklearn
 
+.. _changes_0_20_1:
+
+Version 0.20.1
+==============
+
+**October XX, 2018**
+
+This is a bug-fix release with some minor documentation improvements and
+enhancements to features released in 0.20.0.
+
+- |Efficiency| make :class:`cluster.MeanShift` no longer try to do nested
+  parallelism as the overhead would hurt performance significantly when
+  ``n_jobs > 1``.
+  :issue:`12159` by :user:`Olivier Grisel <ogrisel>`.
+
+- |Fix| :func:`linear_model.SGDClassifier` and variants
+  with ``early_stopping=True`` would not use a consistent validation
+  split in the multiclass case and this would cause a crash when using
+  those estimators as part of parallel parameter search or cross-validation.
+  :issue:`12122` by :user:`Olivier Grisel <ogrisel>`.
+
 .. _changes_0_20:
 
 Version 0.20.0


### PR DESCRIPTION
Note that the two fixes documented in this PR have already been merged to master and already backported in the 0.20.X branch.

However this eager backport was probably a bad idea. In general we don't want to update the 0.20 website as long as the 0.20.1 release is not tagged. So instead it's better to maintain a 0.20.1 backport PR that accumulates all the backports.

For those two fixes it's not a big deal as they do not change the documentation/docstrings or examples.