### PR TITLE
[MRG + 2] Add label accuracy to micro-average in classification report (from #12353)

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -599,7 +599,7 @@ and inferred labels::
         class 1       0.00      0.00      0.00         1
         class 2       1.00      0.50      0.67         2
    <BLANKLINE>
-      micro avg       0.60      0.60      0.60         5
+       accuracy                           0.60         5
       macro avg       0.56      0.50      0.49         5
    weighted avg       0.67      0.60      0.59         5
    <BLANKLINE>

--- a/doc/tutorial/text_analytics/working_with_text_data.rst
+++ b/doc/tutorial/text_analytics/working_with_text_data.rst
@@ -156,8 +156,8 @@ It is possible to get back the category names as follows::
   sci.med
 
 You might have noticed that the samples were shuffled randomly when we called
-``fetch_20newsgroups(..., shuffle=True, random_state=42)``: this is useful if 
-you wish to select only a subset of samples to quickly train a model and get a 
+``fetch_20newsgroups(..., shuffle=True, random_state=42)``: this is useful if
+you wish to select only a subset of samples to quickly train a model and get a
 first idea of the results before re-training on the complete dataset later.
 
 
@@ -205,7 +205,7 @@ Tokenizing text with ``scikit-learn``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Text preprocessing, tokenizing and filtering of stopwords are all included
-in :class:`CountVectorizer`, which builds a dictionary of features and 
+in :class:`CountVectorizer`, which builds a dictionary of features and
 transforms documents to feature vectors::
 
   >>> from sklearn.feature_extraction.text import CountVectorizer
@@ -214,8 +214,8 @@ transforms documents to feature vectors::
   >>> X_train_counts.shape
   (2257, 35788)
 
-:class:`CountVectorizer` supports counts of N-grams of words or consecutive 
-characters. Once fitted, the vectorizer has built a dictionary of feature 
+:class:`CountVectorizer` supports counts of N-grams of words or consecutive
+characters. Once fitted, the vectorizer has built a dictionary of feature
 indices::
 
   >>> count_vect.vocabulary_.get(u'algorithm')
@@ -327,7 +327,7 @@ like a compound classifier::
 
 
 The names ``vect``, ``tfidf`` and ``clf`` (classifier) are arbitrary.
-We will use them to perform grid search for suitable hyperparameters below. 
+We will use them to perform grid search for suitable hyperparameters below.
 We can now train the model with a single command::
 
   >>> text_clf.fit(twenty_train.data, twenty_train.target)  # doctest: +ELLIPSIS
@@ -369,7 +369,7 @@ classifier object into our pipeline::
   >>> np.mean(predicted == twenty_test.target)            # doctest: +ELLIPSIS
   0.9127...
 
-We achieved 91.3% accuracy using the SVM. ``scikit-learn`` provides further 
+We achieved 91.3% accuracy using the SVM. ``scikit-learn`` provides further
 utilities for more detailed performance analysis of the results::
 
   >>> from sklearn import metrics
@@ -383,7 +383,7 @@ utilities for more detailed performance analysis of the results::
                  sci.med       0.94      0.90      0.92       396
   soc.religion.christian       0.90      0.95      0.93       398
   <BLANKLINE>
-               micro avg       0.91      0.91      0.91      1502
+                accuracy                           0.91      1502
                macro avg       0.92      0.91      0.91      1502
             weighted avg       0.92      0.91      0.91      1502
   <BLANKLINE>

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -85,7 +85,7 @@ Support for Python 3.4 and below has been officially dropped.
   :issue:`11179` by :user:`Shangwu Yao <ShangwuYao>` and `Joel Nothman`_.
 
 - |Fix| Add label `accuracy` ìnstead `micro-average` on
-  :func:metrics.classification_report to avoid confusing. `micro-average` is
+  :func:`metrics.classification_report` to avoid confusing. `micro-average` is
   only shown for multi-label or multi-class with a subset of classes because
   it is accuracy otherwise.
   :issue:`12334` by :user:`Emmanuel Arias <eamanu@eamanu.com>`,

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -84,6 +84,11 @@ Support for Python 3.4 and below has been officially dropped.
   metrics such as recall, specificity, fall out and miss rate.
   :issue:`11179` by :user:`Shangwu Yao <ShangwuYao>` and `Joel Nothman`_.
 
+- |Fix| Add label `accuracy` ìnstead `micro-average` on
+  :func:metrics.classification_report to avoid confusing. `micro-average` is
+  only shown for multi-label or multi-class with a subset of classes because
+  it is accuracy otherwise.
+
 :mod:`sklearn.model_selection`
 ......................
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -84,7 +84,7 @@ Support for Python 3.4 and below has been officially dropped.
   metrics such as recall, specificity, fall out and miss rate.
   :issue:`11179` by :user:`Shangwu Yao <ShangwuYao>` and `Joel Nothman`_.
 
-- |Fix| Use label `accuracy` ìnstead of `micro-average` on
+- |Enhancement| Use label `accuracy` instead of `micro-average` on
   :func:`metrics.classification_report` to avoid confusion. `micro-average` is
   only shown for multi-label or multi-class with a subset of classes because
   it is otherwise identical to accuracy.

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -88,6 +88,8 @@ Support for Python 3.4 and below has been officially dropped.
   :func:metrics.classification_report to avoid confusing. `micro-average` is
   only shown for multi-label or multi-class with a subset of classes because
   it is accuracy otherwise.
+  :issue:`12334` by :user:`Emmanuel Arias <eamanu@eamanu.com>`,
+  `Joel Nothman`_ and `Andreas Müller`_
 
 :mod:`sklearn.model_selection`
 ......................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -84,10 +84,10 @@ Support for Python 3.4 and below has been officially dropped.
   metrics such as recall, specificity, fall out and miss rate.
   :issue:`11179` by :user:`Shangwu Yao <ShangwuYao>` and `Joel Nothman`_.
 
-- |Fix| Add label `accuracy` ìnstead `micro-average` on
-  :func:`metrics.classification_report` to avoid confusing. `micro-average` is
+- |Fix| Use label `accuracy` ìnstead of `micro-average` on
+  :func:`metrics.classification_report` to avoid confusion. `micro-average` is
   only shown for multi-label or multi-class with a subset of classes because
-  it is accuracy otherwise.
+  it is otherwise identical to accuracy.
   :issue:`12334` by :user:`Emmanuel Arias <eamanu@eamanu.com>`,
   `Joel Nothman`_ and `Andreas Müller`_
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -127,10 +127,7 @@ def test_classification_report_dictionary_output():
                                      'precision': 0.5260083136726211,
                                      'recall': 0.596146953405018,
                                      'support': 75},
-                       'micro avg': {'f1-score': 0.5333333333333333,
-                                     'precision': 0.5333333333333333,
-                                     'recall': 0.5333333333333333,
-                                     'support': 75},
+                       'accuracy': 0.5333333333333333,
                        'weighted avg': {'f1-score': 0.47310435663627154,
                                         'precision': 0.5137535108414785,
                                         'recall': 0.5333333333333333,
@@ -143,10 +140,14 @@ def test_classification_report_dictionary_output():
     # assert the 2 dicts are equal.
     assert(report.keys() == expected_report.keys())
     for key in expected_report:
-        assert report[key].keys() == expected_report[key].keys()
-        for metric in expected_report[key]:
-            assert_almost_equal(expected_report[key][metric],
-                                report[key][metric])
+        if key == 'accuracy':
+            assert isinstance(report[key], float)
+            assert report[key] == expected_report[key]
+        else:
+            assert report[key].keys() == expected_report[key].keys()
+            for metric in expected_report[key]:
+                assert_almost_equal(expected_report[key][metric],
+                                    report[key][metric])
 
     assert type(expected_report['setosa']['precision']) == float
     assert type(expected_report['macro avg']['precision']) == float
@@ -885,7 +886,7 @@ def test_classification_report_multiclass():
   versicolor       0.33      0.10      0.15        31
    virginica       0.42      0.90      0.57        20
 
-   micro avg       0.53      0.53      0.53        75
+    accuracy                           0.53        75
    macro avg       0.53      0.60      0.51        75
 weighted avg       0.51      0.53      0.47        75
 """
@@ -905,7 +906,7 @@ def test_classification_report_multiclass_balanced():
            1       0.33      0.33      0.33         3
            2       0.33      0.33      0.33         3
 
-   micro avg       0.33      0.33      0.33         9
+    accuracy                           0.33         9
    macro avg       0.33      0.33      0.33         9
 weighted avg       0.33      0.33      0.33         9
 """
@@ -925,7 +926,7 @@ def test_classification_report_multiclass_with_label_detection():
            1       0.33      0.10      0.15        31
            2       0.42      0.90      0.57        20
 
-   micro avg       0.53      0.53      0.53        75
+    accuracy                           0.53        75
    macro avg       0.53      0.60      0.51        75
 weighted avg       0.51      0.53      0.47        75
 """
@@ -969,7 +970,7 @@ def test_classification_report_multiclass_with_string_label():
        green       0.33      0.10      0.15        31
          red       0.42      0.90      0.57        20
 
-   micro avg       0.53      0.53      0.53        75
+    accuracy                           0.53        75
    macro avg       0.53      0.60      0.51        75
 weighted avg       0.51      0.53      0.47        75
 """
@@ -983,7 +984,7 @@ weighted avg       0.51      0.53      0.47        75
            b       0.33      0.10      0.15        31
            c       0.42      0.90      0.57        20
 
-   micro avg       0.53      0.53      0.53        75
+    accuracy                           0.53        75
    macro avg       0.53      0.60      0.51        75
 weighted avg       0.51      0.53      0.47        75
 """
@@ -1006,7 +1007,7 @@ def test_classification_report_multiclass_with_unicode_label():
       green\xa2       0.33      0.10      0.15        31
         red\xa2       0.42      0.90      0.57        20
 
-   micro avg       0.53      0.53      0.53        75
+    accuracy                           0.53        75
    macro avg       0.53      0.60      0.51        75
 weighted avg       0.51      0.53      0.47        75
 """
@@ -1028,7 +1029,7 @@ def test_classification_report_multiclass_with_long_string_label():
 greengreengreengreengreen       0.33      0.10      0.15        31
                       red       0.42      0.90      0.57        20
 
-                micro avg       0.53      0.53      0.53        75
+                 accuracy                           0.53        75
                 macro avg       0.53      0.60      0.51        75
              weighted avg       0.51      0.53      0.47        75
 """

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -947,7 +947,7 @@ def test_classification_report_multiclass_with_digits():
   versicolor    0.33333   0.09677   0.15000        31
    virginica    0.41860   0.90000   0.57143        20
 
-   micro avg    0.53333   0.53333   0.53333        75
+    accuracy                        0.53333        75
    macro avg    0.52601   0.59615   0.50998        75
 weighted avg    0.51375   0.53333   0.47310        75
 """


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->
Add label accuracy to micro-average. 

This is the same that #12353, but this is a clean PR, without conflicts. 

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #12334

#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
