### PR TITLE
[MRG] Fixes out of bound check in *SearchCV for callable refit

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -698,7 +698,8 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
                 self.best_index_ = self.refit(results)
                 if not isinstance(self.best_index_, (int, np.integer)):
                     raise TypeError('best_index_ returned is not an integer')
-                if self.best_index_ < 0 or self.best_index_ >= len(results):
+                if (self.best_index_ < 0 or
+                   self.best_index_ >= len(results["params"])):
                     raise IndexError('best_index_ index out of range')
             else:
                 self.best_index_ = results["rank_test_%s"

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -651,7 +651,8 @@ def test_refit_callable_invalid_type():
         clf.fit(X, y)
 
 
-def test_refit_callable_out_bound():
+@pytest.mark.parametrize('out_bound_value', [-1, 2])
+def test_refit_callable_out_bound(out_bound_value):
     """
     Test implementation catches the errors when 'best_index_' returns an
     out of bound result.
@@ -660,7 +661,7 @@ def test_refit_callable_out_bound():
         """
         A dummy function tests when returned 'best_index_' is out of bounds.
         """
-        return -1
+        return out_bound_value
 
     X, y = make_classification(n_samples=100, n_features=4,
                                random_state=42)

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -652,7 +652,8 @@ def test_refit_callable_invalid_type():
 
 
 @pytest.mark.parametrize('out_bound_value', [-1, 2])
-def test_refit_callable_out_bound(out_bound_value):
+@pytest.mark.parametrize('search_cv', [RandomizedSearchCV, GridSearchCV])
+def test_refit_callable_out_bound(out_bound_value, search_cv):
     """
     Test implementation catches the errors when 'best_index_' returns an
     out of bound result.
@@ -666,9 +667,8 @@ def test_refit_callable_out_bound(out_bound_value):
     X, y = make_classification(n_samples=100, n_features=4,
                                random_state=42)
 
-    clf = GridSearchCV(LinearSVC(random_state=42), {'C': [0.1, 1]},
-                       scoring='precision', refit=refit_callable_out_bound,
-                       cv=5)
+    clf = search_cv(LinearSVC(random_state=42), {'C': [0.1, 1]},
+                    scoring='precision', refit=refit_callable_out_bound, cv=5)
     with pytest.raises(IndexError, match='best_index_ index out of range'):
         clf.fit(X, y)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/13413


#### What does this implement/fix? Explain your changes.
Fixes out of bound check in `*SearchCV` for a callable refit.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->