### PR TITLE
[MRG] Update default test_size of ShuffleSplit for 0.21

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1267,7 +1267,7 @@ class RepeatedStratifiedKFold(_RepeatedSplits):
 class BaseShuffleSplit(metaclass=ABCMeta):
     """Base class for ShuffleSplit and StratifiedShuffleSplit"""
 
-    def __init__(self, n_splits=10, test_size="default", train_size=None,
+    def __init__(self, n_splits=10, test_size=None, train_size=None,
                  random_state=None):
         _validate_shuffle_split_init(test_size, train_size)
         self.n_splits = n_splits
@@ -1354,15 +1354,12 @@ class ShuffleSplit(BaseShuffleSplit):
     n_splits : int, default 10
         Number of re-shuffling & splitting iterations.
 
-    test_size : float, int, None, default=0.1
+    test_size : float, int, None, default=None
         If float, should be between 0.0 and 1.0 and represent the proportion
         of the dataset to include in the test split. If int, represents the
         absolute number of test samples. If None, the value is set to the
-        complement of the train size. By default (the parameter is
-        unspecified), the value is set to 0.1.
-        The default will change in version 0.21. It will remain 0.1 only
-        if ``train_size`` is unspecified, otherwise it will complement
-        the specified ``train_size``.
+        complement of the train size. If ``train_size`` is also None, it will
+        be set to 0.1.
 
     train_size : float, int, or None, default=None
         If float, should be between 0.0 and 1.0 and represent the
@@ -1411,7 +1408,8 @@ class ShuffleSplit(BaseShuffleSplit):
         n_samples = _num_samples(X)
         n_train, n_test = _validate_shuffle_split(n_samples,
                                                   self.test_size,
-                                                  self.train_size)
+                                                  self.train_size,
+                                                  0.1)
         rng = check_random_state(self.random_state)
         for i in range(self.n_splits):
             # random partition
@@ -1449,14 +1447,12 @@ class GroupShuffleSplit(ShuffleSplit):
     n_splits : int (default 5)
         Number of re-shuffling & splitting iterations.
 
-    test_size : float, int, None, optional
+    test_size : float, int, None, optional (default=None)
         If float, should be between 0.0 and 1.0 and represent the proportion
         of the dataset to include in the test split. If int, represents the
         absolute number of test groups. If None, the value is set to the
-        complement of the train size. By default, the value is set to 0.2.
-        The default will change in version 0.21. It will remain 0.2 only
-        if ``train_size`` is unspecified, otherwise it will complement
-        the specified ``train_size``.
+        complement of the train size. If ``train_size`` is also None, it will
+        be set to 0.2.
 
     train_size : float, int, or None, default is None
         If float, should be between 0.0 and 1.0 and represent the
@@ -1472,16 +1468,8 @@ class GroupShuffleSplit(ShuffleSplit):
 
     '''
 
-    def __init__(self, n_splits=5, test_size="default", train_size=None,
+    def __init__(self, n_splits=5, test_size=0.2, train_size=None,
                  random_state=None):
-        if test_size == "default":
-            if train_size is not None:
-                warnings.warn("From version 0.21, test_size will always "
-                              "complement train_size unless both "
-                              "are specified.",
-                              FutureWarning)
-            test_size = 0.2
-
         super().__init__(
             n_splits=n_splits,
             test_size=test_size,
@@ -1624,14 +1612,12 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     n_splits : int, default 10
         Number of re-shuffling & splitting iterations.
 
-    test_size : float, int, None, optional
+    test_size : float, int, None, optional (default=None)
         If float, should be between 0.0 and 1.0 and represent the proportion
         of the dataset to include in the test split. If int, represents the
         absolute number of test samples. If None, the value is set to the
-        complement of the train size. By default, the value is set to 0.1.
-        The default will change in version 0.21. It will remain 0.1 only
-        if ``train_size`` is unspecified, otherwise it will complement
-        the specified ``train_size``.
+        complement of the train size. If ``train_size`` is also None, it will
+        be set to 0.1.
 
     train_size : float, int, or None, default is None
         If float, should be between 0.0 and 1.0 and represent the
@@ -1667,16 +1653,19 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     TRAIN: [0 5 1] TEST: [3 4 2]
     """
 
-    def __init__(self, n_splits=10, test_size="default", train_size=None,
+    def __init__(self, n_splits=10, test_size=None, train_size=None,
                  random_state=None):
         super().__init__(
-            n_splits, test_size, train_size, random_state)
+            n_splits=n_splits,
+            test_size=test_size,
+            train_size=train_size,
+            random_state=random_state)
 
     def _iter_indices(self, X, y, groups=None):
         n_samples = _num_samples(X)
         y = check_array(y, ensure_2d=False, dtype=None)
         n_train, n_test = _validate_shuffle_split(n_samples, self.test_size,
-                                                  self.train_size)
+                                                  self.train_size, 0.1)
 
         if y.ndim == 2:
             # for multi-label y, map each distinct row to a string repr
@@ -1776,17 +1765,6 @@ def _validate_shuffle_split_init(test_size, train_size):
     NOTE This does not take into account the number of samples which is known
     only at split
     """
-    if test_size == "default":
-        if train_size is not None:
-            warnings.warn("From version 0.21, test_size will always "
-                          "complement train_size unless both "
-                          "are specified.",
-                          FutureWarning)
-        test_size = 0.1
-
-    if test_size is None and train_size is None:
-        raise ValueError('test_size and train_size can not both be None')
-
     if test_size is not None:
         if np.asarray(test_size).dtype.kind == 'f':
             if test_size >= 1. or test_size <= 0:
@@ -1802,58 +1780,68 @@ def _validate_shuffle_split_init(test_size, train_size):
             if train_size >= 1. or train_size <= 0:
                 raise ValueError('train_size=%f should be in the (0, 1) range '
                                  'or be an integer' % train_size)
-            elif (np.asarray(test_size).dtype.kind == 'f' and
-                    (
-                        (train_size + test_size) > 1. or
-                        (train_size + test_size) < 0)):
-                raise ValueError('The sum of test_size and train_size = %f, '
-                                 'should be in the (0, 1) range. Reduce '
-                                 'test_size and/or train_size.' %
-                                 (train_size + test_size))
         elif np.asarray(train_size).dtype.kind != 'i':
             # int values are checked during split based on the input
             raise ValueError("Invalid value for train_size: %r" % train_size)
 
+    if (np.asarray(test_size).dtype.kind == 'f' and
+       np.asarray(train_size).dtype.kind == 'f' and
+       train_size + test_size > 1):
+        raise ValueError(
+            'The sum of test_size and train_size = {}, should be in the (0, 1)'
+            ' range. Reduce test_size and/or train_size.'
+            .format(train_size + test_size))
 
-def _validate_shuffle_split(n_samples, test_size, train_size):
+
+def _validate_shuffle_split(n_samples, test_size, train_size,
+                            default_test_size=None):
     """
     Validation helper to check if the test/test sizes are meaningful wrt to the
     size of the data (n_samples)
     """
-    if (test_size is not None and
-            (np.asarray(test_size).dtype.kind == 'i' and
-                (test_size >= n_samples or test_size <= 0)) or
-            (np.asarray(test_size).dtype.kind == 'f' and
-                (test_size <= 0 or test_size >= 1))):
-        raise ValueError('test_size=%d should be either positive and smaller '
-                         'than the number of samples %d or a float in the '
-                         '(0,1) range' % (test_size, n_samples))
+    if test_size is None and train_size is None:
+        test_size = default_test_size
 
-    if (train_size is not None and
-            (np.asarray(train_size).dtype.kind == 'i' and
-                (train_size >= n_samples or train_size <= 0)) or
-            (np.asarray(train_size).dtype.kind == 'f' and
-                (train_size <= 0 or train_size >= 1))):
-        raise ValueError('train_size=%d should be either positive and smaller '
-                         'than the number of samples %d or a float in the '
-                         '(0,1) range' % (train_size, n_samples))
+    test_size_type = np.asarray(test_size).dtype.kind
+    train_size_type = np.asarray(train_size).dtype.kind
 
-    if test_size == "default":
-        test_size = 0.1
+    if (test_size_type == 'i' and (test_size >= n_samples or test_size <= 0)
+       or test_size_type == 'f' and (test_size <= 0 or test_size >= 1)):
+        raise ValueError('test_size={0} should be either positive and smaller'
+                         ' than the number of samples {1} or a float in the '
+                         '(0, 1) range'.format(test_size, n_samples))
 
-    if np.asarray(test_size).dtype.kind == 'f':
+    if (train_size_type == 'i' and (train_size >= n_samples or train_size <= 0)
+       or train_size_type == 'f' and (train_size <= 0 or train_size >= 1)):
+        raise ValueError('train_size={0} should be either positive and smaller'
+                         ' than the number of samples {1} or a float in the '
+                         '(0, 1) range'.format(train_size, n_samples))
+
+    if train_size is not None and train_size_type not in ('i', 'f'):
+        raise ValueError("Invalid value for train_size: {}".format(train_size))
+    if test_size is not None and test_size_type not in ('i', 'f'):
+        raise ValueError("Invalid value for test_size: {}".format(test_size))
+
+    if (train_size_type == 'f' and test_size_type == 'f' and
+            train_size + test_size > 1):
+        raise ValueError(
+            'The sum of test_size and train_size = {}, should be in the (0, 1)'
+            ' range. Reduce test_size and/or train_size.'
+            .format(train_size + test_size))
+
+    if test_size_type == 'f':
         n_test = ceil(test_size * n_samples)
-    elif np.asarray(test_size).dtype.kind == 'i':
+    elif test_size_type == 'i':
         n_test = float(test_size)
+
+    if train_size_type == 'f':
+        n_train = floor(train_size * n_samples)
+    elif train_size_type == 'i':
+        n_train = float(train_size)
 
     if train_size is None:
         n_train = n_samples - n_test
-    elif np.asarray(train_size).dtype.kind == 'f':
-        n_train = floor(train_size * n_samples)
-    else:
-        n_train = float(train_size)
-
-    if test_size is None:
+    elif test_size is None:
         n_test = n_samples - n_train
 
     if n_train + n_test > n_samples:
@@ -2091,14 +2079,12 @@ def train_test_split(*arrays, **options):
         Allowed inputs are lists, numpy arrays, scipy-sparse
         matrices or pandas dataframes.
 
-    test_size : float, int or None, optional (default=0.25)
+    test_size : float, int or None, optional (default=None)
         If float, should be between 0.0 and 1.0 and represent the proportion
         of the dataset to include in the test split. If int, represents the
         absolute number of test samples. If None, the value is set to the
-        complement of the train size. By default, the value is set to 0.25.
-        The default will change in version 0.21. It will remain 0.25 only
-        if ``train_size`` is unspecified, otherwise it will complement
-        the specified ``train_size``.
+        complement of the train size. If ``train_size`` is also None, it will
+        be set to 0.25.
 
     train_size : float, int, or None, (default=None)
         If float, should be between 0.0 and 1.0 and represent the
@@ -2166,7 +2152,7 @@ def train_test_split(*arrays, **options):
     n_arrays = len(arrays)
     if n_arrays == 0:
         raise ValueError("At least one array required as input")
-    test_size = options.pop('test_size', 'default')
+    test_size = options.pop('test_size', None)
     train_size = options.pop('train_size', None)
     random_state = options.pop('random_state', None)
     stratify = options.pop('stratify', None)
@@ -2175,28 +2161,17 @@ def train_test_split(*arrays, **options):
     if options:
         raise TypeError("Invalid parameters passed: %s" % str(options))
 
-    if test_size == 'default':
-        test_size = None
-        if train_size is not None:
-            warnings.warn("From version 0.21, test_size will always "
-                          "complement train_size unless both "
-                          "are specified.",
-                          FutureWarning)
-
-    if test_size is None and train_size is None:
-        test_size = 0.25
-
     arrays = indexable(*arrays)
+
+    n_samples = _num_samples(arrays[0])
+    n_train, n_test = _validate_shuffle_split(n_samples, test_size,
+                                              train_size, 0.25)
 
     if shuffle is False:
         if stratify is not None:
             raise ValueError(
                 "Stratified train/test split is not implemented for "
                 "shuffle=False")
-
-        n_samples = _num_samples(arrays[0])
-        n_train, n_test = _validate_shuffle_split(n_samples, test_size,
-                                                  train_size)
 
         train = np.arange(n_train)
         test = np.arange(n_train, n_train + n_test)
@@ -2207,8 +2182,8 @@ def train_test_split(*arrays, **options):
         else:
             CVClass = ShuffleSplit
 
-        cv = CVClass(test_size=test_size,
-                     train_size=train_size,
+        cv = CVClass(test_size=n_test,
+                     train_size=n_train,
                      random_state=random_state)
 
         train, test = next(cv.split(X=arrays[0], y=stratify))

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1269,7 +1269,6 @@ class BaseShuffleSplit(metaclass=ABCMeta):
 
     def __init__(self, n_splits=10, test_size=None, train_size=None,
                  random_state=None):
-        _validate_shuffle_split_init(test_size, train_size)
         self.n_splits = n_splits
         self.test_size = test_size
         self.train_size = train_size
@@ -1758,40 +1757,6 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
         """
         y = check_array(y, ensure_2d=False, dtype=None)
         return super().split(X, y, groups)
-
-
-def _validate_shuffle_split_init(test_size, train_size):
-    """Validation helper to check the test_size and train_size at init
-
-    NOTE This does not take into account the number of samples which is known
-    only at split
-    """
-    if test_size is not None:
-        if np.asarray(test_size).dtype.kind == 'f':
-            if test_size >= 1. or test_size <= 0:
-                raise ValueError(
-                    'test_size=%f should be in the (0, 1) range '
-                    'or be an integer' % test_size)
-        elif np.asarray(test_size).dtype.kind != 'i':
-            # int values are checked during split based on the input
-            raise ValueError("Invalid value for test_size: %r" % test_size)
-
-    if train_size is not None:
-        if np.asarray(train_size).dtype.kind == 'f':
-            if train_size >= 1. or train_size <= 0:
-                raise ValueError('train_size=%f should be in the (0, 1) range '
-                                 'or be an integer' % train_size)
-        elif np.asarray(train_size).dtype.kind != 'i':
-            # int values are checked during split based on the input
-            raise ValueError("Invalid value for train_size: %r" % train_size)
-
-    if (np.asarray(test_size).dtype.kind == 'f' and
-       np.asarray(train_size).dtype.kind == 'f' and
-       train_size + test_size > 1):
-        raise ValueError(
-            'The sum of test_size and train_size = {}, should be in the (0, 1)'
-            ' range. Reduce test_size and/or train_size.'
-            .format(train_size + test_size))
 
 
 def _validate_shuffle_split(n_samples, test_size, train_size,

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2130,8 +2130,7 @@ def train_test_split(*arrays, **options):
     arrays = indexable(*arrays)
 
     n_samples = _num_samples(arrays[0])
-    n_train, n_test = _validate_shuffle_split(n_samples, test_size,
-                                              train_size,
+    n_train, n_test = _validate_shuffle_split(n_samples, test_size, train_size,
                                               default_test_size=0.25)
 
     if shuffle is False:

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1409,7 +1409,7 @@ class ShuffleSplit(BaseShuffleSplit):
         n_train, n_test = _validate_shuffle_split(n_samples,
                                                   self.test_size,
                                                   self.train_size,
-                                                  0.1)
+                                                  default_test_size=0.1)
         rng = check_random_state(self.random_state)
         for i in range(self.n_splits):
             # random partition
@@ -1665,7 +1665,8 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
         n_samples = _num_samples(X)
         y = check_array(y, ensure_2d=False, dtype=None)
         n_train, n_test = _validate_shuffle_split(n_samples, self.test_size,
-                                                  self.train_size, 0.1)
+                                                  self.train_size,
+                                                  default_test_size=0.1)
 
         if y.ndim == 2:
             # for multi-label y, map each distinct row to a string repr
@@ -2165,7 +2166,8 @@ def train_test_split(*arrays, **options):
 
     n_samples = _num_samples(arrays[0])
     n_train, n_test = _validate_shuffle_split(n_samples, test_size,
-                                              train_size, 0.25)
+                                              train_size,
+                                              default_test_size=0.25)
 
     if shuffle is False:
         if stratify is not None:

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1273,6 +1273,7 @@ class BaseShuffleSplit(metaclass=ABCMeta):
         self.test_size = test_size
         self.train_size = train_size
         self.random_state = random_state
+        self._default_test_size = 0.1
 
     def split(self, X, y=None, groups=None):
         """Generate indices to split data into training and test set.
@@ -1402,13 +1403,21 @@ class ShuffleSplit(BaseShuffleSplit):
     TRAIN: [3 4 1] TEST: [5 2]
     TRAIN: [3 5 1] TEST: [2 4]
     """
+    def __init__(self, n_splits=10, test_size=None, train_size=None,
+                 random_state=None):
+        super().__init__(
+            n_splits=n_splits,
+            test_size=test_size,
+            train_size=train_size,
+            random_state=random_state)
+        self._default_test_size = 0.1
 
     def _iter_indices(self, X, y=None, groups=None):
         n_samples = _num_samples(X)
-        n_train, n_test = _validate_shuffle_split(n_samples,
-                                                  self.test_size,
-                                                  self.train_size,
-                                                  default_test_size=0.1)
+        n_train, n_test = _validate_shuffle_split(
+            n_samples, self.test_size, self.train_size,
+            default_test_size=self._default_test_size)
+
         rng = check_random_state(self.random_state)
         for i in range(self.n_splits):
             # random partition
@@ -1467,13 +1476,14 @@ class GroupShuffleSplit(ShuffleSplit):
 
     '''
 
-    def __init__(self, n_splits=5, test_size=0.2, train_size=None,
+    def __init__(self, n_splits=5, test_size=None, train_size=None,
                  random_state=None):
         super().__init__(
             n_splits=n_splits,
             test_size=test_size,
             train_size=train_size,
             random_state=random_state)
+        self._default_test_size = 0.2
 
     def _iter_indices(self, X, y, groups):
         if groups is None:
@@ -1659,13 +1669,14 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
             test_size=test_size,
             train_size=train_size,
             random_state=random_state)
+        self._default_test_size = 0.1
 
     def _iter_indices(self, X, y, groups=None):
         n_samples = _num_samples(X)
         y = check_array(y, ensure_2d=False, dtype=None)
-        n_train, n_test = _validate_shuffle_split(n_samples, self.test_size,
-                                                  self.train_size,
-                                                  default_test_size=0.1)
+        n_train, n_test = _validate_shuffle_split(
+            n_samples, self.test_size, self.train_size,
+            default_test_size=self._default_test_size)
 
         if y.ndim == 2:
             # for multi-label y, map each distinct row to a string repr

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -570,12 +570,31 @@ def test_shuffle_split():
                           (0.8, 8, 2)])
 def test_shuffle_split_default_test_size(split_class, train_size, exp_train,
                                          exp_test):
-    # Check that the default value has the expected behavior, i.e. complement
-    # train_size unless both are specified.
+    # Check that the default value has the expected behavior, i.e. 0.1 if both
+    # unspecified or complement train_size unless both are specified.
     X = np.ones(10)
     y = np.ones(10)
 
     X_train, X_test = next(split_class(train_size=train_size).split(X, y))
+
+    assert len(X_train) == exp_train
+    assert len(X_test) == exp_test
+
+
+@pytest.mark.parametrize("train_size, exp_train, exp_test",
+                         [(None, 8, 2),
+                          (8, 8, 2),
+                          (0.8, 8, 2)])
+def test_group_shuffle_split_default_test_size(train_size, exp_train,
+                                               exp_test):
+    # Check that the default value has the expected behavior, i.e. 0.2 if both
+    # unspecified or complement train_size unless both are specified.
+    X = np.ones(10)
+    y = np.ones(10)
+    groups = range(10)
+
+    X_train, X_test = next(GroupShuffleSplit(train_size=train_size)
+                           .split(X, y, groups))
 
     assert len(X_train) == exp_train
     assert len(X_test) == exp_test

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -17,7 +17,6 @@ from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_warns_message
-from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_no_warnings
@@ -1158,20 +1157,17 @@ def test_train_test_split_list_input():
         np.testing.assert_equal(y_test3, y_test2)
 
 
-@ignore_warnings
-def test_shufflesplit_errors():
-    # When the {test|train}_size is a float/invalid, error is raised at init
-    assert_raises(ValueError, ShuffleSplit, test_size=2.0)
-    assert_raises(ValueError, ShuffleSplit, test_size=1.0)
-    assert_raises(ValueError, ShuffleSplit, test_size=0.1, train_size=0.95)
-    assert_raises(ValueError, ShuffleSplit, train_size=1j)
-
-    # When the {test|train}_size is an int, validation is based on the input X
-    # and happens at split(...)
-    assert_raises(ValueError, next, ShuffleSplit(test_size=11).split(X))
-    assert_raises(ValueError, next, ShuffleSplit(test_size=10).split(X))
-    assert_raises(ValueError, next, ShuffleSplit(test_size=8,
-                                                 train_size=3).split(X))
+@pytest.mark.parametrize("test_size, train_size",
+                         [(2.0, None),
+                          (1.0, None),
+                          (0.1, 0.95),
+                          (None, 1j),
+                          (11, None),
+                          (10, None),
+                          (8, 3)])
+def test_shufflesplit_errors(test_size, train_size):
+    with pytest.raises(ValueError):
+        next(ShuffleSplit(test_size=test_size, train_size=train_size).split(X))
 
 
 def test_shufflesplit_reproducible():

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -161,7 +161,7 @@ def test_cross_validator_with_default_params():
     lolo_repr = "LeaveOneGroupOut()"
     lopo_repr = "LeavePGroupsOut(n_groups=2)"
     ss_repr = ("ShuffleSplit(n_splits=10, random_state=0, "
-               "test_size='default',\n       train_size=None)")
+               "test_size=None, train_size=None)")
     ps_repr = "PredefinedSplit(test_fold=array([1, 1, 2, 2]))"
 
     n_splits_expected = [n_samples, comb(n_samples, p), n_splits, n_splits,
@@ -580,12 +580,6 @@ def test_stratified_shuffle_split_init():
 
     X = np.arange(9)
     y = np.asarray([0, 0, 0, 1, 1, 1, 2, 2, 2])
-    # Check that errors are raised if there is not enough samples
-    assert_raises(ValueError, StratifiedShuffleSplit, 3, 0.5, 0.6)
-    assert_raises(ValueError, next,
-                  StratifiedShuffleSplit(3, 8, 0.6).split(X, y))
-    assert_raises(ValueError, next,
-                  StratifiedShuffleSplit(3, 0.6, 8).split(X, y))
 
     # Train size or test size too small
     assert_raises(ValueError, next,
@@ -1005,11 +999,8 @@ def test_repeated_stratified_kfold_determinstic_split():
 
 def test_train_test_split_errors():
     pytest.raises(ValueError, train_test_split)
-    with warnings.catch_warnings():
-        # JvR: Currently, a future warning is raised if test_size is not
-        # given. As that is the point of this test, ignore the future warning
-        warnings.filterwarnings("ignore", category=FutureWarning)
-        pytest.raises(ValueError, train_test_split, range(3), train_size=1.1)
+
+    pytest.raises(ValueError, train_test_split, range(3), train_size=1.1)
 
     pytest.raises(ValueError, train_test_split, range(3), test_size=0.6,
                   train_size=0.6)
@@ -1028,7 +1019,7 @@ def test_train_test_split_errors():
     with pytest.raises(ValueError,
                        match=r'train_size=11 should be either positive and '
                              r'smaller than the number of samples 10 or a '
-                             r'float in the \(0,1\) range'):
+                             r'float in the \(0, 1\) range'):
         train_test_split(range(10), train_size=11, test_size=1)
 
 
@@ -1042,7 +1033,8 @@ def test_train_test_split_errors():
     (0.8, 0.),
     (0.8, -.2)])
 def test_train_test_split_invalid_sizes1(train_size, test_size):
-    with pytest.raises(ValueError, match=r'should be in the \(0, 1\) range'):
+    with pytest.raises(ValueError,
+                       match=r'should be .* in the \(0, 1\) range'):
         train_test_split(range(10), train_size=train_size, test_size=test_size)
 
 
@@ -1169,7 +1161,6 @@ def test_train_test_split_list_input():
 @ignore_warnings
 def test_shufflesplit_errors():
     # When the {test|train}_size is a float/invalid, error is raised at init
-    assert_raises(ValueError, ShuffleSplit, test_size=None, train_size=None)
     assert_raises(ValueError, ShuffleSplit, test_size=2.0)
     assert_raises(ValueError, ShuffleSplit, test_size=1.0)
     assert_raises(ValueError, ShuffleSplit, test_size=0.1, train_size=0.95)
@@ -1447,14 +1438,6 @@ def test_nested_cv():
                           cv=inner_cv, error_score='raise', iid=False)
         cross_val_score(gs, X=X, y=y, groups=groups, cv=outer_cv,
                         fit_params={'groups': groups})
-
-
-def test_train_test_default_warning():
-    assert_warns(FutureWarning, ShuffleSplit, train_size=0.75)
-    assert_warns(FutureWarning, GroupShuffleSplit, train_size=0.75)
-    assert_warns(FutureWarning, StratifiedShuffleSplit, train_size=0.75)
-    assert_warns(FutureWarning, train_test_split, range(3),
-                 train_size=0.75)
 
 
 def test_nsplit_default_warn():

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -583,8 +583,8 @@ def test_shuffle_split_default_test_size(split_class, train_size, exp_train,
 
 @pytest.mark.parametrize("train_size, exp_train, exp_test",
                          [(None, 8, 2),
-                          (8, 8, 2),
-                          (0.8, 8, 2)])
+                          (7, 7, 3),
+                          (0.7, 7, 3)])
 def test_group_shuffle_split_default_test_size(train_size, exp_train,
                                                exp_test):
     # Check that the default value has the expected behavior, i.e. 0.2 if both

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1050,6 +1050,19 @@ def test_train_test_split_invalid_sizes2(train_size, test_size):
         train_test_split(range(10), train_size=train_size, test_size=test_size)
 
 
+@pytest.mark.parametrize("train_size, exp_train, exp_test",
+                         [(None, 7, 3),
+                          (8, 8, 2),
+                          (0.8, 8, 2)])
+def test_train_test_split_default_test_size(train_size, exp_train, exp_test):
+    # Check that the default value has the expected behavior, i.e. complement
+    # train_size unless both are specified.
+    X_train, X_test = train_test_split(X, train_size=train_size)
+
+    assert len(X_train) == exp_train
+    assert len(X_test) == exp_test
+
+
 def test_train_test_split():
     X = np.arange(100).reshape((10, 10))
     X_s = coo_matrix(X)

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -562,6 +562,25 @@ def test_shuffle_split():
         assert_array_equal(t3[1], t4[1])
 
 
+@pytest.mark.parametrize("split_class", [ShuffleSplit,
+                                         StratifiedShuffleSplit])
+@pytest.mark.parametrize("train_size, exp_train, exp_test",
+                         [(None, 9, 1),
+                          (8, 8, 2),
+                          (0.8, 8, 2)])
+def test_shuffle_split_default_test_size(split_class, train_size, exp_train,
+                                         exp_test):
+    # Check that the default value has the expected behavior, i.e. complement
+    # train_size unless both are specified.
+    X = np.ones(10)
+    y = np.ones(10)
+
+    X_train, X_test = next(split_class(train_size=train_size).split(X, y))
+
+    assert len(X_train) == exp_train
+    assert len(X_test) == exp_test
+
+
 @ignore_warnings
 def test_stratified_shuffle_split_init():
     X = np.arange(7)


### PR DESCRIPTION
Complement of #13443 in order to clean the deprecations for 0.21

I moved the `_split` part a this separate PR because the change is not straightforward and needs more work.

I've set `test_size` default value to None, which will be interpreted as the default value (depending on the estimator) when `train_size` is also None.