### PR TITLE
[MRG] Fixed randomness of test_logreg_cv_penalty

### DIFF
--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1152,12 +1152,15 @@ def test_logreg_l1_sparse_data():
 @pytest.mark.filterwarnings('ignore: You should specify a value')  # 0.22
 def test_logreg_cv_penalty():
     # Test that the correct penalty is passed to the final fit.
-    X, y = make_classification(n_samples=50, n_features=20, random_state=0)
-    lr_cv = LogisticRegressionCV(penalty="l1", Cs=[1.0], solver='saga')
+    rng = np.random.RandomState(6)
+    X, y = make_classification(n_samples=50, n_features=20, random_state=rng)
+    lr_cv = LogisticRegressionCV(penalty="l2", Cs=[1.0], solver='saga',
+                                 random_state=rng)
     lr_cv.fit(X, y)
-    lr = LogisticRegression(penalty="l1", C=1.0, solver='saga')
+    lr = LogisticRegression(penalty="l2", C=1.0, solver='saga',
+                            random_state=rng)
     lr.fit(X, y)
-    assert_equal(np.count_nonzero(lr_cv.coef_), np.count_nonzero(lr.coef_))
+    assert_array_almost_equal(lr_cv.coef_, lr.coef_, decimal=3)
 
 
 def test_logreg_predict_proba_multinomial():

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1150,19 +1150,24 @@ def test_logreg_l1_sparse_data():
 
 @pytest.mark.filterwarnings('ignore: Default multi_class will')  # 0.22
 @pytest.mark.filterwarnings('ignore: You should specify a value')  # 0.22
-def test_logreg_cv_penalty():
+@pytest.mark.parametrize('penalty', ('l1', 'l2'))
+def test_logreg_cv_penalty(penalty):
     # Test that the correct penalty is passed to the final fit.
-    rng = np.random.RandomState(6)
-    X, y = make_classification(n_samples=50, n_features=20, random_state=rng)
-    lr_cv = LogisticRegressionCV(penalty="l2", Cs=[1.0], solver='saga',
-                                 random_state=rng)
+    random_state = 0
+    X, y = make_classification(n_samples=50, n_features=20,
+                               random_state=random_state)
+    lr_cv = LogisticRegressionCV(penalty=penalty, Cs=[1.0], solver='saga',
+                                 random_state=random_state)
     lr_cv.fit(X, y)
-    lr = LogisticRegression(penalty="l2", C=1.0, solver='saga',
-                            random_state=rng)
+    lr = LogisticRegression(penalty=penalty, C=1.0, solver='saga',
+                            random_state=random_state)
     lr.fit(X, y)
     # Note: due to warm-starting in LogisticRegressionCV, it is normal to
     # observe slightly different coefficient values
-    assert_array_almost_equal(lr_cv.coef_, lr.coef_, decimal=3)
+    if penalty == 'l2':
+        assert_array_almost_equal(lr_cv.coef_, lr.coef_, decimal=3)
+    else:
+        assert_equal(np.count_nonzero(lr_cv.coef_), np.count_nonzero(lr.coef_))
 
 
 def test_logreg_predict_proba_multinomial():

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1160,6 +1160,8 @@ def test_logreg_cv_penalty():
     lr = LogisticRegression(penalty="l2", C=1.0, solver='saga',
                             random_state=rng)
     lr.fit(X, y)
+    # Note: due to warm-starting in LogisticRegressionCV, it is normal to
+    # observe slightly different coefficient values
     assert_array_almost_equal(lr_cv.coef_, lr.coef_, decimal=3)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

In `test_logistic.py`, the test `test_log_reg_cv_penalty` randomly fails.
Setting an rng seed to 6 will make it fail invariably:

```python
@pytest.mark.filterwarnings('ignore: Default multi_class will')  # 0.22
@pytest.mark.filterwarnings('ignore: You should specify a value')  # 0.22
def test_logreg_cv_penalty():
    # Test that the correct penalty is passed to the final fit.
    rng = np.random.RandomState(6)
    X, y = make_classification(n_samples=50, n_features=20, random_state=rng)
    lr_cv = LogisticRegressionCV(penalty="l1", Cs=[1.0], solver='saga',
                                 random_state=rng)
    lr_cv.fit(X, y)
    lr = LogisticRegression(penalty="l1", C=1.0, solver='saga',
                            random_state=rng)
    lr.fit(X, y)
    assert_equal(np.count_nonzero(lr_cv.coef_), np.count_nonzero(lr.coef_))
```

This PR sets a RNG, changes the penalty from l1 to l2, and checks that the coefficients are almost equal instead of checking the sparsity of the coefficients with l1.

Note: I tried keeping the initial loss l1, but with `rng = np.random.RandomState(6)` the coefficients would still be slightly different and the tests would fail. I think this is because the RNG is consumed differently in `LogisticRegression` and in `LogisticRegressionCV`

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
