### PR TITLE
[WIP] Consistent and informative error message for partial_fit when n_features changes

### DIFF
--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -14,7 +14,7 @@ from ..base import TransformerMixin, ClusterMixin, BaseEstimator
 from ..externals.six.moves import xrange
 from ..utils import check_array
 from ..utils.extmath import row_norms, safe_sparse_dot
-from ..utils.validation import check_is_fitted
+from ..utils.validation import check_is_fitted, check_partial_fit_n_features
 from ..exceptions import NotFittedError, ConvergenceWarning
 from .hierarchical import AgglomerativeClustering
 
@@ -546,11 +546,8 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
         # Should raise an error if one does not fit before predicting.
         if not (is_fitted or has_partial_fit):
             raise NotFittedError("Fit training data before predicting")
-
-        if is_fitted and X.shape[1] != self.subcluster_centers_.shape[1]:
-            raise ValueError(
-                "Training data and predicted data do "
-                "not have same number of features.")
+        if is_fitted:
+            check_partial_fit_n_features(X, self.subcluster_centers_, self)
 
     def predict(self, X):
         """

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -27,7 +27,7 @@ from ..utils.validation import _num_samples
 from ..utils import check_array
 from ..utils import gen_batches
 from ..utils import check_random_state
-from ..utils.validation import check_is_fitted
+from ..utils.validation import check_is_fitted, check_partial_fit_n_features
 from ..utils.validation import FLOAT_DTYPES
 from ..utils import Parallel
 from ..utils import delayed
@@ -1694,6 +1694,7 @@ class MiniBatchKMeans(KMeans):
             random_reassign = False
             distances = None
         else:
+            check_partial_fit_n_features(X, self.cluster_centers_, self)
             # The lower the minimum count is, the more we do random
             # reassignment, however, we don't want to do random
             # reassignment too often, to allow for building up counts

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -19,7 +19,7 @@ from ..externals.six.moves import zip
 from ..utils import (check_array, check_random_state, gen_even_slices,
                      gen_batches)
 from ..utils.extmath import randomized_svd, row_norms
-from ..utils.validation import check_is_fitted
+from ..utils.validation import check_is_fitted, check_partial_fit_n_features
 from ..linear_model import Lasso, orthogonal_mp_gram, LassoLars, Lars
 
 
@@ -1412,6 +1412,7 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
             self.random_state_ = check_random_state(self.random_state)
         X = check_array(X)
         if hasattr(self, 'components_'):
+            check_partial_fit_n_features(X, self.components_, self)
             dict_init = self.components_
         else:
             dict_init = self.dict_init

--- a/sklearn/decomposition/incremental_pca.py
+++ b/sklearn/decomposition/incremental_pca.py
@@ -244,6 +244,13 @@ class IncrementalPCA(_BasePCA):
         else:
             self.n_components_ = self.n_components
 
+        if (self.components_ is not None) and (self.components_.shape[0] !=
+                                               self.n_components_):
+            raise ValueError("Number of components has changed from %i "
+                             "to %i between calls to partial_fit! Try "
+                             "setting n_components to a fixed value." %
+                             (self.components_.shape[0], self.n_components_))
+
         # This is the first partial_fit
         if not hasattr(self, 'n_samples_seen_'):
             self.n_samples_seen_ = 0

--- a/sklearn/decomposition/incremental_pca.py
+++ b/sklearn/decomposition/incremental_pca.py
@@ -11,6 +11,7 @@ from scipy import linalg
 from .base import _BasePCA
 from ..utils import check_array, gen_batches
 from ..utils.extmath import svd_flip, _incremental_mean_and_var
+from ..utils.validation import check_partial_fit_n_features
 
 
 class IncrementalPCA(_BasePCA):
@@ -224,6 +225,8 @@ class IncrementalPCA(_BasePCA):
         n_samples, n_features = X.shape
         if not hasattr(self, 'components_'):
             self.components_ = None
+        elif self.components_ is not None:
+            check_partial_fit_n_features(X, self.components_, self)
 
         if self.n_components is None:
             if self.components_ is None:
@@ -240,13 +243,6 @@ class IncrementalPCA(_BasePCA):
                              "%d." % (self.n_components, n_samples))
         else:
             self.n_components_ = self.n_components
-
-        if (self.components_ is not None) and (self.components_.shape[0] !=
-                                               self.n_components_):
-            raise ValueError("Number of input features has changed from %i "
-                             "to %i between calls to partial_fit! Try "
-                             "setting n_components to a fixed value." %
-                             (self.components_.shape[0], self.n_components_))
 
         # This is the first partial_fit
         if not hasattr(self, 'n_samples_seen_'):

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -19,7 +19,7 @@ from ..base import BaseEstimator, TransformerMixin
 from ..utils import (check_random_state, check_array,
                      gen_batches, gen_even_slices)
 from ..utils.fixes import logsumexp
-from ..utils.validation import check_non_negative
+from ..utils.validation import check_non_negative, check_partial_fit_n_features
 from ..utils import Parallel, delayed, effective_n_jobs
 from ..externals.six.moves import xrange
 from ..exceptions import NotFittedError
@@ -493,12 +493,8 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         # initialize parameters or check
         if not hasattr(self, 'components_'):
             self._init_latent_vars(n_features)
-
-        if n_features != self.components_.shape[1]:
-            raise ValueError(
-                "The provided data has %d dimensions while "
-                "the model was trained with feature size %d." %
-                (n_features, self.components_.shape[1]))
+        else:
+            check_partial_fit_n_features(X, self.components_, self)
 
         n_jobs = effective_n_jobs(self.n_jobs)
         with Parallel(n_jobs=n_jobs, verbose=max(0,

--- a/sklearn/decomposition/tests/test_online_lda.py
+++ b/sklearn/decomposition/tests/test_online_lda.py
@@ -142,21 +142,6 @@ def test_lda_fit_transform(method):
     assert_array_almost_equal(X_fit, X_trans, 4)
 
 
-def test_lda_partial_fit_dim_mismatch():
-    # test `n_features` mismatch in `partial_fit`
-    rng = np.random.RandomState(0)
-    n_components = rng.randint(3, 6)
-    n_col = rng.randint(6, 10)
-    X_1 = np.random.randint(4, size=(10, n_col))
-    X_2 = np.random.randint(4, size=(10, n_col + 1))
-    lda = LatentDirichletAllocation(n_components=n_components,
-                                    learning_offset=5., total_samples=20,
-                                    random_state=rng)
-    lda.partial_fit(X_1)
-    assert_raises_regexp(ValueError, r"^The provided data has",
-                         lda.partial_fit, X_2)
-
-
 def test_invalid_params():
     # test `_check_params` method
     X = np.ones((5, 10))
@@ -202,7 +187,7 @@ def test_lda_transform_mismatch():
                                     random_state=rng)
     lda.partial_fit(X)
     assert_raises_regexp(ValueError, r"^The provided data has",
-                         lda.partial_fit, X_2)
+                         lda.transform, X_2)
 
 
 @if_safe_multiprocessing_with_blas

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -18,7 +18,7 @@ from ..base import BaseEstimator, RegressorMixin
 from ..utils import check_array, check_random_state, check_X_y
 from ..utils.extmath import safe_sparse_dot
 from ..utils.multiclass import _check_partial_fit_first_call
-from ..utils.validation import check_is_fitted
+from ..utils.validation import check_is_fitted, check_partial_fit_n_features
 from ..exceptions import ConvergenceWarning
 from ..externals import six
 from ..model_selection import StratifiedShuffleSplit, ShuffleSplit
@@ -533,9 +533,8 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
         if getattr(self, "coef_", None) is None or coef_init is not None:
             self._allocate_parameter_mem(n_classes, n_features,
                                          coef_init, intercept_init)
-        elif n_features != self.coef_.shape[-1]:
-            raise ValueError("Number of features %d does not match previous "
-                             "data %d." % (n_features, self.coef_.shape[-1]))
+        else:
+            check_partial_fit_n_features(X, self.coef_, self)
 
         self.loss_function_ = self._get_loss_function(loss)
         if not hasattr(self, "t_"):
@@ -1144,9 +1143,9 @@ class BaseSGDRegressor(BaseSGD, RegressorMixin):
         if getattr(self, "coef_", None) is None:
             self._allocate_parameter_mem(1, n_features, coef_init,
                                          intercept_init)
-        elif n_features != self.coef_.shape[-1]:
-            raise ValueError("Number of features %d does not match previous "
-                             "data %d." % (n_features, self.coef_.shape[-1]))
+        else:
+            check_partial_fit_n_features(X, self.coef_, self)
+
         if self.average > 0 and getattr(self, "average_coef_", None) is None:
             self.average_coef_ = np.zeros(n_features,
                                           dtype=np.float64,

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -30,7 +30,7 @@ from .utils import check_X_y, check_array, check_consistent_length
 from .utils.extmath import safe_sparse_dot
 from .utils.fixes import logsumexp
 from .utils.multiclass import _check_partial_fit_first_call
-from .utils.validation import check_is_fitted
+from .utils.validation import check_is_fitted, check_partial_fit_n_features
 from .externals import six
 
 __all__ = ['BernoulliNB', 'GaussianNB', 'MultinomialNB', 'ComplementNB']
@@ -382,9 +382,8 @@ class GaussianNB(BaseNB):
                 self.class_prior_ = np.zeros(len(self.classes_),
                                              dtype=np.float64)
         else:
-            if X.shape[1] != self.theta_.shape[1]:
-                msg = "Number of features %d does not match previous data %d."
-                raise ValueError(msg % (X.shape[1], self.theta_.shape[1]))
+            check_partial_fit_n_features(X, self.theta_, self)
+
             # Put epsilon back in each time
             self.sigma_[:, :] -= self.epsilon_
 
@@ -527,9 +526,8 @@ class BaseDiscreteNB(BaseNB):
             self.class_count_ = np.zeros(n_effective_classes, dtype=np.float64)
             self.feature_count_ = np.zeros((n_effective_classes, n_features),
                                            dtype=np.float64)
-        elif n_features != self.coef_.shape[1]:
-            msg = "Number of features %d does not match previous data %d."
-            raise ValueError(msg % (n_features, self.coef_.shape[-1]))
+        else:
+            check_partial_fit_n_features(X, self.coef_, self)
 
         Y = label_binarize(y, classes=self.classes_)
         if Y.shape[1] == 1:

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -24,7 +24,7 @@ from ..utils import shuffle
 from ..utils import check_array, check_X_y, column_or_1d
 from ..exceptions import ConvergenceWarning
 from ..utils.extmath import safe_sparse_dot
-from ..utils.validation import check_is_fitted
+from ..utils.validation import check_is_fitted, check_partial_fit_n_features
 from ..utils.multiclass import _check_partial_fit_first_call, unique_labels
 from ..utils.multiclass import type_of_target
 

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -340,6 +340,8 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
                                            incremental):
             # First time training the model
             self._initialize(y, layer_units)
+        else:
+            check_partial_fit_n_features(X, self.coefs_[0].T, self)
 
         # lbfgs does not support mini-batches
         if self.solver == 'lbfgs':

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -21,7 +21,7 @@ from ..utils import check_random_state
 from ..utils import gen_even_slices
 from ..utils.extmath import safe_sparse_dot
 from ..utils.extmath import log_logistic
-from ..utils.validation import check_is_fitted
+from ..utils.validation import check_is_fitted, check_partial_fit_n_features
 
 
 class BernoulliRBM(BaseEstimator, TransformerMixin):
@@ -243,6 +243,8 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
                     (self.n_components, X.shape[1])
                 ),
                 order='F')
+        else:
+            check_partial_fit_n_features(X, self.components_, self)
         if not hasattr(self, 'intercept_hidden_'):
             self.intercept_hidden_ = np.zeros(self.n_components, )
         if not hasattr(self, 'intercept_visible_'):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -7,7 +7,6 @@ import traceback
 import pickle
 from copy import deepcopy
 from functools import partial
-import pytest
 
 import numpy as np
 from scipy import sparse
@@ -1260,15 +1259,14 @@ def check_estimators_partial_fit_n_features(name, estimator_orig):
     except NotImplementedError:
         return
 
-    try:
-        with pytest.raises(ValueError, match="Number of input features has "
-                                             "changed .* between calls to "
-                                             "partial_fit"):
-            estimator.partial_fit(X[:, :-1], y)
-    except pytest.fail.Exception:
-        raise AssertionError("The estimator {} does not raise an appropriate "
-                             "error when the number of features changes "
-                             "between calls to partial_fit.".format(name))
+    match = ("Number of input features has changed .* between "
+             "calls to partial_fit")
+    msg = ("The estimator {} does not raise an appropriate error when "
+           "the number of features changes between calls to "
+           "partial_fit.".format(name))
+
+    with assert_raises_regex(ValueError, match, msg=msg):
+        estimator.partial_fit(X[:, :-1], y)
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -971,3 +971,26 @@ def check_non_negative(X, whom):
 
     if X_min < 0:
         raise ValueError("Negative values in data passed to %s" % whom)
+
+
+def check_partial_fit_n_features(X, components, estimator):
+    """
+    Check if number of features is preseved between calls to partial_fit.
+
+    Parameters
+    ----------
+    X : array-like
+        Input data for the new call to partial_fit
+
+    components : array_like
+        Fitted attribute of an estimator which has the same number of features
+        as the input data from the first fit.
+
+    estimator : estimator instance.
+        Estimator instance for which the check is performed.
+    """
+    if X.shape[-1] != components.shape[-1]:
+        raise ValueError("Number of input features has changed from {0} to {1}"
+                         " between calls to partial_fit of {2}."
+                         "".format(X.shape[-1], components.shape[-1],
+                                   type(estimator).__name__))


### PR DESCRIPTION
This is WIP towards it. Extension of #12431 

Currently, when n_features changes between calls to partial_fit, for some estimators an error is raised with an informative error message, and for other estimators an error is raised but the message is not very informative (broadcasting error from numpy or bad shape from pairwise, ...).

In addition, for estimators which give an informative error message, the message differs between estimators.

Finally, there is a common test which checks that an estimator raises an error in that case. However, it's only done for classifiers, regressors and clusterers.

This PR fixes these 3 aspects:
- add a helper validation function to check if partial_fit is called on input data with appropriate number of features.
- modify the common tests to match the error message, ensuring consistency across estimators.
- modify the common tests to check partial_fit for all estimators.