### PR TITLE
[MRG] Added documentation of intercept_ attribute of BayesianRidge

### DIFF
--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -59,11 +59,13 @@ class BayesianRidge(LinearModel, RegressorMixin):
         If True, compute the log marginal likelihood at each iteration of the
         optimization. Default is False.
 
-    fit_intercept : boolean, optional
-        Whether to calculate the intercept for this model. If set
-        to false, no intercept will be used in calculations
+    fit_intercept : boolean, optional, default True
+        Whether to calculate the intercept for this model.
+        The intercept is not treated as a probabilistic parameter
+        and thus has no associated variance. If set
+        to False, no intercept will be used in calculations
         (e.g. data is expected to be already centered).
-        Default is True.
+
 
     normalize : boolean, optional, default False
         This parameter is ignored when ``fit_intercept`` is set to False.
@@ -84,6 +86,10 @@ class BayesianRidge(LinearModel, RegressorMixin):
     ----------
     coef_ : array, shape = (n_features,)
         Coefficients of the regression model (mean of distribution).
+
+    intercept_ : float
+        Independent term in decision function. Set to 0.0 if
+        ``fit_intercept = False``.
 
     alpha_ : float
        Estimated precision of the noise.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #13409
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Adds note that the intercept_ parameter does not have a probabilistic posterior associated, is only a point estimate. Ideally, it would optionally be treated as a probabilistic parameter, but this is non-trivial, as the prior should be uniform, which differs from the dependent parameters.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
