### PR TITLE
[WIP] pairwise_distances(X) should always have 0 diagonal  intial commit

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -251,7 +251,10 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
     distances += YY
     np.maximum(distances, 0, out=distances)
 
-    distances = _set_diagonal_pairwise(distances, X, Y)
+    if X is Y:
+        # Ensure that distances between vectors and themselves are set to 0.0.
+        # This may not be the case due to floating point rounding errors.
+        distances.flat[::distances.shape[0] + 1] = 0.0
 
     return distances if squared else np.sqrt(distances, out=distances)
 
@@ -543,7 +546,11 @@ def cosine_distances(X, Y=None):
     S *= -1
     S += 1
     np.clip(S, 0, 2, out=S)
-    return _set_diagonal_pairwise(S, X, Y)
+    if X is Y or Y is None:
+        # Ensure that distances between vectors and themselves are set to 0.0.
+        # This may not be the case due to floating point rounding errors.
+        S[np.diag_indices_from(S)] = 0.0
+    return S
 
 
 # Paired distances

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1295,8 +1295,13 @@ def _set_diagonal_pairwise(distances, X, Y):
         A distance matrix D.
     """
     if Y is None or X is Y:
+        if not np.allclose(distances[np.diag_indices(X.shape[0])], 0.0):
+            warnings.warn("The specified metric is not a valid dissimilarity "
+                          "metric; it does not return metric(x, x) == 0 for "
+                          "some values. In version 0.23, the diagonal of "
+                          "pairwise_distances(X) will be set to 0.",
+                          FutureWarning)
         np.fill_diagonal(distances, 0.0)
-
     return distances
 
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1284,6 +1284,27 @@ def pairwise_distances_chunked(X, Y=None, reduce_func=None,
         yield D_chunk
 
 
+def set_diagonal_pairwise(distances, X, Y):
+    """Set the diagonal of unary pairwise distance to 0. This ensure that
+    the distances between themselves are always 0.0.
+
+    Parameters
+    ----------
+    X : array [n_samples_a, n_samples_a]
+        Array of pairwise distances between samples, or a feature array.
+
+    Y : array [n_samples_b, n_features]
+        Second feature array
+
+    distances : array [n_samples_a, n_samples_a] or [n_samples_a, n_samples_b]
+        A distance matrix D.
+    """
+    if Y is None or X is Y:
+        np.fill_diagonal(distances, 0)
+
+    return distances
+
+
 def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=None, **kwds):
     """ Compute the distance matrix from a vector array X and optional Y.
 
@@ -1400,7 +1421,9 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=None, **kwds):
                                                       **kwds))
         func = partial(distance.cdist, metric=metric, **kwds)
 
-    return _parallel_pairwise(X, Y, func, n_jobs, **kwds)
+    return set_diagonal_pairwise(
+        _parallel_pairwise(X, Y, func, n_jobs, **kwds),
+        X, Y)
 
 
 # These distances recquire boolean arrays, when using scipy.spatial.distance

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -484,7 +484,7 @@ def check_pairwise_distances_chunked(X, Y, working_memory, metric='euclidean'):
     S = pairwise_distances(X, Y, metric=metric)
     assert_array_almost_equal(blockwise_distances, S)
 
-
+@ignore_warnings
 @pytest.mark.parametrize(
         'metric',
         ('euclidean', 'manhattan', 'cosine'))
@@ -495,7 +495,7 @@ def test_pairwise_distances_diagonal(metric):
         pairwise_distances(X, metric=metric)[np.diag_indices(X.shape[0])]
         )
 
-
+@ignore_warnings
 @pytest.mark.parametrize(
         'metric',
         ('euclidean', 'l2', 'sqeuclidean'))

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -501,7 +501,7 @@ def test_pairwise_distances_diagonal(metric):
         ('euclidean', 'l2', 'sqeuclidean'))
 def test_pairwise_distances_chunked_diagonal(metric):
     rng = np.random.RandomState(0)
-    X = rng.normal(size=(1000, 10), )
+    X = rng.normal(size=(1000, 10))
     chunks = list(pairwise_distances_chunked(X, working_memory=1,
                                              metric=metric))
     assert len(chunks) > 1

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -490,7 +490,7 @@ def check_pairwise_distances_chunked(X, Y, working_memory, metric='euclidean'):
         ('euclidean', 'manhattan', 'cosine'))
 def test_pairwise_distances_diagonal(metric):
     rng = np.random.RandomState(0)
-    X = rng.normal(size=(1000, 10), scale=1e10)
+    X = rng.normal(size=(1000, 10))
     assert not np.any(
         pairwise_distances(X, metric=metric)[np.diag_indices(X.shape[0])]
         )
@@ -501,7 +501,7 @@ def test_pairwise_distances_diagonal(metric):
         ('euclidean', 'l2', 'sqeuclidean'))
 def test_pairwise_distances_chunked_diagonal(metric):
     rng = np.random.RandomState(0)
-    X = rng.normal(size=(1000, 10), scale=1e10)
+    X = rng.normal(size=(1000, 10), )
     chunks = list(pairwise_distances_chunked(X, working_memory=1,
                                              metric=metric))
     assert len(chunks) > 1

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -484,31 +484,30 @@ def check_pairwise_distances_chunked(X, Y, working_memory, metric='euclidean'):
     S = pairwise_distances(X, Y, metric=metric)
     assert_array_almost_equal(blockwise_distances, S)
 
-@ignore_warnings
+
 @pytest.mark.parametrize(
         'metric',
         ('euclidean', 'manhattan', 'cosine'))
 def test_pairwise_distances_diagonal(metric):
     rng = np.random.RandomState(0)
-    X = rng.normal(size=(1000, 10))
+    X = rng.normal(size=(1000, 10), scale=1e10)
     assert not np.any(
         pairwise_distances(X, metric=metric)[np.diag_indices(X.shape[0])]
         )
 
-@ignore_warnings
+
 @pytest.mark.parametrize(
         'metric',
         ('euclidean', 'l2', 'sqeuclidean'))
 def test_pairwise_distances_chunked_diagonal(metric):
     rng = np.random.RandomState(0)
-    X = rng.normal(size=(1000, 10))
+    X = rng.normal(size=(1000, 10), scale=1e10)
     chunks = list(pairwise_distances_chunked(X, working_memory=1,
                                              metric=metric))
     assert len(chunks) > 1
     assert_array_almost_equal(np.diag(np.vstack(chunks)), 0, decimal=10)
 
 
-@ignore_warnings
 def test_pairwise_distances_chunked():
     # Test the pairwise_distance helper function.
     rng = np.random.RandomState(0)

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -487,6 +487,17 @@ def check_pairwise_distances_chunked(X, Y, working_memory, metric='euclidean'):
 
 @pytest.mark.parametrize(
         'metric',
+        ('euclidean', 'manhattan', 'cosine'))
+def test_pairwise_distances_diagonal(metric):
+    rng = np.random.RandomState(0)
+    X = rng.normal(size=(1000, 10), scale=1e10)
+    assert not np.any(
+        pairwise_distances(X, metric=metric)[np.diag_indices(X.shape[0])]
+        )
+
+
+@pytest.mark.parametrize(
+        'metric',
         ('euclidean', 'l2', 'sqeuclidean'))
 def test_pairwise_distances_chunked_diagonal(metric):
     rng = np.random.RandomState(0)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

Fix #12628
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
I Add a method `set_diagonal_pairwise(distances, X, Y)` that will check if the conditions are met and then set diagonal to 0.0 using: `np.fill_diagonal` (https://github.com/scikit-learn/scikit-learn/issues/12628#issuecomment-440648630)

I decided create a method to don't add logical code to the methods.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
