### PR TITLE
[MRG] Fix warm_start behavior in multilayer perceptron

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -41,7 +41,7 @@ Changelog
 :mod:`sklearn.tree`
 ...................
 
-- |Fix| Fixed bug in :func:`tree.export_text` when the tree has one feature and 
+- |Fix| Fixed bug in :func:`tree.export_text` when the tree has one feature and
   a single feature name is passed in. :pr:`14053` by `Thomas Fan`
 
 :mod:`sklearn.neighbors`
@@ -65,7 +65,7 @@ Changelog
 :mod:`sklearn.decomposition`
 ............................
 
-- |Fix| Fixed a bug in :class:`cross_decomposition.CCA` improving numerical 
+- |Fix| Fixed a bug in :class:`cross_decomposition.CCA` improving numerical
   stability when `Y` is close to zero. :pr:`13903` by `Thomas Fan`_.
 
 :mod:`sklearn.metrics`
@@ -94,7 +94,7 @@ Changelog
 ................................
 
 - |Fix| Fixed a bug where :func:`min_max_axis` would fail on 32-bit systems
-  for certain large inputs. This affects :class:`preprocessing.MaxAbsScaler`, 
+  for certain large inputs. This affects :class:`preprocessing.MaxAbsScaler`,
   :func:`preprocessing.normalize` and :class:`preprocessing.LabelBinarizer`.
   :pr:`13741` by :user:`Roddy MacSween <rlms>`.
 
@@ -726,10 +726,10 @@ Support for Python 3.4 and below has been officially dropped.
   in version 0.21 and will be removed in version 0.23. :pr:`10580` by
   :user:`Reshama Shaikh <reshamas>` and :user:`Sandra Mitrovic <SandraMNE>`.
 
-- |Fix| The function :func:`metrics.pairwise.euclidean_distances`, and 
-  therefore several estimators with ``metric='euclidean'``, suffered from 
-  numerical precision issues with ``float32`` features. Precision has been 
-  increased at the cost of a small drop of performance. :pr:`13554` by 
+- |Fix| The function :func:`metrics.pairwise.euclidean_distances`, and
+  therefore several estimators with ``metric='euclidean'``, suffered from
+  numerical precision issues with ``float32`` features. Precision has been
+  increased at the cost of a small drop of performance. :pr:`13554` by
   :user:`Celelibi` and :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 - |API| :func:`metrics.jaccard_similarity_score` is deprecated in favour of
@@ -801,7 +801,7 @@ Support for Python 3.4 and below has been officially dropped.
   `predict_proba` method incorrectly checked for `predict_proba` attribute in
   the estimator object.
   :pr:`12222` by :user:`Rebekah Kim <rebekahkim>`
-  
+
 :mod:`sklearn.neighbors`
 ........................
 
@@ -830,6 +830,13 @@ Support for Python 3.4 and below has been officially dropped.
   validation sets for early stopping were not sampled with stratification. In
   the multilabel case however, splits are still not stratified.
   :pr:`13164` by :user:`Nicolas Hug<NicolasHug>`.
+
+- |API| The default behavior of the option :code:`warm_start=True` in
+  :class:`neural_network.MLPClassifier` and
+  :class:`neural_network.MLPRegressor` will be changed to behave like
+  :code:`warm_start='full'` in version 0.23. A FutureWarning is raised when the
+  default value is used. :issue:`12605` by
+  :user:`Sam Waterbury <samwaterbury>`.
 
 :mod:`sklearn.pipeline`
 .......................
@@ -1019,7 +1026,7 @@ Baibak, daten-kieker, Denis Kataev, Didi Bar-Zev, Dillon Gardner, Dmitry Mottl,
 Dmitry Vukolov, Dougal J. Sutherland, Dowon, drewmjohnston, Dror Atariah,
 Edward J Brown, Ekaterina Krivich, Elizabeth Sander, Emmanuel Arias, Eric
 Chang, Eric Larson, Erich Schubert, esvhd, Falak, Feda Curic, Federico Caselli,
-Frank Hoang, Fibinse Xavier`, Finn O'Shea, Gabriel Marzinotto, Gabriel Vacaliuc, 
+Frank Hoang, Fibinse Xavier`, Finn O'Shea, Gabriel Marzinotto, Gabriel Vacaliuc,
 Gabriele Calvo, Gael Varoquaux, GauravAhlawat, Giuseppe Vettigli, Greg Gandenberger,
 Guillaume Fournier, Guillaume Lemaitre, Gustavo De Mari Pereira, Hanmin Qin,
 haroldfox, hhu-luqi, Hunter McGushion, Ian Sanders, JackLangerman, Jacopo

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -485,8 +485,7 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
     def _fit_stochastic(self, X, y, activations, deltas, coef_grads,
                         intercept_grads, layer_units, partial):
 
-        if not hasattr(self, '_optimizer') or (not partial and
-                                               not self.warm_start):
+        if not (hasattr(self, '_optimizer') and (partial or self.warm_start)):
             params = self.coefs_ + self.intercepts_
 
             if self.solver == 'sgd':
@@ -814,9 +813,9 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         previous solution. See :term:`the Glossary <warm_start>`.
 
         .. deprecated:: 0.21
-           ``warm_start=True`` will adopt the new behavior of 'warm_start=full'
+           `warm_start=True` will adopt the new behavior of `warm_start='full'`
            in 0.23. To continue using the old behavior, use the function
-           ``partial_fit`` instead or set 'max_iter=1'.
+           `partial_fit` instead or set `max_iter=1`.
 
     momentum : float, default 0.9
         Momentum for gradient descent update. Should be between 0 and 1. Only
@@ -1211,9 +1210,9 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
         previous solution. See :term:`the Glossary <warm_start>`.
 
         .. deprecated:: 0.21
-           ``warm_start=True`` will adopt the new behavior of 'warm_start=full'
+           `warm_start=True` will adopt the new behavior of `warm_start='full'`
            in 0.23. To continue using the old behavior, use the function
-           ``partial_fit`` instead or set 'max_iter=1'.
+           `partial_fit` instead or set `max_iter=1`.
 
     momentum : float, default 0.9
         Momentum for gradient descent update.  Should be between 0 and 1. Only

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -299,7 +299,7 @@ def test_lbfgs_regression_maxfun(X, y):
     assert_raises(ValueError, mlp.fit, X, y)
 
 
-@ignore_warnings(category=FutureWarning)
+@ignore_warnings(category=FutureWarning)  # FIXME this can be removed in 0.23
 def test_learning_rate_warmstart():
     # Tests that warm_start reuse past solutions.
     X = [[3, 2], [1, 6], [5, 6], [-2, -4]]
@@ -633,7 +633,7 @@ def test_adaptive_learning_rate():
 
 
 @ignore_warnings(category=RuntimeWarning)
-@ignore_warnings(category=FutureWarning)
+@ignore_warnings(category=FutureWarning)  # FIXME this can be removed in 0.23
 def test_warm_start():
     X = X_iris
     y = y_iris
@@ -659,23 +659,24 @@ def test_warm_start():
         assert_raise_message(ValueError, message, clf.fit, X, y_i)
 
 
-@ignore_warnings(category=FutureWarning)
+@ignore_warnings(category=FutureWarning)  # FIXME this can be removed in 0.23
 def test_warm_start_full():
     # Test to make sure it is fitting for more than 1 iteration
     X = Xboston
     y = yboston
 
-    mlp = MLPRegressor(solver='adam', max_iter=150, hidden_layer_sizes=50,
-                       random_state=1, warm_start='full')
+    mlp = MLPRegressor(solver='adam', max_iter=10, hidden_layer_sizes=50,
+                       random_state=1, warm_start='full', early_stopping=False)
     with ignore_warnings(category=ConvergenceWarning):
         mlp.fit(X, y)
 
-    assert mlp.score(X, y) > -4.
+    assert mlp.n_iter_ == 10
 
 
+# FIXME remove this test in 0.23 when the behavior of warm_start changes
 def test_warm_start_future_warning():
-    # FutureWarning should be raised for warm_start=True in <0.22
-    message = 'The behavior of warm_start=True will change in 0.22 ' \
+    # FutureWarning should be raised for warm_start=True in <0.23
+    message = 'The behavior of warm_start=True will change in 0.23 ' \
               'to behave like warm_start=\'full\'. To continue ' \
               'using the old behavior, set max_iter=1 or switch to ' \
               'partial_fit.'

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -299,6 +299,7 @@ def test_lbfgs_regression_maxfun(X, y):
     assert_raises(ValueError, mlp.fit, X, y)
 
 
+@ignore_warnings(category=FutureWarning)
 def test_learning_rate_warmstart():
     # Tests that warm_start reuse past solutions.
     X = [[3, 2], [1, 6], [5, 6], [-2, -4]]
@@ -632,6 +633,7 @@ def test_adaptive_learning_rate():
 
 
 @ignore_warnings(category=RuntimeWarning)
+@ignore_warnings(category=FutureWarning)
 def test_warm_start():
     X = X_iris
     y = y_iris
@@ -657,6 +659,7 @@ def test_warm_start():
         assert_raise_message(ValueError, message, clf.fit, X, y_i)
 
 
+@ignore_warnings(category=FutureWarning)
 def test_warm_start_full():
     # Test to make sure it is fitting for more than 1 iteration
     X = Xboston
@@ -664,7 +667,8 @@ def test_warm_start_full():
 
     mlp = MLPRegressor(solver='adam', max_iter=150, hidden_layer_sizes=50,
                        random_state=1, warm_start='full')
-    mlp.fit(X, y)
+    with ignore_warnings(category=ConvergenceWarning):
+        mlp.fit(X, y)
 
     assert mlp.score(X, y) > -4.
 

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -23,8 +23,9 @@ from sklearn.neural_network import MLPRegressor
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.preprocessing import StandardScaler, MinMaxScaler
 from scipy.sparse import csr_matrix
-from sklearn.utils.testing import assert_raises, ignore_warnings
-from sklearn.utils.testing import assert_raise_message
+from sklearn.utils.testing import (assert_raises, assert_greater, assert_equal,
+                                   assert_false, ignore_warnings)
+from sklearn.utils.testing import assert_raise_message, assert_warns_message
 
 
 ACTIVATION_TYPES = ["identity", "logistic", "tanh", "relu"]
@@ -654,6 +655,27 @@ def test_warm_start():
                    'classes as in the previous call to fit.'
                    ' Previously got [0 1 2], `y` has %s' % np.unique(y_i))
         assert_raise_message(ValueError, message, clf.fit, X, y_i)
+
+
+def test_warm_start_full():
+    # Test to make sure it is fitting for more than 1 iteration
+    X = Xboston
+    y = yboston
+
+    mlp = MLPRegressor(solver='adam', max_iter=150, hidden_layer_sizes=50,
+                       random_state=1, warm_start='full')
+    mlp.fit(X, y)
+
+    assert mlp.score(X, y) > -4.
+
+
+def test_warm_start_future_warning():
+    # FutureWarning should be raised for warm_start=True in <0.22
+    message = 'The behavior of warm_start=True will change in 0.22 ' \
+              'to behave like warm_start=\'full\'. To continue ' \
+              'using the old behavior, set max_iter=1 or switch to ' \
+              'partial_fit.'
+    assert_warns_message(FutureWarning, message, MLPRegressor, warm_start=True)
 
 
 def test_n_iter_no_change():

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -672,6 +672,11 @@ def test_warm_start_full():
 
     assert mlp.n_iter_ == 10
 
+    with ignore_warnings(category=ConvergenceWarning):
+        mlp.fit(X, y)
+
+    assert mlp.n_iter_ == 20
+
 
 # FIXME remove this test in 0.23 when the behavior of warm_start changes
 def test_warm_start_future_warning():

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -23,8 +23,7 @@ from sklearn.neural_network import MLPRegressor
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.preprocessing import StandardScaler, MinMaxScaler
 from scipy.sparse import csr_matrix
-from sklearn.utils.testing import (assert_raises, assert_greater, assert_equal,
-                                   assert_false, ignore_warnings)
+from sklearn.utils.testing import assert_raises, ignore_warnings
 from sklearn.utils.testing import assert_raise_message, assert_warns_message
 
 


### PR DESCRIPTION
Addresses #12505 (continued)

This PR addresses the unexpected behavior of `warm_start` in the multilayer perceptron. To recap, the current behavior is that warm_start breaks after a single iteration. I took the first steps of changing this by:
* Reworking the MLP classes to support the change
* Adding an option `warm_start='full'` to represent the future behavior
* Raising a FutureWarning for `warm_start=True` that it will be changed in 0.22

There are two FIXMEs in the file that indicate the very simple changes required to make the transition in 0.22 (just remove the warning and remove an if statement condition). I tested making those 0.22 changes and it works as intended. Lastly, I added 2 tests: one for the FutureWarning and one for the new `warm_start='full'` option.

Please let me know also if I got the futurewarning/deprecation stuff right.

@jnothman tagging you again

Edit: The test that's failing is because the FutureWarning I added is getting raised.
Edit 2: fixed tests