### PR TITLE
[MRG] Minor duplication in metric.__init__

### DIFF
--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -115,7 +115,6 @@ __all__ = [
     'pairwise_distances',
     'pairwise_distances_argmin',
     'pairwise_distances_argmin_min',
-    'pairwise_distances_argmin_min',
     'pairwise_distances_chunked',
     'pairwise_kernels',
     'precision_recall_curve',


### PR DESCRIPTION
Small duplication in `metric.__init__`'s `__all__` variable.