### PR TITLE
Impose shared memory when fitting a SGDClassifier

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -94,6 +94,14 @@ Changelog
   those estimators as part of parallel parameter search or cross-validation.
   :issue:`12122` by :user:`Olivier Grisel <ogrisel>`.
 
+- |Fix| Fixed a bug affecting :func:`SGDClassifier.fit` in the multiclass
+  case. Each one-versus-all step is run in a :class:`joblib.Parallel` call and
+  mutating a common parameter, causing a segmentation fault if called within a
+  backend using processes and not threads. We now use ``require=sharedmem``
+  at the :class:`Parallel` instance creation.
+  :issue:`12518` by :user:`Pierre Glaser <pierreglaser>` and
+  :user:`Olivier Grisel <ogrisel>`.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -639,7 +639,7 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
         validation_mask = self._make_validation_split(y)
 
         # Use joblib to fit OvA in parallel.
-        result = Parallel(n_jobs=self.n_jobs, prefer="threads",
+        result = Parallel(n_jobs=self.n_jobs, require="sharedmem",
                           verbose=self.verbose)(
             delayed(fit_binary)(self, i, X, y, alpha, C, learning_rate,
                                 max_iter, self._expanded_class_weight[i],

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -19,6 +19,7 @@ from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import ignore_warnings
+from sklearn.utils import parallel_backend
 
 from sklearn import linear_model, datasets, metrics
 from sklearn.base import clone, is_classifier
@@ -1534,30 +1535,30 @@ def test_SGDClassifier_fit_for_all_backends():
 
     # We further test a case where memmapping would have been used if
     # SGDClassifier.fit was called from a loky or multiprocessing backend. In
-    # this specific case, in-place modiciation of clf.coef_ would have caused a
-    # segmentation fault
+    # this specific case, in-place modification of clf.coef_ would have caused
+    # a segmentation fault when trying to write in a readonly memory mapped
+    # buffer.
 
     random_state = 42
 
     # Create a classification problem with 50000 features and 20 classes. Using
     # loky or multiprocessing this make the clf.coef_ exceed the threshold
     # above which memmaping is used in joblib and loky (1MB as of 2018/11/1).
-    sparse_X = sp.random(1000, 50000, density=0.01, format='csr',
-                         random_state=random_state)
+    X = sp.random(1000, 50000, density=0.01, format='csr',
+                  random_state=random_state)
     y = np.random.choice(20, 1000)
 
     # begin by fitting a SGD classifier sequentially
     clf = SGDClassifier(tol=1e-3, max_iter=1000, n_jobs=1,
                         random_state=random_state)
-    clf.fit(sparse_X, y=y)
+    clf.fit(X, y)
     coef_sequential_fitting = clf.coef_
 
     # fit a SGDClassifier for each available backend, and make sure the
     # coefficients are equal to those obtained using a sequential fit
-    from sklearn.externals.joblib import parallel_backend
     for backend in ['threading', 'multiprocessing', 'loky']:
         clf = SGDClassifier(tol=1e-3, max_iter=1000, n_jobs=4,
                             random_state=random_state)
         with parallel_backend(backend=backend):
-            clf.fit(sparse_X, y=y)
+            clf.fit(X, y)
         assert_array_equal(coef_sequential_fitting, clf.coef_)

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -1541,27 +1541,24 @@ def test_SGDClassifier_fit_for_all_backends(backend):
     # a segmentation fault when trying to write in a readonly memory mapped
     # buffer.
 
-    random_state = 42
+    random_state = np.random.RandomState(42)
 
     # Create a classification problem with 50000 features and 20 classes. Using
     # loky or multiprocessing this make the clf.coef_ exceed the threshold
     # above which memmaping is used in joblib and loky (1MB as of 2018/11/1).
     X = sp.random(1000, 50000, density=0.01, format='csr',
                   random_state=random_state)
+    y = random_state.choice(20, 1000)
 
-    np.random.seed(random_state)
-    y = np.random.choice(20, 1000)
+    # Begin by fitting a SGD classifier sequentially
+    clf_sequential = SGDClassifier(tol=1e-3, max_iter=1000, n_jobs=1,
+                                   random_state=42)
+    clf_sequential.fit(X, y)
 
-    # begin by fitting a SGD classifier sequentially
-    clf = SGDClassifier(tol=1e-3, max_iter=1000, n_jobs=1,
-                        random_state=random_state)
-    clf.fit(X, y)
-    coef_sequential_fitting = clf.coef_
-
-    # fit a SGDClassifier using the specified backend, and make sure the
+    # Fit a SGDClassifier using the specified backend, and make sure the
     # coefficients are equal to those obtained using a sequential fit
-    clf = SGDClassifier(tol=1e-3, max_iter=1000, n_jobs=4,
-                        random_state=random_state)
+    clf_parallel = SGDClassifier(tol=1e-3, max_iter=1000, n_jobs=4,
+                                 random_state=42)
     with parallel_backend(backend=backend):
-        clf.fit(X, y)
-    assert_array_almost_equal(coef_sequential_fitting, clf.coef_)
+        clf_parallel.fit(X, y)
+    assert_array_almost_equal(clf_sequential.coef_, clf_parallel.coef_)

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -1546,6 +1546,8 @@ def test_SGDClassifier_fit_for_all_backends():
     # above which memmaping is used in joblib and loky (1MB as of 2018/11/1).
     X = sp.random(1000, 50000, density=0.01, format='csr',
                   random_state=random_state)
+
+    np.random.seed(random_state)
     y = np.random.choice(20, 1000)
 
     # begin by fitting a SGD classifier sequentially
@@ -1561,4 +1563,4 @@ def test_SGDClassifier_fit_for_all_backends():
                             random_state=random_state)
         with parallel_backend(backend=backend):
             clf.fit(X, y)
-        assert_array_equal(coef_sequential_fitting, clf.coef_)
+        assert_array_almost_equal(coef_sequential_fitting, clf.coef_)

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -1518,6 +1518,11 @@ def test_multi_core_gridsearch_and_early_stopping():
     assert search.best_score_ > 0.8
 
 
+@pytest.mark.skipif(
+        not hasattr(sp, 'random'),
+        reason="this test uses scipy.random, that was introduced in version  "
+        "0.17. This skip condition can be dropped as soon as we drop support "
+        "for scipy versions older than 0.17")
 def test_SGDClassifier_fit_for_all_backends():
     # This is a non-regression smoke test. In the multi-class case,
     # SGDClassifier.fit fits each class in a one-versus-all fashion using


### PR DESCRIPTION
Fixes #12518 

Previously, fitting a `SGDClassifier` instance in a multi-class setting involved modifying in-place its `coef_` attribute in the workers created by a `joblib.Parallel` call. However, this `Parallel` call was not requiring shared memory. For this reason, calling `SGDClassifier.fit` from a context manager with a `loky` or a `multiprocessing` backend (where workers are processes, and memory is not shared)  was causing a segmentation fault in the worker processes.

This PR fixes it by changing the soft constraint `prefer='threads'` into the hard constraint `require='sharedmem'` when instantiating the `Parallel` instance.

We also introduce a non-regression test that makes sure that fitting a `SGDClassifier` in a parallel fashion yields coefficients identical to those obtained from a sequential fit, and this for each backend (`loky`, `threading`, `multiprocessing`)