### PR TITLE
Changed joblib URL

### DIFF
--- a/doc/developers/performance.rst
+++ b/doc/developers/performance.rst
@@ -383,7 +383,7 @@ TODO: give a simple teaser example here.
 
 Checkout the official joblib documentation:
 
-- https://pythonhosted.org/joblib
+- https://joblib.readthedocs.io
 
 
 .. _warm-restarts:


### PR DESCRIPTION
Changed the joblib URL as that migrated to readthedocs.io