### PR TITLE
CI install pillow in pypy job

### DIFF
--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -22,7 +22,7 @@ which python
 #      compatibility is resolved for numpy v1.6.x. For instance,
 #      when PyPy3 >6.0 is released (see numpy/numpy#12740)
 pip install --extra-index https://antocuni.github.io/pypy-wheels/ubuntu "numpy==1.15.*" Cython pytest
-pip install "scipy>=1.1.0" sphinx numpydoc docutils joblib
+pip install "scipy>=1.1.0" sphinx numpydoc docutils joblib pillow
 
 ccache -M 512M
 export CCACHE_COMPRESS=1


### PR DESCRIPTION
Resolves pypy job failure in master.
See https://circleci.com/gh/scikit-learn/scikit-learn/45605
We install pillow in other Circle jobs (and other CIs), so I think it's reasonable to install it in pypy job.
Unable to test (See #13014).