### PR TITLE
[MRG] Update `quantile_transform` `copy` default to True

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -272,7 +272,7 @@ Support for Python 3.4 and below has been officially dropped.
   broken when X was of dtype bool.
   :issue:`13328` by `Alexandre Gramfort`_.
 
-- |API|  The use of :class:`linear_model.lars_path` with ``X=None`` 
+- |API|  The use of :class:`linear_model.lars_path` with ``X=None``
   while passing ``Gram`` is deprecated in version 0.21 and will be removed
   in version 0.23. Use :class:`linear_model.lars_path_gram` instead.
   :issue:`11699` by :user:`Kuai Yu <yukuairoy>`.
@@ -457,6 +457,13 @@ Support for Python 3.4 and below has been officially dropped.
   equal to n_samples. Values of n_quantiles larger than n_samples were either
   useless or resulting in a wrong approximation of the cumulative distribution
   function estimator. :issue:`13333` by :user:`Albert Thomas <albertcthomas>`.
+
+- |API| Deprecate default `copy=False` value of
+  :func:`preprocessing.data.quantile_transform`. The default will be updated
+  to True to be more consistent with the default `copy` values of other functions
+  in :mod:`sklearn.preprocessing.data` and avoid unexpected side effects by
+  modifying the value of `X` inplace.
+  :issue:`13459` by :user:`Hunter McGushion <HunterMcGushion>`.
 
 :mod:`sklearn.svm`
 ..................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -458,11 +458,11 @@ Support for Python 3.4 and below has been officially dropped.
   useless or resulting in a wrong approximation of the cumulative distribution
   function estimator. :issue:`13333` by :user:`Albert Thomas <albertcthomas>`.
 
-- |API| Deprecate default `copy=False` value of
-  :func:`preprocessing.data.quantile_transform`. The default will be updated
-  to True to be more consistent with the default `copy` values of other functions
-  in :mod:`sklearn.preprocessing.data` and avoid unexpected side effects by
-  modifying the value of `X` inplace.
+- |API| The default value of `copy` in :func:`preprocessing.quantile_transform`
+  will change from False to True in 0.23 in order to make it more consistent
+  with the default `copy` values of other functions in
+  :mod:`preprocessing.data` and prevent unexpected side effects by modifying
+  the value of `X` inplace.
   :issue:`13459` by :user:`Hunter McGushion <HunterMcGushion>`.
 
 :mod:`sklearn.svm`

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2517,7 +2517,7 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
     >>> from sklearn.preprocessing import quantile_transform
     >>> rng = np.random.RandomState(0)
     >>> X = np.sort(rng.normal(loc=0.5, scale=0.25, size=(25, 1)), axis=0)
-    >>> quantile_transform(X, n_quantiles=10, random_state=0)
+    >>> quantile_transform(X, n_quantiles=10, random_state=0, copy=False)
     ... # doctest: +ELLIPSIS
     array([...])
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2543,12 +2543,13 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
     <sphx_glr_auto_examples_preprocessing_plot_all_scaling.py>`.
     """
     if copy == "warn":
-        warnings.warn("The default value of the `copy` parameter has "
-                      "been scheduled to be changed in 0.21. In 0.23, "
-                      "its default value will be updated from False "
-                      "to True. To avoid unexpected inplace modifications "
-                      "of `X` and to prepare for the change in 0.23, it "
-                      "is recommended to explicitly set `copy=True`",
+        warnings.warn("The default value of `copy` will change from False to "
+                      "True in 0.23 in order to make it more consistent with "
+                      "the default `copy` values of other functions in "
+                      ":mod:`sklearn.preprocessing.data` and prevent "
+                      "unexpected side effects by modifying the value of `X` "
+                      "inplace. To avoid inplace modifications of `X`, it is "
+                      "recommended to explicitly set `copy=True`",
                       FutureWarning)
         copy = False
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2431,7 +2431,7 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
                        ignore_implicit_zeros=False,
                        subsample=int(1e5),
                        random_state=None,
-                       copy=False):
+                       copy=True):
     """Transform features using quantiles information.
 
     This method transforms the features to follow a uniform or a normal

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2431,7 +2431,7 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
                        ignore_implicit_zeros=False,
                        subsample=int(1e5),
                        random_state=None,
-                       copy=True):
+                       copy="warn"):
     """Transform features using quantiles information.
 
     This method transforms the features to follow a uniform or a normal
@@ -2489,9 +2489,18 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
         by np.random. Note that this is used by subsampling and smoothing
         noise.
 
-    copy : boolean, optional, (default=True)
+    copy : boolean, optional, (default="warn")
         Set to False to perform inplace transformation and avoid a copy (if the
-        input is already a numpy array).
+        input is already a numpy array). If True, a copy of `X` is transformed,
+        leaving the original `X` unchanged
+
+        .. deprecated:: 0.21
+            The default value of parameter `copy` will be changed from False to
+            True in 0.23. The current default of False is being changed to make
+            it more consistent with the default `copy` values of other functions
+            in :mod:`sklearn.preprocessing.data`. Furthermore, the current
+            default of False may have unexpected side effects by modifying the
+            value of `X` inplace. For more information see PR #13459
 
     Attributes
     ----------
@@ -2532,6 +2541,16 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
     see :ref:`examples/preprocessing/plot_all_scaling.py
     <sphx_glr_auto_examples_preprocessing_plot_all_scaling.py>`.
     """
+    if copy == "warn":
+        warnings.warn("The default value of the `copy` parameter has "
+                      "been scheduled to be changed in 0.21. In 0.23, "
+                      "its default value will be updated from False "
+                      "to True. To avoid unexpected inplace modifications "
+                      "of `X` and to prepare for the change in 0.23, it "
+                      "is recommended to explicitly set `copy=True`",
+                      FutureWarning)
+        copy = False
+
     n = QuantileTransformer(n_quantiles=n_quantiles,
                             output_distribution=output_distribution,
                             subsample=subsample,

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2500,8 +2500,7 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
             make it more consistent with the default `copy` values of other
             functions in :mod:`sklearn.preprocessing.data`. Furthermore, the
             current default of False may have unexpected side effects by
-            modifying the value of `X` inplace. For more information see
-            PR #13459
+            modifying the value of `X` inplace
 
     Attributes
     ----------
@@ -2517,7 +2516,7 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
     >>> from sklearn.preprocessing import quantile_transform
     >>> rng = np.random.RandomState(0)
     >>> X = np.sort(rng.normal(loc=0.5, scale=0.25, size=(25, 1)), axis=0)
-    >>> quantile_transform(X, n_quantiles=10, random_state=0, copy=False)
+    >>> quantile_transform(X, n_quantiles=10, random_state=0, copy=True)
     ... # doctest: +ELLIPSIS
     array([...])
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2495,12 +2495,13 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
         leaving the original `X` unchanged
 
         .. deprecated:: 0.21
-            The default value of parameter `copy` will be changed from False to
-            True in 0.23. The current default of False is being changed to make
-            it more consistent with the default `copy` values of other functions
-            in :mod:`sklearn.preprocessing.data`. Furthermore, the current
-            default of False may have unexpected side effects by modifying the
-            value of `X` inplace. For more information see PR #13459
+            The default value of parameter `copy` will be changed from False
+            to True in 0.23. The current default of False is being changed to
+            make it more consistent with the default `copy` values of other
+            functions in :mod:`sklearn.preprocessing.data`. Furthermore, the
+            current default of False may have unexpected side effects by
+            modifying the value of `X` inplace. For more information see
+            PR #13459
 
     Attributes
     ----------

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1447,6 +1447,7 @@ def test_quantile_transform_sparse_toy():
     assert_array_almost_equal(X.toarray(), X_trans_inv.toarray())
 
 
+@pytest.mark.filterwarnings("ignore: The default value of `copy`")  # 0.23
 def test_quantile_transform_axis1():
     X = np.array([[0, 25, 50, 75, 100],
                   [2, 4, 6, 8, 10],
@@ -2153,6 +2154,7 @@ def test_fit_cold_start():
         scaler.fit_transform(X_2d)
 
 
+@pytest.mark.filterwarnings("ignore: The default value of `copy`")  # 0.23
 def test_quantile_transform_valid_axis():
     X = np.array([[0, 25, 50, 75, 100],
                   [2, 4, 6, 8, 10],

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1526,6 +1526,17 @@ def test_quantile_transform_nan():
     assert not np.isnan(transformer.quantiles_[:, 1:]).any()
 
 
+def test_deprecated_quantile_transform_copy():
+    future_message = ("The default value of the `copy` parameter has "
+                      "been scheduled to be changed in 0.21. In 0.23, "
+                      "its default value will be updated from False "
+                      "to True. To avoid unexpected inplace modifications "
+                      "of `X` and to prepare for the change in 0.23, it "
+                      "is recommended to explicitly set `copy=True`")
+    assert_warns_message(FutureWarning, future_message, quantile_transform,
+                         np.array([[0, 1], [0, 0.5], [1, 0]]))
+
+
 def test_robust_scaler_invalid_range():
     for range_ in [
         (-1, 90),

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1527,12 +1527,13 @@ def test_quantile_transform_nan():
 
 
 def test_deprecated_quantile_transform_copy():
-    future_message = ("The default value of the `copy` parameter has "
-                      "been scheduled to be changed in 0.21. In 0.23, "
-                      "its default value will be updated from False "
-                      "to True. To avoid unexpected inplace modifications "
-                      "of `X` and to prepare for the change in 0.23, it "
-                      "is recommended to explicitly set `copy=True`")
+    future_message = ("The default value of `copy` will change from False to "
+                      "True in 0.23 in order to make it more consistent with "
+                      "the default `copy` values of other functions in "
+                      ":mod:`sklearn.preprocessing.data` and prevent "
+                      "unexpected side effects by modifying the value of `X` "
+                      "inplace. To avoid inplace modifications of `X`, it is "
+                      "recommended to explicitly set `copy=True`")
     assert_warns_message(FutureWarning, future_message, quantile_transform,
                          np.array([[0, 1], [0, 0.5], [1, 0]]))
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
- Changes default value for the `copy` kwarg in :func:`preprocessing.data.quantile_transform` from False to True
- The original default of `copy=False` was in conflict with the function's documentation:
https://github.com/scikit-learn/scikit-learn/blob/ffc63c6508817112ebb5157fc36696d4bf00e53b/sklearn/preprocessing/data.py#L2492
- This was the only function in the module, whose default `copy` kwarg value was False
- Seems like True was the intended default, since performing an in-place transformation by default is pretty unexpected - At least, it was for me

#### Any other comments?
- If the signature was correct, and `copy=False` was the intended default, I'd be happy to update the documentation instead
- In any case, the documentation conflicts with the actual signature