### PR TITLE
[MRG] Fast PolynomialFeatures on dense arrays

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -52,7 +52,7 @@ Support for Python 3.4 and below has been officially dropped.
 :mod:`sklearn.preprocessing`
 ............................
 
-- |Efficiency| Speed improvement in :class:`preprocessing.PolynomialFeatures`,
+- |Efficiency| |API| Speed improvement in :class:`preprocessing.PolynomialFeatures`,
   in the dense case. Also added a new parameter ``order`` which control output
   order for further speed performances. :issue:`12251` by `Tom Dupre la Tour`_.
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -53,7 +53,7 @@ Support for Python 3.4 and below has been officially dropped.
 ............................
 
 - |Efficiency| |API| Speed improvement in :class:`preprocessing.PolynomialFeatures`,
-  in the dense case. Also added a new parameter ``order`` which control output
+  in the dense case. Also added a new parameter ``order`` which controls output
   order for further speed performances. :issue:`12251` by `Tom Dupre la Tour`_.
 
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -48,6 +48,15 @@ Support for Python 3.4 and below has been officially dropped.
   to set and that scales better, by :user:`Shane <espg>` and
   :user:`Adrin Jalali <adrinjalali>`.
 
+
+:mod:`sklearn.preprocessing`
+............................
+
+- |Efficiency| Speed improvement in :class:`preprocessing.PolynomialFeatures`,
+  in the dense case. Also added a new parameter ``order`` which control output
+  order for further speed performances. :issue:`12249` by `Tom Dupre la Tour`_.
+
+
 Multiple modules
 ................
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -54,7 +54,7 @@ Support for Python 3.4 and below has been officially dropped.
 
 - |Efficiency| Speed improvement in :class:`preprocessing.PolynomialFeatures`,
   in the dense case. Also added a new parameter ``order`` which control output
-  order for further speed performances. :issue:`12249` by `Tom Dupre la Tour`_.
+  order for further speed performances. :issue:`12251` by `Tom Dupre la Tour`_.
 
 
 Multiple modules

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1323,7 +1323,7 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         all polynomial powers are zero (i.e. a column of ones - acts as an
         intercept term in a linear model).
 
-    order: str in {'C', 'F'}, default 'C'
+    order : str in {'C', 'F'}, default 'C'
         Order of output array in the dense case. 'F' order is faster to
         compute, but may slow down subsequent estimators.
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1323,6 +1323,12 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         all polynomial powers are zero (i.e. a column of ones - acts as an
         intercept term in a linear model).
 
+    order: str in {'C', 'F'}, default 'C'
+        Order of output array in the dense case. 'F' order is faster to
+        compute, but may slow down subsequent estimators.
+
+        .. versionadded:: 0.21
+
     Examples
     --------
     >>> X = np.arange(6).reshape(3, 2)
@@ -1363,10 +1369,12 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
     See :ref:`examples/linear_model/plot_polynomial_interpolation.py
     <sphx_glr_auto_examples_linear_model_plot_polynomial_interpolation.py>`
     """
-    def __init__(self, degree=2, interaction_only=False, include_bias=True):
+    def __init__(self, degree=2, interaction_only=False, include_bias=True,
+                 order='C'):
         self.degree = degree
         self.interaction_only = interaction_only
         self.include_bias = include_bias
+        self.order = order
 
     @staticmethod
     def _combinations(n_features, degree, interaction_only, include_bias):
@@ -1454,7 +1462,7 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         """
         check_is_fitted(self, ['n_input_features_', 'n_output_features_'])
 
-        X = check_array(X, dtype=FLOAT_DTYPES, accept_sparse='csc')
+        X = check_array(X, order='F', dtype=FLOAT_DTYPES, accept_sparse='csc')
         n_samples, n_features = X.shape
 
         if n_features != self.n_input_features_:
@@ -1475,7 +1483,8 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
                     columns.append(sparse.csc_matrix(np.ones((X.shape[0], 1))))
             XP = sparse.hstack(columns, dtype=X.dtype).tocsc()
         else:
-            XP = np.empty((n_samples, self.n_output_features_), dtype=X.dtype)
+            XP = np.empty((n_samples, self.n_output_features_), dtype=X.dtype,
+                          order=self.order)
             for i, comb in enumerate(combinations):
                 XP[:, i] = X[:, comb].prod(1)
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -157,6 +157,17 @@ def test_polynomial_feature_names():
                        feature_names)
 
 
+def test_polynomial_feature_array_order():
+    X = np.arange(10).reshape(5, 2)
+
+    def is_c_contiguous(a):
+        return np.isfortran(a.T)
+
+    assert is_c_contiguous(PolynomialFeatures().fit_transform(X))
+    assert is_c_contiguous(PolynomialFeatures(order='C').fit_transform(X))
+    assert np.isfortran(PolynomialFeatures(order='F').fit_transform(X))
+
+
 @pytest.mark.parametrize(['deg', 'include_bias', 'interaction_only', 'dtype'],
                          [(1, True, False, int),
                           (2, True, False, int),


### PR DESCRIPTION
### Idea:
Computations in `PolynomialFeatures` are performed on columns, so best performances are obtained using fortran-ordered ('F') arrays.

### Proposed changes:
1. add `order='F'` in `check_array` when checking the **input**, to speed up computations.
2. add new parameter `order` to control order of the **output**, for further speed improvements. It defaults to 'C' not to change current behavior.

Here is a benchmark for the first change (i.e. `order='C'`, as in master):
![order c](https://user-images.githubusercontent.com/11065596/46364475-31dfef00-c676-11e8-85d2-6104bce547bf.png)

Here is a benchmark for both changes (i.e. `order='F'`):
![order f](https://user-images.githubusercontent.com/11065596/46364524-589e2580-c676-11e8-9170-3e4c4fb5a486.png)

We can see that code is **2 to 5 times faster** for large input arrays.

Benchmark script in the details.
<details>

```py
from time import time

import pandas as pd
import numpy as np
import matplotlib.pyplot as plt

from sklearn.preprocessing import PolynomialFeatures
from sklearn.utils.validation import check_array, FLOAT_DTYPES

order = 'C'


###############################################################################
# function to benchmark (proposed in [True, False])
def fit_transform(self, X, proposed, order):
    self.fit(X)

    if proposed:
        X = check_array(X, order='F', dtype=FLOAT_DTYPES, accept_sparse='csc')
    else:
        X = check_array(X, dtype=FLOAT_DTYPES, accept_sparse='csc')

    n_samples, n_features = X.shape
    if n_features != self.n_input_features_:
        raise ValueError("X shape does not match training shape")
    combinations = self._combinations(n_features, self.degree,
                                      self.interaction_only, self.include_bias)

    order = order if proposed else 'C'

    XP = np.empty((n_samples, self.n_output_features_), dtype=X.dtype,
                  order=order)
    for i, comb in enumerate(combinations):
        XP[:, i] = X[:, comb].prod(1)

    return XP


###############################################################################
# Benchmark
est = PolynomialFeatures()
results = []
for n_samples in [100, 300, 1000, 3000, 10000]:
    for n_features in [4, 16, 64, 256]:
        X = np.random.randn(n_samples, n_features)
        n_repeat = max(1, 6553600 // n_samples // n_features // n_features)

        for proposed in [False, True]:
            print('.', end='', flush=True)
            t0 = time()
            for _ in range(n_repeat):
                XP = fit_transform(est, X, proposed, order)
            duration = (time() - t0) / n_repeat
            # print(np.isfortran(XP))
            results.append((n_samples, n_features, proposed, duration))

###############################################################################
# Plot with pandas
df = pd.DataFrame(results,
                  columns=['n_samples', 'n_features', 'proposed', 'duration'])
fig, axes = plt.subplots(ncols=2, figsize=(12, 5))

# first plot
ax = axes[0]
table = df.pivot_table(index='n_samples', columns=['n_features', 'proposed'],
                       values='duration')
table.plot(ax=ax, logy=True, logx=True, marker='o', colormap='viridis')
ax.set_title('Time duration (sec)')

# second plot
ax = axes[1]
table_proposed = df[df['proposed']].pivot_table(
    index='n_samples', columns='n_features', values='duration')
table_master = df[~df['proposed']].pivot_table(
    index='n_samples', columns='n_features', values='duration')
table_normed = table_proposed / table_master
table_normed.plot(ax=ax, logx=True, marker='o', colormap='viridis')
ax.set_title('Time ratio: proposed / master')

plt.subplots_adjust(top=0.90)
fig.suptitle("order = '%s'" % order, fontsize=16)
plt.show()
```

<\details>
