### PR TITLE
Add warning about model persistance

### DIFF
--- a/doc/modules/model_persistence.rst
+++ b/doc/modules/model_persistence.rst
@@ -74,6 +74,9 @@ and security. Because of this,
   other versions, this is entirely unsupported and inadvisable. It should 
   also be kept in mind that operations performed on such data could give
   different and unexpected results.
+* There is no guarantee that models saved with one version of Python (major
+  or minor) will successfully load in another version, even if scikit-learn
+  versions are the same.
 
 In order to rebuild a similar model with future versions of scikit-learn,
 additional metadata should be saved along the pickled model:


### PR DESCRIPTION
#### What does this implement/fix?

I had a problem where models created with python 3.6.1 could not be loaded using python 3.7.1. Some warning like this in the docs would hopefully prevent other people from having the same problem. Currently python versions are not mentioned in the docs as something important.