### PR TITLE
[MRG] Fix unset local variable due to missing else

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1846,10 +1846,15 @@ def _validate_shuffle_split(n_samples, test_size, train_size):
     if test_size == "default":
         test_size = 0.1
 
-    if np.asarray(test_size).dtype.kind == 'f':
+    if test_size is None:
+        pass
+    elif np.asarray(test_size).dtype.kind == 'f':
         n_test = ceil(test_size * n_samples)
     elif np.asarray(test_size).dtype.kind == 'i':
         n_test = float(test_size)
+    else:
+        raise TypeError('test_size must be of type float or integer; got '
+                        '%s' % (type(test_size)))
 
     if train_size is None:
         n_train = n_samples - n_test

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1479,6 +1479,11 @@ def test_check_cv_default_warn():
     assert_no_warnings(check_cv, cv=5)
 
 
+def test_validate_shuffle_split_type_warn():
+    assert_raises(TypeError, _validate_shuffle_split, 100, test_size='3',
+                  train_size=None)
+
+
 def test_build_repr():
     class MockSplitter:
         def __init__(self, a, b=0, c=None):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
None

#### What does this implement/fix? Explain your changes.

Add missing else clause that raises a TypeError to avoid the following UnboundLocalError error when passing a wrong type e.g. to train_test_split test_size:

File "...sklearn/model_selection/_split.py", line 1849, in _validate_shuffle_split
n_train = n_samples - n_test
UnboundLocalError: local variable 'n_test' referenced before assignment

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
