### PR TITLE
MAINT Pin numpy version 1.5.* for pypy

### DIFF
--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -18,7 +18,7 @@ source pypy-env/bin/activate
 python --version
 which python
 
-pip install --extra-index https://antocuni.github.io/pypy-wheels/ubuntu numpy Cython pytest
+pip install --extra-index https://antocuni.github.io/pypy-wheels/ubuntu "numpy==1.5.*" Cython pytest
 pip install "scipy>=1.1.0" sphinx numpydoc docutils joblib
 
 ccache -M 512M

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -18,6 +18,8 @@ source pypy-env/bin/activate
 python --version
 which python
 
+# XXX: numpy version pinning can be reverted once PyPy
+#      compatibility is resolved for numpy v1.6.x (see numpy/numpy#12740)
 pip install --extra-index https://antocuni.github.io/pypy-wheels/ubuntu "numpy==1.5.*" Cython pytest
 pip install "scipy>=1.1.0" sphinx numpydoc docutils joblib
 

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -19,7 +19,8 @@ python --version
 which python
 
 # XXX: numpy version pinning can be reverted once PyPy
-#      compatibility is resolved for numpy v1.6.x (see numpy/numpy#12740)
+#      compatibility is resolved for numpy v1.6.x. For instance,
+#      when PyPy3 >6.0 is released (see numpy/numpy#12740)
 pip install --extra-index https://antocuni.github.io/pypy-wheels/ubuntu "numpy==1.5.*" Cython pytest
 pip install "scipy>=1.1.0" sphinx numpydoc docutils joblib
 


### PR DESCRIPTION
Closes https://github.com/scikit-learn/scikit-learn/issues/13009

Temporarily revert to numpy 1.5.x for PyPy due to https://github.com/numpy/numpy/issues/12740