### PR TITLE
DOC Move MultiTaskElasticNet what's new from 0.21 to 0.20.3

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -15,6 +15,13 @@ enhancements to features released in 0.20.0.
 Changelog
 ---------
 
+:mod:`sklearn.linear_model`
+...........................
+
+- |Fix| Fixed a bug in :class:`linear_model.MultiTaskElasticNet` and
+  :class:`linear_model.MultiTaskLasso` which were breaking when
+  ``warm_start = True``. :issue:`12360` by :user:`Aakanksha Joshi <joaak>`.
+
 :mod:`sklearn.preprocessing`
 ............................
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -109,10 +109,6 @@ Support for Python 3.4 and below has been officially dropped.
   weights would not be correctly updated in some cases.
   :issue:`11646` by `Tom Dupre la Tour`_.
 
-- |Fix| Fixed a bug in :class:`linear_model.MultiTaskElasticNet` and
-  :class:`linear_model.MultiTaskLasso` which were breaking when
-  ``warm_start = True``. :issue:`12360` by :user:`Aakanksha Joshi <joaak>`.
-
 - |API| :func:`linear_model.logistic_regression_path` is deprecated
   in version 0.21 and will be removed in version 0.23.
   :issue:`12821` by :user:`Nicolas Hug <NicolasHug>`.


### PR DESCRIPTION
Closes #12853 
I guess it's reasonable to tag this one as 0.20.3 and close #12853 
ping @agramfort @jnothman 