### PR TITLE
MAINT hotfix circle-ci job dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ workflows:
                 - 0.20.X
       - deploy:
           requires:
-            - python3
+            - doc
   pypy:
     triggers:
       - schedule:


### PR DESCRIPTION
After changing the circle-ci job names in #12746 I forgot to change the dependency of the _deploy_ step. This fixes that.