### PR TITLE
[MRG] FIX row_norms return dtype same as input

### DIFF
--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -39,12 +39,11 @@ def _csr_row_norms(np.ndarray[floating, ndim=1, mode="c"] X_data,
     cdef:
         unsigned long long n_samples = shape[0]
         unsigned long long n_features = shape[1]
-        np.ndarray[DOUBLE, ndim=1, mode="c"] norms
+        floating[::1] norms = np.zeros(n_samples, dtype=X_data.dtype)
 
-        np.npy_intp i, j
+        unsigned long long i
+        int j
         double sum_
-
-    norms = np.zeros(n_samples, dtype=np.float64)
 
     for i in range(n_samples):
         sum_ = 0.0

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -18,7 +18,8 @@ from sklearn.utils.sparsefuncs import (mean_variance_axis,
                                        count_nonzero, csc_median_axis_0)
 from sklearn.utils.sparsefuncs_fast import (assign_rows_csr,
                                             inplace_csr_row_normalize_l1,
-                                            inplace_csr_row_normalize_l2)
+                                            inplace_csr_row_normalize_l2,
+                                            csr_row_norms)
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_allclose
 
@@ -512,3 +513,14 @@ def test_inplace_normalize():
                 if inplace_csr_row_normalize is inplace_csr_row_normalize_l2:
                     X_csr.data **= 2
                 assert_array_almost_equal(np.abs(X_csr).sum(axis=1), ones)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_csr_row_norms(dtype):
+    # checks that csr_row_norms returns the same output as
+    # scipy.sparse.linalg.norm, and that the dype is the same X's.
+    X = sp.random(100, 10, format='csr', dtype=dtype)
+    scipy_norms = sp.linalg.norm(X, axis=1)**2
+    norms = csr_row_norms(X)
+    assert norms.dtype.type is dtype
+    assert_array_almost_equal(norms, scipy_norms)

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -518,7 +518,7 @@ def test_inplace_normalize():
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_csr_row_norms(dtype):
     # checks that csr_row_norms returns the same output as
-    # scipy.sparse.linalg.norm, and that the dype is the same X's.
+    # scipy.sparse.linalg.norm, and that the dype is the same as X.
     X = sp.random(100, 10, format='csr', dtype=dtype)
     scipy_norms = sp.linalg.norm(X, axis=1)**2
     norms = csr_row_norms(X)


### PR DESCRIPTION
Fixes #12422

Ensure that the norms returned by row_norms have the same dtype as their input, for dense and sparse input.
