### PR TITLE
[WIP] Fix for repeated sentence in doc/developers/contributing.rst [Issue #13537]

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -328,8 +328,7 @@ rules before submitting a pull request:
 * Documentation and high-coverage tests are necessary for enhancements to be
   accepted. Bug-fixes or new features should be provided with
   `non-regression tests
-  <https://en.wikipedia.org/wiki/Non-regression_testing>`_. These tests
-  verify the correct behavior of the fix or feature. These tests verify the
+  <https://en.wikipedia.org/wiki/Non-regression_testing>`_. These tests verify the
   correct behavior of the fix or feature. In this manner, further
   modifications on the code base are granted to be consistent with the
   desired behavior. For the case of bug fixes, at the time of the PR, the


### PR DESCRIPTION
#### Reference Issues/PRs

This PR is a fix for issue #13537.

#### What does this implement/fix? Explain your changes.

The fix removes a repeated sentence in the contributor docs in [`doc/developers/contributing.rst`](https://github.com/scikit-learn/scikit-learn/blob/master/doc/developers/contributing.rst).