### PR TITLE
FIX learning_rate default value in update_terminal_regions

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -78,8 +78,14 @@ Support for Python 3.4 and below has been officially dropped.
   problems. :issue:`12715` by :user:`Nicolas Hug<NicolasHug>`.
 
 - |Fix| Fixed a bug in :mod:`ensemble` where the ``predict`` method would
-   error for multiclass multioutput forests models if any targets were strings.
-   :issue:`12834` by :user:`Elizabeth Sander <elsander>`.
+  error for multiclass multioutput forests models if any targets were strings.
+  :issue:`12834` by :user:`Elizabeth Sander <elsander>`.
+
+- |Fix| Fixed a bug in :class:`ensemble.gradient_boosting.LossFunction` and
+  :class:`ensemble.gradient_boosting.LeastSquaresError` where the default
+  value of ``learning_rate`` in ``update_terminal_regions`` is not consistent
+  with the document and the caller functions.
+  :issue:`6463` by :user:`movelikeriver <movelikeriver>`.
 
 :mod:`sklearn.linear_model`
 ...........................
@@ -139,7 +145,7 @@ Support for Python 3.4 and below has been officially dropped.
 ..............................
 
 - |Enhancement| Classes :class:`~model_selection.GridSearchCV`,
-  :class:`~model_selection.RandomSearchCV`, and methods
+  :class:`~model_selection.RandomizedSearchCV`, and methods
   :func:`~model_selection.cross_val_score`,
   :func:`~model_selection.cross_val_predict`,
   :func:`~model_selection.cross_validate`, now print train scores when

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -355,7 +355,7 @@ class LossFunction(object, metaclass=ABCMeta):
 
     def update_terminal_regions(self, tree, X, y, residual, y_pred,
                                 sample_weight, sample_mask,
-                                learning_rate=1.0, k=0):
+                                learning_rate=0.1, k=0):
         """Update the terminal regions (=leaves) of the given tree and
         updates the current predictions of the model. Traverses tree
         and invokes template method `_update_terminal_region`.
@@ -469,7 +469,7 @@ class LeastSquaresError(RegressionLossFunction):
 
     def update_terminal_regions(self, tree, X, y, residual, y_pred,
                                 sample_weight, sample_mask,
-                                learning_rate=1.0, k=0):
+                                learning_rate=0.1, k=0):
         """Least squares does not need to update terminal regions.
 
         But it has to update the predictions.
@@ -1201,7 +1201,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             # update tree leaves
             loss.update_terminal_regions(tree.tree_, X, y, residual, y_pred,
                                          sample_weight, sample_mask,
-                                         self.learning_rate, k=k)
+                                         learning_rate=self.learning_rate, k=k)
 
             # add tree to ensemble
             self.estimators_[i, k] = tree


### PR DESCRIPTION
Closes #6463 Closes #12921 
Encountered unexpected problems when trying to resolve the conflicts so I open a new PR.
Already +2 in #6463 so we can merge this directly when CIs are green.
