### PR TITLE
[MRG] Fix make flake8-diff command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,4 +60,4 @@ code-analysis:
 	pylint -E -i y sklearn/ -d E1103,E0611,E1101
 
 flake8-diff:
-	./build_tools/travis/flake8_diff.sh
+	./build_tools/circle/flake8_diff.sh

--- a/build_tools/circle/flake8_diff.sh
+++ b/build_tools/circle/flake8_diff.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script is used in Travis to check that PRs do not add obvious
+# This script is used in CircleCI to check that PRs do not add obvious
 # flake8 violations. It relies on two things:
 #   - find common ancestor between branch and
 #     scikit-learn/scikit-learn remote
@@ -10,7 +10,7 @@
 # Additional features:
 #   - the line numbers in Travis match the local branch on the PR
 #     author machine.
-#   - ./build_tools/travis/flake8_diff.sh can be run locally for quick
+#   - ./build_tools/circle/flake8_diff.sh can be run locally for quick
 #     turn-around
 
 set -e

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -276,7 +276,7 @@ rules before submitting a pull request:
 
 * Follow the `coding-guidelines`_ (see below). To make sure that
   your PR does not add PEP8 violations you can run
-  `./build_tools/travis/flake8_diff.sh` or `make flake8-diff` on a
+  `./build_tools/circle/flake8_diff.sh` or `make flake8-diff` on a
   Unix-like system.
 
 * When applicable, use the validation tools and scripts in the


### PR DESCRIPTION
`build_tools/travis/flake8_diff.sh` was moved to `build_tools/circle/flake8_diff.sh` in #12606

It breaks `make flake8-diff`.
It was also still referenced as `travis/flake8_diff.sh` in the dev guide.