### PR TITLE
DOC Clarify what the decision function in SVM calculates

### DIFF
--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -383,7 +383,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
         return X
 
     def _decision_function(self, X):
-        """Distance of the samples X to the separating hyperplane.
+        """Evaluates the decision function for the samples in X.
 
         Parameters
         ----------
@@ -528,7 +528,7 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
         return np.asarray(y, dtype=np.float64, order='C')
 
     def decision_function(self, X):
-        """Distance of the samples X to the separating hyperplane.
+        """Evaluates the decision function for the samples in X.
 
         Parameters
         ----------
@@ -541,6 +541,10 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
             in the model.
             If decision_function_shape='ovr', the shape is (n_samples,
             n_classes)
+        
+        Notes
+        ------
+        The function values are proportional to the distance of the samples X to the separating hyperplane. If the exact distances are required, divide the function values by the norm of the weight vector (``coef_``). See also `this question <https://stats.stackexchange.com/questions/14876/interpreting-distance-from-hyperplane-in-svm>`_ for further details.
         """
         dec = self._decision_function(X)
         if self.decision_function_shape == 'ovr' and len(self.classes_) > 2:

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -540,16 +540,16 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
             Returns the decision function of the sample for each class
             in the model.
             If decision_function_shape='ovr', the shape is (n_samples,
-            n_classes)
+            n_classes).
 
         Notes
         ------
-        The function values are proportional to the distance of the samples X
-        to the separating hyperplane. If the exact distances are required,
-        divide the function values by the norm of the weight vector
-        (``coef_``). See also `this question <https://stats.stackexchange.com/
-        questions/14876/interpreting-distance-from-hyperplane-in-svm>`_ for
-        further details.
+        If decision_function_shape='ovo', the function values are proportional
+        to the distance of the samples X to the separating hyperplane. If the
+        exact distances are required, divide the function values by the norm of
+        the weight vector (``coef_``). See also `this question
+        <https://stats.stackexchange.com/questions/14876/
+        interpreting-distance-from-hyperplane-in-svm>`_ for further details.
         """
         dec = self._decision_function(X)
         if self.decision_function_shape == 'ovr' and len(self.classes_) > 2:

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -541,7 +541,7 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
             in the model.
             If decision_function_shape='ovr', the shape is (n_samples,
             n_classes)
-        
+
         Notes
         ------
         The function values are proportional to the distance of the samples X

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -544,7 +544,12 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
         
         Notes
         ------
-        The function values are proportional to the distance of the samples X to the separating hyperplane. If the exact distances are required, divide the function values by the norm of the weight vector (``coef_``). See also `this question <https://stats.stackexchange.com/questions/14876/interpreting-distance-from-hyperplane-in-svm>`_ for further details.
+        The function values are proportional to the distance of the samples X
+        to the separating hyperplane. If the exact distances are required,
+        divide the function values by the norm of the weight vector
+        (``coef_``). See also `this question <https://stats.stackexchange.com/
+        questions/14876/interpreting-distance-from-hyperplane-in-svm>`_ for
+        further details.
         """
         dec = self._decision_function(X)
         if self.decision_function_shape == 'ovr' and len(self.classes_) > 2:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Strictly speaking, the decision function of an SVM does not calculate the distance to the hyperplane. Instead the function value is only proportional to this distance. Since I stumbled over this, I made this small clarification and added a note for users who need the exact distance.

If this simplification was intentional, I would suggest to keep at least the note.