### PR TITLE
change from 'means_prior' to  'mean_prior'

### DIFF
--- a/sklearn/mixture/bayesian_mixture.py
+++ b/sklearn/mixture/bayesian_mixture.py
@@ -266,7 +266,7 @@ class BayesianGaussianMixture(BaseMixture):
     mean_precision_ : array-like, shape (n_components,)
         The precision of each components on the mean distribution (Gaussian).
 
-    means_prior_ : array-like, shape (n_features,)
+    mean_prior_ : array-like, shape (n_features,)
         The prior on the mean distribution (Gaussian).
 
     degrees_of_freedom_prior_ : float

--- a/sklearn/mixture/tests/test_bayesian_mixture.py
+++ b/sklearn/mixture/tests/test_bayesian_mixture.py
@@ -118,7 +118,7 @@ def test_bayesian_mixture_weights_prior_initialisation():
     assert_almost_equal(1. / n_components, bgmm.weight_concentration_prior_)
 
 
-def test_bayesian_mixture_means_prior_initialisation():
+def test_bayesian_mixture_mean_prior_initialisation():
     rng = np.random.RandomState(0)
     n_samples, n_components, n_features = 10, 3, 2
     X = rng.rand(n_samples, n_features)


### PR DESCRIPTION


#### Reference Issues/PRs

#13088

#### What does this implement/fix? Explain your changes.

There is 'means_prior_' in [bayesian_mixture.py](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/mixture/bayesian_mixture.py#L269) Attributes.

change from 
```python
269    means_prior_ : array-like, shape (n_features,)
270        The prior on the mean distribution (Gaussian).
```

to

```python
269    mean_prior_ : array-like, shape (n_features,)
270        The prior on the mean distribution (Gaussian).
```
, and

in [test_bayesian_mixture.py](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/mixture/tests/test_bayesian_mixture.py )

change from
```python
121    def test_bayesian_mixture_means_prior_initialisation():
```

to

```python
121    def test_bayesian_mixture_mean_prior_initialisation():
```
.

#### Any other comments?
Sorry, I erased the branch of local before merge......
#13089