### PR TITLE
[MRG+2] FIX olivetti_faces DESCR to point to the good location

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -51,6 +51,10 @@ Changelog
   for values of ``n_informative`` parameter larger than 64.
   :issue:`10811` by :user:`Roman Feldbauer <VarIr>`.
 
+- |Fix| Fixed olivetti faces dataset ``DESCR`` attribute to point to the right
+  location in :func:`datasets.fetch_olivetti_faces`. :issue:`12441` by
+  :user:`Jérémie du Boisberranger <jeremiedbb>`
+
 :mod:`sklearn.ensemble`
 .......................
 

--- a/sklearn/datasets/olivetti_faces.py
+++ b/sklearn/datasets/olivetti_faces.py
@@ -124,7 +124,7 @@ def fetch_olivetti_faces(data_home=None, shuffle=False, random_state=0,
         target = target[order]
 
     module_path = dirname(__file__)
-    with open(join(module_path, 'descr', 'covtype.rst')) as rst_file:
+    with open(join(module_path, 'descr', 'olivetti_faces.rst')) as rst_file:
         fdescr = rst_file.read()
 
     return Bunch(data=faces.reshape(len(faces), -1),


### PR DESCRIPTION
Fixes #12440 

Comes from a bad copy paste...

it would be nice to have a backport in 0.20.1, since it was introduce in 0.20, to not provide wrong informations for too long.