### PR TITLE
added assertion for ValueError when cv iterator is empty

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -668,6 +668,17 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
                                in product(candidate_params,
                                           cv.split(X, y, groups)))
 
+                if out is None or len(out) < 1:
+                    raise ValueError('No fits were performed. Was the CV'
+                                     'iterator empty? Were there no '
+                                     'candidates?')
+                elif len(out) != n_candidates * n_splits:
+                    raise ValueError('cv.split and cv.get_n_splits returned '
+                                     'inconsistent results. Expected {} '
+                                     'splits, got {}'
+                                     .format(n_splits,
+                                             len(out) // n_candidates))
+
                 all_candidate_params.extend(candidate_params)
                 all_out.extend(out)
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -669,9 +669,9 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
                                           cv.split(X, y, groups)))
 
                 if len(out) < 1:
-                    raise ValueError('No fits were performed. Was the CV '
-                                     'iterator empty? Were there no '
-                                     'candidates?')
+                    raise ValueError('No fits were performed. '
+                                     'Was the CV iterator empty? '
+                                     'Were there no candidates?')
                 elif len(out) != n_candidates * n_splits:
                     raise ValueError('cv.split and cv.get_n_splits returned '
                                      'inconsistent results. Expected {} '

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -668,8 +668,8 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
                                in product(candidate_params,
                                           cv.split(X, y, groups)))
 
-                if out is None or len(out) < 1:
-                    raise ValueError('No fits were performed. Was the CV'
+                if len(out) < 1:
+                    raise ValueError('No fits were performed. Was the CV '
                                      'iterator empty? Were there no '
                                      'candidates?')
                 elif len(out) != n_candidates * n_splits:

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1745,5 +1745,8 @@ def test_empty_cv_iterator_error():
                                cv=cv, n_jobs=-1)
 
     # assert that this raises an error
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError,
+                       message='No fits were performed. Was the CV '
+                               'iterator empty? Were there no '
+                               'candidates?'):
         ridge.fit(X[:train_size], y[:train_size])

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1763,7 +1763,7 @@ def test_random_search_bad_cv():
             return 1
 
     # create bad cv
-    cv = BrokenKFold()
+    cv = BrokenKFold(n_splits=3)
 
     train_size = 100
     ridge = RandomizedSearchCV(Ridge(), {'alpha': [1e-3, 1e-2, 1e-1]},

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1728,8 +1728,7 @@ def test_deprecated_grid_search_iid():
 
 
 def test_empty_cv_iterator_error():
-    # Generate sample data
-    X, y = make_blobs(n_samples=54, random_state=0, centers=2)
+    # Use global X, y
 
     # create cv
     cv = KFold(n_splits=3).split(X)
@@ -1751,8 +1750,7 @@ def test_empty_cv_iterator_error():
 
 
 def test_random_search_bad_cv():
-    # Generate sample data
-    X, y = make_blobs(n_samples=54, random_state=0, centers=2)
+    # Use global X, y
 
     class BrokenKFold(KFold):
         def get_n_splits(self, *args, **kw):

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1729,12 +1729,10 @@ def test_deprecated_grid_search_iid():
 
 def test_empty_cv_iterator_error():
     # Generate sample data
-    rng = np.random.RandomState(0)
-    X = 5 * rng.rand(10000, 1)
-    y = np.sin(X).ravel()
+    X, y = make_blobs(n_samples=54, random_state=0, centers=2)
 
     # create cv
-    cv = KFold(n_splits=5).split(X)
+    cv = KFold(n_splits=3).split(X)
 
     # pop all of it, this should cause the expected ValueError
     [u for u in cv]
@@ -1754,9 +1752,7 @@ def test_empty_cv_iterator_error():
 
 def test_random_search_bad_cv():
     # Generate sample data
-    rng = np.random.RandomState(0)
-    X = 5 * rng.rand(10000, 1)
-    y = np.sin(X).ravel()
+    X, y = make_blobs(n_samples=54, random_state=0, centers=2)
 
     class BrokenKFold(KFold):
         def get_n_splits(self, *args, **kw):

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1747,6 +1747,6 @@ def test_empty_cv_iterator_error():
     # assert that this raises an error
     with pytest.raises(ValueError,
                        match='No fits were performed. '
-                             'Was the CV iterator empty\? '
-                             'Were there no candidates\?'):
+                             'Was the CV iterator empty\\? '
+                             'Were there no candidates\\?'):
         ridge.fit(X[:train_size], y[:train_size])

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1746,7 +1746,7 @@ def test_empty_cv_iterator_error():
 
     # assert that this raises an error
     with pytest.raises(ValueError,
-                       message='No fits were performed. Was the CV '
-                               'iterator empty? Were there no '
-                               'candidates?'):
+                       match='No fits were performed. '
+                             'Was the CV iterator empty\? '
+                             'Were there no candidates\?'):
         ridge.fit(X[:train_size], y[:train_size])

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1750,3 +1750,28 @@ def test_empty_cv_iterator_error():
                              'Was the CV iterator empty\\? '
                              'Were there no candidates\\?'):
         ridge.fit(X[:train_size], y[:train_size])
+
+
+def test_random_search_bad_cv():
+    # Generate sample data
+    rng = np.random.RandomState(0)
+    X = 5 * rng.rand(10000, 1)
+    y = np.sin(X).ravel()
+
+    class BrokenKFold(KFold):
+        def get_n_splits(self, *args, **kw):
+            return 1
+
+    # create bad cv
+    cv = BrokenKFold()
+
+    train_size = 100
+    ridge = RandomizedSearchCV(Ridge(), {'alpha': [1e-3, 1e-2, 1e-1]},
+                               cv=cv, n_jobs=-1)
+
+    # assert that this raises an error
+    with pytest.raises(ValueError,
+                       match='cv.split and cv.get_n_splits returned '
+                             'inconsistent results. Expected \\d+ '
+                             'splits, got \\d+'):
+        ridge.fit(X[:train_size], y[:train_size])

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1725,3 +1725,25 @@ def test_deprecated_grid_search_iid():
     grid = GridSearchCV(SVC(gamma='scale'), param_grid={'C': [1]}, cv=KFold(2))
     # no warning because no stratification and 54 % 2 == 0
     assert_no_warnings(grid.fit, X, y)
+
+
+def test_empty_cv_iterator_error():
+    # Generate sample data
+    rng = np.random.RandomState(0)
+    X = 5 * rng.rand(10000, 1)
+    y = np.sin(X).ravel()
+
+    # create cv
+    cv = KFold(n_splits=5).split(X)
+
+    # pop all of it, this should cause the expected ValueError
+    [u for u in cv]
+    # cv is empty now
+
+    train_size = 100
+    ridge = RandomizedSearchCV(Ridge(), {'alpha': [1e-3, 1e-2, 1e-1]},
+                               cv=cv, n_jobs=-1)
+
+    # assert that this raises an error
+    with pytest.raises(ValueError):
+        ridge.fit(X[:train_size], y[:train_size])


### PR DESCRIPTION
Fixes #12856. ValueError is now raised when empty CV iterator is given. Added test case `test_empty_cv_iterator_error` in `model_selection/test_search.py`.

Thanks.