### PR TITLE
[WIP] "other"/min_freq in OneHot and OrdinalEncoder

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -82,6 +82,7 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
             if self._categories == 'auto':
                 Xi, group = _group_values(Xi.copy(), min_freq=self.min_freq)
                 cats = _encode(Xi)
+                self.groups_.append(group)
             else:
                 cats = np.array(self._categories[i], dtype=X.dtype)
                 if self.handle_unknown == 'error':
@@ -90,7 +91,6 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
                         msg = ("Found unknown categories {0} in column {1}"
                                " during fit".format(diff, i))
                         raise ValueError(msg)
-            self.groups_.append(group)
             self.categories_.append(cats)
 
     def _transform(self, X, handle_unknown='error'):
@@ -102,7 +102,10 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
 
         for i in range(n_features):
             Xi = X[:, i]
-            Xi, _ = _group_values(Xi, group=self.groups_[i])
+            try:
+                Xi, _ = _group_values(Xi, group=self.groups_[i])
+            except IndexError:
+                pass
             diff, valid_mask = _encode_check_unknown(Xi, self.categories_[i],
                                                      return_mask=True)
 

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -516,6 +516,13 @@ def test_one_hot_encoder_raise_missing(X, handle_unknown):
     with pytest.raises(ValueError, match="Input contains NaN"):
         ohe.transform(X)
 
+def test_one_hot_encoder_min_freq_fit_not_inplace():
+    arr = np.array([[1, 1], [2, 3], [1, 2], [3, 2], [1, 4]])
+    expected = arr.copy()
+    enc = OneHotEncoder(min_freq=0.4, categories='auto')
+    enc.fit(arr)
+    assert_array_equal(arr, expected)
+
 
 @pytest.mark.parametrize("X", [
     [['abc', 2, 55], ['def', 1, 55]],
@@ -616,6 +623,14 @@ def test_categorical_encoder_stub():
     assert_raises(RuntimeError, CategoricalEncoder, encoding='ordinal')
 
 
+def test_ordinal_encoder_min_freq_fit_not_inplace():
+    arr = np.array([[1, 1], [2, 3], [1, 2], [3, 2], [1, 4]])
+    expected = arr.copy()
+    enc = OrdinalEncoder(min_freq=0.4)
+    enc.fit(arr)
+    assert_array_equal(arr, expected)
+
+
 @pytest.mark.parametrize(
     "values, min_freq, exp_values, exp_group",
     [(np.array([1, 2, 3, 3, 3], dtype='int64'),
@@ -630,6 +645,10 @@ def test_categorical_encoder_stub():
       0.2,
       np.array([1, 2, 3, 3, 3], dtype='int64'),
       np.array([], dtype='int64')),
+     (np.array([1, 2, 3, 3, 3], dtype='int64'),
+      0,
+      np.array([1, 2, 3, 3, 3], dtype='int64'),
+      None),
      (np.array(['a', 'b', 'c', 'c', 'c'], dtype=object),
       0.3,
       np.array(['a', 'a', 'c', 'c', 'c'], dtype=object),
@@ -642,6 +661,10 @@ def test_categorical_encoder_stub():
       0.2,
       np.array(['a', 'b', 'c', 'c', 'c'], dtype=object),
       np.array([], dtype=object)),
+     (np.array(['a', 'b', 'c', 'c', 'c'], dtype=object),
+      0,
+      np.array(['a', 'b', 'c', 'c', 'c'], dtype=object),
+      None),
      (np.array(['a', 'b', 'c', 'c', 'c'], dtype=str),
       0.3,
       np.array(['a', 'a', 'c', 'c', 'c'], dtype=str),
@@ -653,8 +676,12 @@ def test_categorical_encoder_stub():
      (np.array(['a', 'b', 'c', 'c', 'c'], dtype=str),
       0.2,
       np.array(['a', 'b', 'c', 'c', 'c'], dtype=str),
-      np.array([], dtype=str))],
-    ids=(['int64']*3 + ['object']*3 + ['str']*3))
+      np.array([], dtype=str)),
+     (np.array(['a', 'b', 'c', 'c', 'c'], dtype=str),
+      0,
+      np.array(['a', 'b', 'c', 'c', 'c'], dtype=str),
+      None)],
+    ids=(['int64']*4 + ['object']*4 + ['str']*4))
 def test_group_values_freq(values, min_freq, exp_values, exp_group):
     values, group = _group_values(values, min_freq)
     assert_array_equal(values, exp_values)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes: #12153
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Currently, adds the option to add a frequency threshold to OneHot- and OrdinalEncoder.
All categories below this threshold are determined, sorted and mapped to the first category.

What needs to be done?
- [X] Adds `min_df`with implementation to Ordinal- and OneHotEncoder
- [ ] Example in `examples/ ` folder
- [ ] Documentation
- [ ] Probably add more tests and remove some tests
- [ ] add option to add a name of the `other` group -> What to do if not object/str? What happens if `other`already there?
- [ ] With a threshold, encoders are not "really" invertible anymore -> add at least documentation?
- [ ] Align if function names are appropriate


#### Any other comments?
Further points of extension:

* Instead of `min_freq` add `top_n` categories. Moreover, one could use integers instead of floats in `min_freq`. `top_n`and `min_freq`could interact
* Allow an array of frequencies for each feature
*  One could provide a mapping, to group certain values in a category together. It might be though, that a different Encoder would be more suitable

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->