### PR TITLE
[MRG] Move RandomTreesEmbedding criterion & max_features to be class attributes

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -1766,8 +1766,6 @@ class ExtraTreesRegressor(ForestRegressor):
 
 
 class RandomTreesEmbedding(BaseForest):
-    criterion = 'mse'
-    max_features = 1
     """An ensemble of totally random trees.
 
     An unsupervised transformation of a dataset to a high-dimensional
@@ -1897,6 +1895,9 @@ class RandomTreesEmbedding(BaseForest):
            NIPS 2007
 
     """
+
+    criterion = 'mse'
+    max_features = 1
 
     def __init__(self,
                  n_estimators='warn',

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -1766,6 +1766,8 @@ class ExtraTreesRegressor(ForestRegressor):
 
 
 class RandomTreesEmbedding(BaseForest):
+    criterion = 'mse'
+    max_features = 1
     """An ensemble of totally random trees.
 
     An unsupervised transformation of a dataset to a high-dimensional
@@ -1925,12 +1927,10 @@ class RandomTreesEmbedding(BaseForest):
             verbose=verbose,
             warm_start=warm_start)
 
-        self.criterion = 'mse'
         self.max_depth = max_depth
         self.min_samples_split = min_samples_split
         self.min_samples_leaf = min_samples_leaf
         self.min_weight_fraction_leaf = min_weight_fraction_leaf
-        self.max_features = 1
         self.max_leaf_nodes = max_leaf_nodes
         self.min_impurity_decrease = min_impurity_decrease
         self.min_impurity_split = min_impurity_split


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes https://github.com/scikit-learn/scikit-learn/issues/12290.


#### What does this implement/fix? Explain your changes.
As per the discussion in https://github.com/scikit-learn/scikit-learn/issues/12290, the `__init__` function in the `RandomTreesEmbedding` class sets `self.criterion` and `self.max_features` even though they are not input parameters into the class. Instead of doing this, we'd like to move these properties to be class attributes instead, set outside of the `__init__` method, per a suggestion given by @jnothman .

