### PR TITLE
Fix parallel backend neighbors

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -23,6 +23,11 @@ enhancements to features released in 0.20.0.
   those estimators as part of parallel parameter search or cross-validation.
   :issue:`12122` by :user:`Olivier Grisel <ogrisel>`.
 
+- |Fix| force the parallelism backend to :code:`threading` for
+  :class:`neighbors.KDTree` and :class:`neighbors.BallTree` in Python 2.7 to
+  avoid pickling errors caused by the serialization of their methods.
+  :issue:`12171` by :user:`Thomas Moreau <tomMoral>`
+
 .. _changes_0_20:
 
 Version 0.20.0

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -9,6 +9,7 @@
 from functools import partial
 from distutils.version import LooseVersion
 
+import sys
 import warnings
 from abc import ABCMeta, abstractmethod
 
@@ -429,7 +430,8 @@ class KNeighborsMixin(object):
                 raise ValueError(
                     "%s does not work with sparse matrices. Densify the data, "
                     "or set algorithm='brute'" % self._fit_method)
-            if LooseVersion(joblib_version) < LooseVersion('0.12'):
+            if (sys.version_info < (3,) or
+                    LooseVersion(joblib_version) < LooseVersion('0.12')):
                 # Deal with change of API in joblib
                 delayed_query = delayed(self._tree.query,
                                         check_pickle=False)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1317,11 +1317,12 @@ def test_same_radius_neighbors_parallel(algorithm):
         assert_array_equal(ind[i], ind_parallel[i])
     assert_array_almost_equal(graph, graph_parallel)
 
+
 @pytest.mark.parametrize('backend', ['loky', 'multiprocessing', 'threading'])
 @pytest.mark.parametrize('algorithm', ALGORITHMS)
 def test_knn_forcing_backend(backend, algorithm):
-    # Non-regression test which ensure the knn is properly working
-    # even when forcing the global joblib backend
+    # Non-regression test which ensure the knn methods are properly working
+    # even when forcing the global joblib backend.
     with parallel_backend(backend):
         X, y = datasets.make_classification(n_samples=30, n_features=5,
                                             n_redundant=0, random_state=0)
@@ -1331,9 +1332,9 @@ def test_knn_forcing_backend(backend, algorithm):
                                              algorithm=algorithm,
                                              n_jobs=3)
         clf.fit(X_train, y_train)
-        y = clf.predict(X_test)
-        dist, ind = clf.kneighbors(X_test)
-        graph = clf.kneighbors_graph(X_test, mode='distance').toarray()
+        clf.predict(X_test)
+        clf.kneighbors(X_test)
+        clf.kneighbors_graph(X_test, mode='distance').toarray()
 
 
 def test_dtype_convert():

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -27,6 +27,8 @@ from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.validation import check_random_state
 
+from sklearn.externals.joblib import parallel_backend
+
 rng = np.random.RandomState(0)
 # load and shuffle iris dataset
 iris = datasets.load_iris()
@@ -1314,6 +1316,24 @@ def test_same_radius_neighbors_parallel(algorithm):
         assert_array_almost_equal(dist[i], dist_parallel[i])
         assert_array_equal(ind[i], ind_parallel[i])
     assert_array_almost_equal(graph, graph_parallel)
+
+@pytest.mark.parametrize('backend', ['loky', 'multiprocessing', 'threading'])
+@pytest.mark.parametrize('algorithm', ALGORITHMS)
+def test_knn_forcing_backend(backend, algorithm):
+    # Non-regression test which ensure the knn is properly working
+    # even when forcing the global joblib backend
+    with parallel_backend(backend):
+        X, y = datasets.make_classification(n_samples=30, n_features=5,
+                                            n_redundant=0, random_state=0)
+        X_train, X_test, y_train, y_test = train_test_split(X, y)
+
+        clf = neighbors.KNeighborsClassifier(n_neighbors=3,
+                                             algorithm=algorithm,
+                                             n_jobs=3)
+        clf.fit(X_train, y_train)
+        y = clf.predict(X_test)
+        dist, ind = clf.kneighbors(X_test)
+        graph = clf.kneighbors_graph(X_test, mode='distance').toarray()
 
 
 def test_dtype_convert():


### PR DESCRIPTION
Fixes #12171 


This forces the `joblib` backend to `threading` in neighbors for python2.7 as the KDTree and BallTree methods are not picklable.
