### PR TITLE
[MRG] Fix CircleCI builds by using sphinx-gallery 0.2.0

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -124,7 +124,7 @@ conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
   joblib
 
 source activate testenv
-pip install sphinx-gallery
+pip install sphinx-gallery==0.2.0
 pip install numpydoc==0.8
 
 # Build and install scikit-learn in dev mode


### PR DESCRIPTION
sphinx-gallery 0.3 has changed the figure numbering in some edge cases. I'll create an issue in sphinx-gallery to track this problem (done in https://github.com/sphinx-gallery/sphinx-gallery/issues/464) but I think in the mean time the simplest is to use the previous sphinx-gallery release.

Note: sphinx-gallery 0.3 has been released 3 days ago which does match the failures in master on CircleCI which started 2 days ago, e.g. https://circleci.com/gh/scikit-learn/scikit-learn/52538