### PR TITLE
[WIP] Change default convergence params for classes using liblinear (LinearSVM and LogisticRegression)

### DIFF
--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -20,7 +20,7 @@ from scipy.special import expit
 from .base import LinearClassifierMixin, SparseCoefMixin, BaseEstimator
 from .sag import sag_solver
 from ..preprocessing import LabelEncoder, LabelBinarizer
-from ..svm.base import _fit_liblinear
+from ..svm.base import _fit_liblinear, _get_liblinear_solver_type
 from ..utils import check_array, check_consistent_length, compute_class_weight
 from ..utils import check_random_state
 from ..utils.extmath import (log_logistic, safe_sparse_dot, softmax,
@@ -1518,14 +1518,14 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         else:
             C_ = self.C
             penalty = self.penalty
-        if ((not isinstance(self.max_iter, numbers.Number) and 
-                not self.max_iter == 'auto') or
-            self.max_iter < 0):
+        if ((not isinstance(self.max_iter, numbers.Number) and
+             not self.max_iter == 'auto') or 
+            (isinstance(self.max_iter, numbers.Number) and self.max_iter < 0)):
             raise ValueError("Maximum number of iteration must be positive or "
                              "'auto'; got (max_iter=%r)" % self.max_iter)
         if ((not isinstance(self.tol, numbers.Number) and
-                not self.tol == 'auto') or
-            self.tol < 0):
+             not self.tol == 'auto') or 
+            (isinstance(self.tol, numbers.Number) and self.tol < 0)):
             raise ValueError("Tolerance for stopping criteria must be "
                              "positive or 'auto'; got (tol=%r)" % self.tol)
 
@@ -1534,9 +1534,6 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         else:
             _dtype = [np.float64, np.float32]
         
-        self.tol_, self.max_iter_ = _check_convergence_params(solver, self.tol,
-                self.max_iter)
-
         X, y = check_X_y(X, y, accept_sparse='csr', dtype=_dtype, order="C",
                          accept_large_sparse=solver != 'liblinear')
         check_classification_targets(y)
@@ -1545,6 +1542,17 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
 
         multi_class = _check_multi_class(self.multi_class, solver,
                                          len(self.classes_))
+
+        # Determine the subsolver to use according to estimator params to set
+        # the right default for max_iter and tol. Only liblinear has subsolvers
+        loss = 'logistic_regression'
+        if solver == 'liblinear':
+            internal_solver = _get_liblinear_solver_type(multi_class,
+                    self.penalty, loss, self.dual)
+        else:
+            internal_solver = 0
+        self.tol_, self.max_iter_ = _check_convergence_params(solver, self.tol,
+                self.max_iter, internal_solver)
 
         if solver == 'liblinear':
             if effective_n_jobs(self.n_jobs) != 1:
@@ -1981,15 +1989,17 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         solver = _check_solver(self.solver, self.penalty, self.dual)
 
         if ((not isinstance(self.max_iter, numbers.Number) and
-                not self.max_iter == 'auto') or
-            self.max_iter < 0):
+             not self.max_iter == 'auto') or 
+            (isinstance(self.max_iter, numbers.Number) and self.max_iter < 0)):
             raise ValueError("Maximum number of iteration must be positive or "
                              "'auto'; got (max_iter=%r)" % self.max_iter)
-        if ((not isinstance(self.tol, numbers.Number) and 
-                not self.tol == 'auto') or
-            self.tol < 0):
+        
+        if ((not isinstance(self.tol, numbers.Number) and
+             not self.tol == 'auto') or 
+            (isinstance(self.tol, numbers.Number) and self.tol < 0)):
             raise ValueError("Tolerance for stopping criteria must be "
                              "positive or 'auto'; got (tol=%r)" % self.tol)
+
         if self.penalty == 'elasticnet':
             if self.l1_ratios is None or len(self.l1_ratios) == 0 or any(
                     (not isinstance(l1_ratio, numbers.Number) or l1_ratio < 0
@@ -2081,8 +2091,16 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         else:
             prefer = 'processes'
         
+        # Determine the subsolver to use according to estimator params to set
+        # the right default for max_iter and tol. Only liblinear has subsolvers
+        loss = 'logistic_regression'
+        if solver == 'liblinear':
+            internal_solver = _get_liblinear_solver_type(multi_class,
+                    self.penalty, loss, self.dual)
+        else:
+            internal_solver = 0
         self.tol_, self.max_iter_ = _check_convergence_params(solver, self.tol,
-                self.max_iter)
+                self.max_iter, internal_solver)
 
         fold_coefs_ = Parallel(n_jobs=self.n_jobs, verbose=self.verbose,
                                **_joblib_parallel_args(prefer=prefer))(

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -30,6 +30,7 @@ from ..utils.fixes import logsumexp
 from ..utils.optimize import newton_cg
 from ..utils.validation import check_X_y
 from ..utils import deprecated
+from ..utils.solver_convergence import _check_convergence_params
 from ..exceptions import (NotFittedError, ConvergenceWarning,
                           ChangedBehaviorWarning)
 from ..utils.multiclass import check_classification_targets
@@ -1528,6 +1529,9 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
             _dtype = np.float64
         else:
             _dtype = [np.float64, np.float32]
+        
+        self.tol, self.max_iter = _check_convergence_params(self.tol,
+                self.max_iter, solver)
 
         X, y = check_X_y(X, y, accept_sparse='csr', dtype=_dtype, order="C",
                          accept_large_sparse=solver != 'liblinear')

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -221,8 +221,8 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
                           DeprecationWarning)
         # ---------------------------------------------------------------------
 
-        self.tol, self.max_iter = _check_convergence_params(self.tol,
-                self.max_iter)
+        self.tol_, self.max_iter_ = _check_convergence_params('liblinear', 
+                self.tol, self.max_iter)
 
         if self.C < 0:
             raise ValueError("Penalty term must be positive; got (C=%r)"
@@ -237,7 +237,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         self.coef_, self.intercept_, self.n_iter_ = _fit_liblinear(
             X, y, self.C, self.fit_intercept, self.intercept_scaling,
             self.class_weight, self.penalty, self.dual, self.verbose,
-            self.max_iter, self.tol, self.random_state, self.multi_class,
+            self.max_iter_, self.tol_, self.random_state, self.multi_class,
             self.loss, sample_weight=sample_weight)
 
         if self.multi_class == "crammer_singer" and len(self.classes_) == 2:
@@ -412,8 +412,8 @@ class LinearSVR(LinearModel, RegressorMixin):
                           DeprecationWarning)
         # ---------------------------------------------------------------------
 
-        self.tol, self.max_iter = _check_convergence_params(self.tol,
-                self.max_iter)
+        self.tol_, self.max_iter_ = _check_convergence_params('liblinear', 
+                self.tol, self.max_iter)
 
         if self.C < 0:
             raise ValueError("Penalty term must be positive; got (C=%r)"
@@ -426,7 +426,7 @@ class LinearSVR(LinearModel, RegressorMixin):
         self.coef_, self.intercept_, self.n_iter_ = _fit_liblinear(
             X, y, self.C, self.fit_intercept, self.intercept_scaling,
             None, penalty, self.dual, self.verbose,
-            self.max_iter, self.tol, self.random_state, loss=self.loss,
+            self.max_iter_, self.tol_, self.random_state, loss=self.loss,
             epsilon=self.epsilon, sample_weight=sample_weight)
         self.coef_ = self.coef_.ravel()
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -8,6 +8,7 @@ from ..linear_model.base import LinearClassifierMixin, SparseCoefMixin, \
 from ..utils import check_X_y
 from ..utils.validation import _num_samples
 from ..utils.multiclass import check_classification_targets
+from ..utils.solver_convergence import _check_convergence_params
 
 
 class LinearSVC(BaseEstimator, LinearClassifierMixin,
@@ -220,6 +221,9 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
                           DeprecationWarning)
         # ---------------------------------------------------------------------
 
+        self.tol, self.max_iter = _check_convergence_params(self.tol,
+                self.max_iter)
+
         if self.C < 0:
             raise ValueError("Penalty term must be positive; got (C=%r)"
                              % self.C)
@@ -407,6 +411,9 @@ class LinearSVR(LinearModel, RegressorMixin):
             warnings.warn(msg % (old_loss, self.loss, old_loss, '1.0'),
                           DeprecationWarning)
         # ---------------------------------------------------------------------
+
+        self.tol, self.max_iter = _check_convergence_params(self.tol,
+                self.max_iter)
 
         if self.C < 0:
             raise ValueError("Penalty term must be positive; got (C=%r)"

--- a/sklearn/utils/solver_convergence.py
+++ b/sklearn/utils/solver_convergence.py
@@ -1,0 +1,14 @@
+def _check_convergence_params (tol, max_iter, solver='liblinear'):
+    default_tol = 1e-4
+    default_max_iter = 1000
+    if ((tol == 'auto' and max_iter != 'auto') or 
+            (tol != 'auto' and max_iter == 'auto')):
+        raise ValueError("'auto' value on tol and max_iter can only be "
+                            "used simultaneously. Either provide a numeric "
+                            "for both values or set both to 'auto'")
+    
+    if tol == 'auto' and max_iter == 'auto':
+        tol = default_tol
+        max_iter = default_max_iter
+
+    return tol, max_iter

--- a/sklearn/utils/solver_convergence.py
+++ b/sklearn/utils/solver_convergence.py
@@ -1,6 +1,17 @@
-def _check_convergence_params (tol, max_iter, solver='liblinear'):
-    default_tol = 1e-4
-    default_max_iter = 1000
+DEFAULT_CONV = {'liblinear': {0: (1e-2, 1000), 1: (1e-1, 1000), 2: (1e-2, 1000),
+                              3: (1e-1, 1000), 4: (1e-1, 1000), 5: (1e-2, 1000),
+                              6: (1e-2, 1000), 7: (1e-1, 1000),
+                              11: (1e-3, 1000), 12: (1e-1, 1000),
+                              13: (1e-1, 1000)},
+                'lbfgs': {0: (1e-4, 15000)},
+                'sag': {0: (1e-3, 1000)},
+                'saga': {0: (1e-3, 1000)},
+                'newton-cg': {0: (1e-4, 100)},
+                'logistic': {0: (1e-4, 1e2)},
+                'svm': {0: (1e-4, 1e3)}}
+
+
+def _check_convergence_params(solver, tol, max_iter):
     if ((tol == 'auto' and max_iter != 'auto') or 
             (tol != 'auto' and max_iter == 'auto')):
         raise ValueError("'auto' value on tol and max_iter can only be "
@@ -8,7 +19,7 @@ def _check_convergence_params (tol, max_iter, solver='liblinear'):
                             "for both values or set both to 'auto'")
     
     if tol == 'auto' and max_iter == 'auto':
-        tol = default_tol
-        max_iter = default_max_iter
+        tol = DEFAULT_CONV[solver][0][0]
+        max_iter = DEFAULT_CONV[solver][0][1]
 
     return tol, max_iter

--- a/sklearn/utils/solver_convergence.py
+++ b/sklearn/utils/solver_convergence.py
@@ -11,7 +11,7 @@ DEFAULT_CONV = {'liblinear': {0: (1e-2, 1000), 1: (1e-1, 1000), 2: (1e-2, 1000),
                 'svm': {0: (1e-4, 1e3)}}
 
 
-def _check_convergence_params(solver, tol, max_iter):
+def _check_convergence_params(solver, tol, max_iter, internal_solver=0):
     if ((tol == 'auto' and max_iter != 'auto') or 
             (tol != 'auto' and max_iter == 'auto')):
         raise ValueError("'auto' value on tol and max_iter can only be "
@@ -19,7 +19,6 @@ def _check_convergence_params(solver, tol, max_iter):
                             "for both values or set both to 'auto'")
     
     if tol == 'auto' and max_iter == 'auto':
-        tol = DEFAULT_CONV[solver][0][0]
-        max_iter = DEFAULT_CONV[solver][0][1]
+        tol, max_iter = DEFAULT_CONV[solver][internal_solver]
 
     return tol, max_iter

--- a/sklearn/utils/tests/test_solver_convergence.py
+++ b/sklearn/utils/tests/test_solver_convergence.py
@@ -47,3 +47,13 @@ def test_ko_check_convergence_params(solver):
     max_iter = 100
     with pytest.raises(ValueError):
         _check_convergence_params(solver, tol, max_iter)
+
+
+@pytest.mark.parametrize("internal_solver",
+        list(DEFAULT_CONV['liblinear'].keys()))
+def test_internal_solver_check_convergence_params(internal_solver):
+    solver = 'liblinear'
+    default_tol, default_max_iter = DEFAULT_CONV[solver][internal_solver]
+    assert((default_tol, default_max_iter),
+           _check_convergence_params('liblinear', 'auto', 'auto',
+                                     internal_solver))

--- a/sklearn/utils/tests/test_solver_convergence.py
+++ b/sklearn/utils/tests/test_solver_convergence.py
@@ -1,0 +1,41 @@
+from ..solver_convergence import _check_convergence_params
+from sklearn.utils.testing import assert_raises
+
+
+def test_check_convergence_params():
+    default_tol = 1e-4
+    default_max_iter = 1000
+    all_solvers = ['liblinear', 'newton-cg', 'lbfgs', 'sag', 'saga']
+
+    # Check if inputed tol and max_iter are correctly returned
+    tol = 1e-3
+    max_iter = 100
+    for solver in all_solvers :
+        assert((tol, max_iter) == 
+               _check_convergence_params(tol, max_iter, solver))
+    
+    # Check if when tol and max_iter are auto, they are consequently and 
+    # automatically set
+    tol = 'auto'
+    max_iter = 'auto'
+    for solver in all_solvers :
+        assert((default_tol, default_max_iter) == 
+               _check_convergence_params(tol, max_iter, solver))
+
+
+def test_errors_check_convergence_params():
+    all_solvers = ['liblinear', 'newton-cg', 'lbfgs', 'sag', 'saga']
+
+    # Check if when tol is inputed and max_iter is auto an error is raised
+    tol = 1e-4
+    max_iter = 'auto'
+    for solver in all_solvers :
+        assert_raises(ValueError, _check_convergence_params, tol,
+                      max_iter, solver)
+
+    # Check if when tol is auto and max_iter is inputed an error is raised
+    tol = 'auto'
+    max_iter = 100
+    for solver in all_solvers :
+        assert_raises(ValueError, _check_convergence_params, tol,
+                      max_iter, solver)

--- a/sklearn/utils/tests/test_solver_convergence.py
+++ b/sklearn/utils/tests/test_solver_convergence.py
@@ -1,41 +1,49 @@
+import pytest
+
 from ..solver_convergence import _check_convergence_params
-from sklearn.utils.testing import assert_raises
+#from sklearn.linear_model import LogisticRegression, LogisticRegressionCV
+#from sklearn.svm import LinearSVC, LinearSVR
 
+DEFAULT_CONV = {'liblinear': {0: (1e-2, 1000), 1: (1e-1, 1000), 2: (1e-2, 1000),
+                              3: (1e-1, 1000), 4: (1e-1, 1000), 5: (1e-2, 1000),
+                              6: (1e-2, 1000), 7: (1e-1, 1000),
+                              11: (1e-3, 1000), 12: (1e-1, 1000),
+                              13: (1e-1, 1000)},
+                'lbfgs': {0: (1e-4, 15000)},
+                'sag': {0: (1e-3, 1000)},
+                'saga': {0: (1e-3, 1000)},
+                'newton-cg': {0: (1e-4, 100)},
+                'logistic': {0: (1e-4, 1e2)},
+                'svm': {0: (1e-4, 1e3)}}
+ALL_SOLVERS = ['liblinear', 'lbfgs', 'sag', 'saga', 'newton-cg']
 
-def test_check_convergence_params():
-    default_tol = 1e-4
-    default_max_iter = 1000
-    all_solvers = ['liblinear', 'newton-cg', 'lbfgs', 'sag', 'saga']
-
-    # Check if inputed tol and max_iter are correctly returned
-    tol = 1e-3
-    max_iter = 100
-    for solver in all_solvers :
-        assert((tol, max_iter) == 
-               _check_convergence_params(tol, max_iter, solver))
-    
+@pytest.mark.parametrize("solver", ALL_SOLVERS)
+def test_ok_check_convergence_params(solver):
     # Check if when tol and max_iter are auto, they are consequently and 
     # automatically set
     tol = 'auto'
     max_iter = 'auto'
-    for solver in all_solvers :
-        assert((default_tol, default_max_iter) == 
-               _check_convergence_params(tol, max_iter, solver))
+    default_tol = DEFAULT_CONV[solver][0][0]
+    default_max_iter = DEFAULT_CONV[solver][0][1]
+    assert((default_tol, default_max_iter) == _check_convergence_params(solver,
+            tol, max_iter))
+
+    # Check if inputed tol and max_iter are correctly returned
+    tol = 1e-2
+    max_iter = 10000
+    assert((tol, max_iter) == _check_convergence_params(solver, tol, max_iter))
 
 
-def test_errors_check_convergence_params():
-    all_solvers = ['liblinear', 'newton-cg', 'lbfgs', 'sag', 'saga']
-
+@pytest.mark.parametrize("solver", ALL_SOLVERS)
+def test_ko_check_convergence_params(solver):
     # Check if when tol is inputed and max_iter is auto an error is raised
     tol = 1e-4
     max_iter = 'auto'
-    for solver in all_solvers :
-        assert_raises(ValueError, _check_convergence_params, tol,
-                      max_iter, solver)
+    with pytest.raises(ValueError):
+        _check_convergence_params(solver, tol, max_iter)
 
     # Check if when tol is auto and max_iter is inputed an error is raised
     tol = 'auto'
     max_iter = 100
-    for solver in all_solvers :
-        assert_raises(ValueError, _check_convergence_params, tol,
-                      max_iter, solver)
+    with pytest.raises(ValueError):
+        _check_convergence_params(solver, tol, max_iter)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #11536 

#### What does this implement/fix? Explain your changes.
This Pull request is meant to implement an automatic determination of the value of convergence parameters (max_iter and tol).

#### TODO

- [x] Initialize the structure of the code
- [x] Fill in the blank left in the code structure to implement the switch on the solver type to determine max_iter and tol
- [x] Set defaults corresponding to solver defaults
- [ ] Check if solver defaults generates convergence warnings
- [ ] Identify better defaults through benchmarks
- [ ] Investigate changing the type of tol of lbfgs to ftol rather than pgtol