### PR TITLE
Using working_memory in mlp.predict_proba

### DIFF
--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -1051,7 +1051,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
 
         Returns
         -------
-        y_prob : ssdsdsarray-like, shape (n_samples, n_classes)
+        y_prob : array-like, shape (n_samples, n_classes)
             The predicted probability of the sample for each class in the
             model, where classes are ordered as they are in `self.classes_`.
         """

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -1060,7 +1060,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         # efficiency. As we do not know the shape of the output,
         # we simply test the output size for a single sample
         # and use the shape of the output
-        y_pred = np.empty((x_axis0_size,) + 1)
+        y_pred = np.empty((x_axis0_size,1))
 
         # Call the classifier in chunks.
         for x_chunk in gen_batches(X.shape[0], chunk_size):

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -1060,7 +1060,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         # efficiency. As we do not know the shape of the output,
         # we simply test the output size for a single sample
         # and use the shape of the output
-        y_pred = np.empty((x_axis0_size,) + self._predict(X[0:1]).shape[1:])
+        y_pred = np.empty((x_axis0_size,) + 1)
 
         # Call the classifier in chunks.
         for x_chunk in gen_batches(X.shape[0], chunk_size):

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -1060,7 +1060,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         # efficiency. As we do not know the shape of the output,
         # we simply test the output size for a single sample
         # and use the shape of the output
-        y_pred = np.empty((x_axis0_size,1))
+        y_pred = np.empty((x_axis0_size, 1))
 
         # Call the classifier in chunks.
         for x_chunk in gen_batches(X.shape[0], chunk_size):

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -19,7 +19,7 @@ from ._stochastic_optimizers import SGDOptimizer, AdamOptimizer
 from ..model_selection import train_test_split
 from ..externals import six
 from ..preprocessing import LabelBinarizer
-from ..utils import gen_batches, check_random_state, get_chunk_n_rows
+from ..utils import gen_batches, check_random_state
 from ..utils import shuffle
 from ..utils import check_array, check_X_y, column_or_1d
 from ..exceptions import ConvergenceWarning

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -1058,19 +1058,23 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         check_is_fitted(self, "coefs_")
         # split and collate depending on the working_memory
         x_axis0_size = X.shape[0]
-        if not maxr:
-            chunk_size = get_chunk_n_rows(row_bytes=sys.getsizeof(X[0:1]), max_n_rows=x_axis0_size)
+        if not max_row_chunk:
+            chunk_size = get_chunk_n_rows(row_bytes=sys.getsizeof(X[0:1]),
+                                          max_n_rows=x_axis0_size)
         else:
             chunk_size = max_row_chunk
-        # Pre-allocate the entire result set to avoid array copying for efficiency.
-        # As we do not know the shape of the output, we simply test the output
-        # size for a single sample and use the shape of the output
+        # Pre-allocate the entire result set to avoid array copying for
+        # efficiency. As we do not know the shape of the output,
+        # we simply test the output size for a single sample
+        # and use the shape of the output
         y_pred = np.empty((x_axis0_size,) + self._predict(X[0:1]).shape[1:])
 
         # Call the classifier in chunks.
         y_chunk_pos = 0
-        for x_chunk in np.array_split(X, np.arange(chunk_size, x_axis0_size, chunk_size), axis=0):
-            y_pred[y_chunk_pos:y_chunk_pos + x_chunk.shape[0]] = self._predict(x_chunk)
+        for x_chunk in np.array_split(X, np.arange(chunk_size, x_axis0_size,
+                                                   chunk_size), axis=0):
+            y_pred[y_chunk_pos:y_chunk_pos + x_chunk.shape[0]] = self._predict(
+                x_chunk)
             y_chunk_pos += x_chunk.shape[0]
 
         if self.n_outputs_ == 1:

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -1060,7 +1060,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         # efficiency. As we do not know the shape of the output,
         # we simply test the output size for a single sample
         # and use the shape of the output
-        y_pred = np.empty((x_axis0_size, 1))
+        y_pred = np.empty((x_axis0_size,) + (self.n_outputs_,))
 
         # Call the classifier in chunks.
         for x_chunk in gen_batches(X.shape[0], chunk_size):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #12675 and will work on similar usages after having a check with the moderators.


#### What does this implement/fix? Explain your changes.
This changes use the `working_memory` parameter from config or the mentioned number of samples to be predicted per call to `predict_proba` in the `MLPClassifier`. In-code comments are present to make it more clear.

#### Any other comments?
Please let me know if its ok to make the same modification to other functions calling `_predict`, if yes, we can move the fix to the `_predict` function itself

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
