### PR TITLE
[MRG] Fix for sphinx-gallery 0.3.1 + 404 errors on Debian Jessie packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   doc-min-dependencies:
     docker:
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.6
     environment:
       - MINICONDA_PATH: ~/miniconda
       - CONDA_ENV_NAME: testenv
@@ -32,7 +32,7 @@ jobs:
 
   doc:
     docker:
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.6
     environment:
       - MINICONDA_PATH: ~/miniconda
       - CONDA_ENV_NAME: testenv
@@ -61,7 +61,7 @@ jobs:
 
   lint:
     docker:
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.6
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh
@@ -90,7 +90,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.6
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -101,7 +101,7 @@ sudo -E apt-get -yq remove texlive-binaries --purge
 sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes \
     install dvipng texlive-latex-base texlive-latex-extra \
     texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended\
-    latexmk
+    latexmk gsfonts
 
 # deactivate circleci virtualenv and setup a miniconda env instead
 if [[ `type -t deactivate` ]]; then

--- a/doc/modules/calibration.rst
+++ b/doc/modules/calibration.rst
@@ -171,7 +171,7 @@ probability vectors predicted by the same classifier after sigmoid calibration
 on a hold-out validation set. Colors indicate the true class of an instance
 (red: class 1, green: class 2, blue: class 3).
 
-.. figure:: ../auto_examples/calibration/images/sphx_glr_plot_calibration_multiclass_000.png
+.. figure:: ../auto_examples/calibration/images/sphx_glr_plot_calibration_multiclass_001.png
    :target: ../auto_examples/calibration/plot_calibration_multiclass.html
    :align: center
 
@@ -183,7 +183,7 @@ method='sigmoid' on the remaining 200 datapoints reduces the confidence of the
 predictions, i.e., moves the probability vectors from the edges of the simplex
 towards the center:
 
-.. figure:: ../auto_examples/calibration/images/sphx_glr_plot_calibration_multiclass_001.png
+.. figure:: ../auto_examples/calibration/images/sphx_glr_plot_calibration_multiclass_002.png
    :target: ../auto_examples/calibration/plot_calibration_multiclass.html
    :align: center
 

--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -88,14 +88,14 @@ estimate the noise level of data. An illustration of the
 log-marginal-likelihood (LML) landscape shows that there exist two local
 maxima of LML.
 
-.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpr_noisy_000.png
+.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpr_noisy_001.png
    :target: ../auto_examples/gaussian_process/plot_gpr_noisy.html
    :align: center
 
 The first corresponds to a model with a high noise level and a
 large length scale, which explains all variations in the data by noise.
 
-.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpr_noisy_001.png
+.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpr_noisy_002.png
    :target: ../auto_examples/gaussian_process/plot_gpr_noisy.html
    :align: center
 
@@ -106,7 +106,7 @@ hyperparameters, the gradient-based optimization might also converge to the
 high-noise solution. It is thus important to repeat the optimization several
 times for different initializations.
 
-.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpr_noisy_002.png
+.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpr_noisy_003.png
    :target: ../auto_examples/gaussian_process/plot_gpr_noisy.html
    :align: center
 
@@ -306,11 +306,11 @@ The second figure shows the log-marginal-likelihood for different choices of
 the kernel's hyperparameters, highlighting the two choices of the
 hyperparameters used in the first figure by black dots.
 
-.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpc_000.png
+.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpc_001.png
    :target: ../auto_examples/gaussian_process/plot_gpc.html
    :align: center
 
-.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpc_001.png
+.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpc_002.png
    :target: ../auto_examples/gaussian_process/plot_gpc.html
    :align: center
 
@@ -493,7 +493,7 @@ kernel as covariance function have mean square derivatives of all orders, and ar
 very smooth. The prior and posterior of a GP resulting from an RBF kernel are shown in
 the following figure:
 
-.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpr_prior_posterior_000.png
+.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpr_prior_posterior_001.png
    :target: ../auto_examples/gaussian_process/plot_gpr_prior_posterior.html
    :align: center
 
@@ -534,7 +534,7 @@ allows adapting to the properties of the true underlying functional relation.
 The prior and posterior of a GP resulting from a Matérn kernel are shown in
 the following figure:
 
-.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpr_prior_posterior_004.png
+.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpr_prior_posterior_005.png
    :target: ../auto_examples/gaussian_process/plot_gpr_prior_posterior.html
    :align: center
 
@@ -556,7 +556,7 @@ The kernel is given by:
 The prior and posterior of a GP resulting from a :class:`RationalQuadratic` kernel are shown in
 the following figure:
 
-.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpr_prior_posterior_001.png
+.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpr_prior_posterior_002.png
    :target: ../auto_examples/gaussian_process/plot_gpr_prior_posterior.html
    :align: center
 
@@ -574,7 +574,7 @@ The kernel is given by:
 The prior and posterior of a GP resulting from an ExpSineSquared kernel are shown in
 the following figure:
 
-.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpr_prior_posterior_002.png
+.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpr_prior_posterior_003.png
    :target: ../auto_examples/gaussian_process/plot_gpr_prior_posterior.html
    :align: center
 
@@ -594,7 +594,7 @@ is called the homogeneous linear kernel, otherwise it is inhomogeneous. The kern
 The :class:`DotProduct` kernel is commonly combined with exponentiation. An example with exponent 2 is
 shown in the following figure:
 
-.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpr_prior_posterior_003.png
+.. figure:: ../auto_examples/gaussian_process/images/sphx_glr_plot_gpr_prior_posterior_004.png
    :target: ../auto_examples/gaussian_process/plot_gpr_prior_posterior.html
    :align: center
 

--- a/examples/calibration/plot_calibration_multiclass.py
+++ b/examples/calibration/plot_calibration_multiclass.py
@@ -64,7 +64,7 @@ sig_clf_probs = sig_clf.predict_proba(X_test)
 sig_score = log_loss(y_test, sig_clf_probs)
 
 # Plot changes in predicted probabilities via arrows
-plt.figure(0)
+plt.figure()
 colors = ["r", "g", "b"]
 for i in range(clf_probs.shape[0]):
     plt.arrow(clf_probs[i, 0], clf_probs[i, 1],
@@ -131,7 +131,7 @@ print(" * classifier trained on 600 datapoints and calibrated on "
       "200 datapoint: %.3f" % sig_score)
 
 # Illustrate calibrator
-plt.figure(1)
+plt.figure()
 # generate grid over 2-simplex
 p1d = np.linspace(0, 1, 20)
 p0, p1 = np.meshgrid(p1d, p1d)

--- a/examples/exercises/plot_iris_exercise.py
+++ b/examples/exercises/plot_iris_exercise.py
@@ -35,11 +35,11 @@ X_test = X[int(.9 * n_sample):]
 y_test = y[int(.9 * n_sample):]
 
 # fit the model
-for fig_num, kernel in enumerate(('linear', 'rbf', 'poly')):
+for kernel in ('linear', 'rbf', 'poly'):
     clf = svm.SVC(kernel=kernel, gamma=10)
     clf.fit(X_train, y_train)
 
-    plt.figure(fig_num)
+    plt.figure()
     plt.clf()
     plt.scatter(X[:, 0], X[:, 1], c=y, zorder=10, cmap=plt.cm.Paired,
                 edgecolor='k', s=20)

--- a/examples/gaussian_process/plot_gpc.py
+++ b/examples/gaussian_process/plot_gpc.py
@@ -63,7 +63,7 @@ print("Log-loss: %.3f (initial) %.3f (optimized)"
 
 
 # Plot posteriors
-plt.figure(0)
+plt.figure()
 plt.scatter(X[:train_size, 0], y[:train_size], c='k', label="Train data",
             edgecolors=(0, 0, 0))
 plt.scatter(X[train_size:, 0], y[train_size:], c='g', label="Test data",
@@ -80,7 +80,7 @@ plt.ylim(-0.25, 1.5)
 plt.legend(loc="best")
 
 # Plot LML landscape
-plt.figure(1)
+plt.figure()
 theta0 = np.logspace(0, 8, 30)
 theta1 = np.logspace(-1, 1, 29)
 Theta0, Theta1 = np.meshgrid(theta0, theta1)

--- a/examples/gaussian_process/plot_gpr_noisy.py
+++ b/examples/gaussian_process/plot_gpr_noisy.py
@@ -35,7 +35,7 @@ X = rng.uniform(0, 5, 20)[:, np.newaxis]
 y = 0.5 * np.sin(3 * X[:, 0]) + rng.normal(0, 0.5, X.shape[0])
 
 # First run
-plt.figure(0)
+plt.figure()
 kernel = 1.0 * RBF(length_scale=100.0, length_scale_bounds=(1e-2, 1e3)) \
     + WhiteKernel(noise_level=1, noise_level_bounds=(1e-10, 1e+1))
 gp = GaussianProcessRegressor(kernel=kernel,
@@ -54,7 +54,7 @@ plt.title("Initial: %s\nOptimum: %s\nLog-Marginal-Likelihood: %s"
 plt.tight_layout()
 
 # Second run
-plt.figure(1)
+plt.figure()
 kernel = 1.0 * RBF(length_scale=1.0, length_scale_bounds=(1e-2, 1e3)) \
     + WhiteKernel(noise_level=1e-5, noise_level_bounds=(1e-10, 1e+1))
 gp = GaussianProcessRegressor(kernel=kernel,
@@ -73,7 +73,7 @@ plt.title("Initial: %s\nOptimum: %s\nLog-Marginal-Likelihood: %s"
 plt.tight_layout()
 
 # Plot LML landscape
-plt.figure(2)
+plt.figure()
 theta0 = np.logspace(-2, 3, 49)
 theta1 = np.logspace(-2, 0, 50)
 Theta0, Theta1 = np.meshgrid(theta0, theta1)

--- a/examples/gaussian_process/plot_gpr_prior_posterior.py
+++ b/examples/gaussian_process/plot_gpr_prior_posterior.py
@@ -33,12 +33,12 @@ kernels = [1.0 * RBF(length_scale=1.0, length_scale_bounds=(1e-1, 10.0)),
            1.0 * Matern(length_scale=1.0, length_scale_bounds=(1e-1, 10.0),
                         nu=1.5)]
 
-for fig_index, kernel in enumerate(kernels):
+for kernel in kernels:
     # Specify Gaussian Process
     gp = GaussianProcessRegressor(kernel=kernel)
 
     # Plot prior
-    plt.figure(fig_index, figsize=(8, 8))
+    plt.figure(figsize=(8, 8))
     plt.subplot(2, 1, 1)
     X_ = np.linspace(0, 5, 100)
     y_mean, y_std = gp.predict(X_[:, np.newaxis], return_std=True)


### PR DESCRIPTION
sphinx-gallery 0.3 has changed the output figure numbering in some edge cases (mostly 0.3.1 ignores matplotlib figure numbers see https://github.com/sphinx-gallery/sphinx-gallery/issues/464 for more details). This PR replaces #13513 and should fix the CircleCI build failures in master, e.g. circleci.com/gh/scikit-learn/scikit-learn/52538.

