### PR TITLE
Add a backward compatible flag `train_score_size` to the cross_validate function.

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -563,11 +563,12 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         if return_train_score:
             if train_score_size is not None:
                 X_train_split, _, y_train_split, _ = train_test_split(
-                    X_train, y_train, train_size=train_score_size, stratify=y_train)
+                    X_train, y_train, train_size=train_score_size,
+                    stratify=y_train)
             else:
                 X_train_split, y_train_split = X_train, y_train
-            train_scores = _score(estimator, X_train_split, y_train_split, scorer,
-                                  is_multimetric)
+            train_scores = _score(estimator, X_train_split, y_train_split,
+                                  scorer, is_multimetric)
     if verbose > 2:
         if is_multimetric:
             for scorer_name in sorted(test_scores):

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -28,7 +28,7 @@ from ..utils._joblib import Parallel, delayed
 from ..utils._joblib import logger
 from ..metrics.scorer import check_scoring, _check_multimetric_scoring
 from ..exceptions import FitFailedWarning
-from ._split import check_cv
+from ._split import check_cv, train_test_split
 from ..preprocessing import LabelEncoder
 
 
@@ -38,8 +38,9 @@ __all__ = ['cross_validate', 'cross_val_score', 'cross_val_predict',
 
 def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv='warn',
                    n_jobs=None, verbose=0, fit_params=None,
-                   pre_dispatch='2*n_jobs', return_train_score=False,
-                   return_estimator=False, error_score='raise-deprecating'):
+                   pre_dispatch='2*n_jobs', return_train_score="warn",
+                   return_estimator=False, error_score='raise-deprecating',
+                   train_score_size=None):
     """Evaluate metric(s) by cross-validation and also record fit/score times.
 
     Read more in the :ref:`User Guide <multimetric_cross_validation>`.
@@ -145,6 +146,16 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv='warn',
         Default is 'raise-deprecating' but from version 0.22 it will change
         to np.nan.
 
+    train_score_size : int, or float, optional, default None
+        The size of the train set used to compute train scores if
+        `return_train_score` is set to True.
+
+        The default is None in which case the full train set is used.
+        If set to an integer then that many samples will be used.
+        If set to a float, it should be between 0 and 1. The train-set size
+        will be computed as a fraction of the total training set used
+        in a fold during cross validation.
+
     Returns
     -------
     scores : dict of float arrays of shape=(n_splits,)
@@ -229,7 +240,7 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv='warn',
             clone(estimator), X, y, scorers, train, test, verbose, None,
             fit_params, return_train_score=return_train_score,
             return_times=True, return_estimator=return_estimator,
-            error_score=error_score)
+            error_score=error_score, train_score_size=train_score_size)
         for train, test in cv.split(X, y, groups))
 
     zipped_scores = list(zip(*scores))
@@ -390,7 +401,7 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
                    parameters, fit_params, return_train_score=False,
                    return_parameters=False, return_n_test_samples=False,
                    return_times=False, return_estimator=False,
-                   error_score='raise-deprecating'):
+                   error_score='raise-deprecating', train_score_size=None):
     """Fit estimator and compute scores for a given dataset split.
 
     Parameters
@@ -550,7 +561,12 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         test_scores = _score(estimator, X_test, y_test, scorer, is_multimetric)
         score_time = time.time() - start_time - fit_time
         if return_train_score:
-            train_scores = _score(estimator, X_train, y_train, scorer,
+            if train_score_size is not None:
+                X_train_split, _, y_train_split, _ = train_test_split(
+                    X_train, y_train, train_size=train_score_size, stratify=y_train)
+            else:
+                X_train_split, y_train_split = X_train, y_train
+            train_scores = _score(estimator, X_train_split, y_train_split, scorer,
                                   is_multimetric)
     if verbose > 2:
         if is_multimetric:


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
I did not create a separate issue since this is a small code change.

#### What does this implement/fix? Explain your changes.
This code adds a backward compatible flag `train_score_size` to the cross_validate function.
With this flag, we can request to subsample the training set for computing the train_scores
to save time. Currently, the documentation just warns users that setting `return_train_score` 
to True may be time-consuming and slow. This flag offers a way to improve this situation.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
