### PR TITLE
DOC reference the HTTPS url for the nightly builds

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -34,9 +34,7 @@ Installing nightly builds
 
 The continuous integration servers of the scikit-learn project build, test
 and upload wheel packages for the most recent Python version on a nightly
-basis to help users test bleeding edge features or bug fixes:
-
-::
+basis to help users test bleeding edge features or bug fixes::
 
   pip install --pre -f https://sklearn-nightly.scdn8.secure.raxcdn.com scikit-learn
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -38,7 +38,7 @@ basis to help users test bleeding edge features or bug fixes:
 
 ::
 
-  pip install --pre -f https://ea8f9da187ce3f7323b4-ef5ddc96fef712c596c71d053dc2ad71.ssl.cf2.rackcdn.com/ scikit-learn
+  pip install --pre -f https://sklearn-nightly.scdn8.secure.raxcdn.com scikit-learn
 
 
 .. _install_bleeding_edge:

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -27,6 +27,20 @@ There are different ways to get scikit-learn installed:
     If you wish to contribute to the project, you need to
     :ref:`install the latest development version<install_bleeding_edge>`.
 
+.. _install_nightly_builds:
+
+Installing nightly builds
+=========================
+
+The continuous integration servers of the scikit-learn project build, test
+and upload wheel packages for the most recent Python version on a nightly
+basis to help users test bleeding edge features or bug fixes:
+
+::
+
+  pip install --pre -f https://ea8f9da187ce3f7323b4-ef5ddc96fef712c596c71d053dc2ad71.ssl.cf2.rackcdn.com/ scikit-learn
+
+
 .. _install_bleeding_edge:
 
 Building from source


### PR DESCRIPTION
We decided not to mention http://nightly.scikit-learn.org on purpose because we could not find an easy way to configure HTTPS on a CNAME entry pointing to a cloud file container on rackspace.

This page in the rackspace documentation says that this feature is not supported:

https://support.rackspace.com/how-to/using-cnames-with-cloud-files-containers/

@thomasjpfan is trying to investigate if we can get a shorter HTTPS URL on rackspace via another mean.