### PR TITLE
[MRG] Fix empty clusters not correctly relocated

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -88,7 +88,11 @@ Support for Python 3.4 and below has been officially dropped.
 - |API| The ``n_components_`` attribute in :class:`cluster.AgglomerativeClustering`
   and :class:`cluster.FeatureAgglomeration` has been renamed to
   ``n_connected_components_``.
+
   :issue:`13427` by :user:`Stephane Couvreur <scouvreur>`.
+- |Fix| Fixed a bug in :class:`KMeans` where empty clusters weren't correctly
+  relocated when using sample weights. :issue:``
+  by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 :mod:`sklearn.datasets`
 .......................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -91,7 +91,7 @@ Support for Python 3.4 and below has been officially dropped.
 
   :issue:`13427` by :user:`Stephane Couvreur <scouvreur>`.
 - |Fix| Fixed a bug in :class:`KMeans` where empty clusters weren't correctly
-  relocated when using sample weights. :issue:``
+  relocated when using sample weights. :issue:`13486`
   by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 :mod:`sklearn.datasets`

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -88,8 +88,8 @@ Support for Python 3.4 and below has been officially dropped.
 - |API| The ``n_components_`` attribute in :class:`cluster.AgglomerativeClustering`
   and :class:`cluster.FeatureAgglomeration` has been renamed to
   ``n_connected_components_``.
-
   :issue:`13427` by :user:`Stephane Couvreur <scouvreur>`.
+
 - |Fix| Fixed a bug in :class:`KMeans` where empty clusters weren't correctly
   relocated when using sample weights. :issue:`13486`
   by :user:`Jérémie du Boisberranger <jeremiedbb>`.

--- a/sklearn/cluster/_k_means.pyx
+++ b/sklearn/cluster/_k_means.pyx
@@ -309,7 +309,7 @@ def _centers_dense(np.ndarray[floating, ndim=2] X,
         for i, cluster_id in enumerate(empty_clusters):
             # XXX two relocated clusters could be close to each other
             far_index = far_from_centers[i]
-            new_center = X[far_index]
+            new_center = X[far_index] * sample_weight[far_index]
             centers[cluster_id] = new_center
             weight_in_cluster[cluster_id] = sample_weight[far_index]
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -9,6 +9,7 @@ import pytest
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raises_regex
@@ -922,3 +923,15 @@ def test_iter_attribute():
     estimator = KMeans(algorithm="elkan", max_iter=1)
     estimator.fit(np.random.rand(10, 10))
     assert estimator.n_iter_ == 1
+
+
+def test_k_means_empty_cluster_relocated():
+    X = np.array([[-1], [1]])
+    sample_weight = [1.9, 0.1]
+    init = np.array([[-1], [10]])
+
+    km = KMeans(n_clusters=2, init=init, n_init=1)
+    km.fit(X, sample_weight=sample_weight)
+
+    assert len(set(km.labels_)) == 2
+    assert_allclose(km.cluster_centers_, [[-1], [1]])

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -926,6 +926,8 @@ def test_iter_attribute():
 
 
 def test_k_means_empty_cluster_relocated():
+    # check that empty clusters are correctly relocated when using sample
+    # weights (#13486)
     X = np.array([[-1], [1]])
     sample_weight = [1.9, 0.1]
     init = np.array([[-1], [10]])


### PR DESCRIPTION
When using sample weights in KMeans, empty clusters are not correctly relocated.

basically what was done is
```python
# for some i
new_center = X[i]  # should be multiplied by the weight
...
new_center /= sample_weight[i]
```

the added test fails on master