### PR TITLE
[MRG + 2] Print train scores in _fit_and_score

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -79,6 +79,16 @@ Support for Python 3.4 and below has been officially dropped.
   metrics such as recall, specificity, fall out and miss rate.
   :issue:`11179` by :user:`Shangwu Yao <ShangwuYao>` and `Joel Nothman`_.
 
+:mod:`sklearn.model_selection`
+......................
+
+- |Enhancement| Method :func:`_fit_and_score` now prints train_scores when
+  `return_train_scores` is True and `verbose` > 2.
+  :issue:`12613` by :user:`Marc Torrellas <marctorrellas>`.
+
+- |API| Additional tests for :func:`_fit_and_score` and :func:`_score`.
+  :issue:`12613` by :user:`Marc Torrellas <marctorrellas>`.
+
 :mod:`sklearn.neighbors`
 ........................
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -86,9 +86,6 @@ Support for Python 3.4 and below has been officially dropped.
   `return_train_scores` is True and `verbose` > 2.
   :issue:`12613` by :user:`Marc Torrellas <marctorrellas>`.
 
-- |API| Additional tests for :func:`_fit_and_score` and :func:`_score`.
-  :issue:`12613` by :user:`Marc Torrellas <marctorrellas>`.
-
 :mod:`sklearn.neighbors`
 ........................
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -504,7 +504,6 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
 
     is_multimetric = not callable(scorer)
     n_scorers = len(scorer.keys()) if is_multimetric else 1
-
     try:
         if y_train is None:
             estimator.fit(X_train, **fit_params)
@@ -551,24 +550,23 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         # _score will return dict if is_multimetric is True
         test_scores = _score(estimator, X_test, y_test, scorer, is_multimetric)
         score_time = time.time() - start_time - fit_time
-        if return_train_score or verbose > 3:
+        if return_train_score:
             train_scores = _score(estimator, X_train, y_train, scorer,
                                   is_multimetric)
-    if verbose > 3:
+    if verbose > 2:
         if is_multimetric:
-            for scorer_name in train_scores:
+            for scorer_name, test_score in test_scores.items():
                 msg += ", %s=" % scorer_name
-                msg += "(train=%.3f, test=%.3f)" % (train_scores[scorer_name],
-                                                    test_scores[scorer_name])
+                if return_train_score:
+                    msg += "(train=%.3f," % train_scores[scorer_name]
+                    msg += " test=%.3f)" % test_score
+                else:
+                    msg += "%.3f" % test_score
         else:
-            msg += ", score=(train=%.3f, test=%.3f)" % (train_scores,
-                                                        test_scores)
-    elif verbose > 2:
-        if is_multimetric:
-            for scorer_name, score in test_scores.items():
-                msg += ", %s=%.3f" % (scorer_name, score)
-        else:
-            msg += ", score=%.3f" % test_scores
+            msg += ", score="
+            msg += ("%.3f" % test_scores if not return_train_score else
+                    "(train=%.3f, test=%.3f)" % (train_scores, test_scores))
+
     if verbose > 1:
         total_time = score_time + fit_time
         end_msg = "%s, total=%s" % (msg, logger.short_format_time(total_time))
@@ -600,14 +598,8 @@ def _score(estimator, X_test, y_test, scorer, is_multimetric=False):
             score = scorer(estimator, X_test)
         else:
             score = scorer(estimator, X_test, y_test)
-
         if hasattr(score, 'item'):
-            try:
-                # e.g. unwrap memmapped scalars
-                score = score.item()
-            except ValueError:
-                # non-scalar?
-                pass
+            score = score.item()
 
         if not isinstance(score, numbers.Number):
             raise ValueError("scoring must return a number, got %s (%s) "

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -559,9 +559,10 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
             for scorer_name in train_scores:
                 msg += ", %s=" % scorer_name
                 msg += "(train=%.3f, test=%.3f)" % (train_scores[scorer_name],
-                                                test_scores[scorer_name])
+                                                    test_scores[scorer_name])
         else:
-            msg += ", score=(train=%s, test=%.3f)" % (train_scores, test_scores)
+            msg += ", score=(train=%.3f, test=%.3f)" % (train_scores,
+                                                        test_scores)
     elif verbose > 2:
         if is_multimetric:
             for scorer_name, score in test_scores.items():

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -555,13 +555,13 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
                                   is_multimetric)
     if verbose > 2:
         if is_multimetric:
-            for scorer_name, test_score in test_scores.items():
+            for scorer_name in sorted(test_scores):
                 msg += ", %s=" % scorer_name
                 if return_train_score:
                     msg += "(train=%.3f," % train_scores[scorer_name]
-                    msg += " test=%.3f)" % test_score
+                    msg += " test=%.3f)" % test_scores[scorer_name]
                 else:
-                    msg += "%.3f" % test_score
+                    msg += "%.3f" % test_scores[scorer_name]
         else:
             msg += ", score="
             msg += ("%.3f" % test_scores if not return_train_score else

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -598,8 +598,14 @@ def _score(estimator, X_test, y_test, scorer, is_multimetric=False):
             score = scorer(estimator, X_test)
         else:
             score = scorer(estimator, X_test, y_test)
+
         if hasattr(score, 'item'):
-            score = score.item()
+            try:
+                # e.g. unwrap memmapped scalars
+                score = score.item()
+            except ValueError:
+                # non-scalar?
+                pass
 
         if not isinstance(score, numbers.Number):
             raise ValueError("scoring must return a number, got %s (%s) "

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -551,23 +551,23 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         # _score will return dict if is_multimetric is True
         test_scores = _score(estimator, X_test, y_test, scorer, is_multimetric)
         score_time = time.time() - start_time - fit_time
-        if return_train_score:
+        if return_train_score or verbose > 3:
             train_scores = _score(estimator, X_train, y_train, scorer,
                                   is_multimetric)
     if verbose > 3:
         if is_multimetric:
             for scorer_name in train_scores:
                 msg += ", %s=" % scorer_name
-                msg += "(train=%s, test=%s)" % (train_scores[scorer_name],
+                msg += "(train=%.3f, test=%.3f)" % (train_scores[scorer_name],
                                                 test_scores[scorer_name])
         else:
-            msg += ", score=(train=%s, test=%s)" % (train_scores, test_scores)
+            msg += ", score=(train=%s, test=%.3f)" % (train_scores, test_scores)
     elif verbose > 2:
         if is_multimetric:
             for scorer_name, score in test_scores.items():
-                msg += ", %s=%s" % (scorer_name, score)
+                msg += ", %s=%.3f" % (scorer_name, score)
         else:
-            msg += ", score=%s" % test_scores
+            msg += ", score=%.3f" % test_scores
     if verbose > 1:
         total_time = score_time + fit_time
         end_msg = "%s, total=%s" % (msg, logger.short_format_time(total_time))

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -554,8 +554,15 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         if return_train_score:
             train_scores = _score(estimator, X_train, y_train, scorer,
                                   is_multimetric)
-
-    if verbose > 2:
+    if verbose > 3:
+        if is_multimetric:
+            for scorer_name in train_scores:
+                msg += ", %s=" % scorer_name
+                msg += "(train=%s, test=%s)" % (train_scores[scorer_name],
+                                                test_scores[scorer_name])
+        else:
+            msg += ", score=(train=%s, test=%s)" % (train_scores, test_scores)
+    elif verbose > 2:
         if is_multimetric:
             for scorer_name, score in test_scores.items():
                 msg += ", %s=%s" % (scorer_name, score)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1581,7 +1581,7 @@ def test_fit_and_score_verbosity(capsys, return_train_score, scorer, expected):
 
 
 def test_score():
-    error_message = "scoring must return a number, got None (<class 'NoneType'"
+    error_message = "scoring must return a number, got None"
 
     def two_params_scorer(estimator, X_test):
         return None

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -29,7 +29,7 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.mocking import CheckingClassifier, MockDataFrame
 
-from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import cross_val_score, ShuffleSplit
 from sklearn.model_selection import cross_val_predict
 from sklearn.model_selection import cross_validate
 from sklearn.model_selection import permutation_test_score
@@ -44,6 +44,7 @@ from sklearn.model_selection import learning_curve
 from sklearn.model_selection import validation_curve
 from sklearn.model_selection._validation import _check_is_permutation
 from sklearn.model_selection._validation import _fit_and_score
+from sklearn.model_selection._validation import _score
 
 from sklearn.datasets import make_regression
 from sklearn.datasets import load_boston
@@ -1477,7 +1478,7 @@ def test_permutation_test_score_pandas():
         permutation_test_score(clf, X_df, y_ser)
 
 
-def test_fit_and_score():
+def test_fit_and_score_failing():
     # Create a failing classifier to deliberately fail
     failing_clf = FailingClassifier(FailingClassifier.FAILING_PARAMETER)
     # dummy X data
@@ -1537,3 +1538,48 @@ def test_fit_and_score():
                          error_score='unvalid-string')
 
     assert_equal(failing_clf.score(), 0.)  # FailingClassifier coverage
+
+
+def test_fit_and_score_working():
+    X, y = make_classification(n_samples=30, random_state=0)
+    clf = SVC(kernel="linear", random_state=0)
+    train, test = next(ShuffleSplit().split(X))
+    # Test return_parameters option
+    fit_and_score_args = [clf, X, y, dict(), train, test, 0]
+    fit_and_score_kwargs = {'parameters': {'max_iter': 100, 'tol': 0.1},
+                            'fit_params': None,
+                            'return_parameters': True}
+    result = _fit_and_score(*fit_and_score_args,
+                            **fit_and_score_kwargs)
+    assert result[-1] == fit_and_score_kwargs['parameters']
+
+
+def test_fit_and_score_verbosity(capsys):
+    X, y = make_classification(n_samples=30, random_state=0)
+    clf = SVC(kernel="linear", random_state=0)
+    train, test = next(ShuffleSplit().split(X))
+
+    def scorer(i, j, k):
+        return 3.4213
+    fit_and_score_args = [clf, X, y, scorer, train, test, 10, None, None]
+    _fit_and_score(*fit_and_score_args)
+    out, _ = capsys.readouterr()
+    assert out.split('\n')[1] == ("[CV] .................................... "
+                                  ", score=3.421, total=   0.0s")
+    fit_and_score_kwargs = {'return_train_score': True}
+    _fit_and_score(*fit_and_score_args, **fit_and_score_kwargs)
+    out, _ = capsys.readouterr()
+    # these dots could be generated as in the script?
+    assert out.split('\n')[1] == ("[CV] ................ "
+                                  ", score=(train=3.421, test=3.421), "
+                                  "total=   0.0s")
+
+
+def test_score():
+    error_message = "scoring must return a number, got None (<class 'NoneType'"
+
+    def scorer(estimator, X_test):
+        return None
+    fit_and_score_args = [None, None, None, scorer]
+    assert_raise_message(ValueError, error_message,
+                         _score, *fit_and_score_args)


### PR DESCRIPTION
This small feature was first mentioned (afaik) in Issue [#12598](https://github.com/scikit-learn/scikit-learn/issues/12598)

#### What does this implement/fix? Explain your changes.

It is a simple change in `_fit_and_score` allowing to print both train and test scores. This is used for different purposes: cross-validation (with any kind of splitter: Kfold, etc), grid/random search, learning curves. I also modified the format so that 3 decimals places are printed only

#### Any other comments?

There was no documentation for the different verbosity levels, so I left the docstring untouched. Happy to explain what the different levels print if required
