### PR TITLE
MNT Change show_versions format to suit markdown

### DIFF
--- a/sklearn/utils/_show_versions.py
+++ b/sklearn/utils/_show_versions.py
@@ -103,17 +103,14 @@ def show_versions():
     deps_info = _get_deps_info()
     blas_info = _get_blas_info()
 
-    print('\nSystem')
-    print('------')
+    print('\nSystem:')
     for k, stat in sys_info.items():
         print("{k:>10}: {stat}".format(k=k, stat=stat))
 
-    print('\nBLAS')
-    print('----')
+    print('\nBLAS:')
     for k, stat in blas_info.items():
         print("{k:>10}: {stat}".format(k=k, stat=stat))
 
-    print('\nPython deps')
-    print('-----------')
+    print('\nPython deps:')
     for k, stat in deps_info.items():
         print("{k:>10}: {stat}".format(k=k, stat=stat))


### PR DESCRIPTION
Currently, we encourage users to report detailed platform information with show_versions, but the format seems strange, see e.g., #12250 
This PR slightly change the format of show_versions to better support markdown, though it will make the output less beautiful :)
New format:
#### Versions
System:
   machine: Windows-10-10.0.16299-SP0
    python: 3.5.4 |Continuum Analytics, Inc.| (default, Aug 14 2017, 13:41:13) [MSC v.1900 64 bit (AMD64)]
executable: C:\Anaconda2\envs\scikit_learn\python.exe

BLAS:
    macros: SCIPY_MKL_H=None, HAVE_CBLAS=None
  lib_dirs: C:\Anaconda2\Library\lib
cblas_libs: mkl_rt

Python deps:
    pandas: 0.23.3
    Cython: 0.28.5
       pip: 18.0
   sklearn: 0.21.dev0
     numpy: 1.15.1
setuptools: 40.0.0
     scipy: 1.1.0