### PR TITLE
Check arguments of `MissingIndicator` imputer when handling sparse arrays

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -82,7 +82,7 @@ Support for Python 3.4 and below has been officially dropped.
 - |Fix| Fixed a bug in :class:`decomposition.NMF` where `init = 'nndsvd'`,
   `init = 'nndsvda'`, and `init = 'nndsvdar'` are allowed when
   `n_components < n_features` instead of
-  `n_components <= min(n_samples, n_features)`. 
+  `n_components <= min(n_samples, n_features)`.
   :issue:`11650` by :user:`Hossein Pourbozorg <hossein-pourbozorg>` and
   :user:`Zijie (ZJ) Poh <zjpoh>`.
 
@@ -133,6 +133,10 @@ Support for Python 3.4 and below has been officially dropped.
   function of other features in a round-robin fashion. :issue:`8478` and
   :issue:`12177` by :user:`Sergey Feldman <sergeyf>` :user:`Ben Lawson
   <benlawson>`.
+  
+- |Fix| In :class:`impute.MissingIndicator` avoid implicit densification by
+  raising an exception if input is sparse add `missing_values` property
+  is set to 0. :issue:`12750` by :user:`Bartosz Telenczuk <btel>`.
 
 :mod:`sklearn.linear_model`
 ...........................
@@ -167,7 +171,7 @@ Support for Python 3.4 and below has been officially dropped.
 
 - |Fix| Fixed a bug in :class:`linear_model.LassoLarsIC`, where user input
    ``copy_X=False`` at instance creation would be overridden by default
-   parameter value ``copy_X=True`` in ``fit``. 
+   parameter value ``copy_X=True`` in ``fit``.
    :issue:`12972` by :user:`Lucio Fernandez-Arjona <luk-f-a>`
 
 :mod:`sklearn.manifold`

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -133,10 +133,10 @@ Support for Python 3.4 and below has been officially dropped.
   function of other features in a round-robin fashion. :issue:`8478` and
   :issue:`12177` by :user:`Sergey Feldman <sergeyf>` :user:`Ben Lawson
   <benlawson>`.
-  
+
 - |Fix| In :class:`impute.MissingIndicator` avoid implicit densification by
   raising an exception if input is sparse add `missing_values` property
-  is set to 0. :issue:`12750` by :user:`Bartosz Telenczuk <btel>`.
+  is set to 0. :issue:`13240` by :user:`Bartosz Telenczuk <btel>`.
 
 :mod:`sklearn.linear_model`
 ...........................

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -1109,6 +1109,7 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
 
     def __init__(self, missing_values=np.nan, features="missing-only",
                  sparse="auto", error_on_new=True):
+
         self.missing_values = missing_values
         self.features = features
         self.sparse = sparse
@@ -1206,6 +1207,9 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
         if self.features not in ('missing-only', 'all'):
             raise ValueError("'features' has to be either 'missing-only' or "
                              "'all'. Got {} instead.".format(self.features))
+
+        if isinstance(self.sparse, bool) and self.sparse and self.missing_values == 0:
+            raise ValueError("'missing_values' can not be 0 when 'sparse' is True")
 
         if not ((isinstance(self.sparse, str) and
                 self.sparse == "auto") or isinstance(self.sparse, bool)):

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -1109,7 +1109,6 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
 
     def __init__(self, missing_values=np.nan, features="missing-only",
                  sparse="auto", error_on_new=True):
-
         self.missing_values = missing_values
         self.features = features
         self.sparse = sparse
@@ -1209,7 +1208,7 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
                              "'all'. Got {} instead.".format(self.features))
 
         if self.sparse is True and self.missing_values == 0:
-            raise ValueError("'missing_values' can not be 0 "
+            raise ValueError("'missing_values' cannot be 0 "
                              "when 'sparse' is True")
 
         if sparse.issparse(X):

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -1207,10 +1207,6 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
             raise ValueError("'features' has to be either 'missing-only' or "
                              "'all'. Got {} instead.".format(self.features))
 
-        if self.sparse is True and self.missing_values == 0:
-            raise ValueError("'missing_values' cannot be 0 "
-                             "when 'sparse' is True")
-
         if sparse.issparse(X):
             # missing_values = 0 not allowed with sparse data as it would
             # force densification
@@ -1251,6 +1247,14 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
         if X.shape[1] != self._n_features:
             raise ValueError("X has a different number of features "
                              "than during fitting.")
+
+        if sparse.issparse(X):
+            # missing_values = 0 not allowed with sparse data as it would
+            # force densification
+            if self.missing_values == 0:
+                raise ValueError("Imputation not possible when missing_values "
+                                 "== 0 and input is sparse. Provide a dense "
+                                 "array instead.")
 
         imputer_mask, features = self._get_missing_features_info(X)
 

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -1134,7 +1134,7 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
             The features containing missing values.
 
         """
-        if sparse.issparse(X) and self.missing_values != 0:
+        if sparse.issparse(X):
             mask = _get_mask(X.data, self.missing_values)
 
             # The imputer mask will be constructed with the same sparse format
@@ -1157,10 +1157,6 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
             elif imputer_mask.format == 'csr':
                 imputer_mask = imputer_mask.tocsc()
         else:
-            if sparse.issparse(X):
-                # case of sparse matrix with 0 as missing values. Implicit and
-                # explicit zeros are considered as missing values.
-                X = X.toarray()
             imputer_mask = _get_mask(X, self.missing_values)
             features_with_missing = np.flatnonzero(imputer_mask.sum(axis=0))
 

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -1181,13 +1181,12 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
                              "with integer dtype or an array of string values "
                              "with an object dtype.".format(X.dtype))
 
-        if sparse.issparse(X):
+        if sparse.issparse(X) and self.missing_values == 0:
             # missing_values = 0 not allowed with sparse data as it would
             # force densification
-            if self.missing_values == 0:
-                raise ValueError("Sparse input with missing_values=0 is "
-                                 "not supported. Provide a dense "
-                                 "array instead.")
+            raise ValueError("Sparse input with missing_values=0 is "
+                             "not supported. Provide a dense "
+                             "array instead.")
 
         return X
 

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -1211,6 +1211,14 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
         if isinstance(self.sparse, bool) and self.sparse and self.missing_values == 0:
             raise ValueError("'missing_values' can not be 0 when 'sparse' is True")
 
+        if sparse.issparse(X):
+            # missing_values = 0 not allowed with sparse data as it would
+            # force densification
+            if self.missing_values == 0:
+                raise ValueError("Imputation not possible when missing_values "
+                                 "== 0 and input is sparse. Provide a dense "
+                                 "array instead.")
+
         if not ((isinstance(self.sparse, str) and
                 self.sparse == "auto") or isinstance(self.sparse, bool)):
             raise ValueError("'sparse' has to be a boolean or 'auto'. "

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -1180,6 +1180,15 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
                              "categorical data represented either as an array "
                              "with integer dtype or an array of string values "
                              "with an object dtype.".format(X.dtype))
+
+        if sparse.issparse(X):
+            # missing_values = 0 not allowed with sparse data as it would
+            # force densification
+            if self.missing_values == 0:
+                raise ValueError("Sparse input with missing_values=0 is "
+                                 "not supported. Provide a dense "
+                                 "array instead.")
+
         return X
 
     def fit(self, X, y=None):
@@ -1202,14 +1211,6 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
         if self.features not in ('missing-only', 'all'):
             raise ValueError("'features' has to be either 'missing-only' or "
                              "'all'. Got {} instead.".format(self.features))
-
-        if sparse.issparse(X):
-            # missing_values = 0 not allowed with sparse data as it would
-            # force densification
-            if self.missing_values == 0:
-                raise ValueError("Imputation not possible when missing_values "
-                                 "== 0 and input is sparse. Provide a dense "
-                                 "array instead.")
 
         if not ((isinstance(self.sparse, str) and
                 self.sparse == "auto") or isinstance(self.sparse, bool)):
@@ -1243,14 +1244,6 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
         if X.shape[1] != self._n_features:
             raise ValueError("X has a different number of features "
                              "than during fitting.")
-
-        if sparse.issparse(X):
-            # missing_values = 0 not allowed with sparse data as it would
-            # force densification
-            if self.missing_values == 0:
-                raise ValueError("Imputation not possible when missing_values "
-                                 "== 0 and input is sparse. Provide a dense "
-                                 "array instead.")
 
         imputer_mask, features = self._get_missing_features_info(X)
 

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -1208,8 +1208,9 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
             raise ValueError("'features' has to be either 'missing-only' or "
                              "'all'. Got {} instead.".format(self.features))
 
-        if isinstance(self.sparse, bool) and self.sparse and self.missing_values == 0:
-            raise ValueError("'missing_values' can not be 0 when 'sparse' is True")
+        if self.sparse is True and self.missing_values == 0:
+            raise ValueError("'missing_values' can not be 0 "
+                             "when 'sparse' is True")
 
         if sparse.issparse(X):
             # missing_values = 0 not allowed with sparse data as it would

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -1013,15 +1013,17 @@ def test_missing_indicator_raise_on_sparse_with_missing_0(arr_type):
                         [4, 12, 10]])
 
     # convert the input to the right array format
-    X_fit = arr_type(X_fit)
-    X_trans = arr_type(X_trans)
+    X_fit_sparse = arr_type(X_fit)
+    X_trans_sparse = arr_type(X_trans)
 
     indicator = MissingIndicator(missing_values=missing_values)
 
-    with pytest.raises(ValueError):
-        indicator.fit_transform(X_fit)
-    with pytest.raises(ValueError):
-        indicator.transform(X_trans)
+    with pytest.raises(ValueError, match="Sparse input with missing_values=0"):
+        indicator.fit_transform(X_fit_sparse)
+
+    indicator.fit_transform(X_fit)
+    with pytest.raises(ValueError, match="Sparse input with missing_values=0"):
+        indicator.transform(X_trans_sparse)
 
 
 @pytest.mark.parametrize("param_sparse", [True, False, 'auto'])

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -972,8 +972,6 @@ def test_missing_indicator_new(missing_values, arr_type, dtype, param_features,
     indicator = MissingIndicator(missing_values=missing_values,
                                  features=param_features,
                                  sparse=False)
-
-
     X_fit_mask = indicator.fit_transform(X_fit)
     X_trans_mask = indicator.transform(X_trans)
 
@@ -1046,7 +1044,6 @@ def test_missing_indicator_sparse_param(arr_type, missing_values,
 
     indicator = MissingIndicator(missing_values=missing_values,
                                  sparse=param_sparse)
-
     X_fit_mask = indicator.fit_transform(X_fit)
     X_trans_mask = indicator.transform(X_trans)
 

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -923,6 +923,9 @@ def test_iterative_imputer_early_stopping():
      (np.array([[-1, 1], [1, 2]]), np.array([[-1, 1], [1, 2]]),
       {'features': 'all', 'sparse': 'random'},
       "'sparse' has to be a boolean or 'auto'"),
+     (np.array([[-1, 1], [1, 2]]), np.array([[-1, 1], [1, 2]]),
+      {'missing_values': 0, 'sparse': True},
+      "'missing_values' can not be 0 when 'sparse' is True"),
      (np.array([['a', 'b'], ['c', 'a']], dtype=str),
       np.array([['a', 'b'], ['c', 'a']], dtype=str),
       {}, "MissingIndicator does not support data with dtype")]
@@ -932,6 +935,7 @@ def test_missing_indicator_error(X_fit, X_trans, params, msg_err):
     indicator.set_params(**params)
     with pytest.raises(ValueError, match=msg_err):
         indicator.fit(X_fit).transform(X_trans)
+
 
 
 @pytest.mark.parametrize(
@@ -981,6 +985,11 @@ def test_missing_indicator_new(missing_values, arr_type, dtype, param_features,
     assert isinstance(X_trans_mask, np.ndarray)
 
     indicator.set_params(sparse=True)
+    if missing_values == 0:
+        with pytest.raises(ValueError):
+            X_fit_mask_sparse = indicator.fit_transform(X_fit)
+        return
+
     X_fit_mask_sparse = indicator.fit_transform(X_fit)
     X_trans_mask_sparse = indicator.transform(X_trans)
 
@@ -1009,8 +1018,16 @@ def test_missing_indicator_sparse_param(arr_type, missing_values,
 
     indicator = MissingIndicator(missing_values=missing_values,
                                  sparse=param_sparse)
+
+    if param_sparse is True and missing_values == 0:
+        with pytest.raises(ValueError):
+            X_fit_mask = indicator.fit_transform(X_fit)
+        return
+
     X_fit_mask = indicator.fit_transform(X_fit)
     X_trans_mask = indicator.transform(X_trans)
+
+
 
     if param_sparse is True:
         assert X_fit_mask.format == 'csc'

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -923,9 +923,6 @@ def test_iterative_imputer_early_stopping():
      (np.array([[-1, 1], [1, 2]]), np.array([[-1, 1], [1, 2]]),
       {'features': 'all', 'sparse': 'random'},
       "'sparse' has to be a boolean or 'auto'"),
-     (np.array([[-1, 1], [1, 2]]), np.array([[-1, 1], [1, 2]]),
-      {'missing_values': 0, 'sparse': True},
-      "'missing_values' cannot be 0 when 'sparse' is True"),
      (np.array([['a', 'b'], ['c', 'a']], dtype=str),
       np.array([['a', 'b'], ['c', 'a']], dtype=str),
       {}, "MissingIndicator does not support data with dtype")]
@@ -972,6 +969,8 @@ def test_missing_indicator_new(missing_values, arr_type, dtype, param_features,
     if sparse.issparse(X_fit) and missing_values == 0:
         with pytest.raises(ValueError):
             X_fit_mask_sparse = indicator.fit_transform(X_fit)
+        with pytest.raises(ValueError):
+            X_trans_mask = indicator.transform(X_trans)
         return
 
     X_fit_mask = indicator.fit_transform(X_fit)
@@ -990,10 +989,6 @@ def test_missing_indicator_new(missing_values, arr_type, dtype, param_features,
     assert isinstance(X_trans_mask, np.ndarray)
 
     indicator.set_params(sparse=True)
-    if missing_values == 0:
-        with pytest.raises(ValueError):
-            X_fit_mask_sparse = indicator.fit_transform(X_fit)
-        return
 
     X_fit_mask_sparse = indicator.fit_transform(X_fit)
     X_trans_mask_sparse = indicator.transform(X_trans)
@@ -1024,14 +1019,11 @@ def test_missing_indicator_sparse_param(arr_type, missing_values,
     indicator = MissingIndicator(missing_values=missing_values,
                                  sparse=param_sparse)
 
-    if param_sparse is True and missing_values == 0:
-        with pytest.raises(ValueError):
-            X_fit_mask = indicator.fit_transform(X_fit)
-        return
-
     if sparse.issparse(X_fit) and missing_values == 0:
         with pytest.raises(ValueError):
             X_fit_mask = indicator.fit_transform(X_fit)
+        with pytest.raises(ValueError):
+            X_trans_mask = indicator.transform(X_trans)
         return
 
     X_fit_mask = indicator.fit_transform(X_fit)

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -969,6 +969,13 @@ def test_missing_indicator_new(missing_values, arr_type, dtype, param_features,
     indicator = MissingIndicator(missing_values=missing_values,
                                  features=param_features,
                                  sparse=False)
+
+
+    if sparse.issparse(X_fit) and missing_values == 0:
+        with pytest.raises(ValueError):
+            X_fit_mask_sparse = indicator.fit_transform(X_fit)
+        return
+
     X_fit_mask = indicator.fit_transform(X_fit)
     X_trans_mask = indicator.transform(X_trans)
 
@@ -1020,6 +1027,11 @@ def test_missing_indicator_sparse_param(arr_type, missing_values,
                                  sparse=param_sparse)
 
     if param_sparse is True and missing_values == 0:
+        with pytest.raises(ValueError):
+            X_fit_mask = indicator.fit_transform(X_fit)
+        return
+
+    if sparse.issparse(X_fit) and missing_values == 0:
         with pytest.raises(ValueError):
             X_fit_mask = indicator.fit_transform(X_fit)
         return

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -970,7 +970,6 @@ def test_missing_indicator_new(missing_values, arr_type, dtype, param_features,
                                  features=param_features,
                                  sparse=False)
 
-
     if sparse.issparse(X_fit) and missing_values == 0:
         with pytest.raises(ValueError):
             X_fit_mask_sparse = indicator.fit_transform(X_fit)
@@ -1038,8 +1037,6 @@ def test_missing_indicator_sparse_param(arr_type, missing_values,
 
     X_fit_mask = indicator.fit_transform(X_fit)
     X_trans_mask = indicator.transform(X_trans)
-
-
 
     if param_sparse is True:
         assert X_fit_mask.format == 'csc'

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -989,7 +989,6 @@ def test_missing_indicator_new(missing_values, arr_type, dtype, param_features,
     assert isinstance(X_trans_mask, np.ndarray)
 
     indicator.set_params(sparse=True)
-
     X_fit_mask_sparse = indicator.fit_transform(X_fit)
     X_trans_mask_sparse = indicator.transform(X_trans)
 

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -1023,6 +1023,7 @@ def test_missing_indicator_raise_on_sparse_with_missing_0(arr_type):
     with pytest.raises(ValueError):
         indicator.transform(X_trans)
 
+
 @pytest.mark.parametrize("param_sparse", [True, False, 'auto'])
 @pytest.mark.parametrize("missing_values, arr_type",
                          [(np.nan, np.array),

--- a/sklearn/tests/test_impute.py
+++ b/sklearn/tests/test_impute.py
@@ -925,7 +925,7 @@ def test_iterative_imputer_early_stopping():
       "'sparse' has to be a boolean or 'auto'"),
      (np.array([[-1, 1], [1, 2]]), np.array([[-1, 1], [1, 2]]),
       {'missing_values': 0, 'sparse': True},
-      "'missing_values' can not be 0 when 'sparse' is True"),
+      "'missing_values' cannot be 0 when 'sparse' is True"),
      (np.array([['a', 'b'], ['c', 'a']], dtype=str),
       np.array([['a', 'b'], ['c', 'a']], dtype=str),
       {}, "MissingIndicator does not support data with dtype")]
@@ -935,7 +935,6 @@ def test_missing_indicator_error(X_fit, X_trans, params, msg_err):
     indicator.set_params(**params)
     with pytest.raises(ValueError, match=msg_err):
         indicator.fit(X_fit).transform(X_trans)
-
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes issue #12750 

#### What does this implement/fix? Explain your changes.

This PR implements a simple check of the arguments to make sure that the MissingIndicator raises an exception when both arguments `sparse=True` and `missing_values=0` or array is sparse and `missing_values=0`. It fixes old tests that allowed for these cases and implements one new test.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
