### PR TITLE
Hotfix Skip non deterministic tests on PowerPC

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -556,7 +556,7 @@ class MultiOutputMixin(object):
 
 
 class _UnstableArchMixin(object):
-    """Mark estimators that are non-determinstic on 32bit and PowerPC"""
+    """Mark estimators that are non-determinstic on 32bit or PowerPC"""
     def _more_tags(self):
         return {'non_deterministic': (
             _IS_32BIT or platform.machine().startswith(('ppc', 'powerpc')))}

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -555,8 +555,8 @@ class MultiOutputMixin(object):
         return {'multioutput': True}
 
 
-class _UnstableOn32BitMixin(object):
-    """Mark estimators that are non-determinstic on 32bit."""
+class _UnstableArchMixin(object):
+    """Mark estimators that are non-determinstic on 32bit and PowerPC"""
     def _more_tags(self):
         return {'non_deterministic': (
             _IS_32BIT or platform.machine().startswith(('ppc', 'powerpc')))}

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -6,7 +6,7 @@
 import copy
 import warnings
 from collections import defaultdict
-import struct
+import platform
 import inspect
 
 import numpy as np
@@ -558,7 +558,8 @@ class MultiOutputMixin(object):
 class _UnstableOn32BitMixin(object):
     """Mark estimators that are non-determinstic on 32bit."""
     def _more_tags(self):
-        return {'non_deterministic': _IS_32BIT}
+        return {'non_deterministic': (
+            _IS_32BIT or platform.machine().startswith(('ppc', 'powerpc')))}
 
 
 def is_classifier(estimator):

--- a/sklearn/cross_decomposition/cca_.py
+++ b/sklearn/cross_decomposition/cca_.py
@@ -1,10 +1,10 @@
 from .pls_ import _PLS
-from ..base import _UnstableOn32BitMixin
+from ..base import _UnstableArchMixin
 
 __all__ = ['CCA']
 
 
-class CCA(_PLS, _UnstableOn32BitMixin):
+class CCA(_PLS, _UnstableArchMixin):
     """CCA Canonical Correlation Analysis.
 
     CCA inherits from PLS with mode="B" and deflation_mode="canonical".

--- a/sklearn/manifold/locally_linear.py
+++ b/sklearn/manifold/locally_linear.py
@@ -9,7 +9,7 @@ from scipy.linalg import eigh, svd, qr, solve
 from scipy.sparse import eye, csr_matrix
 from scipy.sparse.linalg import eigsh
 
-from ..base import BaseEstimator, TransformerMixin, _UnstableOn32BitMixin
+from ..base import BaseEstimator, TransformerMixin, _UnstableArchMixin
 from ..utils import check_random_state, check_array
 from ..utils.extmath import stable_cumsum
 from ..utils.validation import check_is_fitted
@@ -519,7 +519,7 @@ def locally_linear_embedding(
 
 
 class LocallyLinearEmbedding(BaseEstimator, TransformerMixin,
-                             _UnstableOn32BitMixin):
+                             _UnstableArchMixin):
     """Locally Linear Embedding
 
     Read more in the :ref:`User Guide <locally_linear_embedding>`.


### PR DESCRIPTION
An attempt to work around https://github.com/scikit-learn/scikit-learn/issues/13051 by extending the tests currently considered non determinisitic on 32 bit arch to PowerPC as well.

Closes #13051

The `platform.machine` settings can be seen e.g. [here](https://github.com/python/cpython/blob/f14c28f39766855420dd58d209da4ad847f3030e/Lib/test/test_sysconfig.py#L402).

Ideally, it would be good to understand why these are non-deterministic (on 32 bit arch as well) but meanwhile since we are not officially supporting PowerPC this aims to avoid new bug reports from debian maintainers while packaging scikit-learn, for tests that we deem acceptable to skip on 32 bit arch.