### PR TITLE
DOC: Clarify `cv` parameter description in `GridSearchCV`

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -153,8 +153,8 @@ indices, for example::
   ...         yield idx, idx
   ...         i += 1
   ...
-  >>> cv = custom_cv_2folds(iris.data)
-  >>> cross_val_score(clf, iris.data, iris.target, cv=cv)
+  >>> custom_cv = custom_cv_2folds(iris.data)
+  >>> cross_val_score(clf, iris.data, iris.target, cv=custom_cv)
   array([1.        , 0.973...])
 
 .. topic:: Data transformation with held out data

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -142,6 +142,21 @@ validation iterator instead, for instance::
   >>> cross_val_score(clf, iris.data, iris.target, cv=cv)  # doctest: +ELLIPSIS
   array([0.977..., 0.977..., 1.  ..., 0.955..., 1.        ])
 
+Another option is to use an iterable yielding (train, test) splits as arrays of
+indices, for example::
+
+  >>> def custom_cv_2folds(X):
+  ...     n = X.shape[0]
+  ...     i = 1
+  ...     while i <= 2:
+  ...         idx = np.arange(n * (i - 1) / 2, n * i / 2, dtype=int)
+  ...         yield idx, idx
+  ...         i += 1
+  ...
+  >>> cv = custom_cv_2folds(iris.data)
+  >>> cross_val_score(clf, iris.data, iris.target, cv=cv)
+  array([1.        , 0.973...])
+
 .. topic:: Data transformation with held out data
 
     Just as it is important to test a predictor on data held-out from

--- a/examples/model_selection/plot_learning_curve.py
+++ b/examples/model_selection/plot_learning_curve.py
@@ -53,8 +53,8 @@ def plot_learning_curve(estimator, title, X, y, ylim=None, cv=None,
         Possible inputs for cv are:
           - None, to use the default 3-fold cross-validation,
           - integer, to specify the number of folds.
-          - An object to be used as a cross-validation generator.
-          - An iterable yielding train/test splits.
+          - :term:`CV splitter <CV splitter>`,
+          - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if ``y`` is binary or multiclass,
         :class:`StratifiedKFold` used. If the estimator is not a classifier

--- a/examples/model_selection/plot_learning_curve.py
+++ b/examples/model_selection/plot_learning_curve.py
@@ -53,7 +53,7 @@ def plot_learning_curve(estimator, title, X, y, ylim=None, cv=None,
         Possible inputs for cv are:
           - None, to use the default 3-fold cross-validation,
           - integer, to specify the number of folds.
-          - :term:`CV splitter <CV splitter>`,
+          - :term:`CV splitter`,
           - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if ``y`` is binary or multiclass,

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -63,8 +63,8 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train/test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if ``y`` is binary or multiclass,
         :class:`sklearn.model_selection.StratifiedKFold` is used. If ``y`` is

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -63,7 +63,7 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if ``y`` is binary or multiclass,

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -491,8 +491,8 @@ class GraphicalLassoCV(GraphicalLasso):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train/test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs :class:`KFold` is used.
 
@@ -897,8 +897,8 @@ class GraphLassoCV(GraphicalLassoCV):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train/test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs :class:`KFold` is used.
 

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -491,7 +491,7 @@ class GraphicalLassoCV(GraphicalLasso):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs :class:`KFold` is used.
@@ -897,7 +897,7 @@ class GraphLassoCV(GraphicalLassoCV):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs :class:`KFold` is used.

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -356,7 +356,7 @@ class RFECV(RFE, MetaEstimatorMixin):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if ``y`` is binary or multiclass,

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -356,8 +356,8 @@ class RFECV(RFE, MetaEstimatorMixin):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train/test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if ``y`` is binary or multiclass,
         :class:`sklearn.model_selection.StratifiedKFold` is used. If the

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1307,8 +1307,8 @@ class LassoCV(LinearModelCV, RegressorMixin):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train/test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, :class:`KFold` is used.
 
@@ -1477,8 +1477,8 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train/test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, :class:`KFold` is used.
 
@@ -2015,8 +2015,8 @@ class MultiTaskElasticNetCV(LinearModelCV, RegressorMixin):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train/test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, :class:`KFold` is used.
 
@@ -2194,8 +2194,8 @@ class MultiTaskLassoCV(LinearModelCV, RegressorMixin):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train/test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, :class:`KFold` is used.
 

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1307,7 +1307,7 @@ class LassoCV(LinearModelCV, RegressorMixin):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, :class:`KFold` is used.
@@ -1477,7 +1477,7 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, :class:`KFold` is used.
@@ -2015,7 +2015,7 @@ class MultiTaskElasticNetCV(LinearModelCV, RegressorMixin):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, :class:`KFold` is used.
@@ -2194,7 +2194,7 @@ class MultiTaskLassoCV(LinearModelCV, RegressorMixin):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, :class:`KFold` is used.

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -1007,8 +1007,8 @@ class LarsCV(Lars):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train/test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, :class:`KFold` is used.
 
@@ -1230,8 +1230,8 @@ class LassoLarsCV(LarsCV):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train/test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, :class:`KFold` is used.
 

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -1007,7 +1007,7 @@ class LarsCV(Lars):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, :class:`KFold` is used.
@@ -1230,7 +1230,7 @@ class LassoLarsCV(LarsCV):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, :class:`KFold` is used.

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -790,8 +790,8 @@ class OrthogonalMatchingPursuitCV(LinearModel, RegressorMixin):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train/test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, :class:`KFold` is used.
 

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -790,7 +790,7 @@ class OrthogonalMatchingPursuitCV(LinearModel, RegressorMixin):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, :class:`KFold` is used.

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1211,8 +1211,8 @@ class RidgeCV(_BaseRidgeCV, RegressorMixin):
 
         - None, to use the efficient Leave-One-Out cross-validation
         - integer, to specify the number of folds.
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train/test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if ``y`` is binary or multiclass,
         :class:`sklearn.model_selection.StratifiedKFold` is used, else,
@@ -1323,8 +1323,8 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
         - None, to use the efficient Leave-One-Out cross-validation
         - integer, to specify the number of folds.
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train/test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         Refer :ref:`User Guide <cross_validation>` for the various
         cross-validation strategies that can be used here.

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1211,7 +1211,7 @@ class RidgeCV(_BaseRidgeCV, RegressorMixin):
 
         - None, to use the efficient Leave-One-Out cross-validation
         - integer, to specify the number of folds.
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if ``y`` is binary or multiclass,
@@ -1323,7 +1323,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
         - None, to use the efficient Leave-One-Out cross-validation
         - integer, to specify the number of folds.
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         Refer :ref:`User Guide <cross_validation>` for the various

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -901,7 +901,7 @@ class GridSearchCV(BaseSearchCV):
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
@@ -1235,7 +1235,7 @@ class RandomizedSearchCV(BaseSearchCV):
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -901,10 +901,8 @@ class GridSearchCV(BaseSearchCV):
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - A :term:`CV splitter <CV splitter>` object. See
-          :ref:`sphx_glr_auto_examples_svm_plot_rbf_parameters.py` for
-          an example.
-        - An iterable yielding train, test splits as arrays of indices.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
         either binary or multiclass, :class:`StratifiedKFold` is used. In all
@@ -983,34 +981,6 @@ class GridSearchCV(BaseSearchCV):
      'rank_test_score', 'split0_test_score',...
      'split2_test_score', ...
      'std_fit_time', 'std_score_time', 'std_test_score']
-
-    >>> from sklearn import svm, datasets
-    >>> from sklearn.model_selection import GridSearchCV
-    >>> import numpy as np
-    >>> iris = datasets.load_iris()
-    >>> svc = svm.SVC(gamma="scale")
-    >>> parameters = {'kernel':('linear', 'rbf'), 'C':[1, 10]}
-    >>> def custom_cv_2folds(X):
-    ...     n = X.shape[0]
-    ...     i = 1
-    ...     while i <= 2:
-    ...         idx = np.arange(n * (i - 1) / 2, n * i / 2, dtype=int)
-    ...         yield idx, idx
-    ...         i += 1
-    ...
-    >>> cv = custom_cv_2folds(iris.data)
-    >>> clf = GridSearchCV(svc, parameters, cv=cv)
-    >>> clf.fit(iris.data, iris.target)
-    GridSearchCV(cv=...,
-           error_score='raise-deprecating',
-           estimator=SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0,
-      decision_function_shape='ovr', degree=3, gamma='scale', kernel='rbf',
-      max_iter=-1, probability=False, random_state=None, shrinking=True,
-      tol=0.001, verbose=False),
-           iid='warn', n_jobs=None,
-           param_grid={'kernel': ('linear', 'rbf'), 'C': [1, 10]},
-           pre_dispatch='2*n_jobs', refit=True, return_train_score=False,
-           scoring=None, verbose=0)
 
     Attributes
     ----------

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1235,8 +1235,8 @@ class RandomizedSearchCV(BaseSearchCV):
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train, test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
         either binary or multiclass, :class:`StratifiedKFold` is used. In all

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1001,7 +1001,7 @@ class GridSearchCV(BaseSearchCV):
     >>> cv = custom_cv_2folds(iris.data)
     >>> clf = GridSearchCV(svc, parameters, cv=cv)
     >>> clf.fit(iris.data, iris.target)
-    GridSearchCV(cv=<generator object custom_cv_2folds at 0x10f9bf048>,
+    GridSearchCV(cv=...,
            error_score='raise-deprecating',
            estimator=SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0,
       decision_function_shape='ovr', degree=3, gamma='scale', kernel='rbf',

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -901,8 +901,10 @@ class GridSearchCV(BaseSearchCV):
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train, test splits.
+        - A :term:`CV splitter <CV splitter>` object. See
+          :ref:`sphx_glr_auto_examples_svm_plot_rbf_parameters.py` for
+          an example.
+        - An iterable yielding train, test splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
         either binary or multiclass, :class:`StratifiedKFold` is used. In all
@@ -981,6 +983,34 @@ class GridSearchCV(BaseSearchCV):
      'rank_test_score', 'split0_test_score',...
      'split2_test_score', ...
      'std_fit_time', 'std_score_time', 'std_test_score']
+
+    >>> from sklearn import svm, datasets
+    >>> from sklearn.model_selection import GridSearchCV
+    >>> import numpy as np
+    >>> iris = datasets.load_iris()
+    >>> svc = svm.SVC(gamma="scale")
+    >>> parameters = {'kernel':('linear', 'rbf'), 'C':[1, 10]}
+    >>> def custom_cv_2folds(X):
+    ...     n = X.shape[0]
+    ...     i = 1
+    ...     while i <= 2:
+    ...         idx = np.arange(n * (i - 1) / 2, n * i / 2, dtype=int)
+    ...         yield idx, idx
+    ...         i += 1
+    ...
+    >>> cv = custom_cv_2folds(iris.data)
+    >>> clf = GridSearchCV(svc, parameters, cv=cv)
+    >>> clf.fit(iris.data, iris.target)
+    GridSearchCV(cv=<generator object custom_cv_2folds at 0x10f9bf048>,
+           error_score='raise-deprecating',
+           estimator=SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0,
+      decision_function_shape='ovr', degree=3, gamma='scale', kernel='rbf',
+      max_iter=-1, probability=False, random_state=None, shrinking=True,
+      tol=0.001, verbose=False),
+           iid='warn', n_jobs=None,
+           param_grid={'kernel': ('linear', 'rbf'), 'C': [1, 10]},
+           pre_dispatch='2*n_jobs', refit=True, return_train_score=False,
+           scoring=None, verbose=0)
 
     Attributes
     ----------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1913,8 +1913,8 @@ def check_cv(cv='warn', y=None, classifier=False):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train/test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if classifier is True and ``y`` is either
         binary or multiclass, :class:`StratifiedKFold` is used. In all other

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1913,7 +1913,7 @@ def check_cv(cv='warn', y=None, classifier=False):
 
         - None, to use the default 3-fold cross-validation,
         - integer, to specify the number of folds.
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if classifier is True and ``y`` is either

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -82,8 +82,8 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv='warn',
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train, test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
         either binary or multiclass, :class:`StratifiedKFold` is used. In all
@@ -292,8 +292,8 @@ def cross_val_score(estimator, X, y=None, groups=None, scoring=None, cv='warn',
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train, test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
         either binary or multiclass, :class:`StratifiedKFold` is used. In all
@@ -666,8 +666,8 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv='warn',
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train, test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
         either binary or multiclass, :class:`StratifiedKFold` is used. In all
@@ -957,8 +957,8 @@ def permutation_test_score(estimator, X, y, groups=None, cv='warn',
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train, test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
         either binary or multiclass, :class:`StratifiedKFold` is used. In all
@@ -1109,8 +1109,8 @@ def learning_curve(estimator, X, y, groups=None,
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train, test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
         either binary or multiclass, :class:`StratifiedKFold` is used. In all
@@ -1360,8 +1360,8 @@ def validation_curve(estimator, X, y, param_name, param_range, groups=None,
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - An object to be used as a cross-validation generator.
-        - An iterable yielding train, test splits.
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
         either binary or multiclass, :class:`StratifiedKFold` is used. In all

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -82,7 +82,7 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv='warn',
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
@@ -292,7 +292,7 @@ def cross_val_score(estimator, X, y=None, groups=None, scoring=None, cv='warn',
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
@@ -666,7 +666,7 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv='warn',
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
@@ -957,7 +957,7 @@ def permutation_test_score(estimator, X, y, groups=None, cv='warn',
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
@@ -1109,7 +1109,7 @@ def learning_curve(estimator, X, y, groups=None,
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
@@ -1360,7 +1360,7 @@ def validation_curve(estimator, X, y, param_name, param_range, groups=None,
 
         - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -511,9 +511,9 @@ class ClassifierChain(_BaseChain, ClassifierMixin, MetaEstimatorMixin):
         If cv is None the true labels are used when fitting. Otherwise
         possible inputs for cv are:
 
-        * integer, to specify the number of folds in a (Stratified)KFold,
-        * An object to be used as a cross-validation generator.
-        * An iterable yielding train, test splits.
+        - integer, to specify the number of folds in a (Stratified)KFold,
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
     random_state : int, RandomState instance or None, optional (default=None)
         If int, random_state is the seed used by the random number generator;
@@ -667,9 +667,9 @@ class RegressorChain(_BaseChain, RegressorMixin, MetaEstimatorMixin):
         If cv is None the true labels are used when fitting. Otherwise
         possible inputs for cv are:
 
-        * integer, to specify the number of folds in a (Stratified)KFold,
-        * An object to be used as a cross-validation generator.
-        * An iterable yielding train, test splits.
+        - integer, to specify the number of folds in a (Stratified)KFold,
+        - :term:`CV splitter <CV splitter>`,
+        - An iterable yielding (train, test) splits as arrays of indices.
 
     random_state : int, RandomState instance or None, optional (default=None)
         If int, random_state is the seed used by the random number generator;

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -512,7 +512,7 @@ class ClassifierChain(_BaseChain, ClassifierMixin, MetaEstimatorMixin):
         possible inputs for cv are:
 
         - integer, to specify the number of folds in a (Stratified)KFold,
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
     random_state : int, RandomState instance or None, optional (default=None)
@@ -668,7 +668,7 @@ class RegressorChain(_BaseChain, RegressorMixin, MetaEstimatorMixin):
         possible inputs for cv are:
 
         - integer, to specify the number of folds in a (Stratified)KFold,
-        - :term:`CV splitter <CV splitter>`,
+        - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
     random_state : int, RandomState instance or None, optional (default=None)


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

This PR addresses issue #12466.

#### What does this implement/fix? Explain your changes.

This PR does the 3 following things:
- Rewrite the `cv` parameter description in `GridSearchCV`
- Link the new `CV splitter` description to an existing example
- Add an example with a custom iterable

Thanks for reviewing this!

Close #12466 
