### PR TITLE
Fix #13194: Ensure monotonic bin edges for KBinsDiscretizer strategy quantile

### DIFF
--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -161,6 +161,10 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
             elif self.strategy == 'quantile':
                 quantiles = np.linspace(0, 100, n_bins[jj] + 1)
                 bin_edges[jj] = np.asarray(np.percentile(column, quantiles))
+                # Edge cases can lead to numerically unstable values in case of
+                # identical percentiles, but we need to make them monotonic
+                # https://github.com/numpy/numpy/issues/10373
+                np.maximum.accumulate(bin_edges[jj], out=bin_edges[jj])
 
             elif self.strategy == 'kmeans':
                 from ..cluster import KMeans  # fixes import loops

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -145,13 +145,22 @@ def test_numeric_stability():
         assert_array_equal(Xt_expected, Xt)
 
 
+def test_percentile_numeric_stability():
+    X = np.array([0.05, 0.05, 0.95]).reshape(-1, 1)
+    Xt_expected = np.array([5, 5, 9]).reshape(-1, 1)
+
+    Xt = KBinsDiscretizer(n_bins=10,
+                          encode='ordinal',
+                          strategy='quantile').fit_transform(X)
+    assert_array_equal(Xt_expected, Xt)
+
+
 def test_invalid_encode_option():
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], encode='invalid-encode')
     assert_raise_message(ValueError, "Valid options for 'encode' are "
                          "('onehot', 'onehot-dense', 'ordinal'). "
                          "Got encode='invalid-encode' instead.",
                          est.fit, X)
-
 
 def test_encode_options():
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3],


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #13194

#### What does this implement/fix? Explain your changes.
The percentiles returned from np.percentile are monotonic up to possible numeric instabilities. Monotonicity is enforced by applying a simple maximum on subsequent values to deal with this case and increase robustness.

#### Any other comments?
The additional line is a no-op in almost all cases. This is unfortunate, but since there is essentially no performance impact, I guess robustness is worth the effort.
