### PR TITLE
[MRG] Update setup and travis to support OpenMP

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -25,6 +25,13 @@ then
 	# export CCACHE_LOGFILE=/tmp/ccache.log
 	# ~60M is used by .ccache when compiling from scratch at the time of writing
 	ccache --max-size 100M --show-stats
+elif [ $TRAVIS_OS_NAME = "osx" ]
+then
+    # use clang installed by conda which supports OpenMP
+    export CC=clang
+    export CXX=clang
+    # avoid error due to multiple openmp libraries loaded simultaneously
+    export KMP_DUPLICATE_LIB_OK=TRUE
 fi
 
 make_conda() {
@@ -38,6 +45,8 @@ make_conda() {
     if [ $TRAVIS_OS_NAME = "osx" ]
 	then
 		fname=Miniconda3-latest-MacOSX-x86_64.sh
+        # we need to install a version on clang which supports OpenMP
+        TO_INSTALL="$TO_INSTALL llvm-openmp clang"
 	else
 		fname=Miniconda3-latest-Linux-x86_64.sh
 	fi

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -31,8 +31,8 @@ then
     brew install libomp
 
     # enable OpenMP support for Apple-clang
-    export CC=clang
-    export CXX=clang++
+    export CC=/usr/bin/clang
+    export CXX=/usr/bin/clang++
     export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"
     export CFLAGS="$CFLAGS -I/usr/local/opt/libomp/include"
     export CXXFLAGS="$CXXFLAGS -I/usr/local/opt/libomp/include"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -27,10 +27,19 @@ then
 	ccache --max-size 100M --show-stats
 elif [ $TRAVIS_OS_NAME = "osx" ]
 then
-    # use clang installed by conda which supports OpenMP
+    # install OpenMP not present by default on osx
+    brew install libomp
+
+    # enable OpenMP support for Apple-clang
     export CC=clang
-    export CXX=clang
-    # avoid error due to multiple openmp libraries loaded simultaneously
+    export CXX=clang++
+    export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"
+    export CFLAGS="$CFLAGS -I/usr/local/opt/libomp/include"
+    export CXXFLAGS="$CXXFLAGS -I/usr/local/opt/libomp/include"
+    export LDFLAGS="$LDFLAGS -L/usr/local/opt/libomp/lib -lomp"
+    export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
+
+    # avoid error due to multiple OpenMP libraries loaded simultaneously
     export KMP_DUPLICATE_LIB_OK=TRUE
 fi
 
@@ -45,8 +54,6 @@ make_conda() {
     if [ $TRAVIS_OS_NAME = "osx" ]
 	then
 		fname=Miniconda3-latest-MacOSX-x86_64.sh
-        # we need to install a version on clang which supports OpenMP
-        TO_INSTALL="$TO_INSTALL llvm-openmp clang"
 	else
 		fname=Miniconda3-latest-Linux-x86_64.sh
 	fi

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -46,8 +46,8 @@ Scikit-learn requires:
 
 Building Scikit-learn also requires
 
-- OpenMP
 - Cython >=0.28.5
+- OpenMP
 
 Running tests requires
 
@@ -117,8 +117,11 @@ You first need to install the OpenMP library::
 
 Then you need to set the following environment variables::
 
-    export CC="clang -Xpreprocessor -fopenmp"
+    export CC=clang
+    export CXX=clang++
+    export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"
     export CFLAGS="$CFLAGS -I/usr/local/opt/libomp/include"
+    export CXXFLAGS="$CXXFLAGS -I/usr/local/opt/libomp/include"
     export LDFLAGS="$LDFLAGS -L/usr/local/opt/libomp/lib -lomp"
     export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -46,7 +46,8 @@ Scikit-learn requires:
 
 Building Scikit-learn also requires
 
-- Cython >=0.23 
+- Cython >=0.23
+- OpenMP
 
 Running tests requires
 
@@ -102,6 +103,27 @@ On Unix-like systems, you can simply type ``make`` in the top-level folder to
 build in-place and launch all the tests. Have a look at the ``Makefile`` for
 additional utilities.
 
+Mac OSX
+-------
+
+The default C compiler, Apple-clang, on Mac OSX does not directly support
+OpenMP. The first solution to build scikit-learn is to install another C
+compiler such as gcc or llvm-clang. Another solution is to enable OpenMP
+support on the default Apple-clang.
+
+You first need to install the OpenMP library::
+
+    brew install libomp
+
+Then you need to set the following environment variables::
+
+    export CC="clang -Xpreprocessor -fopenmp"
+    export CFLAGS="$CFLAGS -I/usr/local/opt/libomp/include"
+    export LDFLAGS="$LDFLAGS -L/usr/local/opt/libomp/lib -lomp"
+    export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
+
+Finally you can build the package using the standard command.
+
 Installing build dependencies
 =============================
 
@@ -111,7 +133,7 @@ Linux
 Installing from source requires you to have installed the scikit-learn runtime
 dependencies, Python development headers and a working C/C++ compiler.
 Under Debian-based operating systems, which include Ubuntu::
-    
+
     sudo apt-get install build-essential python3-dev python3-setuptools \
                      python3-numpy python3-scipy \
                      libatlas-dev libatlas3-base

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -46,7 +46,7 @@ Scikit-learn requires:
 
 Building Scikit-learn also requires
 
-- Cython >=0.23
+- Cython >=0.23 
 - OpenMP
 
 Running tests requires

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -109,7 +109,8 @@ Mac OSX
 The default C compiler, Apple-clang, on Mac OSX does not directly support
 OpenMP. The first solution to build scikit-learn is to install another C
 compiler such as gcc or llvm-clang. Another solution is to enable OpenMP
-support on the default Apple-clang.
+support on the default Apple-clang. In the following we present how to
+configure this second option.
 
 You first need to install the OpenMP library::
 

--- a/setup.py
+++ b/setup.py
@@ -125,8 +125,7 @@ def get_openmp_flag(compiler):
     return ['-fopenmp']
 
 
-OPENMP_EXTENSIONS = ["sklearn.cluster._k_means_lloyd",
-                     "sklearn.cluster._k_means_elkan"]
+OPENMP_EXTENSIONS = []
 
 
 # custom build_ext command to set OpenMP compile flags depending on os and

--- a/setup.py
+++ b/setup.py
@@ -110,8 +110,18 @@ def get_openmp_flag(compiler):
     elif sys.platform == "darwin" and ('icc' in compiler or 'icl' in compiler):
         return ['-openmp']
     elif sys.platform == "darwin" and 'openmp' in os.getenv('CC', ''):
-        # -fopenmp can't be passed as compile arg when using apple clang
+        # -fopenmp can't be passed as compile flag when using Apple-clang.
+        # OpenMP support has to be enabled during preprocessing.
+        #
+        # For example, our macOS wheel build jobs use the following environment
+        # variables to build with Apple clang and the brew installed "libomp":
+        #
+        # export CC="clang -Xpreprocessor -fopenmp"
+        # export CFLAGS="$CFLAGS -I/usr/local/opt/libomp/include"
+        # export LDFLAGS="$LDFLAGS -L/usr/local/opt/libomp/lib -lomp"
+        # export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
         return ['']
+    # Default flag for GCC and clang:
     return ['-fopenmp']
 
 

--- a/setup.py
+++ b/setup.py
@@ -109,14 +109,14 @@ def get_openmp_flag(compiler):
         return ['/openmp']
     elif sys.platform == "darwin" and ('icc' in compiler or 'icl' in compiler):
         return ['-openmp']
-    elif sys.platform == "darwin" and 'openmp' in os.getenv('CC', ''):
+    elif sys.platform == "darwin" and 'openmp' in os.getenv('CPPFLAGS', ''):
         # -fopenmp can't be passed as compile flag when using Apple-clang.
         # OpenMP support has to be enabled during preprocessing.
         #
         # For example, our macOS wheel build jobs use the following environment
-        # variables to build with Apple clang and the brew installed "libomp":
+        # variables to build with Apple-clang and the brew installed "libomp":
         #
-        # export CC="clang -Xpreprocessor -fopenmp"
+        # export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"
         # export CFLAGS="$CFLAGS -I/usr/local/opt/libomp/include"
         # export LDFLAGS="$LDFLAGS -L/usr/local/opt/libomp/lib -lomp"
         # export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
@@ -125,7 +125,8 @@ def get_openmp_flag(compiler):
     return ['-fopenmp']
 
 
-OPENMP_EXTENSIONS = []
+OPENMP_EXTENSIONS = ["sklearn.cluster._k_means_lloyd",
+                     "sklearn.cluster._k_means_elkan"]
 
 
 # custom build_ext command to set OpenMP compile flags depending on os and


### PR DESCRIPTION
Two PRs introduce the use of OpenMP is sklearn: #11950 and #12807.

Using OpenMP requires special compile flags depending on platform and compiler. This PR update the setup to add the correct flag by introspecting the compiler used at build time. There's also an update of travis for osx job because the default apple clang compiler does not support OpenMP.