### PR TITLE
[MRG+2] FIX: force consistency outputs of DummyClassifier's predict_proba when strategy is stratified

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -95,6 +95,14 @@ Support for Python 3.4 and below has been officially dropped.
   ``n_components`` is changed to ``min(n_features, n_classes - 1)`` if so.
   Previously the change was made, but silently. :issue:`11526` by
   :user:`William de Vazelhes<wdevazelhes>`.
+  
+:mod:`sklearn.dummy`
+....................................
+
+- |Fix| Fixed a bug in :class:`dummy.DummyClassifier` where the
+  ``predict_proba`` method was returning int32 array instead of
+  float64 for the ``stratified`` strategy. :issue:`13266` by
+  :user:`Christos Aridas<chkoar>`.
 
 :mod:`sklearn.ensemble`
 .......................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -97,7 +97,7 @@ Support for Python 3.4 and below has been officially dropped.
   :user:`William de Vazelhes<wdevazelhes>`.
   
 :mod:`sklearn.dummy`
-....................................
+....................
 
 - |Fix| Fixed a bug in :class:`dummy.DummyClassifier` where the
   ``predict_proba`` method was returning int32 array instead of

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -277,6 +277,7 @@ class DummyClassifier(BaseEstimator, ClassifierMixin, MultiOutputMixin):
 
             elif self.strategy == "stratified":
                 out = rs.multinomial(1, class_prior_[k], size=n_samples)
+                out = out.astype(np.float64)
 
             elif self.strategy == "uniform":
                 out = np.ones((n_samples, n_classes_[k]), dtype=np.float64)

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -711,18 +711,13 @@ def test_regressor_prediction_independent_of_X(strategy):
     assert_array_equal(predictions1, predictions2)
 
 
-@pytest.mark.parametrize("strategy", [
-    "stratified",
-    "most_frequent",
-    "prior",
-    "uniform",
-    "constant"
-])
+@pytest.mark.parametrize(
+    "strategy", ["stratified", "most_frequent", "prior", "uniform", "constant"]
+)
 def test_dtype_of_classifier_probas(strategy):
     y = [0, 2, 1, 1]
-    X = [[0]] * 4
+    X = np.zeros(4)
     model = DummyClassifier(strategy=strategy, random_state=0, constant=0)
-    model.fit(X, y)
-    probas = model.predict_proba(X)
+    probas = model.fit(X, y).predict_proba(X)
 
-    assert probas.dtype == np.float
+    assert probas.dtype == np.float64

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -709,3 +709,20 @@ def test_regressor_prediction_independent_of_X(strategy):
     predictions2 = reg2.predict(X2)
 
     assert_array_equal(predictions1, predictions2)
+
+
+@pytest.mark.parametrize("strategy", [
+    "stratified",
+    "most_frequent",
+    "prior",
+    "uniform",
+    "constant"
+])
+def test_dtype_of_classifier_probas(strategy):
+    y = [0, 2, 1, 1]
+    X = [[0]] * 4
+    model = DummyClassifier(strategy=strategy, random_state=0, constant=0)
+    model.fit(X, y)
+    probas = model.predict_proba(X)
+
+    assert probas.dtype == np.float


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The DummyClassifier's `predict_proba` method returns a `float64` array in all strategies except the stratified strategy which returns a `int32` array.

