### PR TITLE
[MRG+1] Regressor chain tags

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -460,6 +460,7 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
             The predicted values.
 
         """
+        check_is_fitted(self, 'estimators_')
         X = check_array(X, accept_sparse=True)
         Y_pred_chain = np.zeros((X.shape[0], len(self.estimators_)))
         for chain_idx, estimator in enumerate(self.estimators_):

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -636,7 +636,7 @@ class ClassifierChain(_BaseChain, ClassifierMixin, MetaEstimatorMixin):
         return Y_decision
 
     def _more_tags(self):
-        return {'_skip_test': True}
+        return {'multioutput_only': True}
 
 
 class RegressorChain(_BaseChain, RegressorMixin, MetaEstimatorMixin):
@@ -722,5 +722,4 @@ class RegressorChain(_BaseChain, RegressorMixin, MetaEstimatorMixin):
         return self
 
     def _more_tags(self):
-        # FIXME
-        return {'_skip_test': True}
+        return {'multioutput_only': True}

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -637,7 +637,8 @@ class ClassifierChain(_BaseChain, ClassifierMixin, MetaEstimatorMixin):
         return Y_decision
 
     def _more_tags(self):
-        return {'multioutput_only': True}
+        return {'_skip_test': True,
+                'multioutput_only': True}
 
 
 class RegressorChain(_BaseChain, RegressorMixin, MetaEstimatorMixin):


### PR DESCRIPTION
This unskips the common tests on the regressor chain.
The classifier chain still fails because it's multilabel only, and there's no tag for that and no handling in the common tests.