### PR TITLE
TST don't test utils.fixes docstrings

### DIFF
--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -64,6 +64,9 @@ def test_docstring_parameters():
 
     incorrect = []
     for name in PUBLIC_MODULES:
+        if name == 'sklearn.utils.fixes':
+            # We cannot always control these docstrings
+            continue
         with warnings.catch_warnings(record=True):
             module = importlib.import_module(name)
         classes = inspect.getmembers(module, inspect.isclass)


### PR DESCRIPTION
Partial fix for #12548. If code coverage does not drop, then this indicates the code is working.
