### PR TITLE
[MRG] FIX make count_nonzero dtype invariant wrt axis

### DIFF
--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -467,7 +467,8 @@ def count_nonzero(X, axis=None, sample_weight=None):
     elif axis == 1:
         out = np.diff(X.indptr)
         if sample_weight is None:
-            return out
+            # astype here is for consistency with axis=0 dtype
+            return out.astype('intp')
         return out * sample_weight
     elif axis == 0:
         if sample_weight is None:

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -443,6 +443,19 @@ def test_count_nonzero():
     assert_raises(TypeError, count_nonzero, X_csc)
     assert_raises(ValueError, count_nonzero, X_csr, axis=2)
 
+    assert (count_nonzero(X_csr, axis=0).dtype ==
+            count_nonzero(X_csr, axis=1).dtype)
+    assert (count_nonzero(X_csr, axis=0, sample_weight=sample_weight).dtype ==
+            count_nonzero(X_csr, axis=1, sample_weight=sample_weight).dtype)
+
+    # Check dtypes with large sparse matrices too
+    X_csr = sp.csr_matrix((X_csr.data, X_csr.indices.astype(np.int64),
+                           X_csr.indptr.astype(np.int64)), shape=X_csr.shape)
+    assert (count_nonzero(X_csr, axis=0).dtype ==
+            count_nonzero(X_csr, axis=1).dtype)
+    assert (count_nonzero(X_csr, axis=0, sample_weight=sample_weight).dtype ==
+            count_nonzero(X_csr, axis=1, sample_weight=sample_weight).dtype)
+
 
 def test_csc_row_median():
     # Test csc_row_median actually calculates the median.

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -449,8 +449,8 @@ def test_count_nonzero():
             count_nonzero(X_csr, axis=1, sample_weight=sample_weight).dtype)
 
     # Check dtypes with large sparse matrices too
-    X_csr = sp.csr_matrix((X_csr.data, X_csr.indices.astype(np.int64),
-                           X_csr.indptr.astype(np.int64)), shape=X_csr.shape)
+    X_csr.indices = X_csr.indices.astype(np.int64)
+    X_csr.indptr = X_csr.indptr.astype(np.int64)
     assert (count_nonzero(X_csr, axis=0).dtype ==
             count_nonzero(X_csr, axis=1).dtype)
     assert (count_nonzero(X_csr, axis=0, sample_weight=sample_weight).dtype ==


### PR DESCRIPTION
Pulled out of #11179, where using `samplewise=True` changed the confusion matrix dtype.

I don't think this should affect any public interfaces until #11179.