### PR TITLE
[MRG] EXA remove unused start_date/end_date variables

### DIFF
--- a/examples/applications/plot_stock_market.py
+++ b/examples/applications/plot_stock_market.py
@@ -85,8 +85,6 @@ print(__doc__)
 # that we get high-tech firms, and before the 2008 crash). This kind of
 # historical data can be obtained for from APIs like the quandl.com and
 # alphavantage.co ones.
-start_date = datetime(2003, 1, 1).date()
-end_date = datetime(2008, 1, 1).date()
 
 symbol_dict = {
     'TOT': 'Total',


### PR DESCRIPTION
The financial data comes from CSVs that cover 2003-01-01 to 2007-12-31. For example, here is the [Apple data](https://github.com/scikit-learn/examples-data/blob/master/financial-data/AAPL.csv)

Historic note: because there were troubles with finding a website that gives us financial data after the Google finance URL shut down we ended up having a copy of the CSV in the `scikit-learn/examples-data` repo. More details: https://github.com/scikit-learn/scikit-learn/pull/10958.
