### PR TITLE
MNT Update deprecation message in RegressorMixin.score to tell users how to avoid the warning

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -367,8 +367,9 @@ class RegressorMixin:
         with `metrics.r2_score`. This will influence the ``score`` method of
         all the multioutput regressors (except for
         `multioutput.MultiOutputRegressor`). To specify the default value
-        manually and avoid the warning,, please either call `metrics.r2_score`
-        directly or make a custom scorer with `metrics.make_scorer`.
+        manually and avoid the warning, please either call `metrics.r2_score`
+        directly or make a custom scorer with `metrics.make_scorer` (the
+        built-in scorer ``'r2'`` uses ``multioutput='uniform_average'``).
         """
 
         from .metrics import r2_score
@@ -383,8 +384,9 @@ class RegressorMixin:
                           "with 'metrics.r2_score'. To specify the default "
                           "value manually and avoid the warning, please "
                           "either call 'metrics.r2_score' directly or make a "
-                          "custom scorer with 'metrics.make_scorer'.",
-                          FutureWarning)
+                          "custom scorer with 'metrics.make_scorer' (the "
+                          "built-in scorer 'r2' uses "
+                          "multioutput='uniform_average').", FutureWarning)
         return r2_score(y, y_pred, sample_weight=sample_weight,
                         multioutput='variance_weighted')
 

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -366,9 +366,9 @@ class RegressorMixin:
         ``multioutput='uniform_average'`` from version 0.23 to keep consistent
         with `metrics.r2_score`. This will influence the ``score`` method of
         all the multioutput regressors (except for
-        `multioutput.MultiOutputRegressor`). To use the new default, please
-        either call `metrics.r2_score` directly or make a custom scorer with
-        `metrics.make_scorer`.
+        `multioutput.MultiOutputRegressor`). To specify the default value
+        manually and avoid the warning,, please either call `metrics.r2_score`
+        directly or make a custom scorer with `metrics.make_scorer`.
         """
 
         from .metrics import r2_score
@@ -380,9 +380,10 @@ class RegressorMixin:
             warnings.warn("The default value of multioutput (not exposed in "
                           "score method) will change from 'variance_weighted' "
                           "to 'uniform_average' in 0.23 to keep consistent "
-                          "with 'metrics.r2_score'. To use the new default, "
-                          "please either call 'metrics.r2_score' directly or "
-                          "make a custom scorer with 'metrics.make_scorer'.",
+                          "with 'metrics.r2_score'. To specify the default "
+                          "value manually and avoid the warning, please "
+                          "either call 'metrics.r2_score' directly or make a "
+                          "custom scorer with 'metrics.make_scorer'.",
                           FutureWarning)
         return r2_score(y, y_pred, sample_weight=sample_weight,
                         multioutput='variance_weighted')

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -505,5 +505,7 @@ def test_regressormixin_score_multioutput():
            "with 'metrics.r2_score'. To specify the default "
            "value manually and avoid the warning, please "
            "either call 'metrics.r2_score' directly or make a "
-           "custom scorer with 'metrics.make_scorer'.")
+           "custom scorer with 'metrics.make_scorer' (the "
+           "built-in scorer 'r2' uses "
+           "multioutput='uniform_average').")
     assert_warns_message(FutureWarning, msg, reg.score, X, y)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -502,7 +502,8 @@ def test_regressormixin_score_multioutput():
     msg = ("The default value of multioutput (not exposed in "
            "score method) will change from 'variance_weighted' "
            "to 'uniform_average' in 0.23 to keep consistent "
-           "with 'metrics.r2_score'. To use the new default, "
-           "please either call 'metrics.r2_score' directly or "
-           "make a custom scorer with 'metrics.make_scorer'.")
+           "with 'metrics.r2_score'. To specify the default "
+           "value manually and avoid the warning, please "
+           "either call 'metrics.r2_score' directly or make a "
+           "custom scorer with 'metrics.make_scorer'.")
     assert_warns_message(FutureWarning, msg, reg.score, X, y)


### PR DESCRIPTION
In response to @amueller 's comment https://github.com/scikit-learn/scikit-learn/pull/13157#issuecomment-474044113