### PR TITLE
fix check_array dtype check for pandas series

### DIFF
--- a/doc/whats_new/_contributors.rst
+++ b/doc/whats_new/_contributors.rst
@@ -48,7 +48,7 @@
 
 .. _Bertrand Thirion: https://team.inria.fr/parietal/bertrand-thirions-page
 
-.. _Andreas Müller: https://peekaboo-vision.blogspot.com/
+.. _Andreas Müller: https://amueller.github.io/
 
 .. _Matthieu Perrot: http://brainvisa.info/biblio/lnao/en/Author/PERROT-M.html
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -177,7 +177,7 @@ Changelog
   :class:`decomposition.IncrementalPCA` when using float32 datasets.
   :issue:`12338` by :user:`bauks <bauks>`.
 
-- |Fix| Calling :func:`utils.check_array` on pandas `Series`, which
+- |Fix| Calling :func:`utils.check_array` on `pandas.Series`, which
   raised an error in 0.20.0, now returns the expected output again.
   :issue:`12625` by `Andreas Müller`_
   

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -176,6 +176,10 @@ Changelog
   precision issues in :class:`preprocessing.StandardScaler` and
   :class:`decomposition.IncrementalPCA` when using float32 datasets.
   :issue:`12338` by :user:`bauks <bauks>`.
+
+- |Fix| Calling :func:`utils.check_array` on pandas `Series`, which
+  raised an error in 0.20.0, now returns the expected output again.
+  :issue:`12625` by `Andreas Müller`_
   
 Miscellaneous
 .............

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -694,6 +694,12 @@ def test_suppress_validation():
     assert_raises(ValueError, assert_all_finite, X)
 
 
+def test_check_array_series():
+    # regression test that check_array works on pandas Series
+    pd = importorskip("pandas")
+    check_array(pd.Series([1, 2, 3]), ensure_2d=False, warn_on_dtype=True)
+
+
 def test_check_dataframe_warns_on_dtype():
     # Check that warn_on_dtype also works for DataFrames.
     # https://github.com/scikit-learn/scikit-learn/issues/10948

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -697,7 +697,8 @@ def test_suppress_validation():
 def test_check_array_series():
     # regression test that check_array works on pandas Series
     pd = importorskip("pandas")
-    check_array(pd.Series([1, 2, 3]), ensure_2d=False, warn_on_dtype=True)
+    res = check_array(pd.Series([1, 2, 3]), ensure_2d=False, warn_on_dtype=True)
+    assert_array_equal(res, np.array([1, 2, 3]))
 
 
 def test_check_dataframe_warns_on_dtype():

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -697,7 +697,8 @@ def test_suppress_validation():
 def test_check_array_series():
     # regression test that check_array works on pandas Series
     pd = importorskip("pandas")
-    res = check_array(pd.Series([1, 2, 3]), ensure_2d=False, warn_on_dtype=True)
+    res = check_array(pd.Series([1, 2, 3]), ensure_2d=False,
+                      warn_on_dtype=True)
     assert_array_equal(res, np.array([1, 2, 3]))
 
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -478,6 +478,7 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
     # DataFrame), and store them. If not, store None.
     dtypes_orig = None
     if hasattr(array, "dtypes") and hasattr(array, "__array__"):
+        # ndmin in case dtypes is a scalar (for Series)
         dtypes_orig = np.array(array.dtypes, ndmin=1)
 
     if dtype_numeric:

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -477,9 +477,8 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
     # check if the object contains several dtypes (typically a pandas
     # DataFrame), and store them. If not, store None.
     dtypes_orig = None
-    if hasattr(array, "dtypes") and hasattr(array, "__array__"):
-        # ndmin in case dtypes is a scalar (for Series)
-        dtypes_orig = np.array(array.dtypes, ndmin=1)
+    if hasattr(array, "dtypes") and len(array.dtypes):
+        dtypes_orig = np.array(array.dtypes)
 
     if dtype_numeric:
         if dtype_orig is not None and dtype_orig.kind == "O":

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -478,7 +478,7 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
     # DataFrame), and store them. If not, store None.
     dtypes_orig = None
     if hasattr(array, "dtypes") and hasattr(array, "__array__"):
-        dtypes_orig = np.array(array.dtypes)
+        dtypes_orig = np.array(array.dtypes, ndmin=1)
 
     if dtype_numeric:
         if dtype_orig is not None and dtype_orig.kind == "O":


### PR DESCRIPTION

#### Reference Issues/PRs
Example: Fixes #12622

#### What does this implement/fix? Explain your changes.
Can't call set on zero-ndim array.

does this need a whatsnew? probably?