### PR TITLE
[MRG] Implement randomized PCA

### DIFF
--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -117,9 +117,6 @@ class PCA(_BasePCA):
     It can also use the scipy.sparse.linalg ARPACK implementation of the
     truncated SVD.
 
-    Notice that this class does not support sparse input. See
-    :class:`TruncatedSVD` for an alternative with sparse data.
-
     Read more in the :ref:`User Guide <PCA>`.
 
     Parameters
@@ -168,6 +165,9 @@ class PCA(_BasePCA):
             dimension of the data, then the more efficient 'randomized'
             method is enabled. Otherwise the exact full SVD is computed and
             optionally truncated afterwards.
+
+            in case sparse data is used, 'randomized' is used as this is the
+            only method that supports sparse data.
         full :
             run exact full SVD calling the standard LAPACK solver via
             `scipy.linalg.svd` and select the components by postprocessing
@@ -176,7 +176,8 @@ class PCA(_BasePCA):
             `scipy.sparse.linalg.svds`. It requires strictly
             0 < n_components < min(X.shape)
         randomized :
-            run randomized SVD by the method of Halko et al.
+            run randomized SVD by the method of Halko et al. This is the only
+            method that supports sparse data.
 
         .. versionadded:: 0.18.0
 

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -159,24 +159,24 @@ class PCA(_BasePCA):
 
     svd_solver : string {'auto', 'full', 'arpack', 'randomized'}
         auto :
-            the solver is selected by a default policy based on `X.shape` and
+            The solver is selected by a default policy based on `X.shape` and
             `n_components`: if the input data is larger than 500x500 and the
             number of components to extract is lower than 80% of the smallest
             dimension of the data, then the more efficient 'randomized'
             method is enabled. Otherwise the exact full SVD is computed and
             optionally truncated afterwards.
 
-            in case sparse data is used, 'randomized' is used as this is the
+            In case sparse data is used, 'randomized' is used as this is the
             only method that supports sparse data.
         full :
-            run exact full SVD calling the standard LAPACK solver via
+            Run exact full SVD calling the standard LAPACK solver via
             `scipy.linalg.svd` and select the components by postprocessing
         arpack :
-            run SVD truncated to n_components calling ARPACK solver via
+            Run SVD truncated to n_components calling ARPACK solver via
             `scipy.sparse.linalg.svds`. It requires strictly
             0 < n_components < min(X.shape)
         randomized :
-            run randomized SVD by the method of Halko et al. This is the only
+            Run randomized SVD by the method of Halko et al. This is the only
             method that supports sparse data.
 
         .. versionadded:: 0.18.0
@@ -403,7 +403,7 @@ class PCA(_BasePCA):
         # Ensure we don't try call arpack or full on a sparse matrix
         if issparse(X) and self._fit_svd_solver != 'randomized':
             raise ValueError(
-                'only the randomized solver supports sparse matrices'
+                'Only the randomized solver supports sparse matrices'
             )
 
         # Call different fits for either full or truncated SVD

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -257,35 +257,33 @@ def test_singular_values():
 
     X = rng.randn(n_samples, n_features)
 
-    pca = PCA(n_components=2, svd_solver='full',
-              random_state=rng).fit(X)
-    apca = PCA(n_components=2, svd_solver='arpack',
-               random_state=rng).fit(X)
+    pca = PCA(n_components=2, svd_solver='full', random_state=rng).fit(X)
+    apca = PCA(n_components=2, svd_solver='arpack', random_state=rng).fit(X)
     # Increase the number of power iterations to get greater accuracy in tests
     rpca = PCA(n_components=2, svd_solver='randomized', iterated_power=40,
                random_state=rng).fit(X)
-    assert_allclose(pca.singular_values_, apca.singular_values_, atol=12)
-    assert_allclose(pca.singular_values_, rpca.singular_values_, atol=12)
-    assert_allclose(apca.singular_values_, rpca.singular_values_, atol=12)
+    assert_allclose(pca.singular_values_, apca.singular_values_)
+    assert_allclose(pca.singular_values_, rpca.singular_values_)
+    assert_allclose(apca.singular_values_, rpca.singular_values_)
 
     # Compare to the Frobenius norm
     X_pca = pca.transform(X)
     X_apca = apca.transform(X)
     X_rpca = rpca.transform(X)
-    assert_array_almost_equal(np.sum(pca.singular_values_**2.0),
-                              np.linalg.norm(X_pca, "fro")**2.0, 12)
-    assert_array_almost_equal(np.sum(apca.singular_values_**2.0),
-                              np.linalg.norm(X_apca, "fro")**2.0, 9)
-    assert_array_almost_equal(np.sum(rpca.singular_values_**2.0),
-                              np.linalg.norm(X_rpca, "fro")**2.0, 0)
+    assert_array_almost_equal(np.sum(pca.singular_values_ ** 2.0),
+                              np.linalg.norm(X_pca, "fro") ** 2.0, 12)
+    assert_array_almost_equal(np.sum(apca.singular_values_ ** 2.0),
+                              np.linalg.norm(X_apca, "fro") ** 2.0, 9)
+    assert_array_almost_equal(np.sum(rpca.singular_values_ ** 2.0),
+                              np.linalg.norm(X_rpca, "fro") ** 2.0, 0)
 
     # Compare to the 2-norms of the score vectors
-    assert_array_almost_equal(pca.singular_values_,
-                              np.sqrt(np.sum(X_pca**2.0, axis=0)), 12)
-    assert_array_almost_equal(apca.singular_values_,
-                              np.sqrt(np.sum(X_apca**2.0, axis=0)), 12)
-    assert_array_almost_equal(rpca.singular_values_,
-                              np.sqrt(np.sum(X_rpca**2.0, axis=0)), 12)
+    assert_allclose(pca.singular_values_,
+                    np.sqrt(np.sum(X_pca ** 2.0, axis=0)))
+    assert_allclose(apca.singular_values_,
+                    np.sqrt(np.sum(X_apca ** 2.0, axis=0)))
+    assert_allclose(rpca.singular_values_,
+                    np.sqrt(np.sum(X_rpca ** 2.0, axis=0)))
 
     # Set the singular values and see what we get back
     rng = np.random.RandomState(0)
@@ -299,7 +297,7 @@ def test_singular_values():
     rpca = PCA(n_components=3, svd_solver='randomized', random_state=rng)
     X_pca = pca.fit_transform(X)
 
-    X_pca /= np.sqrt(np.sum(X_pca**2.0, axis=0))
+    X_pca /= np.sqrt(np.sum(X_pca ** 2.0, axis=0))
     X_pca[:, 0] *= 3.142
     X_pca[:, 1] *= 2.718
 
@@ -308,9 +306,9 @@ def test_singular_values():
     apca.fit(X_hat)
     rpca.fit(X_hat)
 
-    assert_array_almost_equal(pca.singular_values_, [3.142, 2.718, 1.0], 14)
-    assert_array_almost_equal(apca.singular_values_, [3.142, 2.718, 1.0], 14)
-    assert_array_almost_equal(rpca.singular_values_, [3.142, 2.718, 1.0], 14)
+    assert_allclose(pca.singular_values_, [3.142, 2.718, 1.0])
+    assert_allclose(apca.singular_values_, [3.142, 2.718, 1.0])
+    assert_allclose(rpca.singular_values_, [3.142, 2.718, 1.0])
 
 
 def test_pca_check_projection():

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -261,11 +261,12 @@ def test_singular_values():
               random_state=rng).fit(X)
     apca = PCA(n_components=2, svd_solver='arpack',
                random_state=rng).fit(X)
+    # Increase the number of power iterations to get greater accuracy in tests
     rpca = PCA(n_components=2, svd_solver='randomized', iterated_power=40,
                random_state=rng).fit(X)
-    assert_array_almost_equal(pca.singular_values_, apca.singular_values_, 12)
-    assert_array_almost_equal(pca.singular_values_, rpca.singular_values_, 12)
-    assert_array_almost_equal(apca.singular_values_, rpca.singular_values_, 12)
+    assert_allclose(pca.singular_values_, apca.singular_values_, 12)
+    assert_allclose(pca.singular_values_, rpca.singular_values_, 12)
+    assert_allclose(apca.singular_values_, rpca.singular_values_, 12)
 
     # Compare to the Frobenius norm
     X_pca = pca.transform(X)
@@ -693,11 +694,10 @@ def test_pca_sparse_input_randomized_solver():
     X = rng.binomial(1, 0.1, (n_samples, n_features))
     X_sp = sp.sparse.csr_matrix(X)
 
-    # Compute the complete decomposition on the dense matrix
+    # Compute the randomized decomposition on the dense matrix
     pca = PCA(n_components=3, svd_solver='randomized',
               random_state=0).fit(X)
-    # And compute a randomized decomposition on the sparse matrix. Increase the
-    # number of power iterations to account for the non-zero means
+    # And compute the randomized decomposition on the sparse matrix.
     pca_sp = PCA(n_components=3, svd_solver='randomized',
                  random_state=0).fit(X_sp)
 
@@ -717,7 +717,9 @@ def test_pca_sparse_input_bad_solvers(svd_solver):
 
     pca = PCA(n_components=3, svd_solver=svd_solver)
 
-    assert_raises(ValueError, pca.fit, X)
+    with pytest.raises(ValueError, match='only the randomized solver supports '
+                                         'sparse matrices'):
+        pca.fit(X)
 
 
 def test_pca_auto_solver_selects_randomized_solver_for_sparse_matrices():

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -264,9 +264,9 @@ def test_singular_values():
     # Increase the number of power iterations to get greater accuracy in tests
     rpca = PCA(n_components=2, svd_solver='randomized', iterated_power=40,
                random_state=rng).fit(X)
-    assert_allclose(pca.singular_values_, apca.singular_values_, 12)
-    assert_allclose(pca.singular_values_, rpca.singular_values_, 12)
-    assert_allclose(apca.singular_values_, rpca.singular_values_, 12)
+    assert_allclose(pca.singular_values_, apca.singular_values_, atol=12)
+    assert_allclose(pca.singular_values_, rpca.singular_values_, atol=12)
+    assert_allclose(apca.singular_values_, rpca.singular_values_, atol=12)
 
     # Compare to the Frobenius norm
     X_pca = pca.transform(X)
@@ -717,7 +717,7 @@ def test_pca_sparse_input_bad_solvers(svd_solver):
 
     pca = PCA(n_components=3, svd_solver=svd_solver)
 
-    with pytest.raises(ValueError, match='only the randomized solver supports '
+    with pytest.raises(ValueError, match='Only the randomized solver supports '
                                          'sparse matrices'):
         pca.fit(X)
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -376,6 +376,8 @@ def randomized_pca(A, n_components, n_oversamples=10, n_iter="auto",
                    random_state=0):
     """Computes a truncated randomized PCA decomposition.
 
+    .. versionadded:: 0.21
+
     Parameters
     ----------
     A : ndarray or sparse matrix
@@ -397,8 +399,6 @@ def randomized_pca(A, n_components, n_oversamples=10, n_iter="auto",
         (< .1 * min(X.shape)) `n_iter` in which case is set to 7.
         This improves precision with few components.
 
-        .. versionchanged:: 0.18
-
     power_iteration_normalizer : 'auto' (default), 'QR', 'LU', 'none'
         Whether the power iterations are normalized with step-by-step
         QR factorization (the slowest but most accurate), 'none'
@@ -406,8 +406,6 @@ def randomized_pca(A, n_components, n_oversamples=10, n_iter="auto",
         typically 5 or larger), or 'LU' factorization (numerically stable
         but can lose slightly in accuracy). The 'auto' mode applies no
         normalization if `n_iter` <= 2 and switches to LU otherwise.
-
-        .. versionadded:: 0.18
 
     flip_sign : boolean, (True by default)
         The output of a singular value decomposition is only unique up to a
@@ -454,9 +452,6 @@ def randomized_pca(A, n_components, n_oversamples=10, n_iter="auto",
 
     n_samples, n_features = A.shape
 
-    # Use `mean_variance_axis` instead of `A.sum` as it is much more memory
-    # efficient than scipy's implementation. See GH
-    # https://github.com/scikit-learn/scikit-learn/pull/12841#issuecomment-460238233
     if sparse.issparse(A):
         means, _ = mean_variance_axis(A, axis=0)
     else:
@@ -468,7 +463,6 @@ def randomized_pca(A, n_components, n_oversamples=10, n_iter="auto",
             size=(n_features, n_components + n_oversamples)
         )
         if A.dtype.kind == "f":
-            # Ensure f32 is preserved as f32
             Q = Q.astype(A.dtype, copy=False)
 
         Q = safe_sparse_dot(A, Q) - safe_sparse_dot(c, Q)
@@ -493,7 +487,6 @@ def randomized_pca(A, n_components, n_oversamples=10, n_iter="auto",
             size=(n_samples, n_components + n_oversamples)
         )
         if A.dtype.kind == "f":
-            # Ensure f32 is preserved as f32
             Q = Q.astype(A.dtype, copy=False)
 
         Q = safe_sparse_dot(A.T, Q) - \

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -437,6 +437,8 @@ def randomized_pca(A, n_components, n_oversamples=10, n_iter="auto",
       Li, Huamin, et al. 2017
 
     """
+    random_state = check_random_state(random_state)
+
     if n_iter == "auto":
         # Checks if the number of iterations is explicitly specified
         # Adjust n_iter. 7 was found a good compromise for PCA.

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -214,15 +214,10 @@ def randomized_range_finder(A, size, n_iter,
     # Perform power iterations with Q to further 'imprint' the top
     # singular vectors of A in Q
     for i in range(n_iter):
-        if power_iteration_normalizer == 'none':
-            Q = safe_sparse_dot(A, Q)
-            Q = safe_sparse_dot(A.T, Q)
-        elif power_iteration_normalizer == 'LU':
-            Q, _ = linalg.lu(safe_sparse_dot(A, Q), permute_l=True)
-            Q, _ = linalg.lu(safe_sparse_dot(A.T, Q), permute_l=True)
-        elif power_iteration_normalizer == 'QR':
-            Q, _ = linalg.qr(safe_sparse_dot(A, Q), mode='economic')
-            Q, _ = linalg.qr(safe_sparse_dot(A.T, Q), mode='economic')
+        Q = safe_sparse_dot(A, Q)
+        Q = _normalize_power_iteration(Q, power_iteration_normalizer)
+        Q = safe_sparse_dot(A.T, Q)
+        Q = _normalize_power_iteration(Q, power_iteration_normalizer)
 
     # Sample the range of A using by linear projection of Q
     # Extract an orthonormal basis

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -440,7 +440,8 @@ def randomized_pca(A, n_components, n_oversamples=10, n_iter="auto",
     """
     if n_iter == "auto":
         # Checks if the number of iterations is explicitly specified
-        # Adjust n_iter. 7 was found a good compromise for PCA. See sklearn #5299
+        # Adjust n_iter. 7 was found a good compromise for PCA.
+        # See sklearn #5299
         n_iter = 7 if n_components < .1 * min(A.shape) else 4
 
     # Deal with "auto" mode
@@ -455,7 +456,9 @@ def randomized_pca(A, n_components, n_oversamples=10, n_iter="auto",
     c = np.atleast_2d(A.mean(axis=0))
 
     if n_samples >= n_features:
-        Q = random_state.normal(size=(n_features, n_components + n_oversamples))
+        Q = random_state.normal(
+            size=(n_features, n_components + n_oversamples)
+        )
         if A.dtype.kind == "f":
             # Ensure f32 is preserved as f32
             Q = Q.astype(A.dtype, copy=False)
@@ -464,30 +467,36 @@ def randomized_pca(A, n_components, n_oversamples=10, n_iter="auto",
 
         # Normalized power iterations
         for _ in range(n_iter):
-            Q = safe_sparse_dot(A.T, Q) - safe_sparse_dot(c.T, Q.sum(axis=0)[None, :])
+            Q = safe_sparse_dot(A.T, Q) - \
+                safe_sparse_dot(c.T, Q.sum(axis=0)[None, :])
             Q = _normalize_power_iteration(Q, power_iteration_normalizer)
             Q = safe_sparse_dot(A, Q) - safe_sparse_dot(c, Q)
             Q = _normalize_power_iteration(Q, power_iteration_normalizer)
 
         Q, _ = linalg.qr(Q, mode="economic")
 
-        QA = safe_sparse_dot(A.T, Q) - safe_sparse_dot(c.T, Q.sum(axis=0)[None, :])
+        QA = safe_sparse_dot(A.T, Q) - \
+            safe_sparse_dot(c.T, Q.sum(axis=0)[None, :])
         R, s, V = linalg.svd(QA.T, full_matrices=False)
         U = Q.dot(R)
 
     else:  # n_features > n_samples
-        Q = random_state.normal(size=(n_samples, n_components + n_oversamples))
+        Q = random_state.normal(
+            size=(n_samples, n_components + n_oversamples)
+        )
         if A.dtype.kind == "f":
             # Ensure f32 is preserved as f32
             Q = Q.astype(A.dtype, copy=False)
 
-        Q = safe_sparse_dot(A.T, Q) - safe_sparse_dot(c.T, Q.sum(axis=0)[None, :])
+        Q = safe_sparse_dot(A.T, Q) - \
+            safe_sparse_dot(c.T, Q.sum(axis=0)[None, :])
 
         # Normalized power iterations
         for _ in range(n_iter):
             Q = safe_sparse_dot(A, Q) - safe_sparse_dot(c, Q)
             Q = _normalize_power_iteration(Q, power_iteration_normalizer)
-            Q = safe_sparse_dot(A.T, Q) - safe_sparse_dot(c.T, Q.sum(axis=0)[None, :])
+            Q = safe_sparse_dot(A.T, Q) - \
+                safe_sparse_dot(c.T, Q.sum(axis=0)[None, :])
             Q = _normalize_power_iteration(Q, power_iteration_normalizer)
 
         Q, _ = linalg.qr(Q, mode="economic")

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -386,14 +386,14 @@ def randomized_pca(A, n_components, n_oversamples=10, n_iter="auto",
     n_components : int
         Number of singular values and vectors to extract.
 
-    n_oversamples : int (default is 10)
+    n_oversamples : int (default=10)
         Additional number of random vectors to sample the range of M so as
         to ensure proper conditioning. The total number of random vectors
         used to find the range of M is n_components + n_oversamples. Smaller
         number can improve speed but can negatively impact the quality of
         approximation of singular vectors and singular values.
 
-    n_iter : int or 'auto' (default is 'auto')
+    n_iter : int or 'auto' (default='auto')
         Number of power iterations. It can be used to deal with very noisy
         problems. When 'auto', it is set to 4, unless `n_components` is small
         (< .1 * min(X.shape)) `n_iter` in which case is set to 7.
@@ -407,7 +407,7 @@ def randomized_pca(A, n_components, n_oversamples=10, n_iter="auto",
         but can lose slightly in accuracy). The 'auto' mode applies no
         normalization if `n_iter` <= 2 and switches to LU otherwise.
 
-    flip_sign : boolean, (True by default)
+    flip_sign : boolean, (default=True)
         The output of a singular value decomposition is only unique up to a
         permutation of the signs of the singular vectors. If `flip_sign` is
         set to `True`, the sign ambiguity is resolved by making the largest

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -61,8 +61,8 @@ def inplace_csr_row_scale(X, scale):
     X.data *= np.repeat(scale, np.diff(X.indptr))
 
 
-def mean_variance_axis(X, axis):
-    """Compute mean and variance along an axix on a CSR or CSC matrix
+def mean_variance_axis(X, axis, ddof=0):
+    """Compute mean and variance along an axis on a CSR or CSC matrix
 
     Parameters
     ----------
@@ -71,6 +71,11 @@ def mean_variance_axis(X, axis):
 
     axis : int (either 0 or 1)
         Axis along which the axis should be computed.
+
+    ddof : int, optional
+        “Delta Degrees of Freedom”: the divisor used in the calculation is
+        ``N - ddof``, where ``N`` represents the number of elements. By default
+        ddof is zero.
 
     Returns
     -------
@@ -82,18 +87,24 @@ def mean_variance_axis(X, axis):
         Feature-wise variances
 
     """
+    if ddof < 0:
+        raise ValueError('ddof cannot be <0')
+
+    if ddof >= X.shape[axis]:
+        raise ValueError('ddof cannot be <N')
+
     _raise_error_wrong_axis(axis)
 
     if isinstance(X, sp.csr_matrix):
         if axis == 0:
-            return _csr_mean_var_axis0(X)
+            return _csr_mean_var_axis0(X, ddof=ddof)
         else:
-            return _csc_mean_var_axis0(X.T)
+            return _csc_mean_var_axis0(X.T, ddof=ddof)
     elif isinstance(X, sp.csc_matrix):
         if axis == 0:
-            return _csc_mean_var_axis0(X)
+            return _csc_mean_var_axis0(X, ddof=ddof)
         else:
-            return _csr_mean_var_axis0(X.T)
+            return _csr_mean_var_axis0(X.T, ddof=ddof)
     else:
         _raise_typeerror(X)
 

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -87,13 +87,13 @@ def mean_variance_axis(X, axis, ddof=0):
         Feature-wise variances
 
     """
+    _raise_error_wrong_axis(axis)
+
     if ddof < 0:
         raise ValueError('ddof cannot be <0')
 
     if ddof >= X.shape[axis]:
         raise ValueError('ddof cannot be <N')
-
-    _raise_error_wrong_axis(axis)
 
     if isinstance(X, sp.csr_matrix):
         if axis == 0:

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -72,10 +72,9 @@ def mean_variance_axis(X, axis, ddof=0):
     axis : int (either 0 or 1)
         Axis along which the axis should be computed.
 
-    ddof : int, optional
+    ddof : int, optional (default=0)
         “Delta Degrees of Freedom”: the divisor used in the calculation is
-        ``N - ddof``, where ``N`` represents the number of elements. By default
-        ddof is zero.
+        ``N - ddof``, where ``N`` represents the number of elements.
 
         .. versionadded:: 0.21
 
@@ -95,7 +94,10 @@ def mean_variance_axis(X, axis, ddof=0):
         raise ValueError('ddof cannot be <0')
 
     if ddof >= X.shape[axis]:
-        raise ValueError('ddof must be <N')
+        raise ValueError(
+            'ddof=%r must be smaller than the number of samples=%r' % (
+                ddof, X.shape[axis])
+        )
 
     if isinstance(X, sp.csr_matrix):
         if axis == 0:

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -77,6 +77,8 @@ def mean_variance_axis(X, axis, ddof=0):
         ``N - ddof``, where ``N`` represents the number of elements. By default
         ddof is zero.
 
+        .. versionadded:: 0.21
+
     Returns
     -------
 
@@ -93,7 +95,7 @@ def mean_variance_axis(X, axis, ddof=0):
         raise ValueError('ddof cannot be <0')
 
     if ddof >= X.shape[axis]:
-        raise ValueError('ddof cannot be <N')
+        raise ValueError('ddof must be <N')
 
     if isinstance(X, sp.csr_matrix):
         if axis == 0:

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -63,10 +63,9 @@ def csr_mean_variance_axis0(X, ddof=0):
     X : CSR sparse matrix, shape (n_samples, n_features)
         Input data.
 
-    ddof : int, optional
+    ddof : int, optional (default=0)
         “Delta Degrees of Freedom”: the divisor used in the calculation is
-        ``N - ddof``, where ``N`` represents the number of elements. By default
-        ddof is zero.
+        ``N - ddof``, where ``N`` represents the number of elements.
 
         .. versionadded:: 0.21
 
@@ -156,10 +155,9 @@ def csc_mean_variance_axis0(X, ddof=0):
     X : CSC sparse matrix, shape (n_samples, n_features)
         Input data.
 
-    ddof : int, optional
+    ddof : int, optional (default=0)
         “Delta Degrees of Freedom”: the divisor used in the calculation is
-        ``N - ddof``, where ``N`` represents the number of elements. By default
-        ddof is zero.
+        ``N - ddof``, where ``N`` represents the number of elements.
 
         .. versionadded:: 0.21
 

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -68,6 +68,8 @@ def csr_mean_variance_axis0(X, ddof=0):
         ``N - ddof``, where ``N`` represents the number of elements. By default
         ddof is zero.
 
+        .. versionadded:: 0.21
+
     Returns
     -------
     means : float array with shape (n_features,)
@@ -158,6 +160,8 @@ def csc_mean_variance_axis0(X, ddof=0):
         “Delta Degrees of Freedom”: the divisor used in the calculation is
         ``N - ddof``, where ``N`` represents the number of elements. By default
         ddof is zero.
+
+        .. versionadded:: 0.21
 
     Returns
     -------

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -137,7 +137,11 @@ def _csr_mean_variance_axis0(np.ndarray[floating, ndim=1, mode="c"] X_data,
 
     for i in xrange(n_features):
         variances[i] += (n_samples - counts_nan[i] - counts[i]) * means[i]**2
-        variances[i] /= (n_samples - ddof - counts_nan[i])
+        # int(n_samples) is necessary to convert from unsigned int to any int
+        if int(n_samples) - ddof - counts_nan[i] > 0:
+            variances[i] /= n_samples - ddof - counts_nan[i]
+        else:
+            variances[i] = np.nan
 
     return means, variances, counts_nan
 
@@ -222,7 +226,11 @@ def _csc_mean_variance_axis0(np.ndarray[floating, ndim=1] X_data,
                 variances[i] += diff * diff
 
         variances[i] += (n_samples - counts_nan[i] - counts) * means[i]**2
-        variances[i] /= (n_samples - ddof - counts_nan[i])
+        # int(n_samples) is necessary to convert from unsigned int to any int
+        if int(n_samples) - ddof - counts_nan[i] > 0:
+            variances[i] /= n_samples - ddof - counts_nan[i]
+        else:
+            variances[i] = np.nan
 
     return means, variances, counts_nan
 

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -108,14 +108,16 @@ def test_mean_variance_negative_ddof():
     X, _ = make_classification(5, 4, random_state=0)
     X = sp.csr_matrix(X)
 
-    assert_raises(ValueError, mean_variance_axis, X, axis=0, ddof=-5)
+    with pytest.raises(ValueError, match='ddof cannot be <0'):
+        mean_variance_axis(X, axis=0, ddof=-5)
 
 
 def test_mean_variance_too_large_ddof():
     X, _ = make_classification(5, 4, random_state=0)
     X = sp.csr_matrix(X)
 
-    assert_raises(ValueError, mean_variance_axis, X, axis=0, ddof=10)
+    with pytest.raises(ValueError, match='ddof must be <N'):
+        mean_variance_axis(X, axis=0, ddof=10)
 
 
 @pytest.mark.parametrize("axis", (0, 1))
@@ -132,12 +134,12 @@ def test_mean_variance_with_ddof_and_nan_values(axis, sparse_constructor):
     x[:-1, 0] = np.nan
     x[0, :-1] = np.nan
 
-    assert_equal(mean_variance_axis(x, axis=axis, ddof=0)[1],
-                 [0] * 5)
-    assert_equal(mean_variance_axis(x, axis=axis, ddof=2)[1],
-                 [np.nan] + [0] * 4)
-    assert_equal(mean_variance_axis(x, axis=axis, ddof=4)[1],
-                 [np.nan] * 4 + [0])
+    assert_array_equal(mean_variance_axis(x, axis=axis, ddof=0)[1],
+                       [0] * 5)
+    assert_array_equal(mean_variance_axis(x, axis=axis, ddof=2)[1],
+                       [np.nan] + [0] * 4)
+    assert_array_equal(mean_variance_axis(x, axis=axis, ddof=4)[1],
+                       [np.nan] * 4 + [0])
 
 
 def test_incr_mean_variance_axis():

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -85,6 +85,39 @@ def test_mean_variance_axis1():
             assert_array_almost_equal(X_vars, np.var(X_test, axis=0))
 
 
+@pytest.mark.parametrize('axis', (0, 1))
+def test_mean_variance_with_ddof(axis):
+    X, _ = make_classification(5, 4, random_state=0)
+    # Sparsify the array a little bit
+    X[[0, 2, 4], [0, 1, 3]] = 0
+
+    # Test on csr matrices
+    X_csr = sp.csr_matrix(X)
+    mean, variance = mean_variance_axis(X_csr, axis=axis, ddof=1)
+    assert_allclose(mean, np.mean(X, axis=axis))
+    assert_allclose(variance, np.var(X, axis=axis, ddof=1))
+
+    # Test on csc matrices
+    X_csc = sp.csc_matrix(X)
+    mean, variance = mean_variance_axis(X_csc, axis=axis, ddof=1)
+    assert_allclose(mean, np.mean(X, axis=axis))
+    assert_allclose(variance, np.var(X, axis=axis, ddof=1))
+
+
+def test_negative_ddof():
+    X, _ = make_classification(5, 4, random_state=0)
+    X = sp.csr_matrix(X)
+
+    assert_raises(ValueError, mean_variance_axis, X, axis=0, ddof=-5)
+
+
+def test_too_large_ddof():
+    X, _ = make_classification(5, 4, random_state=0)
+    X = sp.csr_matrix(X)
+
+    assert_raises(ValueError, mean_variance_axis, X, axis=0, ddof=10)
+
+
 def test_incr_mean_variance_axis():
     for axis in [0, 1]:
         rng = np.random.RandomState(0)

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -116,7 +116,8 @@ def test_mean_variance_too_large_ddof():
     X, _ = make_classification(5, 4, random_state=0)
     X = sp.csr_matrix(X)
 
-    with pytest.raises(ValueError, match='ddof must be <N'):
+    with pytest.raises(ValueError, match='ddof=10 must be smaller than the '
+                                         'number of samples=5'):
         mean_variance_axis(X, axis=0, ddof=10)
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Following the discussion in #12794, I've changed the randomized SVD implementation so it now supports computing PCA as well, without ever having to explicitly centering X. This is especially useful for large sparse matrices, which can't be centered.


#### What does this implement/fix? Explain your changes.

1. Add degrees of freedom (ddof) parameters to sparse functions that compute variance. Error checking has been added for negative ddof, when `ddof >= n_samples` or when the data contain NaNs and `n_samples - ddof - num_nans <= 0`.

2. Implement the randomized PCA algorithm. I was unable to reuse the `randomized_svd` (although the algorithms are conceptually very similar, their code is slightly different).

    In the case where there are more features than samples, it is more efficient to transpose the matrix and work with that. However, simply transposing isn't ok, because we also need the means from the original columns. This would make `randomized_svd` quite complicated. Furthermore, `randomized_svd` is strongly tied to `randomized_range_finder`, and I would need to add similar changes to both functions, making them quite confusing. For these reasons, I strongly feel adding the similar `randomized_pca` function is justified.

#### Any other comments?

The previous behaviour raised a `TypeError` if a sparse matrix was passed to `PCA.fit`. The behaviour is now somewhat different. Sparse matrices are supported with `svd_solver='randomized'`, otherwise a `ValueError` is raised indicating the wrong solver. If the solver is set to `auto` then the `randomized` solver is always selected for sparse matrices.


