### PR TITLE
[MRG+1] Enforce deterministic output in kernel PCA

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -76,15 +76,16 @@ Support for Python 3.4 and below has been officially dropped.
   the default value is used.
   :issue:`12988` by :user:`Zijie (ZJ) Poh <zjpoh>`.
 
-:mod:`sklearn.decomposition`
-............................
-
 - |Fix| Fixed a bug in :class:`decomposition.NMF` where `init = 'nndsvd'`,
   `init = 'nndsvda'`, and `init = 'nndsvdar'` are allowed when
   `n_components < n_features` instead of
   `n_components <= min(n_samples, n_features)`. 
   :issue:`11650` by :user:`Hossein Pourbozorg <hossein-pourbozorg>` and
   :user:`Zijie (ZJ) Poh <zjpoh>`.
+
+- |Enhancement| :class:`decomposition.KernelPCA` now has deterministic output 
+  (resolved sign ambiguity in eigenvalue decomposition of the kernel matrix).
+  :issue:`13241` by :user:`Aurélien Bellet <bellet>`.
 
 :mod:`sklearn.discriminant_analysis`
 ....................................

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -212,8 +212,6 @@ class KernelPCA(BaseEstimator, TransformerMixin, _UnstableOn32BitMixin):
                                                 v0=v0)
 
         # flip eigenvectors' sign to enforce deterministic output
-        # note: copying the second element is needed so that both inputs do
-        # not refer to the same object
         self.alphas_, _ = svd_flip(self.alphas_,
                                    np.empty_like(self.alphas_).T)
 

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -214,7 +214,8 @@ class KernelPCA(BaseEstimator, TransformerMixin, _UnstableOn32BitMixin):
         # flip eigenvectors' sign to enforce deterministic output
         # note: copying the second element is needed so that both inputs do
         # not refer to the same object
-        self.alphas_, _ = svd_flip(self.alphas_, self.alphas_.copy().T)
+        self.alphas_, _ = svd_flip(self.alphas_,
+                                   np.empty_like(self.alphas_).T)
 
         # sort eigenvectors in descending order
         indices = self.lambdas_.argsort()[::-1]

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -8,6 +8,7 @@ from scipy import linalg
 from scipy.sparse.linalg import eigsh
 
 from ..utils import check_random_state
+from ..utils.extmath import svd_flip
 from ..utils.validation import check_is_fitted, check_array
 from ..exceptions import NotFittedError
 from ..base import BaseEstimator, TransformerMixin, _UnstableOn32BitMixin
@@ -209,6 +210,11 @@ class KernelPCA(BaseEstimator, TransformerMixin, _UnstableOn32BitMixin):
                                                 tol=self.tol,
                                                 maxiter=self.max_iter,
                                                 v0=v0)
+
+        # flip eigenvectors' sign to enforce deterministic output
+        # note: copying the second element is needed so that both inputs do
+        # not refer to the same object
+        self.alphas_, _ = svd_flip(self.alphas_, self.alphas_.copy().T)
 
         # sort eigenvectors in descending order
         indices = self.lambdas_.argsort()[::-1]

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -4,7 +4,7 @@ import pytest
 
 from sklearn.utils.testing import (assert_array_almost_equal, assert_less,
                                    assert_equal, assert_not_equal,
-                                   assert_raises, assert_array_equal)
+                                   assert_raises)
 
 from sklearn.decomposition import PCA, KernelPCA
 from sklearn.datasets import make_circles
@@ -85,7 +85,7 @@ def test_kernel_pca_deterministic_output():
             transformed_X[i, :] = kpca.fit_transform(X)[0]
             i += 1
 
-    assert_array_equal(np.isclose(transformed_X, transformed_X[0, :]), True)
+    assert np.isclose(transformed_X, transformed_X[0, :]).all()
 
 
 def test_kernel_pca_sparse():

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -4,7 +4,7 @@ import pytest
 
 from sklearn.utils.testing import (assert_array_almost_equal, assert_less,
                                    assert_equal, assert_not_equal,
-                                   assert_raises)
+                                   assert_raises, assert_array_equal)
 
 from sklearn.decomposition import PCA, KernelPCA
 from sklearn.datasets import make_circles
@@ -69,6 +69,23 @@ def test_kernel_pca_consistent_transform():
     X[:, 0] = 666
     transformed2 = kpca.transform(X_copy)
     assert_array_almost_equal(transformed1, transformed2)
+
+
+def test_kernel_pca_deterministic_output():
+    state = np.random.RandomState(0)
+    X = state.rand(10, 10)
+    eigen_solver = ('arpack', 'dense')
+    transformed_X = np.zeros((10 * len(eigen_solver), 2))
+
+    i = 0
+    for solver in eigen_solver:
+        for _ in range(10):
+            kpca = KernelPCA(n_components=2, eigen_solver=solver,
+                             random_state=i)
+            transformed_X[i, :] = kpca.fit_transform(X)[0]
+            i += 1
+
+    assert_array_equal(np.isclose(transformed_X, transformed_X[0, :]), True)
 
 
 def test_kernel_pca_sparse():

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -4,7 +4,7 @@ import pytest
 
 from sklearn.utils.testing import (assert_array_almost_equal, assert_less,
                                    assert_equal, assert_not_equal,
-                                   assert_raises)
+                                   assert_raises, assert_allclose)
 
 from sklearn.decomposition import PCA, KernelPCA
 from sklearn.datasets import make_circles
@@ -75,17 +75,15 @@ def test_kernel_pca_deterministic_output():
     rng = np.random.RandomState(0)
     X = rng.rand(10, 10)
     eigen_solver = ('arpack', 'dense')
-    transformed_X = np.zeros((10 * len(eigen_solver), 2))
 
-    i = 0
     for solver in eigen_solver:
-        for _ in range(10):
+        transformed_X = np.zeros((20, 2))
+        for i in range(20):
             kpca = KernelPCA(n_components=2, eigen_solver=solver,
                              random_state=i)
             transformed_X[i, :] = kpca.fit_transform(X)[0]
-            i += 1
-
-    assert np.isclose(transformed_X, transformed_X[0, :]).all()
+        assert_allclose(
+            transformed_X, np.tile(transformed_X[0, :], 20).reshape(20, 2))
 
 
 def test_kernel_pca_sparse():

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -72,8 +72,8 @@ def test_kernel_pca_consistent_transform():
 
 
 def test_kernel_pca_deterministic_output():
-    state = np.random.RandomState(0)
-    X = state.rand(10, 10)
+    rng = np.random.RandomState(0)
+    X = rng.rand(10, 10)
     eigen_solver = ('arpack', 'dense')
     transformed_X = np.zeros((10 * len(eigen_solver), 2))
 

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -80,7 +80,7 @@ def test_kernel_pca_deterministic_output():
         transformed_X = np.zeros((20, 2))
         for i in range(20):
             kpca = KernelPCA(n_components=2, eigen_solver=solver,
-                             random_state=i)
+                             random_state=rng)
             transformed_X[i, :] = kpca.fit_transform(X)[0]
         assert_allclose(
             transformed_X, np.tile(transformed_X[0, :], 20).reshape(20, 2))

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -6,6 +6,7 @@ import pytest
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_raise_message
@@ -706,16 +707,14 @@ def test_pca_dtype_preservation(svd_solver):
 def test_pca_deterministic_output():
     rng = np.random.RandomState(0)
     X = rng.rand(10, 10)
-    transformed_X = np.zeros((10 * len(solver_list), 2))
 
-    i = 0
     for solver in solver_list:
-        for _ in range(10):
+        transformed_X = np.zeros((20, 2))
+        for i in range(20):
             pca = PCA(n_components=2, svd_solver=solver, random_state=i)
             transformed_X[i, :] = pca.fit_transform(X)[0]
-            i += 1
-
-    assert np.isclose(transformed_X, transformed_X[0, :]).all()
+        assert_allclose(
+            transformed_X, np.tile(transformed_X[0, :], 20).reshape(20, 2))
 
 
 def check_pca_float_dtype_preservation(svd_solver):

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -6,6 +6,7 @@ import pytest
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_raise_message
@@ -701,6 +702,21 @@ def test_pca_bad_solver():
 def test_pca_dtype_preservation(svd_solver):
     check_pca_float_dtype_preservation(svd_solver)
     check_pca_int_dtype_upcast_to_double(svd_solver)
+
+
+def test_pca_deterministic_output():
+    state = np.random.RandomState(0)
+    X = state.rand(10, 10)
+    transformed_X = np.zeros((10 * len(solver_list), 2))
+
+    i = 0
+    for solver in solver_list:
+        for _ in range(10):
+            pca = PCA(n_components=2, svd_solver=solver, random_state=i)
+            transformed_X[i, :] = pca.fit_transform(X)[0]
+            i += 1
+
+    assert_array_equal(np.isclose(transformed_X, transformed_X[0, :]), True)
 
 
 def check_pca_float_dtype_preservation(svd_solver):

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -6,7 +6,6 @@ import pytest
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_raise_message
@@ -716,7 +715,7 @@ def test_pca_deterministic_output():
             transformed_X[i, :] = pca.fit_transform(X)[0]
             i += 1
 
-    assert_array_equal(np.isclose(transformed_X, transformed_X[0, :]), True)
+    assert np.isclose(transformed_X, transformed_X[0, :]).all()
 
 
 def check_pca_float_dtype_preservation(svd_solver):

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -705,8 +705,8 @@ def test_pca_dtype_preservation(svd_solver):
 
 
 def test_pca_deterministic_output():
-    state = np.random.RandomState(0)
-    X = state.rand(10, 10)
+    rng = np.random.RandomState(0)
+    X = rng.rand(10, 10)
     transformed_X = np.zeros((10 * len(solver_list), 2))
 
     i = 0

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -711,7 +711,7 @@ def test_pca_deterministic_output():
     for solver in solver_list:
         transformed_X = np.zeros((20, 2))
         for i in range(20):
-            pca = PCA(n_components=2, svd_solver=solver, random_state=i)
+            pca = PCA(n_components=2, svd_solver=solver, random_state=rng)
             transformed_X[i, :] = pca.fit_transform(X)[0]
         assert_allclose(
             transformed_X, np.tile(transformed_X[0, :], 20).reshape(20, 2))


### PR DESCRIPTION
Fixes #8798 

This PR adds a call to `svd_flip` to ensure that the output of KPCA is deterministic, as done for PCA.

Example code:
```
import numpy as np
from sklearn.decomposition import KernelPCA

np.random.seed(42)
data = np.random.rand(12).reshape(4, 3)

for i in range(10):
    kpca = KernelPCA(n_components=2, eigen_solver='arpack')
    print(kpca.fit_transform(data)[0])
```

Output before this PR:
```
[-0.42930193 -0.11840723]
[0.42930193 0.11840723]
[-0.42930193 -0.11840723]
[0.42930193 0.11840723]
[-0.42930193 -0.11840723]
[0.42930193 0.11840723]
[-0.42930193 -0.11840723]
[ 0.42930193 -0.11840723]
[0.42930193 0.11840723]
[-0.42930193 -0.11840723]
```

With this PR:
```
[-0.42930193 -0.11840723]
[-0.42930193 -0.11840723]
[-0.42930193 -0.11840723]
[-0.42930193 -0.11840723]
[-0.42930193 -0.11840723]
[-0.42930193 -0.11840723]
[-0.42930193 -0.11840723]
[-0.42930193 -0.11840723]
[-0.42930193 -0.11840723]
[-0.42930193 -0.11840723]
```


Some comments:

- Calling `svd_flip` directly requires to copy the fitted `self.alphas_`, which is not great. The alternative would be to add an equivalent of `svd_flip` for eigendecomposition (taking a single input instead of two). I can easily do this if this is the preferred solution.
- This deterministic behavior does not seem to be tested for PCA, so I did not add any test here either. Can do if needed.