### PR TITLE
[MRG] Ignores maint_tools in pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ addopts =
     --ignore benchmarks
     --ignore doc
     --ignore examples
+    --ignore maint_tools
     --doctest-modules
     --disable-pytest-warnings
     -rs


### PR DESCRIPTION
This PR updates the pytest config to ignore `maint_tools`.