### PR TITLE
[MRG] ENH simplify transform for uniform output in QuantileTransformer

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -271,7 +271,7 @@ distribution function of the feature and :math:`G^{-1}` the
 `quantile function <https://en.wikipedia.org/wiki/Quantile_function>`_ of the
 desired output distribution :math:`G`. This formula is using the two following
 facts: (i) if :math:`X` is a random variable with a continuous cumulative
-distribution :math:`F` then :math:`F(X)` is uniformly distributed on
+distribution function :math:`F` then :math:`F(X)` is uniformly distributed on
 :math:`[0,1]`; (ii) if :math:`U` is a random variable with uniform distribution
 on :math:`[0,1]` then :math:`G^{-1}(U)` has distribution :math:`G`. By performing
 a rank transformation, a quantile transform smooths out unusual distributions

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -260,18 +260,33 @@ defined by :math:`phi` followed by removal of the mean in that space.
 Non-linear transformation
 =========================
 
+Two types of transformations are available: quantile transforms and power
+transforms. Both quantile and power transforms are based on monotonic
+transformations of the features and thus preserve the rank of the values
+along each feature.
+
+Quantile transforms put all features into the same desired distribution based
+on the formula :math:`G^{-1}(F(X))` where :math:`F` is the cumulative
+distribution function of the feature and :math:`G^{-1}` the
+`quantile function <https://en.wikipedia.org/wiki/Quantile_function>`_ of the
+desired output distribution :math:`G`. This formula is using the two following
+facts: (i) if :math:`X` is a random variable with a continuous cumulative
+distribution :math:`F` then :math:`F(X)` is uniformly distributed on
+:math:`[0,1]`; (ii) if :math:`U` is a random variable with uniform distribution
+on :math:`[0,1]` then :math:`G^{-1}(U)` has distribution :math:`G`. By performing
+a rank transformation, a quantile transform smooths out unusual distributions
+and is less influenced by outliers than scaling methods. It does, however,
+distort correlations and distances within and across features.
+
+Power transforms are a family of parametric transformations that aim to map
+data from any distribution to as close to a Gaussian distribution.
+
 Mapping to a Uniform distribution
 ---------------------------------
 
-Like scalers, :class:`QuantileTransformer` puts all features into the same,
-known range or distribution. However, by performing a rank transformation, it
-smooths out unusual distributions and is less influenced by outliers than
-scaling methods. It does, however, distort correlations and distances within
-and across features.
-
 :class:`QuantileTransformer` and :func:`quantile_transform` provide a
-non-parametric transformation based on the quantile function to map the data to
-a uniform distribution with values between 0 and 1::
+non-parametric transformation to map the data to a uniform distribution
+with values between 0 and 1::
 
   >>> from sklearn.datasets import load_iris
   >>> from sklearn.model_selection import train_test_split

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2220,10 +2220,14 @@ class QuantileTransformer(BaseEstimator, TransformerMixin):
 
         # find index for lower and higher bounds
         with np.errstate(invalid='ignore'):  # hide NaN comparison warnings
-            lower_bounds_idx = (X_col - BOUNDS_THRESHOLD <
-                                lower_bound_x)
-            upper_bounds_idx = (X_col + BOUNDS_THRESHOLD >
-                                upper_bound_x)
+            if output_distribution == 'normal':
+                lower_bounds_idx = (X_col - BOUNDS_THRESHOLD <
+                                    lower_bound_x)
+                upper_bounds_idx = (X_col + BOUNDS_THRESHOLD >
+                                    upper_bound_x)
+            if output_distribution == 'uniform':
+                lower_bounds_idx = (X_col == lower_bound_x)
+                upper_bounds_idx = (X_col == upper_bound_x)
 
         isfinite_mask = ~np.isnan(X_col)
         X_col_finite = X_col[isfinite_mask]

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2251,10 +2251,9 @@ class QuantileTransformer(BaseEstimator, TransformerMixin):
                     # find the value to clip the data to avoid mapping to
                     # infinity. Clip such that the inverse transform will be
                     # consistent
-                    clip_min = stats.norm.ppf(BOUNDS_THRESHOLD -
-                                                       np.spacing(1))
+                    clip_min = stats.norm.ppf(BOUNDS_THRESHOLD - np.spacing(1))
                     clip_max = stats.norm.ppf(1 - (BOUNDS_THRESHOLD -
-                                                            np.spacing(1)))
+                                                   np.spacing(1)))
                     X_col = np.clip(X_col, clip_min, clip_max)
                 # else output distribution is uniform and the ppf is the
                 # identity function so we let X_col unchanged

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1995,10 +1995,12 @@ class QuantileTransformer(BaseEstimator, TransformerMixin):
     to spread out the most frequent values. It also reduces the impact of
     (marginal) outliers: this is therefore a robust preprocessing scheme.
 
-    The transformation is applied on each feature independently.
-    The cumulative distribution function of a feature is used to project the
-    original values. Features values of new/unseen data that fall below
-    or above the fitted range will be mapped to the bounds of the output
+    The transformation is applied on each feature independently. First an
+    estimate of the cumulative distribution function of a feature is
+    used to map the original values to a uniform distribution. The obtained
+    values are then mapped to the desired output distribution using the
+    associated quantile function. Features values of new/unseen data that fall
+    below or above the fitted range will be mapped to the bounds of the output
     distribution. Note that this transform is non-linear. It may distort linear
     correlations between variables measured at the same scale but renders
     variables measured at different scales more directly comparable.
@@ -2273,7 +2275,7 @@ class QuantileTransformer(BaseEstimator, TransformerMixin):
                 raise ValueError('QuantileTransformer only accepts'
                                  ' non-negative sparse matrices.')
 
-        # check the output PDF
+        # check the output distribution
         if self.output_distribution not in ('normal', 'uniform'):
             raise ValueError("'output_distribution' has to be either 'normal'"
                              " or 'uniform'. Got '{}' instead.".format(
@@ -2380,10 +2382,12 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
     to spread out the most frequent values. It also reduces the impact of
     (marginal) outliers: this is therefore a robust preprocessing scheme.
 
-    The transformation is applied on each feature independently.
-    The cumulative distribution function of a feature is used to project the
-    original values. Features values of new/unseen data that fall below
-    or above the fitted range will be mapped to the bounds of the output
+    The transformation is applied on each feature independently. First an
+    estimate of the cumulative distribution function of a feature is
+    used to map the original values to a uniform distribution. The obtained
+    values are then mapped to the desired output distribution using the
+    associated quantile function. Features values of new/unseen data that fall
+    below or above the fitted range will be mapped to the bounds of the output
     distribution. Note that this transform is non-linear. It may distort linear
     correlations between variables measured at the same scale but renders
     variables measured at different scales more directly comparable.

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2213,8 +2213,7 @@ class QuantileTransformer(BaseEstimator, TransformerMixin):
             #  for inverse transform, match a uniform distribution
             with np.errstate(invalid='ignore'):  # hide NaN comparison warnings
                 if output_distribution == 'normal':
-                    output_distribution = getattr(stats, 'norm')
-                    X_col = output_distribution.cdf(X_col)
+                    X_col = stats.norm.cdf(X_col)
                 # else output distribution is already a uniform distribution
 
         # find index for lower and higher bounds
@@ -2248,14 +2247,13 @@ class QuantileTransformer(BaseEstimator, TransformerMixin):
         if not inverse:
             with np.errstate(invalid='ignore'):  # hide NaN comparison warnings
                 if output_distribution == 'normal':
-                    output_distribution = getattr(stats, 'norm')
-                    X_col = output_distribution.ppf(X_col)
+                    X_col = stats.norm.ppf(X_col)
                     # find the value to clip the data to avoid mapping to
                     # infinity. Clip such that the inverse transform will be
                     # consistent
-                    clip_min = output_distribution.ppf(BOUNDS_THRESHOLD -
+                    clip_min = stats.norm.ppf(BOUNDS_THRESHOLD -
                                                        np.spacing(1))
-                    clip_max = output_distribution.ppf(1 - (BOUNDS_THRESHOLD -
+                    clip_max = stats.norm.ppf(1 - (BOUNDS_THRESHOLD -
                                                             np.spacing(1)))
                     X_col = np.clip(X_col, clip_min, clip_max)
                 # else output distribution is uniform and the ppf is the

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -54,6 +54,7 @@ from sklearn.preprocessing.data import add_dummy_feature
 from sklearn.preprocessing.data import PolynomialFeatures
 from sklearn.preprocessing.data import PowerTransformer
 from sklearn.preprocessing.data import power_transform
+from sklearn.preprocessing.data import BOUNDS_THRESHOLD
 from sklearn.exceptions import DataConversionWarning, NotFittedError
 
 from sklearn.base import clone
@@ -1471,12 +1472,13 @@ def test_quantile_transform_bounds():
 
 
 def test_quantile_transform_and_inverse():
-    # iris dataset
-    X = iris.data
-    transformer = QuantileTransformer(n_quantiles=1000, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans_inv = transformer.inverse_transform(X_trans)
-    assert_array_almost_equal(X, X_trans_inv)
+    X_1 = iris.data
+    X_2 = np.array([[0.], [BOUNDS_THRESHOLD/10], [1.5], [2], [3], [3], [4]])
+    for X in [X_1, X_2]:
+        transformer = QuantileTransformer(n_quantiles=1000, random_state=0)
+        X_trans = transformer.fit_transform(X)
+        X_trans_inv = transformer.inverse_transform(X_trans)
+        assert_array_almost_equal(X, X_trans_inv, decimal=9)
 
 
 def test_quantile_transform_nan():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1473,7 +1473,7 @@ def test_quantile_transform_bounds():
 
 def test_quantile_transform_and_inverse():
     X_1 = iris.data
-    X_2 = np.array([[0.], [BOUNDS_THRESHOLD/10], [1.5], [2], [3], [3], [4]])
+    X_2 = np.array([[0.], [BOUNDS_THRESHOLD / 10], [1.5], [2], [3], [3], [4]])
     for X in [X_1, X_2]:
         transformer = QuantileTransformer(n_quantiles=1000, random_state=0)
         X_trans = transformer.fit_transform(X)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #12775

#### What does this implement/fix? Explain your changes.
- [x] Add details in doc about what is done in the transform: basically G^-1(F(X)) where F is the empirical cdf of the data and G the output distribution. In the case of the uniform distribution output this becomes F(X). Also add in the doc that such a transform is monotonic and thus preserves the rank of the values along each feature.
- [x] Simplify transform for uniform distribution as cdf and ppf of the uniform distribution on [0,1] are the identity function

#### Any other comments?
~Check whether we can use the samples instead of `n_quantiles`.~ I will try this on my side and open a separate PR if successful.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
