### PR TITLE
[MRG] Fix missing assert and parametrize some k-means tests

### DIFF
--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -181,12 +181,6 @@ def _check_fitted_model(km):
                          % km.n_clusters, km.fit, [[0., 1.]])
 
 
-def test_k_means_plus_plus_init():
-    km = KMeans(init="k-means++", n_clusters=n_clusters,
-                random_state=42).fit(X)
-    _check_fitted_model(km)
-
-
 def test_k_means_new_centers():
     # Explore the part of the code where a new center is reassigned
     X = np.array([[0, 0, 1, 1],
@@ -229,24 +223,6 @@ def test_k_means_precompute_distances_flag():
     assert_raises(ValueError, km.fit, X)
 
 
-def test_k_means_plus_plus_init_sparse():
-    km = KMeans(init="k-means++", n_clusters=n_clusters, random_state=42)
-    km.fit(X_csr)
-    _check_fitted_model(km)
-
-
-def test_k_means_random_init():
-    km = KMeans(init="random", n_clusters=n_clusters, random_state=42)
-    km.fit(X)
-    _check_fitted_model(km)
-
-
-def test_k_means_random_init_sparse():
-    km = KMeans(init="random", n_clusters=n_clusters, random_state=42)
-    km.fit(X_csr)
-    _check_fitted_model(km)
-
-
 def test_k_means_plus_plus_init_not_precomputed():
     km = KMeans(init="k-means++", n_clusters=n_clusters, random_state=42,
                 precompute_distances=False).fit(X)
@@ -259,10 +235,12 @@ def test_k_means_random_init_not_precomputed():
     _check_fitted_model(km)
 
 
-def test_k_means_perfect_init():
-    km = KMeans(init=centers.copy(), n_clusters=n_clusters, random_state=42,
-                n_init=1)
-    km.fit(X)
+@pytest.mark.parametrize('representation', ['dense', 'sparse'])
+@pytest.mark.parametrize('init', ['random', 'k-means++', centers.copy()])
+def test_k_means_init(representation, init):
+    data = {'dense': X, 'sparse': X_csr}[representation]
+    km = KMeans(init=init, n_clusters=n_clusters, random_state=42, n_init=1)
+    km.fit(data)
     _check_fitted_model(km)
 
 
@@ -315,13 +293,6 @@ def test_k_means_fortran_aligned_data():
     assert_array_equal(km.labels_, labels)
 
 
-def test_mb_k_means_plus_plus_init_dense_array():
-    mb_k_means = MiniBatchKMeans(init="k-means++", n_clusters=n_clusters,
-                                 random_state=42)
-    mb_k_means.fit(X)
-    _check_fitted_model(mb_k_means)
-
-
 def test_mb_kmeans_verbose():
     mb_k_means = MiniBatchKMeans(init="k-means++", n_clusters=n_clusters,
                                  random_state=42, verbose=1)
@@ -333,38 +304,11 @@ def test_mb_kmeans_verbose():
         sys.stdout = old_stdout
 
 
-def test_mb_k_means_plus_plus_init_sparse_matrix():
-    mb_k_means = MiniBatchKMeans(init="k-means++", n_clusters=n_clusters,
-                                 random_state=42)
-    mb_k_means.fit(X_csr)
-    _check_fitted_model(mb_k_means)
-
-
 def test_minibatch_init_with_large_k():
     mb_k_means = MiniBatchKMeans(init='k-means++', init_size=10, n_clusters=20)
     # Check that a warning is raised, as the number clusters is larger
     # than the init_size
     assert_warns(RuntimeWarning, mb_k_means.fit, X)
-
-
-def test_minibatch_k_means_random_init_dense_array():
-    # increase n_init to make random init stable enough
-    mb_k_means = MiniBatchKMeans(init="random", n_clusters=n_clusters,
-                                 random_state=42, n_init=10).fit(X)
-    _check_fitted_model(mb_k_means)
-
-
-def test_minibatch_k_means_random_init_sparse_csr():
-    # increase n_init to make random init stable enough
-    mb_k_means = MiniBatchKMeans(init="random", n_clusters=n_clusters,
-                                 random_state=42, n_init=10).fit(X_csr)
-    _check_fitted_model(mb_k_means)
-
-
-def test_minibatch_k_means_perfect_init_dense_array():
-    mb_k_means = MiniBatchKMeans(init=centers.copy(), n_clusters=n_clusters,
-                                 random_state=42, n_init=1).fit(X)
-    _check_fitted_model(mb_k_means)
 
 
 def test_minibatch_k_means_init_multiple_runs_with_explicit_centers():
@@ -373,9 +317,13 @@ def test_minibatch_k_means_init_multiple_runs_with_explicit_centers():
     assert_warns(RuntimeWarning, mb_k_means.fit, X)
 
 
-def test_minibatch_k_means_perfect_init_sparse_csr():
-    mb_k_means = MiniBatchKMeans(init=centers.copy(), n_clusters=n_clusters,
-                                 random_state=42, n_init=1).fit(X_csr)
+@pytest.mark.parametrize('representation', ['dense', 'sparse'])
+@pytest.mark.parametrize('init', ["random", 'k-means++', centers.copy()])
+def test_minibatch_k_means_init(representation, init):
+    data = {'dense': X, 'sparse': X_csr}[representation]
+    mb_k_means = MiniBatchKMeans(init=init, n_clusters=n_clusters,
+                                 random_state=42, n_init=10)
+    mb_k_means.fit(data)
     _check_fitted_model(mb_k_means)
 
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -235,10 +235,9 @@ def test_k_means_random_init_not_precomputed():
     _check_fitted_model(km)
 
 
-@pytest.mark.parametrize('representation', ['dense', 'sparse'])
+@pytest.mark.parametrize('data', [X, X_csr], ids=['dense', 'sparse'])
 @pytest.mark.parametrize('init', ['random', 'k-means++', centers.copy()])
-def test_k_means_init(representation, init):
-    data = {'dense': X, 'sparse': X_csr}[representation]
+def test_k_means_init(data, init):
     km = KMeans(init=init, n_clusters=n_clusters, random_state=42, n_init=1)
     km.fit(data)
     _check_fitted_model(km)
@@ -317,10 +316,9 @@ def test_minibatch_k_means_init_multiple_runs_with_explicit_centers():
     assert_warns(RuntimeWarning, mb_k_means.fit, X)
 
 
-@pytest.mark.parametrize('representation', ['dense', 'sparse'])
+@pytest.mark.parametrize('data', [X, X_csr], ids=['dense', 'sparse'])
 @pytest.mark.parametrize('init', ["random", 'k-means++', centers.copy()])
-def test_minibatch_k_means_init(representation, init):
-    data = {'dense': X, 'sparse': X_csr}[representation]
+def test_minibatch_k_means_init(data, init):
     mb_k_means = MiniBatchKMeans(init=init, n_clusters=n_clusters,
                                  random_state=42, n_init=10)
     mb_k_means.fit(data)
@@ -545,10 +543,9 @@ def test_score(algo):
     assert_greater(s2, s1)
 
 
-@pytest.mark.parametrize('representation', ['dense', 'sparse'])
+@pytest.mark.parametrize('data', [X, X_csr], ids=['dense', 'sparse'])
 @pytest.mark.parametrize('init', ['random', 'k-means++', centers.copy()])
-def test_predict_minibatch(representation, init):
-    data = {'dense': X, 'sparse': X_csr}[representation]
+def test_predict_minibatch(data, init):
     mb_k_means = MiniBatchKMeans(n_clusters=n_clusters, init=init,
                                  n_init=10, random_state=0).fit(data)
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -714,7 +714,7 @@ def test_full_vs_elkan():
     km1.fit(X)
     km2.fit(X)
 
-    homogeneity_score(km1.predict(X), km2.predict(X)) == 1.0
+    assert homogeneity_score(km1.predict(X), km2.predict(X)) == 1.0
 
 
 def test_n_init():

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -621,7 +621,7 @@ def test_fit_transform():
 @pytest.mark.parametrize('algo', ['full', 'elkan'])
 def test_predict_equal_labels(algo):
     km = KMeans(random_state=13, n_jobs=1, n_init=1, max_iter=1,
-                algorithm='algo')
+                algorithm=algo)
     km.fit(X)
     assert_array_equal(km.predict(X), km.labels_)
 


### PR DESCRIPTION
Noticed a missing `assert` in k-means tests, meaning the test would always pass.

I took the opportunity to parametrize some of the k-means test. I did not make any changes to the tests, just avoided code redundancy. I was doing it in #11950 but it will be more reviewable if I do it here, in a separate PR.