### PR TITLE
DOC: sklearn.manifold.TSNE perplexity docstring potentially misleading

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ jobs:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh
       - restore_cache:
-          key: v1-datasets-{{ .Branch }}
+          key: v2-datasets-{{ .Branch }}
       - run: ./build_tools/circle/build_doc.sh
       - save_cache:
-          key: v1-datasets-{{ .Branch }}
+          key: v2-datasets-{{ .Branch }}
           paths:
             - ~/scikit_learn_data
       - store_artifacts:
@@ -51,10 +51,10 @@ jobs:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh
       - restore_cache:
-          key: v1-datasets-{{ .Branch }}-python2
+          key: v2-datasets-{{ .Branch }}-python2
       - run: ./build_tools/circle/build_doc.sh
       - save_cache:
-          key: v1-datasets-{{ .Branch }}-python2
+          key: v2-datasets-{{ .Branch }}-python2
           paths:
             - ~/scikit_learn_data
       - store_artifacts:


### PR DESCRIPTION
The documentation for sklearn.manifold.TSNE on the perplexity parameter has the following sentences:

Consider selecting a value between 5 and 50. The choice is not extremely critical since t-SNE is quite insensitive to this parameter.

Given personal experimentation with the parameter, sklearn docs examining how perplexity impacts shape, and the article here, isn't it misleading to claim that t-SNE is insensitive to the perplexity parameter value? Should it instead be changed to something like: