### PR TITLE
increase verbosity threshold for cross validation

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -477,7 +477,7 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     estimator : estimator object
         The fitted estimator
     """
-    if verbose > 1:
+    if verbose > 2:
         if parameters is None:
             msg = ''
         else:


### PR DESCRIPTION

#### Reference Issues/PRs
Fixes https://github.com/scikit-learn/scikit-learn/issues/12958

#### What does this implement/fix? Explain your changes.
Increase the verbosity threshold of cross validation from `> 1` to `> 2`.

Currently verbosity level 1 prints:

```
[Parallel(n_jobs=-1)]: Using backend LokyBackend with 8 concurrent workers.
[Parallel(n_jobs=-1)]: Done  30 out of  30 | elapsed: 46.5min finished
```

and verbosity level 2 prints:

```
[Parallel(n_jobs=-1)]: Using backend LokyBackend with 8 concurrent workers.
[Parallel(n_jobs=-1)]: Done   1 out of  10 | elapsed:   40.9s remaining:  2.7min
[CV] estimator__alpha=1.356430250055455e-06 ..........................
[CV] estimator__alpha=1.356430250055455e-06 ..........................
[CV] estimator__alpha=8.022557928125194e-06 ..........................
[CV] estimator__alpha=1.1751658491093436e-05 .........................
[CV] estimator__alpha=1.1751658491093436e-05 .........................
[CV] estimator__alpha=1.1751658491093436e-05 .........................
[CV] estimator__alpha=1.356430250055455e-06 ..........................
[CV] estimator__alpha=8.022557928125194e-06 ..........................
[Parallel(n_jobs=-1)]: Done   2 out of  10 | elapsed:   40.9s remaining:  2.7min
...
[Parallel(n_jobs=-1)]: Done  30 out of  30 | elapsed: 46.5min finished

```

After this change, verbosity level 2 will only print each joblib iteration:

```
[Parallel(n_jobs=-1)]: Using backend LokyBackend with 8 concurrent workers.
[Parallel(n_jobs=-1)]: Done   1 out of  10 | elapsed:   40.9s remaining:  2.7min
[Parallel(n_jobs=-1)]: Done   2 out of  10 | elapsed:   40.9s remaining:  2.7min
....
[Parallel(n_jobs=-1)]: Done  30 out of  30 | elapsed: 46.5min finished
```

**Goal**: I want to see when each iteration completes but don't want to liter the logs with all the intermediate alphas. This change will allow me to now do that at verbosity level 2.