### PR TITLE
[MRG] FIX #10561: more tolerance in float equality for 0 bandwidth

### DIFF
--- a/sklearn/cluster/tests/test_mean_shift.py
+++ b/sklearn/cluster/tests/test_mean_shift.py
@@ -36,7 +36,7 @@ def test_estimate_bandwidth_1sample():
     # Test estimate_bandwidth when n_samples=1 and quantile<1, so that
     # n_neighbors is set to 1.
     bandwidth = estimate_bandwidth(X, n_samples=1, quantile=0.3)
-    assert_equal(bandwidth, 0.)
+    assert_array_almost_equal(bandwidth, 0., decimal=5)
 
 
 def test_mean_shift():


### PR DESCRIPTION
The test was new in 0.20, hence the new failure on some Debian platforms