### PR TITLE
[MRG] Fix typo in clustering documentation, AMI->FMI

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -1551,7 +1551,7 @@ Advantages
 - **Upper-bounded at 1**:  Values close to zero indicate two label
   assignments that are largely independent, while values close to one
   indicate significant agreement. Further, values of exactly 0 indicate
-  **purely** independent label assignments and a AMI of exactly 1 indicates
+  **purely** independent label assignments and a FMI of exactly 1 indicates
   that the two label assignments are equal (with or without permutation).
 
 - **No assumption is made on the cluster structure**: can be used


### PR DESCRIPTION
This should be a *very* easy one!

I am replacing a single character in the documentation, which fixes a typographical error.

In the clustering documentation, a lot of the evaluation methods have the same advantages and drawbacks (because most of them require ground-truth labels, which always has certain pros and cons), so the text for these sections were originally copy-pasted from others and adapted. One of the adaptations was missed, so there is one point in the FMI (Fowlkes-Mallows index) section where it says AMI (i.e. Adjusted Mutual Information) instead.