### PR TITLE
[MRG] FIX pairwise distances with 'seuclidean' or 'mahalanobis' metrics

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -46,6 +46,16 @@ Changelog
   data, which raised an error in 0.20.0, now returns the expected output again.
   :issue:`12699` by `Joris Van den Bossche`_.
 
+:mod:`sklearn.metrics`
+......................
+
+- |Fix| Fixed a bug in :func:`metrics.pairwise_distances` and
+  :func:`metrics.pairwise_distances_chunked` where parameters of
+  ``"seuclidean"`` and ``"mahalanobis"`` metrics need to be pre-computed
+  before the data is split into chunks. :issue:`12701` by
+  :user:`Jeremie du Boisberranger <jeremiedbb>`.
+
+
 .. _changes_0_20_1:
 
 Version 0.20.1

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -50,10 +50,10 @@ Changelog
 ......................
 
 - |Fix| Fixed a bug in :func:`metrics.pairwise_distances` and
-  :func:`metrics.pairwise_distances_chunked` where parameters of
-  ``"seuclidean"`` and ``"mahalanobis"`` metrics need to be pre-computed
-  before the data is split into chunks. :issue:`12701` by
-  :user:`Jeremie du Boisberranger <jeremiedbb>`.
+  :func:`metrics.pairwise_distances_chunked` where parameters ``V`` of
+  ``"seuclidean"`` and ``VI`` of ``"mahalanobis"`` metrics were computed after
+  the data was split into chunks instead of being pre-computed on whole data.
+  :issue:`12701` by :user:`Jeremie du Boisberranger <jeremiedbb>`.
 
 
 .. _changes_0_20_1:

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1264,6 +1264,19 @@ def pairwise_distances_chunked(X, Y=None, reduce_func=None,
                                         working_memory=working_memory)
         slices = gen_batches(n_samples_X, chunk_n_rows)
 
+    if metric == "seuclidean" and 'V' not in kwds:
+        if X is Y and effective_n_jobs(n_jobs) == 1:
+            V = np.var(X, axis=0, ddof=1)
+        else:
+            V = np.var(np.vstack([X, Y]), axis=0, ddof=1)
+        kwds.update({'V': V})
+    elif metric == "mahalanobis" and 'VI' not in kwds:
+        if X is Y and effective_n_jobs(n_jobs) == 1:
+            VI = np.linalg.inv(np.cov(X.T)).T
+        else:
+            VI = np.linalg.inv(np.cov(np.vstack([X, Y]).T)).T
+        kwds.update({'VI': VI})
+
     for sl in slices:
         if sl.start == 0 and sl.stop == n_samples_X:
             X_chunk = X  # enable optimised paths for X is Y
@@ -1394,6 +1407,19 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=None, **kwds):
 
         dtype = bool if metric in PAIRWISE_BOOLEAN_FUNCTIONS else None
         X, Y = check_pairwise_arrays(X, Y, dtype=dtype)
+
+        if metric == "seuclidean" and 'V' not in kwds:
+            if X is Y and effective_n_jobs(n_jobs) == 1:
+                V = np.var(X, axis=0, ddof=1)
+            else:
+                V = np.var(np.vstack([X, Y]), axis=0, ddof=1)
+            kwds.update({'V': V})
+        elif metric == "mahalanobis" and 'VI' not in kwds:
+            if X is Y and effective_n_jobs(n_jobs) == 1:
+                VI = np.linalg.inv(np.cov(X.T)).T
+            else:
+                VI = np.linalg.inv(np.cov(np.vstack([X, Y]).T)).T
+            kwds.update({'VI': VI})
 
         if effective_n_jobs(n_jobs) == 1 and X is Y:
             return distance.squareform(distance.pdist(X, metric=metric,

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1265,13 +1265,13 @@ def pairwise_distances_chunked(X, Y=None, reduce_func=None,
         slices = gen_batches(n_samples_X, chunk_n_rows)
 
     if metric == "seuclidean" and 'V' not in kwds:
-        if X is Y and effective_n_jobs(n_jobs) == 1:
+        if X is Y:
             V = np.var(X, axis=0, ddof=1)
         else:
             V = np.var(np.vstack([X, Y]), axis=0, ddof=1)
         kwds.update({'V': V})
     elif metric == "mahalanobis" and 'VI' not in kwds:
-        if X is Y and effective_n_jobs(n_jobs) == 1:
+        if X is Y:
             VI = np.linalg.inv(np.cov(X.T)).T
         else:
             VI = np.linalg.inv(np.cov(np.vstack([X, Y]).T)).T
@@ -1409,13 +1409,13 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=None, **kwds):
         X, Y = check_pairwise_arrays(X, Y, dtype=dtype)
 
         if metric == "seuclidean" and 'V' not in kwds:
-            if X is Y and effective_n_jobs(n_jobs) == 1:
+            if X is Y:
                 V = np.var(X, axis=0, ddof=1)
             else:
                 V = np.var(np.vstack([X, Y]), axis=0, ddof=1)
             kwds.update({'V': V})
         elif metric == "mahalanobis" and 'VI' not in kwds:
-            if X is Y and effective_n_jobs(n_jobs) == 1:
+            if X is Y:
                 VI = np.linalg.inv(np.cov(X.T)).T
             else:
                 VI = np.linalg.inv(np.cov(np.vstack([X, Y]).T)).T

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -5,8 +5,11 @@ from numpy import linalg
 
 from scipy.sparse import dok_matrix, csr_matrix, issparse
 from scipy.spatial.distance import cosine, cityblock, minkowski, wminkowski
+from scipy.spatial.distance import cdist, pdist, squareform
 
 import pytest
+
+from sklearn import set_config
 
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_array_almost_equal
@@ -893,3 +896,33 @@ def test_check_preserve_type():
                                                    XB.astype(np.float))
     assert_equal(XA_checked.dtype, np.float)
     assert_equal(XB_checked.dtype, np.float)
+
+
+@pytest.mark.parametrize("n_jobs", [1, 2, -1])
+@pytest.mark.parametrize("metric", ["seuclidean", "mahalanobis"])
+@pytest.mark.parametrize("dist_function",
+                         [pairwise_distances, pairwise_distances_chunked])
+@pytest.mark.parametrize("y_is_x", [True, False], ids=["Y==X", "Y!=X"])
+def test_pairwise_distances_data_derived_params(n_jobs, metric, dist_function,
+                                                y_is_x):
+    # check that pairwise_distances give the same result in sequential and
+    # parallel, when metric has data-derived parameters.
+    set_config(working_memory=0.1)  # to have more than 1 chunk
+
+    rng = np.random.RandomState(0)
+
+    X = rng.random_sample((1000, 10))
+
+    if y_is_x:
+        Y = X
+        if n_jobs == 1:
+            expected_dist = squareform(pdist(X, metric=metric))
+        else:
+            expected_dist = cdist(X, Y, metric=metric)
+    else:
+        Y = rng.random_sample((1000, 10))
+        expected_dist = cdist(X, Y, metric=metric)
+
+    dist = np.vstack(dist_function(X, Y, metric=metric, n_jobs=n_jobs))
+
+    assert_allclose(dist, expected_dist)

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -898,7 +898,7 @@ def test_check_preserve_type():
     assert_equal(XB_checked.dtype, np.float)
 
 
-@pytest.mark.parametrize("n_jobs", [1, 2, -1])
+@pytest.mark.parametrize("n_jobs", [1, 2])
 @pytest.mark.parametrize("metric", ["seuclidean", "mahalanobis"])
 @pytest.mark.parametrize("dist_function",
                          [pairwise_distances, pairwise_distances_chunked])
@@ -909,7 +909,6 @@ def test_pairwise_distances_data_derived_params(n_jobs, metric, dist_function,
     # parallel, when metric has data-derived parameters.
     with config_context(working_memory=0.1):  # to have more than 1 chunk
         rng = np.random.RandomState(0)
-
         X = rng.random_sample((1000, 10))
 
         if y_is_x:
@@ -928,7 +927,6 @@ def test_pairwise_distances_data_derived_params(n_jobs, metric, dist_function,
                 params = {'VI': np.linalg.inv(np.cov(np.vstack([X, Y]).T)).T}
 
         expected_dist_explicit_params = cdist(X, Y, metric=metric, **params)
-
         dist = np.vstack(dist_function(X, Y, metric=metric, n_jobs=n_jobs))
 
         assert_allclose(dist, expected_dist_explicit_params)

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -9,7 +9,7 @@ from scipy.spatial.distance import cdist, pdist, squareform
 
 import pytest
 
-from sklearn import set_config
+from sklearn import set_config, get_config
 
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_array_almost_equal
@@ -907,6 +907,7 @@ def test_pairwise_distances_data_derived_params(n_jobs, metric, dist_function,
                                                 y_is_x):
     # check that pairwise_distances give the same result in sequential and
     # parallel, when metric has data-derived parameters.
+    wm = get_config()['working_memory']
     set_config(working_memory=0.1)  # to have more than 1 chunk
 
     rng = np.random.RandomState(0)
@@ -926,3 +927,5 @@ def test_pairwise_distances_data_derived_params(n_jobs, metric, dist_function,
     dist = np.vstack(dist_function(X, Y, metric=metric, n_jobs=n_jobs))
 
     assert_allclose(dist, expected_dist)
+
+    set_config(working_memory=wm)  # reset working memory to initial value


### PR DESCRIPTION
Fixes #12672 

The issue affects `pairwise_distances` and `pairwise_distances_chunked`. When metrics params are not provided for these metrics, they are computed for each chunk of data instead of being precomputed for whole data. These two metrics are the only one with data-derived params.