### PR TITLE
[MRG] MNT Change default metric in OPTICS

### DIFF
--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -22,7 +22,7 @@ from ..base import BaseEstimator, ClusterMixin
 from ..metrics import pairwise_distances
 
 
-def optics(X, min_samples=5, max_eps=np.inf, metric='euclidean',
+def optics(X, min_samples=5, max_eps=np.inf, metric='minkowski',
            p=2, metric_params=None, maxima_ratio=.75,
            rejection_ratio=.7, similarity_threshold=0.4,
            significant_min=.003, min_cluster_size=.005,
@@ -60,7 +60,7 @@ def optics(X, min_samples=5, max_eps=np.inf, metric='euclidean',
         clusters across all scales; reducing `max_eps` will result in
         shorter run times.
 
-    metric : string or callable, optional (default='euclidean')
+    metric : string or callable, optional (default='minkowski')
         metric to use for distance computation. Any metric from scikit-learn
         or scipy.spatial.distance can be used.
 
@@ -215,7 +215,7 @@ class OPTICS(BaseEstimator, ClusterMixin):
         clusters across all scales; reducing `max_eps` will result in
         shorter run times.
 
-    metric : string or callable, optional (default='euclidean')
+    metric : string or callable, optional (default='minkowski')
         metric to use for distance computation. Any metric from scikit-learn
         or scipy.spatial.distance can be used.
 
@@ -353,7 +353,7 @@ class OPTICS(BaseEstimator, ClusterMixin):
     the Conference "Lernen, Wissen, Daten, Analysen" (LWDA) (2018): 318-329.
     """
 
-    def __init__(self, min_samples=5, max_eps=np.inf, metric='euclidean',
+    def __init__(self, min_samples=5, max_eps=np.inf, metric='minkowski',
                  p=2, metric_params=None, maxima_ratio=.75,
                  rejection_ratio=.7, similarity_threshold=0.4,
                  significant_min=.003, min_cluster_size=.005,

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -39,7 +39,7 @@ def test_correct_number_of_clusters():
     X = generate_clustered_data(n_clusters=n_clusters)
     # Parameters chosen specifically for this task.
     # Compute OPTICS
-    clust = OPTICS(max_eps=5.0 * 6.0, min_samples=4, metric='euclidean')
+    clust = OPTICS(max_eps=5.0 * 6.0, min_samples=4)
     clust.fit(X)
     # number of clusters, ignoring noise if present
     n_clusters_1 = len(set(clust.labels_)) - int(-1 in clust.labels_)

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -366,7 +366,7 @@ def test_compare_to_ELKI():
     # Tests against known extraction array
     # Does NOT work with metric='euclidean', because sklearn euclidean has
     # worse numeric precision. 'minkowski' is slower but more accurate.
-    clust = OPTICS(min_samples=5, metric='minkowski').fit(X)
+    clust = OPTICS(min_samples=5).fit(X)
 
     assert_array_equal(clust.ordering_, np.array(o))
     assert_array_equal(clust.predecessor_[clust.ordering_], np.array(p))


### PR DESCRIPTION
part of #12437
Change the default metric from ``euclidean`` to ``minkowski`` because
(1) We have parameter ``p`` here.
(2)  ``euclidean`` from scikit-learn is not robust.