### PR TITLE
[MRG+2] Fix warning in MultinomialNB.partial_fit when target class was not yet observed

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -460,8 +460,14 @@ class BaseDiscreteNB(BaseNB):
                                  " classes.")
             self.class_log_prior_ = np.log(class_prior)
         elif self.fit_prior:
+            with warnings.catch_warnings():
+                # silence the warning when count is 0 because class was not yet
+                # observed
+                warnings.simplefilter("ignore", RuntimeWarning)
+                log_class_count = np.log(self.class_count_)
+
             # empirical prior, with sample_weight taken into account
-            self.class_log_prior_ = (np.log(self.class_count_) -
+            self.class_log_prior_ = (log_class_count -
                                      np.log(self.class_count_.sum()))
         else:
             self.class_log_prior_ = np.full(n_classes, -np.log(n_classes))

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -245,6 +245,7 @@ def check_partial_fit(cls):
     assert_array_equal(clf1.class_count_, clf3.class_count_)
     assert_array_equal(clf1.feature_count_, clf3.feature_count_)
 
+
 def test_mnb_prior_unobserved_targets():
     # test smoothing of prior for yet unobserved targets
 
@@ -253,9 +254,22 @@ def test_mnb_prior_unobserved_targets():
     y = np.array([0, 1])
 
     clf = MultinomialNB()
-    clf.partial_fit(X, y, classes=[0, 1, 2])
-    assert_no_warnings(clf.partial_fit, X, y, classes=[0, 1, 2])
 
+    assert_no_warnings(
+        clf.partial_fit, X, y, classes=[0, 1, 2]
+    )
+
+    assert clf.predict([[0, 1]]) == 0
+    assert clf.predict([[1, 0]]) == 1
+    assert clf.predict([[1, 1]]) == 0
+
+    assert_no_warnings(
+        clf.partial_fit, [[1, 1]], [2]
+    )
+
+    assert clf.predict([[0, 1]]) == 0
+    assert clf.predict([[1, 0]]) == 1
+    assert clf.predict([[1, 1]]) == 2
 
 @pytest.mark.parametrize("cls", [MultinomialNB, BernoulliNB])
 def test_discretenb_partial_fit(cls):

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -18,6 +18,8 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import assert_no_warnings
+
 
 from sklearn.naive_bayes import GaussianNB, BernoulliNB
 from sklearn.naive_bayes import MultinomialNB, ComplementNB
@@ -248,13 +250,11 @@ def test_mnb_prior_unobserved_targets():
 
     # Create toy training data
     X = np.array([[0, 1], [1, 0]])
-    y = np.array([1, 2, 3, 4, 5, 6])
-
-    # All possible targets
-    classes = np.append(y, 7)
+    y = np.array([0, 1])
 
     clf = MultinomialNB()
-    clf.partial_fit(X, y, classes=classes)
+    clf.partial_fit(X, y, classes=[0, 1, 2])
+    assert_no_warnings(clf.partial_fit, X, y, classes=[0, 1, 2])
 
 
 @pytest.mark.parametrize("cls", [MultinomialNB, BernoulliNB])

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -20,7 +20,6 @@ from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_no_warnings
 
-
 from sklearn.naive_bayes import GaussianNB, BernoulliNB
 from sklearn.naive_bayes import MultinomialNB, ComplementNB
 
@@ -270,6 +269,7 @@ def test_mnb_prior_unobserved_targets():
     assert clf.predict([[0, 1]]) == 0
     assert clf.predict([[1, 0]]) == 1
     assert clf.predict([[1, 1]]) == 2
+
 
 @pytest.mark.parametrize("cls", [MultinomialNB, BernoulliNB])
 def test_discretenb_partial_fit(cls):

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -243,6 +243,19 @@ def check_partial_fit(cls):
     assert_array_equal(clf1.class_count_, clf3.class_count_)
     assert_array_equal(clf1.feature_count_, clf3.feature_count_)
 
+def test_mnb_prior_unobserved_targets():
+    # test smoothing of prior for yet unobserved targets
+
+    # Create toy training data
+    X = np.array([[0, 1], [1, 0]])
+    y = np.array([1, 2, 3, 4, 5, 6])
+
+    # All possible targets
+    classes = np.append(y, 7)
+
+    clf = MultinomialNB()
+    clf.partial_fit(X, y, classes=classes)
+
 
 @pytest.mark.parametrize("cls", [MultinomialNB, BernoulliNB])
 def test_discretenb_partial_fit(cls):

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -262,6 +262,7 @@ def test_mnb_prior_unobserved_targets():
     assert clf.predict([[1, 0]]) == 1
     assert clf.predict([[1, 1]]) == 0
 
+    # add a training example with previously unobserved class
     assert_no_warnings(
         clf.partial_fit, [[1, 1]], [2]
     )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

Fixes #13232 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

It silences the runtime warning in `partial_fit` when a target class was not observed, which results in log of 0s. This should not affect the predictions as demonstrated in the implemented unit test. It does have an unpleasant effect of producing -inf in `class_log_prior_` attribute when the class was not yet observed. This value is then updated after adding a training case with such a class. 

#### Any other comments?

Ping: @GaelVaroquaux 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
