### PR TITLE
MNT simplify some tree code with memoryviews

### DIFF
--- a/sklearn/tree/_criterion.pxd
+++ b/sklearn/tree/_criterion.pxd
@@ -25,7 +25,7 @@ cdef class Criterion:
     # such as the mean in regression and class probabilities in classification.
 
     # Internal structures
-    cdef const DOUBLE_t[:, ::1] y                # Values of y
+    cdef const DOUBLE_t[:, ::1] y        # Values of y
     cdef DOUBLE_t* sample_weight         # Sample weights
 
     cdef SIZE_t* samples                 # Sample indices in X, y

--- a/sklearn/tree/_criterion.pxd
+++ b/sklearn/tree/_criterion.pxd
@@ -1,3 +1,4 @@
+# cython: language_level=3
 # Authors: Gilles Louppe <g.louppe@gmail.com>
 #          Peter Prettenhofer <peter.prettenhofer@gmail.com>
 #          Brian Holt <bdholt1@gmail.com>
@@ -12,11 +13,11 @@
 import numpy as np
 cimport numpy as np
 
-ctypedef np.npy_float32 DTYPE_t          # Type of X
-ctypedef np.npy_float64 DOUBLE_t         # Type of y, sample_weight
-ctypedef np.npy_intp SIZE_t              # Type for indices and counters
-ctypedef np.npy_int32 INT32_t            # Signed 32 bit integer
-ctypedef np.npy_uint32 UINT32_t          # Unsigned 32 bit integer
+from ._tree cimport DTYPE_t          # Type of X
+from ._tree cimport DOUBLE_t         # Type of y, sample_weight
+from ._tree cimport SIZE_t           # Type for indices and counters
+from ._tree cimport INT32_t          # Signed 32 bit integer
+from ._tree cimport UINT32_t         # Unsigned 32 bit integer
 
 cdef class Criterion:
     # The criterion computes the impurity of a node and the reduction of

--- a/sklearn/tree/_criterion.pxd
+++ b/sklearn/tree/_criterion.pxd
@@ -25,7 +25,7 @@ cdef class Criterion:
     # such as the mean in regression and class probabilities in classification.
 
     # Internal structures
-    cdef DOUBLE_t[:, :] y                # Values of y
+    cdef const DOUBLE_t[:, ::1] y                # Values of y
     cdef DOUBLE_t* sample_weight         # Sample weights
 
     cdef SIZE_t* samples                 # Sample indices in X, y
@@ -53,7 +53,7 @@ cdef class Criterion:
     # statistics correspond to samples[start:pos] and samples[pos:end].
 
     # Methods
-    cdef int init(self, DOUBLE_t[:, :] y, DOUBLE_t* sample_weight,
+    cdef int init(self, const DOUBLE_t[:, ::1] y, DOUBLE_t* sample_weight,
                   double weighted_n_samples, SIZE_t* samples, SIZE_t start,
                   SIZE_t end) nogil except -1
     cdef int reset(self) nogil except -1

--- a/sklearn/tree/_criterion.pxd
+++ b/sklearn/tree/_criterion.pxd
@@ -24,8 +24,7 @@ cdef class Criterion:
     # such as the mean in regression and class probabilities in classification.
 
     # Internal structures
-    cdef DOUBLE_t* y                     # Values of y
-    cdef SIZE_t y_stride                 # Stride in y (since n_outputs >= 1)
+    cdef DOUBLE_t[:, :] y                # Values of y
     cdef DOUBLE_t* sample_weight         # Sample weights
 
     cdef SIZE_t* samples                 # Sample indices in X, y
@@ -53,7 +52,7 @@ cdef class Criterion:
     # statistics correspond to samples[start:pos] and samples[pos:end].
 
     # Methods
-    cdef int init(self, DOUBLE_t* y, SIZE_t y_stride, DOUBLE_t* sample_weight,
+    cdef int init(self, DOUBLE_t[:, :] y, DOUBLE_t* sample_weight,
                   double weighted_n_samples, SIZE_t* samples, SIZE_t start,
                   SIZE_t end) nogil except -1
     cdef int reset(self) nogil except -1

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -302,6 +302,7 @@ cdef class ClassificationCriterion(Criterion):
         """
 
         self.y = y
+        cdef DOUBLE_t[:, :] y_memview = y
         self.sample_weight = sample_weight
         self.samples = samples
         self.start = start
@@ -334,7 +335,7 @@ cdef class ClassificationCriterion(Criterion):
 
             # Count weighted class frequency for each target
             for k in range(self.n_outputs):
-                c = <SIZE_t> y[i, k]
+                c = <SIZE_t> y_memview[i, k]
                 sum_total[k * self.sum_stride + c] += w
 
             self.weighted_n_node_samples += w
@@ -772,7 +773,7 @@ cdef class RegressionCriterion(Criterion):
                 w = sample_weight[i]
 
             for k in range(self.n_outputs):
-                y_ik = y[i, k]
+                y_ik = self.y[i, k]
                 w_y_ik = w * y_ik
                 self.sum_total[k] += w_y_ik
                 self.sq_sum_total += w_y_ik * y_ik
@@ -1067,7 +1068,7 @@ cdef class MAE(RegressionCriterion):
                 w = sample_weight[i]
 
             for k in range(self.n_outputs):
-                y_ik = y[i, k]
+                y_ik = self.y[i, k]
 
                 # push method ends up calling safe_realloc, hence `except -1`
                 # push all values to the right side,

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -287,7 +287,7 @@ cdef class ClassificationCriterion(Criterion):
 
         Parameters
         ----------
-        y : array-like, dtype=const DOUBLE_t[:, ::1]
+        y : array-like, dtype=DOUBLE_t
             The target stored as a buffer for memory efficiency
         sample_weight : array-like, dtype=DTYPE_t
             The weight of each sample

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -287,7 +287,7 @@ cdef class ClassificationCriterion(Criterion):
 
         Parameters
         ----------
-        y : array-like, dtype=DOUBLE_t[:, :]
+        y : array-like, dtype=const DOUBLE_t[:, ::1]
             The target stored as a buffer for memory efficiency
         sample_weight : array-like, dtype=DTYPE_t
             The weight of each sample

--- a/sklearn/tree/_splitter.pxd
+++ b/sklearn/tree/_splitter.pxd
@@ -60,8 +60,7 @@ cdef class Splitter:
     cdef bint presort                    # Whether to use presorting, only
                                          # allowed on dense data
 
-    cdef DOUBLE_t* y
-    cdef SIZE_t y_stride
+    cdef DOUBLE_t[:, :] y
     cdef DOUBLE_t* sample_weight
 
     # The samples vector `samples` is maintained by the Splitter object such
@@ -81,7 +80,7 @@ cdef class Splitter:
     # This allows optimization with depth-based tree building.
 
     # Methods
-    cdef int init(self, object X, np.ndarray y,
+    cdef int init(self, object X, DOUBLE_t[:, :] y,
                   DOUBLE_t* sample_weight,
                   np.ndarray X_idx_sorted=*) except -1
 

--- a/sklearn/tree/_splitter.pxd
+++ b/sklearn/tree/_splitter.pxd
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 # Authors: Gilles Louppe <g.louppe@gmail.com>
 #          Peter Prettenhofer <peter.prettenhofer@gmail.com>
 #          Brian Holt <bdholt1@gmail.com>
@@ -14,11 +16,11 @@ cimport numpy as np
 
 from ._criterion cimport Criterion
 
-ctypedef np.npy_float32 DTYPE_t          # Type of X
-ctypedef np.npy_float64 DOUBLE_t         # Type of y, sample_weight
-ctypedef np.npy_intp SIZE_t              # Type for indices and counters
-ctypedef np.npy_int32 INT32_t            # Signed 32 bit integer
-ctypedef np.npy_uint32 UINT32_t          # Unsigned 32 bit integer
+from ._tree cimport DTYPE_t          # Type of X
+from ._tree cimport DOUBLE_t         # Type of y, sample_weight
+from ._tree cimport SIZE_t           # Type for indices and counters
+from ._tree cimport INT32_t          # Signed 32 bit integer
+from ._tree cimport UINT32_t         # Unsigned 32 bit integer
 
 cdef struct SplitRecord:
     # Data to track sample split

--- a/sklearn/tree/_splitter.pxd
+++ b/sklearn/tree/_splitter.pxd
@@ -62,7 +62,7 @@ cdef class Splitter:
     cdef bint presort                    # Whether to use presorting, only
                                          # allowed on dense data
 
-    cdef DOUBLE_t[:, :] y
+    cdef const DOUBLE_t[:, ::1] y
     cdef DOUBLE_t* sample_weight
 
     # The samples vector `samples` is maintained by the Splitter object such
@@ -82,7 +82,7 @@ cdef class Splitter:
     # This allows optimization with depth-based tree building.
 
     # Methods
-    cdef int init(self, object X, DOUBLE_t[:, :] y,
+    cdef int init(self, object X, const DOUBLE_t[:, ::1] y,
                   DOUBLE_t* sample_weight,
                   np.ndarray X_idx_sorted=*) except -1
 

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -92,8 +92,6 @@ cdef class Splitter:
         self.n_features = 0
         self.feature_values = NULL
 
-        self.y = NULL
-        self.y_stride = 0
         self.sample_weight = NULL
 
         self.max_features = max_features
@@ -118,7 +116,7 @@ cdef class Splitter:
 
     cdef int init(self,
                    object X,
-                   np.ndarray[DOUBLE_t, ndim=2, mode="c"] y,
+                   DOUBLE_t[:, :] y,
                    DOUBLE_t* sample_weight,
                    np.ndarray X_idx_sorted=None) except -1:
         """Initialize the splitter.
@@ -179,8 +177,7 @@ cdef class Splitter:
         safe_realloc(&self.feature_values, n_samples)
         safe_realloc(&self.constant_features, n_features)
 
-        self.y = <DOUBLE_t*> y.data
-        self.y_stride = <SIZE_t> y.strides[0] / <SIZE_t> y.itemsize
+        self.y = y
 
         self.sample_weight = sample_weight
         return 0
@@ -206,7 +203,6 @@ cdef class Splitter:
         self.end = end
 
         self.criterion.init(self.y,
-                            self.y_stride,
                             self.sample_weight,
                             self.weighted_n_samples,
                             self.samples,
@@ -264,7 +260,7 @@ cdef class BaseDenseSplitter(Splitter):
 
     cdef int init(self,
                   object X,
-                  np.ndarray[DOUBLE_t, ndim=2, mode="c"] y,
+                  DOUBLE_t[:, :] y,
                   DOUBLE_t* sample_weight,
                   np.ndarray X_idx_sorted=None) except -1:
         """Initialize the splitter
@@ -882,7 +878,7 @@ cdef class BaseSparseSplitter(Splitter):
 
     cdef int init(self,
                   object X,
-                  np.ndarray[DOUBLE_t, ndim=2, mode="c"] y,
+                  DOUBLE_t[:, :] y,
                   DOUBLE_t* sample_weight,
                   np.ndarray X_idx_sorted=None) except -1:
         """Initialize the splitter

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -241,8 +241,6 @@ cdef class Splitter:
 
 cdef class BaseDenseSplitter(Splitter):
     cdef DTYPE_t [:, :] X
-    #cdef SIZE_t X_sample_stride
-    #cdef SIZE_t X_feature_stride
 
     cdef np.ndarray X_idx_sorted
     cdef INT32_t* X_idx_sorted_ptr
@@ -254,9 +252,6 @@ cdef class BaseDenseSplitter(Splitter):
                   SIZE_t min_samples_leaf, double min_weight_leaf,
                   object random_state, bint presort):
 
-        #self.X = NULL
-        #self.X_sample_stride = 0
-        #self.X_feature_stride = 0
         self.X_idx_sorted_ptr = NULL
         self.X_idx_sorted_stride = 0
         self.sample_mask = NULL
@@ -281,12 +276,7 @@ cdef class BaseDenseSplitter(Splitter):
         # Call parent init
         Splitter.init(self, X, y, sample_weight)
 
-        # Initialize X
-        #cdef np.ndarray X_ndarray = X
-
         self.X = X
-        #self.X_sample_stride = <SIZE_t> X.strides[0] / <SIZE_t> X.itemsize
-        #self.X_feature_stride = <SIZE_t> X.strides[1] / <SIZE_t> X.itemsize
 
         if self.presort == 1:
             self.X_idx_sorted = X_idx_sorted
@@ -329,8 +319,6 @@ cdef class BestSplitter(BaseDenseSplitter):
 
         cdef DTYPE_t [:, :] X = self.X
         cdef DTYPE_t* Xf = self.feature_values
-        #cdef SIZE_t X_sample_stride = self.X_sample_stride
-        #cdef SIZE_t X_feature_stride = self.X_feature_stride
         cdef SIZE_t max_features = self.max_features
         cdef SIZE_t min_samples_leaf = self.min_samples_leaf
         cdef double min_weight_leaf = self.min_weight_leaf
@@ -414,7 +402,6 @@ cdef class BestSplitter(BaseDenseSplitter):
                 f_j += n_found_constants
                 # f_j in the interval [n_total_constants, f_i[
                 current.feature = features[f_j]
-                #feature_offset = self.X_feature_stride * current.feature
 
                 # Sort samples along that feature; either by utilizing
                 # presorting, or by copying the values into an array and
@@ -493,7 +480,6 @@ cdef class BestSplitter(BaseDenseSplitter):
 
         # Reorganize into samples[start:best.pos] + samples[best.pos:end]
         if best.pos < end:
-            #feature_offset = X_feature_stride * best.feature
             partition_end = end
             p = start
 
@@ -677,8 +663,6 @@ cdef class RandomSplitter(BaseDenseSplitter):
 
         cdef DTYPE_t [:, :] X = self.X
         cdef DTYPE_t* Xf = self.feature_values
-        #cdef SIZE_t X_sample_stride = self.X_sample_stride
-        #cdef SIZE_t X_feature_stride = self.X_feature_stride
         cdef SIZE_t max_features = self.max_features
         cdef SIZE_t min_samples_leaf = self.min_samples_leaf
         cdef double min_weight_leaf = self.min_weight_leaf
@@ -753,7 +737,6 @@ cdef class RandomSplitter(BaseDenseSplitter):
                 # f_j in the interval [n_total_constants, f_i[
 
                 current.feature = features[f_j]
-                #feature_stride = X_feature_stride * current.feature
 
                 # Find min, max
                 min_feature_value = X[samples[start], current.feature]
@@ -828,7 +811,6 @@ cdef class RandomSplitter(BaseDenseSplitter):
                         best = current  # copy
 
         # Reorganize into samples[start:best.pos] + samples[best.pos:end]
-        #feature_stride = X_feature_stride * best.feature
         if best.pos < end:
             if current.feature != best.feature:
                 partition_end = end

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -116,7 +116,7 @@ cdef class Splitter:
 
     cdef int init(self,
                    object X,
-                   DOUBLE_t[:, :] y,
+                   DOUBLE_t[:, ::1] y,
                    DOUBLE_t* sample_weight,
                    np.ndarray X_idx_sorted=None) except -1:
         """Initialize the splitter.
@@ -260,7 +260,7 @@ cdef class BaseDenseSplitter(Splitter):
 
     cdef int init(self,
                   object X,
-                  DOUBLE_t[:, :] y,
+                  DOUBLE_t[:, ::1] y,
                   DOUBLE_t* sample_weight,
                   np.ndarray X_idx_sorted=None) except -1:
         """Initialize the splitter
@@ -878,7 +878,7 @@ cdef class BaseSparseSplitter(Splitter):
 
     cdef int init(self,
                   object X,
-                  DOUBLE_t[:, :] y,
+                  DOUBLE_t[:, ::1] y,
                   DOUBLE_t* sample_weight,
                   np.ndarray X_idx_sorted=None) except -1:
         """Initialize the splitter

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -236,7 +236,7 @@ cdef class Splitter:
 
 
 cdef class BaseDenseSplitter(Splitter):
-    cdef DTYPE_t [:, :] X
+    cdef DTYPE_t[:, :] X
 
     cdef np.ndarray X_idx_sorted
     cdef INT32_t* X_idx_sorted_ptr
@@ -313,7 +313,7 @@ cdef class BestSplitter(BaseDenseSplitter):
         cdef SIZE_t* constant_features = self.constant_features
         cdef SIZE_t n_features = self.n_features
 
-        cdef DTYPE_t [:, :] X = self.X
+        cdef DTYPE_t[:, :] X = self.X
         cdef DTYPE_t* Xf = self.feature_values
         cdef SIZE_t max_features = self.max_features
         cdef SIZE_t min_samples_leaf = self.min_samples_leaf
@@ -657,7 +657,7 @@ cdef class RandomSplitter(BaseDenseSplitter):
         cdef SIZE_t* constant_features = self.constant_features
         cdef SIZE_t n_features = self.n_features
 
-        cdef DTYPE_t [:, :] X = self.X
+        cdef DTYPE_t[:, :] X = self.X
         cdef DTYPE_t* Xf = self.feature_values
         cdef SIZE_t max_features = self.max_features
         cdef SIZE_t min_samples_leaf = self.min_samples_leaf

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -313,7 +313,6 @@ cdef class BestSplitter(BaseDenseSplitter):
         cdef SIZE_t* constant_features = self.constant_features
         cdef SIZE_t n_features = self.n_features
 
-        cdef DTYPE_t[:, :] X = self.X
         cdef DTYPE_t* Xf = self.feature_values
         cdef SIZE_t max_features = self.max_features
         cdef SIZE_t min_samples_leaf = self.min_samples_leaf
@@ -411,11 +410,11 @@ cdef class BestSplitter(BaseDenseSplitter):
                         j = X_idx_sorted[i + feature_idx_offset]
                         if sample_mask[j] == 1:
                             samples[p] = j
-                            Xf[p] = X[j, current.feature]
+                            Xf[p] = self.X[j, current.feature]
                             p += 1
                 else:
                     for i in range(start, end):
-                        Xf[i] = X[samples[i], current.feature]
+                        Xf[i] = self.X[samples[i], current.feature]
 
                     sort(Xf + start, samples + start, end - start)
 
@@ -480,7 +479,7 @@ cdef class BestSplitter(BaseDenseSplitter):
             p = start
 
             while p < partition_end:
-                if X[samples[p], best.feature] <= best.threshold:
+                if self.X[samples[p], best.feature] <= best.threshold:
                     p += 1
 
                 else:
@@ -657,7 +656,6 @@ cdef class RandomSplitter(BaseDenseSplitter):
         cdef SIZE_t* constant_features = self.constant_features
         cdef SIZE_t n_features = self.n_features
 
-        cdef DTYPE_t[:, :] X = self.X
         cdef DTYPE_t* Xf = self.feature_values
         cdef SIZE_t max_features = self.max_features
         cdef SIZE_t min_samples_leaf = self.min_samples_leaf
@@ -735,12 +733,12 @@ cdef class RandomSplitter(BaseDenseSplitter):
                 current.feature = features[f_j]
 
                 # Find min, max
-                min_feature_value = X[samples[start], current.feature]
+                min_feature_value = self.X[samples[start], current.feature]
                 max_feature_value = min_feature_value
                 Xf[start] = min_feature_value
 
                 for p in range(start + 1, end):
-                    current_feature_value = X[samples[p], current.feature]
+                    current_feature_value = self.X[samples[p], current.feature]
                     Xf[p] = current_feature_value
 
                     if current_feature_value < min_feature_value:
@@ -813,7 +811,7 @@ cdef class RandomSplitter(BaseDenseSplitter):
                 p = start
 
                 while p < partition_end:
-                    if X[samples[p], best.feature] <= best.threshold:
+                    if self.X[samples[p], best.feature] <= best.threshold:
                         p += 1
 
                     else:

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -914,7 +914,7 @@ cdef class Tree:
             raise ValueError("X.dtype should be np.float32, got %s" % X.dtype)
 
         # Extract input
-        cdef float [:, :] X_ndarray = X
+        cdef DTYPE_t[:, :] X_ndarray = X
         cdef SIZE_t n_samples = X.shape[0]
 
         # Initialize output

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -794,10 +794,7 @@ cdef class Tree:
             raise ValueError("X.dtype should be np.float32, got %s" % X.dtype)
 
         # Extract input
-        cdef np.ndarray X_ndarray = X
-        cdef DTYPE_t* X_ptr = <DTYPE_t*> X_ndarray.data
-        cdef SIZE_t X_sample_stride = <SIZE_t> X.strides[0] / <SIZE_t> X.itemsize
-        cdef SIZE_t X_fx_stride = <SIZE_t> X.strides[1] / <SIZE_t> X.itemsize
+        cdef float [:, :] X_ndarray = X
         cdef SIZE_t n_samples = X.shape[0]
 
         # Initialize output
@@ -814,8 +811,7 @@ cdef class Tree:
                 # While node not a leaf
                 while node.left_child != _TREE_LEAF:
                     # ... and node.right_child != _TREE_LEAF:
-                    if X_ptr[X_sample_stride * i +
-                             X_fx_stride * node.feature] <= node.threshold:
+                    if X_ndarray[i, node.feature] <= node.threshold:
                         node = &self.nodes[node.left_child]
                     else:
                         node = &self.nodes[node.right_child]

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -794,7 +794,7 @@ cdef class Tree:
             raise ValueError("X.dtype should be np.float32, got %s" % X.dtype)
 
         # Extract input
-        cdef float [:, :] X_ndarray = X
+        cdef DTYPE_t [:, :] X_ndarray = X
         cdef SIZE_t n_samples = X.shape[0]
 
         # Initialize output
@@ -914,10 +914,7 @@ cdef class Tree:
             raise ValueError("X.dtype should be np.float32, got %s" % X.dtype)
 
         # Extract input
-        cdef np.ndarray X_ndarray = X
-        cdef DTYPE_t* X_ptr = <DTYPE_t*> X_ndarray.data
-        cdef SIZE_t X_sample_stride = <SIZE_t> X.strides[0] / <SIZE_t> X.itemsize
-        cdef SIZE_t X_fx_stride = <SIZE_t> X.strides[1] / <SIZE_t> X.itemsize
+        cdef float [:, :] X_ndarray = X
         cdef SIZE_t n_samples = X.shape[0]
 
         # Initialize output
@@ -944,8 +941,7 @@ cdef class Tree:
                     indices_ptr[indptr_ptr[i + 1]] = <SIZE_t>(node - self.nodes)
                     indptr_ptr[i + 1] += 1
 
-                    if X_ptr[X_sample_stride * i +
-                             X_fx_stride * node.feature] <= node.threshold:
+                    if X_ndarray[i, node.feature] <= node.threshold:
                         node = &self.nodes[node.left_child]
                     else:
                         node = &self.nodes[node.right_child]

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -794,7 +794,7 @@ cdef class Tree:
             raise ValueError("X.dtype should be np.float32, got %s" % X.dtype)
 
         # Extract input
-        cdef DTYPE_t [:, :] X_ndarray = X
+        cdef DTYPE_t[:, :] X_ndarray = X
         cdef SIZE_t n_samples = X.shape[0]
 
         # Initialize output

--- a/sklearn/tree/_utils.pxd
+++ b/sklearn/tree/_utils.pxd
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 # Authors: Gilles Louppe <g.louppe@gmail.com>
 #          Peter Prettenhofer <peter.prettenhofer@gmail.com>
 #          Arnaud Joly <arnaud.v.joly@gmail.com>
@@ -10,7 +12,7 @@
 
 import numpy as np
 cimport numpy as np
-from _tree cimport Node
+from ._tree cimport Node
 from sklearn.neighbors.quad_tree cimport Cell
 
 ctypedef np.npy_float32 DTYPE_t          # Type of X


### PR DESCRIPTION
Related to #10624

This for now is more of a question, before potentially going further.

There are parts of the tree code which can be significantly simplified using memoryviews, like the one presented in this PR. The question is, is this change valid? I think it passes all the tests and dosn't add anything to the time required for the tests, but I'm not sure if our tests cover things such as passing a readonly array to the function, which I guess is an edge case reading the discussion there.