### PR TITLE
[MRG] Fix bug in graph lasso when n_features=2

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -29,6 +29,13 @@ Changelog
   negative indexes in the columns list of the transformers.
   :issue:`12946` by :user:`Pierre Tallotte <pierretallotte>`.
 
+:mod:`sklearn.covariance`
+......................
+
+- |Fix| Fixed a bug in :func:`covariance.graphical_lasso` so that the case
+  `n_features=2` is handled correctly. :issue:`13276` by :user:`Aurélien
+  Bellet <bellet>`.
+
 :mod:`sklearn.decomposition`
 ............................
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -32,9 +32,9 @@ Changelog
 :mod:`sklearn.covariance`
 ......................
 
-- |Fix| Fixed a bug in :func:`covariance.graphical_lasso` so that the case
-  `n_features=2` is handled correctly. :issue:`13276` by :user:`Aurélien
-  Bellet <bellet>`.
+- |Fix| Fixed a regression in :func:`covariance.graphical_lasso` so that
+  the case `n_features=2` is handled correctly. :issue:`13276` by
+  :user:`Aurélien Bellet <bellet>`.
 
 :mod:`sklearn.decomposition`
 ............................

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -204,7 +204,7 @@ def graphical_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
         # https://github.com/scikit-learn/scikit-learn/issues/4134
         d_gap = np.inf
         # set a sub_covariance buffer
-        sub_covariance = np.ascontiguousarray(covariance_[1:, 1:]).copy()
+        sub_covariance = np.copy(covariance_[1:, 1:], order='C')
         for i in range(max_iter):
             for idx in range(n_features):
                 # To keep the contiguous matrix `sub_covariance` equal to

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -204,7 +204,7 @@ def graphical_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
         # https://github.com/scikit-learn/scikit-learn/issues/4134
         d_gap = np.inf
         # set a sub_covariance buffer
-        sub_covariance = np.ascontiguousarray(covariance_[1:, 1:])
+        sub_covariance = np.ascontiguousarray(covariance_[1:, 1:]).copy()
         for i in range(max_iter):
             for idx in range(n_features):
                 # To keep the contiguous matrix `sub_covariance` equal to

--- a/sklearn/covariance/tests/test_graph_lasso.py
+++ b/sklearn/covariance/tests/test_graph_lasso.py
@@ -89,6 +89,24 @@ def test_graph_lasso_iris():
 
 
 @ignore_warnings(category=DeprecationWarning)
+def test_graph_lasso_2D():
+    # Hard-coded solution from Python skggm package
+    # obtained by calling `quic(emp_cov, lam=.1, tol=1e-8)`
+    cov_skggm = np.array([[3.09550269, 1.186972],
+                         [1.186972, 0.57713289]])
+
+    icov_skggm = np.array([[1.52836773, -3.14334831],
+                          [-3.14334831,  8.19753385]])
+    X = datasets.load_iris().data[:, 2:]
+    emp_cov = empirical_covariance(X)
+    for method in ('cd', 'lars'):
+        cov, icov = graph_lasso(emp_cov, alpha=.1, return_costs=False,
+                                mode=method)
+        assert_array_almost_equal(cov, cov_skggm)
+        assert_array_almost_equal(icov, icov_skggm)
+
+
+@ignore_warnings(category=DeprecationWarning)
 def test_graph_lasso_iris_singular():
     # Small subset of rows to test the rank-deficient case
     # Need to choose samples such that none of the variances are zero

--- a/sklearn/covariance/tests/test_graph_lasso.py
+++ b/sklearn/covariance/tests/test_graph_lasso.py
@@ -89,24 +89,6 @@ def test_graph_lasso_iris():
 
 
 @ignore_warnings(category=DeprecationWarning)
-def test_graph_lasso_2D():
-    # Hard-coded solution from Python skggm package
-    # obtained by calling `quic(emp_cov, lam=.1, tol=1e-8)`
-    cov_skggm = np.array([[3.09550269, 1.186972],
-                         [1.186972, 0.57713289]])
-
-    icov_skggm = np.array([[1.52836773, -3.14334831],
-                          [-3.14334831,  8.19753385]])
-    X = datasets.load_iris().data[:, 2:]
-    emp_cov = empirical_covariance(X)
-    for method in ('cd', 'lars'):
-        cov, icov = graph_lasso(emp_cov, alpha=.1, return_costs=False,
-                                mode=method)
-        assert_array_almost_equal(cov, cov_skggm)
-        assert_array_almost_equal(icov, icov_skggm)
-
-
-@ignore_warnings(category=DeprecationWarning)
 def test_graph_lasso_iris_singular():
     # Small subset of rows to test the rank-deficient case
     # Need to choose samples such that none of the variances are zero

--- a/sklearn/covariance/tests/test_graphical_lasso.py
+++ b/sklearn/covariance/tests/test_graphical_lasso.py
@@ -85,6 +85,23 @@ def test_graphical_lasso_iris():
         assert_array_almost_equal(icov, icov_R)
 
 
+def test_graph_lasso_2D():
+    # Hard-coded solution from Python skggm package
+    # obtained by calling `quic(emp_cov, lam=.1, tol=1e-8)`
+    cov_skggm = np.array([[3.09550269, 1.186972],
+                         [1.186972, 0.57713289]])
+
+    icov_skggm = np.array([[1.52836773, -3.14334831],
+                          [-3.14334831,  8.19753385]])
+    X = datasets.load_iris().data[:, 2:]
+    emp_cov = empirical_covariance(X)
+    for method in ('cd', 'lars'):
+        cov, icov = graphical_lasso(emp_cov, alpha=.1, return_costs=False,
+                                    mode=method)
+        assert_array_almost_equal(cov, cov_skggm)
+        assert_array_almost_equal(icov, icov_skggm)
+
+
 def test_graphical_lasso_iris_singular():
     # Small subset of rows to test the rank-deficient case
     # Need to choose samples such that none of the variances are zero


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes a bug introduced in #9858
Related to some discussions in #12228 

#### What does this implement/fix? Explain your changes.

This PR fixes a subtle bug in the graph lasso implementation, which was introduced in PR #9858 proposing an online way to update the matrix `sub_covariance` (leading to significant speed ups for large dense matrices). This bug affects both the CD and LARS solvers as it is in the outer loop.

More precisely, the problem originates from the fact that `np.ascontiguousarray` does not always copy the original array:

```
In [1]: 
   ...: import numpy as np
   ...: a = np.arange(10)
   ...: print(a)
   ...: b = np.ascontiguousarray(a)
   ...: b[0] = -1
   ...: print(a)
   ...: 
[0 1 2 3 4 5 6 7 8 9]
[-1  1  2  3  4  5  6  7  8  9]
```

This problem led to the matrix `covariance_` being modified when `sub_covariance` is updated, which is not correct.

Example of incorrect behavior on a simple PSD matrix taken from https://github.com/scikit-learn/scikit-learn/issues/12228#issuecomment-459391872:

```
In [1]: import numpy as np 
   ...: from sklearn.covariance import graphical_lasso
   ...: 
   ...: A = np.array([[6., 2.],
   ...:               [2., 1.]])
   ...: cov, _ = graphical_lasso(A, alpha=0.1, verbose=True, max_iter=5)
   ...: print(cov)
   ...: 
[graphical_lasso] Iteration   0, cost  1.24e+01, dual gap 4.728e-01
[graphical_lasso] Iteration   1, cost  1.19e+01, dual gap -9.262e-01
[graphical_lasso] Iteration   2, cost  1.19e+01, dual gap -9.262e-01
[graphical_lasso] Iteration   3, cost  1.19e+01, dual gap -9.262e-01
[graphical_lasso] Iteration   4, cost  1.19e+01, dual gap -9.262e-01
/home/aurelien/Documents/research/github/scikit-learn/sklearn/covariance/graph_lasso_.py:265: ConvergenceWarning: graphical_lasso: did not converge after 5 iteration: dual gap: -9.262e-01
  % (max_iter, d_gap), ConvergenceWarning)
[[6.  1.9]
 [1.9 6. ]]
```

With this PR:
```
In [1]: import numpy as np 
   ...: from sklearn.covariance import graphical_lasso
   ...: 
   ...: A = np.array([[6., 2.],
   ...:               [2., 1.]])
   ...: cov, _ = graphical_lasso(A, alpha=0.1, verbose=True, max_iter=5)
   ...: print(cov)
   ...: 
[graphical_lasso] Iteration   0, cost  1.02e+01, dual gap 3.331e-16
[[6.  1.9]
 [1.9 1. ]]
```

This is consistent with the output of graph lasso as implemented in package [skggm](https://github.com/skggm/skggm):

```
In [1]: import numpy as np 
   ...: from inverse_covariance import quic
   ...: 
   ...: A = np.array([[6., 2.],
   ...:               [2., 1.]])
   ...: _, cov, _, _, _, _ = quic(A, lam=0.1)
   ...: print(cov)
   ...:               
[[6.00000005 1.9       ]
 [1.9        1.00000001]]
```

**UPDATE:** the problem arises only when `n_features=2`, hence has small scope. This explains why the tests passed for PR #9858. The root cause of the problem can still valid for larger matrices, as seen in this example:

```
In [1]: import numpy as np
   ...: a = np.ones((3, 3))
   ...: print(a)
   ...: b = np.ascontiguousarray(a)
   ...: b[0] = [-1, -2, -1]
   ...: print(a)
   ...: 
[[1. 1. 1.]
 [1. 1. 1.]
 [1. 1. 1.]]
[[-1. -2. -1.]
 [ 1.  1.  1.]
 [ 1.  1.  1.]]
```

However slicing the two dimensions at the same time (as done for graph lasso) forces `np.ascontiguousarray` to make a copy when `n_features>2`:

```
In [1]: import numpy as np
   ...: a = np.ones((3, 3))
   ...: print(a)
   ...: b = np.ascontiguousarray(a[1:, 1:])
   ...: b[0] = [-1, -2]
   ...: print(a)
   ...: 
[[1. 1. 1.]
 [1. 1. 1.]
 [1. 1. 1.]]
[[1. 1. 1.]
 [1. 1. 1.]
 [1. 1. 1.]]
```

When `n_features=2`, the output is a single value (which is already contiguous), hence the bug.