### PR TITLE
[MRG] Adapts cdist jaccard to scipy 1.2.0

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -39,6 +39,7 @@ Changelog
 
 - |Fix| Fixed :class:`sklearn.neighbors.dist_metrics.JaccardDistance` distance
   function to return 0 when two all-zero vectors are compared.
+  :issue:`12685` by :user:`Thomas Fan <thomasjpfan>`.
 
 .. _changes_0_20_1:
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -21,8 +21,6 @@ occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
 - :mod:`sklearn.neighbors` when ``metric=='jaccard'`` (bug fix)
-- :mod:`sklearn.metrics.pairwise` when ``metric=='jaccard'` and Scipy >= 1.2.0
-  (bug fix)
 
 Changelog
 ---------

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -12,6 +12,18 @@ Version 0.20.2
 This is a bug-fix release with some minor documentation improvements and
 enhancements to features released in 0.20.0.
 
+Changed models
+--------------
+
+The following estimators and functions, when fit with the same data and
+parameters, may produce different models from the previous version. This often
+occurs due to changes in the modelling logic (bug fixes or enhancements), or in
+random sampling procedures.
+
+- :mod:`sklearn.neighbors` when ``metric=='jaccard'`` (bug fix)
+- :mod:`sklearn.metrics.pairwise` when ``metric=='jaccard'` and Scipy >= 1.2.0
+  (bug fix)
+
 Changelog
 ---------
 
@@ -22,6 +34,11 @@ Changelog
   parameter may not have been updated correctly when a step is set to ``None``
   or ``'passthrough'``. :user:`Thomas Fan <thomasjpfan>`.
 
+:mod:`sklearn.neighbors`
+........................
+
+- |Fix| Fixed :class:`sklearn.neighbors.dist_metrics.JaccardDistance` distance
+  function to return 0 when two all-zero vectors are compared.
 
 .. _changes_0_20_1:
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -37,7 +37,7 @@ Changelog
 :mod:`sklearn.neighbors`
 ........................
 
-- |Fix| Fixed :class:`sklearn.neighbors.dist_metrics.JaccardDistance` distance
+- |Fix| Fixed :class:`sklearn.neighbors.DistanceMetric` jaccard distance
   function to return 0 when two all-zero vectors are compared.
   :issue:`12685` by :user:`Thomas Fan <thomasjpfan>`.
 

--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -788,6 +788,9 @@ cdef class JaccardDistance(DistanceMetric):
             tf2 = x2[j] != 0
             nnz += (tf1 or tf2)
             n_eq += (tf1 and tf2)
+        # Based on https://github.com/scipy/scipy/pull/7373
+        # When comparing two all-zero vectors, scipy>=1.2.0 jaccard metric
+        # was changed to return 0, instead of nan.
         if nnz == 0:
             return 0
         return (nnz - n_eq) * 1.0 / nnz

--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -788,6 +788,8 @@ cdef class JaccardDistance(DistanceMetric):
             tf2 = x2[j] != 0
             nnz += (tf1 or tf2)
             n_eq += (tf1 and tf2)
+        if nnz == 0:
+            return 0
         return (nnz - n_eq) * 1.0 / nnz
 
 

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -6,6 +6,8 @@ from numpy.testing import assert_array_almost_equal
 
 import pytest
 
+from distutils.version import LooseVersion
+from scipy import __version__ as scipy_version
 from scipy.spatial.distance import cdist
 from sklearn.neighbors.dist_metrics import DistanceMetric
 from sklearn.neighbors import BallTree
@@ -101,6 +103,8 @@ def check_pdist(metric, kwargs, D_true):
 def check_pdist_bool(metric, D_true):
     dm = DistanceMetric.get_metric(metric)
     D12 = dm.pairwise(X1_bool)
+    if (metric == 'jaccard' and LooseVersion(scipy_version) < '1.2.0'):
+        D_true[np.isnan(D_true)] = 0
     assert_array_almost_equal(D12, D_true)
 
 

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -103,7 +103,7 @@ def check_pdist(metric, kwargs, D_true):
 def check_pdist_bool(metric, D_true):
     dm = DistanceMetric.get_metric(metric)
     D12 = dm.pairwise(X1_bool)
-    if (metric == 'jaccard' and LooseVersion(scipy_version) < '1.2.0'):
+    if metric == 'jaccard' and LooseVersion(scipy_version) < '1.2.0':
         D_true[np.isnan(D_true)] = 0
     assert_array_almost_equal(D12, D_true)
 

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -103,6 +103,9 @@ def check_pdist(metric, kwargs, D_true):
 def check_pdist_bool(metric, D_true):
     dm = DistanceMetric.get_metric(metric)
     D12 = dm.pairwise(X1_bool)
+    # Based on https://github.com/scipy/scipy/pull/7373
+    # When comparing two all-zero vectors, scipy>=1.2.0 jaccard metric
+    # was changed to return 0, instead of nan.
     if metric == 'jaccard' and LooseVersion(scipy_version) < '1.2.0':
         D_true[np.isnan(D_true)] = 0
     assert_array_almost_equal(D12, D_true)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #12685 


#### What does this implement/fix? Explain your changes.
Adjusts `JaccardDistance.dist` to match with scipy 1.2.0 version.

#### Any other comments?
The test `check_pdist_bool` had to be adjusted to be backwards compatible with older versions of scipy.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->