### PR TITLE
MNT require linting first on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,11 @@ workflows:
   build-doc-and-deploy:
     jobs:
       - doc
+          requires:
+            - lint
       - doc-min-dependencies
+          requires:
+            - lint
       - lint
       - pypy3:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,13 +109,13 @@ workflows:
   version: 2
   build-doc-and-deploy:
     jobs:
-      - doc
-          requires:
-            - lint
-      - doc-min-dependencies
-          requires:
-            - lint
       - lint
+      - doc:
+          requires:
+            - lint
+      - doc-min-dependencies:
+          requires:
+            - lint
       - pypy3:
           filters:
             branches:


### PR DESCRIPTION
Doc build takes a lot of time, and since we don't accept anything which fails on linting, we can require lint on the doc builds to optimize the circleci runs a bit.