### PR TITLE
Remove DeprecationWarning in label.py:151

### DIFF
--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -151,7 +151,7 @@ def _encode_check_unknown(values, uniques, return_mask=False):
         unique_values = np.unique(values)
         diff = list(np.setdiff1d(unique_values, uniques, assume_unique=True))
         if return_mask:
-            if diff:
+            if len(diff) > 0:
                 valid_mask = np.in1d(values, uniques)
             else:
                 valid_mask = np.ones(len(values), dtype=bool)


### PR DESCRIPTION
Im often seeing this and would like to contribute! 
```
python3.6/site-packages/scikit_learn-0.19.2-py3.6-macosx-10.7-x86_64.egg/sklearn/preprocessing/label.py:151: DeprecationWarning: The truth value of an empty array is ambiguous. Returning False, but in future this will result in an error. Use `array.size > 0` to check that an array is not empty.
```
