### PR TITLE
Add get_n_leaves() and get_max_depth() to DesicionTrees

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -63,7 +63,7 @@ Support for Python 3.4 and below has been officially dropped.
   on it, including :class:`tree.DecisionTreeClassifier`,
   :class:`tree.DecisionTreeRegressor`, :class:`tree.ExtraTreeClassifier`,
   and :class:`tree.ExtraTreeRegressor`.
-  :issue:`7613` by :user:`Adrin Jalali <adrinjalali>`.
+  :issue:`12300` by :user:`Adrin Jalali <adrinjalali>`.
 
 Multiple modules
 ................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -58,7 +58,7 @@ Support for Python 3.4 and below has been officially dropped.
 
 :mod:`sklearn.tree`
 ...................
-- |Feature| ``get_n_leaves()`` and ``get_max_depth()`` have been added to
+- |Feature| ``get_n_leaves()`` and ``get_depth()`` have been added to
   :class:`tree.BaseDecisionTree` and consequently all estimators based
   on it, including :class:`tree.DecisionTreeClassifier`,
   :class:`tree.DecisionTreeRegressor`, :class:`tree.ExtraTreeClassifier`,

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -56,6 +56,15 @@ Support for Python 3.4 and below has been officially dropped.
   order for further speed performances. :issue:`12251` by `Tom Dupre la Tour`_.
 
 
+:mod:`sklearn.tree`
+...................
+- |Feature| ``get_n_leaves()`` and ``get_max_depth()`` have been added to
+  :class:`tree.BaseDecisionTree` and consequently all estimators based
+  on it, including :class:`tree.DecisionTreeClassifier`,
+  :class:`tree.DecisionTreeRegressor`, :class:`tree.ExtraTreeClassifier`,
+  and :class:`tree.ExtraTreeRegressor`.
+  :issue:`7613` by :user:`Adrin Jalali <adrinjalali>`.
+
 Multiple modules
 ................
 

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -574,6 +574,12 @@ cdef class Tree:
         def __get__(self):
             return self._get_node_ndarray()['right_child'][:self.node_count]
 
+    property n_leaves:
+        def __get__(self):
+            return np.sum(np.logical_and(
+                self.children_left == -1,
+                self.children_right == -1))
+
     property feature:
         def __get__(self):
             return self._get_node_ndarray()['feature'][:self.node_count]

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -524,7 +524,7 @@ cdef class Tree:
         great as `node_count`.
 
     max_depth : int
-        The maximal depth of the tree.
+        The depth of the tree, i.e. the maximum depth of its leaves.
 
     children_left : array of int, shape [node_count]
         children_left[i] holds the node id of the left child of node i.

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1215,8 +1215,7 @@ def test_max_leaf_nodes():
     k = 4
     for name, TreeEstimator in ALL_TREES.items():
         est = TreeEstimator(max_depth=None, max_leaf_nodes=k + 1).fit(X, y)
-        tree = est.tree_
-        assert_equal((tree.children_left == TREE_LEAF).sum(), k + 1)
+        assert_equal(est.get_n_leaves(), k + 1)
 
         # max_leaf_nodes in (0, 1) should raise ValueError
         est = TreeEstimator(max_depth=None, max_leaf_nodes=0)
@@ -1233,8 +1232,7 @@ def test_max_leaf_nodes_max_depth():
     k = 4
     for name, TreeEstimator in ALL_TREES.items():
         est = TreeEstimator(max_depth=1, max_leaf_nodes=k).fit(X, y)
-        tree = est.tree_
-        assert_greater(tree.max_depth, 1)
+        assert_greater(est.get_max_depth(), 1)
 
 
 def test_arrays_persist():

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1232,7 +1232,7 @@ def test_max_leaf_nodes_max_depth():
     k = 4
     for name, TreeEstimator in ALL_TREES.items():
         est = TreeEstimator(max_depth=1, max_leaf_nodes=k).fit(X, y)
-        assert_greater(est.get_max_depth(), 1)
+        assert_greater(est.get_depth(), 1)
 
 
 def test_arrays_persist():

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -111,7 +111,8 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
     def get_depth(self):
         """Returns the depth of the decision tree.
 
-        The depth of a tree is defined as the maximum depth of its leaves.
+        The depth of a tree is the maximum distance between the root
+        and any leaf.
         """
         check_is_fitted(self, 'tree_')
         return self.tree_.max_depth

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -108,6 +108,14 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
         self.class_weight = class_weight
         self.presort = presort
 
+    def get_max_depth(self):
+        check_is_fitted(self, 'tree_')
+        return self.tree_.max_depth
+
+    def get_n_leaves(self):
+        check_is_fitted(self, 'tree_')
+        return self.tree_.n_leaves
+
     def fit(self, X, y, sample_weight=None, check_input=True,
             X_idx_sorted=None):
 

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -109,10 +109,15 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
         self.presort = presort
 
     def get_max_depth(self):
+        """Returns the depth of the decision tree, i.e. the maximum
+        depth of its leaves.
+        """
         check_is_fitted(self, 'tree_')
         return self.tree_.max_depth
 
     def get_n_leaves(self):
+        """Returns the number of leaves of the decision tree.
+        """
         check_is_fitted(self, 'tree_')
         return self.tree_.n_leaves
 

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -109,8 +109,9 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
         self.presort = presort
 
     def get_depth(self):
-        """Returns the depth of the decision tree, i.e. the maximum
-        depth of its leaves.
+        """Returns the depth of the decision tree.
+
+        The depth of a tree is defined as the maximum depth of its leaves.
         """
         check_is_fitted(self, 'tree_')
         return self.tree_.max_depth

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -108,7 +108,7 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
         self.class_weight = class_weight
         self.presort = presort
 
-    def get_max_depth(self):
+    def get_depth(self):
         """Returns the depth of the decision tree, i.e. the maximum
         depth of its leaves.
         """


### PR DESCRIPTION
See #7613 (it technically fixes the original issue, but more discussion's going on there)

To count the leaves, I'm checking left AND right children of of each node, which should be the case in a general tree. But in most of the tests, only left or right children are checked and not both. I suppose it doesn't happen that only one of the children are set and not the other, but still, it can a potential source of a bug, I think.

I couldn't really come up with a nice test for the two functions, so I've just replaced the equivalent ones in one of the existing tests. We could replace more of those in tests though.