### PR TITLE
FIX Correct the definition of gamma=`scale` in svm

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -102,7 +102,7 @@ Usage examples:
     >>> clf = svm.SVC(gamma='scale', random_state=0)
     >>> cross_val_score(clf, X, y, scoring='recall_macro',
     ...                 cv=5)  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-    array([0.96..., 1.  ..., 0.96..., 0.96..., 1.        ])
+    array([0.96..., 0.96..., 0.96..., 0.93..., 1.        ])
     >>> model = svm.SVC()
     >>> cross_val_score(model, X, y, cv=5, scoring='wrong_choice')
     Traceback (most recent call last):
@@ -1947,7 +1947,7 @@ change the kernel::
 
   >>> clf = SVC(gamma='scale', kernel='rbf', C=1).fit(X_train, y_train)
   >>> clf.score(X_test, y_test)  # doctest: +ELLIPSIS
-  0.97...
+  0.94...
 
 We see that the accuracy was boosted to almost 100%.  A cross validation
 strategy is recommended for a better estimate of the accuracy, if it

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -344,7 +344,7 @@ once will overwrite what was learned by any previous ``fit()``::
     max_iter=-1, probability=False, random_state=None, shrinking=True,
     tol=0.001, verbose=False)
   >>> clf.predict(X_test)
-  array([1, 0, 1, 1, 0])
+  array([0, 0, 0, 1, 0])
 
 Here, the default kernel ``rbf`` is first changed to ``linear`` via
 :func:`SVC.set_params()<sklearn.svm.SVC.set_params>` after the estimator has

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -36,6 +36,14 @@ Changelog
   threaded when `n_jobs > 1` or `n_jobs = -1`.
   :issue:`13005` by :user:`Prabakaran Kumaresshan <nixphix>`.
 
+:mod:`sklearn.feature_extraction`
+.................................
+
+- |Fix| Fixed a bug in :class:`feature_extraction.text.CountVectorizer` which 
+  would result in the sparse feature matrix having conflicting `indptr` and
+  `indices` precisions under very large vocabularies. :issue:`11295` by
+  :user:`Gabriel Vacaliuc <gvacaliuc>`.
+
 :mod:`sklearn.impute`
 .....................
 
@@ -68,13 +76,15 @@ Changelog
   with a warning in :class:`preprocessing.KBinsDiscretizer`.
   :issue:`13165` by :user:`Hanmin Qin <qinhanmin2014>`.
 
-:mod:`sklearn.feature_extraction.text`
-......................................
+:mod:`sklearn.svm`
+..................
 
-- |Fix| Fixed a bug in :class:`feature_extraction.text.CountVectorizer` which 
-  would result in the sparse feature matrix having conflicting `indptr` and
-  `indices` precisions under very large vocabularies. :issue:`11295` by
-  :user:`Gabriel Vacaliuc <gvacaliuc>`.
+- |FIX| Fixed a bug in :class:`svm.SVC`, :class:`svm.NuSVC`, :class:`svm.SVR`,
+  :class:`svm.NuSVR` and :class:`svm.OneClassSVM` where the ``scale`` option
+  of parameter ``gamma`` is erroneously defined as
+  ``1 / (n_features * X.std())``. It's now defined as
+  ``1 / (n_features * X.var())``.
+  :issue:`13221` by :user:`Hanmin Qin <qinhanmin2014>`.
 
 .. _changes_0_20_2:
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1710,19 +1710,23 @@ def test_deprecated_grid_search_iid():
     depr_message = ("The default of the `iid` parameter will change from True "
                     "to False in version 0.22")
     X, y = make_blobs(n_samples=54, random_state=0, centers=2)
-    grid = GridSearchCV(SVC(gamma='scale'), param_grid={'C': [1]}, cv=3)
+    grid = GridSearchCV(SVC(gamma='scale', random_state=0),
+                        param_grid={'C': [10]}, cv=3)
     # no warning with equally sized test sets
     assert_no_warnings(grid.fit, X, y)
 
-    grid = GridSearchCV(SVC(gamma='scale'), param_grid={'C': [1]}, cv=5)
+    grid = GridSearchCV(SVC(gamma='scale', random_state=0),
+                        param_grid={'C': [10]}, cv=5)
     # warning because 54 % 5 != 0
     assert_warns_message(DeprecationWarning, depr_message, grid.fit, X, y)
 
-    grid = GridSearchCV(SVC(gamma='scale'), param_grid={'C': [1]}, cv=2)
+    grid = GridSearchCV(SVC(gamma='scale', random_state=0),
+                        param_grid={'C': [10]}, cv=2)
     # warning because stratification into two classes and 27 % 2 != 0
     assert_warns_message(DeprecationWarning, depr_message, grid.fit, X, y)
 
-    grid = GridSearchCV(SVC(gamma='scale'), param_grid={'C': [1]}, cv=KFold(2))
+    grid = GridSearchCV(SVC(gamma='scale', random_state=0),
+                        param_grid={'C': [10]}, cv=KFold(2))
     # no warning because no stratification and 54 % 2 == 0
     assert_no_warnings(grid.fit, X, y)
 

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -169,19 +169,19 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
 
         if self.gamma in ('scale', 'auto_deprecated'):
             if sparse:
-                # std = sqrt(E[X^2] - E[X]^2)
-                X_std = np.sqrt((X.multiply(X)).mean() - (X.mean())**2)
+                # var = E[X^2] - E[X]^2
+                X_var = (X.multiply(X)).mean() - (X.mean()) ** 2
             else:
-                X_std = X.std()
+                X_var = X.var()
             if self.gamma == 'scale':
-                if X_std != 0:
-                    self._gamma = 1.0 / (X.shape[1] * X_std)
+                if X_var != 0:
+                    self._gamma = 1.0 / (X.shape[1] * X_var)
                 else:
                     self._gamma = 1.0
             else:
                 kernel_uses_gamma = (not callable(self.kernel) and self.kernel
                                      not in ('linear', 'precomputed'))
-                if kernel_uses_gamma and not np.isclose(X_std, 1.0):
+                if kernel_uses_gamma and not np.isclose(X_var, 1.0):
                     # NOTE: when deprecation ends we need to remove explicitly
                     # setting `gamma` in examples (also in tests). See
                     # https://github.com/scikit-learn/scikit-learn/pull/10331

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -463,7 +463,7 @@ class SVC(BaseSVC):
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
 
         Current default is 'auto' which uses 1 / n_features,
-        if ``gamma='scale'`` is passed then it uses 1 / (n_features * X.std())
+        if ``gamma='scale'`` is passed then it uses 1 / (n_features * X.var())
         as value of gamma. The current default of gamma, 'auto', will change
         to 'scale' in version 0.22. 'auto_deprecated', a deprecated version of
         'auto' is used as a default indicating that no explicit value of gamma
@@ -651,7 +651,7 @@ class NuSVC(BaseSVC):
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
 
         Current default is 'auto' which uses 1 / n_features,
-        if ``gamma='scale'`` is passed then it uses 1 / (n_features * X.std())
+        if ``gamma='scale'`` is passed then it uses 1 / (n_features * X.var())
         as value of gamma. The current default of gamma, 'auto', will change
         to 'scale' in version 0.22. 'auto_deprecated', a deprecated version of
         'auto' is used as a default indicating that no explicit value of gamma
@@ -812,7 +812,7 @@ class SVR(BaseLibSVM, RegressorMixin):
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
 
         Current default is 'auto' which uses 1 / n_features,
-        if ``gamma='scale'`` is passed then it uses 1 / (n_features * X.std())
+        if ``gamma='scale'`` is passed then it uses 1 / (n_features * X.var())
         as value of gamma. The current default of gamma, 'auto', will change
         to 'scale' in version 0.22. 'auto_deprecated', a deprecated version of
         'auto' is used as a default indicating that no explicit value of gamma
@@ -948,7 +948,7 @@ class NuSVR(BaseLibSVM, RegressorMixin):
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
 
         Current default is 'auto' which uses 1 / n_features,
-        if ``gamma='scale'`` is passed then it uses 1 / (n_features * X.std())
+        if ``gamma='scale'`` is passed then it uses 1 / (n_features * X.var())
         as value of gamma. The current default of gamma, 'auto', will change
         to 'scale' in version 0.22. 'auto_deprecated', a deprecated version of
         'auto' is used as a default indicating that no explicit value of gamma
@@ -1065,7 +1065,7 @@ class OneClassSVM(BaseLibSVM, OutlierMixin):
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
 
         Current default is 'auto' which uses 1 / n_features,
-        if ``gamma='scale'`` is passed then it uses 1 / (n_features * X.std())
+        if ``gamma='scale'`` is passed then it uses 1 / (n_features * X.var())
         as value of gamma. The current default of gamma, 'auto', will change
         to 'scale' in version 0.22. 'auto_deprecated', a deprecated version of
         'auto' is used as a default indicating that no explicit value of gamma

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -87,9 +87,9 @@ def test_svc():
     kernels = ["linear", "poly", "rbf", "sigmoid"]
     for dataset in datasets:
         for kernel in kernels:
-            clf = svm.SVC(gamma='scale', kernel=kernel, probability=True,
+            clf = svm.SVC(gamma=1, kernel=kernel, probability=True,
                           random_state=0, decision_function_shape='ovo')
-            sp_clf = svm.SVC(gamma='scale', kernel=kernel, probability=True,
+            sp_clf = svm.SVC(gamma=1, kernel=kernel, probability=True,
                              random_state=0, decision_function_shape='ovo')
             check_svm_model_equal(clf, sp_clf, *dataset)
 

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -293,8 +293,8 @@ def test_sparse_oneclasssvm(datasets_index, kernel):
                 [X_blobs[:80], None, X_blobs[80:]],
                 [iris.data, None, iris.data]]
     dataset = datasets[datasets_index]
-    clf = svm.OneClassSVM(gamma='scale', kernel=kernel)
-    sp_clf = svm.OneClassSVM(gamma='scale', kernel=kernel)
+    clf = svm.OneClassSVM(gamma=1, kernel=kernel)
+    sp_clf = svm.OneClassSVM(gamma=1, kernel=kernel)
     check_svm_model_equal(clf, sp_clf, *dataset)
 
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -243,11 +243,11 @@ def test_oneclass():
     clf.fit(X)
     pred = clf.predict(T)
 
-    assert_array_equal(pred, [-1, -1, -1])
+    assert_array_equal(pred, [1, -1, -1])
     assert_equal(pred.dtype, np.dtype('intp'))
-    assert_array_almost_equal(clf.intercept_, [-1.117], decimal=3)
+    assert_array_almost_equal(clf.intercept_, [-1.218], decimal=3)
     assert_array_almost_equal(clf.dual_coef_,
-                              [[0.681, 0.139, 0.68, 0.14, 0.68, 0.68]],
+                              [[0.750, 0.750, 0.750, 0.750]],
                               decimal=3)
     assert_raises(AttributeError, lambda: clf.coef_)
 
@@ -1003,9 +1003,9 @@ def test_gamma_scale():
 
     clf = svm.SVC(gamma='scale')
     assert_no_warnings(clf.fit, X, y)
-    assert_equal(clf._gamma, 2.)
+    assert_almost_equal(clf._gamma, 4)
 
-    # X_std ~= 1 shouldn't raise warning, for when
+    # X_var ~= 1 shouldn't raise warning, for when
     # gamma is not explicitly set.
     X, y = [[1, 2], [3, 2 * np.sqrt(6) / 3 + 2]], [0, 1]
     assert_no_warnings(clf.fit, X, y)


### PR DESCRIPTION
Closes #12741 
See https://github.com/scikit-learn/scikit-learn/pull/13186#issuecomment-466041087:
And I'm wondering whether it's possible to solve #12741 in 0.20.3 by changing the definition of `gamma='scale'` directly, since it's introduced erroneously in 0.20. This is an embarrassing mistake and I think it'll be much more difficult to solve it in 0.21.X (maybe at that time we'll need to deprecate scale and introduce another option).