### PR TITLE
MNT Redundant check in regression metrics

### DIFF
--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -347,8 +347,7 @@ def median_absolute_error(y_true, y_pred):
     0.5
 
     """
-    y_type, y_true, y_pred, _ = _check_reg_targets(y_true, y_pred,
-                                                   'uniform_average')
+    y_type, y_true, y_pred, _ = _check_reg_targets(y_true, y_pred, None)
     if y_type == 'continuous-multioutput':
         raise ValueError("Multioutput not supported in median_absolute_error")
     return np.median(np.abs(y_pred - y_true))

--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -613,7 +613,6 @@ def max_error(y_true, y_pred):
     1
     """
     y_type, y_true, y_pred, _ = _check_reg_targets(y_true, y_pred, None)
-    check_consistent_length(y_true, y_pred)
     if y_type == 'continuous-multioutput':
         raise ValueError("Multioutput not supported in max_error")
     return np.max(np.abs(y_true - y_pred))


### PR DESCRIPTION
(1) Remove redundant check in ``median_absolute_error`` since multioutput is not supported.
(2) Remove redundant check in ``max_error`` since this check is included in _check_reg_targets.