### PR TITLE
DOC fix math typo in model_evaluation's explained_variance

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1618,7 +1618,7 @@ then the explained variance is estimated as follow:
 
 .. math::
 
-  \texttt{explained\_{}variance}(y, \hat{y}) = 1 - \frac{Var\{ y - \hat{y}\}}{Var\{y\}}
+  \texttt{explained_variance}(y, \hat{y}) = 1 - \frac{Var\{ y - \hat{y}\}}{Var\{y\}}
 
 The best possible score is 1.0, lower values are worse.
 


### PR DESCRIPTION
Right now the explained_variance is [shown](https://scikit-learn.org/stable/modules/model_evaluation.html#explained-variance-score) as:

![explained_variance](https://user-images.githubusercontent.com/1663864/49699417-2e666800-fbd1-11e8-98e5-486ed1cf5685.png)

This PR simply removes the extra `\` and `{}`, which is what I suppose we intend to have here.