### PR TITLE
DOC Fix a typo in cross_validation.rst

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -249,9 +249,9 @@ Or as a dict mapping scorer name to a predefined or custom scoring function::
     >>> scores = cross_validate(clf, iris.data, iris.target, scoring=scoring,
     ...                         cv=5, return_train_score=True)
     >>> sorted(scores.keys())                 # doctest: +NORMALIZE_WHITESPACE
-    ['fit_time', 'score_time', 'test_prec_macro', 'test_rec_micro',
-     'train_prec_macro', 'train_rec_micro']
-    >>> scores['train_rec_micro']                         # doctest: +ELLIPSIS
+    ['fit_time', 'score_time', 'test_prec_macro', 'test_rec_macro',
+     'train_prec_macro', 'train_rec_macro']
+    >>> scores['train_rec_macro']                         # doctest: +ELLIPSIS
     array([0.97..., 0.97..., 0.99..., 0.98..., 0.98...])
 
 Here is an example of ``cross_validate`` using a single metric::

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -245,7 +245,7 @@ Or as a dict mapping scorer name to a predefined or custom scoring function::
 
     >>> from sklearn.metrics.scorer import make_scorer
     >>> scoring = {'prec_macro': 'precision_macro',
-    ...            'rec_micro': make_scorer(recall_score, average='micro')}
+    ...            'rec_macro': make_scorer(recall_score, average='macro')}
     >>> scores = cross_validate(clf, iris.data, iris.target, scoring=scoring,
     ...                         cv=5, return_train_score=True)
     >>> sorted(scores.keys())                 # doctest: +NORMALIZE_WHITESPACE

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -245,7 +245,7 @@ Or as a dict mapping scorer name to a predefined or custom scoring function::
 
     >>> from sklearn.metrics.scorer import make_scorer
     >>> scoring = {'prec_macro': 'precision_macro',
-    ...            'rec_micro': make_scorer(recall_score, average='macro')}
+    ...            'rec_micro': make_scorer(recall_score, average='micro')}
     >>> scores = cross_validate(clf, iris.data, iris.target, scoring=scoring,
     ...                         cv=5, return_train_score=True)
     >>> sorted(scores.keys())                 # doctest: +NORMALIZE_WHITESPACE


### PR DESCRIPTION
#### Reference Issues/PRs

None

#### What does this implement/fix? Explain your changes.

I believe there is a typo in the documentation for cross validation, as I have changed.

#### Any other comments?

Options could be either change the key name in the dict `scoring` or the keyword argument in `make_scorer`.

I went for the second option.