### PR TITLE
Fix inconsistent labels returned by BayesianGaussianMixture.fit_predict

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -71,6 +71,14 @@ Changelog
   those estimators as part of parallel parameter search or cross-validation.
   :issue:`12122` by :user:`Olivier Grisel <ogrisel>`.
 
+:mod:`sklearn.mixture`
+........................
+
+- |Fix| :func:`mixture.BayesianGaussianMixture` ensure that ``fit_predict``
+  always yield assignments consistent with ``fit`` followed by ``predict`` even
+  if the convergence criterion is too loose or not met. :issue:`12451`
+  by :user:`Olivier Grisel <ogrisel>`.
+
 :mod:`sklearn.neighbors`
 ........................
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -74,7 +74,8 @@ Changelog
 :mod:`sklearn.mixture`
 ........................
 
-- |Fix| :func:`mixture.BayesianGaussianMixture` ensure that ``fit_predict``
+- |Fix| Ensure that the ``fit_predict`` method of
+  :class:`mixture.GaussianMixture` and :class:`mixture.BayesianGaussianMixture`
   always yield assignments consistent with ``fit`` followed by ``predict`` even
   if the convergence criterion is too loose or not met. :issue:`12451`
   by :user:`Olivier Grisel <ogrisel>`.

--- a/sklearn/mixture/base.py
+++ b/sklearn/mixture/base.py
@@ -260,6 +260,11 @@ class BaseMixture(six.with_metaclass(ABCMeta, DensityMixin, BaseEstimator)):
                 best_params = self._get_parameters()
                 best_n_iter = n_iter
 
+        # Always do a final e-step to guarantee that the labels returned by
+        # fit_predict(X) are always consistent with fit(X).predict(X)
+        # for any value of max_iter and tol (and any random_state).
+        _, log_resp = self._e_step(X)
+
         if not self.converged_:
             warnings.warn('Initialization %d did not converge. '
                           'Try different init parameters, '

--- a/sklearn/mixture/tests/test_bayesian_mixture.py
+++ b/sklearn/mixture/tests/test_bayesian_mixture.py
@@ -426,13 +426,13 @@ def test_invariant_translation():
             assert_almost_equal(bgmm1.covariances_, bgmm2.covariances_)
 
 
-@pytest.mark.parametrize(('seed', 'max_iter', 'tol'), [
+@ignore_warnings(category=ConvergenceWarning)  # we test non-converged cases
+@pytest.mark.parametrize('seed, max_iter, tol', [
     (0, 2, 1e-7),    # strict non-convergence
     (1, 2, 1e-1),    # loose non-convergence
     (3, 300, 1e-7),  # strict convergence
     (4, 300, 1e-1),  # loose convergence
 ])
-@ignore_warnings(category=ConvergenceWarning)  # we test non-converged cases
 def test_bayesian_mixture_fit_predict(seed, max_iter, tol):
     rng = np.random.RandomState(seed)
     rand_data = RandomData(rng, scale=7)

--- a/sklearn/mixture/tests/test_bayesian_mixture.py
+++ b/sklearn/mixture/tests/test_bayesian_mixture.py
@@ -426,7 +426,7 @@ def test_invariant_translation():
             assert_almost_equal(bgmm1.covariances_, bgmm2.covariances_)
 
 
-@pytest.mark.parametrize('seed, max_iter, tol', [
+@pytest.mark.parametrize(('seed', 'max_iter', 'tol'), [
     (0, 2, 1e-7),    # strict non-convergence
     (1, 2, 1e-1),    # loose non-convergence
     (3, 300, 1e-7),  # strict convergence

--- a/sklearn/mixture/tests/test_bayesian_mixture.py
+++ b/sklearn/mixture/tests/test_bayesian_mixture.py
@@ -5,6 +5,7 @@ import copy
 
 import numpy as np
 from scipy.special import gammaln
+import pytest
 
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_almost_equal
@@ -425,15 +426,22 @@ def test_invariant_translation():
             assert_almost_equal(bgmm1.covariances_, bgmm2.covariances_)
 
 
-def test_bayesian_mixture_fit_predict():
-    rng = np.random.RandomState(0)
+@pytest.mark.parametrize('seed, max_iter, tol', [
+    (0, 2, 1e-7),    # strict non-convergence
+    (1, 2, 1e-1),    # loose non-convergence
+    (3, 300, 1e-7),  # strict convergence
+    (4, 300, 1e-1),  # loose convergence
+])
+@ignore_warnings(category=ConvergenceWarning)  # we test non-converged cases
+def test_bayesian_mixture_fit_predict(seed, max_iter, tol):
+    rng = np.random.RandomState(seed)
     rand_data = RandomData(rng, scale=7)
     n_components = 2 * rand_data.n_components
 
     for covar_type in COVARIANCE_TYPE:
         bgmm1 = BayesianGaussianMixture(n_components=n_components,
-                                        max_iter=100, random_state=rng,
-                                        tol=1e-3, reg_covar=0)
+                                        max_iter=max_iter, random_state=rng,
+                                        tol=tol, reg_covar=0)
         bgmm1.covariance_type = covar_type
         bgmm2 = copy.deepcopy(bgmm1)
         X = rand_data.X[covar_type]

--- a/sklearn/mixture/tests/test_bayesian_mixture.py
+++ b/sklearn/mixture/tests/test_bayesian_mixture.py
@@ -426,7 +426,7 @@ def test_invariant_translation():
             assert_almost_equal(bgmm1.covariances_, bgmm2.covariances_)
 
 
-@ignore_warnings(category=ConvergenceWarning)  # we test non-converged cases
+@pytest.mark.filterwarnings("ignore:.*did not converge.*")
 @pytest.mark.parametrize('seed, max_iter, tol', [
     (0, 2, 1e-7),    # strict non-convergence
     (1, 2, 1e-1),    # loose non-convergence

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -9,6 +9,7 @@ import warnings
 import numpy as np
 
 from scipy import stats, linalg
+import pytest
 
 from sklearn.covariance import EmpiricalCovariance
 from sklearn.datasets.samples_generator import make_spd_matrix
@@ -571,8 +572,15 @@ def test_gaussian_mixture_predict_predict_proba():
         assert_greater(adjusted_rand_score(Y, Y_pred), .95)
 
 
-def test_gaussian_mixture_fit_predict():
-    rng = np.random.RandomState(0)
+@pytest.mark.filterwarnings("ignore:.*did not converge.*")
+@pytest.mark.parametrize('seed, max_iter, tol', [
+    (0, 2, 1e-7),    # strict non-convergence
+    (1, 2, 1e-1),    # loose non-convergence
+    (3, 300, 1e-7),  # strict convergence
+    (4, 300, 1e-1),  # loose convergence
+])
+def test_gaussian_mixture_fit_predict(seed, max_iter, tol):
+    rng = np.random.RandomState(seed)
     rand_data = RandomData(rng)
     for covar_type in COVARIANCE_TYPE:
         X = rand_data.X[covar_type]
@@ -581,7 +589,8 @@ def test_gaussian_mixture_fit_predict():
                             random_state=rng, weights_init=rand_data.weights,
                             means_init=rand_data.means,
                             precisions_init=rand_data.precisions[covar_type],
-                            covariance_type=covar_type)
+                            covariance_type=covar_type,
+                            max_iter=max_iter, tol=tol)
 
         # check if fit_predict(X) is equivalent to fit(X).predict(X)
         f = copy.deepcopy(g)


### PR DESCRIPTION
This is a fix for the issue reported in #12266. It includes a non-regression test to highlight the problem. I will add a changelog entry once the PR is open.