### PR TITLE
FIX #13117: Remove multiple output from LinearModelCV doc

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1084,10 +1084,10 @@ class LinearModelCV(LinearModel, metaclass=ABCMeta):
             to avoid unnecessary memory duplication. If y is mono-output,
             X can be sparse.
 
-        y : array-like, shape 
-              - (n_samples,), valid for `ElasticNetCV` and `LassoCV`.
-              - (n_samples, n_tasks), valid for `MultiTaskElasticNetCV` and 
-                `MultitaskLassoCV`.
+        y : array-like,
+              - shape (n_samples,), valid for `ElasticNetCV` and `LassoCV`.
+              - shape (n_samples, n_tasks), valid for `MultiTaskElasticNetCV` 
+                and `MultitaskLassoCV`.
             Target values
         """
         y = check_array(y, copy=False, dtype=[np.float64, np.float32],

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1086,7 +1086,7 @@ class LinearModelCV(LinearModel, metaclass=ABCMeta):
 
         y : array-like, shape 
               - (n_samples,), valid for `ElasticNetCV` and `LassoCV`.
-              - (n_samples, n_targets), valid for `MultiTaskElasticNetCV` and `MultitaskLassoCV`.
+              - (n_samples, n_tasks), valid for `MultiTaskElasticNetCV` and `MultitaskLassoCV`.
             Target values
         """
         y = check_array(y, copy=False, dtype=[np.float64, np.float32],
@@ -1132,7 +1132,7 @@ class LinearModelCV(LinearModel, metaclass=ABCMeta):
         if isinstance(X, np.ndarray) or sparse.isspmatrix(X):
             # Keep a reference to X
             reference_to_old_X = X
-            # Let us not impose fortran ordering so far: it is
+            # Let us not impose fortran ordering so far: it isadrinjalali
             # not useful for the cross-validation loop and will be done
             # by the model fitting itself
             X = check_array(X, 'csc', copy=False)

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1084,7 +1084,9 @@ class LinearModelCV(LinearModel, metaclass=ABCMeta):
             to avoid unnecessary memory duplication. If y is mono-output,
             X can be sparse.
 
-        y : array-like, shape (n_samples,)
+        y : array-like, shape 
+              - (n_samples,), valid for `ElasticNetCV` and `LassoCV`.
+              - (n_samples, n_targets), valid for `MultiTaskElasticNetCV` and `MultitaskLassoCV`.
             Target values
         """
         y = check_array(y, copy=False, dtype=[np.float64, np.float32],

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1133,7 +1133,7 @@ class LinearModelCV(LinearModel, metaclass=ABCMeta):
         if isinstance(X, np.ndarray) or sparse.isspmatrix(X):
             # Keep a reference to X
             reference_to_old_X = X
-            # Let us not impose fortran ordering so far: it isadrinjalali
+            # Let us not impose fortran ordering so far: it is
             # not useful for the cross-validation loop and will be done
             # by the model fitting itself
             X = check_array(X, 'csc', copy=False)

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1086,7 +1086,8 @@ class LinearModelCV(LinearModel, metaclass=ABCMeta):
 
         y : array-like, shape 
               - (n_samples,), valid for `ElasticNetCV` and `LassoCV`.
-              - (n_samples, n_tasks), valid for `MultiTaskElasticNetCV` and `MultitaskLassoCV`.
+              - (n_samples, n_tasks), valid for `MultiTaskElasticNetCV` and 
+                `MultitaskLassoCV`.
             Target values
         """
         y = check_array(y, copy=False, dtype=[np.float64, np.float32],

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1084,7 +1084,7 @@ class LinearModelCV(LinearModel, metaclass=ABCMeta):
             to avoid unnecessary memory duplication. If y is mono-output,
             X can be sparse.
 
-        y : array-like, shape (n_samples,) or (n_samples, n_targets)
+        y : array-like, shape (n_samples,)
             Target values
         """
         y = check_array(y, copy=False, dtype=[np.float64, np.float32],


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #13117 

#### What does this implement/fix? Explain your changes.
Fixes documentation of class `LinearModelCV()`, since it there is a check that
does not allow `y` to have more than 1 dimension (multiple outputs)

#### Any other comments?
I thinks this could be improved, since both `ElasticNet()` and `Lasso()` support multiple targets. I don't see a reason why `LinearModelCV()` could not accept multiple targets as well.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
