### PR TITLE
[MRG] Add distance metric_params argument to TSNE constructor

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -43,9 +43,9 @@ Support for Python 3.4 and below has been officially dropped.
 :mod:`sklearn.manifold`
 ......................
 
-- |Enhancement| add ``metric_params`` parameter to :class:`manifold.TSNE`
-  constructor for additional parameters of distance metric to use in
-  optimization. :issue:`11793` by :user:`Muneeb Aadil <muneebaadil>`.
+- |Enhancement| add ``metric_params`` and ``p`` parameters to
+  :class:`manifold.TSNE` constructor for additional parameters of distance
+  metric to use in optimization. :issue:`11793` by :user:`Muneeb Aadil <muneebaadil>`.
 
 :mod:`sklearn.linear_model`
 ...........................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -45,7 +45,7 @@ Support for Python 3.4 and below has been officially dropped.
 
 - |Enhancement| add ``metric_params`` and ``p`` parameters to
   :class:`manifold.TSNE` constructor for additional parameters of distance
-  metric to use in optimization. :issue:`11793` by :user:`Muneeb Aadil <muneebaadil>`.
+  metric to use in optimization. :issue:`12387` by :user:`Muneeb Aadil <muneebaadil>`.
 
 :mod:`sklearn.linear_model`
 ...........................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -40,6 +40,13 @@ Support for Python 3.4 and below has been officially dropped.
 - An entry goes here
 - An entry goes here
 
+:mod:`sklearn.manifold`
+......................
+
+- |Enhancement| add ``metric_params`` parameter to :class:`manifold.TSNE`
+  constructor for additional parameters of distance criteria to use in
+  optimization. :issue:`11793` by :user:`Muneeb Aadil <muneebaadil>`.
+
 :mod:`sklearn.cluster`
 ......................
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -44,7 +44,7 @@ Support for Python 3.4 and below has been officially dropped.
 ......................
 
 - |Enhancement| add ``metric_params`` parameter to :class:`manifold.TSNE`
-  constructor for additional parameters of distance criteria to use in
+  constructor for additional parameters of distance metric to use in
   optimization. :issue:`11793` by :user:`Muneeb Aadil <muneebaadil>`.
 
 :mod:`sklearn.linear_model`

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -549,7 +549,7 @@ class TSNE(BaseEstimator):
         interpreted as squared euclidean distance.
 
     metric_params : dictionary, optional (default: None)
-        Keyword arguments of distance metric to use
+        Keyword arguments of distance metric to use.
 
     init : string or numpy array, optional (default: "random")
         Initialization of embedding. Possible options are 'random', 'pca',

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -687,8 +687,8 @@ class TSNE(BaseEstimator):
         if not (self.metric_params is None or
                 type(self.metric_params) == dict and
                 len(self.metric_params) > 0):
-            raise TypeError("'metric_params' parameter must be either None or\
-                             non empty dicionary")
+            raise TypeError("'metric_params' parameter must be either None or "
+                            "non empty dicionary")
         if self.method == 'barnes_hut' and sp.issparse(X):
             raise TypeError('A sparse matrix was passed, but dense '
                             'data is required for method="barnes_hut". Use '

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -637,7 +637,7 @@ class TSNE(BaseEstimator):
     def __init__(self, n_components=2, perplexity=30.0,
                  early_exaggeration=12.0, learning_rate=200.0, n_iter=1000,
                  n_iter_without_progress=300, min_grad_norm=1e-7,
-                 metric="euclidean", p=2, metric_params=None, init="random",
+                 metric="minkowski", p=2, metric_params=None, init="random",
                  verbose=0, random_state=None, method='barnes_hut', angle=0.5):
         self.n_components = n_components
         self.perplexity = perplexity

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -548,6 +548,9 @@ class TSNE(BaseEstimator):
         the distance between them. The default is "euclidean" which is
         interpreted as squared euclidean distance.
 
+    metric_params : dictionary, optional (default: {})
+        Keyword arguments of distance metric to use
+
     init : string or numpy array, optional (default: "random")
         Initialization of embedding. Possible options are 'random', 'pca',
         and a numpy array of shape (n_samples, n_components).
@@ -628,8 +631,8 @@ class TSNE(BaseEstimator):
     def __init__(self, n_components=2, perplexity=30.0,
                  early_exaggeration=12.0, learning_rate=200.0, n_iter=1000,
                  n_iter_without_progress=300, min_grad_norm=1e-7,
-                 metric="euclidean", init="random", verbose=0,
-                 random_state=None, method='barnes_hut', angle=0.5):
+                 metric="euclidean", metric_params = {}, init="random",
+                 verbose=0, random_state=None, method='barnes_hut', angle=0.5):
         self.n_components = n_components
         self.perplexity = perplexity
         self.early_exaggeration = early_exaggeration
@@ -638,6 +641,7 @@ class TSNE(BaseEstimator):
         self.n_iter_without_progress = n_iter_without_progress
         self.min_grad_norm = min_grad_norm
         self.metric = metric
+        self.metric_params = metric_params
         self.init = init
         self.verbose = verbose
         self.random_state = random_state
@@ -720,9 +724,11 @@ class TSNE(BaseEstimator):
 
                 if self.metric == "euclidean":
                     distances = pairwise_distances(X, metric=self.metric,
-                                                   squared=True)
+                                                   squared=True,
+                                                   **self.metric_params)
                 else:
-                    distances = pairwise_distances(X, metric=self.metric)
+                    distances = pairwise_distances(X, metric=self.metric,
+                                                   **self.metric_params)
 
                 if np.any(distances < 0):
                     raise ValueError("All distances should be positive, the "
@@ -747,7 +753,8 @@ class TSNE(BaseEstimator):
 
             # Find the nearest neighbors for every point
             knn = NearestNeighbors(algorithm='auto', n_neighbors=k,
-                                   metric=self.metric)
+                                   metric=self.metric,
+                                   metric_params=self.metric_params)
             t0 = time()
             knn.fit(X)
             duration = time() - t0

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -684,9 +684,9 @@ class TSNE(BaseEstimator):
                 raise ValueError("All distances should be positive, the "
                                  "precomputed distances given as X is not "
                                  "correct")
-        if not ((self.metric_params is None) or
-                ((type(self.metric_params) == dict) and
-                (len(self.metric_params) > 0))):
+        if not (self.metric_params is None or
+                type(self.metric_params) == dict and
+                len(self.metric_params) > 0):
             raise TypeError("'metric_params' parameter must be either None or\
                              non empty dicionary")
         if self.method == 'barnes_hut' and sp.issparse(X):
@@ -761,7 +761,7 @@ class TSNE(BaseEstimator):
                 print("[t-SNE] Computing {} nearest neighbors...".format(k))
 
             # Find the nearest neighbors for every point
-            if (self.metric_params is None) or not ('p' in self.metric_params):
+            if self.metric_params is None or 'p' not in self.metric_params:
                 knn = NearestNeighbors(algorithm='auto', n_neighbors=k,
                                        metric=self.metric,
                                        metric_params=self.metric_params)

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -855,12 +855,12 @@ def test_tsne_with_different_distance_metrics():
 
 
 def test_tsne_with_mahalanobis_distance():
-    """Make sure if it fixes the proposes issue (#11793)"""
+    # issue # 11793
     random_state = check_random_state(0)
     n_features = 10
     n_embedding = 3
     n_samples = 500
-    X = random_state.randn(n_samples, n_features).astype(np.float32)
+    X = random_state.randn(n_samples, n_features)
 
     # 1. raises error here (original issue)
     tsne = TSNE(verbose=1, perplexity=40, n_iter=250, learning_rate=50,
@@ -868,14 +868,7 @@ def test_tsne_with_mahalanobis_distance():
     ref = "Must provide either V or VI for Mahalanobis distance"
     assert_raises_regexp(ValueError, ref, tsne.fit_transform, X)
 
-    # 2. error fix: provide distance metric parameters in a dictionary
-    # it now provides the embedding results in correct shape
-    tsne = TSNE(verbose=1, perplexity=40, n_iter=250, learning_rate=50,
-                n_components=n_embedding, random_state=0, metric='mahalanobis',
-                metric_params={'V': np.cov(X.T)})
-    assert_equal((n_samples, n_embedding), tsne.fit_transform(X).shape)
-
-    # 3. check for correct answer
+    # 2. check for correct answer
     precomputed_X = squareform(pdist(X, metric='mahalanobis'), checks=True)
     ref = TSNE(verbose=1, perplexity=40, n_iter=250, learning_rate=50,
                n_components=n_embedding, random_state=0,
@@ -894,7 +887,7 @@ def test_tsne_with_metric_params_type():
     n_features = 10
     n_embedding = 3
     n_samples = 15
-    X = random_state.randn(n_samples, n_features).astype(np.float32)
+    X = random_state.randn(n_samples, n_features)
 
     # using metric_params = None when not required for euclidean distance
     # runs okay and does not generate an error

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -878,38 +878,3 @@ def test_tsne_with_mahalanobis_distance():
                n_components=n_embedding, random_state=0, metric='mahalanobis',
                metric_params={'V': np.cov(X.T)}).fit_transform(X)
     assert_array_equal(ref, now)
-
-
-def test_tsne_with_metric_params_type():
-    """Makes sure tsne interface intended output for all possible metric_params
-    type"""
-    random_state = check_random_state(0)
-    n_features = 10
-    n_embedding = 3
-    n_samples = 15
-    X = random_state.randn(n_samples, n_features)
-
-    # using metric_params = None when not required for euclidean distance
-    # runs okay and does not generate an error
-    tsne = TSNE(verbose=1, perplexity=40, n_iter=250, learning_rate=50,
-                n_components=n_embedding, random_state=0, metric='euclidean')
-    assert_equal((n_samples, n_embedding), tsne.fit_transform(X).shape)
-
-    # using metric_params = {} when not required for euclidean distance
-    # generates a type error
-    tsne = TSNE(verbose=1, perplexity=40, n_iter=250, learning_rate=50,
-                n_components=n_embedding, random_state=0, metric='euclidean',
-                metric_params={})
-    assert_raises(TypeError, tsne.fit_transform, X)
-
-    # using metric_params with 'VI' key is already tested on above function
-
-    # testing metric_params having 'p' with minkowski distance
-    # note: minkowski distance with p=1 is equivalent to manhattan distance
-    now = TSNE(verbose=1, perplexity=40, n_iter=250, learning_rate=50,
-               n_components=n_embedding, random_state=0, metric='minkowski',
-               metric_params={'p': 1}).fit_transform(X)
-    ref = TSNE(verbose=1, perplexity=40, n_iter=250, learning_rate=50,
-               n_components=n_embedding, random_state=0,
-               metric='precomputed').fit_transform(manhattan_distances(X))
-    assert_array_equal(ref, now)

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -276,7 +276,7 @@ def test_fit_csr_matrix():
     X[(np.random.randint(0, 100, 50), np.random.randint(0, 2, 50))] = 0.0
     X_csr = sp.csr_matrix(X)
     tsne = TSNE(n_components=2, perplexity=10, learning_rate=100.0,
-                random_state=0, method='exact')
+                random_state=0, method='exact', metric="euclidean")
     X_embedded = tsne.fit_transform(X_csr)
     assert_almost_equal(trustworthiness(X_csr, X_embedded, n_neighbors=1), 1.0,
                         decimal=1)

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -885,3 +885,38 @@ def test_tsne_with_mahalanobis_distance():
                n_components=n_embedding, random_state=0, metric='mahalanobis',
                metric_params={'V': np.cov(X.T)}).fit_transform(X)
     assert_array_equal(ref, now)
+
+
+def test_tsne_with_metric_params_type():
+    """Makes sure tsne interface intended output for all possible metric_params
+    type"""
+    random_state = check_random_state(0)
+    n_features = 10
+    n_embedding = 3
+    n_samples = 15
+    X = random_state.randn(n_samples, n_features).astype(np.float32)
+
+    # using metric_params = None when not required for euclidean distance
+    # runs okay and does not generate an error
+    tsne = TSNE(verbose=1, perplexity=40, n_iter=250, learning_rate=50,
+                n_components=n_embedding, random_state=0, metric='euclidean')
+    assert_equal((n_samples, n_embedding), tsne.fit_transform(X).shape)
+
+    # using metric_params = {} when not required for euclidean distance
+    # generates a type error
+    tsne = TSNE(verbose=1, perplexity=40, n_iter=250, learning_rate=50,
+                n_components=n_embedding, random_state=0, metric='euclidean',
+                metric_params={})
+    assert_raises(TypeError, tsne.fit_transform, X)
+
+    # using metric_params with 'VI' key is already tested on above function
+
+    # testing metric_params having 'p' with minkowski distance
+    # note: minkowski distance with p=1 is equivalent to manhattan distance
+    now = TSNE(verbose=1, perplexity=40, n_iter=250, learning_rate=50,
+               n_components=n_embedding, random_state=0, metric='minkowski',
+               metric_params={'p': 1}).fit_transform(X)
+    ref = TSNE(verbose=1, perplexity=40, n_iter=250, learning_rate=50,
+               n_components=n_embedding, random_state=0,
+               metric='precomputed').fit_transform(manhattan_distances(X))
+    assert_array_equal(ref, now)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #11793 


#### What does this implement/fix? Explain your changes.
it adds a dictionary parameter to TSNE constructor which represents the keyword arguments for distance metric to be used inside TSNE optimization

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
