### PR TITLE
MNT CI fix scikit-image dependency for latest numpy

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -124,7 +124,11 @@ conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
   joblib
 
 source activate testenv
-pip install scikit-image=="${SCIKIT_IMAGE_VERSION:-*}"
+if [[ -n "$SCIKIT_IMAGE_VERSION" ]]; then
+    pip install scikit-image=="$SCIKIT_IMAGE_VERSION"
+else
+    pip install scikit-image
+fi
 pip install sphinx-gallery
 pip install numpydoc==0.8
 

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -120,10 +120,11 @@ conda update --yes --quiet conda
 conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
   numpy="${NUMPY_VERSION:-*}" scipy="${SCIPY_VERSION:-*}" cython \
   pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=1.6.2 pillow \
-  scikit-image="${SCIKIT_IMAGE_VERSION:-*}" pandas="${PANDAS_VERSION:-*}" \
+  pandas="${PANDAS_VERSION:-*}" \
   joblib
 
 source activate testenv
+pip install scikit-image=="${SCIKIT_IMAGE_VERSION:-*}"
 pip install sphinx-gallery
 pip install numpydoc==0.8
 


### PR DESCRIPTION
The latest numpy has removed `_validate_lengths` used by `skimage`. It's fixed in the latest release but not available on conda, hence our circleci/doc build fails.

This PR moves installation of skimage from conda to pip.