### PR TITLE
[MRG] Fix: SkLearn `.score()` method generating error with Dask DataFrames

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -1253,9 +1253,8 @@ Miscellaneous
   happens immediately (i.e., without a deprecation cycle).
   :issue:`11741` by `Olivier Grisel`_.
 
-- |Fix| Fixed a bug in validation.py where :func: `_num_samples()` would not properly
-  handle checking the shape of Dask DataFrames after an update to Dask. 
-  :issue:`12462` by :user:`zwmiller`
+- |Fix| Fixed a bug in validation helpers where passing a Dask DataFrame results
+  in an error. :issue:`12462` by :user:`Zachariah Miller <zwmiller>`
 
 Changes to estimator checks
 ---------------------------

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -1253,6 +1253,10 @@ Miscellaneous
   happens immediately (i.e., without a deprecation cycle).
   :issue:`11741` by `Olivier Grisel`_.
 
+- |Fix| Fixed a bug in validation.py where :func: `_num_samples()` would not properly
+  handle checking the shape of Dask DataFrames after an update to Dask. 
+  :issue:`12462` by :user:`zwmiller`
+
 Changes to estimator checks
 ---------------------------
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -41,6 +41,7 @@ from sklearn.utils.validation import (
     check_memory,
     check_non_negative,
     LARGE_SPARSE_SUPPORTED,
+    _num_samples
 )
 import sklearn
 
@@ -786,3 +787,14 @@ def test_check_X_y_informative_error():
     X = np.ones((2, 2))
     y = None
     assert_raise_message(ValueError, "y cannot be None", check_X_y, X, y)
+
+def test_retrieve_samples_from_non_standard_shape():
+    class TestNonNumericShape:
+        def __init__(self):
+            self.shape = ("not numeric",)
+
+        def __len__(self):
+            return len([1,2,3])
+
+    X = TestNonNumericShape()
+    assert _num_samples(X) == len(X)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -794,7 +794,7 @@ def test_retrieve_samples_from_non_standard_shape():
             self.shape = ("not numeric",)
 
         def __len__(self):
-            return len([1,2,3])
+            return len([1, 2, 3])
 
     X = TestNonNumericShape()
     assert _num_samples(X) == len(X)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -788,6 +788,7 @@ def test_check_X_y_informative_error():
     y = None
     assert_raise_message(ValueError, "y cannot be None", check_X_y, X, y)
 
+
 def test_retrieve_samples_from_non_standard_shape():
     class TestNonNumericShape:
         def __init__(self):

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -140,7 +140,11 @@ def _num_samples(x):
         if len(x.shape) == 0:
             raise TypeError("Singleton array %r cannot be considered"
                             " a valid collection." % x)
-        return x.shape[0]
+        # Check that shape is returning an integer or default to len
+        if isinstance(x.shape[0], int):
+            return x.shape[0]
+        else:
+            return len(x)
     else:
         return len(x)
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -141,7 +141,8 @@ def _num_samples(x):
             raise TypeError("Singleton array %r cannot be considered"
                             " a valid collection." % x)
         # Check that shape is returning an integer or default to len
-        if isinstance(x.shape[0], int):
+        # Dask dataframes may not return numeric shape[0] value
+        if isinstance(x.shape[0], numbers.Integral):
             return x.shape[0]
         else:
             return len(x)


### PR DESCRIPTION
update _num_samples to check the type of shape before using it as reference for size of objects

#### Reference Issues/PRs

Fixes #12461 


#### What does this implement/fix? Explain your changes.

In utils/validation.py `_num_samples()` attempts to use the `.shape` attribute as a stand in for the size of an array if `.shape` is available. Dask has updated their dataframes to have a `.shape` attribute, but that attribute does not conform to the format `(int, int, int,)` and as such any sklearn method that relies on `_num_samples()` crashes. This PR simply adds a check to see if the output of `.shape[0]` contains an instance of int, and if not defaults to computing the `len()` of the object. 

#### Any other comments?

Upon running `make` and `make flake8-diff` I see no failed tests (though several skipped tests do occur). The [WIP] is because I'm willing to add a test to make sure that the behavior passes with Dask DataFrames in future updates, but am unsure how to add a test properly in the SkLearn schema. If no test is needed, this should be ready for merge.