### PR TITLE
[MRG] Use Scipy cython BLAS API instead of bundled CBLAS

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -155,6 +155,10 @@ Support for Python 3.4 and below has been officially dropped.
   and now it returns NaN and raises :class:`exceptions.UndefinedMetricWarning`.
   :issue:`12855` by :user:`Pawel Sendyk <psendyk>.`
 
+- |Efficiency| The pairwise manhattan distances with sparse input now uses the
+  BLAS shipped with scipy instead of the bundled BLAS. :issue:`12732` by
+  :user:`Jérémie du Boisberranger <jeremiedbb>`
+
 :mod:`sklearn.model_selection`
 ..............................
 

--- a/sklearn/metrics/pairwise_fast.pyx
+++ b/sklearn/metrics/pairwise_fast.pyx
@@ -13,8 +13,7 @@ cimport numpy as np
 from cython cimport floating
 
 
-cdef extern from "cblas.h":
-    double cblas_dasum(int, const double *, int) nogil
+from ..utils._cython_blas cimport _xasum
 
 
 np.import_array()
@@ -67,4 +66,4 @@ def _sparse_manhattan(floating[::1] X_data, int[:] X_indices, int[:] X_indptr,
                 for j in range(Y_indptr[iy], Y_indptr[iy + 1]):
                     row[Y_indices[j]] -= Y_data[j]
 
-                D[ix, iy] = cblas_dasum(n_features, &row[0], 1)
+                D[ix, iy] = _xasum(n_features, &row[0], 1)

--- a/sklearn/metrics/pairwise_fast.pyx
+++ b/sklearn/metrics/pairwise_fast.pyx
@@ -12,7 +12,6 @@ import numpy as np
 cimport numpy as np
 from cython cimport floating
 
-
 from ..utils._cython_blas cimport _asum
 
 

--- a/sklearn/metrics/pairwise_fast.pyx
+++ b/sklearn/metrics/pairwise_fast.pyx
@@ -13,7 +13,7 @@ cimport numpy as np
 from cython cimport floating
 
 
-from ..utils._cython_blas cimport _xasum
+from ..utils._cython_blas cimport _asum
 
 
 np.import_array()
@@ -66,4 +66,4 @@ def _sparse_manhattan(floating[::1] X_data, int[:] X_indices, int[:] X_indptr,
                 for j in range(Y_indptr[iy], Y_indptr[iy + 1]):
                     row[Y_indices[j]] -= Y_data[j]
 
-                D[ix, iy] = _xasum(n_features, &row[0], 1)
+                D[ix, iy] = _asum(n_features, &row[0], 1)

--- a/sklearn/metrics/setup.py
+++ b/sklearn/metrics/setup.py
@@ -1,32 +1,25 @@
 import os
-import os.path
 
-import numpy
 from numpy.distutils.misc_util import Configuration
-
-from sklearn._build_utils import get_blas_info
 
 
 def configuration(parent_package="", top_path=None):
     config = Configuration("metrics", parent_package, top_path)
 
-    cblas_libs, blas_info = get_blas_info()
+    libraries = []
     if os.name == 'posix':
-        cblas_libs.append('m')
+        libraries.append('m')
 
     config.add_subpackage('cluster')
+
     config.add_extension("pairwise_fast",
                          sources=["pairwise_fast.pyx"],
-                         include_dirs=[os.path.join('..', 'src', 'cblas'),
-                                       numpy.get_include(),
-                                       blas_info.pop('include_dirs', [])],
-                         libraries=cblas_libs,
-                         extra_compile_args=blas_info.pop('extra_compile_args',
-                                                          []),
-                         **blas_info)
+                         libraries=libraries)
+
     config.add_subpackage('tests')
 
     return config
+
 
 if __name__ == "__main__":
     from numpy.distutils.core import setup

--- a/sklearn/utils/_cython_blas.pxd
+++ b/sklearn/utils/_cython_blas.pxd
@@ -4,26 +4,32 @@ from cython cimport floating
 
 
 cpdef enum BLAS_Order:
-    RowMajor
-    ColMajor
+    RowMajor  # C contiguous
+    ColMajor  # Fortran contiguous
 
 
 cpdef enum BLAS_Trans:
-    Trans = 116    # correspond to 'n'
-    NoTrans = 110  # correspond to 't'
+    NoTrans = 110  # correspond to 'n'
+    Trans = 116    # correspond to 't'
 
 
 # BLAS Level 1 ################################################################
 cdef floating _dot(int, floating*, int, floating*, int) nogil
+
 cdef floating _asum(int, floating*, int) nogil
+
 cdef void _axpy(int, floating, floating*, int, floating*, int) nogil
+
 cdef floating _nrm2(int, floating*, int) nogil
+
 cdef void _copy(int, floating*, int, floating*, int) nogil
+
 cdef void _scal(int, floating, floating*, int) nogil
 
 # BLAS Level 2 ################################################################
 cdef void _gemv(BLAS_Order, BLAS_Trans, int, int, floating, floating*, int,
                 floating*, int, floating, floating*, int) nogil
+
 cdef void _ger(BLAS_Order, int, int, floating, floating*, int, floating*, int,
                floating*, int) nogil
 

--- a/sklearn/utils/_cython_blas.pxd
+++ b/sklearn/utils/_cython_blas.pxd
@@ -1,0 +1,20 @@
+from cython cimport floating
+
+
+# BLAS Level 1 ################################################################
+cdef floating _xdot(int, floating*, int, floating*, int) nogil
+cdef floating _xasum(int, floating*, int) nogil
+cdef void _xaxpy(int, floating, floating*, int, floating*, int) nogil
+cdef floating _xnrm2(int, floating*, int) nogil
+cdef void _xcopy(int, floating*, int, floating*, int) nogil
+cdef void _xscal(int, floating, floating*, int) nogil
+
+# BLAS Level 2 ################################################################
+cdef void _xgemv(char, char, int, int, floating, floating*, int, floating*,
+                 int, floating, floating*, int) nogil
+cdef void _xger(char, int, int, floating, floating*, int, floating*, int,
+                floating*, int) nogil
+
+# BLASLevel 3 ################################################################
+cdef void _xgemm(char, char, char, int, int, int, floating, floating*, int,
+                 floating*, int, floating, floating*, int) nogil

--- a/sklearn/utils/_cython_blas.pxd
+++ b/sklearn/utils/_cython_blas.pxd
@@ -23,11 +23,11 @@ cdef void _scal(int, floating, floating*, int) nogil
 
 # BLAS Level 2 ################################################################
 cdef void _gemv(BLAS_Order, BLAS_Trans, int, int, floating, floating*, int,
-                 floating*, int, floating, floating*, int) nogil
+                floating*, int, floating, floating*, int) nogil
 cdef void _ger(BLAS_Order, int, int, floating, floating*, int, floating*, int,
-                floating*, int) nogil
+               floating*, int) nogil
 
 # BLASLevel 3 ################################################################
 cdef void _gemm(BLAS_Order, BLAS_Trans, BLAS_Trans, int, int, int, floating,
-                 floating*, int, floating*, int, floating, floating*,
-                 int) nogil
+                floating*, int, floating*, int, floating, floating*,
+                int) nogil

--- a/sklearn/utils/_cython_blas.pxd
+++ b/sklearn/utils/_cython_blas.pxd
@@ -14,20 +14,20 @@ cpdef enum BLAS_Trans:
 
 
 # BLAS Level 1 ################################################################
-cdef floating _xdot(int, floating*, int, floating*, int) nogil
-cdef floating _xasum(int, floating*, int) nogil
-cdef void _xaxpy(int, floating, floating*, int, floating*, int) nogil
-cdef floating _xnrm2(int, floating*, int) nogil
-cdef void _xcopy(int, floating*, int, floating*, int) nogil
-cdef void _xscal(int, floating, floating*, int) nogil
+cdef floating _dot(int, floating*, int, floating*, int) nogil
+cdef floating _asum(int, floating*, int) nogil
+cdef void _axpy(int, floating, floating*, int, floating*, int) nogil
+cdef floating _nrm2(int, floating*, int) nogil
+cdef void _copy(int, floating*, int, floating*, int) nogil
+cdef void _scal(int, floating, floating*, int) nogil
 
 # BLAS Level 2 ################################################################
-cdef void _xgemv(BLAS_Order, BLAS_Trans, int, int, floating, floating*, int,
+cdef void _gemv(BLAS_Order, BLAS_Trans, int, int, floating, floating*, int,
                  floating*, int, floating, floating*, int) nogil
-cdef void _xger(BLAS_Order, int, int, floating, floating*, int, floating*, int,
+cdef void _ger(BLAS_Order, int, int, floating, floating*, int, floating*, int,
                 floating*, int) nogil
 
 # BLASLevel 3 ################################################################
-cdef void _xgemm(BLAS_Order, BLAS_Trans, BLAS_Trans, int, int, int, floating,
+cdef void _gemm(BLAS_Order, BLAS_Trans, BLAS_Trans, int, int, int, floating,
                  floating*, int, floating*, int, floating, floating*,
                  int) nogil

--- a/sklearn/utils/_cython_blas.pxd
+++ b/sklearn/utils/_cython_blas.pxd
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 from cython cimport floating
 
 

--- a/sklearn/utils/_cython_blas.pxd
+++ b/sklearn/utils/_cython_blas.pxd
@@ -3,6 +3,16 @@
 from cython cimport floating
 
 
+cpdef enum BLAS_Order:
+    RowMajor
+    ColMajor
+
+
+cpdef enum BLAS_Trans:
+    Trans = 116
+    NoTrans = 110
+
+
 # BLAS Level 1 ################################################################
 cdef floating _xdot(int, floating*, int, floating*, int) nogil
 cdef floating _xasum(int, floating*, int) nogil
@@ -12,11 +22,12 @@ cdef void _xcopy(int, floating*, int, floating*, int) nogil
 cdef void _xscal(int, floating, floating*, int) nogil
 
 # BLAS Level 2 ################################################################
-cdef void _xgemv(char, char, int, int, floating, floating*, int, floating*,
-                 int, floating, floating*, int) nogil
-cdef void _xger(char, int, int, floating, floating*, int, floating*, int,
+cdef void _xgemv(BLAS_Order, BLAS_Trans, int, int, floating, floating*, int,
+                 floating*, int, floating, floating*, int) nogil
+cdef void _xger(BLAS_Order, int, int, floating, floating*, int, floating*, int,
                 floating*, int) nogil
 
 # BLASLevel 3 ################################################################
-cdef void _xgemm(char, char, char, int, int, int, floating, floating*, int,
-                 floating*, int, floating, floating*, int) nogil
+cdef void _xgemm(BLAS_Order, BLAS_Trans, BLAS_Trans, int, int, int, floating,
+                 floating*, int, floating*, int, floating, floating*,
+                 int) nogil

--- a/sklearn/utils/_cython_blas.pxd
+++ b/sklearn/utils/_cython_blas.pxd
@@ -9,8 +9,8 @@ cpdef enum BLAS_Order:
 
 
 cpdef enum BLAS_Trans:
-    Trans = 116
-    NoTrans = 110
+    Trans = 116    # correspond to 'n'
+    NoTrans = 110  # correspond to 't'
 
 
 # BLAS Level 1 ################################################################

--- a/sklearn/utils/_cython_blas.pyx
+++ b/sklearn/utils/_cython_blas.pyx
@@ -1,5 +1,3 @@
-# cython: boundscheck=False, wraparound=False, cdivision=True
-
 from cython cimport floating
 
 from scipy.linalg.cython_blas cimport sdot, ddot

--- a/sklearn/utils/_cython_blas.pyx
+++ b/sklearn/utils/_cython_blas.pyx
@@ -18,7 +18,7 @@ from scipy.linalg.cython_blas cimport sgemm, dgemm
 ################
 
 cdef floating _dot(int n, floating *x, int incx,
-                    floating *y, int incy) nogil:
+                   floating *y, int incy) nogil:
     """x.T.y"""
     if floating is float:
         return sdot(&n, x, &incx, y, &incy)
@@ -43,7 +43,7 @@ cpdef _asum_memview(floating[::1] x):
 
 
 cdef void _axpy(int n, floating alpha, floating *x, int incx,
-                 floating *y, int incy) nogil:
+                floating *y, int incy) nogil:
     """y := alpha * x + y"""
     if floating is float:
         saxpy(&n, &alpha, x, &incx, y, &incy)
@@ -96,12 +96,12 @@ cpdef _scal_memview(floating alpha, floating[::1] x):
 ################
 
 cdef void _gemv(BLAS_Order order, BLAS_Trans ta, int m, int n, floating alpha,
-                 floating *A, int lda, floating *x, int incx,
-                 floating beta, floating *y, int incy) nogil:
+                floating *A, int lda, floating *x, int incx,
+                floating beta, floating *y, int incy) nogil:
     """y := alpha * op(A).x + beta * y"""
     cdef char ta_ = ta
     if order == RowMajor:
-        ta_ = NoTrans if ta == Trans else Trans 
+        ta_ = NoTrans if ta == Trans else Trans
         if floating is float:
             sgemv(&ta_, &n, &m, &alpha, A, &lda, x, &incx, &beta, y, &incy)
         else:
@@ -114,8 +114,8 @@ cdef void _gemv(BLAS_Order order, BLAS_Trans ta, int m, int n, floating alpha,
 
 
 cpdef _gemv_memview(BLAS_Order order, BLAS_Trans ta, floating alpha,
-                     floating[:, :] A, floating[::1] x, floating beta,
-                     floating[::1] y):
+                    floating[:, :] A, floating[::1] x, floating beta,
+                    floating[::1] y):
     cdef:
         int m = A.shape[0]
         int n = A.shape[1]
@@ -125,7 +125,7 @@ cpdef _gemv_memview(BLAS_Order order, BLAS_Trans ta, floating alpha,
 
 
 cdef void _ger(BLAS_Order order, int m, int n, floating alpha, floating *x,
-                int incx, floating *y, int incy, floating *A, int lda) nogil:
+               int incx, floating *y, int incy, floating *A, int lda) nogil:
     """A := alpha * x.y.T + A"""
     if order == RowMajor:
         if floating is float:
@@ -139,14 +139,14 @@ cdef void _ger(BLAS_Order order, int m, int n, floating alpha, floating *x,
             dger(&m, &n, &alpha, x, &incx, y, &incy, A, &lda)
 
 
-cpdef _ger_memview(BLAS_Order order, floating alpha, floating[::1] x, floating[::] y,
-                    floating[:, :] A):
+cpdef _ger_memview(BLAS_Order order, floating alpha, floating[::1] x,
+                   floating[::] y, floating[:, :] A):
     cdef:
         BLAS_Order order_ = ColMajor if order == ColMajor else RowMajor
         int m = A.shape[0]
         int n = A.shape[1]
         int lda = m if order == ColMajor else n
-    
+
     _ger(order_, m, n, alpha, &x[0], 1, &y[0], 1, &A[0, 0], lda)
 
 
@@ -155,8 +155,8 @@ cpdef _ger_memview(BLAS_Order order, floating alpha, floating[::1] x, floating[:
 ################
 
 cdef void _gemm(BLAS_Order order, BLAS_Trans ta, BLAS_Trans tb, int m, int n,
-                 int k, floating alpha, floating *A, int lda, floating *B,
-                 int ldb, floating beta, floating *C, int ldc) nogil:
+                int k, floating alpha, floating *A, int lda, floating *B,
+                int ldb, floating beta, floating *C, int ldc) nogil:
     """C := alpha * op(A).op(B) + beta * C"""
     cdef:
         char ta_ = ta
@@ -178,8 +178,8 @@ cdef void _gemm(BLAS_Order order, BLAS_Trans ta, BLAS_Trans tb, int m, int n,
 
 
 cpdef _gemm_memview(BLAS_Order order, BLAS_Trans ta, BLAS_Trans tb,
-                     floating alpha, floating[:, :] A, floating[:, :] B,
-                     floating beta, floating[:, :] C):
+                    floating alpha, floating[:, :] A, floating[:, :] B,
+                    floating beta, floating[:, :] C):
     cdef:
         int m = A.shape[0] if ta == NoTrans else A.shape[1]
         int n = B.shape[1] if tb == NoTrans else B.shape[0]
@@ -196,4 +196,4 @@ cpdef _gemm_memview(BLAS_Order order, BLAS_Trans ta, BLAS_Trans tb,
         ldc = n
 
     _gemm(order, ta, tb, m, n, k, alpha, &A[0, 0],
-           lda, &B[0, 0], ldb, beta, &C[0, 0], ldc)
+          lda, &B[0, 0], ldb, beta, &C[0, 0], ldc)

--- a/sklearn/utils/_cython_blas.pyx
+++ b/sklearn/utils/_cython_blas.pyx
@@ -17,7 +17,7 @@ from scipy.linalg.cython_blas cimport sgemm, dgemm
 # BLAS Level 1 #
 ################
 
-cdef floating _xdot(int n, floating *x, int incx,
+cdef floating _dot(int n, floating *x, int incx,
                     floating *y, int incy) nogil:
     """x.T.y"""
     if floating is float:
@@ -26,11 +26,11 @@ cdef floating _xdot(int n, floating *x, int incx,
         return ddot(&n, x, &incx, y, &incy)
 
 
-cpdef _xdot_memview(floating[::1] x, floating[::1] y):
-    return _xdot(x.shape[0], &x[0], 1, &y[0], 1)
+cpdef _dot_memview(floating[::1] x, floating[::1] y):
+    return _dot(x.shape[0], &x[0], 1, &y[0], 1)
 
 
-cdef floating _xasum(int n, floating *x, int incx) nogil:
+cdef floating _asum(int n, floating *x, int incx) nogil:
     """sum(|x_i|)"""
     if floating is float:
         return sasum(&n, x, &incx)
@@ -38,11 +38,11 @@ cdef floating _xasum(int n, floating *x, int incx) nogil:
         return dasum(&n, x, &incx)
 
 
-cpdef _xasum_memview(floating[::1] x):
-    return _xasum(x.shape[0], &x[0], 1)
+cpdef _asum_memview(floating[::1] x):
+    return _asum(x.shape[0], &x[0], 1)
 
 
-cdef void _xaxpy(int n, floating alpha, floating *x, int incx,
+cdef void _axpy(int n, floating alpha, floating *x, int incx,
                  floating *y, int incy) nogil:
     """y := alpha * x + y"""
     if floating is float:
@@ -51,11 +51,11 @@ cdef void _xaxpy(int n, floating alpha, floating *x, int incx,
         daxpy(&n, &alpha, x, &incx, y, &incy)
 
 
-cpdef _xaxpy_memview(floating alpha, floating[::1] x, floating[::1] y):
-    _xaxpy(x.shape[0], alpha, &x[0], 1, &y[0], 1)
+cpdef _axpy_memview(floating alpha, floating[::1] x, floating[::1] y):
+    _axpy(x.shape[0], alpha, &x[0], 1, &y[0], 1)
 
 
-cdef floating _xnrm2(int n, floating *x, int incx) nogil:
+cdef floating _nrm2(int n, floating *x, int incx) nogil:
     """sqrt(sum((x_i)^2))"""
     if floating is float:
         return snrm2(&n, x, &incx)
@@ -63,11 +63,11 @@ cdef floating _xnrm2(int n, floating *x, int incx) nogil:
         return dnrm2(&n, x, &incx)
 
 
-cpdef _xnrm2_memview(floating[::1] x):
-    return _xnrm2(x.shape[0], &x[0], 1)
+cpdef _nrm2_memview(floating[::1] x):
+    return _nrm2(x.shape[0], &x[0], 1)
 
 
-cdef void _xcopy(int n, floating *x, int incx, floating *y, int incy) nogil:
+cdef void _copy(int n, floating *x, int incx, floating *y, int incy) nogil:
     """y := x"""
     if floating is float:
         scopy(&n, x, &incx, y, &incy)
@@ -75,11 +75,11 @@ cdef void _xcopy(int n, floating *x, int incx, floating *y, int incy) nogil:
         dcopy(&n, x, &incx, y, &incy)
 
 
-cpdef _xcopy_memview(floating[::1] x, floating[::1] y):
-    _xcopy(x.shape[0], &x[0], 1, &y[0], 1)
+cpdef _copy_memview(floating[::1] x, floating[::1] y):
+    _copy(x.shape[0], &x[0], 1, &y[0], 1)
 
 
-cdef void _xscal(int n, floating alpha, floating *x, int incx) nogil:
+cdef void _scal(int n, floating alpha, floating *x, int incx) nogil:
     """x := alpha * x"""
     if floating is float:
         sscal(&n, &alpha, x, &incx)
@@ -87,15 +87,15 @@ cdef void _xscal(int n, floating alpha, floating *x, int incx) nogil:
         dscal(&n, &alpha, x, &incx)
 
 
-cpdef _xscal_memview(floating alpha, floating[::1] x):
-    _xscal(x.shape[0], alpha, &x[0], 1)
+cpdef _scal_memview(floating alpha, floating[::1] x):
+    _scal(x.shape[0], alpha, &x[0], 1)
 
 
 ################
 # BLAS Level 2 #
 ################
 
-cdef void _xgemv(BLAS_Order order, BLAS_Trans ta, int m, int n, floating alpha,
+cdef void _gemv(BLAS_Order order, BLAS_Trans ta, int m, int n, floating alpha,
                  floating *A, int lda, floating *x, int incx,
                  floating beta, floating *y, int incy) nogil:
     """y := alpha * op(A).x + beta * y"""
@@ -113,7 +113,7 @@ cdef void _xgemv(BLAS_Order order, BLAS_Trans ta, int m, int n, floating alpha,
             dgemv(&ta_, &m, &n, &alpha, A, &lda, x, &incx, &beta, y, &incy)
 
 
-cpdef _xgemv_memview(BLAS_Order order, BLAS_Trans ta, floating alpha,
+cpdef _gemv_memview(BLAS_Order order, BLAS_Trans ta, floating alpha,
                      floating[:, :] A, floating[::1] x, floating beta,
                      floating[::1] y):
     cdef:
@@ -121,10 +121,10 @@ cpdef _xgemv_memview(BLAS_Order order, BLAS_Trans ta, floating alpha,
         int n = A.shape[1]
         int lda = m if order == ColMajor else n
 
-    _xgemv(order, ta, m, n, alpha, &A[0, 0], lda, &x[0], 1, beta, &y[0], 1)
+    _gemv(order, ta, m, n, alpha, &A[0, 0], lda, &x[0], 1, beta, &y[0], 1)
 
 
-cdef void _xger(BLAS_Order order, int m, int n, floating alpha, floating *x,
+cdef void _ger(BLAS_Order order, int m, int n, floating alpha, floating *x,
                 int incx, floating *y, int incy, floating *A, int lda) nogil:
     """A := alpha * x.y.T + A"""
     if order == RowMajor:
@@ -139,7 +139,7 @@ cdef void _xger(BLAS_Order order, int m, int n, floating alpha, floating *x,
             dger(&m, &n, &alpha, x, &incx, y, &incy, A, &lda)
 
 
-cpdef _xger_memview(BLAS_Order order, floating alpha, floating[::1] x, floating[::] y,
+cpdef _ger_memview(BLAS_Order order, floating alpha, floating[::1] x, floating[::] y,
                     floating[:, :] A):
     cdef:
         BLAS_Order order_ = ColMajor if order == ColMajor else RowMajor
@@ -147,14 +147,14 @@ cpdef _xger_memview(BLAS_Order order, floating alpha, floating[::1] x, floating[
         int n = A.shape[1]
         int lda = m if order == ColMajor else n
     
-    _xger(order_, m, n, alpha, &x[0], 1, &y[0], 1, &A[0, 0], lda)
+    _ger(order_, m, n, alpha, &x[0], 1, &y[0], 1, &A[0, 0], lda)
 
 
 ################
 # BLAS Level 3 #
 ################
 
-cdef void _xgemm(BLAS_Order order, BLAS_Trans ta, BLAS_Trans tb, int m, int n,
+cdef void _gemm(BLAS_Order order, BLAS_Trans ta, BLAS_Trans tb, int m, int n,
                  int k, floating alpha, floating *A, int lda, floating *B,
                  int ldb, floating beta, floating *C, int ldc) nogil:
     """C := alpha * op(A).op(B) + beta * C"""
@@ -177,7 +177,7 @@ cdef void _xgemm(BLAS_Order order, BLAS_Trans ta, BLAS_Trans tb, int m, int n,
                   &lda, B, &ldb, &beta, C, &ldc)
 
 
-cpdef _xgemm_memview(BLAS_Order order, BLAS_Trans ta, BLAS_Trans tb,
+cpdef _gemm_memview(BLAS_Order order, BLAS_Trans ta, BLAS_Trans tb,
                      floating alpha, floating[:, :] A, floating[:, :] B,
                      floating beta, floating[:, :] C):
     cdef:
@@ -195,5 +195,5 @@ cpdef _xgemm_memview(BLAS_Order order, BLAS_Trans ta, BLAS_Trans tb,
         ldb = n if tb == NoTrans else k
         ldc = n
 
-    _xgemm(order, ta, tb, m, n, k, alpha, &A[0, 0],
+    _gemm(order, ta, tb, m, n, k, alpha, &A[0, 0],
            lda, &B[0, 0], ldb, beta, &C[0, 0], ldc)

--- a/sklearn/utils/_cython_blas.pyx
+++ b/sklearn/utils/_cython_blas.pyx
@@ -1,0 +1,195 @@
+# cython: boundscheck=False, wraparound=False, cdivision=True
+
+from cython cimport floating
+
+from scipy.linalg.cython_blas cimport sdot, ddot
+from scipy.linalg.cython_blas cimport sasum, dasum
+from scipy.linalg.cython_blas cimport saxpy, daxpy
+from scipy.linalg.cython_blas cimport snrm2, dnrm2
+from scipy.linalg.cython_blas cimport scopy, dcopy
+from scipy.linalg.cython_blas cimport sscal, dscal
+from scipy.linalg.cython_blas cimport sgemv, dgemv
+from scipy.linalg.cython_blas cimport sger, dger
+from scipy.linalg.cython_blas cimport sgemm, dgemm
+
+
+################
+# BLAS Level 1 #
+################
+
+cdef floating _xdot(int n, floating *x, int incx,
+                    floating *y, int incy) nogil:
+    """x.T.y"""
+    if floating is float:
+        return sdot(&n, x, &incx, y, &incy)
+    else:
+        return ddot(&n, x, &incx, y, &incy)
+
+
+cpdef _xdot_memview(floating[::1] x, floating[::1] y):
+    return _xdot(x.shape[0], &x[0], 1, &y[0], 1)
+
+
+cdef floating _xasum(int n, floating *x, int incx) nogil:
+    """sum(|x_i|)"""
+    if floating is float:
+        return sasum(&n, x, &incx)
+    else:
+        return dasum(&n, x, &incx)
+
+
+cpdef _xasum_memview(floating[::1] x):
+    return _xasum(x.shape[0], &x[0], 1)
+
+
+cdef void _xaxpy(int n, floating alpha, floating *x, int incx,
+                 floating *y, int incy) nogil:
+    """y := alpha * x + y"""
+    if floating is float:
+        saxpy(&n, &alpha, x, &incx, y, &incy)
+    else:
+        daxpy(&n, &alpha, x, &incx, y, &incy)
+
+
+cpdef _xaxpy_memview(floating alpha, floating[::1] x, floating[::1] y):
+    _xaxpy(x.shape[0], alpha, &x[0], 1, &y[0], 1)
+
+
+cdef floating _xnrm2(int n, floating *x, int incx) nogil:
+    """sqrt(sum((x_i)^2))"""
+    if floating is float:
+        return snrm2(&n, x, &incx)
+    else:
+        return dnrm2(&n, x, &incx)
+
+
+cpdef _xnrm2_memview(floating[::1] x):
+    return _xnrm2(x.shape[0], &x[0], 1)
+
+
+cdef void _xcopy(int n, floating *x, int incx, floating *y, int incy) nogil:
+    """y := x"""
+    if floating is float:
+        scopy(&n, x, &incx, y, &incy)
+    else:
+        dcopy(&n, x, &incx, y, &incy)
+
+
+cpdef _xcopy_memview(floating[::1] x, floating[::1] y):
+    _xcopy(x.shape[0], &x[0], 1, &y[0], 1)
+
+
+cdef void _xscal(int n, floating alpha, floating *x, int incx) nogil:
+    """x := alpha * x"""
+    if floating is float:
+        sscal(&n, &alpha, x, &incx)
+    else:
+        dscal(&n, &alpha, x, &incx)
+
+
+cpdef _xscal_memview(floating alpha, floating[::1] x):
+    _xscal(x.shape[0], alpha, &x[0], 1)
+
+
+################
+# BLAS Level 2 #
+################
+
+cdef void _xgemv(char layout, char ta, int m, int n, floating alpha,
+                 floating *A, int lda, floating *x, int incx,
+                 floating beta, floating *y, int incy) nogil:
+    """y := alpha * op(A).x + beta * y"""
+    if layout == 'C':
+        ta = 'n' if ta == 't' else 't' 
+        if floating is float:
+            sgemv(&ta, &n, &m, &alpha, A, &lda, x, &incx, &beta, y, &incy)
+        else:
+            dgemv(&ta, &n, &m, &alpha, A, &lda, x, &incx, &beta, y, &incy)
+    elif layout == 'F':
+        if floating is float:
+            sgemv(&ta, &m, &n, &alpha, A, &lda, x, &incx, &beta, y, &incy)
+        else:
+            dgemv(&ta, &m, &n, &alpha, A, &lda, x, &incx, &beta, y, &incy)
+
+
+cpdef _xgemv_memview(layout, ta, floating alpha, floating[:, :] A,
+                     floating[::1] x, floating beta, floating[::1] y):
+    cdef:
+        char layout_ = 'F' if layout == 'F' else 'C'
+        char ta_ = 'n' if ta == 'n' else 't'
+        int m = A.shape[0]
+        int n = A.shape[1]
+        int lda = m if layout == 'F' else n
+
+    _xgemv(layout_, ta_, m, n, alpha, &A[0, 0], lda,
+           &x[0], 1, beta, &y[0], 1)
+
+
+cdef void _xger(char layout, int m, int n, floating alpha, floating *x,
+                int incx, floating *y, int incy, floating *A, int lda) nogil:
+    """A := alpha * x.y.T + A"""
+    if layout == 'C':
+        if floating is float:
+            sger(&n, &m, &alpha, y, &incy, x, &incx, A, &lda)
+        else:
+            dger(&n, &m, &alpha, y, &incy, x, &incx, A, &lda)
+    elif layout == 'F':
+        if floating is float:
+            sger(&m, &n, &alpha, x, &incx, y, &incy, A, &lda)
+        else:
+            dger(&m, &n, &alpha, x, &incx, y, &incy, A, &lda)
+
+
+cpdef _xger_memview(layout, floating alpha, floating[::1] x, floating[::] y,
+                    floating[:, :] A):
+    cdef:
+        char layout_ = 'F' if layout == 'F' else 'C'
+        int m = A.shape[0]
+        int n = A.shape[1]
+        int lda = m if layout[0] == 'F' else n
+    
+    _xger(layout_, m, n, alpha, &x[0], 1, &y[0], 1, &A[0, 0], lda)
+
+
+################
+# BLAS Level 3 #
+################
+
+cdef void _xgemm(char layout, char ta, char tb, int m, int n, int k,
+                 floating alpha, floating *A, int lda, floating *B, int ldb,
+                 floating beta, floating *C, int ldc) nogil:
+    """C := alpha * op(A).op(B) + beta * C"""
+    if layout == 'C':
+        if floating is float:
+            sgemm(&tb, &ta, &n, &m, &k, &alpha, B, &ldb, A, &lda, &beta, C, &ldc)
+        else:
+            dgemm(&tb, &ta, &n, &m, &k, &alpha, B, &ldb, A, &lda, &beta, C, &ldc)
+    elif layout == 'F':
+        if floating is float:
+            sgemm(&ta, &tb, &m, &n, &k, &alpha, A, &lda, B, &ldb, &beta, C, &ldc)
+        else:
+            dgemm(&ta, &tb, &m, &n, &k, &alpha, A, &lda, B, &ldb, &beta, C, &ldc)
+
+
+cpdef _xgemm_memview(layout, ta, tb, floating alpha, floating[:, :] A,
+                     floating[:, :] B, floating beta, floating[:, :] C):
+    cdef:
+        char layout_ = 'F' if layout == 'F' else 'C'
+        char ta_ = 'n' if ta == 'n' else 't'
+        char tb_ = 'n' if tb == 'n' else 't'
+        int m = A.shape[0] if ta[0] == 'n' else A.shape[1]
+        int n = B.shape[1] if tb[0] == 'n' else B.shape[0]
+        int k = A.shape[1] if ta[0] == 'n' else A.shape[0]
+        int lda, ldb, ldc
+
+    if layout == 'F':
+        lda = m if ta == 'n' else k
+        ldb = k if tb == 'n' else n
+        ldc = m
+    else:
+        lda = k if ta == 'n' else m
+        ldb = n if tb == 'n' else k
+        ldc = n
+
+    _xgemm(layout_, ta_, tb_, m, n, k, alpha,
+           &A[0, 0], lda, &B[0, 0], ldb, beta, &C[0, 0], ldc)

--- a/sklearn/utils/_cython_blas.pyx
+++ b/sklearn/utils/_cython_blas.pyx
@@ -13,6 +13,13 @@ from scipy.linalg.cython_blas cimport sger, dger
 from scipy.linalg.cython_blas cimport sgemm, dgemm
 
 
+cdef:
+    char ColMajor = b'F'
+    char RowMajor = b'C'
+    char Trans = b't'
+    char NoTrans = b'n'
+
+
 ################
 # BLAS Level 1 #
 ################
@@ -99,13 +106,13 @@ cdef void _xgemv(char layout, char ta, int m, int n, floating alpha,
                  floating *A, int lda, floating *x, int incx,
                  floating beta, floating *y, int incy) nogil:
     """y := alpha * op(A).x + beta * y"""
-    if layout == 'C':
-        ta = 'n' if ta == 't' else 't' 
+    if layout == RowMajor:
+        ta = NoTrans if ta == Trans else Trans 
         if floating is float:
             sgemv(&ta, &n, &m, &alpha, A, &lda, x, &incx, &beta, y, &incy)
         else:
             dgemv(&ta, &n, &m, &alpha, A, &lda, x, &incx, &beta, y, &incy)
-    elif layout == 'F':
+    elif layout == ColMajor:
         if floating is float:
             sgemv(&ta, &m, &n, &alpha, A, &lda, x, &incx, &beta, y, &incy)
         else:
@@ -115,8 +122,8 @@ cdef void _xgemv(char layout, char ta, int m, int n, floating alpha,
 cpdef _xgemv_memview(layout, ta, floating alpha, floating[:, :] A,
                      floating[::1] x, floating beta, floating[::1] y):
     cdef:
-        char layout_ = 'F' if layout == 'F' else 'C'
-        char ta_ = 'n' if ta == 'n' else 't'
+        char layout_ = ColMajor if layout == 'F' else RowMajor
+        char ta_ = NoTrans if ta == 'n' else Trans
         int m = A.shape[0]
         int n = A.shape[1]
         int lda = m if layout == 'F' else n
@@ -128,12 +135,12 @@ cpdef _xgemv_memview(layout, ta, floating alpha, floating[:, :] A,
 cdef void _xger(char layout, int m, int n, floating alpha, floating *x,
                 int incx, floating *y, int incy, floating *A, int lda) nogil:
     """A := alpha * x.y.T + A"""
-    if layout == 'C':
+    if layout == RowMajor:
         if floating is float:
             sger(&n, &m, &alpha, y, &incy, x, &incx, A, &lda)
         else:
             dger(&n, &m, &alpha, y, &incy, x, &incx, A, &lda)
-    elif layout == 'F':
+    elif layout == ColMajor:
         if floating is float:
             sger(&m, &n, &alpha, x, &incx, y, &incy, A, &lda)
         else:
@@ -143,10 +150,10 @@ cdef void _xger(char layout, int m, int n, floating alpha, floating *x,
 cpdef _xger_memview(layout, floating alpha, floating[::1] x, floating[::] y,
                     floating[:, :] A):
     cdef:
-        char layout_ = 'F' if layout == 'F' else 'C'
+        char layout_ = ColMajor if layout == 'F' else RowMajor
         int m = A.shape[0]
         int n = A.shape[1]
-        int lda = m if layout[0] == 'F' else n
+        int lda = m if layout == 'F' else n
     
     _xger(layout_, m, n, alpha, &x[0], 1, &y[0], 1, &A[0, 0], lda)
 
@@ -159,12 +166,12 @@ cdef void _xgemm(char layout, char ta, char tb, int m, int n, int k,
                  floating alpha, floating *A, int lda, floating *B, int ldb,
                  floating beta, floating *C, int ldc) nogil:
     """C := alpha * op(A).op(B) + beta * C"""
-    if layout == 'C':
+    if layout == RowMajor:
         if floating is float:
             sgemm(&tb, &ta, &n, &m, &k, &alpha, B, &ldb, A, &lda, &beta, C, &ldc)
         else:
             dgemm(&tb, &ta, &n, &m, &k, &alpha, B, &ldb, A, &lda, &beta, C, &ldc)
-    elif layout == 'F':
+    elif layout == ColMajor:
         if floating is float:
             sgemm(&ta, &tb, &m, &n, &k, &alpha, A, &lda, B, &ldb, &beta, C, &ldc)
         else:
@@ -174,12 +181,12 @@ cdef void _xgemm(char layout, char ta, char tb, int m, int n, int k,
 cpdef _xgemm_memview(layout, ta, tb, floating alpha, floating[:, :] A,
                      floating[:, :] B, floating beta, floating[:, :] C):
     cdef:
-        char layout_ = 'F' if layout == 'F' else 'C'
-        char ta_ = 'n' if ta == 'n' else 't'
-        char tb_ = 'n' if tb == 'n' else 't'
-        int m = A.shape[0] if ta[0] == 'n' else A.shape[1]
-        int n = B.shape[1] if tb[0] == 'n' else B.shape[0]
-        int k = A.shape[1] if ta[0] == 'n' else A.shape[0]
+        char layout_ = ColMajor if layout == 'F' else RowMajor
+        char ta_ = NoTrans if ta == 'n' else Trans
+        char tb_ = NoTrans if tb == 'n' else Trans
+        int m = A.shape[0] if ta == 'n' else A.shape[1]
+        int n = B.shape[1] if tb == 'n' else B.shape[0]
+        int k = A.shape[1] if ta == 'n' else A.shape[0]
         int lda, ldb, ldc
 
     if layout == 'F':

--- a/sklearn/utils/setup.py
+++ b/sklearn/utils/setup.py
@@ -34,8 +34,7 @@ def configuration(parent_package='', top_path=None):
                          libraries=cblas_libs,
                          include_dirs=cblas_includes,
                          extra_compile_args=cblas_compile_args,
-                         **blas_info
-                         )
+                         **blas_info)
 
     config.add_extension('murmurhash',
                          sources=['murmurhash.pyx', join(

--- a/sklearn/utils/setup.py
+++ b/sklearn/utils/setup.py
@@ -24,6 +24,10 @@ def configuration(parent_package='', top_path=None):
     config.add_extension('sparsefuncs_fast', sources=['sparsefuncs_fast.pyx'],
                          libraries=libraries)
 
+    config.add_extension('_cython_blas',
+                         sources=['_cython_blas.pyx'],
+                         libraries=libraries)
+
     config.add_extension('arrayfuncs',
                          sources=['arrayfuncs.pyx'],
                          depends=[join('src', 'cholesky_delete.h')],

--- a/sklearn/utils/tests/test_cython_blas.py
+++ b/sklearn/utils/tests/test_cython_blas.py
@@ -17,7 +17,7 @@ from sklearn.utils._cython_blas import _xgemm_memview
 
 
 NUMPY_TO_CYTHON = {np.float32: cython.float, np.float64: cython.double}
-RTOL = {np.float32: 1e-4, np.float64: 1e-12}
+RTOL = {np.float32: 1e-3, np.float64: 1e-12}
 
 
 def _no_op(x):

--- a/sklearn/utils/tests/test_cython_blas.py
+++ b/sklearn/utils/tests/test_cython_blas.py
@@ -20,6 +20,7 @@ from sklearn.utils._cython_blas import Trans, NoTrans
 
 NUMPY_TO_CYTHON = {np.float32: cython.float, np.float64: cython.double}
 RTOL = {np.float32: 1e-6, np.float64: 1e-12}
+ORDER = {RowMajor: 'C', ColMajor: 'F'}
 
 
 def _no_op(x):
@@ -120,7 +121,7 @@ def test_gemv(dtype, opA, transA, order):
 
     rng = np.random.RandomState(0)
     A = np.asarray(opA(rng.random_sample((20, 10)).astype(dtype, copy=False)),
-                   order=order)
+                   order=ORDER[order])
     x = rng.random_sample(10).astype(dtype, copy=False)
     y = rng.random_sample(20).astype(dtype, copy=False)
     alpha, beta = 2.5, -0.5
@@ -141,7 +142,7 @@ def test_ger(dtype, order):
     x = rng.random_sample(10).astype(dtype, copy=False)
     y = rng.random_sample(20).astype(dtype, copy=False)
     A = np.asarray(rng.random_sample((10, 20)).astype(dtype, copy=False),
-                   order=order)
+                   order=ORDER[order])
     alpha = 2.5
 
     expected = alpha * np.outer(x, y) + A
@@ -164,11 +165,11 @@ def test_gemm(dtype, opA, transA, opB, transB, order):
 
     rng = np.random.RandomState(0)
     A = np.asarray(opA(rng.random_sample((30, 10)).astype(dtype, copy=False)),
-                   order=order)
+                   order=ORDER[order])
     B = np.asarray(opB(rng.random_sample((10, 20)).astype(dtype, copy=False)),
-                   order=order)
+                   order=ORDER[order])
     C = np.asarray(rng.random_sample((30, 20)).astype(dtype, copy=False),
-                   order=order)
+                   order=ORDER[order])
     alpha, beta = 2.5, -0.5
 
     expected = alpha * opA(A).dot(opB(B)) + beta * C

--- a/sklearn/utils/tests/test_cython_blas.py
+++ b/sklearn/utils/tests/test_cython_blas.py
@@ -5,15 +5,15 @@ import numpy as np
 
 from sklearn.utils.testing import assert_allclose
 
-from sklearn.utils._cython_blas import _xdot_memview
-from sklearn.utils._cython_blas import _xasum_memview
-from sklearn.utils._cython_blas import _xaxpy_memview
-from sklearn.utils._cython_blas import _xnrm2_memview
-from sklearn.utils._cython_blas import _xcopy_memview
-from sklearn.utils._cython_blas import _xscal_memview
-from sklearn.utils._cython_blas import _xgemv_memview
-from sklearn.utils._cython_blas import _xger_memview
-from sklearn.utils._cython_blas import _xgemm_memview
+from sklearn.utils._cython_blas import _dot_memview
+from sklearn.utils._cython_blas import _asum_memview
+from sklearn.utils._cython_blas import _axpy_memview
+from sklearn.utils._cython_blas import _nrm2_memview
+from sklearn.utils._cython_blas import _copy_memview
+from sklearn.utils._cython_blas import _scal_memview
+from sklearn.utils._cython_blas import _gemv_memview
+from sklearn.utils._cython_blas import _ger_memview
+from sklearn.utils._cython_blas import _gemm_memview
 from sklearn.utils._cython_blas import RowMajor, ColMajor
 from sklearn.utils._cython_blas import Trans, NoTrans
 
@@ -29,7 +29,7 @@ def _no_op(x):
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_dot(dtype):
-    dot = _xdot_memview[NUMPY_TO_CYTHON[dtype]]
+    dot = _dot_memview[NUMPY_TO_CYTHON[dtype]]
 
     rng = np.random.RandomState(0)
     x = rng.random_sample(10).astype(dtype, copy=False)
@@ -43,7 +43,7 @@ def test_dot(dtype):
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_asum(dtype):
-    asum = _xasum_memview[NUMPY_TO_CYTHON[dtype]]
+    asum = _asum_memview[NUMPY_TO_CYTHON[dtype]]
 
     rng = np.random.RandomState(0)
     x = rng.random_sample(10).astype(dtype, copy=False)
@@ -56,7 +56,7 @@ def test_asum(dtype):
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_axpy(dtype):
-    axpy = _xaxpy_memview[NUMPY_TO_CYTHON[dtype]]
+    axpy = _axpy_memview[NUMPY_TO_CYTHON[dtype]]
 
     rng = np.random.RandomState(0)
     x = rng.random_sample(10).astype(dtype, copy=False)
@@ -71,7 +71,7 @@ def test_axpy(dtype):
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_nrm2(dtype):
-    nrm2 = _xnrm2_memview[NUMPY_TO_CYTHON[dtype]]
+    nrm2 = _nrm2_memview[NUMPY_TO_CYTHON[dtype]]
 
     rng = np.random.RandomState(0)
     x = rng.random_sample(10).astype(dtype, copy=False)
@@ -84,7 +84,7 @@ def test_nrm2(dtype):
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_copy(dtype):
-    copy = _xcopy_memview[NUMPY_TO_CYTHON[dtype]]
+    copy = _copy_memview[NUMPY_TO_CYTHON[dtype]]
 
     rng = np.random.RandomState(0)
     x = rng.random_sample(10).astype(dtype, copy=False)
@@ -98,7 +98,7 @@ def test_copy(dtype):
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_scal(dtype):
-    scal = _xscal_memview[NUMPY_TO_CYTHON[dtype]]
+    scal = _scal_memview[NUMPY_TO_CYTHON[dtype]]
 
     rng = np.random.RandomState(0)
     x = rng.random_sample(10).astype(dtype, copy=False)
@@ -117,7 +117,7 @@ def test_scal(dtype):
 @pytest.mark.parametrize("order", [RowMajor, ColMajor],
                          ids=["RowMajor", "ColMajor"])
 def test_gemv(dtype, opA, transA, order):
-    gemv = _xgemv_memview[NUMPY_TO_CYTHON[dtype]]
+    gemv = _gemv_memview[NUMPY_TO_CYTHON[dtype]]
 
     rng = np.random.RandomState(0)
     A = np.asarray(opA(rng.random_sample((20, 10)).astype(dtype, copy=False)),
@@ -136,7 +136,7 @@ def test_gemv(dtype, opA, transA, order):
 @pytest.mark.parametrize("order", [RowMajor, ColMajor],
                          ids=["RowMajor", "ColMajor"])
 def test_ger(dtype, order):
-    ger = _xger_memview[NUMPY_TO_CYTHON[dtype]]
+    ger = _ger_memview[NUMPY_TO_CYTHON[dtype]]
 
     rng = np.random.RandomState(0)
     x = rng.random_sample(10).astype(dtype, copy=False)
@@ -161,7 +161,7 @@ def test_ger(dtype, order):
 @pytest.mark.parametrize("order", [RowMajor, ColMajor],
                          ids=["RowMajor", "ColMajor"])
 def test_gemm(dtype, opA, transA, opB, transB, order):
-    gemm = _xgemm_memview[NUMPY_TO_CYTHON[dtype]]
+    gemm = _gemm_memview[NUMPY_TO_CYTHON[dtype]]
 
     rng = np.random.RandomState(0)
     A = np.asarray(opA(rng.random_sample((30, 10)).astype(dtype, copy=False)),

--- a/sklearn/utils/tests/test_cython_blas.py
+++ b/sklearn/utils/tests/test_cython_blas.py
@@ -127,7 +127,7 @@ def test_gemv(dtype, opA, transA, order):
     alpha, beta = 2.5, -0.5
 
     expected = alpha * opA(A).dot(x) + beta * y
-    gemv(order, transA, alpha, A, x, beta, y)
+    gemv(transA, alpha, A, x, beta, y)
 
     assert_allclose(y, expected, rtol=RTOL[dtype])
 
@@ -146,7 +146,7 @@ def test_ger(dtype, order):
     alpha = 2.5
 
     expected = alpha * np.outer(x, y) + A
-    ger(order, alpha, x, y, A)
+    ger(alpha, x, y, A)
 
     assert_allclose(A, expected, rtol=RTOL[dtype])
 
@@ -173,6 +173,6 @@ def test_gemm(dtype, opA, transA, opB, transB, order):
     alpha, beta = 2.5, -0.5
 
     expected = alpha * opA(A).dot(opB(B)) + beta * C
-    gemm(order, transA, transB, alpha, A, B, beta, C)
+    gemm(transA, transB, alpha, A, B, beta, C)
 
     assert_allclose(C, expected, rtol=RTOL[dtype])

--- a/sklearn/utils/tests/test_cython_blas.py
+++ b/sklearn/utils/tests/test_cython_blas.py
@@ -17,7 +17,7 @@ from sklearn.utils._cython_blas import _xgemm_memview
 
 
 NUMPY_TO_CYTHON = {np.float32: cython.float, np.float64: cython.double}
-RTOL = {np.float32: 1e-4, np.float64: 1e-13}
+RTOL = {np.float32: 1e-3, np.float64: 1e-13}
 
 
 def _no_op(x):

--- a/sklearn/utils/tests/test_cython_blas.py
+++ b/sklearn/utils/tests/test_cython_blas.py
@@ -17,6 +17,7 @@ from sklearn.utils._cython_blas import _xgemm_memview
 
 
 NUMPY_TO_CYTHON = {np.float32: cython.float, np.float64: cython.double}
+RTOL = {np.float32: 1e-4, np.float64: 1e-13}
 
 
 def _no_op(x):
@@ -124,7 +125,7 @@ def test_gemv(dtype, opA, transA, layout):
     expected = alpha * opA(A).dot(x) + beta * y
     gemv(layout, transA, alpha, A, x, beta, y)
 
-    assert_allclose(y, expected, rtol=1e-4)
+    assert_allclose(y, expected, rtol=RTOL[dtype])
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
@@ -142,7 +143,7 @@ def test_ger(dtype, layout):
     expected = alpha * np.outer(x, y) + A
     ger(layout, alpha, x, y, A)
 
-    assert_allclose(A, expected, rtol=1e-4)
+    assert_allclose(A, expected, rtol=RTOL[dtype])
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
@@ -168,4 +169,4 @@ def test_gemm(dtype, opA, transA, opB, transB, layout):
     expected = alpha * opA(A).dot(opB(B)) + beta * C
     gemm(layout, transA, transB, alpha, A, B, beta, C)
 
-    assert_allclose(C, expected, rtol=1e-4)
+    assert_allclose(C, expected, rtol=RTOL[dtype])

--- a/sklearn/utils/tests/test_cython_blas.py
+++ b/sklearn/utils/tests/test_cython_blas.py
@@ -1,0 +1,171 @@
+import pytest
+import cython
+
+import numpy as np
+
+from sklearn.utils.testing import assert_allclose
+
+from sklearn.utils._cython_blas import _xdot_memview
+from sklearn.utils._cython_blas import _xasum_memview
+from sklearn.utils._cython_blas import _xaxpy_memview
+from sklearn.utils._cython_blas import _xnrm2_memview
+from sklearn.utils._cython_blas import _xcopy_memview
+from sklearn.utils._cython_blas import _xscal_memview
+from sklearn.utils._cython_blas import _xgemv_memview
+from sklearn.utils._cython_blas import _xger_memview
+from sklearn.utils._cython_blas import _xgemm_memview
+
+
+NUMPY_TO_CYTHON = {np.float32: cython.float, np.float64: cython.double}
+
+
+def _no_op(x):
+    return x
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_dot(dtype):
+    dot = _xdot_memview[NUMPY_TO_CYTHON[dtype]]
+
+    rng = np.random.RandomState(0)
+    x = rng.random_sample(10).astype(dtype, copy=False)
+    y = rng.random_sample(10).astype(dtype, copy=False)
+
+    expected = x.dot(y)
+    actual = dot(x, y)
+
+    assert_allclose(actual, expected)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_asum(dtype):
+    asum = _xasum_memview[NUMPY_TO_CYTHON[dtype]]
+
+    rng = np.random.RandomState(0)
+    x = rng.random_sample(10).astype(dtype, copy=False)
+
+    expected = np.abs(x).sum()
+    actual = asum(x)
+
+    assert_allclose(actual, expected)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_axpy(dtype):
+    axpy = _xaxpy_memview[NUMPY_TO_CYTHON[dtype]]
+
+    rng = np.random.RandomState(0)
+    x = rng.random_sample(10).astype(dtype, copy=False)
+    y = rng.random_sample(10).astype(dtype, copy=False)
+    alpha = 1.23
+
+    expected = alpha * x + y
+    axpy(alpha, x, y)
+
+    assert_allclose(y, expected)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_nrm2(dtype):
+    nrm2 = _xnrm2_memview[NUMPY_TO_CYTHON[dtype]]
+
+    rng = np.random.RandomState(0)
+    x = rng.random_sample(10).astype(dtype, copy=False)
+
+    expected = np.linalg.norm(x)
+    actual = nrm2(x)
+
+    assert_allclose(actual, expected)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_copy(dtype):
+    copy = _xcopy_memview[NUMPY_TO_CYTHON[dtype]]
+
+    rng = np.random.RandomState(0)
+    x = rng.random_sample(10).astype(dtype, copy=False)
+    y = np.empty_like(x)
+
+    expected = x.copy()
+    copy(x, y)
+
+    assert_allclose(y, expected)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_scal(dtype):
+    scal = _xscal_memview[NUMPY_TO_CYTHON[dtype]]
+
+    rng = np.random.RandomState(0)
+    x = rng.random_sample(10).astype(dtype, copy=False)
+    alpha = 1.23
+
+    expected = alpha * x
+    scal(alpha, x)
+
+    assert_allclose(x, expected)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("opA, transA",
+                         [(_no_op, 'n'), (np.transpose, 't')],
+                         ids=["A", "A.T"])
+@pytest.mark.parametrize("layout", ['C', 'F'])
+def test_gemv(dtype, opA, transA, layout):
+    gemv = _xgemv_memview[NUMPY_TO_CYTHON[dtype]]
+
+    rng = np.random.RandomState(0)
+    A = np.asarray(opA(rng.random_sample((20, 10)).astype(dtype, copy=False)),
+                   order=layout)
+    x = rng.random_sample(10).astype(dtype, copy=False)
+    y = rng.random_sample(20).astype(dtype, copy=False)
+    alpha, beta = 1.23, -3.21
+
+    expected = alpha * opA(A).dot(x) + beta * y
+    gemv(layout, transA, alpha, A, x, beta, y)
+
+    assert_allclose(y, expected, rtol=1e-4)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("layout", ['C', 'F'])
+def test_ger(dtype, layout):
+    ger = _xger_memview[NUMPY_TO_CYTHON[dtype]]
+
+    rng = np.random.RandomState(0)
+    x = rng.random_sample(10).astype(dtype, copy=False)
+    y = rng.random_sample(20).astype(dtype, copy=False)
+    A = np.asarray(rng.random_sample((10, 20)).astype(dtype, copy=False),
+                   order=layout)
+    alpha = 1.23
+
+    expected = alpha * np.outer(x, y) + A
+    ger(layout, alpha, x, y, A)
+
+    assert_allclose(A, expected, rtol=1e-4)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("opB, transB",
+                         [(_no_op, 'n'), (np.transpose, 't')],
+                         ids=["B", "B.T"])
+@pytest.mark.parametrize("opA, transA",
+                         [(_no_op, 'n'), (np.transpose, 't')],
+                         ids=["A", "A.T"])
+@pytest.mark.parametrize("layout", ['C', 'F'])
+def test_gemm(dtype, opA, transA, opB, transB, layout):
+    gemm = _xgemm_memview[NUMPY_TO_CYTHON[dtype]]
+
+    rng = np.random.RandomState(0)
+    A = np.asarray(opA(rng.random_sample((30, 10)).astype(dtype, copy=False)),
+                   order=layout)
+    B = np.asarray(opB(rng.random_sample((10, 20)).astype(dtype, copy=False)),
+                   order=layout)
+    C = np.asarray(rng.random_sample((30, 20)).astype(dtype, copy=False),
+                   order=layout)
+    alpha, beta = 1.23, -3.21
+
+    expected = alpha * opA(A).dot(opB(B)) + beta * C
+    gemm(layout, transA, transB, alpha, A, B, beta, C)
+
+    assert_allclose(C, expected, rtol=1e-4)

--- a/sklearn/utils/tests/test_cython_blas.py
+++ b/sklearn/utils/tests/test_cython_blas.py
@@ -17,7 +17,7 @@ from sklearn.utils._cython_blas import _xgemm_memview
 
 
 NUMPY_TO_CYTHON = {np.float32: cython.float, np.float64: cython.double}
-RTOL = {np.float32: 1e-3, np.float64: 1e-12}
+RTOL = {np.float32: 1e-6, np.float64: 1e-12}
 
 
 def _no_op(x):
@@ -35,7 +35,7 @@ def test_dot(dtype):
     expected = x.dot(y)
     actual = dot(x, y)
 
-    assert_allclose(actual, expected)
+    assert_allclose(actual, expected, rtol=RTOL[dtype])
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
@@ -48,7 +48,7 @@ def test_asum(dtype):
     expected = np.abs(x).sum()
     actual = asum(x)
 
-    assert_allclose(actual, expected)
+    assert_allclose(actual, expected, rtol=RTOL[dtype])
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
@@ -58,12 +58,12 @@ def test_axpy(dtype):
     rng = np.random.RandomState(0)
     x = rng.random_sample(10).astype(dtype, copy=False)
     y = rng.random_sample(10).astype(dtype, copy=False)
-    alpha = 1.23
+    alpha = 2.5
 
     expected = alpha * x + y
     axpy(alpha, x, y)
 
-    assert_allclose(y, expected)
+    assert_allclose(y, expected, rtol=RTOL[dtype])
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
@@ -76,7 +76,7 @@ def test_nrm2(dtype):
     expected = np.linalg.norm(x)
     actual = nrm2(x)
 
-    assert_allclose(actual, expected)
+    assert_allclose(actual, expected, rtol=RTOL[dtype])
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
@@ -90,7 +90,7 @@ def test_copy(dtype):
     expected = x.copy()
     copy(x, y)
 
-    assert_allclose(y, expected)
+    assert_allclose(y, expected, rtol=RTOL[dtype])
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
@@ -99,12 +99,12 @@ def test_scal(dtype):
 
     rng = np.random.RandomState(0)
     x = rng.random_sample(10).astype(dtype, copy=False)
-    alpha = 1.23
+    alpha = 2.5
 
     expected = alpha * x
     scal(alpha, x)
 
-    assert_allclose(x, expected)
+    assert_allclose(x, expected, rtol=RTOL[dtype])
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
@@ -120,7 +120,7 @@ def test_gemv(dtype, opA, transA, layout):
                    order=layout)
     x = rng.random_sample(10).astype(dtype, copy=False)
     y = rng.random_sample(20).astype(dtype, copy=False)
-    alpha, beta = 1.23, -3.21
+    alpha, beta = 2.5, -0.5
 
     expected = alpha * opA(A).dot(x) + beta * y
     gemv(layout, transA, alpha, A, x, beta, y)
@@ -138,7 +138,7 @@ def test_ger(dtype, layout):
     y = rng.random_sample(20).astype(dtype, copy=False)
     A = np.asarray(rng.random_sample((10, 20)).astype(dtype, copy=False),
                    order=layout)
-    alpha = 1.23
+    alpha = 2.5
 
     expected = alpha * np.outer(x, y) + A
     ger(layout, alpha, x, y, A)
@@ -164,7 +164,7 @@ def test_gemm(dtype, opA, transA, opB, transB, layout):
                    order=layout)
     C = np.asarray(rng.random_sample((30, 20)).astype(dtype, copy=False),
                    order=layout)
-    alpha, beta = 1.23, -3.21
+    alpha, beta = 2.5, -0.5
 
     expected = alpha * opA(A).dot(opB(B)) + beta * C
     gemm(layout, transA, transB, alpha, A, B, beta, C)

--- a/sklearn/utils/tests/test_cython_blas.py
+++ b/sklearn/utils/tests/test_cython_blas.py
@@ -17,7 +17,7 @@ from sklearn.utils._cython_blas import _xgemm_memview
 
 
 NUMPY_TO_CYTHON = {np.float32: cython.float, np.float64: cython.double}
-RTOL = {np.float32: 1e-3, np.float64: 1e-13}
+RTOL = {np.float32: 1e-4, np.float64: 1e-12}
 
 
 def _no_op(x):


### PR DESCRIPTION
First step to tackle #11638

This PR add a new module in utils, `_cython_blas`, which contains helpers for the BLAS functions shipped with scipy in `scipy.cython_blas`. 

- The scipy functions expect fortran aligned arrays. These helpers allow to specify the memory layout as it is in CBLAS, and can be used as drop in replacement in sklearn.
- BLAS functions are not fused (e.g. `sgemm` and `dgemm` for float and double matrix matrix multiplication). These helpers are fused,  `sgemv` and `dgemv` are replaced by `_xgemv`, which avoids the redundant
```python
if floating is float:
    dot = sdot
else:
    dot = ddot
```
I still have to fill the docstrings.

For now the module only contains helpers for the BLAS functions which were already used in sklearn (+gemm because I'm using it in another PR :) ). We can add other BLAS functions as we need them.

This module comes with a test suite, which tests the helpers for all type/layout/transpose configurations.

I also added an example of use in sklearn pairwise_fast with the `asum` function, see `sklearn/metrics/pairwise_fast.pyx` and `sklearn/metrics/setup.py`.

I don't think I'll replace all occurences of CBLAS use in sklearn in this PR. I think it would be easier to do it in separate PRs. Removing the bundled CBLAS will only be possible once all replacement are done.

Finally, this PR requires an upgrade of scipy minimal version > 0.16, which seems to be on it's way (#12184)