### PR TITLE
MNT cover cython code in code coverage tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 branch = True
 source = sklearn
 include = */sklearn/*
+plugins = Cython.Coverage
 omit =
     */sklearn/externals/*
     */benchmarks/*


### PR DESCRIPTION
Related to #8163 (it doesn't close it since this is not adding directives to individual cython files)

Also noticed that we're not covering cython code while working on #12866

I guess we can add this to the coveragerc, but leave adding support for specific cython files to separate issues, since we may realize there's a bunch of code we're not testing for which we should write new tests.