### PR TITLE
[MRG] Fix comment in plot-iris-logistic example

### DIFF
--- a/examples/linear_model/plot_iris_logistic.py
+++ b/examples/linear_model/plot_iris_logistic.py
@@ -30,7 +30,7 @@ Y = iris.target
 
 logreg = LogisticRegression(C=1e5, solver='lbfgs', multi_class='multinomial')
 
-# we create an instance of Neighbours Classifier and fit the data.
+# Create an instance of Logistic Regression Classifier and fit the data.
 logreg.fit(X, Y)
 
 # Plot the decision boundary. For that, we will assign a color to each


### PR DESCRIPTION
Just a quick fix to correct the classifier name in the example's comment.
(Looks like the original line has been copied from another file and left unchanged.)
Also fixes the beginning of the comment to match the style of the other comments in the example.