### PR TITLE
[MRG] Fix #13134: Ensure sorted bin edges for KBinsDiscretizer strategy kmeans

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -55,6 +55,10 @@ Changelog
 :mod:`sklearn.preprocessing`
 ............................
 
+- |Fix| Fixed a bug in :class:`preprocessing.KBinsDiscretizer` where
+  ``strategy='kmeans'`` fails with an error during transformation due to unsorted
+  bin edges. :issue:`13134` by :user:`Sandro Casagrande <SandroCasagrande>`.
+
 - |Fix| Fixed a bug in :class:`preprocessing.OneHotEncoder` where the
   deprecation of ``categorical_features`` was handled incorrectly in
   combination with ``handle_unknown='ignore'``.

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -172,6 +172,8 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
                 # 1D k-means procedure
                 km = KMeans(n_clusters=n_bins[jj], init=init, n_init=1)
                 centers = km.fit(column[:, None]).cluster_centers_[:, 0]
+                # Must sort, centers may be unsorted even with sorted init
+                centers.sort()
                 bin_edges[jj] = (centers[1:] + centers[:-1]) * 0.5
                 bin_edges[jj] = np.r_[col_min, bin_edges[jj], col_max]
 

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -185,11 +185,12 @@ def test_invalid_strategy_option():
 
 
 @pytest.mark.parametrize(
-    'strategy, expected_2bins, expected_3bins',
-    [('uniform', [0, 0, 0, 0, 1, 1], [0, 0, 0, 0, 2, 2]),
-     ('kmeans', [0, 0, 0, 0, 1, 1], [0, 0, 1, 1, 2, 2]),
-     ('quantile', [0, 0, 0, 1, 1, 1], [0, 0, 1, 1, 2, 2])])
-def test_nonuniform_strategies(strategy, expected_2bins, expected_3bins):
+    'strategy, expected_2bins, expected_3bins, expected_5bins',
+    [('uniform', [0, 0, 0, 0, 1, 1], [0, 0, 0, 0, 2, 2], [0, 0, 1, 1, 4, 4]),
+     ('kmeans', [0, 0, 0, 0, 1, 1], [0, 0, 1, 1, 2, 2], [0, 0, 1, 2, 3, 4]),
+     ('quantile', [0, 0, 0, 1, 1, 1], [0, 0, 1, 1, 2, 2], [0, 1, 2, 3, 4, 4])])
+def test_nonuniform_strategies(
+        strategy, expected_2bins, expected_3bins, expected_5bins):
     X = np.array([0, 0.5, 2, 3, 9, 10]).reshape(-1, 1)
 
     # with 2 bins
@@ -201,6 +202,11 @@ def test_nonuniform_strategies(strategy, expected_2bins, expected_3bins):
     est = KBinsDiscretizer(n_bins=3, strategy=strategy, encode='ordinal')
     Xt = est.fit_transform(X)
     assert_array_equal(expected_3bins, Xt.ravel())
+
+    # with 5 bins
+    est = KBinsDiscretizer(n_bins=5, strategy=strategy, encode='ordinal')
+    Xt = est.fit_transform(X)
+    assert_array_equal(expected_5bins, Xt.ravel())
 
 
 @pytest.mark.parametrize('strategy', ['uniform', 'kmeans', 'quantile'])


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #13134

#### What does this implement/fix? Explain your changes.
Since centers returned by 1d kmeans can be unsorted, I simply added a sort before constructing the bin edges. I also added a test which reproduces the issue when not sorting centers. 

#### Any other comments?
Performance of sorting centers should not be an issue compared to kmeans itself. In most circumstances the list of centers is already sorted, but afaik in this situation checking if the numpy array is sorted is not better than invoking sort() directly (https://stackoverflow.com/questions/47004506/check-if-a-numpy-array-is-sorted), so I skipped the check.