### PR TITLE
 Reduce precision requirements for float32 PCA

### DIFF
--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -721,6 +721,7 @@ def check_pca_float_dtype_preservation(svd_solver):
     assert pca_64.transform(X_64).dtype == np.float64
     assert pca_32.transform(X_32).dtype == np.float32
 
+    # decimal=5 fails on mac with scipy = 1.1.0
     assert_array_almost_equal(pca_64.components_, pca_32.components_,
                               decimal=4)
 

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -722,7 +722,7 @@ def check_pca_float_dtype_preservation(svd_solver):
     assert pca_32.transform(X_32).dtype == np.float32
 
     assert_array_almost_equal(pca_64.components_, pca_32.components_,
-                              decimal=5)
+                              decimal=4)
 
 
 def check_pca_int_dtype_upcast_to_double(svd_solver):


### PR DESCRIPTION
Fixes #12823, building on #12824 to run tests in mac

* [x] check if tests now pass
* [x] revert travis changes before merge