### PR TITLE
Fixes for #10890: `_pairwise_callable` function doesn't work with pairwise metrics functions from sklearn itself

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1582,7 +1582,6 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
         if filter_params:
             kwds = dict((k, kwds[k]) for k in kwds
                         if k in KERNEL_PARAMS[metric])
-        func = PAIRWISE_KERNEL_FUNCTIONS[metric]
         func = metric
     elif callable(metric):
         func = partial(_pairwise_callable, metric=metric, **kwds)

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1578,6 +1578,12 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
             kwds = dict((k, kwds[k]) for k in kwds
                         if k in KERNEL_PARAMS[metric])
         func = PAIRWISE_KERNEL_FUNCTIONS[metric]
+    elif metric in PAIRWISE_KERNEL_FUNCTIONS.values():
+        if filter_params:
+            kwds = dict((k, kwds[k]) for k in kwds
+                        if k in KERNEL_PARAMS[metric])
+        func = PAIRWISE_KERNEL_FUNCTIONS[metric]
+        func = metric
     elif callable(metric):
         func = partial(_pairwise_callable, metric=metric, **kwds)
     else:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs #10890 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Check if the metric is in `PAIRWISE_KERNEL_FUNCTIONS.values()` in addition to `PAIRWISE_KERNEL_FUNCTIONS.values.keys()`.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->