### PR TITLE
EXA Use stem plot for ElasticNet and Lasso coefficients

### DIFF
--- a/examples/linear_model/plot_lasso_and_elasticnet.py
+++ b/examples/linear_model/plot_lasso_and_elasticnet.py
@@ -22,7 +22,7 @@ np.random.seed(42)
 n_samples, n_features = 50, 100
 X = np.random.randn(n_samples, n_features)
 idx = np.arange(n_features)
-coef = (- 1) ** idx * np.exp(- idx / 10)
+coef = (-1) ** idx * np.exp(-idx / 10)
 coef[10:] = 0  # sparsify coef
 y = np.dot(X, coef)
 

--- a/examples/linear_model/plot_lasso_and_elasticnet.py
+++ b/examples/linear_model/plot_lasso_and_elasticnet.py
@@ -58,12 +58,12 @@ r2_score_enet = r2_score(y_test, y_pred_enet)
 print(enet)
 print("r^2 on test data : %f" % r2_score_enet)
 
-plt.plot(enet.coef_, color='lightgreen', linewidth=2,
-         label='Elastic net coefficients')
-plt.plot(lasso.coef_, color='gold', linewidth=2,
-         label='Lasso coefficients')
-plt.plot(coef, '--', color='navy', label='original coefficients')
+plt.stem(np.where(enet.coef_)[0], enet.coef_[enet.coef_ != 0], 'C1--',
+         markerfmt='C1x', label='Elastic net coefficients')
+plt.stem(np.where(lasso.coef_)[0], lasso.coef_[lasso.coef_ != 0], 'C2--',
+         markerfmt='C2x', label='Lasso coefficients')
+plt.stem(np.where(coef)[0], coef[coef != 0], label='original coefficients')
 plt.legend(loc='best')
-plt.title("Lasso R^2: %f, Elastic Net R^2: %f"
-          % (r2_score_lasso, r2_score_enet))
+plt.title("Lasso $R^2$: %.3f, Elastic Net $R^2$: %.3f"
+        % (r2_score_lasso, r2_score_enet))
 plt.show()

--- a/examples/linear_model/plot_lasso_and_elasticnet.py
+++ b/examples/linear_model/plot_lasso_and_elasticnet.py
@@ -22,9 +22,7 @@ np.random.seed(42)
 n_samples, n_features = 50, 200
 X = np.random.randn(n_samples, n_features)
 coef = 3 * np.random.randn(n_features)
-inds = np.arange(n_features)
-np.random.shuffle(inds)
-coef[inds[10:]] = 0  # sparsify coef
+coef[10:] = 0  # sparsify coef
 y = np.dot(X, coef)
 
 # add noise
@@ -58,12 +56,12 @@ r2_score_enet = r2_score(y_test, y_pred_enet)
 print(enet)
 print("r^2 on test data : %f" % r2_score_enet)
 
-plt.stem(np.where(enet.coef_)[0], enet.coef_[enet.coef_ != 0], 'C1--',
+plt.stem(np.where(enet.coef_)[0], enet.coef_[enet.coef_ != 0], 'C1-',
          markerfmt='C1x', label='Elastic net coefficients')
-plt.stem(np.where(lasso.coef_)[0], lasso.coef_[lasso.coef_ != 0], 'C2--',
+plt.stem(np.where(lasso.coef_)[0], lasso.coef_[lasso.coef_ != 0], 'C2-',
          markerfmt='C2x', label='Lasso coefficients')
 plt.stem(np.where(coef)[0], coef[coef != 0], label='original coefficients')
 plt.legend(loc='best')
 plt.title("Lasso $R^2$: %.3f, Elastic Net $R^2$: %.3f"
-        % (r2_score_lasso, r2_score_enet))
+          % (r2_score_lasso, r2_score_enet))
 plt.show()

--- a/examples/linear_model/plot_lasso_and_elasticnet.py
+++ b/examples/linear_model/plot_lasso_and_elasticnet.py
@@ -57,12 +57,15 @@ r2_score_enet = r2_score(y_test, y_pred_enet)
 print(enet)
 print("r^2 on test data : %f" % r2_score_enet)
 
-plt.stem(np.where(enet.coef_)[0], enet.coef_[enet.coef_ != 0], 'C1-',
-         markerfmt='C1x', label='Elastic net coefficients')
-plt.stem(np.where(lasso.coef_)[0], lasso.coef_[lasso.coef_ != 0], 'C2-',
-         markerfmt='C2x', label='Lasso coefficients')
+m, s, _ = plt.stem(np.where(enet.coef_)[0], enet.coef_[enet.coef_ != 0],
+                   markerfmt='x', label='Elastic net coefficients')
+plt.setp([m, s], color="#2ca02c")
+m, s, _ = plt.stem(np.where(lasso.coef_)[0], lasso.coef_[lasso.coef_ != 0],
+                   markerfmt='x', label='Lasso coefficients')
+plt.setp([m, s], color='#ff7f0e')
 plt.stem(np.where(coef)[0], coef[coef != 0], label='true coefficients',
-         markerfmt='C0x')
+         markerfmt='bx')
+
 plt.legend(loc='best')
 plt.title("Lasso $R^2$: %.3f, Elastic Net $R^2$: %.3f"
           % (r2_score_lasso, r2_score_enet))

--- a/examples/linear_model/plot_lasso_and_elasticnet.py
+++ b/examples/linear_model/plot_lasso_and_elasticnet.py
@@ -60,7 +60,8 @@ plt.stem(np.where(enet.coef_)[0], enet.coef_[enet.coef_ != 0], 'C1-',
          markerfmt='C1x', label='Elastic net coefficients')
 plt.stem(np.where(lasso.coef_)[0], lasso.coef_[lasso.coef_ != 0], 'C2-',
          markerfmt='C2x', label='Lasso coefficients')
-plt.stem(np.where(coef)[0], coef[coef != 0], label='original coefficients')
+plt.stem(np.where(coef)[0], coef[coef != 0], label='original coefficients',
+         markerfmt='C0x')
 plt.legend(loc='best')
 plt.title("Lasso $R^2$: %.3f, Elastic Net $R^2$: %.3f"
           % (r2_score_lasso, r2_score_enet))

--- a/examples/linear_model/plot_lasso_and_elasticnet.py
+++ b/examples/linear_model/plot_lasso_and_elasticnet.py
@@ -61,7 +61,7 @@ plt.stem(np.where(enet.coef_)[0], enet.coef_[enet.coef_ != 0], 'C1-',
          markerfmt='C1x', label='Elastic net coefficients')
 plt.stem(np.where(lasso.coef_)[0], lasso.coef_[lasso.coef_ != 0], 'C2-',
          markerfmt='C2x', label='Lasso coefficients')
-plt.stem(np.where(coef)[0], coef[coef != 0], label='original coefficients',
+plt.stem(np.where(coef)[0], coef[coef != 0], label='true coefficients',
          markerfmt='C0x')
 plt.legend(loc='best')
 plt.title("Lasso $R^2$: %.3f, Elastic Net $R^2$: %.3f"

--- a/examples/linear_model/plot_lasso_and_elasticnet.py
+++ b/examples/linear_model/plot_lasso_and_elasticnet.py
@@ -19,9 +19,10 @@ from sklearn.metrics import r2_score
 # Generate some sparse data to play with
 np.random.seed(42)
 
-n_samples, n_features = 50, 200
+n_samples, n_features = 50, 100
 X = np.random.randn(n_samples, n_features)
-coef = 3 * np.random.randn(n_features)
+idx = np.arange(n_features)
+coef = (- 1) ** idx * np.exp(- idx / 10)
 coef[10:] = 0  # sparsify coef
 y = np.dot(X, coef)
 

--- a/examples/linear_model/plot_lasso_and_elasticnet.py
+++ b/examples/linear_model/plot_lasso_and_elasticnet.py
@@ -21,12 +21,14 @@ np.random.seed(42)
 
 n_samples, n_features = 50, 100
 X = np.random.randn(n_samples, n_features)
+
+# Decreasing coef w. alternated signs for visualization
 idx = np.arange(n_features)
 coef = (-1) ** idx * np.exp(-idx / 10)
 coef[10:] = 0  # sparsify coef
 y = np.dot(X, coef)
 
-# add noise
+# Add noise
 y += 0.01 * np.random.normal(size=n_samples)
 
 # Split data in train set and test set


### PR DESCRIPTION


#### What does this implement/fix? Explain your changes.
Current plot in Lasso/Elastic net example uses lines and is somehow difficult to read.

To me, it makes little sense to use lines to plot coefficients, since there is no "order" or proximity between feature indices. Using a stem plot, and plotting only non-zero values, is clearer IMO.
I have also used math formatting for `R^2` and fewer significant digits in the legend.

Current plot:
![image](https://scikit-learn.org/stable/_images/sphx_glr_plot_lasso_and_elasticnet_001.png)

Proposed:
![image](https://user-images.githubusercontent.com/8993218/54182657-75703c00-44e5-11e9-895d-ee1c65ed525c.png)


#### Any other comments?
A notable drawback is that it makes the code a little bit more complicated
