### PR TITLE
MAINT: pin flake8 to stable version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       - run: ./build_tools/circle/checkout_merge_commit.sh
       - run:
           name: dependencies
-          command: sudo pip install flake8
+          command: sudo pip install flake8==3.6.0
       - run:
           name: flake8
           command: ./build_tools/circle/flake8_diff.sh


### PR DESCRIPTION
Currently, the linter build is falling because of `flake8`. I would suggest pinning the version until the fix is in the next release. I will open an issue upstream to solve the problem.