### PR TITLE
fix classes parameter using unique_labels 

### DIFF
--- a/examples/model_selection/plot_confusion_matrix.py
+++ b/examples/model_selection/plot_confusion_matrix.py
@@ -33,6 +33,7 @@ import matplotlib.pyplot as plt
 from sklearn import svm, datasets
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import confusion_matrix
+from sklearn.utils.multiclass import unique_labels
 
 # import some data to play with
 iris = datasets.load_iris()
@@ -95,7 +96,7 @@ plot_confusion_matrix(cnf_matrix, classes=class_names,
 
 # Plot normalized confusion matrix
 plt.figure()
-plot_confusion_matrix(cnf_matrix, classes=class_names, normalize=True,
+plot_confusion_matrix(cnf_matrix, classes=class_names[unique_labels(y_test,y_pred)], normalize=True,
                       title='Normalized confusion matrix')
 
 plt.show()


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #12700 

#### What does this implement/fix? Explain your changes.
Changes plot_confusion_matrix parameter classes=class_names to classes=class_names[unique_labels(y_test,y_pred)]

This will enable the plotting to not break down when test data does not contain all classes

#### Any other comments?
This is unecessary if the test data contain all possible labels

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
