### PR TITLE
FIX test_svmlight_format.py::test_dump on ARM

### DIFF
--- a/sklearn/datasets/tests/test_svmlight_format.py
+++ b/sklearn/datasets/tests/test_svmlight_format.py
@@ -226,7 +226,7 @@ def test_dump():
     for X in (X_sparse, X_dense, X_sliced):
         for y in (y_sparse, y_dense, y_sliced):
             for zero_based in (True, False):
-                for dtype in [np.float32, np.float64, np.int32]:
+                for dtype in [np.float32, np.float64, np.int32, np.int64]:
                     f = BytesIO()
                     # we need to pass a comment to get the version info in;
                     # LibSVM doesn't grok comments so they're not put in by
@@ -237,7 +237,13 @@ def test_dump():
                         # when it is sparse
                         y = y.T
 
-                    dump_svmlight_file(X.astype(dtype), y, f, comment="test",
+                    # Note: with dtype=np.int32 we are performing unsafe casts,
+                    # where X.astype(dtype) overflows. The result is
+                    # then platform dependent and X_dense.astype(dtype) may be
+                    # different from X_sparse.astype(dtype).asarray().
+                    X_input = X.astype(dtype)
+
+                    dump_svmlight_file(X_input, y, f, comment="test",
                                        zero_based=zero_based)
                     f.seek(0)
 
@@ -257,17 +263,21 @@ def test_dump():
                     assert_array_equal(X2.sorted_indices().indices, X2.indices)
 
                     X2_dense = X2.toarray()
+                    if sp.issparse(X_input):
+                        X_input_dense = X_input.toarray()
+                    else:
+                        X_input_dense = X_input
 
                     if dtype == np.float32:
                         # allow a rounding error at the last decimal place
                         assert_array_almost_equal(
-                            X_dense.astype(dtype), X2_dense, 4)
+                            X_input_dense, X2_dense, 4)
                         assert_array_almost_equal(
                             y_dense.astype(dtype), y2, 4)
                     else:
                         # allow a rounding error at the last decimal place
                         assert_array_almost_equal(
-                            X_dense.astype(dtype), X2_dense, 15)
+                            X_input_dense, X2_dense, 15)
                         assert_array_almost_equal(
                             y_dense.astype(dtype), y2, 15)
 


### PR DESCRIPTION
Closes https://github.com/scikit-learn/scikit-learn/issues/13050
Closes https://github.com/scikit-learn/scikit-learn/issues/13258 (opened a duplicate issue by mistake)

Fixes the `test_svmlight_format.py::test_dump` test for ARM 64 bit.

See  https://github.com/scikit-learn/scikit-learn/issues/13258#issuecomment-467090846 for the description of the issue.