### PR TITLE
[MRG] Fix selection of solver in ridge_regression when solver=='auto'

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -177,9 +177,9 @@ Support for Python 3.4 and below has been officially dropped.
 - |Enhancement| Minimized the validation of X in
   :class:`ensemble.AdaBoostClassifier` and :class:`ensemble.AdaBoostRegressor`
   :issue:`13174` by :user:`Christos Aridas <chkoar>`.
-  
+
 - |Enhancement| :class:`ensemble.IsolationForest` now exposes ``warm_start``
-  parameter, allowing iterative addition of trees to an isolation 
+  parameter, allowing iterative addition of trees to an isolation
   forest. :issue:`13496` by :user:`Peter Marko <petibear>`.
 
 - |Efficiency| Make :class:`ensemble.IsolationForest` more memory efficient
@@ -339,6 +339,11 @@ Support for Python 3.4 and below has been officially dropped.
   :class:`linear_model.stochastic_gradient.BaseSGDClassifier` that was not
   deterministic when trained in a multi-class setting on several threads.
   :issue:`13422` by :user:`Clément Doumouro <ClemDoum>`.
+
+- |Fix| Fixed bug in :func:`linear_model.ridge.ridge_regression` that
+  caused unhandled exception for arguments ``return_intercept=True`` and
+  ``solver=auto`` (default) or any other solver different from ``sag``.
+  :issue:`13363` by :user:`Bartosz Telenczuk <btel>`
 
 :mod:`sklearn.manifold`
 ............................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -340,7 +340,9 @@ Support for Python 3.4 and below has been officially dropped.
   deterministic when trained in a multi-class setting on several threads.
   :issue:`13422` by :user:`Clément Doumouro <ClemDoum>`.
 
-- |Fix| Fixed bug in :func:`linear_model.ridge.ridge_regression` that
+- |Fix| Fixed bug in :func:`linear_model.ridge.ridge_regression`,
+  :class:`linear_model.ridge.Ridge` and
+  :class:`linear_model.ridge.ridge.RidgeClassifier` that
   caused unhandled exception for arguments ``return_intercept=True`` and
   ``solver=auto`` (default) or any other solver different from ``sag``.
   :issue:`13363` by :user:`Bartosz Telenczuk <btel>`

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -347,6 +347,10 @@ Support for Python 3.4 and below has been officially dropped.
   ``solver=auto`` (default) or any other solver different from ``sag``.
   :issue:`13363` by :user:`Bartosz Telenczuk <btel>`
 
+- |Fix| :func:`linear_model.ridge.ridge_regression` will now raise an exception
+  if ``return_intercept=True`` and solver is different from ``sag``. Previously,
+  only warning was issued. :issue:`13363` by :user:`Bartosz Telenczuk <btel>`
+
 - |API| :func:`linear_model.ridge.ridge_regression` will choose ``sparse_cg``
   solver for sparse inputs when ``solver=auto`` and ``sample_weight``
   is provided (previously `cholesky` solver was selected). :issue:`13363`

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -345,6 +345,11 @@ Support for Python 3.4 and below has been officially dropped.
   ``solver=auto`` (default) or any other solver different from ``sag``.
   :issue:`13363` by :user:`Bartosz Telenczuk <btel>`
 
+- |API| :func:`linear_model.ridge.ridge_regression` will choose ``sparse_cg``
+  solver for sparse inputs when ``solver=auto`` and ``sample_weight``
+  is provided (previously `cholesky` solver was selected). :issue:`13363`
+  by :user:`Bartosz Telenczuk <btel>`
+
 :mod:`sklearn.manifold`
 ............................
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -384,10 +384,9 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
                          " 'lsqr', 'sag' or 'saga'. Got %s." % solver)
 
     if return_intercept and solver != 'sag':
-        warnings.warn("In Ridge, only 'sag' solver can directly fit the "
-                      "intercept. Solver has been "
-                      "automatically changed into 'sag'.")
-        solver = 'sag'
+        raise ValueError("In Ridge, only 'sag' solver can directly fit the "
+                         "intercept. Solver has been "
+                         "automatically changed into 'sag'.")
 
     _dtype = [np.float64, np.float32]
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -384,7 +384,7 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
                          " 'lsqr', 'sag' or 'saga'. Got %s." % solver)
 
     if return_intercept and solver != 'sag':
-        warnings.warn("In Ridge, only 'sag' solver can currently fit the "
+        warnings.warn("In Ridge, only 'sag' solver can directly fit the "
                       "intercept. Solver has been "
                       "automatically changed into 'sag'.")
         solver = 'sag'

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -385,8 +385,8 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
 
     if return_intercept and solver != 'sag':
         raise ValueError("In Ridge, only 'sag' solver can directly fit the "
-                         "intercept. Solver has been "
-                         "automatically changed into 'sag'.")
+                         "intercept. Please change solver to 'sag' or set "
+                         "return_intercept=False.")
 
     _dtype = [np.float64, np.float32]
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -387,15 +387,11 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
     if solver not in ('sparse_cg', 'cholesky', 'svd', 'lsqr', 'sag', 'saga'):
         raise ValueError('Solver %s not understood' % solver)
 
-    if return_intercept and sparse.issparse(X) and solver != 'sag':
+    if return_intercept and solver != 'sag':
         warnings.warn("In Ridge, only 'sag' solver can currently fit the "
                       "intercept. Solver has been "
                       "automatically changed into 'sag'.")
         solver = 'sag'
-
-    if return_intercept and solver not in ['sag', 'saga']:
-        raise ValueError("return_intercept=True is only supported with sag "
-                         "and saga solvers")
 
     _dtype = [np.float64, np.float32]
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -383,7 +383,7 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
             solver = "cholesky"
 
     if solver not in ('sparse_cg', 'cholesky', 'svd', 'lsqr', 'sag', 'saga'):
-        raise ValueError("Known solver are 'sparse_cg', 'cholesky', 'svd'"
+        raise ValueError("Known solvers are 'sparse_cg', 'cholesky', 'svd'"
                          " 'lsqr', 'sag' or 'saga'. Got %s." % solver)
 
     if return_intercept and solver != 'sag':

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -372,7 +372,7 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
 
     def _select_auto_mode():
         if return_intercept:
-            # only sag and saga support fitting intercept directly
+            # only sag supports fitting intercept directly
             return "sag"
         if has_sw:
             # this should be changed since all solvers support sample_weights

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -370,19 +370,17 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
 
     has_sw = sample_weight is not None
 
-    def _select_auto_mode():
+    if solver == 'auto':
         if return_intercept:
             # only sag supports fitting intercept directly
-            return "sag"
-        if has_sw:
+            solver = "sag"
+        elif has_sw:
             # this should be changed since all solvers support sample_weights
-            return "cholesky"
-        if sparse.issparse(X):
-            return "sparse_cg"
-        return "cholesky"
-
-    if solver == 'auto':
-        solver = _select_auto_mode()
+            solver = "cholesky"
+        elif sparse.issparse(X):
+            solver = "sparse_cg"
+        else:
+            solver = "cholesky"
 
     if solver not in ('sparse_cg', 'cholesky', 'svd', 'lsqr', 'sag', 'saga'):
         raise ValueError('Solver %s not understood' % solver)

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -374,13 +374,10 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         if return_intercept:
             # only sag supports fitting intercept directly
             solver = "sag"
-        elif has_sw:
-            # this should be changed since all solvers support sample_weights
+        elif not sparse.issparse(X):
             solver = "cholesky"
-        elif sparse.issparse(X):
-            solver = "sparse_cg"
         else:
-            solver = "cholesky"
+            solver = "sparse_cg"
 
     if solver not in ('sparse_cg', 'cholesky', 'svd', 'lsqr', 'sag', 'saga'):
         raise ValueError("Known solvers are 'sparse_cg', 'cholesky', 'svd'"

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -383,7 +383,8 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
             solver = "cholesky"
 
     if solver not in ('sparse_cg', 'cholesky', 'svd', 'lsqr', 'sag', 'saga'):
-        raise ValueError('Solver %s not understood' % solver)
+        raise ValueError("Known solver are 'sparse_cg', 'cholesky', 'svd'"
+                         " 'lsqr', 'sag' or 'saga'. Got %s." % solver)
 
     if return_intercept and solver != 'sag':
         warnings.warn("In Ridge, only 'sag' solver can currently fit the "

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -384,11 +384,18 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
     if solver == 'auto':
         solver = _select_auto_mode()
 
+    if solver not in ('sparse_cg', 'cholesky', 'svd', 'lsqr', 'sag', 'saga'):
+        raise ValueError('Solver %s not understood' % solver)
+
     if return_intercept and sparse.issparse(X) and solver != 'sag':
         warnings.warn("In Ridge, only 'sag' solver can currently fit the "
                       "intercept. Solver has been "
                       "automatically changed into 'sag'.")
         solver = 'sag'
+
+    if return_intercept and solver not in ['sag', 'saga']:
+        raise ValueError("return_intercept=True is only supported with sag "
+                         "and saga solvers")
 
     _dtype = [np.float64, np.float32]
 
@@ -440,8 +447,6 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
     if alpha.size == 1 and n_targets > 1:
         alpha = np.repeat(alpha, n_targets)
 
-    if solver not in ('sparse_cg', 'cholesky', 'svd', 'lsqr', 'sag', 'saga'):
-        raise ValueError('Solver %s not understood' % solver)
 
     n_iter = None
     if solver == 'sparse_cg':

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -863,10 +863,10 @@ def test_ridge_regression_check_arguments_validity(return_intercept,
                               )
     if return_intercept:
         coef, intercept = target
-        assert_allclose(coef, true_coefs, atol=0.1)
-        assert_allclose(intercept, 0, atol=0.1)
+        assert_allclose(coef, true_coefs, atol=0.03)
+        assert_allclose(intercept, 0, atol=0.03)
     else:
-        assert_allclose(target, true_coefs, atol=0.1)
+        assert_allclose(target, true_coefs, atol=0.03)
 
 
 def test_ridge_regression_warns_with_return_intercept():

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -875,16 +875,13 @@ def test_ridge_regression_warns_with_return_intercept():
                            bias=10., random_state=42)
 
     for solver in ['sparse_cg', 'cholesky', 'svd', 'lsqr', 'saga']:
-        with pytest.warns(UserWarning) as record:
+        with pytest.warns(UserWarning, match="In Ridge, only 'sag' solver"):
             target = ridge_regression(X, y, 1,
                                       solver=solver,
                                       return_intercept=True
                                       )
             assert len(target) == 2
             assert target[0].shape == (2,)
-
-        for r in record:
-            r.message.args[0].startswith("return_intercept=True is only")
 
     with pytest.warns(None) as record:
         target = ridge_regression(X, y, 1,

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -876,7 +876,7 @@ def test_ridge_regression_fail_with_return_intercept():
         target = ridge_regression(X, y, 1,
                                   solver=solver,
                                   return_intercept=True
-                                 )
+                                  )
         assert len(target) == 2
         assert target[0].shape == (2,)
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -855,26 +855,26 @@ def test_ridge_regression_check_arguments_validity(return_intercept,
     X = rng.rand(1000, 3)
     true_coefs = [1, 2, 0.1]
     y = np.dot(X, true_coefs)
-    intercept = 0.
+    true_intercept = 0.
     if return_intercept:
-        intercept = 10000.
-    y += intercept
+        true_intercept = 10000.
+    y += true_intercept
     X_testing = arr_type(X)
 
     alpha, atol, tol = 1e-3, 1e-4, 1e-6
-    target = ridge_regression(X_testing, y, alpha=alpha,
-                              solver=solver,
-                              sample_weight=sample_weight,
-                              return_intercept=return_intercept,
-                              tol=tol,
-                              )
+    out = ridge_regression(X_testing, y, alpha=alpha,
+                           solver=solver,
+                           sample_weight=sample_weight,
+                           return_intercept=return_intercept,
+                           tol=tol,
+                           )
 
     if return_intercept:
-        coef, intercept = target
+        coef, intercept = out
         assert_allclose(coef, true_coefs, rtol=0, atol=atol)
-        assert_allclose(intercept, intercept, rtol=0, atol=atol)
+        assert_allclose(intercept, true_intercept, rtol=0, atol=atol)
     else:
-        assert_allclose(target, true_coefs, rtol=0, atol=atol)
+        assert_allclose(out, true_coefs, rtol=0, atol=atol)
 
 
 def test_ridge_regression_warns_with_return_intercept():

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -778,7 +778,7 @@ def test_raises_value_error_if_solver_not_supported():
     wrong_solver = "This is not a solver (MagritteSolveCV QuantumBitcoin)"
 
     exception = ValueError
-    message = ("Known solver are 'sparse_cg', 'cholesky', 'svd'"
+    message = ("Known solvers are 'sparse_cg', 'cholesky', 'svd'"
                " 'lsqr', 'sag' or 'saga'. Got %s." % wrong_solver)
 
     def func():

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -840,14 +840,22 @@ def test_ridge_fit_intercept_sparse():
 @pytest.mark.parametrize('return_intercept', [False, True])
 @pytest.mark.parametrize('sample_weight', [None, np.ones(1000)])
 @pytest.mark.parametrize('arr_type', [np.array, sp.csr_matrix])
-def test_ridge_check_auto_modes(return_intercept, sample_weight, arr_type):
+@pytest.mark.parametrize('solver', ['auto', 'sparse_cg', 'cholesky', 'lsqr',
+                                    'sag', 'saga'])
+def test_ridge_regression_check_arguments_validity(return_intercept,
+                                                   sample_weight, arr_type,
+                                                   solver):
+    """check if all combinations of arguments give valid estimations"""
+
+    # test excludes 'svd' solver because it raises exception for sparse inputs
+
     X = np.random.rand(1000, 3)
     true_coefs = [1, 2, 0.1]
     y = np.dot(X, true_coefs)
     X_testing = arr_type(X)
 
     target = ridge_regression(X_testing, y, 1,
-                              solver='auto',
+                              solver=solver,
                               sample_weight=sample_weight,
                               return_intercept=return_intercept
                               )

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -859,6 +859,27 @@ def test_ridge_check_auto_modes(return_intercept, sample_weight, arr_type):
         assert_array_almost_equal(target, true_coefs, decimal=1)
 
 
+def test_ridge_regression_fail_with_return_intercept():
+    # return_itercept is only supported by sag/saga
+
+    X, y = make_regression(n_samples=1000, n_features=2, n_informative=2,
+                           bias=10., random_state=42)
+
+    for solver in ['sparse_cg', 'cholesky', 'svd', 'lsqr']:
+        with pytest.raises(ValueError, match="return_intercept=True is only"):
+            target = ridge_regression(X, y, 1,
+                                      solver=solver,
+                                      return_intercept=True
+                                      )
+
+    for solver in ['saga', 'sag']:
+        target = ridge_regression(X, y, 1,
+                                  solver=solver,
+                                  return_intercept=True
+                                 )
+        assert len(target) == 2
+        assert target[0].shape == (2,)
+
 def test_errors_and_values_helper():
     ridgecv = _RidgeGCV()
     rng = check_random_state(42)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -867,7 +867,7 @@ def test_ridge_regression_check_arguments_validity(return_intercept,
         assert_array_almost_equal(target, true_coefs, decimal=1)
 
 
-def test_ridge_regression_fail_with_return_intercept():
+def test_ridge_regression_warns_with_return_intercept():
     # return_itercept is only supported by sag/saga
 
     X, y = make_regression(n_samples=1000, n_features=2, n_informative=2,

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -7,6 +7,7 @@ import pytest
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_greater
@@ -862,10 +863,10 @@ def test_ridge_regression_check_arguments_validity(return_intercept,
                               )
     if return_intercept:
         coef, intercept = target
-        assert_array_almost_equal(coef, true_coefs, decimal=1)
-        assert_array_almost_equal(intercept, 0, decimal=1)
+        assert_allclose(coef, true_coefs, atol=0.1)
+        assert_allclose(intercept, 0, atol=0.1)
     else:
-        assert_array_almost_equal(target, true_coefs, decimal=1)
+        assert_allclose(target, true_coefs, atol=0.1)
 
 
 def test_ridge_regression_warns_with_return_intercept():

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -865,20 +865,28 @@ def test_ridge_regression_fail_with_return_intercept():
     X, y = make_regression(n_samples=1000, n_features=2, n_informative=2,
                            bias=10., random_state=42)
 
-    for solver in ['sparse_cg', 'cholesky', 'svd', 'lsqr']:
-        with pytest.raises(ValueError, match="return_intercept=True is only"):
+    for solver in ['sparse_cg', 'cholesky', 'svd', 'lsqr', 'saga']:
+        with pytest.warns(UserWarning) as record:
             target = ridge_regression(X, y, 1,
                                       solver=solver,
                                       return_intercept=True
                                       )
+            assert len(target) == 2
+            assert target[0].shape == (2,)
 
-    for solver in ['saga', 'sag']:
+        for r in record:
+            r.message.args[0].startswith("return_intercept=True is only")
+
+    with pytest.warns(None) as record:
         target = ridge_regression(X, y, 1,
-                                  solver=solver,
+                                  solver="sag",
                                   return_intercept=True
                                   )
         assert len(target) == 2
         assert target[0].shape == (2,)
+
+    # no warning should be raised
+    assert len(record) == 0
 
 def test_errors_and_values_helper():
     ridgecv = _RidgeGCV()

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -887,25 +887,6 @@ def test_ridge_regression_check_arguments_validity(return_intercept,
         assert_allclose(out, true_coefs, rtol=0, atol=atol)
 
 
-def test_ridge_regression_warns_with_return_intercept():
-    # return_itercept is only supported by sag/saga
-
-    X, y = make_regression(n_samples=1000, n_features=2, n_informative=2,
-                           bias=10., random_state=42)
-
-    for solver in ['sparse_cg', 'cholesky', 'svd', 'lsqr', 'saga']:
-
-
-        assert_raises_regex(ValueError,
-                            "In Ridge, only 'sag' solver",
-                            ridge_regression, X, y, 1, solver=solver,
-                            return_intercept=True)
-
-    target = ridge_regression(X, y, 1,
-                              solver="sag",
-                              return_intercept=True
-                              )
-
 def test_errors_and_values_helper():
     ridgecv = _RidgeGCV()
     rng = check_random_state(42)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -859,11 +859,11 @@ def test_ridge_regression_check_arguments_validity(return_intercept,
                               sample_weight=sample_weight,
                               return_intercept=return_intercept
                               )
-    try:
+    if return_intercept:
         coef, intercept = target
         assert_array_almost_equal(coef, true_coefs, decimal=1)
         assert_array_almost_equal(intercept, 0, decimal=1)
-    except ValueError:
+    else:
         assert_array_almost_equal(target, true_coefs, decimal=1)
 
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -778,7 +778,8 @@ def test_raises_value_error_if_solver_not_supported():
     wrong_solver = "This is not a solver (MagritteSolveCV QuantumBitcoin)"
 
     exception = ValueError
-    message = "Solver %s not understood" % wrong_solver
+    message = ("Known solver are 'sparse_cg', 'cholesky', 'svd'"
+               " 'lsqr', 'sag' or 'saga'. Got %s." % wrong_solver)
 
     def func():
         X = np.eye(3)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -837,6 +837,28 @@ def test_ridge_fit_intercept_sparse():
         assert_array_almost_equal(dense.coef_, sparse.coef_)
 
 
+@pytest.mark.parametrize('return_intercept', [False, True])
+@pytest.mark.parametrize('sample_weight', [None, np.ones(1000)])
+@pytest.mark.parametrize('arr_type', [np.array, sp.csr_matrix])
+def test_ridge_check_auto_modes(return_intercept, sample_weight, arr_type):
+    X = np.random.rand(1000, 3)
+    true_coefs = [1, 2, 0.1]
+    y = np.dot(X, true_coefs)
+    X_testing = arr_type(X)
+
+    target = ridge_regression(X_testing, y, 1,
+                              solver='auto',
+                              sample_weight=sample_weight,
+                              return_intercept=return_intercept
+                              )
+    try:
+        coef, intercept = target
+        assert_array_almost_equal(coef, true_coefs, decimal=1)
+        assert_array_almost_equal(intercept, 0, decimal=1)
+    except ValueError:
+        assert_array_almost_equal(target, true_coefs, decimal=1)
+
+
 def test_errors_and_values_helper():
     ridgecv = _RidgeGCV()
     rng = check_random_state(42)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -863,10 +863,10 @@ def test_ridge_regression_check_arguments_validity(return_intercept,
                               )
     if return_intercept:
         coef, intercept = target
-        assert_allclose(coef, true_coefs, atol=0.03)
-        assert_allclose(intercept, 0, atol=0.03)
+        assert_allclose(coef, true_coefs, rtol=0, atol=0.03)
+        assert_allclose(intercept, 0, rtol=0, atol=0.03)
     else:
-        assert_allclose(target, true_coefs, atol=0.03)
+        assert_allclose(target, true_coefs, rtol=0, atol=0.03)
 
 
 def test_ridge_regression_warns_with_return_intercept():

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -851,7 +851,8 @@ def test_ridge_regression_check_arguments_validity(return_intercept,
 
     # test excludes 'svd' solver because it raises exception for sparse inputs
 
-    X = np.random.rand(1000, 3)
+    rng = check_random_state(42)
+    X = rng.rand(1000, 3)
     true_coefs = [1, 2, 0.1]
     y = np.dot(X, true_coefs)
     X_testing = arr_type(X)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -855,19 +855,26 @@ def test_ridge_regression_check_arguments_validity(return_intercept,
     X = rng.rand(1000, 3)
     true_coefs = [1, 2, 0.1]
     y = np.dot(X, true_coefs)
+    intercept = 0.
+    if return_intercept:
+        intercept = 10000.
+    y += intercept
     X_testing = arr_type(X)
 
-    target = ridge_regression(X_testing, y, 1,
+    alpha, atol, tol = 1e-3, 1e-4, 1e-6
+    target = ridge_regression(X_testing, y, alpha=alpha,
                               solver=solver,
                               sample_weight=sample_weight,
-                              return_intercept=return_intercept
+                              return_intercept=return_intercept,
+                              tol=tol,
                               )
+
     if return_intercept:
         coef, intercept = target
-        assert_allclose(coef, true_coefs, rtol=0, atol=0.03)
-        assert_allclose(intercept, 0, rtol=0, atol=0.03)
+        assert_allclose(coef, true_coefs, rtol=0, atol=atol)
+        assert_allclose(intercept, intercept, rtol=0, atol=atol)
     else:
-        assert_allclose(target, true_coefs, rtol=0, atol=0.03)
+        assert_allclose(target, true_coefs, rtol=0, atol=atol)
 
 
 def test_ridge_regression_warns_with_return_intercept():


### PR DESCRIPTION
Continues the work started in #13336. ~~Must be reviewed as an addition to #13336 and merged after~~ (merged)

Fixes #13362.


#### What does this implement/fix? Explain your changes.

The solver that was selected when `solver` argument of ridge_regression was set to `'auto'`  was ambiguous and sometimes even incorrect (see #13362). This PR tries to make it more explicit. 

#### Any other comments?

Ping: @agramfort 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
