### PR TITLE
MNT Remove utils.fixes.euler_gamma

### DIFF
--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -3,13 +3,11 @@
 # License: BSD 3 clause
 
 
-import numpy as np
-from warnings import warn
-from sklearn.utils.fixes import euler_gamma
-
-from scipy.sparse import issparse
-
 import numbers
+import numpy as np
+from scipy.sparse import issparse
+from warnings import warn
+
 from ..tree import ExtraTreeRegressor
 from ..utils import check_random_state, check_array
 from ..utils.fixes import _joblib_parallel_args
@@ -443,7 +441,7 @@ def _average_path_length(n_samples_leaf):
         if n_samples_leaf <= 1:
             return 1.
         else:
-            return 2. * (np.log(n_samples_leaf - 1.) + euler_gamma) - 2. * (
+            return 2. * (np.log(n_samples_leaf - 1.) + np.euler_gamma) - 2. * (
                 n_samples_leaf - 1.) / n_samples_leaf
 
     else:
@@ -457,7 +455,7 @@ def _average_path_length(n_samples_leaf):
 
         average_path_length[mask] = 1.
         average_path_length[not_mask] = 2. * (
-            np.log(n_samples_leaf[not_mask] - 1.) + euler_gamma) - 2. * (
+            np.log(n_samples_leaf[not_mask] - 1.) + np.euler_gamma) - 2. * (
                 n_samples_leaf[not_mask] - 1.) / n_samples_leaf[not_mask]
 
         return average_path_length.reshape(n_samples_leaf_shape)

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -10,7 +10,6 @@ import pytest
 
 import numpy as np
 
-from sklearn.utils.fixes import euler_gamma
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
@@ -264,8 +263,8 @@ def test_iforest_average_path_length():
     # It tests non-regression for #8549 which used the wrong formula
     # for average path length, strictly for the integer case
 
-    result_one = 2. * (np.log(4.) + euler_gamma) - 2. * 4. / 5.
-    result_two = 2. * (np.log(998.) + euler_gamma) - 2. * 998. / 999.
+    result_one = 2. * (np.log(4.) + np.euler_gamma) - 2. * 4. / 5.
+    result_two = 2. * (np.log(998.) + np.euler_gamma) - 2. * 998. / 999.
     assert_almost_equal(_average_path_length(1), 1., decimal=10)
     assert_almost_equal(_average_path_length(5), result_one, decimal=10)
     assert_almost_equal(_average_path_length(999), result_two, decimal=10)

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -29,10 +29,6 @@ def _parse_version(version_string):
     return tuple(version)
 
 
-# < numpy 1.8.0
-euler_gamma = getattr(np, 'euler_gamma',
-                      0.577215664901532860606512090082402431)
-
 np_version = _parse_version(np.__version__)
 sp_version = _parse_version(scipy.__version__)
 


### PR DESCRIPTION
np.euler_gamma is introduced in numpy 1.8.0. Our minimal requirement is 1.11.0.
We've decided that we can remove things in utils.fixes directly.