### PR TITLE
MNT fix cd_fast.pyx warning issues

### DIFF
--- a/sklearn/linear_model/cd_fast.pyx
+++ b/sklearn/linear_model/cd_fast.pyx
@@ -248,6 +248,7 @@ def enet_coordinate_descent(floating[::1] w,
                     break
 
         else:
+            # for/else, runs if for doesn't end with a `break`
             with gil:
                 warnings.warn("Objective did not converge. You might want to "
                               "increase the number of iterations. Duality "
@@ -462,6 +463,7 @@ def sparse_enet_coordinate_descent(floating [::1] w,
                     break
 
         else:
+            # for/else, runs if for doesn't end with a `break`
             with gil:
                 warnings.warn("Objective did not converge. You might want to "
                               "increase the number of iterations. Duality "
@@ -614,6 +616,7 @@ def enet_coordinate_descent_gram(floating[::1] w,
                     break
 
         else:
+            # for/else, runs if for doesn't end with a `break`
             with gil:
                 warnings.warn("Objective did not converge. You might want to "
                               "increase the number of iterations. Duality "
@@ -808,6 +811,7 @@ def enet_coordinate_descent_multi_task(floating[::1, :] W, floating l1_reg,
                     # return if we reached desired tolerance
                     break
         else:
+            # for/else, runs if for doesn't end with a `break`
             with gil:
                 warnings.warn("Objective did not converge. You might want to "
                               "increase the number of iterations. Duality "

--- a/sklearn/linear_model/cd_fast.pyx
+++ b/sklearn/linear_model/cd_fast.pyx
@@ -154,8 +154,8 @@ def enet_coordinate_descent(floating[::1] w,
     cdef UINT32_t* rand_r_state = &rand_r_state_seed
 
     if alpha == 0 and beta == 0:
-        warnings.warn("Coordinate descent with no regularization may lead to unexpected"
-            " results and is discouraged.")
+        warnings.warn("Coordinate descent with no regularization may lead to "
+                      "unexpected results and is discouraged.")
 
     with nogil:
         # R = y - np.dot(X, w)
@@ -249,10 +249,10 @@ def enet_coordinate_descent(floating[::1] w,
 
         else:
             with gil:
-                warnings.warn("Objective did not converge."
-                " You might want to increase the number of iterations."
-                " Duality gap: {}, tolerance: {}".format(gap, tol),
-                ConvergenceWarning)
+                warnings.warn("Objective did not converge. You might want to "
+                              "increase the number of iterations. Duality "
+                              "gap: {}, tolerance: {}".format(gap, tol),
+                              ConvergenceWarning)
 
     return w, gap, tol, n_iter + 1
 
@@ -463,10 +463,10 @@ def sparse_enet_coordinate_descent(floating [::1] w,
 
         else:
             with gil:
-                warnings.warn("Objective did not converge."
-                " You might want to increase the number of iterations."
-                " Duality gap: {}, tolerance: {}".format(gap, tol),
-                ConvergenceWarning)
+                warnings.warn("Objective did not converge. You might want to "
+                              "increase the number of iterations. Duality "
+                              "gap: {}, tolerance: {}".format(gap, tol),
+                              ConvergenceWarning)
 
     return w, gap, tol, n_iter + 1
 
@@ -613,12 +613,12 @@ def enet_coordinate_descent_gram(floating[::1] w,
                     # return if we reached desired tolerance
                     break
 
-
-        with gil:
-            warnings.warn("Objective did not converge."
-            " You might want to increase the number of iterations."
-            " Duality gap: {}, tolerance: {}".format(gap, tol),
-            ConvergenceWarning)
+        else:
+            with gil:
+                warnings.warn("Objective did not converge. You might want to "
+                              "increase the number of iterations. Duality "
+                              "gap: {}, tolerance: {}".format(gap, tol),
+                              ConvergenceWarning)
 
     return np.asarray(w), gap, tol, n_iter + 1
 
@@ -807,11 +807,11 @@ def enet_coordinate_descent_multi_task(floating[::1, :] W, floating l1_reg,
                 if gap < tol:
                     # return if we reached desired tolerance
                     break
-                else:
-                    with gil:
-                        warnings.warn("Objective did not converge."
-                        " You might want to increase the number of iterations."
-                        " Duality gap: {}, tolerance: {}".format(gap, tol),
-                        ConvergenceWarning)
+        else:
+            with gil:
+                warnings.warn("Objective did not converge. You might want to "
+                              "increase the number of iterations. Duality "
+                              "gap: {}, tolerance: {}".format(gap, tol),
+                              ConvergenceWarning)
 
     return np.asarray(W), gap, tol, n_iter + 1

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -854,11 +854,11 @@ def test_convergence_warnings():
 
     # check that the model fails to converge
     with pytest.warns(ConvergenceWarning):
-        model = MultiTaskElasticNet(max_iter=1, tol=0).fit(X, y)
+        MultiTaskElasticNet(max_iter=1, tol=0).fit(X, y)
 
     # check that the model converges w/o warnings
     with pytest.warns(None) as record:
-        model = MultiTaskElasticNet(max_iter=1000).fit(X, y)
+        MultiTaskElasticNet(max_iter=1000).fit(X, y)
 
     assert not record.list
 
@@ -867,12 +867,11 @@ def test_sparse_input_convergence_warning():
     X, y, _, _ = build_dataset(n_samples=1000, n_features=500)
 
     with pytest.warns(ConvergenceWarning):
-        clf = ElasticNet(max_iter=1, tol=0).fit(
+        ElasticNet(max_iter=1, tol=0).fit(
             sparse.csr_matrix(X, dtype=np.float32), y)
 
     # check that the model converges w/o warnings
     with pytest.warns(None) as record:
-        model = Lasso(max_iter=1000).fit(
-            sparse.csr_matrix(X, dtype=np.float32), y)
+        Lasso(max_iter=1000).fit(sparse.csr_matrix(X, dtype=np.float32), y)
 
     assert not record.list

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -845,3 +845,34 @@ def test_enet_coordinate_descent(klass, n_classes, kwargs):
     if klass == Lasso:
         y = y.ravel()
     assert_warns(ConvergenceWarning, clf.fit, X, y)
+
+
+def test_convergence_warnings():
+    random_state = np.random.RandomState(0)
+    X = random_state.standard_normal((1000, 500))
+    y = random_state.standard_normal((1000, 3))
+
+    # check that the model fails to converge
+    with pytest.warns(ConvergenceWarning):
+        model = MultiTaskElasticNet(max_iter=1, tol=0).fit(X, y)
+
+    # check that the model converges w/o warnings
+    with pytest.warns(None) as record:
+        model = MultiTaskElasticNet(max_iter=1000).fit(X, y)
+
+    assert not record.list
+
+
+def test_sparse_input_convergence_warning():
+    X, y, _, _ = build_dataset(n_samples=1000, n_features=500)
+
+    with pytest.warns(ConvergenceWarning):
+        clf = ElasticNet(max_iter=1, tol=0).fit(
+            sparse.csr_matrix(X, dtype=np.float32), y)
+
+    # check that the model converges w/o warnings
+    with pytest.warns(None) as record:
+        model = Lasso(max_iter=1000).fit(
+            sparse.csr_matrix(X, dtype=np.float32), y)
+
+    assert not record.list


### PR DESCRIPTION
Fixes #13394 

This fixes issues with the "Objective did not converge...." warnings.

There were some indentation and missing `else` issues.