### PR TITLE
Don't use global np.random.seed in tests

### DIFF
--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -96,7 +96,6 @@ def setup_module(module):
     """Fixture for the tests to assure globally controllable seeding of RNGs"""
     import os
     import numpy as np
-    import random
 
     # It could have been provided in the environment
     _random_seed = os.environ.get('SKLEARN_SEED', None)
@@ -104,5 +103,5 @@ def setup_module(module):
         _random_seed = np.random.uniform() * (2 ** 31 - 1)
     _random_seed = int(_random_seed)
     print("I: Seeding RNGs with %r" % _random_seed)
-    np.random.seed(_random_seed)
-    random.seed(_random_seed)
+    rng = np.RandomState(_random_seed)
+    rng.seed(_random_seed)

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -103,5 +103,5 @@ def setup_module(module):
         _random_seed = np.random.uniform() * (2 ** 31 - 1)
     _random_seed = int(_random_seed)
     print("I: Seeding RNGs with %r" % _random_seed)
-    rng = np.RandomState(_random_seed)
+    rng = np.random.RandomState(_random_seed)
     rng.seed(_random_seed)

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -96,6 +96,7 @@ def setup_module(module):
     """Fixture for the tests to assure globally controllable seeding of RNGs"""
     import os
     import numpy as np
+    import random
 
     # It could have been provided in the environment
     _random_seed = os.environ.get('SKLEARN_SEED', None)
@@ -103,5 +104,5 @@ def setup_module(module):
         _random_seed = np.random.uniform() * (2 ** 31 - 1)
     _random_seed = int(_random_seed)
     print("I: Seeding RNGs with %r" % _random_seed)
-    rng = np.random.RandomState(_random_seed)
-    rng.seed(_random_seed)
+    np.random.seed(_random_seed)
+    random.seed(_random_seed)

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -120,8 +120,8 @@ class EmpiricalCovariance(BaseEstimator):
     >>> from sklearn.datasets import make_gaussian_quantiles
     >>> real_cov = np.array([[.8, .3],
     ...                      [.3, .4]])
-    >>> np.random.seed(0)
-    >>> X = np.random.multivariate_normal(mean=[0, 0],
+    >>> rng = np.RandomState(42)
+    >>> X = rng.multivariate_normal(mean=[0, 0],
     ...                                   cov=real_cov,
     ...                                   size=500)
     >>> cov = EmpiricalCovariance().fit(X)

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -120,7 +120,7 @@ class EmpiricalCovariance(BaseEstimator):
     >>> from sklearn.datasets import make_gaussian_quantiles
     >>> real_cov = np.array([[.8, .3],
     ...                      [.3, .4]])
-    >>> rng = np.RandomState(42)
+    >>> rng = np.random.RandomState(0)
     >>> X = rng.multivariate_normal(mean=[0, 0],
     ...                                   cov=real_cov,
     ...                                   size=500)

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -586,7 +586,7 @@ class MinCovDet(EmpiricalCovariance):
     >>> from sklearn.datasets import make_gaussian_quantiles
     >>> real_cov = np.array([[.8, .3],
     ...                      [.3, .4]])
-    >>> rng = np.RandomState(42)
+    >>> rng = np.random.RandomState(0)
     >>> X = rng.multivariate_normal(mean=[0, 0],
     ...                                   cov=real_cov,
     ...                                   size=500)

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -586,8 +586,8 @@ class MinCovDet(EmpiricalCovariance):
     >>> from sklearn.datasets import make_gaussian_quantiles
     >>> real_cov = np.array([[.8, .3],
     ...                      [.3, .4]])
-    >>> np.random.seed(0)
-    >>> X = np.random.multivariate_normal(mean=[0, 0],
+    >>> rng = np.RandomState(42)
+    >>> X = rng.multivariate_normal(mean=[0, 0],
     ...                                   cov=real_cov,
     ...                                   size=500)
     >>> cov = MinCovDet(random_state=0).fit(X)

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -103,7 +103,7 @@ class ShrunkCovariance(EmpiricalCovariance):
     >>> from sklearn.datasets import make_gaussian_quantiles
     >>> real_cov = np.array([[.8, .3],
     ...                      [.3, .4]])
-    >>> rng = np.RandomState(42)
+    >>> rng = np.random.RandomState(0)
     >>> X = rng.multivariate_normal(mean=[0, 0],
     ...                                   cov=real_cov,
     ...                                   size=500)

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -103,8 +103,8 @@ class ShrunkCovariance(EmpiricalCovariance):
     >>> from sklearn.datasets import make_gaussian_quantiles
     >>> real_cov = np.array([[.8, .3],
     ...                      [.3, .4]])
-    >>> np.random.seed(0)
-    >>> X = np.random.multivariate_normal(mean=[0, 0],
+    >>> rng = np.RandomState(42)
+    >>> X = rng.multivariate_normal(mean=[0, 0],
     ...                                   cov=real_cov,
     ...                                   size=500)
     >>> cov = ShrunkCovariance().fit(X)

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -54,7 +54,6 @@ def test_fastica_simple(add_noise=False):
     # Test the FastICA algorithm on very simple data.
     rng = np.random.RandomState(0)
     # scipy.stats uses the global RNG:
-    np.random.seed(0)
     n_samples = 1000
     # Generate two sources:
     s1 = (2 * np.sin(np.linspace(0, 100, n_samples)) > 0) - 1

--- a/sklearn/linear_model/huber.py
+++ b/sklearn/linear_model/huber.py
@@ -196,7 +196,7 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
     >>> import numpy as np
     >>> from sklearn.linear_model import HuberRegressor, LinearRegression
     >>> from sklearn.datasets import make_regression
-    >>> rng = np.RandomState(42)
+    >>> rng = np.random.RandomState(0)
     >>> X, y, coef = make_regression(
     ...     n_samples=200, n_features=2, noise=4.0, coef=True, random_state=0)
     >>> X[:4] = rng.uniform(10, 20, (4, 2))

--- a/sklearn/linear_model/huber.py
+++ b/sklearn/linear_model/huber.py
@@ -196,11 +196,11 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
     >>> import numpy as np
     >>> from sklearn.linear_model import HuberRegressor, LinearRegression
     >>> from sklearn.datasets import make_regression
-    >>> np.random.seed(0)
+    >>> rng = np.RandomState(42)
     >>> X, y, coef = make_regression(
     ...     n_samples=200, n_features=2, noise=4.0, coef=True, random_state=0)
-    >>> X[:4] = np.random.uniform(10, 20, (4, 2))
-    >>> y[:4] = np.random.uniform(10, 20, 4)
+    >>> X[:4] = rng.uniform(10, 20, (4, 2))
+    >>> y[:4] = rng.uniform(10, 20, 4)
     >>> huber = HuberRegressor().fit(X, y)
     >>> huber.score(X, y) # doctest: +ELLIPSIS
     -7.284608623514573

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -640,9 +640,9 @@ class Ridge(_BaseRidge, RegressorMixin):
     >>> from sklearn.linear_model import Ridge
     >>> import numpy as np
     >>> n_samples, n_features = 10, 5
-    >>> np.random.seed(0)
-    >>> y = np.random.randn(n_samples)
-    >>> X = np.random.randn(n_samples, n_features)
+    >>> rng = np.RandomState(42)
+    >>> y = rng.randn(n_samples)
+    >>> X = rng.randn(n_samples, n_features)
     >>> clf = Ridge(alpha=1.0)
     >>> clf.fit(X, y) # doctest: +NORMALIZE_WHITESPACE
     Ridge(alpha=1.0, copy_X=True, fit_intercept=True, max_iter=None,

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -640,7 +640,7 @@ class Ridge(_BaseRidge, RegressorMixin):
     >>> from sklearn.linear_model import Ridge
     >>> import numpy as np
     >>> n_samples, n_features = 10, 5
-    >>> rng = np.RandomState(42)
+    >>> rng = np.random.RandomState(0)
     >>> y = rng.randn(n_samples)
     >>> X = rng.randn(n_samples, n_features)
     >>> clf = Ridge(alpha=1.0)

--- a/sklearn/linear_model/sag.py
+++ b/sklearn/linear_model/sag.py
@@ -201,7 +201,7 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1., beta=0.,
     >>> import numpy as np
     >>> from sklearn import linear_model
     >>> n_samples, n_features = 10, 5
-    >>> rng = np.RandomState(42)
+    >>> rng = np.random.RandomState(0)
     >>> X = rng.randn(n_samples, n_features)
     >>> y = rng.randn(n_samples)
     >>> clf = linear_model.Ridge(solver='sag')

--- a/sklearn/linear_model/sag.py
+++ b/sklearn/linear_model/sag.py
@@ -201,9 +201,9 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1., beta=0.,
     >>> import numpy as np
     >>> from sklearn import linear_model
     >>> n_samples, n_features = 10, 5
-    >>> np.random.seed(0)
-    >>> X = np.random.randn(n_samples, n_features)
-    >>> y = np.random.randn(n_samples)
+    >>> rng = np.RandomState(42)
+    >>> X = rng.randn(n_samples, n_features)
+    >>> y = rng.randn(n_samples)
     >>> clf = linear_model.Ridge(solver='sag')
     >>> clf.fit(X, y)
     ... #doctest: +NORMALIZE_WHITESPACE

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -1559,9 +1559,9 @@ class SGDRegressor(BaseSGDRegressor):
     >>> import numpy as np
     >>> from sklearn import linear_model
     >>> n_samples, n_features = 10, 5
-    >>> np.random.seed(0)
-    >>> y = np.random.randn(n_samples)
-    >>> X = np.random.randn(n_samples, n_features)
+    >>> rng = np.RandomState(42)
+    >>> y = rng.randn(n_samples)
+    >>> X = rng.randn(n_samples, n_features)
     >>> clf = linear_model.SGDRegressor(max_iter=1000, tol=1e-3)
     >>> clf.fit(X, y)
     ... #doctest: +NORMALIZE_WHITESPACE

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -1559,7 +1559,7 @@ class SGDRegressor(BaseSGDRegressor):
     >>> import numpy as np
     >>> from sklearn import linear_model
     >>> n_samples, n_features = 10, 5
-    >>> rng = np.RandomState(42)
+    >>> rng = np.random.RandomState(0)
     >>> y = rng.randn(n_samples)
     >>> X = rng.randn(n_samples, n_features)
     >>> clf = linear_model.SGDRegressor(max_iter=1000, tol=1e-3)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -228,7 +228,7 @@ class ParameterSampler:
     >>> from sklearn.model_selection import ParameterSampler
     >>> from scipy.stats.distributions import expon
     >>> import numpy as np
-    >>> rng = np.RandomState(42)
+    >>> rng = np.random.RandomState(0)
     >>> param_grid = {'a':[1, 2], 'b': expon()}
     >>> param_list = list(ParameterSampler(param_grid, n_iter=4))
     >>> rounded_list = [dict((k, round(v, 6)) for (k, v) in d.items())

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -230,7 +230,8 @@ class ParameterSampler:
     >>> import numpy as np
     >>> rng = np.random.RandomState(0)
     >>> param_grid = {'a':[1, 2], 'b': expon()}
-    >>> param_list = list(ParameterSampler(param_grid, n_iter=4, random_state=rng))
+    >>> param_list = list(ParameterSampler(param_grid, n_iter=4,
+    ...                                    random_state=rng))
     >>> rounded_list = [dict((k, round(v, 6)) for (k, v) in d.items())
     ...                 for d in param_list]
     >>> rounded_list == [{'b': 0.89856, 'a': 1},

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -228,7 +228,7 @@ class ParameterSampler:
     >>> from sklearn.model_selection import ParameterSampler
     >>> from scipy.stats.distributions import expon
     >>> import numpy as np
-    >>> np.random.seed(0)
+    >>> rng = np.RandomState(42)
     >>> param_grid = {'a':[1, 2], 'b': expon()}
     >>> param_list = list(ParameterSampler(param_grid, n_iter=4))
     >>> rounded_list = [dict((k, round(v, 6)) for (k, v) in d.items())

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -230,7 +230,7 @@ class ParameterSampler:
     >>> import numpy as np
     >>> rng = np.random.RandomState(0)
     >>> param_grid = {'a':[1, 2], 'b': expon()}
-    >>> param_list = list(ParameterSampler(param_grid, n_iter=4))
+    >>> param_list = list(ParameterSampler(param_grid, n_iter=4, random_state=rng))
     >>> rounded_list = [dict((k, round(v, 6)) for (k, v) in d.items())
     ...                 for d in param_list]
     >>> rounded_list == [{'b': 0.89856, 'a': 1},

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -302,8 +302,8 @@ Examples
 Query for k-nearest neighbors
 
     >>> import numpy as np
-    >>> np.random.seed(0)
-    >>> X = np.random.random((10, 3))  # 10 points in 3 dimensions
+    >>> rng = np.RandomState(42)
+    >>> X = rng.random((10, 3))  # 10 points in 3 dimensions
     >>> tree = {BinaryTree}(X, leaf_size=2)              # doctest: +SKIP
     >>> dist, ind = tree.query(X[:1], k=3)                # doctest: +SKIP
     >>> print(ind)  # indices of 3 closest neighbors
@@ -316,8 +316,8 @@ pickle operation: the tree needs not be rebuilt upon unpickling.
 
     >>> import numpy as np
     >>> import pickle
-    >>> np.random.seed(0)
-    >>> X = np.random.random((10, 3))  # 10 points in 3 dimensions
+    >>> rng = np.RandomState(42)
+    >>> X = rng.random((10, 3))  # 10 points in 3 dimensions
     >>> tree = {BinaryTree}(X, leaf_size=2)        # doctest: +SKIP
     >>> s = pickle.dumps(tree)                     # doctest: +SKIP
     >>> tree_copy = pickle.loads(s)                # doctest: +SKIP
@@ -330,8 +330,8 @@ pickle operation: the tree needs not be rebuilt upon unpickling.
 Query for neighbors within a given radius
 
     >>> import numpy as np
-    >>> np.random.seed(0)
-    >>> X = np.random.random((10, 3))  # 10 points in 3 dimensions
+    >>> rng = np.RandomState(42)
+    >>> X = rng.random((10, 3))  # 10 points in 3 dimensions
     >>> tree = {BinaryTree}(X, leaf_size=2)     # doctest: +SKIP
     >>> print(tree.query_radius(X[:1], r=0.3, count_only=True))
     3
@@ -343,8 +343,8 @@ Query for neighbors within a given radius
 Compute a gaussian kernel density estimate:
 
     >>> import numpy as np
-    >>> np.random.seed(1)
-    >>> X = np.random.random((100, 3))
+    >>> rng = np.RandomState(42)
+    >>> X = rng.random((100, 3))
     >>> tree = {BinaryTree}(X)                # doctest: +SKIP
     >>> tree.kernel_density(X[:3], h=0.1, kernel='gaussian')
     array([ 6.94114649,  7.83281226,  7.2071716 ])
@@ -352,8 +352,8 @@ Compute a gaussian kernel density estimate:
 Compute a two-point auto-correlation function
 
     >>> import numpy as np
-    >>> np.random.seed(0)
-    >>> X = np.random.random((30, 3))
+    >>> rng = np.RandomState(42)
+    >>> X = rng.random((30, 3))
     >>> r = np.linspace(0, 1, 5)
     >>> tree = {BinaryTree}(X)                # doctest: +SKIP
     >>> tree.two_point_correlation(X, r)

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -303,7 +303,7 @@ Query for k-nearest neighbors
 
     >>> import numpy as np
     >>> rng = np.random.RandomState(0)
-    >>> X = rng.random((10, 3))  # 10 points in 3 dimensions
+    >>> X = rng.random_sample((10, 3))  # 10 points in 3 dimensions
     >>> tree = {BinaryTree}(X, leaf_size=2)              # doctest: +SKIP
     >>> dist, ind = tree.query(X[:1], k=3)                # doctest: +SKIP
     >>> print(ind)  # indices of 3 closest neighbors
@@ -317,7 +317,7 @@ pickle operation: the tree needs not be rebuilt upon unpickling.
     >>> import numpy as np
     >>> import pickle
     >>> rng = np.random.RandomState(0)
-    >>> X = rng.random((10, 3))  # 10 points in 3 dimensions
+    >>> X = rng.random_sample((10, 3))  # 10 points in 3 dimensions
     >>> tree = {BinaryTree}(X, leaf_size=2)        # doctest: +SKIP
     >>> s = pickle.dumps(tree)                     # doctest: +SKIP
     >>> tree_copy = pickle.loads(s)                # doctest: +SKIP
@@ -331,7 +331,7 @@ Query for neighbors within a given radius
 
     >>> import numpy as np
     >>> rng = np.random.RandomState(0)
-    >>> X = rng.random((10, 3))  # 10 points in 3 dimensions
+    >>> X = rng.random_sample((10, 3))  # 10 points in 3 dimensions
     >>> tree = {BinaryTree}(X, leaf_size=2)     # doctest: +SKIP
     >>> print(tree.query_radius(X[:1], r=0.3, count_only=True))
     3
@@ -344,7 +344,7 @@ Compute a gaussian kernel density estimate:
 
     >>> import numpy as np
     >>> rng = np.random.RandomState(42)
-    >>> X = rng.random((100, 3))
+    >>> X = rng.random_sample((100, 3))
     >>> tree = {BinaryTree}(X)                # doctest: +SKIP
     >>> tree.kernel_density(X[:3], h=0.1, kernel='gaussian')
     array([ 6.94114649,  7.83281226,  7.2071716 ])
@@ -353,7 +353,7 @@ Compute a two-point auto-correlation function
 
     >>> import numpy as np
     >>> rng = np.random.RandomState(0)
-    >>> X = rng.random((30, 3))
+    >>> X = rng.random_sample((30, 3))
     >>> r = np.linspace(0, 1, 5)
     >>> tree = {BinaryTree}(X)                # doctest: +SKIP
     >>> tree.two_point_correlation(X, r)

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -302,7 +302,7 @@ Examples
 Query for k-nearest neighbors
 
     >>> import numpy as np
-    >>> rng = np.RandomState(42)
+    >>> rng = np.random.RandomState(0)
     >>> X = rng.random((10, 3))  # 10 points in 3 dimensions
     >>> tree = {BinaryTree}(X, leaf_size=2)              # doctest: +SKIP
     >>> dist, ind = tree.query(X[:1], k=3)                # doctest: +SKIP
@@ -316,7 +316,7 @@ pickle operation: the tree needs not be rebuilt upon unpickling.
 
     >>> import numpy as np
     >>> import pickle
-    >>> rng = np.RandomState(42)
+    >>> rng = np.random.RandomState(0)
     >>> X = rng.random((10, 3))  # 10 points in 3 dimensions
     >>> tree = {BinaryTree}(X, leaf_size=2)        # doctest: +SKIP
     >>> s = pickle.dumps(tree)                     # doctest: +SKIP
@@ -330,7 +330,7 @@ pickle operation: the tree needs not be rebuilt upon unpickling.
 Query for neighbors within a given radius
 
     >>> import numpy as np
-    >>> rng = np.RandomState(42)
+    >>> rng = np.random.RandomState(0)
     >>> X = rng.random((10, 3))  # 10 points in 3 dimensions
     >>> tree = {BinaryTree}(X, leaf_size=2)     # doctest: +SKIP
     >>> print(tree.query_radius(X[:1], r=0.3, count_only=True))
@@ -343,7 +343,7 @@ Query for neighbors within a given radius
 Compute a gaussian kernel density estimate:
 
     >>> import numpy as np
-    >>> rng = np.RandomState(42)
+    >>> rng = np.random.RandomState(42)
     >>> X = rng.random((100, 3))
     >>> tree = {BinaryTree}(X)                # doctest: +SKIP
     >>> tree.kernel_density(X[:3], h=0.1, kernel='gaussian')
@@ -352,7 +352,7 @@ Compute a gaussian kernel density estimate:
 Compute a two-point auto-correlation function
 
     >>> import numpy as np
-    >>> rng = np.RandomState(42)
+    >>> rng = np.random.RandomState(0)
     >>> X = rng.random((30, 3))
     >>> r = np.linspace(0, 1, 5)
     >>> tree = {BinaryTree}(X)                # doctest: +SKIP

--- a/sklearn/neighbors/tests/test_ball_tree.py
+++ b/sklearn/neighbors/tests/test_ball_tree.py
@@ -152,9 +152,9 @@ def compute_kernel_slow(Y, X, kernel, h):
 @pytest.mark.parametrize("breadth_first", [True, False])
 def test_ball_tree_kde(kernel, h, rtol, atol, breadth_first, n_samples=100,
                        n_features=3):
-    np.random.seed(0)
-    X = np.random.random((n_samples, n_features))
-    Y = np.random.random((n_samples, n_features))
+    rng = np.RandomState(42)
+    X = rng.random((n_samples, n_features))
+    Y = rng.random((n_samples, n_features))
     bt = BallTree(X, leaf_size=10)
 
     dens_true = compute_kernel_slow(Y, X, kernel, h)

--- a/sklearn/neighbors/tests/test_ball_tree.py
+++ b/sklearn/neighbors/tests/test_ball_tree.py
@@ -153,8 +153,8 @@ def compute_kernel_slow(Y, X, kernel, h):
 def test_ball_tree_kde(kernel, h, rtol, atol, breadth_first, n_samples=100,
                        n_features=3):
     rng = np.random.RandomState(0)
-    X = rng.random((n_samples, n_features))
-    Y = rng.random((n_samples, n_features))
+    X = rng.random_sample((n_samples, n_features))
+    Y = rng.random_sample((n_samples, n_features))
     bt = BallTree(X, leaf_size=10)
 
     dens_true = compute_kernel_slow(Y, X, kernel, h)

--- a/sklearn/neighbors/tests/test_ball_tree.py
+++ b/sklearn/neighbors/tests/test_ball_tree.py
@@ -152,7 +152,7 @@ def compute_kernel_slow(Y, X, kernel, h):
 @pytest.mark.parametrize("breadth_first", [True, False])
 def test_ball_tree_kde(kernel, h, rtol, atol, breadth_first, n_samples=100,
                        n_features=3):
-    rng = np.RandomState(42)
+    rng = np.random.RandomState(0)
     X = rng.random((n_samples, n_features))
     Y = rng.random((n_samples, n_features))
     bt = BallTree(X, leaf_size=10)

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -590,7 +590,7 @@ class SparseRandomProjection(BaseRandomProjection):
     >>> from sklearn.random_projection import SparseRandomProjection
     >>> rng = np.random.RandomState(42)
     >>> X = rng.rand(100, 10000)
-    >>> transformer = SparseRandomProjection()
+    >>> transformer = SparseRandomProjection(random_state=rng)
     >>> X_new = transformer.fit_transform(X)
     >>> X_new.shape
     (100, 3947)

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -588,8 +588,8 @@ class SparseRandomProjection(BaseRandomProjection):
     --------
     >>> import numpy as np
     >>> from sklearn.random_projection import SparseRandomProjection
-    >>> np.random.seed(42)
-    >>> X = np.random.rand(100, 10000)
+    >>> rng = np.RandomState(42)
+    >>> X = rng.rand(100, 10000)
     >>> transformer = SparseRandomProjection()
     >>> X_new = transformer.fit_transform(X)
     >>> X_new.shape

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -588,7 +588,7 @@ class SparseRandomProjection(BaseRandomProjection):
     --------
     >>> import numpy as np
     >>> from sklearn.random_projection import SparseRandomProjection
-    >>> rng = np.RandomState(42)
+    >>> rng = np.random.RandomState(0)
     >>> X = rng.rand(100, 10000)
     >>> transformer = SparseRandomProjection()
     >>> X_new = transformer.fit_transform(X)

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -588,7 +588,7 @@ class SparseRandomProjection(BaseRandomProjection):
     --------
     >>> import numpy as np
     >>> from sklearn.random_projection import SparseRandomProjection
-    >>> rng = np.random.RandomState(0)
+    >>> rng = np.random.RandomState(42)
     >>> X = rng.rand(100, 10000)
     >>> transformer = SparseRandomProjection()
     >>> X_new = transformer.fit_transform(X)

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -466,8 +466,9 @@ class GaussianRandomProjection(BaseRandomProjection):
     --------
     >>> import numpy as np
     >>> from sklearn.random_projection import GaussianRandomProjection
-    >>> X = np.random.rand(100, 10000)
-    >>> transformer = GaussianRandomProjection()
+    >>> rng = np.random.RandomState(42)
+    >>> X = rng.rand(100, 10000)
+    >>> transformer = GaussianRandomProjection(random_state=rng)
     >>> X_new = transformer.fit_transform(X)
     >>> X_new.shape
     (100, 3947)

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -874,9 +874,9 @@ class SVR(BaseLibSVM, RegressorMixin):
     >>> from sklearn.svm import SVR
     >>> import numpy as np
     >>> n_samples, n_features = 10, 5
-    >>> np.random.seed(0)
-    >>> y = np.random.randn(n_samples)
-    >>> X = np.random.randn(n_samples, n_features)
+    >>> rng = np.RandomState(42)
+    >>> y = rng.randn(n_samples)
+    >>> X = rng.randn(n_samples, n_features)
     >>> clf = SVR(gamma='scale', C=1.0, epsilon=0.2)
     >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
     SVR(C=1.0, cache_size=200, coef0=0.0, degree=3, epsilon=0.2, gamma='scale',

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -874,7 +874,7 @@ class SVR(BaseLibSVM, RegressorMixin):
     >>> from sklearn.svm import SVR
     >>> import numpy as np
     >>> n_samples, n_features = 10, 5
-    >>> rng = np.RandomState(42)
+    >>> rng = np.random.RandomState(0)
     >>> y = rng.randn(n_samples)
     >>> X = rng.randn(n_samples, n_features)
     >>> clf = SVR(gamma='scale', C=1.0, epsilon=0.2)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Don't use global np.random.seed in tests #13345
<!--
Example: Fixes #13345  See also #3456. 
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Replaced instances in tests and doctests where seed was set globally using `np.random.seed` with 
`rng = np.random.RandomState`
so that the class variable `rng `can be used to generate random numbers instead of the global value of seed set using np.random.seed.

#### Any other comments?
Issue  #13345 can be checked for more details


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
