### PR TITLE
[MRG] Add early exaggeration iterations as argument to t-SNE

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -518,22 +518,22 @@ class TSNE(BaseEstimator):
         learning rate is too low, most points may look compressed in a dense
         cloud with few outliers. If the cost function gets stuck in a bad local
         minimum increasing the learning rate may help.
-        Some discussion on how to set learning rate optimally can be found 
-        at https://doi.org/10.1101/451690. Effective use of this parameter has 
+        Some discussion on how to set learning rate optimally can be found
+        at https://doi.org/10.1101/451690. Effective use of this parameter has
         the benefit of decreasing the number of iterations required
         for a good embedding.
 
     n_iter : int, optional (default: 1000)
         Maximum number of iterations for the optimization. Must be greater than
-        or equal to n_iter_early_exag. If embedding quality is suffering as a consequence
-        of increasing number of samples being embedded, increasing this value 
-        and n_iter_early_exag proportionately can help.
+        or equal to n_iter_early_exag. If embedding quality is suffering as a
+        consequence of increasing number of samples being embedded, increasing
+        this value and n_iter_early_exag proportionately can help.
 
     n_iter_early_exag : int, optional (default: 250)
-        Number of iterations out of total n_iter that the algorithm should spend
-        in the early exaggeration phase. If embedding quality is suffering as a consequence
-        of increasing number of samples being embedded, increasing this value 
-        and n_iter proportionately can help.
+        Number of iterations out of total n_iter that t-SNE should spend
+        in the early exaggeration phase. If embedding quality is suffering as a
+        consequence of increasing number of samples being embedded, increasing
+        this value and n_iter proportionately can help.
 
     n_iter_without_progress : int, optional (default: 300)
         Maximum number of iterations without progress before we abort the
@@ -637,9 +637,10 @@ class TSNE(BaseEstimator):
 
     def __init__(self, n_components=2, perplexity=30.0,
                  early_exaggeration=12.0, learning_rate=200.0, n_iter=1000,
-                 n_iter_early_exag=250, n_iter_without_progress=300, min_grad_norm=1e-7,
-                 metric="euclidean", init="random", verbose=0,
-                 random_state=None, method='barnes_hut', angle=0.5):
+                 n_iter_early_exag=250, n_iter_without_progress=300,
+                 min_grad_norm=1e-7, metric="euclidean",
+                 init="random", verbose=0, random_state=None,
+                 method='barnes_hut', angle=0.5):
         self.n_components = n_components
         self.perplexity = perplexity
         self.early_exaggeration = early_exaggeration
@@ -715,7 +716,8 @@ class TSNE(BaseEstimator):
                              .format(self.early_exaggeration))
 
         if self.n_iter < self.n_iter_early_exag:
-            raise ValueError("n_iter should be greater than or equal to n_iter_early_exag")
+            raise ValueError("n_iter should be greater than or equal "
+                             "to n_iter_early_exag.")
 
         n_samples = X.shape[0]
 
@@ -845,8 +847,9 @@ class TSNE(BaseEstimator):
         else:
             obj_func = _kl_divergence
 
-        # Learning schedule (part 1): do n_iter_early_exag iteration with lower momentum but
-        # higher learning rate controlled via the early exageration parameter
+        # Learning schedule (part 1): do n_iter_early_exag iteration with
+        # lower momentum but higher learning rate controlled via 
+        # the early exageration parameter
         P *= self.early_exaggeration
         params, kl_divergence, it = _gradient_descent(obj_func, params,
                                                       **opt_args)

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -518,15 +518,27 @@ class TSNE(BaseEstimator):
         learning rate is too low, most points may look compressed in a dense
         cloud with few outliers. If the cost function gets stuck in a bad local
         minimum increasing the learning rate may help.
+        Some discussion on how to set learning rate optimally can be found 
+        at https://doi.org/10.1101/451690. Effective use of this parameter has 
+        the benefit of decreasing the number of iterations required
+        for a good embedding.
 
     n_iter : int, optional (default: 1000)
-        Maximum number of iterations for the optimization. Should be at
-        least 250.
+        Maximum number of iterations for the optimization. Must be greater than
+        or equal to n_iter_early_exag. If embedding quality is suffering as a consequence
+        of increasing number of samples being embedded, increasing this value 
+        and n_iter_early_exag proportionately can help.
+
+    n_iter_early_exag : int, optional (default: 250)
+        Number of iterations out of total n_iter that the algorithm should spend
+        in the early exaggeration phase. If embedding quality is suffering as a consequence
+        of increasing number of samples being embedded, increasing this value 
+        and n_iter proportionately can help.
 
     n_iter_without_progress : int, optional (default: 300)
         Maximum number of iterations without progress before we abort the
-        optimization, used after 250 initial iterations with early
-        exaggeration. Note that progress is only checked every 50 iterations so
+        optimization, used after early exaggeration.
+        Note that progress is only checked every 50 iterations so
         this value is rounded to the next multiple of 50.
 
         .. versionadded:: 0.17
@@ -619,15 +631,13 @@ class TSNE(BaseEstimator):
         Journal of Machine Learning Research 15(Oct):3221-3245, 2014.
         https://lvdmaaten.github.io/publications/papers/JMLR_2014.pdf
     """
-    # Control the number of exploration iterations with early_exaggeration on
-    _EXPLORATION_N_ITER = 250
 
     # Control the number of iterations between progress checks
     _N_ITER_CHECK = 50
 
     def __init__(self, n_components=2, perplexity=30.0,
                  early_exaggeration=12.0, learning_rate=200.0, n_iter=1000,
-                 n_iter_without_progress=300, min_grad_norm=1e-7,
+                 n_iter_early_exag=250, n_iter_without_progress=300, min_grad_norm=1e-7,
                  metric="euclidean", init="random", verbose=0,
                  random_state=None, method='barnes_hut', angle=0.5):
         self.n_components = n_components
@@ -635,6 +645,7 @@ class TSNE(BaseEstimator):
         self.early_exaggeration = early_exaggeration
         self.learning_rate = learning_rate
         self.n_iter = n_iter
+        self.n_iter_early_exag = n_iter_early_exag
         self.n_iter_without_progress = n_iter_without_progress
         self.min_grad_norm = min_grad_norm
         self.metric = metric
@@ -703,8 +714,8 @@ class TSNE(BaseEstimator):
             raise ValueError("early_exaggeration must be at least 1, but is {}"
                              .format(self.early_exaggeration))
 
-        if self.n_iter < 250:
-            raise ValueError("n_iter should be at least 250")
+        if self.n_iter < self.n_iter_early_exag:
+            raise ValueError("n_iter should be greater than or equal to n_iter_early_exag")
 
         n_samples = X.shape[0]
 
@@ -822,8 +833,8 @@ class TSNE(BaseEstimator):
             "verbose": self.verbose,
             "kwargs": dict(skip_num_points=skip_num_points),
             "args": [P, degrees_of_freedom, n_samples, self.n_components],
-            "n_iter_without_progress": self._EXPLORATION_N_ITER,
-            "n_iter": self._EXPLORATION_N_ITER,
+            "n_iter_without_progress": self.n_iter_early_exag,
+            "n_iter": self.n_iter_early_exag,
             "momentum": 0.5,
         }
         if self.method == 'barnes_hut':
@@ -834,7 +845,7 @@ class TSNE(BaseEstimator):
         else:
             obj_func = _kl_divergence
 
-        # Learning schedule (part 1): do 250 iteration with lower momentum but
+        # Learning schedule (part 1): do n_iter_early_exag iteration with lower momentum but
         # higher learning rate controlled via the early exageration parameter
         P *= self.early_exaggeration
         params, kl_divergence, it = _gradient_descent(obj_func, params,
@@ -846,8 +857,8 @@ class TSNE(BaseEstimator):
         # Learning schedule (part 2): disable early exaggeration and finish
         # optimization with a higher momentum at 0.8
         P /= self.early_exaggeration
-        remaining = self.n_iter - self._EXPLORATION_N_ITER
-        if it < self._EXPLORATION_N_ITER or remaining > 0:
+        remaining = self.n_iter - self.n_iter_early_exag
+        if it < self.n_iter_early_exag or remaining > 0:
             opt_args['n_iter'] = self.n_iter
             opt_args['it'] = it + 1
             opt_args['momentum'] = 0.8

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -848,7 +848,7 @@ class TSNE(BaseEstimator):
             obj_func = _kl_divergence
 
         # Learning schedule (part 1): do n_iter_early_exag iteration with
-        # lower momentum but higher learning rate controlled via 
+        # lower momentum but higher learning rate controlled via
         # the early exageration parameter
         P *= self.early_exaggeration
         params, kl_divergence, it = _gradient_descent(obj_func, params,

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -678,7 +678,7 @@ def test_n_iter_without_progress():
         tsne = TSNE(n_iter_without_progress=-1, verbose=2, learning_rate=1e8,
                     random_state=0, method=method, n_iter=351, init="random")
         tsne._N_ITER_CHECK = 1
-        tsne._EXPLORATION_N_ITER = 0
+        tsne.n_iter_early_exag = 0
 
         old_stdout = sys.stdout
         sys.stdout = StringIO()
@@ -827,7 +827,7 @@ def test_bh_match_exact():
                     init="random", random_state=0, n_iter=251,
                     perplexity=30.0, angle=0)
         # Kill the early_exaggeration
-        tsne._EXPLORATION_N_ITER = 0
+        tsne.n_iter_early_exag = 0
         X_embeddeds[method] = tsne.fit_transform(X)
         n_iter[method] = tsne.n_iter_
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Converting early exaggeration iterations from a private constant to a public member variable of the TSNE class. The default value for this new argument is set at 250 such that code using previous versions of sklearn will still get identical results if no action is taken to account for the change.

Being able to set this variable is an important component of running t-SNE and it shouldn't be hidden. Other implementations ([e.g., LvdM's](https://github.com/lvdmaaten/bhtsne/blob/master/tsne.h#L44-L45)) expose it. In the LvdM case it's actually via two arguments but sklearn doesn't distinguish between momentum switch and stop lying. It doesn't seem necessary to treat the two arguments differently.

This change is motivated by [recent work](https://doi.org/10.1101/451690) that shows a high quality embedding can be achieved with much fewer than 250 early exaggeration iterations.

#### Any other comments?

Validated that results are identical before and after change for the same inputs.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
