### PR TITLE
Add float32 support for Latent Dirichlet Allocation

### DIFF
--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -17,7 +17,8 @@ from scipy.special import gammaln
 
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import (check_random_state, check_array,
-                     gen_batches, gen_even_slices)
+                     gen_batches, gen_even_slices,
+                     as_float_array)
 from ..utils.fixes import logsumexp
 from ..utils.validation import check_non_negative
 from ..utils._joblib import Parallel, delayed, effective_n_jobs
@@ -529,6 +530,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         """
         self._check_params()
         X = self._check_non_neg_array(X, "LatentDirichletAllocation.fit")
+        X = as_float_array(X)
         n_samples, n_features = X.shape
         max_iter = self.max_iter
         evaluate_every = self.evaluate_every

--- a/sklearn/decomposition/tests/test_online_lda.py
+++ b/sklearn/decomposition/tests/test_online_lda.py
@@ -399,3 +399,30 @@ def test_verbosity(verbose, evaluate_every, expected_lines,
                    expected_perplexities):
     check_verbosity(verbose, evaluate_every, expected_lines,
                     expected_perplexities)
+
+
+def test_lda_dtype_match():
+    # Test that np.float32 input data is not cast to np.float64 when possible
+    n_components, X = _build_sparse_mtx()
+    X_32 = np.array(X).astype(np.float32)
+    X_64 = np.array(X).astype(np.float64)
+
+    for learning_met in ['batch', 'online']:
+        # Check type consistency
+        clf_32 = LatentDirichletAllocation(n_components=n_components,
+                                           learning_method=learning_met,
+                              learning_offset=10., total_samples=100,
+                              random_state=42)
+        clf_32.fit(X_32)
+        assert_equal(clf_32.components_ .dtype, X_32.dtype)
+
+        clf_64 = LatentDirichletAllocation(n_components=n_components,
+                                           learning_method=learning_met,
+                                           learning_offset=10., total_samples=100,
+                                           random_state=42)
+        clf_64.fit(X_64)
+        assert_equal(clf_64.components_.dtype, X_64.dtype)
+
+        # Check value consistency between types
+        rtol = 1e-6
+        assert_allclose(clf_32.components_ , clf_64.components_.astype(np.float32), rtol=rtol)

--- a/sklearn/decomposition/tests/test_online_lda.py
+++ b/sklearn/decomposition/tests/test_online_lda.py
@@ -402,8 +402,11 @@ def test_verbosity(verbose, evaluate_every, expected_lines,
 
 
 @pytest.mark.parametrize("data_type, expected_type", [
-    (np.float32, np.float32), (np.float64, np.float64), (np.int32, np.float32),
-    (np.int64, np.float64)])
+    (np.float32, np.float32),
+    (np.float64, np.float64),
+    (np.int32, np.float64),
+    (np.int64, np.float64)
+])
 def test_lda_dtype_match(data_type, expected_type):
     n_components, X = _build_sparse_mtx()
     for learning_method in ['batch', 'online']:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
this PR works on #11000 by preserving the dtype in Latent Dirichlet Allocation.

cross reference: [#8769 (comment)](https://github.com/scikit-learn/scikit-learn/issues/8769#issuecomment-306725215)
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
