### PR TITLE
[MRG] Fix builtin PrettyPrinter usage on estimators

### DIFF
--- a/sklearn/utils/_pprint.py
+++ b/sklearn/utils/_pprint.py
@@ -321,7 +321,10 @@ class _EstimatorPrettyPrinter(pprint.PrettyPrinter):
         self._format(v, stream, indent + len(rep) + len(middle), allowance,
                      context, level)
 
-    _dispatch = pprint.PrettyPrinter._dispatch
+    # Note: need to copy _dispatch to prevent instances of the builtin
+    # PrettyPrinter class to call methods of _EstimatorPrettyPrinter (see issue
+    # 12906)
+    _dispatch = pprint.PrettyPrinter._dispatch.copy()
     _dispatch[BaseEstimator.__repr__] = _pprint_estimator
     _dispatch[KeyValTuple.__repr__] = _pprint_key_val_tuple
 

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -1,4 +1,5 @@
 import re
+from pprint import PrettyPrinter
 
 from sklearn.utils._pprint import _EstimatorPrettyPrinter
 from sklearn.pipeline import make_pipeline, Pipeline
@@ -311,3 +312,11 @@ def test_length_constraint():
     vectorizer = CountVectorizer(vocabulary=vocabulary)
     repr_ = vectorizer.__repr__()
     assert '...' in repr_
+
+
+def test_builtin_prettyprinter():
+    # non regression test than ensures we can still use the builtin
+    # PrettyPrinter class for estimators (as done e.g. by joblib).
+    # Used to be a bug
+
+    PrettyPrinter().pprint(LogisticRegression())


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #12906

#### What does this implement/fix? Explain your changes.

This PR makes a copy of the `_dispatch` dict in `_EstimatorPrettyPrinter` to prevent the builtin `PrettyPrinter` class to **directly** call `_EstimatorPrettyPrinter._print_estimator` on estimator objects, which fails since `_print_estimator` assumes the object is an instance of `_EstimatorPrettyPrinter` with specific attributes. 

#### Any other comments?

Note that even when only `PrettyPrinter` is used, estimators will still be rendered with `_EstimatorPrettyPrinter` since `PrettyPrinter` internally uses `repr()` which itself uses `_EstimatorPrettyPrinter`.

So using `PrettyPrinter` or `_EstimatorPrettyPrinter` on an estimator has the exact same effect.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
