### PR TITLE
MNT CI run all examples if some code is changed 

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -57,6 +57,13 @@ get_build_type() {
         echo QUICK BUILD: no changed filenames for $git_range
         return
     fi
+    # changed code files in sklearn/ which are not a test
+    changed_codes=$(echo "$filenames" | grep -E "^sklearn/.*(\.py$|\.pxd$|\.pyx$)" | grep -v -E "(test_|tests)")
+    if [[ -n "$changed_codes" ]]
+    then
+        echo BUILD: detected sklearn/ filename modified in $git_range: $changed_codes
+        return
+    fi
     changed_examples=$(echo "$filenames" | grep -e ^examples/)
     if [[ -n "$changed_examples" ]]
     then


### PR DESCRIPTION
The take from the discussion in #12797 is that we'd like to try and run all examples (almost) always.

We also know that running all examples is unnecessary if the PR doesn't touch any code (e.g. documentation or CI related PRs). Therefore this PR does a complete doc build only if there's some change in `.py`, `.pyx`, or `.pxd` files.

An alternative is to remove the part in `get_build_type` which deals with changed files completely, and always return BUILD. But that would have some unnecessary overhead in build time.