### PR TITLE
[MRG] ENH iForest - expose warm_start (#13451)

### DIFF
--- a/doc/modules/outlier_detection.rst
+++ b/doc/modules/outlier_detection.rst
@@ -269,6 +269,20 @@ This algorithm is illustrated below.
     * Liu, Fei Tony, Ting, Kai Ming and Zhou, Zhi-Hua. "Isolation forest."
       Data Mining, 2008. ICDM'08. Eighth IEEE International Conference on.
 
+.. _iforest_warm_start:
+
+Fitting additional trees
+~~~~~~~~~~~~~~~~~~~~~~~~
+The :class:`ensemble.IsolationForest` supports ``warm_start=True`` which
+allows you to add more trees to an already fitted model.
+
+::
+
+  >>> clf = IsolationForest(n_estimators=100, warm_start=True)
+  >>> clf.fit(X)
+  >>> clf.set_params(n_estimators=200)  # set warm_start and new nr of trees
+  >>> clf.fit(X) # fit additional 100 trees
+
 
 Local Outlier Factor
 --------------------

--- a/doc/modules/outlier_detection.rst
+++ b/doc/modules/outlier_detection.rst
@@ -252,6 +252,21 @@ This algorithm is illustrated below.
    :align: center
    :scale: 75%
 
+.. _iforest_warm_start:
+
+The :class:`ensemble.IsolationForest` supports ``warm_start=True`` which
+allows you to add more trees to an already fitted model::
+
+  >>> from sklearn.ensemble import IsolationForest
+  >>> import numpy as np
+  >>> X = np.array([[-1, -1], [-2, -1], [-3, -2], [0, 0], [-20, 50], [3, 5]])
+  >>> # fit 10 trees
+  >>> clf = IsolationForest(n_estimators=10, warm_start=True)
+  >>> clf.fit(X)  # doctest: +SKIP
+  >>> # add & fit 10 more trees
+  >>> clf.set_params(n_estimators=20)  # doctest: +SKIP
+  >>> clf.fit(X)  # doctest: +SKIP
+
 .. topic:: Examples:
 
    * See :ref:`sphx_glr_auto_examples_ensemble_plot_isolation_forest.py` for
@@ -268,20 +283,6 @@ This algorithm is illustrated below.
 
     * Liu, Fei Tony, Ting, Kai Ming and Zhou, Zhi-Hua. "Isolation forest."
       Data Mining, 2008. ICDM'08. Eighth IEEE International Conference on.
-
-.. _iforest_warm_start:
-
-Fitting additional trees
-~~~~~~~~~~~~~~~~~~~~~~~~
-The :class:`ensemble.IsolationForest` supports ``warm_start=True`` which
-allows you to add more trees to an already fitted model.
-
-::
-
-  >>> clf = IsolationForest(n_estimators=100, warm_start=True)
-  >>> clf.fit(X)
-  >>> clf.set_params(n_estimators=200)  # set warm_start and new nr of trees
-  >>> clf.fit(X) # fit additional 100 trees
 
 
 Local Outlier Factor

--- a/doc/modules/outlier_detection.rst
+++ b/doc/modules/outlier_detection.rst
@@ -260,12 +260,10 @@ allows you to add more trees to an already fitted model::
   >>> from sklearn.ensemble import IsolationForest
   >>> import numpy as np
   >>> X = np.array([[-1, -1], [-2, -1], [-3, -2], [0, 0], [-20, 50], [3, 5]])
-  >>> # fit 10 trees
   >>> clf = IsolationForest(n_estimators=10, warm_start=True)
-  >>> clf.fit(X)  # doctest: +SKIP
-  >>> # add & fit 10 more trees
-  >>> clf.set_params(n_estimators=20)  # doctest: +SKIP
-  >>> clf.fit(X)  # doctest: +SKIP
+  >>> clf.fit(X)  # fit 10 trees  # doctest: +SKIP
+  >>> clf.set_params(n_estimators=20)  # add 10 more trees  # doctest: +SKIP
+  >>> clf.fit(X)  # fit the added trees  # doctest: +SKIP
 
 .. topic:: Examples:
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -179,6 +179,10 @@ Support for Python 3.4 and below has been officially dropped.
   prediction step, thus capping the memory usage. :issue:`13283` by
   `Nicolas Goix`_.
 
+- |Enhancement| :class:`ensemble.IsolationForest` now exposes ``warm_start``
+  parameter, allowing iterative addition of trees to an isolation 
+  forest. :issue:`13451` by :user:`Peter Marko <petibear>`.
+
 - |Fix| Fixed a bug in :class:`ensemble.GradientBoostingClassifier` where
   the gradients would be incorrectly computed in multiclass classification
   problems. :issue:`12715` by :user:`Nicolas Hug<NicolasHug>`.

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -181,7 +181,7 @@ Support for Python 3.4 and below has been officially dropped.
 
 - |Enhancement| :class:`ensemble.IsolationForest` now exposes ``warm_start``
   parameter, allowing iterative addition of trees to an isolation 
-  forest. :issue:`13451` by :user:`Peter Marko <petibear>`.
+  forest. :issue:`13496` by :user:`Peter Marko <petibear>`.
 
 - |Fix| Fixed a bug in :class:`ensemble.GradientBoostingClassifier` where
   the gradients would be incorrectly computed in multiclass classification

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -120,6 +120,10 @@ class IsolationForest(BaseBagging, OutlierMixin):
     verbose : int, optional (default=0)
         Controls the verbosity of the tree building process.
 
+    warm_start : bool, optional (default=False)
+        When set to ``True``, reuse the solution of the previous call to fit
+        and add more estimators to the ensemble, otherwise, just fit a whole
+        new forest. See :term:`the Glossary <warm_start>`.
 
     Attributes
     ----------
@@ -173,7 +177,8 @@ class IsolationForest(BaseBagging, OutlierMixin):
                  n_jobs=None,
                  behaviour='old',
                  random_state=None,
-                 verbose=0):
+                 verbose=0,
+                 warm_start=False):
         super().__init__(
             base_estimator=ExtraTreeRegressor(
                 max_features=1,
@@ -185,6 +190,7 @@ class IsolationForest(BaseBagging, OutlierMixin):
             n_estimators=n_estimators,
             max_samples=max_samples,
             max_features=max_features,
+            warm_start=warm_start,
             n_jobs=n_jobs,
             random_state=random_state,
             verbose=verbose)

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -125,6 +125,8 @@ class IsolationForest(BaseBagging, OutlierMixin):
         and add more estimators to the ensemble, otherwise, just fit a whole
         new forest. See :term:`the Glossary <warm_start>`.
 
+        .. versionadded:: 0.21
+
     Attributes
     ----------
     estimators_ : list of DecisionTreeClassifier

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -297,7 +297,7 @@ def test_score_samples():
 
 @pytest.mark.filterwarnings('ignore:default contamination')
 @pytest.mark.filterwarnings('ignore:behaviour="old"')
-def test_iforest_warmstart():
+def test_iforest_warm_start():
     """Test iterative addition of iTrees to an iForest """
 
     rng = check_random_state(0)

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -297,6 +297,34 @@ def test_score_samples():
 
 @pytest.mark.filterwarnings('ignore:default contamination')
 @pytest.mark.filterwarnings('ignore:behaviour="old"')
+def test_iforest_warmstart():
+    """Test iterative addition of iTrees to an iForest """
+
+    rng = check_random_state(0)
+
+    # Generate regular observations
+    X = 0.3 * rng.randn(90, 2)
+    X_reg = np.r_[X + 4, X - 4]
+    # Generate some abnormal observations
+    X_outliers = rng.uniform(low=-2, high=2, size=(20, 2))
+    X_train = np.r_[X_reg, X_outliers]
+
+    # fit first 10 trees
+    clf = IsolationForest(n_estimators=10, max_samples=20,
+                          random_state=rng, warm_start=True)
+    clf.fit(X_train)
+    # keep the 1st tree
+    tree_1 = clf.estimators_[0]
+    # fit another 10 trees
+    clf.n_estimators += 10
+    clf.fit(X_train)
+    # expecting 20 fitted trees and no overwritten trees
+    assert len(clf.estimators_) == 20
+    assert clf.estimators_[0] is tree_1
+
+
+@pytest.mark.filterwarnings('ignore:default contamination')
+@pytest.mark.filterwarnings('ignore:behaviour="old"')
 def test_deprecation():
     X = [[0.0], [1.0]]
     clf = IsolationForest()

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -301,23 +301,17 @@ def test_iforest_warmstart():
     """Test iterative addition of iTrees to an iForest """
 
     rng = check_random_state(0)
-
-    # Generate regular observations
-    X = 0.3 * rng.randn(90, 2)
-    X_reg = np.r_[X + 4, X - 4]
-    # Generate some abnormal observations
-    X_outliers = rng.uniform(low=-2, high=2, size=(20, 2))
-    X_train = np.r_[X_reg, X_outliers]
+    X = iris.data
 
     # fit first 10 trees
     clf = IsolationForest(n_estimators=10, max_samples=20,
                           random_state=rng, warm_start=True)
-    clf.fit(X_train)
-    # keep the 1st tree
+    clf.fit(X)
+    # remember the 1st tree
     tree_1 = clf.estimators_[0]
     # fit another 10 trees
-    clf.n_estimators += 10
-    clf.fit(X_train)
+    clf.set_params(n_estimators=20)
+    clf.fit(X)
     # expecting 20 fitted trees and no overwritten trees
     assert len(clf.estimators_) == 20
     assert clf.estimators_[0] is tree_1

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -301,7 +301,7 @@ def test_iforest_warmstart():
     """Test iterative addition of iTrees to an iForest """
 
     rng = check_random_state(0)
-    X = iris.data
+    X = rng.randn(20, 2)
 
     # fit first 10 trees
     clf = IsolationForest(n_estimators=10, max_samples=20,


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #13451

#### What does this implement/fix? Explain your changes.
This PR exposes `warm_start` in the `sklearn.ensemble.IsolationForest`. 
It also adds a test ` sklearn/ensemble/tests/test_iforest.py` to check whether iterative addition of iTrees to an iForest works as expected.

#### Any other comments?
Shouldn't there be a `.. versionadded:: 0.??` added, please? If so, what number?




