### PR TITLE
BLD PyPy needs joblib

### DIFF
--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -19,7 +19,7 @@ python --version
 which python
 
 pip install --extra-index https://antocuni.github.io/pypy-wheels/ubuntu numpy Cython pytest
-pip install "scipy>=1.1.0" sphinx numpydoc docutils
+pip install "scipy>=1.1.0" sphinx numpydoc docutils joblib
 
 ccache -M 512M
 export CCACHE_COMPRESS=1


### PR DESCRIPTION
The PyPy build needs joblib to run doctests in documentation. See current failure at https://circleci.com/gh/scikit-learn/scikit-learn/38663?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification