### PR TITLE
Fixing summary table in the linear model documentation.

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -775,20 +775,29 @@ The "saga" solver [7]_ is a variant of "sag" that also supports the
 non-smooth `penalty="l1"` option. This is therefore the solver of choice
 for sparse multinomial logistic regression.
 
-In a nutshell, the following table summarizes the solvers characteristics:
+In a nutshell, the following table summarizes the penalties supported by each solver:
 
-============================   ===========  =======  ===========  =====  ======
-solver                         'liblinear'  'lbfgs'  'newton-cg'  'sag'  'saga'
-============================   ===========  =======  ===========  =====  ======
-Multinomial + L2 penalty       no           yes      yes          yes    yes
-OVR + L2 penalty               yes          yes      yes          yes    yes
-Multinomial + L1 penalty       no           no       no           no     yes
-OVR + L1 penalty               yes          no       no           no     yes
-============================   ===========  =======  ===========  =====  ======
-Penalize the intercept (bad)   yes          no       no           no     no
-Faster for large datasets      no           no       no           yes    yes
-Robust to unscaled datasets    yes          yes      yes          no     no
-============================   ===========  =======  ===========  =====  ======
++------------------------------+-----------------+-------------+-----------------+-----------+------------+
+|                              |                       **Solvers**                                        |
++------------------------------+-----------------+-------------+-----------------+-----------+------------+
+| **Penalties**                | **'liblinear'** | **'lbfgs'** | **'newton-cg'** | **'sag'** | **'saga'** |
++------------------------------+-----------------+-------------+-----------------+-----------+------------+
+| Multinomial + L2 penalty     |       no        |     yes     |       yes       |    yes    |    yes     |
++------------------------------+-----------------+-------------+-----------------+-----------+------------+
+| OVR + L2 penalty             |       yes       |     yes     |       yes       |    yes    |    yes     |
++------------------------------+-----------------+-------------+-----------------+-----------+------------+
+| Multinomial + L1 penalty     |       no        |     no      |       no        |    no     |    yes     |
++------------------------------+-----------------+-------------+-----------------+-----------+------------+
+| OVR + L1 penalty             |       yes       |     no      |       no        |    no     |    yes     |
++------------------------------+-----------------+-------------+-----------------+-----------+------------+
+| **Behaviors**                |                                                                          |
++------------------------------+-----------------+-------------+-----------------+-----------+------------+
+| Penalize the intercept (bad) |       yes       |     no      |       no        |    no     |    no      |
++------------------------------+-----------------+-------------+-----------------+-----------+------------+
+| Faster for large datasets    |       no        |     no      |       no        |    yes    |    yes     |
++------------------------------+-----------------+-------------+-----------------+-----------+------------+
+| Robust to unscaled datasets  |       yes       |     yes     |       yes       |    no     |    no      |
++------------------------------+-----------------+-------------+-----------------+-----------+------------+
 
 The "saga" solver is often the best choice. The "liblinear" solver is
 used by default for historical reasons.


### PR DESCRIPTION
I corrected the formatting of the table summarizing logistic regression "solver" behaviors and penalties in the linear model documentation.

#### Reference Issues/PRs
The formatting error was suggested in the following document: https://docs.google.com/document/d/1dgEPcGnbfs6DRs7qtZMkbF6mLP6cywfn46rMFGRmTQg/edit


#### What does this implement/fix? Explain your changes.
I updated the table formatting to allow two table sections, one for penalties and one for behaviors.