### PR TITLE
[MRG+2] DOC data centering in PCA

### DIFF
--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -23,7 +23,7 @@ scikit-learn, :class:`PCA` is implemented as a *transformer* object
 that learns :math:`n` components in its ``fit`` method, and can be used on new
 data to project it on these components.
 
-PCA centers but does not scale it the input data for each feature before
+PCA centers but does not scale the input data for each feature before
 applying the SVD. The optional parameter parameter ``whiten=True`` makes it
 possible to project the data onto the singular space while scaling each
 component to unit variance. This is often useful if the models down-stream make
@@ -81,8 +81,8 @@ in order update ``explained_variance_ratio_`` incrementally. This is why
 memory usage depends on the number of samples per batch, rather than the
 number of samples to be processed in the dataset.
 
-As in :class:`PCA`, IncrementalPCA centers but does not scale it the input data
-for each feature before applying the SVD.
+As in :class:`PCA`, :class:`IncrementalPCA` centers but does not scale the
+input data for each feature before applying the SVD.
 
 .. figure:: ../auto_examples/decomposition/images/sphx_glr_plot_incremental_pca_001.png
     :target: ../auto_examples/decomposition/plot_incremental_pca.html

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -23,13 +23,13 @@ scikit-learn, :class:`PCA` is implemented as a *transformer* object
 that learns :math:`n` components in its ``fit`` method, and can be used on new
 data to project it on these components.
 
-PCA centers the input data for each feature before applying the SVD. The
-optional parameter parameter ``whiten=True`` makes it possible to
-project the data onto the singular space while scaling each component
-to unit variance. This is often useful if the models down-stream make
-strong assumptions on the isotropy of the signal: this is for example
-the case for Support Vector Machines with the RBF kernel and the K-Means
-clustering algorithm.
+PCA centers but does not scale it the input data for each feature before
+applying the SVD. The optional parameter parameter ``whiten=True`` makes it
+possible to project the data onto the singular space while scaling each
+component to unit variance. This is often useful if the models down-stream make
+strong assumptions on the isotropy of the signal: this is for example the case
+for Support Vector Machines with the RBF kernel and the K-Means clustering
+algorithm.
 
 Below is an example of the iris dataset, which is comprised of 4
 features, projected on the 2 dimensions that explain most variance:
@@ -80,6 +80,9 @@ out-of-core Principal Component Analysis either by:
 in order update ``explained_variance_ratio_`` incrementally. This is why
 memory usage depends on the number of samples per batch, rather than the
 number of samples to be processed in the dataset.
+
+As in :class:`PCA`, IncrementalPCA centers but does not scale it the input data
+for each feature before applying the SVD.
 
 .. figure:: ../auto_examples/decomposition/images/sphx_glr_plot_incremental_pca_001.png
     :target: ../auto_examples/decomposition/plot_incremental_pca.html

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -30,6 +30,9 @@ strong assumptions on the isotropy of the signal: this is for example
 the case for Support Vector Machines with the RBF kernel and the K-Means
 clustering algorithm.
 
+Note: the :class:`PCA` object centers the input data for each feature before
+applying the SVD.
+
 Below is an example of the iris dataset, which is comprised of 4
 features, projected on the 2 dimensions that explain most variance:
 

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -23,15 +23,13 @@ scikit-learn, :class:`PCA` is implemented as a *transformer* object
 that learns :math:`n` components in its ``fit`` method, and can be used on new
 data to project it on these components.
 
-The optional parameter ``whiten=True`` makes it possible to
+PCA centers the input data for each feature before applying the SVD. The
+optional parameter parameter ``whiten=True`` makes it possible to
 project the data onto the singular space while scaling each component
 to unit variance. This is often useful if the models down-stream make
 strong assumptions on the isotropy of the signal: this is for example
 the case for Support Vector Machines with the RBF kernel and the K-Means
 clustering algorithm.
-
-Note: the :class:`PCA` object centers the input data for each feature before
-applying the SVD.
 
 Below is an example of the iris dataset, which is comprised of 4
 features, projected on the 2 dimensions that explain most variance:

--- a/sklearn/decomposition/incremental_pca.py
+++ b/sklearn/decomposition/incremental_pca.py
@@ -16,8 +16,9 @@ class IncrementalPCA(_BasePCA):
     """Incremental principal components analysis (IPCA).
 
     Linear dimensionality reduction using Singular Value Decomposition of
-    centered data, keeping only the most significant singular vectors to
-    project the data to a lower dimensional space.
+    the data, keeping only the most significant singular vectors to
+    project the data to a lower dimensional space. The input data is centered
+    but not scaled for each feature before applying the SVD.
 
     Depending on the size of the input data, this algorithm can be much more
     memory efficient than a PCA.

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -106,7 +106,7 @@ class PCA(_BasePCA):
 
     Linear dimensionality reduction using Singular Value Decomposition of the
     data to project it to a lower dimensional space. The input data is centered
-    for each feature before applying the SVD.
+    but not scaled for each feature before applying the SVD.
 
     It uses the LAPACK implementation of the full SVD or a randomized truncated
     SVD by the method of Halko et al. 2009, depending on the shape of the input

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -108,11 +108,12 @@ class PCA(_BasePCA):
     """Principal component analysis (PCA)
 
     Linear dimensionality reduction using Singular Value Decomposition of the
-    data to project it to a lower dimensional space.
+    data to project it to a lower dimensional space. 
 
     It uses the LAPACK implementation of the full SVD or a randomized truncated
     SVD by the method of Halko et al. 2009, depending on the shape of the input
-    data and the number of components to extract.
+    data and the number of components to extract. It centers the data matrix
+    columnwise (but does not scale it) before performing Singular Value Decomposition.
 
     It can also use the scipy.sparse.linalg ARPACK implementation of the
     truncated SVD.

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -108,12 +108,12 @@ class PCA(_BasePCA):
     """Principal component analysis (PCA)
 
     Linear dimensionality reduction using Singular Value Decomposition of the
-    data to project it to a lower dimensional space.
+    data to project it to a lower dimensional space. The input data is centered
+    for each feature before applying the SVD.
 
     It uses the LAPACK implementation of the full SVD or a randomized truncated
     SVD by the method of Halko et al. 2009, depending on the shape of the input
-    data and the number of components to extract. The input data is centered
-    for each feature before applying the SVD.
+    data and the number of components to extract.
 
     It can also use the scipy.sparse.linalg ARPACK implementation of the
     truncated SVD.

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -112,8 +112,8 @@ class PCA(_BasePCA):
 
     It uses the LAPACK implementation of the full SVD or a randomized truncated
     SVD by the method of Halko et al. 2009, depending on the shape of the input
-    data and the number of components to extract. It centers the data matrix
-    columnwise (but does not scale it) before performing Singular Value Decomposition.
+    data and the number of components to extract. The input data is centered
+    for each feature before applying the SVD.
 
     It can also use the scipy.sparse.linalg ARPACK implementation of the
     truncated SVD.

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -108,7 +108,7 @@ class PCA(_BasePCA):
     """Principal component analysis (PCA)
 
     Linear dimensionality reduction using Singular Value Decomposition of the
-    data to project it to a lower dimensional space. 
+    data to project it to a lower dimensional space.
 
     It uses the LAPACK implementation of the full SVD or a randomized truncated
     SVD by the method of Halko et al. 2009, depending on the shape of the input


### PR DESCRIPTION
Continues #9934. 

The previous PR #9934 improves the PCA documentation by expliciting that PCA centers the data before SVD. This additional information was not added to IPCA. This new PR does.
