### PR TITLE
[MRG] TST Remove test_import_sklearn_no_warnings

### DIFF
--- a/sklearn/tests/test_init.py
+++ b/sklearn/tests/test_init.py
@@ -1,12 +1,5 @@
 # Basic unittests to test functioning of module's top-level
 
-import subprocess
-
-import pkgutil
-
-import pytest
-
-import sklearn
 from sklearn.utils.testing import assert_equal
 
 __author__ = 'Yaroslav Halchenko'
@@ -25,37 +18,3 @@ def test_import_skl():
     # "import *" is discouraged outside of the module level, hence we
     # rely on setting up the variable above
     assert_equal(_top_import_error, None)
-
-
-def test_import_sklearn_no_warnings():
-    # Test that importing scikit-learn main modules doesn't raise any warnings.
-
-    try:
-        pkgs = pkgutil.iter_modules(path=sklearn.__path__, prefix='sklearn.')
-        import_modules = '; '.join(['import ' + modname
-                                    for _, modname, _ in pkgs
-                                    if (not modname.startswith('_') and
-                                        # add deprecated top level modules
-                                        # below to ignore them
-                                        modname not in [])])
-
-        message = subprocess.check_output(['python', '-Wdefault',
-                                           '-c', import_modules],
-                                          stderr=subprocess.STDOUT)
-        message = message.decode("utf-8")
-        message = '\n'.join([line for line in message.splitlines()
-                             if not (
-                                     # ignore ImportWarning due to Cython
-                                     "ImportWarning" in line or
-                                     # ignore DeprecationWarning due to pytest
-                                     "pytest" in line or
-                                     # ignore DeprecationWarnings due to
-                                     # numpy.oldnumeric
-                                     "oldnumeric" in line
-                                     )])
-        assert 'Warning' not in message
-        assert 'Error' not in message
-
-    except Exception as e:
-        pytest.skip('soft-failed test_import_sklearn_no_warnings.\n'
-                    ' %s, \n %s' % (e, message))


### PR DESCRIPTION
This removes the `test_import_sklearn_no_warnings` added in https://github.com/scikit-learn/scikit-learn/pull/11431 (by me) as it is indeed of limited use.

In the original motivation was to detect when importing scikit-learn or one of the top level modules produces warning. However since warnings can be due to causes outside our control (same as e.g. for our DeprecationWarning detection) it was decided to only warn in this case instead of failing. So currently this has as much values as the warnings caught during collection time in the logs. And the new pytest warning capture at collection time could be used to achieve the same effect better. 

Incidentally this also lead to one PyPy test failure in https://github.com/scikit-learn/scikit-learn/issues/12243 (because of the exceptions handling that's not general enough in this test). I think it might be also worth back-porting this to 0.20.1 to reduce the risk of this test failing in other environments..

TBH, both reviewers found this test dubious at the time, and I heard another similar opinion post-merge.