### PR TITLE
[MRG+2] Minimize the validation of X in adaboost

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -118,6 +118,9 @@ Support for Python 3.4 and below has been officially dropped.
   value of ``learning_rate`` in ``update_terminal_regions`` is not consistent
   with the document and the caller functions.
   :issue:`6463` by :user:`movelikeriver <movelikeriver>`.
+  
+- |Enhancement| Minimized the validation of X in :class:`ensemble.AdaBoostClassifier`
+  and :class:`ensemble.AdaBoostRegressor` :issue:`13174` by :user:`Christos Aridas <chkoar>`.
 
 :mod:`sklearn.externals`
 ........................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -119,8 +119,9 @@ Support for Python 3.4 and below has been officially dropped.
   with the document and the caller functions.
   :issue:`6463` by :user:`movelikeriver <movelikeriver>`.
   
-- |Enhancement| Minimized the validation of X in :class:`ensemble.AdaBoostClassifier`
-  and :class:`ensemble.AdaBoostRegressor` :issue:`13174` by :user:`Christos Aridas <chkoar>`.
+- |Enhancement| Minimized the validation of X in
+  :class:`ensemble.AdaBoostClassifier` and :class:`ensemble.AdaBoostRegressor`
+  :issue:`13174` by :user:`Christos Aridas <chkoar>`.
 
 :mod:`sklearn.externals`
 ........................

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -497,9 +497,9 @@ def test_multidimensional_X():
 
     rng = np.random.RandomState(0)
 
-    X = rng.random.randn(50, 3, 3)
-    yc = rng.random.choice([0, 1], 50)
-    yr = rng.random.randn(50)
+    X = rng.randn(50, 3, 3)
+    yc = rng.choice([0, 1], 50)
+    yr = rng.randn(50)
 
     boost = AdaBoostClassifier(DummyClassifier())
     boost.fit(X, yc)

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -319,155 +319,6 @@ def test_sample_weight_missing():
     clf = AdaBoostRegressor(KMeans())
     assert_raises(ValueError, clf.fit, X, y_regr)
 
-
-def test_sparse_classification():
-    # Check classification with sparse input.
-
-    class CustomSVC(SVC):
-        """SVC variant that records the nature of the training set."""
-
-        def fit(self, X, y, sample_weight=None):
-            """Modification on fit caries data type for later verification."""
-            super().fit(X, y, sample_weight=sample_weight)
-            self.data_type_ = type(X)
-            return self
-
-    X, y = datasets.make_multilabel_classification(n_classes=1, n_samples=15,
-                                                   n_features=5,
-                                                   random_state=42)
-    # Flatten y to a 1d array
-    y = np.ravel(y)
-
-    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
-
-    for sparse_format in [csc_matrix, csr_matrix, lil_matrix, coo_matrix,
-                          dok_matrix]:
-        X_train_sparse = sparse_format(X_train)
-        X_test_sparse = sparse_format(X_test)
-
-        # Trained on sparse format
-        sparse_classifier = AdaBoostClassifier(
-            base_estimator=CustomSVC(gamma='scale', probability=True),
-            random_state=1,
-            algorithm="SAMME"
-        ).fit(X_train_sparse, y_train)
-
-        # Trained on dense format
-        dense_classifier = AdaBoostClassifier(
-            base_estimator=CustomSVC(gamma='scale', probability=True),
-            random_state=1,
-            algorithm="SAMME"
-        ).fit(X_train, y_train)
-
-        # predict
-        sparse_results = sparse_classifier.predict(X_test_sparse)
-        dense_results = dense_classifier.predict(X_test)
-        assert_array_equal(sparse_results, dense_results)
-
-        # decision_function
-        sparse_results = sparse_classifier.decision_function(X_test_sparse)
-        dense_results = dense_classifier.decision_function(X_test)
-        assert_array_almost_equal(sparse_results, dense_results)
-
-        # predict_log_proba
-        sparse_results = sparse_classifier.predict_log_proba(X_test_sparse)
-        dense_results = dense_classifier.predict_log_proba(X_test)
-        assert_array_almost_equal(sparse_results, dense_results)
-
-        # predict_proba
-        sparse_results = sparse_classifier.predict_proba(X_test_sparse)
-        dense_results = dense_classifier.predict_proba(X_test)
-        assert_array_almost_equal(sparse_results, dense_results)
-
-        # score
-        sparse_results = sparse_classifier.score(X_test_sparse, y_test)
-        dense_results = dense_classifier.score(X_test, y_test)
-        assert_array_almost_equal(sparse_results, dense_results)
-
-        # staged_decision_function
-        sparse_results = sparse_classifier.staged_decision_function(
-            X_test_sparse)
-        dense_results = dense_classifier.staged_decision_function(X_test)
-        for sprase_res, dense_res in zip(sparse_results, dense_results):
-            assert_array_almost_equal(sprase_res, dense_res)
-
-        # staged_predict
-        sparse_results = sparse_classifier.staged_predict(X_test_sparse)
-        dense_results = dense_classifier.staged_predict(X_test)
-        for sprase_res, dense_res in zip(sparse_results, dense_results):
-            assert_array_equal(sprase_res, dense_res)
-
-        # staged_predict_proba
-        sparse_results = sparse_classifier.staged_predict_proba(X_test_sparse)
-        dense_results = dense_classifier.staged_predict_proba(X_test)
-        for sprase_res, dense_res in zip(sparse_results, dense_results):
-            assert_array_almost_equal(sprase_res, dense_res)
-
-        # staged_score
-        sparse_results = sparse_classifier.staged_score(X_test_sparse,
-                                                        y_test)
-        dense_results = dense_classifier.staged_score(X_test, y_test)
-        for sprase_res, dense_res in zip(sparse_results, dense_results):
-            assert_array_equal(sprase_res, dense_res)
-
-        # Verify sparsity of data is maintained during training
-        types = [i.data_type_ for i in sparse_classifier.estimators_]
-
-        assert all([(t == csc_matrix or t == csr_matrix)
-                   for t in types])
-
-
-def test_sparse_regression():
-    # Check regression with sparse input.
-
-    class CustomSVR(SVR):
-        """SVR variant that records the nature of the training set."""
-
-        def fit(self, X, y, sample_weight=None):
-            """Modification on fit caries data type for later verification."""
-            super().fit(X, y, sample_weight=sample_weight)
-            self.data_type_ = type(X)
-            return self
-
-    X, y = datasets.make_regression(n_samples=15, n_features=50, n_targets=1,
-                                    random_state=42)
-
-    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
-
-    for sparse_format in [csc_matrix, csr_matrix, lil_matrix, coo_matrix,
-                          dok_matrix]:
-        X_train_sparse = sparse_format(X_train)
-        X_test_sparse = sparse_format(X_test)
-
-        # Trained on sparse format
-        sparse_classifier = AdaBoostRegressor(
-            base_estimator=CustomSVR(gamma='scale'),
-            random_state=1
-        ).fit(X_train_sparse, y_train)
-
-        # Trained on dense format
-        dense_classifier = dense_results = AdaBoostRegressor(
-            base_estimator=CustomSVR(gamma='scale'),
-            random_state=1
-        ).fit(X_train, y_train)
-
-        # predict
-        sparse_results = sparse_classifier.predict(X_test_sparse)
-        dense_results = dense_classifier.predict(X_test)
-        assert_array_almost_equal(sparse_results, dense_results)
-
-        # staged_predict
-        sparse_results = sparse_classifier.staged_predict(X_test_sparse)
-        dense_results = dense_classifier.staged_predict(X_test)
-        for sprase_res, dense_res in zip(sparse_results, dense_results):
-            assert_array_almost_equal(sprase_res, dense_res)
-
-        types = [i.data_type_ for i in sparse_classifier.estimators_]
-
-        assert all([(t == csc_matrix or t == csr_matrix)
-                   for t in types])
-
-
 def test_sample_weight_adaboost_regressor():
     """
     AdaBoostRegressor should work without sample_weights in the base estimator
@@ -486,3 +337,42 @@ def test_sample_weight_adaboost_regressor():
     boost = AdaBoostRegressor(DummyEstimator(), n_estimators=3)
     boost.fit(X, y_regr)
     assert_equal(len(boost.estimator_weights_), len(boost.estimator_errors_))
+
+
+def test_multidimensional_X():
+    class DummyClassifier(BaseEstimator):
+
+        def fit(self, X, y, sample_weight=None):
+            self.classes_ = np.unique(y)
+            return self
+
+        def predict(self, X):
+            n_samples = X.shape[0]
+            predictions = np.random.choice(self.classes_, n_samples)
+            return predictions
+
+        def predict_proba(self, X):
+            n_samples = X.shape[0]
+            n_classes = len(self.classes_)
+            probas = np.random.randn(n_samples, n_classes)
+            return probas
+
+    class DummyRegressor(BaseEstimator):
+
+        def fit(self, X, y, sample_weight=None):
+            return self
+
+        def predict(self, X):
+            n_samples = X.shape[0]
+            predictions = np.random.randn(n_samples)
+            return predictions
+
+
+    X = np.random.randn(50, 3,3)
+    yc = np.random.choice([0,1], 50)
+    yr = np.random.randn(50)
+
+    boost = AdaBoostClassifier(DummyClassifier())
+    boost.fit(X,yc)
+    boost = AdaBoostRegressor(DummyRegressor())
+    boost.fit(X,yc)

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -525,6 +525,9 @@ def test_multidimensional_X():
 
     boost = AdaBoostClassifier(DummyClassifier())
     boost.fit(X, yc)
+    boost.predict(X)
+    boost.predict_proba(X)
 
     boost = AdaBoostRegressor(DummyRegressor())
-    boost.fit(X, yr)
+    boost.fit(X, yc)
+    boost.predict(X)

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -484,11 +484,11 @@ def test_sample_weight_adaboost_regressor():
 
     boost = AdaBoostRegressor(DummyEstimator(), n_estimators=3)
     boost.fit(X, y_regr)
-    assert_equal(len(boost.estimator_weights_), len(boost.estimator_errors_))       
-        
-        
+    assert_equal(len(boost.estimator_weights_), len(boost.estimator_errors_))
+
+
 def test_multidimensional_X():
-    """ 
+    """
     Check that the AdaBoost estimators can work with n-dimensional
     data matrix
     """

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -9,10 +9,15 @@ from sklearn.utils.testing import assert_equal, assert_greater
 from sklearn.utils.testing import assert_raises, assert_raises_regexp
 
 from sklearn.base import BaseEstimator
-from sklearn.model_selection import GridSearchCV
+from sklearn.model_selection import GridSearchCV, train_test_split
 from sklearn.ensemble import AdaBoostClassifier
 from sklearn.ensemble import AdaBoostRegressor
 from sklearn.ensemble import weight_boosting
+from scipy.sparse import csc_matrix
+from scipy.sparse import csr_matrix
+from scipy.sparse import coo_matrix
+from scipy.sparse import dok_matrix
+from scipy.sparse import lil_matrix
 from sklearn.svm import SVC, SVR
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.utils import shuffle
@@ -371,3 +376,149 @@ def test_multidimensional_X():
 
     boost = AdaBoostRegressor(DummyRegressor())
     boost.fit(X, yr)
+
+
+def test_sparse_classification():
+    # Check classification with sparse input.
+
+    class CustomSVC(SVC):
+        """SVC variant that records the nature of the training set."""
+
+        def fit(self, X, y, sample_weight=None):
+            """Modification on fit caries data type for later verification."""
+            super().fit(X, y, sample_weight=sample_weight)
+            self.data_type_ = type(X)
+            return self
+
+    X, y = datasets.make_multilabel_classification(n_classes=1, n_samples=15,
+                                                   n_features=5,
+                                                   random_state=42)
+    # Flatten y to a 1d array
+    y = np.ravel(y)
+
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+    for sparse_format in [csc_matrix, csr_matrix, lil_matrix, coo_matrix,
+                          dok_matrix]:
+        X_train_sparse = sparse_format(X_train)
+        X_test_sparse = sparse_format(X_test)
+
+        # Trained on sparse format
+        sparse_classifier = AdaBoostClassifier(
+            base_estimator=CustomSVC(gamma='scale', probability=True),
+            random_state=1,
+            algorithm="SAMME"
+        ).fit(X_train_sparse, y_train)
+
+        # Trained on dense format
+        dense_classifier = AdaBoostClassifier(
+            base_estimator=CustomSVC(gamma='scale', probability=True),
+            random_state=1,
+            algorithm="SAMME"
+        ).fit(X_train, y_train)
+
+        # predict
+        sparse_results = sparse_classifier.predict(X_test_sparse)
+        dense_results = dense_classifier.predict(X_test)
+        assert_array_equal(sparse_results, dense_results)
+
+        # decision_function
+        sparse_results = sparse_classifier.decision_function(X_test_sparse)
+        dense_results = dense_classifier.decision_function(X_test)
+        assert_array_almost_equal(sparse_results, dense_results)
+
+        # predict_log_proba
+        sparse_results = sparse_classifier.predict_log_proba(X_test_sparse)
+        dense_results = dense_classifier.predict_log_proba(X_test)
+        assert_array_almost_equal(sparse_results, dense_results)
+
+        # predict_proba
+        sparse_results = sparse_classifier.predict_proba(X_test_sparse)
+        dense_results = dense_classifier.predict_proba(X_test)
+        assert_array_almost_equal(sparse_results, dense_results)
+
+        # score
+        sparse_results = sparse_classifier.score(X_test_sparse, y_test)
+        dense_results = dense_classifier.score(X_test, y_test)
+        assert_array_almost_equal(sparse_results, dense_results)
+
+        # staged_decision_function
+        sparse_results = sparse_classifier.staged_decision_function(
+            X_test_sparse)
+        dense_results = dense_classifier.staged_decision_function(X_test)
+        for sprase_res, dense_res in zip(sparse_results, dense_results):
+            assert_array_almost_equal(sprase_res, dense_res)
+
+        # staged_predict
+        sparse_results = sparse_classifier.staged_predict(X_test_sparse)
+        dense_results = dense_classifier.staged_predict(X_test)
+        for sprase_res, dense_res in zip(sparse_results, dense_results):
+            assert_array_equal(sprase_res, dense_res)
+
+        # staged_predict_proba
+        sparse_results = sparse_classifier.staged_predict_proba(X_test_sparse)
+        dense_results = dense_classifier.staged_predict_proba(X_test)
+        for sprase_res, dense_res in zip(sparse_results, dense_results):
+            assert_array_almost_equal(sprase_res, dense_res)
+
+        # staged_score
+        sparse_results = sparse_classifier.staged_score(X_test_sparse,
+                                                        y_test)
+        dense_results = dense_classifier.staged_score(X_test, y_test)
+        for sprase_res, dense_res in zip(sparse_results, dense_results):
+            assert_array_equal(sprase_res, dense_res)
+
+        # Verify sparsity of data is maintained during training
+        types = [i.data_type_ for i in sparse_classifier.estimators_]
+
+        assert all([(t == csc_matrix or t == csr_matrix)  for t in types])
+
+
+def test_sparse_regression():
+    # Check regression with sparse input.
+
+    class CustomSVR(SVR):
+        """SVR variant that records the nature of the training set."""
+
+        def fit(self, X, y, sample_weight=None):
+            """Modification on fit caries data type for later verification."""
+            super().fit(X, y, sample_weight=sample_weight)
+            self.data_type_ = type(X)
+            return self
+
+    X, y = datasets.make_regression(n_samples=15, n_features=50, n_targets=1,
+                                    random_state=42)
+
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+    for sparse_format in [csc_matrix, csr_matrix, lil_matrix, coo_matrix,
+                          dok_matrix]:
+        X_train_sparse = sparse_format(X_train)
+        X_test_sparse = sparse_format(X_test)
+
+        # Trained on sparse format
+        sparse_classifier = AdaBoostRegressor(
+            base_estimator=CustomSVR(gamma='scale'),
+            random_state=1
+        ).fit(X_train_sparse, y_train)
+
+        # Trained on dense format
+        dense_classifier = dense_results = AdaBoostRegressor(
+            base_estimator=CustomSVR(gamma='scale'),
+            random_state=1
+        ).fit(X_train, y_train)
+
+        # predict
+        sparse_results = sparse_classifier.predict(X_test_sparse)
+        dense_results = dense_classifier.predict(X_test)
+        assert_array_almost_equal(sparse_results, dense_results)
+
+        # staged_predict
+        sparse_results = sparse_classifier.staged_predict(X_test_sparse)
+        dense_results = dense_classifier.staged_predict(X_test)
+        for sprase_res, dense_res in zip(sparse_results, dense_results):
+            assert_array_almost_equal(sprase_res, dense_res)
+
+        types = [i.data_type_ for i in sparse_classifier.estimators_]
+
+        assert all([(t == csc_matrix or t == csr_matrix) for t in types])

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -501,7 +501,7 @@ def test_multidimensional_X():
     yc = rng.choice([0, 1], 50)
     yr = rng.randn(50)
 
-    boost = AdaBoostClassifier(DummyClassifier())
+    boost = AdaBoostClassifier(DummyClassifier(strategy='most_frequent'))
     boost.fit(X, yc)
     boost.predict(X)
     boost.predict_proba(X)

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -529,5 +529,5 @@ def test_multidimensional_X():
     boost.predict_proba(X)
 
     boost = AdaBoostRegressor(DummyRegressor())
-    boost.fit(X, yc)
+    boost.fit(X, yr)
     boost.predict(X)

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -484,7 +484,7 @@ def test_sample_weight_adaboost_regressor():
 
     boost = AdaBoostRegressor(DummyEstimator(), n_estimators=3)
     boost.fit(X, y_regr)
-assert_equal(len(boost.estimator_weights_), len(boost.estimator_errors_))       
+    assert_equal(len(boost.estimator_weights_), len(boost.estimator_errors_))       
         
         
 def test_multidimensional_X():

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -9,16 +9,10 @@ from sklearn.utils.testing import assert_equal, assert_greater
 from sklearn.utils.testing import assert_raises, assert_raises_regexp
 
 from sklearn.base import BaseEstimator
-from sklearn.model_selection import train_test_split
 from sklearn.model_selection import GridSearchCV
 from sklearn.ensemble import AdaBoostClassifier
 from sklearn.ensemble import AdaBoostRegressor
 from sklearn.ensemble import weight_boosting
-from scipy.sparse import csc_matrix
-from scipy.sparse import csr_matrix
-from scipy.sparse import coo_matrix
-from scipy.sparse import dok_matrix
-from scipy.sparse import lil_matrix
 from sklearn.svm import SVC, SVR
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.utils import shuffle
@@ -319,6 +313,7 @@ def test_sample_weight_missing():
     clf = AdaBoostRegressor(KMeans())
     assert_raises(ValueError, clf.fit, X, y_regr)
 
+
 def test_sample_weight_adaboost_regressor():
     """
     AdaBoostRegressor should work without sample_weights in the base estimator
@@ -332,7 +327,7 @@ def test_sample_weight_adaboost_regressor():
             pass
 
         def predict(self, X):
-            return np.zeros(X.shape[0])
+            return np.zeros(len(X))
 
     boost = AdaBoostRegressor(DummyEstimator(), n_estimators=3)
     boost.fit(X, y_regr)
@@ -347,32 +342,33 @@ def test_multidimensional_X():
             return self
 
         def predict(self, X):
-            n_samples = X.shape[0]
+            n_samples = len(X)
             predictions = np.random.choice(self.classes_, n_samples)
             return predictions
 
         def predict_proba(self, X):
-            n_samples = X.shape[0]
+            n_samples = len(X)
             n_classes = len(self.classes_)
             probas = np.random.randn(n_samples, n_classes)
             return probas
 
     class DummyRegressor(BaseEstimator):
 
-        def fit(self, X, y, sample_weight=None):
+        def fit(self, X, y):
             return self
 
         def predict(self, X):
-            n_samples = X.shape[0]
+            n_samples = len(X)
             predictions = np.random.randn(n_samples)
             return predictions
 
-
-    X = np.random.randn(50, 3,3)
-    yc = np.random.choice([0,1], 50)
+    X = np.random.randn(50, 3, 3).tolist()
+    yc = np.random.choice([0, 1], 50)
     yr = np.random.randn(50)
 
     boost = AdaBoostClassifier(DummyClassifier())
-    boost.fit(X,yc)
+    boost.fit(X, yc)
+
     boost = AdaBoostRegressor(DummyRegressor())
-    boost.fit(X,yc)
+    boost.fit(X, yr)
+

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -371,4 +371,3 @@ def test_multidimensional_X():
 
     boost = AdaBoostRegressor(DummyRegressor())
     boost.fit(X, yr)
-

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -492,36 +492,14 @@ def test_multidimensional_X():
     Check that the AdaBoost estimators can work with n-dimensional
     data matrix
     """
-    class DummyClassifier(BaseEstimator):
 
-        def fit(self, X, y, sample_weight=None):
-            self.classes_ = np.unique(y)
-            return self
+    from sklearn.dummy import DummyClassifier, DummyRegressor
 
-        def predict(self, X):
-            n_samples = len(X)
-            predictions = np.random.choice(self.classes_, n_samples)
-            return predictions
+    rng = np.random.RandomState(0)
 
-        def predict_proba(self, X):
-            n_samples = len(X)
-            n_classes = len(self.classes_)
-            probas = np.random.randn(n_samples, n_classes)
-            return probas
-
-    class DummyRegressor(BaseEstimator):
-
-        def fit(self, X, y):
-            return self
-
-        def predict(self, X):
-            n_samples = len(X)
-            predictions = np.random.randn(n_samples)
-            return predictions
-
-    X = np.random.randn(50, 3, 3)
-    yc = np.random.choice([0, 1], 50)
-    yr = np.random.randn(50)
+    X = rng.random.randn(50, 3, 3)
+    yc = rng.random.choice([0, 1], 50)
+    yr = rng.random.randn(50)
 
     boost = AdaBoostClassifier(DummyClassifier())
     boost.fit(X, yc)

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -471,7 +471,7 @@ def test_sparse_classification():
         # Verify sparsity of data is maintained during training
         types = [i.data_type_ for i in sparse_classifier.estimators_]
 
-        assert all([(t == csc_matrix or t == csr_matrix)  for t in types])
+        assert all([(t == csc_matrix or t == csr_matrix) for t in types])
 
 
 def test_sparse_regression():

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -44,6 +44,14 @@ __all__ = [
 ]
 
 
+def _len(X):
+    try:
+        n = X.shape[0]
+    except AttributeError:
+        n = len(X)
+    return n
+
+
 class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
     """Base class for AdaBoost estimators.
 
@@ -107,8 +115,8 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
 
         if sample_weight is None:
             # Initialize weights to 1 / n_samples
-            sample_weight = np.empty(len(X), dtype=np.float64)
-            sample_weight[:] = 1. / len(X)
+            sample_weight = np.empty(_len(X), dtype=np.float64)
+            sample_weight[:] = 1. / _len(X)
         else:
             sample_weight = check_array(sample_weight, ensure_2d=False)
             # Normalize existing weights
@@ -740,7 +748,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         n_classes = self.n_classes_
 
         if n_classes == 1:
-            return np.ones((len(X), 1))
+            return np.ones((_len(X), 1))
 
         if self.algorithm == 'SAMME.R':
             # The weights are all 1. for SAMME.R
@@ -990,7 +998,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         # For NumPy >= 1.7.0 use np.random.choice
         cdf = stable_cumsum(sample_weight)
         cdf /= cdf[-1]
-        uniform_samples = random_state.random_sample(len(X))
+        uniform_samples = random_state.random_sample(_len(X))
         bootstrap_idx = cdf.searchsorted(uniform_samples, side='right')
         # searchsorted returns a scalar
         bootstrap_idx = np.array(bootstrap_idx, copy=False)
@@ -1051,10 +1059,10 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         median_or_above = weight_cdf >= 0.5 * weight_cdf[:, -1][:, np.newaxis]
         median_idx = median_or_above.argmax(axis=1)
 
-        median_estimators = sorted_idx[np.arange(len(X)), median_idx]
+        median_estimators = sorted_idx[np.arange(_len(X)), median_idx]
 
         # Return median predictions
-        return predictions[np.arange(len(X)), median_estimators]
+        return predictions[np.arange(_len(X)), median_estimators]
 
     def predict(self, X):
         """Predict regression value for X.

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -105,7 +105,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         if self.learning_rate <= 0:
             raise ValueError("learning_rate must be greater than zero")
 
-        accept_sparse = ['csr', 'csc', 'lil']
+        accept_sparse = ['csr', 'csc']
         X, y = check_X_y(X, y,
                          accept_sparse=accept_sparse,
                          ensure_2d=False,

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -36,7 +36,9 @@ from ..tree import DecisionTreeClassifier, DecisionTreeRegressor
 from ..utils import check_array, check_random_state, check_X_y, safe_indexing
 from ..utils.extmath import stable_cumsum
 from ..metrics import accuracy_score, r2_score
-from sklearn.utils.validation import has_fit_parameter, check_is_fitted, _num_samples
+from sklearn.utils.validation import check_is_fitted
+from sklearn.utils.validation import has_fit_parameter
+from sklearn.utils.validation import _num_samples
 
 __all__ = [
     'AdaBoostClassifier',

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -73,10 +73,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. COO, DOK, and LIL are converted to CSR. The dtype is
-            forced to DTYPE from tree._tree if the base classifier of this
-            ensemble weighted boosting classifier is a tree or forest.
+            The training input samples.
 
         y : array-like of shape = [n_samples]
             The target values (class labels in classification, real numbers in
@@ -162,8 +159,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
             The index of the current boost iteration.
 
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. COO, DOK, and LIL are converted to CSR.
+            The training input samples.
 
         y : array-like of shape = [n_samples]
             The target values (class labels).
@@ -200,8 +196,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK and LIL are converted to CSR.
+            The training input samples.
 
         y : array-like, shape = [n_samples]
             Labels for X.
@@ -363,8 +358,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK and LIL are converted to CSR.
+            The training input samples.
 
         y : array-like of shape = [n_samples]
             The target values (class labels).
@@ -415,8 +409,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             The index of the current boost iteration.
 
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK and LIL are converted to CSR.
+            The training input samples.
 
         y : array-like of shape = [n_samples]
             The target values (class labels).
@@ -563,8 +556,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK and LIL are converted to CSR.
+            The training input samples.
 
         Returns
         -------
@@ -616,8 +608,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK and LIL are converted to CSR.
+            The training input samples.
 
         Returns
         -------
@@ -658,8 +649,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK and LIL are converted to CSR.
+            The training input samples.
 
         Returns
         -------
@@ -711,8 +701,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK and LIL are converted to CSR.
+            The training input samples.
 
         Returns
         -------
@@ -759,8 +748,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK and LIL are converted to CSR.
+            The training input samples.
 
         Returns
         -------
@@ -805,8 +793,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK and LIL are converted to CSR.
+            The training input samples.
 
         Returns
         -------
@@ -905,8 +892,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK and LIL are converted to CSR.
+            The training input samples.
 
         y : array-like of shape = [n_samples]
             The target values (real numbers).
@@ -944,8 +930,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
             The index of the current boost iteration.
 
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK and LIL are converted to CSR.
+            The training input samples.
 
         y : array-like of shape = [n_samples]
             The target values (class labels in classification, real numbers in
@@ -1052,8 +1037,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK and LIL are converted to CSR.
+            The training input samples.
 
         Returns
         -------
@@ -1077,8 +1061,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK and LIL are converted to CSR.
+            The training input samples.
 
         Returns
         -------

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -36,9 +36,9 @@ from ..tree import DecisionTreeClassifier, DecisionTreeRegressor
 from ..utils import check_array, check_random_state, check_X_y, safe_indexing
 from ..utils.extmath import stable_cumsum
 from ..metrics import accuracy_score, r2_score
-from sklearn.utils.validation import check_is_fitted
-from sklearn.utils.validation import has_fit_parameter
-from sklearn.utils.validation import _num_samples
+from ..utils.validation import check_is_fitted
+from ..utils.validation import has_fit_parameter
+from ..utils.validation import _num_samples
 
 __all__ = [
     'AdaBoostClassifier',

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -97,16 +97,11 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         if self.learning_rate <= 0:
             raise ValueError("learning_rate must be greater than zero")
 
-        if (self.base_estimator is None or
-                isinstance(self.base_estimator, (BaseDecisionTree,
-                                                 BaseForest))):
-            dtype = DTYPE
-            accept_sparse = 'csc'
-        else:
-            dtype = None
-            accept_sparse = ['csr', 'csc']
 
-        X, y = check_X_y(X, y, accept_sparse=accept_sparse, dtype=dtype,
+        X, y = check_X_y(X, y, 
+                         accept_sparse=True, 
+                         ensure_2d=False, 
+                         allow_nd=True,
                          y_numeric=is_regressor(self))
 
         if sample_weight is None:
@@ -261,13 +256,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
 
     def _validate_X_predict(self, X):
         """Ensure that X is in the proper format"""
-        if (self.base_estimator is None or
-                isinstance(self.base_estimator,
-                           (BaseDecisionTree, BaseForest))):
-            X = check_array(X, accept_sparse='csr', dtype=DTYPE)
-
-        else:
-            X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])
+        X = check_array(X, accept_sparse=True, ensure_2d=False, allow_nd=True)
 
         return X
 

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -69,11 +69,24 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         self.learning_rate = learning_rate
         self.random_state = random_state
 
-    def _validate_data(self, X):
-        return check_array(X,
-                           accept_sparse=True,
-                           ensure_2d=False,
-                           allow_nd=True)
+    def _validate_data(self, X, y=None):
+
+        accept_sparse = ['csr', 'csc']
+        if y is None:
+            ret = check_array(X,
+                              accept_sparse=accept_sparse,
+                              ensure_2d=False,
+                              allow_nd=True,
+                              dtype=None)
+        else:
+            
+            ret = check_X_y(X, y,
+                            accept_sparse=accept_sparse,
+                            ensure_2d=False,
+                            allow_nd=True,
+                            dtype=None,
+                            y_numeric=is_regressor(self))
+        return ret
 
     def fit(self, X, y, sample_weight=None):
         """Build a boosted classifier/regressor from the training set (X, y).
@@ -81,7 +94,8 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
         y : array-like of shape = [n_samples]
             The target values (class labels in classification, real numbers in
@@ -99,13 +113,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         if self.learning_rate <= 0:
             raise ValueError("learning_rate must be greater than zero")
 
-        accept_sparse = ['csr', 'csc']
-        X, y = check_X_y(X, y,
-                         accept_sparse=accept_sparse,
-                         ensure_2d=False,
-                         allow_nd=True,
-                         dtype=None,
-                         y_numeric=is_regressor(self))
+        X, y = self._validate_data(X,y)
 
         if sample_weight is None:
             # Initialize weights to 1 / n_samples
@@ -175,7 +183,8 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
             The index of the current boost iteration.
 
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
         y : array-like of shape = [n_samples]
             The target values (class labels).
@@ -212,7 +221,8 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
         y : array-like, shape = [n_samples]
             Labels for X.
@@ -376,7 +386,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
         y : array-like of shape = [n_samples]
             The target values (class labels).
@@ -574,7 +585,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
         Returns
         -------
@@ -603,7 +615,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : array-like of shape = [n_samples, n_features]
-            The input samples.
+            The input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
         Returns
         -------
@@ -630,7 +643,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
         Returns
         -------
@@ -672,7 +686,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
         Returns
         -------
@@ -725,7 +740,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
         Returns
         -------
@@ -773,7 +789,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
         Returns
         -------
@@ -819,7 +836,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
         Returns
         -------
@@ -919,7 +937,8 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
         y : array-like of shape = [n_samples]
             The target values (real numbers).
@@ -1064,7 +1083,8 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
         Returns
         -------

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -648,9 +648,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             values closer to -1 or 1 mean more like the first or second
             class in ``classes_``, respectively.
         """
-        self._validate_data(X)
-
         check_is_fitted(self, "n_classes_")
+        self._validate_data(X)
 
         n_classes = self.n_classes_
         classes = self.classes_[:, np.newaxis]
@@ -691,9 +690,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             values closer to -1 or 1 mean more like the first or second
             class in ``classes_``, respectively.
         """
-        self._validate_data(X)
-
         check_is_fitted(self, "n_classes_")
+        self._validate_data(X)
 
         n_classes = self.n_classes_
         classes = self.classes_[:, np.newaxis]
@@ -741,9 +739,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             The class probabilities of the input samples. The order of
             outputs is the same of that of the `classes_` attribute.
         """
-        self._validate_data(X)
-
         check_is_fitted(self, "n_classes_")
+        self._validate_data(X)
 
         n_classes = self.n_classes_
 
@@ -1080,9 +1077,8 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         y : array of shape = [n_samples]
             The predicted regression values.
         """
-        X = self._validate_data(X)
-
         check_is_fitted(self, "estimator_weights_")
+        X = self._validate_data(X)
 
         return self._get_median_predict(X, len(self.estimators_))
 
@@ -1106,9 +1102,8 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         y : generator of array, shape = [n_samples]
             The predicted regression values.
         """
-        self._validate_data(X)
-
         check_is_fitted(self, "estimator_weights_")
+        self._validate_data(X)
 
         for i, _ in enumerate(self.estimators_, 1):
             yield self._get_median_predict(X, limit=i)

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -79,7 +79,6 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
                               allow_nd=True,
                               dtype=None)
         else:
-            
             ret = check_X_y(X, y,
                             accept_sparse=accept_sparse,
                             ensure_2d=False,
@@ -113,7 +112,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         if self.learning_rate <= 0:
             raise ValueError("learning_rate must be greater than zero")
 
-        X, y = self._validate_data(X,y)
+        X, y = self._validate_data(X, y)
 
         if sample_weight is None:
             # Initialize weights to 1 / n_samples

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -233,7 +233,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         -------
         z : float
         """
-        self._validate_data(X)
+        X = self._validate_data(X)
 
         for y_pred in self.staged_predict(X):
             if is_classifier(self):
@@ -592,7 +592,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         y : array of shape = [n_samples]
             The predicted classes.
         """
-        self._validate_data(X)
+        X = self._validate_data(X)
 
         pred = self.decision_function(X)
 
@@ -622,7 +622,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         y : generator of array, shape = [n_samples]
             The predicted classes.
         """
-        self._validate_data(X)
+        X = self._validate_data(X)
 
         n_classes = self.n_classes_
         classes = self.classes_
@@ -656,7 +656,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             class in ``classes_``, respectively.
         """
         check_is_fitted(self, "n_classes_")
-        self._validate_data(X)
+        X = self._validate_data(X)
 
         n_classes = self.n_classes_
         classes = self.classes_[:, np.newaxis]
@@ -699,7 +699,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             class in ``classes_``, respectively.
         """
         check_is_fitted(self, "n_classes_")
-        self._validate_data(X)
+        X = self._validate_data(X)
 
         n_classes = self.n_classes_
         classes = self.classes_[:, np.newaxis]
@@ -749,7 +749,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             outputs is the same of that of the `classes_` attribute.
         """
         check_is_fitted(self, "n_classes_")
-        self._validate_data(X)
+        X = self._validate_data(X)
 
         n_classes = self.n_classes_
 
@@ -797,7 +797,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             The class probabilities of the input samples. The order of
             outputs is the same of that of the `classes_` attribute.
         """
-        self._validate_data(X)
+        X = self._validate_data(X)
 
         n_classes = self.n_classes_
         proba = None
@@ -844,7 +844,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             The class probabilities of the input samples. The order of
             outputs is the same of that of the `classes_` attribute.
         """
-        self._validate_data(X)
+        X = self._validate_data(X)
         return np.log(self.predict_proba(X))
 
 
@@ -1116,7 +1116,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
             The predicted regression values.
         """
         check_is_fitted(self, "estimator_weights_")
-        self._validate_data(X)
+        X = self._validate_data(X)
 
         for i, _ in enumerate(self.estimators_, 1):
             yield self._get_median_predict(X, limit=i)

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -70,7 +70,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         self.random_state = random_state
 
     def _validate_data(self, X, y=None):
-        
+
         # Accept or convert to these sparse matrix formats so we can
         # use safe_indexing
         accept_sparse = ['csr', 'csc']

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -70,7 +70,9 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         self.random_state = random_state
 
     def _validate_data(self, X, y=None):
-
+        
+        # Accept or convert to these sparse matrix formats so we can
+        # use safe_indexing
         accept_sparse = ['csr', 'csc']
         if y is None:
             ret = check_array(X,

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -30,13 +30,10 @@ import numpy as np
 from scipy.special import xlogy
 
 from .base import BaseEnsemble
-from ..base import ClassifierMixin, RegressorMixin, is_regressor, is_classifier
+from ..base import ClassifierMixin, RegressorMixin, is_classifier
 
-from .forest import BaseForest
 from ..tree import DecisionTreeClassifier, DecisionTreeRegressor
-from ..tree.tree import BaseDecisionTree
-from ..tree._tree import DTYPE
-from ..utils import check_array, check_X_y, check_random_state
+from ..utils import check_array, check_random_state, safe_indexing
 from ..utils.extmath import stable_cumsum
 from ..metrics import accuracy_score, r2_score
 from sklearn.utils.validation import has_fit_parameter, check_is_fitted
@@ -97,17 +94,10 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         if self.learning_rate <= 0:
             raise ValueError("learning_rate must be greater than zero")
 
-
-        X, y = check_X_y(X, y, 
-                         accept_sparse=True, 
-                         ensure_2d=False, 
-                         allow_nd=True,
-                         y_numeric=is_regressor(self))
-
         if sample_weight is None:
             # Initialize weights to 1 / n_samples
-            sample_weight = np.empty(X.shape[0], dtype=np.float64)
-            sample_weight[:] = 1. / X.shape[0]
+            sample_weight = np.empty(len(X), dtype=np.float64)
+            sample_weight[:] = 1. / len(X)
         else:
             sample_weight = check_array(sample_weight, ensure_2d=False)
             # Normalize existing weights
@@ -253,12 +243,6 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
                 "Unable to compute feature importances "
                 "since base_estimator does not have a "
                 "feature_importances_ attribute")
-
-    def _validate_X_predict(self, X):
-        """Ensure that X is in the proper format"""
-        X = check_array(X, accept_sparse=True, ensure_2d=False, allow_nd=True)
-
-        return X
 
 
 def _samme_proba(estimator, n_classes, X):
@@ -646,7 +630,6 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             class in ``classes_``, respectively.
         """
         check_is_fitted(self, "n_classes_")
-        X = self._validate_X_predict(X)
 
         n_classes = self.n_classes_
         classes = self.classes_[:, np.newaxis]
@@ -689,7 +672,6 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             class in ``classes_``, respectively.
         """
         check_is_fitted(self, "n_classes_")
-        X = self._validate_X_predict(X)
 
         n_classes = self.n_classes_
         classes = self.classes_[:, np.newaxis]
@@ -741,10 +723,9 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         check_is_fitted(self, "n_classes_")
 
         n_classes = self.n_classes_
-        X = self._validate_X_predict(X)
 
         if n_classes == 1:
-            return np.ones((X.shape[0], 1))
+            return np.ones((len(X), 1))
 
         if self.algorithm == 'SAMME.R':
             # The weights are all 1. for SAMME.R
@@ -787,7 +768,6 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             The class probabilities of the input samples. The order of
             outputs is the same of that of the `classes_` attribute.
         """
-        X = self._validate_X_predict(X)
 
         n_classes = self.n_classes_
         proba = None
@@ -997,14 +977,16 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         # For NumPy >= 1.7.0 use np.random.choice
         cdf = stable_cumsum(sample_weight)
         cdf /= cdf[-1]
-        uniform_samples = random_state.random_sample(X.shape[0])
+        uniform_samples = random_state.random_sample(len(X))
         bootstrap_idx = cdf.searchsorted(uniform_samples, side='right')
         # searchsorted returns a scalar
         bootstrap_idx = np.array(bootstrap_idx, copy=False)
 
         # Fit on the bootstrapped sample and obtain a prediction
         # for all samples in the training set
-        estimator.fit(X[bootstrap_idx], y[bootstrap_idx])
+        X_ = safe_indexing(X, bootstrap_idx)
+        y_ = safe_indexing(y, bootstrap_idx)
+        estimator.fit(X_, y_)
         y_predict = estimator.predict(X)
 
         error_vect = np.abs(y_predict - y)
@@ -1056,10 +1038,10 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         median_or_above = weight_cdf >= 0.5 * weight_cdf[:, -1][:, np.newaxis]
         median_idx = median_or_above.argmax(axis=1)
 
-        median_estimators = sorted_idx[np.arange(X.shape[0]), median_idx]
+        median_estimators = sorted_idx[np.arange(len(X)), median_idx]
 
         # Return median predictions
-        return predictions[np.arange(X.shape[0]), median_estimators]
+        return predictions[np.arange(len(X)), median_estimators]
 
     def predict(self, X):
         """Predict regression value for X.
@@ -1079,7 +1061,6 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
             The predicted regression values.
         """
         check_is_fitted(self, "estimator_weights_")
-        X = self._validate_X_predict(X)
 
         return self._get_median_predict(X, len(self.estimators_))
 
@@ -1105,7 +1086,6 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
             The predicted regression values.
         """
         check_is_fitted(self, "estimator_weights_")
-        X = self._validate_X_predict(X)
 
         for i, _ in enumerate(self.estimators_, 1):
             yield self._get_median_predict(X, limit=i)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #7768. Takes over #8304.


#### What does this implement/fix? Explain your changes.
This PR (almost) transfers the responsibility of the validation of `X `and `y`  from AdaBoost to the base estimator.


#### Any other comments?
I retained all the tests. If we want to relax the check about sparsity we should remove the `test_sparse_classification` and `test_sparse_regression` tests.