### PR TITLE
[MRG] Raise descriptive ValueError if number of samples equals number of classes in Linear Discriminant Analysis

### DIFF
--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -355,16 +355,6 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
         y : array-like, shape (n_samples,) or (n_samples, n_targets)
             Target values.
         """
-        n_samples, n_features = X.shape
-        n_classes = len(self.classes_)
-
-        if n_samples <= n_classes:
-            raise ValueError("The number of samples must be more "
-                             "than the number of classes. "
-                             "Currently, you have {} samples and {} "
-                             "classes.".format(n_samples, n_classes))
-
-
         self.means_ = _class_means(X, y)
         if self.store_covariance:
             self.covariance_ = _class_cov(X, y, self.priors_)
@@ -434,6 +424,12 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
         """
         X, y = check_X_y(X, y, ensure_min_samples=2, estimator=self)
         self.classes_ = unique_labels(y)
+        n_samples, _ = X.shape
+        n_classes = len(self.classes_)
+
+        if n_samples == n_classes:
+            raise ValueError("The number of samples must be more "
+                             "than the number of classes.")
 
         if self.priors is None:  # estimate priors from sample
             _, y_t = np.unique(y, return_inverse=True)  # non-negative ints

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -355,6 +355,9 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
         y : array-like, shape (n_samples,) or (n_samples, n_targets)
             Target values.
         """
+        n_samples, n_features = X.shape
+        n_classes = len(self.classes_)
+
         self.means_ = _class_means(X, y)
         if self.store_covariance:
             self.covariance_ = _class_cov(X, y, self.priors_)

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -358,6 +358,13 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
         n_samples, n_features = X.shape
         n_classes = len(self.classes_)
 
+        if n_samples <= n_classes:
+            raise ValueError("The number of samples must be more "
+                             "than the number of classes. "
+                             "Currently, you have {} samples and {} "
+                             "classes.".format(n_samples, n_classes))
+
+
         self.means_ = _class_means(X, y)
         if self.store_covariance:
             self.covariance_ = _class_cov(X, y, self.priors_)

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -355,7 +355,7 @@ def test_covariance():
 
 
 @pytest.mark.parametrize("solver", ['svd, lsqr', 'eigen'])
-def test_raises_value_error_on_same_number_of_classes_and_samples():
+def test_raises_value_error_on_same_number_of_classes_and_samples(solver):
     """
     Tests that if the number of samples equals the number
     of classes, a ValueError is raised.

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -354,6 +354,7 @@ def test_covariance():
     assert_almost_equal(c_s, c_s.T)
 
 
+@pytest.mark.parametrize("solver", ['svd, lsqr', 'eigen'])
 def test_raises_value_error_on_same_number_of_classes_and_samples():
     """
     Tests that if the number of samples equals the number
@@ -361,6 +362,6 @@ def test_raises_value_error_on_same_number_of_classes_and_samples():
     """
     X = np.array([[0.5, 0.6], [0.6, 0.5]])
     y = np.array(["a", "b"])
-    clf = LinearDiscriminantAnalysis()
+    clf = LinearDiscriminantAnalysis(solver=solver)
     with pytest.raises(ValueError, match="The number of samples must be more"):
         clf.fit(X, y)

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -361,6 +361,6 @@ def test_raises_value_error_on_same_number_of_classes_and_samples():
     """
     X = np.array([[0.5, 0.6], [0.6, 0.5]])
     y = np.array(["a", "b"])
-    clf = LinearDiscriminantAnalysis(solver="svd")
+    clf = LinearDiscriminantAnalysis()
     with pytest.raises(ValueError, match="The number of samples must be more"):
         clf.fit(X, y)

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+import pytest
+
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_equal
@@ -350,3 +352,15 @@ def test_covariance():
 
     c_s = _cov(x, 'auto')
     assert_almost_equal(c_s, c_s.T)
+
+
+def test_raises_value_error_on_same_number_of_classes_and_samples():
+    """
+    Tests that if the number of samples equals the number
+    of classes, a ValueError is raised.
+    """
+    X = np.array([[0.5, 0.6], [0.6, 0.5]])
+    y = np.array(["a", "b"])
+    clf = LinearDiscriminantAnalysis(solver="svd")
+    with pytest.raises(ValueError, match="The number of samples must be more"):
+        clf.fit(X, y)


### PR DESCRIPTION
Fixes #12374

Before: Failed with division by zero error if no_classes == no_sample in Linear Discriminant Analysis.

After: This PR raises a more descriptive ValueError, explaining the problem.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
