### PR TITLE
MNT redundant from __future__ import

### DIFF
--- a/sklearn/utils/_random.pyx
+++ b/sklearn/utils/_random.pyx
@@ -13,7 +13,6 @@ The module contains:
     * Several algorithms to sample integers without replacement.
 
 """
-from __future__ import division
 cimport cython
 
 import numpy as np

--- a/sklearn/utils/_random.pyx
+++ b/sklearn/utils/_random.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=3
 # cython: boundscheck=False
 # cython: wraparound=False
 #


### PR DESCRIPTION
Closes #12779, missing in #12791
Remove all from __future__ imports (apart from ``sklearn/externals/``)