### PR TITLE
Fix cross-entropy typo in decision tree docs

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -453,7 +453,7 @@ Common measures of impurity are Gini
 
     H(X_m) = \sum_k p_{mk} (1 - p_{mk})
 
-Cross-Entropy
+Entropy
 
 .. math::
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

None


#### What does this implement/fix? Explain your changes.

Fixes a typo where the impurity measure for decision trees was referred to as "cross-entropy" instead of "entropy."

