### PR TITLE
[MRG] Use fast pairwise distance calculations for metric='sqeuclidean'

### DIFF
--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -73,14 +73,13 @@ def optics(X, min_samples=5, max_eps=np.inf, metric='minkowski',
 
         Valid values for metric are:
 
-        - from scikit-learn: ['cityblock', 'cosine', 'euclidean', 'l1', 'l2',
-          'manhattan']
+        - from scikit-learn: ['cityblock', 'cosine', 'euclidean',
+          'sqeuclidean', 'l1', 'l2', 'manhattan']
 
         - from scipy.spatial.distance: ['braycurtis', 'canberra', 'chebyshev',
           'correlation', 'dice', 'hamming', 'jaccard', 'kulsinski',
           'mahalanobis', 'minkowski', 'rogerstanimoto', 'russellrao',
-          'seuclidean', 'sokalmichener', 'sokalsneath', 'sqeuclidean',
-          'yule']
+          'seuclidean', 'sokalmichener', 'sokalsneath', 'yule']
 
         See the documentation for scipy.spatial.distance for details on these
         metrics.

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -306,13 +306,12 @@ def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
         Valid values for metric are:
 
         - from scikit-learn: ['cityblock', 'cosine', 'euclidean', 'l1', 'l2',
-          'manhattan']
+          'sqeuclidean', 'manhattan']
 
         - from scipy.spatial.distance: ['braycurtis', 'canberra', 'chebyshev',
           'correlation', 'dice', 'hamming', 'jaccard', 'kulsinski',
           'mahalanobis', 'minkowski', 'rogerstanimoto', 'russellrao',
-          'seuclidean', 'sokalmichener', 'sokalsneath', 'sqeuclidean',
-          'yule']
+          'seuclidean', 'sokalmichener', 'sokalsneath', 'yule']
 
         See the documentation for scipy.spatial.distance for details on these
         metrics.
@@ -403,14 +402,13 @@ def pairwise_distances_argmin(X, Y, axis=1, metric="euclidean",
 
         Valid values for metric are:
 
-        - from scikit-learn: ['cityblock', 'cosine', 'euclidean', 'l1', 'l2',
-          'manhattan']
+        - from scikit-learn: ['cityblock', 'cosine', 'euclidean',
+          'sqeuclidean', 'l1', 'l2', 'manhattan']
 
         - from scipy.spatial.distance: ['braycurtis', 'canberra', 'chebyshev',
           'correlation', 'dice', 'hamming', 'jaccard', 'kulsinski',
           'mahalanobis', 'minkowski', 'rogerstanimoto', 'russellrao',
-          'seuclidean', 'sokalmichener', 'sokalsneath', 'sqeuclidean',
-          'yule']
+          'seuclidean', 'sokalmichener', 'sokalsneath', 'yule']
 
         See the documentation for scipy.spatial.distance for details on these
         metrics.
@@ -1016,6 +1014,7 @@ PAIRWISE_DISTANCE_FUNCTIONS = {
     'cityblock': manhattan_distances,
     'cosine': cosine_distances,
     'euclidean': euclidean_distances,
+    'sqeuclidean': partial(euclidean_distances, squared=True),
     'l2': euclidean_distances,
     'l1': manhattan_distances,
     'manhattan': manhattan_distances,
@@ -1294,13 +1293,13 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=None, **kwds):
 
     Valid values for metric are:
 
-    - From scikit-learn: ['cityblock', 'cosine', 'euclidean', 'l1', 'l2',
-      'manhattan']. These metrics support sparse matrix inputs.
+    - From scikit-learn: ['cityblock', 'cosine', 'euclidean', 'sqeuclidean',
+      'l1', 'l2', 'manhattan']. These metrics support sparse matrix inputs.
 
     - From scipy.spatial.distance: ['braycurtis', 'canberra', 'chebyshev',
       'correlation', 'dice', 'hamming', 'jaccard', 'kulsinski', 'mahalanobis',
       'minkowski', 'rogerstanimoto', 'russellrao', 'seuclidean',
-      'sokalmichener', 'sokalsneath', 'sqeuclidean', 'yule']
+      'sokalmichener', 'sokalsneath', 'yule']
       See the documentation for scipy.spatial.distance for details on these
       metrics. These metrics do not support sparse matrix inputs.
 

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -62,10 +62,13 @@ def test_pairwise_distances():
     S = pairwise_distances(X, Y, metric="euclidean")
     S2 = euclidean_distances(X, Y)
     assert_array_almost_equal(S, S2)
+    # Test sqeuclidean distance
+    S = pairwise_distances(X, Y, metric="sqeuclidean")
+    assert_allclose(S, S2**2)
     # Test with tuples as X and Y
     X_tuples = tuple([tuple([v for v in row]) for row in X])
     Y_tuples = tuple([tuple([v for v in row]) for row in Y])
-    S2 = pairwise_distances(X_tuples, Y_tuples, metric="euclidean")
+    S = pairwise_distances(X_tuples, Y_tuples, metric="euclidean")
     assert_array_almost_equal(S, S2)
     # "cityblock" uses scikit-learn metric, cityblock (function) is
     # scipy.spatial.

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -71,14 +71,13 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin,
 
         Valid values for metric are:
 
-        - from scikit-learn: ['cityblock', 'cosine', 'euclidean', 'l1', 'l2',
-          'manhattan']
+        - from scikit-learn: ['cityblock', 'cosine', 'euclidean',
+          'sqeuclidean', 'l1', 'l2', 'manhattan']
 
         - from scipy.spatial.distance: ['braycurtis', 'canberra', 'chebyshev',
           'correlation', 'dice', 'hamming', 'jaccard', 'kulsinski',
           'mahalanobis', 'minkowski', 'rogerstanimoto', 'russellrao',
-          'seuclidean', 'sokalmichener', 'sokalsneath', 'sqeuclidean',
-          'yule']
+          'seuclidean', 'sokalmichener', 'sokalsneath', 'yule']
 
         See the documentation for scipy.spatial.distance for details on these
         metrics:

--- a/sklearn/neighbors/unsupervised.py
+++ b/sklearn/neighbors/unsupervised.py
@@ -53,14 +53,13 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
 
         Valid values for metric are:
 
-        - from scikit-learn: ['cityblock', 'cosine', 'euclidean', 'l1', 'l2',
-          'manhattan']
+        - from scikit-learn: ['cityblock', 'cosine', 'euclidean', 'sqeuclidean',
+          'l1', 'l2', 'manhattan']
 
         - from scipy.spatial.distance: ['braycurtis', 'canberra', 'chebyshev',
           'correlation', 'dice', 'hamming', 'jaccard', 'kulsinski',
           'mahalanobis', 'minkowski', 'rogerstanimoto', 'russellrao',
-          'seuclidean', 'sokalmichener', 'sokalsneath', 'sqeuclidean',
-          'yule']
+          'seuclidean', 'sokalmichener', 'sokalsneath', 'yule']
 
         See the documentation for scipy.spatial.distance for details on these
         metrics.

--- a/sklearn/neighbors/unsupervised.py
+++ b/sklearn/neighbors/unsupervised.py
@@ -53,8 +53,8 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
 
         Valid values for metric are:
 
-        - from scikit-learn: ['cityblock', 'cosine', 'euclidean', 'sqeuclidean',
-          'l1', 'l2', 'manhattan']
+        - from scikit-learn: ['cityblock', 'cosine', 'euclidean',
+          'sqeuclidean', 'l1', 'l2', 'manhattan']
 
         - from scipy.spatial.distance: ['braycurtis', 'canberra', 'chebyshev',
           'correlation', 'dice', 'hamming', 'jaccard', 'kulsinski',


### PR DESCRIPTION
Closes https://github.com/scikit-learn/scikit-learn/issues/12600

For `pairwise_distance(.., metric='sqeuclidean')`, this uses the fast `euclidean_distance(..., squared=True)` function to be consistent with `metric='euclidean'`, instead of the slower (but more accurate) `pdist` from scipy (cf parent issue for benchmarks).

`metric='sqeuclidean'` is not used in the code base, so it's not really critical, but it may make some users applications faster.