### PR TITLE
[MRG]: Small fix in compose.rst

### DIFF
--- a/doc/modules/compose.rst
+++ b/doc/modules/compose.rst
@@ -494,9 +494,11 @@ above example would be::
   >>> from sklearn.compose import make_column_transformer
   >>> column_trans = make_column_transformer(
   ...     ('city', CountVectorizer(analyzer=lambda x: [x])),
-  ...     ('title', CountVectorizer()))
+  ...     ('title', CountVectorizer()),
+  ...     remainder=MinMaxScaler())
   >>> column_trans # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-  ColumnTransformer(n_jobs=None, remainder='drop', sparse_threshold=0.3,
+  ColumnTransformer(n_jobs=None, remainder=MinMaxScaler(copy=True, ...),
+           sparse_threshold=0.3,
            transformer_weights=None,
            transformers=[('countvectorizer-1', ...)
 

--- a/doc/modules/compose.rst
+++ b/doc/modules/compose.rst
@@ -486,7 +486,7 @@ the transformation::
          [0.5, 0.5],
          [1. , 0. ]])
 
-The :func:`~sklearn.compose.make_columntransformer` function is available
+The :func:`~sklearn.compose.make_column_transformer` function is available
 to more easily create a :class:`~sklearn.compose.ColumnTransformer` object.
 Specifically, the names will be given automatically. The equivalent for the
 above example would be::


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
The compose doc states:

>  The `sklearn.compose.make_column_transformer` function is available
to more easily create a `sklearn.compose.ColumnTransformer` object.
Specifically, the names will be given automatically. The equivalent for the
above example would be

The "above example" sets the `remainder` to `MinMaxScaler`, while example for `make_column_transformer` uses the default remainder: `drop`.

#### What does this implement/fix? Explain your changes.
This PR updates the code snippet to use `MinMaxScaler`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->