### PR TITLE
removed pprint function

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -60,58 +60,6 @@ def clone(estimator, safe=True):
                                (estimator, name))
     return new_object
 
-
-###############################################################################
-def _pprint(params, offset=0, printer=repr):
-    """Pretty print the dictionary 'params'
-
-    Parameters
-    ----------
-    params : dict
-        The dictionary to pretty print
-
-    offset : int
-        The offset in characters to add at the begin of each line.
-
-    printer : callable
-        The function to convert entries to strings, typically
-        the builtin str or repr
-
-    """
-    # Do a multi-line justified repr:
-    options = np.get_printoptions()
-    np.set_printoptions(precision=5, threshold=64, edgeitems=2)
-    params_list = list()
-    this_line_length = offset
-    line_sep = ',\n' + (1 + offset // 2) * ' '
-    for i, (k, v) in enumerate(sorted(params.items())):
-        if type(v) is float:
-            # use str for representing floating point numbers
-            # this way we get consistent representation across
-            # architectures and versions.
-            this_repr = '%s=%s' % (k, str(v))
-        else:
-            # use repr of the rest
-            this_repr = '%s=%s' % (k, printer(v))
-        if len(this_repr) > 500:
-            this_repr = this_repr[:300] + '...' + this_repr[-100:]
-        if i > 0:
-            if (this_line_length + len(this_repr) >= 75 or '\n' in this_repr):
-                params_list.append(line_sep)
-                this_line_length = len(line_sep)
-            else:
-                params_list.append(', ')
-                this_line_length += 2
-        params_list.append(this_repr)
-        this_line_length += len(this_repr)
-
-    np.set_printoptions(**options)
-    lines = ''.join(params_list)
-    # Strip trailing space to avoid nightmare in doctests
-    lines = '\n'.join(l.rstrip(' ') for l in lines.split('\n'))
-    return lines
-
-
 ###############################################################################
 class BaseEstimator:
     """Base class for all estimators in scikit-learn

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -24,7 +24,7 @@ from ..utils.validation import _num_samples, column_or_1d
 from ..utils.validation import check_array
 from ..utils.multiclass import type_of_target
 from ..utils.fixes import comb
-from ..base import _pprint
+from ..utils import _pprint
 
 __all__ = ['BaseCrossValidator',
            'KFold',


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #13159 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Removed the _pprint() from this file: https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/base.py (line no: 65) because new pprint is there in utils.
Also updated the _pprint() import in https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/model_selection/_split.py (line no:27) , now it imports from utils instead of ..base

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
