### PR TITLE
[MRG] Configures Appveyor to fail fast after sklearn installation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,6 +64,13 @@ install:
   # Install the generated wheel package to test it
   - "pip install --pre --no-index --find-links dist/ scikit-learn"
 
+  # If there is a newer build queued for the same PR, cancel this one.
+  # credits: JuliaLang developers.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=500).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
+
 # Not a .NET project, we build scikit-learn in the install step instead
 build: false
 


### PR DESCRIPTION
This PR configures Appveyor check for a newer build **after** sklearn installation and cancel the current build if a newer build exists.