### PR TITLE
[MRG] DOC Mention StandardScaler ddof

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -478,10 +478,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
 
     where `u` is the mean of the training samples or zero if `with_mean=False`,
     and `s` is the standard deviation of the training samples or one if
-    `with_std=False`. Note that `s` is a biased estimator of the standard
-    deviation, equivalent to numpy.sqrt(numpy.var(x, ddof=0)), and that it is
-    unlikely that using this estimator as opposed its unbiased counterpart
-    will affect model performance.
+    `with_std=False`.
 
     Centering and scaling happen independently on each feature by computing
     the relevant statistics on the samples in the training set. Mean and
@@ -577,6 +574,10 @@ class StandardScaler(BaseEstimator, TransformerMixin):
     -----
     NaNs are treated as missing values: disregarded in fit, and maintained in
     transform.
+    
+    We use a biased estimator for the standard deviation, equivalent to
+    `numpy.std(x, ddof=0)`. Note, however, that the choice of `ddof` is
+    unlikely to affect model performance.
 
     For a comparison of the different scalers, transformers, and normalizers,
     see :ref:`examples/preprocessing/plot_all_scaling.py

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -479,7 +479,9 @@ class StandardScaler(BaseEstimator, TransformerMixin):
     where `u` is the mean of the training samples or zero if `with_mean=False`,
     and `s` is the standard deviation of the training samples or one if
     `with_std=False`. Note that `s` is a biased estimator of the standard
-    deviation, equivalent to numpy.sqrt(numpy.var(x, ddof=0)).
+    deviation, equivalent to numpy.sqrt(numpy.var(x, ddof=0)), and that it is
+    unlikely that using this estimator as opposed its unbiased counterpart
+    will affect model performance.
 
     Centering and scaling happen independently on each feature by computing
     the relevant statistics on the samples in the training set. Mean and

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -479,7 +479,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
     where `u` is the mean of the training samples or zero if `with_mean=False`,
     and `s` is the standard deviation of the training samples or one if
     `with_std=False`. Note that `s` is a biased estimator of the standard
-    deviation, equivalent to numpy.var(x, ddof=0).
+    deviation, equivalent to np.sqrt(numpy.var(x, ddof=0)).
 
     Centering and scaling happen independently on each feature by computing
     the relevant statistics on the samples in the training set. Mean and

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -479,7 +479,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
     where `u` is the mean of the training samples or zero if `with_mean=False`,
     and `s` is the standard deviation of the training samples or one if
     `with_std=False`. Note that `s` is a biased estimator of the standard
-    deviation, equivalent to np.sqrt(numpy.var(x, ddof=0)).
+    deviation, equivalent to numpy.sqrt(numpy.var(x, ddof=0)).
 
     Centering and scaling happen independently on each feature by computing
     the relevant statistics on the samples in the training set. Mean and

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -123,6 +123,10 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
     NaNs are treated as missing values: disregarded to compute the statistics,
     and maintained during the data transformation.
 
+    We use a biased estimator for the standard deviation, equivalent to
+    `numpy.std(x, ddof=0)`. Note that the choice of `ddof` is unlikely to
+    affect model performance.
+
     For a comparison of the different scalers, transformers, and normalizers,
     see :ref:`examples/preprocessing/plot_all_scaling.py
     <sphx_glr_auto_examples_preprocessing_plot_all_scaling.py>`.

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -576,8 +576,8 @@ class StandardScaler(BaseEstimator, TransformerMixin):
     transform.
     
     We use a biased estimator for the standard deviation, equivalent to
-    `numpy.std(x, ddof=0)`. Note, however, that the choice of `ddof` is
-    unlikely to affect model performance.
+    `numpy.std(x, ddof=0)`. Note that the choice of `ddof` is unlikely to
+    affect model performance.
 
     For a comparison of the different scalers, transformers, and normalizers,
     see :ref:`examples/preprocessing/plot_all_scaling.py

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -478,7 +478,8 @@ class StandardScaler(BaseEstimator, TransformerMixin):
 
     where `u` is the mean of the training samples or zero if `with_mean=False`,
     and `s` is the standard deviation of the training samples or one if
-    `with_std=False`.
+    `with_std=False`. Note that `s` is a biased estimator of the standard
+    deviation, equivalent to numpy.var(x, ddof=0).
 
     Centering and scaling happen independently on each feature by computing
     the relevant statistics on the samples in the training set. Mean and


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #7757
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Expands the documentation so it's clear that the estimate of the standard deviation in StandardScaler is the biased one (equivalent to numpy.sqrt(numpy.var(x, ddof=0))).

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
