### PR TITLE
Updated the base.OutlierMixin.fit_predict method docstring 

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -502,7 +502,7 @@ class OutlierMixin(object):
     _estimator_type = "outlier_detector"
 
     def fit_predict(self, X, y=None):
-        """Performs outlier detection on X.
+        """Performs fit on X and returns labels for X.
 
         Returns -1 for outliers and 1 for inliers.
 


### PR DESCRIPTION
to emphasze that it performs a fit on X before returning the predictions on X

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

The docstring for OutlierMixin.fit_predict in sklearn/base.py only says that it makes predictions on X and not that it also performs a fit first.  I have modified the docstring to show that it does perform the fit first.  Somewhere I got the idea that fit_predict was for predictions on the data that was fit, but it is obviously not.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->