### PR TITLE
[MRG] Cleaning of _log_logistic_sigmoid

### DIFF
--- a/sklearn/utils/_logistic_sigmoid.pyx
+++ b/sklearn/utils/_logistic_sigmoid.pyx
@@ -1,7 +1,7 @@
 #cython: boundscheck=False
 #cython: cdivision=True
 #cython: wraparound=False
-# cython: language_level=3
+#cython: language_level=3
 
 from libc.math cimport log, exp
 
@@ -11,17 +11,21 @@ cimport numpy as np
 ctypedef np.float64_t DTYPE_t
 
 
-cdef DTYPE_t _inner_log_logistic_sigmoid(DTYPE_t x):
+cdef inline DTYPE_t _inner_log_logistic_sigmoid(const DTYPE_t x):
     """Log of the logistic sigmoid function log(1 / (1 + e ** -x))"""
     if x > 0:
-        return -log(1 + exp(-x))
+        return -log(1. + exp(-x))
     else:
-        return x - log(1 + exp(x))
+        return x - log(1. + exp(x))
 
 
-def _log_logistic_sigmoid(int n_samples, int n_features, 
-                           np.ndarray[DTYPE_t, ndim=2] X,
-                           np.ndarray[DTYPE_t, ndim=2] out):
+def _log_logistic_sigmoid(int n_samples, int n_features,
+                          DTYPE_t[:, :] X,
+                          DTYPE_t[:, :] out):
+    cdef:
+        unsigned int i
+        unsigned int j
+
     for i in range(n_samples):
         for j in range(n_features):
             out[i, j] = _inner_log_logistic_sigmoid(X[i, j])

--- a/sklearn/utils/_logistic_sigmoid.pyx
+++ b/sklearn/utils/_logistic_sigmoid.pyx
@@ -19,7 +19,8 @@ cdef inline DTYPE_t _inner_log_logistic_sigmoid(const DTYPE_t x):
         return x - log(1. + exp(x))
 
 
-def _log_logistic_sigmoid(int n_samples, int n_features,
+def _log_logistic_sigmoid(unsigned int n_samples,
+                          unsigned int n_features,
                           DTYPE_t[:, :] X,
                           DTYPE_t[:, :] out):
     cdef:


### PR DESCRIPTION
This PR slightly improves the code of `_log_logistic_sigmoid`:

- loop variables are `cdef`ed
- helper function is inlined
- use views instead of numpy arrays
- indentation is corrected

The code is a tiny bit faster, though nothing to be excited about:

```py
from sklearn.utils.extmath import log_logistic
import numpy as np
from time import time

X = np.random.normal(size=(1000, 2000))

n_runs = 100
times = []
for _ in range(n_runs):
    tic = time()
    log_logistic(X)
    times.append(time() - tic)

print(np.mean(times))
print(np.std(times))
```

This PR
```
0.08370588779449463
0.0011843339434451441
```

On master
```
0.08642879486083985
0.003170202198760095
```

ping @qinhanmin2014 	since this somehow follows #13509