### PR TITLE
MRG don't warn on changing dtypes in scalers

### DIFF
--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -16,7 +16,7 @@ from sklearn.utils.testing import assert_almost_equal
 
 from sklearn.base import BaseEstimator
 from sklearn.compose import ColumnTransformer, make_column_transformer
-from sklearn.exceptions import NotFittedError, DataConversionWarning
+from sklearn.exceptions import NotFittedError
 from sklearn.preprocessing import StandardScaler, Normalizer, OneHotEncoder
 from sklearn.feature_extraction import DictVectorizer
 
@@ -336,11 +336,8 @@ def test_column_transformer_list():
         ('categorical', OneHotEncoder(), [2]),
     ])
 
-    with pytest.warns(DataConversionWarning):
-        # TODO: this warning is not very useful in this case, would be good
-        # to get rid of it
-        assert_array_equal(ct.fit_transform(X_list), expected_result)
-        assert_array_equal(ct.fit(X_list).transform(X_list), expected_result)
+    assert_array_equal(ct.fit_transform(X_list), expected_result)
+    assert_array_equal(ct.fit(X_list).transform(X_list), expected_result)
 
 
 def test_column_transformer_sparse_stacking():

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -659,8 +659,8 @@ class StandardScaler(BaseEstimator, TransformerMixin):
             Ignored
         """
         X = check_array(X, accept_sparse=('csr', 'csc'), copy=self.copy,
-                        warn_on_dtype=False, estimator=self, dtype=FLOAT_DTYPES,
-                        force_all_finite='allow-nan')
+                        warn_on_dtype=False, estimator=self,
+                        dtype=FLOAT_DTYPES, force_all_finite='allow-nan')
 
         # Even in the case of `with_mean=False`, we update the mean anyway
         # This is needed for the incremental computation of the var

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -137,7 +137,7 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
 
     """  # noqa
     X = check_array(X, accept_sparse='csc', copy=copy, ensure_2d=False,
-                    warn_on_dtype=True, estimator='the scale function',
+                    warn_on_dtype=False, estimator='the scale function',
                     dtype=FLOAT_DTYPES, force_all_finite='allow-nan')
     if sparse.issparse(X):
         if with_mean:
@@ -348,7 +348,7 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
             raise TypeError("MinMaxScaler does no support sparse input. "
                             "You may consider to use MaxAbsScaler instead.")
 
-        X = check_array(X, copy=self.copy, warn_on_dtype=True,
+        X = check_array(X, copy=self.copy, warn_on_dtype=False,
                         estimator=self, dtype=FLOAT_DTYPES,
                         force_all_finite="allow-nan")
 
@@ -468,7 +468,7 @@ def minmax_scale(X, feature_range=(0, 1), axis=0, copy=True):
     """  # noqa
     # Unlike the scaler object, this function allows 1d input.
     # If copy is required, it will be done inside the scaler object.
-    X = check_array(X, copy=False, ensure_2d=False, warn_on_dtype=True,
+    X = check_array(X, copy=False, ensure_2d=False, warn_on_dtype=False,
                     dtype=FLOAT_DTYPES, force_all_finite='allow-nan')
     original_ndim = X.ndim
 
@@ -659,7 +659,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
             Ignored
         """
         X = check_array(X, accept_sparse=('csr', 'csc'), copy=self.copy,
-                        warn_on_dtype=True, estimator=self, dtype=FLOAT_DTYPES,
+                        warn_on_dtype=False, estimator=self, dtype=FLOAT_DTYPES,
                         force_all_finite='allow-nan')
 
         # Even in the case of `with_mean=False`, we update the mean anyway
@@ -753,7 +753,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         check_is_fitted(self, 'scale_')
 
         copy = copy if copy is not None else self.copy
-        X = check_array(X, accept_sparse='csr', copy=copy, warn_on_dtype=True,
+        X = check_array(X, accept_sparse='csr', copy=copy, warn_on_dtype=False,
                         estimator=self, dtype=FLOAT_DTYPES,
                         force_all_finite='allow-nan')
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -54,7 +54,7 @@ from sklearn.preprocessing.data import PolynomialFeatures
 from sklearn.preprocessing.data import PowerTransformer
 from sklearn.preprocessing.data import power_transform
 from sklearn.preprocessing.data import BOUNDS_THRESHOLD
-from sklearn.exceptions import DataConversionWarning, NotFittedError
+from sklearn.exceptions import NotFittedError
 
 from sklearn.base import clone
 from sklearn.pipeline import Pipeline
@@ -1693,19 +1693,6 @@ def test_maxabs_scaler_transform_one_row_csr():
     assert_array_almost_equal(X_trans.toarray(), X_expected.toarray())
     X_scaled_back = scaler.inverse_transform(X_trans)
     assert_array_almost_equal(X.toarray(), X_scaled_back.toarray())
-
-
-def test_warning_scaling_integers():
-    # Check warning when scaling integer data
-    X = np.array([[1, 2, 0],
-                  [0, 0, 0]], dtype=np.uint8)
-
-    w = "Data with input dtype uint8 was converted to float64"
-
-    clean_warning_registry()
-    assert_warns_message(DataConversionWarning, w, scale, X)
-    assert_warns_message(DataConversionWarning, w, StandardScaler().fit, X)
-    assert_warns_message(DataConversionWarning, w, MinMaxScaler().fit, X)
 
 
 def test_maxabs_scaler_1d():


### PR DESCRIPTION
Don't warn on changing dtypes in scalers. It's really annoying and doesn't seem very useful.