### PR TITLE
[MRG] t-SNE perplexity docstring update

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -507,7 +507,8 @@ class TSNE(BaseEstimator):
         The perplexity is related to the number of nearest neighbors that
         is used in other manifold learning algorithms. Larger datasets
         usually require a larger perplexity. Consider selecting a value
-        between 5 and 50. Different values can result in significanlty different results.
+        between 5 and 50. Different values can result in significanlty
+        different results.
 
     early_exaggeration : float, optional (default: 12.0)
         Controls how tight natural clusters in the original space are in

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -507,8 +507,7 @@ class TSNE(BaseEstimator):
         The perplexity is related to the number of nearest neighbors that
         is used in other manifold learning algorithms. Larger datasets
         usually require a larger perplexity. Consider selecting a value
-        between 5 and 50. While the choice is not extremely critical, results
-        have been shown to change considerably across perplexity values.
+        between 5 and 50. Different values can result in significanlty different results.
 
     early_exaggeration : float, optional (default: 12.0)
         Controls how tight natural clusters in the original space are in

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -507,8 +507,8 @@ class TSNE(BaseEstimator):
         The perplexity is related to the number of nearest neighbors that
         is used in other manifold learning algorithms. Larger datasets
         usually require a larger perplexity. Consider selecting a value
-        between 5 and 50. The choice is not extremely critical since t-SNE
-        is quite insensitive to this parameter.
+        between 5 and 50. While the choice is not extremely critical, results
+        have been shown to change considerably across perplexity values.
 
     early_exaggeration : float, optional (default: 12.0)
         Controls how tight natural clusters in the original space are in


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses #13040 

#### What does this implement/fix? Explain your changes.
Updating the perplexity parameter docstring in order to show that the perplexity value does impact the results more than what the current docstring implied.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
