### PR TITLE
removing _pprint function

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -62,57 +62,6 @@ def clone(estimator, safe=True):
 
 
 ###############################################################################
-def _pprint(params, offset=0, printer=repr):
-    """Pretty print the dictionary 'params'
-
-    Parameters
-    ----------
-    params : dict
-        The dictionary to pretty print
-
-    offset : int
-        The offset in characters to add at the begin of each line.
-
-    printer : callable
-        The function to convert entries to strings, typically
-        the builtin str or repr
-
-    """
-    # Do a multi-line justified repr:
-    options = np.get_printoptions()
-    np.set_printoptions(precision=5, threshold=64, edgeitems=2)
-    params_list = list()
-    this_line_length = offset
-    line_sep = ',\n' + (1 + offset // 2) * ' '
-    for i, (k, v) in enumerate(sorted(params.items())):
-        if type(v) is float:
-            # use str for representing floating point numbers
-            # this way we get consistent representation across
-            # architectures and versions.
-            this_repr = '%s=%s' % (k, str(v))
-        else:
-            # use repr of the rest
-            this_repr = '%s=%s' % (k, printer(v))
-        if len(this_repr) > 500:
-            this_repr = this_repr[:300] + '...' + this_repr[-100:]
-        if i > 0:
-            if (this_line_length + len(this_repr) >= 75 or '\n' in this_repr):
-                params_list.append(line_sep)
-                this_line_length = len(line_sep)
-            else:
-                params_list.append(', ')
-                this_line_length += 2
-        params_list.append(this_repr)
-        this_line_length += len(this_repr)
-
-    np.set_printoptions(**options)
-    lines = ''.join(params_list)
-    # Strip trailing space to avoid nightmare in doctests
-    lines = '\n'.join(l.rstrip(' ') for l in lines.split('\n'))
-    return lines
-
-
-###############################################################################
 class BaseEstimator:
     """Base class for all estimators in scikit-learn
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #13159 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
I have removed the _pprint() from https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/base.py
It's already there in the sklearn.utils
#### Any other comments?
Please merge this PR

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
