### PR TITLE
[MRG+1] DOC: fix formatting in whats_new

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -197,7 +197,7 @@ Support for Python 3.4 and below has been officially dropped.
 
 - |Enhancement| :class:`linear_model.make_dataset` now preserves
   ``float32`` and ``float64`` dtypes. :issue:`8769` and :issue:`11000` by
-  :user:`Nelle Varoquaux`, :user:`Arthur Imbert <Henley13>`,
+  :user:`Nelle Varoquaux <NelleV>`, :user:`Arthur Imbert <Henley13>`,
   :user:`Guillaume Lemaitre <glemaitre>`, and :user:`Joan Massich <massich>`
 
 - |Enhancement| :class:`linear_model.LogisticRegression` now supports an
@@ -437,7 +437,8 @@ Multiple modules
   :func:`sklearn.set_config`. :issue:`11705` by :user:`Nicolas Hug
   <NicolasHug>`.
 - |Efficiency| Memory copies are avoided when casting arrays to a different
-  dtype in multiple estimators. :issue:`11973` by :user:`Roman Yurchak`.
+  dtype in multiple estimators. :issue:`11973` by :user:`Roman Yurchak
+  <rth>`.
 
 
 Changes to estimator checks

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -97,8 +97,8 @@ Support for Python 3.4 and below has been officially dropped.
 ....................................
 
 - |Enhancement| :class:`discriminant_analysis.LinearDiscriminantAnalysis` now
-  preserves ``float32`` and ``float64`` dtypes. :issues:`8769` and
-  :issues:`11000` by :user:`Thibault Sejourne <thibsej>`
+  preserves ``float32`` and ``float64`` dtypes. :issue:`8769` and
+  :issue:`11000` by :user:`Thibault Sejourne <thibsej>`
 
 - |Fix| A ``ChangedBehaviourWarning`` is now raised when
   :class:`discriminant_analysis.LinearDiscriminantAnalysis` is given as
@@ -196,8 +196,8 @@ Support for Python 3.4 and below has been officially dropped.
   with the 'saga' solver. :issue:`11646` by :user:`Nicolas Hug <NicolasHug>`.
 
 - |Enhancement| :class:`linear_model.make_dataset` now preserves
-  ``float32`` and ``float64`` dtypes. :issues:`8769` and :issues:`11000` by
-  :user:`Nelle Varoquaux`_, :user:`Arthur Imbert <Henley13>`,
+  ``float32`` and ``float64`` dtypes. :issue:`8769` and :issue:`11000` by
+  :user:`Nelle Varoquaux`, :user:`Arthur Imbert <Henley13>`,
   :user:`Guillaume Lemaitre <glemaitre>`, and :user:`Joan Massich <massich>`
 
 - |Enhancement| :class:`linear_model.LogisticRegression` now supports an
@@ -221,9 +221,9 @@ Support for Python 3.4 and below has been officially dropped.
   :user:`Albert Thomas <albertcthomas>`.
 
 - |Fix| Fixed a bug in :class:`linear_model.LassoLarsIC`, where user input
-   ``copy_X=False`` at instance creation would be overridden by default
-   parameter value ``copy_X=True`` in ``fit``.
-   :issue:`12972` by :user:`Lucio Fernandez-Arjona <luk-f-a>`
+  ``copy_X=False`` at instance creation would be overridden by default
+  parameter value ``copy_X=True`` in ``fit``.
+  :issue:`12972` by :user:`Lucio Fernandez-Arjona <luk-f-a>`
 
 - |Fix| Fixed a bug in :class:`linear_model.LinearRegression` that
   was not returning the same coeffecients and intercepts with
@@ -278,7 +278,7 @@ Support for Python 3.4 and below has been officially dropped.
 
 - |Fix| The metric :func:`metrics.r2_score` is degenerate with a single sample
   and now it returns NaN and raises :class:`exceptions.UndefinedMetricWarning`.
-  :issue:`12855` by :user:`Pawel Sendyk <psendyk>.`
+  :issue:`12855` by :user:`Pawel Sendyk <psendyk>`.
 
 - |API| The parameter ``labels`` in :func:`metrics.hamming_loss` is deprecated
   in version 0.21 and will be removed in version 0.23.
@@ -437,7 +437,7 @@ Multiple modules
   :func:`sklearn.set_config`. :issue:`11705` by :user:`Nicolas Hug
   <NicolasHug>`.
 - |Efficiency| Memory copies are avoided when casting arrays to a different
-  dtype in multiple estimators. :issue:`11973` by :user:`Roman Yurchak`_.
+  dtype in multiple estimators. :issue:`11973` by :user:`Roman Yurchak`.
 
 
 Changes to estimator checks


### PR DESCRIPTION
A simple fix because I was distracted by formatting errors in the whats_new for 0.21.