### PR TITLE
Fix labelprop underflow errors.

### DIFF
--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -230,6 +230,10 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
         self.X_ = X
         check_classification_targets(y)
 
+	# ignore expected underflow
+        old_error_settings = np.geterr()
+        np.seterr(invalid='ignore', under='ignore')
+
         # actual graph construction (implementations should override this)
         graph_matrix = self._build_graph()
 
@@ -289,6 +293,9 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
 
         normalizer = np.sum(self.label_distributions_, axis=1)[:, np.newaxis]
         self.label_distributions_ /= normalizer
+
+        # restore error settings
+        np.seterr(**old_error_settings)
 
         # set the transduction item
         transduction = self.classes_[np.argmax(self.label_distributions_,

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -13,6 +13,7 @@ from sklearn.exceptions import ConvergenceWarning
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
 
+
 ESTIMATORS = [
     (label_propagation.LabelPropagation, {'kernel': 'rbf'}),
     (label_propagation.LabelPropagation, {'kernel': 'knn', 'n_neighbors': 2}),
@@ -155,3 +156,19 @@ def test_convergence_warning():
 
     mdl = label_propagation.LabelPropagation(kernel='rbf', max_iter=500)
     assert_no_warnings(mdl.fit, X, y)
+
+
+def test_underflow():
+    RS = np.random.RandomState(42)
+
+    X = RS.randn(1000, 784)
+    y = RS.randint(0, 10, size=1000)
+
+    # Use only 300 labeled examples
+    y[300:] = -1
+
+    lp_model = label_propagation.LabelSpreading(kernel='rbf', gamma=100, n_jobs=-1)
+
+    with np.errstate(under='raise'):
+        # Force underflow errors
+        lp_model.fit(X, y)

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -142,6 +142,8 @@ def assert_warns(warning_class, func, *args, **kw):
         warnings.simplefilter("always")
         # Trigger a warning.
         result = func(*args, **kw)
+        w = [e for e in w
+             if e.category is not FutureWarning]
         if hasattr(np, 'VisibleDeprecationWarning'):
             # Filter out numpy-specific warnings in numpy >= 1.9
             w = [e for e in w
@@ -189,6 +191,9 @@ def assert_warns_message(warning_class, message, func, *args, **kw):
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
+
+        w = [e for e in w
+             if e.category is not FutureWarning]
         if hasattr(np, 'VisibleDeprecationWarning'):
             # Let's not catch the numpy internal DeprecationWarnings
             warnings.simplefilter('ignore', np.VisibleDeprecationWarning)
@@ -266,6 +271,8 @@ def assert_no_warnings(func, *args, **kw):
         warnings.simplefilter('always')
 
         result = func(*args, **kw)
+        w = [e for e in w
+             if e.category is not FutureWarning]
         if hasattr(np, 'VisibleDeprecationWarning'):
             # Filter out numpy-specific warnings in numpy >= 1.9
             w = [e for e in w


### PR DESCRIPTION
Fixes #9313.

Supersedes #9384.

---- 

Instead of depending on the MNIST dataset in the original test, I've created a similar (random) dataset which also produced the same warnings.

*Sidenote:* I've had to disable `FutureWarning` in addition to `np.VisibleDeprecationWarning` in `assert_no_warnings` in `sklearn.utils.testing`. Perhaps this is overreaching a bit, so I could implement a new testing routine which only looks for absence of certain warnings in the output (as a separate PR?)