### PR TITLE
[MRG] DOC Remove mentions of removed AUTHORS.rst file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,5 @@ recursive-include examples *
 recursive-include sklearn *.c *.h *.pyx *.pxd *.pxi
 recursive-include sklearn/datasets *.csv *.csv.gz *.rst *.jpg *.txt *.arff.gz *.json.gz
 include COPYING
-include AUTHORS.rst
 include README.rst
 

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,8 @@ SciPy and distributed under the 3-Clause BSD license.
 
 The project was started in 2007 by David Cournapeau as a Google Summer
 of Code project, and since then many volunteers have contributed. See
-the `AUTHORS.rst <AUTHORS.rst>`_ file for a complete list of contributors.
+the `About us <http://scikit-learn.org/dev/about.html#authors>`_ page
+for a list of core contributors.
 
 It is currently maintained by a team of volunteers.
 
@@ -143,7 +144,8 @@ Project History
 
 The project was started in 2007 by David Cournapeau as a Google Summer
 of Code project, and since then many volunteers have contributed. See
-the  `AUTHORS.rst <AUTHORS.rst>`_ file for a complete list of contributors.
+the  `About us <http://scikit-learn.org/dev/about.html#authors>`_ page
+for a list of core contributors.
 
 The project is currently maintained by a team of volunteers.
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Since https://github.com/scikit-learn/scikit-learn/pull/11708 was merged the links to the `AUTHORS.rst` file in the README have inadvertently been broken. This PR amends them to point to the "Authors" section of the "About us" page of the website. It also removes this file from the MANIFEST.


#### Any other comments?

Apologies for the trivial contribution! I promise that my next contribution will be more substantial...