### PR TITLE
MNT CI remove non-cron travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,51 +20,6 @@ env:
 
 matrix:
   include:
-    # Latest dependencies on macOS with MKL
-    - env: DISTRIB="conda" PYTHON_VERSION="*" INSTALL_MKL="true"
-           NUMPY_VERSION="*" SCIPY_VERSION="*" CYTHON_VERSION="*"
-           PILLOW_VERSION="*" JOBLIB_VERSION="*" COVERAGE=true
-      language: generic
-      if: type != cron
-      os: osx
-      addons:
-        homebrew:
-          packages:
-            # For travis_fastfail.sh
-            - jq
-            # install OpenMP not present by default on osx
-            - libomp
-    # Linux environment to test that scikit-learn can be built against
-    # versions of numpy, scipy with ATLAS that comes with Ubuntu Xenial 16.04
-    # i.e. numpy 1.11 and scipy 0.17
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.5"
-           NUMPY_VERSION="1.11.0" SCIPY_VERSION="0.17.0"
-           PILLOW_VERSION="4.0.0" COVERAGE=true
-           SKLEARN_SITE_JOBLIB=1 JOBLIB_VERSION="0.11"
-      if: type != cron
-      addons:
-        apt:
-          packages:
-            # these only required by the DISTRIB="ubuntu" builds:
-            - python3-scipy
-            - libatlas3-base
-            - libatlas-base-dev
-            - libatlas-dev
-    # Linux + Python 3.5 build with OpenBLAS and without SITE_JOBLIB
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="false"
-           NUMPY_VERSION="1.11.0" SCIPY_VERSION="0.17.0" CYTHON_VERSION="*"
-           PILLOW_VERSION="4.0.0" COVERAGE=true
-      if: type != cron
-    # Linux environment to test the latest available dependencies and MKL.
-    # It runs tests requiring pandas and PyAMG.
-    # It also runs with the site joblib instead of the vendored copy of joblib.
-    - env: DISTRIB="conda" PYTHON_VERSION="*" INSTALL_MKL="true"
-           NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
-           CYTHON_VERSION="*" PYAMG_VERSION="*" PILLOW_VERSION="*"
-           JOBLIB_VERSION="*" COVERAGE=true
-           CHECK_PYTEST_SOFT_DEPENDENCY="true" TEST_DOCSTRINGS="true"
-           SKLEARN_SITE_JOBLIB=1 CHECK_WARNINGS="true"
-      if: type != cron
     # Linux environment to test scikit-learn against numpy and scipy master
     # installed from their CI wheels in a virtualenv with the Python
     # interpreter provided by travis.


### PR DESCRIPTION
removes the non-cron travis jobs from `.travis.yml`.

We can move the cron job to Azure and then remove travis ci.