### PR TITLE
Warn if eps is not specificed for DBSCAN

### DIFF
--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -9,6 +9,8 @@ DBSCAN: Density-Based Spatial Clustering of Applications with Noise
 #
 # License: BSD 3 clause
 
+import warnings
+
 import numpy as np
 import warnings
 from scipy import sparse
@@ -20,9 +22,9 @@ from ..neighbors import NearestNeighbors
 from ._dbscan_inner import dbscan_inner
 
 
-def dbscan(X, eps=0.5, min_samples=5, metric='minkowski', metric_params=None,
-           algorithm='auto', leaf_size=30, p=2, sample_weight=None,
-           n_jobs=None):
+def dbscan(X, eps='warn', min_samples=5, metric='minkowski',
+           metric_params=None, algorithm='auto', leaf_size=30, p=2,
+           sample_weight=None, n_jobs=None):
     """Perform DBSCAN clustering from vector array or distance matrix.
 
     Read more in the :ref:`User Guide <dbscan>`.
@@ -136,6 +138,11 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski', metric_params=None,
     DBSCAN revisited, revisited: why and how you should (still) use DBSCAN.
     ACM Transactions on Database Systems (TODS), 42(3), 19.
     """
+    if eps == 'warn':
+        warnings.warn("There is no good default value for the 'eps' "
+                      "parameter of DBSCAN. Because of legacy reasons, "
+                      "sklearn uses eps=0.5 as default.")
+        eps = 0.5      # use old default value
     if not eps > 0.0:
         raise ValueError("eps must be positive.")
 
@@ -316,7 +323,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
     ACM Transactions on Database Systems (TODS), 42(3), 19.
     """
 
-    def __init__(self, eps=0.5, min_samples=5, metric='euclidean',
+    def __init__(self, eps='warn', min_samples=5, metric='euclidean',
                  metric_params=None, algorithm='auto', leaf_size=30, p=None,
                  n_jobs=None):
         self.eps = eps


### PR DESCRIPTION
1. The **default** `eps=0.5` parameter makes little sense for most data sets. A good value depends on the data set and distance function. 0.5 may work for a particularly dimensionality of normalized data with Euclidean and a typical toy example data set size, but usually will be a bad choice. Even most of the examples from sklearn use different values. If you have lots of data points, a smaller eps may be necessary, for example.
Hence, the user has to experiment with this parameter, the default usually won't give good results. By making it required instead of optional, we can prevent this mistake.

2. The **description** of the `eps` parameter is misleading. This was recently discussed on SO: https://stackoverflow.com/a/55388827/1939754 ("DBSCAN eps incorrect behaviour")
As user Anonymousse stated, the old description is wrong (it's distance from some core point, not pairwise distances), but in particular it also is not a global diameter.