### PR TITLE
[MRG] add drop_first option to OneHotEncoder

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -489,7 +489,7 @@ Continuing the example above::
   >>> enc = preprocessing.OneHotEncoder()
   >>> X = [['male', 'from US', 'uses Safari'], ['female', 'from Europe', 'uses Firefox']]
   >>> enc.fit(X)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-  OneHotEncoder(categorical_features=None, categories=None,
+  OneHotEncoder(categorical_features=None, categories=None, drop_first=False,
          dtype=<... 'numpy.float64'>, handle_unknown='error',
          n_values=None, sparse=True)
   >>> enc.transform([['female', 'from US', 'uses Safari'],
@@ -516,7 +516,7 @@ dataset::
     >>> X = [['male', 'from US', 'uses Safari'], ['female', 'from Europe', 'uses Firefox']]
     >>> enc.fit(X) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
     OneHotEncoder(categorical_features=None,
-           categories=[...],
+           categories=[...], drop_first=False,
            dtype=<... 'numpy.float64'>, handle_unknown='error',
            n_values=None, sparse=True)
     >>> enc.transform([['female', 'from Asia', 'uses Chrome']]).toarray()
@@ -533,12 +533,30 @@ columns for this feature will be all zeros
     >>> enc = preprocessing.OneHotEncoder(handle_unknown='ignore')
     >>> X = [['male', 'from US', 'uses Safari'], ['female', 'from Europe', 'uses Firefox']]
     >>> enc.fit(X) # doctest: +ELLIPSIS  +NORMALIZE_WHITESPACE
-    OneHotEncoder(categorical_features=None, categories=None,
+    OneHotEncoder(categorical_features=None, categories=None, drop_first=False,
            dtype=<... 'numpy.float64'>, handle_unknown='ignore',
            n_values=None, sparse=True)
     >>> enc.transform([['female', 'from Asia', 'uses Chrome']]).toarray()
     array([[1., 0., 0., 0., 0., 0.]])
 
+Using ``drop_first=True``, each column is encoded into ``n_categories - 1``
+columns instead of ``n_categories`` columns. This is useful to avoid
+co-linearity in the input matrix in non-regularized logistic regression
+(:class:`LinearRegression <sklearn.linear_model.LinearRegression>`), which
+would cause the covariance matrix to be non-invertible::
+
+  >>> enc = preprocessing.OneHotEncoder(drop_first=True)
+  >>> X = [['male', 'from US', 'uses Safari'], ['female', 'from Europe', 'uses Firefox']]
+  >>> enc.fit(X) # doctest: +ELLIPSIS  +NORMALIZE_WHITESPACE
+  OneHotEncoder(categorical_features=None, categories=None, drop_first=True,
+                dtype=<class 'numpy.float64'>, handle_unknown='error',
+                n_values=None, sparse=True)
+  >>> enc.transform([['female', 'from US', 'uses Safari'],
+  ...                ['male', 'from Europe', 'uses Safari'],
+  ...                ['female', 'from US', 'uses Firefox']]).toarray()
+  array([[0., 1., 1.],
+         [1., 0., 1.],
+         [0., 1., 0.]])
 
 See :ref:`dict_feature_extraction` for categorical features that are represented
 as a dict, not as scalars.

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -540,8 +540,9 @@ columns for this feature will be all zeros
     array([[1., 0., 0., 0., 0., 0.]])
 
 Using ``drop_first=True``, each column is encoded into ``n_categories - 1``
-columns instead of ``n_categories`` columns. This is useful to avoid
-co-linearity in the input matrix in non-regularized logistic regression
+columns instead of ``n_categories`` columns. In this case ``'handle_unknown'``
+must be set to ``'error'``. This is useful to avoid co-linearity in the
+input matrix in non-regularized logistic regression
 (:class:`LinearRegression <sklearn.linear_model.LinearRegression>`), which
 would cause the covariance matrix to be non-invertible::
 

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -181,7 +181,7 @@ class OneHotEncoder(_BaseEncoder):
         useful in unregularized linear regression (:class:`LinearRegression
         <sklearn.linear_model.LinearRegression>`) where co-linearity between
         the input features must be avoided. If ``True``, ``handle_unkown``
-        must be set to ``error``.
+        must be set to ``'error'``.
 
     n_values : 'auto', int or array of ints, default='auto'
         Number of values per feature.
@@ -254,7 +254,7 @@ class OneHotEncoder(_BaseEncoder):
     >>> enc.fit(X)
     ... # doctest: +ELLIPSIS
     ... # doctest: +NORMALIZE_WHITESPACE
-    OneHotEncoder(categorical_features=None, categories=None,
+    OneHotEncoder(categorical_features=None, categories=None, drop_first=False,
            dtype=<... 'numpy.float64'>, handle_unknown='ignore',
            n_values=None, sparse=True)
 

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -175,6 +175,14 @@ class OneHotEncoder(_BaseEncoder):
         will be all zeros. In the inverse transform, an unknown category
         will be denoted as None.
 
+    drop_first: bool, default=False.
+        If ``True``, the columns of the first categories are dropped and each
+        variable is thus encoded into ``n_categories - 1`` columns. This is
+        useful in unregularized linear regression (:class:`LinearRegression
+        <sklearn.linear_model.LinearRegression>`) where co-linearity between
+        the input features must be avoided. If ``True``, ``handle_unkown``
+        must be set to ``error``.
+
     n_values : 'auto', int or array of ints, default='auto'
         Number of values per feature.
 

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -588,8 +588,8 @@ class OneHotEncoder(_BaseEncoder):
                                 dtype=self.dtype)
 
         if self.drop_first:
-            firsts = feature_indices
-            to_keep = np.full(indices.shape[0], True)
+            firsts = feature_indices[:-1]
+            to_keep = np.full(out.shape[1], True)
             to_keep[firsts] = False
             out = out[:, to_keep]
 

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -618,7 +618,7 @@ class OneHotEncoder(_BaseEncoder):
         if self.drop_first:
             # Remove the columns of the first categories
             firsts = feature_indices[:-1]
-            to_keep = np.full(out.shape[1], True)
+            to_keep = np.full(out.shape[1], True, dtype=np.bool)
             to_keep[firsts] = False
             out = out[:, to_keep]
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Closes #6488

#### What does this implement/fix? Explain your changes.

This PR adds a `drop_first` option to `OneHotEncoder`.
Each feature is encoded into `n_unique_values - 1` columns instead of `n_unique_values` columns. The first one is dropped, resulting in all of the others being zero.

#### Any other comments?

This is incompatible with `handle_missing='ignore'` because the ignored missing categories result in all of the one-hot columns being zeros, which is also how the first category is treated when `drop_first=True`. So by allowing both, there would be no way to distinguish between a missing category and the first one.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
