### PR TITLE
[MRG] Make pytest error on FutureWarning and DeprecationWarning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ addopts =
     -Werror::DeprecationWarning
     -Werror::FutureWarning
 
-
 filterwarnings =
     ignore:the matrix subclass:PendingDeprecationWarning
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,9 @@ addopts =
     --doctest-modules
     --disable-pytest-warnings
     -rs
+    -Werror::DeprecationWarning
+    -Werror::FutureWarning
+
 
 filterwarnings =
     ignore:the matrix subclass:PendingDeprecationWarning


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #13396




#### What does this implement/fix? Explain your changes.

This PR adds the `-Werror::DeprecationWarning` and `-Werror::FutureWarning` flags as the default parameters to `pytest` in `setup.cfg`.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
