### PR TITLE
ENH: Add support for cosine distance in k-means

### DIFF
--- a/examples/text/plot_document_clustering.py
+++ b/examples/text/plot_document_clustering.py
@@ -92,6 +92,12 @@ op.add_option("--use-hashing",
 op.add_option("--n-features", type=int, default=10000,
               help="Maximum number of features (dimensions)"
                    " to extract from text.")
+op.add_option("--no-remove",
+              action="store_false", dest="remove_extra", default=True,
+              help="Keep 'headers', 'footers', 'quotes'")
+op.add_option("--metric",
+              dest="metric", type="str", default="euclidean",
+              help="Specify the distance metric to use for KMeans.")
 op.add_option("--verbose",
               action="store_true", dest="verbose", default=False,
               help="Print progress reports inside k-means algorithm.")
@@ -126,7 +132,11 @@ categories = [
 print("Loading 20 newsgroups dataset for categories:")
 print(categories)
 
-dataset = fetch_20newsgroups(subset='all', categories=categories,
+remove = ()
+if opts.remove_extra:
+    remove = ('headers', 'footers', 'quotes')
+
+dataset = fetch_20newsgroups(subset='all', categories=categories, remove=remove,
                              shuffle=True, random_state=42)
 
 print("%d documents" % len(dataset.data))
@@ -186,10 +196,10 @@ if opts.n_components:
 
 if opts.minibatch:
     km = MiniBatchKMeans(n_clusters=true_k, init='k-means++', n_init=1,
-                         init_size=1000, batch_size=1000, verbose=opts.verbose)
+                         init_size=1000, batch_size=1000, verbose=opts.verbose, metric=opts.metric)
 else:
     km = KMeans(n_clusters=true_k, init='k-means++', max_iter=100, n_init=1,
-                verbose=opts.verbose)
+                verbose=opts.verbose, metric=opts.metric)
 
 print("Clustering sparse data with %s" % km)
 t0 = time()

--- a/examples/text/plot_document_clustering.py
+++ b/examples/text/plot_document_clustering.py
@@ -136,8 +136,8 @@ remove = ()
 if opts.remove_extra:
     remove = ('headers', 'footers', 'quotes')
 
-dataset = fetch_20newsgroups(subset='all', categories=categories, remove=remove,
-                             shuffle=True, random_state=42)
+dataset = fetch_20newsgroups(subset='all', categories=categories,
+                             remove=remove, shuffle=True, random_state=42)
 
 print("%d documents" % len(dataset.data))
 print("%d categories" % len(dataset.target_names))
@@ -196,7 +196,8 @@ if opts.n_components:
 
 if opts.minibatch:
     km = MiniBatchKMeans(n_clusters=true_k, init='k-means++', n_init=1,
-                         init_size=1000, batch_size=1000, verbose=opts.verbose, metric=opts.metric)
+                         init_size=1000, batch_size=1000, verbose=opts.verbose,
+                         metric=opts.metric)
 else:
     km = KMeans(n_clusters=true_k, init='k-means++', max_iter=100, n_init=1,
                 verbose=opts.verbose, metric=opts.metric)

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -69,7 +69,8 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None,
     metric : string, default 'euclidean'
         metric to use for distance computation.
 
-        Valid values for metric are ['cosine', 'euclidean'].
+        Valid values for metric are:
+            ['euclidean', 'cosine']
 
     Notes
     -----
@@ -125,7 +126,8 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None,
         # Compute distances to center candidates
         if metric == 'euclidean':
             distance_to_candidates = euclidean_distances(
-                X[candidate_ids], X, Y_norm_squared=x_squared_norms, squared=True)
+                X[candidate_ids], X, Y_norm_squared=x_squared_norms,
+                squared=True)
         else:
             distance_to_candidates = cosine_distances(X[candidate_ids], X)
 
@@ -288,7 +290,8 @@ def k_means(X, n_clusters, sample_weight=None, init='k-means++',
     metric : string, default 'euclidean'
         metric to use for distance computation.
 
-        Valid values for metric are ['cosine', 'euclidean'].
+        Valid values for metric are:
+            ['euclidean', 'cosine']
 
     Returns
     -------
@@ -375,13 +378,15 @@ def k_means(X, n_clusters, sample_weight=None, init='k-means++',
         # the right result.
         algorithm = "full"
     if algorithm == "auto":
-        algorithm = "full" if sp.issparse(X) or metric != 'euclidean' else 'elkan'
+        algorithm = "full" if sp.issparse(
+            X) or metric != 'euclidean' else 'elkan'
     if algorithm == "full":
         kmeans_single = _kmeans_single_lloyd
     elif algorithm == "elkan":
         if metric != 'euclidean':
-            raise ValueError("Algorithm 'elkan' must use 'euclidean' metric, got"
-                             " %s" % str(metric))
+            raise ValueError(
+                "Algorithm 'elkan' must use 'euclidean' metric, got"
+                " %s" % str(metric))
         kmeans_single = _kmeans_single_elkan
     else:
         raise ValueError("Algorithm must be 'auto', 'full' or 'elkan', got"
@@ -536,7 +541,8 @@ def _kmeans_single_lloyd(X, sample_weight, n_clusters, max_iter=300,
     metric : string, default 'euclidean'
         metric to use for distance computation.
 
-        Valid values for metric are ['cosine', 'euclidean'].
+        Valid values for metric are:
+            ['euclidean', 'cosine']
 
     Returns
     -------
@@ -643,7 +649,8 @@ def _labels_inertia_precompute_dense(X, sample_weight, x_squared_norms,
     metric : string, default 'euclidean'
         metric to use for distance computation.
 
-        Valid values for metric are ['cosine', 'euclidean'].
+        Valid values for metric are:
+            ['euclidean', 'cosine']
 
     Returns
     -------
@@ -661,7 +668,8 @@ def _labels_inertia_precompute_dense(X, sample_weight, x_squared_norms,
     # TODO: Once PR #7383 is merged use check_inputs=False in metric_kwargs.
     if metric == 'euclidean':
         labels, mindist = pairwise_distances_argmin_min(
-            X=X, Y=centers, metric='euclidean', metric_kwargs={'squared': True})
+            X=X, Y=centers,
+            metric='euclidean', metric_kwargs={'squared': True})
     else:
         labels, mindist = pairwise_distances_argmin_min(
             X=X, Y=centers, metric=metric)
@@ -707,7 +715,8 @@ def _labels_inertia(X, sample_weight, x_squared_norms, centers,
     metric : string, default 'euclidean'
         metric to use for distance computation.
 
-        Valid values for metric are ['cosine', 'euclidean'].
+        Valid values for metric are:
+            ['euclidean', 'cosine']
 
     Returns
     -------
@@ -780,7 +789,8 @@ def _init_centroids(X, k, init, random_state=None, x_squared_norms=None,
     metric : string, default 'euclidean'
         metric to use for distance computation.
 
-        Valid values for metric are ['cosine', 'euclidean'].
+        Valid values for metric are:
+            ['euclidean', 'cosine']
 
     Returns
     -------
@@ -915,7 +925,8 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
     metric : string, default 'euclidean'
         metric to use for distance computation.
 
-        Valid values for metric are ['cosine', 'euclidean'].
+        Valid values for metric are:
+            ['euclidean', 'cosine']
 
     Attributes
     ----------
@@ -1240,7 +1251,8 @@ def _mini_batch_step(X, sample_weight, x_squared_norms, centers, weight_sums,
     metric : string, default 'euclidean'
         metric to use for distance computation.
 
-        Valid values for metric are ['cosine', 'euclidean'].
+        Valid values for metric are:
+            ['euclidean', 'cosine']
 
     verbose : bool, optional, default False
         Controls the verbosity.
@@ -1488,7 +1500,8 @@ class MiniBatchKMeans(KMeans):
     metric : string, default 'euclidean'
         metric to use for distance computation.
 
-        Valid values for metric are ['cosine', 'euclidean'].
+        Valid values for metric are:
+            ['euclidean', 'cosine']
 
     Attributes
     ----------
@@ -1740,7 +1753,8 @@ class MiniBatchKMeans(KMeans):
         metric : string, default 'euclidean'
             metric to use for distance computation.
 
-            Valid values for metric are ['cosine', 'euclidean'].
+            Valid values for metric are:
+                ['euclidean', 'cosine']
 
         Returns
         -------
@@ -1756,9 +1770,10 @@ class MiniBatchKMeans(KMeans):
         slices = gen_batches(X.shape[0], self.batch_size)
         if metric == 'euclidean':
             x_squared_norms = row_norms(X, squared=True)
-            results = [_labels_inertia(X[s], sample_weight[s], x_squared_norms[s],
-                                       self.cluster_centers_,
-                                       metric=metric) for s in slices]
+            results = [
+                _labels_inertia(X[s], sample_weight[s], x_squared_norms[s],
+                                self.cluster_centers_,
+                                metric=metric) for s in slices]
         else:
             results = [_labels_inertia(X[s], sample_weight[s], None,
                                        self.cluster_centers_,
@@ -1862,5 +1877,5 @@ class MiniBatchKMeans(KMeans):
         check_is_fitted(self)
 
         X = self._check_test_data(X)
-        return self._labels_inertia_minibatch(X, sample_weight, metric=self.metric)[0]
-
+        return self._labels_inertia_minibatch(X, sample_weight,
+                                              metric=self.metric)[0]

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -357,15 +357,19 @@ def k_means(X, n_clusters, sample_weight=None, init='k-means++',
                 % n_init, RuntimeWarning, stacklevel=2)
             n_init = 1
 
-    if metric in ['cosine', 'euclidean']:
-        # subtract of mean of x for more accurate distance computations
-        if not sp.issparse(X):
-            X_mean = X.mean(axis=0)
-            # The copy was already done above
-            X -= X_mean
+    if metric not in ['euclidean', 'cosine']:
+        raise ValueError("the metric parameter for the k-means should "
+                         "be 'euclidean' or 'cosine', "
+                         "'%s' (type '%s') was passed." % (metric, type(init)))
 
-            if hasattr(init, '__array__'):
-                init -= X_mean
+    # subtract of mean of x for more accurate distance computations
+    if not sp.issparse(X):
+        X_mean = X.mean(axis=0)
+        # The copy was already done above
+        X -= X_mean
+
+        if hasattr(init, '__array__'):
+            init -= X_mean
 
     # precompute squared norms of data points
     x_squared_norms = None

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -245,6 +245,13 @@ def test_k_means_precompute_distances_flag():
         km.fit(X)
 
 
+def test_k_means_metric_value():
+    # check that a warning is raised if the metric is not supported
+    km = KMeans(metric="wrong")
+    with pytest.raises(ValueError):
+        km.fit(X)
+
+
 def test_k_means_plus_plus_init_not_precomputed():
     km = KMeans(init="k-means++", n_clusters=n_clusters, random_state=42,
                 precompute_distances=False).fit(X)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

See also #1188.

#### What does this implement/fix? Explain your changes.

Adds support for cosine distance in k-means including the minibatch implementation. We trust that users know what they're doing and allow the metric to be a callable with metric_kwargs. 

#### Any other comments?

I enabled the cleaning of headers, footers, and quotes from the 20newsgroups dataset documents for the example program plot_document_clustering.py. Now it clearly shows improvements in the metrics V-measure and ARI when using cosine distance for text document clustering. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
