### PR TITLE
Updated error message to remove deprecated n_values

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -81,7 +81,7 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
 
         if self._categories != 'auto':
             if len(self._categories) != n_features:
-                raise ValueError("Shape mismatch: if n_values is an array,"
+                raise ValueError("Shape mismatch: if categories is an array,"
                                  " it has to be of shape (n_features,).")
 
         self.categories_ = []
@@ -571,7 +571,7 @@ class OneHotEncoder(_BaseEncoder):
                                 " 'auto', int or array of ints, got %r"
                                 % type(self._n_values))
             if n_values.ndim < 1 or n_values.shape[0] != X.shape[1]:
-                raise ValueError("Shape mismatch: if n_values is an array,"
+                raise ValueError("Shape mismatch: if categories is an array,"
                                  " it has to be of shape (n_features,).")
 
         self._n_values_ = n_values

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -571,7 +571,7 @@ class OneHotEncoder(_BaseEncoder):
                                 " 'auto', int or array of ints, got %r"
                                 % type(self._n_values))
             if n_values.ndim < 1 or n_values.shape[0] != X.shape[1]:
-                raise ValueError("Shape mismatch: if categories is an array,"
+                raise ValueError("Shape mismatch: if n_values is an array,"
                                  " it has to be of shape (n_features,).")
 
         self._n_values_ = n_values

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -692,12 +692,15 @@ def test_ordinal_encoder_raise_missing(X):
     with pytest.raises(ValueError, match="Input contains NaN"):
         ohe.transform(X)
 
+
 def test_ordinal_encoder_raise_categories_shape():
 
     X = np.array([['Low', 'Medium', 'High', 'Medium', 'Low']], dtype=object).T
-    cats = ['Low','Medium', 'High']
+    cats = ['Low', 'Medium', 'High']
     enc = OrdinalEncoder(categories=cats)
-    with pytest.raises(ValueError, match="Shape mismatch: if categories is an array,"):
+    msg = ("Shape mismatch: if categories is an array,")
+    #       "Call 'fit' with appropriate arguments before using this method.")
+    with pytest.raises(ValueError, match=msg):
         enc.fit(X)
 
 def test_encoder_dtypes():

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -699,7 +699,7 @@ def test_ordinal_encoder_raise_categories_shape():
     cats = ['Low', 'Medium', 'High']
     enc = OrdinalEncoder(categories=cats)
     msg = ("Shape mismatch: if categories is an array,")
-    #       "Call 'fit' with appropriate arguments before using this method.")
+    
     with pytest.raises(ValueError, match=msg):
         enc.fit(X)
 

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -699,7 +699,7 @@ def test_ordinal_encoder_raise_categories_shape():
     cats = ['Low', 'Medium', 'High']
     enc = OrdinalEncoder(categories=cats)
     msg = ("Shape mismatch: if categories is an array,")
-    
+
     with pytest.raises(ValueError, match=msg):
         enc.fit(X)
 

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -692,6 +692,13 @@ def test_ordinal_encoder_raise_missing(X):
     with pytest.raises(ValueError, match="Input contains NaN"):
         ohe.transform(X)
 
+def test_ordinal_encoder_raise_categories_shape():
+
+    X = np.array([['Low', 'Medium', 'High', 'Medium', 'Low']], dtype=object).T
+    cats = ['Low','Medium', 'High']
+    enc = OrdinalEncoder(categories=cats)
+    with pytest.raises(ValueError, match="Shape mismatch: if categories is an array,"):
+        enc.fit(X)
 
 def test_encoder_dtypes():
     # check that dtypes are preserved when determining categories


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #13446

#### What does this implement/fix? Explain your changes.
Updated error message to use categories in place of the deprecated n_values

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
