### PR TITLE
FIX skip external modules during all_estimators

### DIFF
--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -647,7 +647,7 @@ def all_estimators(include_meta_estimators=None,
     path = sklearn.__path__
     for importer, modname, ispkg in pkgutil.walk_packages(
             path=path, prefix='sklearn.', onerror=lambda x: None):
-        if ".tests." in modname:
+        if ".tests." in modname or "externals" in modname:
             continue
         if IS_PYPY and ('_svmlight_format' in modname or
                         'feature_extraction._hashing' in modname):


### PR DESCRIPTION
`sklearn.utils.testing.all_estimators` imports the modules it fetches the estimators from. When trying to import the `externals.joblib.testing` module, a `ModuleNotFoundError` is raised if `pytest` is not installed.
I propose to skip the `externals` package, where there is no estimators. 
ping @glemaitre  