### PR TITLE
[MRG+1] Adding multi output checks to common tests

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -598,3 +598,9 @@ These changes mostly affect library developers.
   :pr:`14336` by :user:`Gregory Dexter <gdex1>`.
 
 - |Fix| Added ``check_transformer_data_not_an_array`` to checks where missing
+
+- Added two common multioutput estimator tests
+  :func:`~utils.estimator_checks.check_classifier_multioutput` and
+  :func:`~utils.estimator_checks.check_regressor_multioutput`.
+  :pr:`13392` by :user:`Rok Mihevc <rok>`.
+

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -597,10 +597,10 @@ These changes mostly affect library developers.
 - Added check that pairwise estimators raise error on non-square data
   :pr:`14336` by :user:`Gregory Dexter <gdex1>`.
 
-- |Fix| Added ``check_transformer_data_not_an_array`` to checks where missing
-
 - Added two common multioutput estimator tests
   :func:`~utils.estimator_checks.check_classifier_multioutput` and
   :func:`~utils.estimator_checks.check_regressor_multioutput`.
   :pr:`13392` by :user:`Rok Mihevc <rok>`.
+
+- |Fix| Added ``check_transformer_data_not_an_array`` to checks where missing
 

--- a/examples/model_selection/plot_roc.py
+++ b/examples/model_selection/plot_roc.py
@@ -150,7 +150,7 @@ plt.show()
 # Area under ROC for the multiclass problem
 # .........................................
 # The :func:`sklearn.metrics.roc_auc_score` function can be used for
-# multi-class classification. The mutliclass One-vs-One scheme compares every
+# multi-class classification. The multi-class One-vs-One scheme compares every
 # unique pairwise combination of classes. In this section, we calcuate the AUC
 # using the OvR and OvO schemes. We report a macro average, and a
 # prevalence-weighted average.

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1294,27 +1294,6 @@ def test_backend_respected():
     assert ba.count == 0
 
 
-@pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
-@pytest.mark.parametrize('oob_score', (True, False))
-def test_multi_target(name, oob_score):
-    ForestClassifier = FOREST_CLASSIFIERS[name]
-
-    clf = ForestClassifier(bootstrap=True, oob_score=oob_score)
-
-    X = iris.data
-
-    # Make multi column mixed type target.
-    y = np.vstack([
-        iris.target.astype(float),
-        iris.target.astype(int),
-        iris.target.astype(str),
-    ]).T
-
-    # Try to fit and predict.
-    clf.fit(X, y)
-    clf.predict(X)
-
-
 def test_forest_feature_importances_sum():
     X, y = make_classification(n_samples=15, n_informative=3, random_state=1,
                                n_classes=3)

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1027,7 +1027,7 @@ def _path_residuals(X, y, train, test, path, path_params, alphas=None,
     return this_mses
 
 
-class _BaseLinearModelCV(LinearModel, metaclass=ABCMeta):
+class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
     """Base class for iterative model fitting along a regularization path"""
 
     @abstractmethod
@@ -1223,11 +1223,7 @@ class _BaseLinearModelCV(LinearModel, metaclass=ABCMeta):
         return self
 
 
-class LinearModelCV(MultiOutputMixin, _BaseLinearModelCV):
-    pass
-
-
-class LassoCV(RegressorMixin, _BaseLinearModelCV):
+class LassoCV(RegressorMixin, LinearModelCV):
     """Lasso linear model with iterative fitting along a regularization path.
 
     See glossary entry for :term:`cross-validation estimator`.
@@ -1392,8 +1388,10 @@ class LassoCV(RegressorMixin, _BaseLinearModelCV):
             cv=cv, verbose=verbose, n_jobs=n_jobs, positive=positive,
             random_state=random_state, selection=selection)
 
+    def _more_tags(self):
+        return {'multioutput': False}
 
-class ElasticNetCV(RegressorMixin, _BaseLinearModelCV):
+class ElasticNetCV(RegressorMixin, LinearModelCV):
     """Elastic Net model with iterative fitting along a regularization path.
 
     See glossary entry for :term:`cross-validation estimator`.
@@ -1597,6 +1595,8 @@ class ElasticNetCV(RegressorMixin, _BaseLinearModelCV):
         self.random_state = random_state
         self.selection = selection
 
+    def _more_tags(self):
+        return {'multioutput': False}
 
 ###############################################################################
 # Multi Task ElasticNet and Lasso models (with joint feature selection)
@@ -1913,8 +1913,7 @@ class MultiTaskLasso(MultiTaskElasticNet):
         self.selection = selection
 
 
-class MultiTaskElasticNetCV(MultiOutputMixin, RegressorMixin,
-                            _BaseLinearModelCV):
+class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
     """Multi-task L1/L2 ElasticNet with built-in cross-validation.
 
     See glossary entry for :term:`cross-validation estimator`.
@@ -2102,7 +2101,7 @@ class MultiTaskElasticNetCV(MultiOutputMixin, RegressorMixin,
         return {'multioutput_only': True}
 
 
-class MultiTaskLassoCV(RegressorMixin, _BaseLinearModelCV):
+class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
     """Multi-task Lasso model trained with L1/L2 mixed-norm as regularizer.
 
     See glossary entry for :term:`cross-validation estimator`.

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1027,7 +1027,7 @@ def _path_residuals(X, y, train, test, path, path_params, alphas=None,
     return this_mses
 
 
-class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
+class _BaseLinearModelCV(LinearModel, metaclass=ABCMeta):
     """Base class for iterative model fitting along a regularization path"""
 
     @abstractmethod
@@ -1223,7 +1223,11 @@ class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
         return self
 
 
-class LassoCV(RegressorMixin, LinearModelCV):
+class LinearModelCV(MultiOutputMixin, _BaseLinearModelCV):
+    pass
+
+
+class LassoCV(RegressorMixin, _BaseLinearModelCV):
     """Lasso linear model with iterative fitting along a regularization path.
 
     See glossary entry for :term:`cross-validation estimator`.
@@ -1389,7 +1393,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
             random_state=random_state, selection=selection)
 
 
-class ElasticNetCV(RegressorMixin, LinearModelCV):
+class ElasticNetCV(RegressorMixin, _BaseLinearModelCV):
     """Elastic Net model with iterative fitting along a regularization path.
 
     See glossary entry for :term:`cross-validation estimator`.
@@ -1909,7 +1913,8 @@ class MultiTaskLasso(MultiTaskElasticNet):
         self.selection = selection
 
 
-class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
+class MultiTaskElasticNetCV(MultiOutputMixin, RegressorMixin,
+                            _BaseLinearModelCV):
     """Multi-task L1/L2 ElasticNet with built-in cross-validation.
 
     See glossary entry for :term:`cross-validation estimator`.
@@ -2097,7 +2102,7 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         return {'multioutput_only': True}
 
 
-class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
+class MultiTaskLassoCV(RegressorMixin, _BaseLinearModelCV):
     """Multi-task Lasso model trained with L1/L2 mixed-norm as regularizer.
 
     See glossary entry for :term:`cross-validation estimator`.

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -761,7 +761,7 @@ def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
 ###############################################################################
 # Estimator classes
 
-class Lars(MultiOutputMixin, RegressorMixin, LinearModel):
+class _BaseLars(RegressorMixin, LinearModel):
     """Least Angle Regression model a.k.a. LAR
 
     Read more in the :ref:`User Guide <least_angle_regression>`.
@@ -969,7 +969,11 @@ class Lars(MultiOutputMixin, RegressorMixin, LinearModel):
         return self
 
 
-class LassoLars(Lars):
+class Lars(MultiOutputMixin, _BaseLars):
+    pass
+
+
+class _BaseLassoLars(_BaseLars):
     """Lasso model fit with Least Angle Regression a.k.a. Lars
 
     It is a Linear Model trained with an L1 prior as regularizer.
@@ -1229,7 +1233,11 @@ def _lars_path_residues(X_train, y_train, X_test, y_test, Gram=None,
     return alphas, active, coefs, residues.T
 
 
-class LarsCV(Lars):
+class LassoLars(MultiOutputMixin, _BaseLassoLars):
+    pass
+
+
+class LarsCV(_BaseLars):
     """Cross-validated Least Angle Regression model.
 
     See glossary entry for :term:`cross-validation estimator`.
@@ -1601,7 +1609,7 @@ class LassoLarsCV(LarsCV):
         # to avoid setting n_nonzero_coefs
 
 
-class LassoLarsIC(LassoLars):
+class LassoLarsIC(_BaseLassoLars):
     """Lasso model fit with Lars using BIC or AIC for model selection
 
     The optimization objective for Lasso is::

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -761,7 +761,7 @@ def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
 ###############################################################################
 # Estimator classes
 
-class _BaseLars(RegressorMixin, LinearModel):
+class Lars(MultiOutputMixin, RegressorMixin, LinearModel):
     """Least Angle Regression model a.k.a. LAR
 
     Read more in the :ref:`User Guide <least_angle_regression>`.
@@ -969,11 +969,7 @@ class _BaseLars(RegressorMixin, LinearModel):
         return self
 
 
-class Lars(MultiOutputMixin, _BaseLars):
-    pass
-
-
-class _BaseLassoLars(_BaseLars):
+class LassoLars(Lars):
     """Lasso model fit with Least Angle Regression a.k.a. Lars
 
     It is a Linear Model trained with an L1 prior as regularizer.
@@ -1233,11 +1229,7 @@ def _lars_path_residues(X_train, y_train, X_test, y_test, Gram=None,
     return alphas, active, coefs, residues.T
 
 
-class LassoLars(MultiOutputMixin, _BaseLassoLars):
-    pass
-
-
-class LarsCV(_BaseLars):
+class LarsCV(Lars):
     """Cross-validated Least Angle Regression model.
 
     See glossary entry for :term:`cross-validation estimator`.
@@ -1365,6 +1357,9 @@ class LarsCV(_BaseLars):
                          precompute=precompute,
                          n_nonzero_coefs=500,
                          eps=eps, copy_X=copy_X, fit_path=True)
+
+    def _more_tags(self):
+        return {'multioutput': False}
 
     def fit(self, X, y):
         """Fit the model using X, y as training data.
@@ -1609,7 +1604,7 @@ class LassoLarsCV(LarsCV):
         # to avoid setting n_nonzero_coefs
 
 
-class LassoLarsIC(_BaseLassoLars):
+class LassoLarsIC(LassoLars):
     """Lasso model fit with Lars using BIC or AIC for model selection
 
     The optimization objective for Lasso is::
@@ -1736,6 +1731,9 @@ class LassoLarsIC(_BaseLassoLars):
         self.precompute = precompute
         self.eps = eps
         self.fit_path = True
+
+    def _more_tags(self):
+        return {'multioutput': False}
 
     def fit(self, X, y, copy_X=None):
         """Fit the model using X, y as training data.

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -521,7 +521,7 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         return coef
 
 
-class _BaseRidge(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
+class _BaseRidge(LinearModel, metaclass=ABCMeta):
     @abstractmethod
     def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
                  copy_X=True, max_iter=None, tol=1e-3, solver="auto",
@@ -602,7 +602,7 @@ class _BaseRidge(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
         return self
 
 
-class Ridge(RegressorMixin, _BaseRidge):
+class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
     """Linear least squares with l2 regularization.
 
     Minimizes the objective function::
@@ -1506,7 +1506,7 @@ class _RidgeGCV(LinearModel):
         return self
 
 
-class _BaseRidgeCV(MultiOutputMixin, LinearModel):
+class _BaseRidgeCV(LinearModel):
     def __init__(self, alphas=(0.1, 1.0, 10.0),
                  fit_intercept=True, normalize=False, scoring=None,
                  cv=None, gcv_mode=None,
@@ -1578,7 +1578,7 @@ class _BaseRidgeCV(MultiOutputMixin, LinearModel):
         return self
 
 
-class RidgeCV(RegressorMixin, _BaseRidgeCV):
+class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
     """Ridge regression with built-in cross-validation.
 
     See glossary entry for :term:`cross-validation estimator`.

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -148,6 +148,11 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
               metric_params=metric_params, n_jobs=n_jobs, **kwargs)
         self.weights = _check_weights(weights)
 
+    @property
+    def _pairwise(self):
+        # For cross-validation routines to split data correctly
+        return self.metric == 'precomputed'
+
     def predict(self, X):
         """Predict the target for the provided data
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1823,26 +1823,6 @@ def test_empty_leaf_infinite_threshold():
         assert len(empty_leaf) == 0
 
 
-@pytest.mark.parametrize('name', CLF_TREES)
-def test_multi_target(name):
-    Tree = CLF_TREES[name]
-
-    clf = Tree()
-
-    X = iris.data
-
-    # Make multi column mixed type target.
-    y = np.vstack([
-        iris.target.astype(float),
-        iris.target.astype(int),
-        iris.target.astype(str),
-    ]).T
-
-    # Try to fit and predict.
-    clf.fit(X, y)
-    clf.predict(X)
-
-
 def test_decision_tree_memmap():
     # check that decision trees supports read-only buffer (#13626)
     X = np.random.RandomState(0).random_sample((10, 2)).astype(np.float32)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1500,7 +1500,7 @@ def check_estimators_partial_fit_n_features(name, estimator_orig):
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))
 def check_classifier_multioutput(name, estimator):
-    n_samples = 42
+    n_samples, n_labels = 42, 5
     n_labels = 5
     tags = _safe_tags(estimator)
     estimator = clone(estimator)
@@ -1510,7 +1510,10 @@ def check_classifier_multioutput(name, estimator):
     estimator.fit(X, y)
     y_pred = estimator.predict(X)
 
-    assert y_pred.shape == (n_samples, n_labels), y_pred.shape
+    assert (y_pred.shape == (n_samples, n_labels),
+            "The shape of the prediction for multioutput data is "
+            " incorrect. Expected {}, got {}."
+            .format((n_samples, n_labels), y_pred.shape))
     assert y_pred.dtype.kind == 'i'
 
     if hasattr(estimator, "decision_function"):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1500,25 +1500,29 @@ def check_estimators_partial_fit_n_features(name, estimator_orig):
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))
 def check_classifier_multioutput(name, estimator):
-    n_samples, n_labels = 42, 5
+    n_samples, n_labels, n_classes = 42, 5, 3
     tags = _safe_tags(estimator)
     estimator = clone(estimator)
     X, y = make_multilabel_classification(random_state=42,
                                           n_samples=n_samples,
-                                          n_labels=n_labels)
+                                          n_labels=n_labels,
+                                          n_classes=n_classes)
     estimator.fit(X, y)
     y_pred = estimator.predict(X)
 
-    assert (y_pred.shape == (n_samples, n_labels),
-            "The shape of the prediction for multioutput data is "
-            " incorrect. Expected {}, got {}."
-            .format((n_samples, n_labels), y_pred.shape))
+    assert y_pred.shape == (n_samples, n_classes), (
+        "The shape of the prediction for multioutput data is "
+        "incorrect. Expected {}, got {}."
+        .format((n_samples, n_labels), y_pred.shape))
     assert y_pred.dtype.kind == 'i'
 
     if hasattr(estimator, "decision_function"):
         decision = estimator.decision_function(X)
         assert isinstance(decision, np.ndarray)
-        assert decision.shape == (n_samples, n_labels)
+        assert decision.shape == (n_samples, n_classes), (
+            "The shape of the decision function output for "
+            "multioutput data is incorrect. Expected {}, got {}."
+            .format((n_samples, n_classes), decision.shape))
 
         dec_pred = (decision > 0).astype(np.int)
         dec_exp = estimator.classes_[dec_pred]
@@ -1528,19 +1532,25 @@ def check_classifier_multioutput(name, estimator):
         y_prob = estimator.predict_proba(X)
 
         if isinstance(y_prob, list) and not tags['poor_score']:
-            for i in range(n_labels):
-                y_prob[i].shape == (n_samples, n_labels)
+            for i in range(n_classes):
+                assert y_prob[i].shape == (n_samples, 2), (
+                    "The shape of the probability for multioutput data is"
+                    " incorrect. Expected {}, got {}."
+                    .format((n_samples, 2), y_prob[i].shape))
                 assert_array_equal(
                     np.argmax(y_prob[i], axis=1).astype(np.int),
                     y_pred[:, i]
                 )
         elif not tags['poor_score']:
-            y_prob.shape == (n_samples, n_labels)
+            assert y_prob.shape == (n_samples, n_classes), (
+                "The shape of the probability for multioutput data is"
+                " incorrect. Expected {}, got {}."
+                .format((n_samples, n_classes), y_prob.shape))
             assert_array_equal(y_prob.round().astype(int), y_pred)
 
     if (hasattr(estimator, "decision_function") and
             hasattr(estimator, "predict_proba")):
-        for i in range(n_labels):
+        for i in range(n_classes):
             y_proba = estimator.predict_proba(X)[:, i]
             y_decision = estimator.decision_function(X)
             assert_array_equal(rankdata(y_proba), rankdata(y_decision[:, i]))
@@ -1561,8 +1571,12 @@ def check_regressor_multioutput(name, estimator):
     estimator.fit(X, y)
     y_pred = estimator.predict(X)
 
-    assert y_pred.dtype == np.dtype('float')
-    assert y_pred.shape == y.shape
+    assert y_pred.dtype == np.dtype('float64'), (
+        "Multioutput predictions by a regressor are expected to be"
+        " floating-point precision. Got {} instead".format(y_pred.dtype))
+    assert y_pred.shape == y.shape, (
+        "The shape of the orediction for multioutput data is incorrect."
+        " Expected {}, got {}.")
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -38,7 +38,6 @@ from ..base import (clone, ClusterMixin, is_classifier, is_regressor,
                     BaseEstimator)
 
 from ..metrics import accuracy_score, adjusted_rand_score, f1_score
-
 from ..random_projection import BaseRandomProjection
 from ..feature_selection import SelectKBest
 from ..pipeline import make_pipeline
@@ -54,12 +53,12 @@ from .import shuffle
 from .import deprecated
 from .validation import has_fit_parameter, _num_samples
 from ..preprocessing import StandardScaler
-from ..datasets import load_iris, load_boston, make_blobs
+from ..datasets import (load_iris, load_boston, make_blobs,
+                        make_multilabel_classification, make_regression)
 
 
 BOSTON = None
 CROSS_DECOMPOSITION = ['PLSCanonical', 'PLSRegression', 'CCA', 'PLSSVD']
-
 
 def _safe_tags(estimator, key=None):
     # if estimator doesn't have _get_tags, use _DEFAULT_TAGS
@@ -125,6 +124,8 @@ def _yield_classifier_checks(name, classifier):
     yield check_classifiers_one_label
     yield check_classifiers_classes
     yield check_estimators_partial_fit_n_features
+    if tags["multioutput"]:
+        yield check_classifier_multioutput
     # basic consistency testing
     yield check_classifiers_train
     yield partial(check_classifiers_train, readonly_memmap=True)
@@ -174,6 +175,8 @@ def _yield_regressor_checks(name, regressor):
     yield partial(check_regressors_train, readonly_memmap=True)
     yield check_regressor_data_not_an_array
     yield check_estimators_partial_fit_n_features
+    if tags["multioutput"]:
+        yield check_regressor_multioutput
     yield check_regressors_no_decision_function
     if not tags["no_validation"]:
         yield check_supervised_y_2d
@@ -1493,6 +1496,71 @@ def check_estimators_partial_fit_n_features(name, estimator_orig):
                            " changes between calls to "
                            "partial_fit.".format(name)):
         estimator.partial_fit(X[:, :-1], y)
+
+
+@ignore_warnings(category=(DeprecationWarning, FutureWarning))
+def check_classifier_multioutput(name, estimator):
+    n_samples = 42
+    n_labels = 5
+    tags = _safe_tags(estimator)
+    estimator = clone(estimator)
+    X, y = make_multilabel_classification(random_state=42,
+                                          n_samples=n_samples,
+                                          n_labels=n_labels)
+    estimator.fit(X, y)
+    y_pred = estimator.predict(X)
+
+    assert y_pred.shape == (n_samples, n_labels), y_pred.shape
+    assert y_pred.dtype.kind == 'i'
+
+    if hasattr(estimator, "decision_function"):
+        decision = estimator.decision_function(X)
+        assert isinstance(decision, np.ndarray)
+        assert decision.shape == (n_samples, n_labels)
+
+        dec_pred = (decision > 0).astype(np.int)
+        dec_exp = estimator.classes_[dec_pred]
+        assert_array_equal(dec_exp, y_pred)
+
+    if hasattr(estimator, "predict_proba"):
+        y_prob = estimator.predict_proba(X)
+
+        if isinstance(y_prob, list) and not tags['poor_score']:
+            for i in range(n_labels):
+                y_prob[i].shape == (n_samples, n_labels)
+                assert_array_equal(
+                    np.argmax(y_prob[i], axis=1).astype(np.int),
+                    y_pred[:, i]
+                )
+        elif not tags['poor_score']:
+            y_prob.shape == (n_samples, n_labels)
+            assert_array_equal(y_prob.round().astype(int), y_pred)
+
+    if (hasattr(estimator, "decision_function") and
+            hasattr(estimator, "predict_proba")):
+        for i in range(n_labels):
+            y_proba = estimator.predict_proba(X)[:, i]
+            y_decision = estimator.decision_function(X)
+            assert_array_equal(rankdata(y_proba), rankdata(y_decision[:, i]))
+
+
+@ignore_warnings(category=(DeprecationWarning, FutureWarning))
+def check_regressor_multioutput(name, estimator):
+    estimator = clone(estimator)
+    n_samples = n_features = 10
+
+    if not _is_pairwise_metric(estimator):
+        n_samples = n_samples + 1
+
+    X, y = make_regression(random_state=42, n_targets=5,
+                           n_samples=n_samples, n_features=n_features)
+    X = pairwise_estimator_convert_X(X, estimator)
+
+    estimator.fit(X, y)
+    y_pred = estimator.predict(X)
+
+    assert y_pred.dtype == np.dtype('float')
+    assert y_pred.shape == y.shape
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1501,7 +1501,6 @@ def check_estimators_partial_fit_n_features(name, estimator_orig):
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))
 def check_classifier_multioutput(name, estimator):
     n_samples, n_labels = 42, 5
-    n_labels = 5
     tags = _safe_tags(estimator)
     estimator = clone(estimator)
     X, y = make_multilabel_classification(random_state=42,

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -282,7 +282,7 @@ class UntaggedBinaryClassifier(DecisionTreeClassifier):
     # Toy classifier that only supports binary classification, will fail tests.
     def fit(self, X, y, sample_weight=None):
         super().fit(X, y, sample_weight)
-        if self.n_classes_ > 2:
+        if np.all(self.n_classes_ > 2):
             raise ValueError('Only 2 classes are supported')
         return self
 
@@ -296,7 +296,7 @@ class TaggedBinaryClassifier(UntaggedBinaryClassifier):
 class RequiresPositiveYRegressor(LinearRegression):
 
     def fit(self, X, y):
-        X, y = check_X_y(X, y)
+        X, y = check_X_y(X, y, multi_output=True)
         if (y <= 0).any():
             raise ValueError('negative y values not supported!')
         return super().fit(X, y)
@@ -423,7 +423,9 @@ def test_check_estimator():
     check_estimator(TaggedBinaryClassifier)
 
     # Check regressor with requires_positive_y estimator tag
-    check_estimator(RequiresPositiveYRegressor)
+    msg = 'negative y values not supported!'
+    assert_raises_regex(ValueError, msg, check_estimator,
+                        RequiresPositiveYRegressor)
 
 
 def test_check_outlier_corruption():
@@ -511,7 +513,7 @@ def test_check_no_attributes_set_in_init():
 
 def test_check_estimator_pairwise():
     # check that check_estimator() works on estimator with _pairwise
-    # kernel or  metric
+    # kernel or metric
 
     # test precomputed kernel
     est = SVC(kernel='precomputed')


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #13187.

#### Changes

This implements new classifier and regressor checks to test for multi-output support in common tests.
Some random forest and tree classifier test are removed as they are duplicating this functionality.