### PR TITLE
[MRG] plot_document_classification_20newsgroups.py fails when run with --all_categories option

### DIFF
--- a/examples/text/plot_document_classification_20newsgroups.py
+++ b/examples/text/plot_document_classification_20newsgroups.py
@@ -145,7 +145,7 @@ print("%d documents - %0.3fMB (training set)" % (
     len(data_train.data), data_train_size_mb))
 print("%d documents - %0.3fMB (test set)" % (
     len(data_test.data), data_test_size_mb))
-print("%d categories" % len(categories))
+print("%d categories" % len(target_names))
 print()
 
 # split a training set and a test set


### PR DESCRIPTION
Running `plot_document_classification_20newsgroups.py --all_categories` throws `TypeError` because we are trying to calculate `len(categories)` when `categories=None`.

I propose calculating the length of `target_names` instead which should always give the correct answer.