### PR TITLE
joblib 0.13.0

### DIFF
--- a/sklearn/externals/joblib/__init__.py
+++ b/sklearn/externals/joblib/__init__.py
@@ -14,11 +14,11 @@ data and has specific optimizations for `numpy` arrays. It is
     ==================== ===============================================
     **Documentation:**       https://joblib.readthedocs.io
 
-    **Download:**            https://pypi.org/project/joblib/#files
+    **Download:**            http://pypi.python.org/pypi/joblib#downloads
 
-    **Source code:**         https://github.com/joblib/joblib
+    **Source code:**         http://github.com/joblib/joblib
 
-    **Report issues:**       https://github.com/joblib/joblib/issues
+    **Report issues:**       http://github.com/joblib/joblib/issues
     ==================== ===============================================
 
 
@@ -106,7 +106,7 @@ Main features
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.12.5'
+__version__ = '0.13.0'
 
 
 from .memory import Memory, MemorizedResult, register_store_backend
@@ -123,8 +123,11 @@ from .parallel import register_parallel_backend
 from .parallel import parallel_backend
 from .parallel import effective_n_jobs
 
+from .externals.loky import wrap_non_picklable_objects
+
 
 __all__ = ['Memory', 'MemorizedResult', 'PrintTime', 'Logger', 'hash', 'dump',
            'load', 'Parallel', 'delayed', 'cpu_count', 'effective_n_jobs',
            'register_parallel_backend', 'parallel_backend',
-           'register_store_backend', 'register_compressor']
+           'register_store_backend', 'register_compressor',
+           'wrap_non_picklable_objects']

--- a/sklearn/externals/joblib/_dask.py
+++ b/sklearn/externals/joblib/_dask.py
@@ -145,7 +145,7 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
         return (DaskDistributedBackend, ())
 
     def get_nested_backend(self):
-        return DaskDistributedBackend(client=self.client)
+        return DaskDistributedBackend(client=self.client), -1
 
     def configure(self, n_jobs=1, parallel=None, **backend_args):
         return self.effective_n_jobs(n_jobs)

--- a/sklearn/externals/joblib/_parallel_backends.py
+++ b/sklearn/externals/joblib/_parallel_backends.py
@@ -126,9 +126,9 @@ class ParallelBackendBase(with_metaclass(ABCMeta)):
         """
         nesting_level = getattr(self, 'nesting_level', 0) + 1
         if nesting_level > 1:
-            return SequentialBackend(nesting_level=nesting_level)
+            return SequentialBackend(nesting_level=nesting_level), None
         else:
-            return ThreadingBackend(nesting_level=nesting_level)
+            return ThreadingBackend(nesting_level=nesting_level), None
 
     @contextlib.contextmanager
     def retrieval_context(self):
@@ -185,8 +185,12 @@ class SequentialBackend(ParallelBackendBase):
         return result
 
     def get_nested_backend(self):
-        nested_level = getattr(self, 'nesting_level', 0) + 1
-        return SequentialBackend(nesting_level=nested_level)
+        # import is not top level to avoid cyclic import errors.
+        from .parallel import get_active_backend
+
+        # SequentialBackend should neither change the nesting level, the
+        # default backend or the number of jobs. Just return the current one.
+        return get_active_backend()
 
 
 class PoolManagerMixin(object):

--- a/sklearn/externals/joblib/compressor.py
+++ b/sklearn/externals/joblib/compressor.py
@@ -30,7 +30,7 @@ except ImportError:
     lz4 = None
 
 LZ4_NOT_INSTALLED_ERROR = ('LZ4 is not installed. Install it with pip: '
-                           'https://python-lz4.readthedocs.io/')
+                           'http://python-lz4.readthedocs.io/')
 
 # Registered compressors
 _COMPRESSORS = {}

--- a/sklearn/externals/joblib/externals/cloudpickle/__init__.py
+++ b/sklearn/externals/joblib/externals/cloudpickle/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from .cloudpickle import *
 
-__version__ = '0.5.6'
+__version__ = '0.6.1'

--- a/sklearn/externals/joblib/externals/cloudpickle/cloudpickle.py
+++ b/sklearn/externals/joblib/externals/cloudpickle/cloudpickle.py
@@ -42,20 +42,20 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 from __future__ import print_function
 
-import dis
-from functools import partial
-import imp
 import io
-import itertools
-import logging
+import dis
+import sys
+import types
 import opcode
-import operator
 import pickle
 import struct
-import sys
-import traceback
-import types
+import logging
 import weakref
+import operator
+import importlib
+import itertools
+import traceback
+from functools import partial
 
 
 # cloudpickle is meant for inter process communication: we expect all
@@ -76,6 +76,22 @@ else:
     from pickle import _Pickler as Pickler
     from io import BytesIO as StringIO
     PY3 = True
+
+
+# Container for the global namespace to ensure consistent unpickling of
+# functions defined in dynamic modules (modules not registed in sys.modules).
+_dynamic_modules_globals = weakref.WeakValueDictionary()
+
+
+class _DynamicModuleFuncGlobals(dict):
+    """Global variables referenced by a function defined in a dynamic module
+
+    To avoid leaking references we store such context in a WeakValueDictionary
+    instance.  However instances of python builtin types such as dict cannot
+    be used directly as values in such a construct, hence the need for a
+    derived class.
+    """
+    pass
 
 
 def _make_cell_set_template_code():
@@ -288,20 +304,10 @@ class CloudPickler(Pickler):
         """
         Save a module as an import
         """
-        mod_name = obj.__name__
-        # If module is successfully found then it is not a dynamically created module
-        if hasattr(obj, '__file__'):
-            is_dynamic = False
-        else:
-            try:
-                _find_module(mod_name)
-                is_dynamic = False
-            except ImportError:
-                is_dynamic = True
-
         self.modules.add(obj)
-        if is_dynamic:
-            self.save_reduce(dynamic_subimport, (obj.__name__, vars(obj)), obj=obj)
+        if _is_dynamic(obj):
+            self.save_reduce(dynamic_subimport, (obj.__name__, vars(obj)),
+                             obj=obj)
         else:
             self.save_reduce(subimport, (obj.__name__,), obj=obj)
 
@@ -566,7 +572,7 @@ class CloudPickler(Pickler):
             'name': func.__name__,
             'doc': func.__doc__,
         }
-        if hasattr(func, '__annotations__'):
+        if hasattr(func, '__annotations__') and sys.version_info >= (3, 7):
             state['annotations'] = func.__annotations__
         if hasattr(func, '__qualname__'):
             state['qualname'] = func.__qualname__
@@ -661,6 +667,13 @@ class CloudPickler(Pickler):
         The name of this method is somewhat misleading: all types get
         dispatched here.
         """
+        if obj is type(None):
+            return self.save_reduce(type, (None,), obj=obj)
+        elif obj is type(Ellipsis):
+            return self.save_reduce(type, (Ellipsis,), obj=obj)
+        elif obj is type(NotImplemented):
+            return self.save_reduce(type, (NotImplemented,), obj=obj)
+
         if obj.__module__ == "__main__":
             return self.save_dynamic_class(obj)
 
@@ -933,7 +946,7 @@ def subimport(name):
 
 
 def dynamic_subimport(name, vars):
-    mod = imp.new_module(name)
+    mod = types.ModuleType(name)
     mod.__dict__.update(vars)
     return mod
 
@@ -1090,12 +1103,18 @@ def _make_skel_func(code, cell_count, base_globals=None):
     if base_globals is None:
         base_globals = {}
     elif isinstance(base_globals, str):
-        if sys.modules.get(base_globals, None) is not None:
-            # this checks if we can import the previous environment the object
-            # lived in
-            base_globals = vars(sys.modules[base_globals])
-        else:
-            base_globals = {}
+        base_globals_name = base_globals
+        try:
+            # First try to reuse the globals from the module containing the
+            # function. If it is not possible to retrieve it, fallback to an
+            # empty dictionary.
+            base_globals = vars(importlib.import_module(base_globals))
+        except ImportError:
+            base_globals = _dynamic_modules_globals.get(
+                    base_globals_name, None)
+            if base_globals is None:
+                base_globals = _DynamicModuleFuncGlobals()
+            _dynamic_modules_globals[base_globals_name] = base_globals
 
     base_globals['__builtins__'] = __builtins__
 
@@ -1125,19 +1144,31 @@ def _rehydrate_skeleton_class(skeleton_class, class_dict):
     return skeleton_class
 
 
-def _find_module(mod_name):
+def _is_dynamic(module):
     """
-    Iterate over each part instead of calling imp.find_module directly.
-    This function is able to find submodules (e.g. scikit.tree)
+    Return True if the module is special module that cannot be imported by its
+    name.
     """
-    path = None
-    for part in mod_name.split('.'):
-        if path is not None:
-            path = [path]
-        file, path, description = imp.find_module(part, path)
-        if file is not None:
-            file.close()
-    return path, description
+    # Quick check: module that have __file__ attribute are not dynamic modules.
+    if hasattr(module, '__file__'):
+        return False
+
+    if hasattr(module, '__spec__'):
+        return module.__spec__ is None
+    else:
+        # Backward compat for Python 2
+        import imp
+        try:
+            path = None
+            for part in module.__name__.split('.'):
+                if path is not None:
+                    path = [path]
+                f, path, description = imp.find_module(part, path)
+                if f is not None:
+                    f.close()
+        except ImportError:
+            return True
+        return False
 
 
 """Constructors for 3rd party libraries

--- a/sklearn/externals/joblib/externals/loky/__init__.py
+++ b/sklearn/externals/joblib/externals/loky/__init__.py
@@ -9,14 +9,17 @@ from ._base import TimeoutError, CancelledError
 from ._base import ALL_COMPLETED, FIRST_COMPLETED, FIRST_EXCEPTION
 
 from .backend.context import cpu_count
+from .backend.reduction import set_loky_pickler
 from .reusable_executor import get_reusable_executor
+from .cloudpickle_wrapper import wrap_non_picklable_objects
 from .process_executor import BrokenProcessPool, ProcessPoolExecutor
 
 
 __all__ = ["get_reusable_executor", "cpu_count", "wait", "as_completed",
            "Future", "Executor", "ProcessPoolExecutor",
            "BrokenProcessPool", "CancelledError", "TimeoutError",
-           "FIRST_COMPLETED", "FIRST_EXCEPTION", "ALL_COMPLETED", ]
+           "FIRST_COMPLETED", "FIRST_EXCEPTION", "ALL_COMPLETED",
+           "wrap_non_picklable_objects", "set_loky_pickler"]
 
 
-__version__ = '2.3.1'
+__version__ = '2.4.2'

--- a/sklearn/externals/joblib/externals/loky/backend/__init__.py
+++ b/sklearn/externals/joblib/externals/loky/backend/__init__.py
@@ -3,8 +3,6 @@ import sys
 
 from .context import get_context
 
-LOKY_PICKLER = os.environ.get("LOKY_PICKLER")
-
 if sys.version_info > (3, 4):
 
     def _make_name():

--- a/sklearn/externals/joblib/externals/loky/backend/compat.py
+++ b/sklearn/externals/joblib/externals/loky/backend/compat.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 ###############################################################################
 # Compat file to import the correct modules for each platform and python
 # version.
@@ -7,12 +6,12 @@
 #
 import sys
 
-if sys.version_info[:2] >= (3, 3):
+PY3 = sys.version_info[:2] >= (3, 3)
+
+if PY3:
     import queue
 else:
     import Queue as queue
-
-from pickle import PicklingError
 
 if sys.version_info >= (3, 4):
     from multiprocessing.process import BaseProcess
@@ -21,6 +20,22 @@ else:
 
 # Platform specific compat
 if sys.platform == "win32":
-    from .compat_win32 import *
+    from .compat_win32 import wait
 else:
-    from .compat_posix import *
+    from .compat_posix import wait
+
+
+def set_cause(exc, cause):
+    exc.__cause__ = cause
+
+    if not PY3:
+        # Preformat message here.
+        if exc.__cause__ is not None:
+            exc.args = ("{}\n\nThis was caused directly by {}".format(
+                exc.args if len(exc.args) != 1 else exc.args[0],
+                str(exc.__cause__)),)
+
+    return exc
+
+
+__all__ = ["queue", "BaseProcess", "set_cause", "wait"]

--- a/sklearn/externals/joblib/externals/loky/backend/queues.py
+++ b/sklearn/externals/joblib/externals/loky/backend/queues.py
@@ -22,7 +22,7 @@ from multiprocessing.queues import Full
 from multiprocessing.queues import _sentinel, Queue as mp_Queue
 from multiprocessing.queues import SimpleQueue as mp_SimpleQueue
 
-from .reduction import CustomizableLokyPickler
+from .reduction import loads, dumps
 from .context import assert_spawning, get_context
 
 
@@ -147,8 +147,7 @@ class Queue(mp_Queue):
                             return
 
                         # serialize the data before acquiring the lock
-                        obj_ = CustomizableLokyPickler.dumps(
-                            obj, reducers=reducers)
+                        obj_ = dumps(obj, reducers=reducers)
                         if wacquire is None:
                             send_bytes(obj_)
                         else:
@@ -227,12 +226,12 @@ class SimpleQueue(mp_SimpleQueue):
             with self._rlock:
                 res = self._reader.recv_bytes()
             # unserialize the data after having released the lock
-            return CustomizableLokyPickler.loads(res)
+            return loads(res)
 
     # Overload put to use our customizable reducer
     def put(self, obj):
         # serialize the data before acquiring the lock
-        obj = CustomizableLokyPickler.dumps(obj, reducers=self._reducers)
+        obj = dumps(obj, reducers=self._reducers)
         if self._wlock is None:
             # writes to a message oriented win32 pipe are atomic
             self._writer.send_bytes(obj)

--- a/sklearn/externals/joblib/externals/loky/backend/reduction.py
+++ b/sklearn/externals/joblib/externals/loky/backend/reduction.py
@@ -9,16 +9,19 @@
 #    on the fly.
 #
 import io
+import os
 import sys
 import functools
-import warnings
 from multiprocessing import util
 try:
     # Python 2 compat
-    from cPickle import loads
+    from cPickle import loads as pickle_loads
 except ImportError:
-    from pickle import loads
+    from pickle import loads as pickle_loads
     import copyreg
+
+from pickle import HIGHEST_PROTOCOL
+
 
 if sys.platform == "win32":
     if sys.version_info[:2] > (3, 3):
@@ -26,48 +29,16 @@ if sys.platform == "win32":
     else:
         from multiprocessing.forking import duplicate
 
-from pickle import HIGHEST_PROTOCOL
-from . import LOKY_PICKLER
-
-Pickler = None
-try:
-    if LOKY_PICKLER is None or LOKY_PICKLER == "":
-        from pickle import Pickler
-    elif LOKY_PICKLER == "cloudpickle":
-        from cloudpickle import CloudPickler as Pickler
-    elif LOKY_PICKLER == "dill":
-        from dill import Pickler
-    elif LOKY_PICKLER != "pickle":
-        from importlib import import_module
-        mpickle = import_module(LOKY_PICKLER)
-        Pickler = mpickle.Pickler
-    util.debug("Using default backend {} for pickling."
-               .format(LOKY_PICKLER if LOKY_PICKLER is not None
-                       else "pickle"))
-except ImportError:
-    warnings.warn("Failed to import {} as asked in LOKY_PICKLER. Make sure"
-                  " it is correctly installed on your system. Falling back"
-                  " to default builtin pickle.".format(LOKY_PICKLER))
-except AttributeError:  # pragma: no cover
-    warnings.warn("Failed to find Pickler object in module {}. The module "
-                  "specified in LOKY_PICKLER should implement a Pickler "
-                  "object. Falling back to default builtin pickle."
-                  .format(LOKY_PICKLER))
-
-
-if Pickler is None:
-    from pickle import Pickler
-
 
 ###############################################################################
 # Enable custom pickling in Loky.
 # To allow instance customization of the pickling process, we use 2 classes.
-# _LokyPickler gives module level customization and CustomizablePickler permits
-# to use instance base custom reducers.  Only CustomizablePickler should be
-# used.
+# _ReducerRegistry gives module level customization and CustomizablePickler
+# permits to use instance base custom reducers. Only CustomizablePickler
+# should be used.
 
-class _LokyPickler(Pickler):
-    """Pickler that uses custom reducers.
+class _ReducerRegistry(object):
+    """Registry for custom reducers.
 
     HIGHEST_PROTOCOL is selected by default as this pickler is used
     to pickle ephemeral datastructures for interprocess communication
@@ -78,86 +49,29 @@ class _LokyPickler(Pickler):
     # We override the pure Python pickler as its the only way to be able to
     # customize the dispatch table without side effects in Python 2.6
     # to 3.2. For Python 3.3+ leverage the new dispatch_table
-    # feature from https://bugs.python.org/issue14166 that makes it possible
+    # feature from http://bugs.python.org/issue14166 that makes it possible
     # to use the C implementation of the Pickler which is faster.
 
-    if hasattr(Pickler, 'dispatch'):
-        # Make the dispatch registry an instance level attribute instead of
-        # a reference to the class dictionary under Python 2
-        dispatch = Pickler.dispatch.copy()
-    else:
-        # Under Python 3 initialize the dispatch table with a copy of the
-        # default registry
-        dispatch_table = copyreg.dispatch_table.copy()
+    dispatch_table = {}
 
     @classmethod
     def register(cls, type, reduce_func):
         """Attach a reducer function to a given type in the dispatch table."""
-        if hasattr(Pickler, 'dispatch'):
+        if sys.version_info < (3,):
             # Python 2 pickler dispatching is not explicitly customizable.
             # Let us use a closure to workaround this limitation.
             def dispatcher(cls, obj):
                 reduced = reduce_func(obj)
                 cls.save_reduce(obj=obj, *reduced)
-            cls.dispatch[type] = dispatcher
+            cls.dispatch_table[type] = dispatcher
         else:
             cls.dispatch_table[type] = reduce_func
-
-
-class CustomizableLokyPickler(Pickler):
-    def __init__(self, writer, reducers=None, protocol=HIGHEST_PROTOCOL):
-        Pickler.__init__(self, writer, protocol=protocol)
-        if reducers is None:
-            reducers = {}
-        if hasattr(Pickler, 'dispatch'):
-            # Make the dispatch registry an instance level attribute instead of
-            # a reference to the class dictionary under Python 2
-            self.dispatch = _LokyPickler.dispatch.copy()
-        else:
-            # Under Python 3 initialize the dispatch table with a copy of the
-            # default registry
-            self.dispatch_table = _LokyPickler.dispatch_table.copy()
-        for type, reduce_func in reducers.items():
-            self.register(type, reduce_func)
-
-    def register(self, type, reduce_func):
-        """Attach a reducer function to a given type in the dispatch table."""
-        if hasattr(Pickler, 'dispatch'):
-            # Python 2 pickler dispatching is not explicitly customizable.
-            # Let us use a closure to workaround this limitation.
-            def dispatcher(self, obj):
-                reduced = reduce_func(obj)
-                self.save_reduce(obj=obj, *reduced)
-            self.dispatch[type] = dispatcher
-        else:
-            self.dispatch_table[type] = reduce_func
-
-    @classmethod
-    def loads(self, buf):
-        if sys.version_info < (3, 3) and isinstance(buf, io.BytesIO):
-            buf = buf.getvalue()
-        return loads(buf)
-
-    @classmethod
-    def dumps(cls, obj, reducers=None, protocol=None):
-        buf = io.BytesIO()
-        p = cls(buf, reducers=reducers, protocol=protocol)
-        p.dump(obj)
-        if sys.version_info < (3, 3):
-            return buf.getvalue()
-        return buf.getbuffer()
-
-
-def dump(obj, file, reducers=None, protocol=None):
-    '''Replacement for pickle.dump() using LokyPickler.'''
-    CustomizableLokyPickler(file, reducers=reducers,
-                            protocol=protocol).dump(obj)
 
 
 ###############################################################################
 # Registers extra pickling routines to improve picklization  for loky
 
-register = _LokyPickler.register
+register = _ReducerRegistry.register
 
 
 # make methods picklable
@@ -205,3 +119,134 @@ if sys.platform != "win32":
     from ._posix_reduction import _mk_inheritable  # noqa: F401
 else:
     from . import _win_reduction  # noqa: F401
+
+# global variable to change the pickler behavior
+try:
+    from sklearn.externals.joblib.externals import cloudpickle  # noqa: F401
+    DEFAULT_ENV = "cloudpickle"
+except ImportError:
+    # If cloudpickle is not present, fallback to pickle
+    DEFAULT_ENV = "pickle"
+
+ENV_LOKY_PICKLER = os.environ.get("LOKY_PICKLER", DEFAULT_ENV)
+_LokyPickler = None
+_loky_pickler_name = None
+
+
+def set_loky_pickler(loky_pickler=None):
+    global _LokyPickler, _loky_pickler_name
+
+    if loky_pickler is None:
+        loky_pickler = ENV_LOKY_PICKLER
+
+    loky_pickler_cls = None
+
+    # The default loky_pickler is cloudpickle
+    if loky_pickler in ["", None]:
+        loky_pickler = "cloudpickle"
+
+    if loky_pickler == _loky_pickler_name:
+        return
+
+    if loky_pickler == "cloudpickle":
+        from sklearn.externals.joblib.externals.cloudpickle import CloudPickler as loky_pickler_cls
+    else:
+        try:
+            from importlib import import_module
+            module_pickle = import_module(loky_pickler)
+            loky_pickler_cls = module_pickle.Pickler
+        except (ImportError, AttributeError) as e:
+            extra_info = ("\nThis error occurred while setting loky_pickler to"
+                          " '{}', as required by the env variable LOKY_PICKLER"
+                          " or the function set_loky_pickler."
+                          .format(loky_pickler))
+            e.args = (e.args[0] + extra_info,) + e.args[1:]
+            e.msg = e.args[0]
+            raise e
+
+    util.debug("Using '{}' for serialization."
+               .format(loky_pickler if loky_pickler else "cloudpickle"))
+
+    class CustomizablePickler(loky_pickler_cls):
+        _loky_pickler_cls = loky_pickler_cls
+
+        if sys.version_info < (3,):
+            # Make the dispatch registry an instance level attribute instead of
+            # a reference to the class dictionary under Python 2
+            _dispatch = loky_pickler_cls.dispatch.copy()
+            _dispatch.update(_ReducerRegistry.dispatch_table)
+        else:
+            # Under Python 3 initialize the dispatch table with a copy of the
+            # default registry
+            _dispatch_table = copyreg.dispatch_table.copy()
+            _dispatch_table.update(_ReducerRegistry.dispatch_table)
+
+        def __init__(self, writer, reducers=None, protocol=HIGHEST_PROTOCOL):
+            loky_pickler_cls.__init__(self, writer, protocol=protocol)
+            if reducers is None:
+                reducers = {}
+            if sys.version_info < (3,):
+                self.dispatch = self._dispatch.copy()
+            else:
+                self.dispatch_table = self._dispatch_table.copy()
+            for type, reduce_func in reducers.items():
+                self.register(type, reduce_func)
+
+        def register(self, type, reduce_func):
+            """Attach a reducer function to a given type in the dispatch table.
+            """
+            if sys.version_info < (3,):
+                # Python 2 pickler dispatching is not explicitly customizable.
+                # Let us use a closure to workaround this limitation.
+                    def dispatcher(self, obj):
+                        reduced = reduce_func(obj)
+                        self.save_reduce(obj=obj, *reduced)
+                    self.dispatch[type] = dispatcher
+            else:
+                self.dispatch_table[type] = reduce_func
+
+    _LokyPickler = CustomizablePickler
+    _loky_pickler_name = loky_pickler
+
+
+def get_loky_pickler_name():
+    global _loky_pickler_name
+    return _loky_pickler_name
+
+
+def get_loky_pickler():
+    global _LokyPickler
+    return _LokyPickler
+
+
+# Set it to its default value
+set_loky_pickler()
+
+
+def loads(buf):
+    # Compat for python2.7 version
+    if sys.version_info < (3, 3) and isinstance(buf, io.BytesIO):
+        buf = buf.getvalue()
+    return pickle_loads(buf)
+
+
+def dump(obj, file, reducers=None, protocol=None):
+    '''Replacement for pickle.dump() using _LokyPickler.'''
+    global _LokyPickler
+    _LokyPickler(file, reducers=reducers, protocol=protocol).dump(obj)
+
+
+def dumps(obj, reducers=None, protocol=None):
+    global _LokyPickler
+
+    buf = io.BytesIO()
+    dump(obj, buf, reducers=reducers, protocol=protocol)
+    if sys.version_info < (3, 3):
+        return buf.getvalue()
+    return buf.getbuffer()
+
+
+__all__ = ["dump", "dumps", "loads", "register", "set_loky_pickler"]
+
+if sys.platform == "win32":
+    __all__ += ["duplicate"]

--- a/sklearn/externals/joblib/externals/loky/backend/semaphore_tracker.py
+++ b/sklearn/externals/joblib/externals/loky/backend/semaphore_tracker.py
@@ -23,10 +23,10 @@
 #
 
 import os
-import signal
 import sys
-import threading
+import signal
 import warnings
+import threading
 
 from . import spawn
 from multiprocessing import util
@@ -35,6 +35,9 @@ try:
     from _multiprocessing import sem_unlink
 except ImportError:
     from .semlock import sem_unlink
+
+if sys.version_info < (3,):
+    BrokenPipeError = IOError
 
 __all__ = ['ensure_running', 'register', 'unregister']
 

--- a/sklearn/externals/joblib/externals/loky/backend/utils.py
+++ b/sklearn/externals/joblib/externals/loky/backend/utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 import errno
 import signal
 import warnings
@@ -9,6 +10,9 @@ try:
     import psutil
 except ImportError:
     psutil = None
+
+
+WIN32 = sys.platform == "win32"
 
 
 def _flag_current_thread_clean_exit():
@@ -110,3 +114,59 @@ def _recursive_terminate(pid):
             # level function raise a warning and retry to kill the process.
             if e.errno != errno.ESRCH:
                 raise
+
+
+def get_exitcodes_terminated_worker(processes):
+    """Return a formated string with the exitcodes of terminated workers.
+
+    If necessary, wait (up to .25s) for the system to correctly set the
+    exitcode of one terminated worker.
+    """
+    patience = 5
+
+    # Catch the exitcode of the terminated workers. There should at least be
+    # one. If not, wait a bit for the system to correctly set the exitcode of
+    # the terminated worker.
+    exitcodes = [p.exitcode for p in processes.values()
+                 if p.exitcode is not None]
+    while len(exitcodes) == 0 and patience > 0:
+        patience -= 1
+        exitcodes = [p.exitcode for p in processes.values()
+                     if p.exitcode is not None]
+        time.sleep(.05)
+
+    return _format_exitcodes(exitcodes)
+
+
+def _format_exitcodes(exitcodes):
+    """Format a list of exit code with names of the signals if possible"""
+    str_exitcodes = ["{}({})".format(_get_exitcode_name(e), e)
+                     for e in exitcodes if e is not None]
+    return "{" + ", ".join(str_exitcodes) + "}"
+
+
+def _get_exitcode_name(exitcode):
+    if sys.platform == "win32":
+        # The exitcode are unreliable  on windows (see bpo-31863).
+        # For this case, return UNKNOWN
+        return "UNKNOWN"
+
+    if exitcode < 0:
+        try:
+            import signal
+            if sys.version_info > (3, 5):
+                return signal.Signals(-exitcode).name
+
+            # construct an inverse lookup table
+            for v, k in signal.__dict__.items():
+                if (v.startswith('SIG') and not v.startswith('SIG_') and
+                        k == -exitcode):
+                        return v
+        except ValueError:
+            return "UNKNOWN"
+    elif exitcode != 255:
+        # The exitcode are unreliable on forkserver were 255 is always returned
+        # (see bpo-30589). For this case, return UNKNOWN
+        return "EXIT"
+
+    return "UNKNOWN"

--- a/sklearn/externals/joblib/externals/loky/cloudpickle_wrapper.py
+++ b/sklearn/externals/joblib/externals/loky/cloudpickle_wrapper.py
@@ -1,53 +1,113 @@
-import os
 import inspect
 from functools import partial
 
-from .backend import LOKY_PICKLER
-
 try:
-    from cloudpickle import dumps, loads
+    from sklearn.externals.joblib.externals.cloudpickle import dumps, loads
     cloudpickle = True
 except ImportError:
     cloudpickle = False
 
-if not LOKY_PICKLER and cloudpickle:
-    wrap_cache = dict()
 
-    class CloudpickledObjectWrapper(object):
-        def __init__(self, obj):
-            self.pickled_obj = dumps(obj)
+WRAP_CACHE = dict()
 
-        def __reduce__(self):
-            return loads, (self.pickled_obj,)
 
-    def _wrap_non_picklable_objects(obj):
-        need_wrap = "__main__" in getattr(obj, "__module__", "")
-        if isinstance(obj, partial):
-            return partial(
-                _wrap_non_picklable_objects(obj.func),
-                *[_wrap_non_picklable_objects(a) for a in obj.args],
-                **{k: _wrap_non_picklable_objects(v)
-                   for k, v in obj.keywords.items()}
-            )
-        if callable(obj):
-            # Need wrap if the object is a function defined in a local scope of
-            # another function.
-            func_code = getattr(obj, "__code__", "")
-            need_wrap |= getattr(func_code, "co_flags", 0) & inspect.CO_NESTED
+class CloudpickledObjectWrapper(object):
+    def __init__(self, obj, keep_wrapper=False):
+        self._obj = obj
+        self._keep_wrapper = keep_wrapper
 
-            # Need wrap if the obj is a lambda expression
-            func_name = getattr(obj, "__name__", "")
-            need_wrap |= "<lambda>" in func_name
+    def __reduce__(self):
+        _pickled_object = dumps(self._obj)
+        if not self._keep_wrapper:
+            return loads, (_pickled_object,)
 
-        if not need_wrap:
-            return obj
+        return _reconstruct_wrapper, (_pickled_object, self._keep_wrapper)
 
-        wrapped_obj = wrap_cache.get(obj)
-        if wrapped_obj is None:
-            wrapped_obj = CloudpickledObjectWrapper(obj)
-            wrap_cache[obj] = wrapped_obj
-        return wrapped_obj
+    def __getattr__(self, attr):
+        # Ensure that the wrapped object can be used seemlessly as the
+        # previous object.
+        if attr not in ['_obj', '_keep_wrapper']:
+            return getattr(self._obj, attr)
+        return getattr(self, attr)
 
-else:
-    def _wrap_non_picklable_objects(obj):
+
+# Make sure the wrapped object conserves the callable property
+class CallableObjectWrapper(CloudpickledObjectWrapper):
+
+    def __call__(self, *args, **kwargs):
+        return self._obj(*args, **kwargs)
+
+
+def _wrap_non_picklable_objects(obj, keep_wrapper):
+    if callable(obj):
+        return CallableObjectWrapper(obj, keep_wrapper=keep_wrapper)
+    return CloudpickledObjectWrapper(obj, keep_wrapper=keep_wrapper)
+
+
+def _reconstruct_wrapper(_pickled_object, keep_wrapper):
+    obj = loads(_pickled_object)
+    return _wrap_non_picklable_objects(obj, keep_wrapper)
+
+
+def _wrap_objects_when_needed(obj):
+    # Function to introspect an object and decide if it should be wrapped or
+    # not.
+    if not cloudpickle:
         return obj
+
+    need_wrap = "__main__" in getattr(obj, "__module__", "")
+    if isinstance(obj, partial):
+        return partial(
+            _wrap_objects_when_needed(obj.func),
+            *[_wrap_objects_when_needed(a) for a in obj.args],
+            **{k: _wrap_objects_when_needed(v)
+                for k, v in obj.keywords.items()}
+        )
+    if callable(obj):
+        # Need wrap if the object is a function defined in a local scope of
+        # another function.
+        func_code = getattr(obj, "__code__", "")
+        need_wrap |= getattr(func_code, "co_flags", 0) & inspect.CO_NESTED
+
+        # Need wrap if the obj is a lambda expression
+        func_name = getattr(obj, "__name__", "")
+        need_wrap |= "<lambda>" in func_name
+
+    if not need_wrap:
+        return obj
+
+    wrapped_obj = WRAP_CACHE.get(obj)
+    if wrapped_obj is None:
+        wrapped_obj = _wrap_non_picklable_objects(obj, keep_wrapper=False)
+        WRAP_CACHE[obj] = wrapped_obj
+    return wrapped_obj
+
+
+def wrap_non_picklable_objects(obj, keep_wrapper=True):
+    """Wrapper for non-picklable object to use cloudpickle to serialize them.
+
+    Note that this wrapper tends to slow down the serialization process as it
+    is done with cloudpickle which is typically slower compared to pickle. The
+    proper way to solve serialization issues is to avoid defining functions and
+    objects in the main scripts and to implement __reduce__ functions for
+    complex classes.
+    """
+    if not cloudpickle:
+        raise ImportError("could not from sklearn.externals.joblib.externals import cloudpickle. Please install "
+                          "cloudpickle to allow extended serialization. "
+                          "(`pip install cloudpickle`).")
+
+    # If obj is a  class, create a CloudpickledClassWrapper which instantiates
+    # the object internally and wrap it directly in a CloudpickledObjectWrapper
+    if inspect.isclass(obj):
+        class CloudpickledClassWrapper(CloudpickledObjectWrapper):
+            def __init__(self, *args, **kwargs):
+                self._obj = obj(*args, **kwargs)
+                self._keep_wrapper = keep_wrapper
+
+        CloudpickledClassWrapper.__name__ = obj.__name__
+        return CloudpickledClassWrapper
+
+    # If obj is an instance of a class, just wrap it in a regular
+    # CloudpickledObjectWrapper
+    return _wrap_non_picklable_objects(obj, keep_wrapper=keep_wrapper)

--- a/sklearn/externals/joblib/memory.py
+++ b/sklearn/externals/joblib/memory.py
@@ -247,8 +247,21 @@ class MemorizedResult(Logger):
                                    metadata=self.metadata)
         else:
             msg = None
-        return self.store_backend.load_item(
-            [self.func_id, self.args_id], msg=msg, verbose=self.verbose)
+
+        try:
+            return self.store_backend.load_item(
+                [self.func_id, self.args_id], msg=msg, verbose=self.verbose)
+        except (ValueError, KeyError) as exc:
+            # KeyError is expected under Python 2.7, ValueError under Python 3
+            new_exc = KeyError(
+                "Error while trying to load a MemorizedResult's value. "
+                "It seems that this folder is corrupted : {}".format(
+                    os.path.join(
+                        self.store_backend.location, self.func_id,
+                        self.args_id)
+                ))
+            new_exc.__cause__ = exc
+            raise new_exc
 
     def clear(self):
         """Clear value from cache"""

--- a/sklearn/externals/joblib/parallel.py
+++ b/sklearn/externals/joblib/parallel.py
@@ -203,95 +203,29 @@ if hasattr(mp, 'get_context'):
         DEFAULT_MP_CONTEXT = mp.get_context(method=method)
 
 
-class CloudpickledObjectWrapper(object):
-    def __init__(self, obj):
-        self.pickled_obj = dumps(obj)
-
-    def __reduce__(self):
-        return loads, (self.pickled_obj,)
-
-
-def _need_pickle_wrapping(obj):
-    if isinstance(obj, list) and len(obj) >= 1:
-        # Make the assumption that the content of the list is homogeneously
-        # typed.
-        return _need_pickle_wrapping(obj[0])
-    elif isinstance(obj, dict) and len(obj) >= 1:
-        # Make the assumption that the content of the dict is homogeneously
-        # typed.
-        k, v = next(iter(obj.items()))
-        return _need_pickle_wrapping(v) or _need_pickle_wrapping(k)
-    elif isinstance(obj, partial):
-        return _need_pickle_wrapping(obj.func)
-
-    # Warning: obj.__module__ can be defined and set to None
-    module = getattr(obj, "__module__", None)
-    need_wrap = module is not None and "__main__" in module
-    if callable(obj):
-        # Need wrap if the object is a function defined in a local scope of
-        # another function.
-        func_code = getattr(obj, "__code__", "")
-        need_wrap |= getattr(func_code, "co_flags", 0) & inspect.CO_NESTED
-
-        # Need wrap if the obj is a lambda expression
-        func_name = getattr(obj, "__name__", "")
-        need_wrap |= "<lambda>" in func_name
-
-        # Need wrap if obj is a bound method of an instance of an
-        # interactively defined class
-        method_self = getattr(obj, '__self__', None)
-        if not need_wrap and method_self is not None:
-            # Recursively introspect the instanc of the method
-            return _need_pickle_wrapping(method_self)
-    return need_wrap
-
-
 class BatchedCalls(object):
     """Wrap a sequence of (func, args, kwargs) tuples as a single callable"""
 
-    def __init__(self, iterator_slice, backend, pickle_cache=None):
+    def __init__(self, iterator_slice, backend_and_jobs, pickle_cache=None):
         self.items = list(iterator_slice)
         self._size = len(self.items)
-        self._backend = backend
+        if isinstance(backend_and_jobs, tuple):
+            self._backend, self._n_jobs = backend_and_jobs
+        else:
+            # this is for backward compatibility purposes. Before 0.12.6,
+            # nested backends were returned without n_jobs indications.
+            self._backend, self._n_jobs = backend_and_jobs, None
         self._pickle_cache = pickle_cache if pickle_cache is not None else {}
 
     def __call__(self):
-        with parallel_backend(self._backend):
+        # Set the default nested backend to self._backend but do not set the
+        # change the default number of processes to -1
+        with parallel_backend(self._backend, n_jobs=self._n_jobs):
             return [func(*args, **kwargs)
                     for func, args, kwargs in self.items]
 
     def __len__(self):
         return self._size
-
-    @staticmethod
-    def _wrap_non_picklable_objects(obj, pickle_cache):
-        if not _need_pickle_wrapping(obj):
-            return obj
-        try:
-            wrapped_obj = pickle_cache.get(obj)
-            hashable = True
-        except TypeError:
-            # obj is not hashable: cannot be cached
-            wrapped_obj = None
-            hashable = False
-        if wrapped_obj is None:
-            wrapped_obj = CloudpickledObjectWrapper(obj)
-            if hashable:
-                pickle_cache[obj] = wrapped_obj
-        return wrapped_obj
-
-    def __getstate__(self):
-        items = [(self._wrap_non_picklable_objects(func, self._pickle_cache),
-                  [self._wrap_non_picklable_objects(a, self._pickle_cache)
-                   for a in args],
-                  {k: self._wrap_non_picklable_objects(a, self._pickle_cache)
-                   for k, a in kwargs.items()}
-                  )
-                 for func, args, kwargs in self.items]
-        return (items, self._size, self._backend)
-
-    def __setstate__(self, state):
-        self.items, self._size, self._backend = state
 
 
 ###############################################################################

--- a/sklearn/externals/joblib/pool.py
+++ b/sklearn/externals/joblib/pool.py
@@ -68,7 +68,7 @@ class CustomizablePickler(Pickler):
     # We override the pure Python pickler as its the only way to be able to
     # customize the dispatch table without side effects in Python 2.7
     # to 3.2. For Python 3.3+ leverage the new dispatch_table
-    # feature from https://bugs.python.org/issue14166 that makes it possible
+    # feature from http://bugs.python.org/issue14166 that makes it possible
     # to use the C implementation of the Pickler which is faster.
 
     def __init__(self, writer, reducers=None, protocol=HIGHEST_PROTOCOL):


### PR DESCRIPTION
This updates joblib to 0.13.0 that now uses cloudpickle by default deterministically.
This should fix the following issues:

- Fixes #12413 (pickling error on custom estimator)
- Fixes #12250 (idem)
- Fixes #12523 (BrokenPipeError undefined on Python 2)
- Fixes #12474 and #12434 (deprecation warning for imp)