### PR TITLE
[MRG] MAINT: Fix cython warnings

### DIFF
--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -16,8 +16,7 @@ from libc.math cimport sqrt, log
 import numpy as np
 cimport numpy as np
 
-from sklearn.neighbors import quad_tree
-from sklearn.neighbors cimport quad_tree
+from sklearn.neighbors.quad_tree cimport _QuadTree
 
 cdef char* EMPTY_STRING = ""
 
@@ -50,7 +49,7 @@ cdef float compute_gradient(float[:] val_P,
                             np.int64_t[:] neighbors,
                             np.int64_t[:] indptr,
                             float[:, :] tot_force,
-                            quad_tree._QuadTree qt,
+                            _QuadTree qt,
                             float theta,
                             int dof,
                             long start,
@@ -164,7 +163,7 @@ cdef float compute_gradient_positive(float[:] val_P,
 
 cdef void compute_gradient_negative(float[:, :] pos_reference,
                                     float* neg_f,
-                                    quad_tree._QuadTree qt,
+                                    _QuadTree qt,
                                     double* sum_Q,
                                     int dof,
                                     float theta,
@@ -262,8 +261,7 @@ def gradient(float[:] val_P,
     assert n == indptr.shape[0] - 1, m
     if verbose > 10:
         printf("[t-SNE] Initializing tree of n_dimensions %i\n", n_dimensions)
-    cdef quad_tree._QuadTree qt = quad_tree._QuadTree(pos_output.shape[1],
-                                                      verbose)
+    cdef _QuadTree qt = _QuadTree(pos_output.shape[1], verbose)
     if verbose > 10:
         printf("[t-SNE] Inserting %li points\n", pos_output.shape[0])
     qt.build_tree(pos_output)

--- a/sklearn/svm/libsvm.pyx
+++ b/sklearn/svm/libsvm.pyx
@@ -34,7 +34,6 @@ Authors
 import warnings
 import  numpy as np
 cimport numpy as np
-from . cimport libsvm
 from libc.stdlib cimport free
 
 cdef extern from *:

--- a/sklearn/utils/seq_dataset.pxd.tp
+++ b/sklearn/utils/seq_dataset.pxd.tp
@@ -1,3 +1,4 @@
+# cython: language_level=3
 {{py:
 
 """
@@ -21,7 +22,6 @@ def get_dispatch(dtypes):
         yield name, c_type
 
 }}
-# cython: language_level=3
 {{for name, c_type in get_dispatch(dtypes)}}
 
 #------------------------------------------------------------------------------

--- a/sklearn/utils/seq_dataset.pxd.tp
+++ b/sklearn/utils/seq_dataset.pxd.tp
@@ -21,7 +21,7 @@ def get_dispatch(dtypes):
         yield name, c_type
 
 }}
-
+# cython: language_level=3
 {{for name, c_type in get_dispatch(dtypes)}}
 
 #------------------------------------------------------------------------------

--- a/sklearn/utils/seq_dataset.pyx.tp
+++ b/sklearn/utils/seq_dataset.pyx.tp
@@ -1,3 +1,7 @@
+# cython: language_level=3
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: wraparound=False
 {{py:
 
 """
@@ -26,7 +30,6 @@ def get_dispatch(dtypes):
         yield name, c_type, np_type
 
 }}
-# cython: language_level=3
 {{for name, c_type, np_type in get_dispatch(dtypes)}}
 
 #------------------------------------------------------------------------------
@@ -35,11 +38,6 @@ def get_dispatch(dtypes):
 Dataset abstractions for sequential data access.
 WARNING: Do not edit .pyx file directly, it is generated from .pyx.tp
 """
-
-# cython: language_level=3
-# cython: cdivision=True
-# cython: boundscheck=False
-# cython: wraparound=False
 
 cimport cython
 from libc.limits cimport INT_MAX

--- a/sklearn/utils/seq_dataset.pyx.tp
+++ b/sklearn/utils/seq_dataset.pyx.tp
@@ -26,7 +26,7 @@ def get_dispatch(dtypes):
         yield name, c_type, np_type
 
 }}
-
+# cython: language_level=3
 {{for name, c_type, np_type in get_dispatch(dtypes)}}
 
 #------------------------------------------------------------------------------
@@ -36,6 +36,7 @@ Dataset abstractions for sequential data access.
 WARNING: Do not edit .pyx file directly, it is generated from .pyx.tp
 """
 
+# cython: language_level=3
 # cython: cdivision=True
 # cython: boundscheck=False
 # cython: wraparound=False


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->
#### What does this implement/fix? Explain your changes.
1. Adds `cython_language=3` to `seq_dataset.*.tp`
2. Directly cimports `_QuadTree`. Previously, there was an warning:
```
sklearn/manifold/_barnes_hut_tsne.pyx: cannot find cimported module 'sklearn.neighbors'
```
This meant that the Cython code was going through Python to use `_QuadTree`.
3. Removes `from . cimport libsvm`, because it is not cimportable: 
```
sklearn/svm/libsvm.pyx: cannot find cimported module '.'
```


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->