### PR TITLE
[MRG] add input order is not preserved by fit transform and transform to documentation Conventions section

### DIFF
--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -263,6 +263,24 @@ Conventions
 scikit-learn estimators follow certain rules to make their behavior more
 predictive.  These are described in more detail in the :ref:`glossary`.
 
+Preservation of Input Ordering
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``fit_transform`` and ``transform`` do not preserve the order of the input array::
+
+  >>> import numpy as np
+  >>> from sklearn.decomposition import PCA
+
+  >>> X = np.random.uniform(-1, 1, size=(10, 10))
+  >>> print(x.flags.c_contiguous)
+  >>> True
+
+  >>> X_transformed = PCA().fit_transform(x)
+  >>> print(X_transformed.flags.c_contiguous)
+  >>> False
+
+In this example, ``X`` is c_contiguous, while is ``X_transformed`` is not c_contiguous after transformation.
+
 Type casting
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!-- Fixes #5419 -->

#### What does this implement/fix? Explain your changes.
Updates documentation Conventions page to address that fit_transform and transform do not preserve the order of the input array. Issue: PCA().fit_transform changes array order #5419

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
