### PR TITLE
[MRG] Ignore PendingDepWarnings of matrix subclass with pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,9 @@ addopts =
     --disable-pytest-warnings
     -rs
 
+filterwarnings =
+    ignore:the matrix subclass:PendingDeprecationWarning
+
 [wheelhouse_uploader]
 artifact_indexes=
     # Wheels built by travis (only for specific tags):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Partially addresses #12327

#### What does this implement/fix? Explain your changes.

numpy is deprecating the use of the `matrix` class.
scipy still uses it extensively, and has filtered out the related pending deprecation warnings in https://github.com/scipy/scipy/pull/8887.

However these warnings still show up (for a reason that I don't understand) in pytest (https://github.com/scipy/scipy/issues/9734).

This PR makes pytest ignore these warnings and avoids incredibly long logs in appveyor.

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
