### PR TITLE
[MRG] Update transform glossary definition. (#wimlds)

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1367,6 +1367,8 @@ Methods
         If the estimator was not already :term:`fitted`, calling this method
         should raise a :class:`exceptions.NotFittedError`.
 
+        :term:`transform` does not preserve the order (memory layout) of the input array.
+
 .. _glossary_parameters:
 
 Parameters

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1367,7 +1367,12 @@ Methods
         If the estimator was not already :term:`fitted`, calling this method
         should raise a :class:`exceptions.NotFittedError`.
 
-        :term:`transform` does not preserve the order (memory layout) of the input array.
+        During transformation, the order of the input samples may not be
+        preserved, though :term:`transform` will often preserve dtype where
+        possible. If copy=False, the input samples will be modified directly,
+        if possible. Where copy is unavailable, the input's memory order will be
+        retained. See `<https://docs.scipy.org/doc/numpy/glossary.html#term-row-major>`_ 
+        for more information on row ordering.
 
 .. _glossary_parameters:
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Issue: PCA().fit_transform changes array order #5419 

This PR finishes out the work done on #12213. 
#### What does this implement/fix? Explain your changes.
This PR updates the `transform` glossary entry to address the fact that `transform` does not preserve the memory order of the input array.



#### Any other comments?
#wimlds

cc: @reshamas , @NicolasHug  
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
