### PR TITLE
Add attributes to MultiOutputRegressor docstring

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -217,7 +217,7 @@ class MultiOutputRegressor(MultiOutputEstimator, RegressorMixin):
         When individual estimators are fast to train or predict
         using `n_jobs>1` can result in slower performance due
         to the overhead of spawning processes.
-        
+
     Attributes
     ----------
     estimators_ : list of ``n_output`` estimators

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -217,6 +217,11 @@ class MultiOutputRegressor(MultiOutputEstimator, RegressorMixin):
         When individual estimators are fast to train or predict
         using `n_jobs>1` can result in slower performance due
         to the overhead of spawning processes.
+        
+    Attributes
+    ----------
+    estimators_ : list of ``n_output`` estimators
+        Estimators used for predictions.
     """
 
     def __init__(self, estimator, n_jobs=None):


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

`MultiOutputRegressor()` is missing the `estimators_` attribute in the documentation

#### Any other comments?

`MultiOutputClassifier()` is fine, so I just copied the Attributes part from the docstring

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
