### PR TITLE
FIX ElasticNetCV doctest failure on ARM

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1554,7 +1554,7 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
            normalize=False, positive=False, precompute='auto', random_state=0,
            selection='cyclic', tol=0.0001, verbose=0)
     >>> print(regr.alpha_) # doctest: +ELLIPSIS
-    0.1994727942696716
+    0.199...
     >>> print(regr.intercept_) # doctest: +ELLIPSIS
     0.398...
     >>> print(regr.predict([[0, 0]])) # doctest: +ELLIPSIS


### PR DESCRIPTION
Related to https://github.com/scikit-learn/scikit-learn/issues/13036

This fixes a docstring failure on ARM 64 bit,
```
_______________________________________ [doctest] sklearn.linear_model.coordinate_descent.ElasticNetCV ________________________________________
1547     >>> from sklearn.datasets import make_regression
1548
1549     >>> X, y = make_regression(n_features=2, random_state=0)
1550     >>> regr = ElasticNetCV(cv=5, random_state=0)
1551     >>> regr.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
1552     ElasticNetCV(alphas=None, copy_X=True, cv=5, eps=0.001, fit_intercept=True,
1553            l1_ratio=0.5, max_iter=1000, n_alphas=100, n_jobs=None,
1554            normalize=False, positive=False, precompute='auto', random_state=0,
1555            selection='cyclic', tol=0.0001, verbose=0)
1556     >>> print(regr.alpha_) # doctest: +ELLIPSIS
Expected:
    0.1994727942696716
Got:
    0.19947279426967165
```