### PR TITLE
MRG Emeritus core devs on website

### DIFF
--- a/build_tools/generate_authors_table.py
+++ b/build_tools/generate_authors_table.py
@@ -10,15 +10,11 @@ import sys
 import requests
 import getpass
 
-try:
-    # With authentication: up to 5000 requests per hour.
-    print("user:", file=sys.stderr)
-    user = input()
-    passwd = getpass.getpass()
-    auth = (user, passwd)
-except IndexError:
-    # Without authentication: up to 60 requests per hour.
-    auth = None
+# With authentication: up to 5000 requests per hour.
+print("user:", file=sys.stderr)
+user = input()
+passwd = getpass.getpass("Password or access token:\n")
+auth = (user, passwd)
 
 ROW_SIZE = 7
 LOGO_URL = 'https://avatars2.githubusercontent.com/u/365630?v=4'
@@ -40,22 +36,22 @@ def get_contributors():
     """Get the list of contributor profiles. Require admin rights."""
     # get members of scikit-learn teams on GitHub
     members = []
-    for team in [11523, 33471]:
-        for page in [1, 2]:  # 30 per page
-            members.extend(requests.get(
-                "https://api.github.com/teams/%d/members?page=%d"
-                % (team, page), auth=auth).json())
+    team = 11523
+    for page in [1, 2]:  # 30 per page
+        reply = requests.get(
+            "https://api.github.com/teams/%d/members?page=%d"
+            % (team, page), auth=auth)
+        reply.raise_for_status()
+        members.extend(reply.json())
 
     # keep only the logins
     logins = [c['login'] for c in members]
     # add missing contributors with GitHub accounts
-    logins.extend(['dubourg', 'jarrodmillman', 'mbrucher', 'thouis'])
+    logins.extend(['jarrodmillman', 'thouis'])
     # add missing contributors without GitHub accounts
     logins.extend(['Angel Soler Gollonet'])
     # remove duplicate
     logins = set(logins)
-    # remove CI
-    logins.remove('sklearn-ci')
 
     # get profiles from GitHub
     profiles = [get_profile(login) for login in logins]
@@ -78,7 +74,6 @@ def get_profile(login):
 
         # fix missing names
         missing_names = {'bthirion': 'Bertrand Thirion',
-                         'dubourg': 'Vincent Dubourg',
                          'Duchesnay': 'Edouard Duchesnay',
                          'Lars': 'Lars Buitinck',
                          'MechCoder': 'Manoj Kumar'}

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -46,6 +46,7 @@ The following people have been active contributors in the past, but are no longe
 - Raghav Rajagopalan
 - Robert Layton
 - Ron Weiss
+- Thouis (Ray) Jones
 - Vincent Dubourg
 - Vincent Michel
 - Virgile Fritsch

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -17,7 +17,7 @@ been leading the development.
 Authors
 -------
 
-The following people have been core contributors to scikit-learn's development
+The following people are currently core contributors to scikit-learn's development
 and maintenance:
 
 .. include:: authors.rst
@@ -31,12 +31,31 @@ in the FAQ.
 
    :ref:`How you can contribute to the project <contributing>`
 
-.. _citing-scikit-learn:
+Emeritus Core Developers
+------------------------
+The following people have been active contributors in the past, but are no longer active in the project
+
+- Alexander Fabisch
+- Alexandre Passos
+- Chris Gorgolewski
+- David Cournapeau
+- David Warde-Farley
+- Jake Vanderplas
+- Kyle Kastner
+- Matthieu Brucher
+- Raghav Rajagopalan
+- Robert Layton
+- Ron Weiss
+- Vincent Dubourg
+- Vincent Michel
+- Virgile Fritsch
 
 Governance
 ----------
 The decision making process and governance structure of scikit-learn is laid
 out in the `governance document <governance>`_.
+
+.. _citing-scikit-learn:
 
 Citing scikit-learn
 -------------------

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -17,16 +17,8 @@
     <p>Joris Van den Bossche</p>
     </td>
     <td>
-    <a href='https://github.com/mbrucher'><img src='https://avatars1.githubusercontent.com/u/321752?v=4' class='avatar' /></a> <br />
-    <p>Matthieu Brucher</p>
-    </td>
-    <td>
     <a href='https://github.com/larsmans'><img src='https://avatars1.githubusercontent.com/u/335383?v=4' class='avatar' /></a> <br />
     <p>Lars Buitinck</p>
-    </td>
-    <td>
-    <a href='https://github.com/cournape'><img src='https://avatars1.githubusercontent.com/u/25111?v=4' class='avatar' /></a> <br />
-    <p>David Cournapeau</p>
     </td>
     <td>
     <a href='https://github.com/ndawe'><img src='https://avatars1.githubusercontent.com/u/202816?v=4' class='avatar' /></a> <br />
@@ -36,12 +28,6 @@
     <a href='https://github.com/lucidfrontier45'><img src='https://avatars2.githubusercontent.com/u/655305?v=4' class='avatar' /></a> <br />
     <p>Shiqiao Du</p>
     </td>
-    </tr>
-    <tr>
-    <td>
-    <a href='https://github.com/dubourg'><img src='https://avatars0.githubusercontent.com/u/401766?v=4' class='avatar' /></a> <br />
-    <p>Vincent Dubourg</p>
-    </td>
     <td>
     <a href='https://github.com/duchesnay'><img src='https://avatars1.githubusercontent.com/u/344402?v=4' class='avatar' /></a> <br />
     <p>Edouard Duchesnay</p>
@@ -50,14 +36,8 @@
     <a href='https://github.com/lesteve'><img src='https://avatars1.githubusercontent.com/u/1680079?v=4' class='avatar' /></a> <br />
     <p>Loïc Estève</p>
     </td>
-    <td>
-    <a href='https://github.com/AlexanderFabisch'><img src='https://avatars1.githubusercontent.com/u/869592?v=4' class='avatar' /></a> <br />
-    <p>Alexander Fabisch</p>
-    </td>
-    <td>
-    <a href='https://github.com/VirgileFritsch'><img src='https://avatars3.githubusercontent.com/u/263280?v=4' class='avatar' /></a> <br />
-    <p>Virgile Fritsch</p>
-    </td>
+    </tr>
+    <tr>
     <td>
     <a href='https://github.com/satra'><img src='https://avatars2.githubusercontent.com/u/184063?v=4' class='avatar' /></a> <br />
     <p>Satrajit Ghosh</p>
@@ -65,12 +45,6 @@
     <td>
     <a href=''><img src='https://avatars2.githubusercontent.com/u/365630?v=4' class='avatar' /></a> <br />
     <p>Angel Soler Gollonet</p>
-    </td>
-    </tr>
-    <tr>
-    <td>
-    <a href='https://github.com/chrisfilo'><img src='https://avatars2.githubusercontent.com/u/238759?v=4' class='avatar' /></a> <br />
-    <p>Chris Gorgolewski</p>
     </td>
     <td>
     <a href='https://github.com/agramfort'><img src='https://avatars2.githubusercontent.com/u/161052?v=4' class='avatar' /></a> <br />
@@ -89,10 +63,6 @@
     <p>Yaroslav Halchenko</p>
     </td>
     <td>
-    <a href='https://github.com/bdholt1'><img src='https://avatars0.githubusercontent.com/u/937444?v=4' class='avatar' /></a> <br />
-    <p>Brian Holt</p>
-    </td>
-    <td>
     <a href='https://github.com/adrinjalali'><img src='https://avatars3.githubusercontent.com/u/1663864?v=4' class='avatar' /></a> <br />
     <p>Adrin Jalali</p>
     </td>
@@ -107,16 +77,8 @@
     <p>Thouis (Ray) Jones</p>
     </td>
     <td>
-    <a href='https://github.com/kastnerkyle'><img src='https://avatars2.githubusercontent.com/u/1563421?v=4' class='avatar' /></a> <br />
-    <p>Kyle Kastner</p>
-    </td>
-    <td>
     <a href='https://github.com/MechCoder'><img src='https://avatars3.githubusercontent.com/u/1867024?v=4' class='avatar' /></a> <br />
     <p>Manoj Kumar</p>
-    </td>
-    <td>
-    <a href='https://github.com/robertlayton'><img src='https://avatars2.githubusercontent.com/u/800543?v=4' class='avatar' /></a> <br />
-    <p>Robert Layton</p>
     </td>
     <td>
     <a href='https://github.com/glemaitre'><img src='https://avatars2.githubusercontent.com/u/7454015?v=4' class='avatar' /></a> <br />
@@ -126,8 +88,6 @@
     <a href='https://github.com/weilinear'><img src='https://avatars0.githubusercontent.com/u/2232328?v=4' class='avatar' /></a> <br />
     <p>Wei Li</p>
     </td>
-    </tr>
-    <tr>
     <td>
     <a href='https://github.com/paolo-losi'><img src='https://avatars1.githubusercontent.com/u/264906?v=4' class='avatar' /></a> <br />
     <p>Paolo Losi</p>
@@ -136,13 +96,11 @@
     <a href='https://github.com/glouppe'><img src='https://avatars3.githubusercontent.com/u/477771?v=4' class='avatar' /></a> <br />
     <p>Gilles Louppe</p>
     </td>
+    </tr>
+    <tr>
     <td>
     <a href='https://github.com/jmetzen'><img src='https://avatars1.githubusercontent.com/u/1116263?v=4' class='avatar' /></a> <br />
     <p>Jan Hendrik Metzen</p>
-    </td>
-    <td>
-    <a href='https://github.com/vmichel'><img src='https://avatars1.githubusercontent.com/u/295195?v=4' class='avatar' /></a> <br />
-    <p>Vincent Michel</p>
     </td>
     <td>
     <a href='https://github.com/jarrodmillman'><img src='https://avatars1.githubusercontent.com/u/123428?v=4' class='avatar' /></a> <br />
@@ -156,15 +114,9 @@
     <a href='https://github.com/vene'><img src='https://avatars0.githubusercontent.com/u/241745?v=4' class='avatar' /></a> <br />
     <p>Vlad Niculae</p>
     </td>
-    </tr>
-    <tr>
     <td>
     <a href='https://github.com/jnothman'><img src='https://avatars2.githubusercontent.com/u/78827?v=4' class='avatar' /></a> <br />
     <p>Joel Nothman</p>
-    </td>
-    <td>
-    <a href='https://github.com/alextp'><img src='https://avatars0.githubusercontent.com/u/5061?v=4' class='avatar' /></a> <br />
-    <p>Alexandre Passos</p>
     </td>
     <td>
     <a href='https://github.com/fabianp'><img src='https://avatars3.githubusercontent.com/u/277639?v=4' class='avatar' /></a> <br />
@@ -174,20 +126,16 @@
     <a href='https://github.com/pprett'><img src='https://avatars0.githubusercontent.com/u/111730?v=4' class='avatar' /></a> <br />
     <p>Peter Prettenhofer</p>
     </td>
+    </tr>
+    <tr>
     <td>
     <a href='https://github.com/qinhanmin2014'><img src='https://avatars2.githubusercontent.com/u/12003569?v=4' class='avatar' /></a> <br />
     <p>Hanmin Qin</p>
     </td>
     <td>
-    <a href='https://github.com/raghavrv'><img src='https://avatars3.githubusercontent.com/u/9487348?v=4' class='avatar' /></a> <br />
-    <p>(Venkat) Raghav, Rajagopalan</p>
-    </td>
-    <td>
     <a href='https://github.com/jmschrei'><img src='https://avatars2.githubusercontent.com/u/3916816?v=4' class='avatar' /></a> <br />
     <p>Jacob Schreiber</p>
     </td>
-    </tr>
-    <tr>
     <td>
     <a href='https://github.com/bthirion'><img src='https://avatars1.githubusercontent.com/u/234454?v=4' class='avatar' /></a> <br />
     <p>Bertrand Thirion</p>
@@ -197,27 +145,13 @@
     <p>Tom Dupré la Tour</p>
     </td>
     <td>
-    <a href='https://github.com/jakevdp'><img src='https://avatars0.githubusercontent.com/u/781659?v=4' class='avatar' /></a> <br />
-    <p>Jake Vanderplas</p>
+    <a href='https://github.com/GaelVaroquaux'><img src='https://avatars3.githubusercontent.com/u/208217?v=4' class='avatar' /></a> <br />
+    <p>Gael Varoquaux</p>
     </td>
     <td>
     <a href='https://github.com/NelleV'><img src='https://avatars0.githubusercontent.com/u/184798?v=4' class='avatar' /></a> <br />
     <p>Nelle Varoquaux</p>
     </td>
-    <td>
-    <a href='https://github.com/GaelVaroquaux'><img src='https://avatars3.githubusercontent.com/u/208217?v=4' class='avatar' /></a> <br />
-    <p>Gael Varoquaux</p>
-    </td>
-    <td>
-    <a href='https://github.com/dwf'><img src='https://avatars1.githubusercontent.com/u/60206?v=4' class='avatar' /></a> <br />
-    <p>David Warde-Farley</p>
-    </td>
-    <td>
-    <a href='https://github.com/ronw'><img src='https://avatars2.githubusercontent.com/u/113819?v=4' class='avatar' /></a> <br />
-    <p>Ron Weiss</p>
-    </td>
-    </tr>
-    <tr>
     <td>
     <a href='https://github.com/rth'><img src='https://avatars0.githubusercontent.com/u/630936?v=4' class='avatar' /></a> <br />
     <p>Roman Yurchak</p>


### PR DESCRIPTION
Also see #13257.

I added a new section "emeritus core devs" to the about page.
We could have that in authors as well, but then we would need to autogenerate it.
Given that @GaelVaroquaux wanted dates when people became active, I thought doing it explicitly might be better.
Also, I removed the historic "reviewers" group that hasn't been used, and dropped the emeritus core devs from the "core developers group" in the org.
We could have an "emeritus" group in the org, but that seems like just more email traffic for people not really associated with the project any more.

The criterion that I applied for determining who to message has been "hasn't voted in the governance vote and has not been active", so that's only a subset of those that we should email according to the governance doc, but I thought it would be a good start.