### PR TITLE
don't set check_pickle on new joblib on python2.7

### DIFF
--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -439,11 +439,12 @@ class KNeighborsMixin(object):
                 raise ValueError(
                     "%s does not work with sparse matrices. Densify the data, "
                     "or set algorithm='brute'" % self._fit_method)
-            if (sys.version_info < (3,) or
-                    LooseVersion(joblib_version) < LooseVersion('0.12')):
+            old_joblib = LooseVersion(joblib_version) < LooseVersion('0.12')
+            if sys.version_info < (3,) or old_joblib:
                 # Deal with change of API in joblib
+                check_pickle = False if old_joblib else None
                 delayed_query = delayed(_tree_query_parallel_helper,
-                                        check_pickle=False)
+                                        check_pickle=check_pickle)
                 parallel_kwargs = {"backend": "threading"}
             else:
                 delayed_query = delayed(_tree_query_parallel_helper)


### PR DESCRIPTION
Fixes #12643.

too late/cold here for a non-regression test, also not sure if we test that combination anywhere.