### PR TITLE
[MRG] FIX gradient boosting with sklearn estimator as init

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -71,6 +71,12 @@ Support for Python 3.4 and below has been officially dropped.
   communication overhead. :issue:`12543` by :user:`Isaac Storch <istorch>`
   and `Olivier Grisel`_.
 
+- |Fix| Fixed a bug in :class:`ensemble.GradientBoostingClassifier` and
+  :class:`ensemble.GradientBoostingRegressor`, which didn't support
+  scikit-learn estimators as inital estimator. Also added support of initial
+  estimator which does not support sample weights. :issue:`12436` by
+  :user:`Jérémie du Boisberranger <jeremiedbb>`
+
 :mod:`sklearn.linear_model`
 ...........................
 
@@ -118,7 +124,7 @@ Support for Python 3.4 and below has been officially dropped.
 
 - |API| The parameter ``labels`` in :func:`metrics.hamming_loss` is deprecated
   in version 0.21 and will be removed in version 0.23.
-  :issue:`10580` by :user:`Reshama Shaikh <reshamas>` and `Sandra 
+  :issue:`10580` by :user:`Reshama Shaikh <reshamas>` and :user:`Sandra 
   Mitrovic <SandraMNE>`.
 
 :mod:`sklearn.model_selection`
@@ -182,7 +188,6 @@ Support for Python 3.4 and below has been officially dropped.
   and :class:`tree.ExtraTreeRegressor`.
   :issue:`12300` by :user:`Adrin Jalali <adrinjalali>`.
 
-<<<<<<< 048dd794c301ac6bee38790b26da3e3f758ee042
 - |Fix| Fixed an issue with :class:`tree.BaseDecisionTree`
   and consequently all estimators based
   on it, including :class:`tree.DecisionTreeClassifier`,
@@ -194,8 +199,6 @@ Support for Python 3.4 and below has been officially dropped.
   :pr:`12344` by :user:`Adrin Jalali <adrinjalali>`.
 
 
-=======
->>>>>>> fix merge conflicts
 Multiple modules
 ................
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -182,6 +182,7 @@ Support for Python 3.4 and below has been officially dropped.
   and :class:`tree.ExtraTreeRegressor`.
   :issue:`12300` by :user:`Adrin Jalali <adrinjalali>`.
 
+<<<<<<< 048dd794c301ac6bee38790b26da3e3f758ee042
 - |Fix| Fixed an issue with :class:`tree.BaseDecisionTree`
   and consequently all estimators based
   on it, including :class:`tree.DecisionTreeClassifier`,
@@ -193,6 +194,8 @@ Support for Python 3.4 and below has been officially dropped.
   :pr:`12344` by :user:`Adrin Jalali <adrinjalali>`.
 
 
+=======
+>>>>>>> fix merge conflicts
 Multiple modules
 ................
 

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1436,10 +1436,11 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             if y_pred.ndim == 1:
                 y_pred = y_pred[:, np.newaxis]
 
-            if self.loss_.K >= 2 and y_pred.shape[1] != self.n_classes_:
+            if (self.loss_.is_multi_class
+                    and y_pred.shape[1] != self.n_classes_):
                 # multiclass classification needs y_pred to be of shape
-                # (n_samples, K) where K is the number of classes.
-                y_tmp = np.zeros((y_pred.shape[0], self.loss_.K),
+                # (n_samples, n_classes).
+                y_tmp = np.zeros((y_pred.shape[0], self.n_classes_),
                                  dtype=np.float64)
                 for k, class_ in enumerate(self.classes_):
                     y_tmp[:, k] = np.ravel(y_pred) == class_

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -57,7 +57,7 @@ from ..utils import check_consistent_length
 from ..utils import deprecated
 from ..utils.fixes import logsumexp
 from ..utils.stats import _weighted_percentile
-from ..utils.validation import check_is_fitted, has_fit_parameter
+from ..utils.validation import check_is_fitted
 from ..utils.multiclass import check_classification_targets
 from ..exceptions import NotFittedError
 
@@ -1421,14 +1421,15 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             self._init_state()
 
             # fit initial model
-            if has_fit_parameter(self.init_, "sample_weight"):
-                self.init_.fit(X, y, sample_weight)
-            elif sample_weight_was_none:
-                self.init_.fit(X, y)
-            else:
-                raise ValueError(
-                    "The initial estimator {} does not support sample weights "
-                    "yet.".format(self.init_.__class__.__name__))
+            try:
+                self.init_.fit(X, y, sample_weight=sample_weight)
+            except TypeError:
+                if sample_weight_was_none:
+                    self.init_.fit(X, y)
+                else:
+                    raise ValueError(
+                        "The initial estimator {} does not support sample "
+                        "weights yet.".format(self.init_.__class__.__name__))
 
             # init predictions
             y_pred = self.init_.predict(X).astype(np.float64, copy=False)

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1397,10 +1397,10 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         if sample_weight is None:
             sample_weight = np.ones(n_samples, dtype=np.float32)
-            sample_weight_was_none = True
+            sample_weight_is_none = True
         else:
             sample_weight = column_or_1d(sample_weight, warn=True)
-            sample_weight_was_none = False
+            sample_weight_is_none = False
 
         check_consistent_length(X, y, sample_weight)
 
@@ -1424,12 +1424,12 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             try:
                 self.init_.fit(X, y, sample_weight=sample_weight)
             except TypeError:
-                if sample_weight_was_none:
+                if sample_weight_is_none:
                     self.init_.fit(X, y)
                 else:
                     raise ValueError(
                         "The initial estimator {} does not support sample "
-                        "weights yet.".format(self.init_.__class__.__name__))
+                        "weights.".format(self.init_.__class__.__name__))
 
             # init predictions
             y_pred = self.init_.predict(X).astype(np.float64, copy=False)

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1435,6 +1435,16 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             y_pred = self.init_.predict(X).astype(np.float64, copy=False)
             if y_pred.ndim == 1:
                 y_pred = y_pred[:, np.newaxis]
+
+            if self.loss_.K >= 2 and y_pred.shape[1] != self.n_classes_:
+                # multiclass classification needs y_pred to be of shape
+                # (n_samples, K) where K is the number of classes.
+                y_tmp = np.zeros((y_pred.shape[0], self.loss_.K),
+                                 dtype=np.float64)
+                for k, class_ in enumerate(self.classes_):
+                    y_tmp[:, k] = np.ravel(y_pred) == class_
+                y_pred = y_tmp
+
             begin_at_stage = 0
 
             # The rng state must be preserved if warm_start is True

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1421,7 +1421,9 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             self.init_.fit(X, y, sample_weight)
 
             # init predictions
-            y_pred = self.init_.predict(X)
+            y_pred = self.init_.predict(X).astype(np.float64, copy=False)
+            if y_pred.shape == (X.shape[0],):
+                y_pred = y_pred[:, np.newaxis]
             begin_at_stage = 0
 
             # The rng state must be preserved if warm_start is True

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -55,9 +55,9 @@ from ..utils import check_X_y
 from ..utils import column_or_1d
 from ..utils import check_consistent_length
 from ..utils import deprecated
-from ..utils.fixes import logsumexp, signature
+from ..utils.fixes import logsumexp
 from ..utils.stats import _weighted_percentile
-from ..utils.validation import check_is_fitted
+from ..utils.validation import check_is_fitted, has_fit_parameter
 from ..utils.multiclass import check_classification_targets
 from ..exceptions import NotFittedError
 
@@ -1421,7 +1421,7 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             self._init_state()
 
             # fit initial model
-            if "sample_weight" in signature(self.init_.fit).parameters:
+            if has_fit_parameter(self.init_, "sample_weight"):
                 self.init_.fit(X, y, sample_weight)
             elif sample_weight_was_none:
                 self.init_.fit(X, y)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1328,7 +1328,7 @@ def test_gradient_boosting_validation_fraction():
     assert gbc.n_estimators_ < gbc3.n_estimators_
 
 
-class _NoSampleWaightWrapper:
+class _NoSampleWeightWrapper:
     def __init__(self, est):
         self.est = est
 
@@ -1359,7 +1359,7 @@ def test_gradient_boosting_with_init(task):
     gb(init=init_est).fit(X, y, sample_weight=sample_weight)
 
     # init does not support sample weights
-    init_est = _NoSampleWaightWrapper(init())
+    init_est = _NoSampleWeightWrapper(init())
     gb(init=init_est).fit(X, y)  # ok no sample weights
     with pytest.raises(ValueError):
         gb(init=init_est).fit(X, y, sample_weight=sample_weight)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1332,7 +1332,7 @@ def test_gradient_boosting_with_init(estimator):
     X = np.random.random_sample((100, 5))
 
     if estimator is "classifier":
-        init = LogisticRegression()
+        init = LogisticRegression(solver="lbfgs")
         est = GradientBoostingClassifier
         y = np.random.randint(0, 2, 100)
     else:

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1349,17 +1349,18 @@ def test_gradient_boosting_with_init(task):
     # estimator.
     # Check that an error is raised if trying to fit with sample weight but
     # inital estimator does not support sample weight
-    gb, dataset_maker, init = task
+    gb, dataset_maker, init_estimator = task
 
     X, y = dataset_maker()
-    sample_weight = np.random.rand(100)
+    sample_weight = np.random.RandomState(42).rand(100)
 
     # init supports sample weights
-    init_est = init()
+    init_est = init_estimator()
     gb(init=init_est).fit(X, y, sample_weight=sample_weight)
 
     # init does not support sample weights
-    init_est = _NoSampleWeightWrapper(init())
+    init_est = _NoSampleWeightWrapper(init_estimator())
     gb(init=init_est).fit(X, y)  # ok no sample weights
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError,
+                       match="estimator.*does not support sample weights"):
         gb(init=init_est).fit(X, y, sample_weight=sample_weight)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1339,11 +1339,16 @@ class _NoSampleWeightWrapper:
         return self.est.predict(X)
 
 
+def _make_multiclass():
+    return make_classification(n_classes=3, n_clusters_per_class=1)
+
+
 @pytest.mark.parametrize(
     "task",
     [(GradientBoostingClassifier, make_classification, DummyClassifier),
+     (GradientBoostingClassifier, _make_multiclass, DummyClassifier),
      (GradientBoostingRegressor, make_regression, DummyRegressor)],
-    ids=["classification", "regression"])
+    ids=["binary classification", "multiclass classification", "regression"])
 def test_gradient_boosting_with_init(task):
     # Check that GradientBoostingRegressor works when init is a sklearn
     # estimator.

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -33,6 +33,7 @@ from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import skip_if_32bit
 from sklearn.exceptions import DataConversionWarning
 from sklearn.exceptions import NotFittedError
+from sklearn.linear_model import LinearRegression, LogisticRegression
 
 GRADIENT_BOOSTING_ESTIMATORS = [GradientBoostingClassifier,
                                 GradientBoostingRegressor]
@@ -1323,3 +1324,21 @@ def test_gradient_boosting_validation_fraction():
     gbr3.fit(X_train, y_train)
     assert gbr.n_estimators_ < gbr3.n_estimators_
     assert gbc.n_estimators_ < gbc3.n_estimators_
+
+
+@pytest.mark.parametrize("estimator", ["classifier", "regressor"])
+def test_gradient_boosting_with_init(estimator):
+    # Check that Gradient Boosting works when init is a sklearn estimator.
+    X = np.random.random_sample((100, 5))
+
+    if estimator is "classifier":
+        init = LogisticRegression()
+        est = GradientBoostingClassifier
+        y = np.random.randint(0, 2, 100)
+    else:
+        init = LinearRegression()
+        est = GradientBoostingRegressor
+        y = np.random.rand(100)
+
+    est = est(init=init)
+    est.fit(X, y)


### PR DESCRIPTION
Fixes #10302, Fixes #12429, Fixes #2691

Gradient Boosting used to fail when init was a sklearn estimator, which is a bit ironic :)
Issue was that the predict output didn't have the expected shape. And apparently there was no test for the init parameter with other estimator than default.

*Edit* Also accept initial estimator which does not support sample weights as long as the gradient boosting is not fitted with sample weights