### PR TITLE
[MRG] Adds Azure Tests For Windows 32 bit Python 3.5

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,11 +64,11 @@ jobs:
     name: Windows
     vmImage: vs2017-win2016
     matrix:
-      py37:
+      py37_64:
         PYTHON_VERSION: '3.7'
         CHECK_WARNINGS: 'true'
         PYTHON_ARCH: '64'
-      py35:
+      py35_32:
         PYTHON_VERSION: '3.5'
         PYTHON_ARCH: '32'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,71 +1,74 @@
 # Adapted from https://github.com/pandas-dev/pandas/blob/master/azure-pipelines.yml
 jobs:
-- template: build_tools/azure/posix.yml
-  parameters:
-    name: Linux
-    vmImage: ubuntu-16.04
-    matrix:
-      # Linux environment to test that scikit-learn can be built against
-      # versions of numpy, scipy with ATLAS that comes with Ubuntu Xenial 16.04
-      # i.e. numpy 1.11 and scipy 0.17
-      py35_np_atlas:
-        DISTRIB: 'ubuntu'
-        PYTHON_VERSION: '3.5'
-        SKLEARN_SITE_JOBLIB: '1'
-        JOBLIB_VERSION: '0.11'
-      # Linux + Python 3.5 build with OpenBLAS and without SITE_JOBLIB
-      py35_conda_openblas:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '3.5'
-        INSTALL_MKL: 'false'
-        NUMPY_VERSION: '1.11.0'
-        SCIPY_VERSION: '0.17.0'
-        CYTHON_VERSION: '*'
-        PILLOW_VERSION: '4.0.0'
-        COVERAGE: 'true'
-      # Linux environment to test the latest available dependencies and MKL.
-      # It runs tests requiring pandas and PyAMG.
-      # It also runs with the site joblib instead of the vendored copy of joblib.
-      pylatest_conda:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '*'
-        INSTALL_MKL: 'true'
-        NUMPY_VERSION: '*'
-        SCIPY_VERSION: '*'
-        PANDAS_VERSION: '*'
-        CYTHON_VERSION: '*'
-        PYAMG_VERSION: '*'
-        PILLOW_VERSION: '*'
-        JOBLIB_VERSION: '*'
-        COVERAGE: 'true'
-        CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-        TEST_DOCSTRINGS: 'true'
-        SKLEARN_SITE_JOBLIB: '1'
-        CHECK_WARNINGS: 'true'
+# - template: build_tools/azure/posix.yml
+#   parameters:
+#     name: Linux
+#     vmImage: ubuntu-16.04
+#     matrix:
+#       # Linux environment to test that scikit-learn can be built against
+#       # versions of numpy, scipy with ATLAS that comes with Ubuntu Xenial 16.04
+#       # i.e. numpy 1.11 and scipy 0.17
+#       py35_np_atlas:
+#         DISTRIB: 'ubuntu'
+#         PYTHON_VERSION: '3.5'
+#         SKLEARN_SITE_JOBLIB: '1'
+#         JOBLIB_VERSION: '0.11'
+#       # Linux + Python 3.5 build with OpenBLAS and without SITE_JOBLIB
+#       py35_conda_openblas:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '3.5'
+#         INSTALL_MKL: 'false'
+#         NUMPY_VERSION: '1.11.0'
+#         SCIPY_VERSION: '0.17.0'
+#         CYTHON_VERSION: '*'
+#         PILLOW_VERSION: '4.0.0'
+#         COVERAGE: 'true'
+#       # Linux environment to test the latest available dependencies and MKL.
+#       # It runs tests requiring pandas and PyAMG.
+#       # It also runs with the site joblib instead of the vendored copy of joblib.
+#       pylatest_conda:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '*'
+#         INSTALL_MKL: 'true'
+#         NUMPY_VERSION: '*'
+#         SCIPY_VERSION: '*'
+#         PANDAS_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         PYAMG_VERSION: '*'
+#         PILLOW_VERSION: '*'
+#         JOBLIB_VERSION: '*'
+#         COVERAGE: 'true'
+#         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+#         TEST_DOCSTRINGS: 'true'
+#         SKLEARN_SITE_JOBLIB: '1'
+#         CHECK_WARNINGS: 'true'
 
-- template: build_tools/azure/posix.yml
-  parameters:
-    name: macOS
-    vmImage: xcode9-macos10.13
-    matrix:
-      pylatest_conda:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '*'
-        INSTALL_MKL: 'true'
-        NUMPY_VERSION: '*'
-        SCIPY_VERSION: '*'
-        CYTHON_VERSION: '*'
-        PILLOW_VERSION: '*'
-        JOBLIB_VERSION: '*'
-        COVERAGE: 'true'
+# - template: build_tools/azure/posix.yml
+#   parameters:
+#     name: macOS
+#     vmImage: xcode9-macos10.13
+#     matrix:
+#       pylatest_conda:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '*'
+#         INSTALL_MKL: 'true'
+#         NUMPY_VERSION: '*'
+#         SCIPY_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         PILLOW_VERSION: '*'
+#         JOBLIB_VERSION: '*'
+#         COVERAGE: 'true'
 
 - template: build_tools/azure/windows.yml
   parameters:
     name: Windows
     vmImage: vs2017-win2016
     matrix:
-      py37:
-        CONDA_PY: '3.7'
-        CHECK_WARNINGS: 'true'
+      # py37:
+      #   CONDA_PY: '3.7.2'
+      #   CHECK_WARNINGS: 'true'
+      #   PYTHON_ARCH: '64'
       py35:
-        CONDA_PY: '3.5'
+        CONDA_PY: '3.5.6'
+        PYTHON_ARCH: '32'
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,74 +1,74 @@
 # Adapted from https://github.com/pandas-dev/pandas/blob/master/azure-pipelines.yml
 jobs:
-# - template: build_tools/azure/posix.yml
-#   parameters:
-#     name: Linux
-#     vmImage: ubuntu-16.04
-#     matrix:
-#       # Linux environment to test that scikit-learn can be built against
-#       # versions of numpy, scipy with ATLAS that comes with Ubuntu Xenial 16.04
-#       # i.e. numpy 1.11 and scipy 0.17
-#       py35_np_atlas:
-#         DISTRIB: 'ubuntu'
-#         PYTHON_VERSION: '3.5'
-#         SKLEARN_SITE_JOBLIB: '1'
-#         JOBLIB_VERSION: '0.11'
-#       # Linux + Python 3.5 build with OpenBLAS and without SITE_JOBLIB
-#       py35_conda_openblas:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '3.5'
-#         INSTALL_MKL: 'false'
-#         NUMPY_VERSION: '1.11.0'
-#         SCIPY_VERSION: '0.17.0'
-#         CYTHON_VERSION: '*'
-#         PILLOW_VERSION: '4.0.0'
-#         COVERAGE: 'true'
-#       # Linux environment to test the latest available dependencies and MKL.
-#       # It runs tests requiring pandas and PyAMG.
-#       # It also runs with the site joblib instead of the vendored copy of joblib.
-#       pylatest_conda:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '*'
-#         INSTALL_MKL: 'true'
-#         NUMPY_VERSION: '*'
-#         SCIPY_VERSION: '*'
-#         PANDAS_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         PYAMG_VERSION: '*'
-#         PILLOW_VERSION: '*'
-#         JOBLIB_VERSION: '*'
-#         COVERAGE: 'true'
-#         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-#         TEST_DOCSTRINGS: 'true'
-#         SKLEARN_SITE_JOBLIB: '1'
-#         CHECK_WARNINGS: 'true'
+- template: build_tools/azure/posix.yml
+  parameters:
+    name: Linux
+    vmImage: ubuntu-16.04
+    matrix:
+      # Linux environment to test that scikit-learn can be built against
+      # versions of numpy, scipy with ATLAS that comes with Ubuntu Xenial 16.04
+      # i.e. numpy 1.11 and scipy 0.17
+      py35_np_atlas:
+        DISTRIB: 'ubuntu'
+        PYTHON_VERSION: '3.5'
+        SKLEARN_SITE_JOBLIB: '1'
+        JOBLIB_VERSION: '0.11'
+      # Linux + Python 3.5 build with OpenBLAS and without SITE_JOBLIB
+      py35_conda_openblas:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '3.5'
+        INSTALL_MKL: 'false'
+        NUMPY_VERSION: '1.11.0'
+        SCIPY_VERSION: '0.17.0'
+        CYTHON_VERSION: '*'
+        PILLOW_VERSION: '4.0.0'
+        COVERAGE: 'true'
+      # Linux environment to test the latest available dependencies and MKL.
+      # It runs tests requiring pandas and PyAMG.
+      # It also runs with the site joblib instead of the vendored copy of joblib.
+      pylatest_conda:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '*'
+        INSTALL_MKL: 'true'
+        NUMPY_VERSION: '*'
+        SCIPY_VERSION: '*'
+        PANDAS_VERSION: '*'
+        CYTHON_VERSION: '*'
+        PYAMG_VERSION: '*'
+        PILLOW_VERSION: '*'
+        JOBLIB_VERSION: '*'
+        COVERAGE: 'true'
+        CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+        TEST_DOCSTRINGS: 'true'
+        SKLEARN_SITE_JOBLIB: '1'
+        CHECK_WARNINGS: 'true'
 
-# - template: build_tools/azure/posix.yml
-#   parameters:
-#     name: macOS
-#     vmImage: xcode9-macos10.13
-#     matrix:
-#       pylatest_conda:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '*'
-#         INSTALL_MKL: 'true'
-#         NUMPY_VERSION: '*'
-#         SCIPY_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         PILLOW_VERSION: '*'
-#         JOBLIB_VERSION: '*'
-#         COVERAGE: 'true'
+- template: build_tools/azure/posix.yml
+  parameters:
+    name: macOS
+    vmImage: xcode9-macos10.13
+    matrix:
+      pylatest_conda:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '*'
+        INSTALL_MKL: 'true'
+        NUMPY_VERSION: '*'
+        SCIPY_VERSION: '*'
+        CYTHON_VERSION: '*'
+        PILLOW_VERSION: '*'
+        JOBLIB_VERSION: '*'
+        COVERAGE: 'true'
 
 - template: build_tools/azure/windows.yml
   parameters:
     name: Windows
     vmImage: vs2017-win2016
     matrix:
-      # py37:
-      #   CONDA_PY: '3.7.2'
-      #   CHECK_WARNINGS: 'true'
-      #   PYTHON_ARCH: '64'
+      py37:
+        PYTHON_VERSION: '3.7'
+        CHECK_WARNINGS: 'true'
+        PYTHON_ARCH: '64'
       py35:
-        CONDA_PY: '3.5.6'
+        PYTHON_VERSION: '3.5'
         PYTHON_ARCH: '32'
 

--- a/build_tools/azure/install.cmd
+++ b/build_tools/azure/install.cmd
@@ -6,13 +6,17 @@ set PIP_INSTALL=pip install -q
 
 @echo on
 
-@rem Deactivate any environment
-call deactivate
-@rem Clean up any left-over from a previous build
-conda remove --all -q -y -n %VIRTUALENV%
-conda create -n %VIRTUALENV% -q -y python=%CONDA_PY% numpy scipy cython pytest wheel pillow
+IF "%PYTHON_ARCH%"=="64" (
+    @rem Deactivate any environment
+    call deactivate
+    @rem Clean up any left-over from a previous build
+    conda remove --all -q -y -n %VIRTUALENV%
+    conda create -n %VIRTUALENV% -q -y python=%PYTHON_VERSION% numpy scipy cython pytest wheel pillow
 
-call activate %VIRTUALENV%
+    call activate %VIRTUALENV%
+) else (
+    pip install numpy scipy cython pytest wheel pillow
+)
 python -m pip install -U pip
 python --version
 pip --version

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -27,7 +27,7 @@ jobs:
         versionSpec: '$(PYTHON_VERSION)'
         addToPath: true
         architecture: 'x86'
-      displayName: Use 32 bit Python
+      displayName: Use 32 bit System Python
       condition: eq(variables['PYTHON_ARCH'], '32')
     - script: |
         build_tools\\azure\\install.cmd

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -27,7 +27,7 @@ jobs:
         versionSpec: '$(PYTHON_VERSION)'
         addToPath: true
         architecture: 'x86'
-      displayName: Use Python 32 bit
+      displayName: Use 32 bit Python
       condition: eq(variables['PYTHON_ARCH'], '32')
     - script: |
         build_tools\\azure\\install.cmd

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -5,7 +5,7 @@ parameters:
   matrix: []
 
 jobs:
-- job: ${{ parameters.name }}
+- job: ${{ format('{0}-$(PYTHON_ARCH)', parameters.name }}
   pool:
     vmImage: ${{ parameters.vmImage }}
   variables:

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -5,7 +5,7 @@ parameters:
   matrix: []
 
 jobs:
-- job: ${{ format('{0}-{1}', parameters.name, variables['PYTHON_ARCH']) }}
+- job: ${{ format('{0} $(PYTHON_ARCH)', parameters.name) }}
   pool:
     vmImage: ${{ parameters.vmImage }}
   variables:

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -21,7 +21,6 @@ jobs:
     - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
       displayName: Add conda to PATH for 64 bit Python
       condition: eq(variables['PYTHON_ARCH'], '64')
-    - powershell: Write-Host "##vso[task.prependpath]$env:AGENT_WORKFOLDER\miniconda\Scripts"
     - task: UsePythonVersion@0
       inputs:
         versionSpec: '$(PYTHON_VERSION)'

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -21,21 +21,23 @@ jobs:
     - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
       displayName: Add conda to PATH for 64 bit Python
       condition: eq(variables['PYTHON_ARCH'], '64')
-    - powershell: |
-        $wc = New-Object net.webclient
-        $wc.Downloadfile("https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86.exe", "miniconda.exe")
-        Start-Process "miniconda.exe" /qn -Wait
-      displayName: Add conda to PATH for 32 bit Python
+    - powershell: Write-Host "##vso[task.prependpath]$env:AGENT_WORKFOLDER\miniconda\Scripts"
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '$(PYTHON_VERSION)'
+        addToPath: true
+        architecture: 'x86'
+      displayName: Use Python 32 bit
       condition: eq(variables['PYTHON_ARCH'], '32')
-    # - script: |
-    #     build_tools\\azure\\install.cmd
-    #   displayName: 'Install'
-    # - script: |
-    #     build_tools\\azure\\test_script.cmd
-    #   displayName: 'Test Library'
-    # - task: PublishTestResults@2
-    #   inputs:
-    #     testResultsFiles: '$(TMP_FOLDER)\$(JUNITXML)'
-    #     testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
-    #   displayName: 'Publish Test Results'
-    #   condition: succeededOrFailed()
+    - script: |
+        build_tools\\azure\\install.cmd
+      displayName: 'Install'
+    - script: |
+        build_tools\\azure\\test_script.cmd
+      displayName: 'Test Library'
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: '$(TMP_FOLDER)\$(JUNITXML)'
+        testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
+      displayName: 'Publish Test Results'
+      condition: succeededOrFailed()

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -19,16 +19,23 @@ jobs:
 
   steps:
     - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-      displayName: Add conda to PATH
-    - script: |
-        build_tools\\azure\\install.cmd
-      displayName: 'Install'
-    - script: |
-        build_tools\\azure\\test_script.cmd
-      displayName: 'Test Library'
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFiles: '$(TMP_FOLDER)\$(JUNITXML)'
-        testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
-      displayName: 'Publish Test Results'
-      condition: succeededOrFailed()
+      displayName: Add conda to PATH for 64 bit Python
+      condition: eq(variables['PYTHON_ARCH'], '64')
+    - powershell: |
+        $wc = New-Object net.webclient
+        $wc.Downloadfile("https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86.exe", "miniconda.exe")
+        Start-Process "miniconda.exe" /qn -Wait
+      displayName: Add conda to PATH for 32 bit Python
+      condition: eq(variables['PYTHON_ARCH'], '32')
+    # - script: |
+    #     build_tools\\azure\\install.cmd
+    #   displayName: 'Install'
+    # - script: |
+    #     build_tools\\azure\\test_script.cmd
+    #   displayName: 'Test Library'
+    # - task: PublishTestResults@2
+    #   inputs:
+    #     testResultsFiles: '$(TMP_FOLDER)\$(JUNITXML)'
+    #     testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
+    #   displayName: 'Publish Test Results'
+    #   condition: succeededOrFailed()

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -5,7 +5,7 @@ parameters:
   matrix: []
 
 jobs:
-- job: ${{ format('{0} $(PYTHON_ARCH)', parameters.name) }}
+- job: ${{ parameters.name }}
   pool:
     vmImage: ${{ parameters.vmImage }}
   variables:

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -5,7 +5,7 @@ parameters:
   matrix: []
 
 jobs:
-- job: ${{ format('{0}-$(PYTHON_ARCH)', parameters.name }}
+- job: ${{ format('{0}-$(PYTHON_ARCH)', parameters.name) }}
   pool:
     vmImage: ${{ parameters.vmImage }}
   variables:

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -5,7 +5,7 @@ parameters:
   matrix: []
 
 jobs:
-- job: ${{ format('{0}-$(PYTHON_ARCH)', parameters.name) }}
+- job: ${{ format('{0}-{1}', parameters.name, variables['PYTHON_ARCH']) }}
   pool:
     vmImage: ${{ parameters.vmImage }}
   variables:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
See also https://github.com/scikit-learn/scikit-learn/pull/13284
See also https://github.com/scikit-learn/scikit-learn/issues/13293

#### What does this implement/fix? Explain your changes.
Uses the system 32-bit Python 3.5 on Windows. This puts the test closer to the target audience of this test: users that install Python 32-bit from python.org. (Since it is the default)

#### Any other comments?
With this update, we can now remove appveyor from our CI.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->