### PR TITLE
TST IterativeImputer: Check predictor type

### DIFF
--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -565,7 +565,7 @@ def test_iterative_imputer_predictors(predictor):
     # check that types are correct for predictors
     hashes = []
     for triplet in imputer.imputation_sequence_:
-        assert triplet.predictor
+        assert isinstance(triplet.predictor, type(predictor))
         hashes.append(id(triplet.predictor))
 
     # check that each predictor is unique


### PR DESCRIPTION
Strengthen the test a little. 

There should be a further test to check behaviour when predictor=None, but perhaps that belongs in #13038