### PR TITLE
[ENH] Error raised for RationalQuadratic kernel

### DIFF
--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1442,10 +1442,6 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
     """
     def __init__(self, length_scale=1.0, alpha=1.0,
                  length_scale_bounds=(1e-5, 1e5), alpha_bounds=(1e-5, 1e5)):
-        if len(np.atleast_1d(length_scale)) > 1:
-            raise AttributeError(
-                "RationalQuadratic kernel only supports isotropic version, "
-                "please use a single scalar for length_scale")
         self.length_scale = length_scale
         self.alpha = alpha
         self.length_scale_bounds = length_scale_bounds
@@ -1486,6 +1482,10 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
         """
+        if len(np.atleast_1d(self.length_scale)) > 1:
+            raise AttributeError(
+                "RationalQuadratic kernel only supports isotropic version, "
+                "please use a single scalar for length_scale")
         X = np.atleast_2d(X)
         if Y is None:
             dists = squareform(pdist(X, metric='sqeuclidean'))

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1442,6 +1442,10 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
     """
     def __init__(self, length_scale=1.0, alpha=1.0,
                  length_scale_bounds=(1e-5, 1e5), alpha_bounds=(1e-5, 1e5)):
+        if len(np.atleast_1d(length_scale)) > 1:
+            raise AttributeError(
+                "RationalQuadratic kernel only supports isotropic version, "
+                "please use a single scalar for length_scale")
         self.length_scale = length_scale
         self.alpha = alpha
         self.length_scale_bounds = length_scale_bounds

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -17,9 +17,9 @@ from sklearn.gaussian_process.kernels \
             Exponentiation, Kernel)
 from sklearn.base import clone
 
-from sklearn.utils.testing import (assert_equal, assert_almost_equal,
-                                   assert_not_equal, assert_array_equal,
-                                   assert_array_almost_equal, assert_raises)
+from sklearn.utils.testing import (assert_almost_equal, assert_array_equal,
+                                   assert_array_almost_equal,
+                                   assert_raise_message)
 
 
 X = np.random.RandomState(0).normal(0, 1, (5, 2))
@@ -347,4 +347,8 @@ def test_warns_on_get_params_non_attribute():
 
 
 def test_rational_quadratic_kernel():
-    assert_raises(AttributeError, RationalQuadratic, [1., 1.])
+    kernel = RationalQuadratic(length_scale=[1., 1.])
+    assert_raise_message(AttributeError,
+                         "RationalQuadratic kernel only supports isotropic "
+                         "version, please use a single "
+                         "scalar for length_scale", kernel, X)

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -17,9 +17,9 @@ from sklearn.gaussian_process.kernels \
             Exponentiation, Kernel)
 from sklearn.base import clone
 
-from sklearn.utils.testing import (assert_almost_equal,
-                                   assert_array_equal,
-                                   assert_array_almost_equal)
+from sklearn.utils.testing import (assert_equal, assert_almost_equal,
+                                   assert_not_equal, assert_array_equal,
+                                   assert_array_almost_equal, assert_raises)
 
 
 X = np.random.RandomState(0).normal(0, 1, (5, 2))
@@ -344,3 +344,7 @@ def test_warns_on_get_params_non_attribute():
         params = est.get_params()
 
     assert params['param'] is None
+
+
+def test_rational_quadratic_kernel():
+    assert_raises(AttributeError, RationalQuadratic, [1., 1.])


### PR DESCRIPTION
In gaussian_process.kernels.RationalQuadratic, only the isotropic version is supported for now. However it is still possible to pass an array of scalars for the constructor and an error will only be raised when using the kernel on data.

The error message that is shown is the following : 
```python
>>> from sklearn.gaussian_process.kernels import RationalQuadratic
>>> kernel = RationalQuadratic(length_scale=[1., 1.]) # creates the kernel
>>> kernel([.5, .7]) # apply it on a point
~/.local/lib/python3.6/site-packages/sklearn/gaussian_process/kernels.py in __call__(self, X, Y, eval_gradient)
   1481         if Y is None:
   1482             dists = squareform(pdist(X, metric='sqeuclidean'))
-> 1483             tmp = dists / (2 * self.alpha * self.length_scale ** 2)
   1484             base = (1 + tmp)
   1485             K = base ** -self.alpha

TypeError: unsupported operand type(s) for ** or pow(): 'list' and 'int'
```
With this PR a specific AttributeError is raised when passing a `length_scale` parameter which is not a float or an array with a single element to the RationalQuadratic kernel constructor. 

Another strategy could be to raise a Warning and to set `length_scale = length_scale[0]`. 