### PR TITLE
[MRG] Fix label_ranking_average_precision_score: sample_weighting isn't applied to items with zero true labels #13412

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -318,9 +318,9 @@ Support for Python 3.4 and below has been officially dropped.
   and now it returns NaN and raises :class:`exceptions.UndefinedMetricWarning`.
   :issue:`12855` by :user:`Pawel Sendyk <psendyk>`.
 
-- |Fix| :func:`metrics.label_ranking_average_precision_score` was returning
-  incorrect values where some samples had degenerate labels and `sample_weight`
-  was used.
+- |Fix| Fixed a bug in :func:`metrics.label_ranking_average_precision_score` 
+  where sample_weight wasn't taken into account for samples with degenerate
+  labels.
   :issue:`13447` by :user:`Dan Ellis <dpwe>`.
 
 - |API| The parameter ``labels`` in :func:`metrics.hamming_loss` is deprecated

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -321,6 +321,7 @@ Support for Python 3.4 and below has been officially dropped.
 - |Fix| :func:`metrics.label_ranking_average_precision_score` was returning
   incorrect values where some samples had degenerate labels and `sample_weight`
   was used.
+  :issue:`13447` by :user:`Dan Ellis <dpwe>`.
 
 - |API| The parameter ``labels`` in :func:`metrics.hamming_loss` is deprecated
   in version 0.21 and will be removed in version 0.23.

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -318,6 +318,10 @@ Support for Python 3.4 and below has been officially dropped.
   and now it returns NaN and raises :class:`exceptions.UndefinedMetricWarning`.
   :issue:`12855` by :user:`Pawel Sendyk <psendyk>`.
 
+- |Fix| :func:`metrics.label_ranking_average_precision_score` was returning
+  incorrect values where some samples had degenerate labels and `sample_weight`
+  was used.
+
 - |API| The parameter ``labels`` in :func:`metrics.hamming_loss` is deprecated
   in version 0.21 and will be removed in version 0.23.
   :issue:`10580` by :user:`Reshama Shaikh <reshamas>` and `Sandra

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -728,13 +728,13 @@ def label_ranking_average_precision_score(y_true, y_score, sample_weight=None):
         if (relevant.size == 0 or relevant.size == n_labels):
             # If all labels are relevant or unrelevant, the score is also
             # equal to 1. The label ranking has no meaning.
-            out += 1.
-            continue
+            aux = 1.
+        else:
+            scores_i = y_score[i]
+            rank = rankdata(scores_i, 'max')[relevant]
+            L = rankdata(scores_i[relevant], 'max')
+            aux = (L / rank).mean()
 
-        scores_i = y_score[i]
-        rank = rankdata(scores_i, 'max')[relevant]
-        L = rankdata(scores_i[relevant], 'max')
-        aux = (L / rank).mean()
         if sample_weight is not None:
             aux = aux * sample_weight[i]
         out += aux

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -952,23 +952,12 @@ def test_alternative_lrap_implementation(n_samples, n_classes, random_state):
                n_classes, n_samples, random_state)
 
 
-def test_lrap_sample_weighting():
-    # Per sample APs are 0.5, 0.75, and 1.0.
-    y_true = np.array([[1, 0, 0, 0], [1, 0, 0, 1], [1, 1, 0, 0]],
-                      dtype=np.bool)
-    y_score = np.array([[0.3, 0.4, 0.2, 0.1], [0.1, 0.2, 0.3, 0.4],
-                        [0.4, 0.3, 0.2, 0.1]])
-    samplewise_lraps = np.array([0.5, 0.75, 1.0])
-    sample_weight = np.array([1.0, 1.0, 0.0])
-
-    assert_almost_equal(
-        label_ranking_average_precision_score(y_true, y_score,
-                                              sample_weight=sample_weight),
-        np.sum(sample_weight * samplewise_lraps)/np.sum(sample_weight))
-
-
 def test_lrap_sample_weighting_zero_labels():
-    # Per sample APs are 0.5, 0.75, and 1.0 (default for zero labels).
+    # Degenerate sample labeling (e.g., zero labels for a sample) is a valid
+    # special case for lrap (the sample is considered to achieve perfect
+    # precision), but this case is not tested in test_common.
+    # For these test samples, the APs are 0.5, 0.75, and 1.0 (default for zero
+    # labels).
     y_true = np.array([[1, 0, 0, 0], [1, 0, 0, 1], [0, 0, 0, 0]],
                       dtype=np.bool)
     y_score = np.array([[0.3, 0.4, 0.2, 0.1], [0.1, 0.2, 0.3, 0.4],
@@ -979,7 +968,7 @@ def test_lrap_sample_weighting_zero_labels():
     assert_almost_equal(
         label_ranking_average_precision_score(y_true, y_score,
                                               sample_weight=sample_weight),
-        np.sum(sample_weight * samplewise_lraps)/np.sum(sample_weight))
+        np.sum(sample_weight * samplewise_lraps) / np.sum(sample_weight))
 
 
 def test_coverage_error():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -954,7 +954,8 @@ def test_alternative_lrap_implementation(n_samples, n_classes, random_state):
 
 def test_lrap_sample_weighting():
     # Per sample APs are 0.5, 0.75, and 1.0.
-    y_true = np.array([[1, 0, 0, 0], [1, 0, 0, 1], [1, 1, 0, 0]], dtype=np.bool)
+    y_true = np.array([[1, 0, 0, 0], [1, 0, 0, 1], [1, 1, 0, 0]],
+                      dtype=np.bool)
     y_score = np.array([[0.3, 0.4, 0.2, 0.1], [0.1, 0.2, 0.3, 0.4],
                         [0.4, 0.3, 0.2, 0.1]])
     samplewise_lraps = np.array([0.5, 0.75, 1.0])
@@ -968,8 +969,10 @@ def test_lrap_sample_weighting():
 
 def test_lrap_sample_weighting_zero_labels():
     # Per sample APs are 0.5, 0.75, and 1.0 (default for zero labels).
-    y_true = np.array([[1, 0, 0, 0], [1, 0, 0, 1], [0, 0, 0, 0]], dtype=np.bool)
-    y_score = np.array([[0.3, 0.4, 0.2, 0.1], [0.1, 0.2, 0.3, 0.4], [0.4, 0.3, 0.2, 0.1]])
+    y_true = np.array([[1, 0, 0, 0], [1, 0, 0, 1], [0, 0, 0, 0]],
+                      dtype=np.bool)
+    y_score = np.array([[0.3, 0.4, 0.2, 0.1], [0.1, 0.2, 0.3, 0.4],
+                        [0.4, 0.3, 0.2, 0.1]])
     samplewise_lraps = np.array([0.5, 0.75, 1.0])
     sample_weight = np.array([1.0, 1.0, 0.0])
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -952,6 +952,33 @@ def test_alternative_lrap_implementation(n_samples, n_classes, random_state):
                n_classes, n_samples, random_state)
 
 
+def test_lrap_sample_weighting():
+    # Per sample APs are 0.5, 0.75, and 1.0.
+    y_true = np.array([[1, 0, 0, 0], [1, 0, 0, 1], [1, 1, 0, 0]], dtype=np.bool)
+    y_score = np.array([[0.3, 0.4, 0.2, 0.1], [0.1, 0.2, 0.3, 0.4],
+                        [0.4, 0.3, 0.2, 0.1]])
+    samplewise_lraps = np.array([0.5, 0.75, 1.0])
+    sample_weight = np.array([1.0, 1.0, 0.0])
+
+    assert_almost_equal(
+        label_ranking_average_precision_score(y_true, y_score,
+                                              sample_weight=sample_weight),
+        np.sum(sample_weight * samplewise_lraps)/np.sum(sample_weight))
+
+
+def test_lrap_sample_weighting_zero_labels():
+    # Per sample APs are 0.5, 0.75, and 1.0 (default for zero labels).
+    y_true = np.array([[1, 0, 0, 0], [1, 0, 0, 1], [0, 0, 0, 0]], dtype=np.bool)
+    y_score = np.array([[0.3, 0.4, 0.2, 0.1], [0.1, 0.2, 0.3, 0.4], [0.4, 0.3, 0.2, 0.1]])
+    samplewise_lraps = np.array([0.5, 0.75, 1.0])
+    sample_weight = np.array([1.0, 1.0, 0.0])
+
+    assert_almost_equal(
+        label_ranking_average_precision_score(y_true, y_score,
+                                              sample_weight=sample_weight),
+        np.sum(sample_weight * samplewise_lraps)/np.sum(sample_weight))
+
+
 def test_coverage_error():
     # Toy case
     assert_almost_equal(coverage_error([[0, 1]], [[0.25, 0.75]]), 1)


### PR DESCRIPTION
Fixes #13412 

#### What does this implement/fix? Explain your changes.

`sklearn.metrics.label_ranking_average_precision_score` supports a `sample_weight` argument to allow different contributions of individual trial samples.  However, in the case where certain samples had degenerate labels (all true or none true), the special case logic that gave these samples a precision of 1.0 failed to apply the `sample_weight`s.  This is now corrected, with tests that exercise `sample_weight` without degenerate labels (a test that passed before the code was modified), and with degenerate labels (a test that failed until this change was applied).

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
