### PR TITLE
[MRG] Raetsch datasets added

### DIFF
--- a/doc/datasets/index.rst
+++ b/doc/datasets/index.rst
@@ -546,3 +546,27 @@ Note: if you manage your own numerical data it is recommended to use an
 optimized file format such as HDF5 to reduce data load times. Various libraries
 such as H5Py, PyTables and pandas provides a Python interface for reading and 
 writing data in that format.
+
+Donwloading Gunnar Raetsch benchmark datasets
+---------------------------------------------
+
+`Gunnar Raetsch benchmark datasets
+<https://github.com/tdiethe/gunnar_raetsch_benchmark_datasets>`
+have been used in several publications and include the 100 folds used for the CV
+evaluation of the model. Also, the first 5 folds can be used in the inner loop
+of a nested CV strategy to replicate the hyper-parameter search used by the
+authors.
+
+The available datasets are: 'banana', 'breast_cancer', 'diabetis',
+'flare_solar', 'german', 'heart', 'image', 'ringnorm', 'splice', 'thyroid',
+'titanic', 'twonorm' and 'waveform'.
+
+@misc{Diethe15,
+      Author = {Diethe, T.},
+      Date-Added = {2015-05-06 14:18:52 +0000},
+      Date-Modified = {2015-05-28 14:17:57 +0000},
+      Doi = {DOI: http://dx.doi.org/10.5281/zenodo.18110},
+      Howpublished = {\url{https://github.com/tdiethe/gunnar\_raetsch\_benchmark\_datasets/}},
+      Keywords = {dataset},
+      Title = {{13 benchmark datasets derived from the UCI, DELVE and STATLOG repositories}},
+      Year = {2015}}

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -259,6 +259,7 @@ Loaders
    datasets.fetch_lfw_people
    datasets.fetch_olivetti_faces
    datasets.fetch_openml
+   datasets.fetch_raetsch
    datasets.fetch_rcv1
    datasets.fetch_species_distributions
    datasets.get_data_home

--- a/sklearn/datasets/__init__.py
+++ b/sklearn/datasets/__init__.py
@@ -23,6 +23,7 @@ from .twenty_newsgroups import fetch_20newsgroups
 from .twenty_newsgroups import fetch_20newsgroups_vectorized
 from .mldata import fetch_mldata, mldata_filename
 from .openml import fetch_openml
+from .raetsch import fetch_raetsch
 from .samples_generator import make_classification
 from .samples_generator import make_multilabel_classification
 from .samples_generator import make_hastie_10_2
@@ -66,6 +67,7 @@ __all__ = ['clear_data_home',
            'fetch_rcv1',
            'fetch_kddcup99',
            'fetch_openml',
+           'fetch_raetsch',
            'get_data_home',
            'load_boston',
            'load_diabetes',

--- a/sklearn/datasets/raetsch.py
+++ b/sklearn/datasets/raetsch.py
@@ -1,0 +1,48 @@
+import os
+from scipy.io import loadmat
+from sklearn.datasets.base import (_fetch_remote, get_data_home, Bunch,
+                                   RemoteFileMetadata)
+
+
+DATASETS = {'banana', 'breast_cancer', 'diabetis', 'flare_solar', 'german',
+            'heart', 'image', 'ringnorm', 'splice', 'thyroid', 'titanic',
+            'twonorm', 'waveform'}
+ARCHIVE = RemoteFileMetadata(filename='benchmarks.mat',
+                             url='https://github.com/tdiethe/gunnar_raetsch_benchmark_datasets/raw/master/benchmarks.mat',
+                             checksum=('47c19e4bc4716edc4077cfa5ea61edf4d02af4ec51a0ecfe035626ae8b561c75'))
+
+
+def fetch_raetsch(name, data_home=None):
+    """Fetch Gunnar Raetsch's dataset.
+
+    Fetch a Gunnar Raetsch's benchmark dataset by name. Availabe datasets are
+    'banana', 'breast_cancer', 'diabetis', 'flare_solar', 'german', 'heart',
+    'image', 'ringnorm', 'splice', 'thyroid', 'titanic', 'twonorm' and
+    'waveform'. More info at
+    https://github.com/tdiethe/gunnar_raetsch_benchmark_datasets.
+
+    Parameters
+    ----------
+    name : string
+        Dataset name.
+    data_home : string or None, default None
+        Specify another download and cache folder for the data sets. By default
+        all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
+
+    Returns
+    -------
+    data : Bunch
+        Dictionary-like object with all the data and metadata.
+
+    """
+    if name not in DATASETS:
+        raise Exception('Avaliable datasets are ' + str(list(DATASETS)))
+    dirname = os.path.join(get_data_home(data_home=data_home), 'raetsch')
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
+    filename = _fetch_remote(ARCHIVE, dirname=dirname)
+    X, y, train_splits, test_splits = loadmat(filename)[name][0][0]
+    inner_cv = zip(train_splits[:5] - 1, test_splits[:5] - 1)
+    outer_cv = zip(train_splits - 1, test_splits - 1)
+    return Bunch(data=X, target=y, inner_cv=inner_cv, outer_cv=outer_cv,
+                 DESCR=name)

--- a/sklearn/datasets/tests/test_raetsch.py
+++ b/sklearn/datasets/tests/test_raetsch.py
@@ -1,0 +1,19 @@
+"""
+Test the Raetsch loader.
+"""
+
+from skdatasets.raetsch import fetch_raetsch
+
+
+def check(data, shape):
+    """Check dataset properties."""
+    assert data.data.shape == shape
+    assert data.target.shape[0] == shape[0]
+    assert hasattr(data.inner_cv, '__iter__')
+    assert hasattr(data.outer_cv, '__iter__')
+
+
+def test_fetch_raetsch_banana():
+    """Tests Gunnar Raetsch banana dataset."""
+    data = fetch_raetsch('banana')
+    check(data, (5300, 2))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

This PR adds the 'fetch_raetsch' function that can be used to fetch Gunnar Raetsch benchmark datasets (see https://github.com/tdiethe/gunnar_raetsch_benchmark_datasets and https://www.is.mpg.de/publications/812). 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
