### PR TITLE
[MRG] NMF and non_negative_factorization have inconsistent default init

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -63,9 +63,10 @@ Support for Python 3.4 and below has been officially dropped.
 
 - |API| The default value of the :code:`init` argument in
   :func:`decomposition.non_negative_factorization` will change from
-  :code:`random` to :code:`None` to match :class:`decomposition.NMF`
-  in version 0.23.  A FutureWarning is raised when the default value
-  is used.  :issue:`12988` by :user:`Zijie (ZJ) Poh <zjpoh>`.
+  :code:`random` to :code:`None` in version 0.23 to make it consistent with
+  :class:`decomposition.NMF`. A FutureWarning is raised when
+  the default value is used.
+  :issue:`12988` by :user:`Zijie (ZJ) Poh <zjpoh>`.
 
 :mod:`sklearn.discriminant_analysis`
 ....................................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -58,6 +58,15 @@ Support for Python 3.4 and below has been officially dropped.
     :class:`datasets.svmlight_format` :issue:`10727` by
     :user:`Bryan K Woods <bryan-woods>`,
 
+:mod:`sklearn.decomposition`
+............................
+
+- |API| The default value of the :code:`init` argument in
+  :func:`decomposition.non_negative_factorization` will change from
+  :code:`random` to :code:`None` to match :class:`decomposition.NMF`
+  in version 0.23.  A FutureWarning is raised when the default value
+  is used.  :issue:`12988` by :user:`Zijie (ZJ) Poh <zjpoh>`.
+
 :mod:`sklearn.discriminant_analysis`
 ....................................
 

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -261,8 +261,10 @@ def _initialize_nmf(X, n_components, init=None, eps=1e-6,
 
     init :  None | 'random' | 'nndsvd' | 'nndsvda' | 'nndsvdar'
         Method used to initialize the procedure.
-        Default: 'nndsvd' if n_components < n_features, otherwise 'random'.
+        Default: None.
         Valid options:
+
+        - None: 'nndsvd' if n_components < n_features, otherwise 'random'.
 
         - 'random': non-negative random matrices, scaled with:
             sqrt(X.mean() / n_components)
@@ -878,10 +880,16 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
         Number of components, if n_components is not set all features
         are kept.
 
-    init :  None | 'random' | 'nndsvd' | 'nndsvda' | 'nndsvdar' | 'custom'
+    init : None | 'random' | 'nndsvd' | 'nndsvda' | 'nndsvdar' | 'custom'
         Method used to initialize the procedure.
         Default: 'random'.
+
+        The default value will change from 'random' to None in version 0.23
+        to make it consistent with decomposition.NMF.
+
         Valid options:
+
+        - None: 'nndsvd' if n_components < n_features, otherwise 'random'.
 
         - 'random': non-negative random matrices, scaled with:
             sqrt(X.mean() / n_components)
@@ -1093,10 +1101,12 @@ class NMF(BaseEstimator, TransformerMixin):
         Number of components, if n_components is not set all features
         are kept.
 
-    init :  'random' | 'nndsvd' |  'nndsvda' | 'nndsvdar' | 'custom'
+    init : None | 'random' | 'nndsvd' |  'nndsvda' | 'nndsvdar' | 'custom'
         Method used to initialize the procedure.
-        Default: 'nndsvd' if n_components < n_features, otherwise random.
+        Default: None.
         Valid options:
+
+        - None: 'nndsvd' if n_components < n_features, otherwise random.
 
         - 'random': non-negative random matrices, scaled with:
             sqrt(X.mean() / n_components)

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -1009,7 +1009,7 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
         raise ValueError("Tolerance for stopping criteria must be "
                          "positive; got (tol=%r)" % tol)
 
-    if init == "warn" and n_components <= min(n_samples, n_features):
+    if init == "warn" and n_components < n_features:
         warnings.warn("The default value of init will change from "
                       "random to None in 0.23.", FutureWarning)
         init = "random"

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -1009,9 +1009,10 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
         raise ValueError("Tolerance for stopping criteria must be "
                          "positive; got (tol=%r)" % tol)
 
-    if init == "warn" and n_components < n_features:
-        warnings.warn("The default value of init will change from "
-                      "random to None in 0.23.", FutureWarning)
+    if init == "warn":
+        if n_components < n_features:
+            warnings.warn("The default value of init will change from "
+                          "random to None in 0.23.", FutureWarning)
         init = "random"
 
     # check W and H, or initialize them

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -831,7 +831,7 @@ def _fit_multiplicative_update(X, W, H, beta_loss='frobenius',
 
 
 def non_negative_factorization(X, W=None, H=None, n_components=None,
-                               init='random', update_H=True, solver='cd',
+                               init='warn', update_H=True, solver='cd',
                                beta_loss='frobenius', tol=1e-4,
                                max_iter=200, alpha=0., l1_ratio=0.,
                                regularization=None, random_state=None,
@@ -880,7 +880,8 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
 
     init :  None | 'random' | 'nndsvd' | 'nndsvda' | 'nndsvdar' | 'custom'
         Method used to initialize the procedure.
-        Default: 'random'.
+        Default: 'nndsvd' if n_components <= min(n_samples, n_features),
+            otherwise 'random'.
         Valid options:
 
         - 'random': non-negative random matrices, scaled with:
@@ -985,6 +986,11 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
     Fevotte, C., & Idier, J. (2011). Algorithms for nonnegative matrix
     factorization with the beta-divergence. Neural Computation, 23(9).
     """
+
+    if init == "warn":
+        warnings.warn("The default value of init will change from "
+                      "random to None in 0.22.", FutureWarning)
+        init = None
 
     X = check_array(X, accept_sparse=('csr', 'csc'), dtype=float)
     check_non_negative(X, "NMF (input X)")

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -880,8 +880,7 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
 
     init :  None | 'random' | 'nndsvd' | 'nndsvda' | 'nndsvdar' | 'custom'
         Method used to initialize the procedure.
-        Default: 'nndsvd' if n_components <= min(n_samples, n_features),
-            otherwise 'random'.
+        Default: 'random'.
         Valid options:
 
         - 'random': non-negative random matrices, scaled with:
@@ -990,7 +989,7 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
     if init == "warn":
         warnings.warn("The default value of init will change from "
                       "random to None in 0.22.", FutureWarning)
-        init = None
+        init = "random"
 
     X = check_array(X, accept_sparse=('csr', 'csc'), dtype=float)
     check_non_negative(X, "NMF (input X)")

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -1020,7 +1020,8 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
     if init == "warn":
         if n_components < n_features:
             warnings.warn("The default value of init will change from "
-                          "random to None in 0.23.", FutureWarning)
+                          "random to None in 0.23 to make it consistent "
+                          "with decomposition.NMF.", FutureWarning)
         init = "random"
 
     # check W and H, or initialize them

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -986,11 +986,6 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
     factorization with the beta-divergence. Neural Computation, 23(9).
     """
 
-    if init == "warn":
-        warnings.warn("The default value of init will change from "
-                      "random to None in 0.22.", FutureWarning)
-        init = "random"
-
     X = check_array(X, accept_sparse=('csr', 'csc'), dtype=float)
     check_non_negative(X, "NMF (input X)")
     beta_loss = _check_string_param(solver, regularization, beta_loss, init)
@@ -1013,6 +1008,11 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
     if not isinstance(tol, numbers.Number) or tol < 0:
         raise ValueError("Tolerance for stopping criteria must be "
                          "positive; got (tol=%r)" % tol)
+
+    if init == "warn" and n_components <= min(n_samples, n_features):
+        warnings.warn("The default value of init will change from "
+                      "random to None in 0.23.", FutureWarning)
+        init = "random"
 
     # check W and H, or initialize them
     if init == 'custom' and update_H:

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -10,6 +10,7 @@ from scipy.sparse import csc_matrix
 import pytest
 
 from sklearn.utils.testing import assert_raise_message, assert_no_warnings
+from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_almost_equal
@@ -213,7 +214,8 @@ def test_non_negative_factorization_checking():
     A = np.ones((2, 2))
     # Test parameters checking is public function
     nnmf = non_negative_factorization
-    assert_no_warnings(nnmf, A, A, A, np.int64(1))
+    msg = "The default value of init will change from random to None in 0.23."
+    assert_warns_message(FutureWarning, msg, nnmf, A, A, A, np.int64(1))
     msg = ("Number of components must be a positive integer; "
            "got (n_components=1.5)")
     assert_raise_message(ValueError, msg, nnmf, A, A, A, 1.5)

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -214,7 +214,9 @@ def test_non_negative_factorization_checking():
     A = np.ones((2, 2))
     # Test parameters checking is public function
     nnmf = non_negative_factorization
-    msg = "The default value of init will change from random to None in 0.23."
+    msg = ("The default value of init will change from "
+           "random to None in 0.23 to make it consistent "
+           "with decomposition.NMF.")
     assert_warns_message(FutureWarning, msg, nnmf, A, A, A, np.int64(1))
     msg = ("Number of components must be a positive integer; "
            "got (n_components=1.5)")

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -218,10 +218,10 @@ def test_non_negative_factorization_checking():
     assert_warns_message(FutureWarning, msg, nnmf, A, A, A, np.int64(1))
     msg = ("Number of components must be a positive integer; "
            "got (n_components=1.5)")
-    assert_raise_message(ValueError, msg, nnmf, A, A, A, 1.5)
+    assert_raise_message(ValueError, msg, nnmf, A, A, A, 1.5, 'random')
     msg = ("Number of components must be a positive integer; "
            "got (n_components='2')")
-    assert_raise_message(ValueError, msg, nnmf, A, A, A, '2')
+    assert_raise_message(ValueError, msg, nnmf, A, A, A, '2', 'random')
     msg = "Negative values in data passed to NMF (input H)"
     assert_raise_message(ValueError, msg, nnmf, A, A, -A, 2, 'custom')
     msg = "Negative values in data passed to NMF (input W)"

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -382,8 +382,8 @@ def test_nmf_negative_beta_loss():
 
     def _assert_nmf_no_nan(X, beta_loss):
         W, H, _ = non_negative_factorization(
-            X, n_components=n_components, solver='mu', beta_loss=beta_loss,
-            random_state=0, max_iter=1000)
+            X, init='random', n_components=n_components, solver='mu',
+            beta_loss=beta_loss, random_state=0, max_iter=1000)
         assert not np.any(np.isnan(W))
         assert not np.any(np.isnan(H))
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #12988. See also #11667.

#### What does this implement/fix? Explain your changes.

Changed the default in `non_negative_factorization` with a deprecation process.

<!--
#### Any other comments?



Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
