### PR TITLE
[MRG+1] DOC more detailed note on SVC and SVR scalability

### DIFF
--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -431,7 +431,9 @@ class SVC(BaseSVC):
 
     The implementation is based on libsvm. The fit time complexity
     is more than quadratic with the number of samples which makes it hard
-    to scale to dataset with more than a couple of 10000 samples.
+    to scale to dataset with more than a couple of 10000 samples. For large
+    datasets consider using :class:`LinearSVC` or :class:`SGDClassifier`
+    instead.
 
     The multiclass support is handled according to a one-vs-one scheme.
 
@@ -791,7 +793,11 @@ class SVR(BaseLibSVM, RegressorMixin):
 
     The free parameters in the model are C and epsilon.
 
-    The implementation is based on libsvm.
+    The implementation is based on libsvm. The fit time complexity
+    is more than quadratic with the number of samples which makes it hard
+    to scale to dataset with more than a couple of 10000 samples. For large
+    datasets consider using :class:`LinearSVR` or :class:`SGDRegressor`
+    instead.
 
     Read more in the :ref:`User Guide <svm_regression>`.
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -432,9 +432,9 @@ class SVC(BaseSVC):
     The implementation is based on libsvm. The fit time complexity
     is more than quadratic with the number of samples which makes it hard
     to scale to datasets with more than a couple of 10000 samples. For large
-    datasets consider using :class:`LinearSVC` or :class:`SGDClassifier`
-    instead, possibly after a class:`sklearn.kernel_approximation.Nystroem`
-    transformer.
+    datasets consider using :class:`sklearn.linear_model.LinearSVR` or
+    :class:`sklearn.linear_model.SGDRegressor` instead, possibly after a
+    :class:`sklearn.kernel_approximation.Nystroem` transformer.
 
     The multiclass support is handled according to a one-vs-one scheme.
 
@@ -797,9 +797,9 @@ class SVR(BaseLibSVM, RegressorMixin):
     The implementation is based on libsvm. The fit time complexity
     is more than quadratic with the number of samples which makes it hard
     to scale to datasets with more than a couple of 10000 samples. For large
-    datasets consider using :class:`LinearSVR` or :class:`SGDRegressor`
-    instead, possibly after a class:`sklearn.kernel_approximation.Nystroem`
-    transformer.
+    datasets consider using :class:`sklearn.linear_model.LinearSVR` or
+    :class:`sklearn.linear_model.SGDRegressor` instead, possibly after a
+    :class:`sklearn.kernel_approximation.Nystroem` transformer.
 
     Read more in the :ref:`User Guide <svm_regression>`.
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -432,8 +432,8 @@ class SVC(BaseSVC):
     The implementation is based on libsvm. The fit time complexity
     is more than quadratic with the number of samples which makes it hard
     to scale to datasets with more than a couple of 10000 samples. For large
-    datasets consider using :class:`sklearn.linear_model.LinearSVR` or
-    :class:`sklearn.linear_model.SGDRegressor` instead, possibly after a
+    datasets consider using :class:`sklearn.linear_model.LinearSVC` or
+    :class:`sklearn.linear_model.SGDClassifier` instead, possibly after a
     :class:`sklearn.kernel_approximation.Nystroem` transformer.
 
     The multiclass support is handled according to a one-vs-one scheme.

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -431,9 +431,10 @@ class SVC(BaseSVC):
 
     The implementation is based on libsvm. The fit time complexity
     is more than quadratic with the number of samples which makes it hard
-    to scale to dataset with more than a couple of 10000 samples. For large
+    to scale to datasets with more than a couple of 10000 samples. For large
     datasets consider using :class:`LinearSVC` or :class:`SGDClassifier`
-    instead.
+    instead, possibly after a class:`sklearn.kernel_approximation.Nystroem`
+    transformer.
 
     The multiclass support is handled according to a one-vs-one scheme.
 
@@ -795,9 +796,10 @@ class SVR(BaseLibSVM, RegressorMixin):
 
     The implementation is based on libsvm. The fit time complexity
     is more than quadratic with the number of samples which makes it hard
-    to scale to dataset with more than a couple of 10000 samples. For large
+    to scale to datasets with more than a couple of 10000 samples. For large
     datasets consider using :class:`LinearSVR` or :class:`SGDRegressor`
-    instead.
+    instead, possibly after a class:`sklearn.kernel_approximation.Nystroem`
+    transformer.
 
     Read more in the :ref:`User Guide <svm_regression>`.
 


### PR DESCRIPTION
This extends the note in the SVC / SVR on their bad scalability with the suggestion to use LinearSVC/LinearSVR or SDG classifier/regressor on larger datasets.

Just saw some usage of `SVC(kernel='linear')` on large datasets, so putting it in the docstring in addition to the user manual might be useful. 