### PR TITLE
[MRG+1] Expose SAGA solver for ElasticNet regression #12907

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -114,6 +114,9 @@ Support for Python 3.4 and below has been officially dropped.
   :class:`linear_model.LogisticRegressionCV` now support Elastic-Net penalty,
   with the 'saga' solver. :issue:`11646` by :user:`Nicolas Hug <NicolasHug>`.
 
+- |Feature| :class:`linear_model.ElasticNet` now supports the 'saga' solver.
+  :issue:`12966` by :user:`Christian Lorentzen <lorentzenchr>`.
+
 - |Enhancement| :class:`linear_model.LogisticRegression` now supports an
   unregularized objective by setting ``penalty`` to ``'none'``. This is
   equivalent to setting ``C=np.inf`` with l2 regularization. Not supported

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -612,7 +612,7 @@ class ElasticNet(LinearModel, RegressorMixin):
           features with approximately the same scale. You can preprocess the
           data with a scaler from sklearn.preprocessing.
 
-          .. versionadded:: TODO
+          .. versionadded:: 0.21
 
     Attributes
     ----------

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -798,8 +798,6 @@ class ElasticNet(LinearModel, RegressorMixin):
 
         if self.solver == 'saga':
             max_squared_sum = row_norms(X, squared=True).max()
-        else:
-            max_squared_sum = None
 
         if not self.warm_start or not hasattr(self, "coef_"):
             coef_ = np.zeros((n_targets, n_features), dtype=X.dtype,
@@ -811,8 +809,7 @@ class ElasticNet(LinearModel, RegressorMixin):
 
         if self.solver == 'cd':
             dual_gaps_ = np.zeros(n_targets, dtype=X.dtype)
-        else:
-            dual_gaps_ = None
+
         self.n_iter_ = []
 
         for k in range(n_targets):

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -635,7 +635,7 @@ class ElasticNet(LinearModel, RegressorMixin):
     n_iter_ : array-like, shape (n_targets,)
         For ``solver='cd'``, the number of iterations run by the solver to
         reach the specified tolerance.
-        For ``solver='saga'``, the number of full pass on all samples.
+        For ``solver='saga'``, the number of full passes on all samples.
 
     Examples
     --------
@@ -646,8 +646,9 @@ class ElasticNet(LinearModel, RegressorMixin):
     >>> regr = ElasticNet(random_state=0)
     >>> regr.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
     ElasticNet(alpha=1.0, copy_X=True, fit_intercept=True, l1_ratio=0.5,
-          max_iter=1000, normalize=False, positive=False, precompute=False,
-          random_state=0, selection='cyclic', tol=0.0001, warm_start=False)
+           max_iter=1000, normalize=False, positive=False, precompute=False,
+           random_state=0, selection='cyclic', solver='cd', tol=0.0001,
+           warm_start=False)
     >>> print(regr.coef_) # doctest: +ELLIPSIS
     [18.83816048 64.55968825]
     >>> print(regr.intercept_) # doctest: +ELLIPSIS

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -561,7 +561,7 @@ class ElasticNet(LinearModel, RegressorMixin):
         on an estimator with ``normalize=False``.
 
     precompute : True | False | array-like
-        relevant only if ``solver='cd'``
+        Relevant only if ``solver='cd'``.
         Whether to use a precomputed Gram matrix to speed up
         calculations. The Gram matrix can also be passed as argument.
         For sparse input this option is always ``True`` to preserve sparsity.
@@ -584,9 +584,8 @@ class ElasticNet(LinearModel, RegressorMixin):
         See :term:`the Glossary <warm_start>`.
 
     positive : bool, optional
-        If ``solver='cd'`` and set to ``True``, forces the coefficients to be
-        positive. ``solver='saga'`` can only be used if set to ``False`` as
-        it can't enforce positive coefficients.
+        Only valid for ``solver='cd'``. If set to ``True``, forces the
+        coefficients to be positive.
 
     random_state : int, RandomState instance or None, optional, default None
         The seed of the pseudo random number generator that selects a random
@@ -597,7 +596,7 @@ class ElasticNet(LinearModel, RegressorMixin):
         'random'.
 
     selection : str, default 'cyclic'
-        relevant only if ``solver='cd'``
+        Relevant only if ``solver='cd'``.
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
@@ -630,7 +629,8 @@ class ElasticNet(LinearModel, RegressorMixin):
     n_iter_ : array-like, shape (n_targets,)
         For ``solver='cd'``, the number of iterations run by the solver to
         reach the specified tolerance.
-        For ``solver='saga'``, the number of full passes on all samples.
+        For ``solver='saga'``, the number of full passes on all samples until
+        convergence.
 
     Examples
     --------

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -560,11 +560,17 @@ class ElasticNet(LinearModel, RegressorMixin):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    copy_X : boolean, optional, default True
-        If ``True``, X will be copied; else, it may be overwritten.
+    precompute : True | False | array-like
+        relevant only if ``solver='cd'``
+        Whether to use a precomputed Gram matrix to speed up
+        calculations. The Gram matrix can also be passed as argument.
+        For sparse input this option is always ``True`` to preserve sparsity.
 
     max_iter : int, optional
         The maximum number of iterations
+
+    copy_X : boolean, optional, default True
+        If ``True``, X will be copied; else, it may be overwritten.
 
     tol : float, optional
         The tolerance for the optimization: if the updates are
@@ -572,9 +578,32 @@ class ElasticNet(LinearModel, RegressorMixin):
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    solver : str, {'auto', 'cd', 'saga'}, \
-             optional (default='cd').
+    warm_start : bool, optional
+        When set to ``True``, reuse the solution of the previous call to fit as
+        initialization, otherwise, just erase the previous solution.
+        See :term:`the Glossary <warm_start>`.
 
+    positive : bool, optional
+        If ``solver='cd'`` and set to ``True``, forces the coefficients to be
+        positive. ``solver='saga'`` can only be used if set to ``False`` as
+        it can't enforce positive coefficients.
+
+    random_state : int, RandomState instance or None, optional, default None
+        The seed of the pseudo random number generator that selects a random
+        feature to update.  If int, random_state is the seed used by the random
+        number generator; If RandomState instance, random_state is the random
+        number generator; If None, the random number generator is the
+        RandomState instance used by `np.random`. Used when ``selection`` ==
+        'random'.
+
+    selection : str, default 'cyclic'
+        relevant only if ``solver='cd'``
+        If set to 'random', a random coefficient is updated every iteration
+        rather than looping over features sequentially by default. This
+        (setting to 'random') often leads to significantly faster convergence
+        especially when tol is higher than 1e-4.
+
+    solver : str, {'auto', 'cd', 'saga'}, optional, default 'cd'
         Algorithm to use in the optimization problem.
 
         - 'auto' chooses the solver automatically based on the type of data.
@@ -589,36 +618,6 @@ class ElasticNet(LinearModel, RegressorMixin):
           data with a scaler from sklearn.preprocessing.
 
           .. versionadded:: TODO
-
-    warm_start : bool, optional
-        When set to ``True``, reuse the solution of the previous call to fit as
-        initialization, otherwise, just erase the previous solution.
-        See :term:`the Glossary <warm_start>`.
-
-    random_state : int, RandomState instance or None, optional, default None
-        The seed of the pseudo random number generator that selects a random
-        feature to update.  If int, random_state is the seed used by the random
-        number generator; If RandomState instance, random_state is the random
-        number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`. Used when ``selection`` ==
-        'random'.
-
-    precompute : True | False | array-like
-        Only if ``solver='cd'``.
-        Whether to use a precomputed Gram matrix to speed up
-        calculations. The Gram matrix can also be passed as argument.
-        For sparse input this option is always ``True`` to preserve sparsity.
-
-    positive : bool, optional
-        Only if ``solver='cd'``.
-        When set to ``True``, forces the coefficients to be positive.
-
-    selection : str, default 'cyclic'
-        Only if ``solver='cd'``.
-        If set to 'random', a random coefficient is updated every iteration
-        rather than looping over features sequentially by default. This
-        (setting to 'random') often leads to significantly faster convergence
-        especially when tol is higher than 1e-4.
 
     Attributes
     ----------
@@ -684,22 +683,22 @@ class ElasticNet(LinearModel, RegressorMixin):
     path = staticmethod(enet_path)
 
     def __init__(self, alpha=1.0, l1_ratio=0.5, fit_intercept=True,
-                 normalize=False, copy_X=True, max_iter=1000, tol=1e-4,
-                 solver='cd', warm_start=False, random_state=None,
-                 precompute=False, positive=False, selection='cyclic'):
+                 normalize=False, precompute=False, max_iter=1000,
+                 copy_X=True, tol=1e-4, warm_start=False, positive=False,
+                 random_state=None, selection='cyclic', solver='cd'):
         self.alpha = alpha
         self.l1_ratio = l1_ratio
         self.fit_intercept = fit_intercept
         self.normalize = normalize
-        self.copy_X = copy_X
-        self.max_iter = max_iter
-        self.tol = tol
-        self.solver = solver
-        self.warm_start = warm_start
-        self.random_state = random_state
         self.precompute = precompute
+        self.max_iter = max_iter
+        self.copy_X = copy_X
+        self.tol = tol
+        self.warm_start = warm_start
         self.positive = positive
+        self.random_state = random_state
         self.selection = selection
+        self.solver = solver
 
     def fit(self, X, y, check_input=True):
         """Fit model with coordinate descent.

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -740,9 +740,6 @@ class ElasticNet(LinearModel, RegressorMixin):
         if isinstance(self.precompute, str):
             raise ValueError('precompute should be one of True, False or'
                              ' array-like. Got %r' % self.precompute)
-        elif self.precompute is not False and self.solver == 'saga':
-            warnings.warn("The solver 'saga' does not use the precomputed "
-                          " Gram matrix", category=UserWarning)
 
         if self.positive and self.solver == 'saga':
             raise ValueError("ElasticNet supports positive contraints for "
@@ -780,6 +777,9 @@ class ElasticNet(LinearModel, RegressorMixin):
             precompute_ = self.precompute
         else:
             precompute_ = False
+            if self.precompute is not precompute_:
+                warnings.warn("The solver 'saga' does not use the precomputed "
+                              " Gram matrix", category=UserWarning)
         X, y, X_offset, y_offset, X_scale, precompute, Xy = \
             _pre_fit(X, y, None, precompute_, self.normalize,
                      self.fit_intercept, copy=should_copy,

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -732,14 +732,17 @@ class ElasticNet(LinearModel, RegressorMixin):
                     raise ValueError("l1_ratio must be between 0 and 1;"
                                      " got (l1_ratio=%r)" % self.l1_ratio)
 
-        if isinstance(self.precompute, str):
-            raise ValueError('precompute should be one of True, False or'
-                             ' array-like. Got %r' % self.precompute)
-
         all_solvers = ['cd', 'saga']
         if self.solver not in all_solvers:
             raise ValueError("ElasticNet Regression supports only solvers in"
                              " {}, got {}.".format(all_solvers, self.solver))
+
+        if isinstance(self.precompute, str):
+            raise ValueError('precompute should be one of True, False or'
+                             ' array-like. Got %r' % self.precompute)
+        elif self.precompute is not False and self.solver == 'saga':
+            warnings.warn("The solver 'saga' does not use the precomputed "
+                          " Gram matrix", category=UserWarning)
 
         if self.positive and self.solver == 'saga':
             raise ValueError("ElasticNet supports positive contraints for "

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -729,8 +729,8 @@ class ElasticNet(LinearModel, RegressorMixin):
 
         if (not isinstance(self.l1_ratio, numbers.Number) or
                 self.l1_ratio < 0 or self.l1_ratio > 1):
-                    raise ValueError("l1_ratio must be between 0 and 1;"
-                                     " got (l1_ratio=%r)" % self.l1_ratio)
+            raise ValueError("l1_ratio must be between 0 and 1;"
+                             " got (l1_ratio=%r)" % self.l1_ratio)
 
         all_solvers = ['cd', 'saga']
         if self.solver not in all_solvers:

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -833,7 +833,7 @@ class ElasticNet(LinearModel, RegressorMixin):
             should_copy = self.copy_X and not X_copied
             if self.precompute is not False:
                 warnings.warn("The solver 'saga' does not use the precomputed "
-                              " Gram matrix", category=UserWarning)
+                              "Gram matrix", category=UserWarning)
             X, y, X_offset, y_offset, X_scale, precompute, Xy = \
                 _pre_fit(X, y, None, False, self.normalize,
                          self.fit_intercept, copy=should_copy,
@@ -860,8 +860,8 @@ class ElasticNet(LinearModel, RegressorMixin):
             for k in range(n_targets):
                 this_coef, this_iter, warm_start_sag = sag_solver(
                     X, y[:, k], sample_weight=None, loss='squared',
-                    alpha=n_samples*self.alpha*(1 - self.l1_ratio),
-                    beta=n_samples*self.alpha*self.l1_ratio,
+                    alpha=n_samples * self.alpha * (1 - self.l1_ratio),
+                    beta=n_samples * self.alpha * self.l1_ratio,
                     max_iter=self.max_iter, tol=self.tol, verbose=0,
                     random_state=self.random_state, check_input=False,
                     max_squared_sum=max_squared_sum,

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -90,7 +90,7 @@ def test_enet_toy():
 
     for solver in ['cd', 'saga']:
         # this should be the same as lasso
-        clf = ElasticNet(alpha=1e-8, l1_ratio=1.0, solver=solver, tol=1e-7)
+        clf = ElasticNet(alpha=1e-8, l1_ratio=1.0, solver=solver, tol=1e-8)
         clf.fit(X, Y)
         pred = clf.predict(T)
         assert_array_almost_equal(clf.coef_, [1])
@@ -99,7 +99,7 @@ def test_enet_toy():
             assert_almost_equal(clf.dual_gap_, 0)
 
         clf = ElasticNet(alpha=0.5, l1_ratio=0.3, max_iter=100,
-                         precompute=False, solver=solver, tol=1e-5)
+                         precompute=False, solver=solver, tol=1e-6)
         clf.fit(X, Y)
         pred = clf.predict(T)
         assert_array_almost_equal(clf.coef_, [0.50819], decimal=3)
@@ -455,7 +455,7 @@ def test_enet_multitarget():
                                      estimator.dual_gap_)
 
         for k in range(n_targets):
-            estimator.fit(X, y[ :, k])
+            estimator.fit(X, y[:, k])
             assert_array_almost_equal(coef[k, :], estimator.coef_)
             assert_array_almost_equal(intercept[k], estimator.intercept_)
             if solver == 'cd':

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -89,7 +89,7 @@ def test_enet_toy():
     T = [[2.], [3.], [4.]]  # test sample
 
     # Be careful with tests for the saga solver for this very small dataset.
-    # The result depends on random_state and my give wrong resultsself.
+    # The result depends on random_state, it may give wrong results.
     # See issue #13021.
 
     for solver in ['cd', 'saga']:

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -88,9 +88,14 @@ def test_enet_toy():
     Y = [-1, 0, 1]       # just a straight line
     T = [[2.], [3.], [4.]]  # test sample
 
+    # Be careful with tests for the saga solver for this very small dataset.
+    # The result depends on random_state and my give wrong resultsself.
+    # See issue #13021.
+
     for solver in ['cd', 'saga']:
         # this should be the same as lasso
-        clf = ElasticNet(alpha=1e-8, l1_ratio=1.0, solver=solver, tol=1e-8)
+        clf = ElasticNet(alpha=1e-8, l1_ratio=1.0, solver=solver, tol=1e-8,
+                         random_state=2)
         clf.fit(X, Y)
         pred = clf.predict(T)
         assert_array_almost_equal(clf.coef_, [1])
@@ -99,7 +104,8 @@ def test_enet_toy():
             assert_almost_equal(clf.dual_gap_, 0)
 
         clf = ElasticNet(alpha=0.5, l1_ratio=0.3, max_iter=100,
-                         precompute=False, solver=solver, tol=1e-6)
+                         precompute=False, solver=solver, tol=1e-6,
+                         random_state=2)
         clf.fit(X, Y)
         pred = clf.predict(T)
         assert_array_almost_equal(clf.coef_, [0.50819], decimal=3)
@@ -115,15 +121,17 @@ def test_enet_toy():
         if solver == 'cd':
             assert_almost_equal(clf.dual_gap_, 0)
 
-        clf.set_params(max_iter=100, precompute=np.dot(X.T, X))
-        clf.fit(X, Y)  # with Gram
-        pred = clf.predict(T)
-        assert_array_almost_equal(clf.coef_, [0.50819], decimal=3)
-        assert_array_almost_equal(pred, [1.0163, 1.5245, 2.0327], decimal=3)
         if solver == 'cd':
+            clf.set_params(max_iter=100, precompute=np.dot(X.T, X))
+            clf.fit(X, Y)  # with Gram
+            pred = clf.predict(T)
+            assert_array_almost_equal(clf.coef_, [0.50819], decimal=3)
+            assert_array_almost_equal(pred, [1.0163, 1.5245, 2.0327],
+                                      decimal=3)
             assert_almost_equal(clf.dual_gap_, 0)
 
-        clf = ElasticNet(alpha=0.5, l1_ratio=0.5, solver=solver)
+        clf = ElasticNet(alpha=0.5, l1_ratio=0.5, solver=solver,
+                         random_state=2)
         clf.fit(X, Y)
         pred = clf.predict(T)
         assert_array_almost_equal(clf.coef_, [0.45454], 3)

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -114,20 +114,28 @@ def test_enet_toy(solver):
         assert_almost_equal(clf.dual_gap_, 0)
 
     clf.set_params(max_iter=100, precompute=True)
-    clf.fit(X, Y)  # with Gram
+    if solver == 'saga':
+        with pytest.warns(UserWarning):
+            clf.fit(X, Y)
+    else:
+        clf.fit(X, Y)  # with Gram
     pred = clf.predict(T)
     assert_array_almost_equal(clf.coef_, [0.50819], decimal=3)
     assert_array_almost_equal(pred, [1.0163, 1.5245, 2.0327], decimal=3)
     if solver == 'cd':
         assert_almost_equal(clf.dual_gap_, 0)
 
-    if solver == 'cd':
-        clf.set_params(max_iter=100, precompute=np.dot(X.T, X))
+    clf.set_params(max_iter=100, precompute=np.dot(X.T, X))
+    if solver == 'saga':
+        with pytest.warns(UserWarning):
+            clf.fit(X, Y)
+    else:
         clf.fit(X, Y)  # with Gram
-        pred = clf.predict(T)
-        assert_array_almost_equal(clf.coef_, [0.50819], decimal=3)
-        assert_array_almost_equal(pred, [1.0163, 1.5245, 2.0327],
-                                  decimal=3)
+    pred = clf.predict(T)
+    assert_array_almost_equal(clf.coef_, [0.50819], decimal=3)
+    assert_array_almost_equal(pred, [1.0163, 1.5245, 2.0327],
+                              decimal=3)
+    if solver == 'cd':
         assert_almost_equal(clf.dual_gap_, 0)
 
     clf = ElasticNet(alpha=0.5, l1_ratio=0.5, solver=solver,


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #12907.

#### What does this implement/fix? Explain your changes.
A new argument 'solver' is introduced in ElasticNet. In addition to the default 'cd' one can also choose 'saga' to use the SAGA solver, see also Ridge and LogisticRegression.
The same tests as for coordinate descent are done for saga.

#### Any other comments?
Open question: So far ElasticNet via cd does not support sample_weight. It could be included via SAGA. Should this go in this PR or rather in a new issue?