### PR TITLE
[MRG] Refactors tests to assert error message directly 

### DIFF
--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -586,10 +586,10 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
                 assert not hasattr(clf, 'predict_log_proba')
                 with pytest.raises(AttributeError) as excinfo:
                     clf.predict_proba
-                    assert message == str(excinfo.value)
+                assert message == str(excinfo.value)
                 with pytest.raises(AttributeError) as excinfo:
                     clf.predict_log_proba
-                    assert message == str(excinfo.value)
+                assert message == str(excinfo.value)
 
     def test_sgd_proba(self):
         # Check SGD.predict_proba

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -584,12 +584,12 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
                            "available for loss={!r}".format(loss))
                 assert not hasattr(clf, 'predict_proba')
                 assert not hasattr(clf, 'predict_log_proba')
-                with pytest.raises(AttributeError,
-                                   match=message):
+                with pytest.raises(AttributeError) as excinfo:
                     clf.predict_proba
-                with pytest.raises(AttributeError,
-                                   match=message):
+                    assert message == str(excinfo.value)
+                with pytest.raises(AttributeError) as excinfo:
                     clf.predict_log_proba
+                    assert message == str(excinfo.value)
 
     def test_sgd_proba(self):
         # Check SGD.predict_proba


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
When using the `match` regex parameter in `pytest.raises`, a message such as `hello world probability estimates are not available for loss='hinge'` would still match and pass the test. This PR asserts the error message directly.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->