### PR TITLE
WEB/DOC link to dev docs instead of contributing docs in the menu

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -41,7 +41,6 @@ ticket to the
 also welcome to post feature requests or pull requests.
 
 
-==================
 Ways to contribute
 ==================
 

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -89,7 +89,7 @@
             <li><a href="{{ pathto('modules/classes') }}">API</a></li>
             <li><a href="{{ pathto('glossary') }}">Glossary</a></li>
             <li><a href="{{ pathto('faq') }}">FAQ</a></li>
-            <li><a href="{{ pathto('developers/contributing') }}">Contributing</a></li>
+            <li><a href="{{ pathto('developers/index') }}">Development</a></li>
             <li><a href="{{ pathto('roadmap') }}">Roadmap</a></li>
             <li class="divider"></li>
                 <script>if (VERSION_SUBDIR != "stable") document.write('<li><a href="http://scikit-learn.org/stable/documentation.html">Stable version</a></li>')</script>


### PR DESCRIPTION
Pet peeve of mine:
Right now the "Documentation" page links to the developer docs, while the menu links to "developers/contributing". All of the other menu entries correspond to one of the "big tocs" shown on the "Documentation" page: API, User Guide, Tutorial etc. But "Contributing" links into "developers/contributing" making the "developers" docs harder to find, which also means they are in worse shape then the overall docs.

I think we should link to the higher level toc in the menu to be consistent with the "Documentation" page. We might want to reorder the items in the "Developer" toc, though (like putting installation above contributing maybe?).  I didn't do that here.