### PR TITLE
[MRG] FIX: Allow coef_=None with warm_start=True in MultiTaskElasticNet

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1797,7 +1797,7 @@ class MultiTaskElasticNet(Lasso):
         X, y, X_offset, y_offset, X_scale = _preprocess_data(
             X, y, self.fit_intercept, self.normalize, copy=False)
 
-        if not self.warm_start or not hasattr(self, "coef_"):
+        if not self.warm_start or getattr(self, "coef_", None) is None:
             self.coef_ = np.zeros((n_tasks, n_features), dtype=X.dtype.type,
                                   order='F')
 

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -405,7 +405,8 @@ def test_multi_task_lasso_and_enet():
     assert 0 < clf.dual_gap_ < 1e-5
     assert_array_almost_equal(clf.coef_[0], clf.coef_[1])
 
-    clf = MultiTaskElasticNet(alpha=1.0, tol=1e-8, max_iter=1)
+    clf = MultiTaskElasticNet(alpha=1.0, tol=1e-8, max_iter=1, warm_start=True)
+    clf.coef_ = None  # ensure that this is still supported with warm_start
     assert_warns_message(ConvergenceWarning, 'did not converge', clf.fit, X, Y)
 
 


### PR DESCRIPTION
This restores the ability to have `clf.coef_ = None` during fitting with `clf = MultiTaskElasticNet(..., warm_start=True)`. Code that currently works with the latest release started emitting this error when running on `sklearn` master (now shown with the error in the test suite when the changes to `coordinate_descent.py` are omitted):
```
sklearn/linear_model/tests/test_coordinate_descent.py:410: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sklearn/utils/testing.py:196: in assert_warns_message
    result = func(*args, **kw)
sklearn/linear_model/coordinate_descent.py:1816: in fit
    check_random_state(self.random_state), random)
```
One potential alternative is that I could in my code set `warm_start=False` if the user supplies `coef_ = None`, rather than always passing `warm_start=True`. Feel free to close if that's the preferred way, though it's possible other people might also get hit by this problem if they also relied on `warm_start=True` followed by `clf.coef_ = None` working.

Just modified an existing test to avoid adding to test time, but can split it off if it seems worthwhile.