### PR TITLE
[MRG] DOC: Moves whats new entry on Pipeline's passthrough to 0.21

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -32,13 +32,6 @@ Changelog
   unexpected error when columns is pandas Index or pandas Series.
   :issue:`12704` by :user:`Hanmin Qin <qinhanmin2014>`.
 
-:mod:`sklearn.pipeline`
-.......................
-
-- |Fix| Fixed a regression in :class:`pipeline.Pipeline` where the ``steps``
-  parameter may not have been updated correctly when a step is set to ``None``
-  or ``'passthrough'``. :user:`Thomas Fan <thomasjpfan>`.
-
 :mod:`sklearn.neighbors`
 ........................
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -147,6 +147,10 @@ Support for Python 3.4 and below has been officially dropped.
 - |API| :class:`pipeline.Pipeline` now supports using ``'passthrough'`` as a
   transformer. :issue:`11144` by :user:`Thomas Fan <thomasjpfan>`.
 
+- |Fix| Fixed a regression in :class:`pipeline.Pipeline` where the ``steps``
+  parameter may not have been updated correctly when a step is set to ``None``
+  or ``'passthrough'``. :user:`Thomas Fan <thomasjpfan>`.
+
 :mod:`sklearn.preprocessing`
 ............................
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
See also https://github.com/scikit-learn/scikit-learn/pull/12659

#### What does this implement/fix? Explain your changes.
Moves whats new entry about Pipeline's "passthrough" to 0.21.

#### Any other comments?
Since this is a bug fix for an unreleased feature, does this bug fix need a whats new entry?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->