### PR TITLE
[MRG] Modify KBinsDiscretizer test using kmeans due to unstable local minimum

### DIFF
--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -189,10 +189,10 @@ def test_invalid_strategy_option():
 @pytest.mark.parametrize(
     'strategy, expected_2bins, expected_3bins',
     [('uniform', [0, 0, 0, 0, 1, 1], [0, 0, 0, 0, 2, 2]),
-     ('kmeans', [0, 0, 0, 0, 1, 1], [0, 1, 1, 1, 2, 2]),
+     ('kmeans', [0, 0, 0, 0, 1, 1], [0, 0, 1, 1, 2, 2]),
      ('quantile', [0, 0, 0, 1, 1, 1], [0, 0, 1, 1, 2, 2])])
 def test_nonuniform_strategies(strategy, expected_2bins, expected_3bins):
-    X = np.array([0, 1, 2, 3, 9, 10]).reshape(-1, 1)
+    X = np.array([0, 0.5, 2, 3, 9, 10]).reshape(-1, 1)
 
     # with 2 bins
     est = KBinsDiscretizer(n_bins=2, strategy=strategy, encode='ordinal')


### PR DESCRIPTION
The test `test_nonuniform_strategies` tests KBinsDiscretizer using "kmeans" strategy. However, the dataset made for this test has an unstable local minimum due to a sample point equidistant from 2 centers. This tie can cause failure if order is modified in KMeans, [see (comment)](https://github.com/scikit-learn/scikit-learn/pull/11950#issuecomment-432588865)