### PR TITLE
Fixes #12814 Bad link in ParameterGrid documentation

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -53,7 +53,7 @@ class ParameterGrid(object):
     Can be used to iterate over parameter value combinations with the
     Python built-in function iter.
 
-    Read more in the :ref:`User Guide <search>`.
+    Read more in the :ref:`User Guide <grid_search>`.
 
     Parameters
     ----------


### PR DESCRIPTION
The webpage of the documentation of selection.ParameterGrid (https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.ParameterGrid.html)
includes a link labelled as "Read more in the User Guide.".

The underlying URL under "User Guide" wrongly target "https://scikit-learn.org/stable/search.html". 

Correct the link to target https://scikit-learn.org/stable/modules/grid_search.html 
