### PR TITLE
[MRG] Removes total_seconds completely in benchmarks

### DIFF
--- a/benchmarks/bench_glm.py
+++ b/benchmarks/bench_glm.py
@@ -7,7 +7,6 @@ Data comes from a random square matrix.
 from datetime import datetime
 import numpy as np
 from sklearn import linear_model
-from sklearn.utils.bench import total_seconds
 
 
 if __name__ == '__main__':
@@ -34,17 +33,17 @@ if __name__ == '__main__':
         start = datetime.now()
         ridge = linear_model.Ridge(alpha=1.)
         ridge.fit(X, Y)
-        time_ridge[i] = total_seconds(datetime.now() - start)
+        time_ridge[i] = (datetime.now() - start).total_seconds()
 
         start = datetime.now()
         ols = linear_model.LinearRegression()
         ols.fit(X, Y)
-        time_ols[i] = total_seconds(datetime.now() - start)
+        time_ols[i] = (datetime.now() - start).total_seconds()
 
         start = datetime.now()
         lasso = linear_model.LassoLars()
         lasso.fit(X, Y)
-        time_lasso[i] = total_seconds(datetime.now() - start)
+        time_lasso[i] = (datetime.now() - start).total_seconds()
 
     plt.figure('scikit-learn GLM benchmark results')
     plt.xlabel('Dimensions')

--- a/benchmarks/bench_isotonic.py
+++ b/benchmarks/bench_isotonic.py
@@ -16,7 +16,6 @@ import numpy as np
 import gc
 from datetime import datetime
 from sklearn.isotonic import isotonic_regression
-from sklearn.utils.bench import total_seconds
 from scipy.special import expit
 import matplotlib.pyplot as plt
 import argparse
@@ -55,8 +54,7 @@ def bench_isotonic_regression(Y):
 
     tstart = datetime.now()
     isotonic_regression(Y)
-    delta = datetime.now() - tstart
-    return total_seconds(delta)
+    return (datetime.now() - tstart).total_seconds()
 
 
 if __name__ == '__main__':

--- a/doc/developers/utilities.rst
+++ b/doc/developers/utilities.rst
@@ -173,12 +173,6 @@ Graph Routines
   connectivity matrix is a ``scipy.sparse.csr_matrix``.
 
 
-Benchmarking
-------------
-
-- :func:`bench.total_seconds`:  Used in ``benchmarks/bench_glm.py``.
-
-
 Testing Functions
 =================
 

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1429,7 +1429,6 @@ Low-level methods
    utils.arrayfuncs.min_pos
    utils.as_float_array
    utils.assert_all_finite
-   utils.bench.total_seconds
    utils.check_X_y
    utils.check_array
    utils.check_consistent_length


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Recently, `utils.bench.total_seconds` was removed from sklearn. This PR removes the last few mentions of it.

#### What does this implement/fix? Explain your changes.
Updates benchmark examples to use Python's `timedelta.total_seconds`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->