### PR TITLE
[MRG] ENH Quantile bin support for calibration_curve

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -43,6 +43,14 @@ Support for Python 3.4 and below has been officially dropped.
     section should be ordered according to the label ordering above. Entries
     should end with: :issue:`123456` by :user:`Joe Bloggs <joeongithub>`.
 
+:mod:`sklearn.calibration`
+..........................
+
+- |Enhancement| Added support to bin the data passed into
+  :class:`calibration.calibration_curve` by quantiles instead of uniformly
+  between 0 and 1.
+  :issue:`13086` by :user:`Scott Cole <srcole>`.
+
 :mod:`sklearn.cluster`
 ......................
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -520,7 +520,7 @@ class _SigmoidCalibration(BaseEstimator, RegressorMixin):
 
 
 def calibration_curve(y_true, y_prob, normalize=False, n_bins=5,
-                      quantile_split=False):
+                      strategy='uniform'):
     """Compute true and predicted probabilities for a calibration curve.
 
      The method assumes the inputs come from a binary classifier.
@@ -547,11 +547,12 @@ def calibration_curve(y_true, y_prob, normalize=False, n_bins=5,
         points (i.e. without corresponding values in y_prob) will not be
         returned, thus there may be fewer than n_bins in the return value.
 
-    quantile_split : bool, optional, default=False
-        Whether the probability space should be split into equally-spaced
-        bin edges, (i.e., 0, 0.2, 0.4, 0.6, 0.8, 1.0). If True, the bin
-        edges be chosen in order to split the data into roughly equally
-        sized bins.
+    strategy : {'uniform', 'quantile'}, (default='uniform')
+        Strategy used to define the widths of the bins.
+        uniform
+            All bins in each feature have identical widths.
+        quantile
+            All bins in each feature have the same number of points.
 
     Returns
     -------
@@ -579,11 +580,14 @@ def calibration_curve(y_true, y_prob, normalize=False, n_bins=5,
 
     y_true = _check_binary_probabilistic_predictions(y_true, y_prob)
 
-    if quantile_split:  # Determine bin edges by distribution of data
+    if strategy == 'quantile':  # Determine bin edges by distribution of data
         quantiles = np.linspace(0, 1, n_bins + 1)
-        bins = np.quantile(y_prob, quantiles)
-    else:
+        bins = np.percentile(y_prob, quantiles * 100)
+    elif strategy == 'uniform':
         bins = np.linspace(0., 1. + 1e-8, n_bins + 1)
+    else:
+        raise ValueError("Invalid entry to 'strategy' input. Strategy "
+                         "must be either 'quantile' or 'uniform'.")
 
     binids = np.digitize(y_prob, bins) - 1
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -549,10 +549,11 @@ def calibration_curve(y_true, y_prob, normalize=False, n_bins=5,
 
     strategy : {'uniform', 'quantile'}, (default='uniform')
         Strategy used to define the widths of the bins.
+
         uniform
-            All bins in each feature have identical widths.
+            All bins have identical widths.
         quantile
-            All bins in each feature have the same number of points.
+            All bins have the same number of points.
 
     Returns
     -------

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -519,7 +519,8 @@ class _SigmoidCalibration(BaseEstimator, RegressorMixin):
         return expit(-(self.a_ * T + self.b_))
 
 
-def calibration_curve(y_true, y_prob, normalize=False, n_bins=5, quantile_split=False):
+def calibration_curve(y_true, y_prob, normalize=False, n_bins=5,
+                      quantile_split=False):
     """Compute true and predicted probabilities for a calibration curve.
 
      The method assumes the inputs come from a binary classifier.

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -519,7 +519,7 @@ class _SigmoidCalibration(BaseEstimator, RegressorMixin):
         return expit(-(self.a_ * T + self.b_))
 
 
-def calibration_curve(y_true, y_prob, normalize=False, n_bins=5):
+def calibration_curve(y_true, y_prob, normalize=False, n_bins=5, quantile_split=False):
     """Compute true and predicted probabilities for a calibration curve.
 
      The method assumes the inputs come from a binary classifier.
@@ -545,6 +545,12 @@ def calibration_curve(y_true, y_prob, normalize=False, n_bins=5):
         Number of bins. A bigger number requires more data. Bins with no data
         points (i.e. without corresponding values in y_prob) will not be
         returned, thus there may be fewer than n_bins in the return value.
+
+    quantile_split : bool, optional, default=False
+        Whether the probability space should be split into equally-spaced
+        bin edges, (i.e., 0, 0.2, 0.4, 0.6, 0.8, 1.0). If True, the bin
+        edges be chosen in order to split the data into roughly equally
+        sized bins.
 
     Returns
     -------
@@ -572,7 +578,12 @@ def calibration_curve(y_true, y_prob, normalize=False, n_bins=5):
 
     y_true = _check_binary_probabilistic_predictions(y_true, y_prob)
 
-    bins = np.linspace(0., 1. + 1e-8, n_bins + 1)
+    if quantile_split:  # Determine bin edges by distribution of data
+        quantiles = np.linspace(0, 1, n_bins + 1)
+        bins = np.quantile(y_prob, quantiles)
+    else:
+        bins = np.linspace(0., 1. + 1e-8, n_bins + 1)
+
     binids = np.digitize(y_prob, bins) - 1
 
     bin_sums = np.bincount(binids, weights=y_prob, minlength=len(bins))

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -583,6 +583,7 @@ def calibration_curve(y_true, y_prob, normalize=False, n_bins=5,
     if strategy == 'quantile':  # Determine bin edges by distribution of data
         quantiles = np.linspace(0, 1, n_bins + 1)
         bins = np.percentile(y_prob, quantiles * 100)
+        bins[-1] = bins[-1] + 1e-8
     elif strategy == 'uniform':
         bins = np.linspace(0., 1. + 1e-8, n_bins + 1)
     else:

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -263,7 +263,7 @@ def test_calibration_curve():
     y_true2 = np.array([0, 0, 0, 0, 1, 1])
     y_pred2 = np.array([0., 0.1, 0.2, 0.5, 0.9, 1.])
     prob_true_quantile, prob_pred_quantile = \
-        calibration_curve(y_true2, y_pred2, n_bins=2, quantile_split=True)
+        calibration_curve(y_true2, y_pred2, n_bins=2, strategy='quantile')
 
     assert_equal(len(prob_true_quantile), len(prob_pred_quantile))
     assert_equal(len(prob_true_quantile), 2)

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -259,6 +259,17 @@ def test_calibration_curve():
     assert_raises(ValueError, calibration_curve, [1.1], [-0.1],
                   normalize=False)
 
+    # test that quantiles work as expected
+    y_true2 = np.array([0, 0, 0, 0, 1, 1])
+    y_pred2 = np.array([0., 0.1, 0.2, 0.5, 0.9, 1.])
+    prob_true_quantile, prob_pred_quantile = \
+        calibration_curve(y_true2, y_pred2, n_bins=2, quantile_split=True)
+
+    assert_equal(len(prob_true_quantile), len(prob_pred_quantile))
+    assert_equal(len(prob_true_quantile), 2)
+    assert_almost_equal(prob_true_quantile, [0, 2 / 3])
+    assert_almost_equal(prob_pred_quantile, [0.1, 0.8])
+
 
 def test_calibration_nan_imputer():
     """Test that calibration can accept nan"""

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -266,10 +266,14 @@ def test_calibration_curve():
         y_true2, y_pred2, n_bins=2, strategy='quantile')
         calibration_curve(y_true2, y_pred2, n_bins=2, strategy='quantile')
 
-    assert_equal(len(prob_true_quantile), len(prob_pred_quantile))
-    assert_equal(len(prob_true_quantile), 2)
+    assert len(prob_true_quantile) == len(prob_pred_quantile)
+    assert len(prob_true_quantile) == 2
     assert_almost_equal(prob_true_quantile, [0, 2 / 3])
     assert_almost_equal(prob_pred_quantile, [0.1, 0.8])
+    
+    # Check that error is raised when invalid strategy is selected
+    assert_raises(ValueError, calibration_curve, y_true2, y_pred2,
+                  strategy='percentile')
 
 
 def test_calibration_nan_imputer():

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -264,7 +264,6 @@ def test_calibration_curve():
     y_pred2 = np.array([0., 0.1, 0.2, 0.5, 0.9, 1.])
     prob_true_quantile, prob_pred_quantile = calibration_curve(
         y_true2, y_pred2, n_bins=2, strategy='quantile')
-        calibration_curve(y_true2, y_pred2, n_bins=2, strategy='quantile')
 
     assert len(prob_true_quantile) == len(prob_pred_quantile)
     assert len(prob_true_quantile) == 2

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -262,7 +262,8 @@ def test_calibration_curve():
     # test that quantiles work as expected
     y_true2 = np.array([0, 0, 0, 0, 1, 1])
     y_pred2 = np.array([0., 0.1, 0.2, 0.5, 0.9, 1.])
-    prob_true_quantile, prob_pred_quantile = \
+    prob_true_quantile, prob_pred_quantile = calibration_curve(
+        y_true2, y_pred2, n_bins=2, strategy='quantile')
         calibration_curve(y_true2, y_pred2, n_bins=2, strategy='quantile')
 
     assert_equal(len(prob_true_quantile), len(prob_pred_quantile))

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -269,7 +269,7 @@ def test_calibration_curve():
     assert len(prob_true_quantile) == 2
     assert_almost_equal(prob_true_quantile, [0, 2 / 3])
     assert_almost_equal(prob_pred_quantile, [0.1, 0.8])
-    
+
     # Check that error is raised when invalid strategy is selected
     assert_raises(ValueError, calibration_curve, y_true2, y_pred2,
                   strategy='percentile')


### PR DESCRIPTION
Fixes #13086

As discussed in issue #13086, I’ve added support for the bins in calibration_curve to be set by equally separated quantiles of the data.

To do this, I added a new kwarg, `quantile_split` which is False by default, but adds the functionality when it is set to True.

I added a simple test for the functionality within tests.test_calibration.test_calibration_curve that mimics the tests for the basic functionality.

Any suggestions for changes? Should we add a more illustrative example to the examples pages?