### PR TITLE
Explain solver choices for LogisticRegression

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -817,11 +817,10 @@ The following table summarizes the penalties supported by each solver:
 | Robust to unscaled datasets  |       yes       |     yes     |       yes       |    no     |    no      |
 +------------------------------+-----------------+-------------+-----------------+-----------+------------+
 
-The "saga" solver is often the best choice but requires scaling. The
-"lbfgs" solver is used by default for historical reasons.
-
+The "lbfgs" solver is used by default for its robustness. For large datasets
+the "saga" solver is usually faster.
 For large dataset, you may also consider using :class:`SGDClassifier`
-with 'log' loss.
+with 'log' loss, which might be even faster but require more tuning.
 
 .. topic:: Examples:
 


### PR DESCRIPTION
Cleaning up after #12735.
ping @agramfort in case he disagrees.

We are just making lbfgs the default in 0.22, so it's definitely not the default for historical reasons!