### PR TITLE
[MRG] Fix GBDT init parameter when it's a pipeline

### DIFF
--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1493,9 +1493,9 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                         raise ValueError(msg)
                     except ValueError as e:
                         if 'not enough values to unpack' in str(e):  # pipeline
-                            raise ValueError(msg)
+                            raise ValueError(msg) from e
                         else:  # regular estimator whose input checking failed
-                            raise e
+                            raise
 
                 raw_predictions = \
                     self.loss_.get_init_raw_predictions(X, self.init_)

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1445,6 +1445,12 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         if sample_weight_is_none:
             sample_weight = np.ones(n_samples, dtype=np.float32)
         else:
+            from sklearn.pipeline import Pipeline
+            if isinstance(self.init, Pipeline):
+                raise ValueError(
+                    'The init estimator is a pipeline, '
+                    'pipelines do not support sample_weight.'
+                    )
             sample_weight = column_or_1d(sample_weight, warn=True)
             sample_weight_is_none = False
 
@@ -1484,7 +1490,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             else:
                 try:
                     self.init_.fit(X, y, sample_weight=sample_weight)
-                except TypeError:
+                except (TypeError, ValueError):
                     if sample_weight_is_none:
                         self.init_.fit(X, y)
                     else:

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1492,7 +1492,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                     except TypeError:  # regular estimator without SW support
                         raise ValueError(msg)
                     except ValueError as e:
-                        if 'not enough values to unpack':  # pipeline
+                        if 'not enough values to unpack' in str(e):  # pipeline
                             raise ValueError(msg)
                         else:  # regular estimator whose input checking failed
                             raise e

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1482,6 +1482,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                 raw_predictions = np.zeros(shape=(X.shape[0], self.loss_.K),
                                            dtype=np.float64)
             else:
+                # XXX clean this once we have a support_sample_weight tag
                 if sample_weight_is_none:
                     self.init_.fit(X, y)
                 else:

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1445,12 +1445,6 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         if sample_weight_is_none:
             sample_weight = np.ones(n_samples, dtype=np.float32)
         else:
-            from sklearn.pipeline import Pipeline
-            if isinstance(self.init, Pipeline):
-                raise ValueError(
-                    'The init estimator is a pipeline, '
-                    'pipelines do not support sample_weight.'
-                    )
             sample_weight = column_or_1d(sample_weight, warn=True)
             sample_weight_is_none = False
 

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -39,6 +39,8 @@ from sklearn.utils.testing import skip_if_32bit
 from sklearn.exceptions import DataConversionWarning
 from sklearn.exceptions import NotFittedError
 from sklearn.dummy import DummyClassifier, DummyRegressor
+from sklearn.pipeline import make_pipeline
+from sklearn.linear_model import LinearRegression
 
 
 GRADIENT_BOOSTING_ESTIMATORS = [GradientBoostingClassifier,
@@ -1364,6 +1366,20 @@ def test_gradient_boosting_with_init(gb, dataset_maker, init_estimator):
     with pytest.raises(ValueError,
                        match="estimator.*does not support sample weights"):
         gb(init=init_est).fit(X, y, sample_weight=sample_weight)
+
+
+def test_gradient_boosting_with_init_pipeline():
+    # Check that the init estimator can be a pipeline (see issue #13466)
+
+    X, y = make_regression(random_state=0)
+    init = make_pipeline(LinearRegression())
+    gb = GradientBoostingRegressor(init=init)
+    gb.fit(X, y)
+
+    with pytest.raises(
+        ValueError,
+        match='The init estimator is a pipeline, pipelines do not support'):
+        gb.fit(X, y, sample_weight=np.ones(X.shape[0]))
 
 
 @pytest.mark.parametrize('estimator, missing_method', [

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1375,7 +1375,7 @@ def test_gradient_boosting_with_init_pipeline():
     X, y = make_regression(random_state=0)
     init = make_pipeline(LinearRegression())
     gb = GradientBoostingRegressor(init=init)
-    gb.fit(X, y)
+    gb.fit(X, y)  # pipeline without sample_weight works fine
 
     with pytest.raises(
             ValueError,
@@ -1391,8 +1391,9 @@ def test_gradient_boosting_with_init_pipeline():
             ValueError,
             match='nu <= 0 or nu > 1'):
         # Note that NuSVR properly supports sample_weight
-        est = NuSVR(gamma='auto', nu=1.5)
-        est.fit(X, y, sample_weight=np.ones(X.shape[0]))
+        init = NuSVR(gamma='auto', nu=1.5)
+        gb = GradientBoostingRegressor(init=init)
+        gb.fit(X, y, sample_weight=np.ones(X.shape[0]))
 
 
 @pytest.mark.parametrize('estimator, missing_method', [

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1385,8 +1385,8 @@ def test_gradient_boosting_with_init_pipeline():
 
     # Passing sample_weight to a pipeline raises a ValueError. This test makes
     # sure we make the distinction between ValueError raised by a pipeline that
-    # was passes sample_weight, or by a regular estimator whose input checking
-    # failed.
+    # was passed sample_weight, and a ValueError raised by a regular estimator
+    # whose input checking failed.
     with pytest.raises(
             ValueError,
             match='nu <= 0 or nu > 1'):

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1377,8 +1377,9 @@ def test_gradient_boosting_with_init_pipeline():
     gb.fit(X, y)
 
     with pytest.raises(
-        ValueError,
-        match='The init estimator is a pipeline, pipelines do not support'):
+            ValueError,
+            match='The initial estimator Pipeline does not support sample '
+                  'weights'):
         gb.fit(X, y, sample_weight=np.ones(X.shape[0]))
 
 

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -41,6 +41,7 @@ from sklearn.exceptions import NotFittedError
 from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.pipeline import make_pipeline
 from sklearn.linear_model import LinearRegression
+from sklearn.svm import NuSVR
 
 
 GRADIENT_BOOSTING_ESTIMATORS = [GradientBoostingClassifier,
@@ -1381,6 +1382,17 @@ def test_gradient_boosting_with_init_pipeline():
             match='The initial estimator Pipeline does not support sample '
                   'weights'):
         gb.fit(X, y, sample_weight=np.ones(X.shape[0]))
+
+    # Passing sample_weight to a pipeline raises a ValueError. This test makes
+    # sure we make the distinction between ValueError raised by a pipeline that
+    # was passes sample_weight, or by a regular estimator whose input checking
+    # failed.
+    with pytest.raises(
+            ValueError,
+            match='nu <= 0 or nu > 1'):
+        # Note that NuSVR properly supports sample_weight
+        est = NuSVR(gamma='auto', nu=1.5)
+        est.fit(X, y, sample_weight=np.ones(X.shape[0]))
 
 
 @pytest.mark.parametrize('estimator, missing_method', [


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #13466

#### What does this implement/fix? Explain your changes.

This PR fixes the support of the init estimator of GBDTs when init is a pipeline.

Note that pipeline do not support sample weights.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
