### PR TITLE
[MRG] CLN: remove duplicate validation of X in Encoders transform

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -675,15 +675,9 @@ class OneHotEncoder(_BaseEncoder):
 
     def _transform_new(self, X):
         """New implementation assuming categorical input"""
-        X_temp = check_array(X, dtype=None)
-        if not hasattr(X, 'dtype') and np.issubdtype(X_temp.dtype, np.str_):
-            X = check_array(X, dtype=np.object)
-        else:
-            X = X_temp
-
-        n_samples, n_features = X.shape
-
         X_int, X_mask = self._transform(X, handle_unknown=self.handle_unknown)
+
+        n_samples, n_features = X_int.shape
 
         if self.drop is not None:
             to_drop = self.drop_idx_.reshape(1, -1)

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -675,6 +675,7 @@ class OneHotEncoder(_BaseEncoder):
 
     def _transform_new(self, X):
         """New implementation assuming categorical input"""
+        # validation of X happens in _check_X called by _transform
         X_int, X_mask = self._transform(X, handle_unknown=self.handle_unknown)
 
         n_samples, n_features = X_int.shape


### PR DESCRIPTION
The `self._transform` method already calls `self._check_X` which does this same validation (check_array) of X, so it should not be needed here (and confirmed by by the passing tests).

This also prevented actually handling the DataFrame column by column on transform (https://github.com/scikit-learn/scikit-learn/pull/13253), but this is difficult to test now since both numpy and python encoding methods result in the same.