### PR TITLE
TST Only use activate for conda builds on windows

### DIFF
--- a/build_tools/azure/test_script.cmd
+++ b/build_tools/azure/test_script.cmd
@@ -1,6 +1,9 @@
 @echo on
 
-call activate %VIRTUALENV%
+@rem Only 64 bit uses conda
+IF "%PYTHON_ARCH%"=="64" (
+    call activate %VIRTUALENV%
+)
 
 mkdir %TMP_FOLDER%
 cd %TMP_FOLDER%

--- a/build_tools/azure/upload_codecov.cmd
+++ b/build_tools/azure/upload_codecov.cmd
@@ -1,6 +1,9 @@
 @echo on
 
-call activate %VIRTUALENV%
+@rem Only 64 bit uses conda
+IF "%PYTHON_ARCH%"=="64" (
+    call activate %VIRTUALENV%
+)
 
 copy %TMP_FOLDER%\.coverage %BUILD_REPOSITORY_LOCALPATH%
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/13512

#### What does this implement/fix? Explain your changes.
Only 64 bit Windows uses conda which has access to the `activate` command.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->