### PR TITLE
Converting http to https (3)...

### DIFF
--- a/benchmarks/bench_covertype.py
+++ b/benchmarks/bench_covertype.py
@@ -34,10 +34,10 @@ The same task has been used in a number of papers including:
    S. Shalev-Shwartz, Y. Singer, N. Srebro - In Proceedings of ICML '07.
 
  * `"Training Linear SVMs in Linear Time"
-   <www.cs.cornell.edu/People/tj/publications/joachims_06a.pdf>`_
+   <https://www.cs.cornell.edu/people/tj/publications/joachims_06a.pdf>`_
    T. Joachims - In SIGKDD '06
 
-[1] http://archive.ics.uci.edu/ml/datasets/Covertype
+[1] https://archive.ics.uci.edu/ml/datasets/Covertype
 
 """
 from __future__ import division, print_function

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -99,14 +99,14 @@ full-time. It also hosts coding sprints and other events.
    :align: center
    :target: https://www.inria.fr
 
-`Paris-Saclay Center for Data Science <http://www.datascience-paris-saclay.fr>`_
+`Paris-Saclay Center for Data Science <https://www.datascience-paris-saclay.fr/>`_
 funded one year for a developer to work on the project full-time
 (2014-2015) and 50% of the time of Guillaume Lemaitre (2016-2017).
 
 .. image:: images/cds-logo.png
    :width: 200pt
    :align: center
-   :target: http://www.datascience-paris-saclay.fr
+   :target: https://www.datascience-paris-saclay.fr/
 
 `NYU Moore-Sloan Data Science Environment <https://cds.nyu.edu/mooresloan/>`_
 funded Andreas Mueller (2014-2016) to work on this project. The Moore-Sloan Data Science
@@ -118,14 +118,14 @@ Environment also funds several students to work on the project part-time.
    :target: https://cds.nyu.edu/mooresloan/
 
 
-`Télécom Paristech <http://www.telecom-paristech.com>`_ funded Manoj Kumar (2014),
+`Télécom Paristech <https://www.telecom-paristech.fr/>`_ funded Manoj Kumar (2014),
 Tom Dupré la Tour (2015), Raghav RV (2015-2017), Thierry Guillemot (2016-2017)
 and Albert Thomas (2017) to work on scikit-learn.
 
 .. image:: themes/scikit-learn/static/img/telecom.png
    :width: 100pt
    :align: center
-   :target: http://www.telecom-paristech.fr/
+   :target: https://www.telecom-paristech.fr/
 
 
 `Columbia University <https://columbia.edu/>`_ funds Andreas Müller since 2016.

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -170,7 +170,7 @@ General Concepts
         :class:`~sklearn.preprocessing.OneHotEncoder` can be used to
         one-hot encode categorical features.
         See also :ref:`preprocessing_categorical_features` and the
-        `http://contrib.scikit-learn.org/categorical-encoding
+        `https://contrib.scikit-learn.org/categorical-encoding/
         <category_encoders>`_ package for tools related to encoding
         categorical features.
 

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -286,7 +286,7 @@ small, as shown in the example and cited reference.
 .. topic:: References:
 
  * `"Web Scale K-Means clustering"
-   <http://www.eecs.tufts.edu/~dsculley/papers/fastkmeans.pdf>`_
+   <https://www.eecs.tufts.edu/~dsculley/papers/fastkmeans.pdf>`_
    D. Sculley, *Proceedings of the 19th international conference on World
    wide web* (2010)
 
@@ -445,7 +445,7 @@ works well for a small number of clusters but is not advised when using
 many clusters.
 
 For two clusters, it solves a convex relaxation of the `normalised
-cuts <http://people.eecs.berkeley.edu/~malik/papers/SM-ncut.pdf>`_ problem on
+cuts <https://people.eecs.berkeley.edu/~malik/papers/SM-ncut.pdf>`_ problem on
 the similarity graph: cutting the graph in two so that the weight of the
 edges cut is small compared to the weights of the edges inside each
 cluster. This criteria is especially interesting when working on images:
@@ -1008,7 +1008,7 @@ the user is advised
 
  * Tian Zhang, Raghu Ramakrishnan, Maron Livny
    BIRCH: An efficient data clustering method for large databases.
-   http://www.cs.sfu.ca/CourseCentral/459/han/papers/zhang96.pdf
+   https://www.cs.sfu.ca/CourseCentral/459/han/papers/zhang96.pdf
 
  * Roberto Perdisci
    JBirch - Java implementation of BIRCH clustering algorithm
@@ -1144,7 +1144,7 @@ random labelings by defining the adjusted Rand index as follows:
 .. topic:: References
 
  * `Comparing Partitions
-   <http://link.springer.com/article/10.1007%2FBF01908075>`_
+   <https://link.springer.com/article/10.1007%2FBF01908075>`_
    L. Hubert and P. Arabie, Journal of Classification 1985
 
  * `Wikipedia entry for the adjusted Rand index
@@ -1483,7 +1483,7 @@ mean of homogeneity and completeness**:
 .. topic:: References
 
  * `V-Measure: A conditional entropy-based external cluster evaluation
-   measure <http://aclweb.org/anthology/D/D07/D07-1043.pdf>`_
+   measure <https://aclweb.org/anthology/D/D07/D07-1043.pdf>`_
    Andrew Rosenberg and Julia Hirschberg, 2007
 
  .. [B2011] `Identication and Characterization of Events in Social Media

--- a/doc/modules/compose.rst
+++ b/doc/modules/compose.rst
@@ -380,7 +380,7 @@ ColumnTransformer for heterogeneous data
 Many datasets contain features of different types, say text, floats, and dates,
 where each type of feature requires separate preprocessing or feature
 extraction steps.  Often it is easiest to preprocess data before applying
-scikit-learn methods, for example using `pandas <http://pandas.pydata.org/>`__.
+scikit-learn methods, for example using `pandas <https://pandas.pydata.org/>`__.
 Processing your data before passing it to scikit-learn might be problematic for
 one of the following reasons:
 
@@ -395,7 +395,7 @@ transformations for different columns of the data, within a
 :class:`~sklearn.pipeline.Pipeline` that is safe from data leakage and that can
 be parametrized. :class:`~sklearn.compose.ColumnTransformer` works on
 arrays, sparse matrices, and
-`pandas DataFrames <http://pandas.pydata.org/pandas-docs/stable/>`__.
+`pandas DataFrames <https://pandas.pydata.org/pandas-docs/stable/>`__.
 
 To each column, a different transformation can be applied, such as
 preprocessing or a specific feature extraction method::

--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -264,7 +264,7 @@ paper. It is the same algorithm as in the R ``glasso`` package.
 .. topic:: References:
 
    * Friedman et al, `"Sparse inverse covariance estimation with the
-     graphical lasso" <http://biostatistics.oxfordjournals.org/content/9/3/432.short>`_,
+     graphical lasso" <https://biostatistics.oxfordjournals.org/content/9/3/432.short>`_,
      Biostatistics 9, pp 432, 2008
 
 .. _robust_covariance:

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -422,7 +422,7 @@ fold cross validation should be preferred to LOO.
  * R. Bharat Rao, G. Fung, R. Rosales, `On the Dangers of Cross-Validation. An Experimental Evaluation
    <https://people.csail.mit.edu/romer/papers/CrossVal_SDM08.pdf>`_, SIAM 2008;
  * G. James, D. Witten, T. Hastie, R Tibshirani, `An Introduction to
-   Statistical Learning <http://www-bcf.usc.edu/~gareth/ISL>`_, Springer 2013.
+   Statistical Learning <https://www-bcf.usc.edu/~gareth/ISL/>`_, Springer 2013.
 
 
 Leave P Out (LPO)

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -270,10 +270,10 @@ factorization, while larger values shrink many coefficients to zero.
 .. topic:: References:
 
   .. [Mrl09] `"Online Dictionary Learning for Sparse Coding"
-     <http://www.di.ens.fr/sierra/pdfs/icml09.pdf>`_
+     <https://www.di.ens.fr/sierra/pdfs/icml09.pdf>`_
      J. Mairal, F. Bach, J. Ponce, G. Sapiro, 2009
   .. [Jen09] `"Structured Sparse Principal Component Analysis"
-     <www.di.ens.fr/~fbach/sspca_AISTATS2010.pdf>`_
+     <https://www.di.ens.fr/~fbach/sspca_AISTATS2010.pdf>`_
      R. Jenatton, G. Obozinski, F. Bach, 2009
 
 
@@ -289,7 +289,7 @@ where :math:`k` is a user-specified parameter.
 When truncated SVD is applied to term-document matrices
 (as returned by ``CountVectorizer`` or ``TfidfVectorizer``),
 this transformation is known as
-`latent semantic analysis <http://nlp.stanford.edu/IR-book/pdf/18lsi.pdf>`_
+`latent semantic analysis <https://nlp.stanford.edu/IR-book/pdf/18lsi.pdf>`_
 (LSA), because it transforms such matrices
 to a "semantic" space of low dimensionality.
 In particular, LSA is known to combat the effects of synonymy and polysemy
@@ -354,7 +354,7 @@ compensating for LSA's erroneous assumptions about textual data.
   * Christopher D. Manning, Prabhakar Raghavan and Hinrich Schütze (2008),
     *Introduction to Information Retrieval*, Cambridge University Press,
     chapter 18: `Matrix decompositions & latent semantic indexing
-    <http://nlp.stanford.edu/IR-book/pdf/18lsi.pdf>`_
+    <https://nlp.stanford.edu/IR-book/pdf/18lsi.pdf>`_
 
 
 .. _DictionaryLearning:
@@ -495,7 +495,7 @@ extracted from part of the image of a raccoon face looks like.
 .. topic:: References:
 
   * `"Online dictionary learning for sparse coding"
-    <http://www.di.ens.fr/sierra/pdfs/icml09.pdf>`_
+    <https://www.di.ens.fr/sierra/pdfs/icml09.pdf>`_
     J. Mairal, F. Bach, J. Ponce, G. Sapiro, 2009
 
 .. _MiniBatchDictionaryLearning:

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -207,7 +207,7 @@ otherwise the features will not be mapped evenly to the columns.
 
  * Kilian Weinberger, Anirban Dasgupta, John Langford, Alex Smola and
    Josh Attenberg (2009). `Feature hashing for large scale multitask learning
-   <http://alex.smola.org/papers/2009/Weinbergeretal09.pdf>`_. Proc. ICML.
+   <https://alex.smola.org/papers/2009/Weinbergeretal09.pdf>`_. Proc. ICML.
 
  * `MurmurHash3 <https://github.com/aappleby/smhasher>`_.
 
@@ -409,7 +409,7 @@ identify and warn about some kinds of inconsistencies.
 
     .. [NQY18] J. Nothman, H. Qin and R. Yurchak (2018).
                `"Stop Word Lists in Free Open-source Software Packages"
-               <http://aclweb.org/anthology/W18-2502>`__.
+               <https://aclweb.org/anthology/W18-2502>`__.
                In *Proc. Workshop for NLP Open Source Software*.
 
 .. _tfidf:
@@ -673,7 +673,7 @@ The output is not shown here.
 
 For an introduction to Unicode and character encodings in general,
 see Joel Spolsky's `Absolute Minimum Every Software Developer Must Know
-About Unicode <http://www.joelonsoftware.com/articles/Unicode.html>`_.
+About Unicode <https://www.joelonsoftware.com/articles/Unicode.html>`_.
 
 .. _`ftfy`: https://github.com/LuminosoInsight/python-ftfy
 
@@ -932,7 +932,7 @@ Some tips and tricks:
     scikit-learn codebase, but can be added by customizing either the
     tokenizer or the analyzer.
     Here's a ``CountVectorizer`` with a tokenizer and lemmatizer using
-    `NLTK <http://www.nltk.org>`_::
+    `NLTK <https://www.nltk.org/>`_::
 
         >>> from nltk import word_tokenize          # doctest: +SKIP
         >>> from nltk.stem import WordNetLemmatizer # doctest: +SKIP

--- a/doc/modules/kernel_approximation.rst
+++ b/doc/modules/kernel_approximation.rst
@@ -194,7 +194,7 @@ or store training examples.
 .. topic:: References:
 
     .. [RR2007] `"Random features for large-scale kernel machines"
-      <http://www.robots.ox.ac.uk/~vgg/rg/papers/randomfeatures.pdf>`_
+      <https://www.robots.ox.ac.uk/~vgg/rg/papers/randomfeatures.pdf>`_
       Rahimi, A. and Recht, B. - Advances in neural information processing 2007,
     .. [LS2010] `"Random Fourier approximations for skewed multiplicative histogram kernels"
       <http://www.maths.lth.se/matematiklth/personal/sminchis/papers/lis_dagm10.pdf>`_

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -508,7 +508,7 @@ column is always zero.
 .. topic:: References:
 
  * Original Algorithm is detailed in the paper `Least Angle Regression
-   <http://www-stat.stanford.edu/~hastie/Papers/LARS/LeastAngle_2002.pdf>`_
+   <https://www-stat.stanford.edu/~hastie/Papers/LARS/LeastAngle_2002.pdf>`_
    by Hastie et al.
 
 
@@ -547,7 +547,7 @@ previously chosen dictionary elements.
 
 .. topic:: References:
 
- * http://www.cs.technion.ac.il/~ronrubin/Publications/KSVD-OMP-v2.pdf
+ * https://www.cs.technion.ac.il/~ronrubin/Publications/KSVD-OMP-v2.pdf
 
  * `Matching pursuits with time-frequency dictionaries
    <http://blanche.polytechnique.fr/~mallat/papiers/MallatPursuit93.pdf>`_,
@@ -710,7 +710,7 @@ ARD is also known in the literature as *Sparse Bayesian Learning* and
 
     .. [1] Christopher M. Bishop: Pattern Recognition and Machine Learning, Chapter 7.2.1
 
-    .. [2] David Wipf and Srikantan Nagarajan: `A new view of automatic relevance determination <http://papers.nips.cc/paper/3372-a-new-view-of-automatic-relevance-determination.pdf>`_
+    .. [2] David Wipf and Srikantan Nagarajan: `A new view of automatic relevance determination <https://papers.nips.cc/paper/3372-a-new-view-of-automatic-relevance-determination.pdf>`_
 
     .. [3] Michael E. Tipping: `Sparse Bayesian Learning and the Relevance Vector Machine <http://www.jmlr.org/papers/volume1/tipping01a/tipping01a.pdf>`_
 

--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -343,7 +343,7 @@ The overall complexity of spectral embedding is
 
    * `"Laplacian Eigenmaps for Dimensionality Reduction
      and Data Representation"
-     <http://web.cse.ohio-state.edu/~mbelkin/papers/LEM_NC_03.pdf>`_
+     <https://web.cse.ohio-state.edu/~mbelkin/papers/LEM_NC_03.pdf>`_
      M. Belkin, P. Niyogi, Neural Computation, June 2003; 15 (6):1373-1396
 
 
@@ -461,15 +461,15 @@ order to avoid that, the disparities :math:`\hat{d}_{ij}` are normalized.
 .. topic:: References:
 
   * `"Modern Multidimensional Scaling - Theory and Applications"
-    <http://www.springer.com/fr/book/9780387251509>`_
+    <https://www.springer.com/fr/book/9780387251509>`_
     Borg, I.; Groenen P. Springer Series in Statistics (1997)
 
   * `"Nonmetric multidimensional scaling: a numerical method"
-    <http://link.springer.com/article/10.1007%2FBF02289694>`_
+    <https://link.springer.com/article/10.1007%2FBF02289694>`_
     Kruskal, J. Psychometrika, 29 (1964)
 
   * `"Multidimensional scaling by optimizing goodness of fit to a nonmetric hypothesis"
-    <http://link.springer.com/article/10.1007%2FBF02289565>`_
+    <https://link.springer.com/article/10.1007%2FBF02289565>`_
     Kruskal, J. Psychometrika, 29, (1964)
 
 .. _t_sne:
@@ -561,7 +561,7 @@ is a tradeoff between performance and accuracy. Larger angles imply that we
 can approximate larger regions by a single point, leading to better speed
 but less accurate results.
 
-`"How to Use t-SNE Effectively" <http://distill.pub/2016/misread-tsne/>`_
+`"How to Use t-SNE Effectively" <https://distill.pub/2016/misread-tsne/>`_
 provides a good discussion of the effects of the various parameters, as well
 as interactive plots to explore the effects of different parameters.
 

--- a/doc/modules/metrics.rst
+++ b/doc/modules/metrics.rst
@@ -63,7 +63,7 @@ is equivalent to :func:`linear_kernel`, only slower.)
 
     * C.D. Manning, P. Raghavan and H. Schütze (2008). Introduction to
       Information Retrieval. Cambridge University Press.
-      http://nlp.stanford.edu/IR-book/html/htmledition/the-vector-space-model-for-scoring-1.html
+      https://nlp.stanford.edu/IR-book/html/htmledition/the-vector-space-model-for-scoring-1.html
 
 .. _linear_kernel:
 
@@ -149,7 +149,7 @@ Manhattan distance between the input vectors.
 
 It has proven useful in ML applied to noiseless data.
 See e.g. `Machine learning for quantum mechanics in a nutshell
-<http://onlinelibrary.wiley.com/doi/10.1002/qua.24954/abstract/>`_.
+<https://onlinelibrary.wiley.com/doi/10.1002/qua.24954/abstract/>`_.
 
 .. _chi2_kernel:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -775,7 +775,7 @@ binary classification and multilabel indicator format.
 .. topic:: References:
 
   .. [Manning2008] C.D. Manning, P. Raghavan, H. Schütze, `Introduction to Information Retrieval
-     <http://nlp.stanford.edu/IR-book/html/htmledition/evaluation-of-ranked-retrieval-results-1.html>`_,
+     <https://nlp.stanford.edu/IR-book/html/htmledition/evaluation-of-ranked-retrieval-results-1.html>`_,
      2008.
   .. [Everingham2010] M. Everingham, L. Van Gool, C.K.I. Williams, J. Winn, A. Zisserman,
      `The Pascal Visual Object Classes (VOC) Challenge
@@ -785,7 +785,7 @@ binary classification and multilabel indicator format.
      <http://www.machinelearning.org/proceedings/icml2006/030_The_Relationship_Bet.pdf>`_,
      ICML 2006.
   .. [Flach2015] P.A. Flach, M. Kull, `Precision-Recall-Gain Curves: PR Analysis Done Right
-     <http://papers.nips.cc/paper/5867-precision-recall-gain-curves-pr-analysis-done-right.pdf>`_,
+     <https://papers.nips.cc/paper/5867-precision-recall-gain-curves-pr-analysis-done-right.pdf>`_,
      NIPS 2015.
 
 

--- a/doc/modules/model_persistence.rst
+++ b/doc/modules/model_persistence.rst
@@ -87,4 +87,4 @@ another architecture is not supported.
 
 If you want to know more about these issues and explore other possible
 serialization methods, please refer to this
-`talk by Alex Gaynor <http://pyvideo.org/video/2566/pickles-are-for-delis-not-software>`_.
+`talk by Alex Gaynor <https://pyvideo.org/video/2566/pickles-are-for-delis-not-software>`_.

--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -72,7 +72,7 @@ it is known to be a bad estimator, so the probability outputs from
 .. topic:: References:
 
  * H. Zhang (2004). `The optimality of Naive Bayes.
-   <http://www.cs.unb.ca/~hzhang/publications/FLAIRS04ZhangH.pdf>`_
+   <https://www.cs.unb.ca/~hzhang/publications/FLAIRS04ZhangH.pdf>`_
    Proc. FLAIRS.
 
 .. _gaussian_naive_bayes:

--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -307,7 +307,7 @@ keyword ``algorithm = 'kd_tree'``, and are computed using the class
 .. topic:: References:
 
    * `"Multidimensional binary search trees used for associative searching"
-     <http://dl.acm.org/citation.cfm?doid=361002.361007>`_,
+     <https://dl.acm.org/citation.cfm?doid=361002.361007>`_,
      Bentley, J.L., Communications of the ACM (1975)
 
 

--- a/doc/modules/neural_networks_unsupervised.rst
+++ b/doc/modules/neural_networks_unsupervised.rst
@@ -152,10 +152,10 @@ explore the space more thoroughly.
 .. topic:: References:
 
     * `"A fast learning algorithm for deep belief nets"
-      <http://www.cs.toronto.edu/~hinton/absps/fastnc.pdf>`_
+      <https://www.cs.toronto.edu/~hinton/absps/fastnc.pdf>`_
       G. Hinton, S. Osindero, Y.-W. Teh, 2006
 
     * `"Training Restricted Boltzmann Machines using Approximations to
       the Likelihood Gradient"
-      <http://www.cs.toronto.edu/~tijmen/pcd/pcd.pdf>`_
+      <https://www.cs.toronto.edu/~tijmen/pcd/pcd.pdf>`_
       T. Tieleman, 2008

--- a/doc/modules/outlier_detection.rst
+++ b/doc/modules/outlier_detection.rst
@@ -153,7 +153,7 @@ but regular, observation outside the frontier.
 .. topic:: References:
 
     * `Estimating the support of a high-dimensional distribution
-      <http://dl.acm.org/citation.cfm?id=1119749>`_ Schölkopf,
+      <https://dl.acm.org/citation.cfm?id=1119749>`_ Schölkopf,
       Bernhard, et al. Neural computation 13.7 (2001): 1443-1471.
 
 .. topic:: Examples:

--- a/doc/modules/random_projection.rst
+++ b/doc/modules/random_projection.rst
@@ -22,7 +22,7 @@ technique for distance based method.
 .. topic:: References:
 
  * Sanjoy Dasgupta. 2000.
-   `Experiments with random projection. <http://cseweb.ucsd.edu/~dasgupta/papers/randomf.pdf>`_
+   `Experiments with random projection. <https://cseweb.ucsd.edu/~dasgupta/papers/randomf.pdf>`_
    In Proceedings of the Sixteenth conference on Uncertainty in artificial
    intelligence (UAI'00), Craig Boutilier and Moisés Goldszmidt (Eds.). Morgan
    Kaufmann Publishers Inc., San Francisco, CA, USA, 143-151.

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -125,8 +125,8 @@ Using the Iris dataset, we can construct a tree as follows::
     >>> clf = clf.fit(iris.data, iris.target)
 
 Once trained, we can export the tree in `Graphviz
-<http://www.graphviz.org/>`_ format using the :func:`export_graphviz`
-exporter. If you use the `conda <http://conda.io>`_ package manager, the graphviz binaries  
+<https://www.graphviz.org/>`_ format using the :func:`export_graphviz`
+exporter. If you use the `conda <https://conda.io/>`_ package manager, the graphviz binaries  
 and the python package can be installed with 
 
     conda install python-graphviz

--- a/doc/presentations.rst
+++ b/doc/presentations.rst
@@ -50,7 +50,7 @@ Videos
     section :ref:`stat_learn_tut_index`.
 
 - `Statistical Learning for Text Classification with scikit-learn and NLTK
-  <http://www.pyvideo.org/video/417/pycon-2011--statistical-machine-learning-for-text>`_
+  <https://pyvideo.org/video/417/pycon-2011--statistical-machine-learning-for-text>`_
   (and `slides <https://www.slideshare.net/ogrisel/statistical-machine-learning-for-text-classification-with-scikitlearn-and-nltk>`_)
   by `Olivier Grisel`_ at PyCon 2011
 
@@ -74,5 +74,5 @@ Videos
 
 
 .. _Gael Varoquaux: http://gael-varoquaux.info
-.. _Jake Vanderplas: http://staff.washington.edu/jakevdp
+.. _Jake Vanderplas: https://staff.washington.edu/jakevdp
 .. _Olivier Grisel: https://twitter.com/ogrisel

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -244,7 +244,7 @@ Other packages useful for data analysis and machine learning.
 - `Sacred <https://github.com/IDSIA/Sacred>`_ Tool to help you configure,
   organize, log and reproduce experiments
 
-- `Seaborn <http://stanford.edu/~mwaskom/software/seaborn/>`_ Visualization library based on
+- `Seaborn <https://stanford.edu/~mwaskom/software/seaborn/>`_ Visualization library based on
   matplotlib. It provides a high-level interface for drawing attractive statistical graphics.
 
 - `Deep Learning <http://deeplearning.net/software_links/>`_ A curated list of deep learning

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -28,7 +28,7 @@ User questions
   tag.
 
 - For general theoretical or methodological Machine Learning questions
-  `stack exchange <http://stats.stackexchange.com/>`_ is probably a more
+  `stack exchange <https://stats.stackexchange.com/>`_ is probably a more
   suitable venue.
 
 In both cases please use a descriptive question in the title field (e.g.

--- a/doc/testimonials/testimonials.rst
+++ b/doc/testimonials/testimonials.rst
@@ -775,7 +775,7 @@ Trent McConaghy, founder, Solido Design Automation Inc.
 
 .. image:: images/infonea.jpg
     :width: 120pt
-    :target: http://www.infonea.com/en
+    :target: http://www.infonea.com/en/
 
 .. raw:: html
 

--- a/doc/themes/scikit-learn/static/ML_MAPS_README.rst
+++ b/doc/themes/scikit-learn/static/ML_MAPS_README.rst
@@ -5,10 +5,10 @@ This document is intended to explain how to edit
 the machine learning cheat sheet, originally created
 by Andreas Mueller:
 
-(http://peekaboo-vision.blogspot.de/2013/01/machine-learning-cheat-sheet-for-scikit.html)
+(https://peekaboo-vision.blogspot.de/2013/01/machine-learning-cheat-sheet-for-scikit.html)
 
 The image is made interactive using an imagemap, and uses the jQuery Map Hilight plugin module
-by David Lynch (http://davidlynch.org/projects/maphilight/docs/) to highlight
+by David Lynch (https://davidlynch.org/projects/maphilight/docs/) to highlight
 the different items on the image upon mouseover.
 
 Modifying the map on the docs is currently a little bit tedious,

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -76,7 +76,7 @@ Loading an example dataset
 
 `scikit-learn` comes with a few standard datasets, for instance the
 `iris <https://en.wikipedia.org/wiki/Iris_flower_data_set>`_ and `digits
-<http://archive.ics.uci.edu/ml/datasets/Pen-Based+Recognition+of+Handwritten+Digits>`_
+<https://archive.ics.uci.edu/ml/datasets/Pen-Based+Recognition+of+Handwritten+Digits>`_
 datasets for classification and the `boston house prices dataset
 <https://archive.ics.uci.edu/ml/machine-learning-databases/housing/>`_ for regression.
 

--- a/doc/tutorial/machine_learning_map/ML_MAPS_README.txt
+++ b/doc/tutorial/machine_learning_map/ML_MAPS_README.txt
@@ -5,10 +5,10 @@ This document is intended to explain how to edit
 the machine learning cheat sheet, originally created
 by Andreas Mueller:
 
-(http://peekaboo-vision.blogspot.de/2013/01/machine-learning-cheat-sheet-for-scikit.html)
+(https://peekaboo-vision.blogspot.de/2013/01/machine-learning-cheat-sheet-for-scikit.html)
 
 The image is made interactive using an imagemap, and uses the jQuery Map Hilight plugin module
-by David Lynch (http://davidlynch.org/projects/maphilight/docs/) to highlight
+by David Lynch (https://davidlynch.org/projects/maphilight/docs/) to highlight
 the different items on the image upon mouseover.
 
 Modifying the map on the docs is currently a little bit tedious,

--- a/doc/tutorial/machine_learning_map/pyparsing.py
+++ b/doc/tutorial/machine_learning_map/pyparsing.py
@@ -895,7 +895,7 @@ class ParseResults(object):
         """
         Pretty-printer for parsed results as a list, using the C{pprint} module.
         Accepts additional positional or keyword args as defined for the 
-        C{pprint.pprint} method. (U{http://docs.python.org/3/library/pprint.html#pprint.pprint})
+        C{pprint.pprint} method. (U{https://docs.python.org/3/library/pprint.html#pprint.pprint})
 
         Example::
             ident = Word(alphas, alphanums)

--- a/doc/tutorial/statistical_inference/finding_help.rst
+++ b/doc/tutorial/statistical_inference/finding_help.rst
@@ -25,7 +25,7 @@ Q&A communities with Machine Learning practitioners
 
 .. _`How do I learn machine learning?`: https://www.quora.com/How-do-I-learn-machine-learning-1
 
-.. _`multiple subdomains for Machine Learning questions`: http://meta.stackexchange.com/questions/130524/which-stack-exchange-website-for-machine-learning-and-computational-algorithms
+.. _`multiple subdomains for Machine Learning questions`: https://meta.stackexchange.com/q/130524
 
 -- _'An excellent free online course for Machine Learning taught by Professor Andrew Ng of Stanford': https://www.coursera.org/learn/machine-learning
 

--- a/doc/whats_new/_contributors.rst
+++ b/doc/whats_new/_contributors.rst
@@ -52,7 +52,7 @@
 
 .. _Matthieu Perrot: http://brainvisa.info/biblio/lnao/en/Author/PERROT-M.html
 
-.. _Jake Vanderplas: http://staff.washington.edu/jakevdp/
+.. _Jake Vanderplas: https://staff.washington.edu/jakevdp/
 
 .. _Gilles Louppe: http://www.montefiore.ulg.ac.be/~glouppe/
 
@@ -64,7 +64,7 @@
 
 .. _Brian Holt: http://personal.ee.surrey.ac.uk/Personal/B.Holt
 
-.. _Satrajit Ghosh: http://www.mit.edu/~satra/
+.. _Satrajit Ghosh: https://www.mit.edu/~satra/
 
 .. _Robert Layton: https://twitter.com/robertlayton
 

--- a/doc/whats_new/v0.14.rst
+++ b/doc/whats_new/v0.14.rst
@@ -51,7 +51,7 @@ Changelog
 
 - Added an interactive version of `Andreas Müller`_'s
   `Machine Learning Cheat Sheet (for scikit-learn)
-  <http://peekaboo-vision.blogspot.de/2013/01/machine-learning-cheat-sheet-for-scikit.html>`_
+  <https://peekaboo-vision.blogspot.de/2013/01/machine-learning-cheat-sheet-for-scikit.html>`_
   to the documentation. See :ref:`Choosing the right estimator <ml_map>`.
   By `Jaques Grobler`_.
 

--- a/doc/whats_new/v0.19.rst
+++ b/doc/whats_new/v0.19.rst
@@ -811,7 +811,7 @@ Miscellaneous
   Python 2. :issue:`9284` by :user:`Sebastin Santy <SebastinSanty>`.
 
 - Several minor issues were fixed with thanks to the alerts of
-  [lgtm.com](http://lgtm.com). :issue:`9278` by :user:`Jean Helie <jhelie>`,
+  [lgtm.com](https://lgtm.com/). :issue:`9278` by :user:`Jean Helie <jhelie>`,
   among others.
 
 API changes summary

--- a/examples/datasets/plot_digits_last_image.py
+++ b/examples/datasets/plot_digits_last_image.py
@@ -12,7 +12,7 @@ In order to utilize an 8x8 figure like this, we'd have to
 first transform it into a feature vector with length 64.
 
 See `here
-<http://archive.ics.uci.edu/ml/datasets/Pen-Based+Recognition+of+Handwritten+Digits>`_
+<https://archive.ics.uci.edu/ml/datasets/Pen-Based+Recognition+of+Handwritten+Digits>`_
 for more information about this dataset.
 """
 print(__doc__)

--- a/examples/manifold/plot_t_sne_perplexity.py
+++ b/examples/manifold/plot_t_sne_perplexity.py
@@ -18,7 +18,7 @@ visually diverge from S-curve topology on the S-curve dataset even for
 larger perplexity values.
 
 For further details, "How to Use t-SNE Effectively"
-http://distill.pub/2016/misread-tsne/ provides a good discussion of the
+https://distill.pub/2016/misread-tsne/ provides a good discussion of the
 effects of various parameters, as well as interactive plots to explore
 those effects.
 """

--- a/examples/preprocessing/plot_all_scaling.py
+++ b/examples/preprocessing/plot_all_scaling.py
@@ -8,7 +8,7 @@ Compare the effect of different scalers on data with outliers
 
 Feature 0 (median income in a block) and feature 5 (number of households) of
 the `California housing dataset
-<http://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.html>`_ have very
+<https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.html>`_ have very
 different scales and contain some very large outliers. These two
 characteristics lead to difficulties to visualize the data and, more
 importantly, they can degrade the predictive performance of many machine

--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -404,7 +404,7 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
     ----------
     * Tian Zhang, Raghu Ramakrishnan, Maron Livny
       BIRCH: An efficient data clustering method for large databases.
-      http://www.cs.sfu.ca/CourseCentral/459/han/papers/zhang96.pdf
+      https://www.cs.sfu.ca/CourseCentral/459/han/papers/zhang96.pdf
 
     * Roberto Perdisci
       JBirch - Java implementation of BIRCH clustering algorithm

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -1447,7 +1447,7 @@ class MiniBatchKMeans(KMeans):
 
     Notes
     -----
-    See http://www.eecs.tufts.edu/~dsculley/papers/fastkmeans.pdf
+    See https://www.eecs.tufts.edu/~dsculley/papers/fastkmeans.pdf
 
     """
 

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -53,7 +53,7 @@ def discretize(vectors, copy=True, max_svd_restarts=30, n_iter_max=20,
 
     - Multiclass spectral clustering, 2003
       Stella X. Yu, Jianbo Shi
-      http://www1.icsi.berkeley.edu/~stellayu/publication/doc/2003kwayICCV.pdf
+      https://www1.icsi.berkeley.edu/~stellayu/publication/doc/2003kwayICCV.pdf
 
     Notes
     -----
@@ -237,7 +237,7 @@ def spectral_clustering(affinity, n_clusters=8, n_components=None,
 
     - Multiclass spectral clustering, 2003
       Stella X. Yu, Jianbo Shi
-      http://www1.icsi.berkeley.edu/~stellayu/publication/doc/2003kwayICCV.pdf
+      https://www1.icsi.berkeley.edu/~stellayu/publication/doc/2003kwayICCV.pdf
 
     Notes
     ------
@@ -422,7 +422,7 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
 
     - Multiclass spectral clustering, 2003
       Stella X. Yu, Jianbo Shi
-      http://www1.icsi.berkeley.edu/~stellayu/publication/doc/2003kwayICCV.pdf
+      https://www1.icsi.berkeley.edu/~stellayu/publication/doc/2003kwayICCV.pdf
     """
 
     def __init__(self, n_clusters=8, eigen_solver=None, random_state=None,

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -527,7 +527,7 @@ def load_digits(n_class=10, return_X_y=False):
         .. versionadded:: 0.18
 
     This is a copy of the test set of the UCI ML hand-written digits datasets
-    http://archive.ics.uci.edu/ml/datasets/Optical+Recognition+of+Handwritten+Digits
+    https://archive.ics.uci.edu/ml/datasets/Optical+Recognition+of+Handwritten+Digits
 
     Examples
     --------

--- a/sklearn/datasets/california_housing.py
+++ b/sklearn/datasets/california_housing.py
@@ -36,7 +36,7 @@ from ..utils import Bunch
 from ..externals import joblib
 
 # The original data can be found at:
-# http://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.tgz
+# https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.tgz
 ARCHIVE = RemoteFileMetadata(
     filename='cal_housing.tgz',
     url='https://ndownloader.figshare.com/files/5976036',

--- a/sklearn/datasets/covtype.py
+++ b/sklearn/datasets/covtype.py
@@ -5,7 +5,7 @@ real-valued features.
 
 The dataset page is available from UCI Machine Learning Repository
 
-    http://archive.ics.uci.edu/ml/datasets/Covertype
+    https://archive.ics.uci.edu/ml/datasets/Covertype
 
 Courtesy of Jock A. Blackard and Colorado State University.
 """
@@ -31,7 +31,7 @@ from ..externals import joblib
 from ..utils import check_random_state
 
 # The original data can be found in:
-# http://archive.ics.uci.edu/ml/machine-learning-databases/covtype/covtype.data.gz
+# https://archive.ics.uci.edu/ml/machine-learning-databases/covtype/covtype.data.gz
 ARCHIVE = RemoteFileMetadata(
     filename='covtype.data.gz',
     url='https://ndownloader.figshare.com/files/5976039',

--- a/sklearn/datasets/descr/covtype.rst
+++ b/sklearn/datasets/descr/covtype.rst
@@ -8,7 +8,7 @@ collected for the task of predicting each patch's cover type,
 i.e. the dominant species of tree.
 There are seven covertypes, making this a multiclass classification problem.
 Each sample has 54 features, described on the
-`dataset's homepage <http://archive.ics.uci.edu/ml/datasets/Covertype>`__.
+`dataset's homepage <https://archive.ics.uci.edu/ml/datasets/Covertype>`__.
 Some of the features are boolean indicators,
 while others are discrete or continuous measurements.
 

--- a/sklearn/datasets/descr/diabetes.rst
+++ b/sklearn/datasets/descr/diabetes.rst
@@ -31,8 +31,8 @@ quantitative measure of disease progression one year after baseline.
 Note: Each of these 10 feature variables have been mean centered and scaled by the standard deviation times `n_samples` (i.e. the sum of squares of each column totals 1).
 
 Source URL:
-http://www4.stat.ncsu.edu/~boos/var.select/diabetes.html
+https://www4.stat.ncsu.edu/~boos/var.select/diabetes.html
 
 For more information see:
 Bradley Efron, Trevor Hastie, Iain Johnstone and Robert Tibshirani (2004) "Least Angle Regression," Annals of Statistics (with discussion), 407-499.
-(http://web.stanford.edu/~hastie/Papers/LARS/LeastAngle_2002.pdf)
+(https://web.stanford.edu/~hastie/Papers/LARS/LeastAngle_2002.pdf)

--- a/sklearn/datasets/descr/digits.rst
+++ b/sklearn/datasets/descr/digits.rst
@@ -13,7 +13,7 @@ Optical recognition of handwritten digits dataset
     :Date: July; 1998
 
 This is a copy of the test set of the UCI ML hand-written digits datasets
-http://archive.ics.uci.edu/ml/datasets/Optical+Recognition+of+Handwritten+Digits
+https://archive.ics.uci.edu/ml/datasets/Optical+Recognition+of+Handwritten+Digits
 
 The data set contains images of hand-written digits: 10 classes where
 each class refers to a digit.

--- a/sklearn/datasets/descr/kddcup99.rst
+++ b/sklearn/datasets/descr/kddcup99.rst
@@ -6,7 +6,7 @@ Kddcup 99 dataset
 The KDD Cup '99 dataset was created by processing the tcpdump portions
 of the 1998 DARPA Intrusion Detection System (IDS) Evaluation dataset,
 created by MIT Lincoln Lab [1]. The artificial data (described on the `dataset's
-homepage <http://kdd.ics.uci.edu/databases/kddcup99/kddcup99.html>`_) was
+homepage <https://kdd.ics.uci.edu/databases/kddcup99/kddcup99.html>`_) was
 generated using a closed network and hand-injected attacks to produce a
 large number of different types of attack with normal activity in the
 background. As the initial goal was to produce a large training set for

--- a/sklearn/datasets/descr/wine_data.rst
+++ b/sklearn/datasets/descr/wine_data.rst
@@ -71,7 +71,7 @@ Via Brigata Salerno, 16147 Genoa, Italy.
 Citation:
 
 Lichman, M. (2013). UCI Machine Learning Repository
-[http://archive.ics.uci.edu/ml]. Irvine, CA: University of California,
+[https://archive.ics.uci.edu/ml]. Irvine, CA: University of California,
 School of Information and Computer Science. 
 
 .. topic:: References

--- a/sklearn/datasets/images/README.txt
+++ b/sklearn/datasets/images/README.txt
@@ -3,9 +3,9 @@ Released under a creative commons license. [1]
 Attribution: Some rights reserved by danielbuechele [2]
 Retrieved 21st August, 2011 from [3] by Robert Layton
 
-[1] http://creativecommons.org/licenses/by/2.0/
-[2] http://www.flickr.com/photos/danielbuechele/
-[3] http://www.flickr.com/photos/danielbuechele/6061409035/sizes/z/in/photostream/
+[1] https://creativecommons.org/licenses/by/2.0/
+[2] https://www.flickr.com/photos/danielbuechele/
+[3] https://www.flickr.com/photos/danielbuechele/6061409035/sizes/z/in/photostream/
 
 
 Image: flower.jpg
@@ -13,9 +13,9 @@ Released under a creative commons license. [1]
 Attribution: Some rights reserved by danielbuechele [2]
 Retrieved 21st August, 2011 from [3] by Robert Layton
 
-[1] http://creativecommons.org/licenses/by/2.0/
-[2] http://www.flickr.com/photos/vultilion/
-[3] http://www.flickr.com/photos/vultilion/6056698931/sizes/z/in/photostream/
+[1] https://creativecommons.org/licenses/by/2.0/
+[2] https://www.flickr.com/photos/vultilion/
+[3] https://www.flickr.com/photos/vultilion/6056698931/sizes/z/in/photostream/
 
 
 

--- a/sklearn/datasets/kddcup99.py
+++ b/sklearn/datasets/kddcup99.py
@@ -27,7 +27,7 @@ from ..utils import check_random_state
 from ..utils import shuffle as shuffle_method
 
 # The original data can be found at:
-# http://archive.ics.uci.edu/ml/machine-learning-databases/kddcup99-mld/kddcup.data.gz
+# https://archive.ics.uci.edu/ml/machine-learning-databases/kddcup99-mld/kddcup.data.gz
 ARCHIVE = RemoteFileMetadata(
     filename='kddcup99_data',
     url='https://ndownloader.figshare.com/files/5976045',
@@ -35,7 +35,7 @@ ARCHIVE = RemoteFileMetadata(
               '343652c9db428893e7494f837b274292'))
 
 # The original data can be found at:
-# http://archive.ics.uci.edu/ml/machine-learning-databases/kddcup99-mld/kddcup.data_10_percent.gz
+# https://archive.ics.uci.edu/ml/machine-learning-databases/kddcup99-mld/kddcup.data_10_percent.gz
 ARCHIVE_10_PERCENT = RemoteFileMetadata(
     filename='kddcup99_10_data',
     url='https://ndownloader.figshare.com/files/5976042',

--- a/sklearn/datasets/species_distributions.py
+++ b/sklearn/datasets/species_distributions.py
@@ -56,7 +56,7 @@ from sklearn.externals import joblib
 PY3_OR_LATER = sys.version_info[0] >= 3
 
 # The original data can be found at:
-# http://biodiversityinformatics.amnh.org/open_source/maxent/samples.zip
+# https://biodiversityinformatics.amnh.org/open_source/maxent/samples.zip
 SAMPLES = RemoteFileMetadata(
     filename='samples.zip',
     url='https://ndownloader.figshare.com/files/5976075',
@@ -64,7 +64,7 @@ SAMPLES = RemoteFileMetadata(
               '3c098f7f85955e89d321ee8efe37ac28'))
 
 # The original data can be found at:
-# http://biodiversityinformatics.amnh.org/open_source/maxent/coverages.zip
+# https://biodiversityinformatics.amnh.org/open_source/maxent/coverages.zip
 COVERAGES = RemoteFileMetadata(
     filename='coverages.zip',
     url='https://ndownloader.figshare.com/files/5976078',

--- a/sklearn/decomposition/_online_lda.pyx
+++ b/sklearn/decomposition/_online_lda.pyx
@@ -93,7 +93,7 @@ def _dirichlet_expectation_2d(np.ndarray[ndim=2, dtype=np.float64_t] arr):
 # Psi function for positive arguments. Optimized for speed, not accuracy.
 #
 # After: J. Bernardo (1976). Algorithm AS 103: Psi (Digamma) Function.
-# http://www.uv.es/~bernardo/1976AppStatist.pdf
+# https://www.uv.es/~bernardo/1976AppStatist.pdf
 @cython.cdivision(True)
 cdef double psi(double x) nogil:
     if x <= 1e-6:

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -1129,7 +1129,7 @@ class DictionaryLearning(BaseEstimator, SparseCodingMixin):
     **References:**
 
     J. Mairal, F. Bach, J. Ponce, G. Sapiro, 2009: Online dictionary learning
-    for sparse coding (http://www.di.ens.fr/sierra/pdfs/icml09.pdf)
+    for sparse coding (https://www.di.ens.fr/sierra/pdfs/icml09.pdf)
 
     See also
     --------
@@ -1317,7 +1317,7 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
     **References:**
 
     J. Mairal, F. Bach, J. Ponce, G. Sapiro, 2009: Online dictionary learning
-    for sparse coding (http://www.di.ens.fr/sierra/pdfs/icml09.pdf)
+    for sparse coding (https://www.di.ens.fr/sierra/pdfs/icml09.pdf)
 
     See also
     --------

--- a/sklearn/decomposition/incremental_pca.py
+++ b/sklearn/decomposition/incremental_pca.py
@@ -120,13 +120,13 @@ class IncrementalPCA(_BasePCA):
     `D. Ross, J. Lim, R. Lin, M. Yang, Incremental Learning for Robust Visual
     Tracking, International Journal of Computer Vision, Volume 77, Issue 1-3,
     pp. 125-141, May 2008.`
-    See http://www.cs.toronto.edu/~dross/ivt/RossLimLinYang_ijcv.pdf
+    See https://www.cs.toronto.edu/~dross/ivt/RossLimLinYang_ijcv.pdf
 
     This model is an extension of the Sequential Karhunen-Loeve Transform from:
     `A. Levy and M. Lindenbaum, Sequential Karhunen-Loeve Basis Extraction and
     its Application to Images, IEEE Transactions on Image Processing, Volume 9,
     Number 8, pp. 1371-1374, August 2000.`
-    See http://www.cs.technion.ac.il/~mic/doc/skl-ip.pdf
+    See https://www.cs.technion.ac.il/~mic/doc/skl-ip.pdf
 
     We have specifically abstained from an optimization used by authors of both
     papers, a QR decomposition used in specific situations to reduce the

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -72,7 +72,7 @@ class RBFSampler(BaseEstimator, TransformerMixin):
     [1] "Weighted Sums of Random Kitchen Sinks: Replacing
     minimization with randomization in learning" by A. Rahimi and
     Benjamin Recht.
-    (http://people.eecs.berkeley.edu/~brecht/papers/08.rah.rec.nips.pdf)
+    (https://people.eecs.berkeley.edu/~brecht/papers/08.rah.rec.nips.pdf)
     """
 
     def __init__(self, gamma=1., n_components=100, random_state=None):

--- a/sklearn/linear_model/huber.py
+++ b/sklearn/linear_model/huber.py
@@ -220,7 +220,7 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
     .. [1] Peter J. Huber, Elvezio M. Ronchetti, Robust Statistics
            Concomitant scale estimates, pg 172
     .. [2] Art B. Owen (2006), A robust hybrid of lasso and ridge regression.
-           http://statweb.stanford.edu/~owen/reports/hhu.pdf
+           https://statweb.stanford.edu/~owen/reports/hhu.pdf
     """
 
     def __init__(self, epsilon=1.35, max_iter=100, alpha=0.0001,

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -135,7 +135,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
     References
     ----------
     .. [1] "Least Angle Regression", Effron et al.
-           http://statweb.stanford.edu/~tibs/ftp/lars.pdf
+           https://statweb.stanford.edu/~tibs/ftp/lars.pdf
 
     .. [2] `Wikipedia entry on the Least-angle regression
            <https://en.wikipedia.org/wiki/Least-angle_regression>`_

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -340,7 +340,7 @@ def orthogonal_mp(X, y, n_nonzero_coefs=None, tol=None, precompute=False,
     This implementation is based on Rubinstein, R., Zibulevsky, M. and Elad,
     M., Efficient Implementation of the K-SVD Algorithm using Batch Orthogonal
     Matching Pursuit Technical Report - CS Technion, April 2008.
-    http://www.cs.technion.ac.il/~ronrubin/Publications/KSVD-OMP-v2.pdf
+    https://www.cs.technion.ac.il/~ronrubin/Publications/KSVD-OMP-v2.pdf
 
     """
     X = check_array(X, order='F', copy=copy_X)
@@ -479,7 +479,7 @@ def orthogonal_mp_gram(Gram, Xy, n_nonzero_coefs=None, tol=None,
     This implementation is based on Rubinstein, R., Zibulevsky, M. and Elad,
     M., Efficient Implementation of the K-SVD Algorithm using Batch Orthogonal
     Matching Pursuit Technical Report - CS Technion, April 2008.
-    http://www.cs.technion.ac.il/~ronrubin/Publications/KSVD-OMP-v2.pdf
+    https://www.cs.technion.ac.il/~ronrubin/Publications/KSVD-OMP-v2.pdf
 
     """
     Gram = check_array(Gram, order='F', copy=copy_Gram)
@@ -604,7 +604,7 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
     This implementation is based on Rubinstein, R., Zibulevsky, M. and Elad,
     M., Efficient Implementation of the K-SVD Algorithm using Batch Orthogonal
     Matching Pursuit Technical Report - CS Technion, April 2008.
-    http://www.cs.technion.ac.il/~ronrubin/Publications/KSVD-OMP-v2.pdf
+    https://www.cs.technion.ac.il/~ronrubin/Publications/KSVD-OMP-v2.pdf
 
     See also
     --------

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -508,11 +508,11 @@ def matthews_corrcoef(y_true, y_pred, sample_weight=None):
 
     .. [3] `Gorodkin, (2004). Comparing two K-category assignments by a
         K-category correlation coefficient
-        <http://www.sciencedirect.com/science/article/pii/S1476927104000799>`_
+        <https://www.sciencedirect.com/science/article/pii/S1476927104000799>`_
 
     .. [4] `Jurman, Riccadonna, Furlanello, (2012). A Comparison of MCC and CEN
         Error Measures in MultiClass Prediction
-        <http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0041882>`_
+        <https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0041882>`_
 
     Examples
     --------

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -207,7 +207,7 @@ def adjusted_rand_score(labels_true, labels_pred):
 
     .. [Hubert1985] `L. Hubert and P. Arabie, Comparing Partitions,
       Journal of Classification 1985`
-      http://link.springer.com/article/10.1007%2FBF01908075
+      https://link.springer.com/article/10.1007%2FBF01908075
 
     .. [wk] https://en.wikipedia.org/wiki/Rand_index#Adjusted_Rand_index
 
@@ -350,7 +350,7 @@ def homogeneity_score(labels_true, labels_pred):
 
     .. [1] `Andrew Rosenberg and Julia Hirschberg, 2007. V-Measure: A
        conditional entropy-based external cluster evaluation measure
-       <http://aclweb.org/anthology/D/D07/D07-1043.pdf>`_
+       <https://aclweb.org/anthology/D/D07/D07-1043.pdf>`_
 
     See also
     --------
@@ -424,7 +424,7 @@ def completeness_score(labels_true, labels_pred):
 
     .. [1] `Andrew Rosenberg and Julia Hirschberg, 2007. V-Measure: A
        conditional entropy-based external cluster evaluation measure
-       <http://aclweb.org/anthology/D/D07/D07-1043.pdf>`_
+       <https://aclweb.org/anthology/D/D07/D07-1043.pdf>`_
 
     See also
     --------
@@ -500,7 +500,7 @@ def v_measure_score(labels_true, labels_pred):
 
     .. [1] `Andrew Rosenberg and Julia Hirschberg, 2007. V-Measure: A
        conditional entropy-based external cluster evaluation measure
-       <http://aclweb.org/anthology/D/D07/D07-1043.pdf>`_
+       <https://aclweb.org/anthology/D/D07/D07-1043.pdf>`_
 
     See also
     --------

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -700,7 +700,7 @@ class MultinomialNB(BaseDiscreteNB):
     ----------
     C.D. Manning, P. Raghavan and H. Schuetze (2008). Introduction to
     Information Retrieval. Cambridge University Press, pp. 234-265.
-    http://nlp.stanford.edu/IR-book/html/htmledition/naive-bayes-text-classification-1.html
+    https://nlp.stanford.edu/IR-book/html/htmledition/naive-bayes-text-classification-1.html
     """
 
     def __init__(self, alpha=1.0, fit_prior=True, class_prior=None):
@@ -897,7 +897,7 @@ class BernoulliNB(BaseDiscreteNB):
 
     C.D. Manning, P. Raghavan and H. Schuetze (2008). Introduction to
     Information Retrieval. Cambridge University Press, pp. 234-265.
-    http://nlp.stanford.edu/IR-book/html/htmledition/the-bernoulli-model-1.html
+    https://nlp.stanford.edu/IR-book/html/htmledition/the-bernoulli-model-1.html
 
     A. McCallum and K. Nigam (1998). A comparison of event models for naive
     Bayes text classification. Proc. AAAI/ICML-98 Workshop on Learning for

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -251,7 +251,7 @@ def sparse_random_matrix(n_components, n_features, density='auto',
 
     .. [1] Ping Li, T. Hastie and K. W. Church, 2006,
            "Very Sparse Random Projections".
-           http://web.stanford.edu/~hastie/Papers/Ping/KDD06_rp.pdf
+           https://web.stanford.edu/~hastie/Papers/Ping/KDD06_rp.pdf
 
     .. [2] D. Achlioptas, 2001, "Database-friendly random projections",
            http://www.cs.ucsc.edu/~optas/papers/jl.pdf
@@ -610,7 +610,7 @@ class SparseRandomProjection(BaseRandomProjection):
 
     .. [1] Ping Li, T. Hastie and K. W. Church, 2006,
            "Very Sparse Random Projections".
-           http://web.stanford.edu/~hastie/Papers/Ping/KDD06_rp.pdf
+           https://web.stanford.edu/~hastie/Papers/Ping/KDD06_rp.pdf
 
     .. [2] D. Achlioptas, 2001, "Database-friendly random projections",
            https://users.soe.ucsc.edu/~optas/papers/jl.pdf


### PR DESCRIPTION
Converted ~100 URLs from http to https. I checked the conversions for issues (e.g. a site not supporting https) using Firefox. Not sure if anything relies on URLs being in http format, but I stuck mostly to documenation fixes.

My process is checking the original URL, adding s to the http, and only making the update if it successfully goes to the same page. I don't update an URL if the https version gives the "Insecure Connection" page, or if I'm redirected to an URL that isn't https.

This time I had the following script go over converted URLs, and I only checked what was printed:

    import urllib.request
    import ssl
    for url in url_list:
        try:
            print(url, urllib.request.urlopen(url).getcode())
        except urllib.error.URLError:
            pass
        except ssl.CertificateError:
            pass

So for now, I'm done, but there's probably still conversions to do. Apparently there's an issue to get scikit-learn.org to support https, in which case ~50 additional URLs can be converted.

Apparently SVG namespaces are particular, so I decided not to modify URLs in SVG files. I also passed over the apache URLs, as I didn't know if I should modify the copyright notices.