### PR TITLE
[MRG] Explicitly ignore SparseEfficiencyWarning in DBSCAN

### DIFF
--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -10,11 +10,11 @@ DBSCAN: Density-Based Spatial Clustering of Applications with Noise
 # License: BSD 3 clause
 
 import numpy as np
+import warnings
 from scipy import sparse
 
 from ..base import BaseEstimator, ClusterMixin
 from ..utils import check_array, check_consistent_length
-from ..utils.testing import ignore_warnings
 from ..neighbors import NearestNeighbors
 
 from ._dbscan_inner import dbscan_inner
@@ -145,7 +145,8 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski', metric_params=None,
         X.sum_duplicates()  # XXX: modifies X's internals in-place
 
         # set the diagonal to explicit values, as a point is its own neighbor
-        with ignore_warnings():
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', sparse.SparseEfficiencyWarning)
             X.setdiag(X.diagonal())  # XXX: modifies X's internals in-place
 
         X_mask = X.data <= eps


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

[py](https://github.com/pytest-dev/py) is a commonly used library, which has various utility subpackages, one of them being `apipkg` which implements lazy loading of Python modules. `py` is marked as a runtime dependency of [more than 9K](https://libraries.io/pypi/py/usage) packages on PyPI, so it isn't too easy to avoid.

Importing py itself directly [lazily loads certain packages like `py.test`](https://github.com/pytest-dev/py/blob/master/py/__init__.py#L38). Lazy module loading is implemented by adding to `sys.modules` an `apipkg.AliasModule`, which implements `__getattribute__` as:

```py
        def __getattribute__(self, name):
            try:
                return getattr(getmod(), name)
            except ImportError:
                return None
```
When `py.test` is not installed or cannot be imported, this result in `sys.modules["py.test"]` (and a few others) being `AliasModule` instances for which `module.__warningregistry__` is `None` (as are all attributes).

This is causing issues with `sklearn`. Here is an example I've been hitting although I suspect there could be other occurences:

- The DBSCAN implementation [uses `ignore_warnings`](https://github.com/scikit-learn/scikit-learn/blob/face9daf045846bb0a39bfb396432c8685570cdd/sklearn/cluster/dbscan_.py#L148) to silence warnings.
- `ignore_warnings` in turns relies on `clean_warning_registry`.

This makes it impossible to run `DBSCAN` once `py` has been imported, because `clean_warning_registry` is calling `clear()` on all modules that have a `__warningregistry__` attribute:

```
/opt/venv/python3/lib/python3.6/site-packages/sklearn/cluster/dbscan_.py in dbscan(X, eps, min_samples, metric, metric_params, algorithm, leaf_size, p, sample_weight, n_jobs)
    140 
    141         # set the diagonal to explicit values, as a point is its own neighbor
--> 142         with ignore_warnings():
    143             X.setdiag(X.diagonal())  # XXX: modifies X's internals in-place
    144 

/opt/venv/python3/lib/python3.6/site-packages/sklearn/utils/testing.py in __enter__(self)
    366         self._module.filters = self._filters[:]
    367         self._showwarning = self._module.showwarning
--> 368         clean_warning_registry()
    369         warnings.simplefilter("ignore", self.category)
    370 

/opt/venv/python3/lib/python3.6/site-packages/sklearn/utils/testing.py in clean_warning_registry()
    799             continue
    800         if hasattr(mod, reg):
--> 801             getattr(mod, reg).clear()
    802 
    803 

AttributeError: 'NoneType' object has no attribute 'clear'
```

This PR adds an additional check that `__warningregistry__` is a dictionnary.


#### Any other comments?

I am not familiar enough with the project to know how we would want this to be fixed. In particular:

- The issue really stems from `py`'s lazily loaded modules, and one may wonder whether `sklearn` should be worrying about this at all. Here, the issue could also be fixed by making sure `py.test` can be imported.

- However, `__warningregistry__` isn't really documented either, and one could argue that `sklearn` should be checking whether it is a dictionnary before calling `clear` on it. 

I'll let the maintainers decide whether this small additional check makes sense, in spite of this being a fix for a rather specific problem.