### PR TITLE
[MRG] IterativeImputer: n_iter->max_iter

### DIFF
--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -110,7 +110,7 @@ imputation round are returned.
     IterativeImputer(imputation_order='ascending', initial_strategy='mean',
                      max_iter=10, max_value=None, min_value=None,
                      missing_values=nan, n_nearest_features=None, predictor=None,
-                     random_state=0, sample_posterior=False, verbose=0)
+                     random_state=0, sample_posterior=False, tol=0.001, verbose=0)
     >>> X_test = [[np.nan, 2], [6, np.nan], [np.nan, 6]]
     >>> # the model learns that the second feature is double the first
     >>> print(np.round(imp.transform(X_test)))

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -107,9 +107,9 @@ imputation round are returned.
     >>> from sklearn.impute import IterativeImputer
     >>> imp = IterativeImputer(max_iter=10, random_state=0)
     >>> imp.fit([[1, 2], [3, 6], [4, 8], [np.nan, 3], [7, np.nan]])  # doctest: +NORMALIZE_WHITESPACE
-    IterativeImputer(imputation_order='ascending', initial_strategy='mean',
-                     max_iter=10, max_value=None, min_value=None,
-                     missing_values=nan, n_nearest_features=None, predictor=None,
+    IterativeImputer(estimator=None, imputation_order='ascending',
+                     initial_strategy='mean', max_iter=10, max_value=None,
+                     min_value=None, missing_values=nan, n_nearest_features=None,
                      random_state=0, sample_posterior=False, tol=0.001, verbose=0)
     >>> X_test = [[np.nan, 2], [6, np.nan], [np.nan, 6]]
     >>> # the model learns that the second feature is double the first

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -100,17 +100,17 @@ fashion: at each step, a feature column is designated as output ``y`` and the
 other feature columns are treated as inputs ``X``. A regressor is fit on ``(X,
 y)`` for known ``y``. Then, the regressor is used to predict the missing values
 of ``y``.  This is done for each feature in an iterative fashion, and then is
-repeated for ``n_iter`` imputation rounds. The results of the final imputation
-round are returned.
+repeated for ``max_iter`` imputation rounds. The results of the final
+imputation round are returned.
 
     >>> import numpy as np
     >>> from sklearn.impute import IterativeImputer
-    >>> imp = IterativeImputer(n_iter=10, random_state=0)
+    >>> imp = IterativeImputer(max_iter=10, random_state=0)
     >>> imp.fit([[1, 2], [3, 6], [4, 8], [np.nan, 3], [7, np.nan]])  # doctest: +NORMALIZE_WHITESPACE
     IterativeImputer(imputation_order='ascending', initial_strategy='mean',
-        max_value=None, min_value=None, missing_values=nan, n_iter=10,
-        n_nearest_features=None, predictor=None, random_state=0,
-        sample_posterior=False, verbose=0)
+                     max_iter=10, max_value=None, min_value=None,
+                     missing_values=nan, n_nearest_features=None, predictor=None,
+                     random_state=0, sample_posterior=False, verbose=0)
     >>> X_test = [[np.nan, 2], [6, np.nan], [np.nan, 6]]
     >>> # the model learns that the second feature is double the first
     >>> print(np.round(imp.transform(X_test)))

--- a/examples/impute/plot_iterative_imputer_variants_comparison.py
+++ b/examples/impute/plot_iterative_imputer_variants_comparison.py
@@ -33,7 +33,8 @@ The goal is to compare different predictors to see which one is best for the
 dataset with a single value randomly removed from each row.
 
 For this particular pattern of missing values we see that
-:class:`sklearn.ensemble.ExtraTreesRegressor` give the best results.
+:class:`sklearn.ensemble.ExtraTreesRegressor` and
+:class:`sklearn.linear_model.BayesianRidge` give the best results.
 """
 print(__doc__)
 

--- a/examples/impute/plot_iterative_imputer_variants_comparison.py
+++ b/examples/impute/plot_iterative_imputer_variants_comparison.py
@@ -33,8 +33,7 @@ The goal is to compare different predictors to see which one is best for the
 dataset with a single value randomly removed from each row.
 
 For this particular pattern of missing values we see that
-:class:`sklearn.ensemble.ExtraTreesRegressor` and
-:class:`sklearn.linear_model.BayesianRidge` give the best results.
+:class:`sklearn.ensemble.ExtraTreesRegressor` give the best results.
 """
 print(__doc__)
 
@@ -99,7 +98,7 @@ predictors = [
 score_iterative_imputer = pd.DataFrame()
 for predictor in predictors:
     estimator = make_pipeline(
-        IterativeImputer(random_state=0, predictor=predictor),
+        IterativeImputer(random_state=0, predictor=predictor,verbose=1),
         br_estimator
     )
     score_iterative_imputer[predictor.__class__.__name__] = \

--- a/examples/impute/plot_iterative_imputer_variants_comparison.py
+++ b/examples/impute/plot_iterative_imputer_variants_comparison.py
@@ -98,7 +98,7 @@ predictors = [
 score_iterative_imputer = pd.DataFrame()
 for predictor in predictors:
     estimator = make_pipeline(
-        IterativeImputer(random_state=0, predictor=predictor,verbose=1),
+        IterativeImputer(random_state=0, predictor=predictor),
         br_estimator
     )
     score_iterative_imputer[predictor.__class__.__name__] = \

--- a/examples/impute/plot_iterative_imputer_variants_comparison.py
+++ b/examples/impute/plot_iterative_imputer_variants_comparison.py
@@ -4,10 +4,10 @@ Imputing missing values with variants of IterativeImputer
 =========================================================
 
 The :class:`sklearn.impute.IterativeImputer` class is very flexible - it can be
-used with a variety of predictors to do round-robin regression, treating every
+used with a variety of estimators to do round-robin regression, treating every
 variable as an output in turn.
 
-In this example we compare some predictors for the purpose of missing feature
+In this example we compare some estimators for the purpose of missing feature
 imputation with :class:`sklearn.imputeIterativeImputer`::
 
     :class:`~sklearn.linear_model.BayesianRidge`: regularized linear regression
@@ -27,7 +27,7 @@ Note that :class:`sklearn.neighbors.KNeighborsRegressor` is different from KNN
 imputation, which learns from samples with missing values by using a distance
 metric that accounts for missing values, rather than imputing them.
 
-The goal is to compare different predictors to see which one is best for the
+The goal is to compare different estimators to see which one is best for the
 :class:`sklearn.impute.IterativeImputer` when using a
 :class:`sklearn.linear_model.BayesianRidge` estimator on the California housing
 dataset with a single value randomly removed from each row.
@@ -89,20 +89,20 @@ for strategy in ('mean', 'median'):
     )
 
 # Estimate the score after iterative imputation of the missing values
-# with different predictors
-predictors = [
+# with different estimators
+estimators = [
     BayesianRidge(),
     DecisionTreeRegressor(max_features='sqrt', random_state=0),
     ExtraTreesRegressor(n_estimators=10, n_jobs=-1, random_state=0),
     KNeighborsRegressor(n_neighbors=15)
 ]
 score_iterative_imputer = pd.DataFrame()
-for predictor in predictors:
+for estimator in estimators:
     estimator = make_pipeline(
-        IterativeImputer(random_state=0, predictor=predictor),
+        IterativeImputer(random_state=0, estimator=estimator),
         br_estimator
     )
-    score_iterative_imputer[predictor.__class__.__name__] = \
+    score_iterative_imputer[estimator.__class__.__name__] = \
         cross_val_score(
             estimator, X_missing, y_missing, scoring='neg_mean_squared_error',
             cv=N_SPLITS

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -900,7 +900,7 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
             print("[IterativeImputer] Completing matrix with shape %s"
                   % (X.shape,))
         start_t = time()
-        self.actual_iter = self.max_iter
+        self.n_iter_ = self.max_iter
         if not self.sample_posterior:
             Xt_previous = np.copy(Xt)
             norm_diff_previous = np.inf
@@ -934,7 +934,7 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
                     self.imputation_sequence_ = \
                         self.imputation_sequence_[:-len(ordered_idx)]
                     Xt = np.copy(Xt_previous)
-                    self.actual_iter = i_rnd
+                    self.n_iter_ = i_rnd
                     print('[IterativeImputer] Early stopping criterion '
                           'reached. Using result of round %d' % i_rnd)
                     break
@@ -965,10 +965,10 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
 
         X, Xt, mask_missing_values = self._initial_imputation(X)
 
-        if self.actual_iter == 0:
+        if self.n_iter_ == 0:
             return Xt
 
-        imps_per_round = len(self.imputation_sequence_) // self.actual_iter
+        imps_per_round = len(self.imputation_sequence_) // self.n_iter_
         i_rnd = 0
         if self.verbose > 0:
             print("[IterativeImputer] Completing matrix with shape %s"
@@ -987,7 +987,7 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
                 if self.verbose > 1:
                     print('[IterativeImputer] Ending imputation round '
                           '%d/%d, elapsed time %0.2f'
-                          % (i_rnd + 1, self.actual_iter, time() - start_t))
+                          % (i_rnd + 1, self.n_iter_, time() - start_t))
                 i_rnd += 1
 
         Xt[~mask_missing_values] = X[~mask_missing_values]

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -987,7 +987,7 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
 
         X, Xt, mask_missing_values = self._initial_imputation(X)
 
-        if self.n_iter_ == 0 or np.sum(~mask_missing_values) == 0:
+        if self.n_iter_ == 0 or np.all(mask_missing_values):
             return Xt
 
         imputations_per_round = len(self.imputation_sequence_) // self.n_iter_

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -936,7 +936,7 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
                     Xt = np.copy(Xt_previous)
                     self.actual_iter = i_rnd
                     print('[IterativeImputer] Early stopping criterion '
-                          'reached. Using result of round %d' %i_rnd)
+                          'reached. Using result of round %d' % i_rnd)
                     break
                 else:
                     Xt_previous = np.copy(Xt)

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -646,6 +646,7 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
                                missing_row_mask)
         if self.sample_posterior:
             mus, sigmas = predictor.predict(X_test, return_std=True)
+            print(mus, sigmas, predictor.coef_, predictor.intercept_)
             imputed_values = np.zeros(mus.shape, dtype=X_filled.dtype)
             # two types of problems: (1) non-positive sigmas, (2) mus outside
             # legal range of min_value and max_value (results in inf sample)
@@ -936,12 +937,14 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
             # stop early if difference between consecutive imputations goes up.
             # if so, back off to previous imputation
             if not self.sample_posterior:
-                norm_diff = np.linalg.norm(Xt - Xt_previous) \
-                            / np.linalg.norm(Xt)
+                # norm difference is defined in section 2 for missForest here:
+                # academic.oup.com/bioinformatics/article/28/1/112/219101
+                norm_diff = (np.linalg.norm(Xt - Xt_previous)
+                             / np.linalg.norm(Xt))
                 if norm_diff > norm_diff_previous:
                     self.imputation_sequence_ = \
                         self.imputation_sequence_[:-len(ordered_idx)]
-                    Xt = np.copy(Xt_previous)
+                    Xt = Xt_previous
                     self.n_iter_ = i_rnd
                     print('[IterativeImputer] Early stopping criterion '
                           'reached. Using result of round %d' % i_rnd)

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -909,7 +909,7 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
         self.initial_imputer_ = None
         X, Xt, mask_missing_values = self._initial_imputation(X)
 
-        if self.max_iter == 0 or np.sum(~mask_missing_values) == 0:
+        if self.max_iter == 0 or np.all(mask_missing_values):
             self.n_iter_ = 0
             return Xt
 

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -898,6 +898,8 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
         else:
             self._predictor = clone(self.predictor)
 
+        self.imputation_sequence_ = []
+
         if hasattr(self._predictor, 'random_state'):
             self._predictor.random_state = self.random_state_
 
@@ -907,7 +909,8 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
         self.initial_imputer_ = None
         X, Xt, mask_missing_values = self._initial_imputation(X)
 
-        if self.max_iter == 0:
+        if self.max_iter == 0 or np.sum(~mask_missing_values) == 0:
+            self.n_iter_ = 0
             return Xt
 
         # order in which to impute
@@ -920,7 +923,6 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
         abs_corr_mat = self._get_abs_corr_mat(Xt)
 
         n_samples, n_features = Xt.shape
-        self.imputation_sequence_ = []
         if self.verbose > 0:
             print("[IterativeImputer] Completing matrix with shape %s"
                   % (X.shape,))
@@ -985,7 +987,7 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
 
         X, Xt, mask_missing_values = self._initial_imputation(X)
 
-        if self.n_iter_ == 0:
+        if self.n_iter_ == 0 or np.sum(~mask_missing_values) == 0:
             return Xt
 
         imputations_per_round = len(self.imputation_sequence_) // self.n_iter_

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -944,7 +944,7 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
                                                    predictor)
                 self.imputation_sequence_.append(predictor_triplet)
 
-            if self.verbose > 0:
+            if self.verbose > 1:
                 print('[IterativeImputer] Ending imputation round '
                       '%d/%d, elapsed time %0.2f'
                       % (self.n_iter_, self.max_iter, time() - start_t))

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -960,8 +960,7 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
                         print('[IterativeImputer] Early stopping criterion '
                               'reached.')
                     break
-                else:
-                    Xt_previous = Xt.copy()
+                Xt_previous = Xt.copy()
 
         if not self.sample_posterior:
             warnings.warn("[IterativeImputer] Early stopping criterion not "

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -655,7 +655,7 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
             imputed_values[mus_too_low] = self._min_value
             mus_too_high = mus > self._max_value
             imputed_values[mus_too_high] = self._max_value
-            # the rest can legally sampled
+            # the rest can be sampled without statistical issues
             sample_flag = positive_sigmas & ~mus_too_low & ~mus_too_high
             mus = mus[sample_flag]
             sigmas = sigmas[sample_flag]

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -646,7 +646,6 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
                                missing_row_mask)
         if self.sample_posterior:
             mus, sigmas = predictor.predict(X_test, return_std=True)
-            print(mus, sigmas, predictor.coef_, predictor.intercept_)
             imputed_values = np.zeros(mus.shape, dtype=X_filled.dtype)
             # two types of problems: (1) non-positive sigmas, (2) mus outside
             # legal range of min_value and max_value (results in inf sample)

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -620,9 +620,12 @@ def test_iterative_imputer_clip_truncnorm():
 def test_iterative_imputer_truncated_normal_posterior():
     #  test that the values that are imputed using `sample_posterior=True`
     #  with boundaries (`min_value` and `max_value` are not None) are drawn
-    #  from a distribution that looks gaussian via the Kolmogorov Smirnov test
+    #  from a distribution that looks gaussian via the Kolmogorov Smirnov test.
+    #  note that starting from the wrong random seed will make this test fail
+    #  because random sampling doesn't occur at all when the imputation
+    #  is outside of the (min_value, max_value) range
     pytest.importorskip("scipy", minversion="0.17.0")
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
 
     X = rng.normal(size=(5, 5))
     X[0][0] = np.nan
@@ -634,7 +637,7 @@ def test_iterative_imputer_truncated_normal_posterior():
 
     imputer.fit_transform(X)
     # generate multiple imputations for the single missing value
-    imputations = np.array([imputer.transform(X)[0][0] for _ in range(1000)])
+    imputations = np.array([imputer.transform(X)[0][0] for _ in range(100)])
 
     assert all(imputations >= 0)
     assert all(imputations <= 0.5)

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -542,7 +542,9 @@ def test_iterative_imputer_verbose():
     X = sparse_random_matrix(n, d, density=0.10, random_state=rng).toarray()
     imputer = IterativeImputer(missing_values=0, max_iter=1, verbose=1)
     imputer.fit(X)
-    imputer.verbose = 2
+    imputer.transform(X)
+    imputer = IterativeImputer(missing_values=0, max_iter=1, verbose=2)
+    imputer.fit(X)
     imputer.transform(X)
 
 

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -838,6 +838,7 @@ def test_iterative_imputer_early_stopping():
     X_missing[nan_mask] = np.nan
 
     imputer = IterativeImputer(max_iter=max_iter,
+                               tol=1e-3,
                                sample_posterior=False,
                                verbose=1,
                                random_state=rng)

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -595,10 +595,10 @@ def test_iterative_imputer_imputation_order(imputation_order):
 
 
 @pytest.mark.parametrize(
-    "predictor",
+    "estimator",
     [None, DummyRegressor(), BayesianRidge(), ARDRegression(), RidgeCV()]
 )
-def test_iterative_imputer_predictors(predictor):
+def test_iterative_imputer_estimators(estimator):
     rng = np.random.RandomState(0)
 
     n = 100
@@ -607,19 +607,19 @@ def test_iterative_imputer_predictors(predictor):
 
     imputer = IterativeImputer(missing_values=0,
                                max_iter=1,
-                               predictor=predictor,
+                               estimator=estimator,
                                random_state=rng)
     imputer.fit_transform(X)
 
-    # check that types are correct for predictors
+    # check that types are correct for estimators
     hashes = []
     for triplet in imputer.imputation_sequence_:
-        expected_type = (type(predictor) if predictor is not None
+        expected_type = (type(estimator) if estimator is not None
                          else type(BayesianRidge()))
-        assert isinstance(triplet.predictor, expected_type)
-        hashes.append(id(triplet.predictor))
+        assert isinstance(triplet.estimator, expected_type)
+        hashes.append(id(triplet.estimator))
 
-    # check that each predictor is unique
+    # check that each estimator is unique
     assert len(set(hashes)) == len(hashes)
 
 

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -822,7 +822,7 @@ def test_iterative_imputer_additive_matrix():
     (1, -1e-3, ValueError, 'should be a non-negative float')
 ])
 def test_iterative_imputer_error_param(max_iter, tol, warning_type, warning):
-    X = rng.randn(100, 2)
+    X = np.zeros((100, 2))
     imputer = IterativeImputer(max_iter=max_iter, tol=tol)
     with pytest.raises(warning_type, match=warning):
         imputer.fit_transform(X)

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -829,7 +829,6 @@ def test_iterative_imputer_early_stopping():
     rng = np.random.RandomState(0)
     n = 50
     d = 5
-    max_iter = 100
     A = rng.rand(n, 1)
     B = rng.rand(1, d)
     X = np.dot(A, B)
@@ -837,20 +836,28 @@ def test_iterative_imputer_early_stopping():
     X_missing = X.copy()
     X_missing[nan_mask] = np.nan
 
-    imputer = IterativeImputer(max_iter=max_iter,
+    imputer = IterativeImputer(max_iter=100,
                                tol=1e-3,
                                sample_posterior=False,
                                verbose=1,
                                random_state=rng)
     X_filled_100 = imputer.fit_transform(X_missing)
-    assert(len(imputer.imputation_sequence_) == d * 5)
+    assert len(imputer.imputation_sequence_) == d * imputer.n_iter_
 
-    imputer = IterativeImputer(max_iter=5,
+    imputer = IterativeImputer(max_iter=imputer.n_iter_,
                                sample_posterior=False,
                                verbose=1,
                                random_state=rng)
     X_filled_5 = imputer.fit_transform(X_missing)
     assert_allclose(X_filled_100, X_filled_5, atol=1e-7)
+
+    imputer = IterativeImputer(max_iter=100,
+                               tol=0,
+                               sample_posterior=False,
+                               verbose=1,
+                               random_state=rng)
+    imputer.fit(X_missing)
+    assert imputer.max_iter == imputer.n_iter_
 
 
 @pytest.mark.parametrize(

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -508,6 +508,42 @@ def test_imputation_copy():
     # made, even if copy=False.
 
 
+def test_iterative_imputer_zero_iters():
+    rng = np.random.RandomState(0)
+
+    n = 100
+    d = 10
+    X = sparse_random_matrix(n, d, density=0.10, random_state=rng).toarray()
+    missing_flag = X == 0
+    X[missing_flag] = np.nan
+
+    imputer = IterativeImputer(max_iter=0)
+    X_imputed = imputer.fit_transform(X)
+    # with max_iter=0, only initial imputation is performed
+    assert_allclose(X_imputed, imputer.initial_imputer_.transform(X))
+
+    # repeat but force n_iter_ to 0
+    imputer = IterativeImputer(max_iter=5).fit(X)
+    # transformed should not be equal to initial imputation
+    assert not np.all(imputer.transform(X) ==
+                      imputer.initial_imputer_.transform(X))
+
+    imputer.n_iter_ = 0
+    # now they should be equal as only initial imputation is done
+    assert_allclose(imputer.transform(X),
+                    imputer.initial_imputer_.transform(X))
+
+
+def test_iterative_imputer_verbose():
+    n = 10
+    d = 3
+    X = sparse_random_matrix(n, d, density=0.10).toarray()
+    imputer = IterativeImputer(missing_values=0, max_iter=1, verbose=1)
+    imputer.fit(X)
+    imputer.verbose = 2
+    imputer.transform(X)
+
+
 @pytest.mark.parametrize(
     "imputation_order",
     ['random', 'roman', 'ascending', 'descending', 'arabic']

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -535,13 +535,24 @@ def test_iterative_imputer_zero_iters():
 
 
 def test_iterative_imputer_verbose():
-    n = 10
+    rng = np.random.RandomState(0)
+
+    n = 100
     d = 3
-    X = sparse_random_matrix(n, d, density=0.10).toarray()
+    X = sparse_random_matrix(n, d, density=0.10, random_state=rng).toarray()
     imputer = IterativeImputer(missing_values=0, max_iter=1, verbose=1)
     imputer.fit(X)
     imputer.verbose = 2
     imputer.transform(X)
+
+
+def test_iterative_imputer_all_missing():
+    n = 100
+    d = 3
+    X = np.zeros((n, d))
+    imputer = IterativeImputer(missing_values=0, max_iter=1)
+    X_imputed = imputer.fit_transform(X)
+    assert_allclose(X_imputed, imputer.initial_imputer_.transform(X))
 
 
 @pytest.mark.parametrize(

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -599,16 +599,15 @@ def test_iterative_imputer_clip_truncnorm():
     rng = np.random.RandomState(0)
     n = 100
     d = 10
-    max_iter = 2
     X = sparse_random_matrix(n, d, density=0.10, random_state=rng).toarray()
     X[:, 0] = 1
 
     imputer = IterativeImputer(missing_values=0,
-                               max_iter=max_iter,
+                               max_iter=2,
                                n_nearest_features=5,
                                sample_posterior=True,
-                               min_value=0,
-                               max_value=1,
+                               min_value=0.1,
+                               max_value=0.2,
                                verbose=1,
                                imputation_order='random',
                                random_state=rng)

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -817,14 +817,14 @@ def test_iterative_imputer_additive_matrix():
     assert_allclose(X_test_filled, X_test_est, rtol=1e-3, atol=0.01)
 
 
-@pytest.mark.parametrize("max_iter, tol, warning_type, warning", [
+@pytest.mark.parametrize("max_iter, tol, error_type, warning", [
     (-1, 1e-3, ValueError, 'should be a positive integer'),
     (1, -1e-3, ValueError, 'should be a non-negative float')
 ])
-def test_iterative_imputer_error_param(max_iter, tol, warning_type, warning):
+def test_iterative_imputer_error_param(max_iter, tol, error_type, warning):
     X = np.zeros((100, 2))
     imputer = IterativeImputer(max_iter=max_iter, tol=tol)
-    with pytest.raises(warning_type, match=warning):
+    with pytest.raises(error_type, match=warning):
         imputer.fit_transform(X)
 
 

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -532,7 +532,7 @@ def test_iterative_imputer_imputation_order(imputation_order):
     imputer.fit_transform(X)
     ordered_idx = [i.feat_idx for i in imputer.imputation_sequence_]
 
-    assert len(ordered_idx) // imputer.actual_iter \
+    assert len(ordered_idx) // imputer.n_iter_ \
         == imputer.n_features_with_missing_
 
     if imputation_order == 'roman':

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -771,7 +771,6 @@ def test_iterative_imputer_transform_recovery(rank):
     A = rng.rand(n, rank)
     B = rng.rand(rank, d)
     X_filled = np.dot(A, B)
-    # half is randomly missing
     nan_mask = rng.rand(n, d) < 0.5
     X_missing = X_filled.copy()
     X_missing[nan_mask] = np.nan


### PR DESCRIPTION
This PR addresses a number of discussion, most recently in #11977.

The main purpose of this PR is to provide automatic early stopping. We are going to be using the early stopping rule that is used in the missForest R package: 

> The stopping criterion γ is met as soon as the difference between the newly imputed data matrix and the previous one increases for the first time with respect to both variable types, if present.

This is a sensible criterion, and has the added benefit of not needing to specify a `tol`.

Note that this criterion is not applied when `sample_posterior=True` because there is no steady state.

This PR does a few more things:
1. Reorders the parameters list to be a bit more intuitive.
2. Fixes a bug when `sample_posterior=True` using `truncnormal` to sample from the posterior.