### PR TITLE
DOC add a known issue entry for euclidean_distances precision

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -93,11 +93,16 @@ cannot assure that this list is complete.)
 Known Major Bugs
 ----------------
 
-* :issue:`11924`: :class:`LogisticRegressionCV` with `solver='lbfgs'` and
-  `multi_class='multinomial'` may be non-deterministic or otherwise broken on
-  macOS. This appears to be the case on Travis CI servers, but has not been
-  confirmed on personal MacBooks! This issue has been present in previous
-  releases.
+* :issue:`11924`: :class:`linear_model.LogisticRegressionCV` with
+  `solver='lbfgs'` and `multi_class='multinomial'` may be non-deterministic or
+  otherwise broken on macOS. This appears to be the case on Travis CI servers,
+  but has not been confirmed on personal MacBooks! This issue has been present
+  in previous releases.
+
+* :issue:`9354`: :func:`metrics.pairwise.euclidean_distances` (which is used
+  several times throughout the library) gives results with poor precision,
+  which particularly affects its use with 32-bit float inputs. 32-bit floats
+  were handled with higher precision prior to version 0.19.
 
 Changelog
 ---------

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -101,9 +101,9 @@ Known Major Bugs
 
 * :issue:`9354`: :func:`metrics.pairwise.euclidean_distances` (which is used
   several times throughout the library) gives results with poor precision,
-  which particularly affects its use with 32-bit float inputs. 32-bit floats
-  were handled with higher precision, by casting them to 64-bit, prior to
-  version 0.19.
+  which particularly affects its use with 32-bit float inputs. This became
+  more problematic in versions 0.18 and 0.19 when some algorithms were changed
+  to avoid casting 32-bit data into 64-bit.
 
 Changelog
 ---------

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -102,7 +102,8 @@ Known Major Bugs
 * :issue:`9354`: :func:`metrics.pairwise.euclidean_distances` (which is used
   several times throughout the library) gives results with poor precision,
   which particularly affects its use with 32-bit float inputs. 32-bit floats
-  were handled with higher precision prior to version 0.19.
+  were handled with higher precision, by casting them to 64-bit, prior to
+  version 0.19.
 
 Changelog
 ---------


### PR DESCRIPTION
Reviewing the release notes, I thought the euclidean_distances bug should probably be mentioned in the 0.20.X what's new. Okay to backport directly to the 0.20.X branch so it appears in online docs?