### PR TITLE
Add sparse handling for 'type_of_target'

### DIFF
--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -11,8 +11,7 @@ from itertools import chain
 
 from scipy.sparse import issparse
 from scipy.sparse.base import spmatrix
-from scipy.sparse import dok_matrix
-from scipy.sparse import lil_matrix
+from scipy.sparse import dok_matrix, lil_matrix, bsr_matrix, dia_matrix
 
 import numpy as np
 
@@ -253,7 +252,8 @@ def type_of_target(y):
         # don't transform sparse matrix
         sparse_flag = issparse(y)
         if sparse_flag:
-            if isinstance(y, (dok_matrix, lil_matrix)):
+            if isinstance(y, (dok_matrix, lil_matrix, 
+                              dia_matrix, bsr_matrix)):
                 y = y.tocsr()
         else:
             y = np.asarray(y)
@@ -279,7 +279,7 @@ def type_of_target(y):
 
     if y.ndim == 2 and y.shape[1] == 0:
         return 'unknown'  # [[]]
-    
+
     if y.ndim == 2 and y.shape[1] > 1:
         suffix = "-multioutput"  # [[1, 2], [1, 2]]
     else:
@@ -291,12 +291,13 @@ def type_of_target(y):
             # [.1, .2, 3] or [[.1, .2, 3]] or [[1., .2]] and not [1., 2., 3.]
             return 'continuous' + suffix
 
-        # check if there are zero values for unique value count (do not show up in y.data)
+        # check if there are zero values for unique value count
         add = 0
         if y.nnz != (y.shape[0]*y.shape[1]):
             add = 1
-        
-        if (len(np.unique(y.data))+add > 2) or (y.ndim >= 2 and y[0].shape[1] > 1):
+
+        if (len(np.unique(y.data))+add > 2) or 
+           (y.ndim >= 2 and y[0].shape[1] > 1):
             return 'multiclass' + suffix  # [1, 2, 3] or [[1., 2., 3]] or [[1, 2]]
         else:
             return 'binary'  # [1, 2] or [["a"], ["b"]]

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -250,7 +250,11 @@ def type_of_target(y):
         return 'multilabel-indicator'
 
     try:
-        y = np.asarray(y)
+        # handle sparse output matrices
+        if issparse(y):
+            y = y.toarray()
+        else:
+            y = np.asarray(y)
     except ValueError:
         # Known to fail in numpy 1.3 for array of arrays
         return 'unknown'


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
When using check_classification_targets, a call to type_of_target is made. If the target vector
is a sparse matrix, either single or multi-class, type_of_target will fail because it uses
np.asarray to convert the sparse matrix, which wraps the sparse matrix object in an array
rather than converting. This change checks if the matrix is sparse and uses the correct
.toarray() method to convert it to a normal numpy array. Everything else is left the same.

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
