### PR TITLE
Support area computation of generic curves

### DIFF
--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -425,6 +425,15 @@ def test_auc():
     x = [0, 0.5, 1]
     y = [0, 0.5, 1]
     assert_array_almost_equal(auc(x, y), 0.5)
+    x = [0, 1, 0]
+    y = [0, 0.5, 1]
+    assert_array_almost_equal(auc(x, y), -0.5)
+    x = [0, 1, 0]
+    y = [1, 0.5, 0]
+    assert_array_almost_equal(auc(x, y), 0.5)
+    x = [2, 1, 3, 4]
+    y = [5, 6, 7, 8]
+    assert_array_almost_equal(auc(x, y), 15.0)
 
 
 @pytest.mark.filterwarnings("ignore: The 'reorder' parameter")  # 0.22
@@ -453,19 +462,12 @@ def test_auc_errors():
     # Too few x values
     assert_raises(ValueError, auc, [0.0], [0.1])
 
-    # x is not in order
-    x = [2, 1, 3, 4]
-    y = [5, 6, 7, 8]
-    error_message = ("x is neither increasing nor decreasing : "
-                     "{}".format(np.array(x)))
-    assert_raise_message(ValueError, error_message, auc, x, y)
-
 
 def test_deprecated_auc_reorder():
     depr_message = ("The 'reorder' parameter has been deprecated in version "
                     "0.20 and will be removed in 0.22. It is recommended not "
-                    "to set 'reorder' and ensure that x is monotonic "
-                    "increasing or monotonic decreasing.")
+                    "to set 'reorder' and rest assured that x direction "
+                    "is internally taken into consideration.")
     assert_warns_message(DeprecationWarning, depr_message, auc,
                          [1, 2], [2, 3], reorder=True)
 


### PR DESCRIPTION
#### What does this implement/fix?
This PR addresses the problem of computing the area under curves that its x changes direction as shown in the following figures.

In this case, we want to compute the area under the curve, without miscalculating the loop effect on the area.
![PR_thresholds](https://user-images.githubusercontent.com/42140441/55454161-bdccd680-5619-11e9-853e-7592679677d7.png)
![PR_parametric](https://user-images.githubusercontent.com/42140441/55454162-bdccd680-5619-11e9-9f46-ce96484d830b.png)

```Mathmatica
p[s_] := s (1 + Sin[s*2*Pi]/2)
r[s_] := 1 - s (1 - Sin[s*3*Pi]/2)
Plot[{p[s], r[s]}, {s, 0, 1}, AxesLabel -> {"s", "f(x)"}, 
 PlotLegends -> "Expressions", 
 PlotLabel -> "Precision & Recall vs Threshold", 
 BaseStyle -> {FontWeight -> "Bold", FontSize -> 16}]
ParametricPlot[{p[s], r[s]}, {s, 0, 1}, 
 AxesLabel -> {"r(s)", "p(s)"}, 
 PlotLabel -> "Precision-Recall parametric curve", 
 BaseStyle -> {FontWeight -> "Bold", FontSize -> 16}]
```

This fix relaxes the input requirements, as there is no need to limit the support to curves having their x values monotonically increasing or decreasing. The approach is to split the curve into segments that are monotonically increasing or decreasing, and compute the area under each individual segment separately.