### PR TITLE
[MRG] Fix segfault in AgglomerativeClustering with read-only mmaps

### DIFF
--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -230,6 +230,7 @@ def ward_tree(X, connectivity=None, n_clusters=None, return_distance=False):
                           'retain the lower branches required '
                           'for the specified number of clusters',
                           stacklevel=2)
+        X = np.require(X, requirements="W")
         out = hierarchy.ward(X)
         children_ = out[:, :2].astype(np.intp)
 


### PR DESCRIPTION
This fixes a segfault in AgglomerativeClustering with read-only mmaps that happens inside `ward_tree` when calling `scipy.cluster.hierarchy.ward`.

Closes https://github.com/scikit-learn/scikit-learn/issues/12483

(see the above issue for more details)