### PR TITLE
Copy _make_estimator parameters

### DIFF
--- a/sklearn/ensemble/base.py
+++ b/sklearn/ensemble/base.py
@@ -5,6 +5,7 @@ Base class for ensemble-based estimators.
 # Authors: Gilles Louppe
 # License: BSD 3 clause
 
+import copy
 import numpy as np
 import numbers
 
@@ -124,7 +125,7 @@ class BaseEnsemble(six.with_metaclass(ABCMeta, BaseEstimator,
         sub-estimators.
         """
         estimator = clone(self.base_estimator_)
-        estimator.set_params(**dict((p, getattr(self, p))
+        estimator.set_params(**dict((p, copy.deepcopy(getattr(self, p)))
                                     for p in self.estimator_params))
 
         if random_state is not None:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #12623 


#### What does this implement/fix? Explain your changes.
The issue is that when trees are created by the base ensemble class, the parameters are not copied. This is problematic in the case of the criterion parameter if a Criterion object is passed in. When this happens, all the trees share the same object and mutate it. If n_jobs > 1, they are mutating the same object concurrently.  

#### Any other comments?

I couldn't think of a good test for this fix. Since the repro case causes a segfault it is hard to add a test case that doesn't cause grief.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
