### PR TITLE
Fix numpy vstack on generator expressions

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -103,6 +103,14 @@ Changelog
   :class:`decomposition.IncrementalPCA` when using float32 datasets.
   :issue:`12338` by :user:`bauks <bauks>`.
 
+Miscellaneous
+.............
+
+- |Fix| Make sure to avoid raising ``FutureWarning`` when calling
+  ``np.vstack`` with numpy 1.16 and later (use list comprehensions
+  instead of generator expressions in many locations of the scikit-learn
+  code base). :issue:`12467` by :user:`Olivier Grisel`.
+
 .. _changes_0_20:
 
 Version 0.20.0

--- a/sklearn/cluster/bicluster.py
+++ b/sklearn/cluster/bicluster.py
@@ -305,10 +305,10 @@ class SpectralCoclustering(BaseSpectral):
         self.row_labels_ = labels[:n_rows]
         self.column_labels_ = labels[n_rows:]
 
-        self.rows_ = np.vstack(self.row_labels_ == c
-                               for c in range(self.n_clusters))
-        self.columns_ = np.vstack(self.column_labels_ == c
-                                  for c in range(self.n_clusters))
+        self.rows_ = np.vstack([self.row_labels_ == c
+                                for c in range(self.n_clusters)])
+        self.columns_ = np.vstack([self.column_labels_ == c
+                                   for c in range(self.n_clusters)])
 
 
 class SpectralBiclustering(BaseSpectral):
@@ -504,12 +504,12 @@ class SpectralBiclustering(BaseSpectral):
         self.column_labels_ = self._project_and_cluster(X.T, best_ut.T,
                                                         n_col_clusters)
 
-        self.rows_ = np.vstack(self.row_labels_ == label
-                               for label in range(n_row_clusters)
-                               for _ in range(n_col_clusters))
-        self.columns_ = np.vstack(self.column_labels_ == label
-                                  for _ in range(n_row_clusters)
-                                  for label in range(n_col_clusters))
+        self.rows_ = np.vstack([self.row_labels_ == label
+                                for label in range(n_row_clusters)
+                                for _ in range(n_col_clusters)])
+        self.columns_ = np.vstack([self.column_labels_ == label
+                                   for _ in range(n_row_clusters)
+                                   for label in range(n_col_clusters)])
 
     def _fit_best_piecewise(self, vectors, n_best, n_clusters):
         """Find the ``n_best`` vectors that are best approximated by piecewise

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -629,8 +629,8 @@ def make_circles(n_samples=100, shuffle=True, noise=None, random_state=None,
     inner_circ_x = np.cos(linspace_in) * factor
     inner_circ_y = np.sin(linspace_in) * factor
 
-    X = np.vstack((np.append(outer_circ_x, inner_circ_x),
-                   np.append(outer_circ_y, inner_circ_y))).T
+    X = np.vstack([np.append(outer_circ_x, inner_circ_x),
+                   np.append(outer_circ_y, inner_circ_y)]).T
     y = np.hstack([np.zeros(n_samples_out, dtype=np.intp),
                    np.ones(n_samples_in, dtype=np.intp)])
     if shuffle:
@@ -683,8 +683,8 @@ def make_moons(n_samples=100, shuffle=True, noise=None, random_state=None):
     inner_circ_x = 1 - np.cos(np.linspace(0, np.pi, n_samples_in))
     inner_circ_y = 1 - np.sin(np.linspace(0, np.pi, n_samples_in)) - .5
 
-    X = np.vstack((np.append(outer_circ_x, inner_circ_x),
-                   np.append(outer_circ_y, inner_circ_y))).T
+    X = np.vstack([np.append(outer_circ_x, inner_circ_x),
+                   np.append(outer_circ_y, inner_circ_y)]).T
     y = np.hstack([np.zeros(n_samples_out, dtype=np.intp),
                    np.ones(n_samples_in, dtype=np.intp)])
 
@@ -1593,8 +1593,8 @@ def make_biclusters(shape, n_clusters, noise=0.0, minval=10,
         row_labels = row_labels[row_idx]
         col_labels = col_labels[col_idx]
 
-    rows = np.vstack(row_labels == c for c in range(n_clusters))
-    cols = np.vstack(col_labels == c for c in range(n_clusters))
+    rows = np.vstack([row_labels == c for c in range(n_clusters)])
+    cols = np.vstack([col_labels == c for c in range(n_clusters)])
 
     return result, rows, cols
 
@@ -1689,11 +1689,11 @@ def make_checkerboard(shape, n_clusters, noise=0.0, minval=10,
         row_labels = row_labels[row_idx]
         col_labels = col_labels[col_idx]
 
-    rows = np.vstack(row_labels == label
-                     for label in range(n_row_clusters)
-                     for _ in range(n_col_clusters))
-    cols = np.vstack(col_labels == label
-                     for _ in range(n_row_clusters)
-                     for label in range(n_col_clusters))
+    rows = np.vstack([row_labels == label
+                      for label in range(n_row_clusters)
+                      for _ in range(n_col_clusters)])
+    cols = np.vstack([col_labels == label
+                      for _ in range(n_row_clusters)
+                      for label in range(n_col_clusters)])
 
     return result, rows, cols

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -220,8 +220,8 @@ class DummyClassifier(BaseEstimator, ClassifierMixin):
                              k in range(self.n_outputs_)], [n_samples, 1])
 
             elif self.strategy == "stratified":
-                y = np.vstack(classes_[k][proba[k].argmax(axis=1)] for
-                              k in range(self.n_outputs_)).T
+                y = np.vstack([classes_[k][proba[k].argmax(axis=1)] for
+                               k in range(self.n_outputs_)]).T
 
             elif self.strategy == "uniform":
                 ret = [classes_[k][rs.randint(n_classes_[k], size=n_samples)]

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -478,8 +478,8 @@ class LinearRegression(LinearModel, RegressorMixin):
                 outs = Parallel(n_jobs=n_jobs_)(
                     delayed(sparse_lsqr)(X, y[:, j].ravel())
                     for j in range(y.shape[1]))
-                self.coef_ = np.vstack(out[0] for out in outs)
-                self._residues = np.vstack(out[3] for out in outs)
+                self.coef_ = np.vstack([out[0] for out in outs])
+                self._residues = np.vstack([out[3] for out in outs])
         else:
             self.coef_, self._residues, self.rank_, self.singular_ = \
                 linalg.lstsq(X, y)

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -177,7 +177,7 @@ class _ThresholdScorer(_BaseScorer):
 
                 # For multi-output multi-class estimator
                 if isinstance(y_pred, list):
-                    y_pred = np.vstack(p for p in y_pred).T
+                    y_pred = np.vstack([p for p in y_pred]).T
 
             except (NotImplementedError, AttributeError):
                 y_pred = clf.predict_proba(X)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -385,7 +385,7 @@ def test_thresholded_scorers_multilabel_indicator_data():
     clf.fit(X_train, y_train)
     y_proba = clf.predict_proba(X_test)
     score1 = get_scorer('roc_auc')(clf, X_test, y_test)
-    score2 = roc_auc_score(y_test, np.vstack(p[:, -1] for p in y_proba).T)
+    score2 = roc_auc_score(y_test, np.vstack([p[:, -1] for p in y_proba]).T)
     assert_almost_equal(score1, score2)
 
     # Multi-output multi-class decision_function
@@ -398,7 +398,7 @@ def test_thresholded_scorers_multilabel_indicator_data():
 
     y_proba = clf.decision_function(X_test)
     score1 = get_scorer('roc_auc')(clf, X_test, y_test)
-    score2 = roc_auc_score(y_test, np.vstack(p for p in y_proba).T)
+    score2 = roc_auc_score(y_test, np.vstack([p for p in y_proba]).T)
     assert_almost_equal(score1, score2)
 
     # Multilabel predict_proba

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -420,10 +420,10 @@ class KNeighborsMixin(object):
             kwds = ({'squared': True} if self.effective_metric_ == 'euclidean'
                     else self.effective_metric_params_)
 
-            result = pairwise_distances_chunked(
+            result = list(pairwise_distances_chunked(
                 X, self._fit_X, reduce_func=reduce_func,
                 metric=self.effective_metric_, n_jobs=n_jobs,
-                **kwds)
+                **kwds))
 
         elif self._fit_method in ['ball_tree', 'kd_tree']:
             if issparse(X):

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1382,8 +1382,8 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         combinations = self._combinations(self.n_input_features_, self.degree,
                                           self.interaction_only,
                                           self.include_bias)
-        return np.vstack(np.bincount(c, minlength=self.n_input_features_)
-                         for c in combinations)
+        return np.vstack([np.bincount(c, minlength=self.n_input_features_)
+                          for c in combinations])
 
     def get_feature_names(self, input_features=None):
         """


### PR DESCRIPTION
This workaround should fix the test failing with numpy master (CRON job on travis):

https://travis-ci.org/scikit-learn/scikit-learn/builds/446632038

```python-traceback
407     >>> from sklearn.cluster import SpectralBiclustering
408     >>> import numpy as np
409     >>> X = np.array([[1, 1], [2, 1], [1, 0],
410     ...               [4, 7], [3, 5], [3, 6]])
411     >>> clustering = SpectralBiclustering(n_clusters=2, random_state=0).fit(X)
UNEXPECTED EXCEPTION: ValueError('need at least one array to concatenate')
Traceback (most recent call last):
  File "/home/travis/miniconda/envs/testenv/lib/python3.7/doctest.py", line 1329, in __run
    compileflags, 1), test.globs)
  File "<doctest sklearn.cluster.bicluster.SpectralBiclustering[3]>", line 1, in <module>
  File "/home/travis/build/scikit-learn/scikit-learn/sklearn/cluster/bicluster.py", line 124, in fit
    self._fit(X)
  File "/home/travis/build/scikit-learn/scikit-learn/sklearn/cluster/bicluster.py", line 508, in _fit
    for label in range(n_row_clusters)
  File "/home/travis/miniconda/envs/testenv/lib/python3.7/site-packages/numpy/core/overrides.py", line 151, in public_api
    implementation, public_api, relevant_args, args, kwargs)
  File "/home/travis/miniconda/envs/testenv/lib/python3.7/site-packages/numpy/core/overrides.py", line 96, in array_function_implementation_or_override
    return implementation(*args, **kwargs)
  File "/home/travis/miniconda/envs/testenv/lib/python3.7/site-packages/numpy/core/shape_base.py", line 260, in vstack
    return _nx.concatenate([atleast_2d(_m) for _m in tup], 0)
  File "/home/travis/miniconda/envs/testenv/lib/python3.7/site-packages/numpy/core/overrides.py", line 151, in public_api
    implementation, public_api, relevant_args, args, kwargs)
  File "/home/travis/miniconda/envs/testenv/lib/python3.7/site-packages/numpy/core/overrides.py", line 96, in array_function_implementation_or_override
    return implementation(*args, **kwargs)
  File "/home/travis/miniconda/envs/testenv/lib/python3.7/site-packages/numpy/core/multiarray.py", line 193, in concatenate
    return _multiarray_umath.concatenate(arrays, axis, out)
ValueError: need at least one array to concatenate
```