### PR TITLE
[MRG] Implement fitting intercept with `sparse_cg` solver in Ridge regression

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -225,10 +225,14 @@ Support for Python 3.4 and below has been officially dropped.
   was not returning the same coeffecients and intercepts with
   ``fit_intercept=True`` in sparse and dense case.
   :issue:`13279` by `Alexandre Gramfort`_
-
+  
 - |API| :func:`linear_model.logistic_regression_path` is deprecated
   in version 0.21 and will be removed in version 0.23.
   :issue:`12821` by :user:`Nicolas Hug <NicolasHug>`.
+
+- |Enhancement| `sparse_cg` solver in :class:`linear_model.ridge.Ridge`
+  now supports fitting the intercept (i.e. ``fit_intercept=True``) when
+  inputs are sparse . :issue:`13336` by :user:`Bartosz Telenczuk <btel>`
 
 :mod:`sklearn.manifold`
 ............................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -225,7 +225,7 @@ Support for Python 3.4 and below has been officially dropped.
   was not returning the same coeffecients and intercepts with
   ``fit_intercept=True`` in sparse and dense case.
   :issue:`13279` by `Alexandre Gramfort`_
-  
+
 - |API| :func:`linear_model.logistic_regression_path` is deprecated
   in version 0.21 and will be removed in version 0.23.
   :issue:`12821` by :user:`Nicolas Hug <NicolasHug>`.

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -34,7 +34,7 @@ from ..exceptions import ConvergenceWarning
 
 
 def _solve_sparse_cg(X, y, alpha, max_iter=None, tol=1e-3, verbose=0,
-                     fit_intercept=False, X_offset=None, X_scale=None):
+                     X_offset=None, X_scale=None):
 
     def _get_rescaled_operator(X):
 
@@ -440,7 +440,6 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
                                 max_iter=max_iter,
                                 tol=tol,
                                 verbose=verbose,
-                                fit_intercept=return_intercept,
                                 X_offset=X_offset,
                                 X_scale=X_scale)
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -363,9 +363,9 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
 
 
 def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
-                     max_iter=None, tol=1e-3, verbose=0, random_state=None,
-                     return_n_iter=False, return_intercept=False,
-                     X_scale=None, X_offset=None):
+                      max_iter=None, tol=1e-3, verbose=0, random_state=None,
+                      return_n_iter=False, return_intercept=False,
+                      X_scale=None, X_offset=None):
 
     if (return_intercept and sparse.issparse(X) and
        solver not in ['sag', 'sparse_cg']):
@@ -560,7 +560,7 @@ class _BaseRidge(LinearModel, MultiOutputMixin, metaclass=ABCMeta):
                 params = {'X_offset': X_offset, 'X_scale': X_scale}
             else:
                 params = {}
-                
+
             self.coef_, self.n_iter_ = _ridge_regression(
                 X, y, alpha=self.alpha, sample_weight=sample_weight,
                 max_iter=self.max_iter, tol=self.tol, solver=self.solver,

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -557,8 +557,10 @@ class _BaseRidge(LinearModel, MultiOutputMixin, metaclass=ABCMeta):
             self.intercept_ += y_offset
         else:
             if sparse.issparse(X):
+                # required to fit intercept with sparse_cg solver
                 params = {'X_offset': X_offset, 'X_scale': X_scale}
             else:
+                # for dense matrices or when intercept is set to 0
                 params = {}
 
             self.coef_, self.n_iter_ = _ridge_regression(

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -349,11 +349,12 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
     -----
     This function won't compute the intercept.
     """
-    if return_intercept and sparse.issparse(X) and solver not in ['sag', 'sparse_cg']:
+    if (return_intercept and sparse.issparse(X) and
+       solver not in ['sag', 'sparse_cg']):
         if solver != 'auto':
-            warnings.warn("In Ridge, only 'sag' and 'sparse_cg' solvers can currently fit the "
-                          "intercept when X is sparse. Solver has been "
-                          "automatically changed into 'sag'.")
+            warnings.warn("In Ridge, only 'sag' and 'sparse_cg' solvers "
+                          "can currently fit the intercept when X is sparse."
+                          " Solver has been automatically changed into 'sag'.")
         solver = 'sag'
 
     _dtype = [np.float64, np.float32]
@@ -419,12 +420,12 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
     n_iter = None
     if solver == 'sparse_cg':
         coef = _solve_sparse_cg(X, y, alpha,
-                                 max_iter=max_iter,
-                                 tol=tol,
-                                 verbose=verbose,
-                                 fit_intercept=return_intercept,
-                                 X_offset=X_offset,
-                                 X_scale=X_scale)
+                                max_iter=max_iter,
+                                tol=tol,
+                                verbose=verbose,
+                                fit_intercept=return_intercept,
+                                X_offset=X_offset,
+                                X_scale=X_scale)
 
     elif solver == 'lsqr':
         coef, n_iter = _solve_lsqr(X, y, alpha, max_iter, tol)
@@ -528,7 +529,7 @@ class _BaseRidge(LinearModel, MultiOutputMixin, metaclass=ABCMeta):
 
         # temporary fix for fitting the intercept with sparse data using 'sag'
         if (sparse.issparse(X) and self.fit_intercept and
-            self.solver != 'sparse_cg'):
+           self.solver != 'sparse_cg'):
             self.coef_, self.n_iter_, self.intercept_ = ridge_regression(
                 X, y, alpha=self.alpha, sample_weight=sample_weight,
                 max_iter=self.max_iter, tol=self.tol, solver=self.solver,

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -228,8 +228,7 @@ def _solve_svd(X, y, alpha):
 
 def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
                      max_iter=None, tol=1e-3, verbose=0, random_state=None,
-                     return_n_iter=False, return_intercept=False,
-                     X_scale=None, X_offset=None):
+                     return_n_iter=False, return_intercept=False):
     """Solve the ridge equation by the method of normal equations.
 
     Read more in the :ref:`User Guide <ridge_regression>`.
@@ -349,6 +348,25 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
     -----
     This function won't compute the intercept.
     """
+
+    return _ridge_regression(X, y, alpha,
+                             sample_weight=sample_weight,
+                             solver=solver,
+                             max_iter=max_iter,
+                             tol=tol,
+                             verbose=verbose,
+                             random_state=random_state,
+                             return_n_iter=return_n_iter,
+                             return_intercept=return_intercept,
+                             X_scale=None,
+                             X_offset=None)
+
+
+def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
+                     max_iter=None, tol=1e-3, verbose=0, random_state=None,
+                     return_n_iter=False, return_intercept=False,
+                     X_scale=None, X_offset=None):
+
     if (return_intercept and sparse.issparse(X) and
        solver not in ['sag', 'sparse_cg']):
         if solver != 'auto':
@@ -530,7 +548,7 @@ class _BaseRidge(LinearModel, MultiOutputMixin, metaclass=ABCMeta):
         # temporary fix for fitting the intercept with sparse data using 'sag'
         if (sparse.issparse(X) and self.fit_intercept and
            self.solver != 'sparse_cg'):
-            self.coef_, self.n_iter_, self.intercept_ = ridge_regression(
+            self.coef_, self.n_iter_, self.intercept_ = _ridge_regression(
                 X, y, alpha=self.alpha, sample_weight=sample_weight,
                 max_iter=self.max_iter, tol=self.tol, solver=self.solver,
                 random_state=self.random_state, return_n_iter=True,
@@ -543,7 +561,7 @@ class _BaseRidge(LinearModel, MultiOutputMixin, metaclass=ABCMeta):
                           'X_scale': X_scale}
             else:
                 params = {}
-            self.coef_, self.n_iter_ = ridge_regression(
+            self.coef_, self.n_iter_ = _ridge_regression(
                 X, y, alpha=self.alpha, sample_weight=sample_weight,
                 max_iter=self.max_iter, tol=self.tol, solver=self.solver,
                 random_state=self.random_state, return_n_iter=True,

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -367,12 +367,11 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
                       return_n_iter=False, return_intercept=False,
                       X_scale=None, X_offset=None):
 
-    if (return_intercept and sparse.issparse(X) and
-       solver not in ['sag', 'sparse_cg']):
+    if return_intercept and sparse.issparse(X) and solver != 'sag':
         if solver != 'auto':
-            warnings.warn("In Ridge, only 'sag' and 'sparse_cg' solvers "
-                          "can currently fit the intercept when X is sparse."
-                          " Solver has been automatically changed into 'sag'.")
+            warnings.warn("In Ridge, only 'sag' solver can currently fit the "
+                          "intercept when X is sparse. Solver has been "
+                          "automatically changed into 'sag'.")
         solver = 'sag'
 
     _dtype = [np.float64, np.float32]

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -557,10 +557,10 @@ class _BaseRidge(LinearModel, MultiOutputMixin, metaclass=ABCMeta):
             self.intercept_ += y_offset
         else:
             if sparse.issparse(X):
-                params = {'X_offset': X_offset,
-                          'X_scale': X_scale}
+                params = {'X_offset': X_offset, 'X_scale': X_scale}
             else:
                 params = {}
+                
             self.coef_, self.n_iter_ = _ridge_regression(
                 X, y, alpha=self.alpha, sample_weight=sample_weight,
                 max_iter=self.max_iter, tol=self.tol, solver=self.solver,

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -818,19 +818,22 @@ def test_ridge_fit_intercept_sparse():
 
     X_csr = sp.csr_matrix(X)
 
-    for solver in ['saga', 'sag', 'sparse_cg']:
+    for solver in ['sag', 'sparse_cg']:
         dense = Ridge(alpha=1., tol=1.e-15, solver=solver, fit_intercept=True)
         sparse = Ridge(alpha=1., tol=1.e-15, solver=solver, fit_intercept=True)
         dense.fit(X, y)
-        sparse.fit(X_csr, y)
+        with pytest.warns(None) as record:
+            sparse.fit(X_csr, y)
+        assert len(record) == 0
         assert_almost_equal(dense.intercept_, sparse.intercept_)
         assert_array_almost_equal(dense.coef_, sparse.coef_)
 
     # test the solver switch and the corresponding warning
-    sparse = Ridge(alpha=1., tol=1.e-15, solver='lsqr', fit_intercept=True)
-    assert_warns(UserWarning, sparse.fit, X_csr, y)
-    assert_almost_equal(dense.intercept_, sparse.intercept_)
-    assert_array_almost_equal(dense.coef_, sparse.coef_)
+    for solver in ['saga', 'lsqr']:
+        sparse = Ridge(alpha=1., tol=1.e-15, solver=solver, fit_intercept=True)
+        assert_warns(UserWarning, sparse.fit, X_csr, y)
+        assert_almost_equal(dense.intercept_, sparse.intercept_)
+        assert_array_almost_equal(dense.coef_, sparse.coef_)
 
 
 def test_errors_and_values_helper():

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -815,6 +815,7 @@ def test_n_iter():
 def test_ridge_fit_intercept_sparse():
     X, y = make_regression(n_samples=1000, n_features=2, n_informative=2,
                            bias=10., random_state=42)
+
     X_csr = sp.csr_matrix(X)
 
     for solver in ['saga', 'sag', 'sparse_cg']:
@@ -822,8 +823,8 @@ def test_ridge_fit_intercept_sparse():
         sparse = Ridge(alpha=1., tol=1.e-15, solver=solver, fit_intercept=True)
         dense.fit(X, y)
         sparse.fit(X_csr, y)
-        assert_almost_equal(dense.intercept_, sparse.intercept_)
         assert_array_almost_equal(dense.coef_, sparse.coef_)
+        assert_almost_equal(dense.intercept_, sparse.intercept_)
 
     # test the solver switch and the corresponding warning
     sparse = Ridge(alpha=1., tol=1.e-15, solver='lsqr', fit_intercept=True)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -817,7 +817,7 @@ def test_ridge_fit_intercept_sparse():
                            bias=10., random_state=42)
     X_csr = sp.csr_matrix(X)
 
-    for solver in ['saga', 'sag']:
+    for solver in ['saga', 'sag', 'sparse_cg']:
         dense = Ridge(alpha=1., tol=1.e-15, solver=solver, fit_intercept=True)
         sparse = Ridge(alpha=1., tol=1.e-15, solver=solver, fit_intercept=True)
         dense.fit(X, y)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -823,8 +823,8 @@ def test_ridge_fit_intercept_sparse():
         sparse = Ridge(alpha=1., tol=1.e-15, solver=solver, fit_intercept=True)
         dense.fit(X, y)
         sparse.fit(X_csr, y)
-        assert_array_almost_equal(dense.coef_, sparse.coef_)
         assert_almost_equal(dense.intercept_, sparse.intercept_)
+        assert_array_almost_equal(dense.coef_, sparse.coef_)
 
     # test the solver switch and the corresponding warning
     sparse = Ridge(alpha=1., tol=1.e-15, solver='lsqr', fit_intercept=True)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

See also #470

It follows the same trick as introduced in PR #13279 by @agramfort 

#### What does this implement/fix? Explain your changes.

This implements fitting intercept with `sparse_cg` solver in Ridge regression (i.e. when `fit_intercept==True`) for sparse inputs. It also means that both sparse and dense cases give the same result.

#### Any other comments?

**Important**: This PR changes the auto-selected solver (`solver='auto'`)  from `sag` to `sparse_cg` when `fit_intercept==True` and input is sparse.

There are still problems with the code:

1) 'auto' mode in ridge_regression function may trigger wrong solvers (for example, when inputs is sparse and sample_weight is passed)

2) Warning message about changing the solver is not fully informative/correct. For example, user might choose the `sparse_cg` solver instead of going the `sag` way.

3) The estimator object is not informed about the fact that the solver was changed (or which solver was selected by `auto`)

They are not related to this PR and will be fixed in another PR.



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
