### PR TITLE
FunctionTransformer use as a decorator

### DIFF
--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -1,4 +1,5 @@
 import warnings
+from copy import deepcopy
 
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_array
@@ -80,14 +81,17 @@ class FunctionTransformer(BaseEstimator, TransformerMixin):
     def __init__(self, func=None, inverse_func=None, validate=None,
                  accept_sparse=False, pass_y='deprecated', check_inverse=True,
                  kw_args=None, inv_kw_args=None):
-        self.func = func
-        self.inverse_func = inverse_func
+        self.func = deepcopy(func)
+        self.inverse_func = deepcopy(inverse_func)
         self.validate = validate
         self.accept_sparse = accept_sparse
         self.pass_y = pass_y
         self.check_inverse = check_inverse
         self.kw_args = kw_args
         self.inv_kw_args = inv_kw_args
+
+    def __call__(self, X):
+        return self.func(X)
 
     def _check_input(self, X):
         # FIXME: Future warning to be removed in 0.22

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -1,5 +1,4 @@
 import warnings
-from copy import deepcopy
 
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_array
@@ -81,8 +80,8 @@ class FunctionTransformer(BaseEstimator, TransformerMixin):
     def __init__(self, func=None, inverse_func=None, validate=None,
                  accept_sparse=False, pass_y='deprecated', check_inverse=True,
                  kw_args=None, inv_kw_args=None):
-        self.func = deepcopy(func)
-        self.inverse_func = deepcopy(inverse_func)
+        self.func = func
+        self.inverse_func = inverse_func
         self.validate = validate
         self.accept_sparse = accept_sparse
         self.pass_y = pass_y

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -88,6 +88,25 @@ def test_np_log():
 
 @ignore_warnings(category=FutureWarning)
 # ignore warning for validate=False 0.22
+def test_np_log_decorator():
+    X = np.arange(10).reshape((5, 2))
+
+    @FunctionTransformer
+    def np_log1p(T):
+        return np.log1p(T)
+    # Test that the numpy.log example still works.
+    assert_array_equal(
+        np_log1p.transform(X),
+        np.log1p(X),
+    )
+    assert_array_equal(
+        np_log1p(X),
+        np.log1p(X),
+    )
+
+
+@ignore_warnings(category=FutureWarning)
+# ignore warning for validate=False 0.22
 def test_kw_arg():
     X = np.linspace(0, 1, num=10).reshape((5, 2))
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

We could be using FunctionTransformer as a decorator

```
@FunctionTransformer
def multiply_by_2(X):
    return 2*X

P = Pipeline([("x2", multiply_by_2)])
```
But calling the decorated function `multiply_by_2(X)` causes an error.

This fix allows us to use the `FunctionTransformer` both as a function (`__call__`) and as a transformer (`.transform`)

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
