### PR TITLE
FIX Shuffle each class's samples with different random_state in StratifiedKFold

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -55,8 +55,8 @@ Changelog
 :mod:`sklearn.model_selection`
 ..............................
 
-- |Fix| Fixed a bug where :class:`model_selection.StratifiedKFold` always
-  produce the same splits with different ``random_state``.
+- |Fix| Fixed a bug where :class:`model_selection.StratifiedKFold`
+  shuffle each stratification with the same ``random_state``. 
   :issue:`13124` by :user:`Hanmin Qin <qinhanmin2014>`.
 
 :mod:`sklearn.preprocessing`

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -52,13 +52,6 @@ Changelog
   :class:`linear_model.MultiTaskLasso` which were breaking when
   ``warm_start = True``. :issue:`12360` by :user:`Aakanksha Joshi <joaak>`.
 
-:mod:`sklearn.model_selection`
-..............................
-
-- |Fix| Fixed a bug where :class:`model_selection.StratifiedKFold`
-  shuffle each stratification with the same ``random_state``. 
-  :issue:`13124` by :user:`Hanmin Qin <qinhanmin2014>`.
-
 :mod:`sklearn.preprocessing`
 ............................
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -52,6 +52,13 @@ Changelog
   :class:`linear_model.MultiTaskLasso` which were breaking when
   ``warm_start = True``. :issue:`12360` by :user:`Aakanksha Joshi <joaak>`.
 
+:mod:`sklearn.model_selection`
+..............................
+
+- |Fix| Fixed a bug where :class:`model_selection.StratifiedKFold` always
+  produce the same splits with different ``random_state``.
+  :issue:`13124` by :user:`Hanmin Qin <qinhanmin2014>`.
+
 :mod:`sklearn.preprocessing`
 ............................
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -201,7 +201,7 @@ Support for Python 3.4 and below has been officially dropped.
   :issue:`12613` and :issue:`12669` by :user:`Marc Torrellas <marctorrellas>`.
 
 - |Fix| Fixed a bug where :class:`model_selection.StratifiedKFold`
-  shuffle each stratification with the same ``random_state``. 
+  shuffles each stratification with the same ``random_state``.
   :issue:`13124` by :user:`Hanmin Qin <qinhanmin2014>`.
 
 :mod:`sklearn.neighbors`

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -201,7 +201,8 @@ Support for Python 3.4 and below has been officially dropped.
   :issue:`12613` and :issue:`12669` by :user:`Marc Torrellas <marctorrellas>`.
 
 - |Fix| Fixed a bug where :class:`model_selection.StratifiedKFold`
-  shuffles each stratification with the same ``random_state``.
+  shuffles each class's samples with the same ``random_state``,
+  making ``shuffle=True`` ineffective.
   :issue:`13124` by :user:`Hanmin Qin <qinhanmin2014>`.
 
 :mod:`sklearn.neighbors`

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -200,6 +200,10 @@ Support for Python 3.4 and below has been officially dropped.
   :func:`~model_selection.validation_curve` only the latter is required.
   :issue:`12613` and :issue:`12669` by :user:`Marc Torrellas <marctorrellas>`.
 
+- |Fix| Fixed a bug where :class:`model_selection.StratifiedKFold`
+  shuffle each stratification with the same ``random_state``. 
+  :issue:`13124` by :user:`Hanmin Qin <qinhanmin2014>`.
+
 :mod:`sklearn.neighbors`
 ........................
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -620,10 +620,9 @@ class StratifiedKFold(_BaseKFold):
         super().__init__(n_splits, shuffle, random_state)
 
     def _make_test_folds(self, X, y=None):
-        if self.shuffle:
-            rng = check_random_state(self.random_state)
-        else:
-            rng = self.random_state
+        # Ensure that we do not always produce the same splits
+        # with different random_state
+        rng = check_random_state(self.random_state)
         y = np.asarray(y)
         type_of_target_y = type_of_target(y)
         allowed_target_types = ('binary', 'multiclass')

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -620,8 +620,6 @@ class StratifiedKFold(_BaseKFold):
         super().__init__(n_splits, shuffle, random_state)
 
     def _make_test_folds(self, X, y=None):
-        # Ensure that we do not always produce the same splits
-        # with different random_state
         rng = check_random_state(self.random_state)
         y = np.asarray(y)
         type_of_target_y = type_of_target(y)

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -620,7 +620,10 @@ class StratifiedKFold(_BaseKFold):
         super().__init__(n_splits, shuffle, random_state)
 
     def _make_test_folds(self, X, y=None):
-        rng = self.random_state
+        if self.shuffle:
+            rng = check_random_state(self.random_state)
+        else:
+            rng = self.random_state
         y = np.asarray(y)
         type_of_target_y = type_of_target(y)
         allowed_target_types = ('binary', 'multiclass')

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -576,8 +576,7 @@ class StratifiedKFold(_BaseKFold):
             ``n_splits`` default value will change from 3 to 5 in v0.22.
 
     shuffle : boolean, optional
-        Whether to shuffle each stratification of the data before splitting
-        into batches.
+        Whether to shuffle each class's samples before splitting into batches.
 
     random_state : int, RandomState instance or None, optional, default=None
         If int, random_state is the seed used by the random number generator;

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -493,7 +493,7 @@ def test_shuffle_stratifiedkfold():
         assert_not_equal(set(test0), set(test1))
     check_cv_coverage(kf0, X_40, y, groups=None, expected_n_splits=5)
 
-    # Ensure that we shuffle each stratification with different
+    # Ensure that we shuffle each class's samples with different
     # random_state in StratifiedKFold
     # See https://github.com/scikit-learn/scikit-learn/pull/13124
     X = np.arange(10)

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -493,6 +493,17 @@ def test_shuffle_stratifiedkfold():
         assert_not_equal(set(test0), set(test1))
     check_cv_coverage(kf0, X_40, y, groups=None, expected_n_splits=5)
 
+    # Ensure that we shuffle each stratification with different
+    # random_state in StratifiedKFold
+    # See https://github.com/scikit-learn/scikit-learn/pull/13124
+    X = np.arange(10)
+    y = [0] * 5 + [1] * 5
+    kf1 = StratifiedKFold(5, shuffle=True, random_state=0)
+    kf2 = StratifiedKFold(5, shuffle=True, random_state=1)
+    test_set1 = sorted(list(map(lambda x: tuple(x[1]), kf1.split(X, y))))
+    test_set2 = sorted(list(map(lambda x: tuple(x[1]), kf2.split(X, y))))
+    assert test_set1 != test_set2
+
 
 def test_kfold_can_detect_dependent_samples_on_digits():  # see #2372
     # The digits samples are dependent: they are apparently grouped by authors

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -500,8 +500,8 @@ def test_shuffle_stratifiedkfold():
     y = [0] * 5 + [1] * 5
     kf1 = StratifiedKFold(5, shuffle=True, random_state=0)
     kf2 = StratifiedKFold(5, shuffle=True, random_state=1)
-    test_set1 = sorted(list(map(lambda x: tuple(x[1]), kf1.split(X, y))))
-    test_set2 = sorted(list(map(lambda x: tuple(x[1]), kf2.split(X, y))))
+    test_set1 = sorted([tuple(s[1]) for s in kf1.split(X, y)])
+    test_set2 = sorted([tuple(s[1]) for s in kf2.split(X, y)])
     assert test_set1 != test_set2
 
 


### PR DESCRIPTION
Fixes #13110 
Our StratifiedKFold shuffle each class's samples with same random_state (i.e., in the same way). This is not good IMO:
(1) We can only get certain splits.
```python
import numpy as np
from sklearn.model_selection import StratifiedKFold
X = np.arange(20)
y = [0] * 10 + [1] * 10
StratifiedKFold(n_splits=5, shuffle=True, random_state=XXX)
# all the test folds in the split will be [a, b, 10+a, 10+b]
```
(2) When there're only two samples in the groups, users will always get the same splits with different random_state.
```python
import numpy as np
from sklearn.model_selection import StratifiedKFold
X = np.arange(10)
y = [0] * 5 + [1] * 5
StratifiedKFold(n_splits=5, shuffle=True, random_state=XXX)
# the test folds will always be [[0, 5], [1, 6], [2, 7], [3, 8], [4, 9]]
```
Revert part of #7823, I think it's a regression introduced in 0.19, ping @jnothman @amueller 
