### PR TITLE
[MRG] MNT Make check_X_y raise a better error when y is None

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -780,3 +780,9 @@ def test_check_non_negative(retype):
     A[0, 0] = -1
     X = retype(A)
     assert_raises_regex(ValueError, "Negative ", check_non_negative, X, "")
+
+
+def test_check_X_y_informative_error():
+    X = np.ones((2, 2))
+    y = None
+    assert_raise_message(ValueError, "y cannot be None", check_X_y, X, y)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -736,6 +736,9 @@ def check_X_y(X, y, accept_sparse=False, accept_large_sparse=True,
     y_converted : object
         The converted and validated y.
     """
+    if y is None:
+        raise ValueError("y cannot be None")
+
     X = check_array(X, accept_sparse=accept_sparse,
                     accept_large_sparse=accept_large_sparse,
                     dtype=dtype, order=order, copy=copy,


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes https://github.com/scikit-learn/scikit-learn/issues/11257, also closes https://github.com/scikit-learn/scikit-learn/pull/11261, closes https://github.com/scikit-learn/scikit-learn/pull/11270, closes https://github.com/scikit-learn/scikit-learn/pull/11273, and closes https://github.com/scikit-learn/scikit-learn/pull/11297.

#### What does this implement/fix? Explain your changes.
Previously passing `y=None` to the `check_X_y` function would fail later on in either the `check_array` or in the `column_or_1d` functions with a potentially obscure error that referenced an invalid shape. This PR adds a check in the `check_X_y` function in order to raise immediately with a more informative exception.

#### Any other comments?
There were several attempts to fix this issue (https://github.com/scikit-learn/scikit-learn/pull/11261, https://github.com/scikit-learn/scikit-learn/pull/11270, https://github.com/scikit-learn/scikit-learn/pull/11273, https://github.com/scikit-learn/scikit-learn/pull/11297), all of which were closed or became stale. My solution, which is different from all the above, tries to follow the recommendation in @qinhanmin2014's comment (https://github.com/scikit-learn/scikit-learn/pull/11273#issuecomment-397804618) to work (only) in the `check_X_y` function.
