### PR TITLE
FIX remove all mention to externals.joblib in the codebase

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,8 @@ scikit-learn requires:
 Scikit-learn 0.21 and later will require Python 3.5 or newer.
 
 For running the examples Matplotlib >= 1.4 is required. A few examples
-require scikit-image >= 0.11.3 and a few examples require pandas >= 0.17.1.
+require scikit-image >= 0.11.3, a few examples require pandas >= 0.17.1
+and a few example require joblib >= 0.11.
 
 scikit-learn also uses CBLAS, the C interface to the Basic Linear Algebra
 Subprograms library. scikit-learn comes with a reference implementation, but

--- a/benchmarks/bench_covertype.py
+++ b/benchmarks/bench_covertype.py
@@ -50,6 +50,7 @@ import os
 from time import time
 import argparse
 import numpy as np
+from joblib import Memory
 
 from sklearn.datasets import fetch_covtype, get_data_home
 from sklearn.svm import LinearSVC
@@ -59,7 +60,6 @@ from sklearn.tree import DecisionTreeClassifier
 from sklearn.ensemble import RandomForestClassifier, ExtraTreesClassifier
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.metrics import zero_one_loss
-from sklearn.utils._joblib import Memory
 from sklearn.utils import check_array
 
 # Memoize the data extraction and memory map the resulting

--- a/benchmarks/bench_covertype.py
+++ b/benchmarks/bench_covertype.py
@@ -59,7 +59,7 @@ from sklearn.tree import DecisionTreeClassifier
 from sklearn.ensemble import RandomForestClassifier, ExtraTreesClassifier
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.metrics import zero_one_loss
-from sklearn.utils import Memory
+from sklearn.utils._joblib import Memory
 from sklearn.utils import check_array
 
 # Memoize the data extraction and memory map the resulting

--- a/benchmarks/bench_mnist.py
+++ b/benchmarks/bench_mnist.py
@@ -35,13 +35,13 @@ import os
 from time import time
 import argparse
 import numpy as np
+from joblib import Memory
 
 from sklearn.datasets import fetch_mldata
 from sklearn.datasets import get_data_home
 from sklearn.ensemble import ExtraTreesClassifier
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.dummy import DummyClassifier
-from sklearn.utils._joblib import Memory
 from sklearn.kernel_approximation import Nystroem
 from sklearn.kernel_approximation import RBFSampler
 from sklearn.metrics import zero_one_loss

--- a/benchmarks/bench_mnist.py
+++ b/benchmarks/bench_mnist.py
@@ -41,7 +41,7 @@ from sklearn.datasets import get_data_home
 from sklearn.ensemble import ExtraTreesClassifier
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.dummy import DummyClassifier
-from sklearn.utils import Memory
+from sklearn.utils._joblib import Memory
 from sklearn.kernel_approximation import Nystroem
 from sklearn.kernel_approximation import RBFSampler
 from sklearn.metrics import zero_one_loss

--- a/benchmarks/bench_plot_nmf.py
+++ b/benchmarks/bench_plot_nmf.py
@@ -22,7 +22,7 @@ from sklearn.decomposition.nmf import NMF
 from sklearn.decomposition.nmf import _initialize_nmf
 from sklearn.decomposition.nmf import _beta_divergence
 from sklearn.decomposition.nmf import INTEGER_TYPES, _check_init
-from sklearn.utils import Memory
+from sklearn.utils._joblib import Memory
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils.extmath import safe_sparse_dot, squared_norm
 from sklearn.utils import check_array

--- a/benchmarks/bench_plot_nmf.py
+++ b/benchmarks/bench_plot_nmf.py
@@ -14,6 +14,7 @@ import numbers
 
 import numpy as np
 import matplotlib.pyplot as plt
+from joblib import Memory
 import pandas
 
 from sklearn.utils.testing import ignore_warnings
@@ -22,7 +23,6 @@ from sklearn.decomposition.nmf import NMF
 from sklearn.decomposition.nmf import _initialize_nmf
 from sklearn.decomposition.nmf import _beta_divergence
 from sklearn.decomposition.nmf import INTEGER_TYPES, _check_init
-from sklearn.utils._joblib import Memory
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils.extmath import safe_sparse_dot, squared_norm
 from sklearn.utils import check_array

--- a/benchmarks/bench_rcv1_logreg_convergence.py
+++ b/benchmarks/bench_rcv1_logreg_convergence.py
@@ -4,11 +4,11 @@
 # License: BSD 3 clause
 
 import matplotlib.pyplot as plt
+from joblib import Memory
 import numpy as np
 import gc
 import time
 
-from sklearn.utils._joblib import Memory
 from sklearn.linear_model import (LogisticRegression, SGDClassifier)
 from sklearn.datasets import fetch_rcv1
 from sklearn.linear_model.sag import get_auto_step_size

--- a/benchmarks/bench_rcv1_logreg_convergence.py
+++ b/benchmarks/bench_rcv1_logreg_convergence.py
@@ -8,7 +8,7 @@ import numpy as np
 import gc
 import time
 
-from sklearn.utils import Memory
+from sklearn.utils._joblib import Memory
 from sklearn.linear_model import (LogisticRegression, SGDClassifier)
 from sklearn.datasets import fetch_rcv1
 from sklearn.linear_model.sag import get_auto_step_size

--- a/benchmarks/bench_saga.py
+++ b/benchmarks/bench_saga.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from sklearn.datasets import fetch_rcv1, load_iris, load_digits, \
     fetch_20newsgroups_vectorized
-from sklearn.utils import delayed, Parallel, Memory
+from sklearn.utils._joblib import delayed, Parallel, Memory
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import log_loss
 from sklearn.model_selection import train_test_split

--- a/benchmarks/bench_saga.py
+++ b/benchmarks/bench_saga.py
@@ -7,12 +7,12 @@ import json
 import time
 from os.path import expanduser
 
+from joblib import delayed, Parallel, Memory
 import matplotlib.pyplot as plt
 import numpy as np
 
 from sklearn.datasets import fetch_rcv1, load_iris, load_digits, \
     fetch_20newsgroups_vectorized
-from sklearn.utils._joblib import delayed, Parallel, Memory
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import log_loss
 from sklearn.model_selection import train_test_split

--- a/benchmarks/bench_tsne_mnist.py
+++ b/benchmarks/bench_tsne_mnist.py
@@ -15,7 +15,7 @@ import numpy as np
 import json
 import argparse
 
-from sklearn.utils import Memory
+from sklearn.utils._joblib import Memory
 from sklearn.datasets import fetch_mldata
 from sklearn.manifold import TSNE
 from sklearn.neighbors import NearestNeighbors

--- a/benchmarks/bench_tsne_mnist.py
+++ b/benchmarks/bench_tsne_mnist.py
@@ -14,8 +14,8 @@ from time import time
 import numpy as np
 import json
 import argparse
+from joblib import Memory
 
-from sklearn.utils._joblib import Memory
 from sklearn.datasets import fetch_mldata
 from sklearn.manifold import TSNE
 from sklearn.neighbors import NearestNeighbors

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -120,7 +120,8 @@ conda update --yes --quiet conda
 conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
   numpy="${NUMPY_VERSION:-*}" scipy="${SCIPY_VERSION:-*}" cython \
   pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=1.6.2 pillow \
-  scikit-image="${SCIKIT_IMAGE_VERSION:-*}" pandas="${PANDAS_VERSION:-*}"
+  scikit-image="${SCIKIT_IMAGE_VERSION:-*}" pandas="${PANDAS_VERSION:-*}" \
+  joblib
 
 source activate testenv
 pip install sphinx-gallery

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1482,18 +1482,10 @@ Utilities from joblib:
 
 .. autosummary::
    :toctree: generated/
-   :template: class.rst
-
-   utils.Memory
-   utils.Parallel
-
-.. autosummary::
-   :toctree: generated/
    :template: function.rst
 
-   utils.cpu_count
-   utils.delayed
    utils.parallel_backend
+   utils.register_parallel_backend
 
 Recently deprecated
 ===================
@@ -1503,8 +1495,17 @@ To be removed in 0.23
 
 .. autosummary::
    :toctree: generated/
+   :template: deprecated_class.rst
+
+   utils.Memory
+   utils.Parallel
+
+.. autosummary::
+   :toctree: generated/
    :template: deprecated_function.rst
 
+   utils.cpu_count
+   utils.delayed
    metrics.calinski_harabaz_score
 
 

--- a/doc/modules/model_persistence.rst
+++ b/doc/modules/model_persistence.rst
@@ -36,22 +36,22 @@ persistence model, namely `pickle <https://docs.python.org/2/library/pickle.html
   0
 
 In the specific case of scikit-learn, it may be better to use
-joblib's replacement of pickle (``joblib.dump`` & ``joblib.load``),
+joblib's replacement of pickle in utils (``dump`` & ``load``),
 which is more efficient on objects that carry large numpy arrays internally as
 is often the case for fitted scikit-learn estimators, but can only pickle to the
 disk and not to a string::
 
-  >>> from sklearn.utils import joblib
-  >>> joblib.dump(clf, 'filename.joblib') # doctest: +SKIP
+  >>> from sklearn.utils import dump, load
+  >>> dump(clf, 'filename.joblib') # doctest: +SKIP
 
 Later you can load back the pickled model (possibly in another Python process)
 with::
 
-  >>> clf = joblib.load('filename.joblib') # doctest:+SKIP
+  >>> clf = load('filename.joblib') # doctest:+SKIP
 
 .. note::
 
-   ``joblib.dump`` and ``joblib.load`` functions also accept file-like object
+   ``dump`` and ``load`` functions also accept file-like object
    instead of filenames. More information on data persistence with Joblib is
    available `here <https://pythonhosted.org/joblib/persistence.html>`_.
 

--- a/doc/modules/model_persistence.rst
+++ b/doc/modules/model_persistence.rst
@@ -35,11 +35,11 @@ persistence model, namely `pickle <https://docs.python.org/2/library/pickle.html
   >>> y[0]
   0
 
-In the specific case of scikit-learn, it may be better to use
-joblib's replacement of pickle in utils (``dump`` & ``load``),
-which is more efficient on objects that carry large numpy arrays internally as
-is often the case for fitted scikit-learn estimators, but can only pickle to the
-disk and not to a string::
+In the specific case of scikit-learn, it may be better to use joblib's
+replacement of pickle (``dump`` & ``load``), which is more efficient on
+objects that carry large numpy arrays internally as is often the case for
+fitted scikit-learn estimators, but can only pickle to the disk and not to a
+string::
 
   >>> from joblib import dump, load
   >>> dump(clf, 'filename.joblib') # doctest: +SKIP
@@ -53,7 +53,7 @@ with::
 
    ``dump`` and ``load`` functions also accept file-like object
    instead of filenames. More information on data persistence with Joblib is
-   available `here <https://pythonhosted.org/joblib/persistence.html>`_.
+   available `here <https://joblib.readthedocs.io/en/latest/persistence.html>`_.
 
 .. _persistence_limitations:
 

--- a/doc/modules/model_persistence.rst
+++ b/doc/modules/model_persistence.rst
@@ -41,7 +41,7 @@ which is more efficient on objects that carry large numpy arrays internally as
 is often the case for fitted scikit-learn estimators, but can only pickle to the
 disk and not to a string::
 
-  >>> from sklearn.externals import joblib
+  >>> from sklearn.utils import joblib
   >>> joblib.dump(clf, 'filename.joblib') # doctest: +SKIP
 
 Later you can load back the pickled model (possibly in another Python process)

--- a/doc/modules/model_persistence.rst
+++ b/doc/modules/model_persistence.rst
@@ -41,7 +41,7 @@ which is more efficient on objects that carry large numpy arrays internally as
 is often the case for fitted scikit-learn estimators, but can only pickle to the
 disk and not to a string::
 
-  >>> from sklearn.utils import dump, load
+  >>> from joblib import dump, load
   >>> dump(clf, 'filename.joblib') # doctest: +SKIP
 
 Later you can load back the pickled model (possibly in another Python process)

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -234,21 +234,21 @@ persistence model, `pickle <https://docs.python.org/2/library/pickle.html>`_::
   0
 
 In the specific case of scikit-learn, it may be more interesting to use
-joblib's replacement for pickle (``joblib.dump`` & ``joblib.load``),
+joblib's replacement for pickle in utils (``dump`` & ``load``),
 which is more efficient on big data but it can only pickle to the disk
 and not to a string::
 
-  >>> from sklearn.utils import joblib
-  >>> joblib.dump(clf, 'filename.joblib') # doctest: +SKIP
+  >>> from sklearn.utils import dump, load
+  >>> dump(clf, 'filename.joblib') # doctest: +SKIP
 
 Later, you can reload the pickled model (possibly in another Python process)
 with::
 
-  >>> clf = joblib.load('filename.joblib') # doctest:+SKIP
+  >>> clf = load('filename.joblib') # doctest:+SKIP
 
 .. note::
 
-    ``joblib.dump`` and ``joblib.load`` functions also accept file-like object
+    ``dump`` and ``load`` functions also accept file-like object
     instead of filenames. More information on data persistence with Joblib is
     available `here <https://joblib.readthedocs.io/en/latest/persistence.html>`_.
 

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -238,7 +238,7 @@ joblib's replacement for pickle in utils (``dump`` & ``load``),
 which is more efficient on big data but it can only pickle to the disk
 and not to a string::
 
-  >>> from sklearn.utils import dump, load
+  >>> from joblib import dump, load
   >>> dump(clf, 'filename.joblib') # doctest: +SKIP
 
 Later, you can reload the pickled model (possibly in another Python process)

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -238,7 +238,7 @@ joblib's replacement for pickle (``joblib.dump`` & ``joblib.load``),
 which is more efficient on big data but it can only pickle to the disk
 and not to a string::
 
-  >>> from sklearn.externals import joblib
+  >>> from sklearn.utils import joblib
   >>> joblib.dump(clf, 'filename.joblib') # doctest: +SKIP
 
 Later, you can reload the pickled model (possibly in another Python process)

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -234,7 +234,7 @@ persistence model, `pickle <https://docs.python.org/2/library/pickle.html>`_::
   0
 
 In the specific case of scikit-learn, it may be more interesting to use
-joblib's replacement for pickle in utils (``dump`` & ``load``),
+joblib's replacement for pickle (``joblib.dump`` & ``joblib.load``),
 which is more efficient on big data but it can only pickle to the disk
 and not to a string::
 
@@ -248,7 +248,7 @@ with::
 
 .. note::
 
-    ``dump`` and ``load`` functions also accept file-like object
+    ``joblib.dump`` and ``joblib.load`` functions also accept file-like object
     instead of filenames. More information on data persistence with Joblib is
     available `here <https://joblib.readthedocs.io/en/latest/persistence.html>`_.
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -175,9 +175,9 @@ Changelog
 Miscellaneous
 .............
 
-- |Fix| Deprecated using joblib from `sklearn.utils` and removed all
-  mentions to `sklearn.externals.joblib`. Only `parallel_backend` and
-  `register_parallel_backend` are accessible in `utils`.
+- |Fix| Removed all mentions of `sklearn.externals.joblib`, and deprecated
+  joblib methods exposed in `sklearn.utils`, except for
+  :func:`utils.parallel_backend` and :func:`utils.register_parallel_backend`.
   :issue:`12345` by :user:`Thomas Moreau <tomMoral>`
 
 - |Fix| When using site joblib by setting the environment variable
@@ -192,7 +192,6 @@ Miscellaneous
 .. _changes_0_20:
 
 Version 0.20.0
-
 ==============
 
 **September, 2018**

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -175,12 +175,13 @@ Changelog
 Miscellaneous
 .............
 
-- |Fix| Removed all mentions of `sklearn.externals.joblib`, and deprecated
-  joblib methods exposed in `sklearn.utils`, except for
+- |API| Removed all mentions of ``sklearn.externals.joblib``, and deprecated
+  joblib methods exposed in ``sklearn.utils``, except for
   :func:`utils.parallel_backend` and :func:`utils.register_parallel_backend`,
   which impact the behavior of `sklearn`. Other functionalities are part of
-  the [joblib](https://joblib.readthedocs.io/) package and should be used
-  directly, by installing it.
+  the `joblib <https://joblib.readthedocs.io/>`_ package and should be used
+  directly, by installing it. The goal of this change is to prepare for
+  unvendoring joblib in future version of scikit-learn.
   :issue:`12345` by :user:`Thomas Moreau <tomMoral>`
 
 - |Fix| When using site joblib by setting the environment variable

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -175,12 +175,14 @@ Changelog
 Miscellaneous
 .............
 
+- |Fix| Deprecated using joblib from `sklearn.utils` and removed all
+  mentions to `sklearn.externals.joblib`. Only `parallel_backend` and
+  `register_parallel_backend` are accessible in `utils`.
+  :issue:`12345` by :user:`Thomas Moreau <tomMoral>`
+
 - |Fix| When using site joblib by setting the environment variable
   `SKLEARN_SITE_JOBLIB`, added compatibility with joblib 0.11 in addition
   to 0.12+. :issue:`12350` by `Joel Nothman`_ and `Roman Yurchak`_.
-
-Miscellaneous
-.............
 
 - |Fix| Make sure to avoid raising ``FutureWarning`` when calling
   ``np.vstack`` with numpy 1.16 and later (use list comprehensions
@@ -190,6 +192,7 @@ Miscellaneous
 .. _changes_0_20:
 
 Version 0.20.0
+
 ==============
 
 **September, 2018**

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -178,9 +178,10 @@ Miscellaneous
 - |API| Removed all mentions of ``sklearn.externals.joblib``, and deprecated
   joblib methods exposed in ``sklearn.utils``, except for
   :func:`utils.parallel_backend` and :func:`utils.register_parallel_backend`,
-  which impact the behavior of `sklearn`. Other functionalities are part of
-  the `joblib <https://joblib.readthedocs.io/>`_ package and should be used
-  directly, by installing it. The goal of this change is to prepare for
+  which allow users to configure parallel computation in scikit-learn.
+  Other functionalities are part of `joblib <https://joblib.readthedocs.io/>`_.
+  package and should be used directly, by installing it.
+  The goal of this change is to prepare for
   unvendoring joblib in future version of scikit-learn.
   :issue:`12345` by :user:`Thomas Moreau <tomMoral>`
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -177,7 +177,10 @@ Miscellaneous
 
 - |Fix| Removed all mentions of `sklearn.externals.joblib`, and deprecated
   joblib methods exposed in `sklearn.utils`, except for
-  :func:`utils.parallel_backend` and :func:`utils.register_parallel_backend`.
+  :func:`utils.parallel_backend` and :func:`utils.register_parallel_backend`,
+  which impact the behavior of `sklearn`. Other functionalities are part of
+  the [joblib](https://joblib.readthedocs.io/) package and should be used
+  directly, by installing it.
   :issue:`12345` by :user:`Thomas Moreau <tomMoral>`
 
 - |Fix| When using site joblib by setting the environment variable

--- a/examples/applications/wikipedia_principal_eigenvector.py
+++ b/examples/applications/wikipedia_principal_eigenvector.py
@@ -44,8 +44,9 @@ import numpy as np
 
 from scipy import sparse
 
+from joblib import Memory
+
 from sklearn.decomposition import randomized_svd
-from sklearn.utils import Memory
 from sklearn.externals.six.moves.urllib.request import urlopen
 from sklearn.externals.six import iteritems
 

--- a/examples/cluster/plot_feature_agglomeration_vs_univariate_selection.py
+++ b/examples/cluster/plot_feature_agglomeration_vs_univariate_selection.py
@@ -24,13 +24,13 @@ import tempfile
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy import linalg, ndimage
+from joblib import Memory
 
 from sklearn.feature_extraction.image import grid_to_graph
 from sklearn import feature_selection
 from sklearn.cluster import FeatureAgglomeration
 from sklearn.linear_model import BayesianRidge
 from sklearn.pipeline import Pipeline
-from sklearn.utils import Memory
 from sklearn.model_selection import GridSearchCV
 from sklearn.model_selection import KFold
 

--- a/examples/compose/plot_compare_reduction.py
+++ b/examples/compose/plot_compare_reduction.py
@@ -105,7 +105,7 @@ plt.show()
 
 from tempfile import mkdtemp
 from shutil import rmtree
-from sklearn.utils import Memory
+from joblib import Memory
 
 # Create a temporary folder to store the transformers of the pipeline
 cachedir = mkdtemp()

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -29,9 +29,9 @@ from ..utils import gen_batches
 from ..utils import check_random_state
 from ..utils.validation import check_is_fitted
 from ..utils.validation import FLOAT_DTYPES
-from ..utils import Parallel
-from ..utils import delayed
-from ..utils import effective_n_jobs
+from ..utils._joblib import Parallel
+from ..utils._joblib import delayed
+from ..utils._joblib import effective_n_jobs
 from ..externals.six import string_types
 from ..exceptions import ConvergenceWarning
 from . import _k_means

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -24,8 +24,8 @@ from ..utils import check_random_state, gen_batches, check_array
 from ..base import BaseEstimator, ClusterMixin
 from ..neighbors import NearestNeighbors
 from ..metrics.pairwise import pairwise_distances_argmin
-from ..utils import Parallel
-from ..utils import delayed
+from ..utils._joblib import Parallel
+from ..utils._joblib import delayed
 
 
 def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0,

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -14,7 +14,7 @@ import numpy as np
 from scipy import sparse
 
 from ..base import clone, TransformerMixin
-from ..utils import Parallel, delayed
+from ..utils._joblib import Parallel, delayed
 from ..externals import six
 from ..pipeline import _fit_transform_one, _transform_one, _name_estimators
 from ..preprocessing import FunctionTransformer

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -23,7 +23,7 @@ from ..utils.fixes import _Sequence as Sequence
 from ..linear_model import lars_path
 from ..linear_model import cd_fast
 from ..model_selection import check_cv, cross_val_score
-from ..utils import Parallel, delayed
+from ..utils._joblib import Parallel, delayed
 
 
 # Helper functions to compute the objective and dual objective functions

--- a/sklearn/datasets/california_housing.py
+++ b/sklearn/datasets/california_housing.py
@@ -33,7 +33,7 @@ from .base import _fetch_remote
 from .base import _pkl_filepath
 from .base import RemoteFileMetadata
 from ..utils import Bunch
-from ..utils._joblib import dump, load
+from ..utils import _joblib
 
 # The original data can be found at:
 # https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.tgz
@@ -124,11 +124,11 @@ def fetch_california_housing(data_home=None, download_if_missing=True,
             columns_index = [8, 7, 2, 3, 4, 5, 6, 1, 0]
             cal_housing = cal_housing[:, columns_index]
 
-            dump(cal_housing, filepath, compress=6)
+            _joblib.dump(cal_housing, filepath, compress=6)
         remove(archive_path)
 
     else:
-        cal_housing = load(filepath)
+        cal_housing = _joblib.load(filepath)
 
     feature_names = ["MedInc", "HouseAge", "AveRooms", "AveBedrms",
                      "Population", "AveOccup", "Latitude", "Longitude"]

--- a/sklearn/datasets/california_housing.py
+++ b/sklearn/datasets/california_housing.py
@@ -33,7 +33,7 @@ from .base import _fetch_remote
 from .base import _pkl_filepath
 from .base import RemoteFileMetadata
 from ..utils import Bunch
-from ..externals import joblib
+from ..utils import joblib
 
 # The original data can be found at:
 # https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.tgz

--- a/sklearn/datasets/california_housing.py
+++ b/sklearn/datasets/california_housing.py
@@ -33,7 +33,7 @@ from .base import _fetch_remote
 from .base import _pkl_filepath
 from .base import RemoteFileMetadata
 from ..utils import Bunch
-from ..utils import dump, load
+from ..utils._joblib import dump, load
 
 # The original data can be found at:
 # https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.tgz

--- a/sklearn/datasets/california_housing.py
+++ b/sklearn/datasets/california_housing.py
@@ -33,7 +33,7 @@ from .base import _fetch_remote
 from .base import _pkl_filepath
 from .base import RemoteFileMetadata
 from ..utils import Bunch
-from ..utils import joblib
+from ..utils import dump, load
 
 # The original data can be found at:
 # https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.tgz
@@ -124,11 +124,11 @@ def fetch_california_housing(data_home=None, download_if_missing=True,
             columns_index = [8, 7, 2, 3, 4, 5, 6, 1, 0]
             cal_housing = cal_housing[:, columns_index]
 
-            joblib.dump(cal_housing, filepath, compress=6)
+            dump(cal_housing, filepath, compress=6)
         remove(archive_path)
 
     else:
-        cal_housing = joblib.load(filepath)
+        cal_housing = load(filepath)
 
     feature_names = ["MedInc", "HouseAge", "AveRooms", "AveBedrms",
                      "Population", "AveOccup", "Latitude", "Longitude"]

--- a/sklearn/datasets/covtype.py
+++ b/sklearn/datasets/covtype.py
@@ -27,7 +27,7 @@ from .base import RemoteFileMetadata
 from ..utils import Bunch
 from .base import _pkl_filepath
 from ..utils.fixes import makedirs
-from ..externals import joblib
+from ..utils import joblib
 from ..utils import check_random_state
 
 # The original data can be found in:

--- a/sklearn/datasets/covtype.py
+++ b/sklearn/datasets/covtype.py
@@ -27,7 +27,7 @@ from .base import RemoteFileMetadata
 from ..utils import Bunch
 from .base import _pkl_filepath
 from ..utils.fixes import makedirs
-from ..utils._joblib import dump, load
+from ..utils import _joblib
 from ..utils import check_random_state
 
 # The original data can be found in:
@@ -118,16 +118,16 @@ def fetch_covtype(data_home=None, download_if_missing=True,
         X = Xy[:, :-1]
         y = Xy[:, -1].astype(np.int32)
 
-        dump(X, samples_path, compress=9)
-        dump(y, targets_path, compress=9)
+        _joblib.dump(X, samples_path, compress=9)
+        _joblib.dump(y, targets_path, compress=9)
 
     elif not available and not download_if_missing:
         raise IOError("Data not found and `download_if_missing` is False")
     try:
         X, y
     except NameError:
-        X = load(samples_path)
-        y = load(targets_path)
+        X = _joblib.load(samples_path)
+        y = _joblib.load(targets_path)
 
     if shuffle:
         ind = np.arange(X.shape[0])

--- a/sklearn/datasets/covtype.py
+++ b/sklearn/datasets/covtype.py
@@ -27,7 +27,7 @@ from .base import RemoteFileMetadata
 from ..utils import Bunch
 from .base import _pkl_filepath
 from ..utils.fixes import makedirs
-from ..utils import dump, load
+from ..utils._joblib import dump, load
 from ..utils import check_random_state
 
 # The original data can be found in:

--- a/sklearn/datasets/covtype.py
+++ b/sklearn/datasets/covtype.py
@@ -27,7 +27,7 @@ from .base import RemoteFileMetadata
 from ..utils import Bunch
 from .base import _pkl_filepath
 from ..utils.fixes import makedirs
-from ..utils import joblib
+from ..utils import dump, load
 from ..utils import check_random_state
 
 # The original data can be found in:
@@ -118,16 +118,16 @@ def fetch_covtype(data_home=None, download_if_missing=True,
         X = Xy[:, :-1]
         y = Xy[:, -1].astype(np.int32)
 
-        joblib.dump(X, samples_path, compress=9)
-        joblib.dump(y, targets_path, compress=9)
+        dump(X, samples_path, compress=9)
+        dump(y, targets_path, compress=9)
 
     elif not available and not download_if_missing:
         raise IOError("Data not found and `download_if_missing` is False")
     try:
         X, y
     except NameError:
-        X = joblib.load(samples_path)
-        y = joblib.load(targets_path)
+        X = load(samples_path)
+        y = load(targets_path)
 
     if shuffle:
         ind = np.arange(X.shape[0])

--- a/sklearn/datasets/kddcup99.py
+++ b/sklearn/datasets/kddcup99.py
@@ -23,7 +23,7 @@ from .base import get_data_home
 from .base import RemoteFileMetadata
 from ..externals import six
 from ..utils import Bunch
-from ..utils._joblib import dump, load
+from ..utils import _joblib
 from ..utils import check_random_state
 from ..utils import shuffle as shuffle_method
 
@@ -294,8 +294,8 @@ def _fetch_brute_kddcup99(data_home=None,
         # (error: 'Incorrect data length while decompressing[...] the file
         #  could be corrupted.')
 
-        dump(X, samples_path, compress=0)
-        dump(y, targets_path, compress=0)
+        _joblib.dump(X, samples_path, compress=0)
+        _joblib.dump(y, targets_path, compress=0)
     elif not available:
         if not download_if_missing:
             raise IOError("Data not found and `download_if_missing` is False")
@@ -303,8 +303,8 @@ def _fetch_brute_kddcup99(data_home=None,
     try:
         X, y
     except NameError:
-        X = load(samples_path)
-        y = load(targets_path)
+        X = _joblib.load(samples_path)
+        y = _joblib.load(targets_path)
 
     return Bunch(data=X, target=y)
 

--- a/sklearn/datasets/kddcup99.py
+++ b/sklearn/datasets/kddcup99.py
@@ -21,8 +21,9 @@ import numpy as np
 from .base import _fetch_remote
 from .base import get_data_home
 from .base import RemoteFileMetadata
+from ..externals import six
 from ..utils import Bunch
-from ..externals import joblib, six
+from ..utils import joblib
 from ..utils import check_random_state
 from ..utils import shuffle as shuffle_method
 

--- a/sklearn/datasets/kddcup99.py
+++ b/sklearn/datasets/kddcup99.py
@@ -23,7 +23,7 @@ from .base import get_data_home
 from .base import RemoteFileMetadata
 from ..externals import six
 from ..utils import Bunch
-from ..utils import joblib
+from ..utils import dump, load
 from ..utils import check_random_state
 from ..utils import shuffle as shuffle_method
 
@@ -294,8 +294,8 @@ def _fetch_brute_kddcup99(data_home=None,
         # (error: 'Incorrect data length while decompressing[...] the file
         #  could be corrupted.')
 
-        joblib.dump(X, samples_path, compress=0)
-        joblib.dump(y, targets_path, compress=0)
+        dump(X, samples_path, compress=0)
+        dump(y, targets_path, compress=0)
     elif not available:
         if not download_if_missing:
             raise IOError("Data not found and `download_if_missing` is False")
@@ -303,8 +303,8 @@ def _fetch_brute_kddcup99(data_home=None,
     try:
         X, y
     except NameError:
-        X = joblib.load(samples_path)
-        y = joblib.load(targets_path)
+        X = load(samples_path)
+        y = load(targets_path)
 
     return Bunch(data=X, target=y)
 

--- a/sklearn/datasets/kddcup99.py
+++ b/sklearn/datasets/kddcup99.py
@@ -23,7 +23,7 @@ from .base import get_data_home
 from .base import RemoteFileMetadata
 from ..externals import six
 from ..utils import Bunch
-from ..utils import dump, load
+from ..utils._joblib import dump, load
 from ..utils import check_random_state
 from ..utils import shuffle as shuffle_method
 

--- a/sklearn/datasets/lfw.py
+++ b/sklearn/datasets/lfw.py
@@ -20,8 +20,8 @@ from .base import get_data_home, _fetch_remote, RemoteFileMetadata
 from ..utils import deprecated
 from ..utils import Bunch
 from ..utils import Memory
-from ..utils import joblib_version
 from ..externals.six import b
+from ..utils._joblib import __version__ as joblib_version
 
 logger = logging.getLogger(__name__)
 

--- a/sklearn/datasets/lfw.py
+++ b/sklearn/datasets/lfw.py
@@ -21,7 +21,7 @@ from ..utils import deprecated
 from ..utils import Bunch
 from ..utils._joblib import Memory
 from ..externals.six import b
-from ..utils._joblib import __version__ as joblib_version
+from ..utils import _joblib
 
 logger = logging.getLogger(__name__)
 
@@ -328,7 +328,7 @@ def fetch_lfw_people(data_home=None, funneled=True, resize=0.5,
 
     # wrap the loader in a memoizing function that will return memmaped data
     # arrays for optimal memory usage
-    if LooseVersion(joblib_version) < LooseVersion('0.12'):
+    if LooseVersion(_joblib.__version__) < LooseVersion('0.12'):
         # Deal with change of API in joblib
         m = Memory(cachedir=lfw_home, compress=6, verbose=0)
     else:
@@ -499,7 +499,7 @@ def fetch_lfw_pairs(subset='train', data_home=None, funneled=True, resize=0.5,
 
     # wrap the loader in a memoizing function that will return memmaped data
     # arrays for optimal memory usage
-    if LooseVersion(joblib_version) < LooseVersion('0.12'):
+    if LooseVersion(_joblib.__version__) < LooseVersion('0.12'):
         # Deal with change of API in joblib
         m = Memory(cachedir=lfw_home, compress=6, verbose=0)
     else:

--- a/sklearn/datasets/lfw.py
+++ b/sklearn/datasets/lfw.py
@@ -20,7 +20,7 @@ from .base import get_data_home, _fetch_remote, RemoteFileMetadata
 from ..utils import deprecated
 from ..utils import Bunch
 from ..utils import Memory
-from ..utils._joblib import __version__ as joblib_version
+from ..utils import joblib_version
 from ..externals.six import b
 
 logger = logging.getLogger(__name__)

--- a/sklearn/datasets/lfw.py
+++ b/sklearn/datasets/lfw.py
@@ -19,7 +19,7 @@ import numpy as np
 from .base import get_data_home, _fetch_remote, RemoteFileMetadata
 from ..utils import deprecated
 from ..utils import Bunch
-from ..utils import Memory
+from ..utils._joblib import Memory
 from ..externals.six import b
 from ..utils._joblib import __version__ as joblib_version
 

--- a/sklearn/datasets/olivetti_faces.py
+++ b/sklearn/datasets/olivetti_faces.py
@@ -24,7 +24,7 @@ from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from .base import _pkl_filepath
 from ..utils import check_random_state, Bunch
-from ..externals import joblib
+from ..utils import joblib
 
 # The original data can be found at:
 # https://cs.nyu.edu/~roweis/data/olivettifaces.mat

--- a/sklearn/datasets/olivetti_faces.py
+++ b/sklearn/datasets/olivetti_faces.py
@@ -23,7 +23,7 @@ from .base import get_data_home
 from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from .base import _pkl_filepath
-from ..utils._joblib import dump, load
+from ..utils import _joblib
 from ..utils import check_random_state, Bunch
 
 # The original data can be found at:
@@ -104,10 +104,10 @@ def fetch_olivetti_faces(data_home=None, shuffle=False, random_state=0,
         remove(mat_path)
 
         faces = mfile['faces'].T.copy()
-        dump(faces, filepath, compress=6)
+        _joblib.dump(faces, filepath, compress=6)
         del mfile
     else:
-        faces = load(filepath)
+        faces = _joblib.load(filepath)
 
     # We want floating point data, but float32 is enough (there is only
     # one byte of precision in the original uint8s anyway)

--- a/sklearn/datasets/olivetti_faces.py
+++ b/sklearn/datasets/olivetti_faces.py
@@ -23,7 +23,7 @@ from .base import get_data_home
 from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from .base import _pkl_filepath
-from ..utils import dump, load
+from ..utils._joblib import dump, load
 from ..utils import check_random_state, Bunch
 
 # The original data can be found at:

--- a/sklearn/datasets/olivetti_faces.py
+++ b/sklearn/datasets/olivetti_faces.py
@@ -23,8 +23,8 @@ from .base import get_data_home
 from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from .base import _pkl_filepath
+from ..utils import dump, load
 from ..utils import check_random_state, Bunch
-from ..utils import joblib
 
 # The original data can be found at:
 # https://cs.nyu.edu/~roweis/data/olivettifaces.mat
@@ -104,10 +104,10 @@ def fetch_olivetti_faces(data_home=None, shuffle=False, random_state=0,
         remove(mat_path)
 
         faces = mfile['faces'].T.copy()
-        joblib.dump(faces, filepath, compress=6)
+        dump(faces, filepath, compress=6)
         del mfile
     else:
-        faces = joblib.load(filepath)
+        faces = load(filepath)
 
     # We want floating point data, but float32 is enough (there is only
     # one byte of precision in the original uint8s anyway)

--- a/sklearn/datasets/rcv1.py
+++ b/sklearn/datasets/rcv1.py
@@ -22,7 +22,7 @@ from .base import _pkl_filepath
 from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from ..utils.fixes import makedirs
-from ..utils import dump, load
+from ..utils._joblib import dump, load
 from .svmlight_format import load_svmlight_files
 from ..utils import shuffle as shuffle_
 from ..utils import Bunch

--- a/sklearn/datasets/rcv1.py
+++ b/sklearn/datasets/rcv1.py
@@ -22,7 +22,7 @@ from .base import _pkl_filepath
 from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from ..utils.fixes import makedirs
-from ..utils import joblib
+from ..utils import dump, load
 from .svmlight_format import load_svmlight_files
 from ..utils import shuffle as shuffle_
 from ..utils import Bunch
@@ -182,16 +182,16 @@ def fetch_rcv1(data_home=None, subset='all', download_if_missing=True,
         sample_id = np.hstack((Xy[9], Xy[1], Xy[3], Xy[5], Xy[7]))
         sample_id = sample_id.astype(np.uint32)
 
-        joblib.dump(X, samples_path, compress=9)
-        joblib.dump(sample_id, sample_id_path, compress=9)
+        dump(X, samples_path, compress=9)
+        dump(sample_id, sample_id_path, compress=9)
 
         # delete archives
         for f in files:
             f.close()
             remove(f.name)
     else:
-        X = joblib.load(samples_path)
-        sample_id = joblib.load(sample_id_path)
+        X = load(samples_path)
+        sample_id = load(sample_id_path)
 
     # load target (y), categories, and sample_id_bis
     if download_if_missing and (not exists(sample_topics_path) or
@@ -241,11 +241,11 @@ def fetch_rcv1(data_home=None, subset='all', download_if_missing=True,
         categories = categories[order]
         y = sp.csr_matrix(y[:, order])
 
-        joblib.dump(y, sample_topics_path, compress=9)
-        joblib.dump(categories, topics_path, compress=9)
+        dump(y, sample_topics_path, compress=9)
+        dump(categories, topics_path, compress=9)
     else:
-        y = joblib.load(sample_topics_path)
-        categories = joblib.load(topics_path)
+        y = load(sample_topics_path)
+        categories = load(topics_path)
 
     if subset == 'all':
         pass

--- a/sklearn/datasets/rcv1.py
+++ b/sklearn/datasets/rcv1.py
@@ -22,7 +22,7 @@ from .base import _pkl_filepath
 from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from ..utils.fixes import makedirs
-from ..utils._joblib import dump, load
+from ..utils import _joblib
 from .svmlight_format import load_svmlight_files
 from ..utils import shuffle as shuffle_
 from ..utils import Bunch
@@ -182,16 +182,16 @@ def fetch_rcv1(data_home=None, subset='all', download_if_missing=True,
         sample_id = np.hstack((Xy[9], Xy[1], Xy[3], Xy[5], Xy[7]))
         sample_id = sample_id.astype(np.uint32)
 
-        dump(X, samples_path, compress=9)
-        dump(sample_id, sample_id_path, compress=9)
+        _joblib.dump(X, samples_path, compress=9)
+        _joblib.dump(sample_id, sample_id_path, compress=9)
 
         # delete archives
         for f in files:
             f.close()
             remove(f.name)
     else:
-        X = load(samples_path)
-        sample_id = load(sample_id_path)
+        X = _joblib.load(samples_path)
+        sample_id = _joblib.load(sample_id_path)
 
     # load target (y), categories, and sample_id_bis
     if download_if_missing and (not exists(sample_topics_path) or
@@ -241,11 +241,11 @@ def fetch_rcv1(data_home=None, subset='all', download_if_missing=True,
         categories = categories[order]
         y = sp.csr_matrix(y[:, order])
 
-        dump(y, sample_topics_path, compress=9)
-        dump(categories, topics_path, compress=9)
+        _joblib.dump(y, sample_topics_path, compress=9)
+        _joblib.dump(categories, topics_path, compress=9)
     else:
-        y = load(sample_topics_path)
-        categories = load(topics_path)
+        y = _joblib.load(sample_topics_path)
+        categories = _joblib.load(topics_path)
 
     if subset == 'all':
         pass

--- a/sklearn/datasets/rcv1.py
+++ b/sklearn/datasets/rcv1.py
@@ -22,7 +22,7 @@ from .base import _pkl_filepath
 from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from ..utils.fixes import makedirs
-from ..externals import joblib
+from ..utils import joblib
 from .svmlight_format import load_svmlight_files
 from ..utils import shuffle as shuffle_
 from ..utils import Bunch

--- a/sklearn/datasets/species_distributions.py
+++ b/sklearn/datasets/species_distributions.py
@@ -51,7 +51,7 @@ from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from ..utils import Bunch
 from sklearn.datasets.base import _pkl_filepath
-from sklearn.utils import joblib
+from sklearn.utils import dump, load
 
 PY3_OR_LATER = sys.version_info[0] >= 3
 
@@ -265,8 +265,8 @@ def fetch_species_distributions(data_home=None,
                       test=test,
                       train=train,
                       **extra_params)
-        joblib.dump(bunch, archive_path, compress=9)
+        dump(bunch, archive_path, compress=9)
     else:
-        bunch = joblib.load(archive_path)
+        bunch = load(archive_path)
 
     return bunch

--- a/sklearn/datasets/species_distributions.py
+++ b/sklearn/datasets/species_distributions.py
@@ -51,7 +51,7 @@ from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from ..utils import Bunch
 from sklearn.datasets.base import _pkl_filepath
-from sklearn.utils import dump, load
+from sklearn.utils._joblib import dump, load
 
 PY3_OR_LATER = sys.version_info[0] >= 3
 

--- a/sklearn/datasets/species_distributions.py
+++ b/sklearn/datasets/species_distributions.py
@@ -51,7 +51,7 @@ from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from ..utils import Bunch
 from sklearn.datasets.base import _pkl_filepath
-from sklearn.externals import joblib
+from sklearn.utils import joblib
 
 PY3_OR_LATER = sys.version_info[0] >= 3
 

--- a/sklearn/datasets/species_distributions.py
+++ b/sklearn/datasets/species_distributions.py
@@ -51,7 +51,7 @@ from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from ..utils import Bunch
 from sklearn.datasets.base import _pkl_filepath
-from sklearn.utils._joblib import dump, load
+from sklearn.utils import _joblib
 
 PY3_OR_LATER = sys.version_info[0] >= 3
 
@@ -265,8 +265,8 @@ def fetch_species_distributions(data_home=None,
                       test=test,
                       train=train,
                       **extra_params)
-        dump(bunch, archive_path, compress=9)
+        _joblib.dump(bunch, archive_path, compress=9)
     else:
-        bunch = load(archive_path)
+        bunch = _joblib.load(archive_path)
 
     return bunch

--- a/sklearn/datasets/svmlight_format.py
+++ b/sklearn/datasets/svmlight_format.py
@@ -141,7 +141,7 @@ def load_svmlight_file(f, n_features=None, dtype=np.float64,
     --------
     To use joblib.Memory to cache the svmlight file::
 
-        from sklearn.utils import Memory
+        from joblib import Memory
         from sklearn.datasets import load_svmlight_file
         mem = Memory("./mycache")
 

--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -41,11 +41,11 @@ from .base import load_files
 from .base import _pkl_filepath
 from .base import _fetch_remote
 from .base import RemoteFileMetadata
-from ..utils import check_random_state, Bunch
-from ..utils import deprecated
 from ..feature_extraction.text import CountVectorizer
 from ..preprocessing import normalize
-from ..externals import joblib
+from ..utils import joblib
+from ..utils import deprecated
+from ..utils import check_random_state, Bunch
 
 logger = logging.getLogger(__name__)
 

--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -43,8 +43,8 @@ from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from ..feature_extraction.text import CountVectorizer
 from ..preprocessing import normalize
-from ..utils import joblib
 from ..utils import deprecated
+from ..utils import dump, load
 from ..utils import check_random_state, Bunch
 
 logger = logging.getLogger(__name__)
@@ -403,12 +403,12 @@ def fetch_20newsgroups_vectorized(subset="train", remove=(), data_home=None,
                                    download_if_missing=download_if_missing)
 
     if os.path.exists(target_file):
-        X_train, X_test = joblib.load(target_file)
+        X_train, X_test = load(target_file)
     else:
         vectorizer = CountVectorizer(dtype=np.int16)
         X_train = vectorizer.fit_transform(data_train.data).tocsr()
         X_test = vectorizer.transform(data_test.data).tocsr()
-        joblib.dump((X_train, X_test), target_file, compress=9)
+        dump((X_train, X_test), target_file, compress=9)
 
     # the data is stored as int16 for compactness
     # but normalize needs floats

--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -44,7 +44,7 @@ from .base import RemoteFileMetadata
 from ..feature_extraction.text import CountVectorizer
 from ..preprocessing import normalize
 from ..utils import deprecated
-from ..utils import dump, load
+from ..utils._joblib import dump, load
 from ..utils import check_random_state, Bunch
 
 logger = logging.getLogger(__name__)

--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -44,7 +44,7 @@ from .base import RemoteFileMetadata
 from ..feature_extraction.text import CountVectorizer
 from ..preprocessing import normalize
 from ..utils import deprecated
-from ..utils._joblib import dump, load
+from ..utils import _joblib
 from ..utils import check_random_state, Bunch
 
 logger = logging.getLogger(__name__)
@@ -403,12 +403,12 @@ def fetch_20newsgroups_vectorized(subset="train", remove=(), data_home=None,
                                    download_if_missing=download_if_missing)
 
     if os.path.exists(target_file):
-        X_train, X_test = load(target_file)
+        X_train, X_test = _joblib.load(target_file)
     else:
         vectorizer = CountVectorizer(dtype=np.int16)
         X_train = vectorizer.fit_transform(data_train.data).tocsr()
         X_test = vectorizer.transform(data_test.data).tocsr()
-        dump((X_train, X_test), target_file, compress=9)
+        _joblib.dump((X_train, X_test), target_file, compress=9)
 
     # the data is stored as int16 for compactness
     # but normalize needs floats

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -14,7 +14,7 @@ import numpy as np
 from scipy import linalg
 
 from ..base import BaseEstimator, TransformerMixin
-from ..utils import Parallel, delayed, effective_n_jobs
+from ..utils._joblib import Parallel, delayed, effective_n_jobs
 from ..externals.six.moves import zip
 from ..utils import (check_array, check_random_state, gen_even_slices,
                      gen_batches)

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -20,7 +20,7 @@ from ..utils import (check_random_state, check_array,
                      gen_batches, gen_even_slices)
 from ..utils.fixes import logsumexp
 from ..utils.validation import check_non_negative
-from ..utils import Parallel, delayed, effective_n_jobs
+from ..utils._joblib import Parallel, delayed, effective_n_jobs
 from ..externals.six.moves import xrange
 from ..exceptions import NotFittedError
 

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -13,7 +13,7 @@ from warnings import warn
 
 from .base import BaseEnsemble, _partition_estimators
 from ..base import ClassifierMixin, RegressorMixin
-from ..utils import Parallel, delayed
+from ..utils._joblib import Parallel, delayed
 from ..externals.six import with_metaclass
 from ..externals.six.moves import zip
 from ..metrics import r2_score, accuracy_score

--- a/sklearn/ensemble/base.py
+++ b/sklearn/ensemble/base.py
@@ -12,7 +12,7 @@ from ..base import clone
 from ..base import BaseEstimator
 from ..base import MetaEstimatorMixin
 from ..utils import check_random_state
-from ..utils import effective_n_jobs
+from ..utils._joblib import effective_n_jobs
 from ..externals import six
 from abc import ABCMeta, abstractmethod
 

--- a/sklearn/ensemble/base.py
+++ b/sklearn/ensemble/base.py
@@ -13,7 +13,7 @@ from ..base import BaseEstimator
 from ..base import MetaEstimatorMixin
 from ..utils import check_random_state
 from ..externals import six
-from ..externals.joblib import effective_n_jobs
+from .utils import effective_n_jobs
 from abc import ABCMeta, abstractmethod
 
 MAX_RAND_SEED = np.iinfo(np.int32).max

--- a/sklearn/ensemble/base.py
+++ b/sklearn/ensemble/base.py
@@ -12,8 +12,8 @@ from ..base import clone
 from ..base import BaseEstimator
 from ..base import MetaEstimatorMixin
 from ..utils import check_random_state
+from ..utils import effective_n_jobs
 from ..externals import six
-from .utils import effective_n_jobs
 from abc import ABCMeta, abstractmethod
 
 MAX_RAND_SEED = np.iinfo(np.int32).max

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -50,7 +50,7 @@ from scipy.sparse import issparse
 from scipy.sparse import hstack as sparse_hstack
 
 from ..base import ClassifierMixin, RegressorMixin
-from ..utils import Parallel, delayed
+from ..utils._joblib import Parallel, delayed
 from ..externals import six
 from ..metrics import r2_score
 from ..preprocessing import OneHotEncoder

--- a/sklearn/ensemble/partial_dependence.py
+++ b/sklearn/ensemble/partial_dependence.py
@@ -10,7 +10,7 @@ import numpy as np
 from scipy.stats.mstats import mquantiles
 
 from ..utils.extmath import cartesian
-from ..utils import Parallel, delayed
+from ..utils._joblib import Parallel, delayed
 from ..externals import six
 from ..externals.six.moves import map, range, zip
 from ..utils import check_array

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -34,7 +34,7 @@ from sklearn.feature_selection import SelectKBest
 from sklearn.model_selection import train_test_split
 from sklearn.datasets import load_boston, load_iris, make_hastie_10_2
 from sklearn.utils import check_random_state
-from sklearn.utils._joblib import joblib_hash
+from sklearn.utils import _joblib
 from sklearn.preprocessing import FunctionTransformer
 
 from scipy.sparse import csc_matrix, csr_matrix
@@ -227,7 +227,7 @@ class DummySizeEstimator(BaseEstimator):
 
     def fit(self, X, y):
         self.training_size_ = X.shape[0]
-        self.training_hash_ = joblib_hash(X)
+        self.training_hash_ = _joblib.hash(X)
 
 
 def test_bootstrap_samples():

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -33,7 +33,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.feature_selection import SelectKBest
 from sklearn.model_selection import train_test_split
 from sklearn.datasets import load_boston, load_iris, make_hastie_10_2
-from sklearn.utils import check_random_state, hash
+from sklearn.utils import check_random_state, joblib_hash
 from sklearn.preprocessing import FunctionTransformer
 
 from scipy.sparse import csc_matrix, csr_matrix
@@ -226,7 +226,7 @@ class DummySizeEstimator(BaseEstimator):
 
     def fit(self, X, y):
         self.training_size_ = X.shape[0]
-        self.training_hash_ = hash(X)
+        self.training_hash_ = joblib_hash(X)
 
 
 def test_bootstrap_samples():

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -33,7 +33,8 @@ from sklearn.pipeline import make_pipeline
 from sklearn.feature_selection import SelectKBest
 from sklearn.model_selection import train_test_split
 from sklearn.datasets import load_boston, load_iris, make_hastie_10_2
-from sklearn.utils import check_random_state, joblib_hash
+from sklearn.utils import check_random_state
+from sklearn.utils._joblib import joblib_hash
 from sklearn.preprocessing import FunctionTransformer
 
 from scipy.sparse import csc_matrix, csr_matrix

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -25,7 +25,7 @@ import pytest
 from sklearn.utils import _joblib
 from sklearn.utils import parallel_backend
 from sklearn.utils import register_parallel_backend
-from sklearn.externals.joblib.parallel import LokyBackend
+from sklearn.utils._joblib import joblib
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
@@ -1272,7 +1272,7 @@ def test_nestimators_future_warning(forest):
     est = assert_no_warnings(est.fit, X, y)
 
 
-class MyBackend(LokyBackend):
+class MyBackend(joblib._parallel_backends.LokyBackend):
     def __init__(self, *args, **kwargs):
         self.count = 0
         super(MyBackend, self).__init__(*args, **kwargs)

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -22,10 +22,10 @@ from scipy.sparse import coo_matrix
 
 import pytest
 
-from sklearn.utils import _joblib
-from sklearn.utils import parallel_backend
-from sklearn.utils import register_parallel_backend
 from sklearn.utils._joblib import joblib
+from sklearn.utils._joblib import parallel_backend
+from sklearn.utils._joblib import register_parallel_backend
+from sklearn.utils._joblib import __version__ as __joblib_version__
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
@@ -1291,7 +1291,7 @@ class MyBackend(DEFAULT_JOBLIB_BACKEND):
 register_parallel_backend('testing', MyBackend)
 
 
-@pytest.mark.skipif(_joblib.__version__ < LooseVersion('0.12'),
+@pytest.mark.skipif(__joblib_version__ < LooseVersion('0.12'),
                     reason='tests not yet supported in joblib <0.12')
 @skip_if_no_parallel
 def test_backend_respected():

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -17,7 +17,7 @@ from ..base import ClassifierMixin
 from ..base import TransformerMixin
 from ..base import clone
 from ..preprocessing import LabelEncoder
-from ..utils import Parallel, delayed
+from ..utils._joblib import Parallel, delayed
 from ..utils.validation import has_fit_parameter, check_is_fitted
 from ..utils.metaestimators import _BaseComposition
 from ..utils import Bunch

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -15,7 +15,7 @@ from ..base import BaseEstimator
 from ..base import MetaEstimatorMixin
 from ..base import clone
 from ..base import is_classifier
-from ..utils import Parallel, delayed, effective_n_jobs
+from ..utils._joblib import Parallel, delayed, effective_n_jobs
 from ..model_selection import check_cv
 from ..model_selection._validation import _score
 from ..metrics.scorer import check_scoring

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -24,7 +24,7 @@ from scipy import linalg
 from scipy import sparse
 
 from ..externals import six
-from ..utils._jolib import Parallel, delayed
+from ..utils._joblib import Parallel, delayed
 from ..base import BaseEstimator, ClassifierMixin, RegressorMixin
 from ..utils import check_array, check_X_y
 from ..utils.validation import FLOAT_DTYPES

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -24,7 +24,7 @@ from scipy import linalg
 from scipy import sparse
 
 from ..externals import six
-from ..utils import Parallel, delayed
+from ..utils._jolib import Parallel, delayed
 from ..base import BaseEstimator, ClassifierMixin, RegressorMixin
 from ..utils import check_array, check_X_y
 from ..utils.validation import FLOAT_DTYPES

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -18,7 +18,7 @@ from .base import _preprocess_data
 from ..utils import check_array, check_X_y
 from ..utils.validation import check_random_state
 from ..model_selection import check_cv
-from ..utils import Parallel, delayed, effective_n_jobs
+from ..utils._joblib import Parallel, delayed, effective_n_jobs
 from ..externals import six
 from ..externals.six.moves import xrange
 from ..utils.extmath import safe_sparse_dot

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -23,7 +23,7 @@ from ..base import RegressorMixin
 from ..utils import arrayfuncs, as_float_array, check_X_y
 from ..model_selection import check_cv
 from ..exceptions import ConvergenceWarning
-from ..utils import Parallel, delayed
+from ..utils._joblib import Parallel, delayed
 from ..externals.six.moves import xrange
 from ..externals.six import string_types
 

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -32,7 +32,7 @@ from ..utils.validation import check_X_y
 from ..exceptions import (NotFittedError, ConvergenceWarning,
                           ChangedBehaviorWarning)
 from ..utils.multiclass import check_classification_targets
-from ..utils import Parallel, delayed, effective_n_jobs
+from ..utils._joblib import Parallel, delayed, effective_n_jobs
 from ..utils.fixes import _joblib_parallel_args
 from ..model_selection import check_cv
 from ..externals import six

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -16,7 +16,7 @@ from .base import LinearModel, _pre_fit
 from ..base import RegressorMixin
 from ..utils import as_float_array, check_array, check_X_y
 from ..model_selection import check_cv
-from ..utils import Parallel, delayed
+from ..utils._joblib import Parallel, delayed
 
 premature = """ Orthogonal matching pursuit ended prematurely due to linear
 dependence in the dictionary. The requested precision might not have been met.

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -9,7 +9,7 @@ import warnings
 
 from abc import ABCMeta, abstractmethod
 
-from ..utils import Parallel, delayed
+from ..utils._joblib import Parallel, delayed
 
 from ..base import clone, is_classifier
 from .base import LinearClassifierMixin, SparseCoefMixin

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -19,7 +19,6 @@ from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import ignore_warnings
-from sklearn.utils import parallel_backend
 
 from sklearn import linear_model, datasets, metrics
 from sklearn.base import clone, is_classifier
@@ -30,7 +29,9 @@ from sklearn.exceptions import ConvergenceWarning
 from sklearn.model_selection import StratifiedShuffleSplit, ShuffleSplit
 from sklearn.linear_model import sgd_fast
 from sklearn.model_selection import RandomizedSearchCV
-from sklearn.utils import _joblib
+
+from sklearn.utils._joblib import parallel_backend
+from sklearn.utils._joblib import __version__ as __joblib_version__
 
 
 # 0.23. warning about tol not having its correct default value.
@@ -1542,7 +1543,7 @@ def test_SGDClassifier_fit_for_all_backends(backend):
     # a segmentation fault when trying to write in a readonly memory mapped
     # buffer.
 
-    if _joblib.__version__ < LooseVersion('0.12') and backend == 'loky':
+    if __joblib_version__ < LooseVersion('0.12') and backend == 'loky':
         pytest.skip('loky backend does not exist in joblib <0.12')
 
     random_state = np.random.RandomState(42)

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -30,8 +30,8 @@ from sklearn.model_selection import StratifiedShuffleSplit, ShuffleSplit
 from sklearn.linear_model import sgd_fast
 from sklearn.model_selection import RandomizedSearchCV
 
+from sklearn.utils import _joblib
 from sklearn.utils._joblib import parallel_backend
-from sklearn.utils._joblib import __version__ as __joblib_version__
 
 
 # 0.23. warning about tol not having its correct default value.
@@ -1543,7 +1543,7 @@ def test_SGDClassifier_fit_for_all_backends(backend):
     # a segmentation fault when trying to write in a readonly memory mapped
     # buffer.
 
-    if __joblib_version__ < LooseVersion('0.12') and backend == 'loky':
+    if _joblib.__version__ < LooseVersion('0.12') and backend == 'loky':
         pytest.skip('loky backend does not exist in joblib <0.12')
 
     random_state = np.random.RandomState(42)

--- a/sklearn/linear_model/theil_sen.py
+++ b/sklearn/linear_model/theil_sen.py
@@ -20,8 +20,8 @@ from scipy.linalg.lapack import get_lapack_funcs
 from .base import LinearModel
 from ..base import RegressorMixin
 from ..utils import check_random_state
-from ..utils import check_X_y, effective_n_jobs
-from ..utils import Parallel, delayed
+from ..utils import check_X_y
+from ..utils._joblib import Parallel, delayed, effective_n_jobs
 from ..externals.six.moves import xrange as range
 from ..exceptions import ConvergenceWarning
 

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -12,9 +12,9 @@ import warnings
 from ..base import BaseEstimator
 from ..metrics import euclidean_distances
 from ..utils import check_random_state, check_array, check_symmetric
-from ..utils import Parallel
-from ..utils import delayed
-from ..utils import effective_n_jobs
+from ..utils._joblib import Parallel
+from ..utils._joblib import delayed
+from ..utils._joblib import effective_n_jobs
 from ..isotonic import IsotonicRegression
 
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -25,9 +25,9 @@ from ..utils import gen_even_slices
 from ..utils import gen_batches, get_chunk_n_rows
 from ..utils.extmath import row_norms, safe_sparse_dot
 from ..preprocessing import normalize
-from ..utils import Parallel
-from ..utils import delayed
-from ..utils import effective_n_jobs
+from ..utils._joblib import Parallel
+from ..utils._joblib import delayed
+from ..utils._joblib import effective_n_jobs
 
 from .pairwise_fast import _chi2_kernel_fast, _sparse_manhattan
 

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -39,7 +39,7 @@ from sklearn.datasets import load_diabetes
 from sklearn.model_selection import train_test_split, cross_val_score
 from sklearn.model_selection import GridSearchCV
 from sklearn.multiclass import OneVsRestClassifier
-from sklearn.externals import joblib
+from sklearn.utils import joblib
 
 
 REGRESSION_SCORERS = ['explained_variance', 'r2',

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -39,7 +39,7 @@ from sklearn.datasets import load_diabetes
 from sklearn.model_selection import train_test_split, cross_val_score
 from sklearn.model_selection import GridSearchCV
 from sklearn.multiclass import OneVsRestClassifier
-from sklearn.utils import joblib
+from sklearn.utils import dump, load
 
 
 REGRESSION_SCORERS = ['explained_variance', 'r2',
@@ -98,8 +98,8 @@ def setup_module():
     _, y_ml = make_multilabel_classification(n_samples=X.shape[0],
                                              random_state=0)
     filename = os.path.join(TEMP_FOLDER, 'test_data.pkl')
-    joblib.dump((X, y, y_ml), filename)
-    X_mm, y_mm, y_ml_mm = joblib.load(filename, mmap_mode='r')
+    dump((X, y, y_ml), filename)
+    X_mm, y_mm, y_ml_mm = load(filename, mmap_mode='r')
     ESTIMATORS = _make_estimators(X_mm, y_mm, y_ml_mm)
 
 

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -39,7 +39,7 @@ from sklearn.datasets import load_diabetes
 from sklearn.model_selection import train_test_split, cross_val_score
 from sklearn.model_selection import GridSearchCV
 from sklearn.multiclass import OneVsRestClassifier
-from sklearn.utils import dump, load
+from sklearn.utils._joblib import dump, load
 
 
 REGRESSION_SCORERS = ['explained_variance', 'r2',

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -39,7 +39,7 @@ from sklearn.datasets import load_diabetes
 from sklearn.model_selection import train_test_split, cross_val_score
 from sklearn.model_selection import GridSearchCV
 from sklearn.multiclass import OneVsRestClassifier
-from sklearn.utils._joblib import dump, load
+from sklearn.utils import _joblib
 
 
 REGRESSION_SCORERS = ['explained_variance', 'r2',
@@ -98,8 +98,8 @@ def setup_module():
     _, y_ml = make_multilabel_classification(n_samples=X.shape[0],
                                              random_state=0)
     filename = os.path.join(TEMP_FOLDER, 'test_data.pkl')
-    dump((X, y, y_ml), filename)
-    X_mm, y_mm, y_ml_mm = load(filename, mmap_mode='r')
+    _joblib.dump((X, y, y_ml), filename)
+    X_mm, y_mm, y_ml_mm = _joblib.load(filename, mmap_mode='r')
     ESTIMATORS = _make_estimators(X_mm, y_mm, y_ml_mm)
 
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -29,7 +29,7 @@ from ._split import check_cv
 from ._validation import _fit_and_score
 from ._validation import _aggregate_score_dicts
 from ..exceptions import NotFittedError
-from ..utils import Parallel, delayed
+from ..utils._joblib import Parallel, delayed
 from ..externals import six
 from ..utils import check_random_state
 from ..utils.fixes import sp_version

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -24,7 +24,7 @@ from ..base import is_classifier, clone
 from ..utils import indexable, check_random_state, safe_indexing
 from ..utils.validation import _is_arraylike, _num_samples
 from ..utils.metaestimators import _safe_split
-from ..utils import Parallel, delayed
+from ..utils._joblib import Parallel, delayed
 from ..utils._joblib import logger
 from ..externals.six.moves import zip
 from ..metrics.scorer import check_scoring, _check_multimetric_scoring

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -52,8 +52,8 @@ from .utils.multiclass import (_check_partial_fit_first_call,
                                _ovr_decision_function)
 from .utils.metaestimators import _safe_split, if_delegate_has_method
 
-from .utils import Parallel
-from .utils import delayed
+from .utils._joblib import Parallel
+from .utils._joblib import delayed
 from .externals.six.moves import zip as izip
 
 __all__ = [

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -25,7 +25,7 @@ from .utils.fixes import parallel_helper
 from .utils.metaestimators import if_delegate_has_method
 from .utils.validation import check_is_fitted, has_fit_parameter
 from .utils.multiclass import check_classification_targets
-from .utils import Parallel, delayed
+from .utils._joblib import Parallel, delayed
 from .externals import six
 
 __all__ = ["MultiOutputRegressor", "MultiOutputClassifier",

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -25,9 +25,9 @@ from ..utils import check_X_y, check_array, gen_even_slices
 from ..utils.multiclass import check_classification_targets
 from ..utils.validation import check_is_fitted
 from ..externals import six
-from ..utils import joblib_version
-from ..utils import Parallel, delayed, effective_n_jobs
 from ..exceptions import DataConversionWarning
+from ..utils import Parallel, delayed, effective_n_jobs
+from ..utils._joblib import __version__ as joblib_version
 
 VALID_METRICS = dict(ball_tree=BallTree.valid_metrics,
                      kd_tree=KDTree.valid_metrics,

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -26,7 +26,7 @@ from ..utils.multiclass import check_classification_targets
 from ..utils.validation import check_is_fitted
 from ..externals import six
 from ..exceptions import DataConversionWarning
-from ..utils import Parallel, delayed, effective_n_jobs
+from ..utils._joblib import Parallel, delayed, effective_n_jobs
 from ..utils._joblib import __version__ as joblib_version
 
 VALID_METRICS = dict(ball_tree=BallTree.valid_metrics,

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -25,8 +25,8 @@ from ..utils import check_X_y, check_array, gen_even_slices
 from ..utils.multiclass import check_classification_targets
 from ..utils.validation import check_is_fitted
 from ..externals import six
+from ..utils import joblib_version
 from ..utils import Parallel, delayed, effective_n_jobs
-from ..utils._joblib import __version__ as joblib_version
 from ..exceptions import DataConversionWarning
 
 VALID_METRICS = dict(ball_tree=BallTree.valid_metrics,

--- a/sklearn/neighbors/tests/test_kde.py
+++ b/sklearn/neighbors/tests/test_kde.py
@@ -10,7 +10,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.datasets import make_blobs
 from sklearn.model_selection import GridSearchCV
 from sklearn.preprocessing import StandardScaler
-from sklearn.utils import dump, load
+from sklearn.utils._joblib import dump, load
 
 
 def compute_kernel_slow(Y, X, kernel, h):

--- a/sklearn/neighbors/tests/test_kde.py
+++ b/sklearn/neighbors/tests/test_kde.py
@@ -10,7 +10,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.datasets import make_blobs
 from sklearn.model_selection import GridSearchCV
 from sklearn.preprocessing import StandardScaler
-from sklearn.utils._joblib import dump, load
+from sklearn.utils import _joblib
 
 
 def compute_kernel_slow(Y, X, kernel, h):
@@ -218,8 +218,8 @@ def test_pickling(tmpdir):
     scores = kde.score_samples(X)
 
     file_path = str(tmpdir.join('dump.pkl'))
-    dump(kde, file_path)
-    kde = load(file_path)
+    _joblib.dump(kde, file_path)
+    kde = _joblib.load(file_path)
     scores_pickled = kde.score_samples(X)
 
     assert_allclose(scores, scores_pickled)

--- a/sklearn/neighbors/tests/test_kde.py
+++ b/sklearn/neighbors/tests/test_kde.py
@@ -10,7 +10,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.datasets import make_blobs
 from sklearn.model_selection import GridSearchCV
 from sklearn.preprocessing import StandardScaler
-from sklearn.externals import joblib
+from sklearn.utils import joblib
 
 
 def compute_kernel_slow(Y, X, kernel, h):

--- a/sklearn/neighbors/tests/test_kde.py
+++ b/sklearn/neighbors/tests/test_kde.py
@@ -10,7 +10,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.datasets import make_blobs
 from sklearn.model_selection import GridSearchCV
 from sklearn.preprocessing import StandardScaler
-from sklearn.utils import joblib
+from sklearn.utils import dump, load
 
 
 def compute_kernel_slow(Y, X, kernel, h):
@@ -218,8 +218,8 @@ def test_pickling(tmpdir):
     scores = kde.score_samples(X)
 
     file_path = str(tmpdir.join('dump.pkl'))
-    joblib.dump(kde, file_path)
-    kde = joblib.load(file_path)
+    dump(kde, file_path)
+    kde = load(file_path)
     scores_pickled = kde.score_samples(X)
 
     assert_allclose(scores, scores_pickled)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -27,7 +27,7 @@ from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.validation import check_random_state
 
-from sklearn.externals.joblib import parallel_backend
+from sklearn.utils import parallel_backend
 
 rng = np.random.RandomState(0)
 # load and shuffle iris dataset

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -28,7 +28,7 @@ from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.validation import check_random_state
 
 from sklearn.utils._joblib import joblib
-from sklearn.utils import parallel_backend
+from sklearn.utils._joblib import parallel_backend
 
 rng = np.random.RandomState(0)
 # load and shuffle iris dataset

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -27,6 +27,7 @@ from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.validation import check_random_state
 
+from sklearn.utils._joblib import joblib
 from sklearn.utils import parallel_backend
 
 rng = np.random.RandomState(0)
@@ -48,6 +49,7 @@ SPARSE_OR_DENSE = SPARSE_TYPES + (np.asarray,)
 
 ALGORITHMS = ('ball_tree', 'brute', 'kd_tree', 'auto')
 P = (1, 2, 3, 4, np.inf)
+JOBLIB_BACKENDS = list(joblib.parallel.BACKENDS.keys())
 
 # Filter deprecation warnings.
 neighbors.kneighbors_graph = ignore_warnings(neighbors.kneighbors_graph)
@@ -1321,7 +1323,7 @@ def test_same_radius_neighbors_parallel(algorithm):
     assert_array_almost_equal(graph, graph_parallel)
 
 
-@pytest.mark.parametrize('backend', ['loky', 'multiprocessing', 'threading'])
+@pytest.mark.parametrize('backend', JOBLIB_BACKENDS)
 @pytest.mark.parametrize('algorithm', ALGORITHMS)
 def test_knn_forcing_backend(backend, algorithm):
     # Non-regression test which ensure the knn methods are properly working

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -16,7 +16,7 @@ import numpy as np
 from scipy import sparse
 
 from .base import clone, TransformerMixin
-from .utils import Parallel, delayed
+from .utils._joblib import Parallel, delayed
 from .externals import six
 from .utils.metaestimators import if_delegate_has_method
 from .utils import Bunch

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -32,7 +32,7 @@ _DOCSTRING_IGNORES = [
     'sklearn.pipeline.make_pipeline',
     'sklearn.pipeline.make_union',
     'sklearn.utils.extmath.safe_sparse_dot',
-    'Parallel', 'Memory'
+    'sklearn.utils._joblib'
 ]
 
 # Methods where y param should be ignored if y=None by default

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -32,6 +32,7 @@ _DOCSTRING_IGNORES = [
     'sklearn.pipeline.make_pipeline',
     'sklearn.pipeline.make_union',
     'sklearn.utils.extmath.safe_sparse_dot',
+    'Parallel', 'Memory'
 ]
 
 # Methods where y param should be ignored if y=None by default

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -19,7 +19,7 @@ from sklearn.base import clone
 from sklearn.datasets import make_classification
 from sklearn.ensemble import GradientBoostingRegressor, RandomForestClassifier
 from sklearn.exceptions import NotFittedError
-from sklearn.utils import cpu_count
+from sklearn.utils._joblib import cpu_count
 from sklearn.linear_model import Lasso
 from sklearn.linear_model import LogisticRegression
 from sklearn.linear_model import Ridge

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -34,7 +34,7 @@ from sklearn.datasets import load_iris
 from sklearn.preprocessing import StandardScaler
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.utils import Memory
-from sklearn.utils import joblib_version
+from sklearn.utils._joblib import __version__ as joblib_version
 
 
 JUNK_FOOD_DOCS = (

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -924,8 +924,7 @@ def test_pipeline_wrong_memory():
     cached_pipe = Pipeline([('transf', DummyTransf()),
                             ('svc', SVC())], memory=memory)
     assert_raises_regex(ValueError, "'memory' should be None, a string or"
-                        " have the same interface as "
-                        "sklearn.utils.Memory."
+                        " have the same interface as joblib.Memory."
                         " Got memory='1' instead.", cached_pipe.fit, X, y)
 
 
@@ -947,8 +946,7 @@ def test_pipeline_with_cache_attribute():
     pipe = Pipeline([('transf', Transf()), ('clf', Mult())],
                     memory=dummy)
     assert_raises_regex(ValueError, "'memory' should be None, a string or"
-                        " have the same interface as "
-                        "sklearn.utils.Memory."
+                        " have the same interface as joblib.Memory."
                         " Got memory='{}' instead.".format(dummy), pipe.fit, X)
 
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -34,7 +34,7 @@ from sklearn.datasets import load_iris
 from sklearn.preprocessing import StandardScaler
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.utils import Memory
-from sklearn.utils._joblib import __version__ as joblib_version
+from sklearn.utils import joblib_version
 
 
 JUNK_FOOD_DOCS = (

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -33,7 +33,7 @@ from sklearn.decomposition import PCA, TruncatedSVD
 from sklearn.datasets import load_iris
 from sklearn.preprocessing import StandardScaler
 from sklearn.feature_extraction.text import CountVectorizer
-from sklearn.utils import Memory
+from sklearn.utils._joblib import Memory
 from sklearn.utils._joblib import __version__ as joblib_version
 
 

--- a/sklearn/tests/test_site_joblib.py
+++ b/sklearn/tests/test_site_joblib.py
@@ -2,7 +2,7 @@ import os
 import pytest
 from sklearn import externals
 from sklearn.externals import joblib as joblib_vendored
-from sklearn.utils import Parallel, delayed, Memory, parallel_backend
+from sklearn.utils._joblib import Parallel, delayed, Memory, parallel_backend
 
 if os.environ.get('SKLEARN_SITE_JOBLIB', False):
     import joblib as joblib_site

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -5,9 +5,10 @@ import numbers
 import platform
 import struct
 
+import warnings
 import numpy as np
 from scipy.sparse import issparse
-import warnings
+from distutils.version import LooseVersion
 
 from .murmurhash import murmurhash3_32
 from .class_weight import compute_class_weight, compute_sample_weight
@@ -48,9 +49,10 @@ class Parallel(_joblib.Parallel):
     pass
 
 
-@deprecate
-class parallel_backend(_joblib.parallel_backend):
-    pass
+if LooseVersion(_joblib.__version__) >= LooseVersion("0.12"):
+    @deprecate
+    class parallel_backend(_joblib.parallel_backend):
+        pass
 
 
 __all__ = ["murmurhash3_32", "as_float_array",

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -10,18 +10,19 @@ from scipy.sparse import issparse
 import warnings
 
 from .murmurhash import murmurhash3_32
+from .class_weight import compute_class_weight, compute_sample_weight
+from ._joblib import cpu_count, Parallel, Memory, delayed, hash
+from ._joblib import parallel_backend, register_parallel_backend
+from ._joblib import effective_n_jobs, joblib
+from ._joblib import __version__ as joblib_version
+from ..exceptions import DataConversionWarning
+from .fixes import _Sequence as Sequence
+from .deprecation import deprecated
 from .validation import (as_float_array,
                          assert_all_finite,
                          check_random_state, column_or_1d, check_array,
                          check_consistent_length, check_X_y, indexable,
                          check_symmetric)
-from .class_weight import compute_class_weight, compute_sample_weight
-from ._joblib import cpu_count, Parallel, Memory, delayed, hash
-from ._joblib import parallel_backend, register_parallel_backend
-from ._joblib import effective_n_jobs, joblib
-from ..exceptions import DataConversionWarning
-from ..utils.fixes import _Sequence as Sequence
-from .deprecation import deprecated
 from .. import get_config
 
 __all__ = ["murmurhash3_32", "as_float_array",
@@ -32,8 +33,8 @@ __all__ = ["murmurhash3_32", "as_float_array",
            "check_consistent_length", "check_X_y", 'indexable',
            "check_symmetric", "indices_to_mask", "deprecated",
            "cpu_count", "Parallel", "Memory", "delayed", "parallel_backend",
-           "register_parallel_backend", "hash", "effective_n_jobs",
-           "resample", "shuffle"]
+           "register_parallel_backend", "hash", "effective_n_jobs", "joblib",
+           "joblib_version", "resample", "shuffle"]
 
 IS_PYPY = platform.python_implementation() == 'PyPy'
 _IS_32BIT = 8 * struct.calcsize("P") == 32

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -24,6 +24,22 @@ from .validation import (as_float_array,
                          check_symmetric)
 from .. import get_config
 
+# deprecate the joblib API in sklearn in favor of using the system joblib
+msg = ("This function is part of the joblib library. This function is a "
+       "vendored version, modified to be privately used in sklearn. Please "
+       "install joblib to have access to this function.")
+deprecate = deprecated(msg)
+dump = deprecate(dump)
+load = deprecate(load)
+Memory = deprecate(Memory)
+delayed = deprecate(delayed)
+Parallel = deprecate(Parallel)
+cpu_count = deprecate(cpu_count)
+joblib_hash = deprecate(joblib_hash)
+effective_n_jobs = deprecate(effective_n_jobs)
+parallel_backend = deprecate(parallel_backend)
+register_parallel_backend = deprecate(register_parallel_backend)
+
 __all__ = ["murmurhash3_32", "as_float_array",
            "assert_all_finite", "check_array",
            "check_random_state",

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -32,15 +32,14 @@ parallel_backend = _joblib.parallel_backend
 register_parallel_backend = _joblib.register_parallel_backend
 
 # deprecate the joblib API in sklearn in favor of using directly joblib
-msg = ("it is a vendored version, modified to be privately used in sklearn. "
-       "Please install joblib to have access to this function.")
+msg = ("deprecated in version 0.20.1 to be removed in version 0.23. "
+       "Please import this functionality directly from joblib, which can "
+       "be installed with: pip install joblib.")
 deprecate = deprecated(msg)
 
-dump = deprecate(_joblib.dump)
-load = deprecate(_joblib.load)
 delayed = deprecate(_joblib.delayed)
 cpu_count = deprecate(_joblib.cpu_count)
-joblib_hash = deprecate(_joblib.hash)
+hash = deprecate(_joblib.hash)
 effective_n_jobs = deprecate(_joblib.effective_n_jobs)
 
 
@@ -64,8 +63,8 @@ __all__ = ["murmurhash3_32", "as_float_array",
            "check_consistent_length", "check_X_y", 'indexable',
            "check_symmetric", "indices_to_mask", "deprecated",
            "cpu_count", "Parallel", "Memory", "delayed", "parallel_backend",
-           "register_parallel_backend", "joblib_hash", "effective_n_jobs",
-           "resample", "shuffle", "dump", "load"]
+           "register_parallel_backend", "hash", "effective_n_jobs",
+           "resample", "shuffle"]
 
 IS_PYPY = platform.python_implementation() == 'PyPy'
 _IS_32BIT = 8 * struct.calcsize("P") == 32

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -8,11 +8,10 @@ import struct
 import warnings
 import numpy as np
 from scipy.sparse import issparse
-from distutils.version import LooseVersion
 
 from .murmurhash import murmurhash3_32
 from .class_weight import compute_class_weight, compute_sample_weight
-from .import _joblib
+from . import _joblib
 from ..exceptions import DataConversionWarning
 from .fixes import _Sequence as Sequence
 from .deprecation import deprecated

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["murmurhash3_32", "as_float_array",
            "check_consistent_length", "check_X_y", 'indexable',
            "check_symmetric", "indices_to_mask", "deprecated",
            "cpu_count", "Parallel", "Memory", "delayed", "parallel_backend",
-           "register_parallel_backend", "joblib_hash", "effective_n_jobs", 
+           "register_parallel_backend", "joblib_hash", "effective_n_jobs",
            "resample", "shuffle", "dump", "load"]
 
 IS_PYPY = platform.python_implementation() == 'PyPy'

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -49,10 +49,13 @@ class Parallel(_joblib.Parallel):
     pass
 
 
+# deprecate backend change from a function in 0.11 to a class in 0.12
 if LooseVersion(_joblib.__version__) >= LooseVersion("0.12"):
     @deprecate
     class parallel_backend(_joblib.parallel_backend):
         pass
+else:
+    parallel_backend = deprecate(parallel_backend)
 
 
 __all__ = ["murmurhash3_32", "as_float_array",

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -11,10 +11,9 @@ import warnings
 
 from .murmurhash import murmurhash3_32
 from .class_weight import compute_class_weight, compute_sample_weight
-from ._joblib import cpu_count, Parallel, Memory, delayed, hash
+from ._joblib import cpu_count, Parallel, Memory, delayed, joblib_hash
 from ._joblib import parallel_backend, register_parallel_backend
-from ._joblib import effective_n_jobs, joblib
-from ._joblib import __version__ as joblib_version
+from ._joblib import effective_n_jobs, dump, load
 from ..exceptions import DataConversionWarning
 from .fixes import _Sequence as Sequence
 from .deprecation import deprecated
@@ -33,8 +32,8 @@ __all__ = ["murmurhash3_32", "as_float_array",
            "check_consistent_length", "check_X_y", 'indexable',
            "check_symmetric", "indices_to_mask", "deprecated",
            "cpu_count", "Parallel", "Memory", "delayed", "parallel_backend",
-           "register_parallel_backend", "hash", "effective_n_jobs", "joblib",
-           "joblib_version", "resample", "shuffle"]
+           "register_parallel_backend", "joblib_hash", "effective_n_jobs", 
+           "resample", "shuffle", "dump", "load"]
 
 IS_PYPY = platform.python_implementation() == 'PyPy'
 _IS_32BIT = 8 * struct.calcsize("P") == 32

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -55,7 +55,7 @@ if LooseVersion(_joblib.__version__) >= LooseVersion("0.12"):
     class parallel_backend(_joblib.parallel_backend):
         pass
 else:
-    parallel_backend = deprecate(parallel_backend)
+    parallel_backend = deprecate(_joblib.parallel_backend)
 
 
 __all__ = ["murmurhash3_32", "as_float_array",

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -11,9 +11,7 @@ import warnings
 
 from .murmurhash import murmurhash3_32
 from .class_weight import compute_class_weight, compute_sample_weight
-from ._joblib import cpu_count, Parallel, Memory, delayed, joblib_hash
-from ._joblib import parallel_backend, register_parallel_backend
-from ._joblib import effective_n_jobs, dump, load
+from .import _joblib
 from ..exceptions import DataConversionWarning
 from .fixes import _Sequence as Sequence
 from .deprecation import deprecated
@@ -24,21 +22,36 @@ from .validation import (as_float_array,
                          check_symmetric)
 from .. import get_config
 
-# deprecate the joblib API in sklearn in favor of using the system joblib
-msg = ("This function is part of the joblib library. This function is a "
-       "vendored version, modified to be privately used in sklearn. Please "
-       "install joblib to have access to this function.")
+# deprecate the joblib API in sklearn in favor of using directly joblib
+msg = ("it is a vendored version, modified to be privately used in sklearn. "
+       "Please install joblib to have access to this function.")
 deprecate = deprecated(msg)
-dump = deprecate(dump)
-load = deprecate(load)
-Memory = deprecate(Memory)
-delayed = deprecate(delayed)
-Parallel = deprecate(Parallel)
-cpu_count = deprecate(cpu_count)
-joblib_hash = deprecate(joblib_hash)
-effective_n_jobs = deprecate(effective_n_jobs)
-parallel_backend = deprecate(parallel_backend)
-register_parallel_backend = deprecate(register_parallel_backend)
+
+dump = deprecate(_joblib.dump)
+load = deprecate(_joblib.load)
+delayed = deprecate(_joblib.delayed)
+cpu_count = deprecate(_joblib.cpu_count)
+joblib_hash = deprecate(_joblib.joblib_hash)
+effective_n_jobs = deprecate(_joblib.effective_n_jobs)
+register_parallel_backend = deprecate(_joblib.register_parallel_backend)
+
+
+# for classes, deprecated will change the object from _joblib module so we need
+# to subclass the class
+@deprecate
+class Memory(_joblib.Memory):
+    pass
+
+
+@deprecate
+class Parallel(_joblib.Parallel):
+    pass
+
+
+@deprecate
+class parallel_backend(_joblib.parallel_backend):
+    pass
+
 
 __all__ = ["murmurhash3_32", "as_float_array",
            "assert_all_finite", "check_array",

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -18,7 +18,7 @@ from .validation import (as_float_array,
 from .class_weight import compute_class_weight, compute_sample_weight
 from ._joblib import cpu_count, Parallel, Memory, delayed, hash
 from ._joblib import parallel_backend, register_parallel_backend
-from ._joblib import effective_n_jobs
+from ._joblib import effective_n_jobs, joblib
 from ..exceptions import DataConversionWarning
 from ..utils.fixes import _Sequence as Sequence
 from .deprecation import deprecated

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -23,6 +23,15 @@ from .validation import (as_float_array,
                          check_symmetric)
 from .. import get_config
 
+
+# Do not deprecate parallel_backend and register_parallel_backend as they are
+# needed to tune `scikit-learn` behavior and have different effect if called
+# from the vendored version or or the site-package version. The other are
+# utilities that are independent of scikit-learn so they are not part of
+# scikit-learn public API.
+parallel_backend = _joblib.parallel_backend
+register_parallel_backend = _joblib.register_parallel_backend
+
 # deprecate the joblib API in sklearn in favor of using directly joblib
 msg = ("it is a vendored version, modified to be privately used in sklearn. "
        "Please install joblib to have access to this function.")
@@ -32,13 +41,12 @@ dump = deprecate(_joblib.dump)
 load = deprecate(_joblib.load)
 delayed = deprecate(_joblib.delayed)
 cpu_count = deprecate(_joblib.cpu_count)
-joblib_hash = deprecate(_joblib.joblib_hash)
+joblib_hash = deprecate(_joblib.hash)
 effective_n_jobs = deprecate(_joblib.effective_n_jobs)
-register_parallel_backend = deprecate(_joblib.register_parallel_backend)
 
 
-# for classes, deprecated will change the object from _joblib module so we need
-# to subclass the class
+# for classes, deprecated will change the object in _joblib module so we need
+# to subclass them.
 @deprecate
 class Memory(_joblib.Memory):
     pass
@@ -47,15 +55,6 @@ class Memory(_joblib.Memory):
 @deprecate
 class Parallel(_joblib.Parallel):
     pass
-
-
-# deprecate backend change from a function in 0.11 to a class in 0.12
-if LooseVersion(_joblib.__version__) >= LooseVersion("0.12"):
-    @deprecate
-    class parallel_backend(_joblib.parallel_backend):
-        pass
-else:
-    parallel_backend = deprecate(_joblib.parallel_backend)
 
 
 __all__ = ["murmurhash3_32", "as_float_array",

--- a/sklearn/utils/_joblib.py
+++ b/sklearn/utils/_joblib.py
@@ -15,7 +15,7 @@ if _os.environ.get('SKLEARN_SITE_JOBLIB', False):
         from joblib import dump, load
         from joblib import __version__
         from joblib import effective_n_jobs
-        from joblib import hash as joblib_hash
+        from joblib import hash
         from joblib import cpu_count, Parallel, Memory, delayed
         from joblib import parallel_backend, register_parallel_backend
 else:
@@ -24,11 +24,11 @@ else:
     from ..externals.joblib import dump, load
     from ..externals.joblib import __version__
     from ..externals.joblib import effective_n_jobs
-    from ..externals.joblib import hash as joblib_hash
+    from ..externals.joblib import hash
     from ..externals.joblib import cpu_count, Parallel, Memory, delayed
     from ..externals.joblib import parallel_backend, register_parallel_backend
 
 
 __all__ = ["parallel_backend", "register_parallel_backend", "cpu_count",
-           "Parallel", "Memory", "delayed", "joblib_hash", "effective_n_jobs",
-           "joblib_hash", "logger", "dump", "load", "joblib", "__version__"]
+           "Parallel", "Memory", "delayed", "effective_n_jobs", "hash",
+           "logger", "dump", "load", "joblib", "__version__"]

--- a/sklearn/utils/_joblib.py
+++ b/sklearn/utils/_joblib.py
@@ -10,14 +10,25 @@ if _os.environ.get('SKLEARN_SITE_JOBLIB', False):
         _warnings.simplefilter("ignore")
         # joblib imports may raise DeprecationWarning on certain Python
         # versions
-        import joblib  # noqa
-        from joblib import __all__
-        from joblib import *  # noqa
-        from joblib import __version__
+        import joblib
         from joblib import logger
+        from joblib import dump, load
+        from joblib import __version__
+        from joblib import effective_n_jobs
+        from joblib import hash as joblib_hash
+        from joblib import cpu_count, Parallel, Memory, delayed
+        from joblib import parallel_backend, register_parallel_backend
 else:
-    from ..externals import joblib  # noqa
-    from ..externals.joblib import __all__   # noqa
-    from ..externals.joblib import *  # noqa
-    from ..externals.joblib import __version__  # noqa
-    from ..externals.joblib import logger  # noqa
+    from ..externals import joblib
+    from ..externals.joblib import logger
+    from ..externals.joblib import dump, load
+    from ..externals.joblib import __version__
+    from ..externals.joblib import effective_n_jobs
+    from ..externals.joblib import hash as joblib_hash
+    from ..externals.joblib import cpu_count, Parallel, Memory, delayed
+    from ..externals.joblib import parallel_backend, register_parallel_backend
+
+
+__all__ = ["parallel_backend", "register_parallel_backend", "cpu_count",
+           "Parallel", "Memory", "delayed", "joblib_hash", "effective_n_jobs",
+           "joblib_hash", "logger", "dump", "load", "joblib", "__version__"]

--- a/sklearn/utils/_joblib.py
+++ b/sklearn/utils/_joblib.py
@@ -10,11 +10,13 @@ if _os.environ.get('SKLEARN_SITE_JOBLIB', False):
         _warnings.simplefilter("ignore")
         # joblib imports may raise DeprecationWarning on certain Python
         # versions
+        import joblib  # noqa
         from joblib import __all__
         from joblib import *  # noqa
         from joblib import __version__
         from joblib import logger
 else:
+    from ..externals import joblib  # noqa
     from ..externals.joblib import __all__   # noqa
     from ..externals.joblib import *  # noqa
     from ..externals.joblib import __version__  # noqa

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -14,7 +14,7 @@ from scipy.stats import rankdata
 
 from sklearn.externals.six.moves import zip
 from sklearn.utils import IS_PYPY, _IS_32BIT
-from sklearn.utils import joblib_hash, Memory
+from sklearn.utils._joblib import joblib_hash, Memory
 from sklearn.utils.testing import assert_raises, _get_args
 from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.testing import assert_raise_message

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -14,7 +14,8 @@ from scipy.stats import rankdata
 
 from sklearn.externals.six.moves import zip
 from sklearn.utils import IS_PYPY, _IS_32BIT
-from sklearn.utils._joblib import joblib_hash, Memory
+from sklearn.utils import _joblib
+from sklearn.utils._joblib import Memory
 from sklearn.utils.testing import assert_raises, _get_args
 from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.testing import assert_raise_message
@@ -1951,12 +1952,12 @@ def check_estimators_overwrite_params(name, estimator_orig):
         new_value = new_params[param_name]
 
         # We should never change or mutate the internal state of input
-        # parameters by default. To check this we use the joblib_hash function
+        # parameters by default. To check this we use the joblib.hash function
         # that introspects recursively any subobjects to compute a checksum.
         # The only exception to this rule of immutable constructor parameters
         # is possible RandomState instance but in this check we explicitly
         # fixed the random_state params recursively to be integer seeds.
-        assert_equal(joblib_hash(new_value), joblib_hash(original_value),
+        assert_equal(_joblib.hash(new_value), _joblib.hash(original_value),
                      "Estimator %s should not change or mutate "
                      " the parameter %s from %s to %s during fit."
                      % (name, param_name, original_value, new_value))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -14,7 +14,7 @@ from scipy.stats import rankdata
 
 from sklearn.externals.six.moves import zip
 from sklearn.utils import IS_PYPY, _IS_32BIT
-from sklearn.utils._joblib import hash, Memory
+from sklearn.utils import joblib_hash, Memory
 from sklearn.utils.testing import assert_raises, _get_args
 from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.testing import assert_raise_message
@@ -1951,12 +1951,12 @@ def check_estimators_overwrite_params(name, estimator_orig):
         new_value = new_params[param_name]
 
         # We should never change or mutate the internal state of input
-        # parameters by default. To check this we use the joblib.hash function
+        # parameters by default. To check this we use the joblib_hash function
         # that introspects recursively any subobjects to compute a checksum.
         # The only exception to this rule of immutable constructor parameters
         # is possible RandomState instance but in this check we explicitly
         # fixed the random_state params recursively to be integer seeds.
-        assert_equal(hash(new_value), hash(original_value),
+        assert_equal(joblib_hash(new_value), joblib_hash(original_value),
                      "Estimator %s should not change or mutate "
                      " the parameter %s from %s to %s during fit."
                      % (name, param_name, original_value, new_value))

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -44,7 +44,7 @@ except NameError:
 
 import sklearn
 from sklearn.base import BaseEstimator
-from sklearn.utils import joblib
+from sklearn.utils import dump, load
 from sklearn.utils.fixes import signature
 from sklearn.utils import deprecated, IS_PYPY, _IS_32BIT
 
@@ -859,8 +859,8 @@ def create_memmap_backed_data(data, mmap_mode='r', return_folder=False):
     temp_folder = tempfile.mkdtemp(prefix='sklearn_testing_')
     atexit.register(functools.partial(_delete_folder, temp_folder, warn=True))
     filename = op.join(temp_folder, 'data.pkl')
-    joblib.dump(data, filename)
-    memmap_backed_data = joblib.load(filename, mmap_mode=mmap_mode)
+    dump(data, filename)
+    memmap_backed_data = load(filename, mmap_mode=mmap_mode)
     result = (memmap_backed_data if not return_folder
               else (memmap_backed_data, temp_folder))
     return result

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -44,7 +44,7 @@ except NameError:
 
 import sklearn
 from sklearn.base import BaseEstimator
-from sklearn.utils import dump, load
+from sklearn.utils._joblib import dump, load
 from sklearn.utils._joblib import joblib
 from sklearn.utils.fixes import signature
 from sklearn.utils import deprecated, IS_PYPY, _IS_32BIT

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -45,6 +45,7 @@ except NameError:
 import sklearn
 from sklearn.base import BaseEstimator
 from sklearn.utils import dump, load
+from sklearn.utils._joblib import joblib
 from sklearn.utils.fixes import signature
 from sklearn.utils import deprecated, IS_PYPY, _IS_32BIT
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -44,7 +44,6 @@ except NameError:
 
 import sklearn
 from sklearn.base import BaseEstimator
-from sklearn.utils._joblib import dump, load
 from sklearn.utils._joblib import joblib
 from sklearn.utils.fixes import signature
 from sklearn.utils import deprecated, IS_PYPY, _IS_32BIT
@@ -860,8 +859,8 @@ def create_memmap_backed_data(data, mmap_mode='r', return_folder=False):
     temp_folder = tempfile.mkdtemp(prefix='sklearn_testing_')
     atexit.register(functools.partial(_delete_folder, temp_folder, warn=True))
     filename = op.join(temp_folder, 'data.pkl')
-    dump(data, filename)
-    memmap_backed_data = load(filename, mmap_mode=mmap_mode)
+    joblib.dump(data, filename)
+    memmap_backed_data = joblib.load(filename, mmap_mode=mmap_mode)
     result = (memmap_backed_data if not return_folder
               else (memmap_backed_data, temp_folder))
     return result

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -44,7 +44,7 @@ except NameError:
 
 import sklearn
 from sklearn.base import BaseEstimator
-from sklearn.externals import joblib
+from sklearn.utils import joblib
 from sklearn.utils.fixes import signature
 from sklearn.utils import deprecated, IS_PYPY, _IS_32BIT
 

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -8,7 +8,7 @@ from sklearn.externals.six.moves import cStringIO as StringIO
 
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils import deprecated
-from sklearn.utils import joblib_hash
+from sklearn.utils._joblib import joblib_hash
 from sklearn.utils.testing import (assert_raises_regex, assert_equal,
                                    ignore_warnings, assert_warns)
 from sklearn.utils.estimator_checks import check_estimator

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -8,7 +8,7 @@ from sklearn.externals.six.moves import cStringIO as StringIO
 
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils import deprecated
-from sklearn.utils._joblib import joblib_hash
+from sklearn.utils import _joblib
 from sklearn.utils.testing import (assert_raises_regex, assert_equal,
                                    ignore_warnings, assert_warns)
 from sklearn.utils.estimator_checks import check_estimator
@@ -385,9 +385,9 @@ def test_check_estimator_clones():
             set_checking_parameters(est)
             set_random_state(est)
             # without fitting
-            old_hash = joblib_hash(est)
+            old_hash = _joblib.hash(est)
             check_estimator(est)
-        assert_equal(old_hash, joblib_hash(est))
+        assert_equal(old_hash, _joblib.hash(est))
 
         with ignore_warnings(category=(FutureWarning, DeprecationWarning)):
             # when 'est = SGDClassifier()'
@@ -396,9 +396,9 @@ def test_check_estimator_clones():
             set_random_state(est)
             # with fitting
             est.fit(iris.data + 10, iris.target)
-            old_hash = joblib_hash(est)
+            old_hash = _joblib.hash(est)
             check_estimator(est)
-        assert_equal(old_hash, joblib_hash(est))
+        assert_equal(old_hash, _joblib.hash(est))
 
 
 def test_check_estimators_unfitted():

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -5,10 +5,9 @@ import numpy as np
 import scipy.sparse as sp
 
 from sklearn.externals.six.moves import cStringIO as StringIO
-from sklearn.externals import joblib
 
 from sklearn.base import BaseEstimator, ClassifierMixin
-from sklearn.utils import deprecated
+from sklearn.utils import deprecated, joblib
 from sklearn.utils.testing import (assert_raises_regex, assert_equal,
                                    ignore_warnings, assert_warns)
 from sklearn.utils.estimator_checks import check_estimator

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -7,7 +7,8 @@ import scipy.sparse as sp
 from sklearn.externals.six.moves import cStringIO as StringIO
 
 from sklearn.base import BaseEstimator, ClassifierMixin
-from sklearn.utils import deprecated, joblib
+from sklearn.utils import deprecated
+from sklearn.utils import joblib_hash
 from sklearn.utils.testing import (assert_raises_regex, assert_equal,
                                    ignore_warnings, assert_warns)
 from sklearn.utils.estimator_checks import check_estimator
@@ -384,9 +385,9 @@ def test_check_estimator_clones():
             set_checking_parameters(est)
             set_random_state(est)
             # without fitting
-            old_hash = joblib.hash(est)
+            old_hash = joblib_hash(est)
             check_estimator(est)
-        assert_equal(old_hash, joblib.hash(est))
+        assert_equal(old_hash, joblib_hash(est))
 
         with ignore_warnings(category=(FutureWarning, DeprecationWarning)):
             # when 'est = SGDClassifier()'
@@ -395,9 +396,9 @@ def test_check_estimator_clones():
             set_random_state(est)
             # with fitting
             est.fit(iris.data + 10, iris.target)
-            old_hash = joblib.hash(est)
+            old_hash = joblib_hash(est)
             check_estimator(est)
-        assert_equal(old_hash, joblib.hash(est))
+        assert_equal(old_hash, joblib_hash(est))
 
 
 def test_check_estimators_unfitted():

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -275,3 +275,42 @@ def test_get_chunk_n_rows(row_bytes, max_n_rows, working_memory,
                                            ([np.nan], False)])
 def test_is_scalar_nan(value, result):
     assert is_scalar_nan(value) is result
+
+
+def test_deprecation_joblib_api():
+    def check_warning(*args, **kw):
+        return assert_warns_message(
+            DeprecationWarning, "deprecated in version 0.20.1", *args, **kw)
+
+    # Ensure that the joblib API is deprecated in sklearn.util
+    from sklearn.utils import Parallel, Memory, delayed
+    from sklearn.utils import cpu_count, hash, effective_n_jobs
+    check_warning(Memory)
+    check_warning(hash, 1)
+    check_warning(Parallel)
+    check_warning(cpu_count)
+    check_warning(effective_n_jobs, 1)
+    check_warning(delayed, lambda: None)
+
+    # Only parallel_backend and register_parallel_backend are not deprecated in
+    # sklearn.utils
+    from sklearn.utils import parallel_backend, register_parallel_backend
+    assert_no_warnings(parallel_backend, 'loky', None)
+    assert_no_warnings(register_parallel_backend, 'failing', None)
+
+    # Ensure that the deprecation have no side effect in sklearn.utils._joblib
+    from sklearn.utils._joblib import Parallel, Memory, delayed
+    from sklearn.utils._joblib import cpu_count, hash, effective_n_jobs
+    from sklearn.utils._joblib import parallel_backend
+    from sklearn.utils._joblib import register_parallel_backend
+    assert_no_warnings(Memory)
+    assert_no_warnings(hash, 1)
+    assert_no_warnings(Parallel)
+    assert_no_warnings(cpu_count)
+    assert_no_warnings(effective_n_jobs, 1)
+    assert_no_warnings(delayed, lambda: None)
+    assert_no_warnings(parallel_backend, 'loky', None)
+    assert_no_warnings(register_parallel_backend, 'failing', None)
+
+    from sklearn.utils._joblib import joblib
+    del joblib.parallel.BACKENDS['failing']

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -277,7 +277,7 @@ def test_is_scalar_nan(value, result):
     assert is_scalar_nan(value) is result
 
 
-def test_deprecation_joblib_api():
+def test_deprecation_joblib_api(tmpdir):
     def check_warning(*args, **kw):
         return assert_warns_message(
             DeprecationWarning, "deprecated in version 0.20.1", *args, **kw)
@@ -285,7 +285,7 @@ def test_deprecation_joblib_api():
     # Ensure that the joblib API is deprecated in sklearn.util
     from sklearn.utils import Parallel, Memory, delayed
     from sklearn.utils import cpu_count, hash, effective_n_jobs
-    check_warning(Memory)
+    check_warning(Memory , tmpdir)
     check_warning(hash, 1)
     check_warning(Parallel)
     check_warning(cpu_count)
@@ -303,7 +303,7 @@ def test_deprecation_joblib_api():
     from sklearn.utils._joblib import cpu_count, hash, effective_n_jobs
     from sklearn.utils._joblib import parallel_backend
     from sklearn.utils._joblib import register_parallel_backend
-    assert_no_warnings(Memory)
+    assert_no_warnings(Memory, tmpdir)
     assert_no_warnings(hash, 1)
     assert_no_warnings(Parallel)
     assert_no_warnings(cpu_count)

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -285,7 +285,7 @@ def test_deprecation_joblib_api(tmpdir):
     # Ensure that the joblib API is deprecated in sklearn.util
     from sklearn.utils import Parallel, Memory, delayed
     from sklearn.utils import cpu_count, hash, effective_n_jobs
-    check_warning(Memory , tmpdir)
+    check_warning(Memory, tmpdir)
     check_warning(hash, 1)
     check_warning(Parallel)
     check_warning(cpu_count)

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -277,6 +277,10 @@ def test_is_scalar_nan(value, result):
     assert is_scalar_nan(value) is result
 
 
+def dummy_func():
+    pass
+
+
 def test_deprecation_joblib_api(tmpdir):
     def check_warning(*args, **kw):
         return assert_warns_message(
@@ -285,12 +289,12 @@ def test_deprecation_joblib_api(tmpdir):
     # Ensure that the joblib API is deprecated in sklearn.util
     from sklearn.utils import Parallel, Memory, delayed
     from sklearn.utils import cpu_count, hash, effective_n_jobs
-    check_warning(Memory, tmpdir)
+    check_warning(Memory, str(tmpdir))
     check_warning(hash, 1)
     check_warning(Parallel)
     check_warning(cpu_count)
     check_warning(effective_n_jobs, 1)
-    check_warning(delayed, lambda: None)
+    check_warning(delayed, dummy_func)
 
     # Only parallel_backend and register_parallel_backend are not deprecated in
     # sklearn.utils
@@ -303,12 +307,12 @@ def test_deprecation_joblib_api(tmpdir):
     from sklearn.utils._joblib import cpu_count, hash, effective_n_jobs
     from sklearn.utils._joblib import parallel_backend
     from sklearn.utils._joblib import register_parallel_backend
-    assert_no_warnings(Memory, tmpdir)
+    assert_no_warnings(Memory, str(tmpdir))
     assert_no_warnings(hash, 1)
     assert_no_warnings(Parallel)
     assert_no_warnings(cpu_count)
     assert_no_warnings(effective_n_jobs, 1)
-    assert_no_warnings(delayed, lambda: None)
+    assert_no_warnings(delayed, dummy_func)
     assert_no_warnings(parallel_backend, 'loky', None)
     assert_no_warnings(register_parallel_backend, 'failing', None)
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -745,14 +745,13 @@ def test_check_memory():
     memory = check_memory(dummy)
     assert memory is dummy
     assert_raises_regex(ValueError, "'memory' should be None, a string or"
-                        " have the same interface as "
-                        "sklearn.utils.Memory."
+                        " have the same interface as joblib.Memory."
                         " Got memory='1' instead.", check_memory, 1)
     dummy = WrongDummyMemory()
     assert_raises_regex(ValueError, "'memory' should be None, a string or"
-                        " have the same interface as "
-                        "sklearn.utils.Memory. Got memory='{}' "
-                        "instead.".format(dummy), check_memory, dummy)
+                        " have the same interface as joblib.Memory."
+                        " Got memory='{}' instead.".format(dummy),
+                        check_memory, dummy)
 
 
 @pytest.mark.parametrize('copy', [True, False])

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -18,13 +18,14 @@ from distutils.version import LooseVersion
 
 from numpy.core.numeric import ComplexWarning
 
-from . import Memory, joblib_version
+from ..externals import six
 from .fixes import signature
 from .. import get_config as _get_config
-from ..externals import six
 from ..exceptions import NonBLASDotWarning
 from ..exceptions import NotFittedError
 from ..exceptions import DataConversionWarning
+from . import Memory
+from ._joblib import __version__ as joblib_version
 
 FLOAT_DTYPES = (np.float64, np.float32, np.float16)
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -18,14 +18,13 @@ from distutils.version import LooseVersion
 
 from numpy.core.numeric import ComplexWarning
 
-from ..externals import six
-from ..utils.fixes import signature
+from . import Memory, joblib_version
+from .fixes import signature
 from .. import get_config as _get_config
+from ..externals import six
 from ..exceptions import NonBLASDotWarning
 from ..exceptions import NotFittedError
 from ..exceptions import DataConversionWarning
-from ..utils._joblib import Memory
-from ..utils._joblib import __version__ as joblib_version
 
 FLOAT_DTYPES = (np.float64, np.float32, np.float16)
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -24,7 +24,7 @@ from .. import get_config as _get_config
 from ..exceptions import NonBLASDotWarning
 from ..exceptions import NotFittedError
 from ..exceptions import DataConversionWarning
-from . import Memory
+from ._joblib import Memory
 from ._joblib import __version__ as joblib_version
 
 FLOAT_DTYPES = (np.float64, np.float32, np.float16)
@@ -188,8 +188,8 @@ def check_memory(memory):
     """Check that ``memory`` is joblib.Memory-like.
 
     joblib.Memory-like means that ``memory`` can be converted into a
-    sklearn.utils.Memory instance (typically a str denoting the
-    ``cachedir``) or has the same interface (has a ``cache`` method).
+    joblib.Memory instance (typically a str denoting the ``location``)
+    or has the same interface (has a ``cache`` method).
 
     Parameters
     ----------
@@ -212,7 +212,7 @@ def check_memory(memory):
             memory = Memory(location=memory, verbose=0)
     elif not hasattr(memory, 'cache'):
         raise ValueError("'memory' should be None, a string or have the same"
-                         " interface as sklearn.utils.Memory."
+                         " interface as joblib.Memory."
                          " Got memory='{}' instead.".format(memory))
     return memory
 


### PR DESCRIPTION
This PR intends to fix the failure seen in the CRON job using master branch of `joblib`. (See [here]( https://travis-ci.org/scikit-learn/scikit-learn/builds/438229703?utm_source=github_status&utm_medium=notification))

It removes all mention to `externals.joblib` in the codebase and replace it with `sklearn.utils`.

Note that for testing purposes, it is necessary to add the module `joblib` in `utils` to be able to access more advanced functionality of `joblib` without importing directly the module. I am not sure this is the best level to expose this, so let me know if this should only be access from `sklearn.utils._joblib`.