### PR TITLE
[MRG] TST Fix slow test in pairwise.

### DIFF
--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -905,7 +905,7 @@ def test_pairwise_distances_data_derived_params(n_jobs, metric, dist_function,
                                                 y_is_x):
     # check that pairwise_distances give the same result in sequential and
     # parallel, when metric has data-derived parameters.
-    with config_context(working_memory=0.1):  # to have more than 1 chunk
+    with config_context(working_memory=1):  # to have more than 1 chunk
         rng = np.random.RandomState(0)
         X = rng.random_sample((1000, 10))
 


### PR DESCRIPTION
Fixes #13208

I've been able to reproduce locally so it was not a matter of distribution.

The issue was that with the previous working memory, `pairwise_distances_chunked` made 77 chunks, leading to 77 calls to joblib parallel, re-creating the thread-pool each time. (I guess this is a situation where backend='loky' would be better but should not happen in practice)