### PR TITLE
[MRG] Support multi-label probability calibration

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -37,13 +37,20 @@ Changelog
 ..
     Entries should be grouped by module (in alphabetic order) and prefixed with
     one of the labels: |MajorFeature|, |Feature|, |Efficiency|, |Enhancement|,
-    |Fix| or |API| (see whats_new.rst for descriptions).
+    |Fix| or |API| (see changelog_legend.inc for descriptions).
     Entries should be ordered by those labels (e.g. |Fix| after |Efficiency|).
     Changes not specific to a module should be listed under *Multiple Modules*
     or *Miscellaneous*.
     Entries should end with:
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
+
+:mod:`sklearn.calibration`
+..........................
+
+- |Enhancement| :class:`CalibratedClassifierCV` now supports one-dimensional
+  and non-numeric input. :pr:`13060` by
+  :user:`Connor Brinton <connorbrinton>`.
 
 :mod:`sklearn.cluster`
 ......................

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -272,7 +272,8 @@ class CalibratedClassifierCV(ClassifierMixin,
         else:
             X, y = self._validate_data(
                 X, y, accept_sparse=['csc', 'csr', 'coo'],
-                force_all_finite=False, allow_nd=True
+                force_all_finite=False, allow_nd=True, dtype=None,
+                ensure_2d=False, multi_output=True
             )
             # Set `classes_` using all `y`
             label_encoder_ = LabelEncoder().fit(y)
@@ -354,11 +355,12 @@ class CalibratedClassifierCV(ClassifierMixin,
         """
         check_is_fitted(self)
         X = check_array(X, accept_sparse=['csc', 'csr', 'coo'],
-                        force_all_finite=False)
+                        force_all_finite=False, allow_nd=True, dtype=None,
+                        ensure_2d=False)
         # Compute the arithmetic mean of the predictions of the calibrated
         # classifiers
-        mean_proba = np.zeros((X.shape[0], len(self.classes_)))
-        for calibrated_classifier in self.calibrated_classifiers_:
+        mean_proba = self.calibrated_classifiers_[0].predict_proba(X)
+        for calibrated_classifier in self.calibrated_classifiers_[1:]:
             proba = calibrated_classifier.predict_proba(X)
             mean_proba += proba
 


### PR DESCRIPTION
`CalibratedClassifierCV` now handles the calibration process in such a way that probability estimates can be calibrated for multi-label targets. Also loosens input validation requirements to better interoperate with `Pipeline`.

#### Reference Issues/PRs
Fixes #8710.

#### What does this implement/fix? Explain your changes.
Changes include (roughly in source code order):
* Looser input validation on arguments passed to wrapped classifiers (fixes #8710)
* Target classes and type are determined before cross-validation, rather than on each fold individually
* Label predictions from `CalibratedClassifierCV.predict` are obtained using `LabelBinarizer.inverse_transform`, which supports multi-label predictions
* Specialized logic in `_CalibratedClassifier` for handling binary classification problems is tidied and more thoroughly commented
* Shape of uncalibrated estimates from wrapped classifier is checked against the expected shape in `_CalibratedClassifier`
* Simplification of logic in `_CalibratedClassifier.predict_proba` along with more comments explaining what's happening
* Tests for acceptance of 1D feature arrays as input and production of valid multi-label probability predictions

#### Any other comments?
Thanks for working on scikit-learn!