### PR TITLE
Revert "DOC Use defined notation for precision and recall (#12726)"

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -887,7 +887,8 @@ To make this more explicit, consider the following notation:
 * :math:`y_l` the subset of :math:`y` with label :math:`l`
 * similarly, :math:`\hat{y}_s` and :math:`\hat{y}_l` are subsets of
   :math:`\hat{y}`
-* :math:`P(A, B) := \frac{\left| A \cap B \right|}{\left|A\right|}`
+* :math:`P(A, B) := \frac{\left| A \cap B \right|}{\left|A\right|}` for some
+  sets :math:`A` and :math:`B`
 * :math:`R(A, B) := \frac{\left| A \cap B \right|}{\left|B\right|}`
   (Conventions vary on handling :math:`B = \emptyset`; this implementation uses
   :math:`R(A, B):=0`, and similar for :math:`P`.)

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -887,11 +887,11 @@ To make this more explicit, consider the following notation:
 * :math:`y_l` the subset of :math:`y` with label :math:`l`
 * similarly, :math:`\hat{y}_s` and :math:`\hat{y}_l` are subsets of
   :math:`\hat{y}`
-* :math:`P(y_l, \hat{y}_l) := \frac{\left| y_l \cap \hat{y}_l \right|}{\left|y_l\right|}`
-* :math:`R(y_l, \hat{y}_l) := \frac{\left| y_l \cap \hat{y}_l \right|}{\left|\hat{y}_l\right|}`
-  (Conventions vary on handling :math:`\hat{y}_l = \emptyset`; this implementation uses
-  :math:`R(y_l, \hat{y}_l):=0`, and similar for :math:`P`.)
-* :math:`F_\beta(y_l, \hat{y}_l) := \left(1 + \beta^2\right) \frac{P(y_l, \hat{y}_l) \times R(y_l, \hat{y}_l)}{\beta^2 P(y_l, \hat{y}_l) + R(y_l, \hat{y}_l)}`
+* :math:`P(A, B) := \frac{\left| A \cap B \right|}{\left|A\right|}`
+* :math:`R(A, B) := \frac{\left| A \cap B \right|}{\left|B\right|}`
+  (Conventions vary on handling :math:`B = \emptyset`; this implementation uses
+  :math:`R(A, B):=0`, and similar for :math:`P`.)
+* :math:`F_\beta(A, B) := \left(1 + \beta^2\right) \frac{P(A, B) \times R(A, B)}{\beta^2 P(A, B) + R(A, B)}`
 
 Then the metrics are defined as:
 


### PR DESCRIPTION
This reverts commit 1cb56ba882a92e68c26cdc6595d2aa14dce1acf5 introduced in #12726, since it conflates the notation for the specific case of class-wise precision, recall, etc. with the general case.