### PR TITLE
fixed issue #13324 removed warn_on_dtype references in pairwise.py

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -99,19 +99,18 @@ def check_pairwise_arrays(X, Y, precomputed=False, dtype=None):
     """
     X, Y, dtype_float = _return_float_dtype(X, Y)
 
-    warn_on_dtype = dtype is not None
     estimator = 'check_pairwise_arrays'
     if dtype is None:
         dtype = dtype_float
 
     if Y is X or Y is None:
         X = Y = check_array(X, accept_sparse='csr', dtype=dtype,
-                            warn_on_dtype=warn_on_dtype, estimator=estimator)
+                            estimator=estimator)
     else:
         X = check_array(X, accept_sparse='csr', dtype=dtype,
-                        warn_on_dtype=warn_on_dtype, estimator=estimator)
+                        estimator=estimator)
         Y = check_array(Y, accept_sparse='csr', dtype=dtype,
-                        warn_on_dtype=warn_on_dtype, estimator=estimator)
+                        estimator=estimator)
 
     if precomputed:
         if X.shape[1] != Y.shape[0]:


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #13324.

#### What does this implement/fix? Explain your changes.
Per issue [13324](https://github.com/scikit-learn/scikit-learn/issues/13324), warn_on_dtype is deprecated and therefore this commit removes references to it in sklearn/metrics/pairwise.py

#### Any other comments?
This is my first open source pull-request so apologies for any hand-holding that may result, but hopefully I followed all necessary guidelines. Looking forward to continuing to contribute if this was indeed helpful.
