### PR TITLE
[MRG] Remove duplicate import of warnings & unused variables

### DIFF
--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -579,7 +579,6 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
     def _set_oob_score(self, X, y):
         n_samples = y.shape[0]
         n_classes_ = self.n_classes_
-        classes_ = self.classes_
 
         predictions = np.zeros((n_samples, n_classes_))
 

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -41,9 +41,7 @@ Single and multi-output problems are both handled.
 
 from __future__ import division
 
-from warnings import catch_warnings
-from warnings import simplefilter
-from warnings import warn
+from warnings import catch_warnings, simplefilter, warn
 import threading
 
 from abc import ABCMeta, abstractmethod

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -260,7 +260,7 @@ class BaseForest(six.with_metaclass(ABCMeta, BaseEnsemble)):
             X.sort_indices()
 
         # Remap output
-        n_samples, self.n_features_ = X.shape
+        self.n_features_ = X.shape[1]
 
         y = np.atleast_1d(y)
         if y.ndim == 2 and y.shape[1] == 1:

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -41,7 +41,8 @@ Single and multi-output problems are both handled.
 
 from __future__ import division
 
-import warnings
+from warnings import catch_warnings
+from warnings import simplefilter
 from warnings import warn
 import threading
 
@@ -112,8 +113,8 @@ def _parallel_build_trees(tree, forest, X, y, sample_weight, tree_idx, n_trees,
         curr_sample_weight *= sample_counts
 
         if class_weight == 'subsample':
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', DeprecationWarning)
+            with catch_warnings():
+                simplefilter('ignore', DeprecationWarning)
                 curr_sample_weight *= compute_sample_weight('auto', y, indices)
         elif class_weight == 'balanced_subsample':
             curr_sample_weight *= compute_sample_weight('balanced', y, indices)
@@ -244,7 +245,7 @@ class BaseForest(six.with_metaclass(ABCMeta, BaseEnsemble)):
         """
 
         if self.n_estimators == 'warn':
-            warnings.warn("The default value of n_estimators will change from "
+            warn("The default value of n_estimators will change from "
                           "10 in version 0.20 to 100 in 0.22.", FutureWarning)
             self.n_estimators = 10
 

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -208,19 +208,19 @@ class IsolationForest(BaseBagging, OutlierMixin):
         """
         if self.contamination == "legacy":
             warn('default contamination parameter 0.1 will change '
-                          'in version 0.22 to "auto". This will change the '
-                          'predict method behavior.',
-                          FutureWarning)
+                 'in version 0.22 to "auto". This will change the '
+                 'predict method behavior.',
+                 FutureWarning)
             self._contamination = 0.1
         else:
             self._contamination = self.contamination
 
         if self.behaviour == 'old':
             warn('behaviour="old" is deprecated and will be removed '
-                          'in version 0.22. Please use behaviour="new", which '
-                          'makes the decision_function change to match '
-                          'other anomaly detection algorithm API.',
-                          FutureWarning)
+                 'in version 0.22. Please use behaviour="new", which '
+                 'makes the decision_function change to match '
+                 'other anomaly detection algorithm API.',
+                 FutureWarning)
 
         X = check_array(X, accept_sparse=['csc'])
         if issparse(X):
@@ -414,7 +414,7 @@ class IsolationForest(BaseBagging, OutlierMixin):
             raise AttributeError("threshold_ attribute does not exist when "
                                  "behaviour != 'old'")
         warn("threshold_ attribute is deprecated in 0.20 and will"
-                      " be removed in 0.22.", DeprecationWarning)
+             " be removed in 0.22.", DeprecationWarning)
         return self._threshold_
 
 

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -5,7 +5,6 @@
 from __future__ import division
 
 import numpy as np
-import warnings
 from warnings import warn
 from sklearn.utils.fixes import euler_gamma
 
@@ -208,7 +207,7 @@ class IsolationForest(BaseBagging, OutlierMixin):
         self : object
         """
         if self.contamination == "legacy":
-            warnings.warn('default contamination parameter 0.1 will change '
+            warn('default contamination parameter 0.1 will change '
                           'in version 0.22 to "auto". This will change the '
                           'predict method behavior.',
                           FutureWarning)
@@ -217,7 +216,7 @@ class IsolationForest(BaseBagging, OutlierMixin):
             self._contamination = self.contamination
 
         if self.behaviour == 'old':
-            warnings.warn('behaviour="old" is deprecated and will be removed '
+            warn('behaviour="old" is deprecated and will be removed '
                           'in version 0.22. Please use behaviour="new", which '
                           'makes the decision_function change to match '
                           'other anomaly detection algorithm API.',
@@ -414,7 +413,7 @@ class IsolationForest(BaseBagging, OutlierMixin):
         if self.behaviour != 'old':
             raise AttributeError("threshold_ attribute does not exist when "
                                  "behaviour != 'old'")
-        warnings.warn("threshold_ attribute is deprecated in 0.20 and will"
+        warn("threshold_ attribute is deprecated in 0.20 and will"
                       " be removed in 0.22.", DeprecationWarning)
         return self._threshold_
 


### PR DESCRIPTION
Working on #12167

This resolves several LGTM alerts in /ensemble:
1) only importing used attributes/functions from warnings module
2) remove unused variables