### PR TITLE
[MRG+2] Add max_error to the existing set of metrics for regression

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -865,6 +865,7 @@ details.
    :template: function.rst
 
    metrics.explained_variance_score
+   metrics.max_error
    metrics.mean_absolute_error
    metrics.mean_squared_error
    metrics.mean_squared_log_error

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1531,20 +1531,23 @@ function::
     ... # doctest: +ELLIPSIS
     0.990...
 
-
+.. _max_error:
 
 Max error
 -------------------
 
-The :func:`max_error` function computes the  maximum `residual error <https://en.wikipedia.org/wiki/Errors_and_residuals`_,
-a metric that captures the worst case error between the predicted value and the true value.
-In a perfectly fitted single output regression model, `max_error` would be `0` on the training set
-and though this would be highly unlikely in the real world, this metric shows the extent of error that the
-model had when it was fitted.
+The :func:`max_error` function computes the  maximum `residual error
+<https://en.wikipedia.org/wiki/Errors_and_residuals>`_ ,a metric
+that captures the worst case error between the predicted value and
+the true value. In a perfectly fitted single output regression
+model, `max_error` would be `0` on the training set and though this
+would be highly unlikely in the real world, this metric shows the
+extent of error that the model had when it was fitted.
 
 
 If :math:`\hat{y}_i` is the predicted value of the :math:`i`-th sample,
-and :math:`y_i` is the corresponding true value, then the max error is defined as
+and :math:`y_i` is the corresponding true value, then the max error is
+defined as
 
 .. math::
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1537,10 +1537,10 @@ Max error
 -------------------
 
 The :func:`max_error` function computes the  maximum `residual error
-<https://en.wikipedia.org/wiki/Errors_and_residuals>`_ ,a metric
+<https://en.wikipedia.org/wiki/Errors_and_residuals>`_ , a metric
 that captures the worst case error between the predicted value and
 the true value. In a perfectly fitted single output regression
-model, `max_error` would be `0` on the training set and though this
+model, ``max_error`` would be ``0`` on the training set and though this
 would be highly unlikely in the real world, this metric shows the
 extent of error that the model had when it was fitted.
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1536,7 +1536,7 @@ function::
 Max error
 -------------------
 
-The :func:`max_error` function computes the  maximum `residual error
+The :func:`max_error` function computes the maximum `residual error
 <https://en.wikipedia.org/wiki/Errors_and_residuals>`_ , a metric
 that captures the worst case error between the predicted value and
 the true value. In a perfectly fitted single output regression

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1538,8 +1538,8 @@ Max error
 
 The :func:`max_error` function computes the  maximum `residual error <https://en.wikipedia.org/wiki/Errors_and_residuals`_,
 a metric that captures the worst case error between the predicted value and the true value.
-In a perfectly fitted single output regression model, `max_error` would be `0` and though this
-would be highly unlikely in the real world, this metric shows the extent of error that the
+In a perfectly fitted single output regression model, `max_error` would be `0` on the training set
+and though this would be highly unlikely in the real world, this metric shows the extent of error that the
 model had when it was fitted.
 
 
@@ -1554,9 +1554,9 @@ Here is a small example of usage of the :func:`max_error` function::
 
   >>> from sklearn.metrics import max_error
   >>> y_true = [3, 2, 7, 1]
-  >>> y_pred = [4, 2, 7, 1]
+  >>> y_pred = [9, 2, 7, 1]
   >>> max_error(y_true, y_pred)
-  1
+  6
 
 The :func:`max_error` does not support multioutput.
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -84,6 +84,7 @@ Scoring                           Function                                      
 
 **Regression**
 'explained_variance'              :func:`metrics.explained_variance_score`
+'max_error'                       :func:`metrics.max_error`
 'neg_mean_absolute_error'         :func:`metrics.mean_absolute_error`
 'neg_mean_squared_error'          :func:`metrics.mean_squared_error`
 'neg_mean_squared_log_error'      :func:`metrics.mean_squared_log_error`
@@ -1529,6 +1530,35 @@ function::
     >>> explained_variance_score(y_true, y_pred, multioutput=[0.3, 0.7])
     ... # doctest: +ELLIPSIS
     0.990...
+
+
+
+Max error
+-------------------
+
+The :func:`max_error` function computes the  maximum `residual error <https://en.wikipedia.org/wiki/Errors_and_residuals`_,
+a metric that captures the worst case error between the predicted value and the true value.
+In a perfectly fitted single output regression model, `max_error` would be `0` and though this
+would be highly unlikely in the real world, this metric shows the extent of error that the
+model had when it was fitted.
+
+
+If :math:`\hat{y}_i` is the predicted value of the :math:`i`-th sample,
+and :math:`y_i` is the corresponding true value, then the max error is defined as
+
+.. math::
+
+  \text{Max Error}(y, \hat{y}) = max(| y_i - \hat{y}_i |)
+
+Here is a small example of usage of the :func:`max_error` function::
+
+  >>> from sklearn.metrics import max_error
+  >>> y_true = [3, 2, 7, 1]
+  >>> y_pred = [4, 2, 7, 1]
+  >>> max_error(y_true, y_pred)
+  1
+
+The :func:`max_error` does not support multioutput.
 
 .. _mean_absolute_error:
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -56,7 +56,7 @@ Support for Python 3.4 and below has been officially dropped.
 :mod:`sklearn.metrics`
 ......................
 
-- |Feature| Added the :func:`metrics.max_error` and a corresponding
+- |Feature| Added the :func:`metrics.max_error` metric and a corresponding
   ``'max_error'`` scorer for single output regression.
   :issue:`12232` by :user:`Krishna Sangeeth <whiletruelearn>`.
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -57,7 +57,8 @@ Support for Python 3.4 and below has been officially dropped.
 ......................
 
 - |Feature| A new regression metric: :class:`metrics.max_error`: a
-  metric that captures the max residual error, by :user:`Krishna Sangeeth <whiletruelearn>`.
+  metric that captures the max residual error.
+  :issue:`12232` by :user:`Krishna Sangeeth <whiletruelearn>`.
 
 
 Multiple modules

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -56,9 +56,8 @@ Support for Python 3.4 and below has been officially dropped.
 :mod:`sklearn.metrics`
 ......................
 
-- |Feature| A new regression metric: :class:`metrics.max_error`: a
-  metric that captures the maximum residual error and a corresponding
-  ``'max_error'`` scorer for single output regression .
+- |Feature| Added the :func:`metrics.max_error` and a corresponding
+  ``'max_error'`` scorer for single output regression.
   :issue:`12232` by :user:`Krishna Sangeeth <whiletruelearn>`.
 
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -52,6 +52,14 @@ Support for Python 3.4 and below has been officially dropped.
   graph, which would add explicitly zeros on the diagonal even when already
   present. :issue:`12105` by `Tom Dupre la Tour`_.
 
+
+:mod:`sklearn.metrics`
+......................
+
+- |Feature| A new regression metric: :class:`metrics.max_error`: a
+  metric that captures the max residual error, by :user:`Krishna Sangeeth <whiletruelearn>`.
+
+
 Multiple modules
 ................
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -57,7 +57,8 @@ Support for Python 3.4 and below has been officially dropped.
 ......................
 
 - |Feature| A new regression metric: :class:`metrics.max_error`: a
-  metric that captures the max residual error.
+  metric that captures the maximum residual error and a corresponding
+  ``'max_error'`` scorer for single output regression .
   :issue:`12232` by :user:`Krishna Sangeeth <whiletruelearn>`.
 
 

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -60,6 +60,7 @@ from .regression import mean_squared_error
 from .regression import mean_squared_log_error
 from .regression import median_absolute_error
 from .regression import r2_score
+from .regression import max_error
 
 from .scorer import check_scoring
 from .scorer import make_scorer
@@ -99,6 +100,7 @@ __all__ = [
     'log_loss',
     'make_scorer',
     'matthews_corrcoef',
+    'max_error',
     'mean_absolute_error',
     'mean_squared_error',
     'mean_squared_log_error',

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -55,12 +55,13 @@ from .pairwise import pairwise_kernels
 from .pairwise import pairwise_distances_chunked
 
 from .regression import explained_variance_score
+from .regression import max_error
 from .regression import mean_absolute_error
 from .regression import mean_squared_error
 from .regression import mean_squared_log_error
 from .regression import median_absolute_error
 from .regression import r2_score
-from .regression import max_error
+
 
 from .scorer import check_scoring
 from .scorer import make_scorer

--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -588,9 +588,6 @@ def max_error(y_true, y_pred):
     y_pred : array-like of shape = (n_samples)
         Estimated target values.
 
-    sample_weight : array-like of shape = (n_samples), optional
-        Sample weights.
-
     Returns
     -------
     max_error : float
@@ -602,7 +599,7 @@ def max_error(y_true, y_pred):
     >>> y_true = [3, 2, 7, 1]
     >>> y_pred = [4, 2, 7, 1]
     >>> max_error(y_true, y_pred)
-    1.0
+    1
     """
     y_type, y_true, y_pred, _ = _check_reg_targets(y_true, y_pred,
                                                    None)

--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -576,10 +576,9 @@ def r2_score(y_true, y_pred, sample_weight=None,
     return np.average(output_scores, weights=avg_weights)
 
 
-def max_error(y_true, y_pred, sample_weight=None):
+def max_error(y_true, y_pred):
     """
-    The Max-Error metric is the worst case error
-    between the predicted value and the true value.
+    max_error metric calculates the maximum residual error.
 
     Parameters
     ----------
@@ -607,13 +606,7 @@ def max_error(y_true, y_pred, sample_weight=None):
     """
     y_type, y_true, y_pred, _ = _check_reg_targets(y_true, y_pred,
                                                    None)
-    check_consistent_length(y_true, y_pred, sample_weight)
+    check_consistent_length(y_true, y_pred)
     if y_type == 'continuous-multioutput':
         raise ValueError("Multioutput not supported in max_error")
-
-    if sample_weight is not None:
-        sample_weight = column_or_1d(sample_weight)
-        weight = sample_weight[:, np.newaxis]
-    else:
-        weight = 1.
-    return np.max(np.abs(weight * (y_true - y_pred)))
+    return np.max(np.abs(y_true - y_pred))

--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -599,7 +599,7 @@ def max_error(y_true, y_pred):
     >>> from sklearn.metrics import max_error
     >>> y_true = [3.1, 2.4, 7.6, 1.9]
     >>> y_pred = [4.1, 2.3, 7.4, 1.7]
-    >>> median_absolute_error(y_true, y_pred)
+    >>> max_error(y_true, y_pred)
     1.0
     """
     y_type, y_true, y_pred, _ = _check_reg_targets(y_true, y_pred,

--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -580,6 +580,8 @@ def max_error(y_true, y_pred):
     """
     max_error metric calculates the maximum residual error.
 
+    Read more in the :ref:`User Guide <max_error>`.
+
     Parameters
     ----------
     y_true : array-like of shape = (n_samples)

--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -36,7 +36,8 @@ __ALL__ = [
     "mean_squared_log_error",
     "median_absolute_error",
     "r2_score",
-    "explained_variance_score"
+    "explained_variance_score",
+    "max_error"
 ]
 
 
@@ -573,3 +574,37 @@ def r2_score(y_true, y_pred, sample_weight=None,
         avg_weights = multioutput
 
     return np.average(output_scores, weights=avg_weights)
+
+
+def max_error(y_true, y_pred):
+    """
+    The Max-Error metric is the worst case error
+    between the predicted value and the true value.
+
+    Parameters
+    ----------
+    y_true : array-like of shape = (n_samples)
+        Ground truth (correct) target values.
+
+    y_pred : array-like of shape = (n_samples)
+        Estimated target values.
+
+    Returns
+    -------
+    max_error : float
+        A positive floating point value (the best value is 0.0).
+
+    Examples
+    --------
+    >>> from sklearn.metrics import max_error
+    >>> y_true = [3.1, 2.4, 7.6, 1.9]
+    >>> y_pred = [4.1, 2.3, 7.4, 1.7]
+    >>> median_absolute_error(y_true, y_pred)
+    1.0
+    """
+    y_type, y_true, y_pred, _ = _check_reg_targets(y_true, y_pred,
+                                                   'uniform_average')
+    if y_type == 'continuous-multioutput':
+        raise ValueError("Multioutput not supported in max_error")
+    max_error = np.around(np.max(np.abs(y_true - y_pred)), decimals=3)
+    return max_error

--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -31,13 +31,13 @@ from ..externals.six import string_types
 
 
 __ALL__ = [
+    "max_error",
     "mean_absolute_error",
     "mean_squared_error",
     "mean_squared_log_error",
     "median_absolute_error",
     "r2_score",
-    "explained_variance_score",
-    "max_error"
+    "explained_variance_score"
 ]
 
 
@@ -576,7 +576,7 @@ def r2_score(y_true, y_pred, sample_weight=None,
     return np.average(output_scores, weights=avg_weights)
 
 
-def max_error(y_true, y_pred):
+def max_error(y_true, y_pred, sample_weight=None):
     """
     The Max-Error metric is the worst case error
     between the predicted value and the true value.
@@ -589,6 +589,9 @@ def max_error(y_true, y_pred):
     y_pred : array-like of shape = (n_samples)
         Estimated target values.
 
+    sample_weight : array-like of shape = (n_samples), optional
+        Sample weights.
+
     Returns
     -------
     max_error : float
@@ -597,14 +600,20 @@ def max_error(y_true, y_pred):
     Examples
     --------
     >>> from sklearn.metrics import max_error
-    >>> y_true = [3.1, 2.4, 7.6, 1.9]
-    >>> y_pred = [4.1, 2.3, 7.4, 1.7]
+    >>> y_true = [3, 2, 7, 1]
+    >>> y_pred = [4, 2, 7, 1]
     >>> max_error(y_true, y_pred)
     1.0
     """
     y_type, y_true, y_pred, _ = _check_reg_targets(y_true, y_pred,
-                                                   'uniform_average')
+                                                   None)
+    check_consistent_length(y_true, y_pred, sample_weight)
     if y_type == 'continuous-multioutput':
         raise ValueError("Multioutput not supported in max_error")
-    max_error = np.around(np.max(np.abs(y_true - y_pred)), decimals=3)
-    return max_error
+
+    if sample_weight is not None:
+        sample_weight = column_or_1d(sample_weight)
+        weight = sample_weight[:, np.newaxis]
+    else:
+        weight = 1.
+    return np.max(np.abs(weight * (y_true - y_pred)))

--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -603,8 +603,7 @@ def max_error(y_true, y_pred):
     >>> max_error(y_true, y_pred)
     1
     """
-    y_type, y_true, y_pred, _ = _check_reg_targets(y_true, y_pred,
-                                                   None)
+    y_type, y_true, y_pred, _ = _check_reg_targets(y_true, y_pred, None)
     check_consistent_length(y_true, y_pred)
     if y_type == 'continuous-multioutput':
         raise ValueError("Multioutput not supported in max_error")

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -22,7 +22,7 @@ from abc import ABCMeta
 
 import numpy as np
 
-from . import (r2_score, median_absolute_error, mean_absolute_error,
+from . import (r2_score, median_absolute_error, max_error, mean_absolute_error,
                mean_squared_error, mean_squared_log_error, accuracy_score,
                f1_score, roc_auc_score, average_precision_score,
                precision_score, recall_score, log_loss,
@@ -454,6 +454,7 @@ def make_scorer(score_func, greater_is_better=True, needs_proba=False,
 # Standard regression scores
 explained_variance_scorer = make_scorer(explained_variance_score)
 r2_scorer = make_scorer(r2_score)
+max_error_scorer = make_scorer(max_error)
 neg_mean_squared_error_scorer = make_scorer(mean_squared_error,
                                             greater_is_better=False)
 neg_mean_squared_log_error_scorer = make_scorer(mean_squared_log_error,
@@ -498,6 +499,7 @@ fowlkes_mallows_scorer = make_scorer(fowlkes_mallows_score)
 
 SCORERS = dict(explained_variance=explained_variance_scorer,
                r2=r2_scorer,
+               max_error=max_error_scorer,
                neg_median_absolute_error=neg_median_absolute_error_scorer,
                neg_mean_absolute_error=neg_mean_absolute_error_scorer,
                neg_mean_squared_error=neg_mean_squared_error_scorer,

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -454,7 +454,8 @@ def make_scorer(score_func, greater_is_better=True, needs_proba=False,
 # Standard regression scores
 explained_variance_scorer = make_scorer(explained_variance_score)
 r2_scorer = make_scorer(r2_score)
-max_error_scorer = make_scorer(max_error)
+max_error_scorer = make_scorer(max_error,
+                               greater_is_better=False)
 neg_mean_squared_error_scorer = make_scorer(mean_squared_error,
                                             greater_is_better=False)
 neg_mean_squared_log_error_scorer = make_scorer(mean_squared_log_error,

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -40,6 +40,7 @@ from sklearn.metrics import jaccard_similarity_score
 from sklearn.metrics import label_ranking_average_precision_score
 from sklearn.metrics import label_ranking_loss
 from sklearn.metrics import log_loss
+from sklearn.metrics import max_error
 from sklearn.metrics import matthews_corrcoef
 from sklearn.metrics import mean_absolute_error
 from sklearn.metrics import mean_squared_error
@@ -89,6 +90,7 @@ from sklearn.metrics.base import _average_binary_score
 #
 
 REGRESSION_METRICS = {
+    "max_error": max_error,
     "mean_absolute_error": mean_absolute_error,
     "mean_squared_error": mean_squared_error,
     "median_absolute_error": median_absolute_error,
@@ -399,7 +401,7 @@ SYMMETRIC_METRICS = {
     "micro_precision_score", "micro_recall_score",
 
     "matthews_corrcoef_score", "mean_absolute_error", "mean_squared_error",
-    "median_absolute_error",
+    "median_absolute_error", "max_error",
 
     "cohen_kappa_score",
 }
@@ -429,6 +431,7 @@ NOT_SYMMETRIC_METRICS = {
 # No Sample weight support
 METRICS_WITHOUT_SAMPLE_WEIGHT = {
     "median_absolute_error",
+    "max_error"
 }
 
 

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -14,6 +14,7 @@ from sklearn.metrics import mean_absolute_error
 from sklearn.metrics import mean_squared_error
 from sklearn.metrics import mean_squared_log_error
 from sklearn.metrics import median_absolute_error
+from sklearn.metrics import max_error
 from sklearn.metrics import r2_score
 
 from sklearn.metrics.regression import _check_reg_targets
@@ -29,6 +30,7 @@ def test_regression_metrics(n_samples=50):
                                            np.log(1 + y_pred)))
     assert_almost_equal(mean_absolute_error(y_true, y_pred), 1.)
     assert_almost_equal(median_absolute_error(y_true, y_pred), 1.)
+    assert_almost_equal(max_error(y_true, y_pred), 1.)
     assert_almost_equal(r2_score(y_true, y_pred),  0.995, 2)
     assert_almost_equal(explained_variance_score(y_true, y_pred), 1.)
 
@@ -59,6 +61,7 @@ def test_regression_metrics_at_limits():
     assert_almost_equal(mean_squared_log_error([0.], [0.]), 0.00, 2)
     assert_almost_equal(mean_absolute_error([0.], [0.]), 0.00, 2)
     assert_almost_equal(median_absolute_error([0.], [0.]), 0.00, 2)
+    assert_almost_equal(max_error([0.], [0.]), 0.00, 2)
     assert_almost_equal(explained_variance_score([0.], [0.]), 1.00, 2)
     assert_almost_equal(r2_score([0., 1], [0., 1]), 1.00, 2)
     assert_raises_regex(ValueError, "Mean Squared Logarithmic Error cannot be "

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -465,7 +465,7 @@ def test_scorer_sample_weight():
 
     for name, scorer in SCORERS.items():
         if name == "max_error":
-            sample_weight[:10] = 2
+            sample_weight[:10] = 1.01
         if name in MULTILABEL_ONLY_SCORERS:
             target = y_ml_test
         else:

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -464,8 +464,6 @@ def test_scorer_sample_weight():
     estimator = _make_estimators(X_train, y_train, y_ml_train)
 
     for name, scorer in SCORERS.items():
-        if name == "max_error":
-            sample_weight[:10] = 1.01
         if name in MULTILABEL_ONLY_SCORERS:
             target = y_ml_test
         else:

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -458,12 +458,14 @@ def test_scorer_sample_weight():
     X_train, X_test, y_train, y_test, y_ml_train, y_ml_test = split
 
     sample_weight = np.ones_like(y_test)
-    sample_weight[:10] = 2
+    sample_weight[:10] = 0
 
     # get sensible estimators for each metric
     estimator = _make_estimators(X_train, y_train, y_ml_train)
 
     for name, scorer in SCORERS.items():
+        if name == "max_error":
+            sample_weight[:10] = 2
         if name in MULTILABEL_ONLY_SCORERS:
             target = y_ml_test
         else:

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -48,7 +48,7 @@ REGRESSION_SCORERS = ['explained_variance', 'r2',
                       'neg_mean_squared_log_error',
                       'neg_median_absolute_error', 'mean_absolute_error',
                       'mean_squared_error', 'median_absolute_error',
-                      'max_error_scorer']
+                      'max_error']
 
 CLF_SCORERS = ['accuracy', 'balanced_accuracy',
                'f1', 'f1_weighted', 'f1_macro', 'f1_micro',

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -458,7 +458,7 @@ def test_scorer_sample_weight():
     X_train, X_test, y_train, y_test, y_ml_train, y_ml_test = split
 
     sample_weight = np.ones_like(y_test)
-    sample_weight[:10] = 0
+    sample_weight[:10] = 2
 
     # get sensible estimators for each metric
     estimator = _make_estimators(X_train, y_train, y_ml_train)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -47,7 +47,8 @@ REGRESSION_SCORERS = ['explained_variance', 'r2',
                       'neg_mean_absolute_error', 'neg_mean_squared_error',
                       'neg_mean_squared_log_error',
                       'neg_median_absolute_error', 'mean_absolute_error',
-                      'mean_squared_error', 'median_absolute_error']
+                      'mean_squared_error', 'median_absolute_error',
+                      'max_error_scorer']
 
 CLF_SCORERS = ['accuracy', 'balanced_accuracy',
                'f1', 'f1_weighted', 'f1_macro', 'f1_micro',


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #12231

#### What does this implement/fix? Explain your changes.

Added a new metric for regression which is `max_error`. It  is the worst case error between the predicted value and the true value.

```
 >>> from sklearn.metrics import max_error
 >>> y_true = [3.1, 2.4, 7.6, 1.9]
 >>> y_pred = [4.1, 2.3, 7.4, 1.7]
 >>> max_error(y_true, y_pred)
    1.0
```

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
