### PR TITLE
MNT Deprecate assert_true and assert_false

### DIFF
--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -58,6 +58,7 @@ from sklearn.utils._joblib import joblib
 from sklearn.utils._unittest_backport import TestCase
 from sklearn.utils.fixes import signature
 
+
 additional_names_in_all = []
 try:
     from nose.tools import raises as _nose_raises
@@ -94,6 +95,7 @@ __all__.extend(additional_names_in_all)
 _dummy = TestCase('__init__')
 assert_equal = _dummy.assertEqual
 assert_not_equal = _dummy.assertNotEqual
+
 assert_raises = _dummy.assertRaises
 SkipTest = unittest.case.SkipTest
 assert_dict_equal = _dummy.assertDictEqual

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -113,12 +113,12 @@ assert_raises_regex = _dummy.assertRaisesRegex
 assert_raises_regexp = assert_raises_regex
 
 deprecation_message = "'assert_true' deprecated in version 0.21 " \
-                      "and will be removed in version 0.23. " \
+                      "and will be removed in version 0.23." \
                       "Please use 'assert' instead."
 assert_true = deprecated(deprecation_message)(_dummy.assertTrue)
 
 deprecation_message = "'assert_false' deprecated in version 0.21 " \
-                      "and will be removed in version 0.23. " \
+                      "and will be removed in version 0.23." \
                       "Please use 'assert' instead."
 assert_false = deprecated(deprecation_message)(_dummy.assertFalse)
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -113,12 +113,12 @@ assert_raises_regex = _dummy.assertRaisesRegex
 assert_raises_regexp = assert_raises_regex
 
 deprecation_message = "'assert_true' deprecated in version 0.21 " \
-                      "and will be removed in version 0.23." \
+                      "and will be removed in version 0.23. " \
                       "Please use 'assert' instead."
 assert_true = deprecated(deprecation_message)(_dummy.assertTrue)
 
 deprecation_message = "'assert_false' deprecated in version 0.21 " \
-                      "and will be removed in version 0.23." \
+                      "and will be removed in version 0.23. " \
                       "Please use 'assert' instead."
 assert_false = deprecated(deprecation_message)(_dummy.assertFalse)
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -112,11 +112,13 @@ assert_raises_regex = _dummy.assertRaisesRegex
 # the old name for now
 assert_raises_regexp = assert_raises_regex
 
-deprecation_message = "'assert_true' deprecated in version 0.21. " \
+deprecation_message = "'assert_true' deprecated in version 0.21 " \
+                      "and will be removed in version 0.23." \
                       "Please use 'assert' instead."
 assert_true = deprecated(deprecation_message)(_dummy.assertTrue)
 
-deprecation_message = "'assert_false' deprecated in version 0.21. " \
+deprecation_message = "'assert_false' deprecated in version 0.21 " \
+                      "and will be removed in version 0.23." \
                       "Please use 'assert' instead."
 assert_false = deprecated(deprecation_message)(_dummy.assertFalse)
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -58,6 +58,7 @@ from sklearn.utils._joblib import joblib
 from sklearn.utils._unittest_backport import TestCase
 from sklearn.utils.fixes import signature
 
+
 additional_names_in_all = []
 try:
     from nose.tools import raises as _nose_raises
@@ -94,8 +95,7 @@ __all__.extend(additional_names_in_all)
 _dummy = TestCase('__init__')
 assert_equal = _dummy.assertEqual
 assert_not_equal = _dummy.assertNotEqual
-assert_true = _dummy.assertTrue
-assert_false = _dummy.assertFalse
+
 assert_raises = _dummy.assertRaises
 SkipTest = unittest.case.SkipTest
 assert_dict_equal = _dummy.assertDictEqual
@@ -111,6 +111,14 @@ assert_raises_regex = _dummy.assertRaisesRegex
 # assert_raises_regex but lets keep the backward compat in scikit-learn with
 # the old name for now
 assert_raises_regexp = assert_raises_regex
+
+deprecation_message = "'assert_true' deprecated in version 0.21. " \
+                      "Please use 'assert' instead."
+assert_true = deprecated(deprecation_message)(_dummy.assertTrue)
+
+deprecation_message = "'assert_false' deprecated in version 0.21. " \
+                      "Please use 'assert' instead."
+assert_false = deprecated(deprecation_message)(_dummy.assertFalse)
 
 
 def assert_warns(warning_class, func, *args, **kw):

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -58,7 +58,6 @@ from sklearn.utils._joblib import joblib
 from sklearn.utils._unittest_backport import TestCase
 from sklearn.utils.fixes import signature
 
-
 additional_names_in_all = []
 try:
     from nose.tools import raises as _nose_raises
@@ -95,7 +94,6 @@ __all__.extend(additional_names_in_all)
 _dummy = TestCase('__init__')
 assert_equal = _dummy.assertEqual
 assert_not_equal = _dummy.assertNotEqual
-
 assert_raises = _dummy.assertRaises
 SkipTest = unittest.case.SkipTest
 assert_dict_equal = _dummy.assertDictEqual
@@ -112,12 +110,12 @@ assert_raises_regex = _dummy.assertRaisesRegex
 # the old name for now
 assert_raises_regexp = assert_raises_regex
 
-deprecation_message = "'assert_true' deprecated in version 0.21 " \
+deprecation_message = "'assert_true' is deprecated in version 0.21 " \
                       "and will be removed in version 0.23. " \
                       "Please use 'assert' instead."
 assert_true = deprecated(deprecation_message)(_dummy.assertTrue)
 
-deprecation_message = "'assert_false' deprecated in version 0.21 " \
+deprecation_message = "'assert_false' is deprecated in version 0.21 " \
                       "and will be removed in version 0.23. " \
                       "Please use 'assert' instead."
 assert_false = deprecated(deprecation_message)(_dummy.assertFalse)

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -111,12 +111,12 @@ assert_raises_regex = _dummy.assertRaisesRegex
 assert_raises_regexp = assert_raises_regex
 
 deprecation_message = "'assert_true' deprecated in version 0.21 " \
-                      "and will be removed in version 0.23." \
+                      "and will be removed in version 0.23. " \
                       "Please use 'assert' instead."
 assert_true = deprecated(deprecation_message)(_dummy.assertTrue)
 
 deprecation_message = "'assert_false' deprecated in version 0.21 " \
-                      "and will be removed in version 0.23." \
+                      "and will be removed in version 0.23. " \
                       "Please use 'assert' instead."
 assert_false = deprecated(deprecation_message)(_dummy.assertFalse)
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -58,7 +58,6 @@ from sklearn.utils._joblib import joblib
 from sklearn.utils._unittest_backport import TestCase
 from sklearn.utils.fixes import signature
 
-
 additional_names_in_all = []
 try:
     from nose.tools import raises as _nose_raises
@@ -95,7 +94,6 @@ __all__.extend(additional_names_in_all)
 _dummy = TestCase('__init__')
 assert_equal = _dummy.assertEqual
 assert_not_equal = _dummy.assertNotEqual
-
 assert_raises = _dummy.assertRaises
 SkipTest = unittest.case.SkipTest
 assert_dict_equal = _dummy.assertDictEqual


### PR DESCRIPTION
**Reference Issues/PRs**
Fixes #12686

**What does this implement/fix? Explain your changes.**
`assert_true` and `assert_false` have been decorated with `deprecated`

This is my first pull request / contribution to open source. Any feedback is welcome.