### PR TITLE
[MRG] Fix LassoLarsIC: unintuitive copy_X behaviour

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -117,6 +117,11 @@ Support for Python 3.4 and below has been officially dropped.
   in version 0.21 and will be removed in version 0.23.
   :issue:`12821` by :user:`Nicolas Hug <NicolasHug>`.
 
+- |Fix| Fixed a bug in :class:`linear_model.LassoLarsIC`, where user input
+   ``copy_X=False`` at instance creation would be overridden by default
+   parameter value ``copy_X=True`` in ``fit``. 
+   :issue:`12972` by :user:`Lucio Fernandez-Arjona <luk-f-a>`
+
 :mod:`sklearn.manifold`
 ............................
 

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -1479,7 +1479,7 @@ class LassoLarsIC(LassoLars):
         self.eps = eps
         self.fit_path = True
 
-    def fit(self, X, y, copy_X=True):
+    def fit(self, X, y, copy_X=None):
         """Fit the model using X, y as training data.
 
         Parameters
@@ -1498,10 +1498,12 @@ class LassoLarsIC(LassoLars):
         self : object
             returns an instance of self.
         """
+        if copy_X is None:
+            copy_X = self.copy_X
         X, y = check_X_y(X, y, y_numeric=True)
 
         X, y, Xmean, ymean, Xstd = LinearModel._preprocess_data(
-            X, y, self.fit_intercept, self.normalize, self.copy_X)
+            X, y, self.fit_intercept, self.normalize, copy_X)
         max_iter = self.max_iter
 
         Gram = self.precompute

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -1490,7 +1490,9 @@ class LassoLarsIC(LassoLars):
         y : array-like, shape (n_samples,)
             target values. Will be cast to X's dtype if necessary
 
-        copy_X : boolean, optional, default True
+        copy_X : boolean, optional, default None
+            If provided, this parameter will override the choice
+            of copy_X made at instance creation.
             If ``True``, X will be copied; else, it may be overwritten.
 
         Returns

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -18,7 +18,7 @@ from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import TempMemmap
 from sklearn.exceptions import ConvergenceWarning
 from sklearn import linear_model, datasets
-from sklearn.linear_model.least_angle import _lars_path_residues
+from sklearn.linear_model.least_angle import _lars_path_residues, LassoLarsIC
 
 diabetes = datasets.load_diabetes()
 X, y = diabetes.data, diabetes.target
@@ -686,3 +686,102 @@ def test_lasso_lars_vs_R_implementation():
 
     assert_array_almost_equal(r2, skl_betas2, decimal=12)
     ###########################################################################
+
+def test_lasso_lars_copyX_behaviour1():
+    """
+    Test that user input regading copyX is not being overridden (it was until
+    at least version 0.21)
+
+    Correct behaviour is not to create a copy.
+
+    """
+    temp = np.asarray
+    def ident(x, *args, **kwargs):
+        return x
+
+    np.asarray = ident
+    lasso_lars = LassoLarsIC(copy_X=False, precompute=False)
+
+    class CopyCreated(Exception):
+        pass
+
+    class CopyWarningArray(np.ndarray):
+
+        def __new__(subtype, shape, dtype=float, buffer=None, offset=0, strides=None, order=None, info=None):
+            # Create the ndarray instance of our type, given the usual
+            # ndarray input arguments.  This will call the standard
+            # ndarray constructor, but return an object of our type.
+            # It also triggers a call to InfoArray.__array_finalize__
+            obj = super(CopyWarningArray, subtype).__new__(subtype, shape, dtype, buffer, offset, strides, order)
+            # set the new 'info' attribute to the value passed
+            obj.info = info
+            # Finally, we must return the newly created object:
+            return obj
+
+        def copy(self, *args, **kwargs):
+            assert False, "Array is being copied when it should not be copied"
+
+        def __copy__(self, *args, **kwargs):
+            assert False, "Array is being copied when it should not be copied"
+
+        def __deepcopy__(self, *args, **kwargs):
+            assert False, "Array is being copied when it should not be copied"
+
+    X = CopyWarningArray(shape=(20,5), info="CopyWarningArray")
+    X[:,:] = 1
+    y = X[:,2]
+    lasso_lars.fit(X, y)
+    np.asarray = temp
+
+
+def test_lasso_lars_copyX_behaviour2():
+    """
+    Test that user input regading copyX is not being overridden (it was until
+    at least version 0.21)
+
+    Correct behaviour is to create a copy.
+
+    """
+    temp = np.asarray
+
+    def ident(x, *args, **kwargs):
+        return x
+
+    np.asarray = ident
+    np.array = ident
+    lasso_lars = LassoLarsIC(copy_X=True, precompute=False)
+
+    class CopyCreated(Exception):
+        pass
+
+    class CopyWarningArray(np.ndarray):
+
+        def __new__(subtype, shape, dtype=float, buffer=None, offset=0, strides=None, order=None, info=None):
+            # Create the ndarray instance of our type, given the usual
+            # ndarray input arguments.  This will call the standard
+            # ndarray constructor, but return an object of our type.
+            # It also triggers a call to InfoArray.__array_finalize__
+            obj = super(CopyWarningArray, subtype).__new__(subtype, shape, dtype, buffer, offset, strides, order)
+            # set the new 'info' attribute to the value passed
+            obj.info = info
+            # Finally, we must return the newly created object:
+            return obj
+
+        def copy(self, *args, **kwargs):
+            raise CopyCreated
+
+        def __copy__(self, *args, **kwargs):
+            raise CopyCreated
+
+        def __deepcopy__(self, *args, **kwargs):
+            raise CopyCreated
+
+    X = CopyWarningArray(shape=(20, 5), info="CopyWarningArray")
+    X[:, :] = 1
+    y = X[:, 2]
+    # assert_raises(CopyCreated, lasso_lars.fit, X, y)
+    # lasso_lars.fit(X, y)
+    with pytest.raises(CopyCreated):
+        lasso_lars.fit(X, y)
+    np.asarray = temp
+    np.array = temp

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -688,33 +688,17 @@ def test_lasso_lars_vs_R_implementation():
     ###########################################################################
 
 
-def test_lasso_lars_copyX_behaviour1():
+@pytest.mark.parametrize('copy_X', [True, False])
+def test_lasso_lars_copyX_behaviour(copy_X):
     """
-    Test that user input regarding copyX is not being overridden (it was until
+    Test that user input regarding copy_X is not being overridden (it was until
     at least version 0.21)
 
-    Correct behaviour is not to create a copy.
-
     """
-    lasso_lars = LassoLarsIC(copy_X=False, precompute=False)
+    lasso_lars = LassoLarsIC(copy_X=copy_X, precompute=False)
     X = np.random.normal(0, 1, (100, 5))
     X_copy = X.copy()
     y = X[:, 2]
     lasso_lars.fit(X, y)
-    assert not np.array_equal(X, X_copy)
+    assert copy_X == np.array_equal(X, X_copy)
 
-
-def test_lasso_lars_copyX_behaviour2():
-    """
-    Test that user input regarding copyX is not being overridden (it was until
-    at least version 0.21)
-
-    Correct behaviour is to create a copy.
-
-    """
-    lasso_lars = LassoLarsIC(copy_X=True, precompute=False)
-    X = np.random.normal(0, 1, (100, 5))
-    X_copy = X.copy()
-    y = X[:, 2]
-    lasso_lars.fit(X, y)
-    assert np.array_equal(X, X_copy)

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -690,105 +690,31 @@ def test_lasso_lars_vs_R_implementation():
 
 def test_lasso_lars_copyX_behaviour1():
     """
-    Test that user input regading copyX is not being overridden (it was until
+    Test that user input regarding copyX is not being overridden (it was until
     at least version 0.21)
 
     Correct behaviour is not to create a copy.
 
     """
-    temp = np.asarray
-
-    def ident(x, *args, **kwargs):
-        return x
-
-    np.asarray = ident
     lasso_lars = LassoLarsIC(copy_X=False, precompute=False)
-
-    class CopyWarningArray(np.ndarray):
-
-        def __new__(subtype, shape, dtype=float, buffer=None, offset=0,
-                    strides=None, order=None, info=None):
-            # Create the ndarray instance of our type, given the usual
-            # ndarray input arguments.  This will call the standard
-            # ndarray constructor, but return an object of our type.
-            # It also triggers a call to InfoArray.__array_finalize__
-            obj = super(CopyWarningArray, subtype).__new__(subtype, shape,
-                                                           dtype, buffer,
-                                                           offset, strides,
-                                                           order)
-            # set the new 'info' attribute to the value passed
-            obj.info = info
-            # Finally, we must return the newly created object:
-            return obj
-
-        def copy(self, *args, **kwargs):
-            assert False, "Array is being copied when it should not be copied"
-
-        def __copy__(self, *args, **kwargs):
-            assert False, "Array is being copied when it should not be copied"
-
-        def __deepcopy__(self, *args, **kwargs):
-            assert False, "Array is being copied when it should not be copied"
-
-    X = CopyWarningArray(shape=(20, 5), info="CopyWarningArray")
-    X[:, :] = 1
+    X = np.random.normal(0, 1, (100, 5))
+    X_copy = X.copy()
     y = X[:, 2]
     lasso_lars.fit(X, y)
-    np.asarray = temp
+    assert not np.array_equal(X, X_copy)
 
 
 def test_lasso_lars_copyX_behaviour2():
     """
-    Test that user input regading copyX is not being overridden (it was until
+    Test that user input regarding copyX is not being overridden (it was until
     at least version 0.21)
 
     Correct behaviour is to create a copy.
 
     """
-    temp = np.asarray
-
-    def ident(x, *args, **kwargs):
-        return x
-
-    np.asarray = ident
-    np.array = ident
     lasso_lars = LassoLarsIC(copy_X=True, precompute=False)
-
-    class CopyCreated(Exception):
-        pass
-
-    class CopyWarningArray(np.ndarray):
-
-        def __new__(subtype, shape, dtype=float, buffer=None, offset=0,
-                    strides=None, order=None, info=None):
-            # Create the ndarray instance of our type, given the usual
-            # ndarray input arguments.  This will call the standard
-            # ndarray constructor, but return an object of our type.
-            # It also triggers a call to InfoArray.__array_finalize__
-            obj = super(CopyWarningArray, subtype).__new__(subtype, shape,
-                                                           dtype, buffer,
-                                                           offset, strides,
-                                                           order)
-            # set the new 'info' attribute to the value passed
-            obj.info = info
-            # Finally, we must return the newly created object:
-            return obj
-
-        def copy(self, *args, **kwargs):
-            raise CopyCreated
-
-        def __copy__(self, *args, **kwargs):
-            raise CopyCreated
-
-        def __deepcopy__(self, *args, **kwargs):
-            raise CopyCreated
-
-    X = CopyWarningArray(shape=(20, 5), info="CopyWarningArray")
-    X[:, :] = 1
+    X = np.random.normal(0, 1, (100, 5))
+    X_copy = X.copy()
     y = X[:, 2]
-    # assert_raises(CopyCreated, lasso_lars.fit, X, y)
-    # lasso_lars.fit(X, y)
-    with pytest.raises(CopyCreated):
-        lasso_lars.fit(X, y)
-    np.asarray = temp
-    np.array = temp
+    lasso_lars.fit(X, y)
+    assert np.array_equal(X, X_copy)

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -696,9 +696,24 @@ def test_lasso_lars_copyX_behaviour(copy_X):
 
     """
     lasso_lars = LassoLarsIC(copy_X=copy_X, precompute=False)
-    X = np.random.normal(0, 1, (100, 5))
+    rng = np.random.RandomState(0)
+    X = rng.normal(0, 1, (100, 5))
     X_copy = X.copy()
     y = X[:, 2]
     lasso_lars.fit(X, y)
     assert copy_X == np.array_equal(X, X_copy)
 
+
+@pytest.mark.parametrize('copy_X', [True, False])
+def test_lasso_lars_fit_copyX_behaviour(copy_X):
+    """
+    Test that user input to .fit for copy_X overrides default __init__ value
+
+    """
+    lasso_lars = LassoLarsIC(precompute=False)
+    rng = np.random.RandomState(0)
+    X = rng.normal(0, 1, (100, 5))
+    X_copy = X.copy()
+    y = X[:, 2]
+    lasso_lars.fit(X, y, copy_X=copy_X)
+    assert copy_X == np.array_equal(X, X_copy)

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -687,6 +687,7 @@ def test_lasso_lars_vs_R_implementation():
     assert_array_almost_equal(r2, skl_betas2, decimal=12)
     ###########################################################################
 
+
 def test_lasso_lars_copyX_behaviour1():
     """
     Test that user input regading copyX is not being overridden (it was until
@@ -696,23 +697,25 @@ def test_lasso_lars_copyX_behaviour1():
 
     """
     temp = np.asarray
+
     def ident(x, *args, **kwargs):
         return x
 
     np.asarray = ident
     lasso_lars = LassoLarsIC(copy_X=False, precompute=False)
 
-    class CopyCreated(Exception):
-        pass
-
     class CopyWarningArray(np.ndarray):
 
-        def __new__(subtype, shape, dtype=float, buffer=None, offset=0, strides=None, order=None, info=None):
+        def __new__(subtype, shape, dtype=float, buffer=None, offset=0,
+                    strides=None, order=None, info=None):
             # Create the ndarray instance of our type, given the usual
             # ndarray input arguments.  This will call the standard
             # ndarray constructor, but return an object of our type.
             # It also triggers a call to InfoArray.__array_finalize__
-            obj = super(CopyWarningArray, subtype).__new__(subtype, shape, dtype, buffer, offset, strides, order)
+            obj = super(CopyWarningArray, subtype).__new__(subtype, shape,
+                                                           dtype, buffer,
+                                                           offset, strides,
+                                                           order)
             # set the new 'info' attribute to the value passed
             obj.info = info
             # Finally, we must return the newly created object:
@@ -727,9 +730,9 @@ def test_lasso_lars_copyX_behaviour1():
         def __deepcopy__(self, *args, **kwargs):
             assert False, "Array is being copied when it should not be copied"
 
-    X = CopyWarningArray(shape=(20,5), info="CopyWarningArray")
-    X[:,:] = 1
-    y = X[:,2]
+    X = CopyWarningArray(shape=(20, 5), info="CopyWarningArray")
+    X[:, :] = 1
+    y = X[:, 2]
     lasso_lars.fit(X, y)
     np.asarray = temp
 
@@ -756,12 +759,16 @@ def test_lasso_lars_copyX_behaviour2():
 
     class CopyWarningArray(np.ndarray):
 
-        def __new__(subtype, shape, dtype=float, buffer=None, offset=0, strides=None, order=None, info=None):
+        def __new__(subtype, shape, dtype=float, buffer=None, offset=0,
+                    strides=None, order=None, info=None):
             # Create the ndarray instance of our type, given the usual
             # ndarray input arguments.  This will call the standard
             # ndarray constructor, but return an object of our type.
             # It also triggers a call to InfoArray.__array_finalize__
-            obj = super(CopyWarningArray, subtype).__new__(subtype, shape, dtype, buffer, offset, strides, order)
+            obj = super(CopyWarningArray, subtype).__new__(subtype, shape,
+                                                           dtype, buffer,
+                                                           offset, strides,
+                                                           order)
             # set the new 'info' attribute to the value passed
             obj.info = info
             # Finally, we must return the newly created object:


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #12972

#### What does this implement/fix? Explain your changes.
`LassoLarsIC` class accepts a `copy_X` parameter. `LassoLarsIC.fit` also accepts `copy_X` as an argument, with a default value of `True`. The value passed to `fit` will overwrite `self.copy_X` even when the user did not intend that to happen, because `True` is the default value of the argument.

#### Any other comments?
Alternatively, `copy_X` could be removed as an argument of `fit`. This would make `LassoLarsIC.fit` consistent with other estimators (none of which accept `copy_X` as an argument to `fit`). However, this would break existing code.

