### PR TITLE
[MRG]: openml, Adds retrying if reading from cache fails

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -65,6 +65,9 @@ Changelog
   location in :func:`datasets.fetch_olivetti_faces`. :issue:`12441` by
   :user:`Jérémie du Boisberranger <jeremiedbb>`
 
+- |Fix| :func:`datasets.fetch_openml` to retry downloading when reading
+  from local cache fails. :issue:`12517` by :user:`Thomas Fan <thomasjpfan>`.
+
 :mod:`sklearn.decomposition`
 ............................
 

--- a/sklearn/datasets/openml.py
+++ b/sklearn/datasets/openml.py
@@ -55,7 +55,9 @@ def _retry_if_error_with_cache_removed(openml_path, data_home):
                     "Unable to successfully read from cache, "
                     "redownloading file",
                     RuntimeWarning)
-                os.unlink(_get_local_path(openml_path, data_home))
+                local_path = _get_local_path(openml_path, data_home)
+                if os.path.exists(local_path):
+                    os.unlink(local_path)
                 return f()
         return wrapper
     return decorator

--- a/sklearn/datasets/openml.py
+++ b/sklearn/datasets/openml.py
@@ -38,7 +38,7 @@ def _get_local_path(openml_path, data_home):
     return os.path.join(data_home, 'openml.org', openml_path + ".gz")
 
 
-def _retry_if_error_with_cache_removed(openml_path, data_home):
+def _retry_with_clean_cache(openml_path, data_home):
     """If the first call to the decorated function fails, the local cached
     file is removed, and the function is called again. If ``data_home`` is
     ``None``, then the function is called once.
@@ -154,7 +154,7 @@ def _get_json_content_from_openml_api(url, error_message, raise_if_error,
         ``acceptable``
     """
 
-    @_retry_if_error_with_cache_removed(url, data_home)
+    @_retry_with_clean_cache(url, data_home)
     def _load_json():
         with closing(_open_openml_url(url, data_home)) as response:
             return json.loads(response.read().decode("utf-8"))
@@ -351,7 +351,7 @@ def _download_data_arff(file_id, sparse, data_home, encode_nominal=True):
     # production!
     url = _DATA_FILE.format(file_id)
 
-    @_retry_if_error_with_cache_removed(url, data_home)
+    @_retry_with_clean_cache(url, data_home)
     def _arff_load():
         with closing(_open_openml_url(url, data_home)) as response:
             if sparse is True:

--- a/sklearn/datasets/openml.py
+++ b/sklearn/datasets/openml.py
@@ -50,6 +50,8 @@ def _retry_if_error_with_cache_removed(openml_path, data_home):
                 return f()
             try:
                 return f()
+            except HTTPError:
+                raise
             except Exception:
                 warnings.warn(
                     "Invalid cache, redownloading file",

--- a/sklearn/datasets/openml.py
+++ b/sklearn/datasets/openml.py
@@ -52,8 +52,7 @@ def _retry_if_error_with_cache_removed(openml_path, data_home):
                 return f()
             except Exception:
                 warnings.warn(
-                    "Unable to successfully read from cache, "
-                    "redownloading file",
+                    "Invalid cache, redownloading file",
                     RuntimeWarning)
                 local_path = _get_local_path(openml_path, data_home)
                 if os.path.exists(local_path):

--- a/sklearn/datasets/openml.py
+++ b/sklearn/datasets/openml.py
@@ -36,7 +36,7 @@ def _get_local_path(openml_path, data_home):
     return os.path.join(data_home, 'openml.org', openml_path + ".gz")
 
 
-def _open_openml_url(openml_path, data_home, invalidate_cache=False):
+def _open_openml_url(openml_path, data_home):
     """
     Returns a resource from OpenML.org. Caches it to data_home if required.
 
@@ -49,9 +49,6 @@ def _open_openml_url(openml_path, data_home, invalidate_cache=False):
     data_home : str
         Directory to which the files will be cached. If None, no caching will
         be applied.
-
-    invalidate_cache : bool, default=False
-        Remove cached file and redownload file.
 
     Returns
     -------
@@ -73,10 +70,6 @@ def _open_openml_url(openml_path, data_home, invalidate_cache=False):
         return fsrc
 
     local_path = _get_local_path(openml_path, data_home)
-
-    if invalidate_cache and os.path.exists(local_path):
-        os.unlink(local_path)
-
     if not os.path.exists(local_path):
         try:
             os.makedirs(os.path.dirname(local_path))

--- a/sklearn/datasets/openml.py
+++ b/sklearn/datasets/openml.py
@@ -36,7 +36,7 @@ def _get_local_path(openml_path, data_home):
     return os.path.join(data_home, 'openml.org', openml_path + ".gz")
 
 
-def _open_openml_url(openml_path, data_home):
+def _open_openml_url(openml_path, data_home, invalidate_cache=False):
     """
     Returns a resource from OpenML.org. Caches it to data_home if required.
 
@@ -49,6 +49,9 @@ def _open_openml_url(openml_path, data_home):
     data_home : str
         Directory to which the files will be cached. If None, no caching will
         be applied.
+
+    invalidate_cache : bool, default=False
+        Remove cached file and redownload file.
 
     Returns
     -------
@@ -70,6 +73,10 @@ def _open_openml_url(openml_path, data_home):
         return fsrc
 
     local_path = _get_local_path(openml_path, data_home)
+
+    if invalidate_cache and os.path.exists(local_path):
+        os.unlink(local_path)
+
     if not os.path.exists(local_path):
         try:
             os.makedirs(os.path.dirname(local_path))

--- a/sklearn/datasets/openml.py
+++ b/sklearn/datasets/openml.py
@@ -164,8 +164,7 @@ def _get_json_content_from_openml_api(url, error_message, raise_if_error,
         if error.code != 412:
             raise error
 
-    # 412 error
-    # not in except for nicer traceback
+    # 412 error, not in except for nicer traceback
     if raise_if_error:
         raise ValueError(error_message)
     return None

--- a/sklearn/datasets/openml.py
+++ b/sklearn/datasets/openml.py
@@ -114,7 +114,8 @@ def _open_openml_url(openml_path, data_home):
                     with gzip.GzipFile(local_path, 'wb') as fdst:
                         shutil.copyfileobj(fsrc, fdst)
         except Exception:
-            os.unlink(local_path)
+            if os.path.exists(local_path):
+                os.unlink(local_path)
             raise
 
     # XXX: First time, decompression will not be necessary (by using fsrc), but

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -14,7 +14,7 @@ from sklearn.datasets.openml import (_open_openml_url,
                                      _get_data_description_by_id,
                                      _download_data_arff,
                                      _get_local_path,
-                                     _retry_if_error_with_cache_removed)
+                                     _retry_with_clean_cache)
 from sklearn.utils.testing import (assert_warns_message,
                                    assert_raise_message)
 from sklearn.externals.six import string_types
@@ -496,7 +496,7 @@ def test_open_openml_url_cache(monkeypatch, gzip_response, tmpdir):
     assert response1.read() == response2.read()
 
 
-def test_retry_if_error_with_cache_removed(tmpdir):
+def test_retry_with_clean_cache(tmpdir):
     data_id = 61
     openml_path = sklearn.datasets.openml._DATA_FILE.format(data_id)
     cache_directory = str(tmpdir.mkdir('scikit_learn_data'))
@@ -506,7 +506,7 @@ def test_retry_if_error_with_cache_removed(tmpdir):
     with open(location, 'w') as f:
         f.write("")
 
-    @_retry_if_error_with_cache_removed(openml_path, cache_directory)
+    @_retry_with_clean_cache(openml_path, cache_directory)
     def _load_data():
         # The first call will raise an error since location exists
         if os.path.exists(location):
@@ -519,12 +519,12 @@ def test_retry_if_error_with_cache_removed(tmpdir):
     assert result == 1
 
 
-def test_retry_if_error_with_cache_removed_http_error(tmpdir):
+def test_retry_with_clean_cache_http_error(tmpdir):
     data_id = 61
     openml_path = sklearn.datasets.openml._DATA_FILE.format(data_id)
     cache_directory = str(tmpdir.mkdir('scikit_learn_data'))
 
-    @_retry_if_error_with_cache_removed(openml_path, cache_directory)
+    @_retry_with_clean_cache(openml_path, cache_directory)
     def _load_data():
         raise HTTPError(url=None, code=412,
                         msg='Simulated mock error',

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -513,7 +513,7 @@ def test_retry_if_error_with_cache_removed(tmpdir):
             raise Exception("File exist!")
         return 1
 
-    warn_msg = "Unable to successfully read from cache, redownloading file"
+    warn_msg = "Invalid cache, redownloading file"
     with pytest.warns(RuntimeWarning, match=warn_msg):
         result = _load_data()
     assert result == 1

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -519,6 +519,22 @@ def test_retry_if_error_with_cache_removed(tmpdir):
     assert result == 1
 
 
+def test_retry_if_error_with_cache_removed_http_error(tmpdir):
+    data_id = 61
+    openml_path = sklearn.datasets.openml._DATA_FILE.format(data_id)
+    cache_directory = str(tmpdir.mkdir('scikit_learn_data'))
+
+    @_retry_if_error_with_cache_removed(openml_path, cache_directory)
+    def _load_data():
+        raise HTTPError(url=None, code=412,
+                        msg='Simulated mock error',
+                        hdrs=None, fp=None)
+
+    error_msg = "Simulated mock error"
+    with pytest.raises(HTTPError, match=error_msg):
+        _load_data()
+
+
 @pytest.mark.parametrize('gzip_response', [True, False])
 def test_fetch_openml_cache(monkeypatch, gzip_response, tmpdir):
     def _mock_urlopen_raise(request):

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -490,40 +490,9 @@ def test_open_openml_url_cache(monkeypatch, gzip_response, tmpdir):
     # assert file exists
     location = _get_local_path(openml_path, cache_directory)
     assert os.path.isfile(location)
-    stat_before = os.stat(location)
-
     # redownload, to utilize cache
     response2 = _open_openml_url(openml_path, cache_directory)
     assert response1.read() == response2.read()
-
-    stat_after = os.stat(location)
-    assert stat_before == stat_after
-
-
-@pytest.mark.parametrize('gzip_response', [True, False])
-def test_open_openml_url_cache_invalidate_cache(
-        monkeypatch, gzip_response, tmpdir):
-    data_id = 61
-
-    _monkey_patch_webbased_functions(
-        monkeypatch, data_id, gzip_response)
-    openml_path = sklearn.datasets.openml._DATA_FILE.format(data_id)
-    cache_directory = str(tmpdir.mkdir('scikit_learn_data'))
-    # first fill the cache
-    response1 = _open_openml_url(
-        openml_path, cache_directory, invalidate_cache=True)
-    # assert file exists
-    location = _get_local_path(openml_path, cache_directory)
-    assert os.path.isfile(location)
-    stat_before = os.stat(location)
-
-    # redownload, to utilize cache
-    response2 = _open_openml_url(
-        openml_path, cache_directory, invalidate_cache=True)
-    assert response1.read() == response2.read()
-
-    stat_after = os.stat(location)
-    assert stat_before != stat_after
 
 
 @pytest.mark.parametrize('gzip_response', [True, False])

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -490,9 +490,40 @@ def test_open_openml_url_cache(monkeypatch, gzip_response, tmpdir):
     # assert file exists
     location = _get_local_path(openml_path, cache_directory)
     assert os.path.isfile(location)
+    stat_before = os.stat(location)
+
     # redownload, to utilize cache
     response2 = _open_openml_url(openml_path, cache_directory)
     assert response1.read() == response2.read()
+
+    stat_after = os.stat(location)
+    assert stat_before == stat_after
+
+
+@pytest.mark.parametrize('gzip_response', [True, False])
+def test_open_openml_url_cache_invalidate_cache(
+        monkeypatch, gzip_response, tmpdir):
+    data_id = 61
+
+    _monkey_patch_webbased_functions(
+        monkeypatch, data_id, gzip_response)
+    openml_path = sklearn.datasets.openml._DATA_FILE.format(data_id)
+    cache_directory = str(tmpdir.mkdir('scikit_learn_data'))
+    # first fill the cache
+    response1 = _open_openml_url(
+        openml_path, cache_directory, invalidate_cache=True)
+    # assert file exists
+    location = _get_local_path(openml_path, cache_directory)
+    assert os.path.isfile(location)
+    stat_before = os.stat(location)
+
+    # redownload, to utilize cache
+    response2 = _open_openml_url(
+        openml_path, cache_directory, invalidate_cache=True)
+    assert response1.read() == response2.read()
+
+    stat_after = os.stat(location)
+    assert stat_before != stat_after
 
 
 @pytest.mark.parametrize('gzip_response', [True, False])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Resolves https://github.com/scikit-learn/scikit-learn/issues/12517


#### What does this implement/fix? Explain your changes.
Adds a decorator called `_retry_if_error_with_cache_removed` to implement the retry logic, when the read from cache fails.

This PR includes a minor refactoring to use `contextlib.closing` to make sure streams are closed, when an exception gets raised.