### PR TITLE
DOC change normed to density in matplotlib calls in examples

### DIFF
--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -20,7 +20,9 @@ example is based on the Boston housing data set.
 from __future__ import print_function, division
 
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
+from distutils.version import LooseVersion
 
 print(__doc__)
 
@@ -33,6 +35,13 @@ from sklearn.model_selection import train_test_split
 from sklearn.linear_model import RidgeCV
 from sklearn.compose import TransformedTargetRegressor
 from sklearn.metrics import median_absolute_error, r2_score
+
+
+# `normed` is being deprecated in favor of `density` in histograms
+if LooseVersion(matplotlib.__version__) >= '2.1':
+    density_param = {'density': True}
+else:
+    density_param = {'normed': True}
 
 ###############################################################################
 # A synthetic random regression problem is generated. The targets ``y`` are
@@ -54,13 +63,13 @@ y_trans = np.log1p(y)
 
 f, (ax0, ax1) = plt.subplots(1, 2)
 
-ax0.hist(y, bins=100, density=True)
+ax0.hist(y, bins=100, **density_param)
 ax0.set_xlim([0, 2000])
 ax0.set_ylabel('Probability')
 ax0.set_xlabel('Target')
 ax0.set_title('Target distribution')
 
-ax1.hist(y_trans, bins=100, density=True)
+ax1.hist(y_trans, bins=100, **density_param)
 ax1.set_ylabel('Probability')
 ax1.set_xlabel('Target')
 ax1.set_title('Transformed target distribution')
@@ -139,12 +148,12 @@ y_trans = quantile_transform(dataset.data[:, target],
 
 f, (ax0, ax1) = plt.subplots(1, 2)
 
-ax0.hist(y, bins=100, density=True)
+ax0.hist(y, bins=100, **density_param)
 ax0.set_ylabel('Probability')
 ax0.set_xlabel('Target')
 ax0.set_title('Target distribution')
 
-ax1.hist(y_trans, bins=100, density=True)
+ax1.hist(y_trans, bins=100, **density_param)
 ax1.set_ylabel('Probability')
 ax1.set_xlabel('Target')
 ax1.set_title('Transformed target distribution')

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -54,13 +54,13 @@ y_trans = np.log1p(y)
 
 f, (ax0, ax1) = plt.subplots(1, 2)
 
-ax0.hist(y, bins=100, normed=True)
+ax0.hist(y, bins=100, density=True)
 ax0.set_xlim([0, 2000])
 ax0.set_ylabel('Probability')
 ax0.set_xlabel('Target')
 ax0.set_title('Target distribution')
 
-ax1.hist(y_trans, bins=100, normed=True)
+ax1.hist(y_trans, bins=100, density=True)
 ax1.set_ylabel('Probability')
 ax1.set_xlabel('Target')
 ax1.set_title('Transformed target distribution')
@@ -139,12 +139,12 @@ y_trans = quantile_transform(dataset.data[:, target],
 
 f, (ax0, ax1) = plt.subplots(1, 2)
 
-ax0.hist(y, bins=100, normed=True)
+ax0.hist(y, bins=100, density=True)
 ax0.set_ylabel('Probability')
 ax0.set_xlabel('Target')
 ax0.set_title('Target distribution')
 
-ax1.hist(y_trans, bins=100, normed=True)
+ax1.hist(y_trans, bins=100, density=True)
 ax1.set_ylabel('Probability')
 ax1.set_xlabel('Target')
 ax1.set_title('Transformed target distribution')

--- a/examples/neighbors/plot_kde_1d.py
+++ b/examples/neighbors/plot_kde_1d.py
@@ -47,11 +47,11 @@ fig, ax = plt.subplots(2, 2, sharex=True, sharey=True)
 fig.subplots_adjust(hspace=0.05, wspace=0.05)
 
 # histogram 1
-ax[0, 0].hist(X[:, 0], bins=bins, fc='#AAAAFF', normed=True)
+ax[0, 0].hist(X[:, 0], bins=bins, fc='#AAAAFF', density=True)
 ax[0, 0].text(-3.5, 0.31, "Histogram")
 
 # histogram 2
-ax[0, 1].hist(X[:, 0], bins=bins + 0.75, fc='#AAAAFF', normed=True)
+ax[0, 1].hist(X[:, 0], bins=bins + 0.75, fc='#AAAAFF', density=True)
 ax[0, 1].text(-3.5, 0.31, "Histogram, bins shifted")
 
 # tophat KDE

--- a/examples/neighbors/plot_kde_1d.py
+++ b/examples/neighbors/plot_kde_1d.py
@@ -29,10 +29,17 @@ as well.
 # Author: Jake Vanderplas <jakevdp@cs.washington.edu>
 #
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
+from distutils.version import LooseVersion
 from scipy.stats import norm
 from sklearn.neighbors import KernelDensity
 
+# `normed` is being deprecated in favor of `density` in histograms
+if LooseVersion(matplotlib.__version__) >= '2.1':
+    density_param = {'density': True}
+else:
+    density_param = {'normed': True}
 
 #----------------------------------------------------------------------
 # Plot the progression of histograms to kernels
@@ -47,11 +54,11 @@ fig, ax = plt.subplots(2, 2, sharex=True, sharey=True)
 fig.subplots_adjust(hspace=0.05, wspace=0.05)
 
 # histogram 1
-ax[0, 0].hist(X[:, 0], bins=bins, fc='#AAAAFF', density=True)
+ax[0, 0].hist(X[:, 0], bins=bins, fc='#AAAAFF', **density_param)
 ax[0, 0].text(-3.5, 0.31, "Histogram")
 
 # histogram 2
-ax[0, 1].hist(X[:, 0], bins=bins + 0.75, fc='#AAAAFF', density=True)
+ax[0, 1].hist(X[:, 0], bins=bins + 0.75, fc='#AAAAFF', **density_param)
 ax[0, 1].text(-3.5, 0.31, "Histogram, bins shifted")
 
 # tophat KDE

--- a/examples/plot_johnson_lindenstrauss_bound.py
+++ b/examples/plot_johnson_lindenstrauss_bound.py
@@ -187,7 +187,7 @@ for n_components in n_components_range:
           % (np.mean(rates), np.std(rates)))
 
     plt.figure()
-    plt.hist(rates, bins=50, normed=True, range=(0., 2.), edgecolor='k')
+    plt.hist(rates, bins=50, density=True, range=(0., 2.), edgecolor='k')
     plt.xlabel("Squared distances rate: projected / original")
     plt.ylabel("Distribution of samples pairs")
     plt.title("Histogram of pairwise distance rates for n_components=%d" %

--- a/examples/plot_johnson_lindenstrauss_bound.py
+++ b/examples/plot_johnson_lindenstrauss_bound.py
@@ -94,12 +94,20 @@ print(__doc__)
 import sys
 from time import time
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
+from distutils.version import LooseVersion
 from sklearn.random_projection import johnson_lindenstrauss_min_dim
 from sklearn.random_projection import SparseRandomProjection
 from sklearn.datasets import fetch_20newsgroups_vectorized
 from sklearn.datasets import load_digits
 from sklearn.metrics.pairwise import euclidean_distances
+
+# `normed` is being deprecated in favor of `density` in histograms
+if LooseVersion(matplotlib.__version__) >= '2.1':
+    density_param = {'density': True}
+else:
+    density_param = {'normed': True}
 
 # Part 1: plot the theoretical dependency between n_components_min and
 # n_samples
@@ -187,7 +195,7 @@ for n_components in n_components_range:
           % (np.mean(rates), np.std(rates)))
 
     plt.figure()
-    plt.hist(rates, bins=50, density=True, range=(0., 2.), edgecolor='k')
+    plt.hist(rates, bins=50, range=(0., 2.), edgecolor='k', **density_param)
     plt.xlabel("Squared distances rate: projected / original")
     plt.ylabel("Distribution of samples pairs")
     plt.title("Histogram of pairwise distance rates for n_components=%d" %


### PR DESCRIPTION
As pointed out in #12654 by @qinhanmin2014 , the `normed` to `density` issue may be more urgent than the other fixes. Hence here's a fix for those only, in our examples.