### PR TITLE
CI: remove flake8 pinning in circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       - run: ./build_tools/circle/checkout_merge_commit.sh
       - run:
           name: dependencies
-          command: sudo pip install flake8==3.6.0
+          command: sudo pip install flake8
       - run:
           name: flake8
           command: ./build_tools/circle/flake8_diff.sh


### PR DESCRIPTION
Revert the pinning of flake8.

The bug has been fixed and 3.7.2 is out.