### PR TITLE
[MRG] Fix doctest failure

### DIFF
--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -338,10 +338,10 @@ def extract_patches_2d(image, patch_size, max_patches=None, random_state=None):
 
     Examples
     --------
-    >>> from sklearn.datasets import load_sample_images
+    >>> from sklearn.datasets import load_sample_image
     >>> from sklearn.feature_extraction import image
     >>> # Use the array data from the first image in this dataset:
-    >>> one_image = load_sample_images().images[0]
+    >>> one_image = load_sample_image("china.jpg")
     >>> print('Image shape: {}'.format(one_image.shape))
     Image shape: (427, 640, 3)
     >>> patches = image.extract_patches_2d(one_image, (2, 2))

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -347,6 +347,17 @@ def extract_patches_2d(image, patch_size, max_patches=None, random_state=None):
     >>> patches = image.extract_patches_2d(one_image, (2, 2))
     >>> print('Patches shape: {}'.format(patches.shape))
     Patches shape: (272214, 2, 2, 3)
+    >>> # Here are just two of these patches:
+    >>> print(patches[1]) # doctest: +NORMALIZE_WHITESPACE
+    [[[174 201 231]
+      [174 201 231]]
+     [[173 200 230]
+      [173 200 230]]]
+    >>> print(patches[800])# doctest: +NORMALIZE_WHITESPACE
+    [[[187 214 243]
+      [188 215 244]]
+     [[187 214 243]
+      [188 215 244]]]
     """
     i_h, i_w = image.shape[:2]
     p_h, p_w = patch_size


### PR DESCRIPTION
The `extract_patches_2d` doctest fails on some but not all CIs. It's due to the fact that the ordering of the output of `os.listdir(...)` is not the same on the different CIs. I propose to load an explicit image in the docstring example instead.

ping @glemaitre