### PR TITLE
[MRG] Fixes  fbeta_score does not accept beta=0 #13224

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1068,8 +1068,7 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
 
     The `beta` parameter determines the weight of precision in the combined
     score. ``beta < 1`` lends more weight to precision, while ``beta > 1``
-    favors recall (``beta -> 0`` considers only precision, ``beta -> inf``
-    only recall).
+    favors recall (``beta -> inf`` considers only recall).
 
     Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
 
@@ -1410,7 +1409,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     ``UndefinedMetricWarning`` will be raised.
     """
     if beta <= 0:
-        raise ValueError("beta should be >0 in the F-beta score")
+        raise ValueError("beta should be >0 in the F-beta score, use the precision_score function for precision only")
     labels = _check_set_wise_labels(y_true, y_pred, average, labels,
                                     pos_label)
 

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1409,7 +1409,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     ``UndefinedMetricWarning`` will be raised.
     """
     if beta <= 0:
-        raise ValueError("beta should be >0 in the F-beta score, use the precision_score function for precision only")
+        raise ValueError("beta should be >0 in the F-beta score," 
+                         "use the precision_score function for precision only")
     labels = _check_set_wise_labels(y_true, y_pred, average, labels,
                                     pos_label)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

I removed a contradiction in the documentation, where it says beta can be => 0 but if beta = 0 it would raise an error.

#### Any other comments?

I also added this line to the raised error: "use the precision_score function for precision only"

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
