### PR TITLE
ENH Raise an error when pos_label is not in binary y_true

### DIFF
--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -230,6 +230,11 @@ def average_precision_score(y_true, y_score, average="macro", pos_label=1,
         raise ValueError("Parameter pos_label is fixed to 1 for "
                          "multilabel-indicator y_true. Do not set "
                          "pos_label or set pos_label to 1.")
+    elif y_type == "binary":
+        present_labels = np.unique(y_true)
+        if len(present_labels) == 2 and pos_label not in present_labels:
+            raise ValueError("pos_label=%r is invalid. Set it to a label in "
+                             "y_true." % pos_label)
     average_precision = partial(_binary_uninterpolated_average_precision,
                                 pos_label=pos_label)
     return _average_binary_score(average_precision, y_true, y_score,

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -686,17 +686,17 @@ def test_average_precision_score_pos_label_errors():
     # Raise an error when pos_label is not in binary y_true
     y_true = np.array([0, 1])
     y_pred = np.array([0, 1])
-    erorr_message = ("pos_label=2 is invalid. Set it to a label in y_true.")
-    assert_raise_message(ValueError, erorr_message, average_precision_score,
+    error_message = ("pos_label=2 is invalid. Set it to a label in y_true.")
+    assert_raise_message(ValueError, error_message, average_precision_score,
                          y_true, y_pred, pos_label=2)
     # Raise an error for multilabel-indicator y_true with
     # pos_label other than 1
     y_true = np.array([[1, 0], [0, 1], [0, 1], [1, 0]])
     y_pred = np.array([[0.9, 0.1], [0.1, 0.9], [0.8, 0.2], [0.2, 0.8]])
-    erorr_message = ("Parameter pos_label is fixed to 1 for multilabel"
+    error_message = ("Parameter pos_label is fixed to 1 for multilabel"
                      "-indicator y_true. Do not set pos_label or set "
                      "pos_label to 1.")
-    assert_raise_message(ValueError, erorr_message, average_precision_score,
+    assert_raise_message(ValueError, error_message, average_precision_score,
                          y_true, y_pred, pos_label=0)
 
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -682,7 +682,13 @@ def test_average_precision_constant_values():
     assert_equal(average_precision_score(y_true, y_score), .25)
 
 
-def test_average_precision_score_pos_label_multilabel_indicator():
+def test_average_precision_score_pos_label_errors():
+    # Raise an error when pos_label is not in binary y_true
+    y_true = np.array([0, 1])
+    y_pred = np.array([0, 1])
+    erorr_message = ("pos_label=2 is invalid. Set it to a label in y_true.")
+    assert_raise_message(ValueError, erorr_message, average_precision_score,
+                         y_true, y_pred, pos_label=2)
     # Raise an error for multilabel-indicator y_true with
     # pos_label other than 1
     y_true = np.array([[1, 0], [0, 1], [0, 1], [1, 0]])


### PR DESCRIPTION
Part of #12312 
Note to reviewer: _average_binary_score will raise an error at the beginning if y_true is not binary or multilabel-indicator so we don't need to raise an error in average_precision_score.