### PR TITLE
[WIP] Faciitate squaring distances for tSNE with non-Euclidean metric…

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -585,6 +585,13 @@ class TSNE(BaseEstimator):
         in the range of 0.2 - 0.8. Angle less than 0.2 has quickly increasing
         computation time and angle greater 0.8 has quickly increasing error.
 
+    square_distance: bool or string (default: 'legacy')
+        Facilitates squaring the distance matrix.
+        If 'legacy',  the behavior is to square the distance only if 'metric' =
+        'euclidean'.
+        If True, square the distance for all the metrics including precomputed
+        If False, do not square the distance even for 'euclidean' metric
+
     Attributes
     ----------
     embedding_ : array-like, shape (n_samples, n_components)
@@ -629,7 +636,8 @@ class TSNE(BaseEstimator):
                  early_exaggeration=12.0, learning_rate=200.0, n_iter=1000,
                  n_iter_without_progress=300, min_grad_norm=1e-7,
                  metric="euclidean", init="random", verbose=0,
-                 random_state=None, method='barnes_hut', angle=0.5):
+                 random_state=None, method='barnes_hut', angle=0.5,
+                 square_distance='legacy'):
         self.n_components = n_components
         self.perplexity = perplexity
         self.early_exaggeration = early_exaggeration
@@ -643,6 +651,7 @@ class TSNE(BaseEstimator):
         self.random_state = random_state
         self.method = method
         self.angle = angle
+        self.square_distance = square_distance
 
     def _fit(self, X, skip_num_points=0):
         """Fit the model using X as training data.
@@ -706,6 +715,16 @@ class TSNE(BaseEstimator):
         if self.n_iter < 250:
             raise ValueError("n_iter should be at least 250")
 
+        if self.square_distance not in [True, False, 'legacy', 'warn']:
+            raise ValueError("squared_distance should be True, False, 'legacy'"
+                             "or warn")
+
+        if self.square_distance == 'warn':
+            if self.metric != "euclidean":
+                warnings.warn("The default value of square_distance will be"
+                              "set to True in 0.23.", FutureWarning)
+            self.square_distance = True
+
         n_samples = X.shape[0]
 
         neighbors_nn = None
@@ -713,15 +732,26 @@ class TSNE(BaseEstimator):
             # Retrieve the distance matrix, either using the precomputed one or
             # computing it.
             if self.metric == "precomputed":
-                distances = X
+                if self.square_distance is True:
+                    distances = X**2
+                else:
+                    # self.squared_distance is False or 'legacy'
+                    distances = X
             else:
                 if self.verbose:
                     print("[t-SNE] Computing pairwise distances...")
 
-                if self.metric == "euclidean":
+                if self.square_distance == 'legacy':
+                    if self.metric == "euclidean":
+                        distances = pairwise_distances(X, metric=self.metric,
+                                                       squared=True)
+                    else:
+                        distances = pairwise_distances(X, metric=self.metric)
+                elif self.square_distance is True:
                     distances = pairwise_distances(X, metric=self.metric,
                                                    squared=True)
                 else:
+                    # self.squared_distance is False
                     distances = pairwise_distances(X, metric=self.metric)
 
                 if np.any(distances < 0):
@@ -766,13 +796,18 @@ class TSNE(BaseEstimator):
             # Free the memory used by the ball_tree
             del knn
 
-            if self.metric == "euclidean":
-                # knn return the euclidean distance but we need it squared
-                # to be consistent with the 'exact' method. Note that the
-                # the method was derived using the euclidean method as in the
-                # input space. Not sure of the implication of using a different
-                # metric.
+            if self.square_distance == 'legacy':
+                if self.metric == "euclidean":
+                    # knn return the euclidean distance but we need it squared
+                    # to be consistent with the 'exact' method. Note that the
+                    # the method was derived using the euclidean method as in
+                    # the input space. Not sure of the implication of using a
+                    # different metric.
+                    distances_nn **= 2
+            elif self.square_distance is True:
                 distances_nn **= 2
+            else:
+                distances_nn = distances_nn
 
             # compute the joint probability distribution for the input space
             P = _joint_probabilities_nn(distances_nn, neighbors_nn,


### PR DESCRIPTION

#### Reference Issues/PRs
Fixes #12401 

#### What does this implement/fix? Explain your changes.
Added a new parameter square_distance to TSNE class.
If 'legacy' (default) maintains the current behavior i.e. Squares distance only for 'euclidean' metric
If True, squares distances for every metric including 'precomputed'
If False, does not square distances even for 'euclidean' metric
If 'warn' (possible default), FutureWarning is metric is not 'euclidean'

#### Any other comments?