### PR TITLE
[MRG] Added additional tips for pytest usage

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -643,6 +643,8 @@ We expect code coverage of new features to be at least around 90%.
 
    3. Loop.
 
+For guidelines on how to use ``pytest`` efficiently, see the
+:ref:`pytest_tips`.
 
 
 Developers web site

--- a/doc/developers/tips.rst
+++ b/doc/developers/tips.rst
@@ -61,6 +61,9 @@ integration, consider `this browser extension
 <https://github.com/codecov/browser-extension>`_. The coverage of each line
 will be displayed as a color background behind the line number.
 
+
+.. _pytest_tips:
+
 Useful pytest aliases and flags
 -------------------------------
 
@@ -89,6 +92,19 @@ When a unit test fails, the following tricks can make debugging easier:
      shell alias to::
 
          pytest --pdbcls=IPython.terminal.debugger:TerminalPdb --capture no
+
+Other `pytest` options that may become useful include:
+
+  - ``-x`` which exists on the first failed test
+  - ``--lf`` to rerun the tests that failed on the previous run
+  - ``-s`` so that pytest does not capture the output of ``print()``
+    statements
+  - ``--tb=short`` or ``--tb=line`` to control the length of the logs
+
+Since our continuous integration tests will error if ``DeprecationWarning``
+or ``FutureWarning`` aren't properly caught, it is also recommended to run
+``pytest`` along with the ``-Werror::DeprecationWarning`` and
+``-Werror::FutureWarning`` flags.
 
 .. _saved_replies:
 

--- a/doc/developers/tips.rst
+++ b/doc/developers/tips.rst
@@ -95,8 +95,9 @@ When a unit test fails, the following tricks can make debugging easier:
 
 Other `pytest` options that may become useful include:
 
-  - ``-x`` which exists on the first failed test
+  - ``-x`` which exits on the first failed test
   - ``--lf`` to rerun the tests that failed on the previous run
+  - ``--ff`` to rerun all previous tests, runnign the ones that failed first
   - ``-s`` so that pytest does not capture the output of ``print()``
     statements
   - ``--tb=short`` or ``--tb=line`` to control the length of the logs

--- a/doc/developers/tips.rst
+++ b/doc/developers/tips.rst
@@ -97,7 +97,7 @@ Other `pytest` options that may become useful include:
 
   - ``-x`` which exits on the first failed test
   - ``--lf`` to rerun the tests that failed on the previous run
-  - ``--ff`` to rerun all previous tests, runnign the ones that failed first
+  - ``--ff`` to rerun all previous tests, running the ones that failed first
   - ``-s`` so that pytest does not capture the output of ``print()``
     statements
   - ``--tb=short`` or ``--tb=line`` to control the length of the logs


### PR DESCRIPTION
This PR:

- Adds a link from the testing section `contributing.rst` to the pytest tips and tricks.
- Mentions a few useful command options that I personally use all the time (I won't push them though, if you don't think they're appropriate): `-x`, `--lf`, `-s`, `tb=short`
- Recommends using the ``-Werror::DeprecationWarning`` and ``-Werror::FutureWarning`` flags. This isn't mentioned anywhere as far as I know and it is often a source of confusion for new contributors. See e.g. https://github.com/scikit-learn/scikit-learn/issues/13396