### PR TITLE
[MRG] Use defined notation for precision and recall

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -887,11 +887,11 @@ To make this more explicit, consider the following notation:
 * :math:`y_l` the subset of :math:`y` with label :math:`l`
 * similarly, :math:`\hat{y}_s` and :math:`\hat{y}_l` are subsets of
   :math:`\hat{y}`
-* :math:`P(A, B) := \frac{\left| A \cap B \right|}{\left|A\right|}`
-* :math:`R(A, B) := \frac{\left| A \cap B \right|}{\left|B\right|}`
-  (Conventions vary on handling :math:`B = \emptyset`; this implementation uses
-  :math:`R(A, B):=0`, and similar for :math:`P`.)
-* :math:`F_\beta(A, B) := \left(1 + \beta^2\right) \frac{P(A, B) \times R(A, B)}{\beta^2 P(A, B) + R(A, B)}`
+* :math:`P(y_l, \hat{y}_l) := \frac{\left| y_l \cap \hat{y}_l \right|}{\left|\hat{y}_l\right|}`
+* :math:`R(y_l, \hat{y}_l) := \frac{\left| y_l \cap \hat{y}_l \right|}{\left|y_l\right|}`
+  (Conventions vary on handling :math:`\hat{y}_l = \emptyset`; this implementation uses
+  :math:`R(y_l, \hat{y}_l):=0`, and similar for :math:`P`.)
+* :math:`F_\beta(y_l, \hat{y}_l) := \left(1 + \beta^2\right) \frac{P(y_l, \hat{y}_l) \times R(y_l, \hat{y}_l)}{\beta^2 P(y_l, \hat{y}_l) + R(y_l, \hat{y}_l)}`
 
 Then the metrics are defined as:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -887,8 +887,8 @@ To make this more explicit, consider the following notation:
 * :math:`y_l` the subset of :math:`y` with label :math:`l`
 * similarly, :math:`\hat{y}_s` and :math:`\hat{y}_l` are subsets of
   :math:`\hat{y}`
-* :math:`P(y_l, \hat{y}_l) := \frac{\left| y_l \cap \hat{y}_l \right|}{\left|\hat{y}_l\right|}`
-* :math:`R(y_l, \hat{y}_l) := \frac{\left| y_l \cap \hat{y}_l \right|}{\left|y_l\right|}`
+* :math:`P(y_l, \hat{y}_l) := \frac{\left| y_l \cap \hat{y}_l \right|}{\left|y_l\right|}`
+* :math:`R(y_l, \hat{y}_l) := \frac{\left| y_l \cap \hat{y}_l \right|}{\left|\hat{y}_l\right|}`
   (Conventions vary on handling :math:`\hat{y}_l = \emptyset`; this implementation uses
   :math:`R(y_l, \hat{y}_l):=0`, and similar for :math:`P`.)
 * :math:`F_\beta(y_l, \hat{y}_l) := \left(1 + \beta^2\right) \frac{P(y_l, \hat{y}_l) \times R(y_l, \hat{y}_l)}{\beta^2 P(y_l, \hat{y}_l) + R(y_l, \hat{y}_l)}`


### PR DESCRIPTION
Replace undefined symbols `A` and `B` in the definitions of precision, recall, and F-beta with defined symbols `y_l` and `\hat{y}_l`.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

NA

#### What does this implement/fix? Explain your changes.

The user guide on model evaluation defines precision and recall in terms of `A` and `B` without defining those symbols. There does seem to be a convention in the Information Retrieval literature of using `A` refer to relevant document (analogous to positive samples) and `B` to refer to retrieved documents (analogous to positive predictions). We already have defined symbols for those concepts, namely `\hat{y}_l` and `y_l`, respectively, where `l` is the "positive" class label. When I replace `A` with `\hat{y}_l` and `B` with `y_l`, then the resulting definitions of precision and recall are reversed, so I correct that issue in addition to the simple find-and-replace operation.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

The more I look at this section of the document, the more apparent problems I find. I think this PR fixes one of them.