### PR TITLE
CI install pillow in Travis cron job

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -101,6 +101,8 @@ elif [[ "$DISTRIB" == "scipy-dev" ]]; then
     echo "Installing joblib master"
     pip install https://github.com/joblib/joblib/archive/master.zip
     export SKLEARN_SITE_JOBLIB=1
+    echo "Installing pillow master"
+    pip install https://github.com/python-pillow/Pillow/archive/master.zip
     pip install pytest pytest-cov
 fi
 


### PR DESCRIPTION
Resolves Travis cron job failure in master.
See https://travis-ci.org/scikit-learn/scikit-learn/builds/488111910
We install pillow in other Travis jobs (and other CIs), so I think it's reasonable to install it in Travis cron job.
