### PR TITLE
[MRG] BENCH Make benchmarks/bench_text_vectorizers.py run faster

### DIFF
--- a/benchmarks/bench_text_vectorizers.py
+++ b/benchmarks/bench_text_vectorizers.py
@@ -37,7 +37,7 @@ text = fetch_20newsgroups(subset='train').data[:1000]
 print("="*80 + '\n#' + "    Text vectorizers benchmark" + '\n' + '='*80 + '\n')
 print("Using a subset of the 20 newsrgoups dataset ({} documents)."
       .format(len(text)))
-print("This benchmarks runs in ~2 min ...")
+print("This benchmarks runs in ~1 min ...")
 
 res = []
 
@@ -55,7 +55,7 @@ for Vectorizer, (analyzer, ngram_range) in itertools.product(
     dt = timeit.repeat(run_vectorizer(Vectorizer, text, **params),
                        number=1,
                        repeat=n_repeat)
-    bench['time'] = "{:.2f} (+-{:.2f})".format(np.mean(dt), np.std(dt))
+    bench['time'] = "{:.3f} (+-{:.3f})".format(np.mean(dt), np.std(dt))
 
     mem_usage = memory_usage(run_vectorizer(Vectorizer, text, **params))
 

--- a/benchmarks/bench_text_vectorizers.py
+++ b/benchmarks/bench_text_vectorizers.py
@@ -32,12 +32,12 @@ def run_vectorizer(Vectorizer, X, **params):
     return f
 
 
-text = fetch_20newsgroups(subset='train').data
+text = fetch_20newsgroups(subset='train').data[:1000]
 
 print("="*80 + '\n#' + "    Text vectorizers benchmark" + '\n' + '='*80 + '\n')
 print("Using a subset of the 20 newsrgoups dataset ({} documents)."
       .format(len(text)))
-print("This benchmarks runs in ~20 min ...")
+print("This benchmarks runs in ~2 min ...")
 
 res = []
 
@@ -45,7 +45,6 @@ for Vectorizer, (analyzer, ngram_range) in itertools.product(
             [CountVectorizer, TfidfVectorizer, HashingVectorizer],
             [('word', (1, 1)),
              ('word', (1, 2)),
-             ('word', (1, 4)),
              ('char', (4, 4)),
              ('char_wb', (4, 4))
              ]):


### PR DESCRIPTION
Currently `benchmarks/bench_text_vectorizers.py` takes around 20 min to run because it processes the full 20 newsgroups dataset with different vectorization options.

Since the vectorization scales linearly with the dataset size, it is needlessly long, and difficult to use in practice. This PR makes it use only 1000 first documents and skips the most expensive word 4-gram case, which reduces the runtime to around 1 minute.