### PR TITLE
DOC improved example plot in plot_lda_qda.py

### DIFF
--- a/examples/classification/plot_lda_qda.py
+++ b/examples/classification/plot_lda_qda.py
@@ -144,7 +144,7 @@ for i, (X, y) in enumerate([dataset_fixed_cov(), dataset_cov()]):
     splot = plot_data(qda, X, y, y_pred, fig_index=2 * i + 2)
     plot_qda_cov(qda, splot)
     plt.axis('tight')
-plt.suptitle('Linear Discriminant Analysis vs Quadratic Discriminant',
+plt.suptitle('Linear Discriminant Analysis vs Quadratic Discriminant Analysis',
              y=1.02, fontsize=15)
 plt.tight_layout()
 plt.show()

--- a/examples/classification/plot_lda_qda.py
+++ b/examples/classification/plot_lda_qda.py
@@ -146,6 +146,7 @@ for i, (X, y) in enumerate([dataset_fixed_cov(), dataset_cov()]):
     splot = plot_data(qda, X, y, y_pred, fig_index=2 * i + 2)
     plot_qda_cov(qda, splot)
     plt.axis('tight')
-plt.suptitle('Linear Discriminant Analysis vs Quadratic Discriminant', y=1.02, fontsize=15)
+plt.suptitle('Linear Discriminant Analysis vs Quadratic Discriminant',
+             y=1.02, fontsize=15)
 plt.tight_layout()
 plt.show()

--- a/examples/classification/plot_lda_qda.py
+++ b/examples/classification/plot_lda_qda.py
@@ -127,6 +127,7 @@ def plot_qda_cov(qda, splot):
     plot_ellipse(splot, qda.means_[0], qda.covariance_[0], 'red')
     plot_ellipse(splot, qda.means_[1], qda.covariance_[1], 'blue')
 
+
 plt.figure(figsize=(10, 8), facecolor='white')
 for i, (X, y) in enumerate([dataset_fixed_cov(), dataset_cov()]):
     # Linear Discriminant Analysis

--- a/examples/classification/plot_lda_qda.py
+++ b/examples/classification/plot_lda_qda.py
@@ -112,10 +112,10 @@ def plot_ellipse(splot, mean, cov, color):
     angle = 180 * angle / np.pi  # convert to degrees
     # filled Gaussian at 2 standard deviation
     ell = mpl.patches.Ellipse(mean, 2 * v[0] ** 0.5, 2 * v[1] ** 0.5,
-                              180 + angle, facecolor='none',
-                              edgecolor='k', linewidth=2)
+                              180 + angle, facecolor=color,
+                              edgecolor='black', linewidth=2)
     ell.set_clip_box(splot.bbox)
-    ell.set_alpha(0.5)
+    ell.set_alpha(0.2)
     splot.add_artist(ell)
     splot.set_xticks(())
     splot.set_yticks(())

--- a/examples/classification/plot_lda_qda.py
+++ b/examples/classification/plot_lda_qda.py
@@ -72,8 +72,6 @@ def plot_data(lda, X, y, y_pred, fig_index):
     X0_tp, X0_fp = X0[tp0], X0[~tp0]
     X1_tp, X1_fp = X1[tp1], X1[~tp1]
 
-    alpha = 0.5
-
     # class 0: dots
     plt.scatter(X0_tp[:, 0], X0_tp[:, 1], marker='.', color='red')
     plt.scatter(X0_fp[:, 0], X0_fp[:, 1], marker='x',

--- a/examples/classification/plot_lda_qda.py
+++ b/examples/classification/plot_lda_qda.py
@@ -75,16 +75,12 @@ def plot_data(lda, X, y, y_pred, fig_index):
     alpha = 0.5
 
     # class 0: dots
-    plt.plot(X0_tp[:, 0], X0_tp[:, 1], 'o', alpha=alpha,
-             color='red', markeredgecolor='k')
-    plt.plot(X0_fp[:, 0], X0_fp[:, 1], '*', alpha=alpha,
-             color='#990000', markeredgecolor='k')  # dark red
+    plt.scatter(X0_tp[:, 0], X0_tp[:, 1], marker='.', color='red')
+    plt.scatter(X0_fp[:, 0], X0_fp[:, 1], marker='.', color='#990000')  # dark red
 
     # class 1: dots
-    plt.plot(X1_tp[:, 0], X1_tp[:, 1], 'o', alpha=alpha,
-             color='blue', markeredgecolor='k')
-    plt.plot(X1_fp[:, 0], X1_fp[:, 1], '*', alpha=alpha,
-             color='#000099', markeredgecolor='k')  # dark blue
+    plt.scatter(X1_tp[:, 0], X1_tp[:, 1], marker='.', color='blue')
+    plt.scatter(X1_fp[:, 0], X1_fp[:, 1], marker='.', color='#000099')  # dark blue
 
     # class 0 and 1 : areas
     nx, ny = 200, 100
@@ -95,14 +91,14 @@ def plot_data(lda, X, y, y_pred, fig_index):
     Z = lda.predict_proba(np.c_[xx.ravel(), yy.ravel()])
     Z = Z[:, 1].reshape(xx.shape)
     plt.pcolormesh(xx, yy, Z, cmap='red_blue_classes',
-                   norm=colors.Normalize(0., 1.))
-    plt.contour(xx, yy, Z, [0.5], linewidths=2., colors='k')
+                   norm=colors.Normalize(0., 1.), zorder=0)
+    plt.contour(xx, yy, Z, [0.5], linewidths=2., colors='white')
 
     # means
     plt.plot(lda.means_[0][0], lda.means_[0][1],
-             'o', color='black', markersize=10, markeredgecolor='k')
+             '*', color='yellow', markersize=15, markeredgecolor='grey')
     plt.plot(lda.means_[1][0], lda.means_[1][1],
-             'o', color='black', markersize=10, markeredgecolor='k')
+             '*', color='yellow', markersize=15, markeredgecolor='grey')
 
     return splot
 
@@ -114,9 +110,7 @@ def plot_ellipse(splot, mean, cov, color):
     angle = 180 * angle / np.pi  # convert to degrees
     # filled Gaussian at 2 standard deviation
     ell = mpl.patches.Ellipse(mean, 2 * v[0] ** 0.5, 2 * v[1] ** 0.5,
-                              180 + angle, facecolor=color,
-                              edgecolor='yellow',
-                              linewidth=2, zorder=2)
+                              180 + angle, facecolor=color, alpha=1, edgecolor='grey', linewidth=2)
     ell.set_clip_box(splot.bbox)
     ell.set_alpha(0.5)
     splot.add_artist(ell)
@@ -133,6 +127,7 @@ def plot_qda_cov(qda, splot):
     plot_ellipse(splot, qda.means_[0], qda.covariance_[0], 'red')
     plot_ellipse(splot, qda.means_[1], qda.covariance_[1], 'blue')
 
+plt.figure(figsize=(10, 8), facecolor='white')
 for i, (X, y) in enumerate([dataset_fixed_cov(), dataset_cov()]):
     # Linear Discriminant Analysis
     lda = LinearDiscriminantAnalysis(solver="svd", store_covariance=True)
@@ -147,6 +142,5 @@ for i, (X, y) in enumerate([dataset_fixed_cov(), dataset_cov()]):
     splot = plot_data(qda, X, y, y_pred, fig_index=2 * i + 2)
     plot_qda_cov(qda, splot)
     plt.axis('tight')
-plt.suptitle('Linear Discriminant Analysis vs Quadratic Discriminant'
-             'Analysis')
+plt.tight_layout()
 plt.show()

--- a/examples/classification/plot_lda_qda.py
+++ b/examples/classification/plot_lda_qda.py
@@ -77,14 +77,13 @@ def plot_data(lda, X, y, y_pred, fig_index):
     # class 0: dots
     plt.scatter(
         X0_tp[:, 0], X0_tp[:, 1], marker='.', color='red')
-    plt.scatter(
-        X0_fp[:, 0], X0_fp[:, 1], marker='.', color='#990000')  # dark red
+    plt.scatter(X0_fp[:, 0], X0_fp[:, 1], marker='x',
+                s=20, color='#990000')  # dark red
 
     # class 1: dots
-    plt.scatter(
-        X1_tp[:, 0], X1_tp[:, 1], marker='.', color='blue')
-    plt.scatter(
-        X1_fp[:, 0], X1_fp[:, 1], marker='.', color='#000099')  # dark blue
+    plt.scatter(X1_tp[:, 0], X1_tp[:, 1], marker='.', color='blue')
+    plt.scatter(X1_fp[:, 0], X1_fp[:, 1], marker='x',
+                s=20, color='#000099')  # dark blue
 
     # class 0 and 1 : areas
     nx, ny = 200, 100

--- a/examples/classification/plot_lda_qda.py
+++ b/examples/classification/plot_lda_qda.py
@@ -75,8 +75,7 @@ def plot_data(lda, X, y, y_pred, fig_index):
     alpha = 0.5
 
     # class 0: dots
-    plt.scatter(
-        X0_tp[:, 0], X0_tp[:, 1], marker='.', color='red')
+    plt.scatter(X0_tp[:, 0], X0_tp[:, 1], marker='.', color='red')
     plt.scatter(X0_fp[:, 0], X0_fp[:, 1], marker='x',
                 s=20, color='#990000')  # dark red
 
@@ -113,8 +112,8 @@ def plot_ellipse(splot, mean, cov, color):
     angle = 180 * angle / np.pi  # convert to degrees
     # filled Gaussian at 2 standard deviation
     ell = mpl.patches.Ellipse(mean, 2 * v[0] ** 0.5, 2 * v[1] ** 0.5,
-                              180 + angle, facecolor=color, alpha=1,
-                              edgecolor='grey', linewidth=2)
+                              180 + angle, facecolor='none',
+                              edgecolor='k', linewidth=2)
     ell.set_clip_box(splot.bbox)
     ell.set_alpha(0.5)
     splot.add_artist(ell)
@@ -147,5 +146,6 @@ for i, (X, y) in enumerate([dataset_fixed_cov(), dataset_cov()]):
     splot = plot_data(qda, X, y, y_pred, fig_index=2 * i + 2)
     plot_qda_cov(qda, splot)
     plt.axis('tight')
+plt.suptitle('Linear Discriminant Analysis vs Quadratic Discriminant', y=1.02, fontsize=15)
 plt.tight_layout()
 plt.show()

--- a/examples/classification/plot_lda_qda.py
+++ b/examples/classification/plot_lda_qda.py
@@ -75,12 +75,16 @@ def plot_data(lda, X, y, y_pred, fig_index):
     alpha = 0.5
 
     # class 0: dots
-    plt.scatter(X0_tp[:, 0], X0_tp[:, 1], marker='.', color='red')
-    plt.scatter(X0_fp[:, 0], X0_fp[:, 1], marker='.', color='#990000')  # dark red
+    plt.scatter(
+        X0_tp[:, 0], X0_tp[:, 1], marker='.', color='red')
+    plt.scatter(
+        X0_fp[:, 0], X0_fp[:, 1], marker='.', color='#990000')  # dark red
 
     # class 1: dots
-    plt.scatter(X1_tp[:, 0], X1_tp[:, 1], marker='.', color='blue')
-    plt.scatter(X1_fp[:, 0], X1_fp[:, 1], marker='.', color='#000099')  # dark blue
+    plt.scatter(
+        X1_tp[:, 0], X1_tp[:, 1], marker='.', color='blue')
+    plt.scatter(
+        X1_fp[:, 0], X1_fp[:, 1], marker='.', color='#000099')  # dark blue
 
     # class 0 and 1 : areas
     nx, ny = 200, 100
@@ -110,7 +114,8 @@ def plot_ellipse(splot, mean, cov, color):
     angle = 180 * angle / np.pi  # convert to degrees
     # filled Gaussian at 2 standard deviation
     ell = mpl.patches.Ellipse(mean, 2 * v[0] ** 0.5, 2 * v[1] ** 0.5,
-                              180 + angle, facecolor=color, alpha=1, edgecolor='grey', linewidth=2)
+                              180 + angle, facecolor=color, alpha=1,
+                              edgecolor='grey', linewidth=2)
     ell.set_clip_box(splot.bbox)
     ell.set_alpha(0.5)
     splot.add_artist(ell)


### PR DESCRIPTION
Improved the plots on https://scikit-learn.org/stable/auto_examples/classification/plot_lda_qda.html#sphx-glr-auto-examples-classification-plot-lda-qda-py.

Currently, the quadratic decision boundary of QDA is hardly seen in the 4th subplot. As the boundary being quadratic is the most important distinguishment from that of LDA, the current version could be confusing.

The updated plot:

![Imgur](https://i.imgur.com/zlimWZ3.png)