### PR TITLE
DOC removed ambiguity in pipeline gridsearch example

### DIFF
--- a/examples/compose/plot_compare_reduction.py
+++ b/examples/compose/plot_compare_reduction.py
@@ -43,7 +43,8 @@ from sklearn.feature_selection import SelectKBest, chi2
 print(__doc__)
 
 pipe = Pipeline([
-    ('reduce_dim', PCA()),
+     # the reduce_dim stage is populated by the param_grid
+    ('reduce_dim', None),
     ('classify', LinearSVC())
 ])
 

--- a/examples/compose/plot_compare_reduction.py
+++ b/examples/compose/plot_compare_reduction.py
@@ -43,7 +43,7 @@ from sklearn.feature_selection import SelectKBest, chi2
 print(__doc__)
 
 pipe = Pipeline([
-     # the reduce_dim stage is populated by the param_grid
+    # the reduce_dim stage is populated by the param_grid
     ('reduce_dim', None),
     ('classify', LinearSVC())
 ])


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

In the example the dimension reduction method is replaced by the values from the parameter grid. It is confusing to declare it as PCA(), only for this to be ignored. Replacing it with None indicates to the reader that this is blank or a placeholder.

Note: This confusion is not my own. It comes from my students who were confused when reading the example during a tutorial.

