### PR TITLE
Fixing parameter description (for assume_centered)

### DIFF
--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -56,10 +56,10 @@ def empirical_covariance(X, assume_centered=False):
         Data from which to compute the covariance estimate
 
     assume_centered : boolean
-        If True, data are not centered before computation.
+        If True, data will not be centered before computation.
         Useful when working with data whose mean is almost, but not exactly
         zero.
-        If False, data are centered before computation.
+        If False, data will be centered before computation.
 
     Returns
     -------

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -71,10 +71,10 @@ class ShrunkCovariance(EmpiricalCovariance):
         Specify if the estimated precision is stored
 
     assume_centered : boolean, default False
-        If True, data are not centered before computation.
+        If True, data is centered before computation.
         Useful when working with data whose mean is almost, but not exactly
         zero.
-        If False, data are centered before computation.
+        If False, data is not centered before computation.
 
     shrinkage : float, 0 <= shrinkage <= 1, default 0.1
         Coefficient in the convex combination used for the computation
@@ -175,10 +175,10 @@ def ledoit_wolf_shrinkage(X, assume_centered=False, block_size=1000):
         Data from which to compute the Ledoit-Wolf shrunk covariance shrinkage.
 
     assume_centered : bool
-        If True, data are not centered before computation.
+        If True, data is centered before computation.
         Useful to work with data whose mean is significantly equal to
         zero but is not exactly zero.
-        If False, data are centered before computation.
+        If False, data is not centered before computation.
 
     block_size : int
         Size of the blocks into which the covariance matrix will be split.
@@ -270,10 +270,10 @@ def ledoit_wolf(X, assume_centered=False, block_size=1000):
         Data from which to compute the covariance estimate
 
     assume_centered : boolean, default=False
-        If True, data are not centered before computation.
+        If True, data is centered before computation.
         Useful to work with data whose mean is significantly equal to
         zero but is not exactly zero.
-        If False, data are centered before computation.
+        If False, data is not centered before computation.
 
     block_size : int, default=1000
         Size of the blocks into which the covariance matrix will be split.
@@ -339,10 +339,10 @@ class LedoitWolf(EmpiricalCovariance):
         Specify if the estimated precision is stored.
 
     assume_centered : bool, default=False
-        If True, data are not centered before computation.
+        If True, data is centered before computation.
         Useful when working with data whose mean is almost, but not exactly
         zero.
-        If False (default), data are centered before computation.
+        If False (default), data is not centered before computation.
 
     block_size : int, default=1000
         Size of the blocks into which the covariance matrix will be split
@@ -448,10 +448,10 @@ def oas(X, assume_centered=False):
         Data from which to compute the covariance estimate.
 
     assume_centered : boolean
-      If True, data are not centered before computation.
+      If True, data is centered before computation.
       Useful to work with data whose mean is significantly equal to
       zero but is not exactly zero.
-      If False, data are centered before computation.
+      If False, data is not centered before computation.
 
     Returns
     -------
@@ -525,10 +525,10 @@ class OAS(EmpiricalCovariance):
         Specify if the estimated precision is stored.
 
     assume_centered : bool, default=False
-        If True, data are not centered before computation.
+        If True, data is not centered before computation.
         Useful when working with data whose mean is almost, but not exactly
         zero.
-        If False (default), data are centered before computation.
+        If False (default), data is centered before computation.
 
     Attributes
     ----------

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -71,10 +71,10 @@ class ShrunkCovariance(EmpiricalCovariance):
         Specify if the estimated precision is stored
 
     assume_centered : boolean, default False
-        If True, data is centered before computation.
+        If True, data will not be centered before computation.
         Useful when working with data whose mean is almost, but not exactly
         zero.
-        If False, data is not centered before computation.
+        If False, data will be centered before computation.
 
     shrinkage : float, 0 <= shrinkage <= 1, default 0.1
         Coefficient in the convex combination used for the computation
@@ -175,10 +175,10 @@ def ledoit_wolf_shrinkage(X, assume_centered=False, block_size=1000):
         Data from which to compute the Ledoit-Wolf shrunk covariance shrinkage.
 
     assume_centered : bool
-        If True, data is centered before computation.
+        If True, data will not be centered before computation.
         Useful to work with data whose mean is significantly equal to
         zero but is not exactly zero.
-        If False, data is not centered before computation.
+        If False, data will be centered before computation.
 
     block_size : int
         Size of the blocks into which the covariance matrix will be split.
@@ -270,10 +270,10 @@ def ledoit_wolf(X, assume_centered=False, block_size=1000):
         Data from which to compute the covariance estimate
 
     assume_centered : boolean, default=False
-        If True, data is centered before computation.
+        If True, data will not be centered before computation.
         Useful to work with data whose mean is significantly equal to
         zero but is not exactly zero.
-        If False, data is not centered before computation.
+        If False, data will be centered before computation.
 
     block_size : int, default=1000
         Size of the blocks into which the covariance matrix will be split.
@@ -339,10 +339,10 @@ class LedoitWolf(EmpiricalCovariance):
         Specify if the estimated precision is stored.
 
     assume_centered : bool, default=False
-        If True, data is centered before computation.
+        If True, data will not be centered before computation.
         Useful when working with data whose mean is almost, but not exactly
         zero.
-        If False (default), data is not centered before computation.
+        If False (default), data will be centered before computation.
 
     block_size : int, default=1000
         Size of the blocks into which the covariance matrix will be split
@@ -448,10 +448,10 @@ def oas(X, assume_centered=False):
         Data from which to compute the covariance estimate.
 
     assume_centered : boolean
-      If True, data is centered before computation.
+      If True, data will not be centered before computation.
       Useful to work with data whose mean is significantly equal to
       zero but is not exactly zero.
-      If False, data is not centered before computation.
+      If False, data will be centered before computation.
 
     Returns
     -------
@@ -525,10 +525,10 @@ class OAS(EmpiricalCovariance):
         Specify if the estimated precision is stored.
 
     assume_centered : bool, default=False
-        If True, data is not centered before computation.
+        If True, data will not be centered before computation.
         Useful when working with data whose mean is almost, but not exactly
         zero.
-        If False (default), data is centered before computation.
+        If False (default), data will be centered before computation.
 
     Attributes
     ----------


### PR DESCRIPTION
Fixing parameter description (for the parameter assume_centered) and some minor grammatical errors.