### PR TITLE
MAINT: Replace -O4 with -O3

### DIFF
--- a/sklearn/manifold/setup.py
+++ b/sklearn/manifold/setup.py
@@ -22,7 +22,7 @@ def configuration(parent_package="", top_path=None):
                          sources=["_barnes_hut_tsne.pyx"],
                          include_dirs=[numpy.get_include()],
                          libraries=libraries,
-                         extra_compile_args=['-O4'])
+                         extra_compile_args=['-O3'])
 
     config.add_subpackage('tests')
 


### PR DESCRIPTION
Replace `extra_compile_args=['-O4']` with`extra_compile_args=['-O3']` in 
sklearn/manifold/setup.py

Per GCC documentation [1] permitted optimization
forms are -O0, -O1 -O2, -O3, and -Os

[1] https://gcc.gnu.org/onlinedocs/gnat_ugn/Optimization-Levels.html

Using -O4 is interpreted as -O3 with a warning,
at least with some GCC compatible compilers, e.g.
Intel(R) C Compiler

