### PR TITLE
[WIP] Mention of pairwise_distances in Guide on Metrics

### DIFF
--- a/doc/modules/metrics.rst
+++ b/doc/modules/metrics.rst
@@ -38,7 +38,7 @@ the kernel:
 The distances between the row vectors of ``X`` and the row vectors of ``Y``
 can be evaluated using :func:`pairwise_distances`. If ``Y`` is omitted the
 pairwise distances of the row vectors of ``X`` are calculated. Similarly,
-:func:`pairwise_kernel` can be used to calculate the kernel between `X`
+:func:`pairwise.pairwise_kernels` can be used to calculate the kernel between `X`
 and `Y` using different kernel distances. See the API reference for more
 details.
 

--- a/doc/modules/metrics.rst
+++ b/doc/modules/metrics.rst
@@ -39,7 +39,7 @@ The distances between the row vectors of ``X`` and the row vectors of ``Y``
 can be evaluated using :func:`pairwise_distances`. If ``Y`` is omitted the
 pairwise distances of the row vectors of ``X`` are calculated. Similarly,
 :func:`pairwise.pairwise_kernels` can be used to calculate the kernel between `X`
-and `Y` using different kernel distances. See the API reference for more
+and `Y` using different kernel functions. See the API reference for more
 details.
 
     >>> import numpy as np

--- a/doc/modules/metrics.rst
+++ b/doc/modules/metrics.rst
@@ -35,24 +35,30 @@ the kernel:
 
 .. currentmodule:: sklearn.metrics
 
-.. _pairwise_distances:
+The distances between the row vectors of ``X`` and the row vectors of ``Y``
+can be evaluated using :func:`pairwise_distances`. If ``Y`` is omitted the
+pairwise distances of the row vectors of ``X`` are calculated. Similarly,
+:func:`pairwise_kernel` can be used to calculate the kernel between `X`
+and `Y` using different kernel distances. See the API reference for more
+details.
 
-The distances between each row vector of ``X`` and a column vector ``y``
-can be evaluated using :func:`pairwise_distances`. If ``y`` is omitted the
-pairwise distances of the row vectors of ``X`` are calculated.
-
->>> import numpy as np
->>> from sklearn.metrics import pairwise_distances
->>> X = np.array([[2, 3], [3, 5], [5, 8]])
->>> y = np.array([[1, 0]])
->>> pairwise_distances(X, y, metric='manhattan')
-array([[ 4.],
-       [ 7.],
-       [12.]])
->>> pairwise_distances(X, metric='manhattan')
-array([[0., 3., 8.],
-       [3., 0., 5.],
+    >>> import numpy as np
+    >>> from sklearn.metrics import pairwise_distances
+    >>> X = np.array([[2, 3], [3, 5], [5, 8]])
+    >>> Y = np.array([[1, 0], [2, 1]])
+    >>> pairwise_distances(X, Y, metric='manhattan')
+    array([[ 4.,  2.],
+           [ 7.,  5.],
+           [12., 10.]])
+    >>> pairwise_distances(X, metric='manhattan')
+    array([[0., 3., 8.],
+           [3., 0., 5.],
        [8., 5., 0.]])
+    >>> pairwise_kernels(X, Y, metric='linear')
+    array([[ 2.,  7.],
+           [ 3., 11.],
+           [ 5., 18.]])
+
 
 .. currentmodule:: sklearn.metrics.pairwise
 

--- a/doc/modules/metrics.rst
+++ b/doc/modules/metrics.rst
@@ -44,6 +44,7 @@ details.
 
     >>> import numpy as np
     >>> from sklearn.metrics import pairwise_distances
+    >>> from sklearn.metrics.pairwise import pairwise_kernels
     >>> X = np.array([[2, 3], [3, 5], [5, 8]])
     >>> Y = np.array([[1, 0], [2, 1]])
     >>> pairwise_distances(X, Y, metric='manhattan')
@@ -53,7 +54,7 @@ details.
     >>> pairwise_distances(X, metric='manhattan')
     array([[0., 3., 8.],
            [3., 0., 5.],
-       [8., 5., 0.]])
+           [8., 5., 0.]])
     >>> pairwise_kernels(X, Y, metric='linear')
     array([[ 2.,  7.],
            [ 3., 11.],

--- a/doc/modules/metrics.rst
+++ b/doc/modules/metrics.rst
@@ -33,6 +33,27 @@ the kernel:
     2. ``S = 1. / (D / np.max(D))``
 
 
+.. currentmodule:: sklearn.metrics
+
+.. _pairwise_distances:
+
+The distances between each row vector of ``X`` and a column vector ``y``
+can be evaluated using :func:`pairwise_distances`. If ``y`` is omitted the
+pairwise distances of the row vectors of ``X`` are calculated.
+
+>>> import numpy as np
+>>> from sklearn.metrics import pairwise_distances
+>>> X = np.array([[2, 3], [3, 5], [5, 8]])
+>>> y = np.array([[1, 0]])
+>>> pairwise_distances(X, y, metric='manhattan')
+array([[ 4.],
+       [ 7.],
+       [12.]])
+>>> pairwise_distances(X, metric='manhattan')
+array([[0., 3., 8.],
+       [3., 0., 5.],
+       [8., 5., 0.]])
+
 .. currentmodule:: sklearn.metrics.pairwise
 
 .. _cosine_similarity:


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9428.

#### What does this implement/fix? Explain your changes.

Section [4.8. Pairwise metrics, Affinities and Kernels](http://scikit-learn.org/stable/modules/metrics.html) of the guide talks about "evaluate pairwise distances" but does not mention the functions `pairwise_distances` or `pairwise_kernels`.

This hint with some example code has been added.
