### PR TITLE
TST Manually scramble the indices in svm tests

### DIFF
--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -111,10 +111,19 @@ def test_unsorted_indices():
     # make sure dense and sparse SVM give the same result
     assert_array_almost_equal(coef_dense, coef_sorted.toarray())
 
-    X_sparse_unsorted = X_sparse[np.arange(X.shape[0])]
-    X_test_unsorted = X_test[np.arange(X_test.shape[0])]
+    # scramble the indices
+    def scramble_indices(X):
+        new_data = []
+        new_indices = []
+        for i in range(1, len(X.indptr)):
+            new_data.extend(X.data[X.indptr[i - 1]: X.indptr[i]][::-1])
+            new_indices.extend(X.indices[X.indptr[i - 1]: X.indptr[i]][::-1])
+        return sparse.csr_matrix((new_data, new_indices, X.indptr),
+                                 shape=X.shape)
 
-    # make sure we scramble the indices
+    X_sparse_unsorted = scramble_indices(X_sparse)
+    X_test_unsorted = scramble_indices(X_test)
+
     assert not X_sparse_unsorted.has_sorted_indices
     assert not X_test_unsorted.has_sorted_indices
 

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -125,7 +125,6 @@ def test_unsorted_indices():
     X_sparse_unsorted = scramble_indices(X_sparse)
     X_test_unsorted = scramble_indices(X_test)
 
-    # make sure we scramble the indices
     assert not X_sparse_unsorted.has_sorted_indices
     assert not X_test_unsorted.has_sorted_indices
 

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -111,19 +111,21 @@ def test_unsorted_indices():
     # make sure dense and sparse SVM give the same result
     assert_array_almost_equal(coef_dense, coef_sorted.toarray())
 
-    # scramble the indices
+    # reverse each row's indices
     def scramble_indices(X):
         new_data = []
         new_indices = []
         for i in range(1, len(X.indptr)):
-            new_data.extend(X.data[X.indptr[i - 1]: X.indptr[i]][::-1])
-            new_indices.extend(X.indices[X.indptr[i - 1]: X.indptr[i]][::-1])
+            row_slice = slice(*X.indptr[i - 1: i + 1])
+            new_data.extend(X.data[row_slice][::-1])
+            new_indices.extend(X.indices[row_slice][::-1])
         return sparse.csr_matrix((new_data, new_indices, X.indptr),
                                  shape=X.shape)
 
     X_sparse_unsorted = scramble_indices(X_sparse)
     X_test_unsorted = scramble_indices(X_test)
 
+    # make sure we scramble the indices
     assert not X_sparse_unsorted.has_sorted_indices
     assert not X_test_unsorted.has_sorted_indices
 


### PR DESCRIPTION
Closes #12882 
Travis cron job failure due to changes in scipy
```
import numpy as np
import scipy.sparse as sp
X = sp.csr_matrix(np.ones((3, 3)))
print(X.indices)
# [0 1 2 0 1 2 0 1 2]
Xt = X[np.arange(3)]
print(Xt.indices)
# scipy 1.2.0 [2 1 0 2 1 0 2 1 0]
# scipy master [0 1 2 0 1 2 0 1 2]
```