### PR TITLE
DOC: better explain bootstrap option in forests and bagging

### DIFF
--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -475,7 +475,8 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
         - If float, then draw `max_features * X.shape[1]` features.
 
     bootstrap : boolean, optional (default=True)
-        Whether samples are drawn with replacement.
+        Whether samples are drawn with replacement. If False, sampling
+        without replacement is performed.
 
     bootstrap_features : boolean, optional (default=False)
         Whether features are drawn with replacement.
@@ -856,7 +857,8 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
         - If float, then draw `max_features * X.shape[1]` features.
 
     bootstrap : boolean, optional (default=True)
-        Whether samples are drawn with replacement.
+        Whether samples are drawn with replacement. If False, sampling
+        without replacement is performed.
 
     bootstrap_features : boolean, optional (default=False)
         Whether features are drawn with replacement.

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -863,7 +863,8 @@ class RandomForestClassifier(ForestClassifier):
 
 
     bootstrap : boolean, optional (default=True)
-        Whether bootstrap samples are used when building trees.
+        Whether bootstrap samples are used when building trees. If False, the
+        whole datset is used to build each tree.
 
     oob_score : bool (default=False)
         Whether to use out-of-bag samples to estimate
@@ -1153,7 +1154,8 @@ class RandomForestRegressor(ForestRegressor):
            will be removed in 0.25. Use ``min_impurity_decrease`` instead.
 
     bootstrap : boolean, optional (default=True)
-        Whether bootstrap samples are used when building trees.
+        Whether bootstrap samples are used when building trees. If False, the
+        whole datset is used to build each tree.
 
     oob_score : bool, optional (default=False)
         whether to use out-of-bag samples to estimate
@@ -1403,7 +1405,8 @@ class ExtraTreesClassifier(ForestClassifier):
            will be removed in 0.25. Use ``min_impurity_decrease`` instead.
 
     bootstrap : boolean, optional (default=False)
-        Whether bootstrap samples are used when building trees.
+        Whether bootstrap samples are used when building trees. If False, the
+        whole datset is used to build each tree.
 
     oob_score : bool, optional (default=False)
         Whether to use out-of-bag samples to estimate
@@ -1664,7 +1667,8 @@ class ExtraTreesRegressor(ForestRegressor):
            will be removed in 0.25. Use ``min_impurity_decrease`` instead.
 
     bootstrap : boolean, optional (default=False)
-        Whether bootstrap samples are used when building trees.
+        Whether bootstrap samples are used when building trees. If False, the
+        whole datset is used to build each tree.
 
     oob_score : bool, optional (default=False)
         Whether to use out-of-bag samples to estimate the R^2 on unseen data.


### PR DESCRIPTION
Answering a question on the mailing list. Turns out False does very different things in bagging and forests and it's not very clear from the docstring.