### PR TITLE
TST Throw correct error for pytest version.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -16,8 +16,9 @@ from sklearn.utils.fixes import PY3_OR_LATER
 PYTEST_MIN_VERSION = '3.3.0'
 
 if LooseVersion(pytest.__version__) < PYTEST_MIN_VERSION:
-    raise('Your version of pytest is too old, you should have at least '
-          'pytest >= {} installed.'.format(PYTEST_MIN_VERSION))
+    raise ImportError('Your version of pytest is too old, you should have '
+                      'at least pytest >= {} installed.'
+                      .format(PYTEST_MIN_VERSION))
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
This throws the `ImportError` instead of (confusing and incorrect) `TypeError` when the `pytest` version is not adequate.

**Before:**
> ...
> TypeError: exceptions must derive from BaseException
> ERROR: could not load /Users/musically_ut/prog/rare/scikit-learn/conftest.py

**After:**
> ...
> ImportError: Your version of pytest is too old, you should have at least pytest >= 3.3.0 installed.
> ERROR: could not load /Users/musically_ut/prog/rare/scikit-learn/conftest.py