### PR TITLE
[MRG+1] Fix Error: 'MultiTaskLasso' object has no attribute 'coef_' when warm_start = True

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -40,6 +40,12 @@ Support for Python 3.4 and below has been officially dropped.
 - An entry goes here
 - An entry goes here
 
+:mod:`sklearn.linear_model`
+...........................
+- |Fix| Fixed a bug in :class:`linear_model.MultiTaskElasticNet` which was breaking
+  ``MultiTaskElasticNet`` and ``MultiTaskLasso`` when ``warm_start = True``. :issue:`12360`
+  by :user:`Aakanksha Joshi <joaak>`.
+
 :mod:`sklearn.cluster`
 ......................
 

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1795,7 +1795,7 @@ class MultiTaskElasticNet(Lasso):
         X, y, X_offset, y_offset, X_scale = _preprocess_data(
             X, y, self.fit_intercept, self.normalize, copy=False)
 
-        if not self.warm_start or self.coef_ is None:
+        if not self.warm_start or not hasattr(self, "coef_"):
             self.coef_ = np.zeros((n_tasks, n_features), dtype=X.dtype.type,
                                   order='F')
 

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -818,3 +818,15 @@ def test_coef_shape_not_zero():
     est_no_intercept = Lasso(fit_intercept=False)
     est_no_intercept.fit(np.c_[np.ones(3)], np.ones(3))
     assert est_no_intercept.coef_.shape == (1,)
+
+
+def test_warm_start_multitask_lasso():
+    X, y, X_test, y_test = build_dataset()
+    Y = np.c_[y, y]
+    clf = MultiTaskLasso(alpha=0.1, max_iter=5, warm_start=True)
+    ignore_warnings(clf.fit)(X, Y)
+    ignore_warnings(clf.fit)(X, Y)  # do a second round with 5 iterations
+
+    clf2 = MultiTaskLasso(alpha=0.1, max_iter=10)
+    ignore_warnings(clf2.fit)(X, Y)
+    assert_array_almost_equal(clf2.coef_, clf.coef_)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

Fixes #12360 

#### What does this implement/fix? Explain your changes.

In the original source code, within the class MultiTaskElaticNet, `if not self.warm_start or self.coef_ is None:` (line 1798) throws an error that the object has no attribute 'coef_' when a MultiTaskElaticNet/MultiTaskLasso object is created with `warm_start = True`.

Potential Fix:

Replace 

`if not self.warm_start or self.coef_ is None:` 

with 

`if not self.warm_start or not hasattr(self, "coef_"):` 

(The replacement is what has been done in line 733 within the ElasticNet class in the original source code).

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->