### PR TITLE
[MRG] improving examples/mixture/plot_gmm_covariances.py visualisation

### DIFF
--- a/examples/mixture/plot_gmm_covariances.py
+++ b/examples/mixture/plot_gmm_covariances.py
@@ -64,6 +64,7 @@ def make_ellipses(gmm, ax):
         ell.set_clip_box(ax.bbox)
         ell.set_alpha(0.5)
         ax.add_artist(ell)
+        ax.set_aspect('equal', 'datalim')
 
 iris = datasets.load_iris()
 


### PR DESCRIPTION
#### Reference Issues/PRs

This is a one line patch to make ratio equals when visualizing the four plots in plot_gmm_covariances.py.
Before the patch, the "spherical" case is visualized in a way that make the covariances appear non-spherical (top left image). This is confusing w.r.t. the name of the plot, and could lead to users misunderstanding.

#### What does this implement/fix? Explain your changes.
Adding the following line:

ax.set_aspect('equal', 'datalim')

solved the problem, and make spheres appearing as spheres (not as ellipsoids) where needed. Also this improved readability of the global figure.
