### PR TITLE
Make davies-bouldin robust to distance matrices with non-zero diagonals

### DIFF
--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -240,7 +240,7 @@ def pairwise_distances_nonzero_diag(X, Y=None, metric="euclidean", n_jobs=None, 
 
 
 def test_davies_bouldin_nonzero_diag():
-    # Tests the
+    # Test that davies-boulding is invariant to non-zero diagonals on distance matrices
     dataset = datasets.load_iris()
     X = dataset.data
     y = dataset.target

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -230,12 +230,11 @@ def test_davies_bouldin_score():
     pytest.approx(davies_bouldin_score(X, labels), (5. / 4) / 3)
 
 def pairwise_distances_nonzero_diag(X, Y=None, metric="euclidean", n_jobs=None, **kwds):
-
     dists = pairwise_distances(X, Y, metric, n_jobs, **kwds)
-    # Construct a nonzero-diagonal distance matrix
-    diag_dists = np.diag(np.ones(dists.shape[0])) + dists
-
-    return diag_dists
+    
+    if len(np.squeeze(dists).shape) > 1:
+        np.fill_diagonal(dists, np.ones(len(np.diag(dists))))
+    return dists
 
 def test_davies_bouldin_nonzero_diag():
     # Tests the

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -228,3 +228,23 @@ def test_davies_bouldin_score():
     X = ([[0, 0], [2, 2], [3, 3], [5, 5]])
     labels = [0, 0, 1, 2]
     pytest.approx(davies_bouldin_score(X, labels), (5. / 4) / 3)
+
+def pairwise_distances_nonzero_diag(X, Y=None, metric="euclidean", n_jobs=None, **kwds):
+
+    dists = pairwise_distances(X, Y, metric, n_jobs, **kwds)
+    # Construct a nonzero-diagonal distance matrix
+    diag_dists = np.diag(np.ones(dists.shape[0])) + dists
+
+    return diag_dists
+
+def test_davies_bouldin_nonzero_diag():
+    # Tests the
+    dataset = datasets.load_iris()
+    X = dataset.data
+    y = dataset.target
+
+    original_score = davies_bouldin_score(X, y)
+
+    nonzero_diag_score = davies_bouldin_score(X, y, pairwise_distances_func = pairwise_distances_nonzero_diag)
+
+    assert_equal(original_score, nonzero_diag_score)

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -203,7 +203,7 @@ def test_calinski_harabaz_score():
          [[0, 4], [1, 3]] * 5 + [[3, 1], [4, 0]] * 5)
     labels = [0] * 10 + [1] * 10 + [2] * 10 + [3] * 10
     pytest.approx(calinski_harabaz_score(X, labels),
-                        45 * (40 - 4) / (5 * (4 - 1)))
+                  45 * (40 - 4) / (5 * (4 - 1)))
 
 
 def test_davies_bouldin_score():
@@ -229,12 +229,15 @@ def test_davies_bouldin_score():
     labels = [0, 0, 1, 2]
     pytest.approx(davies_bouldin_score(X, labels), (5. / 4) / 3)
 
+
 def pairwise_distances_nonzero_diag(X, Y=None, metric="euclidean", n_jobs=None, **kwds):
+    # Intercept pairwise distances and corrupt the diagonal entries
     dists = pairwise_distances(X, Y, metric, n_jobs, **kwds)
-    
+
     if len(np.squeeze(dists).shape) > 1:
-        np.fill_diagonal(dists, np.ones(len(np.diag(dists))))
+        np.fill_diagonal(dists, 1)
     return dists
+
 
 def test_davies_bouldin_nonzero_diag():
     # Tests the
@@ -244,6 +247,7 @@ def test_davies_bouldin_nonzero_diag():
 
     original_score = davies_bouldin_score(X, y)
 
-    nonzero_diag_score = davies_bouldin_score(X, y, pairwise_distances_func = pairwise_distances_nonzero_diag)
+    nonzero_diag_score = davies_bouldin_score(
+        X, y, pairwise_distances_func=pairwise_distances_nonzero_diag)
 
     assert_equal(original_score, nonzero_diag_score)

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -288,7 +288,7 @@ def calinski_harabaz_score(X, labels):
             (intra_disp * (n_labels - 1.)))
 
 
-def davies_bouldin_score(X, labels):
+def davies_bouldin_score(X, labels, pairwise_distances_func = pairwise_distances):
     """Computes the Davies-Bouldin score.
 
     The score is defined as the ratio of within-cluster distances to
@@ -331,10 +331,10 @@ def davies_bouldin_score(X, labels):
         cluster_k = safe_indexing(X, labels == k)
         centroid = cluster_k.mean(axis=0)
         centroids[k] = centroid
-        intra_dists[k] = np.average(pairwise_distances(
+        intra_dists[k] = np.average(pairwise_distances_func(
             cluster_k, [centroid]))
 
-    centroid_distances = pairwise_distances(centroids)
+    centroid_distances = pairwise_distances_func(centroids)
 
     if np.allclose(intra_dists, 0) or np.allclose(centroid_distances, 0):
         return 0.0

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -335,6 +335,8 @@ def davies_bouldin_score(X, labels, pairwise_distances_func = pairwise_distances
             cluster_k, [centroid]))
 
     centroid_distances = pairwise_distances_func(centroids)
+    # Set diagonal to zero
+    np.fill_diagonal(centroid_distances, np.zeros(len(np.diag(centroid_distances))))
 
     if np.allclose(intra_dists, 0) or np.allclose(centroid_distances, 0):
         return 0.0

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -305,6 +305,9 @@ def davies_bouldin_score(X, labels, pairwise_distances_func=pairwise_distances):
     labels : array-like, shape (``n_samples``,)
         Predicted labels for each sample.
 
+    pairwise_distances_func : callable
+        Function that conforms to :obj:`sklearn.metrics.pairwise_distances`.
+
     Returns
     -------
     score: float

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -288,7 +288,7 @@ def calinski_harabaz_score(X, labels):
             (intra_disp * (n_labels - 1.)))
 
 
-def davies_bouldin_score(X, labels, pairwise_distances_func = pairwise_distances):
+def davies_bouldin_score(X, labels, pairwise_distances_func=pairwise_distances):
     """Computes the Davies-Bouldin score.
 
     The score is defined as the ratio of within-cluster distances to

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -336,7 +336,7 @@ def davies_bouldin_score(X, labels, pairwise_distances_func = pairwise_distances
 
     centroid_distances = pairwise_distances_func(centroids)
     # Set diagonal to zero
-    np.fill_diagonal(centroid_distances, np.zeros(len(np.diag(centroid_distances))))
+    np.fill_diagonal(centroid_distances, 0)
 
     if np.allclose(intra_dists, 0) or np.allclose(centroid_distances, 0):
         return 0.0


### PR DESCRIPTION
#### Reference Issues/PRs

https://github.com/scikit-learn/scikit-learn/pull/12258#issuecomment-429725067

#### What does this implement/fix? Explain your changes.

Davies-Bouldin metric is incorrect when the distance matrices have nonzero diagonals. I have:
- added a line to always set the diagonal entries of the distance matrix to 0
- added a matching test

#### Any other comments?

In order to test this I had to add a new argument to `davies-bouldin`, which is a callable to a `pairwise_distances` compatible function. Someone please check that what I have done conforms to the scikit standards (and also the documentation).