### PR TITLE
[MRG+1] Fix title, overlapping plots and axis labels in plot_ols_ridge_variance.py

### DIFF
--- a/examples/linear_model/plot_ols_ridge_variance.py
+++ b/examples/linear_model/plot_ols_ridge_variance.py
@@ -44,7 +44,7 @@ classifiers = dict(ols=linear_model.LinearRegression(),
 
 fignum = 1
 for name, clf in classifiers.items():
-    fig = plt.figure(fignum, figsize=(4, 3))
+    plt.figure(fignum, figsize=(4, 3))
     plt.clf()
     plt.title(name)
 

--- a/examples/linear_model/plot_ols_ridge_variance.py
+++ b/examples/linear_model/plot_ols_ridge_variance.py
@@ -63,7 +63,7 @@ for name, clf in classifiers.items():
     plt.xlabel('X')
     plt.ylabel('y')
     plt.xlim(0, 2)
+    plt.tight_layout()
     fignum += 1
 
-plt.tight_layout()
 plt.show()

--- a/examples/linear_model/plot_ols_ridge_variance.py
+++ b/examples/linear_model/plot_ols_ridge_variance.py
@@ -61,7 +61,7 @@ for name, clf in classifiers.items():
     ax.set_ylim((0, 1.6))
     ax.set_xlabel('X')
     ax.set_ylabel('y')
-    
+
     fig.tight_layout()
 
 plt.show()

--- a/examples/linear_model/plot_ols_ridge_variance.py
+++ b/examples/linear_model/plot_ols_ridge_variance.py
@@ -42,28 +42,26 @@ np.random.seed(0)
 classifiers = dict(ols=linear_model.LinearRegression(),
                    ridge=linear_model.Ridge(alpha=.1))
 
-fignum = 1
 for name, clf in classifiers.items():
-    plt.figure(fignum, figsize=(4, 3))
-    plt.clf()
-    plt.title(name)
+    fig, ax = plt.subplots(figsize=(4, 3))
 
     for _ in range(6):
         this_X = .1 * np.random.normal(size=(2, 1)) + X_train
         clf.fit(this_X, y_train)
 
-        plt.plot(X_test, clf.predict(X_test), color='gray')
-        plt.scatter(this_X, y_train, s=3, c='gray', marker='o', zorder=10)
+        ax.plot(X_test, clf.predict(X_test), color='gray')
+        ax.scatter(this_X, y_train, s=3, c='gray', marker='o', zorder=10)
 
     clf.fit(X_train, y_train)
-    plt.plot(X_test, clf.predict(X_test), linewidth=2, color='blue')
-    plt.scatter(X_train, y_train, s=30, c='red', marker='+', zorder=10)
+    ax.plot(X_test, clf.predict(X_test), linewidth=2, color='blue')
+    ax.scatter(X_train, y_train, s=30, c='red', marker='+', zorder=10)
 
-    plt.ylim((0, 1.6))
-    plt.xlabel('X')
-    plt.ylabel('y')
-    plt.xlim(0, 2)
-    plt.tight_layout()
-    fignum += 1
+    ax.set_title(name)
+    ax.set_xlim(0, 2)
+    ax.set_ylim((0, 1.6))
+    ax.set_xlabel('X')
+    ax.set_ylabel('y')
+    
+    fig.tight_layout()
 
 plt.show()

--- a/examples/linear_model/plot_ols_ridge_variance.py
+++ b/examples/linear_model/plot_ols_ridge_variance.py
@@ -65,4 +65,5 @@ for name, clf in classifiers.items():
     plt.xlim(0, 2)
     fignum += 1
 
+plt.tight_layout()
 plt.show()

--- a/examples/linear_model/plot_ols_ridge_variance.py
+++ b/examples/linear_model/plot_ols_ridge_variance.py
@@ -47,25 +47,22 @@ for name, clf in classifiers.items():
     fig = plt.figure(fignum, figsize=(4, 3))
     plt.clf()
     plt.title(name)
-    ax = plt.axes([.12, .12, .8, .8])
 
     for _ in range(6):
         this_X = .1 * np.random.normal(size=(2, 1)) + X_train
         clf.fit(this_X, y_train)
 
-        ax.plot(X_test, clf.predict(X_test), color='gray')
-        ax.scatter(this_X, y_train, s=3, c='gray', marker='o', zorder=10)
+        plt.plot(X_test, clf.predict(X_test), color='gray')
+        plt.scatter(this_X, y_train, s=3, c='gray', marker='o', zorder=10)
 
     clf.fit(X_train, y_train)
-    ax.plot(X_test, clf.predict(X_test), linewidth=2, color='blue')
-    ax.scatter(X_train, y_train, s=30, c='red', marker='+', zorder=10)
+    plt.plot(X_test, clf.predict(X_test), linewidth=2, color='blue')
+    plt.scatter(X_train, y_train, s=30, c='red', marker='+', zorder=10)
 
-    ax.set_xticks(())
-    ax.set_yticks(())
-    ax.set_ylim((0, 1.6))
-    ax.set_xlabel('X')
-    ax.set_ylabel('y')
-    ax.set_xlim(0, 2)
+    plt.ylim((0, 1.6))
+    plt.xlabel('X')
+    plt.ylabel('y')
+    plt.xlim(0, 2)
     fignum += 1
 
 plt.show()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #12224

#### What does this implement/fix? Explain your changes.

I removed `plt.axes`, and replaced `ax` with `plt`. The resulting plot does not have the odd overlap between the title and the plot. It also fixes the axis range.

#### Any other comments?

Below are what they look like with the new code:
![figure_1](https://user-images.githubusercontent.com/21180505/46512510-5973ba80-c822-11e8-96c8-bf2c7010de91.png)
![figure_2](https://user-images.githubusercontent.com/21180505/46512511-5973ba80-c822-11e8-86fb-5f6d046e2da2.png)


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
