### PR TITLE
Prediction label retrieval should be moved to after the first fit call

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1290,10 +1290,10 @@ def check_clustering(name, clusterer_orig, readonly_memmap=False):
 
     # fit
     clusterer.fit(X)
+    pred = clusterer.labels_
     # with lists
     clusterer.fit(X.tolist())
 
-    pred = clusterer.labels_
     assert_equal(pred.shape, (n_samples,))
     assert_greater(adjusted_rand_score(pred, y), 0.4)
     # fit another time with ``fit_predict`` and compare results


### PR DESCRIPTION

#### What does this implement/fix? Explain your changes.

In `estimator_checks::check_clustering` a check is made that labels produced by `fit` with the given `random_state` are the same as the result of `fit_predict` with the same `random_state`.

However, the actual retrieval of labels was not made after call `fit(X)`, but after subsequent call `fit(X.tolist())`, which may have consumed from the random stream, which may, in some implementations of KMeans, like that based on Intel DAAL, cause cluster centers to be reordered, and labels to come out equivalent up to a permutation causing a failure.

#### Any other comments?

Hoping for no objections here :)

@GaelVaroquaux 