### PR TITLE
DOC Fix typo in FunctionTransformer

### DIFF
--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -61,7 +61,7 @@ class FunctionTransformer(BaseEstimator, TransformerMixin):
         Indicate that transform should forward the y argument to the
         inner callable.
 
-        .. deprecated::0.19
+        .. deprecated:: 0.19
 
     check_inverse : bool, default=True
        Whether to check that or ``func`` followed by ``inverse_func`` leads to


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### What does this implement/fix? Explain your changes.
Fix typo in FunctionTransformer deprecation of `pass_y` argument.

In the documentation there is no mention of that `pass_y` is deprecated:
https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.FunctionTransformer.html#sklearn.preprocessing.FunctionTransformer

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
