### PR TITLE
[MRG] Add 's' to "correspond" in docs for Hamming Loss.

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1794,7 +1794,7 @@ def hamming_loss(y_true, y_pred, labels=None, sample_weight=None):
 
     Notes
     -----
-    In multiclass classification, the Hamming loss correspond to the Hamming
+    In multiclass classification, the Hamming loss corresponds to the Hamming
     distance between ``y_true`` and ``y_pred`` which is equivalent to the
     subset ``zero_one_loss`` function.
 


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
I added an 's' to the word "correspond" in the docs for Hamming Loss in sklearn/metrics/classification.py .

"Hamming loss correspond to the..." -> "Hamming loss corresponds to the..."

#### Any other comments?
I hope this isn't too small/pedantic of a thing to even fix....

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
