### PR TITLE
Clearer exception on legacy multi-label data representation

### DIFF
--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1609,7 +1609,8 @@ def test__check_targets():
     y2 = [(2,), (0, 2,)]
     msg = ('You appear to be using a legacy multi-label data representation. '
            'Sequence of sequences are no longer supported; use a binary array'
-           ' or sparse matrix instead.')
+           ' or sparse matrix instead - the MultiLabelBinarizer'
+           ' transformer can convert to this format.')
     assert_raise_message(ValueError, msg, _check_targets, y1, y2)
 
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -260,8 +260,8 @@ def type_of_target(y):
             raise ValueError('You appear to be using a legacy multi-label data'
                              ' representation. Sequence of sequences are no'
                              ' longer supported; use a binary array or sparse'
-                             ' matrix instead - the MultiLabelBinarizer transformer'
-                             ' can convert to this format.')
+                             ' matrix instead - the MultiLabelBinarizer'
+                             ' transformer can convert to this format.')
     except IndexError:
         pass
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -260,7 +260,8 @@ def type_of_target(y):
             raise ValueError('You appear to be using a legacy multi-label data'
                              ' representation. Sequence of sequences are no'
                              ' longer supported; use a binary array or sparse'
-                             ' matrix instead.')
+                             ' matrix instead - the MultiLabelBinarizer transformer'
+                             ' can convert to this format.')
     except IndexError:
         pass
 


### PR DESCRIPTION
#### Reference Issues/PRs

See new exception added in #4919

#### What does this implement/fix? Explain your changes.

Motivating example:

```python
>>> from sklearn.metrics import hamming_loss
>>> expt_list = [["A"], ["B"], ["C"], ["D"], ["E"], ["A", "E"]]
>>> pred_list = [["A"], ["B"], ["B", "C"], ["C"], ["E"], ["A"]]
>>> hamming_loss(expt_list, pred_list)
Traceback (most recent call last):
...
ValueError: You appear to be using a legacy multi-label data representation. Sequence of sequences are no longer supported; use a binary array or sparse matrix instead.
```

I would have found it helpful if the exception mentioned the new helper class ``MultiLabelBinarizer``, which could be used here as follows:

```python
>>> from sklearn.metrics import hamming_loss
>>> from sklearn.preprocessing import MultiLabelBinarizer
>>> expt_list = [["A"], ["B"], ["C"], ["D"], ["E"], ["A", "E"]]
>>> pred_list = [["A"], ["B"], ["B", "C"], ["C"], ["E"], ["A"]]
>>> relabel = MultiLabelBinarizer(["A", "B", "C", "D", "E"])  # Could be more classes
>>> expt = relabel.fit_transform(expt_list)
>>> pred = relabel.fit_transform(pred_list)
>>> hamming_loss(expt, pred)
0.13333333333333333
```

#### Any other comments?

Including the helper class name makes it far easier to find documentation on the new way to do this, e.g.

https://scikit-learn.org/stable/modules/multiclass.html#multilabel-classification-format