### PR TITLE
Add classes_ to classifier attributes

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -83,8 +83,8 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
 
     Attributes
     ----------
-    classes_ : array, shape (n_classes)
-        The class labels.
+    classes_ : array, shape = (n_classes,)
+        Class labels.
 
     calibrated_classifiers_ : list (len() equal to cv or 1 if cv == "prefit")
         The list of calibrated classifiers, one for each crossvalidation fold,

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -594,6 +594,9 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
         of the Gaussian distributions along its principal axes, i.e. the
         variance in the rotated coordinate system.
 
+    classes_ : array, shape = (n_classes,)
+        Class labels.
+
     Examples
     --------
     >>> from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1905,6 +1905,9 @@ shape (n_estimators, ``loss_.K``)
         The collection of fitted sub-estimators. ``loss_.K`` is 1 for binary
         classification, otherwise n_classes.
 
+    classes_ : array, shape = (n_classes,)
+        Class labels.
+
     Notes
     -----
     The features are always randomly permuted at each split. Therefore,

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1167,6 +1167,9 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
             In SciPy <= 1.0.0 the number of lbfgs iterations may exceed
             ``max_iter``. ``n_iter_`` will now report at most ``max_iter``.
 
+    classes_ : array, shape = (n_classes,)
+        Class labels.
+
     Examples
     --------
     >>> from sklearn.datasets import load_iris
@@ -1637,6 +1640,9 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
     n_iter_ : array, shape (n_classes, n_folds, n_cs) or (1, n_folds, n_cs)
         Actual number of iterations for all classes, folds and Cs.
         In the binary or multinomial cases, the first dimension is equal to 1.
+
+    classes_ : array, shape = (n_classes,)
+        Class labels.
 
     Examples
     --------

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -133,6 +133,9 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
         The actual number of iterations to reach the stopping criterion.
         For multiclass fits, it is the maximum over every binary fit.
 
+    classes_ : array, shape = (n_classes,)
+        Class labels.
+
     Examples
     --------
     >>> from sklearn.linear_model import PassiveAggressiveClassifier

--- a/sklearn/linear_model/perceptron.py
+++ b/sklearn/linear_model/perceptron.py
@@ -117,6 +117,9 @@ class Perceptron(BaseSGDClassifier):
         The actual number of iterations to reach the stopping criterion.
         For multiclass fits, it is the maximum over every binary fit.
 
+    classes_ : array, shape = (n_classes,)
+        Class labels.
+
     Notes
     -----
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -775,6 +775,9 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         Independent term in decision function. Set to 0.0 if
         ``fit_intercept = False``.
 
+    classes_ : array, shape = (n_classes,)
+        Class labels.
+
     n_iter_ : array or None, shape (n_targets,)
         Actual number of iterations for each target. Available only for
         sag and lsqr solvers. Other solvers will return None.
@@ -1357,6 +1360,9 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
     intercept_ : float | array, shape = (n_targets,)
         Independent term in decision function. Set to 0.0 if
         ``fit_intercept = False``.
+
+    classes_ : array, shape = (n_classes,)
+        Class labels.
 
     alpha_ : float
         Estimated regularization parameter

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -938,6 +938,9 @@ class SGDClassifier(BaseSGDClassifier):
     intercept_ : array, shape (1,) if n_classes == 2 else (n_classes,)
         Constants in decision function.
 
+    classes_ : array, shape = (n_classes,)
+        Class labels.
+
     n_iter_ : int
         The actual number of iterations to reach the stopping criterion.
         For multiclass fits, it is the maximum over every binary fit.

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -143,6 +143,9 @@ class GaussianNB(BaseNB):
     epsilon_ : float
         absolute additive value to variances
 
+    classes_ : array, shape = (n_classes,)
+        Class labels.
+
     Examples
     --------
     >>> import numpy as np
@@ -676,6 +679,9 @@ class MultinomialNB(BaseDiscreteNB):
         during fitting. This value is weighted by the sample weight when
         provided.
 
+    classes_ : array, shape = (n_classes,)
+        Class labels.
+
     Examples
     --------
     >>> import numpy as np
@@ -777,6 +783,9 @@ class ComplementNB(BaseDiscreteNB):
         Number of samples encountered for each feature during fitting. This
         value is weighted by the sample weight when provided.
 
+    classes_ : array, shape = (n_classes,)
+        Class labels.
+
     Examples
     --------
     >>> import numpy as np
@@ -877,6 +886,9 @@ class BernoulliNB(BaseDiscreteNB):
         Number of samples encountered for each (class, feature)
         during fitting. This value is weighted by the sample weight when
         provided.
+
+    classes_ : array, shape = (n_classes,)
+        Class labels.
 
     Examples
     --------

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -82,6 +82,11 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         for more details.
         Doesn't affect :meth:`fit` method.
 
+    Attributes
+    ----------
+    classes_ : array, shape = (n_classes,)
+        Class labels.
+
     Examples
     --------
     >>> X = [[0], [1], [2], [3]]
@@ -295,6 +300,11 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
+
+    Attributes
+    ----------
+    classes_ : array, shape = (n_classes,)
+        Class labels.
 
     Examples
     --------

--- a/sklearn/neighbors/nearest_centroid.py
+++ b/sklearn/neighbors/nearest_centroid.py
@@ -48,6 +48,9 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
     centroids_ : array-like, shape = [n_classes, n_features]
         Centroid of each class
 
+    classes_ : array, shape = (n_classes,)
+        Class labels.
+
     Examples
     --------
     >>> from sklearn.neighbors.nearest_centroid import NearestCentroid

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -340,7 +340,7 @@ class LabelPropagation(BaseLabelPropagation):
     X_ : array, shape = [n_samples, n_features]
         Input array.
 
-    classes_ : array, shape = [n_classes]
+    classes_ : array, shape = (n_classes,)
         The distinct labels used in classifying instances.
 
     label_distributions_ : array, shape = [n_samples, n_classes]
@@ -454,7 +454,7 @@ class LabelSpreading(BaseLabelPropagation):
     X_ : array, shape = [n_samples, n_features]
         Input array.
 
-    classes_ : array, shape = [n_classes]
+    classes_ : array, shape = (n_classes,)
         The distinct labels used in classifying instances.
 
     label_distributions_ : array, shape = [n_samples, n_classes]

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -111,6 +111,9 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
     intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]
         Constants in decision function.
 
+    classes_ : array, shape = (n_classes,)
+        Class labels.
+
     Examples
     --------
     >>> from sklearn.svm import LinearSVC
@@ -556,6 +559,9 @@ class SVC(BaseSVC):
     fit_status_ : int
         0 if correctly fitted, 1 otherwise (will raise warning)
 
+    classes_ : array, shape = (n_classes,)
+        Class labels.
+
     probA_ : array, shape = [n_class * (n_class-1) / 2]
     probB_ : array, shape = [n_class * (n_class-1) / 2]
         If probability=True, the parameters learned in Platt scaling to
@@ -736,6 +742,9 @@ class NuSVC(BaseSVC):
 
     intercept_ : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
+
+    classes_ : array, shape = (n_classes,)
+        Class labels.
 
     Examples
     --------

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -17,6 +17,7 @@ from sklearn.utils.testing import SkipTest
 from sklearn.utils.testing import check_docstring_parameters
 from sklearn.utils.testing import _get_func_name
 from sklearn.utils.testing import ignore_warnings
+from sklearn.utils.testing import all_estimators
 from sklearn.utils.deprecation import _is_deprecated
 
 import pytest
@@ -144,3 +145,15 @@ def test_tabs():
         assert '\t' not in source, ('"%s" has tabs, please remove them ',
                                     'or add it to theignore list'
                                     % modname)
+
+
+@pytest.mark.parametrize('name, Classifier',
+                         all_estimators(type_filter='classifier'))
+def test_classifier_docstring_attributes(name, Classifier):
+    pytest.importorskip('numpydoc')
+    from numpydoc import docscrape
+
+    doc = docscrape.ClassDoc(Classifier)
+    attributes = doc['Attributes']
+    assert attributes
+    assert any(['classes_' in att[0] for att in attributes])

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -1291,6 +1291,11 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
         Note that these weights will be multiplied with sample_weight (passed
         through the fit method) if sample_weight is specified.
 
+    Attributes
+    ----------
+    classes_ : array, shape = (n_classes,)
+        Class labels.
+
     See also
     --------
     ExtraTreeRegressor, sklearn.ensemble.ExtraTreesClassifier,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #11444 

#### What does this implement/fix? Explain your changes.

This PR adds `classes_` to the `Attributes` section for classification estimators. I've also added a test in `sklearn/tests/test_docstring_parameters.py` to check that each classifier has an `Attributes` section in its docstring and `classes_` is listed as an attribute (as proposed in https://github.com/scikit-learn/scikit-learn/issues/11444#issuecomment-402952975)

#### Any other comments?

The list of classifiers that are being checked is given by `all_estimators(type_filter='classifier')` from `sklearn.utils.testing`. If there are other classifiers that should also be added, just let me know and I'll add them to this PR. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
