### PR TITLE
[MRG] Workaround limitation of cloudpickle under PyPy

### DIFF
--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -283,6 +283,15 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
         return self.metric == 'precomputed'
 
 
+def _tree_query_parallel_helper(tree, data, n_neighbors, return_distance):
+    """Helper for the Parallel calls in KNeighborsMixin.kneighbors
+
+    The Cython method tree.query is not directly picklable by cloudpickle
+    under PyPy.
+    """
+    return tree.query(data, n_neighbors, return_distance)
+
+
 class KNeighborsMixin(object):
     """Mixin for k-neighbors searches"""
 
@@ -433,15 +442,15 @@ class KNeighborsMixin(object):
             if (sys.version_info < (3,) or
                     LooseVersion(joblib_version) < LooseVersion('0.12')):
                 # Deal with change of API in joblib
-                delayed_query = delayed(self._tree.query,
+                delayed_query = delayed(_tree_query_parallel_helper,
                                         check_pickle=False)
                 parallel_kwargs = {"backend": "threading"}
             else:
-                delayed_query = delayed(self._tree.query)
+                delayed_query = delayed(_tree_query_parallel_helper)
                 parallel_kwargs = {"prefer": "threads"}
             result = Parallel(n_jobs, **parallel_kwargs)(
                 delayed_query(
-                    X[s], n_neighbors, return_distance)
+                    self._tree, X[s], n_neighbors, return_distance)
                 for s in gen_even_slices(X.shape[0], n_jobs)
             )
         else:
@@ -560,6 +569,15 @@ class KNeighborsMixin(object):
                                       shape=(n_samples1, n_samples2))
 
         return kneighbors_graph
+
+
+def _tree_query_radius_parallel_helper(tree, data, radius, return_distance):
+    """Helper for the Parallel calls in RadiusNeighborsMixin.radius_neighbors
+
+    The Cython method tree.query_radius is not directly picklable by
+    cloudpickle under PyPy.
+    """
+    return tree.query_radius(data, radius, return_distance)
 
 
 class RadiusNeighborsMixin(object):
@@ -718,14 +736,14 @@ class RadiusNeighborsMixin(object):
             n_jobs = effective_n_jobs(self.n_jobs)
             if LooseVersion(joblib_version) < LooseVersion('0.12'):
                 # Deal with change of API in joblib
-                delayed_query = delayed(self._tree.query_radius,
+                delayed_query = delayed(_tree_query_radius_parallel_helper,
                                         check_pickle=False)
                 parallel_kwargs = {"backend": "threading"}
             else:
-                delayed_query = delayed(self._tree.query_radius)
+                delayed_query = delayed(_tree_query_radius_parallel_helper)
                 parallel_kwargs = {"prefer": "threads"}
             results = Parallel(n_jobs, **parallel_kwargs)(
-                delayed_query(X[s], radius, return_distance)
+                delayed_query(self._tree, X[s], radius, return_distance)
                 for s in gen_even_slices(X.shape[0], n_jobs)
             )
             if return_distance:


### PR DESCRIPTION
This is a fix for #12554.

I have tried to have a look as at the dissembled pickle payload of the example in https://github.com/scikit-learn/scikit-learn/issues/12554#issuecomment-437807545 to try to understand what is the cause of the problem and how it differs from the case where we we use pickle with PyPy or cloudpickle with CPython (which both work) but I don't know where to start. But I am lost in PyPy internals

So instead here is a simple workaround.