### PR TITLE
[MRG] DOC update Ridge doc for sparse + fit_intercept

### DIFF
--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -290,7 +290,8 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
 
 
         All last five solvers support both dense and sparse data. However, only
-        'sag' and 'saga' supports sparse input when`fit_intercept` is True.
+        'sag' and 'sparse_cg' supports sparse input when`fit_intercept` is
+        True.
 
         .. versionadded:: 0.17
            Stochastic Average Gradient descent solver.
@@ -651,8 +652,8 @@ class Ridge(_BaseRidge, RegressorMixin):
           approximately the same scale. You can preprocess the data with a
           scaler from sklearn.preprocessing.
 
-        All last five solvers support both dense and sparse data. However,
-        only 'sag' and 'saga' supports sparse input when `fit_intercept` is
+        All last five solvers support both dense and sparse data. However, only
+        'sag' and 'sparse_cg' supports sparse input when `fit_intercept` is
         True.
 
         .. versionadded:: 0.17


### PR DESCRIPTION
After #13336, Ridge supports `solver='sparse_cg'` with `fit_intercept=True` on sparse input.

Also, I don't know if it this is the case for `saga` but when I try to use saga solver I get this warning:
```
In Ridge, only 'sag' solver can currently fit the intercept when X is sparse. Solver has been automatically changed into 'sag'.
```