### PR TITLE
[MRG] Ignore sklearn/externals in codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -19,4 +19,6 @@ coverage:
         # https://github.com/codecov/browser-extension
         target: auto
         threshold: 1%
- 
+
+ignore:
+- "sklearn/externals"


### PR DESCRIPTION
Since we do not test `sklearn/externals`, this PR configures codecov to ignore the folder.