### PR TITLE
[MRG+1] Use openmp flags for all cython extensions

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -6,19 +6,19 @@ UNAMESTR=`uname`
 
 if [[ "$UNAMESTR" == "Darwin" ]]; then
     # install OpenMP not present by default on osx
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install libiomp
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install libomp
 
     # enable OpenMP support for Apple-clang
     export CC=/usr/bin/clang
     export CXX=/usr/bin/clang++
     export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"
-    export CFLAGS="$CFLAGS -I/usr/local/opt/libiomp/include"
-    export CXXFLAGS="$CXXFLAGS -I/usr/local/opt/libiomp/include"
-    export LDFLAGS="$LDFLAGS -L/usr/local/opt/libiomp/lib -liomp"
-    export DYLD_LIBRARY_PATH=/usr/local/opt/libiomp/lib
+    export CFLAGS="$CFLAGS -I/usr/local/opt/libomp/include"
+    export CXXFLAGS="$CXXFLAGS -I/usr/local/opt/libomp/include"
+    export LDFLAGS="$LDFLAGS -L/usr/local/opt/libomp/lib -lomp"
+    export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
 
     # avoid error due to multiple OpenMP libraries loaded simultaneously
-    # export KMP_DUPLICATE_LIB_OK=TRUE
+    export KMP_DUPLICATE_LIB_OK=TRUE
 fi
 
 make_conda() {

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -6,19 +6,19 @@ UNAMESTR=`uname`
 
 if [[ "$UNAMESTR" == "Darwin" ]]; then
     # install OpenMP not present by default on osx
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install libomp
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install libiomp
 
     # enable OpenMP support for Apple-clang
     export CC=/usr/bin/clang
     export CXX=/usr/bin/clang++
     export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"
-    export CFLAGS="$CFLAGS -I/usr/local/opt/libomp/include"
-    export CXXFLAGS="$CXXFLAGS -I/usr/local/opt/libomp/include"
-    export LDFLAGS="$LDFLAGS -L/usr/local/opt/libomp/lib -lomp"
-    export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
+    export CFLAGS="$CFLAGS -I/usr/local/opt/libiomp/include"
+    export CXXFLAGS="$CXXFLAGS -I/usr/local/opt/libiomp/include"
+    export LDFLAGS="$LDFLAGS -L/usr/local/opt/libiomp/lib -liomp"
+    export DYLD_LIBRARY_PATH=/usr/local/opt/libiomp/lib
 
     # avoid error due to multiple OpenMP libraries loaded simultaneously
-    export KMP_DUPLICATE_LIB_OK=TRUE
+    # export KMP_DUPLICATE_LIB_OK=TRUE
 fi
 
 make_conda() {

--- a/setup.py
+++ b/setup.py
@@ -125,9 +125,6 @@ def get_openmp_flag(compiler):
     return ['-fopenmp']
 
 
-OPENMP_EXTENSIONS = []
-
-
 # custom build_ext command to set OpenMP compile flags depending on os and
 # compiler
 # build_ext has to be imported after setuptools
@@ -144,9 +141,8 @@ class build_ext_subclass(build_ext):
         openmp_flag = get_openmp_flag(compiler)
 
         for e in self.extensions:
-            if e.name in OPENMP_EXTENSIONS:
-                e.extra_compile_args += openmp_flag
-                e.extra_link_args += openmp_flag
+            e.extra_compile_args += openmp_flag
+            e.extra_link_args += openmp_flag
 
         build_ext.build_extensions(self)
 


### PR DESCRIPTION
I propose to use the OpenMP flags for all cython extensions instead of manually specifying the ones that actually use it. It's just too easy to forget to add them :)
And the flag has just no effect when there's no OpenMP stuff in an extension.