### PR TITLE
Pandas DataFrame Categories supported by OneHotEncoder

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -60,33 +60,11 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
 
         n_samples, n_features = X.shape
         X_columns = []
+
         if is_fit:
             self.features_dtype = []
         for i in range(n_features):
             Xi = self._get_feature(X, feature_idx=i)
-            if is_fit:
-                # save the dtype or exact categories if category dtype
-                if Xi.dtype.name == 'category':
-                    f_dtype = Xi.cat.categories
-                else:
-                    f_dtype = Xi.dtype
-                self.features_dtype.append(f_dtype)
-            else:
-                # transform, check if dtype is the same as it was passed by fit
-                print(self.features_dtype[i])
-                if not (Xi.dtype == self.features_dtype[i]):
-                    if Xi.dtype.name == 'category': 
-                        # check if categories are the same
-                        if not (Xi.cat.categories == 
-                                self.features_dtype[i]).all():
-                                    raise ValueError("""Categories of 
-                                                        the features were 
-                                                        different in fit() and 
-                                                        in the transform()""")
-                    else:
-                        # features not of the same type in fit and transform
-                        raise ValueError("""Feature has different dtype during
-                                        fit() and during transform()""")
 
             if Xi.dtype.name == 'category':
                 # categorical dtype; do not want to convert to an array,
@@ -97,6 +75,24 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
                 Xi = check_array(Xi, ensure_2d=False, dtype=None,
                                  force_all_finite=needs_validation)
 
+            if is_fit:
+                # save the dtype or exact categories if category dtype
+                if Xi.dtype.name == 'category':
+                    f_dtype = Xi.cat.categories
+                else:
+                    f_dtype = Xi.dtype
+                self.features_dtype.append(f_dtype)
+            else:
+                # transform, check if dtype is the same as it was passed by fit
+                if not (Xi.dtype == self.features_dtype[i]):
+                    if Xi.dtype.name == 'category':
+                        # check if categories are the same
+                        if not (Xi.cat.categories ==
+                                self.features_dtype[i]).all():
+                                    raise ValueError("""Categories of
+                                                        the features were
+                                                        different in fit() and
+                                                        in the transform()""")
             X_columns.append(Xi)
 
         return X_columns, n_samples, n_features

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -371,16 +371,18 @@ def test_categorical_nans(method):
         getattr(oh, method)(X_df)
 
 
-@pytest.mark.parametrize("method", ['fit', 'fit_transform'])
-def test_categorical_undefined_categories(method):
+def test_categorical_same_category_fit_transform():
     # tests that all the categories are included within specified categories
     pd = pytest.importorskip('pandas')
-    cat = pd.Categorical(["a", "g", "c"], categories=["b", "a", "c", "d"])
-    X_df = pd.DataFrame({"A": cat, "B": ["a", "c", "c"]})
+    cat_fit = pd.Categorical(["a", "b"], categories=["b", "a", "c", "d"])
+    cat_transform = pd.Categorical(["b", "a"], categories=["a", "c", "d", "b"])
+    X_fit = pd.DataFrame({"A": cat_fit, "B": ["a", "c"]})
+    X_transform = pd.DataFrame({"A": cat_transform, "B": ["a", "c"]})
 
     oh = OneHotEncoder()
-    with pytest.raises(ValueError, match="Input contains NaN"):
-        getattr(oh, method)(X_df)
+    oh.fit(X_fit)
+    with pytest.raises(ValueError, match="Categories of the features"):
+        oh.transform(X_transform)
 
 def test_one_hot_encoder_set_params():
     X = np.array([[1, 2]]).T

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -381,7 +381,7 @@ def test_categorical_same_category_fit_transform():
 
     oh = OneHotEncoder()
     oh.fit(X_fit)
-    with pytest.raises(ValueError, match="Categories of the features"):
+    with pytest.raises(ValueError, match="Categories of"):
         oh.transform(X_transform)
 
 def test_one_hot_encoder_set_params():

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -346,6 +346,42 @@ def test_one_hot_encoder_dtype_pandas(output_dtype):
     assert_array_equal(oh.fit(X_df).transform(X_df), X_expected)
 
 
+@pytest.mark.parametrize("method", ['fit', 'fit_transform'])
+def test_one_hot_encoder_categorical_dtype(method):
+    pd = pytest.importorskip('pandas')
+    cat = pd.Categorical(["a", "b", "c"], categories=["b", "a", "c", "d"])
+    X_df = pd.DataFrame({"A": cat, "B": ["a", "c", "c"]})
+
+    oh = OneHotEncoder()
+    getattr(oh, method)(X_df)
+    cats = oh.categories_
+    assert_array_equal(cats[0], X_df['A'].cat.categories)
+    assert_array_equal(cats[1], X_df['B'].unique())
+
+
+@pytest.mark.parametrize("method", ['fit', 'fit_transform'])
+def test_categorical_nans(method):
+    # ensures error if categorical datatype contains Nones
+    pd = pytest.importorskip('pandas')
+    cat = pd.Categorical(["a", None, "c"], categories=["b", "a", "c", "d"])
+    X_df = pd.DataFrame({"A": cat, "B": ["a", "c", "c"]})
+
+    oh = OneHotEncoder()
+    with pytest.raises(ValueError, match="Input contains NaN"):
+        getattr(oh, method)(X_df)
+
+
+@pytest.mark.parametrize("method", ['fit', 'fit_transform'])
+def test_categorical_undefined_categories(method):
+    # tests that all the categories are included within specified categories
+    pd = pytest.importorskip('pandas')
+    cat = pd.Categorical(["a", "g", "c"], categories=["b", "a", "c", "d"])
+    X_df = pd.DataFrame({"A": cat, "B": ["a", "c", "c"]})
+
+    oh = OneHotEncoder()
+    with pytest.raises(ValueError, match="Input contains NaN"):
+        getattr(oh, method)(X_df)
+
 def test_one_hot_encoder_set_params():
     X = np.array([[1, 2]]).T
     oh = OneHotEncoder()


### PR DESCRIPTION
If one of the features is Pandas Categorical it is supported by OneHotEncoder and the categories will be kept as set

TODO:
- [ ] Validate the dtype between fit and transform (for now only allow exactly the same dtype)
- [ ] Deprecation path:
  - [ ] By default still do it the old way, but provide a way to opt in to the new behaviour
- [ ] Test that the order of the categories is used