### PR TITLE
Weighted scoring in cross validation (Closes #4632)

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -886,8 +886,6 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
                    splits=True, rank=True,
                    weights=test_sample_counts if iid else None)
             if self.return_train_score:
-                # _store('train_%s' % scorer_name, train_scores[scorer_name],
-                #        splits=True)
                 _store('train_%s' % scorer_name, train_scores[scorer_name],
                        splits=True,
                        weights=train_sample_counts if iid else None)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -664,8 +664,8 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
                 return train_wt, test_wt
 
             def fit_and_score_and_sw_sum(est, X, y, train, test,
-                                          parameters,
-                                          **fit_and_score_kwargs):
+                                         parameters,
+                                         **fit_and_score_kwargs):
                 res = _fit_and_score(est, X, y, train=train, test=test,
                                      parameters=parameters,
                                      **fit_and_score_kwargs)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -840,7 +840,7 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
         if self.return_train_score:
             if train_sample_weight_sums is None:
                 # Because the cv iterators may not iterate over the entire
-                # dataset we can't just use the dataset size directly.
+                # dataset, we can't just use the dataset size directly.
                 samples = int(np.sum(test_sample_counts[:n_splits]))
                 train_sample_counts = samples - \
                     np.array(test_sample_counts[:n_splits], dtype=np.int)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -839,6 +839,8 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
         # test_sample_weight_sums.
         if self.return_train_score:
             if train_sample_weight_sums is None:
+                # Because the cv iterators may not iterate over the entire
+                # dataset we can't just use the dataset size directly.
                 samples = int(np.sum(test_sample_counts[:n_splits]))
                 train_sample_counts = samples - \
                     np.array(test_sample_counts[:n_splits], dtype=np.int)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -840,9 +840,8 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
         if self.return_train_score:
             if train_sample_weight_sums is None:
                 samples = int(np.sum(test_sample_counts[:n_splits]))
-                train_sample_counts = \
-                    np.array(test_sample_counts[:n_splits], dtype=np.int) - \
-                    samples
+                train_sample_counts = samples - \
+                    np.array(test_sample_counts[:n_splits], dtype=np.int)
             else:
                 train_sample_counts = np.array(
                     train_sample_weight_sums[:n_splits],

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -651,7 +651,7 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
             def is_none(x):
                 return x is None
 
-            def collape_nones(xs):
+            def collapse_nones(xs):
                 return None if xs is None or any(map(is_none, xs)) else xs
 
             def weights_sums(train_ind, test_ind, sample_weight):
@@ -702,8 +702,8 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
                 else:
                     out, train_wts, test_wts = ([], [], [])
 
-                train_wts = collape_nones(train_wts)
-                test_wts = collape_nones(test_wts)
+                train_wts = collapse_nones(train_wts)
+                test_wts = collapse_nones(test_wts)
 
                 if len(out) < 1:
                     raise ValueError('No fits were performed. '

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -531,8 +531,8 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
             raise
         elif error_score == 'raise-deprecating':
             warnings.warn("From version 0.22, errors during fit will result "
-                          "in a cross validation score of NaN by default. Use "
-                          "error_score='raise' if you want an exception "
+                          "in a cross validation score of NaN by default. Use"
+                          " error_score='raise' if you want an exception "
                           "raised or error_score=np.nan to adopt the "
                           "behavior from version 0.22.",
                           FutureWarning)
@@ -549,14 +549,15 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
                 if return_train_score:
                     train_scores = error_score
             warnings.warn("Estimator fit failed. The score on this train-test"
-                          " partition for these parameters will be set to %f. "
-                          "Details: \n%s" %
+                          " partition for these parameters will be set to %f."
+                          " Details: \n%s" %
                           (error_score, format_exception_only(type(e), e)[0]),
                           FitFailedWarning)
         else:
             raise ValueError("error_score must be the string 'raise' or a"
                              " numeric value. (Hint: if using 'raise', please"
-                             " make sure that it has been spelled correctly.)")
+                             " make sure that it has been spelled correctly.)"
+                             )
 
     else:
         fit_time = time.time() - start_time
@@ -601,7 +602,8 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     return ret
 
 
-def _score(estimator, X_test, y_test, scorer, is_multimetric=False, sample_weight=None):
+def _score(estimator, X_test, y_test, scorer, is_multimetric=False,
+           sample_weight=None):
     """Compute the score(s) of an estimator on a given test set.
 
     Will return a single float if is_multimetric is False and a dict of floats,
@@ -612,7 +614,8 @@ def _score(estimator, X_test, y_test, scorer, is_multimetric=False, sample_weigh
     # backward compatibility.
 
     if is_multimetric:
-        return _multimetric_score(estimator, X_test, y_test, scorer, sample_weight)
+        return _multimetric_score(estimator, X_test, y_test, scorer,
+                                  sample_weight)
     else:
         score = _apply_scorer(estimator, X_test, y_test, scorer, sample_weight)
 
@@ -712,7 +715,7 @@ def _apply_scorer(estimator, X, y, scorer, sample_weight):
                 raise TypeError(
                     (
                         "Attempted to use 'sample_weight' for training "
-                        "but supplied a scorer that doesn't accept a " 
+                        "but supplied a scorer that doesn't accept a "
                         "'sample_weight' parameter."
                     ), e)
             else:

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -488,7 +488,6 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     # Adjust length of sample weights
     fit_params = fit_params if fit_params is not None else {}
 
-    # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
     # Appears before fit_params indexing because the update to fit_params
     # is reassigned to fit_params and throws away test-based sample weights.
     if 'sample_weight' in fit_params and \
@@ -499,7 +498,6 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
             test)
     else:
         test_sample_weight = None
-    # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
 
     fit_params = {k: _index_param_value(X, v, train)
                   for k, v in fit_params.items()}
@@ -559,19 +557,12 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     else:
         fit_time = time.time() - start_time
         # _score will return dict if is_multimetric is True
-        # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
         test_scores = _score(estimator, X_test, y_test, scorer, is_multimetric, test_sample_weight)
-        # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-        # test_scores = _score(estimator, X_test, y_test, scorer, is_multimetric)
 
         score_time = time.time() - start_time - fit_time
         if return_train_score:
-            # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
             train_scores = _score(estimator, X_train, y_train, scorer,
                                   is_multimetric, fit_params.get('sample_weight', None))
-            # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-            # train_scores = _score(estimator, X_train, y_train, scorer,
-            #                       is_multimetric)
     if verbose > 2:
         if is_multimetric:
             for scorer_name in sorted(test_scores):
@@ -604,35 +595,16 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     return ret
 
 
-# vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
 def _score(estimator, X_test, y_test, scorer, is_multimetric=False, sample_weight=None):
-# ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-# def _score(estimator, X_test, y_test, scorer, is_multimetric=False):
     """Compute the score(s) of an estimator on a given test set.
 
     Will return a single float if is_multimetric is False and a dict of floats,
     if is_multimetric is True
     """
     if is_multimetric:
-        # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
         return _multimetric_score(estimator, X_test, y_test, scorer, sample_weight)
-        # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-        # return _multimetric_score(estimator, X_test, y_test, scorer)
     else:
-        # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
         score = _apply_scorer(estimator, X_test, y_test, scorer, sample_weight)
-        # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-
-        # if y_test is None:
-        #     # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
-        #     score = scorer(estimator, X_test, sample_weight=sample_weight)
-        #     # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-        #     # score = scorer(estimator, X_test)
-        # else:
-        #     # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
-        #     score = scorer(estimator, X_test, y_test, sample_weight=sample_weight)
-        #     # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-        #     # score = scorer(estimator, X_test, y_test)
 
         if hasattr(score, 'item'):
             try:
@@ -649,28 +621,12 @@ def _score(estimator, X_test, y_test, scorer, is_multimetric=False, sample_weigh
     return score
 
 
-# vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
 def _multimetric_score(estimator, X_test, y_test, scorers, sample_weight):
-# ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-# def _multimetric_score(estimator, X_test, y_test, scorers):
     """Return a dict of score for multimetric scoring"""
     scores = {}
 
     for name, scorer in scorers.items():
-        # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
         score = _apply_scorer(estimator, X_test, y_test, scorer, sample_weight)
-        # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-
-        # if y_test is None:
-        #     # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
-        #     score = scorer(estimator, X_test, sample_weight=sample_weight)
-        #     # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-        #     # score = scorer(estimator, X_test)
-        # else:
-        #     # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
-        #     score = scorer(estimator, X_test, y_test, sample_weight=sample_weight)
-        #     # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-        #     # score = scorer(estimator, X_test, y_test)
 
         if hasattr(score, 'item'):
             try:

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -715,6 +715,8 @@ def _apply_scorer(estimator, X, y, scorer, sample_weight):
                         "but supplied a scorer that doesn't accept a " 
                         "'sample_weight' parameter."
                     ), e)
+            else:
+                raise e
     return score
 
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -391,6 +391,10 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
                    error_score='raise-deprecating'):
     """Fit estimator and compute scores for a given dataset split.
 
+    NOTE: If sample_weight is supplied in ``fit_params``, it will be used for
+          both learning and will be passed to scorer for use in metric
+          calculations.
+
     Parameters
     ----------
     estimator : estimator object implementing 'fit'

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -557,12 +557,14 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     else:
         fit_time = time.time() - start_time
         # _score will return dict if is_multimetric is True
-        test_scores = _score(estimator, X_test, y_test, scorer, is_multimetric, test_sample_weight)
+        test_scores = _score(estimator, X_test, y_test, scorer,
+                             is_multimetric, test_sample_weight)
 
         score_time = time.time() - start_time - fit_time
         if return_train_score:
             train_scores = _score(estimator, X_train, y_train, scorer,
-                                  is_multimetric, fit_params.get('sample_weight', None))
+                                  is_multimetric,
+                                  fit_params.get('sample_weight', None))
     if verbose > 2:
         if is_multimetric:
             for scorer_name in sorted(test_scores):
@@ -601,6 +603,10 @@ def _score(estimator, X_test, y_test, scorer, is_multimetric=False, sample_weigh
     Will return a single float if is_multimetric is False and a dict of floats,
     if is_multimetric is True
     """
+
+    # sample_weight is optional because we want to put it at the end to allow
+    # backward compatibility.
+
     if is_multimetric:
         return _multimetric_score(estimator, X_test, y_test, scorer, sample_weight)
     else:

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -698,6 +698,11 @@ def _apply_scorer(estimator, X, y, scorer, sample_weight):
             score = scorer(estimator, X, y)
     else:
         try:
+            # Explicitly force the sample_weight parameter so that an error
+            # will be raised in the event that the scorer doesn't take a
+            # sample_weight argument.  This is preferable to passing it as
+            # a keyword args dict in the case that it just ignores parameters
+            # that are not accepted by the scorer.
             if y is None:
                 score = scorer(estimator, X, sample_weight=sample_weight)
             else:

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1654,20 +1654,19 @@ def test_sample_weight():
     assert test_metric == exp_test_acc
 
 
-@pytest.mark.parametrize(
-    "met_name,metric,greater_is_better,needs_proba,sample_wt", [
-    ("accuracy", accuracy_score, True, False, [1, 999999, 1, 999999]),
-    ("accuracy", accuracy_score, True, False, [100000, 200000, 100000, 200000]),
-    ("accuracy", accuracy_score, True, False, [100000, 100000, 100000, 100000]),
-    ("accuracy", accuracy_score, True, False, [200000, 100000, 200000, 100000]),
-    ("accuracy", accuracy_score, True, False, [999999, 1, 999999, 1]),
-    ("accuracy", accuracy_score, True, False, [2000000, 1000000, 1, 999999]),
-    ("precision", precision_score, True, False, [2000000, 1000000, 1, 999999]),
-    ("neg_log_loss", log_loss, False, True, [2500000, 500000, 200000, 100000]),
-    ("brier_score_loss", brier_score_loss, False, True, [2500000, 500000, 200000, 100000]),
+@pytest.mark.parametrize("metric,greater_is_better,needs_proba,sample_wt", [
+    (accuracy_score, True, False, [1, 999999, 1, 999999]),
+    (accuracy_score, True, False, [100000, 200000, 100000, 200000]),
+    (accuracy_score, True, False, [100000, 100000, 100000, 100000]),
+    (accuracy_score, True, False, [200000, 100000, 200000, 100000]),
+    (accuracy_score, True, False, [999999, 1, 999999, 1]),
+    (accuracy_score, True, False, [2000000, 1000000, 1, 999999]),
+    (precision_score, True, False, [2000000, 1000000, 1, 999999]),
+    (log_loss, False, True, [2500000, 500000, 200000, 100000]),
+    (brier_score_loss, False, True, [2500000, 500000, 200000, 100000]),
 ])
 def test_sample_weight_cross_validation(
-        met_name, metric, greater_is_better, needs_proba, sample_wt):
+        metric, greater_is_better, needs_proba, sample_wt):
     # Test that cross validation properly uses sample_weight from fit_params
     # when calculating the desired metrics.
 
@@ -1704,7 +1703,7 @@ def test_sample_weight_cross_validation(
     gscv = GridSearchCV(
         LogisticRegression(),
         param_grid={"random_state": [15432]},
-        scoring=met_name,
+        scoring=make_scorer(metric, greater_is_better, needs_proba),
         cv=2,
         return_train_score=True
     )

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1671,12 +1671,21 @@ def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2, exp):
     sample_weight = np.array(sample_wt)
 
     sum_sample_weight = np.sum(sample_weight)
+
     norm1_wt_f1 = sample_weight[f1] / np.sum(sample_weight[f1])
+    y1 = y[f1]
+    model2 = [np.round(np.dot(y[f2], sample_weight[f2])/np.sum(sample_weight[f2]))] * len(f2)
+    sklearn_acc1 = accuracy_score(y1, model2, sample_weight=sample_weight[f1])
+
     acc1 = np.dot(y[f1], norm1_wt_f1)
     acc1 = acc1 if not flip_acc_1 else 1 - acc1
     ratio_wt_f1 = np.sum(sample_weight[f1]) / sum_sample_weight
 
     norm1_wt_f2 = sample_weight[f2] / np.sum(sample_weight[f2])
+    y2 = y[f2]
+    model1 = [np.round(np.dot(y[f1], sample_weight[f1])/np.sum(sample_weight[f1]))] * len(f1)
+    sklearn_acc2 = accuracy_score(y2, model1, sample_weight=sample_weight[f2])
+
     acc2 = np.dot(y[f2], norm1_wt_f2)
     acc2 = acc2 if not flip_acc_2 else 1 - acc2
     ratio_wt_f2 = np.sum(sample_weight[f2]) / sum_sample_weight
@@ -1697,6 +1706,8 @@ def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2, exp):
 
     # Assert the above math for exp_cv_acc is correct.
     np.testing.assert_almost_equal(exp_cv_acc, exp, decimal=12)
+    np.testing.assert_almost_equal(acc1, sklearn_acc1, decimal=12)
+    np.testing.assert_almost_equal(acc2, sklearn_acc2, decimal=12)
 
     # Assert that the sample weights for each fold were normalized by the
     # L1 norm.

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1652,13 +1652,13 @@ def test_sample_weight():
     assert test_metric == exp_test_acc
 
 
-@pytest.mark.parametrize("sample_wt,flip_acc_1,flip_acc_2, exp", [
-    ([1, 999999, 1, 999999], False, False, 999999/1000000),
-    ([100000, 200000, 100000, 200000], False, False, 2/3),
-    ([100000, 100000, 100000, 100000], False, False, 1/2),
-    ([200000, 100000, 200000, 100000], True, True, 2/3),
-    ([999999, 1, 999999, 1], True, True, 999999/1000000),
-    ([2000000, 1000000, 1, 999999], False, True, 1000001/4000000)
+@pytest.mark.parametrize("sample_wt,flip_acc_1,flip_acc_2,exp", [
+    ([1, 999999, 1, 999999], True, True, 999999/1000000),
+    ([100000, 200000, 100000, 200000], True, True, 2/3),
+    ([100000, 100000, 100000, 100000], True, True, 1/2),
+    ([200000, 100000, 200000, 100000], False, False, 2/3),
+    ([999999, 1, 999999, 1], False, False, 999999/1000000),
+    ([2000000, 1000000, 1, 999999], True, False, 1000001/4000000)
 ])
 def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2, exp):
     # Test that cross validation properly uses sample_weight from fit_params
@@ -1673,12 +1673,12 @@ def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2, exp):
     sum_sample_weight = np.sum(sample_weight)
     norm1_wt_f1 = sample_weight[f1] / np.sum(sample_weight[f1])
     acc1 = np.dot(y[f1], norm1_wt_f1)
-    acc1 = acc1 if flip_acc_1 else 1 - acc1
+    acc1 = acc1 if not flip_acc_1 else 1 - acc1
     ratio_wt_f1 = np.sum(sample_weight[f1]) / sum_sample_weight
 
     norm1_wt_f2 = sample_weight[f2] / np.sum(sample_weight[f2])
     acc2 = np.dot(y[f2], norm1_wt_f2)
-    acc2 = acc2 if flip_acc_2 else 1 - acc2
+    acc2 = acc2 if not flip_acc_2 else 1 - acc2
     ratio_wt_f2 = np.sum(sample_weight[f2]) / sum_sample_weight
 
     exp_cv_acc = acc1 * ratio_wt_f1 + acc2 * ratio_wt_f2

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1653,7 +1653,11 @@ def test_sample_weight():
 
 
 @pytest.mark.parametrize("sample_wt,flip_acc_1,flip_acc_2", [
+    ([1, 999999, 1, 999999], False, False),
     ([100000, 200000, 100000, 200000], False, False),
+    ([100000, 100000, 100000, 100000], False, False),
+    ([200000, 100000, 200000, 100000], True, True),
+    ([999999, 1, 999999, 1], True, True),
     ([2000000, 1000000, 1, 999999], False, True)
 ])
 def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2):

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1662,13 +1662,14 @@ def test_sample_weight_cross_validation():
     f2 = np.array([2, 3])       # Fold 2.
     sample_weight = np.array([2000000, 1000000, 1, 999999])
 
+    sum_sample_weight = np.sum(sample_weight)
     norm1_wt_f1 = sample_weight[f1] / np.sum(sample_weight[f1])
     acc1 = (1 - np.dot(y[f1], norm1_wt_f1))
-    ratio_wt_f1 = np.sum(sample_weight[f1]) / np.sum(sample_weight)
+    ratio_wt_f1 = np.sum(sample_weight[f1]) / sum_sample_weight
 
     norm1_wt_f2 = sample_weight[f2] / np.sum(sample_weight[f2])
     acc2 = np.dot(y[f2], norm1_wt_f2)
-    ratio_wt_f2 = np.sum(sample_weight[f2]) / np.sum(sample_weight)
+    ratio_wt_f2 = np.sum(sample_weight[f2]) / sum_sample_weight
 
     # 0.25000025 = 1000001 / 4000000 = 1/3 * 3/4 + 1/1000000 * 1/4
     exp_cv_acc = acc1 * ratio_wt_f1 + acc2 * ratio_wt_f2
@@ -1684,6 +1685,13 @@ def test_sample_weight_cross_validation():
     gscv.fit(X, y, sample_weight=sample_weight)
     best_score = gscv.best_score_
     np.testing.assert_almost_equal(best_score, exp_cv_acc)
+
+    # Assert that the sample weights for each fold were normalized by the
+    # L1 norm.
+    np.testing.assert_almost_equal(np.sum(norm1_wt_f1), 1)
+    np.all(norm1_wt_f1 >= 0)
+    np.testing.assert_almost_equal(np.sum(norm1_wt_f2), 1)
+    np.all(norm1_wt_f2 >= 0)
 
 
 @pytest.mark.parametrize("replications,sample_wt,pass_none", [

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1700,9 +1700,10 @@ def test_sample_weight_cross_validation(
     sign = 1 if greater_is_better else -1
     exp_cv_score = sign * (met1 * ratio_wt_f1 + met2 * ratio_wt_f2)
 
+    # There's nothing special about GridSearchCV. Could be RandomizedSearchCV.
     gscv = GridSearchCV(
         LogisticRegression(),
-        param_grid={"random_state": [15432]},
+        {"random_state": [15432]},  # parameters
         scoring=make_scorer(metric, greater_is_better, needs_proba),
         cv=2,
         return_train_score=True

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1653,12 +1653,12 @@ def test_sample_weight():
 
 
 @pytest.mark.parametrize("sample_wt,flip_acc_1,flip_acc_2, exp", [
-    ([1, 999999, 1, 999999], False, False, 0.999999),
-    ([100000, 200000, 100000, 200000], False, False, 2/3.0),
-    ([100000, 100000, 100000, 100000], False, False, 1/2.0),
-    ([200000, 100000, 200000, 100000], True, True, 2/3.0),
-    ([999999, 1, 999999, 1], True, True, 0.999999),
-    ([2000000, 1000000, 1, 999999], False, True, 0.25000025)
+    ([1, 999999, 1, 999999], False, False, 999999/1000000),
+    ([100000, 200000, 100000, 200000], False, False, 2/3),
+    ([100000, 100000, 100000, 100000], False, False, 1/2),
+    ([200000, 100000, 200000, 100000], True, True, 2/3),
+    ([999999, 1, 999999, 1], True, True, 999999/1000000),
+    ([2000000, 1000000, 1, 999999], False, True, 1000001/4000000)
 ])
 def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2, exp):
     # Test that cross validation properly uses sample_weight from fit_params

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1652,15 +1652,15 @@ def test_sample_weight():
     assert test_metric == exp_test_acc
 
 
-@pytest.mark.parametrize("sample_wt,flip_acc_1,flip_acc_2", [
-    ([1, 999999, 1, 999999], False, False),
-    ([100000, 200000, 100000, 200000], False, False),
-    ([100000, 100000, 100000, 100000], False, False),
-    ([200000, 100000, 200000, 100000], True, True),
-    ([999999, 1, 999999, 1], True, True),
-    ([2000000, 1000000, 1, 999999], False, True)
+@pytest.mark.parametrize("sample_wt,flip_acc_1,flip_acc_2, exp", [
+    ([1, 999999, 1, 999999], False, False, 0.999999),
+    ([100000, 200000, 100000, 200000], False, False, 2/3.0),
+    ([100000, 100000, 100000, 100000], False, False, 1/2.0),
+    ([200000, 100000, 200000, 100000], True, True, 2/3.0),
+    ([999999, 1, 999999, 1], True, True, 0.999999),
+    ([2000000, 1000000, 1, 999999], False, True, 0.25000025)
 ])
-def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2):
+def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2, exp):
     # Test that cross validation properly uses sample_weight from fit_params
     # when calculating the desired metrics.
 
@@ -1693,7 +1693,10 @@ def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2):
 
     gscv.fit(X, y, sample_weight=sample_weight)
     best_score = gscv.best_score_
-    np.testing.assert_almost_equal(best_score, exp_cv_acc, decimal=12)
+    np.testing.assert_almost_equal(exp_cv_acc, best_score, decimal=12)
+
+    # Assert the above math for exp_cv_acc is correct.
+    np.testing.assert_almost_equal(exp_cv_acc, exp, decimal=12)
 
     # Assert that the sample weights for each fold were normalized by the
     # L1 norm.

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1632,9 +1632,6 @@ def test_sample_weight():
         error_score='raise-deprecating'
     )
 
-    # It is appropriate to use exact tests and not np.isclose because
-    # accuracy should be computed exactly since it's based on
-    # counts.
     train_metric = res[0][metric_name]
     test_metric = res[1][metric_name]
 
@@ -1644,5 +1641,9 @@ def test_sample_weight():
     assert test_metric != np.sum(y[test]) / y[test].shape[0]
 
     # The proper sampled weighted metric value.
+    #
+    # It is appropriate to use exact tests and not np.isclose because
+    # accuracy should be computed exactly since it's based on
+    # counts.
     assert train_metric == exp_train_pr
     assert test_metric == exp_test_acc

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1582,3 +1582,66 @@ def test_score():
     fit_and_score_args = [None, None, None, two_params_scorer]
     assert_raise_message(ValueError, error_message,
                          _score, *fit_and_score_args)
+
+
+def test_sample_weight():
+    X = np.ones([4, 1])         # Constant features to learn intercept.
+    y = np.array([1, 0, 1, 0])  # Some +/- for both test and train.
+    train = np.array([0, 1])    # First two indices are train.
+    test = np.array([2, 3])     # Last two indices are test.
+    sample_weight = np.array([2000000, 1000000, 1, 1000000])
+
+    exp_test_acc = np.dot(y[test], sample_weight[test]) / np.sum(
+        sample_weight[test])
+    exp_train_pr = np.dot(y[train], sample_weight[train]) / np.sum(
+        sample_weight[train])
+    exp_preds = np.array([exp_train_pr] * test.shape[0])
+
+    random_state = 15432
+    estimator = LogisticRegression()
+
+    # Step 1: Check that the classifier learned the sample weighted class
+    #         prior probability.  Check predict_proba versus the known
+    #         class prior: exp_train_pr.
+    est_clone = clone(estimator)
+    est_clone.set_params(random_state=random_state)
+    est_clone.fit(X[tuple(train), :], y[train], sample_weight[train])
+    preds = est_clone.predict_proba(X[tuple(test), :])[:, 1]
+    np.testing.assert_array_almost_equal(exp_preds, preds)
+
+    # Step 2: Check that the accuracy computation in _fit_and_score
+    #         respects sample_weight.
+
+    metric_name = 'accuracy'
+    scorer = {metric_name: make_scorer(accuracy_score)}
+
+    res = _fit_and_score(
+        estimator, X, y, scorer, train, test,
+        verbose=0,
+        parameters=dict(random_state=random_state),
+        fit_params=dict(sample_weight=sample_weight),
+
+        # Based on parameters from in _fit_and_score when called from
+        # RandomizedSearchCV.fit
+        return_train_score='warn',
+        return_parameters=False,
+        return_n_test_samples=True,
+        return_times=True,
+        return_estimator=False,
+        error_score='raise-deprecating'
+    )
+
+    # It is appropriate to use exact tests and not np.isclose because
+    # accuracy should be computed exactly since it's based on
+    # counts.
+    train_metric = res[0][metric_name]
+    test_metric = res[1][metric_name]
+
+    # Unnecessary extra test to illustrate that this is not the desired
+    # metric value (but previously what has been historically returned).
+    assert train_metric != np.sum(y[train]) / y[train].shape[0]
+    assert test_metric != np.sum(y[test]) / y[test].shape[0]
+
+    # The proper sampled weighted metric value.
+    assert train_metric == exp_train_pr
+    assert test_metric == exp_test_acc

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1603,6 +1603,7 @@ def test_sample_weight():
     # Step 1: Check that the classifier learned the sample weighted class
     #         prior probability.  Check predict_proba versus the known
     #         class prior: exp_train_pr.
+    #
     est_clone = clone(estimator)
     est_clone.set_params(random_state=random_state)
     est_clone.fit(X[tuple(train), :], y[train], sample_weight[train])
@@ -1611,7 +1612,7 @@ def test_sample_weight():
 
     # Step 2: Check that the accuracy computation in _fit_and_score
     #         respects sample_weight.
-
+    #
     metric_name = 'accuracy'
     scorer = {metric_name: make_scorer(accuracy_score)}
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #4632. See also #10806. 

#### What does this implement/fix? Explain your changes.

This PR adds `sample_weight` to metrics in cross validation routines by propagating the `sample_weight` parameter passed to `fit_params`.  It does not provide the ability to use different `sample_weight` values in validation.

#### Any other comments?

A [dask](http://dask.org) version of this PR has been created at https://github.com/dask/dask-ml/pull/481

For more detailed information on the motivation for this PR, see http://deaktator.github.io/2019/03/10/the-error-in-the-comparator/