### PR TITLE
[MRG] Fixes to test_pprint.py breaking after changes to the tested API

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -278,7 +278,7 @@ documentation related to resolving merge conflict using the command line
 Contributing pull requests
 --------------------------
 
-We recommend that that your contribution complies with the following
+We recommend that your contribution complies with the following
 rules before submitting a pull request:
 
 * Follow the `coding-guidelines`_ (see below). To make sure that

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -177,7 +177,8 @@ def test_gradient():
     for n_labels in [2, 3]:
         n_samples = 5
         n_features = 10
-        X = np.random.random((n_samples, n_features))
+        random_state = np.random.RandomState(seed=42)
+        X = random_state.rand(n_samples, n_features)
         y = 1 + np.mod(np.arange(n_samples) + 1, n_labels)
         Y = LabelBinarizer().fit_transform(y)
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -1224,7 +1224,7 @@ class OneClassSVM(BaseLibSVM, OutlierMixin):
         """
         Perform classification on samples in X.
 
-        For an one-class model, +1 or -1 is returned.
+        For a one-class model, +1 or -1 is returned.
 
         Parameters
         ----------

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -6,7 +6,6 @@ import numpy as np
 from sklearn.utils._pprint import _EstimatorPrettyPrinter
 from sklearn.pipeline import make_pipeline
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.feature_selection.base import SelectorMixin
 from sklearn.feature_selection import SelectKBest, chi2
 from sklearn.svm import SVC
 from sklearn.svm import LinearSVC

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -81,7 +81,7 @@ class GridSearchCV(BaseSearchCV):
         self.param_grid = param_grid
 
 
-class CountVectorizer(BaseEstimator, VectorizerMixin):
+class CountVectorizer(BaseEstimator):
     def __init__(self, input='content', encoding='utf-8',
                  decode_error='strict', strip_accents=None,
                  lowercase=True, preprocessor=None, tokenizer=None,

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -12,7 +12,6 @@ from sklearn.model_selection._search import BaseSearchCV
 from sklearn.feature_selection import SelectKBest, chi2
 from sklearn.svm import SVC
 from sklearn.svm import LinearSVC
-from sklearn.impute import SimpleImputer
 from sklearn.feature_extraction.text import VectorizerMixin
 from sklearn import set_config
 
@@ -146,6 +145,16 @@ class NMF(BaseEstimator):
         self.l1_ratio = l1_ratio
         self.verbose = verbose
         self.shuffle = shuffle
+
+
+class SimpleImputer(BaseEstimator):
+    def __init__(self, missing_values=np.nan, strategy="mean",
+                 fill_value=None, verbose=0, copy=True):
+        self.missing_values = missing_values
+        self.strategy = strategy
+        self.fill_value = fill_value
+        self.verbose = verbose
+        self.copy = copy
 
 
 def test_basic():

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -4,8 +4,8 @@ from pprint import PrettyPrinter
 from sklearn.utils._pprint import _EstimatorPrettyPrinter
 from sklearn.pipeline import make_pipeline, Pipeline
 from sklearn.preprocessing import StandardScaler
-from sklearn.base import BaseEstimator
-from sklearn.feature_selection import RFE
+from sklearn.base import BaseEstimator, MetaEstimatorMixin
+from sklearn.feature_selection.base import SelectorMixin
 from sklearn.model_selection import GridSearchCV
 from sklearn.feature_selection import SelectKBest, chi2
 from sklearn.svm import SVC
@@ -45,6 +45,19 @@ class LogisticRegression(BaseEstimator):
         self.warm_start = warm_start
         self.n_jobs = n_jobs
         self.l1_ratio = l1_ratio
+
+    def fit(self, X, y):
+        return self
+
+class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
+    """Feature ranking with recursive feature elimination.
+    """
+    def __init__(self, estimator, n_features_to_select=None, step=1,
+                 verbose=0):
+        self.estimator = estimator
+        self.n_features_to_select = n_features_to_select
+        self.step = step
+        self.verbose = verbose
 
     def fit(self, X, y):
         return self

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -1,6 +1,8 @@
 import re
 from pprint import PrettyPrinter
 
+import numpy as np
+
 from sklearn.utils._pprint import _EstimatorPrettyPrinter
 from sklearn.pipeline import make_pipeline, Pipeline
 from sklearn.preprocessing import StandardScaler
@@ -13,7 +15,7 @@ from sklearn.svm import LinearSVC
 from sklearn.decomposition import PCA
 from sklearn.decomposition import NMF
 from sklearn.impute import SimpleImputer
-from sklearn.feature_extraction.text import CountVectorizer
+from sklearn.feature_extraction.text import VectorizerMixin
 from sklearn import set_config
 
 
@@ -78,6 +80,43 @@ class GridSearchCV(BaseSearchCV):
             pre_dispatch=pre_dispatch, error_score=error_score,
             return_train_score=return_train_score)
         self.param_grid = param_grid
+
+
+class CountVectorizer(BaseEstimator, VectorizerMixin):
+    """Convert a collection of text documents to a matrix of token counts
+    """
+    def __init__(self, input='content', encoding='utf-8',
+                 decode_error='strict', strip_accents=None,
+                 lowercase=True, preprocessor=None, tokenizer=None,
+                 stop_words=None, token_pattern=r"(?u)\b\w\w+\b",
+                 ngram_range=(1, 1), analyzer='word',
+                 max_df=1.0, min_df=1, max_features=None,
+                 vocabulary=None, binary=False, dtype=np.int64):
+        self.input = input
+        self.encoding = encoding
+        self.decode_error = decode_error
+        self.strip_accents = strip_accents
+        self.preprocessor = preprocessor
+        self.tokenizer = tokenizer
+        self.analyzer = analyzer
+        self.lowercase = lowercase
+        self.token_pattern = token_pattern
+        self.stop_words = stop_words
+        self.max_df = max_df
+        self.min_df = min_df
+        if max_df < 0 or min_df < 0:
+            raise ValueError("negative value for max_df or min_df")
+        self.max_features = max_features
+        if max_features is not None:
+            if (not isinstance(max_features, numbers.Integral) or
+                    max_features <= 0):
+                raise ValueError(
+                    "max_features=%r, neither a positive integer nor None"
+                    % max_features)
+        self.ngram_range = ngram_range
+        self.vocabulary = vocabulary
+        self.binary = binary
+        self.dtype = dtype
 
 
 def test_basic():

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -4,7 +4,6 @@ from pprint import PrettyPrinter
 import numpy as np
 
 from sklearn.utils._pprint import _EstimatorPrettyPrinter
-from sklearn.utils.metaestimators import _BaseComposition
 from sklearn.pipeline import make_pipeline
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.feature_selection.base import SelectorMixin
@@ -108,7 +107,7 @@ class CountVectorizer(BaseEstimator):
         self.dtype = dtype
 
 
-class Pipeline(_BaseComposition):
+class Pipeline(BaseEstimator):
     def __init__(self, steps, memory=None):
         self.steps = steps
         self.memory = memory

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -6,8 +6,7 @@ import numpy as np
 from sklearn.utils._pprint import _EstimatorPrettyPrinter
 from sklearn.utils.metaestimators import _BaseComposition
 from sklearn.pipeline import make_pipeline
-from sklearn.preprocessing import StandardScaler
-from sklearn.base import BaseEstimator, MetaEstimatorMixin
+from sklearn.base import BaseEstimator, MetaEstimatorMixin, TransformerMixin
 from sklearn.feature_selection.base import SelectorMixin
 from sklearn.model_selection._search import BaseSearchCV
 from sklearn.feature_selection import SelectKBest, chi2
@@ -49,6 +48,18 @@ class LogisticRegression(BaseEstimator):
         self.l1_ratio = l1_ratio
 
     def fit(self, X, y):
+        return self
+
+
+class StandardScaler(BaseEstimator, TransformerMixin):
+    """Standardize features by removing the mean and scaling to unit variance
+    """
+    def __init__(self, copy=True, with_mean=True, with_std=True):
+        self.with_mean = with_mean
+        self.with_std = with_std
+        self.copy = copy
+
+    def transform(self, X, copy=None):
         return self
 
 

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -4,7 +4,7 @@ from pprint import PrettyPrinter
 from sklearn.utils._pprint import _EstimatorPrettyPrinter
 from sklearn.pipeline import make_pipeline, Pipeline
 from sklearn.preprocessing import StandardScaler
-# from sklearn.linear_model import LogisticRegression
+from sklearn.base import BaseEstimator
 from sklearn.feature_selection import RFE
 from sklearn.model_selection import GridSearchCV
 from sklearn.feature_selection import SelectKBest, chi2
@@ -20,6 +20,7 @@ from sklearn import set_config
 # Ignore flake8 (lots of line too long issues)
 # flake8: noqa
 
+# Constructors excerpted to test pprinting
 class LogisticRegression(BaseEstimator):
     """Logistic Regression (aka logit, MaxEnt) classifier.
     """
@@ -29,7 +30,22 @@ class LogisticRegression(BaseEstimator):
                  random_state=None, solver='warn', max_iter=100,
                  multi_class='warn', verbose=0, warm_start=False, n_jobs=None,
                  l1_ratio=None):
-        pass
+
+        self.penalty = penalty
+        self.dual = dual
+        self.tol = tol
+        self.C = C
+        self.fit_intercept = fit_intercept
+        self.intercept_scaling = intercept_scaling
+        self.class_weight = class_weight
+        self.random_state = random_state
+        self.solver = solver
+        self.max_iter = max_iter
+        self.multi_class = multi_class
+        self.verbose = verbose
+        self.warm_start = warm_start
+        self.n_jobs = n_jobs
+        self.l1_ratio = l1_ratio
 
 def test_basic():
     # Basic pprint test

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -106,15 +106,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         self.stop_words = stop_words
         self.max_df = max_df
         self.min_df = min_df
-        if max_df < 0 or min_df < 0:
-            raise ValueError("negative value for max_df or min_df")
         self.max_features = max_features
-        if max_features is not None:
-            if (not isinstance(max_features, numbers.Integral) or
-                    max_features <= 0):
-                raise ValueError(
-                    "max_features=%r, neither a positive integer nor None"
-                    % max_features)
         self.ngram_range = ngram_range
         self.vocabulary = vocabulary
         self.binary = binary

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -12,7 +12,6 @@ from sklearn.model_selection._search import BaseSearchCV
 from sklearn.feature_selection import SelectKBest, chi2
 from sklearn.svm import SVC
 from sklearn.svm import LinearSVC
-from sklearn.decomposition import PCA
 from sklearn.decomposition import NMF
 from sklearn.impute import SimpleImputer
 from sklearn.feature_extraction.text import VectorizerMixin
@@ -117,6 +116,19 @@ class Pipeline(_BaseComposition):
     def __init__(self, steps, memory=None):
         self.steps = steps
         self.memory = memory
+
+
+class PCA(BaseEstimator):
+    def __init__(self, n_components=None, copy=True, whiten=False,
+                 svd_solver='auto', tol=0.0, iterated_power='auto',
+                 random_state=None):
+        self.n_components = n_components
+        self.copy = copy
+        self.whiten = whiten
+        self.svd_solver = svd_solver
+        self.tol = tol
+        self.iterated_power = iterated_power
+        self.random_state = random_state
 
 
 def test_basic():

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -6,13 +6,11 @@ import numpy as np
 from sklearn.utils._pprint import _EstimatorPrettyPrinter
 from sklearn.utils.metaestimators import _BaseComposition
 from sklearn.pipeline import make_pipeline
-from sklearn.base import BaseEstimator, MetaEstimatorMixin, TransformerMixin
+from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.feature_selection.base import SelectorMixin
-from sklearn.model_selection._search import BaseSearchCV
 from sklearn.feature_selection import SelectKBest, chi2
 from sklearn.svm import SVC
 from sklearn.svm import LinearSVC
-from sklearn.feature_extraction.text import VectorizerMixin
 from sklearn import set_config
 
 

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -122,7 +122,6 @@ class SVC(BaseEstimator):
         self.coef0 = coef0
         self.tol = tol
         self.C = C
-        self.nu = 0.
         self.shrinking = shrinking
         self.probability = probability
         self.cache_size = cache_size

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -59,18 +59,13 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         return self
 
 
-class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
+class RFE(BaseEstimator):
     def __init__(self, estimator, n_features_to_select=None, step=1,
                  verbose=0):
         self.estimator = estimator
         self.n_features_to_select = n_features_to_select
         self.step = step
         self.verbose = verbose
-
-    def _get_support_mask(self):
-        """Delegated from SelectorMixin.
-        """
-        self.SelectorMixin._get_support_mask()
 
 
 class GridSearchCV(BaseSearchCV):

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -30,7 +30,6 @@ class LogisticRegression(BaseEstimator):
                  random_state=None, solver='warn', max_iter=100,
                  multi_class='warn', verbose=0, warm_start=False, n_jobs=None,
                  l1_ratio=None):
-
         self.penalty = penalty
         self.dual = dual
         self.tol = tol

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -24,8 +24,6 @@ from sklearn import set_config
 
 # Constructors excerpted to test pprinting
 class LogisticRegression(BaseEstimator):
-    """Logistic Regression (aka logit, MaxEnt) classifier.
-    """
     def __init__(self, penalty='l2', dual=False, tol=1e-4, C=1.0,
                  fit_intercept=True, intercept_scaling=1, class_weight=None,
                  random_state=None, solver='warn', max_iter=100,
@@ -52,8 +50,6 @@ class LogisticRegression(BaseEstimator):
 
 
 class StandardScaler(BaseEstimator, TransformerMixin):
-    """Standardize features by removing the mean and scaling to unit variance
-    """
     def __init__(self, copy=True, with_mean=True, with_std=True):
         self.with_mean = with_mean
         self.with_std = with_std
@@ -64,8 +60,6 @@ class StandardScaler(BaseEstimator, TransformerMixin):
 
 
 class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
-    """Feature ranking with recursive feature elimination.
-    """
     def __init__(self, estimator, n_features_to_select=None, step=1,
                  verbose=0):
         self.estimator = estimator
@@ -80,8 +74,6 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
 
 
 class GridSearchCV(BaseSearchCV):
-    """Exhaustive search over specified parameter values for an estimator.
-    """
     def __init__(self, estimator, param_grid, scoring=None,
                  n_jobs=None, iid='warn', refit=True, cv='warn', verbose=0,
                  pre_dispatch='2*n_jobs', error_score='raise-deprecating',
@@ -95,8 +87,6 @@ class GridSearchCV(BaseSearchCV):
 
 
 class CountVectorizer(BaseEstimator, VectorizerMixin):
-    """Convert a collection of text documents to a matrix of token counts
-    """
     def __init__(self, input='content', encoding='utf-8',
                  decode_error='strict', strip_accents=None,
                  lowercase=True, preprocessor=None, tokenizer=None,
@@ -132,8 +122,6 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
 
 
 class Pipeline(_BaseComposition):
-    """Pipeline of transforms with a final estimator.
-    """
     def __init__(self, steps, memory=None):
         self.steps = steps
         self._validate_steps()

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -24,7 +24,6 @@ from sklearn import set_config
 class LogisticRegression(BaseEstimator):
     """Logistic Regression (aka logit, MaxEnt) classifier.
     """
-
     def __init__(self, penalty='l2', dual=False, tol=1e-4, C=1.0,
                  fit_intercept=True, intercept_scaling=1, class_weight=None,
                  random_state=None, solver='warn', max_iter=100,
@@ -49,6 +48,7 @@ class LogisticRegression(BaseEstimator):
     def fit(self, X, y):
         return self
 
+
 class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
     """Feature ranking with recursive feature elimination.
     """
@@ -63,6 +63,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         """Delegated from SelectorMixin.
         """
         self.SelectorMixin._get_support_mask()
+
 
 def test_basic():
     # Basic pprint test

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -7,7 +7,6 @@ from sklearn.utils._pprint import _EstimatorPrettyPrinter
 from sklearn.pipeline import make_pipeline
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.feature_selection import SelectKBest, chi2
-from sklearn.svm import LinearSVC
 from sklearn import set_config
 
 
@@ -305,7 +304,7 @@ def test_gridsearch_pipeline():
 
     pipeline = Pipeline([
         ('reduce_dim', PCA()),
-        ('classify', LinearSVC())
+        ('classify', SVC())
     ])
     N_FEATURES_OPTIONS = [2, 4, 8]
     C_OPTIONS = [1, 10, 100, 1000]
@@ -332,15 +331,14 @@ GridSearchCV(cv=3, error_score='raise-deprecating',
                                             svd_solver='auto', tol=0.0,
                                             whiten=False)),
                                        ('classify',
-                                        LinearSVC(C=1.0, class_weight=None,
-                                                  dual=True, fit_intercept=True,
-                                                  intercept_scaling=1,
-                                                  loss='squared_hinge',
-                                                  max_iter=1000,
-                                                  multi_class='ovr',
-                                                  penalty='l2',
-                                                  random_state=None, tol=0.0001,
-                                                  verbose=0))]),
+                                        SVC(C=1.0, cache_size=200,
+                                            class_weight=None, coef0=0.0,
+                                            decision_function_shape='ovr',
+                                            degree=3, gamma='auto_deprecated',
+                                            kernel='rbf', max_iter=-1,
+                                            probability=False,
+                                            random_state=None, shrinking=True,
+                                            tol=0.001, verbose=False))]),
              iid='warn', n_jobs=1,
              param_grid=[{'classify__C': [1, 10, 100, 1000],
                           'reduce_dim': [PCA(copy=True, iterated_power=7,

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -4,7 +4,8 @@ from pprint import PrettyPrinter
 import numpy as np
 
 from sklearn.utils._pprint import _EstimatorPrettyPrinter
-from sklearn.pipeline import make_pipeline, Pipeline
+from sklearn.utils.metaestimators import _BaseComposition
+from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.base import BaseEstimator, MetaEstimatorMixin
 from sklearn.feature_selection.base import SelectorMixin
@@ -117,6 +118,18 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         self.vocabulary = vocabulary
         self.binary = binary
         self.dtype = dtype
+
+
+class Pipeline(_BaseComposition):
+    """Pipeline of transforms with a final estimator.
+    """
+    def __init__(self, steps, memory=None):
+        self.steps = steps
+        self._validate_steps()
+        self.memory = memory
+
+    def _validate_steps(self):
+        return self
 
 
 def test_basic():

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -59,8 +59,10 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         self.step = step
         self.verbose = verbose
 
-    def fit(self, X, y):
-        return self
+    def _get_support_mask(self):
+        """Delegated from SelectorMixin.
+        """
+        self.SelectorMixin._get_support_mask()
 
 def test_basic():
     # Basic pprint test

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -47,6 +47,9 @@ class LogisticRegression(BaseEstimator):
         self.n_jobs = n_jobs
         self.l1_ratio = l1_ratio
 
+    def fit(self, X, y):
+        return self
+
 def test_basic():
     # Basic pprint test
     lr = LogisticRegression()

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -111,11 +111,7 @@ class CountVectorizer(BaseEstimator):
 class Pipeline(_BaseComposition):
     def __init__(self, steps, memory=None):
         self.steps = steps
-        self._validate_steps()
         self.memory = memory
-
-    def _validate_steps(self):
-        return self
 
 
 def test_basic():

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -7,7 +7,6 @@ from sklearn.utils._pprint import _EstimatorPrettyPrinter
 from sklearn.pipeline import make_pipeline
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.feature_selection import SelectKBest, chi2
-from sklearn.svm import SVC
 from sklearn.svm import LinearSVC
 from sklearn import set_config
 
@@ -110,6 +109,29 @@ class Pipeline(BaseEstimator):
     def __init__(self, steps, memory=None):
         self.steps = steps
         self.memory = memory
+
+
+class SVC(BaseEstimator):
+    def __init__(self, C=1.0, kernel='rbf', degree=3, gamma='auto_deprecated',
+                 coef0=0.0, shrinking=True, probability=False,
+                 tol=1e-3, cache_size=200, class_weight=None,
+                 verbose=False, max_iter=-1, decision_function_shape='ovr',
+                 random_state=None):
+        self.kernel = kernel
+        self.degree = degree
+        self.gamma = gamma
+        self.coef0 = coef0
+        self.tol = tol
+        self.C = C
+        self.nu = 0.
+        self.shrinking = shrinking
+        self.probability = probability
+        self.cache_size = cache_size
+        self.class_weight = class_weight
+        self.verbose = verbose
+        self.max_iter = max_iter
+        self.decision_function_shape = decision_function_shape
+        self.random_state = random_state
 
 
 class PCA(BaseEstimator):

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -68,17 +68,22 @@ class RFE(BaseEstimator):
         self.verbose = verbose
 
 
-class GridSearchCV(BaseSearchCV):
+class GridSearchCV(BaseEstimator):
     def __init__(self, estimator, param_grid, scoring=None,
                  n_jobs=None, iid='warn', refit=True, cv='warn', verbose=0,
                  pre_dispatch='2*n_jobs', error_score='raise-deprecating',
                  return_train_score=False):
-        super().__init__(
-            estimator=estimator, scoring=scoring,
-            n_jobs=n_jobs, iid=iid, refit=refit, cv=cv, verbose=verbose,
-            pre_dispatch=pre_dispatch, error_score=error_score,
-            return_train_score=return_train_score)
+        self.estimator = estimator
         self.param_grid = param_grid
+        self.scoring = scoring
+        self.n_jobs = n_jobs
+        self.iid = iid
+        self.refit = refit
+        self.cv = cv
+        self.verbose = verbose
+        self.pre_dispatch = pre_dispatch
+        self.error_score = error_score
+        self.return_train_score = return_train_score
 
 
 class CountVectorizer(BaseEstimator):

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -12,7 +12,6 @@ from sklearn.model_selection._search import BaseSearchCV
 from sklearn.feature_selection import SelectKBest, chi2
 from sklearn.svm import SVC
 from sklearn.svm import LinearSVC
-from sklearn.decomposition import NMF
 from sklearn.impute import SimpleImputer
 from sklearn.feature_extraction.text import VectorizerMixin
 from sklearn import set_config
@@ -129,6 +128,24 @@ class PCA(BaseEstimator):
         self.tol = tol
         self.iterated_power = iterated_power
         self.random_state = random_state
+
+
+class NMF(BaseEstimator):
+    def __init__(self, n_components=None, init=None, solver='cd',
+                 beta_loss='frobenius', tol=1e-4, max_iter=200,
+                 random_state=None, alpha=0., l1_ratio=0., verbose=0,
+                 shuffle=False):
+        self.n_components = n_components
+        self.init = init
+        self.solver = solver
+        self.beta_loss = beta_loss
+        self.tol = tol
+        self.max_iter = max_iter
+        self.random_state = random_state
+        self.alpha = alpha
+        self.l1_ratio = l1_ratio
+        self.verbose = verbose
+        self.shuffle = shuffle
 
 
 def test_basic():

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -4,7 +4,7 @@ from pprint import PrettyPrinter
 from sklearn.utils._pprint import _EstimatorPrettyPrinter
 from sklearn.pipeline import make_pipeline, Pipeline
 from sklearn.preprocessing import StandardScaler
-from sklearn.linear_model import LogisticRegression
+# from sklearn.linear_model import LogisticRegression
 from sklearn.feature_selection import RFE
 from sklearn.model_selection import GridSearchCV
 from sklearn.feature_selection import SelectKBest, chi2
@@ -19,6 +19,17 @@ from sklearn import set_config
 
 # Ignore flake8 (lots of line too long issues)
 # flake8: noqa
+
+class LogisticRegression(BaseEstimator):
+    """Logistic Regression (aka logit, MaxEnt) classifier.
+    """
+
+    def __init__(self, penalty='l2', dual=False, tol=1e-4, C=1.0,
+                 fit_intercept=True, intercept_scaling=1, class_weight=None,
+                 random_state=None, solver='warn', max_iter=100,
+                 multi_class='warn', verbose=0, warm_start=False, n_jobs=None,
+                 l1_ratio=None):
+        pass
 
 def test_basic():
     # Basic pprint test

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -6,7 +6,7 @@ from sklearn.pipeline import make_pipeline, Pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.base import BaseEstimator, MetaEstimatorMixin
 from sklearn.feature_selection.base import SelectorMixin
-from sklearn.model_selection import GridSearchCV
+from sklearn.model_selection._search import BaseSearchCV
 from sklearn.feature_selection import SelectKBest, chi2
 from sklearn.svm import SVC
 from sklearn.svm import LinearSVC
@@ -63,6 +63,21 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         """Delegated from SelectorMixin.
         """
         self.SelectorMixin._get_support_mask()
+
+
+class GridSearchCV(BaseSearchCV):
+    """Exhaustive search over specified parameter values for an estimator.
+    """
+    def __init__(self, estimator, param_grid, scoring=None,
+                 n_jobs=None, iid='warn', refit=True, cv='warn', verbose=0,
+                 pre_dispatch='2*n_jobs', error_score='raise-deprecating',
+                 return_train_score=False):
+        super().__init__(
+            estimator=estimator, scoring=scoring,
+            n_jobs=n_jobs, iid=iid, refit=refit, cv=cv, verbose=verbose,
+            pre_dispatch=pre_dispatch, error_score=error_score,
+            return_train_score=return_train_score)
+        self.param_grid = param_grid
 
 
 def test_basic():


### PR DESCRIPTION
#### Reference Issues/PRs

This PR is an improvement for issue #13508.

#### What does this implement/fix? Explain your changes.

This change attempts to improve pain points found in issue #13470, where changes to the underlying API parameters for which `sklearn/utils/tests/test_pprint.py` is tested causes the test to fail.

As a solution, this PR adds minimal examples of the classes listed below to the test itself.

#### To-do

Example constructors needing to be excerpted to [`test_pprinting`](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/utils/tests/test_pprint.py):
- [x] Logistic Regression
- [x] StandardScaler
- [x] Pipeline
- [x] RFE
- [x] GridSearchCV
- [x] CountVectorizer
- [x] SVC
  - [x] LinearSVC (calls were replaced with SVC and expected string adapted)
- [x] PCA
- [x] NMF
- [x] SimpleImputer
