### PR TITLE
add metric selection flag to MeanShift clustering

### DIFF
--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -28,7 +28,8 @@ from ..utils._joblib import delayed
 
 
 def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0,
-                       metric='minkowski', p=2, metric_params=None, n_jobs=None):
+                       metric='minkowski', p=2, metric_params=None,
+                       n_jobs=None):
     """Estimate the bandwidth to use with the mean-shift algorithm.
 
     That this function takes time at least quadratic in n_samples. For large
@@ -77,7 +78,7 @@ def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0,
         sklearn.metrics.pairwise.pairwise_distances. When p = 1, this is
         equivalent to using manhattan_distance (l1), and euclidean_distance
         (l2) for p = 2. For arbitrary p, minkowski_distance (l_p) is used.
-    
+   
     metric_params : dict, optional (default = None)
         Additional keyword arguments for the metric function.
 
@@ -101,8 +102,8 @@ def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0,
     n_neighbors = int(X.shape[0] * quantile)
     if n_neighbors < 1:  # cannot fit NearestNeighbors with n_neighbors = 0
         n_neighbors = 1
-    nbrs = NearestNeighbors(n_neighbors=n_neighbors, 
-                            metric=metric, p=p, metric_params=metric_params, 
+    nbrs = NearestNeighbors(n_neighbors=n_neighbors,
+                            metric=metric, p=p, metric_params=metric_params,
                             n_jobs=n_jobs)
     nbrs.fit(X)
 
@@ -208,7 +209,7 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
         sklearn.metrics.pairwise.pairwise_distances. When p = 1, this is
         equivalent to using manhattan_distance (l1), and euclidean_distance
         (l2) for p = 2. For arbitrary p, minkowski_distance (l_p) is used.
-    
+   
     metric_params : dict, optional (default = None)
         Additional keyword arguments for the metric function.
 
@@ -255,8 +256,8 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
     # We use n_jobs=1 because this will be used in nested calls under
     # parallel calls to _mean_shift_single_seed so there is no need for
     # for further parallelism.
-    nbrs = NearestNeighbors(radius=bandwidth,  
-                            metric=metric, p=p, metric_params=metric_params, 
+    nbrs = NearestNeighbors(radius=bandwidth, 
+                            metric=metric, p=p, metric_params=metric_params,
                             n_jobs=1).fit(X)
 
     # execute iterations on all seeds in parallel
@@ -285,7 +286,7 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
                                  reverse=True)
     sorted_centers = np.array([tup[0] for tup in sorted_by_intensity])
     unique = np.ones(len(sorted_centers), dtype=np.bool)
-    nbrs = NearestNeighbors(radius=bandwidth, 
+    nbrs = NearestNeighbors(radius=bandwidth,
                             metric=metric, p=p, metric_params=metric_params,
                             n_jobs=n_jobs).fit(sorted_centers)
     for i, center in enumerate(sorted_centers):
@@ -297,7 +298,7 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
     cluster_centers = sorted_centers[unique]
 
     # ASSIGN LABELS: a point belongs to the cluster that it is closest to
-    nbrs = NearestNeighbors(n_neighbors=1,  
+    nbrs = NearestNeighbors(n_neighbors=1, 
                             metric=metric, p=p, metric_params=metric_params,
                             n_jobs=n_jobs).fit(cluster_centers)
     labels = np.zeros(n_samples, dtype=np.int)
@@ -461,23 +462,23 @@ class MeanShift(BaseEstimator, ClusterMixin):
 
     """
     def __init__(self, bandwidth=None, seeds=None, bin_seeding=False,
-                 min_bin_freq=1, cluster_all=True, metric='minkowski', 
+                 min_bin_freq=1, cluster_all=True, metric='minkowski',
                  p=2, metric_params=None, n_jobs=None):
         self.bandwidth = bandwidth
         self.seeds = seeds
         self.bin_seeding = bin_seeding
         self.cluster_all = cluster_all
         self.min_bin_freq = min_bin_freq
-        self.metric=metric 
-        self.p=p 
-        self.metric_params=metric_params
+        self.metric = metric
+        self.p = p
+        self.metric_params = metric_params
         self.n_jobs = n_jobs
 
-        self.metric_kwargs=metric_params
-        if self.metric=='minkowski':
-            if metric_params==None:
-                self.metric_kwargs={}
-            self.metric_kwargs['p']=self.p
+        self.metric_kwargs = metric_params
+        if self.metric == 'minkowski':
+            if metric_params is None:
+                self.metric_kwargs = {}
+            self.metric_kwargs['p'] = self.p
 
     def fit(self, X, y=None):
         """Perform clustering.
@@ -514,5 +515,6 @@ class MeanShift(BaseEstimator, ClusterMixin):
         """
         check_is_fitted(self, "cluster_centers_")
 
-        return pairwise_distances_argmin(X, self.cluster_centers_,  
-                                         metric=self.metric, metric_kwargs=self.metric_kwargs)
+        return pairwise_distances_argmin(X, self.cluster_centers_, 
+                                         metric=self.metric, 
+                                         metric_kwargs=self.metric_kwargs)

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -78,7 +78,7 @@ def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0,
         sklearn.metrics.pairwise.pairwise_distances. When p = 1, this is
         equivalent to using manhattan_distance (l1), and euclidean_distance
         (l2) for p = 2. For arbitrary p, minkowski_distance (l_p) is used.
-   
+
     metric_params : dict, optional (default = None)
         Additional keyword arguments for the metric function.
 
@@ -209,7 +209,7 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
         sklearn.metrics.pairwise.pairwise_distances. When p = 1, this is
         equivalent to using manhattan_distance (l1), and euclidean_distance
         (l2) for p = 2. For arbitrary p, minkowski_distance (l_p) is used.
-   
+
     metric_params : dict, optional (default = None)
         Additional keyword arguments for the metric function.
 

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -256,7 +256,7 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
     # We use n_jobs=1 because this will be used in nested calls under
     # parallel calls to _mean_shift_single_seed so there is no need for
     # for further parallelism.
-    nbrs = NearestNeighbors(radius=bandwidth, 
+    nbrs = NearestNeighbors(radius=bandwidth,
                             metric=metric, p=p, metric_params=metric_params,
                             n_jobs=1).fit(X)
 
@@ -298,7 +298,7 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
     cluster_centers = sorted_centers[unique]
 
     # ASSIGN LABELS: a point belongs to the cluster that it is closest to
-    nbrs = NearestNeighbors(n_neighbors=1, 
+    nbrs = NearestNeighbors(n_neighbors=1,
                             metric=metric, p=p, metric_params=metric_params,
                             n_jobs=n_jobs).fit(cluster_centers)
     labels = np.zeros(n_samples, dtype=np.int)
@@ -496,7 +496,8 @@ class MeanShift(BaseEstimator, ClusterMixin):
             mean_shift(X, bandwidth=self.bandwidth, seeds=self.seeds,
                        min_bin_freq=self.min_bin_freq,
                        bin_seeding=self.bin_seeding,
-                       metric=self.metric, p=self.p, metric_params=self.metric_params,
+                       metric=self.metric, p=self.p,
+                       metric_params=self.metric_params,
                        cluster_all=self.cluster_all, n_jobs=self.n_jobs)
         return self
 
@@ -515,6 +516,6 @@ class MeanShift(BaseEstimator, ClusterMixin):
         """
         check_is_fitted(self, "cluster_centers_")
 
-        return pairwise_distances_argmin(X, self.cluster_centers_, 
-                                         metric=self.metric, 
+        return pairwise_distances_argmin(X, self.cluster_centers_,
+                                         metric=self.metric,
                                          metric_kwargs=self.metric_kwargs)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

No reference issue

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

I added a couple of flags that allow to chose different metrics (and their parameters) when running MeanShift clustering. This feature is already implemented in NearestNeighbors, which is called internallty by MeanShift, I just made the flags explicit in MeanShift too. Euclidean distance is left as the default choice. 

#### Any other comments?

It was tested with Python 3.7 and it seems to work correctly on my machine.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
