### PR TITLE
move to the latest cython in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     # This environment tests that scikit-learn can be built against
     # versions of numpy, scipy with ATLAS that comes with Ubuntu Xenial 16.04
     # i.e. numpy 1.11 and scipy 0.17
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" CYTHON_VERSION="*"
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.5"
            NUMPY_VERSION="1.11.0" SCIPY_VERSION="0.17.0"
            PILLOW_VERSION="4.0.0" COVERAGE=true
            SKLEARN_SITE_JOBLIB=1 JOBLIB_VERSION="0.11"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     # This environment tests that scikit-learn can be built against
     # versions of numpy, scipy with ATLAS that comes with Ubuntu Xenial 16.04
     # i.e. numpy 1.11 and scipy 0.17
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" CYTHON_VERSION="0.28.6"
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" CYTHON_VERSION="*"
            NUMPY_VERSION="1.11.0" SCIPY_VERSION="0.17.0"
            PILLOW_VERSION="4.0.0" COVERAGE=true
            SKLEARN_SITE_JOBLIB=1 JOBLIB_VERSION="0.11"
@@ -38,12 +38,12 @@ matrix:
             - libatlas-dev
     # Python 3.5 build without SITE_JOBLIB
     - env: DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="false"
-           NUMPY_VERSION="1.11.0" SCIPY_VERSION="0.17.0" CYTHON_VERSION="0.25.2"
+           NUMPY_VERSION="1.11.0" SCIPY_VERSION="0.17.0" CYTHON_VERSION="*"
            PILLOW_VERSION="4.0.0" COVERAGE=true
       if: type != cron
     # Python 3.5 build
     - env: DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="false"
-           NUMPY_VERSION="1.11.0" SCIPY_VERSION="0.17.0" CYTHON_VERSION="0.25.2"
+           NUMPY_VERSION="1.11.0" SCIPY_VERSION="0.17.0" CYTHON_VERSION="*"
            PILLOW_VERSION="4.0.0" COVERAGE=true
            SKLEARN_SITE_JOBLIB=1 JOBLIB_VERSION="0.11"
       if: type != cron

--- a/build_tools/appveyor/requirements.txt
+++ b/build_tools/appveyor/requirements.txt
@@ -1,7 +1,6 @@
 numpy
 scipy
-# Pin Cython to avoid bug with 0.28.x on Python 3.7 
-cython==0.27.3
+cython
 pytest
 wheel
 wheelhouse_uploader

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -79,7 +79,7 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # and scipy
     virtualenv --system-site-packages --python=python3 testvenv
     source testvenv/bin/activate
-    pip install pytest pytest-cov cython==$CYTHON_VERSION joblib==$JOBLIB_VERSION
+    pip install pytest pytest-cov cython joblib==$JOBLIB_VERSION
 
 elif [[ "$DISTRIB" == "scipy-dev" ]]; then
     make_conda python=3.7

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -13,7 +13,8 @@ from distutils.version import LooseVersion
 from numpy.distutils.system_info import get_info
 
 DEFAULT_ROOT = 'sklearn'
-CYTHON_MIN_VERSION = '0.29'
+# on conda, this is the latest for python 3.5
+CYTHON_MIN_VERSION = '0.28.5'
 
 
 def get_blas_info():

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -13,7 +13,7 @@ from distutils.version import LooseVersion
 from numpy.distutils.system_info import get_info
 
 DEFAULT_ROOT = 'sklearn'
-CYTHON_MIN_VERSION = '0.23'
+CYTHON_MIN_VERSION = '0.29'
 
 
 def get_blas_info():


### PR DESCRIPTION
My take from the discussion in #12671 is that we release using the latest cython available at the time of the release, which kinda implies we should also test things with the latest cython in our CI.

I suppose #12707 should also be closed by either this one or the release.