### PR TITLE
Univariate scorer classes

### DIFF
--- a/sklearn/feature_selection/__init__.py
+++ b/sklearn/feature_selection/__init__.py
@@ -4,24 +4,14 @@ algorithms. It currently includes univariate filter selection methods and the
 recursive feature elimination algorithm.
 """
 
-from .univariate_selection import chi2
-from .univariate_selection import f_classif
-from .univariate_selection import f_oneway
-from .univariate_selection import f_regression
-from .univariate_selection import SelectPercentile
-from .univariate_selection import SelectKBest
-from .univariate_selection import SelectFpr
-from .univariate_selection import SelectFdr
-from .univariate_selection import SelectFwe
-from .univariate_selection import GenericUnivariateSelect
-
+from .univariate_selection import (
+    chi2, f_classif, f_oneway, f_regression, SelectPercentile,
+    SelectKBest, SelectFpr, SelectFdr, SelectFwe, GenericUnivariateSelect,
+    ANOVAFScorerClassification, ANOVAFScorerRegression, Chi2Scorer,
+    MutualInfoScorerClassification, MutualInfoScorerRegression)
 from .variance_threshold import VarianceThreshold
-
-from .rfe import RFE
-from .rfe import RFECV
-
+from .rfe import RFE, RFECV
 from .from_model import SelectFromModel
-
 from .mutual_info_ import mutual_info_regression, mutual_info_classif
 
 
@@ -40,4 +30,9 @@ __all__ = ['GenericUnivariateSelect',
            'f_oneway',
            'f_regression',
            'mutual_info_classif',
-           'mutual_info_regression']
+           'mutual_info_regression',
+           'ANOVAFScorerClassification',
+           'ANOVAFScorerRegression',
+           'Chi2Scorer',
+           'MutualInfoScorerClassification',
+           'MutualInfoScorerRegression']

--- a/sklearn/feature_selection/tests/test_chi2_scorer.py
+++ b/sklearn/feature_selection/tests/test_chi2_scorer.py
@@ -1,5 +1,5 @@
 """
-Tests for chi2, currently the only feature selection function designed
+Tests for Chi2Scorer, currently the only feature selection function designed
 specifically to work with sparse matrices.
 """
 
@@ -9,7 +9,7 @@ import numpy as np
 from scipy.sparse import coo_matrix, csr_matrix
 import scipy.stats
 
-from sklearn.feature_selection import SelectKBest, chi2
+from sklearn.feature_selection import SelectKBest, Chi2Scorer
 from sklearn.feature_selection.univariate_selection import _chisquare
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_array_almost_equal
@@ -27,8 +27,8 @@ y = [0, 1, 2, 2]
 
 
 def mkchi2(k):
-    """Make k-best chi2 selector"""
-    return SelectKBest(chi2, k=k)
+    """Make k-best Chi2Scorer selector"""
+    return SelectKBest(Chi2Scorer(), k=k)
 
 
 def test_chi2():
@@ -65,7 +65,7 @@ def test_chi2_negative():
     # Check for proper error on negative numbers in the input X.
     X, y = [[0, 1], [-1e-20, 1]], [0, 1]
     for X in (X, np.array(X), csr_matrix(X)):
-        assert_raises(ValueError, chi2, X, y)
+        assert_raises(ValueError, Chi2Scorer().fit, X, y)
 
 
 def test_chi2_unused_feature():
@@ -74,12 +74,12 @@ def test_chi2_unused_feature():
     clean_warning_registry()
     with warnings.catch_warnings(record=True) as warned:
         warnings.simplefilter('always')
-        chi, p = chi2([[1, 0], [0, 0]], [1, 0])
+        scorer = Chi2Scorer().fit([[1, 0], [0, 0]], [1, 0])
         for w in warned:
             if 'divide by zero' in repr(w):
                 raise AssertionError('Found unexpected warning %s' % w)
-    assert_array_equal(chi, [1, np.nan])
-    assert_array_equal(p[1], np.nan)
+    assert_array_equal(scorer.scores_, [1, np.nan])
+    assert_array_equal(scorer.pvalues_[1], np.nan)
 
 
 def test_chisquare():

--- a/sklearn/feature_selection/tests/test_feature_select_scorer.py
+++ b/sklearn/feature_selection/tests/test_feature_select_scorer.py
@@ -1,0 +1,682 @@
+"""
+Todo: cross-check the F-value with stats model
+"""
+from __future__ import division
+import itertools
+import warnings
+import numpy as np
+from scipy import stats, sparse
+
+from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_not_in
+from sklearn.utils.testing import assert_less
+from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import ignore_warnings
+from sklearn.utils.testing import assert_warns_message
+from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import assert_greater_equal
+from sklearn.utils import safe_mask
+
+from sklearn.datasets.samples_generator import (make_classification,
+                                                make_regression)
+from sklearn.feature_selection import (
+    Chi2Scorer, ANOVAFScorerClassification, ANOVAFScorerRegression,
+    MutualInfoScorerClassification, MutualInfoScorerRegression,
+    SelectPercentile, SelectKBest, SelectFpr, SelectFdr, SelectFwe,
+    GenericUnivariateSelect)
+
+
+##############################################################################
+# Test the score functions
+
+def test_f_classif():
+    # Test whether the F test yields meaningful results
+    # on a simple simulated classification problem
+    X, y = make_classification(n_samples=200, n_features=20,
+                               n_informative=3, n_redundant=2,
+                               n_repeated=0, n_classes=8,
+                               n_clusters_per_class=1, flip_y=0.0,
+                               class_sep=10, shuffle=False, random_state=0)
+
+    scorer = ANOVAFScorerClassification().fit(X, y)
+    F, pv = scorer.scores_, scorer.pvalues_
+    scorer = ANOVAFScorerClassification().fit(sparse.csr_matrix(X), y)
+    F_sparse, pv_sparse = scorer.scores_, scorer.pvalues_
+    assert (F > 0).all()
+    assert (pv > 0).all()
+    assert (pv < 1).all()
+    assert (pv[:5] < 0.05).all()
+    assert (pv[5:] > 1.e-4).all()
+    assert_array_almost_equal(F_sparse, F)
+    assert_array_almost_equal(pv_sparse, pv)
+
+
+def test_f_regression():
+    # Test whether the F test yields meaningful results
+    # on a simple simulated regression problem
+    X, y = make_regression(n_samples=200, n_features=20, n_informative=5,
+                           shuffle=False, random_state=0)
+
+    scorer = ANOVAFScorerRegression().fit(X, y)
+    F, pv = scorer.scores_, scorer.pvalues_
+    assert (F > 0).all()
+    assert (pv > 0).all()
+    assert (pv < 1).all()
+    assert (pv[:5] < 0.05).all()
+    assert (pv[5:] > 1.e-4).all()
+
+    # with centering, compare with sparse
+    scorer = ANOVAFScorerRegression(center=True).fit(X, y)
+    F, pv = scorer.scores_, scorer.pvalues_
+    scorer = ANOVAFScorerRegression(center=True).fit(sparse.csr_matrix(X), y)
+    F_sparse, pv_sparse = scorer.scores_, scorer.pvalues_
+    assert_array_almost_equal(F_sparse, F)
+    assert_array_almost_equal(pv_sparse, pv)
+
+    # again without centering, compare with sparse
+    scorer = ANOVAFScorerRegression(center=False).fit(X, y)
+    F, pv = scorer.scores_, scorer.pvalues_
+    scorer = ANOVAFScorerRegression(center=False).fit(sparse.csr_matrix(X), y)
+    F_sparse, pv_sparse = scorer.scores_, scorer.pvalues_
+    assert_array_almost_equal(F_sparse, F)
+    assert_array_almost_equal(pv_sparse, pv)
+
+
+def test_f_regression_input_dtype():
+    # Test whether f_regression returns the same value
+    # for any numeric data_type
+    rng = np.random.RandomState(0)
+    X = rng.rand(10, 20)
+    y = np.arange(10).astype(np.int)
+
+    scorer = ANOVAFScorerRegression().fit(X, y)
+    F1, pv1 = scorer.scores_, scorer.pvalues_
+    scorer = ANOVAFScorerRegression().fit(X, y.astype(np.float))
+    F2, pv2 = scorer.scores_, scorer.pvalues_
+    assert_array_almost_equal(F1, F2, 5)
+    assert_array_almost_equal(pv1, pv2, 5)
+
+
+def test_f_regression_center():
+    # Test whether f_regression preserves dof according to 'center' argument
+    # We use two centered variates so we have a simple relationship between
+    # F-score with variates centering and F-score without variates centering.
+    # Create toy example
+    X = np.arange(-5, 6).reshape(-1, 1)  # X has zero mean
+    n_samples = X.size
+    Y = np.ones(n_samples)
+    Y[::2] *= -1.
+    Y[0] = 0.  # have Y mean being null
+
+    F1 = ANOVAFScorerRegression(center=True).fit(X, Y).scores_
+    F2 = ANOVAFScorerRegression(center=False).fit(X, Y).scores_
+    assert_array_almost_equal(F1 * (n_samples - 1.) / (n_samples - 2.), F2)
+    assert_almost_equal(F2[0], 0.232558139)  # value from statsmodels OLS
+
+
+def test_f_classif_multi_class():
+    # Test whether the F test yields meaningful results
+    # on a simple simulated classification problem
+    X, y = make_classification(n_samples=200, n_features=20,
+                               n_informative=3, n_redundant=2,
+                               n_repeated=0, n_classes=8,
+                               n_clusters_per_class=1, flip_y=0.0,
+                               class_sep=10, shuffle=False, random_state=0)
+
+    scorer = ANOVAFScorerClassification().fit(X, y)
+    F, pv = scorer.scores_, scorer.pvalues_
+    assert (F > 0).all()
+    assert (pv > 0).all()
+    assert (pv < 1).all()
+    assert (pv[:5] < 0.05).all()
+    assert (pv[5:] > 1.e-4).all()
+
+
+def test_select_percentile_classif():
+    # Test whether the relative univariate feature selection
+    # gets the correct items in a simple classification problem
+    # with the percentile heuristic
+    X, y = make_classification(n_samples=200, n_features=20,
+                               n_informative=3, n_redundant=2,
+                               n_repeated=0, n_classes=8,
+                               n_clusters_per_class=1, flip_y=0.0,
+                               class_sep=10, shuffle=False, random_state=0)
+
+    univariate_filter = SelectPercentile(ANOVAFScorerClassification(),
+                                         percentile=25)
+    X_r = univariate_filter.fit(X, y).transform(X)
+    X_r2 = GenericUnivariateSelect(ANOVAFScorerClassification(),
+                                   mode='percentile',
+                                   param=25).fit(X, y).transform(X)
+    assert_array_equal(X_r, X_r2)
+    support = univariate_filter.get_support()
+    gtruth = np.zeros(20)
+    gtruth[:5] = 1
+    assert_array_equal(support, gtruth)
+
+
+def test_select_percentile_classif_sparse():
+    # Test whether the relative univariate feature selection
+    # gets the correct items in a simple classification problem
+    # with the percentile heuristic
+    X, y = make_classification(n_samples=200, n_features=20,
+                               n_informative=3, n_redundant=2,
+                               n_repeated=0, n_classes=8,
+                               n_clusters_per_class=1, flip_y=0.0,
+                               class_sep=10, shuffle=False, random_state=0)
+    X = sparse.csr_matrix(X)
+    univariate_filter = SelectPercentile(ANOVAFScorerClassification(),
+                                         percentile=25)
+    X_r = univariate_filter.fit(X, y).transform(X)
+    X_r2 = GenericUnivariateSelect(ANOVAFScorerClassification(),
+                                   mode='percentile',
+                                   param=25).fit(X, y).transform(X)
+    assert_array_equal(X_r.toarray(), X_r2.toarray())
+    support = univariate_filter.get_support()
+    gtruth = np.zeros(20)
+    gtruth[:5] = 1
+    assert_array_equal(support, gtruth)
+
+    X_r2inv = univariate_filter.inverse_transform(X_r2)
+    assert sparse.issparse(X_r2inv)
+    support_mask = safe_mask(X_r2inv, support)
+    assert_equal(X_r2inv.shape, X.shape)
+    assert_array_equal(X_r2inv[:, support_mask].toarray(), X_r.toarray())
+    # Check other columns are empty
+    assert_equal(X_r2inv.getnnz(), X_r.getnnz())
+
+
+##############################################################################
+# Test univariate selection in classification settings
+
+def test_select_kbest_classif():
+    # Test whether the relative univariate feature selection
+    # gets the correct items in a simple classification problem
+    # with the k best heuristic
+    X, y = make_classification(n_samples=200, n_features=20,
+                               n_informative=3, n_redundant=2,
+                               n_repeated=0, n_classes=8,
+                               n_clusters_per_class=1, flip_y=0.0,
+                               class_sep=10, shuffle=False, random_state=0)
+
+    univariate_filter = SelectKBest(ANOVAFScorerClassification(), k=5)
+    X_r = univariate_filter.fit(X, y).transform(X)
+    X_r2 = GenericUnivariateSelect(ANOVAFScorerClassification(),
+                                   mode='k_best',
+                                   param=5).fit(X, y).transform(X)
+    assert_array_equal(X_r, X_r2)
+    support = univariate_filter.get_support()
+    gtruth = np.zeros(20)
+    gtruth[:5] = 1
+    assert_array_equal(support, gtruth)
+
+
+def test_select_kbest_all():
+    # Test whether k="all" correctly returns all features.
+    X, y = make_classification(n_samples=20, n_features=10,
+                               shuffle=False, random_state=0)
+
+    univariate_filter = SelectKBest(ANOVAFScorerClassification(), k='all')
+    X_r = univariate_filter.fit(X, y).transform(X)
+    assert_array_equal(X, X_r)
+
+
+def test_select_kbest_zero():
+    # Test whether k=0 correctly returns no features.
+    X, y = make_classification(n_samples=20, n_features=10,
+                               shuffle=False, random_state=0)
+
+    univariate_filter = SelectKBest(ANOVAFScorerClassification(), k=0)
+    univariate_filter.fit(X, y)
+    support = univariate_filter.get_support()
+    gtruth = np.zeros(10, dtype=bool)
+    assert_array_equal(support, gtruth)
+    X_selected = assert_warns_message(UserWarning, 'No features were selected',
+                                      univariate_filter.transform, X)
+    assert_equal(X_selected.shape, (20, 0))
+
+
+def test_select_heuristics_classif():
+    # Test whether the relative univariate feature selection
+    # gets the correct items in a simple classification problem
+    # with the fdr, fwe and fpr heuristics
+    X, y = make_classification(n_samples=200, n_features=20,
+                               n_informative=3, n_redundant=2,
+                               n_repeated=0, n_classes=8,
+                               n_clusters_per_class=1, flip_y=0.0,
+                               class_sep=10, shuffle=False, random_state=0)
+
+    univariate_filter = SelectFwe(ANOVAFScorerClassification(), alpha=0.01)
+    X_r = univariate_filter.fit(X, y).transform(X)
+    gtruth = np.zeros(20)
+    gtruth[:5] = 1
+    for mode in ['fdr', 'fpr', 'fwe']:
+        X_r2 = GenericUnivariateSelect(ANOVAFScorerClassification(),
+                                       mode=mode,
+                                       param=0.01).fit(X, y).transform(X)
+        assert_array_equal(X_r, X_r2)
+        support = univariate_filter.get_support()
+        assert_array_almost_equal(support, gtruth)
+
+
+##############################################################################
+# Test univariate selection in regression settings
+
+
+def assert_best_scores_kept(score_filter):
+    scores = score_filter.scores_
+    support = score_filter.get_support()
+    assert_array_almost_equal(np.sort(scores[support]),
+                              np.sort(scores)[-support.sum():])
+
+
+def test_select_percentile_regression():
+    # Test whether the relative univariate feature selection
+    # gets the correct items in a simple regression problem
+    # with the percentile heuristic
+    X, y = make_regression(n_samples=200, n_features=20,
+                           n_informative=5, shuffle=False, random_state=0)
+
+    univariate_filter = SelectPercentile(ANOVAFScorerRegression(),
+                                         percentile=25)
+    X_r = univariate_filter.fit(X, y).transform(X)
+    assert_best_scores_kept(univariate_filter)
+    X_r2 = GenericUnivariateSelect(ANOVAFScorerRegression(),
+                                   mode='percentile',
+                                   param=25).fit(X, y).transform(X)
+    assert_array_equal(X_r, X_r2)
+    support = univariate_filter.get_support()
+    gtruth = np.zeros(20)
+    gtruth[:5] = 1
+    assert_array_equal(support, gtruth)
+    X_2 = X.copy()
+    X_2[:, np.logical_not(support)] = 0
+    assert_array_equal(X_2, univariate_filter.inverse_transform(X_r))
+    # Check inverse_transform respects dtype
+    assert_array_equal(X_2.astype(bool),
+                       univariate_filter.inverse_transform(X_r.astype(bool)))
+
+
+def test_select_percentile_regression_full():
+    # Test whether the relative univariate feature selection
+    # selects all features when '100%' is asked.
+    X, y = make_regression(n_samples=200, n_features=20,
+                           n_informative=5, shuffle=False, random_state=0)
+
+    univariate_filter = SelectPercentile(ANOVAFScorerRegression(),
+                                         percentile=100)
+    X_r = univariate_filter.fit(X, y).transform(X)
+    assert_best_scores_kept(univariate_filter)
+    X_r2 = GenericUnivariateSelect(ANOVAFScorerRegression(),
+                                   mode='percentile',
+                                   param=100).fit(X, y).transform(X)
+    assert_array_equal(X_r, X_r2)
+    support = univariate_filter.get_support()
+    gtruth = np.ones(20)
+    assert_array_equal(support, gtruth)
+
+
+def test_invalid_percentile():
+    X, y = make_regression(n_samples=10, n_features=20,
+                           n_informative=2, shuffle=False, random_state=0)
+
+    assert_raises(ValueError, SelectPercentile(percentile=-1).fit, X, y)
+    assert_raises(ValueError, SelectPercentile(percentile=101).fit, X, y)
+    assert_raises(ValueError, GenericUnivariateSelect(mode='percentile',
+                                                      param=-1).fit, X, y)
+    assert_raises(ValueError, GenericUnivariateSelect(mode='percentile',
+                                                      param=101).fit, X, y)
+
+
+def test_select_kbest_regression():
+    # Test whether the relative univariate feature selection
+    # gets the correct items in a simple regression problem
+    # with the k best heuristic
+    X, y = make_regression(n_samples=200, n_features=20, n_informative=5,
+                           shuffle=False, random_state=0, noise=10)
+
+    univariate_filter = SelectKBest(ANOVAFScorerRegression(), k=5)
+    X_r = univariate_filter.fit(X, y).transform(X)
+    assert_best_scores_kept(univariate_filter)
+    X_r2 = GenericUnivariateSelect(ANOVAFScorerRegression(),
+                                   mode='k_best',
+                                   param=5).fit(X, y).transform(X)
+    assert_array_equal(X_r, X_r2)
+    support = univariate_filter.get_support()
+    gtruth = np.zeros(20)
+    gtruth[:5] = 1
+    assert_array_equal(support, gtruth)
+
+
+def test_select_heuristics_regression():
+    # Test whether the relative univariate feature selection
+    # gets the correct items in a simple regression problem
+    # with the fpr, fdr or fwe heuristics
+    X, y = make_regression(n_samples=200, n_features=20, n_informative=5,
+                           shuffle=False, random_state=0, noise=10)
+
+    univariate_filter = SelectFpr(ANOVAFScorerRegression(), alpha=0.01)
+    X_r = univariate_filter.fit(X, y).transform(X)
+    gtruth = np.zeros(20)
+    gtruth[:5] = 1
+    for mode in ['fdr', 'fpr', 'fwe']:
+        X_r2 = GenericUnivariateSelect(ANOVAFScorerRegression(),
+                                       mode=mode,
+                                       param=0.01).fit(X, y).transform(X)
+        assert_array_equal(X_r, X_r2)
+        support = univariate_filter.get_support()
+        assert_array_equal(support[:5], np.ones((5, ), dtype=np.bool))
+        assert_less(np.sum(support[5:] == 1), 3)
+
+
+def test_boundary_case_ch2():
+    # Test boundary case, and always aim to select 1 feature.
+    X = np.array([[10, 20], [20, 20], [20, 30]])
+    y = np.array([[1], [0], [0]])
+    scorer = Chi2Scorer().fit(X, y)
+    assert_array_almost_equal(scorer.scores_,
+                              np.array([4., 0.71428571]))
+    assert_array_almost_equal(scorer.pvalues_,
+                              np.array([0.04550026, 0.39802472]))
+
+    filter_fdr = SelectFdr(Chi2Scorer(), alpha=0.1)
+    filter_fdr.fit(X, y)
+    support_fdr = filter_fdr.get_support()
+    assert_array_equal(support_fdr, np.array([True, False]))
+
+    filter_kbest = SelectKBest(Chi2Scorer(), k=1)
+    filter_kbest.fit(X, y)
+    support_kbest = filter_kbest.get_support()
+    assert_array_equal(support_kbest, np.array([True, False]))
+
+    filter_percentile = SelectPercentile(Chi2Scorer(), percentile=50)
+    filter_percentile.fit(X, y)
+    support_percentile = filter_percentile.get_support()
+    assert_array_equal(support_percentile, np.array([True, False]))
+
+    filter_fpr = SelectFpr(Chi2Scorer(), alpha=0.1)
+    filter_fpr.fit(X, y)
+    support_fpr = filter_fpr.get_support()
+    assert_array_equal(support_fpr, np.array([True, False]))
+
+    filter_fwe = SelectFwe(Chi2Scorer(), alpha=0.1)
+    filter_fwe.fit(X, y)
+    support_fwe = filter_fwe.get_support()
+    assert_array_equal(support_fwe, np.array([True, False]))
+
+
+def test_select_fdr_regression():
+    # Test that fdr heuristic actually has low FDR.
+    def single_fdr(alpha, n_informative, random_state):
+        X, y = make_regression(n_samples=150, n_features=20,
+                               n_informative=n_informative, shuffle=False,
+                               random_state=random_state, noise=10)
+
+        with warnings.catch_warnings(record=True):
+            # Warnings can be raised when no features are selected
+            # (low alpha or very noisy data)
+            univariate_filter = SelectFdr(ANOVAFScorerRegression(),
+                                          alpha=alpha)
+            X_r = univariate_filter.fit(X, y).transform(X)
+            X_r2 = GenericUnivariateSelect(ANOVAFScorerRegression(),
+                                           mode='fdr',
+                                           param=alpha).fit(X, y).transform(X)
+        assert_array_equal(X_r, X_r2)
+        support = univariate_filter.get_support()
+        num_false_positives = np.sum(support[n_informative:] == 1)
+        num_true_positives = np.sum(support[:n_informative] == 1)
+
+        if num_false_positives == 0:
+            return 0.
+        false_discovery_rate = (num_false_positives /
+                                (num_true_positives + num_false_positives))
+        return false_discovery_rate
+
+    for alpha in [0.001, 0.01, 0.1]:
+        for n_informative in [1, 5, 10]:
+            # As per Benjamini-Hochberg, the expected false discovery rate
+            # should be lower than alpha:
+            # FDR = E(FP / (TP + FP)) <= alpha
+            false_discovery_rate = np.mean([single_fdr(alpha, n_informative,
+                                                       random_state) for
+                                            random_state in range(100)])
+            assert_greater_equal(alpha, false_discovery_rate)
+
+            # Make sure that the empirical false discovery rate increases
+            # with alpha:
+            if false_discovery_rate != 0:
+                assert_greater(false_discovery_rate, alpha / 10)
+
+
+def test_select_fwe_regression():
+    # Test whether the relative univariate feature selection
+    # gets the correct items in a simple regression problem
+    # with the fwe heuristic
+    X, y = make_regression(n_samples=200, n_features=20,
+                           n_informative=5, shuffle=False, random_state=0)
+
+    univariate_filter = SelectFwe(ANOVAFScorerRegression(), alpha=0.01)
+    X_r = univariate_filter.fit(X, y).transform(X)
+    X_r2 = GenericUnivariateSelect(ANOVAFScorerRegression(),
+                                   mode='fwe',
+                                   param=0.01).fit(X, y).transform(X)
+    assert_array_equal(X_r, X_r2)
+    support = univariate_filter.get_support()
+    gtruth = np.zeros(20)
+    gtruth[:5] = 1
+    assert_array_equal(support[:5], np.ones((5, ), dtype=np.bool))
+    assert_less(np.sum(support[5:] == 1), 2)
+
+
+def test_selectkbest_tiebreaking():
+    # Test whether SelectKBest actually selects k features in case of ties.
+    # Prior to 0.11, SelectKBest would return more features than requested.
+    Xs = [[0, 1, 1], [0, 0, 1], [1, 0, 0], [1, 1, 0]]
+    y = [1]
+    dummy_score = lambda X, y: (X[0], X[0])
+    for X in Xs:
+        sel = SelectKBest(dummy_score, k=1)
+        X1 = ignore_warnings(sel.fit_transform)([X], y)
+        assert_equal(X1.shape[1], 1)
+        assert_best_scores_kept(sel)
+
+        sel = SelectKBest(dummy_score, k=2)
+        X2 = ignore_warnings(sel.fit_transform)([X], y)
+        assert_equal(X2.shape[1], 2)
+        assert_best_scores_kept(sel)
+
+
+def test_selectpercentile_tiebreaking():
+    # Test if SelectPercentile selects the right n_features in case of ties.
+    Xs = [[0, 1, 1], [0, 0, 1], [1, 0, 0], [1, 1, 0]]
+    y = [1]
+    dummy_score = lambda X, y: (X[0], X[0])
+    for X in Xs:
+        sel = SelectPercentile(dummy_score, percentile=34)
+        X1 = ignore_warnings(sel.fit_transform)([X], y)
+        assert_equal(X1.shape[1], 1)
+        assert_best_scores_kept(sel)
+
+        sel = SelectPercentile(dummy_score, percentile=67)
+        X2 = ignore_warnings(sel.fit_transform)([X], y)
+        assert_equal(X2.shape[1], 2)
+        assert_best_scores_kept(sel)
+
+
+def test_tied_pvalues():
+    # Test whether k-best and percentiles work with tied pvalues from chi2.
+    # chi2 will return the same p-values for the following features, but it
+    # will return different scores.
+    X0 = np.array([[10000, 9999, 9998], [1, 1, 1]])
+    y = [0, 1]
+
+    for perm in itertools.permutations((0, 1, 2)):
+        X = X0[:, perm]
+        Xt = SelectKBest(Chi2Scorer(), k=2).fit_transform(X, y)
+        assert_equal(Xt.shape, (2, 2))
+        assert_not_in(9998, Xt)
+
+        Xt = SelectPercentile(Chi2Scorer(),
+                              percentile=67).fit_transform(X, y)
+        assert_equal(Xt.shape, (2, 2))
+        assert_not_in(9998, Xt)
+
+
+def test_scorefunc_multilabel():
+    # Test whether k-best and percentiles works with multilabels with chi2.
+
+    X = np.array([[10000, 9999, 0], [100, 9999, 0], [1000, 99, 0]])
+    y = [[1, 1], [0, 1], [1, 0]]
+
+    Xt = SelectKBest(Chi2Scorer(), k=2).fit_transform(X, y)
+    assert_equal(Xt.shape, (3, 2))
+    assert_not_in(0, Xt)
+
+    Xt = SelectPercentile(Chi2Scorer(),
+                          percentile=67).fit_transform(X, y)
+    assert_equal(Xt.shape, (3, 2))
+    assert_not_in(0, Xt)
+
+
+def test_tied_scores():
+    # Test for stable sorting in k-best with tied scores.
+    X_train = np.array([[0, 0, 0], [1, 1, 1]])
+    y_train = [0, 1]
+
+    for n_features in [1, 2, 3]:
+        sel = SelectKBest(Chi2Scorer(),
+                          k=n_features).fit(X_train, y_train)
+        X_test = sel.transform([[0, 1, 2]])
+        assert_array_equal(X_test[0], np.arange(3)[-n_features:])
+
+
+def test_nans():
+    # Assert that SelectKBest and SelectPercentile can handle NaNs.
+    # First feature has zero variance to confuse f_classif (ANOVA) and
+    # make it return a NaN.
+    X = [[0, 1, 0], [0, -1, -1], [0, .5, .5]]
+    y = [1, 0, 1]
+
+    for select in (SelectKBest(ANOVAFScorerClassification(), 2),
+                   SelectPercentile(ANOVAFScorerClassification(),
+                                    percentile=67)):
+        ignore_warnings(select.fit)(X, y)
+        assert_array_equal(select.get_support(indices=True), np.array([1, 2]))
+
+
+def test_score_func_error():
+    X = [[0, 1, 0], [0, -1, -1], [0, .5, .5]]
+    y = [1, 0, 1]
+
+    for SelectFeatures in [SelectKBest, SelectPercentile, SelectFwe,
+                           SelectFdr, SelectFpr, GenericUnivariateSelect]:
+        assert_raises(TypeError, SelectFeatures(score_func=10).fit, X, y)
+
+
+def test_invalid_k():
+    X = [[0, 1, 0], [0, -1, -1], [0, .5, .5]]
+    y = [1, 0, 1]
+
+    assert_raises(ValueError, SelectKBest(k=-1).fit, X, y)
+    assert_raises(ValueError, SelectKBest(k=4).fit, X, y)
+    assert_raises(ValueError,
+                  GenericUnivariateSelect(mode='k_best', param=-1).fit, X, y)
+    assert_raises(ValueError,
+                  GenericUnivariateSelect(mode='k_best', param=4).fit, X, y)
+
+
+def test_f_classif_constant_feature():
+    # Test that f_classif warns if a feature is constant throughout.
+
+    X, y = make_classification(n_samples=10, n_features=5)
+    X[:, 0] = 2.0
+    assert_warns(UserWarning, ANOVAFScorerClassification().fit, X, y)
+
+
+def test_no_feature_selected():
+    rng = np.random.RandomState(0)
+
+    # Generate random uncorrelated data: a strict univariate test should
+    # rejects all the features
+    X = rng.rand(40, 10)
+    y = rng.randint(0, 4, size=40)
+    strict_selectors = [
+        SelectFwe(alpha=0.01).fit(X, y),
+        SelectFdr(alpha=0.01).fit(X, y),
+        SelectFpr(alpha=0.01).fit(X, y),
+        SelectPercentile(percentile=0).fit(X, y),
+        SelectKBest(k=0).fit(X, y),
+    ]
+    for selector in strict_selectors:
+        assert_array_equal(selector.get_support(), np.zeros(10))
+        X_selected = assert_warns_message(
+            UserWarning, 'No features were selected', selector.transform, X)
+        assert_equal(X_selected.shape, (40, 0))
+
+
+def test_mutual_info_classif():
+    X, y = make_classification(n_samples=100, n_features=5,
+                               n_informative=1, n_redundant=1,
+                               n_repeated=0, n_classes=2,
+                               n_clusters_per_class=1, flip_y=0.0,
+                               class_sep=10, shuffle=False, random_state=0)
+
+    # Test in KBest mode.
+    univariate_filter = SelectKBest(MutualInfoScorerClassification(), k=2)
+    X_r = univariate_filter.fit(X, y).transform(X)
+    X_r2 = GenericUnivariateSelect(MutualInfoScorerClassification(),
+                                   mode='k_best',
+                                   param=2).fit(X, y).transform(X)
+    assert_array_equal(X_r, X_r2)
+    support = univariate_filter.get_support()
+    gtruth = np.zeros(5)
+    gtruth[:2] = 1
+    assert_array_equal(support, gtruth)
+
+    # Test in Percentile mode.
+    univariate_filter = SelectPercentile(MutualInfoScorerClassification(),
+                                         percentile=40)
+    X_r = univariate_filter.fit(X, y).transform(X)
+    X_r2 = GenericUnivariateSelect(MutualInfoScorerClassification(),
+                                   mode='percentile',
+                                   param=40).fit(X, y).transform(X)
+    assert_array_equal(X_r, X_r2)
+    support = univariate_filter.get_support()
+    gtruth = np.zeros(5)
+    gtruth[:2] = 1
+    assert_array_equal(support, gtruth)
+
+
+def test_mutual_info_regression():
+    X, y = make_regression(n_samples=100, n_features=10, n_informative=2,
+                           shuffle=False, random_state=0, noise=10)
+
+    # Test in KBest mode.
+    univariate_filter = SelectKBest(MutualInfoScorerRegression(), k=2)
+    X_r = univariate_filter.fit(X, y).transform(X)
+    assert_best_scores_kept(univariate_filter)
+    X_r2 = GenericUnivariateSelect(MutualInfoScorerRegression(),
+                                   mode='k_best',
+                                   param=2).fit(X, y).transform(X)
+    assert_array_equal(X_r, X_r2)
+    support = univariate_filter.get_support()
+    gtruth = np.zeros(10)
+    gtruth[:2] = 1
+    assert_array_equal(support, gtruth)
+
+    # Test in Percentile mode.
+    univariate_filter = SelectPercentile(MutualInfoScorerRegression(),
+                                         percentile=20)
+    X_r = univariate_filter.fit(X, y).transform(X)
+    X_r2 = GenericUnivariateSelect(MutualInfoScorerRegression(),
+                                   mode='percentile',
+                                   param=20).fit(X, y).transform(X)
+    assert_array_equal(X_r, X_r2)
+    support = univariate_filter.get_support()
+    gtruth = np.zeros(10)
+    gtruth[:2] = 1
+    assert_array_equal(support, gtruth)

--- a/sklearn/feature_selection/tests/test_mutual_info_scorer.py
+++ b/sklearn/feature_selection/tests/test_mutual_info_scorer.py
@@ -1,0 +1,207 @@
+from __future__ import division
+
+import numpy as np
+from scipy.sparse import csr_matrix
+
+from sklearn.utils import check_random_state
+from sklearn.utils.testing import (assert_array_equal, assert_almost_equal,
+                                   assert_false, assert_raises, assert_equal,
+                                   assert_greater)
+from sklearn.feature_selection.mutual_info_ import _compute_mi
+from sklearn.feature_selection import (
+    MutualInfoScorerClassification, MutualInfoScorerRegression)
+
+
+def test_compute_mi_dd():
+    # In discrete case computations are straightforward and can be done
+    # by hand on given vectors.
+    x = np.array([0, 1, 1, 0, 0])
+    y = np.array([1, 0, 0, 0, 1])
+
+    H_x = H_y = -(3/5) * np.log(3/5) - (2/5) * np.log(2/5)
+    H_xy = -1/5 * np.log(1/5) - 2/5 * np.log(2/5) - 2/5 * np.log(2/5)
+    I_xy = H_x + H_y - H_xy
+
+    assert_almost_equal(_compute_mi(x, y, True, True), I_xy)
+
+
+def test_compute_mi_cc():
+    # For two continuous variables a good approach is to test on bivariate
+    # normal distribution, where mutual information is known.
+
+    # Mean of the distribution, irrelevant for mutual information.
+    mean = np.zeros(2)
+
+    # Setup covariance matrix with correlation coeff. equal 0.5.
+    sigma_1 = 1
+    sigma_2 = 10
+    corr = 0.5
+    cov = np.array([
+        [sigma_1**2, corr * sigma_1 * sigma_2],
+        [corr * sigma_1 * sigma_2, sigma_2**2]
+    ])
+
+    # True theoretical mutual information.
+    I_theory = (np.log(sigma_1) + np.log(sigma_2) -
+                0.5 * np.log(np.linalg.det(cov)))
+
+    rng = check_random_state(0)
+    Z = rng.multivariate_normal(mean, cov, size=1000)
+
+    x, y = Z[:, 0], Z[:, 1]
+
+    # Theory and computed values won't be very close, assert that the
+    # first figures after decimal point match.
+    for n_neighbors in [3, 5, 7]:
+        I_computed = _compute_mi(x, y, False, False, n_neighbors)
+        assert_almost_equal(I_computed, I_theory, 1)
+
+
+def test_compute_mi_cd():
+    # To test define a joint distribution as follows:
+    # p(x, y) = p(x) p(y | x)
+    # X ~ Bernoulli(p)
+    # (Y | x = 0) ~ Uniform(-1, 1)
+    # (Y | x = 1) ~ Uniform(0, 2)
+
+    # Use the following formula for mutual information:
+    # I(X; Y) = H(Y) - H(Y | X)
+    # Two entropies can be computed by hand:
+    # H(Y) = -(1-p)/2 * ln((1-p)/2) - p/2*log(p/2) - 1/2*log(1/2)
+    # H(Y | X) = ln(2)
+
+    # Now we need to implement sampling from out distribution, which is
+    # done easily using conditional distribution logic.
+
+    n_samples = 1000
+    rng = check_random_state(0)
+
+    for p in [0.3, 0.5, 0.7]:
+        x = rng.uniform(size=n_samples) > p
+
+        y = np.empty(n_samples)
+        mask = x == 0
+        y[mask] = rng.uniform(-1, 1, size=np.sum(mask))
+        y[~mask] = rng.uniform(0, 2, size=np.sum(~mask))
+
+        I_theory = -0.5 * ((1 - p) * np.log(0.5 * (1 - p)) +
+                           p * np.log(0.5 * p) + np.log(0.5)) - np.log(2)
+
+        # Assert the same tolerance.
+        for n_neighbors in [3, 5, 7]:
+            I_computed = _compute_mi(x, y, True, False, n_neighbors)
+            assert_almost_equal(I_computed, I_theory, 1)
+
+
+def test_compute_mi_cd_unique_label():
+    # Test that adding unique label doesn't change MI.
+    n_samples = 100
+    x = np.random.uniform(size=n_samples) > 0.5
+
+    y = np.empty(n_samples)
+    mask = x == 0
+    y[mask] = np.random.uniform(-1, 1, size=np.sum(mask))
+    y[~mask] = np.random.uniform(0, 2, size=np.sum(~mask))
+
+    mi_1 = _compute_mi(x, y, True, False)
+
+    x = np.hstack((x, 2))
+    y = np.hstack((y, 10))
+    mi_2 = _compute_mi(x, y, True, False)
+
+    assert_equal(mi_1, mi_2)
+
+
+# We are going test that feature ordering by MI matches our expectations.
+def test_mutual_info_classif_discrete():
+    X = np.array([[0, 0, 0],
+                  [1, 1, 0],
+                  [2, 0, 1],
+                  [2, 0, 1],
+                  [2, 0, 1]])
+    y = np.array([0, 1, 2, 2, 1])
+
+    # Here X[:, 0] is the most informative feature, and X[:, 1] is weakly
+    # informative.
+    mi = MutualInfoScorerClassification(discrete_features=True).fit(X, y).scores_
+    assert_array_equal(np.argsort(-mi), np.array([0, 2, 1]))
+
+
+def test_mutual_info_regression():
+    # We generate sample from multivariate normal distribution, using
+    # transformation from initially uncorrelated variables. The zero
+    # variables after transformation is selected as the target vector,
+    # it has the strongest correlation with the variable 2, and
+    # the weakest correlation with the variable 1.
+    T = np.array([
+        [1, 0.5, 2, 1],
+        [0, 1, 0.1, 0.0],
+        [0, 0.1, 1, 0.1],
+        [0, 0.1, 0.1, 1]
+    ])
+    cov = T.dot(T.T)
+    mean = np.zeros(4)
+
+    rng = check_random_state(0)
+    Z = rng.multivariate_normal(mean, cov, size=1000)
+    X = Z[:, 1:]
+    y = Z[:, 0]
+
+    mi = MutualInfoScorerRegression(random_state=0).fit(X, y).scores_
+    assert_array_equal(np.argsort(-mi), np.array([1, 2, 0]))
+
+
+def test_mutual_info_classif_mixed():
+    # Here the target is discrete and there are two continuous and one
+    # discrete feature. The idea of this test is clear from the code.
+    rng = check_random_state(0)
+    X = rng.rand(1000, 3)
+    X[:, 1] += X[:, 0]
+    y = ((0.5 * X[:, 0] + X[:, 2]) > 0.5).astype(int)
+    X[:, 2] = X[:, 2] > 0.5
+
+    mi = MutualInfoScorerClassification(discrete_features=[2],
+                                        n_neighbors=3,
+                                        random_state=0).fit(X, y).scores_
+    assert_array_equal(np.argsort(-mi), [2, 0, 1])
+    for n_neighbors in [5, 7, 9]:
+        mi_nn = MutualInfoScorerClassification(discrete_features=[2],
+                                               n_neighbors=n_neighbors,
+                                               random_state=0).fit(X, y).scores_
+        # Check that the continuous values have an higher MI with greater
+        # n_neighbors
+        assert_greater(mi_nn[0], mi[0])
+        assert_greater(mi_nn[1], mi[1])
+        # The n_neighbors should not have any effect on the discrete value
+        # The MI should be the same
+        assert_equal(mi_nn[2], mi[2])
+
+
+def test_mutual_info_options():
+    X = np.array([[0, 0, 0],
+                  [1, 1, 0],
+                  [2, 0, 1],
+                  [2, 0, 1],
+                  [2, 0, 1]], dtype=float)
+    y = np.array([0, 1, 2, 2, 1], dtype=float)
+    X_csr = csr_matrix(X)
+
+    for mi_scorer in (MutualInfoScorerClassification,
+                      MutualInfoScorerRegression):
+        assert_raises(ValueError, mi_scorer(discrete_features=False).fit,
+                      X_csr, y)
+
+        mi_1 = mi_scorer(discrete_features='auto',
+                         random_state=0).fit(X, y).scores_
+        mi_2 = mi_scorer(discrete_features=False,
+                         random_state=0).fit(X, y).scores_
+
+        mi_3 = mi_scorer(discrete_features='auto',
+                         random_state=0).fit(X_csr, y).scores_
+        mi_4 = mi_scorer(discrete_features=True,
+                         random_state=0).fit(X_csr, y).scores_
+
+        assert_array_equal(mi_1, mi_2)
+        assert_array_equal(mi_3, mi_4)
+
+    assert_false(np.allclose(mi_1, mi_3))

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -1,12 +1,11 @@
 """Univariate features selection."""
 
 # Authors: V. Michel, B. Thirion, G. Varoquaux, A. Gramfort, E. Duchesnay.
-#          L. Buitinck, A. Joly
+#          L. Buitinck, A. Joly, L. Hermida
 # License: BSD 3 clause
 
-
-import numpy as np
 import warnings
+import numpy as np
 
 from scipy import special, stats
 from scipy.sparse import issparse
@@ -18,6 +17,7 @@ from ..utils import (as_float_array, check_array, check_X_y, safe_sqr,
 from ..utils.extmath import safe_sparse_dot, row_norms
 from ..utils.validation import check_is_fitted
 from .base import SelectorMixin
+from .mutual_info_ import mutual_info_classif, mutual_info_regression
 
 
 def _clean_nans(scores):
@@ -34,7 +34,6 @@ def _clean_nans(scores):
 
 ######################################################################
 # Scoring functions
-
 
 # The following function is a rewriting of scipy.stats.f_oneway
 # Contrary to the scipy.stats.f_oneway implementation it does not
@@ -307,16 +306,415 @@ def f_regression(X, y, center=True):
 
 
 ######################################################################
-# Base classes
+# Base scorer class
+
+class _BaseScorer(BaseEstimator):
+    """Initialize the univariate feature scorer."""
+    def __init__(self):
+        pass
+
+    def fit(self, X, y):
+        pass
+
+    def _check_params(self, X, y):
+        pass
+
+
+######################################################################
+# Specific scorer classes
+
+class ANOVAFScorerClassification(_BaseScorer):
+    """Compute the ANOVA F-value for the provided sample.
+
+    Read more in the :ref:`User Guide <univariate_feature_selection>`.
+
+    Attributes
+    ----------
+    scores_ : array, shape = [n_features,]
+        The set of F values.
+
+    pvalues_ : array, shape = [n_features,]
+        The set of p-values.
+
+    See also
+    --------
+    ANOVAFScorerRegression: ANOVA F-value between label/feature for regression tasks.
+    Chi2Scorer: Chi-squared stats of non-negative features for classification tasks.
+    MutualInfoScorerClassification: Mutual information for a discrete target.
+    MutualInfoScorerRegression: Mutual information for a continuous target.
+    """
+    def __init__(self):
+        pass
+
+    def fit(self, X, y):
+        """Run feature scorer on (X, y).
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} shape = [n_samples, n_features]
+            The set of regressors that will be tested sequentially.
+
+        y : array of shape (n_samples,)
+            Target vector.
+
+        Returns
+        -------
+        self : object
+            Returns self.
+        """
+        self.scores_, self.pvalues_ = f_classif(X, y)
+        return self
+
+    def _check_params(self, X, y):
+        pass
+
+
+class ANOVAFScorerRegression(_BaseScorer):
+    """Univariate linear regression tests.
+
+    Linear model for testing the individual effect of each of many regressors.
+    This is a scoring function to be used in a feature seletion procedure, not
+    a free standing feature selection procedure.
+
+    This is done in 2 steps:
+
+    1. The correlation between each regressor and the target is computed,
+       that is, ((X[:, i] - mean(X[:, i])) * (y - mean_y)) / (std(X[:, i]) *
+       std(y)).
+    2. It is converted to an F score then to a p-value.
+
+    For more on usage see the :ref:`User Guide <univariate_feature_selection>`.
+
+    Parameters
+    ----------
+    center : boolean, default=True
+        If true, X and y will be centered.
+
+    Attributes
+    ----------
+    scores_ : array, shape=(n_features,)
+        The set of F values.
+
+    pvalues_ : array, shape=(n_features,)
+        The set of p-values.
+
+    See also
+    --------
+    ANOVAFScorerClassification: ANOVA F-value between label/feature for classification tasks.
+    Chi2Scorer: Chi-squared stats of non-negative features for classification tasks.
+    MutualInfoScorerClassification: Mutual information for a discrete target.
+    MutualInfoScorerRegression: Mutual information for a continuous target.
+    """
+    def __init__(self, center=True):
+        self.center = center
+
+    def fit(self, X, y):
+        """Run feature scorer on (X, y).
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}  shape = (n_samples, n_features)
+            The set of regressors that will be tested sequentially.
+
+        y : array of shape (n_samples,).
+            Target vector.
+
+        Returns
+        -------
+        self : object
+            Returns self.
+        """
+        self.scores_, self.pvalues_ = f_regression(X, y, self.center)
+        return self
+
+    def _check_params(self, X, y):
+        pass
+
+
+class Chi2Scorer(_BaseScorer):
+    """Compute chi-squared stats between each non-negative feature and class.
+
+    This score can be used to select the n_features features with the
+    highest values for the test chi-squared statistic from X, which must
+    contain only non-negative features such as booleans or frequencies
+    (e.g., term counts in document classification), relative to the classes.
+
+    Recall that the chi-square test measures dependence between stochastic
+    variables, so using this function "weeds out" the features that are the
+    most likely to be independent of class and therefore irrelevant for
+    classification.
+
+    Read more in the :ref:`User Guide <univariate_feature_selection>`.
+
+    Attributes
+    ----------
+    scores_ : array, shape = (n_features,)
+        chi2 statistics of each feature.
+
+    pvalues_ : array, shape = (n_features,)
+        p-values of each feature.
+
+    Notes
+    -----
+    Complexity of this algorithm is O(n_classes * n_features).
+
+    See also
+    --------
+    ANOVAFScorerClassification: ANOVA F-value between label/feature for classification tasks.
+    ANOVAFScorerRegression: ANOVA F-value between label/feature for regression tasks.
+    MutualInfoScorerClassification: Mutual information for a discrete target.
+    MutualInfoScorerRegression: Mutual information for a continuous target.
+    """
+    def __init__(self):
+        pass
+
+    def fit(self, X, y):
+        """Run feature scorer on (X, y).
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape = (n_samples, n_features_in)
+            Sample vectors.
+
+        y : array-like, shape = (n_samples,)
+            Target vector (class labels).
+
+        Returns
+        -------
+        self : object
+            Returns self.
+        """
+        self.scores_, self.pvalues_ = chi2(X, y)
+        return self
+
+    def _check_params(self, X, y):
+        pass
+
+class MutualInfoScorerClassification(_BaseScorer):
+    """Estimate mutual information for a discrete target variable.
+
+    Mutual information (MI) [1]_ between two random variables is a non-negative
+    value, which measures the dependency between the variables. It is equal
+    to zero if and only if two random variables are independent, and higher
+    values mean higher dependency.
+
+    The function relies on nonparametric methods based on entropy estimation
+    from k-nearest neighbors distances as described in [2]_ and [3]_. Both
+    methods are based on the idea originally proposed in [4]_.
+
+    It can be used for univariate features selection, read more in the
+    :ref:`User Guide <univariate_feature_selection>`.
+
+    Parameters
+    ----------
+    discrete_features : {'auto', bool, array_like}, default 'auto'
+        If bool, then determines whether to consider all features discrete
+        or continuous. If array, then it should be either a boolean mask
+        with shape (n_features,) or array with indices of discrete features.
+        If 'auto', it is assigned to False for dense `X` and to True for
+        sparse `X`.
+
+    n_neighbors : int, default 3
+        Number of neighbors to use for MI estimation for continuous variables,
+        see [2]_ and [3]_. Higher values reduce variance of the estimation, but
+        could introduce a bias.
+
+    copy : bool, default True
+        Whether to make a copy of the given data. If set to False, the initial
+        data will be overwritten.
+
+    random_state : int, RandomState instance or None, optional, default None
+        The seed of the pseudo random number generator for adding small noise
+        to continuous variables in order to remove repeated values.  If int,
+        random_state is the seed used by the random number generator; If
+        RandomState instance, random_state is the random number generator; If
+        None, the random number generator is the RandomState instance used by
+        `np.random`.
+
+    Attributes
+    ----------
+    scores_ : ndarray, shape (n_features,)
+        Estimated mutual information between each feature and the target.
+
+    Notes
+    -----
+    1. The term "discrete features" is used instead of naming them
+       "categorical", because it describes the essence more accurately.
+       For example, pixel intensities of an image are discrete features
+       (but hardly categorical) and you will get better results if mark them
+       as such. Also note, that treating a continuous variable as discrete and
+       vice versa will usually give incorrect results, so be attentive about that.
+    2. True mutual information can't be negative. If its estimate turns out
+       to be negative, it is replaced by zero.
+
+    References
+    ----------
+    .. [1] `Mutual Information <https://en.wikipedia.org/wiki/Mutual_information>`_
+           on Wikipedia.
+    .. [2] A. Kraskov, H. Stogbauer and P. Grassberger, "Estimating mutual
+           information". Phys. Rev. E 69, 2004.
+    .. [3] B. C. Ross "Mutual Information between Discrete and Continuous
+           Data Sets". PLoS ONE 9(2), 2014.
+    .. [4] L. F. Kozachenko, N. N. Leonenko, "Sample Estimate of the Entropy
+           of a Random Vector:, Probl. Peredachi Inf., 23:2 (1987), 9-16
+
+    See also
+    --------
+    ANOVAFScorerClassification: ANOVA F-value between label/feature for classification tasks.
+    ANOVAFScorerRegression: ANOVA F-value between label/feature for regression tasks.
+    Chi2Scorer: Chi-squared stats of non-negative features for classification tasks.
+    MutualInfoScorerRegression: Mutual information for a continuous target.
+    """
+    def __init__(self, discrete_features='auto', n_neighbors=3,
+                 copy=True, random_state=None):
+        self.discrete_features = discrete_features
+        self.n_neighbors = n_neighbors
+        self.copy = copy
+        self.random_state = random_state
+
+    def fit(self, X, y):
+        """Run scorer on (X, y).
+
+        Parameters
+        ----------
+        X : array_like or sparse matrix, shape (n_samples, n_features)
+            Feature matrix.
+
+        y : array_like, shape (n_samples,)
+            Target vector.
+
+        Returns
+        -------
+        self : object
+            Returns self.
+        """
+        self.scores_ = mutual_info_classif(X, y, self.discrete_features,
+                                           self.n_neighbors, self.copy,
+                                           self.random_state)
+        return self
+
+    def _check_params(self, X, y):
+        pass
+
+
+class MutualInfoScorerRegression(_BaseScorer):
+    """Estimate mutual information for a continuous target variable.
+
+    Mutual information (MI) [1]_ between two random variables is a non-negative
+    value, which measures the dependency between the variables. It is equal
+    to zero if and only if two random variables are independent, and higher
+    values mean higher dependency.
+
+    The function relies on nonparametric methods based on entropy estimation
+    from k-nearest neighbors distances as described in [2]_ and [3]_. Both
+    methods are based on the idea originally proposed in [4]_.
+
+    It can be used for univariate features selection, read more in the
+    :ref:`User Guide <univariate_feature_selection>`.
+
+    Parameters
+    ----------
+    discrete_features : {'auto', bool, array_like}, default 'auto'
+        If bool, then determines whether to consider all features discrete
+        or continuous. If array, then it should be either a boolean mask
+        with shape (n_features,) or array with indices of discrete features.
+        If 'auto', it is assigned to False for dense `X` and to True for
+        sparse `X`.
+
+    n_neighbors : int, default 3
+        Number of neighbors to use for MI estimation for continuous variables,
+        see [2]_ and [3]_. Higher values reduce variance of the estimation, but
+        could introduce a bias.
+
+    copy : bool, default True
+        Whether to make a copy of the given data. If set to False, the initial
+        data will be overwritten.
+
+    random_state : int, RandomState instance or None, optional, default None
+        The seed of the pseudo random number generator for adding small noise
+        to continuous variables in order to remove repeated values.
+        If int, random_state is the seed used by the random number generator;
+        If RandomState instance, random_state is the random number generator;
+        If None, the random number generator is the RandomState instance used
+        by `np.random`.
+
+    Attributes
+    ----------
+    scores_ : ndarray, shape (n_features,)
+        Estimated mutual information between each feature and the target.
+
+    Notes
+    -----
+    1. The term "discrete features" is used instead of naming them
+       "categorical", because it describes the essence more accurately.
+       For example, pixel intensities of an image are discrete features
+       (but hardly categorical) and you will get better results if mark them
+       as such. Also note, that treating a continuous variable as discrete and
+       vice versa will usually give incorrect results, so be attentive about that.
+    2. True mutual information can't be negative. If its estimate turns out
+       to be negative, it is replaced by zero.
+
+    References
+    ----------
+    .. [1] `Mutual Information <https://en.wikipedia.org/wiki/Mutual_information>`_
+           on Wikipedia.
+    .. [2] A. Kraskov, H. Stogbauer and P. Grassberger, "Estimating mutual
+           information". Phys. Rev. E 69, 2004.
+    .. [3] B. C. Ross "Mutual Information between Discrete and Continuous
+           Data Sets". PLoS ONE 9(2), 2014.
+    .. [4] L. F. Kozachenko, N. N. Leonenko, "Sample Estimate of the Entropy
+           of a Random Vector", Probl. Peredachi Inf., 23:2 (1987), 9-16
+
+    See also
+    --------
+    ANOVAFScorerClassification: ANOVA F-value between label/feature for classification tasks.
+    ANOVAFScorerRegression: ANOVA F-value between label/feature for regression tasks.
+    Chi2Scorer: Chi-squared stats of non-negative features for classification tasks.
+    MutualInfoScorerClassification: Mutual information for a discrete target.
+    """
+    def __init__(self, discrete_features='auto', n_neighbors=3,
+                 copy=True, random_state=None):
+        self.discrete_features = discrete_features
+        self.n_neighbors = n_neighbors
+        self.copy = copy
+        self.random_state = random_state
+
+    def fit(self, X, y):
+        """Run scorer on (X, y).
+
+        Parameters
+        ----------
+        X : array_like or sparse matrix, shape (n_samples, n_features)
+            Feature matrix.
+
+        y : array_like, shape (n_samples,)
+            Target vector.
+
+        Returns
+        -------
+        self : object
+            Returns self.
+        """
+        self.scores_ = mutual_info_regression(X, y, self.discrete_features,
+                                              self.n_neighbors, self.copy,
+                                              self.random_state)
+        return self
+
+    def _check_params(self, X, y):
+        pass
+
+
+######################################################################
+# Base filter class
 
 class _BaseFilter(BaseEstimator, SelectorMixin):
     """Initialize the univariate feature selection.
 
     Parameters
     ----------
-    score_func : callable
+    score_func : callable or object
         Function taking two arrays X and y, and returning a pair of arrays
-        (scores, pvalues) or a single array with scores.
+        (scores, pvalues) or a single array with scores or a scorer object
     """
 
     def __init__(self, score_func):
@@ -340,21 +738,29 @@ class _BaseFilter(BaseEstimator, SelectorMixin):
         """
         X, y = check_X_y(X, y, ['csr', 'csc'], multi_output=True)
 
-        if not callable(self.score_func):
-            raise TypeError("The score function should be a callable, %s (%s) "
-                            "was passed."
+        if (not callable(self.score_func) and
+            not isinstance(self.score_func, _BaseScorer)):
+            raise TypeError("The score function should be a callable or"
+                            "scorer object, %s (%s) was passed."
                             % (self.score_func, type(self.score_func)))
 
         self._check_params(X, y)
-        score_func_ret = self.score_func(X, y)
-        if isinstance(score_func_ret, (list, tuple)):
-            self.scores_, self.pvalues_ = score_func_ret
-            self.pvalues_ = np.asarray(self.pvalues_)
+        if callable(self.score_func):
+            score_func_ret = self.score_func(X, y)
+            if isinstance(score_func_ret, (list, tuple)):
+                self.scores_, self.pvalues_ = score_func_ret
+                self.pvalues_ = np.asarray(self.pvalues_)
+            else:
+                self.scores_ = score_func_ret
+                self.pvalues_ = None
+            self.scores_ = np.asarray(self.scores_)
         else:
-            self.scores_ = score_func_ret
-            self.pvalues_ = None
-
-        self.scores_ = np.asarray(self.scores_)
+            self.score_func.fit(X, y)
+            self.scores_ = np.asarray(self.score_func.scores_)
+            if hasattr(self.score_func, 'pvalues_'):
+                self.pvalues_ = np.asarray(self.score_func.pvalues_)
+            else:
+                self.pvalues_ = None
 
         return self
 
@@ -372,9 +778,9 @@ class SelectPercentile(_BaseFilter):
 
     Parameters
     ----------
-    score_func : callable
+    score_func : callable or object, default=f_classif
         Function taking two arrays X and y, and returning a pair of arrays
-        (scores, pvalues) or a single array with scores.
+        (scores, pvalues) or a single array with scores or a scorer object.
         Default is f_classif (see below "See also"). The default function only
         works with classification tasks.
 
@@ -408,10 +814,15 @@ class SelectPercentile(_BaseFilter):
     See also
     --------
     f_classif: ANOVA F-value between label/feature for classification tasks.
-    mutual_info_classif: Mutual information for a discrete target.
-    chi2: Chi-squared stats of non-negative features for classification tasks.
     f_regression: F-value between label/feature for regression tasks.
+    chi2: Chi-squared stats of non-negative features for classification tasks.
+    mutual_info_classif: Mutual information for a discrete target.
     mutual_info_regression: Mutual information for a continuous target.
+    ANOVAFScorerClassification: F-value between label/feature for classification tasks.
+    ANOVAFScorerRegression: F-value between label/feature for regression tasks.
+    Chi2Scorer: Chi-squared stats of non-negative features for classification tasks.
+    MutualInfoScorerClassification: Mutual information for a discrete target.
+    MutualInfoScorerRegression: Mutual information for a continuous target.
     SelectKBest: Select features based on the k highest scores.
     SelectFpr: Select features based on a false positive rate test.
     SelectFdr: Select features based on an estimated false discovery rate.
@@ -455,9 +866,9 @@ class SelectKBest(_BaseFilter):
 
     Parameters
     ----------
-    score_func : callable
+    score_func : callable or object, default=f_classif
         Function taking two arrays X and y, and returning a pair of arrays
-        (scores, pvalues) or a single array with scores.
+        (scores, pvalues) or a single array with scores or a scorer object.
         Default is f_classif (see below "See also"). The default function only
         works with classification tasks.
 
@@ -492,11 +903,16 @@ class SelectKBest(_BaseFilter):
     See also
     --------
     f_classif: ANOVA F-value between label/feature for classification tasks.
-    mutual_info_classif: Mutual information for a discrete target.
-    chi2: Chi-squared stats of non-negative features for classification tasks.
     f_regression: F-value between label/feature for regression tasks.
+    chi2: Chi-squared stats of non-negative features for classification tasks.
+    mutual_info_classif: Mutual information for a discrete target.
     mutual_info_regression: Mutual information for a continuous target.
-    SelectPercentile: Select features based on percentile of the highest scores.
+    ANOVAFScorerClassification: F-value between label/feature for classification tasks.
+    ANOVAFScorerRegression: F-value between label/feature for regression tasks.
+    Chi2Scorer: Chi-squared stats of non-negative features for classification tasks.
+    MutualInfoScorerClassification: Mutual information for a discrete target.
+    MutualInfoScorerRegression: Mutual information for a continuous target.
+    SelectKBest: Select features based on the k highest scores.
     SelectFpr: Select features based on a false positive rate test.
     SelectFdr: Select features based on an estimated false discovery rate.
     SelectFwe: Select features based on family-wise error rate.
@@ -540,9 +956,9 @@ class SelectFpr(_BaseFilter):
 
     Parameters
     ----------
-    score_func : callable
+    score_func : callable or object, default=f_classif
         Function taking two arrays X and y, and returning a pair of arrays
-        (scores, pvalues).
+        (scores, pvalues) or a single array with scores or a scorer object.
         Default is f_classif (see below "See also"). The default function only
         works with classification tasks.
 
@@ -571,12 +987,17 @@ class SelectFpr(_BaseFilter):
     See also
     --------
     f_classif: ANOVA F-value between label/feature for classification tasks.
-    chi2: Chi-squared stats of non-negative features for classification tasks.
-    mutual_info_classif:
     f_regression: F-value between label/feature for regression tasks.
-    mutual_info_regression: Mutual information between features and the target.
-    SelectPercentile: Select features based on percentile of the highest scores.
+    chi2: Chi-squared stats of non-negative features for classification tasks.
+    mutual_info_classif: Mutual information for a discrete target.
+    mutual_info_regression: Mutual information for a continuous target.
+    ANOVAFScorerClassification: F-value between label/feature for classification tasks.
+    ANOVAFScorerRegression: F-value between label/feature for regression tasks.
+    Chi2Scorer: Chi-squared stats of non-negative features for classification tasks.
+    MutualInfoScorerClassification: Mutual information for a discrete target.
+    MutualInfoScorerRegression: Mutual information for a continuous target.
     SelectKBest: Select features based on the k highest scores.
+    SelectFpr: Select features based on a false positive rate test.
     SelectFdr: Select features based on an estimated false discovery rate.
     SelectFwe: Select features based on family-wise error rate.
     GenericUnivariateSelect: Univariate feature selector with configurable mode.
@@ -602,9 +1023,9 @@ class SelectFdr(_BaseFilter):
 
     Parameters
     ----------
-    score_func : callable
+    score_func : callable or object, default=f_classif
         Function taking two arrays X and y, and returning a pair of arrays
-        (scores, pvalues).
+        (scores, pvalues) or a single array with scores or a scorer object.
         Default is f_classif (see below "See also"). The default function only
         works with classification tasks.
 
@@ -637,13 +1058,18 @@ class SelectFdr(_BaseFilter):
     See also
     --------
     f_classif: ANOVA F-value between label/feature for classification tasks.
-    mutual_info_classif: Mutual information for a discrete target.
-    chi2: Chi-squared stats of non-negative features for classification tasks.
     f_regression: F-value between label/feature for regression tasks.
-    mutual_info_regression: Mutual information for a contnuous target.
-    SelectPercentile: Select features based on percentile of the highest scores.
+    chi2: Chi-squared stats of non-negative features for classification tasks.
+    mutual_info_classif: Mutual information for a discrete target.
+    mutual_info_regression: Mutual information for a continuous target.
+    ANOVAFScorerClassification: F-value between label/feature for classification tasks.
+    ANOVAFScorerRegression: F-value between label/feature for regression tasks.
+    Chi2Scorer: Chi-squared stats of non-negative features for classification tasks.
+    MutualInfoScorerClassification: Mutual information for a discrete target.
+    MutualInfoScorerRegression: Mutual information for a continuous target.
     SelectKBest: Select features based on the k highest scores.
     SelectFpr: Select features based on a false positive rate test.
+    SelectFdr: Select features based on an estimated false discovery rate.
     SelectFwe: Select features based on family-wise error rate.
     GenericUnivariateSelect: Univariate feature selector with configurable mode.
     """
@@ -671,9 +1097,9 @@ class SelectFwe(_BaseFilter):
 
     Parameters
     ----------
-    score_func : callable
+    score_func : callable or object, default=f_classif
         Function taking two arrays X and y, and returning a pair of arrays
-        (scores, pvalues).
+        (scores, pvalues) or a single array with scores or a scorer object.
         Default is f_classif (see below "See also"). The default function only
         works with classification tasks.
 
@@ -702,12 +1128,19 @@ class SelectFwe(_BaseFilter):
     See also
     --------
     f_classif: ANOVA F-value between label/feature for classification tasks.
-    chi2: Chi-squared stats of non-negative features for classification tasks.
     f_regression: F-value between label/feature for regression tasks.
-    SelectPercentile: Select features based on percentile of the highest scores.
+    chi2: Chi-squared stats of non-negative features for classification tasks.
+    mutual_info_classif: Mutual information for a discrete target.
+    mutual_info_regression: Mutual information for a continuous target.
+    ANOVAFScorerClassification: F-value between label/feature for classification tasks.
+    ANOVAFScorerRegression: F-value between label/feature for regression tasks.
+    Chi2Scorer: Chi-squared stats of non-negative features for classification tasks.
+    MutualInfoScorerClassification: Mutual information for a discrete target.
+    MutualInfoScorerRegression: Mutual information for a continuous target.
     SelectKBest: Select features based on the k highest scores.
     SelectFpr: Select features based on a false positive rate test.
     SelectFdr: Select features based on an estimated false discovery rate.
+    SelectFwe: Select features based on family-wise error rate.
     GenericUnivariateSelect: Univariate feature selector with configurable mode.
     """
 
@@ -734,10 +1167,11 @@ class GenericUnivariateSelect(_BaseFilter):
 
     Parameters
     ----------
-    score_func : callable
+    score_func : callable or object, default=f_classif
         Function taking two arrays X and y, and returning a pair of arrays
-        (scores, pvalues). For modes 'percentile' or 'kbest' it can return
-        a single array scores.
+        (scores, pvalues) or a single array with scores or a scorer object.
+        Default is f_classif (see below "See also"). The default function only
+        works with classification tasks.
 
     mode : {'percentile', 'k_best', 'fpr', 'fdr', 'fwe'}
         Feature selection mode.
@@ -768,15 +1202,20 @@ class GenericUnivariateSelect(_BaseFilter):
     See also
     --------
     f_classif: ANOVA F-value between label/feature for classification tasks.
-    mutual_info_classif: Mutual information for a discrete target.
-    chi2: Chi-squared stats of non-negative features for classification tasks.
     f_regression: F-value between label/feature for regression tasks.
+    chi2: Chi-squared stats of non-negative features for classification tasks.
+    mutual_info_classif: Mutual information for a discrete target.
     mutual_info_regression: Mutual information for a continuous target.
-    SelectPercentile: Select features based on percentile of the highest scores.
+    ANOVAFScorerClassification: F-value between label/feature for classification tasks.
+    ANOVAFScorerRegression: F-value between label/feature for regression tasks.
+    Chi2Scorer: Chi-squared stats of non-negative features for classification tasks.
+    MutualInfoScorerClassification: Mutual information for a discrete target.
+    MutualInfoScorerRegression: Mutual information for a continuous target.
     SelectKBest: Select features based on the k highest scores.
     SelectFpr: Select features based on a false positive rate test.
     SelectFdr: Select features based on an estimated false discovery rate.
     SelectFwe: Select features based on family-wise error rate.
+    GenericUnivariateSelect: Univariate feature selector with configurable mode.
     """
 
     _selection_modes = {'percentile': SelectPercentile,


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #12468

#### What does this implement/fix? Explain your changes.

It's currently not possible to search on parameters of univariate scoring functions.  While it is possible to fix this by potentially adding a score_func_params dict parameter to the univariate selection classes and _BaseFilter parent class, the way you would need to encode parameter searching with this is still somewhat ugly and not consistent with the standard notation used with most everything else.  You cannot use the standard double underscore notation and have to write a list comprehension loop in your param grid, e.g.:

fs__score_func_params = [ {'n_neighbors': i} for i in [ 5, 10, 15 ]]

By introducing new Scorer classes that are estimators and wrap the legacy scoring functions it provides a cleaner and consistent interface to parameter searching and duplicates zero code.  These classes are a new interface and do not affect or alter the current scoring functions or univariate selection classes.  I think in the long run it's a better more future proof design as possibly new univariate selection methods will be added in future.
