### PR TITLE
[MRG] Fix typos in datasets documentation

### DIFF
--- a/doc/datasets/index.rst
+++ b/doc/datasets/index.rst
@@ -50,7 +50,7 @@ These functions return a tuple ``(X, y)`` consisting of a ``n_samples`` *
 ``n_features`` numpy array ``X`` and an array of length ``n_samples``
 containing the targets ``y``.
 
-In addition, there are also miscellanous tools to load datasets of other 
+In addition, there are also miscellaneous tools to load datasets of other 
 formats or from other locations, described in the :ref:`loading_other_datasets`
 section. 
 
@@ -171,7 +171,7 @@ near-equal-size classes separated by concentric hyperspheres.
 :func:`make_circles` and :func:`make_moons` generate 2d binary classification
 datasets that are challenging to certain algorithms (e.g. centroid-based
 clustering or linear classification), including optional Gaussian noise.
-They are useful for visualisation. produces Gaussian
+They are useful for visualisation. Produces Gaussian
 data with a spherical decision boundary for binary classification.
 
 Multilabel
@@ -261,7 +261,7 @@ Sample images
 -------------
 
 Scikit-learn also embed a couple of sample JPEG images published under Creative
-Commons license by their authors. Those image can be useful to test algorithms
+Commons license by their authors. Those images can be useful to test algorithms
 and pipeline on 2D data.
 
 .. autosummary::

--- a/doc/datasets/index.rst
+++ b/doc/datasets/index.rst
@@ -171,8 +171,7 @@ near-equal-size classes separated by concentric hyperspheres.
 :func:`make_circles` and :func:`make_moons` generate 2d binary classification
 datasets that are challenging to certain algorithms (e.g. centroid-based
 clustering or linear classification), including optional Gaussian noise.
-They are useful for visualisation. Produces Gaussian
-data with a spherical decision boundary for binary classification.
+They are useful for visualisation. :func:`make_circles` produces Gaussian data with a spherical decision boundary for binary classification, while :func:`make_moons` produces two interleaving half circles.
 
 Multilabel
 ~~~~~~~~~~

--- a/doc/datasets/index.rst
+++ b/doc/datasets/index.rst
@@ -171,7 +171,9 @@ near-equal-size classes separated by concentric hyperspheres.
 :func:`make_circles` and :func:`make_moons` generate 2d binary classification
 datasets that are challenging to certain algorithms (e.g. centroid-based
 clustering or linear classification), including optional Gaussian noise.
-They are useful for visualisation. :func:`make_circles` produces Gaussian data with a spherical decision boundary for binary classification, while :func:`make_moons` produces two interleaving half circles.
+They are useful for visualisation. :func:`make_circles` produces Gaussian data
+with a spherical decision boundary for binary classification, while
+:func:`make_moons` produces two interleaving half circles.
 
 Multilabel
 ~~~~~~~~~~


### PR DESCRIPTION
Changed spelling and grammar typos on lines 53 (spelling miscellaneous), 174 (Beginning of sentence not capitalized), 264 (grammar implies images not image).

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
