### PR TITLE
Increase of n_init should be expected improve test should use same seeds for both fits 

### DIFF
--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -686,10 +686,10 @@ def test_multiple_init():
     for cv_type in COVARIANCE_TYPE:
         train1 = GaussianMixture(n_components=n_components,
                                  covariance_type=cv_type,
-                                 random_state=rng).fit(X).score(X)
+                                 random_state=0).fit(X).score(X)
         train2 = GaussianMixture(n_components=n_components,
                                  covariance_type=cv_type,
-                                 random_state=rng, n_init=5).fit(X).score(X)
+                                 random_state=0, n_init=5).fit(X).score(X)
         assert_greater_equal(train2, train1)
 
 


### PR DESCRIPTION
The `test_multilpe_init` in [test_gaussian_mixture#L681](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/mixture/tests/test_gaussian_mixture.py#L681) is as follows:

```python
def test_multiple_init():
    # Test that multiple inits does not much worse than a single one
    rng = np.random.RandomState(0)
    n_samples, n_features, n_components = 50, 5, 2
    X = rng.randn(n_samples, n_features)
    for cv_type in COVARIANCE_TYPE:
        train1 = GaussianMixture(n_components=n_components,
                                 covariance_type=cv_type,
                                 random_state=rng).fit(X).score(X)
        train2 = GaussianMixture(n_components=n_components,
                                 covariance_type=cv_type,
                                 random_state=rng, n_init=5).fit(X).score(X)
        assert_greater_equal(train2, train1)
``` 

Because `rng` is an instance of `RandomState`, it is being altered in execution of `train1`, and the second call is made with different state of the pseudo-random state machine.

#### What does this implement/fix? Explain your changes.

I suggest to replace `random_state=rng` with `random_state=0`, or some other fixed value, the same for both `fit` calls.

#### Any other comments?

This does not fix any failing test, but I think is cleaner, and makes more logical sense. 