### PR TITLE
[MRG+1] Fix bug in AffinityPropagation

### DIFF
--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -403,7 +403,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
             raise ValueError("Predict method is not supported when "
                              "affinity='precomputed'.")
 
-        if self.cluster_centers_.size > 0:
+        if self.cluster_centers_.shape[0] > 0:
             return pairwise_distances_argmin(X, self.cluster_centers_)
         else:
             warnings.warn("This model does not have any cluster centers "

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -169,11 +169,7 @@ def test_equal_similarities_and_preferences():
 @pytest.mark.parametrize('centers', [csr_matrix(np.zeros((1, 10))),
                                      np.zeros((1, 10))])
 def test_affinity_propagation_convergence_warning_dense_sparse(centers):
-    """Assert that no convergence warning is printed for the sparse case and
-    the dense case if we have clusters, even if these clusters are zeros (non
-    regression test because of a bug that raised the warning for sparse
-    cluster centers if they were zero). Also check in this toy example that
-    the result is as expected."""
+    """Non-regression, see #13334"""
     rng = np.random.RandomState(42)
     X = rng.rand(40, 10)
     y = (4 * rng.rand(40)).astype(np.int)


### PR DESCRIPTION
This PR introduces a fix and a non regression test on a bug of AffinityPropagation (see #13246, and comment https://github.com/scikit-learn/scikit-learn/pull/13246/files#r260758475)
`.size` on a sparse array of zeros returned 0 doing as if the array was empty which it was not