### PR TITLE
[WIP] Replace externals.six.integer_types with int

### DIFF
--- a/sklearn/neighbors/nca.py
+++ b/sklearn/neighbors/nca.py
@@ -23,7 +23,6 @@ from ..utils.multiclass import check_classification_targets
 from ..utils.random import check_random_state
 from ..utils.validation import (check_is_fitted, check_array, check_X_y,
                                 check_scalar)
-from ..externals.six import integer_types
 from ..exceptions import ConvergenceWarning
 
 
@@ -301,7 +300,7 @@ class NeighborhoodComponentsAnalysis(BaseEstimator, TransformerMixin):
         # Check the preferred dimensionality of the projected space
         if self.n_components is not None:
             check_scalar(self.n_components, 'n_components',
-                         integer_types, 1)
+                         int, 1)
 
             if self.n_components > X.shape[1]:
                 raise ValueError('The preferred dimensionality of the '
@@ -320,9 +319,9 @@ class NeighborhoodComponentsAnalysis(BaseEstimator, TransformerMixin):
                                  .format(X.shape[1],
                                          self.components_.shape[1]))
 
-        check_scalar(self.max_iter, 'max_iter', integer_types, 1)
+        check_scalar(self.max_iter, 'max_iter', int, 1)
         check_scalar(self.tol, 'tol', float, 0.)
-        check_scalar(self.verbose, 'verbose', integer_types, 0)
+        check_scalar(self.verbose, 'verbose', int, 0)
 
         if self.callback is not None:
             if not callable(self.callback):

--- a/sklearn/neighbors/nca.py
+++ b/sklearn/neighbors/nca.py
@@ -299,8 +299,7 @@ class NeighborhoodComponentsAnalysis(BaseEstimator, TransformerMixin):
 
         # Check the preferred dimensionality of the projected space
         if self.n_components is not None:
-            check_scalar(self.n_components, 'n_components',
-                         int, 1)
+            check_scalar(self.n_components, 'n_components', int, 1)
 
             if self.n_components > X.shape[1]:
                 raise ValueError('The preferred dimensionality of the '


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

`six` dependencies were removed in #12639 and the use of `externals.six` was deprecated in #12916

#### What does this implement/fix? Explain your changes.

This PR replaces references to `externals.six.integer_types` with `int` in order to avoid raising a `DeprecationWarning`

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
