### PR TITLE
[MRG] Parallelisation of decomposition/sparse_encode

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -22,6 +22,13 @@ Changelog
   threaded when `n_jobs > 1` or `n_jobs = -1`.
   :issue:`12949` by :user:`Prabakaran Kumaresshan <nixphix>`.
 
+:mod:`sklearn.decomposition`
+...........................
+
+- |Fix| Fixed a bug in :meth:`decomposition.sparse_encode` where computation was single
+  threaded when `n_jobs > 1` or `n_jobs = -1`.
+  :issue:`13005` by :user:`Prabakaran Kumaresshan <nixphix>`.
+
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -25,7 +25,7 @@ Changelog
 :mod:`sklearn.decomposition`
 ...........................
 
-- |Fix| Fixed a bug in :meth:`decomposition.sparse_encode` where computation was single
+- |Fix| Fixed a bug in :func:`decomposition.sparse_encode` where computation was single
   threaded when `n_jobs > 1` or `n_jobs = -1`.
   :issue:`13005` by :user:`Prabakaran Kumaresshan <nixphix>`.
 

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -300,7 +300,7 @@ def sparse_encode(X, dictionary, gram=None, cov=None, algorithm='lasso_lars',
         if regularization is None:
             regularization = 1.
 
-    if effective_n_jobs(n_jobs) or algorithm == 'threshold':
+    if effective_n_jobs(n_jobs) == 1 or algorithm == 'threshold':
         code = _sparse_encode(X,
                               dictionary, gram, cov=cov,
                               algorithm=algorithm,


### PR DESCRIPTION
#### Reference Issues/PRs
xref #12955

#### What does this implement/fix? Explain your changes.
sparse encode (dict learning uses sparse encode) is running in single-threaded mode irrespective of n_jobs parameters, the parallel execution code is unreachable since `effective_n_jobs` always returns a positive integer.

https://github.com/scikit-learn/scikit-learn/blob/ff46f6e594efb2bd7adbeba0cf5f26d5cb3a6231/sklearn/decomposition/dict_learning.py#L303-L316
