### PR TITLE
[MRG] circle-ci should only run/build plot_* files

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -51,7 +51,7 @@ get_build_type() {
     fi
     git_range="origin/master...$CIRCLE_SHA1"
     git fetch origin master >&2 || (echo QUICK BUILD: failed to get changed filenames for $git_range; return)
-    filenames=$(git diff --name-only $git_range -- `find . -name plot_*`)
+    filenames=$(git diff --name-only $git_range -- `git ls-files | grep -E "/plot_|.*rst$"`)
     if [ -z "$filenames" ]
     then
         echo QUICK BUILD: no changed filenames for $git_range

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -51,7 +51,7 @@ get_build_type() {
     fi
     git_range="origin/master...$CIRCLE_SHA1"
     git fetch origin master >&2 || (echo QUICK BUILD: failed to get changed filenames for $git_range; return)
-    filenames=$(git diff --name-only $git_range)
+    filenames=$(git diff --name-only $git_range -- `find . -name plot_*`)
     if [ -z "$filenames" ]
     then
         echo QUICK BUILD: no changed filenames for $git_range

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -101,7 +101,7 @@ sudo -E apt-get -yq remove texlive-binaries --purge
 sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes \
     install dvipng texlive-latex-base texlive-latex-extra \
     texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended\
-    latexmk
+    latexmk tcl tk
 
 # deactivate circleci virtualenv and setup a miniconda env instead
 if [[ `type -t deactivate` ]]; then

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -143,7 +143,7 @@ cd -
 set +o pipefail
 
 affected_doc_paths() {
-    files=$(git diff --name-only origin/master...$CIRCLE_SHA1)
+    files=$(git diff --name-only origin/master...$CIRCLE_SHA1 -- `find . -name plot_*`)
     echo "$files" | grep ^doc/.*\.rst | sed 's/^doc\/\(.*\)\.rst$/\1.html/'
     echo "$files" | grep ^examples/.*.py | sed 's/^\(.*\)\.py$/auto_\1.html/'
     sklearn_files=$(echo "$files" | grep '^sklearn/')

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -143,7 +143,7 @@ cd -
 set +o pipefail
 
 affected_doc_paths() {
-    files=$(git diff --name-only origin/master...$CIRCLE_SHA1 -- `find . -name plot_*`)
+    files=$(git diff --name-only origin/master...$CIRCLE_SHA1)
     echo "$files" | grep ^doc/.*\.rst | sed 's/^doc\/\(.*\)\.rst$/\1.html/'
     echo "$files" | grep ^examples/.*.py | sed 's/^\(.*\)\.py$/auto_\1.html/'
     sklearn_files=$(echo "$files" | grep '^sklearn/')

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -57,7 +57,7 @@ get_build_type() {
         echo QUICK BUILD: no changed filenames for $git_range
         return
     fi
-    changed_examples=$(echo "$filenames" | grep -e grep -e ^examples/.*/plot_)
+    changed_examples=$(echo "$filenames" | grep -E "^examples/(.*/)*plot_")
     if [[ -n "$changed_examples" ]]
     then
         echo BUILD: detected examples/ filename modified in $git_range: $changed_examples

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -51,13 +51,13 @@ get_build_type() {
     fi
     git_range="origin/master...$CIRCLE_SHA1"
     git fetch origin master >&2 || (echo QUICK BUILD: failed to get changed filenames for $git_range; return)
-    filenames=$(git diff --name-only $git_range -- `git ls-files | grep -E "/plot_|.*rst$"`)
+    filenames=$(git diff --name-only $git_range)
     if [ -z "$filenames" ]
     then
         echo QUICK BUILD: no changed filenames for $git_range
         return
     fi
-    changed_examples=$(echo "$filenames" | grep -e ^examples/)
+    changed_examples=$(echo "$filenames" | grep -e grep -e ^examples/.*/plot_)
     if [[ -n "$changed_examples" ]]
     then
         echo BUILD: detected examples/ filename modified in $git_range: $changed_examples

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -101,7 +101,7 @@ sudo -E apt-get -yq remove texlive-binaries --purge
 sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes \
     install dvipng texlive-latex-base texlive-latex-extra \
     texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended\
-    latexmk tcl tk
+    latexmk
 
 # deactivate circleci virtualenv and setup a miniconda env instead
 if [[ `type -t deactivate` ]]; then

--- a/examples/applications/svm_gui.py
+++ b/examples/applications/svm_gui.py
@@ -13,7 +13,7 @@ negative examples click the right button.
 If all examples are from the same class, it uses a one-class SVM.
 
 """
-from __future__ import division, print_function
+# from __future__ import division, print_function
 
 print(__doc__)
 

--- a/examples/applications/svm_gui.py
+++ b/examples/applications/svm_gui.py
@@ -13,7 +13,6 @@ negative examples click the right button.
 If all examples are from the same class, it uses a one-class SVM.
 
 """
-# from __future__ import division, print_function
 
 print(__doc__)
 


### PR DESCRIPTION
Discovered in #12791 that if an example using the `TkAgg` matplotlib bcakend is touched, the doc build fails complaining that the `tk` library is not present.

This PR is to test this hypothesis, and then to propose a fix to those ubuntu images.