### PR TITLE
ENH Remove useless operation in feature_importance_

### DIFF
--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1634,8 +1634,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                 normalize=False) for tree in stage) / len(stage)
             total_sum += stage_sum
 
-        importances = total_sum / len(self.estimators_)
-        importances /= importances.sum()
+        importances = total_sum / total_sum.sum()
         return importances
 
     def _validate_y(self, y, sample_weight):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
In https://github.com/scikit-learn/scikit-learn/pull/11176 the feature improtance computation was fixed, but a useless computation was left. The importance vector elements are first divided by a constant and then scaled over their sum. The first division is, hence, useless.

#### What does this implement/fix? Explain your changes.

The PR removes the useless division performed in feature important computation. This division is made meaningless by the subsequent re-scaling over the sum of all the entries of the importance vector.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

cc @ahmadia @gforsyth @glemaitre @jnothman @ogrisel who worked on that PR.