### PR TITLE
Fix #12904: FunctionTransformer dumped with joblib/pickle with the wrapped function

### DIFF
--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -90,7 +90,7 @@ class FunctionTransformer(BaseEstimator, TransformerMixin):
         self.check_inverse = check_inverse
         self.kw_args = kw_args
         self.inv_kw_args = inv_kw_args
-        
+
     def __getstate__(self):
         self.func_name = self.func.__name__
         self.func_code = marshal.dumps(self.func.__code__)
@@ -98,7 +98,9 @@ class FunctionTransformer(BaseEstimator, TransformerMixin):
         return self.__dict__
 
     def __setstate__(self, d):
-        d["func"] = FunctionType(marshal.loads(d["func_code"]), globals(), d["func_name"])
+        d["func"] = FunctionType(marshal.loads(d["func_code"]),
+                                 globals(),
+                                 d["func_name"])
         del d["func_name"]
         del d["func_code"]
         self.__dict__ = d

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -1,4 +1,6 @@
 import warnings
+import marshal
+from types import FunctionType
 
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_array
@@ -88,6 +90,18 @@ class FunctionTransformer(BaseEstimator, TransformerMixin):
         self.check_inverse = check_inverse
         self.kw_args = kw_args
         self.inv_kw_args = inv_kw_args
+        
+    def __getstate__(self):
+        self.func_name = self.func.__name__
+        self.func_code = marshal.dumps(self.func.__code__)
+        del self.func
+        return self.__dict__
+
+    def __setstate__(self, d):
+        d["func"] = FunctionType(marshal.loads(d["func_code"]), globals(), d["func_name"])
+        del d["func_name"]
+        del d["func_code"]
+        self.__dict__ = d
 
     def _check_input(self, X):
         # FIXME: Future warning to be removed in 0.22

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -1,5 +1,4 @@
 import pytest
-import joblib
 import os
 import numpy as np
 from scipy import sparse
@@ -9,6 +8,7 @@ from sklearn.utils.testing import (assert_equal, assert_array_equal,
                                    assert_allclose_dense_sparse)
 from sklearn.utils.testing import assert_warns_message, assert_no_warnings
 from sklearn.utils.testing import ignore_warnings
+import joblib
 
 
 def _make_func(args_store, kwargs_store, func=lambda X, *a, **k: X):

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -1,4 +1,6 @@
 import pytest
+import joblib
+import os
 import numpy as np
 from scipy import sparse
 
@@ -84,6 +86,29 @@ def test_np_log():
         FunctionTransformer(np.log1p).transform(X),
         np.log1p(X),
     )
+
+
+@ignore_warnings(category=FutureWarning)
+# ignore warning for validate=False 0.22
+def test_joblib():
+    X = np.arange(10).reshape((5, 2))
+
+    def f(X):
+        return X*2
+    # Test that the example still works.
+    assert_array_equal(
+        FunctionTransformer(f).transform(X),
+        X*2,
+    )
+    joblib.dump(f, "test_joblib.joblib")
+    del f
+    # Test that the pickled version works.
+    assert_array_equal(
+        joblib.load("test_joblib.joblib"),
+        X*2,
+    )
+    # Cleanup
+    os.remove("test_joblib.joblib")
 
 
 @ignore_warnings(category=FutureWarning)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #12904 


#### What does this implement/fix? Explain your changes.

```
from sklearn.preprocessing import FunctionTransformer
import joblib

def f(x): return x*x
joblib.dump(FunctionTransformer(f), "t.tmp")

del f
unpickled = joblib.load("t.tmp") # Causes an exception
```


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
