### PR TITLE
TST Use match instead of message in pytest.raises

### DIFF
--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -585,10 +585,10 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
                 assert not hasattr(clf, 'predict_proba')
                 assert not hasattr(clf, 'predict_log_proba')
                 with pytest.raises(AttributeError,
-                                   message=message):
+                                   match=message):
                     clf.predict_proba
                 with pytest.raises(AttributeError,
-                                   message=message):
+                                   match=message):
                     clf.predict_log_proba
 
     def test_sgd_proba(self):

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -481,8 +481,8 @@ def test_shuffle_kfold_stratifiedkfold_reproducibility():
                 # cv.split(...) returns an array of tuples, each tuple
                 # consisting of an array with train indices and test indices
                 with pytest.raises(AssertionError,
-                                   message="The splits for data, are same even"
-                                           " when random state is not set"):
+                                   match="The splits for data, are same even"
+                                         " when random state is not set"):
                     np.testing.assert_array_equal(test_a, test_b)
 
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -480,9 +480,9 @@ def test_shuffle_kfold_stratifiedkfold_reproducibility():
                                                 cv.split(*data)):
                 # cv.split(...) returns an array of tuples, each tuple
                 # consisting of an array with train indices and test indices
-                with pytest.raises(AssertionError,
-                                   match="The splits for data, are same even"
-                                         " when random state is not set"):
+                # Ensure that the splits for data are not same
+                # when random state is not set
+                with pytest.raises(AssertionError):
                     np.testing.assert_array_equal(test_a, test_b)
 
 


### PR DESCRIPTION
Resolve Travis cron job failure on master.
See https://github.com/pytest-dev/pytest/issues/3974, we should use match instead of message to check the error message in pytest.raises.