### PR TITLE
Handle unseen labels in `LabelEncoder`

### DIFF
--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -96,6 +96,9 @@ def _encode(values, uniques=None, encode=False, impute_value=None):
         already have been determined in fit).
     encode : bool, default False
         If True, also encode the values into integer codes based on `uniques`.
+    impute_value: str, int or float, optional
+        If passed, never seen values will be replaced by this value during the
+        encoding process.
 
     Returns
     -------
@@ -170,6 +173,13 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     """Encode labels with value between 0 and n_classes-1.
 
     Read more in the :ref:`User Guide <preprocessing_targets>`.
+
+    Parameters
+    ----------
+    impute_method : str (default: None)
+        Method to use for imputation of unseen labels during transform. By
+        default no imputation is done and a ValueError will be raised if any
+        previously unseen labels are found.
 
     Attributes
     ----------
@@ -301,6 +311,17 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         return {'X_types': ['1dlabels']}
 
     def _calculate_impute_value(self, y):
+        """Calculates the value to be imputed to unseen labels.
+
+        Parameters
+        ----------
+        y : numpy array of shape [n_samples]
+            Target values.
+
+        Returns
+        -------
+        impute_value : str, int or float
+        """
         if self.impute_method == 'most_common':
             values, counts = np.unique(y, return_counts=True)
             impute_value = self.classes_[values[np.argmax(counts)]]

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -193,7 +193,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder()
+    LabelEncoder(impute_method=None)
     >>> le.classes_
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6]) #doctest: +ELLIPSIS
@@ -206,7 +206,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder()
+    LabelEncoder(impute_method=None)
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"]) #doctest: +ELLIPSIS
@@ -222,7 +222,6 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     def __init__(self, impute_method=None):
         self.impute_method = impute_method
-        self.impute_value = None
         return super().__init__()
 
     def fit(self, y):
@@ -278,8 +277,9 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         # transform of empty array is empty array
         if _num_samples(y) == 0:
             return np.array([])
+        impute_value = self.impute_value if self.impute_method else None
         _, y = _encode(y, uniques=self.classes_,
-                       encode=True, impute_value=self.impute_value)
+                       encode=True, impute_value=impute_value)
         return y
 
     def inverse_transform(self, y):

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -222,6 +222,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     def __init__(self, impute_method=None):
         self.impute_method = impute_method
+        self.impute_value = None
         return super().__init__()
 
     def fit(self, y):

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -196,6 +196,38 @@ def test_label_encoder(values, classes, unknown):
     with pytest.raises(ValueError, match="unseen labels"):
         le.transform(unknown)
 
+    with pytest.raises(ValueError, match="impute_method"):
+        LabelEncoder(impute_method='test').fit(values)
+
+    with pytest.raises(ValueError, match="impute_method"):
+        LabelEncoder(impute_method='test').fit_transform(values)
+
+
+@pytest.mark.parametrize(
+        "values, classes, unknown",
+        [(np.array([2, 1, 3, 1, 3, 3], dtype='int64'),
+          np.array([1, 2, 3], dtype='int64'),
+          np.array([4], dtype='int64')),
+         (np.array(['b', 'a', 'c', 'a', 'c', 'c'], dtype=object),
+          np.array(['a', 'b', 'c'], dtype=object),
+          np.array(['d'], dtype=object)),
+         (np.array(['b', 'a', 'c', 'a', 'c', 'c']),
+          np.array(['a', 'b', 'c']),
+          np.array(['d']))],
+        ids=['int64', 'object', 'str'])
+def test_label_encoder_impute_most_common(values, classes, unknown):
+    # Test LabelEncoder's transform, fit_transform and
+    # inverse_transform methods
+    le = LabelEncoder(impute_method='most_common')
+    le.fit(values)
+    assert_array_equal(le.classes_, classes)
+    assert_array_equal(le.transform(values), [1, 0, 2, 0, 2, 2])
+    assert_array_equal(le.inverse_transform([1, 0, 2, 0, 2, 2]), values)
+    assert_array_equal(le.transform(unknown), [2])
+    ret = le.fit_transform(values)
+    assert_array_equal(ret, [1, 0, 2, 0, 2, 2])
+    assert_array_equal(le.transform(unknown), [2])
+
 
 def test_label_encoder_negative_ints():
     le = LabelEncoder()


### PR DESCRIPTION
#### Reference Issues/PRs
There are several issues that reference what this PR addresses: #8136 #3599 #9151 #6231
nevertheless the problem is still open as `CategoricalEncoder` #9151 does not fix the issue as said in some of the threads. Handling unknowns is not currently supported for `encoding='ordinal'`, which is the problem mentioned on some of these issues. 

#### What does this implement/fix? Explain your changes.

The problem here is that `LabelEncoder` as a part of a pipeline will only handle a single feature therefore has no knowledge of how to throw away the complete observation (all other features) if it encounters an unknown value. Therefore the non-support from `CategoricalEncoder`. The only solution is to impute/replace some known value to this unknown ones. To start I propose to give the option to the user to impute the `most_common` seen label during fitting. Next the mean rounded value can be another one for example.

#### Any other comments?
```
from sklearn.preprocessing.label import LabelEncoder
import pandas as pd
import numpy as np

df = pd.DataFrame({
    'training_data': ['A', 'A', 'C', 'B', 'Z', 'C', 'C'],
    'test_data': ['A', 'A', 'C', 'B', 'Z', 'C', 'SOMETHING'],
    'training_data_num': [20., 3., 4., 5., 20., 3., 4.],
    'test_data_num': [3, 3, 100, 5, 4, 4, 2]
})

# it raises ValueError as it should since it found an unseen label
lbl_encoder = LabelEncoder()
lbl_encoder.fit_transform(df['training_data'])
lbl_encoder.transform(df['test_data'])

# with the new changes the user has the option of imputing the unknown values
lbl_encoder = LabelEncoder(impute_method='most_common')
lbl_encoder.fit_transform(df['training_data'])
lbl_encoder.transform(df['test_data'])

lbl_encoder = LabelEncoder(impute_method='most_common')
lbl_encoder.fit_transform(df['training_data_num'])
lbl_encoder.transform(df['test_data_num'])
```
Some of the use cases are when you have ordinal features. In some cases I have also encounter that for memory concern I cannot/don't want to expand to one-hot encoded type vectors, so keeping an ordinal feature is very useful. 