### PR TITLE
[MRG] Adds documentation for parallelisation of custom scorer

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -215,10 +215,10 @@ the following two rules:
   Again, by convention higher numbers are better, so if your scorer
   returns loss, that value should be negated.
 
-In case you require the use of parallelisation (using ``n_jobs`` > 1) with a 
-custom scoring function, please make sure to define the custom function in a 
-module and import it for usage. Doing this, will ensure that the custom
-scoring function is serializable by other ``joblib`` backends prior to Loki backend. 
+While defining the custom scoring function alongside the calling function 
+should work out of the box with the default joblib backend (loky), while
+importing it from another module will be a more robust approach and work
+independently of the joblib backend.
 
 For example, to use, ``n_jobs`` greater than 1 below, ``rmse`` function is 
 saved in a separate module (``custom_scorer_module.py``) and imported::

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -215,9 +215,21 @@ the following two rules:
   Again, by convention higher numbers are better, so if your scorer
   returns loss, that value should be negated.
 
-In case you require the use of parallelisation (using ``n_jobs=-1``) with a 
+In case you require the use of parallelisation (using ``n_jobs`` > 1) with a 
 custom scoring function, please make sure to define the custom function in a 
 module and import it for usage. 
+
+For example, consider the following use of the custom scoring function ``rmse`` 
+in the below code.
+``cross_val_score(elnet_pipe,
+        X_train,
+        y_train,
+        scoring=make_scorer(rmse, greater_is_better=False),
+        cv=rkfold,
+        n_jobs=-1)``
+
+To use, ``n_jobs`` greater than 1 here, ``rmse`` function was saved in a separate module 
+and imported. 
 
 .. _multimetric_scoring:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -215,7 +215,7 @@ the following two rules:
   Again, by convention higher numbers are better, so if your scorer
   returns loss, that value should be negated.
 
-.. note:: **Using custom scorers in functions where `n_jobs > 1`**
+.. note:: **Using custom scorers in functions where n_jobs > 1**
 
     While defining the custom scoring function alongside the calling function 
     should work out of the box with the default joblib backend (loky), 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -215,6 +215,10 @@ the following two rules:
   Again, by convention higher numbers are better, so if your scorer
   returns loss, that value should be negated.
 
+In case you require the use of parallelisation (using ``n_jobs=-1``) with a 
+custom scoring function, please make sure to define the custom function in a 
+module and import it for usage. 
+
 .. _multimetric_scoring:
 
 Using multiple metric evaluation

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -221,14 +221,13 @@ module and import it for usage.
 
 For example, to use, ``n_jobs`` greater than 1 below, ``rmse`` function is 
 saved in a separate module (``custom_scorer_module.py``) and imported::
-  >>> from custom_scorer_module import rmse
+  >>> from custom_scorer_module import rmse # doctest: +SKIP
   >>> cross_val_score(elnet_pipe,
   ...  X_train,
   ...  y_train,
   ...  scoring=make_scorer(rmse, greater_is_better=False),
   ...  cv=rkfold,
   ...  n_jobs=-1)
-
 
 
 .. _multimetric_scoring:

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -215,6 +215,8 @@ the following two rules:
   Again, by convention higher numbers are better, so if your scorer
   returns loss, that value should be negated.
 
+.. notes:: **Using custom scorers in functions where `n_jobs > 1`**
+
 While defining the custom scoring function alongside the calling function 
 should work out of the box with the default joblib backend (loky), 
 importing it from another module will be a more robust approach and work
@@ -224,11 +226,11 @@ For example, to use, ``n_jobs`` greater than 1 below, ``custom_scoring_function`
 function is saved in a user-created module (``custom_scorer_module.py``) and imported::
 
     >>> from custom_scorer_module import custom_scoring_function # doctest: +SKIP
-    >>> cross_val_score(elnet_pipe,
+    >>> cross_val_score(model,
     ...  X_train,
     ...  y_train,
-    ...  scoring=make_scorer(rmse, greater_is_better=False),
-    ...  cv=rkfold,
+    ...  scoring=make_scorer(custom_scoring_function, greater_is_better=False),
+    ...  cv=5,
     ...  n_jobs=-1) # doctest: +SKIP
 
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -227,7 +227,7 @@ saved in a separate module (``custom_scorer_module.py``) and imported::
   ...  y_train,
   ...  scoring=make_scorer(rmse, greater_is_better=False),
   ...  cv=rkfold,
-  ...  n_jobs=-1)
+  ...  n_jobs=-1) # doctest: +SKIP
 
 
 .. _multimetric_scoring:

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -215,24 +215,24 @@ the following two rules:
   Again, by convention higher numbers are better, so if your scorer
   returns loss, that value should be negated.
 
-.. notes:: **Using custom scorers in functions where `n_jobs > 1`**
+.. note:: **Using custom scorers in functions where `n_jobs > 1`**
 
-While defining the custom scoring function alongside the calling function 
-should work out of the box with the default joblib backend (loky), 
-importing it from another module will be a more robust approach and work
-independently of the joblib backend.
+    While defining the custom scoring function alongside the calling function 
+    should work out of the box with the default joblib backend (loky), 
+    importing it from another module will be a more robust approach and work
+    independently of the joblib backend. 
 
-For example, to use, ``n_jobs`` greater than 1 below, ``custom_scoring_function``
-function is saved in a user-created module (``custom_scorer_module.py``) and imported::
+    For example, to use, ``n_jobs`` greater than 1 in the example below, 
+    ``custom_scoring_function`` function is saved in a user-created module 
+    (``custom_scorer_module.py``) and imported::
 
-    >>> from custom_scorer_module import custom_scoring_function # doctest: +SKIP
-    >>> cross_val_score(model,
-    ...  X_train,
-    ...  y_train,
-    ...  scoring=make_scorer(custom_scoring_function, greater_is_better=False),
-    ...  cv=5,
-    ...  n_jobs=-1) # doctest: +SKIP
-
+        >>> from custom_scorer_module import custom_scoring_function # doctest: +SKIP
+        >>> cross_val_score(model,
+        ...  X_train,
+        ...  y_train,
+        ...  scoring=make_scorer(custom_scoring_function, greater_is_better=False),
+        ...  cv=5,
+        ...  n_jobs=-1) # doctest: +SKIP
 
 .. _multimetric_scoring:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -221,13 +221,14 @@ module and import it for usage.
 
 For example, to use, ``n_jobs`` greater than 1 below, ``rmse`` function is 
 saved in a separate module (``custom_scorer_module.py``) and imported::
-  >>> from custom_scorer_module import rmse # doctest: +SKIP
-  >>> cross_val_score(elnet_pipe,
-  ...  X_train,
-  ...  y_train,
-  ...  scoring=make_scorer(rmse, greater_is_better=False),
-  ...  cv=rkfold,
-  ...  n_jobs=-1) # doctest: +SKIP
+
+    >>> from custom_scorer_module import rmse # doctest: +SKIP
+    >>> cross_val_score(elnet_pipe,
+    ...  X_train,
+    ...  y_train,
+    ...  scoring=make_scorer(rmse, greater_is_better=False),
+    ...  cv=rkfold,
+    ...  n_jobs=-1) # doctest: +SKIP
 
 
 .. _multimetric_scoring:

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -219,17 +219,17 @@ In case you require the use of parallelisation (using ``n_jobs`` > 1) with a
 custom scoring function, please make sure to define the custom function in a 
 module and import it for usage. 
 
-For example, consider the following use of the custom scoring function ``rmse`` 
-in the below code.
-``cross_val_score(elnet_pipe,
-        X_train,
-        y_train,
-        scoring=make_scorer(rmse, greater_is_better=False),
-        cv=rkfold,
-        n_jobs=-1)``
+For example, to use, ``n_jobs`` greater than 1 below, ``rmse`` function is 
+saved in a separate module (``custom_scorer_module.py``) and imported::
+  >>> from custom_scorer_module import rmse
+  >>> cross_val_score(elnet_pipe,
+  ...  X_train,
+  ...  y_train,
+  ...  scoring=make_scorer(rmse, greater_is_better=False),
+  ...  cv=rkfold,
+  ...  n_jobs=-1)
 
-To use, ``n_jobs`` greater than 1 here, ``rmse`` function was saved in a separate module 
-and imported. 
+
 
 .. _multimetric_scoring:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -216,14 +216,14 @@ the following two rules:
   returns loss, that value should be negated.
 
 While defining the custom scoring function alongside the calling function 
-should work out of the box with the default joblib backend (loky), while
+should work out of the box with the default joblib backend (loky), 
 importing it from another module will be a more robust approach and work
 independently of the joblib backend.
 
-For example, to use, ``n_jobs`` greater than 1 below, ``rmse`` function is 
-saved in a separate module (``custom_scorer_module.py``) and imported::
+For example, to use, ``n_jobs`` greater than 1 below, ``custom_scoring_function``
+function is saved in a user-created module (``custom_scorer_module.py``) and imported::
 
-    >>> from custom_scorer_module import rmse # doctest: +SKIP
+    >>> from custom_scorer_module import custom_scoring_function # doctest: +SKIP
     >>> cross_val_score(elnet_pipe,
     ...  X_train,
     ...  y_train,

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -217,7 +217,8 @@ the following two rules:
 
 In case you require the use of parallelisation (using ``n_jobs`` > 1) with a 
 custom scoring function, please make sure to define the custom function in a 
-module and import it for usage. 
+module and import it for usage. Doing this, will ensure that the custom
+scoring function is serializable by other ``joblib`` backends prior to Loki backend. 
 
 For example, to use, ``n_jobs`` greater than 1 below, ``rmse`` function is 
 saved in a separate module (``custom_scorer_module.py``) and imported::


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Adds documentation on parallelisation of custom scorers. Without importing from a module, 
joblib is unable to run custom scoring functions in parallel.

Prompted from this discussion - https://github.com/scikit-learn/scikit-learn/issues/10054#issuecomment-428529176

ping @jnothman @amueller 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->



<!--#### What does this implement/fix? Explain your changes.


#### Any other comments?


Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->