### PR TITLE
[MRG+2] Add float32 support for Linear Discriminant Analysis

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -90,6 +90,10 @@ Support for Python 3.4 and below has been officially dropped.
 :mod:`sklearn.discriminant_analysis`
 ....................................
 
+- |Enhancement| :class:`discriminant_analysis.LinearDiscriminantAnalysis` now
+  preserves ``float32`` and ``float64`` dtypes. :issues:`8769` and
+  :issues:`11000` by :user:`Thibault Sejourne <thibsej>`
+
 - |Fix| A ``ChangedBehaviourWarning`` is now raised when
   :class:`discriminant_analysis.LinearDiscriminantAnalysis` is given as
   parameter ``n_components > min(n_features, n_classes - 1)``, and

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -19,7 +19,7 @@ from .base import BaseEstimator, TransformerMixin, ClassifierMixin
 from .linear_model.base import LinearClassifierMixin
 from .covariance import ledoit_wolf, empirical_covariance, shrunk_covariance
 from .utils.multiclass import unique_labels
-from .utils import check_array, check_X_y
+from .utils import check_array, check_X_y, as_float_array
 from .utils.validation import check_is_fitted
 from .utils.multiclass import check_classification_targets
 from .preprocessing import StandardScaler
@@ -427,7 +427,8 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
             Target values.
         """
         # FIXME: Future warning to be removed in 0.23
-        X, y = check_X_y(X, y, ensure_min_samples=2, estimator=self)
+        X = as_float_array(X)
+        X, y = check_X_y(X, y, ensure_min_samples=2, estimator=self, dtype=[np.float64, np.float32])
         self.classes_ = unique_labels(y)
         n_samples, _ = X.shape
         n_classes = len(self.classes_)
@@ -485,10 +486,10 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
             raise ValueError("unknown solver {} (valid solvers are 'svd', "
                              "'lsqr', and 'eigen').".format(self.solver))
         if self.classes_.size == 2:  # treat binary case as a special case
-            my_type = np.float32 if (X.dtype in [np.float32, np.int32]) else np.float64
-            self.coef_ = np.array(self.coef_[1, :] - self.coef_[0, :], ndmin=2, dtype=my_type)
+            self.coef_ = np.array(self.coef_[1, :] - self.coef_[0, :], ndmin=2,
+                                  dtype=X.dtype)
             self.intercept_ = np.array(self.intercept_[1] - self.intercept_[0],
-                                       ndmin=1, dtype=my_type)
+                                       ndmin=1, dtype=X.dtype)
         return self
 
     def transform(self, X):

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -485,7 +485,7 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
             raise ValueError("unknown solver {} (valid solvers are 'svd', "
                              "'lsqr', and 'eigen').".format(self.solver))
         if self.classes_.size == 2:  # treat binary case as a special case
-            my_type = np.float32 if (X.dtype == np.float32) else np.float64
+            my_type = np.float32 if (X.dtype in [np.float32, np.int32]) else np.float64
             self.coef_ = np.array(self.coef_[1, :] - self.coef_[0, :], ndmin=2, dtype=my_type)
             self.intercept_ = np.array(self.intercept_[1] - self.intercept_[0],
                                        ndmin=1, dtype=my_type)

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -485,9 +485,9 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
             raise ValueError("unknown solver {} (valid solvers are 'svd', "
                              "'lsqr', and 'eigen').".format(self.solver))
         if self.classes_.size == 2:  # treat binary case as a special case
-            self.coef_ = np.array(self.coef_[1, :] - self.coef_[0, :], ndmin=2)
+            self.coef_ = np.array(self.coef_[1, :] - self.coef_[0, :], ndmin=2, dtype=X.dtype)
             self.intercept_ = np.array(self.intercept_[1] - self.intercept_[0],
-                                       ndmin=1)
+                                       ndmin=1, dtype=X.dtype)
         return self
 
     def transform(self, X):

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -19,7 +19,7 @@ from .base import BaseEstimator, TransformerMixin, ClassifierMixin
 from .linear_model.base import LinearClassifierMixin
 from .covariance import ledoit_wolf, empirical_covariance, shrunk_covariance
 from .utils.multiclass import unique_labels
-from .utils import check_array, check_X_y, as_float_array
+from .utils import check_array, check_X_y
 from .utils.validation import check_is_fitted
 from .utils.multiclass import check_classification_targets
 from .preprocessing import StandardScaler
@@ -427,7 +427,8 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
             Target values.
         """
         # FIXME: Future warning to be removed in 0.23
-        X, y = check_X_y(X, y, ensure_min_samples=2, estimator=self, dtype=[np.float64, np.float32])
+        X, y = check_X_y(X, y, ensure_min_samples=2, estimator=self,
+                         dtype=[np.float64, np.float32])
         self.classes_ = unique_labels(y)
         n_samples, _ = X.shape
         n_classes = len(self.classes_)

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -485,9 +485,10 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
             raise ValueError("unknown solver {} (valid solvers are 'svd', "
                              "'lsqr', and 'eigen').".format(self.solver))
         if self.classes_.size == 2:  # treat binary case as a special case
-            self.coef_ = np.array(self.coef_[1, :] - self.coef_[0, :], ndmin=2, dtype=X.dtype)
+            my_type = np.float32 if (X.dtype == np.float32) else np.float64
+            self.coef_ = np.array(self.coef_[1, :] - self.coef_[0, :], ndmin=2, dtype=my_type)
             self.intercept_ = np.array(self.intercept_[1] - self.intercept_[0],
-                                       ndmin=1, dtype=X.dtype)
+                                       ndmin=1, dtype=my_type)
         return self
 
     def transform(self, X):

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -427,7 +427,6 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
             Target values.
         """
         # FIXME: Future warning to be removed in 0.23
-        X = as_float_array(X)
         X, y = check_X_y(X, y, ensure_min_samples=2, estimator=self, dtype=[np.float64, np.float32])
         self.classes_ = unique_labels(y)
         n_samples, _ = X.shape

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -298,8 +298,11 @@ def test_lda_dimension_warning(n_classes, n_features):
 
 
 @pytest.mark.parametrize("data_type, expected_type", [
-    (np.float32, np.float32), (np.float64, np.float64), (np.int32, np.float64),
-    (np.int64, np.float64)])
+    (np.float32, np.float32),
+    (np.float64, np.float64),
+    (np.int32, np.float64),
+    (np.int64, np.float64)
+])
 def test_lda_dtype_match(data_type, expected_type):
     for (solver, shrinkage) in solver_shrinkage:
         clf = LinearDiscriminantAnalysis(solver=solver, shrinkage=shrinkage)
@@ -316,8 +319,7 @@ def test_lda_numeric_consistency_float32_float64():
 
         # Check value consistency between types
         rtol = 1e-6
-        assert_allclose(clf_32.coef_, clf_64.coef_.astype(np.float32),
-                        rtol=rtol)
+        assert_allclose(clf_32.coef_, clf_64.coef_, rtol=rtol)
 
 
 def test_qda():

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -298,7 +298,7 @@ def test_lda_dimension_warning(n_classes, n_features):
 
 
 @pytest.mark.parametrize("data_type, expected_type", [
-    (np.float32, np.float32), (np.float64, np.float64), (np.int32, np.float32),
+    (np.float32, np.float32), (np.float64, np.float64), (np.int32, np.float64),
     (np.int64, np.float64)])
 def test_lda_dtype_match(data_type, expected_type):
     for (solver, shrinkage) in solver_shrinkage:

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -296,14 +296,15 @@ def test_lda_dimension_warning(n_classes, n_features):
                       "min(n_features, n_classes - 1).")
         assert_warns_message(FutureWarning, future_msg, lda.fit, X, y)
 
-@pytest.mark.parametrize("data_type, expected_type",[
-    (np.float32, np.float32), (np.float64, np.float64), (np.int32, np.float32), (np.int64, np.float64)])
+
+@pytest.mark.parametrize("data_type, expected_type", [
+    (np.float32, np.float32), (np.float64, np.float64), (np.int32, np.float32),
+    (np.int64, np.float64)])
 def test_lda_dtype_match(data_type, expected_type):
     for (solver, shrinkage) in solver_shrinkage:
         clf = LinearDiscriminantAnalysis(solver=solver, shrinkage=shrinkage)
         clf.fit(X.astype(data_type), y.astype(data_type))
         assert clf.coef_.dtype == expected_type
-
 
 
 def test_lda_numeric_consistency_float32_float64():
@@ -315,7 +316,8 @@ def test_lda_numeric_consistency_float32_float64():
 
         # Check value consistency between types
         rtol = 1e-6
-        assert_allclose(clf_32.coef_, clf_64.coef_.astype(np.float32), rtol=rtol)
+        assert_allclose(clf_32.coef_, clf_64.coef_.astype(np.float32),
+                        rtol=rtol)
 
 
 def test_qda():

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -296,29 +296,22 @@ def test_lda_dimension_warning(n_classes, n_features):
                       "min(n_features, n_classes - 1).")
         assert_warns_message(FutureWarning, future_msg, lda.fit, X, y)
 
+@pytest.mark.parametrize("data_type, expected_type",[
+    (np.float32, np.float32), (np.float64, np.float64), (np.int32, np.float32), (np.int64, np.float64)])
+def test_lda_dtype_match(data_type, expected_type):
+    for (solver, shrinkage) in solver_shrinkage:
+        clf = LinearDiscriminantAnalysis(solver=solver, shrinkage=shrinkage)
+        clf.fit(X.astype(data_type), y.astype(data_type))
+        assert clf.coef_.dtype == expected_type
 
-def test_lda_dtype_match():
-    # Test that np.float32 input data is not cast to np.float64 when possible
-    n_features = 2
-    n_classes = 2
-    n_samples = 1000
-    X, y = make_blobs(n_samples=n_samples, n_features=n_features,
-                      centers=n_classes, random_state=11)
-    X_32 = np.array(X).astype(np.float32)
-    y_32 = np.array(y).astype(np.float32)
-    X_64 = np.array(X).astype(np.float64)
-    y_64 = np.array(y).astype(np.float64)
 
-    for test_case in solver_shrinkage:
-        solver, shrinkage = test_case
-        # Check type consistency
+
+def test_lda_numeric_consistency_float32_float64():
+    for (solver, shrinkage) in solver_shrinkage:
         clf_32 = LinearDiscriminantAnalysis(solver=solver, shrinkage=shrinkage)
-        clf_32.fit(X_32,y_32)
-        assert_equal(clf_32.coef_.dtype, X_32.dtype)
-
+        clf_32.fit(X.astype(np.float32), y.astype(np.float32))
         clf_64 = LinearDiscriminantAnalysis(solver=solver, shrinkage=shrinkage)
-        clf_64.fit(X_64, y_64)
-        assert_equal(clf_64.coef_.dtype, X_64.dtype)
+        clf_64.fit(X.astype(np.float64), y.astype(np.float64))
 
         # Check value consistency between types
         rtol = 1e-6


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
this PR works on #11000 by preserving the dtype in LDA.

cross reference: https://github.com/scikit-learn/scikit-learn/issues/8769#issuecomment-306725215

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
