### PR TITLE
Fix the link to computing docs on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ scikit-learn also uses CBLAS, the C interface to the Basic Linear Algebra
 Subprograms library. scikit-learn comes with a reference implementation, but
 the system CBLAS will be detected by the build system and used if present.
 CBLAS exists in many implementations; see `Linear algebra libraries
-<http://scikit-learn.org/stable/modules/computational_performance.html#linear-algebra-libraries>`_
+<http://scikit-learn.org/stable/modules/computing#linear-algebra-libraries>`_
 for known issues.
 
 User installation


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

On the release of scikit 0.20, the computing docs file have changed from "computational_performance.rst" to "computing.rst"

https://github.com/scikit-learn/scikit-learn/blob/0.20.X/doc/modules/computing.rst
https://github.com/scikit-learn/scikit-learn/blob/0.19.X/doc/modules/computational_performance.rst

In consequence, the link from README.rst pointing to the Linear Algebra section in the Computing page wasn't working because it was pointing to the old link.

So, this PR fixes the broken link of the computing section on the README.rst.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
