### PR TITLE
[MRG] Simplify addition of point (0, 0) in roc_curve

### DIFF
--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -634,7 +634,7 @@ def roc_curve(y_true, y_score, pos_label=None, sample_weight=None,
         tps = tps[optimal_idxs]
         thresholds = thresholds[optimal_idxs]
 
-    # Add an extra threshold position if necessary
+    # Add an extra threshold position
     # to make sure that the curve starts at (0, 0)
     tps = np.r_[0, tps]
     fps = np.r_[0, fps]

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -634,12 +634,11 @@ def roc_curve(y_true, y_score, pos_label=None, sample_weight=None,
         tps = tps[optimal_idxs]
         thresholds = thresholds[optimal_idxs]
 
-    if tps.size == 0 or fps[0] != 0 or tps[0] != 0:
-        # Add an extra threshold position if necessary
-        # to make sure that the curve starts at (0, 0)
-        tps = np.r_[0, tps]
-        fps = np.r_[0, fps]
-        thresholds = np.r_[thresholds[0] + 1, thresholds]
+    # Add an extra threshold position if necessary
+    # to make sure that the curve starts at (0, 0)
+    tps = np.r_[0, tps]
+    fps = np.r_[0, fps]
+    thresholds = np.r_[thresholds[0] + 1, thresholds]
 
     if fps[-1] <= 0:
         warnings.warn("No negative samples in y_true, "


### PR DESCRIPTION
After the modification of #10093, I think we can simplify the code because it's forced that we pass in one of the case tested by the "if": 

- if we have `tps.size == 0` then we pass in it
- otherwise, we have at least one element in `tps` and one element in `fps` (`tps` and `fps` have the same size)
Then the first point is the first classified positive so it's either a true positive or a false positive. So I think we should pass in the "if" statement in any case