### PR TITLE
FIX Remove bins whose width <= 0 with a warning in KBinsDiscretizer

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -64,8 +64,8 @@ Changelog
   combination with ``handle_unknown='ignore'``.
   :issue:`12881` by `Joris Van den Bossche`_.
 
-- |Fix| Redundant bins (i.e., bins whose width <= 0) are removed with a warning
-  in :class:`preprocessing.KBinsDiscretizer`.
+- |Fix| Bins whose width <= 0 are removed with a warning in
+  :class:`preprocessing.KBinsDiscretizer`.
   :issue:`13165` by :user:`Hanmin Qin <qinhanmin2014>`.
 
 :mod:`sklearn.feature_extraction.text`

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -64,6 +64,10 @@ Changelog
   combination with ``handle_unknown='ignore'``.
   :issue:`12881` by `Joris Van den Bossche`_.
 
+- |Fix| Redundant bins (i.e., bins whose width = 0) are removed with a warning
+  in :class:`preprocessing.KBinsDiscretizer`.
+  :issue:`13165` by :user:`Hanmin Qin <qinhanmin2014>`.
+
 :mod:`sklearn.feature_extraction.text`
 ......................................
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -64,7 +64,7 @@ Changelog
   combination with ``handle_unknown='ignore'``.
   :issue:`12881` by `Joris Van den Bossche`_.
 
-- |Fix| Redundant bins (i.e., bins whose width = 0) are removed with a warning
+- |Fix| Redundant bins (i.e., bins whose width <= 0) are removed with a warning
   in :class:`preprocessing.KBinsDiscretizer`.
   :issue:`13165` by :user:`Hanmin Qin <qinhanmin2014>`.
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -64,8 +64,8 @@ Changelog
   combination with ``handle_unknown='ignore'``.
   :issue:`12881` by `Joris Van den Bossche`_.
 
-- |Fix| Bins whose width <= 0 are removed with a warning in
-  :class:`preprocessing.KBinsDiscretizer`.
+- |Fix| Bins whose width are too small (i.e., <= 1e-8) are removed
+  with a warning in :class:`preprocessing.KBinsDiscretizer`.
   :issue:`13165` by :user:`Hanmin Qin <qinhanmin2014>`.
 
 :mod:`sklearn.feature_extraction.text`

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -260,10 +260,6 @@ Support for Python 3.4 and below has been officially dropped.
   in the dense case. Also added a new parameter ``order`` which controls output
   order for further speed performances. :issue:`12251` by `Tom Dupre la Tour`_.
 
-- |Fix| Redundant bins (i.e., bins whose width = 0) are removed with a warning
-  in :class:`preprocessing.KBinsDiscretizer`.
-  :issue:`13165` by :user:`Hanmin Qin <qinhanmin2014>`.
-
 - |Fix| Fixed the calculation overflow when using a float16 dtype with
   :class:`preprocessing.StandardScaler`. :issue:`13007` by
   :user:`Raffaello Baluyot <baluyotraf>`

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -260,6 +260,10 @@ Support for Python 3.4 and below has been officially dropped.
   in the dense case. Also added a new parameter ``order`` which controls output
   order for further speed performances. :issue:`12251` by `Tom Dupre la Tour`_.
 
+- |Fix| Redundant bins (i.e., bins whose width = 0) are removed with a warning
+  in :class:`preprocessing.KBinsDiscretizer`.
+  :issue:`13164` by :user:`Hanmin Qin <qinhanmin2014>`.
+
 - |Fix| Fixed the calculation overflow when using a float16 dtype with
   :class:`preprocessing.StandardScaler`. :issue:`13007` by
   :user:`Raffaello Baluyot <baluyotraf>`

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -262,7 +262,7 @@ Support for Python 3.4 and below has been officially dropped.
 
 - |Fix| Redundant bins (i.e., bins whose width = 0) are removed with a warning
   in :class:`preprocessing.KBinsDiscretizer`.
-  :issue:`13164` by :user:`Hanmin Qin <qinhanmin2014>`.
+  :issue:`13165` by :user:`Hanmin Qin <qinhanmin2014>`.
 
 - |Fix| Fixed the calculation overflow when using a float16 dtype with
   :class:`preprocessing.StandardScaler`. :issue:`13007` by

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -183,7 +183,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
                 bin_edges[jj] = (centers[1:] + centers[:-1]) * 0.5
                 bin_edges[jj] = np.r_[col_min, bin_edges[jj], col_max]
 
-            # Remove redundant bins (i.e., bins whose width = 0)
+            # Remove redundant bins (i.e., bins whose width <= 0)
             if self.strategy in ('quantile', 'kmeans'):
                 mask = np.ediff1d(bin_edges[jj], to_begin=np.inf) > 1e-8
                 bin_edges[jj] = bin_edges[jj][mask]

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -185,7 +185,10 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
 
             # Remove redundant bins (i.e., bins whose width = 0)
             if self.strategy in ('quantile', 'kmeans'):
-                bin_edges[jj] = np.unique(bin_edges[jj])
+                bin_edges[jj] = np.array(
+                    [bin_edges[jj][0]] +
+                    [bin_edges[jj][i] for i in range(1, len(bin_edges[jj]))
+                     if bin_edges[jj][i] - bin_edges[jj][i - 1] > 1e-8])
                 if len(bin_edges[jj]) - 1 != n_bins[jj]:
                     warnings.warn('Redundant bins (i.e., bins whose width = 0)'
                                   ' in feature %d are removed.' % jj)

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -56,8 +56,8 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
     Attributes
     ----------
     n_bins_ : int array, shape (n_features,)
-        Number of bins per feature. Redundant bins (i.e., bins whose width = 0)
-        are removed with a warning.
+        Number of bins per feature. Redundant bins (i.e., bins whose
+        width <= 0) are removed with a warning.
 
     bin_edges_ : array of arrays, shape (n_features, )
         The edges of each bin. Contain arrays of varying shapes ``(n_bins_, )``

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -183,7 +183,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
                 bin_edges[jj] = (centers[1:] + centers[:-1]) * 0.5
                 bin_edges[jj] = np.r_[col_min, bin_edges[jj], col_max]
 
-            # Remove redundant bins (i.e., bins whose width <= 0)
+            # Remove bins whose width are too small (i.e., <= 1e-8)
             if self.strategy in ('quantile', 'kmeans'):
                 mask = np.ediff1d(bin_edges[jj], to_begin=np.inf) > 1e-8
                 bin_edges[jj] = bin_edges[jj][mask]

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -182,7 +182,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
                 centers.sort()
                 bin_edges[jj] = (centers[1:] + centers[:-1]) * 0.5
                 bin_edges[jj] = np.r_[col_min, bin_edges[jj], col_max]
-            
+
             # Remove redundant bins (i.e., bins whose width = 0)
             if self.strategy in ('quantile', 'kmeans'):
                 bin_edges[jj] = np.unique(bin_edges[jj])

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -142,6 +142,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
 
         n_features = X.shape[1]
         n_bins = self._validate_n_bins(n_features)
+        actual_n_bins = n_bins.copy()
 
         bin_edges = np.zeros(n_features, dtype=object)
         for jj in range(n_features):
@@ -176,9 +177,11 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
                 centers.sort()
                 bin_edges[jj] = (centers[1:] + centers[:-1]) * 0.5
                 bin_edges[jj] = np.r_[col_min, bin_edges[jj], col_max]
+            bin_edges[jj] = np.unique(bin_edges[jj])
+            actual_n_bins[jj] = len(bin_edges[jj])
 
         self.bin_edges_ = bin_edges
-        self.n_bins_ = n_bins
+        self.n_bins_ = actual_n_bins
 
         if 'onehot' in self.encode:
             self._encoder = OneHotEncoder(

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -188,7 +188,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
                 mask = np.ediff1d(bin_edges[jj], to_begin=np.inf) > 1e-8
                 bin_edges[jj] = bin_edges[jj][mask]
                 if len(bin_edges[jj]) - 1 != n_bins[jj]:
-                    warnings.warn('Redundant bins (i.e., bins whose width ' 
+                    warnings.warn('Redundant bins (i.e., bins whose width '
                                   '<= 0) in feature %d are removed.' % jj)
                     n_bins[jj] = len(bin_edges[jj]) - 1
 

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -106,7 +106,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
     ``KBinsDiscretizer`` might produce constant features (e.g., when
     ``encode = 'onehot'`` and certain bins do not contain any data).
     These features can be removed with feature selection algorithms
-    (e.g., :class:`sklearn.compose.VarianceThreshold`).
+    (e.g., :class:`sklearn.feature_selection.VarianceThreshold`).
 
     See also
     --------
@@ -189,7 +189,8 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
                 bin_edges[jj] = bin_edges[jj][mask]
                 if len(bin_edges[jj]) - 1 != n_bins[jj]:
                     warnings.warn('Redundant bins (i.e., bins whose width '
-                                  '<= 0) in feature %d are removed.' % jj)
+                                  '<= 0) in feature %d are removed. Consider '
+                                  'decreasing the number of bins.' % jj)
                     n_bins[jj] = len(bin_edges[jj]) - 1
 
         self.bin_edges_ = bin_edges

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -56,8 +56,8 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
     Attributes
     ----------
     n_bins_ : int array, shape (n_features,)
-        Number of bins per feature. Bins whose width <= 0 are removed with a
-        warning.
+        Number of bins per feature. Bins whose width are too small
+        (i.e., <= 1e-8) are removed with a warning.
 
     bin_edges_ : array of arrays, shape (n_features, )
         The edges of each bin. Contain arrays of varying shapes ``(n_bins_, )``
@@ -188,9 +188,9 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
                 mask = np.ediff1d(bin_edges[jj], to_begin=np.inf) > 1e-8
                 bin_edges[jj] = bin_edges[jj][mask]
                 if len(bin_edges[jj]) - 1 != n_bins[jj]:
-                    warnings.warn('Bins whose width <= 0 in feature %d are '
-                                  'removed. Consider decreasing the number of '
-                                  'bins.' % jj)
+                    warnings.warn('Bins whose width are too small (i.e., <= '
+                                  '1e-8) in feature %d are removed. Consider '
+                                  'decreasing the number of bins.' % jj)
                     n_bins[jj] = len(bin_edges[jj]) - 1
 
         self.bin_edges_ = bin_edges

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -56,8 +56,8 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
     Attributes
     ----------
     n_bins_ : int array, shape (n_features,)
-        Number of bins per feature. Redundant bins (i.e., bins whose
-        width <= 0) are removed with a warning.
+        Number of bins per feature. Bins whose width <= 0 are removed with a
+        warning.
 
     bin_edges_ : array of arrays, shape (n_features, )
         The edges of each bin. Contain arrays of varying shapes ``(n_bins_, )``
@@ -188,9 +188,9 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
                 mask = np.ediff1d(bin_edges[jj], to_begin=np.inf) > 1e-8
                 bin_edges[jj] = bin_edges[jj][mask]
                 if len(bin_edges[jj]) - 1 != n_bins[jj]:
-                    warnings.warn('Redundant bins (i.e., bins whose width '
-                                  '<= 0) in feature %d are removed. Consider '
-                                  'decreasing the number of bins.' % jj)
+                    warnings.warn('Bins whose width <= 0 in feature %d are '
+                                  'removed. Consider decreasing the number of '
+                                  'bins.' % jj)
                     n_bins[jj] = len(bin_edges[jj]) - 1
 
         self.bin_edges_ = bin_edges

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -185,13 +185,11 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
 
             # Remove redundant bins (i.e., bins whose width = 0)
             if self.strategy in ('quantile', 'kmeans'):
-                bin_edges[jj] = np.array(
-                    [bin_edges[jj][0]] +
-                    [bin_edges[jj][i] for i in range(1, len(bin_edges[jj]))
-                     if bin_edges[jj][i] - bin_edges[jj][i - 1] > 1e-8])
+                mask = np.ediff1d(bin_edges[jj], to_begin=np.inf) > 1e-8
+                bin_edges[jj] = bin_edges[jj][mask]
                 if len(bin_edges[jj]) - 1 != n_bins[jj]:
-                    warnings.warn('Redundant bins (i.e., bins whose width = 0)'
-                                  ' in feature %d are removed.' % jj)
+                    warnings.warn('Redundant bins (i.e., bins whose width ' 
+                                  '<= 0) in feature %d are removed.' % jj)
                     n_bins[jj] = len(bin_edges[jj]) - 1
 
         self.bin_edges_ = bin_edges

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -7,6 +7,7 @@ import warnings
 from sklearn.preprocessing import KBinsDiscretizer
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.utils.testing import (
+    assert_array_almost_equal,
     assert_array_equal,
     assert_raises,
     assert_raise_message,
@@ -209,24 +210,22 @@ def test_nonuniform_strategies(
     assert_array_equal(expected_5bins, Xt.ravel())
 
 
-@pytest.mark.parametrize('strategy', ['uniform', 'kmeans', 'quantile'])
+@pytest.mark.parametrize(
+    'strategy, expected_inv',
+    [('uniform', [[-1.5, 2., -3.5, -0.5], [-0.5, 3., -2.5, -0.5],
+                  [0.5, 4., -1.5, 0.5], [0.5, 4., -1.5, 1.5]]),
+     ('kmeans', [[-1.375, 2.125, -3.375, -0.5625],
+                 [-1.375, 2.125, -3.375, -0.5625],
+                 [-0.125, 3.375, -2.125, 0.5625],
+                 [0.75, 4.25, -1.25, 1.625 ]]),
+     ('quantile', [[-1.5, 2., -3.5, -0.75], [-0.5, 3., -2.5, 0.],
+                  [0.5, 4., -1.5, 1.25], [0.5, 4., -1.5, 1.25]])])
 @pytest.mark.parametrize('encode', ['ordinal', 'onehot', 'onehot-dense'])
-def test_inverse_transform(strategy, encode):
-    X = np.random.RandomState(0).randn(100, 3)
+def test_inverse_transform(strategy, encode, expected_inv):
     kbd = KBinsDiscretizer(n_bins=3, strategy=strategy, encode=encode)
     Xt = kbd.fit_transform(X)
-    X2 = kbd.inverse_transform(Xt)
-    X2t = kbd.fit_transform(X2)
-    if encode == 'onehot':
-        assert_array_equal(Xt.todense(), X2t.todense())
-    else:
-        assert_array_equal(Xt, X2t)
-    if 'onehot' in encode:
-        Xt = kbd._encoder.inverse_transform(Xt)
-        X2t = kbd._encoder.inverse_transform(X2t)
-
-    assert_array_equal(Xt.max(axis=0) + 1, kbd.n_bins_)
-    assert_array_equal(X2t.max(axis=0) + 1, kbd.n_bins_)
+    Xinv = kbd.inverse_transform(Xt)
+    assert_array_almost_equal(expected_inv, Xinv)
 
 
 @pytest.mark.parametrize('strategy', ['uniform', 'kmeans', 'quantile'])
@@ -253,3 +252,15 @@ def test_overwrite():
     Xinv = est.inverse_transform(Xt)
     assert_array_equal(Xt, Xt_before)
     assert_array_equal(Xinv, np.array([[0.5], [1.5], [2.5], [2.5]]))
+
+
+@pytest.mark.parametrize(
+    'strategy, expected_bin_edges',
+    [('quantile', [0, 1, 3]), ('kmeans', [0, 1.5, 3])])
+def test_redundant_bins(strategy, expected_bin_edges):
+    X = [[0], [0], [0], [0], [3], [3]]
+    kbd = KBinsDiscretizer(n_bins=3, strategy=strategy)
+    msg = ("Redundant bins (i.e., bins whose width = 0) "
+           "in feature 0 are removed.")
+    assert_warns_message(UserWarning, msg, kbd.fit, X)
+    assert_array_almost_equal(kbd.bin_edges_[0], expected_bin_edges)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -260,8 +260,8 @@ def test_overwrite():
 def test_redundant_bins(strategy, expected_bin_edges):
     X = [[0], [0], [0], [0], [3], [3]]
     kbd = KBinsDiscretizer(n_bins=3, strategy=strategy)
-    msg = ("Redundant bins (i.e., bins whose width <= 0) "
-           "in feature 0 are removed.")
+    msg = ("Redundant bins (i.e., bins whose width <= 0) in feature 0 "
+           "are removed. Consider decreasing the number of bins.")
     assert_warns_message(UserWarning, msg, kbd.fit, X)
     assert_array_almost_equal(kbd.bin_edges_[0], expected_bin_edges)
 
@@ -272,8 +272,8 @@ def test_percentile_numeric_stability():
     Xt = np.array([0, 0, 4]).reshape(-1, 1)
     kbd = KBinsDiscretizer(n_bins=10, encode='ordinal',
                            strategy='quantile')
-    msg = ("Redundant bins (i.e., bins whose width <= 0) "
-           "in feature 0 are removed.")
+    msg = ("Redundant bins (i.e., bins whose width <= 0) in feature 0 "
+           "are removed. Consider decreasing the number of bins.")
     assert_warns_message(UserWarning, msg, kbd.fit, X)
     assert_array_almost_equal(kbd.bin_edges_[0], bin_edges)
     assert_array_almost_equal(kbd.transform(X), Xt)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -260,8 +260,8 @@ def test_overwrite():
 def test_redundant_bins(strategy, expected_bin_edges):
     X = [[0], [0], [0], [0], [3], [3]]
     kbd = KBinsDiscretizer(n_bins=3, strategy=strategy)
-    msg = ("Bins whose width <= 0 in feature 0 are removed. "
-           "Consider decreasing the number of bins.")
+    msg = ("Bins whose width are too small (i.e., <= 1e-8) in feature 0 "
+           "are removed. Consider decreasing the number of bins.")
     assert_warns_message(UserWarning, msg, kbd.fit, X)
     assert_array_almost_equal(kbd.bin_edges_[0], expected_bin_edges)
 
@@ -272,8 +272,8 @@ def test_percentile_numeric_stability():
     Xt = np.array([0, 0, 4]).reshape(-1, 1)
     kbd = KBinsDiscretizer(n_bins=10, encode='ordinal',
                            strategy='quantile')
-    msg = ("Bins whose width <= 0 in feature 0 are removed. "
-           "Consider decreasing the number of bins.")
+    msg = ("Bins whose width are too small (i.e., <= 1e-8) in feature 0 "
+           "are removed. Consider decreasing the number of bins.")
     assert_warns_message(UserWarning, msg, kbd.fit, X)
     assert_array_almost_equal(kbd.bin_edges_[0], bin_edges)
     assert_array_almost_equal(kbd.transform(X), Xt)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -260,8 +260,8 @@ def test_overwrite():
 def test_redundant_bins(strategy, expected_bin_edges):
     X = [[0], [0], [0], [0], [3], [3]]
     kbd = KBinsDiscretizer(n_bins=3, strategy=strategy)
-    msg = ("Redundant bins (i.e., bins whose width <= 0) in feature 0 "
-           "are removed. Consider decreasing the number of bins.")
+    msg = ("Bins whose width <= 0 in feature 0 are removed. "
+           "Consider decreasing the number of bins.")
     assert_warns_message(UserWarning, msg, kbd.fit, X)
     assert_array_almost_equal(kbd.bin_edges_[0], expected_bin_edges)
 
@@ -272,8 +272,8 @@ def test_percentile_numeric_stability():
     Xt = np.array([0, 0, 4]).reshape(-1, 1)
     kbd = KBinsDiscretizer(n_bins=10, encode='ordinal',
                            strategy='quantile')
-    msg = ("Redundant bins (i.e., bins whose width <= 0) in feature 0 "
-           "are removed. Consider decreasing the number of bins.")
+    msg = ("Bins whose width <= 0 in feature 0 are removed. "
+           "Consider decreasing the number of bins.")
     assert_warns_message(UserWarning, msg, kbd.fit, X)
     assert_array_almost_equal(kbd.bin_edges_[0], bin_edges)
     assert_array_almost_equal(kbd.transform(X), Xt)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -260,7 +260,7 @@ def test_overwrite():
 def test_redundant_bins(strategy, expected_bin_edges):
     X = [[0], [0], [0], [0], [3], [3]]
     kbd = KBinsDiscretizer(n_bins=3, strategy=strategy)
-    msg = ("Redundant bins (i.e., bins whose width = 0) "
+    msg = ("Redundant bins (i.e., bins whose width <= 0) "
            "in feature 0 are removed.")
     assert_warns_message(UserWarning, msg, kbd.fit, X)
     assert_array_almost_equal(kbd.bin_edges_[0], expected_bin_edges)
@@ -272,7 +272,7 @@ def test_percentile_numeric_stability():
     Xt = np.array([0, 0, 4]).reshape(-1, 1)
     kbd = KBinsDiscretizer(n_bins=10, encode='ordinal',
                            strategy='quantile')
-    msg = ("Redundant bins (i.e., bins whose width = 0) "
+    msg = ("Redundant bins (i.e., bins whose width <= 0) "
            "in feature 0 are removed.")
     assert_warns_message(UserWarning, msg, kbd.fit, X)
     assert_array_almost_equal(kbd.bin_edges_[0], bin_edges)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -264,3 +264,16 @@ def test_redundant_bins(strategy, expected_bin_edges):
            "in feature 0 are removed.")
     assert_warns_message(UserWarning, msg, kbd.fit, X)
     assert_array_almost_equal(kbd.bin_edges_[0], expected_bin_edges)
+
+
+def test_percentile_numeric_stability():
+    X = np.array([0.05, 0.05, 0.95]).reshape(-1, 1)
+    bin_edges = np.array([0.05, 0.23, 0.41, 0.59, 0.77, 0.95])
+    Xt = np.array([0, 0, 4]).reshape(-1, 1)
+    kbd = KBinsDiscretizer(n_bins=10, encode='ordinal',
+                           strategy='quantile')
+    msg = ("Redundant bins (i.e., bins whose width = 0) "
+           "in feature 0 are removed.")
+    assert_warns_message(UserWarning, msg, kbd.fit, X)
+    assert_array_almost_equal(kbd.bin_edges_[0], bin_edges)
+    assert_array_almost_equal(kbd.transform(X), Xt)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -217,9 +217,9 @@ def test_nonuniform_strategies(
      ('kmeans', [[-1.375, 2.125, -3.375, -0.5625],
                  [-1.375, 2.125, -3.375, -0.5625],
                  [-0.125, 3.375, -2.125, 0.5625],
-                 [0.75, 4.25, -1.25, 1.625 ]]),
+                 [0.75, 4.25, -1.25, 1.625]]),
      ('quantile', [[-1.5, 2., -3.5, -0.75], [-0.5, 3., -2.5, 0.],
-                  [0.5, 4., -1.5, 1.25], [0.5, 4., -1.5, 1.25]])])
+                   [0.5, 4., -1.5, 1.25], [0.5, 4., -1.5, 1.25]])])
 @pytest.mark.parametrize('encode', ['ordinal', 'onehot', 'onehot-dense'])
 def test_inverse_transform(strategy, encode, expected_inv):
     kbd = KBinsDiscretizer(n_bins=3, strategy=strategy, encode=encode)


### PR DESCRIPTION
Closes #12774 
Closes #13194 
Closes #13195
(1) Remove bins whose width <= 0 with a warning.
(2) Tell users that KBinsDiscretizer might produce constant features (e.g., when ``encode = 'onehot'`` and certain bins do not contain any data) and these features can be removed with feature selection algorithms (e.g., ``sklearn.compose.VarianceThreshold``).

Similar to #12893, I don't think it's the duty of a preprocessor to remove redundant features.

I think this is a bug (seems that Joel agrees with me in the issue), so we don't need to worry about backward compatibility.