### PR TITLE
[MRG] Fixed plot's titles cropping issue in /auto_examples/linear_model/plot_ols_ridge_variance

### DIFF
--- a/examples/linear_model/plot_ols_ridge_variance.py
+++ b/examples/linear_model/plot_ols_ridge_variance.py
@@ -47,7 +47,7 @@ for name, clf in classifiers.items():
     fig = plt.figure(fignum, figsize=(4, 3))
     plt.clf()
     plt.title(name)
-    ax = plt.axes([.12, .12, .8, .8])
+    ax = plt.axes([.10, .10, .8, .8])
 
     for _ in range(6):
         this_X = .1 * np.random.normal(size=(2, 1)) + X_train

--- a/examples/linear_model/plot_ols_ridge_variance.py
+++ b/examples/linear_model/plot_ols_ridge_variance.py
@@ -66,6 +66,8 @@ for name, clf in classifiers.items():
     ax.set_xlabel('X')
     ax.set_ylabel('y')
     ax.set_xlim(0, 2)
+    ax.xaxis.set_label_coords(0.55, -0.08)
+    ax.yaxis.set_label_coords(-0.08, 0.55)
     fignum += 1
 
 plt.show()


### PR DESCRIPTION
Fixes #12224 
Decreased `left, bottom` among `(left, bottom, width, height)` args of axes method of plots' figures to make the titles visible.
Originally 0.12, now 0.10.
![plots_titles_fixed](https://user-images.githubusercontent.com/13296814/46407012-184caf00-c72b-11e8-8fea-e7730fa273ab.PNG)

