### PR TITLE
[MRG] Fix OpenMP runtime error on mac

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -16,9 +16,6 @@ if [[ "$UNAMESTR" == "Darwin" ]]; then
     export CXXFLAGS="$CXXFLAGS -I/usr/local/opt/libomp/include"
     export LDFLAGS="$LDFLAGS -L/usr/local/opt/libomp/lib -lomp"
     export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
-
-    # avoid error due to multiple OpenMP libraries loaded simultaneously
-    export KMP_DUPLICATE_LIB_OK=TRUE
 fi
 
 make_conda() {

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -38,9 +38,6 @@ then
     export CXXFLAGS="$CXXFLAGS -I/usr/local/opt/libomp/include"
     export LDFLAGS="$LDFLAGS -L/usr/local/opt/libomp/lib -lomp"
     export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
-
-    # avoid error due to multiple OpenMP libraries loaded simultaneously
-    export KMP_DUPLICATE_LIB_OK=TRUE
 fi
 
 make_conda() {

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -51,11 +51,11 @@ __version__ = '0.21.dev0'
 # On OSX, we can get a runtime error due to multiple OpenMP libraries loaded
 # simultaneously. This can happen for instance when calling BLAS inside a
 # prange. Setting the following environment variable allows multiple OpenMP
-# libraries. It should not degrade performances since we manually take care of
-# potential over-subcription performance issues, in sections of the code where
-# nested OpenMP loops can happen, by dynamically reconfiguring the inner OpenMP
-# runtime to temporarily disable it while under the scope of the outer OpenMP
-# parallel section.
+# libraries to be loaded. It should not degrade performances since we manually
+# take care of potential over-subcription performance issues, in sections of
+# the code where nested OpenMP loops can happen, by dynamically reconfiguring
+# the inner OpenMP runtime to temporarily disable it while under the scope of
+# the outer OpenMP parallel section.
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "True")
 
 

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -51,7 +51,11 @@ __version__ = '0.21.dev0'
 # On OSX, we can get a runtime error due to multiple OpenMP libraries loaded
 # simultaneously. This can happen for instance when calling BLAS inside a
 # prange. Setting the following environment variable allows multiple OpenMP
-# libraries.
+# libraries. It should not degrade performances since we manually take care of
+# potential over-subcription performance issues, in sections of the code where
+# nested OpenMP loops can happen, by dynamically reconfiguring the inner OpenMP
+# runtime to temporarily disable it while under the scope of the outer OpenMP
+# parallel section.
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "True")
 
 

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -16,6 +16,7 @@ import sys
 import re
 import warnings
 import logging
+import os
 
 from ._config import get_config, set_config, config_context
 
@@ -45,6 +46,13 @@ warnings.filterwarnings('always', category=DeprecationWarning,
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
 __version__ = '0.21.dev0'
+
+
+# On OSX, we can get a runtime error due to multiple OpenMP libraries loaded
+# simultaneously. This can happen for instance when calling BLAS inside a
+# prange. Setting the following environment variable allows multiple OpenMP
+# libraries.
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "True")
 
 
 try:


### PR DESCRIPTION
Avoids runtime error from OpenMP due to multiple OpenMP runtime libs loaded simultaneously.
Happens when calling BLAS inside prange parallel loop.
Happens only on mac...

ping @ogrisel 