### PR TITLE
fixed failure of test project and cluster

### DIFF
--- a/sklearn/cluster/tests/test_bicluster.py
+++ b/sklearn/cluster/tests/test_bicluster.py
@@ -21,7 +21,7 @@ from sklearn.cluster.bicluster import _scale_normalize
 from sklearn.cluster.bicluster import _bistochastic_normalize
 from sklearn.cluster.bicluster import _log_normalize
 
-from sklearn.metrics import consensus_score
+from sklearn.metrics import (consensus_score, v_measure_score)
 
 from sklearn.datasets import make_biclusters, make_checkerboard
 
@@ -204,7 +204,7 @@ def test_project_and_cluster():
     for mat in (data, csr_matrix(data)):
         labels = model._project_and_cluster(data, vectors,
                                             n_clusters=2)
-        assert_array_equal(labels, [0, 0, 1, 1])
+        assert_almost_equal(v_measure_score(labels, [0, 0, 1, 1]), 1.0)
 
 
 def test_perfect_checkerboard():


### PR DESCRIPTION
#### Description

`KMeans.fit(X)` returns labels for each input point relative to the ordering of `cluster_centers_`.
Hence comparisons of `labels_` in tests becomes fragile if an implementation of `KMeans` reorders `cluster_centers_` relative to what scikit-learn's own implementation does.

#### What does this implement/fix? Explain your changes.

This PR introduces `sklearn.utils.testing.assert_labelarray_equal(x, y)` which checks whether `x` and `y` are vectors equal up to a permutation of labels. 

Example:

```python
import sklearn, sklearn.utils, sklearn.utils.testing, numpy as np

# these label arrays are equivalent with interchanging of labels 0 and 1
sklearn.utils.testing.assert_labelarray_equal([0,1,0], [1,0,1])

# extracting same indexes from permuted list of labels should pass
m = np.random.randint(4,size=100)
sklearn.utils.testing.assert_labelarray_equal( np.take([0,1,2,3], m), np.take([2,1,3,0], m))
sklearn.utils.testing.assert_labelarray_equal( np.take([0,1,2,3], m), np.take([3,2,1,0], m))
```

This change is necessary with optimizations in Intel Distribution for Python, since DAAL may reorder cluster centers.

@GaelVaroquaux 