### PR TITLE
[DOC] contributing.rst: add joblib to doc-build deps

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -432,7 +432,7 @@ Building the documentation
 
 Building the documentation requires installing some additional packages::
 
-    pip install sphinx sphinx-gallery numpydoc matplotlib Pillow pandas scikit-image
+    pip install sphinx sphinx-gallery numpydoc matplotlib Pillow pandas scikit-image joblib
 
 To build the documentation, you need to be in the ``doc`` folder::
 


### PR DESCRIPTION
It adds joblib to the list of `pip install`s before making the docs. 