### PR TITLE
EXA Use cv=5 instead of cv=10 in plot_validation_curve.py

### DIFF
--- a/examples/model_selection/plot_validation_curve.py
+++ b/examples/model_selection/plot_validation_curve.py
@@ -26,7 +26,7 @@ X, y = digits.data, digits.target
 param_range = np.logspace(-6, -1, 5)
 train_scores, test_scores = validation_curve(
     SVC(), X, y, param_name="gamma", param_range=param_range,
-    cv=10, scoring="accuracy", n_jobs=1)
+    cv=5, scoring="accuracy", n_jobs=1)
 train_scores_mean = np.mean(train_scores, axis=1)
 train_scores_std = np.std(train_scores, axis=1)
 test_scores_mean = np.mean(test_scores, axis=1)


### PR DESCRIPTION
cv=5 is faster (reduce run time from ~30s to ~13s) and more consistent with our default.
It produces very similar results ~(I'll post the result after Circle finishes)~
master:
![sphx_glr_plot_validation_curve_001](https://user-images.githubusercontent.com/12003569/50725878-028ec180-1140-11e9-9ab7-b89612941965.png)
this PR:
![sphx_glr_plot_validation_curve_001 1](https://user-images.githubusercontent.com/12003569/50725880-06badf00-1140-11e9-8c72-99614e06e3cc.png)
