### PR TITLE
[MRG+1] Fix shuffle not passed in MLP

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -91,6 +91,13 @@ Support for Python 3.4 and below has been officially dropped.
   when called before fit :issue:`12279` by :user:`Krishna Sangeeth
   <whiletruelearn>`.
 
+:mod:`sklearn.neural_network`
+.............................
+
+- |Fix| Fixed a bug in :class:`neural_network.MLPClassifier` and
+  :class:`neural_network.MLPRegressor` where the option :code:`shuffle=False`
+  was being ignored. :issue:`12582` by :user:`Sam Waterbury <samwaterbury>`.
+
 :mod:`sklearn.pipeline`
 .......................
 

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -503,7 +503,8 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
 
         try:
             for it in range(self.max_iter):
-                X, y = shuffle(X, y, random_state=self._random_state)
+                if self.shuffle:
+                    X, y = shuffle(X, y, random_state=self._random_state)
                 accumulated_loss = 0.0
                 for batch_slice in gen_batches(n_samples, batch_size):
                     activations[0] = X[batch_slice]

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -498,7 +498,8 @@ def test_predict_proba_multilabel():
 def test_shuffle():
     X, y = make_multilabel_classification(n_samples=200, n_features=10,
                                           n_classes=5, n_labels=2,
-                                          allow_unlabeled=False, random_state=0)
+                                          allow_unlabeled=False,
+                                          random_state=0)
 
     # Ensure shuffling happens or doesn't happen when passed as an argument
     mlp1 = MLPClassifier(hidden_layer_sizes=(10,), max_iter=10, random_state=0,

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -24,7 +24,7 @@ from sklearn.preprocessing import StandardScaler, MinMaxScaler
 from scipy.sparse import csr_matrix
 from sklearn.utils.testing import (assert_raises, assert_greater, assert_equal,
                                    assert_false, ignore_warnings)
-from sklearn.utils.testing import assert_raise_message, assert_not_equal
+from sklearn.utils.testing import assert_raise_message
 
 
 np.seterr(all='warn')
@@ -496,37 +496,30 @@ def test_predict_proba_multilabel():
 
 
 def test_shuffle():
-    X, y = make_multilabel_classification(n_samples=200, n_features=10,
-                                          n_classes=5, n_labels=2,
-                                          allow_unlabeled=False,
-                                          random_state=0)
+    # Test that the shuffle parameter affects the training process (it should)
+    X, y = make_regression(n_samples=50, n_features=5, n_targets=1,
+                           random_state=0)
 
-    # Ensure shuffling happens or doesn't happen when passed as an argument
-    mlp1 = MLPClassifier(hidden_layer_sizes=(10,), max_iter=10, random_state=0,
-                         shuffle=True, batch_size=2)
-    mlp2 = MLPClassifier(hidden_layer_sizes=(10,), max_iter=10, random_state=0,
-                         shuffle=False, batch_size=2)
-
-    mlp1.fit(X[:100, ], y[:100, ])
-    mlp2.fit(X[:100, ], y[:100, ])
-    score1 = mlp1.score(X[100:, ], y[100:, ])
-    score2 = mlp2.score(X[100:, ], y[100:, ])
-
-    assert_not_equal(score1, score2)
-
-    # Now ensure that the scores are the same when both do or do not shuffle
+    # The coefficients will be identical if both do or do not shuffle
     for shuffle in [True, False]:
-        mlp1 = MLPClassifier(hidden_layer_sizes=(50,), max_iter=10,
-                             random_state=0, shuffle=shuffle)
-        mlp2 = MLPClassifier(hidden_layer_sizes=(50,), max_iter=10,
-                             random_state=0, shuffle=shuffle)
+        mlp1 = MLPRegressor(hidden_layer_sizes=1, max_iter=1, batch_size=1,
+                            random_state=0, shuffle=shuffle)
+        mlp2 = MLPRegressor(hidden_layer_sizes=1, max_iter=1, batch_size=1,
+                            random_state=0, shuffle=shuffle)
+        mlp1.fit(X, y)
+        mlp2.fit(X, y)
 
-        mlp1.fit(X[:100, ], y[:100, ])
-        mlp2.fit(X[:100, ], y[:100, ])
-        score1 = mlp1.score(X[100:, ], y[100:, ])
-        score2 = mlp2.score(X[100:, ], y[100:, ])
+        assert np.array_equal(mlp1.coefs_[0], mlp2.coefs_[0])
 
-        assert_equal(score1, score2)
+    # The coefficients will be slightly different if shuffle=True
+    mlp1 = MLPRegressor(hidden_layer_sizes=1, max_iter=1, batch_size=1,
+                        random_state=0, shuffle=True)
+    mlp2 = MLPRegressor(hidden_layer_sizes=1, max_iter=1, batch_size=1,
+                        random_state=0, shuffle=False)
+    mlp1.fit(X, y)
+    mlp2.fit(X, y)
+
+    assert not np.array_equal(mlp1.coefs_[0], mlp2.coefs_[0])
 
 
 def test_sparse_matrices():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses https://github.com/scikit-learn/scikit-learn/issues/12505#issuecomment-437485343

Alright, so I listed a few issues with `MLPClassifier` (which also affect `MLPRegressor`) in #12505. The most basic issue was that the `shuffle` argument was being ignored, which is fixed in this first commit.

The rest of the issues I want some input on before I continue. I posted a long message in the original issue thread but here's the tl;dr. They basically boil down to documenting the odd behavior vs. fixing it:

1. The method `partial_fit` is not documented as being incompatible with LBFGS, however if you attempt to use it it raises an error saying that it is incompatible. If I remove the code that raises this error, it works fine with LBFGS as far as I can tell. Unless anyone knows why we shouldn't allow LBFGS with `partial_fit`, I'd say we could remove that restriction. Otherwise, it should be documented.

2. When `warm_start=True`, the `fit` method breaks after a single iteration of training, just like `partial_fit` does. Thus, they perform identically. I don't understand why `fit` should be breaking after 1 iteration for `warm_start=True`. In my opinion it should be changed, but this would change its behavior. Again, if it isn't changed, it should be documented.

3. Not as serious as the other points, but the documentation for `partial_fit` [appears oddly](https://scikit-learn.org/stable/modules/generated/sklearn.neural_network.MLPClassifier.html#sklearn.neural_network.MLPClassifier) due to it being implemented as a `@property`. It could probably be fixed, but I'm not sure if its important or not. I'm not sure of the logic behind why it was implemented this way.

Each of these are easy fixes whichever way we decide to go (3 possibly excluded?). Input would be appreciated!

Also pinging @jnothman since you raised some points in the issue.