### PR TITLE
[MRG] Fix: Deprecate linear assignment (#13464)

### DIFF
--- a/sklearn/metrics/cluster/bicluster.py
+++ b/sklearn/metrics/cluster/bicluster.py
@@ -1,7 +1,7 @@
 
 import numpy as np
 
-from sklearn.utils.linear_assignment_ import linear_assignment
+from scipy.optimize import linear_sum_assignment
 from sklearn.utils.validation import check_consistent_length, check_array
 
 __all__ = ["consensus_score"]
@@ -79,7 +79,7 @@ def consensus_score(a, b, similarity="jaccard"):
     if similarity == "jaccard":
         similarity = _jaccard
     matrix = _pairwise_similarity(a, b, similarity)
-    indices = linear_assignment(1. - matrix)
+    indices = linear_sum_assignment(1. - matrix)
     n_a = len(a[0])
     n_b = len(b[0])
-    return matrix[indices[:, 0], indices[:, 1]].sum() / max(n_a, n_b)
+    return matrix[indices[0], indices[1]].sum() / max(n_a, n_b)

--- a/sklearn/utils/linear_assignment_.py
+++ b/sklearn/utils/linear_assignment_.py
@@ -14,8 +14,9 @@ Hungarian algorithm (also known as Munkres algorithm).
 # LICENSE: BSD
 
 import numpy as np
+from ..utils import deprecated
 
-
+@deprecated("will be removed in 0.23. Use linear_sum_assignment from scipy.optimize.")
 def linear_assignment(X):
     """Solve the linear assignment problem using the Hungarian algorithm.
 

--- a/sklearn/utils/tests/test_linear_assignment.py
+++ b/sklearn/utils/tests/test_linear_assignment.py
@@ -5,7 +5,7 @@ import numpy as np
 
 # XXX we should be testing the public API here
 from sklearn.utils.linear_assignment_ import _hungarian
-
+from sklearn.utils.linear_assignment_ import linear_assignment
 
 def test_hungarian():
     matrices = [
@@ -58,3 +58,12 @@ def test_hungarian():
             x = cost_matrix[r, c]
             total_cost += x
         assert expected_total == total_cost
+
+def test_deprecation():
+    import warnings
+    warnings.filterwarnings('error')
+    try:
+        linear_assignment(np.array([[1, 2], [3, 4]]))
+        assert False
+    except Warning as e:
+        assert ("deprecated" in e.args[0])


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #13464 

#### What does this implement/fix? Explain your changes.
- Adds deprecation warning to linear_assignment in sklearn.utils.linear_assignment_
- Add test for deprecation warning
- Replaces use of linear_assignment from sklearn.utils with linear_sum_assignment from scipy.optimize in sklearn/metrics/cluster/bicluster.py

#### Any other comments?
- May want to check wording of deprecation warning: "will be removed in 0.23. Use linear_sum_assignment from scipy.optimize."
- Should there be any updates to documentation / comments within linear_assignment_.py?
- Is the test case necessary/sufficient?
