### PR TITLE
[MRG] More informative error message in OneHotEncoder(categories=None) with negative integer values

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -421,10 +421,10 @@ class OneHotEncoder(_BaseEncoder):
         dtype = getattr(X, 'dtype', None)
         X = check_array(X, dtype=np.int)
         if np.any(X < 0):
-            raise ValueError("OneHotEncoder in legacy mode cannot handle"
-                             "categories encoded as negative integers."
-                             "Please set categories='auto' explicitly to"
-                             "be able to use arbitrary integer values as"
+            raise ValueError("OneHotEncoder in legacy mode cannot handle "
+                             "categories encoded as negative integers. "
+                             "Please set categories='auto' explicitly to "
+                             "be able to use arbitrary integer values as "
                              "category identifiers.")
         n_samples, n_features = X.shape
         if (isinstance(self.n_values, six.string_types) and
@@ -508,10 +508,10 @@ class OneHotEncoder(_BaseEncoder):
         """Assumes X contains only categorical features."""
         X = check_array(X, dtype=np.int)
         if np.any(X < 0):
-            raise ValueError("OneHotEncoder in legacy mode cannot handle"
-                             "categories encoded as negative integers."
-                             "Please set categories='auto' explicitly to"
-                             "be able to use arbitrary integer values as"
+            raise ValueError("OneHotEncoder in legacy mode cannot handle "
+                             "categories encoded as negative integers. "
+                             "Please set categories='auto' explicitly to "
+                             "be able to use arbitrary integer values as "
                              "category identifiers.")
         n_samples, n_features = X.shape
 

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -421,8 +421,11 @@ class OneHotEncoder(_BaseEncoder):
         dtype = getattr(X, 'dtype', None)
         X = check_array(X, dtype=np.int)
         if np.any(X < 0):
-            raise ValueError("Instantiate using categories='auto' to"
-                             "handle negative integer categories.")
+            raise ValueError("OneHotEncoder in legacy mode cannot handle"
+                             "categories encoded as negative integers."
+                             "Please set categories='auto' explicitly to"
+                             "be able to use arbitrary integer values as"
+                             "category identifiers.")
         n_samples, n_features = X.shape
         if (isinstance(self.n_values, six.string_types) and
                 self.n_values == 'auto'):
@@ -505,8 +508,11 @@ class OneHotEncoder(_BaseEncoder):
         """Assumes X contains only categorical features."""
         X = check_array(X, dtype=np.int)
         if np.any(X < 0):
-            raise ValueError("Instantiate using categories='auto' to"
-                             "handle negative integer categories.")
+            raise ValueError("OneHotEncoder in legacy mode cannot handle"
+                             "categories encoded as negative integers."
+                             "Please set categories='auto' explicitly to"
+                             "be able to use arbitrary integer values as"
+                             "category identifiers.")
         n_samples, n_features = X.shape
 
         indices = self._feature_indices_

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -421,10 +421,8 @@ class OneHotEncoder(_BaseEncoder):
         dtype = getattr(X, 'dtype', None)
         X = check_array(X, dtype=np.int)
         if np.any(X < 0):
-            raise ValueError("X needs to contain only non-negative integers,"
-                             "this behavior is now deprecated. New behaviour"
-                             "supports negative input. Instantiate using"
-                             "`categories='auto'`.")
+            raise ValueError("Instantiate using categories='auto' to"
+                             "handle negative integer categories.")
         n_samples, n_features = X.shape
         if (isinstance(self.n_values, six.string_types) and
                 self.n_values == 'auto'):
@@ -507,10 +505,8 @@ class OneHotEncoder(_BaseEncoder):
         """Assumes X contains only categorical features."""
         X = check_array(X, dtype=np.int)
         if np.any(X < 0):
-            raise ValueError("X needs to contain only non-negative integers,"
-                             "this behavior is now deprecated. New behaviour"
-                             "supports negative input. Instantiate using"
-                             "`categories='auto'`.")
+            raise ValueError("Instantiate using categories='auto' to"
+                             "handle negative integer categories.")
         n_samples, n_features = X.shape
 
         indices = self._feature_indices_

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -421,9 +421,9 @@ class OneHotEncoder(_BaseEncoder):
         dtype = getattr(X, 'dtype', None)
         X = check_array(X, dtype=np.int)
         if np.any(X < 0):
-            raise ValueError("X needs to contain only non-negative integers, "
-                             "this behavior is now deprecated. New behaviour "
-                             "supports negative input. Instantiate using "
+            raise ValueError("X needs to contain only non-negative integers,"
+                             "this behavior is now deprecated. New behaviour"
+                             "supports negative input. Instantiate using"
                              "`categories='auto'`.")
         n_samples, n_features = X.shape
         if (isinstance(self.n_values, six.string_types) and
@@ -507,9 +507,9 @@ class OneHotEncoder(_BaseEncoder):
         """Assumes X contains only categorical features."""
         X = check_array(X, dtype=np.int)
         if np.any(X < 0):
-            raise ValueError("X needs to contain only non-negative integers, "
-                             "this behavior is now deprecated. New behaviour "
-                             "supports negative input. Instantiate using "
+            raise ValueError("X needs to contain only non-negative integers,"
+                             "this behavior is now deprecated. New behaviour"
+                             "supports negative input. Instantiate using"
                              "`categories='auto'`.")
         n_samples, n_features = X.shape
 

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -421,7 +421,10 @@ class OneHotEncoder(_BaseEncoder):
         dtype = getattr(X, 'dtype', None)
         X = check_array(X, dtype=np.int)
         if np.any(X < 0):
-            raise ValueError("X needs to contain only non-negative integers.")
+            raise ValueError("X needs to contain only non-negative integers, "
+                             "this behavior is now deprecated. New behaviour "
+                             "supports negative input. Instantiate using "
+                             "`categories='auto'`.")
         n_samples, n_features = X.shape
         if (isinstance(self.n_values, six.string_types) and
                 self.n_values == 'auto'):
@@ -504,7 +507,10 @@ class OneHotEncoder(_BaseEncoder):
         """Assumes X contains only categorical features."""
         X = check_array(X, dtype=np.int)
         if np.any(X < 0):
-            raise ValueError("X needs to contain only non-negative integers.")
+            raise ValueError("X needs to contain only non-negative integers, "
+                             "this behavior is now deprecated. New behaviour "
+                             "supports negative input. Instantiate using "
+                             "`categories='auto'`.")
         n_samples, n_features = X.shape
 
         indices = self._feature_indices_


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #12179 - Update the error message when negative inputs are provided to OneHotEncoder to show how to negative inputs can be supported by instantiating OneHotEncoder with categories='auto'
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
OneHotEncoder didn't support negative integer inputs. This behavior is 
deprecated. The legacy behaviour currently raises ValueError("X needs 
to contain only non-negative integers."). This error message is now 
extended to show how to activate the new behavior by instantiating the 
OneHotEncoder with categories='auto'.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
