### PR TITLE
DOC use default_role='any'

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -103,7 +103,7 @@ exclude_patterns = ['_build', 'templates', 'includes', 'themes']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+default_role = 'any'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 add_function_parentheses = False


### PR DESCRIPTION
Fixes #11186

I've realised that sphinx's 'any' mostly does what we want:
* resolves references to glossary terms and other things from the std domain (e.g. section refs) before others
* resolves to code objects (e.g. `LogisticRegression`, `linear_model.LogisticRegression`) otherwise
* leaves unlinked otherwise

We may find that we want more control over it than this eventually, but it's a good start.

In all cases it uses `<code>` monospace formatting, which could perhaps be improved upon. CSS can be used to do more styling if appropriate, as each link has classes that indicate the type of the target; alternatively, the role definition can be extended.

We may consider replacing many of our double backticks with single backticks in documentation that is little touched by open PRs.