### PR TITLE
[MRG] Fix incorrect error when OneHotEncoder.transform called prior to fit

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -21,9 +21,7 @@ from ..utils.validation import check_is_fitted
 from .base import _transform_selected
 from .label import _encode, _encode_check_unknown
 
-
 range = six.moves.range
-
 
 __all__ = [
     'OneHotEncoder',
@@ -383,6 +381,11 @@ class OneHotEncoder(_BaseEncoder):
                     "The 'categorical_features' keyword is deprecated in "
                     "version 0.20 and will be removed in 0.22. You can "
                     "use the ColumnTransformer instead.", DeprecationWarning)
+                n_features = X.shape[1]
+                sel = np.zeros(n_features, dtype=bool)
+                sel[np.asarray(self.categorical_features)] = True
+                if sum(sel) == 0:
+                    self.categories_ = list()
                 self._legacy_mode = True
             self._categorical_features = self.categorical_features
         else:
@@ -684,7 +687,7 @@ class OneHotEncoder(_BaseEncoder):
         cats = self.categories_
         if input_features is None:
             input_features = ['x%d' % i for i in range(len(cats))]
-        elif(len(input_features) != len(self.categories_)):
+        elif (len(input_features) != len(self.categories_)):
             raise ValueError(
                 "input_features should have length equal to number of "
                 "features ({}), got {}".format(len(self.categories_),

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -385,7 +385,7 @@ class OneHotEncoder(_BaseEncoder):
                 sel = np.zeros(n_features, dtype=bool)
                 sel[np.asarray(self.categorical_features)] = True
                 if sum(sel) == 0:
-                    self.categories_ = list()
+                    self.categories_ = []
                 self._legacy_mode = True
             self._categorical_features = self.categorical_features
         else:
@@ -687,7 +687,7 @@ class OneHotEncoder(_BaseEncoder):
         cats = self.categories_
         if input_features is None:
             input_features = ['x%d' % i for i in range(len(cats))]
-        elif (len(input_features) != len(self.categories_)):
+        elif len(input_features) != len(self.categories_):
             raise ValueError(
                 "input_features should have length equal to number of "
                 "features ({}), got {}".format(len(self.categories_),

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -381,6 +381,7 @@ class OneHotEncoder(_BaseEncoder):
                     "The 'categorical_features' keyword is deprecated in "
                     "version 0.20 and will be removed in 0.22. You can "
                     "use the ColumnTransformer instead.", DeprecationWarning)
+                # Set categories_ to empty list if no categorical columns exist
                 n_features = X.shape[1]
                 sel = np.zeros(n_features, dtype=bool)
                 sel[np.asarray(self.categorical_features)] = True

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -591,6 +591,7 @@ class OneHotEncoder(_BaseEncoder):
         X_out : sparse matrix if sparse=True else a 2-d array
             Transformed input.
         """
+        check_is_fitted(self, 'categories_')
         if self._legacy_mode:
             return _transform_selected(X, self._legacy_transform, self.dtype,
                                        self._categorical_features,

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy import sparse
 import pytest
 
+from sklearn.exceptions import NotFittedError
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
@@ -248,6 +249,26 @@ def test_one_hot_encoder_handle_unknown():
     # Raise error if handle_unknown is neither ignore or error.
     oh = OneHotEncoder(handle_unknown='42')
     assert_raises(ValueError, oh.fit, X)
+
+
+def test_one_hot_encoder_not_fitted():
+    X = np.array([['a'], ['b']])
+    enc = OneHotEncoder(categories=['a', 'b'])
+    msg = ("This OneHotEncoder instance is not fitted yet. "
+    "Call 'fit' with appropriate arguments before using this method.")
+    with pytest.raises(NotFittedError, match=msg):
+        enc.transform(X)
+
+def test_one_hot_encoder_no_categorical_features():
+    X = np.array([[3, 2, 1], [0, 1, 1]], dtype='float64')
+
+    cat = [False, False, False]
+    enc = OneHotEncoder(categorical_features=cat)
+    X_tr = enc.fit_transform(X)
+    expected_features = np.array(list(), dtype='object')
+    assert_array_equal(X, X_tr)
+    assert_equal(enc.categories_, list())
+    assert_array_equal(enc.get_feature_names(), expected_features)
 
 
 @pytest.mark.parametrize("output_dtype", [np.int32, np.float32, np.float64])

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -255,16 +255,18 @@ def test_one_hot_encoder_not_fitted():
     X = np.array([['a'], ['b']])
     enc = OneHotEncoder(categories=['a', 'b'])
     msg = ("This OneHotEncoder instance is not fitted yet. "
-    "Call 'fit' with appropriate arguments before using this method.")
+           "Call 'fit' with appropriate arguments before using this method.")
     with pytest.raises(NotFittedError, match=msg):
         enc.transform(X)
+
 
 def test_one_hot_encoder_no_categorical_features():
     X = np.array([[3, 2, 1], [0, 1, 1]], dtype='float64')
 
     cat = [False, False, False]
     enc = OneHotEncoder(categorical_features=cat)
-    X_tr = enc.fit_transform(X)
+    with ignore_warnings(category=(DeprecationWarning, FutureWarning)):
+        X_tr = enc.fit_transform(X)
     expected_features = np.array(list(), dtype='object')
     assert_array_equal(X, X_tr)
     assert_equal(enc.categories_, list())

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -269,8 +269,8 @@ def test_one_hot_encoder_no_categorical_features():
         X_tr = enc.fit_transform(X)
     expected_features = np.array(list(), dtype='object')
     assert_array_equal(X, X_tr)
-    assert_equal(enc.categories_, list())
     assert_array_equal(enc.get_feature_names(), expected_features)
+    assert enc.categories_ == []
 
 
 @pytest.mark.parametrize("output_dtype", [np.int32, np.float32, np.float64])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #12395 


#### What does this implement/fix? Explain your changes.
Fix checks for `categories_` attribute when transform is called. 
 
The edge case when class is instantiated with `categorical_features` set to all False,  `_legacy_mode` is set to True but `_legacy_fit_transform` never gets called. To fix this, explicitly tested for this and set `categories_` to an empty list. This fix also allows `get_feature_names` to return an empty array.

```
import numpy as np
from sklearn.preprocessing import OneHotEncoder

X = np.array([[3, 2, 1], [0, 1, 1]])

# Edge case: all non-categorical
cat = [False, False, False]
enc = OneHotEncoder(categorical_features=cat)
enc.fit(X)
print('Categories are {}'.format(enc.categories_))
print('Feature names are {}'.format(enc.get_feature_names()))
```

```
Categories are []
Feature names are []
```

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
