### PR TITLE
DOC better clarify upstream synchronization in contributing guide

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -251,11 +251,19 @@ If any of the above seems like magic to you, then look up the `Git documentation
 web, or ask a friend or another contributor for help.
 
 If some conflicts arise between your branch and the ``master`` branch, you need
-to merge ``master``. The command will be::
+to merge ``master``. For that, you first need to fetch the ``upstream``'s
+``master``, and then merge it into your branch::
 
-  $ git merge master
+  $ git fetch upstream
+  $ git merge upstream/master
 
-with ``master`` being synchronized with the ``upstream``.
+In order to synchronize your ``master`` with the ``upstream``'s (assuming you
+usually work on branches other than your local's ``master``), you can::
+
+  $ git fetch upstream
+  $ git rebase upstream/master
+
+while being in your ``master`` branch.
 
 Subsequently, you need to solve the conflicts. You can refer to the `Git
 documentation related to resolving merge conflict using the command line

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -251,21 +251,18 @@ If any of the above seems like magic to you, then look up the `Git documentation
 web, or ask a friend or another contributor for help.
 
 If some conflicts arise between your branch and the ``master`` branch, you need
-to merge ``master``. For that, you first need to fetch the ``upstream``'s
-``master``, and then merge it into your branch::
+to merge ``master``. For that, you first need to fetch the ``upstream``, and
+then merge its ``master`` into your branch::
 
   $ git fetch upstream
   $ git merge upstream/master
 
 It is recommended to work on temporary branches rather than directly on
-``master``. Since these temporary branches are branched off ``master``, it is
-helpful to keep your local ``master`` up to date with the upstream's
-``master``. To do this, you can::
+``master``. In order to create a branch from the latest ``upstream/master``,
+you can::
 
   $ git fetch upstream
-  $ git rebase upstream/master
-
-while being in your ``master`` branch.
+  $ git checkout -b mybranchname upstream/master
 
 Subsequently, you need to solve the conflicts. You can refer to the `Git
 documentation related to resolving merge conflict using the command line

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -260,7 +260,7 @@ to merge ``master``. For that, you first need to fetch the ``upstream``'s
 It is recommended to work on temporary branches rather than directly on
 ``master``. Since these temporary branches are branched off ``master``, it is
 helpful to keep your local ``master`` up to date with the upstream's
-``master``. Do do this, you can::
+``master``. To do this, you can::
 
   $ git fetch upstream
   $ git rebase upstream/master

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -257,8 +257,10 @@ to merge ``master``. For that, you first need to fetch the ``upstream``'s
   $ git fetch upstream
   $ git merge upstream/master
 
-In order to synchronize your ``master`` with the ``upstream``'s (assuming you
-usually work on branches other than your local's ``master``), you can::
+It is recommended to work on temporary branches rather than directly on
+``master``. Since these temporary branches are branched off ``master``, it is
+helpful to keep your local ``master`` up to date with the upstream's
+``master``. Do do this, you can::
 
   $ git fetch upstream
   $ git rebase upstream/master

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -213,6 +213,22 @@ then submit a "pull request" (PR):
     and start making changes. Always use a ``feature`` branch. It's good practice to
     never work on the ``master`` branch!
 
+.. note::
+
+  In the above setup, your ``origin`` remote repository points to
+  ``YourLogin/scikit-learn.git``. If you wish to fetch/merge from the main
+  repository instead of your forked one, you will need to add another remote
+  to use instead of ``origin``. If we choose the name ``upstream`` for it, the
+  command will be::
+
+        $ git remote add upstream https://github.com/scikit-learn/scikit-learn.git
+
+  And in order to fetch the new remote and base your work on the latest changes
+  of it you can::
+
+        $ git fetch upstream
+        $ git checkout -b mybranchname upstream/master
+
  6. Develop the feature on your feature branch on your computer, using Git to do the
     version control. When you're done editing, add changed files using ``git add``
     and then ``git commit`` files::
@@ -235,15 +251,6 @@ then submit a "pull request" (PR):
   If you are modifying a Cython module, you have to re-run step 4 after modifications
   and before testing them.
 
-.. note::
-
-  In the above setup, your ``origin`` remote repository points to
-  YourLogin/scikit-learn.git. If you wish to fetch/merge from the main
-  repository instead of your forked one, you will need to add another remote
-  to use instead of ``origin``. If we choose the name ``upstream`` for it, the
-  command will be::
-
-        $ git remote add upstream https://github.com/scikit-learn/scikit-learn.git
 
 If any of the above seems like magic to you, then look up the `Git documentation
 <https://git-scm.com/documentation>`_ and the `Git development workflow
@@ -256,13 +263,6 @@ then merge its ``master`` into your branch::
 
   $ git fetch upstream
   $ git merge upstream/master
-
-It is recommended to work on temporary branches rather than directly on
-``master``. In order to create a branch from the latest ``upstream/master``,
-you can::
-
-  $ git fetch upstream
-  $ git checkout -b mybranchname upstream/master
 
 Subsequently, you need to solve the conflicts. You can refer to the `Git
 documentation related to resolving merge conflict using the command line

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -227,7 +227,7 @@ then submit a "pull request" (PR):
   of it you can::
 
         $ git fetch upstream
-        $ git checkout -b mybranchname upstream/master
+        $ git checkout -b my-feature upstream/master
 
  6. Develop the feature on your feature branch on your computer, using Git to do the
     version control. When you're done editing, add changed files using ``git add``


### PR DESCRIPTION
Changes the contributing guides to be explicit about how upstream/master synchronization can be done.