### PR TITLE
Fix to inelegant failure of RandomTreesEmbedding.transform when not fitted

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -2023,4 +2023,5 @@ class RandomTreesEmbedding(BaseForest):
         X_transformed : sparse matrix, shape=(n_samples, n_out)
             Transformed dataset.
         """
+        check_is_fitted(self, 'one_hot_encoder_')
         return self.one_hot_encoder_.transform(self.apply(X))


### PR DESCRIPTION
RandomTreesEmbedding.transform fails with a message about .one_hot_encoder_ missing when it hasn't first been fit.  This message doesn't tell the user what to do to fix the problem.  I've added a check for .one_hot_encoder_ using the standard check_is_fitted method that is used by most other classes with a fit and predict/transform.  This should make it clear that the instance isn't yet fit.

Fixes #12959 

#### What does this implement/fix? Explain your changes.
The current error message that comes from use of a non-fitted RandomTreesEmbedding.transform doesn't help the user locate the problem.  I've added a check_is_fitted() call just before the transform call to check if the fit has been performed and otherwise tell the user to do a fit first.

#### Any other comments?
This code and community is awesome.