### PR TITLE
DOC Remove outdated doc in KBinsDiscretizer

### DIFF
--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -27,12 +27,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
     Parameters
     ----------
     n_bins : int or array-like, shape (n_features,) (default=5)
-        The number of bins to produce. The intervals for the bins are
-        determined by the minimum and maximum of the input data.
-        Raises ValueError if ``n_bins < 2``.
-
-        If ``n_bins`` is an array, and there is an ignored feature at
-        index ``i``, ``n_bins[i]`` will be ignored.
+        The number of bins to produce. Raises ValueError if ``n_bins < 2``.
 
     encode : {'onehot', 'onehot-dense', 'ordinal'}, (default='onehot')
         Method used to encode the transformed result.
@@ -62,8 +57,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
     Attributes
     ----------
     n_bins_ : int array, shape (n_features,)
-        Number of bins per feature. An ignored feature at index ``i``
-        will have ``n_bins_[i] == 0``.
+        Number of bins per feature.
 
     bin_edges_ : array of arrays, shape (n_features, )
         The edges of each bin. Contain arrays of varying shapes ``(n_bins_, )``


### PR DESCRIPTION
We rely on ``ColumnTransformer`` to preprocess part of the features.
We now have multiple strategies so the intervals for the bins are not always determined by the minimum and maximum of the input data.