### PR TITLE
MAINT Fix PyPy CI with numpy 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,11 @@ workflows:
       - doc
       - doc-min-dependencies
       - lint
-      - pypy3
+      - pypy3:
+          filters:
+            branches:
+              only:
+                - 0.20.X
       - deploy:
           requires:
             - doc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,7 @@ workflows:
             branches:
               only:
                 - 0.20.X
+                - /.*pypy.*/
       - deploy:
           requires:
             - doc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,12 +112,7 @@ workflows:
       - doc
       - doc-min-dependencies
       - lint
-      - pypy3:
-          filters:
-            branches:
-              only:
-                - 0.20.X
-                - /.*pypy.*/
+      - pypy3
       - deploy:
           requires:
             - doc

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -21,7 +21,7 @@ which python
 # XXX: numpy version pinning can be reverted once PyPy
 #      compatibility is resolved for numpy v1.6.x. For instance,
 #      when PyPy3 >6.0 is released (see numpy/numpy#12740)
-pip install --extra-index https://antocuni.github.io/pypy-wheels/ubuntu "numpy==1.5.4" Cython pytest
+pip install --extra-index https://antocuni.github.io/pypy-wheels/ubuntu "numpy==1.15.*" Cython pytest
 pip install "scipy>=1.1.0" sphinx numpydoc docutils joblib
 
 ccache -M 512M

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -21,7 +21,7 @@ which python
 # XXX: numpy version pinning can be reverted once PyPy
 #      compatibility is resolved for numpy v1.6.x. For instance,
 #      when PyPy3 >6.0 is released (see numpy/numpy#12740)
-pip install --extra-index https://antocuni.github.io/pypy-wheels/ubuntu "numpy==1.5.*" Cython pytest
+pip install --extra-index https://antocuni.github.io/pypy-wheels/ubuntu "numpy==1.5.4" Cython pytest
 pip install "scipy>=1.1.0" sphinx numpydoc docutils joblib
 
 ccache -M 512M


### PR DESCRIPTION
A second attempt to fix https://github.com/scikit-learn/scikit-learn/issues/13009

Will start by running PyPy CI in this PR. Maybe running that CI for branches that contain the `pypy` key word could be a simple workaround for https://github.com/scikit-learn/scikit-learn/issues/13014