### PR TITLE
adding length function to pipeline.py

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -403,6 +403,11 @@ Support for Python 3.4 and below has been officially dropped.
 - |API| :class:`pipeline.Pipeline` now supports using ``'passthrough'`` as a
   transformer. :issue:`11144` by :user:`Thomas Fan <thomasjpfan>`.
 
+- |Enhancement| :class:`pipeline.Pipeline` now implements a func
+  :func:`__len__()`,
+  that will return the length of the pipeline :issue `13439`
+  by :user:`Lakshya KD <LakshKD>`
+
 :mod:`sklearn.preprocessing`
 ............................
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -405,8 +405,8 @@ Support for Python 3.4 and below has been officially dropped.
 
 - |Enhancement| :class:`pipeline.Pipeline` now implements a func
   :func:`__len__()`,
-  that will return the length of the pipeline :issue `13439`
-  by :user:`Lakshya KD <LakshKD>`
+  that will return the length of the pipeline :issue:`13439`
+  by :user:`Lakshya KD <LakshKD>`.
 
 :mod:`sklearn.preprocessing`
 ............................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -413,8 +413,8 @@ Support for Python 3.4 and below has been officially dropped.
 - |API| :class:`pipeline.Pipeline` now supports using ``'passthrough'`` as a
   transformer. :issue:`11144` by :user:`Thomas Fan <thomasjpfan>`.
 
-- |Enhancement| :class:`pipeline.Pipeline`  implements __len__ and
-  therefore len(pipeline) returns the number of steps in the pipeline.
+- |Enhancement| :class:`pipeline.Pipeline`  implements ``__len__`` and
+  therefore ``len(pipeline)`` returns the number of steps in the pipeline.
   :issue:`13439` by :user:`Lakshya KD <LakshKD>`.
 
 :mod:`sklearn.preprocessing`

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -413,9 +413,9 @@ Support for Python 3.4 and below has been officially dropped.
 - |API| :class:`pipeline.Pipeline` now supports using ``'passthrough'`` as a
   transformer. :issue:`11144` by :user:`Thomas Fan <thomasjpfan>`.
 
-- |Enhancement| :class:`pipeline.Pipeline` implements a func len,
-  that will now work and return the length of the pipeline when called with
-  Pipeline object. :issue:`13439` by :user:`Lakshya KD <LakshKD>`.
+- |Enhancement| :class:`pipeline.Pipeline`  implements __len__ and
+  therefore len(pipeline) returns the number of steps in the pipeline.
+  :issue:`13439` by :user:`Lakshya KD <LakshKD>`.
 
 :mod:`sklearn.preprocessing`
 ............................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -403,10 +403,9 @@ Support for Python 3.4 and below has been officially dropped.
 - |API| :class:`pipeline.Pipeline` now supports using ``'passthrough'`` as a
   transformer. :issue:`11144` by :user:`Thomas Fan <thomasjpfan>`.
 
-- |Enhancement| :class:`pipeline.Pipeline` now implements a func
-  :func:`__len__()`,
-  that will return the length of the pipeline :issue:`13439`
-  by :user:`Lakshya KD <LakshKD>`.
+- |Enhancement| :class:`pipeline.Pipeline` implements a func len,
+  that will now work and return the length of the pipeline when called with
+  Pipeline object. :issue:`13439` by :user:`Lakshya KD <LakshKD>`.
 
 :mod:`sklearn.preprocessing`
 ............................

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -199,7 +199,7 @@ class Pipeline(_BaseComposition):
             if trans is not None and trans != 'passthrough':
                 yield idx, name, trans
 
-    def len(self):
+    def __len__(self):
         """
         Returns the length of the Pipeline
         """

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -199,6 +199,12 @@ class Pipeline(_BaseComposition):
             if trans is not None and trans != 'passthrough':
                 yield idx, name, trans
 
+    def len(self):
+        """
+        Returns the length of the Pipeline
+        """
+        return len(self.steps)
+
     def __getitem__(self, ind):
         """Returns a sub-pipeline or a single esimtator in the pipeline
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -24,13 +24,14 @@ from sklearn.pipeline import Pipeline, FeatureUnion, make_pipeline, make_union
 from sklearn.svm import SVC
 from sklearn.linear_model import LogisticRegression, Lasso
 from sklearn.linear_model import LinearRegression
+from sklearn.linear_model import SGDClassifier
 from sklearn.cluster import KMeans
 from sklearn.feature_selection import SelectKBest, f_classif
 from sklearn.dummy import DummyRegressor
 from sklearn.decomposition import PCA, TruncatedSVD
 from sklearn.datasets import load_iris
 from sklearn.preprocessing import StandardScaler
-from sklearn.feature_extraction.text import CountVectorizer
+from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
 from sklearn.utils._joblib import Memory
 from sklearn.utils._joblib import __version__ as joblib_version
 
@@ -1071,3 +1072,11 @@ def test_make_pipeline_memory():
     assert pipeline.memory is None
 
     shutil.rmtree(cachedir)
+
+def test__len__():
+    pipeline = Pipeline([
+        ('vect', CountVectorizer()),
+        ('tfidf', TfidfTransformer()),
+        ('clf', SGDClassifier()),
+    ])
+    assert_equal(pipeline.__len__(),3)

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -1069,15 +1069,6 @@ def test_make_pipeline_memory():
     assert pipeline.memory is memory
     pipeline = make_pipeline(DummyTransf(), SVC())
     assert pipeline.memory is None
+    assert len(pipeline) == 2
 
     shutil.rmtree(cachedir)
-
-
-def test__len__():
-    scaler_for_pipeline = StandardScaler()
-    km_for_pipeline = KMeans(random_state=0)
-    pipeline = Pipeline([
-        ('scaler', scaler_for_pipeline),
-        ('Kmeans', km_for_pipeline)
-    ])
-    assert len(pipeline) == 2

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -1080,4 +1080,4 @@ def test__len__():
         ('scaler', scaler_for_pipeline),
         ('Kmeans', km_for_pipeline)
     ])
-    assert pipeline.__len__() == 2
+    assert len(pipeline) == 2

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -24,14 +24,13 @@ from sklearn.pipeline import Pipeline, FeatureUnion, make_pipeline, make_union
 from sklearn.svm import SVC
 from sklearn.linear_model import LogisticRegression, Lasso
 from sklearn.linear_model import LinearRegression
-from sklearn.linear_model import SGDClassifier
 from sklearn.cluster import KMeans
 from sklearn.feature_selection import SelectKBest, f_classif
 from sklearn.dummy import DummyRegressor
 from sklearn.decomposition import PCA, TruncatedSVD
 from sklearn.datasets import load_iris
 from sklearn.preprocessing import StandardScaler
-from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
+from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.utils._joblib import Memory
 from sklearn.utils._joblib import __version__ as joblib_version
 
@@ -1075,9 +1074,11 @@ def test_make_pipeline_memory():
 
 
 def test__len__():
+    scaler_for_pipeline = StandardScaler()
+    km_for_pipeline = KMeans(random_state=0)
+    
     pipeline = Pipeline([
-        ('vect', CountVectorizer()),
-        ('tfidf', TfidfTransformer()),
-        ('clf', SGDClassifier()),
+        ('scaler', scaler_for_pipeline),
+        ('Kmeans', km_for_pipeline)
     ])
-    assert_equal(pipeline.__len__(), 3)
+    assert pipeline.__len__() == 2

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -1076,7 +1076,6 @@ def test_make_pipeline_memory():
 def test__len__():
     scaler_for_pipeline = StandardScaler()
     km_for_pipeline = KMeans(random_state=0)
-    
     pipeline = Pipeline([
         ('scaler', scaler_for_pipeline),
         ('Kmeans', km_for_pipeline)

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -1073,10 +1073,11 @@ def test_make_pipeline_memory():
 
     shutil.rmtree(cachedir)
 
+
 def test__len__():
     pipeline = Pipeline([
         ('vect', CountVectorizer()),
         ('tfidf', TfidfTransformer()),
         ('clf', SGDClassifier()),
     ])
-    assert_equal(pipeline.__len__(),3)
+    assert_equal(pipeline.__len__(), 3)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #13418 

#### What does this implement/fix? Explain your changes.
Adding length function in pipeline.py file that will return the length of the pipeline.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
