### PR TITLE
[MRG+1] Convert y in GradientBoosting to float64 instead of float32

### DIFF
--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -44,7 +44,7 @@ from scipy.special import expit
 from time import time
 from ..model_selection import train_test_split
 from ..tree.tree import DecisionTreeRegressor
-from ..tree._tree import DTYPE
+from ..tree._tree import DTYPE, DOUBLE
 from ..tree._tree import TREE_LEAF
 from . import _gb_losses
 
@@ -1432,7 +1432,9 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             self._clear_state()
 
         # Check input
-        X, y = check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'], dtype=DTYPE)
+        X = check_array(X, accept_sparse=['csr', 'csc', 'coo'], dtype=DTYPE)
+        y = check_array(y, accept_sparse='csc', ensure_2d=False, dtype=None)
+
         n_samples, self.n_features_ = X.shape
 
         sample_weight_is_none = sample_weight is None

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1432,6 +1432,8 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             self._clear_state()
 
         # Check input
+        # Since check_array converts both X and y to the same dtype, but the
+        # trees use different types for X and y, checking them separately.
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'], dtype=DTYPE)
         n_samples, self.n_features_ = X.shape
 

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1444,6 +1444,8 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
 
         check_consistent_length(X, y, sample_weight)
 
+        y = check_array(y, accept_sparse='csc', ensure_2d=False, dtype=None)
+        y = column_or_1d(y, warn=True)
         y = self._validate_y(y, sample_weight)
 
         if self.n_iter_no_change is not None:
@@ -1713,8 +1715,6 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
     def _validate_y(self, y, sample_weight):
         # 'sample_weight' is not utilised but is used for
         # consistency with similar method _validate_y of GBC
-        y = check_array(y, accept_sparse='csc', ensure_2d=False, dtype=None)
-        y = column_or_1d(y, warn=True)
         self.n_classes_ = 1
         if y.dtype.kind == 'O':
             y = y.astype(DOUBLE)
@@ -2036,7 +2036,6 @@ shape (n_estimators, ``loss_.K``)
             n_iter_no_change=n_iter_no_change, tol=tol)
 
     def _validate_y(self, y, sample_weight):
-        y = super()._validate_y(y, sample_weight)
         check_classification_targets(y)
         self.classes_, y = np.unique(y, return_inverse=True)
         n_trim_classes = np.count_nonzero(np.bincount(y, sample_weight))

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1433,8 +1433,6 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
 
         # Check input
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'], dtype=DTYPE)
-        y = check_array(y, accept_sparse='csc', ensure_2d=False, dtype=None)
-
         n_samples, self.n_features_ = X.shape
 
         sample_weight_is_none = sample_weight is None
@@ -1715,9 +1713,11 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
     def _validate_y(self, y, sample_weight):
         # 'sample_weight' is not utilised but is used for
         # consistency with similar method _validate_y of GBC
+        y = check_array(y, accept_sparse='csc', ensure_2d=False, dtype=None)
+        y = column_or_1d(y, warn=True)
         self.n_classes_ = 1
         if y.dtype.kind == 'O':
-            y = y.astype(np.float64)
+            y = y.astype(DOUBLE)
         # Default implementation
         return y
 
@@ -2036,6 +2036,7 @@ shape (n_estimators, ``loss_.K``)
             n_iter_no_change=n_iter_no_change, tol=tol)
 
     def _validate_y(self, y, sample_weight):
+        y = super()._validate_y(y, sample_weight)
         check_classification_targets(y)
         self.classes_, y = np.unique(y, return_inverse=True)
         n_trim_classes = np.count_nonzero(np.bincount(y, sample_weight))


### PR DESCRIPTION
Fixes #9098

If not float64, the decision trees would each convert it to a double.