### PR TITLE
[MRG] Convert the negative indices to positive ones in ColumnTransformer._get_column_indices

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -22,6 +22,13 @@ Changelog
   threaded when `n_jobs > 1` or `n_jobs = -1`.
   :issue:`12949` by :user:`Prabakaran Kumaresshan <nixphix>`.
 
+:mod:`sklearn.compose`
+......................
+
+- |Fix| Fixed a bug in :class:`compose.ColumnTransformer` to handle
+  negative indexes in the columns list of the transformers.
+  :issue:`12946` by :user:`Pierre Tallotte <pierretallotte>`.
+
 :mod:`sklearn.linear_model`
 ...........................
 
@@ -36,13 +43,6 @@ Changelog
   deprecation of ``categorical_features`` was handled incorrectly in
   combination with ``handle_unknown='ignore'``.
   :issue:`12881` by `Joris Van den Bossche`_.
-
-:mod:`sklearn.compose`
-............................
-
-- |Fix| Fixed a bug in :class:`compose.ColumnTransformer` to handle
-  negative indexes in the columns list of the transformers.
-  :issue:`12946` by :user:`Pierre Tallotte <pierretallotte>`.
 
 .. _changes_0_20_2:
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -37,6 +37,13 @@ Changelog
   combination with ``handle_unknown='ignore'``.
   :issue:`12881` by `Joris Van den Bossche`_.
 
+:mod:`sklearn.compose`
+............................
+
+- |Fix| Fixed a bug in :class:`compose.ColumnTransformer` to handle
+  negative indexes in the columns list of the transformers.
+  :issue:`12946` by :user:`Pierre Tallotte <pierretallotte>`.
+
 .. _changes_0_20_2:
 
 Version 0.20.2

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -627,14 +627,14 @@ def _get_column_indices(X, key):
 
     """
     n_columns = X.shape[1]
-
+    
     if _check_key_type(key, int):
         if isinstance(key, int):
-            return [key]
+            return [key if key >= 0 else key + n_columns]
         elif isinstance(key, slice):
             return list(range(n_columns)[key])
         else:
-            return list(key)
+            return [idx if idx >= 0 else idx + n_columns for idx in key]
 
     elif _check_key_type(key, str):
         try:

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -627,7 +627,7 @@ def _get_column_indices(X, key):
 
     """
     n_columns = X.shape[1]
-    
+
     if _check_key_type(key, int):
         if isinstance(key, int):
             return [key if key >= 0 else key + n_columns]

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -630,7 +630,9 @@ def _get_column_indices(X, key):
 
     if (_check_key_type(key, int)
             or hasattr(key, 'dtype') and np.issubdtype(key.dtype, np.bool_)):
-        return np.atleast_1d(np.arange(n_columns)[key]).tolist()
+        # Convert key into positive indexes
+        idx = np.arange(n_columns)[key]
+        return np.atleast_1d(idx).tolist()
     elif _check_key_type(key, str):
         try:
             all_columns = list(X.columns)

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -628,7 +628,8 @@ def _get_column_indices(X, key):
     """
     n_columns = X.shape[1]
 
-    if _check_key_type(key, int) or hasattr(key, 'dtype') and np.issubdtype(key.dtype, np.bool_):
+    if (_check_key_type(key, int)
+            or hasattr(key, 'dtype') and np.issubdtype(key.dtype, np.bool_)):
         return np.atleast_1d(np.arange(n_columns)[key]).tolist()
     elif _check_key_type(key, str):
         try:

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -628,14 +628,8 @@ def _get_column_indices(X, key):
     """
     n_columns = X.shape[1]
 
-    if _check_key_type(key, int):
-        if isinstance(key, int):
-            return [key if key >= 0 else key + n_columns]
-        elif isinstance(key, slice):
-            return list(range(n_columns)[key])
-        else:
-            return [idx if idx >= 0 else idx + n_columns for idx in key]
-
+    if _check_key_type(key, int) or hasattr(key, 'dtype') and np.issubdtype(key.dtype, np.bool_):
+        return np.atleast_1d(np.arange(n_columns)[key]).tolist()
     elif _check_key_type(key, str):
         try:
             all_columns = list(X.columns)
@@ -658,10 +652,6 @@ def _get_column_indices(X, key):
             columns = list(key)
 
         return [all_columns.index(col) for col in columns]
-
-    elif hasattr(key, 'dtype') and np.issubdtype(key.dtype, np.bool_):
-        # boolean mask
-        return list(np.arange(n_columns)[key])
     else:
         raise ValueError("No valid specification of the columns. Only a "
                          "scalar, list or slice of all integers or all "

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1019,3 +1019,15 @@ def test_column_transformer_callable_specifier():
     assert_array_equal(ct.fit(X_df).transform(X_df), X_res_first)
     assert callable(ct.transformers[0][2])
     assert ct.transformers_[0][2] == ['first']
+
+
+def test_column_transformer_negative_column_indexes():
+    X = np.random.randn(2, 2)
+    X_categories = np.array([[1], [2]])
+    X = np.concatenate([X, X_categories], axis=1)
+    
+    ohe = OneHotEncoder(categories='auto')
+    
+    tf_1 = ColumnTransformer([('ohe', ohe, [-1])], remainder='passthrough')
+    tf_2 = ColumnTransformer([('ohe', ohe,  [2])], remainder='passthrough')
+    assert_array_equal(tf_1.fit_transform(X), tf_2.fit_transform(X))

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1025,9 +1025,9 @@ def test_column_transformer_negative_column_indexes():
     X = np.random.randn(2, 2)
     X_categories = np.array([[1], [2]])
     X = np.concatenate([X, X_categories], axis=1)
-    
+
     ohe = OneHotEncoder(categories='auto')
-    
+
     tf_1 = ColumnTransformer([('ohe', ohe, [-1])], remainder='passthrough')
     tf_2 = ColumnTransformer([('ohe', ohe,  [2])], remainder='passthrough')
     assert_array_equal(tf_1.fit_transform(X), tf_2.fit_transform(X))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #12946 

#### What does this implement/fix? Explain your changes.
The negative indexes are now converted into positive ones when _get_column_indices is called.
I also add a test case as described in the issue.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
