### PR TITLE
MNT more informative warning in estimator_checks

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2242,9 +2242,11 @@ def check_set_params(name, estimator_orig):
             except (TypeError, ValueError) as e:
                 e_type = e.__class__.__name__
                 # Exception occurred, possibly parameter validation
-                warnings.warn("{} occurred during set_params. "
-                              "It is recommended to delay parameter "
-                              "validation until fit.".format(e_type))
+                warnings.warn("{0} occurred during set_params of param {1} on "
+                              "{2}. It is recommended to delay parameter "
+                              "validation until fit.".format(e_type,
+                                                             param_name,
+                                                             name))
 
                 change_warning_msg = "Estimator's parameters changed after " \
                                      "set_params raised {}".format(e_type)


### PR DESCRIPTION
Following up on #10158

At least in the context of common tests, making this warning more informative will help understanding.