### PR TITLE
Ensure estimators converged in test_bayesian_mixture_fit_predict

### DIFF
--- a/sklearn/mixture/tests/test_bayesian_mixture.py
+++ b/sklearn/mixture/tests/test_bayesian_mixture.py
@@ -11,6 +11,7 @@ from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
 
 from sklearn.metrics.cluster import adjusted_rand_score
+from sklearn.metrics import accuracy_score
 
 from sklearn.mixture.bayesian_mixture import _log_dirichlet_norm
 from sklearn.mixture.bayesian_mixture import _log_wishart_norm
@@ -440,8 +441,11 @@ def test_bayesian_mixture_fit_predict():
 
         Y_pred1 = bgmm1.fit(X).predict(X)
         Y_pred2 = bgmm2.fit_predict(X)
-        assert bgmm1.converged_ and bgmm2.converged_
-        assert_array_equal(Y_pred1, Y_pred2)
+        # can only expect prediction to agree if converged, see PR#12266
+        if bgmm1.converged_ and bgmm2.converged_:
+            assert_array_equal(Y_pred1, Y_pred2)
+        else:
+            assert_greater_equal(accuracy_score(Y_pred1, Y_pred2), 0.99)
 
 
 def test_bayesian_mixture_predict_predict_proba():

--- a/sklearn/mixture/tests/test_bayesian_mixture.py
+++ b/sklearn/mixture/tests/test_bayesian_mixture.py
@@ -432,7 +432,7 @@ def test_bayesian_mixture_fit_predict():
 
     for covar_type in COVARIANCE_TYPE:
         bgmm1 = BayesianGaussianMixture(n_components=n_components,
-                                        max_iter=100, random_state=rng,
+                                        max_iter=250, random_state=rng,
                                         tol=1e-3, reg_covar=0)
         bgmm1.covariance_type = covar_type
         bgmm2 = copy.deepcopy(bgmm1)
@@ -440,6 +440,7 @@ def test_bayesian_mixture_fit_predict():
 
         Y_pred1 = bgmm1.fit(X).predict(X)
         Y_pred2 = bgmm2.fit_predict(X)
+        assert bgmm1.converged_ and bgmm2.converged_
         assert_array_equal(Y_pred1, Y_pred2)
 
 


### PR DESCRIPTION
In the test `test_bayesian_mixture_fit_predict` the `BayesianGaussianMixture` estimators used to build prediction did not converge (as indicated by message).

In such circumstances, `fit_predict(X)` bases its prediction on the data from `e_step` on the last iteration (see  [base.py#L244](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/mixture/base.py#L244) and use: [base.py#L274](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/mixture/base.py#L274)). 

`fit(X).predict(X)` uses data after the `m_step` of the last iterations. 

Hence for the test to reasonably expect the same predictions, estimations must converge. 

The test failure was caught in Intel Distribution for Python, because due to changes to KMeans, the initialization of `BayesianGaussianMixture` was different.

It should be possible to reproduce this failure in current master by playing with `random_state`.

#### What does this implement/fix? Explain your changes.

The change increases `max_iter` keyword value and adds assertions for both estimators to have converged.

#### Any other comments?

Here is the reproducer in current 0.20.0 installed from pip:

```python
import numpy as np
import copy

from sklearn.mixture import BayesianGaussianMixture
from sklearn.utils.testing import assert_array_equal
from sklearn.mixture.tests.test_gaussian_mixture import RandomData

def test_bayesian_mixture_fit_predict(seed):
    rng = np.random.RandomState(seed)
    rand_data = RandomData(rng, scale=7)
    n_components = 2 * rand_data.n_components
    for covar_type in ['full', 'tied', 'diag', 'spherical']:
        bgmm1 = BayesianGaussianMixture(n_components=n_components,
                                        max_iter=100, random_state=rng,
                                        tol=1e-3, reg_covar=0)
        bgmm1.covariance_type = covar_type
        bgmm2 = copy.deepcopy(bgmm1)
        X = rand_data.X[covar_type]
        Y_pred1 = bgmm1.fit(X).predict(X)
        Y_pred2 = bgmm2.fit_predict(X)
        assert_array_equal(Y_pred1, Y_pred2)

# passes, in the test suite, although produces many convergence warnings
test_bayesian_mixture_fit_predict(0) 

# fails with (mismatch 0.2%)
test_bayesian_mixture_fit_predict(1) 
```

@GaelVaroquaux 