### PR TITLE
[MRG] DOC Adds _pairwise property to dev docs

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -115,7 +115,7 @@ following rules before submitting:
    `new algorithm requirements
    <http://scikit-learn.org/stable/faq.html#what-are-the-inclusion-criteria-for-new-algorithms>`_.
 
--  If you are submitting a bug report, we strongly encourage you to follow the guidelines in 
+-  If you are submitting a bug report, we strongly encourage you to follow the guidelines in
    :ref:`filing_bugs`.
 
 .. _filing_bugs:
@@ -193,7 +193,7 @@ then submit a "pull request" (PR):
     account on the GitHub user account. For more details on how to fork a
     repository see `this guide <https://help.github.com/articles/fork-a-repo/>`_.
 
- 3. Clone your fork of the scikit-learn repo from your GitHub account to your 
+ 3. Clone your fork of the scikit-learn repo from your GitHub account to your
     local disk::
 
         $ git clone git@github.com:YourLogin/scikit-learn.git
@@ -203,7 +203,7 @@ then submit a "pull request" (PR):
 
         $ pip install --editable .
 
-    for more details about advanced installation, see the 
+    for more details about advanced installation, see the
     :ref:`install_bleeding_edge` section.
 
  5. Create a branch to hold your development changes::
@@ -342,8 +342,8 @@ rules before submitting a pull request:
   documentation, see the :ref:`contribute_documentation` section.
 
 * The documentation should also include expected time and space complexity
-  of the algorithm and scalability, e.g. "this algorithm can scale to a 
-  large number of samples > 100000, but does not scale in dimensionality: 
+  of the algorithm and scalability, e.g. "this algorithm can scale to a
+  large number of samples > 100000, but does not scale in dimensionality:
   n_features is expected to be lower than 100".
 
 You can also check for common programming errors with the following tools:
@@ -390,7 +390,7 @@ Continuous Integration (CI)
 * Travis is used for testing on Linux platforms
 * Appveyor is used for testing on Windows platforms
 * CircleCI is used to build the docs for viewing, for linting with flake8, and
-    for testing with PyPy on Linux 
+    for testing with PyPy on Linux
 
 Please note that if one of the following markers appear in the latest commit
 message, the following actions are taken.
@@ -489,7 +489,7 @@ documents live in the source code repository under the ``doc/`` directory.
 
 You can edit the documentation using any text editor, and then generate the
 HTML output by typing ``make html`` from the ``doc/`` directory. Alternatively,
-``make`` can be used to quickly generate the documentation without the example 
+``make`` can be used to quickly generate the documentation without the example
 gallery. The resulting HTML files will be placed in ``_build/html/stable`` and are viewable
 in a web browser. See the ``README``file in the ``doc/`` directory for more information.
 
@@ -548,10 +548,10 @@ details, and give intuition to the reader on what the algorithm does.
 
 Basically, to elaborate on the above, it is best to always
 start with a small paragraph with a hand-waving explanation of what the
-method does to the data. Then, it is very helpful to point out why the feature is 
+method does to the data. Then, it is very helpful to point out why the feature is
 useful and when it should be used - the latter also including "big O"
-(:math:`O\left(g\left(n\right)\right)`) complexities of the algorithm, as opposed 
-to just *rules of thumb*, as the latter can be very machine-dependent. If those 
+(:math:`O\left(g\left(n\right)\right)`) complexities of the algorithm, as opposed
+to just *rules of thumb*, as the latter can be very machine-dependent. If those
 complexities are not available, then rules of thumb may be provided instead.
 
 Secondly, a generated figure from an example (as mentioned in the previous
@@ -1228,11 +1228,11 @@ an integer called ``n_iter``.
 Pairwise Attributes
 ^^^^^^^^^^^^^^^^^^^
 
-Estimators that accept ``X`` of shape ``(n_samples, n_samples)`` and defines a
-``_pairwise`` property equal to ``True`` allows for cross-validation of the
-dataset. (e.g., when ``X`` is a precomputed kernel matrix). Specifically, the
-``_pairwise`` property is used by
-``utils.metaestimators._safe_split`` to slice rows and columns.
+An estimator that accept ``X`` of shape ``(n_samples, n_samples)`` and defines
+a :term:`_pairwise` property equal to ``True`` allows for cross-validation of
+the dataset. (e.g., when ``X`` is a precomputed kernel matrix). Specifically,
+the :term:`_pairwise` property is used by ``utils.metaestimators._safe_split``
+to slice rows and columns.
 
 Rolling your own estimator
 ==========================

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1225,6 +1225,14 @@ Optional Arguments
 In iterative algorithms, the number of iterations should be specified by
 an integer called ``n_iter``.
 
+Pairwise Attributes
+^^^^^^^^^^^^^^^^^^^
+
+Estimators that accept ``X`` of shape ``(n_samples, n_samples)`` and defines a
+``_pairwise`` property equal to ``True`` allows for cross-validation of the
+dataset. (e.g., when ``X`` is a precomputed kernel matrix). Specifically, the
+``_pairwise`` property is used by
+``utils.metaestimators._safe_split`` to slice rows and columns.
 
 Rolling your own estimator
 ==========================

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1230,7 +1230,7 @@ Pairwise Attributes
 
 An estimator that accept ``X`` of shape ``(n_samples, n_samples)`` and defines
 a :term:`_pairwise` property equal to ``True`` allows for cross-validation of
-the dataset. (e.g., when ``X`` is a precomputed kernel matrix). Specifically,
+the dataset, e.g. when ``X`` is a precomputed kernel matrix. Specifically,
 the :term:`_pairwise` property is used by ``utils.metaestimators._safe_split``
 to slice rows and columns.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes https://github.com/scikit-learn/scikit-learn/issues/5493
Continues https://github.com/scikit-learn/scikit-learn/pull/8520

#### What does this implement/fix? Explain your changes.
Adds details on the `_pairwise` property and the function, `utils.metaestimators._safe_split`, that uses the property.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->