### PR TITLE
[MRG] remove fit_params from BaseSearchCV.__init__

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -380,15 +380,13 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def __init__(self, estimator, scoring=None,
-                 fit_params=None, n_jobs=None, iid='warn',
+    def __init__(self, estimator, scoring=None, n_jobs=None, iid='warn',
                  refit=True, cv='warn', verbose=0, pre_dispatch='2*n_jobs',
                  error_score='raise-deprecating', return_train_score=True):
 
         self.scoring = scoring
         self.estimator = estimator
         self.n_jobs = n_jobs
-        self.fit_params = fit_params
         self.iid = iid
         self.refit = refit
         self.cv = cv

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -10,7 +10,7 @@ from sklearn.utils.testing import ignore_warnings
 
 from sklearn.preprocessing.imputation import Imputer
 from sklearn.pipeline import Pipeline
-from sklearn.model_selection import GridSearchCV
+from sklearn.model_selection import GridSearchCV, KFold
 from sklearn import tree
 from sklearn.random_projection import sparse_random_matrix
 
@@ -278,9 +278,9 @@ def test_imputation_pipeline_grid_search():
     }
 
     l = 100
-    X = sparse_random_matrix(l, l, density=0.10)
-    Y = sparse_random_matrix(l, 1, density=0.10).toarray()
-    gs = GridSearchCV(pipeline, parameters)
+    X = sparse_random_matrix(l, l, density=0.10, random_state=0)
+    Y = sparse_random_matrix(l, 1, density=0.10, random_state=0).toarray()
+    gs = GridSearchCV(pipeline, parameters, cv=KFold(5, random_state=0))
     gs.fit(X, Y)
 
 

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -10,7 +10,7 @@ from sklearn.utils.testing import ignore_warnings
 
 from sklearn.preprocessing.imputation import Imputer
 from sklearn.pipeline import Pipeline
-from sklearn.model_selection import GridSearchCV, KFold
+from sklearn.model_selection import GridSearchCV
 from sklearn import tree
 from sklearn.random_projection import sparse_random_matrix
 
@@ -280,7 +280,7 @@ def test_imputation_pipeline_grid_search():
     l = 100
     X = sparse_random_matrix(l, l, density=0.10, random_state=0)
     Y = sparse_random_matrix(l, 1, density=0.10, random_state=0).toarray()
-    gs = GridSearchCV(pipeline, parameters, cv=KFold(5, random_state=0))
+    gs = GridSearchCV(pipeline, parameters)
     gs.fit(X, Y)
 
 


### PR DESCRIPTION
`fit_params` in `GridSearchCV` and `RandomizedSearchCV` constructors was deprecated and is now removed for 0.21, but it wasn't removed from the base class `BaseSearchCV`