### PR TITLE
WIP: Add __str__ to BaseEstimator and change __repr_

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -75,7 +75,7 @@ def clone(estimator, safe=True):
 
 
 ###############################################################################
-def _pprint(params, offset=0, printer=repr):
+def _pprint(params, offset=0, printer=repr, max_line_length=75):
     """Pretty print the dictionary 'params'
 
     Parameters
@@ -89,6 +89,10 @@ def _pprint(params, offset=0, printer=repr):
     printer : callable
         The function to convert entries to strings, typically
         the builtin str or repr
+
+    max_line_length : number
+        The maximum number of characters a line can have before it gets broken
+        into multiple lines.
 
     """
     # Do a multi-line justified repr:
@@ -109,7 +113,9 @@ def _pprint(params, offset=0, printer=repr):
         if len(this_repr) > 500:
             this_repr = this_repr[:300] + '...' + this_repr[-100:]
         if i > 0:
-            if (this_line_length + len(this_repr) >= 75 or '\n' in this_repr):
+            break_line = (this_line_length + len(this_repr) >= max_line_length
+                          or '\n' in this_repr)
+            if break_line:
                 params_list.append(line_sep)
                 this_line_length = len(line_sep)
             else:
@@ -224,6 +230,12 @@ class BaseEstimator(object):
         return self
 
     def __repr__(self):
+        class_name = self.__class__.__name__
+        return '%s(%s)' % (class_name, _pprint(self.get_params(deep=False),
+                                               offset=len(class_name),
+                                               max_line_length=float('inf')),)
+
+    def __str__(self):
         class_name = self.__class__.__name__
         return '%s(%s)' % (class_name, _pprint(self.get_params(deep=False),
                                                offset=len(class_name),),)

--- a/sklearn/linear_model/sag.py
+++ b/sklearn/linear_model/sag.py
@@ -214,7 +214,7 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1., beta=0.,
     >>> y = np.array([1, 1, 2, 2])
     >>> clf = linear_model.LogisticRegression(
     ...     solver='sag', multi_class='multinomial')
-    >>> clf.fit(X, y)
+    >>> print(clf.fit(X, y))
     ... #doctest: +NORMALIZE_WHITESPACE
     LogisticRegression(C=1.0, class_weight=None, dual=False,
         fit_intercept=True, intercept_scaling=1, max_iter=100,


### PR DESCRIPTION
Both implementations are very similar. The only difference is the
whitespaces. __repr__ now does not contain newline characters,
meaning it will yield a copy-pastable result on REPL while still
keeping the known behaviour of print(classifier)


## Behaviour before this PR

```
>>> from sklearn.neighbors import KNeighborsClassifier
>>> m = KNeighborsClassifier()
>>> str(m)
"KNeighborsClassifier(algorithm='auto', leaf_size=30, metric='minkowski',\n           metric_params=None, n_jobs=1, n_neighbors=5, p=2,\n           weights='uniform')"
>>> m  # same as repr(m)
"KNeighborsClassifier(algorithm='auto', leaf_size=30, metric='minkowski',\n           metric_params=None, n_jobs=1, n_neighbors=5, p=2,\n           weights='uniform')"
>>> print(m)  # Same as print(str(m))
KNeighborsClassifier(algorithm='auto', leaf_size=30, metric='minkowski',
           metric_params=None, n_jobs=1, n_neighbors=5, p=2,
           weights='uniform')
```

## Behaviour in this PR

The only difference I would like to have is about the whitespaces:

```
>>> from sklearn.neighbors import KNeighborsClassifier
>>> m = KNeighborsClassifier()
>>> str(m)
"KNeighborsClassifier(algorithm='auto', leaf_size=30, metric='minkowski',\n           metric_params=None, n_jobs=1, n_neighbors=5, p=2,\n           weights='uniform')"
>>> m  # same as repr(m) or print(repr(m))
"KNeighborsClassifier(algorithm='auto', leaf_size=30, metric='minkowski', metric_params=None, 
 n_jobs=1, n_neighbors=5, p=2, weights='uniform')"
>>> print(m)  # Same as print(str(m))
KNeighborsClassifier(algorithm='auto', leaf_size=30, metric='minkowski',
           metric_params=None, n_jobs=1, n_neighbors=5, p=2,
           weights='uniform')
```