### PR TITLE
Fix _estimate_mi discrete_features str and value check

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -212,6 +212,15 @@ Support for Python 3.4 and below has been officially dropped.
 - |API| Deprecated :mod:`externals.six` since we have dropped support for
   Python 2.7. :issue:`12916` by :user:`Hanmin Qin <qinhanmin2014>`.
 
+:mod:`sklearn.feature_selection`
+.....................
+
+- |Fix| In :function:`feature_selection.mutual_info_classif` and
+  :function:`feature_selection.mutual_info_regression` fix logic handling
+  `discrete_features` property cases to prevent issues with future versions of
+  numpy. :issue:`13497` by :user:`Leandro Hermida <hermidalc>` and
+  :user:`Adrin Jalali <adrinjalali>`.
+
 :mod:`sklearn.impute`
 .....................
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -212,15 +212,6 @@ Support for Python 3.4 and below has been officially dropped.
 - |API| Deprecated :mod:`externals.six` since we have dropped support for
   Python 2.7. :issue:`12916` by :user:`Hanmin Qin <qinhanmin2014>`.
 
-:mod:`sklearn.feature_selection`
-.....................
-
-- |Fix| In :function:`feature_selection.mutual_info_classif` and
-  :function:`feature_selection.mutual_info_regression` fix logic handling
-  `discrete_features` property cases to prevent issues with future versions of
-  numpy. :issue:`13497` by :user:`Leandro Hermida <hermidalc>` and
-  :user:`Adrin Jalali <adrinjalali>`.
-
 :mod:`sklearn.impute`
 .....................
 

--- a/sklearn/feature_selection/mutual_info_.py
+++ b/sklearn/feature_selection/mutual_info_.py
@@ -10,7 +10,7 @@ from ..neighbors import NearestNeighbors
 from ..preprocessing import scale
 from ..utils import check_random_state
 from ..utils.fixes import _astype_copy_false
-from ..utils.validation import check_X_y
+from ..utils.validation import check_array, check_X_y
 from ..utils.multiclass import check_classification_targets
 
 
@@ -247,17 +247,16 @@ def _estimate_mi(X, y, discrete_features='auto', discrete_target=False,
     X, y = check_X_y(X, y, accept_sparse='csc', y_numeric=not discrete_target)
     n_samples, n_features = X.shape
 
-    if isinstance(discrete_features, str):
-        if discrete_features == 'auto':
-            discrete_features = issparse(X)
-        else:
-            raise ValueError("Invalid string value for discrete_features.")
-
-    if isinstance(discrete_features, bool):
+    if isinstance(discrete_features, (str, bool)):
+        if isinstance(discrete_features, str):
+            if discrete_features == 'auto':
+                discrete_features = issparse(X)
+            else:
+                raise ValueError("Invalid string value for discrete_features.")
         discrete_mask = np.empty(n_features, dtype=bool)
         discrete_mask.fill(discrete_features)
     else:
-        discrete_features = np.asarray(discrete_features)
+        discrete_features = check_array(discrete_features, ensure_2d=False)
         if discrete_features.dtype != 'bool':
             discrete_mask = np.zeros(n_features, dtype=bool)
             discrete_mask[discrete_features] = True

--- a/sklearn/feature_selection/mutual_info_.py
+++ b/sklearn/feature_selection/mutual_info_.py
@@ -248,10 +248,11 @@ def _estimate_mi(X, y, discrete_features='auto', discrete_target=False,
     n_samples, n_features = X.shape
 
     if isinstance(discrete_features, (str, bool)):
-        if discrete_features == 'auto':
-            discrete_features = issparse(X)
-        else:
-            raise ValueError("Invalid string value for discrete_features.")
+        if isinstance(discrete_features, str):
+            if discrete_features == 'auto':
+                discrete_features = issparse(X)
+            else:
+                raise ValueError("Invalid string value for discrete_features.")
         discrete_mask = np.empty(n_features, dtype=bool)
         discrete_mask.fill(discrete_features)
     else:

--- a/sklearn/feature_selection/mutual_info_.py
+++ b/sklearn/feature_selection/mutual_info_.py
@@ -248,11 +248,10 @@ def _estimate_mi(X, y, discrete_features='auto', discrete_target=False,
     n_samples, n_features = X.shape
 
     if isinstance(discrete_features, (str, bool)):
-        if isinstance(discrete_features, str):
-            if discrete_features == 'auto':
-                discrete_features = issparse(X)
-            else:
-                raise ValueError("Invalid string value for discrete_features.")
+        if discrete_features == 'auto':
+            discrete_features = issparse(X)
+        else:
+            raise ValueError("Invalid string value for discrete_features.")
         discrete_mask = np.empty(n_features, dtype=bool)
         discrete_mask.fill(discrete_features)
     else:

--- a/sklearn/feature_selection/mutual_info_.py
+++ b/sklearn/feature_selection/mutual_info_.py
@@ -247,8 +247,11 @@ def _estimate_mi(X, y, discrete_features='auto', discrete_target=False,
     X, y = check_X_y(X, y, accept_sparse='csc', y_numeric=not discrete_target)
     n_samples, n_features = X.shape
 
-    if discrete_features == 'auto':
-        discrete_features = issparse(X)
+    if isinstance(discrete_features, str):
+        if discrete_features == 'auto':
+            discrete_features = issparse(X)
+        else:
+            raise ValueError("Invalid string value for discrete_features.")
 
     if isinstance(discrete_features, bool):
         discrete_mask = np.empty(n_features, dtype=bool)

--- a/sklearn/feature_selection/tests/test_mutual_info.py
+++ b/sklearn/feature_selection/tests/test_mutual_info.py
@@ -183,20 +183,26 @@ def test_mutual_info_options():
     X_csr = csr_matrix(X)
 
     for mutual_info in (mutual_info_regression, mutual_info_classif):
-        assert_raises(ValueError, mutual_info_regression, X_csr, y,
+        assert_raises(ValueError, mutual_info, X_csr, y,
                       discrete_features=False)
         assert_raises(ValueError, mutual_info, X, y,
                       discrete_features='manual')
+        assert_raises(ValueError, mutual_info, X_csr, y,
+                      discrete_features=[True, False, True])
+        assert_raises(IndexError, mutual_info, X, y,
+                      discrete_features=[True, False, True, False])
+        assert_raises(IndexError, mutual_info, X, y, discrete_features=[1, 4])
 
         mi_1 = mutual_info(X, y, discrete_features='auto', random_state=0)
         mi_2 = mutual_info(X, y, discrete_features=False, random_state=0)
-
-        mi_3 = mutual_info(X_csr, y, discrete_features='auto',
+        mi_3 = mutual_info(X_csr, y, discrete_features='auto', random_state=0)
+        mi_4 = mutual_info(X_csr, y, discrete_features=True, random_state=0)
+        mi_5 = mutual_info(X, y, discrete_features=[True, False, True],
                            random_state=0)
-        mi_4 = mutual_info(X_csr, y, discrete_features=True,
-                           random_state=0)
+        mi_6 = mutual_info(X, y, discrete_features=[0, 2], random_state=0)
 
         assert_array_equal(mi_1, mi_2)
         assert_array_equal(mi_3, mi_4)
+        assert_array_equal(mi_5, mi_6)
 
     assert not np.allclose(mi_1, mi_3)

--- a/sklearn/feature_selection/tests/test_mutual_info.py
+++ b/sklearn/feature_selection/tests/test_mutual_info.py
@@ -185,6 +185,8 @@ def test_mutual_info_options():
     for mutual_info in (mutual_info_regression, mutual_info_classif):
         assert_raises(ValueError, mutual_info_regression, X_csr, y,
                       discrete_features=False)
+        assert_raises(ValueError, mutual_info, X, y,
+                      discrete_features='manual')
 
         mi_1 = mutual_info(X, y, discrete_features='auto', random_state=0)
         mi_2 = mutual_info(X, y, discrete_features=False, random_state=0)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #13481

#### What does this implement/fix? Explain your changes.

In `_estimate_mi` the parameter `discrete_features` can be a string value 'auto' as well as an array of indices or a boolean mask.  Code initially checks if `discrete_features == 'auto'` which will error in future versions of numpy.  Fix first checks str instance and then for valid value.
