### PR TITLE
[MRG] MNT DOC Fix the single backtick issues

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -263,7 +263,7 @@ Testing scikit-learn once installed
 -----------------------------------
 
 Testing requires having `pytest <https://docs.pytest.org>`_ >=\ |PytestMinVersion|\ .
-Some tests also require having `pandas <https://pandas.pydata.org/>` installed.
+Some tests also require having `pandas <https://pandas.pydata.org/>`_ installed.
 After installation, the package can be tested by executing *from outside* the
 source directory::
 

--- a/doc/developers/tips.rst
+++ b/doc/developers/tips.rst
@@ -93,7 +93,7 @@ When a unit test fails, the following tricks can make debugging easier:
 
          pytest --pdbcls=IPython.terminal.debugger:TerminalPdb --capture no
 
-Other `pytest` options that may become useful include:
+Other ``pytest`` options that may become useful include:
 
   - ``-x`` which exits on the first failed test
   - ``--lf`` to rerun the tests that failed on the previous run

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -254,7 +254,7 @@ Several scikit-learn tools such as ``GridSearchCV`` and ``cross_val_score``
 rely internally on Python's `multiprocessing` module to parallelize execution
 onto several Python processes by passing ``n_jobs > 1`` as argument.
 
-The problem is that Python ``multiprocessing`` does a ``fork`` system call
+The problem is that Python ``multiprocessing`` does a ```fork``` system call
 without following it with an ``exec`` system call for performance reasons. Many
 libraries like (some versions of) Accelerate / vecLib under OSX, (some versions
 of) MKL, the OpenMP runtime of GCC, nvidia's Cuda (and probably many others),

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -254,7 +254,7 @@ Several scikit-learn tools such as ``GridSearchCV`` and ``cross_val_score``
 rely internally on Python's `multiprocessing` module to parallelize execution
 onto several Python processes by passing ``n_jobs > 1`` as argument.
 
-The problem is that Python ``multiprocessing`` does a ```fork``` system call
+The problem is that Python ``multiprocessing`` does a ``fork`` system call
 without following it with an ``exec`` system call for performance reasons. Many
 libraries like (some versions of) Accelerate / vecLib under OSX, (some versions
 of) MKL, the OpenMP runtime of GCC, nvidia's Cuda (and probably many others),

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -210,7 +210,7 @@ each job).
 
 .. warning::
 
-    The parallel version of K-Means is broken on OS X when `numpy` uses the
+    The parallel version of K-Means is broken on OS X when ``numpy`` uses the
     `Accelerate` Framework. This is expected behavior: `Accelerate` can be called
     after a fork but you need to execv the subprocess with the Python binary
     (which multiprocessing does not do under posix).

--- a/doc/modules/compose.rst
+++ b/doc/modules/compose.rst
@@ -94,7 +94,7 @@ Pipeline::
     >>> pipe['reduce_dim']  # doctest: +NORMALIZE_WHITESPACE
     PCA(copy=True, ...)
 
-Pipeline's `named_steps` attribute allows accessing steps by name with tab
+Pipeline's ``named_steps`` attribute allows accessing steps by name with tab
 completion in interactive environments::
 
     >>> pipe.named_steps.reduce_dim is pipe['reduce_dim']

--- a/doc/modules/computing.rst
+++ b/doc/modules/computing.rst
@@ -555,7 +555,7 @@ These environment variables should be set before importing scikit-learn.
 
 :SKLEARN_ASSUME_FINITE:
 
-    Sets the default value for the `assume_finite` argument of
+    Sets the default value for the ``assume_finite`` argument of
     :func:`sklearn.set_config`.
 
 :SKLEARN_WORKING_MEMORY:

--- a/doc/modules/label_propagation.rst
+++ b/doc/modules/label_propagation.rst
@@ -33,7 +33,7 @@ A few features available in this model:
   * Can be used for classification and regression tasks
   * Kernel methods to project data into alternate dimensional spaces
 
-`scikit-learn` provides two label propagation models:
+``scikit-learn`` provides two label propagation models:
 :class:`LabelPropagation` and :class:`LabelSpreading`. Both work by
 constructing a similarity graph over all items in the input dataset. 
 

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -1197,7 +1197,7 @@ It is advised to set the parameter ``epsilon`` to 1.35 to achieve 95% statistica
 
 Notes
 -----
-The :class:`HuberRegressor` differs from using :class:`SGDRegressor` with loss set to `huber`
+The :class:`HuberRegressor` differs from using :class:`SGDRegressor` with loss set to ``huber``
 in the following ways.
 
 - :class:`HuberRegressor` is scaling invariant. Once ``epsilon`` is set, scaling ``X`` and ``y``

--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -344,7 +344,7 @@ Tips on Practical Use
     best done using :class:`GridSearchCV`, usually in the
     range ``10.0 ** -np.arange(1, 7)``.
 
-  * Empirically, we observed that `L-BFGS` converges faster and
+  * Empirically, we observed that ``L-BFGS`` converges faster and
     with better solutions on small datasets. For relatively large
     datasets, however, `Adam` is very robust. It usually converges
     quickly and gives pretty good performance. `SGD` with momentum or

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -364,7 +364,7 @@ samples drawn from a lognormal distribution to a normal distribution::
          [-0.05...,  0.58..., -0.57...],
          [ 0.69..., -0.84...,  0.10...]])
 
-While the above example sets the `standardize` option to `False`,
+While the above example sets the ``standardize`` option to ``False``,
 :class:`PowerTransformer` will apply zero-mean, unit-variance normalization
 to the transformed output by default.
 

--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -166,7 +166,7 @@ further information.
  - :ref:`sphx_glr_auto_examples_svm_plot_separating_hyperplane_unbalanced.py` (See the ``Note``)
 
 :class:`SGDClassifier` supports averaged SGD (ASGD). Averaging can be enabled
-by setting ```average=True```. ASGD works by averaging the coefficients
+by setting ``average=True``. ASGD works by averaging the coefficients
 of the plain SGD over each iteration over a sample. When using ASGD
 the learning rate can be larger and even constant leading on some
 datasets to a speed up in training time.
@@ -198,7 +198,7 @@ specified via the parameter ``epsilon``. This parameter depends on the
 scale of the target variables.
 
 :class:`SGDRegressor` supports averaged SGD as :class:`SGDClassifier`.
-Averaging can be enabled by setting ```average=True```.
+Averaging can be enabled by setting ``average=True``.
 
 For regression with a squared loss and a l2 penalty, another variant of
 SGD with an averaging strategy is available with Stochastic Average

--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -163,7 +163,7 @@ further information.
  - :ref:`sphx_glr_auto_examples_linear_model_plot_sgd_iris.py`
  - :ref:`sphx_glr_auto_examples_linear_model_plot_sgd_weighted_samples.py`
  - :ref:`sphx_glr_auto_examples_linear_model_plot_sgd_comparison.py`
- - :ref:`sphx_glr_auto_examples_svm_plot_separating_hyperplane_unbalanced.py` (See the `Note`)
+ - :ref:`sphx_glr_auto_examples_svm_plot_separating_hyperplane_unbalanced.py` (See the ``Note``)
 
 :class:`SGDClassifier` supports averaged SGD (ASGD). Averaging can be enabled
 by setting ```average=True```. ASGD works by averaging the coefficients

--- a/doc/roadmap.rst
+++ b/doc/roadmap.rst
@@ -250,7 +250,7 @@ Subpackage-specific goals
 * perhaps we want to be able to get back more than multiple metrics
 * the handling of random states in CV splitters is a poor design and
   contradicts the validation of similar parameters in estimators.
-* exploit warm-starting and path algorithms so the benefits of `EstimatorCV`
+* exploit warm-starting and path algorithms so the benefits of ``EstimatorCV``
   objects can be accessed via `GridSearchCV` and used in Pipelines.
   :issue:`1626`
 * Cross-validation should be able to be replaced by OOB estimates whenever a
@@ -267,7 +267,7 @@ Subpackage-specific goals
 
 :mod:`sklearn.pipeline`
 
-* Performance issues with `Pipeline.memory`
+* Performance issues with ``Pipeline.memory``
 * see "Everything in Scikit-learn should conform to our API contract" above
 * Add a verbose option :issue:`10435`
 

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -74,7 +74,7 @@ Learning problems fall into a few categories:
 Loading an example dataset
 --------------------------
 
-`scikit-learn` comes with a few standard datasets, for instance the
+``scikit-learn`` comes with a few standard datasets, for instance the
 `iris <https://en.wikipedia.org/wiki/Iris_flower_data_set>`_ and `digits
 <https://archive.ics.uci.edu/ml/datasets/Pen-Based+Recognition+of+Handwritten+Digits>`_
 datasets for classification and the `boston house prices dataset

--- a/doc/tutorial/statistical_inference/model_selection.rst
+++ b/doc/tutorial/statistical_inference/model_selection.rst
@@ -90,7 +90,7 @@ methods.
     >>> cross_val_score(svc, X_digits, y_digits, cv=k_fold, n_jobs=-1)
     array([0.96388889, 0.92222222, 0.9637883 , 0.9637883 , 0.93036212])
 
-`n_jobs=-1` means that the computation will be dispatched on all the CPUs
+``n_jobs=-1`` means that the computation will be dispatched on all the CPUs
 of the computer.
 
 Alternatively, the ``scoring`` argument can be provided to specify an alternative

--- a/doc/whats_new/v0.16.rst
+++ b/doc/whats_new/v0.16.rst
@@ -154,7 +154,7 @@ Enhancements
   weight support will automatically benefit from it. By `Noel Dawe`_ and
   `Vlad Niculae`_.
 
-- Added ``newton-cg`` and `lbfgs` solver support in
+- Added ``newton-cg`` and ``lbfgs`` solver support in
   :class:`linear_model.LogisticRegression`. By `Manoj Kumar`_.
 
 - Add ``selection="random"`` parameter to implement stochastic coordinate
@@ -357,7 +357,7 @@ Bug fixes
   l2 regularization and large learning rate values).
   By `Olivier Grisel`_
 
-- When `compute_full_tree` is set to "auto", the full tree is
+- When ``compute_full_tree`` is set to "auto", the full tree is
   built when n_clusters is high and is early stopped when n_clusters is
   low, while the behavior should be vice-versa in
   :class:`cluster.AgglomerativeClustering` (and friends).
@@ -485,14 +485,14 @@ API changes summary
   set by the user. If set to True, then the sample itself is considered
   as the first nearest neighbor.
 
-- `thresh` parameter is deprecated in favor of new `tol` parameter in
+- ``thresh`` parameter is deprecated in favor of new ``tol`` parameter in
   :class:`GMM`, :class:`DPGMM` and :class:`VBGMM`. See `Enhancements`
   section for details. By `Hervé Bredin`_.
 
 - Estimators will treat input with dtype object as numeric when possible.
   By `Andreas Müller`_
 
-- Estimators now raise `ValueError` consistently when fitted on empty
+- Estimators now raise ``ValueError`` consistently when fitted on empty
   data (less than 1 sample or less than 1 feature for 2D input).
   By `Olivier Grisel`_.
 

--- a/doc/whats_new/v0.17.rst
+++ b/doc/whats_new/v0.17.rst
@@ -300,7 +300,7 @@ Bug fixes
 - Fixed bug where :class:`grid_search.RandomizedSearchCV` could consume a
   lot of memory for large discrete grids. By `Joel Nothman`_.
 
-- Fixed bug in :class:`linear_model.LogisticRegressionCV` where `penalty` was ignored
+- Fixed bug in :class:`linear_model.LogisticRegressionCV` where ``penalty`` was ignored
   in the final fit. By `Manoj Kumar`_.
 
 - Fixed bug in :class:`ensemble.forest.ForestClassifier` while computing
@@ -386,12 +386,12 @@ Bug fixes
 
 API changes summary
 -------------------
-- Attribute `data_min`, `data_max` and `data_range` in
+- Attribute ``data_min``, ``data_max`` and ``data_range`` in
   :class:`preprocessing.MinMaxScaler` are deprecated and won't be available
   from 0.19. Instead, the class now exposes `data_min_`, `data_max_`
   and `data_range_`. By :user:`Giorgio Patrini <giorgiop>`.
 
-- All Scaler classes now have an `scale_` attribute, the feature-wise
+- All Scaler classes now have an ```scale_``` attribute, the feature-wise
   rescaling applied by their `transform` methods. The old attribute `std_`
   in :class:`preprocessing.StandardScaler` is deprecated and superseded
   by `scale_`; it won't be available in 0.19. By :user:`Giorgio Patrini <giorgiop>`.

--- a/doc/whats_new/v0.17.rst
+++ b/doc/whats_new/v0.17.rst
@@ -376,7 +376,7 @@ Bug fixes
 
 - Fixed a bug in :class:`linear_model.LogisticRegression` and
   :class:`linear_model.LogisticRegressionCV` when using
-  ``class_weight='balanced'```or ``class_weight='auto'``.
+  ``class_weight='balanced'`` or ``class_weight='auto'``.
   By `Tom Dupre la Tour`_.
 
 - Fixed bug :issue:`5495` when
@@ -391,7 +391,7 @@ API changes summary
   from 0.19. Instead, the class now exposes `data_min_`, `data_max_`
   and `data_range_`. By :user:`Giorgio Patrini <giorgiop>`.
 
-- All Scaler classes now have an ```scale_``` attribute, the feature-wise
+- All Scaler classes now have an ``scale_`` attribute, the feature-wise
   rescaling applied by their `transform` methods. The old attribute `std_`
   in :class:`preprocessing.StandardScaler` is deprecated and superseded
   by `scale_`; it won't be available in 0.19. By :user:`Giorgio Patrini <giorgiop>`.

--- a/doc/whats_new/v0.18.rst
+++ b/doc/whats_new/v0.18.rst
@@ -584,7 +584,7 @@ Linear, kernelized and related models
 
 Decomposition, manifold learning and clustering
 
-- :class:`decomposition.RandomizedPCA` default number of `iterated_power` is 4 instead of 3.
+- :class:`decomposition.RandomizedPCA` default number of ``iterated_power`` is 4 instead of 3.
   :issue:`5141` by :user:`Giorgio Patrini <giorgiop>`.
 
 - :func:`utils.extmath.randomized_svd` performs 4 power iterations by default, instead or 0.

--- a/doc/whats_new/v0.19.rst
+++ b/doc/whats_new/v0.19.rst
@@ -876,7 +876,7 @@ Preprocessing and feature selection
 
 - :class:`feature_selection.SelectFromModel` now validates the ``threshold``
   parameter and sets the ``threshold_`` attribute during the call to
-  ``fit``, and no longer during the call to ``transform```. By `Andreas
+  ``fit``, and no longer during the call to ``transform``. By `Andreas
   Müller`_.
 
 - The ``non_negative`` parameter in :class:`feature_extraction.FeatureHasher`

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -165,7 +165,7 @@ Changelog
 :mod:`sklearn.utils`
 ....................
 
-- |Fix| Calling :func:`utils.check_array` on `pandas.Series` with categorical
+- |Fix| Calling :func:`utils.check_array` on ``pandas.Series`` with categorical
   data, which raised an error in 0.20.0, now returns the expected output again.
   :issue:`12699` by `Joris Van den Bossche`_.
 
@@ -365,7 +365,7 @@ Changelog
   :class:`decomposition.IncrementalPCA` when using float32 datasets.
   :issue:`12338` by :user:`bauks <bauks>`.
 
-- |Fix| Calling :func:`utils.check_array` on `pandas.Series`, which
+- |Fix| Calling :func:`utils.check_array` on ``pandas.Series``, which
   raised an error in 0.20.0, now returns the expected output again.
   :issue:`12625` by `Andreas Müller`_
   
@@ -1125,7 +1125,7 @@ Support for Python 3.3 has been officially dropped.
 :mod:`sklearn.model_selection`
 ..............................
 
-- |Feature| Add `return_estimator` parameter in
+- |Feature| Add ``return_estimator`` parameter in
   :func:`model_selection.cross_validate` to return estimators fitted on each
   split. :issue:`9686` by :user:`Aurélien Bellet <bellet>`.
 
@@ -1136,7 +1136,7 @@ Support for Python 3.3 has been officially dropped.
   hyperparameter optimization and refitting the best model on the whole
   dataset. :issue:`11310` by :user:`Matthias Feurer <mfeurer>`.
 
-- |Feature| Expose `error_score` parameter in
+- |Feature| Expose ``error_score`` parameter in
   :func:`model_selection.cross_validate`,
   :func:`model_selection.cross_val_score`,
   :func:`model_selection.learning_curve` and
@@ -1144,7 +1144,7 @@ Support for Python 3.3 has been officially dropped.
   when an error occurs in :func:`model_selection._fit_and_score`.
   :issue:`11576` by :user:`Samuel O. Ronsin <samronsin>`.
 
-- |Feature| `BaseSearchCV` now has an experimental, private interface to
+- |Feature| ``BaseSearchCV`` now has an experimental, private interface to
   support customized parameter search strategies, through its ``_run_search``
   method. See the implementations in :class:`model_selection.GridSearchCV` and
   :class:`model_selection.RandomizedSearchCV` and please provide feedback if
@@ -1199,7 +1199,7 @@ Support for Python 3.3 has been officially dropped.
   Complement Naive Bayes classifier described in Rennie et al. (2003).
   :issue:`8190` by :user:`Michael A. Alcorn <airalcorn2>`.
 
-- |Feature| Add `var_smoothing` parameter in :class:`naive_bayes.GaussianNB`
+- |Feature| Add ``var_smoothing`` parameter in :class:`naive_bayes.GaussianNB`
   to give a precise control over variances calculation.
   :issue:`9681` by :user:`Dmitry Mottl <Mottl>`.
 
@@ -1444,7 +1444,7 @@ Support for Python 3.3 has been officially dropped.
   :class:`tree._criterion.RegressionCriterion` may now be cimported and
   extended. :issue:`10325` by :user:`Camil Staps <camilstaps>`.
 
-- |Fix| Fixed a bug in :class:`tree.BaseDecisionTree` with `splitter="best"`
+- |Fix| Fixed a bug in :class:`tree.BaseDecisionTree` with ``splitter="best"``
   where split threshold could become infinite when values in X were
   near infinite. :issue:`10536` by :user:`Jonathan Ohayon <Johayon>`.
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -22,7 +22,7 @@ random sampling procedures.
 - :class:`discriminant_analysis.LinearDiscriminantAnalysis` with 'eigen'
   solver. |Fix|
 - :class:`linear_model.BayesianRidge` |Fix|
-- Decision trees and derived ensembles when both `max_depth` and
+- Decision trees and derived ensembles when both ``max_depth`` and
   `max_leaf_nodes` are set. |Fix|
 - :class:`linear_model.LogisticRegression` and
   :class:`linear_model.LogisticRegressionCV` with 'saga' solver. |Fix|
@@ -93,7 +93,7 @@ Support for Python 3.4 and below has been officially dropped.
   (resolved sign ambiguity in eigenvalue decomposition of the kernel matrix).
   :issue:`13241` by :user:`Aurélien Bellet <bellet>`.
 
-- |Fix| Fixed a bug in :class:`decomposition.KernelPCA`, `fit().transform()`
+- |Fix| Fixed a bug in :class:`decomposition.KernelPCA`, ``fit().transform()``
   now produces the correct output (the same as `fit_transform()`) in case
   of non-removed zero eigenvalues (`remove_zero_eig=False`).
   `fit_inverse_transform` was also accelerated by using the same trick as
@@ -254,7 +254,7 @@ Support for Python 3.4 and below has been officially dropped.
   by the liblinear solver. :issue:`12860` by :user:`Nicolas Hug
   <NicolasHug>`.
 
-- |Enhancement| `sparse_cg` solver in :class:`linear_model.Ridge`
+- |Enhancement| ``sparse_cg`` solver in :class:`linear_model.Ridge`
   now supports fitting the intercept (i.e. ``fit_intercept=True``) when
   inputs are sparse. :issue:`13336` by :user:`Bartosz Telenczuk <btel>`.
 
@@ -335,7 +335,7 @@ Support for Python 3.4 and below has been officially dropped.
   BLAS shipped with scipy instead of the bundled BLAS. :issue:`12732` by
   :user:`Jérémie du Boisberranger <jeremiedbb>`
 
-- |Enhancement| Use label `accuracy` instead of `micro-average` on
+- |Enhancement| Use label ``accuracy`` instead of ```micro-average``` on
   :func:`metrics.classification_report` to avoid confusion. `micro-average` is
   only shown for multi-label or multi-class with a subset of classes because
   it is otherwise identical to accuracy.
@@ -486,7 +486,7 @@ Support for Python 3.4 and below has been officially dropped.
   useless or resulting in a wrong approximation of the cumulative distribution
   function estimator. :issue:`13333` by :user:`Albert Thomas <albertcthomas>`.
 
-- |API| The default value of `copy` in :func:`preprocessing.quantile_transform`
+- |API| The default value of ```copy``` in :func:`preprocessing.quantile_transform`
   will change from False to True in 0.23 in order to make it more consistent
   with the default `copy` values of other functions in
   :mod:`preprocessing.data` and prevent unexpected side effects by modifying
@@ -533,7 +533,7 @@ Support for Python 3.4 and below has been officially dropped.
 Multiple modules
 ................
 
-- |MajorFeature| The `__repr__()` method of all estimators (used when calling
+- |MajorFeature| The ``__repr__()`` method of all estimators (used when calling
   `print(estimator)`) has been entirely re-written, building on Python's
   pretty printing standard library. All parameters are printed by default,
   but this can be altered with the ``print_changed_only`` option in

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -335,7 +335,7 @@ Support for Python 3.4 and below has been officially dropped.
   BLAS shipped with scipy instead of the bundled BLAS. :issue:`12732` by
   :user:`Jérémie du Boisberranger <jeremiedbb>`
 
-- |Enhancement| Use label ``accuracy`` instead of ```micro-average``` on
+- |Enhancement| Use label ``accuracy`` instead of ``micro-average`` on
   :func:`metrics.classification_report` to avoid confusion. `micro-average` is
   only shown for multi-label or multi-class with a subset of classes because
   it is otherwise identical to accuracy.
@@ -486,7 +486,7 @@ Support for Python 3.4 and below has been officially dropped.
   useless or resulting in a wrong approximation of the cumulative distribution
   function estimator. :issue:`13333` by :user:`Albert Thomas <albertcthomas>`.
 
-- |API| The default value of ```copy``` in :func:`preprocessing.quantile_transform`
+- |API| The default value of ``copy`` in :func:`preprocessing.quantile_transform`
   will change from False to True in 0.23 in order to make it more consistent
   with the default `copy` values of other functions in
   :mod:`preprocessing.data` and prevent unexpected side effects by modifying

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -464,7 +464,7 @@ class BiclusterMixin:
         return tuple(len(i) for i in indices)
 
     def get_submatrix(self, i, data):
-        """Returns the submatrix corresponding to bicluster `i`.
+        """Returns the submatrix corresponding to bicluster ``i``.
 
         Parameters
         ----------

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -82,7 +82,7 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
         cluster labels for each point
 
     n_iter : int
-        number of iterations run. Returned only if `return_n_iter` is
+        number of iterations run. Returned only if ``return_n_iter`` is
         set to True.
 
     Notes

--- a/sklearn/cluster/bicluster.py
+++ b/sklearn/cluster/bicluster.py
@@ -181,7 +181,7 @@ class SpectralCoclustering(BaseSpectral):
 
     Clusters rows and columns of an array `X` to solve the relaxed
     normalized cut of the bipartite graph created from `X` as follows:
-    the edge between row vertex `i` and column vertex `j` has weight
+    the edge between row vertex ``i`` and column vertex `j` has weight
     `X[i, j]`.
 
     The resulting bicluster structure is block-diagonal, since each
@@ -201,13 +201,13 @@ class SpectralCoclustering(BaseSpectral):
         'randomized' or 'arpack'. If 'randomized', use
         :func:`sklearn.utils.extmath.randomized_svd`, which may be faster
         for large matrices. If 'arpack', use
-        :func:`scipy.sparse.linalg.svds`, which is more accurate, but
+        :func:``scipy.sparse.linalg.svds``, which is more accurate, but
         possibly slower in some cases.
 
     n_svd_vecs : int, optional, default: None
         Number of vectors to use in calculating the SVD. Corresponds
-        to `ncv` when `svd_method=arpack` and `n_oversamples` when
-        `svd_method` is 'randomized`.
+        to ``ncv`` when ``svd_method=arpack`` and ``n_oversamples`` when
+        ``svd_method`` is ``'randomized'``.
 
     mini_batch : bool, optional, default: False
         Whether to use mini-batch k-means, which is faster but may get
@@ -243,10 +243,10 @@ class SpectralCoclustering(BaseSpectral):
     ----------
     rows_ : array-like, shape (n_row_clusters, n_rows)
         Results of the clustering. `rows[i, r]` is True if
-        cluster `i` contains row `r`. Available only after calling ``fit``.
+        cluster ``i`` contains row ``r``. Available only after calling ``fit``.
 
     columns_ : array-like, shape (n_column_clusters, n_columns)
-        Results of the clustering, like `rows`.
+        Results of the clustering, like ``rows``.
 
     row_labels_ : array-like, shape (n_rows,)
         The bicluster label of each row.
@@ -347,13 +347,13 @@ class SpectralBiclustering(BaseSpectral):
         'randomized' or 'arpack'. If 'randomized', uses
         `sklearn.utils.extmath.randomized_svd`, which may be faster
         for large matrices. If 'arpack', uses
-        `scipy.sparse.linalg.svds`, which is more accurate, but
+        ``scipy.sparse.linalg.svds``, which is more accurate, but
         possibly slower in some cases.
 
     n_svd_vecs : int, optional, default: None
         Number of vectors to use in calculating the SVD. Corresponds
-        to `ncv` when `svd_method=arpack` and `n_oversamples` when
-        `svd_method` is 'randomized`.
+        to ``ncv`` when ``svd_method=arpack`` and ``n_oversamples`` when
+        ``svd_method`` is ``'randomized'``.
 
     mini_batch : bool, optional, default: False
         Whether to use mini-batch k-means, which is faster but may get
@@ -389,10 +389,10 @@ class SpectralBiclustering(BaseSpectral):
     ----------
     rows_ : array-like, shape (n_row_clusters, n_rows)
         Results of the clustering. `rows[i, r]` is True if
-        cluster `i` contains row `r`. Available only after calling ``fit``.
+        cluster ``i`` contains row ``r``. Available only after calling ``fit``.
 
     columns_ : array-like, shape (n_column_clusters, n_columns)
-        Results of the clustering, like `rows`.
+        Results of the clustering, like ``rows``.
 
     row_labels_ : array-like, shape (n_rows,)
         Row partition labels.

--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -349,15 +349,15 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
         Number of clusters after the final clustering step, which treats the
         subclusters from the leaves as new samples.
 
-        - `None` : the final clustering step is not performed and the
+        - ``None`` : the final clustering step is not performed and the
           subclusters are returned as they are.
 
         - `sklearn.cluster` Estimator : If a model is provided, the model is
           fit treating the subclusters as new samples and the initial data is
           mapped to the label of the closest subcluster.
 
-        - `int` : the model fit is :class:`AgglomerativeClustering` with
-          `n_clusters` set to be equal to the int.
+        - ``int`` : the model fit is :class:`AgglomerativeClustering` with
+          ``n_clusters`` set to be equal to the int.
 
     compute_labels : bool, default True
         Whether or not to compute labels for each fit.

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -172,7 +172,7 @@ def ward_tree(X, connectivity=None, n_clusters=None, return_distance=False):
     children : 2D array, shape (n_nodes-1, 2)
         The children of each non-leaf node. Values less than `n_samples`
         correspond to leaves of the tree which are the original samples.
-        A node `i` greater than or equal to `n_samples` is a non-leaf
+        A node ``i`` greater than or equal to `n_samples` is a non-leaf
         node and has children `children_[i - n_samples]`. Alternatively
         at the i-th iteration, children[i][0] and children[i][1]
         are merged to form node `n_samples + i`
@@ -391,7 +391,7 @@ def linkage_tree(X, connectivity=None, n_clusters=None, linkage='complete',
     children : 2D array, shape (n_nodes-1, 2)
         The children of each non-leaf node. Values less than `n_samples`
         correspond to leaves of the tree which are the original samples.
-        A node `i` greater than or equal to `n_samples` is a non-leaf
+        A node ``i`` greater than or equal to `n_samples` is a non-leaf
         node and has children `children_[i - n_samples]`. Alternatively
         at the i-th iteration, children[i][0] and children[i][1]
         are merged to form node `n_samples + i`
@@ -608,7 +608,7 @@ def _hc_cut(n_clusters, children, n_leaves):
     children : 2D array, shape (n_nodes-1, 2)
         The children of each non-leaf node. Values less than `n_samples`
         correspond to leaves of the tree which are the original samples.
-        A node `i` greater than or equal to `n_samples` is a non-leaf
+        A node ``i`` greater than or equal to `n_samples` is a non-leaf
         node and has children `children_[i - n_samples]`. Alternatively
         at the i-th iteration, children[i][0] and children[i][1]
         are merged to form node `n_samples + i`
@@ -723,7 +723,7 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
     children_ : array-like, shape (n_samples-1, 2)
         The children of each non-leaf node. Values less than `n_samples`
         correspond to leaves of the tree which are the original samples.
-        A node `i` greater than or equal to `n_samples` is a non-leaf
+        A node ``i`` greater than or equal to `n_samples` is a non-leaf
         node and has children `children_[i - n_samples]`. Alternatively
         at the i-th iteration, children[i][0] and children[i][1]
         are merged to form node `n_samples + i`
@@ -892,7 +892,7 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
     pooling_func : callable, default np.mean
         This combines the values of agglomerated features into a single
         value, and should accept an array of shape [M, N] and the keyword
-        argument `axis=1`, and reduce it to an array of size [M].
+        argument ``axis=1``, and reduce it to an array of size [M].
 
     Attributes
     ----------
@@ -908,7 +908,7 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
     children_ : array-like, shape (n_nodes-1, 2)
         The children of each non-leaf node. Values less than `n_features`
         correspond to leaves of the tree which are the original samples.
-        A node `i` greater than or equal to `n_features` is a non-leaf
+        A node ``i`` greater than or equal to `n_features` is a non-leaf
         node and has children `children_[i - n_features]`. Alternatively
         at the i-th iteration, children[i][0] and children[i][1]
         are merged to form node `n_features + i`

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -291,7 +291,7 @@ def k_means(X, n_clusters, sample_weight=None, init='k-means++',
 
     best_n_iter : int
         Number of iterations corresponding to the best results.
-        Returned only if `return_n_iter` is set to True.
+        Returned only if ``return_n_iter`` is set to True.
 
     """
     if n_init <= 0:
@@ -1051,7 +1051,7 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
     def predict(self, X, sample_weight=None):
         """Predict the closest cluster each sample in X belongs to.
 
-        In the vector quantization literature, `cluster_centers_` is called
+        In the vector quantization literature, ``cluster_centers_`` is called
         the code book and each value returned by `predict` is the index of
         the closest code in the code book.
 
@@ -1720,7 +1720,7 @@ class MiniBatchKMeans(KMeans):
     def predict(self, X, sample_weight=None):
         """Predict the closest cluster each sample in X belongs to.
 
-        In the vector quantization literature, `cluster_centers_` is called
+        In the vector quantization literature, ``cluster_centers_`` is called
         the code book and each value returned by `predict` is the index of
         the closest code in the code book.
 

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -495,8 +495,8 @@ def cluster_optics_dbscan(reachability, core_distances, ordering, eps=0.5):
     Extracting the clusters runs in linear time. Note that if the ``max_eps``
     OPTICS parameter was set to < inf for extracting reachability and ordering
     arrays, DBSCAN extractions will be unstable for ``eps`` values close to
-    ``max_eps``. Setting ``eps`` < (``max_eps`` / 5.0) will guarantee extraction
-    parity with DBSCAN.
+    ``max_eps``. Setting ``eps`` < (``max_eps`` / 5.0) will guarantee
+    extraction parity with DBSCAN.
 
     Parameters
     ----------

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -48,7 +48,7 @@ class OPTICS(BaseEstimator, ClusterMixin):
     max_eps : float, optional (default=np.inf)
         The maximum distance between two samples for them to be considered
         as in the same neighborhood. Default value of "np.inf" will identify
-        clusters across all scales; reducing `max_eps` will result in
+        clusters across all scales; reducing ``max_eps`` will result in
         shorter run times.
 
     metric : string or callable, optional (default='minkowski')
@@ -186,7 +186,7 @@ class OPTICS(BaseEstimator, ClusterMixin):
         """Perform OPTICS clustering
 
         Extracts an ordered list of points and reachability distances, and
-        performs initial clustering using `max_eps` distance specified at
+        performs initial clustering using ``max_eps`` distance specified at
         OPTICS object instantiation.
 
         Parameters
@@ -314,7 +314,7 @@ def compute_optics_graph(X, min_samples, max_eps, metric, p, metric_params,
     max_eps : float, optional (default=np.inf)
         The maximum distance between two samples for them to be considered
         as in the same neighborhood. Default value of "np.inf" will identify
-        clusters across all scales; reducing `max_eps` will result in
+        clusters across all scales; reducing ``max_eps`` will result in
         shorter run times.
 
     metric : string or callable, optional (default='minkowski')
@@ -492,26 +492,26 @@ def _set_reach_dist(core_distances_, reachability_, predecessor_,
 def cluster_optics_dbscan(reachability, core_distances, ordering, eps=0.5):
     """Performs DBSCAN extraction for an arbitrary epsilon.
 
-    Extracting the clusters runs in linear time. Note that if the `max_eps`
+    Extracting the clusters runs in linear time. Note that if the ``max_eps``
     OPTICS parameter was set to < inf for extracting reachability and ordering
-    arrays, DBSCAN extractions will be unstable for `eps` values close to
-    `max_eps`. Setting `eps` < (`max_eps` / 5.0) will guarantee extraction
+    arrays, DBSCAN extractions will be unstable for ``eps`` values close to
+    ``max_eps``. Setting ``eps`` < (``max_eps`` / 5.0) will guarantee extraction
     parity with DBSCAN.
 
     Parameters
     ----------
     reachability : array, shape (n_samples,)
-        Reachability distances calculated by OPTICS (`reachability_`)
+        Reachability distances calculated by OPTICS (``reachability_``)
 
     core_distances : array, shape (n_samples,)
-        Distances at which points become core (`core_distances_`)
+        Distances at which points become core (``core_distances_``)
 
     ordering : array, shape (n_samples,)
-        OPTICS ordered point indices (`ordering_`)
+        OPTICS ordered point indices (``ordering_``)
 
     eps : float, optional (default=0.5)
-        DBSCAN `eps` parameter. Must be set to < `max_eps`. Results
-        will be close to DBSCAN algorithm if `eps` is < (`max_eps` / 5)
+        DBSCAN ``eps`` parameter. Must be set to < ``max_eps``. Results
+        will be close to DBSCAN algorithm if ``eps`` is < (``max_eps`` / 5)
 
     Returns
     -------

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -326,7 +326,7 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
     affinity : string, array-like or callable, default 'rbf'
         If a string, this may be one of 'nearest_neighbors', 'precomputed',
         'rbf' or one of the kernels supported by
-        `sklearn.metrics.pairwise_kernels`.
+        ``sklearn.metrics.pairwise_kernels``.
 
         Only kernels that produce similarity scores (non-negative values that
         increase with similarity) should be used. This property is not checked

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -105,7 +105,7 @@ boolean mask array or callable
     ----------
     transformers_ : list
         The collection of fitted transformers as tuples of
-        (name, fitted_transformer, column). `fitted_transformer` can be an
+        (name, fitted_transformer, column). ``fitted_transformer`` can be an
         estimator, 'drop', or 'passthrough'. In case there were no columns
         selected, this will be the unfitted transformer.
         If there are remaining columns, the final element is a tuple of the
@@ -123,7 +123,7 @@ boolean mask array or callable
     sparse_output_ : boolean
         Boolean flag indicating wether the output of ``transform`` is a
         sparse matrix or a dense numpy array, which depends on the output
-        of the individual transformers and the `sparse_threshold` keyword.
+        of the individual transformers and the ``sparse_threshold`` keyword.
 
     Notes
     -----
@@ -131,7 +131,7 @@ boolean mask array or callable
     order of how the columns are specified in the `transformers` list.
     Columns of the original feature matrix that are not specified are
     dropped from the resulting transformed feature matrix, unless specified
-    in the `passthrough` keyword. Those columns specified with `passthrough`
+    in the ``passthrough`` keyword. Those columns specified with ``passthrough``
     are added at the right to the output of the transformers.
 
     See also

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -128,11 +128,11 @@ boolean mask array or callable
     Notes
     -----
     The order of the columns in the transformed feature matrix follows the
-    order of how the columns are specified in the `transformers` list.
-    Columns of the original feature matrix that are not specified are
-    dropped from the resulting transformed feature matrix, unless specified
-    in the ``passthrough`` keyword. Those columns specified with ``passthrough``
-    are added at the right to the output of the transformers.
+    order of how the columns are specified in the `transformers` list. Columns
+    of the original feature matrix that are not specified are dropped from the
+    resulting transformed feature matrix, unless specified in the
+    ``passthrough`` keyword. Those columns specified with ``passthrough`` are
+    added at the right to the output of the transformers.
 
     See also
     --------

--- a/sklearn/covariance/elliptic_envelope.py
+++ b/sklearn/covariance/elliptic_envelope.py
@@ -43,7 +43,7 @@ class EllipticEnvelope(MinCovDet, OutlierMixin):
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        instance used by ``np.random``.
 
     Attributes
     ----------

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -204,7 +204,7 @@ class EmpiricalCovariance(BaseEstimator):
 
     def score(self, X_test, y=None):
         """Computes the log-likelihood of a Gaussian data set with
-        `self.covariance_` as an estimator of its covariance matrix.
+        ``self.covariance_`` as an estimator of its covariance matrix.
 
         Parameters
         ----------
@@ -220,7 +220,7 @@ class EmpiricalCovariance(BaseEstimator):
         Returns
         -------
         res : float
-            The likelihood of the data set with `self.covariance_` as an
+            The likelihood of the data set with ``self.covariance_`` as an
             estimator of its covariance matrix.
 
         """

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -145,7 +145,8 @@ def graphical_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
         each iteration. Returned only if return_costs is True.
 
     n_iter : int
-        Number of iterations. Returned only if ``return_n_iter`` is set to True.
+        Number of iterations. Returned only if ``return_n_iter`` is set to
+        True.
 
     See Also
     --------
@@ -838,7 +839,8 @@ def graph_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
         each iteration. Returned only if return_costs is True.
 
     n_iter : int
-        Number of iterations. Returned only if ``return_n_iter`` is set to True.
+        Number of iterations. Returned only if ``return_n_iter`` is set to
+        True.
 
     See Also
     --------

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -145,7 +145,7 @@ def graphical_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
         each iteration. Returned only if return_costs is True.
 
     n_iter : int
-        Number of iterations. Returned only if `return_n_iter` is set to True.
+        Number of iterations. Returned only if ``return_n_iter`` is set to True.
 
     See Also
     --------
@@ -155,9 +155,9 @@ def graphical_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
     -----
     The algorithm employed to solve this problem is the GLasso algorithm,
     from the Friedman 2008 Biostatistics paper. It is the same algorithm
-    as in the R `glasso` package.
+    as in the R ``glasso`` package.
 
-    One possible difference with the `glasso` R package is that the
+    One possible difference with the ``glasso`` R package is that the
     diagonal coefficients are not penalized.
 
     """
@@ -838,7 +838,7 @@ def graph_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
         each iteration. Returned only if return_costs is True.
 
     n_iter : int
-        Number of iterations. Returned only if `return_n_iter` is set to True.
+        Number of iterations. Returned only if ``return_n_iter`` is set to True.
 
     See Also
     --------
@@ -848,9 +848,9 @@ def graph_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
     -----
     The algorithm employed to solve this problem is the GLasso algorithm,
     from the Friedman 2008 Biostatistics paper. It is the same algorithm
-    as in the R `glasso` package.
+    as in the R ``glasso`` package.
 
-    One possible difference with the `glasso` R package is that the
+    One possible difference with the ``glasso`` R package is that the
     diagonal coefficients are not penalized.
 
     """

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -64,7 +64,7 @@ def c_step(X, n_support, remaining_iterations=30, initial_estimates=None,
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Returns
     -------
@@ -234,7 +234,7 @@ def select_candidates(X, n_support, n_trials, select=1, n_iter=30,
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     See Also
     ---------
@@ -329,7 +329,7 @@ def fast_mcd(X, support_fraction=None,
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Notes
     -----
@@ -546,7 +546,7 @@ class MinCovDet(EmpiricalCovariance):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Attributes
     ----------

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -139,7 +139,7 @@ def load_files(container_path, description=None, categories=None,
 
     decode_error : {'strict', 'ignore', 'replace'}, optional
         Instruction on what to do if a byte sequence is given to analyze that
-        contains characters not of the given `encoding`. Passed as keyword
+        contains characters not of the given ``encoding``. Passed as keyword
         argument 'errors' to bytes.decode.
 
     random_state : int, RandomState instance or None (default=0)
@@ -268,7 +268,7 @@ def load_wine(return_X_y=False):
     ----------
     return_X_y : boolean, default=False.
         If True, returns ``(data, target)`` instead of a Bunch object.
-        See below for more information about the `data` and `target` object.
+        See below for more information about the ``data`` and `target` object.
 
     Returns
     -------
@@ -343,7 +343,7 @@ def load_iris(return_X_y=False):
     ----------
     return_X_y : boolean, default=False.
         If True, returns ``(data, target)`` instead of a Bunch object. See
-        below for more information about the `data` and `target` object.
+        below for more information about the ``data`` and `target` object.
 
         .. versionadded:: 0.18
 
@@ -355,7 +355,7 @@ def load_iris(return_X_y=False):
         'target_names', the meaning of the labels, 'feature_names', the
         meaning of the features, 'DESCR', the full description of
         the dataset, 'filename', the physical location of
-        iris csv dataset (added in version `0.20`).
+        iris csv dataset (added in version ``0.20``).
 
     (data, target) : tuple if ``return_X_y`` is True
 
@@ -418,7 +418,7 @@ def load_breast_cancer(return_X_y=False):
     ----------
     return_X_y : boolean, default=False
         If True, returns ``(data, target)`` instead of a Bunch object.
-        See below for more information about the `data` and `target` object.
+        See below for more information about the ``data`` and `target` object.
 
         .. versionadded:: 0.18
 
@@ -430,7 +430,7 @@ def load_breast_cancer(return_X_y=False):
         'target_names', the meaning of the labels, 'feature_names', the
         meaning of the features, and 'DESCR', the full description of
         the dataset, 'filename', the physical location of
-        breast cancer csv dataset (added in version `0.20`).
+        breast cancer csv dataset (added in version ``0.20``).
 
     (data, target) : tuple if ``return_X_y`` is True
 
@@ -507,7 +507,7 @@ def load_digits(n_class=10, return_X_y=False):
 
     return_X_y : boolean, default=False.
         If True, returns ``(data, target)`` instead of a Bunch object.
-        See below for more information about the `data` and `target` object.
+        See below for more information about the ``data`` and `target` object.
 
         .. versionadded:: 0.18
 
@@ -581,7 +581,7 @@ def load_diabetes(return_X_y=False):
     ----------
     return_X_y : boolean, default=False.
         If True, returns ``(data, target)`` instead of a Bunch object.
-        See below for more information about the `data` and `target` object.
+        See below for more information about the ``data`` and `target` object.
 
         .. versionadded:: 0.18
 
@@ -592,7 +592,7 @@ def load_diabetes(return_X_y=False):
         'data', the data to learn, 'target', the regression target for each
         sample, 'data_filename', the physical location
         of diabetes data csv dataset, and 'target_filename', the physical
-        location of diabetes targets csv datataset (added in version `0.20`).
+        location of diabetes targets csv datataset (added in version ``0.20``).
 
     (data, target) : tuple if ``return_X_y`` is True
 
@@ -634,7 +634,7 @@ def load_linnerud(return_X_y=False):
     ----------
     return_X_y : boolean, default=False.
         If True, returns ``(data, target)`` instead of a Bunch object.
-        See below for more information about the `data` and `target` object.
+        See below for more information about the ``data`` and `target` object.
 
         .. versionadded:: 0.18
 
@@ -648,7 +648,7 @@ def load_linnerud(return_X_y=False):
         In addition, you will also have access to 'data_filename',
         the physical location of linnerud data csv dataset, and
         'target_filename', the physical location of
-        linnerud targets csv datataset (added in version `0.20`).
+        linnerud targets csv datataset (added in version ``0.20``).
 
     (data, target) : tuple if ``return_X_y`` is True
 
@@ -698,7 +698,7 @@ def load_boston(return_X_y=False):
     ----------
     return_X_y : boolean, default=False.
         If True, returns ``(data, target)`` instead of a Bunch object.
-        See below for more information about the `data` and `target` object.
+        See below for more information about the ``data`` and `target` object.
 
         .. versionadded:: 0.18
 
@@ -709,7 +709,7 @@ def load_boston(return_X_y=False):
         'data', the data to learn, 'target', the regression targets,
         'DESCR', the full description of the dataset,
         and 'filename', the physical location of boston
-        csv dataset (added in version `0.20`).
+        csv dataset (added in version ``0.20``).
 
     (data, target) : tuple if ``return_X_y`` is True
 

--- a/sklearn/datasets/kddcup99.py
+++ b/sklearn/datasets/kddcup99.py
@@ -91,7 +91,7 @@ def fetch_kddcup99(subset=None, data_home=None, shuffle=False,
 
     return_X_y : boolean, default=False.
         If True, returns ``(data, target)`` instead of a Bunch object. See
-        below for more information about the `data` and `target` object.
+        below for more information about the ``data`` and `target` object.
 
         .. versionadded:: 0.20
 

--- a/sklearn/datasets/lfw.py
+++ b/sklearn/datasets/lfw.py
@@ -205,7 +205,7 @@ def _fetch_lfw_people(data_folder_path, slice_=None, color=False, resize=None,
     This operation is meant to be cached by a joblib wrapper.
     """
     # scan the data folder content to retain people with more that
-    # `min_faces_per_person` face pictures
+    # ``min_faces_per_person`` face pictures
     person_names, file_paths = [], []
     for person_name in sorted(listdir(data_folder_path)):
         folder_path = join(data_folder_path, person_name)
@@ -271,7 +271,7 @@ def fetch_lfw_people(data_home=None, funneled=True, resize=0.5,
 
     min_faces_per_person : int, optional, default None
         The extracted dataset will only retain pictures of people that have at
-        least `min_faces_per_person` different pictures.
+        least ``min_faces_per_person`` different pictures.
 
     color : boolean, optional, default False
         Keep the 3 RGB channels instead of averaging them to a single
@@ -289,8 +289,8 @@ def fetch_lfw_people(data_home=None, funneled=True, resize=0.5,
 
     return_X_y : boolean, default=False.
         If True, returns ``(dataset.data, dataset.target)`` instead of a Bunch
-        object. See below for more information about the `dataset.data` and
-        `dataset.target` object.
+        object. See below for more information about the ``dataset.data`` and
+        ``dataset.target`` object.
 
         .. versionadded:: 0.20
 

--- a/sklearn/datasets/mldata.py
+++ b/sklearn/datasets/mldata.py
@@ -64,10 +64,10 @@ def fetch_mldata(dataname, target_name='label', data_name='data',
       2) alternatively, the first column stores target values, and the second
          data values
       3) the data array is stored as `n_features x n_samples` , and thus needs
-         to be transposed to match the `sklearn` standard
+         to be transposed to match the ``sklearn`` standard
 
     Keyword arguments allow to adapt these defaults to specific data sets
-    (see parameters `target_name`, `data_name`, `transpose_data`, and
+    (see parameters ``target_name``, ``data_name``, ``transpose_data``, and
     the examples below).
 
     mldata.org data sets may have multiple columns, which are stored in the
@@ -158,9 +158,9 @@ def fetch_mldata(dataname, target_name='label', data_name='data',
     # 1) there is only one array => it is "data"
     # 2) there are multiple arrays
     #    a) copy all columns in the bunch, using their column name
-    #    b) if there is a column called `target_name`, set "target" to it,
+    #    b) if there is a column called ``target_name``, set "target" to it,
     #        otherwise set "target" to first column
-    #    c) if there is a column called `data_name`, set "data" to it,
+    #    c) if there is a column called ``data_name``, set "data" to it,
     #        otherwise set "data" to second column
 
     dataset = {'DESCR': 'mldata.org dataset: %s' % dataname,

--- a/sklearn/datasets/openml.py
+++ b/sklearn/datasets/openml.py
@@ -488,7 +488,7 @@ def fetch_openml(name=None, version='active', data_id=None, data_home=None,
 
     return_X_y : boolean, default=False.
         If True, returns ``(data, target)`` instead of a Bunch object. See
-        below for more information about the `data` and `target` objects.
+        below for more information about the ``data`` and `target` objects.
 
     Returns
     -------

--- a/sklearn/datasets/rcv1.py
+++ b/sklearn/datasets/rcv1.py
@@ -120,8 +120,8 @@ def fetch_rcv1(data_home=None, subset='all', download_if_missing=True,
 
     return_X_y : boolean, default=False.
         If True, returns ``(dataset.data, dataset.target)`` instead of a Bunch
-        object. See below for more information about the `dataset.data` and
-        `dataset.target` object.
+        object. See below for more information about the ``dataset.data`` and
+        ``dataset.target`` object.
 
         .. versionadded:: 0.20
 

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -268,7 +268,7 @@ def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
         - k times, choose a word: w ~ Multinomial(theta_c)
 
     In the above process, rejection sampling is used to make sure that
-    n is never zero or more than `n_classes`, and that the document length
+    n is never zero or more than ``n_classes``, and that the document length
     is never zero. Likewise, we reject classes which have already been chosen.
 
     Read more in the :ref:`User Guide <sample_generators>`.
@@ -500,7 +500,7 @@ def make_regression(n_samples=100, n_features=100, n_informative=10,
 
     tail_strength : float between 0.0 and 1.0, optional (default=0.5)
         The relative importance of the fat noisy tail of the singular values
-        profile if `effective_rank` is not None.
+        profile if ``effective_rank`` is not None.
 
     noise : float, optional (default=0.0)
         The standard deviation of the gaussian noise applied to the output.
@@ -1540,7 +1540,7 @@ def make_biclusters(shape, n_clusters, noise=0.0, minval=10,
 
     Returns
     -------
-    X : array of shape `shape`
+    X : array of shape ``shape``
         The generated array.
 
     rows : array of shape (n_clusters, X.shape[0],)
@@ -1631,7 +1631,7 @@ def make_checkerboard(shape, n_clusters, noise=0.0, minval=10,
 
     Returns
     -------
-    X : array of shape `shape`
+    X : array of shape ``shape``
         The generated array.
 
     rows : array of shape (n_clusters, X.shape[0],)

--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -222,7 +222,7 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
         - bunch.filenames: list, length [n_samples]
         - bunch.DESCR: a description of the dataset.
         - bunch.target_names: a list of categories of the returned data,
-          length [n_classes]. This depends on the `categories` parameter.
+          length [n_classes]. This depends on the ``categories`` parameter.
     """
 
     data_home = get_data_home(data_home=data_home)

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -228,8 +228,8 @@ def sparse_encode(X, dictionary, gram=None, cov=None, algorithm='lasso_lars',
         penalty applied to the L1 norm.
         If `algorithm='threshold'`, ``alpha`` is the absolute value of the
         threshold below which coefficients will be squashed to zero.
-        If `algorithm='omp'`, ``alpha`` is the tolerance parameter: the value of
-        the reconstruction error targeted. In this case, it overrides
+        If `algorithm='omp'`, ``alpha`` is the tolerance parameter: the value
+        of the reconstruction error targeted. In this case, it overrides
         ``n_nonzero_coefs``.
 
     copy_cov : boolean, optional
@@ -943,8 +943,8 @@ class SparseCoder(BaseEstimator, SparseCodingMixin):
         penalty applied to the L1 norm.
         If `algorithm='threshold'`, ``alpha`` is the absolute value of the
         threshold below which coefficients will be squashed to zero.
-        If `algorithm='omp'`, ``alpha`` is the tolerance parameter: the value of
-        the reconstruction error targeted. In this case, it overrides
+        If `algorithm='omp'`, ``alpha`` is the tolerance parameter: the value
+        of the reconstruction error targeted. In this case, it overrides
         ``n_nonzero_coefs``.
 
     split_sign : bool, False by default
@@ -1071,8 +1071,8 @@ class DictionaryLearning(BaseEstimator, SparseCodingMixin):
         penalty applied to the L1 norm.
         If `algorithm='threshold'`, ``alpha`` is the absolute value of the
         threshold below which coefficients will be squashed to zero.
-        If `algorithm='omp'`, ``alpha`` is the tolerance parameter: the value of
-        the reconstruction error targeted. In this case, it overrides
+        If `algorithm='omp'`, ``alpha`` is the tolerance parameter: the value
+        of the reconstruction error targeted. In this case, it overrides
         ``n_nonzero_coefs``.
 
     n_jobs : int or None, optional (default=None)
@@ -1266,8 +1266,8 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
         penalty applied to the L1 norm.
         If `algorithm='threshold'`, ``alpha`` is the absolute value of the
         threshold below which coefficients will be squashed to zero.
-        If `algorithm='omp'`, ``alpha`` is the tolerance parameter: the value of
-        the reconstruction error targeted. In this case, it overrides
+        If `algorithm='omp'`, ``alpha`` is the tolerance parameter: the value
+        of the reconstruction error targeted. In this case, it overrides
         ``n_nonzero_coefs``.
 
     verbose : bool, optional (default: False)

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -221,16 +221,16 @@ def sparse_encode(X, dictionary, gram=None, cov=None, algorithm='lasso_lars',
     n_nonzero_coefs : int, 0.1 * n_features by default
         Number of nonzero coefficients to target in each column of the
         solution. This is only used by `algorithm='lars'` and `algorithm='omp'`
-        and is overridden by `alpha` in the `omp` case.
+        and is overridden by ``alpha`` in the `omp` case.
 
     alpha : float, 1. by default
-        If `algorithm='lasso_lars'` or `algorithm='lasso_cd'`, `alpha` is the
+        If `algorithm='lasso_lars'` or `algorithm='lasso_cd'`, ``alpha`` is the
         penalty applied to the L1 norm.
-        If `algorithm='threshold'`, `alpha` is the absolute value of the
+        If `algorithm='threshold'`, ``alpha`` is the absolute value of the
         threshold below which coefficients will be squashed to zero.
-        If `algorithm='omp'`, `alpha` is the tolerance parameter: the value of
+        If `algorithm='omp'`, ``alpha`` is the tolerance parameter: the value of
         the reconstruction error targeted. In this case, it overrides
-        `n_nonzero_coefs`.
+        ``n_nonzero_coefs``.
 
     copy_cov : boolean, optional
         Whether to copy the precomputed covariance matrix; if False, it may be
@@ -357,7 +357,7 @@ def _update_dict(dictionary, Y, code, verbose=False, return_r2=False,
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     positive : boolean, optional
         Whether to enforce positivity when finding the dictionary.
@@ -478,7 +478,7 @@ def dict_learning(X, n_components, alpha, max_iter=100, tol=1e-8,
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     return_n_iter : bool
         Whether or not to return the number of iterations.
@@ -505,7 +505,7 @@ def dict_learning(X, n_components, alpha, max_iter=100, tol=1e-8,
         Vector of errors at each iteration.
 
     n_iter : int
-        Number of iterations run. Returned only if `return_n_iter` is
+        Number of iterations run. Returned only if ``return_n_iter`` is
         set to True.
 
     See also
@@ -675,7 +675,7 @@ def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     return_inner_stats : boolean, optional
         Return the inner statistics A (dictionary covariance) and B
@@ -706,14 +706,14 @@ def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
     Returns
     -------
     code : array of shape (n_samples, n_components),
-        the sparse code (only returned if `return_code=True`)
+        the sparse code (only returned if ``return_code=True``)
 
     dictionary : array of shape (n_components, n_features),
         the solutions to the dictionary learning problem
 
     n_iter : int
-        Number of iterations run. Returned only if `return_n_iter` is
-        set to `True`.
+        Number of iterations run. Returned only if ``return_n_iter`` is
+        set to ``True``.
 
     See also
     --------
@@ -867,7 +867,7 @@ class SparseCodingMixin(TransformerMixin):
         """Encode the data as a sparse combination of the dictionary atoms.
 
         Coding method is determined by the object parameter
-        `transform_algorithm`.
+        ``transform_algorithm``.
 
         Parameters
         ----------
@@ -936,16 +936,16 @@ class SparseCoder(BaseEstimator, SparseCodingMixin):
     transform_n_nonzero_coefs : int, ``0.1 * n_features`` by default
         Number of nonzero coefficients to target in each column of the
         solution. This is only used by `algorithm='lars'` and `algorithm='omp'`
-        and is overridden by `alpha` in the `omp` case.
+        and is overridden by ``alpha`` in the `omp` case.
 
     transform_alpha : float, 1. by default
-        If `algorithm='lasso_lars'` or `algorithm='lasso_cd'`, `alpha` is the
+        If `algorithm='lasso_lars'` or `algorithm='lasso_cd'`, ``alpha`` is the
         penalty applied to the L1 norm.
-        If `algorithm='threshold'`, `alpha` is the absolute value of the
+        If `algorithm='threshold'`, ``alpha`` is the absolute value of the
         threshold below which coefficients will be squashed to zero.
-        If `algorithm='omp'`, `alpha` is the tolerance parameter: the value of
+        If `algorithm='omp'`, ``alpha`` is the tolerance parameter: the value of
         the reconstruction error targeted. In this case, it overrides
-        `n_nonzero_coefs`.
+        ``n_nonzero_coefs``.
 
     split_sign : bool, False by default
         Whether to split the sparse feature vector into the concatenation of
@@ -1064,16 +1064,16 @@ class DictionaryLearning(BaseEstimator, SparseCodingMixin):
     transform_n_nonzero_coefs : int, ``0.1 * n_features`` by default
         Number of nonzero coefficients to target in each column of the
         solution. This is only used by `algorithm='lars'` and `algorithm='omp'`
-        and is overridden by `alpha` in the `omp` case.
+        and is overridden by ``alpha`` in the `omp` case.
 
     transform_alpha : float, 1. by default
-        If `algorithm='lasso_lars'` or `algorithm='lasso_cd'`, `alpha` is the
+        If `algorithm='lasso_lars'` or `algorithm='lasso_cd'`, ``alpha`` is the
         penalty applied to the L1 norm.
-        If `algorithm='threshold'`, `alpha` is the absolute value of the
+        If `algorithm='threshold'`, ``alpha`` is the absolute value of the
         threshold below which coefficients will be squashed to zero.
-        If `algorithm='omp'`, `alpha` is the tolerance parameter: the value of
+        If `algorithm='omp'`, ``alpha`` is the tolerance parameter: the value of
         the reconstruction error targeted. In this case, it overrides
-        `n_nonzero_coefs`.
+        ``n_nonzero_coefs``.
 
     n_jobs : int or None, optional (default=None)
         Number of parallel jobs to run.
@@ -1099,7 +1099,7 @@ class DictionaryLearning(BaseEstimator, SparseCodingMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     positive_code : bool
         Whether to enforce positivity when finding the code.
@@ -1259,16 +1259,16 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
     transform_n_nonzero_coefs : int, ``0.1 * n_features`` by default
         Number of nonzero coefficients to target in each column of the
         solution. This is only used by `algorithm='lars'` and `algorithm='omp'`
-        and is overridden by `alpha` in the `omp` case.
+        and is overridden by ``alpha`` in the `omp` case.
 
     transform_alpha : float, 1. by default
-        If `algorithm='lasso_lars'` or `algorithm='lasso_cd'`, `alpha` is the
+        If `algorithm='lasso_lars'` or `algorithm='lasso_cd'`, ``alpha`` is the
         penalty applied to the L1 norm.
-        If `algorithm='threshold'`, `alpha` is the absolute value of the
+        If `algorithm='threshold'`, ``alpha`` is the absolute value of the
         threshold below which coefficients will be squashed to zero.
-        If `algorithm='omp'`, `alpha` is the tolerance parameter: the value of
+        If `algorithm='omp'`, ``alpha`` is the tolerance parameter: the value of
         the reconstruction error targeted. In this case, it overrides
-        `n_nonzero_coefs`.
+        ``n_nonzero_coefs``.
 
     verbose : bool, optional (default: False)
         To control the verbosity of the procedure.
@@ -1282,7 +1282,7 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     positive_code : bool
         Whether to enforce positivity when finding the code.

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -48,7 +48,7 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
     :class:`PPCA`.
 
     FactorAnalysis performs a maximum likelihood estimate of the so-called
-    `loading` matrix, the transformation of the latent variables to the
+    ``loading`` matrix, the transformation of the latent variables to the
     observed ones, using expectation-maximization (EM).
 
     Read more in the :ref:`User Guide <FA>`.
@@ -80,7 +80,7 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         Defaults to 'randomized'. For most applications 'randomized' will
         be sufficiently precise while providing significant speed gains.
         Accuracy can also be improved by setting higher values for
-        `iterated_power`. If this is not sufficient, for maximum precision
+        ``iterated_power``. If this is not sufficient, for maximum precision
         you should choose 'lapack'.
 
     iterated_power : int, optional
@@ -91,7 +91,7 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`. Only used when ``svd_method`` equals 'randomized'.
+        by ``np.random``. Only used when ``svd_method`` equals 'randomized'.
 
     Attributes
     ----------

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -206,7 +206,7 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     return_X_mean : bool, optional
         If True, X_mean is returned too.
@@ -242,7 +242,7 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
         If the algorithm is "deflation", n_iter is the
         maximum number of iterations run across all components. Else
         they are just the number of iterations taken to converge. This is
-        returned only when return_n_iter is set to `True`.
+        returned only when return_n_iter is set to ``True``.
 
     Notes
     -----
@@ -426,7 +426,7 @@ class FastICA(BaseEstimator, TransformerMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Attributes
     ----------

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -79,14 +79,14 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`. Used when ``eigen_solver`` == 'arpack'.
+        by ``np.random``. Used when ``eigen_solver`` == 'arpack'.
 
         .. versionadded:: 0.18
 
     copy_X : boolean, default=True
-        If True, input X is copied and stored by the model in the `X_fit_`
+        If True, input X is copied and stored by the model in the ``X_fit_``
         attribute. If no further changes will be done to X, setting
-        `copy_X=False` saves memory by storing a reference.
+        ``copy_X=False`` saves memory by storing a reference.
 
         .. versionadded:: 0.18
 
@@ -102,12 +102,12 @@ class KernelPCA(BaseEstimator, TransformerMixin):
     ----------
     lambdas_ : array, (n_components,)
         Eigenvalues of the centered kernel matrix in decreasing order.
-        If `n_components` and `remove_zero_eig` are not set,
+        If `n_components` and ``remove_zero_eig`` are not set,
         then all values are stored.
 
     alphas_ : array, (n_samples, n_components)
         Eigenvectors of the centered kernel matrix. If `n_components` and
-        `remove_zero_eig` are not set, then all components are stored.
+        ``remove_zero_eig`` are not set, then all components are stored.
 
     dual_coef_ : array, (n_samples, n_features)
         Inverse transform matrix. Only available when
@@ -118,7 +118,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         Only available when ``fit_inverse_transform`` is True.
 
     X_fit_ : (n_samples, n_features)
-        The data used to fit the model. If `copy_X=False`, then `X_fit_` is
+        The data used to fit the model. If ``copy_X=False``, then ``X_fit_`` is
         a reference. This attribute is used for the calls to transform.
 
     Examples

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -286,7 +286,7 @@ def _initialize_nmf(X, n_components, init=None, eps=1e-6,
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`. Used when ``random`` == 'nndsvdar' or 'random'.
+        by ``np.random``. Used when ``random`` == 'nndsvdar' or 'random'.
 
     Returns
     -------
@@ -471,7 +471,7 @@ def _fit_coordinate_descent(X, W, H, tol=1e-4, max_iter=200, l1_reg_W=0,
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Returns
     -------
@@ -960,7 +960,7 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     verbose : integer, default: 0
         The verbosity level.
@@ -1160,7 +1160,7 @@ class NMF(BaseEstimator, TransformerMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     alpha : double, default: 0.
         Constant that multiplies the regularization terms. Set it to zero to

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -147,15 +147,15 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
     doc_topic_prior : float, optional (default=None)
         Prior of document topic distribution `theta`. If the value is None,
         defaults to `1 / n_components`.
-        In [1]_, this is called `alpha`.
+        In [1]_, this is called ``alpha``.
 
     topic_word_prior : float, optional (default=None)
-        Prior of topic word distribution `beta`. If the value is None, defaults
+        Prior of topic word distribution ``beta``. If the value is None, defaults
         to `1 / n_components`.
-        In [1]_, this is called `eta`.
+        In [1]_, this is called ``eta``.
 
     learning_method : 'batch' | 'online', default='batch'
-        Method used to update `_component`. Only used in `fit` method.
+        Method used to update ``_component``. Only used in `fit` method.
         In general, if the data size is large, the online update will be much
         faster than the batch update.
 
@@ -226,7 +226,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Attributes
     ----------
@@ -234,7 +234,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         Variational parameters for topic word distribution. Since the complete
         conditional for topic word distribution is a Dirichlet,
         ``components_[i, j]`` can be viewed as pseudocount that represents the
-        number of times word `j` was assigned to topic `i`.
+        number of times word ``j`` was assigned to topic ``i``.
         It can also be viewed as distribution over the words for each topic
         after normalization:
         ``model.components_ / model.components_.sum(axis=1)[:, np.newaxis]``.
@@ -408,7 +408,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
     def _em_step(self, X, total_samples, batch_update, parallel=None):
         """EM update for 1 iteration.
 
-        update `_component` by batch VB or online VB.
+        update ``_component`` by batch VB or online VB.
 
         Parameters
         ----------
@@ -513,7 +513,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
     def fit(self, X, y=None):
         """Learn model for the data X with variational Bayes method.
 
-        When `learning_method` is 'online', use mini-batch update.
+        When ``learning_method`` is 'online', use mini-batch update.
         Otherwise, use batch update.
 
         Parameters

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -150,8 +150,8 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         In [1]_, this is called ``alpha``.
 
     topic_word_prior : float, optional (default=None)
-        Prior of topic word distribution ``beta``. If the value is None, defaults
-        to `1 / n_components`.
+        Prior of topic word distribution ``beta``. If the value is None,
+        defaults to `1 / n_components`.
         In [1]_, this is called ``eta``.
 
     learning_method : 'batch' | 'online', default='batch'

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -160,7 +160,7 @@ class PCA(_BasePCA):
 
     svd_solver : string {'auto', 'full', 'arpack', 'randomized'}
         auto :
-            the solver is selected by a default policy based on `X.shape` and
+            the solver is selected by a default policy based on ``X.shape`` and
             `n_components`: if the input data is larger than 500x500 and the
             number of components to extract is lower than 80% of the smallest
             dimension of the data, then the more efficient 'randomized'
@@ -168,10 +168,10 @@ class PCA(_BasePCA):
             optionally truncated afterwards.
         full :
             run exact full SVD calling the standard LAPACK solver via
-            `scipy.linalg.svd` and select the components by postprocessing
+            ``scipy.linalg.svd`` and select the components by postprocessing
         arpack :
             run SVD truncated to n_components calling ARPACK solver via
-            `scipy.sparse.linalg.svds`. It requires strictly
+            ``scipy.sparse.linalg.svds``. It requires strictly
             0 < n_components < min(X.shape)
         randomized :
             run randomized SVD by the method of Halko et al.
@@ -193,7 +193,7 @@ class PCA(_BasePCA):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`. Used when ``svd_solver`` == 'arpack' or 'randomized'.
+        by ``np.random``. Used when ``svd_solver`` == 'arpack' or 'randomized'.
 
         .. versionadded:: 0.18.0
 
@@ -226,7 +226,7 @@ class PCA(_BasePCA):
     mean_ : array, shape (n_features,)
         Per-feature empirical mean, estimated from the training set.
 
-        Equal to `X.mean(axis=0)`.
+        Equal to ``X.mean(axis=0)``.
 
     n_components_ : int
         The estimated number of components. When n_components is set
@@ -257,7 +257,7 @@ class PCA(_BasePCA):
     via the score and score_samples methods.
     See http://www.miketipping.com/papers/met-mppca.pdf
 
-    For svd_solver == 'arpack', refer to `scipy.sparse.linalg.svds`.
+    For svd_solver == 'arpack', refer to ``scipy.sparse.linalg.svds``.
 
     For svd_solver == 'randomized', see:
     *Halko, N., Martinsson, P. G., and Tropp, J. A. (2011).

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -67,7 +67,7 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     normalize_components : boolean, optional (default=False)
         - if False, use a version of Sparse PCA without components
@@ -202,7 +202,7 @@ class SparsePCA(BaseEstimator, TransformerMixin):
 
         To avoid instability issues in case the system is under-determined,
         regularization can be applied (Ridge regression) via the
-        `ridge_alpha` parameter.
+        ``ridge_alpha`` parameter.
 
         Note that Sparse PCA components orthogonality is not enforced as in PCA
         hence one cannot use a simple linear projection.
@@ -290,7 +290,7 @@ class MiniBatchSparsePCA(SparsePCA):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     normalize_components : boolean, optional (default=False)
         - if False, use a version of Sparse PCA without components

--- a/sklearn/decomposition/truncated_svd.py
+++ b/sklearn/decomposition/truncated_svd.py
@@ -59,7 +59,7 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     tol : float, optional
         Tolerance for ARPACK. 0 means machine precision. Ignored by randomized

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -581,7 +581,7 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
 
     store_covariance : boolean
         If True the covariance matrices are computed and stored in the
-        `self.covariance_` attribute.
+        ``self.covariance_`` attribute.
 
         .. versionadded:: 0.17
 

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -52,7 +52,7 @@ class DummyClassifier(BaseEstimator, ClassifierMixin, MultiOutputMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     constant : int or str or array of shape = [n_outputs]
         The explicit constant as predicted by the "constant" strategy. This

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -462,13 +462,13 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
     max_samples : int or float, optional (default=1.0)
         The number of samples to draw from X to train each base estimator.
 
-        - If int, then draw `max_samples` samples.
+        - If int, then draw ``max_samples`` samples.
         - If float, then draw `max_samples * X.shape[0]` samples.
 
     max_features : int or float, optional (default=1.0)
         The number of features to draw from X to train each base estimator.
 
-        - If int, then draw `max_features` features.
+        - If int, then draw ``max_features`` features.
         - If float, then draw `max_features * X.shape[1]` features.
 
     bootstrap : boolean, optional (default=True)
@@ -500,7 +500,7 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     verbose : int, optional (default=0)
         Controls the verbosity when fitting and predicting.
@@ -533,7 +533,7 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
         Decision function computed with out-of-bag estimate on the training
         set. If n_estimators is small it might be possible that a data point
         was never left out during the bootstrap. In this case,
-        `oob_decision_function_` might contain NaN.
+        ``oob_decision_function_`` might contain NaN.
 
     References
     ----------
@@ -844,13 +844,13 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
     max_samples : int or float, optional (default=1.0)
         The number of samples to draw from X to train each base estimator.
 
-        - If int, then draw `max_samples` samples.
+        - If int, then draw ``max_samples`` samples.
         - If float, then draw `max_samples * X.shape[0]` samples.
 
     max_features : int or float, optional (default=1.0)
         The number of features to draw from X to train each base estimator.
 
-        - If int, then draw `max_features` features.
+        - If int, then draw ``max_features`` features.
         - If float, then draw `max_features * X.shape[1]` features.
 
     bootstrap : boolean, optional (default=True)
@@ -879,7 +879,7 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     verbose : int, optional (default=0)
         Controls the verbosity when fitting and predicting.
@@ -903,7 +903,7 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
         Prediction computed with out-of-bag estimate on the training
         set. If n_estimators is small it might be possible that a data point
         was never left out during the bootstrap. In this case,
-        `oob_prediction_` might contain NaN.
+        ``oob_prediction_`` might contain NaN.
 
     References
     ----------

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -781,8 +781,8 @@ class RandomForestClassifier(ForestClassifier):
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
 
-        - If int, then consider `min_samples_split` as the minimum number.
-        - If float, then `min_samples_split` is a fraction and
+        - If int, then consider ``min_samples_split`` as the minimum number.
+        - If float, then ``min_samples_split`` is a fraction and
           `ceil(min_samples_split * n_samples)` are the minimum
           number of samples for each split.
 
@@ -796,8 +796,8 @@ class RandomForestClassifier(ForestClassifier):
         right branches.  This may have the effect of smoothing the model,
         especially in regression.
 
-        - If int, then consider `min_samples_leaf` as the minimum number.
-        - If float, then `min_samples_leaf` is a fraction and
+        - If int, then consider ``min_samples_leaf`` as the minimum number.
+        - If float, then ``min_samples_leaf`` is a fraction and
           `ceil(min_samples_leaf * n_samples)` are the minimum
           number of samples for each node.
 
@@ -812,14 +812,14 @@ class RandomForestClassifier(ForestClassifier):
     max_features : int, float, string or None, optional (default="auto")
         The number of features to consider when looking for the best split:
 
-        - If int, then consider `max_features` features at each split.
-        - If float, then `max_features` is a fraction and
+        - If int, then consider ``max_features`` features at each split.
+        - If float, then ``max_features`` is a fraction and
           `int(max_features * n_features)` features are considered at each
           split.
-        - If "auto", then `max_features=sqrt(n_features)`.
-        - If "sqrt", then `max_features=sqrt(n_features)` (same as "auto").
-        - If "log2", then `max_features=log2(n_features)`.
-        - If None, then `max_features=n_features`.
+        - If "auto", then ``max_features=sqrt(n_features)``.
+        - If "sqrt", then ``max_features=sqrt(n_features)`` (same as "auto").
+        - If "log2", then ``max_features=log2(n_features)``.
+        - If None, then ``max_features=n_features``.
 
         Note: the search for a split does not stop until at least one
         valid partition of the node samples is found, even if it requires to
@@ -877,7 +877,7 @@ class RandomForestClassifier(ForestClassifier):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     verbose : int, optional (default=0)
         Controls the verbosity when fitting and predicting.
@@ -942,7 +942,7 @@ class RandomForestClassifier(ForestClassifier):
         Decision function computed with out-of-bag estimate on the training
         set. If n_estimators is small it might be possible that a data point
         was never left out during the bootstrap. In this case,
-        `oob_decision_function_` might contain NaN.
+        ``oob_decision_function_`` might contain NaN.
 
     Examples
     --------
@@ -1073,8 +1073,8 @@ class RandomForestRegressor(ForestRegressor):
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
 
-        - If int, then consider `min_samples_split` as the minimum number.
-        - If float, then `min_samples_split` is a fraction and
+        - If int, then consider ``min_samples_split`` as the minimum number.
+        - If float, then ``min_samples_split`` is a fraction and
           `ceil(min_samples_split * n_samples)` are the minimum
           number of samples for each split.
 
@@ -1088,8 +1088,8 @@ class RandomForestRegressor(ForestRegressor):
         right branches.  This may have the effect of smoothing the model,
         especially in regression.
 
-        - If int, then consider `min_samples_leaf` as the minimum number.
-        - If float, then `min_samples_leaf` is a fraction and
+        - If int, then consider ``min_samples_leaf`` as the minimum number.
+        - If float, then ``min_samples_leaf`` is a fraction and
           `ceil(min_samples_leaf * n_samples)` are the minimum
           number of samples for each node.
 
@@ -1104,14 +1104,14 @@ class RandomForestRegressor(ForestRegressor):
     max_features : int, float, string or None, optional (default="auto")
         The number of features to consider when looking for the best split:
 
-        - If int, then consider `max_features` features at each split.
-        - If float, then `max_features` is a fraction and
+        - If int, then consider ``max_features`` features at each split.
+        - If float, then ``max_features`` is a fraction and
           `int(max_features * n_features)` features are considered at each
           split.
-        - If "auto", then `max_features=n_features`.
-        - If "sqrt", then `max_features=sqrt(n_features)`.
-        - If "log2", then `max_features=log2(n_features)`.
-        - If None, then `max_features=n_features`.
+        - If "auto", then ``max_features=n_features``.
+        - If "sqrt", then ``max_features=sqrt(n_features)``.
+        - If "log2", then ``max_features=log2(n_features)``.
+        - If None, then ``max_features=n_features``.
 
         Note: the search for a split does not stop until at least one
         valid partition of the node samples is found, even if it requires to
@@ -1160,7 +1160,7 @@ class RandomForestRegressor(ForestRegressor):
 
     n_jobs : int or None, optional (default=None)
         The number of jobs to run in parallel for both `fit` and `predict`.
-        `None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
@@ -1168,7 +1168,7 @@ class RandomForestRegressor(ForestRegressor):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     verbose : int, optional (default=0)
         Controls the verbosity when fitting and predicting.
@@ -1324,8 +1324,8 @@ class ExtraTreesClassifier(ForestClassifier):
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
 
-        - If int, then consider `min_samples_split` as the minimum number.
-        - If float, then `min_samples_split` is a fraction and
+        - If int, then consider ``min_samples_split`` as the minimum number.
+        - If float, then ``min_samples_split`` is a fraction and
           `ceil(min_samples_split * n_samples)` are the minimum
           number of samples for each split.
 
@@ -1339,8 +1339,8 @@ class ExtraTreesClassifier(ForestClassifier):
         right branches.  This may have the effect of smoothing the model,
         especially in regression.
 
-        - If int, then consider `min_samples_leaf` as the minimum number.
-        - If float, then `min_samples_leaf` is a fraction and
+        - If int, then consider ``min_samples_leaf`` as the minimum number.
+        - If float, then ``min_samples_leaf`` is a fraction and
           `ceil(min_samples_leaf * n_samples)` are the minimum
           number of samples for each node.
 
@@ -1355,14 +1355,14 @@ class ExtraTreesClassifier(ForestClassifier):
     max_features : int, float, string or None, optional (default="auto")
         The number of features to consider when looking for the best split:
 
-        - If int, then consider `max_features` features at each split.
-        - If float, then `max_features` is a fraction and
+        - If int, then consider ``max_features`` features at each split.
+        - If float, then ``max_features`` is a fraction and
           `int(max_features * n_features)` features are considered at each
           split.
-        - If "auto", then `max_features=sqrt(n_features)`.
-        - If "sqrt", then `max_features=sqrt(n_features)`.
-        - If "log2", then `max_features=log2(n_features)`.
-        - If None, then `max_features=n_features`.
+        - If "auto", then ``max_features=sqrt(n_features)``.
+        - If "sqrt", then ``max_features=sqrt(n_features)``.
+        - If "log2", then ``max_features=log2(n_features)``.
+        - If None, then ``max_features=n_features``.
 
         Note: the search for a split does not stop until at least one
         valid partition of the node samples is found, even if it requires to
@@ -1419,7 +1419,7 @@ class ExtraTreesClassifier(ForestClassifier):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     verbose : int, optional (default=0)
         Controls the verbosity when fitting and predicting.
@@ -1483,7 +1483,7 @@ class ExtraTreesClassifier(ForestClassifier):
         Decision function computed with out-of-bag estimate on the training
         set. If n_estimators is small it might be possible that a data point
         was never left out during the bootstrap. In this case,
-        `oob_decision_function_` might contain NaN.
+        ``oob_decision_function_`` might contain NaN.
 
     Notes
     -----
@@ -1586,8 +1586,8 @@ class ExtraTreesRegressor(ForestRegressor):
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
 
-        - If int, then consider `min_samples_split` as the minimum number.
-        - If float, then `min_samples_split` is a fraction and
+        - If int, then consider ``min_samples_split`` as the minimum number.
+        - If float, then ``min_samples_split`` is a fraction and
           `ceil(min_samples_split * n_samples)` are the minimum
           number of samples for each split.
 
@@ -1601,8 +1601,8 @@ class ExtraTreesRegressor(ForestRegressor):
         right branches.  This may have the effect of smoothing the model,
         especially in regression.
 
-        - If int, then consider `min_samples_leaf` as the minimum number.
-        - If float, then `min_samples_leaf` is a fraction and
+        - If int, then consider ``min_samples_leaf`` as the minimum number.
+        - If float, then ``min_samples_leaf`` is a fraction and
           `ceil(min_samples_leaf * n_samples)` are the minimum
           number of samples for each node.
 
@@ -1617,14 +1617,14 @@ class ExtraTreesRegressor(ForestRegressor):
     max_features : int, float, string or None, optional (default="auto")
         The number of features to consider when looking for the best split:
 
-        - If int, then consider `max_features` features at each split.
-        - If float, then `max_features` is a fraction and
+        - If int, then consider ``max_features`` features at each split.
+        - If float, then ``max_features`` is a fraction and
           `int(max_features * n_features)` features are considered at each
           split.
-        - If "auto", then `max_features=n_features`.
-        - If "sqrt", then `max_features=sqrt(n_features)`.
-        - If "log2", then `max_features=log2(n_features)`.
-        - If None, then `max_features=n_features`.
+        - If "auto", then ``max_features=n_features``.
+        - If "sqrt", then ``max_features=sqrt(n_features)``.
+        - If "log2", then ``max_features=log2(n_features)``.
+        - If None, then ``max_features=n_features``.
 
         Note: the search for a split does not stop until at least one
         valid partition of the node samples is found, even if it requires to
@@ -1680,7 +1680,7 @@ class ExtraTreesRegressor(ForestRegressor):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     verbose : int, optional (default=0)
         Controls the verbosity when fitting and predicting.
@@ -1804,8 +1804,8 @@ class RandomTreesEmbedding(BaseForest):
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
 
-        - If int, then consider `min_samples_split` as the minimum number.
-        - If float, then `min_samples_split` is a fraction and
+        - If int, then consider ``min_samples_split`` as the minimum number.
+        - If float, then ``min_samples_split`` is a fraction and
           `ceil(min_samples_split * n_samples)` is the minimum
           number of samples for each split.
 
@@ -1819,8 +1819,8 @@ class RandomTreesEmbedding(BaseForest):
         right branches.  This may have the effect of smoothing the model,
         especially in regression.
 
-        - If int, then consider `min_samples_leaf` as the minimum number.
-        - If float, then `min_samples_leaf` is a fraction and
+        - If int, then consider ``min_samples_leaf`` as the minimum number.
+        - If float, then ``min_samples_leaf`` is a fraction and
           `ceil(min_samples_leaf * n_samples)` is the minimum
           number of samples for each node.
 
@@ -1879,7 +1879,7 @@ class RandomTreesEmbedding(BaseForest):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     verbose : int, optional (default=0)
         Controls the verbosity when fitting and predicting.

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -79,7 +79,7 @@ class QuantileEstimator:
     """
     def __init__(self, alpha=0.9):
         if not 0 < alpha < 1.0:
-            raise ValueError("``alpha`` must be in (0, 1.0) but was %r" % alpha)
+            raise ValueError("`alpha` must be in (0, 1.0) but was %r" % alpha)
         self.alpha = alpha
 
     def fit(self, X, y, sample_weight=None):
@@ -1781,8 +1781,9 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
         boosting recovers the AdaBoost algorithm.
 
     learning_rate : float, optional (default=0.1)
-        learning rate shrinks the contribution of each tree by ``learning_rate``.
-        There is a trade-off between learning_rate and n_estimators.
+        learning rate shrinks the contribution of each tree by
+        ``learning_rate``. There is a trade-off between learning_rate and
+        n_estimators.
 
     n_estimators : int (default=100)
         The number of boosting stages to perform. Gradient boosting
@@ -2244,8 +2245,9 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
         allows quantile regression (use ``alpha`` to specify the quantile).
 
     learning_rate : float, optional (default=0.1)
-        learning rate shrinks the contribution of each tree by ``learning_rate``.
-        There is a trade-off between learning_rate and n_estimators.
+        learning rate shrinks the contribution of each tree by
+        ``learning_rate``. There is a trade-off between learning_rate and
+        n_estimators.
 
     n_estimators : int (default=100)
         The number of boosting stages to perform. Gradient boosting

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -79,7 +79,7 @@ class QuantileEstimator:
     """
     def __init__(self, alpha=0.9):
         if not 0 < alpha < 1.0:
-            raise ValueError("`alpha` must be in (0, 1.0) but was %r" % alpha)
+            raise ValueError("``alpha`` must be in (0, 1.0) but was %r" % alpha)
         self.alpha = alpha
 
     def fit(self, X, y, sample_weight=None):
@@ -1781,7 +1781,7 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
         boosting recovers the AdaBoost algorithm.
 
     learning_rate : float, optional (default=0.1)
-        learning rate shrinks the contribution of each tree by `learning_rate`.
+        learning rate shrinks the contribution of each tree by ``learning_rate``.
         There is a trade-off between learning_rate and n_estimators.
 
     n_estimators : int (default=100)
@@ -1792,7 +1792,7 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
     subsample : float, optional (default=1.0)
         The fraction of samples to be used for fitting the individual base
         learners. If smaller than 1.0 this results in Stochastic Gradient
-        Boosting. `subsample` interacts with the parameter `n_estimators`.
+        Boosting. ``subsample`` interacts with the parameter ``n_estimators``.
         Choosing `subsample < 1.0` leads to a reduction of variance
         and an increase in bias.
 
@@ -1809,8 +1809,8 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
 
-        - If int, then consider `min_samples_split` as the minimum number.
-        - If float, then `min_samples_split` is a fraction and
+        - If int, then consider ``min_samples_split`` as the minimum number.
+        - If float, then ``min_samples_split`` is a fraction and
           `ceil(min_samples_split * n_samples)` are the minimum
           number of samples for each split.
 
@@ -1824,8 +1824,8 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
         right branches.  This may have the effect of smoothing the model,
         especially in regression.
 
-        - If int, then consider `min_samples_leaf` as the minimum number.
-        - If float, then `min_samples_leaf` is a fraction and
+        - If int, then consider ``min_samples_leaf`` as the minimum number.
+        - If float, then ``min_samples_leaf`` is a fraction and
           `ceil(min_samples_leaf * n_samples)` are the minimum
           number of samples for each node.
 
@@ -1881,19 +1881,19 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     max_features : int, float, string or None, optional (default=None)
         The number of features to consider when looking for the best split:
 
-        - If int, then consider `max_features` features at each split.
-        - If float, then `max_features` is a fraction and
+        - If int, then consider ``max_features`` features at each split.
+        - If float, then ``max_features`` is a fraction and
           `int(max_features * n_features)` features are considered at each
           split.
-        - If "auto", then `max_features=sqrt(n_features)`.
-        - If "sqrt", then `max_features=sqrt(n_features)`.
-        - If "log2", then `max_features=log2(n_features)`.
-        - If None, then `max_features=n_features`.
+        - If "auto", then ``max_features=sqrt(n_features)``.
+        - If "sqrt", then ``max_features=sqrt(n_features)``.
+        - If "log2", then ``max_features=log2(n_features)``.
+        - If None, then ``max_features=n_features``.
 
         Choosing `max_features < n_features` leads to a reduction of variance
         and an increase in bias.
@@ -2241,10 +2241,10 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
         regression. 'lad' (least absolute deviation) is a highly robust
         loss function solely based on order information of the input
         variables. 'huber' is a combination of the two. 'quantile'
-        allows quantile regression (use `alpha` to specify the quantile).
+        allows quantile regression (use ``alpha`` to specify the quantile).
 
     learning_rate : float, optional (default=0.1)
-        learning rate shrinks the contribution of each tree by `learning_rate`.
+        learning rate shrinks the contribution of each tree by ``learning_rate``.
         There is a trade-off between learning_rate and n_estimators.
 
     n_estimators : int (default=100)
@@ -2255,7 +2255,7 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
     subsample : float, optional (default=1.0)
         The fraction of samples to be used for fitting the individual base
         learners. If smaller than 1.0 this results in Stochastic Gradient
-        Boosting. `subsample` interacts with the parameter `n_estimators`.
+        Boosting. ``subsample`` interacts with the parameter ``n_estimators``.
         Choosing `subsample < 1.0` leads to a reduction of variance
         and an increase in bias.
 
@@ -2272,8 +2272,8 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
 
-        - If int, then consider `min_samples_split` as the minimum number.
-        - If float, then `min_samples_split` is a fraction and
+        - If int, then consider ``min_samples_split`` as the minimum number.
+        - If float, then ``min_samples_split`` is a fraction and
           `ceil(min_samples_split * n_samples)` are the minimum
           number of samples for each split.
 
@@ -2287,8 +2287,8 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
         right branches.  This may have the effect of smoothing the model,
         especially in regression.
 
-        - If int, then consider `min_samples_leaf` as the minimum number.
-        - If float, then `min_samples_leaf` is a fraction and
+        - If int, then consider ``min_samples_leaf`` as the minimum number.
+        - If float, then ``min_samples_leaf`` is a fraction and
           `ceil(min_samples_leaf * n_samples)` are the minimum
           number of samples for each node.
 
@@ -2345,19 +2345,19 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     max_features : int, float, string or None, optional (default=None)
         The number of features to consider when looking for the best split:
 
-        - If int, then consider `max_features` features at each split.
-        - If float, then `max_features` is a fraction and
+        - If int, then consider ``max_features`` features at each split.
+        - If float, then ``max_features`` is a fraction and
           `int(max_features * n_features)` features are considered at each
           split.
-        - If "auto", then `max_features=n_features`.
-        - If "sqrt", then `max_features=sqrt(n_features)`.
-        - If "log2", then `max_features=log2(n_features)`.
-        - If None, then `max_features=n_features`.
+        - If "auto", then ``max_features=n_features``.
+        - If "sqrt", then ``max_features=sqrt(n_features)``.
+        - If "log2", then ``max_features=log2(n_features)``.
+        - If None, then ``max_features=n_features``.
 
         Choosing `max_features < n_features` leads to a reduction of variance
         and an increase in bias.

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -57,7 +57,7 @@ class IsolationForest(BaseBagging, OutlierMixin):
 
     max_samples : int or float, optional (default="auto")
         The number of samples to draw from X to train each base estimator.
-            - If int, then draw `max_samples` samples.
+            - If int, then draw ``max_samples`` samples.
             - If float, then draw `max_samples * X.shape[0]` samples.
             - If "auto", then `max_samples=min(256, n_samples)`.
 
@@ -77,7 +77,7 @@ class IsolationForest(BaseBagging, OutlierMixin):
     max_features : int or float, optional (default=1.0)
         The number of features to draw from X to train each base estimator.
 
-            - If int, then draw `max_features` features.
+            - If int, then draw ``max_features`` features.
             - If float, then draw `max_features * X.shape[1]` features.
 
     bootstrap : boolean, optional (default=False)
@@ -115,7 +115,7 @@ class IsolationForest(BaseBagging, OutlierMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     verbose : int, optional (default=0)
         Controls the verbosity of the tree building process.

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -44,7 +44,7 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
     estimators : list of (string, estimator) tuples
         Invoking the ``fit`` method on the ``VotingClassifier`` will fit clones
         of those original estimators that will be stored in the class attribute
-        ``self.estimators_``. An estimator can be set to `None` using
+        ``self.estimators_``. An estimator can be set to ``None`` using
         ``set_params``.
 
     voting : str, {'hard', 'soft'} (default='hard')
@@ -53,10 +53,10 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
         the sums of the predicted probabilities, which is recommended for
         an ensemble of well-calibrated classifiers.
 
-    weights : array-like, shape = [n_classifiers], optional (default=`None`)
-        Sequence of weights (`float` or `int`) to weight the occurrences of
-        predicted class labels (`hard` voting) or class probabilities
-        before averaging (`soft` voting). Uses uniform weights if `None`.
+    weights : array-like, shape = [n_classifiers], optional (default=``None``)
+        Sequence of weights (``float`` or ``int``) to weight the occurrences of
+        predicted class labels (``hard`` voting) or class probabilities
+        before averaging (``soft`` voting). Uses uniform weights if ``None``.
 
     n_jobs : int or None, optional (default=None)
         The number of jobs to run in parallel for ``fit``.
@@ -75,7 +75,7 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
     ----------
     estimators_ : list of classifiers
         The collection of fitted sub-estimators as defined in ``estimators``
-        that are not `None`.
+        that are not ``None``.
 
     named_estimators_ : Bunch object, a dictionary with attribute access
         Attribute to access any fitted sub-estimators by name.
@@ -206,7 +206,7 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
 
     @property
     def _weights_not_none(self):
-        """Get the weights of not `None` estimators"""
+        """Get the weights of not ``None`` estimators"""
         if self.weights is None:
             return None
         return [w for est, w in zip(self.estimators,
@@ -283,7 +283,7 @@ class VotingClassifier(_BaseComposition, ClassifierMixin, TransformerMixin):
         Returns
         -------
         probabilities_or_labels
-            If `voting='soft'` and `flatten_transform=True`:
+            If `voting='soft'` and ``flatten_transform=True``:
                 returns array-like of shape (n_classifiers, n_samples *
                 n_classes), being class probabilities calculated by each
                 classifier.

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -330,7 +330,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Attributes
     ----------
@@ -905,7 +905,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Attributes
     ----------

--- a/sklearn/externals/joblib/parallel.py
+++ b/sklearn/externals/joblib/parallel.py
@@ -64,7 +64,7 @@ def _register_dask():
         register_parallel_backend('dask', DaskDistributedBackend)
     except ImportError:
         msg = ("To use the dask.distributed backend you must install both "
-               "the `dask` and distributed modules.\n\n"
+               "the ``dask`` and distributed modules.\n\n"
                "See http://dask.pydata.org/en/latest/install.html for more "
                "information.")
         raise ImportError(msg)
@@ -137,7 +137,7 @@ class parallel_backend(object):
     CPU-bound code in a few calls to native code that explicitly releases the
     GIL.
 
-    In addition, if the `dask` and `distributed` Python packages are installed,
+    In addition, if the ``dask`` and ``distributed`` Python packages are installed,
     it is possible to use the 'dask' backend for better scheduling of nested
     parallel calls without over-subscription and potentially distribute
     parallel calls over a networked cluster of several hosts.

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -311,7 +311,7 @@ def extract_patches_2d(image, patch_size, max_patches=None, random_state=None):
     image : array, shape = (image_height, image_width) or
         (image_height, image_width, n_channels)
         The original image data. For color images, the last dimension specifies
-        the channel: a RGB image would have `n_channels=3`.
+        the channel: a RGB image would have ``n_channels=3``.
 
     patch_size : tuple of ints (patch_height, patch_width)
         the dimensions of one patch
@@ -323,17 +323,17 @@ def extract_patches_2d(image, patch_size, max_patches=None, random_state=None):
 
     random_state : int, RandomState instance or None, optional (default=None)
         Pseudo number generator state used for random sampling to use if
-        `max_patches` is not None.  If int, random_state is the seed used by
+        ``max_patches`` is not None.  If int, random_state is the seed used by
         the random number generator; If RandomState instance, random_state is
         the random number generator; If None, the random number generator is
-        the RandomState instance used by `np.random`.
+        the RandomState instance used by ``np.random``.
 
     Returns
     -------
     patches : array, shape = (n_patches, patch_height, patch_width) or
         (n_patches, patch_height, patch_width, n_channels)
-        The collection of patches extracted from the image, where `n_patches`
-        is either `max_patches` or the total number of patches that can be
+        The collection of patches extracted from the image, where ``n_patches``
+        is either ``max_patches`` or the total number of patches that can be
         extracted.
 
     Examples
@@ -410,7 +410,7 @@ def reconstruct_from_patches_2d(patches, image_size):
         (n_patches, patch_height, patch_width, n_channels)
         The complete set of patches. If the patches contain colour information,
         channels are indexed along the last dimension: RGB patches would
-        have `n_channels=3`.
+        have ``n_channels=3``.
 
     image_size : tuple of ints (image_height, image_width) or
         (image_height, image_width, n_channels)
@@ -458,7 +458,7 @@ class PatchExtractor(BaseEstimator):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Examples
     --------
@@ -502,14 +502,14 @@ class PatchExtractor(BaseEstimator):
             (n_samples, image_height, image_width, n_channels)
             Array of images from which to extract patches. For color images,
             the last dimension specifies the channel: a RGB image would have
-            `n_channels=3`.
+            ``n_channels=3``.
 
         Returns
         -------
         patches : array, shape = (n_patches, patch_height, patch_width) or
              (n_patches, patch_height, patch_width, n_channels)
              The collection of patches extracted from the images, where
-             `n_patches` is either `n_samples * max_patches` or the total
+             ``n_patches`` is either `n_samples * max_patches` or the total
              number of patches that can be extracted.
         """
         self.random_state = check_random_state(self.random_state)

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -435,7 +435,7 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin, TransformerMixin):
 
     decode_error : {'strict', 'ignore', 'replace'}
         Instruction on what to do if a byte sequence is given to analyze that
-        contains characters not of the given `encoding`. By default, it is
+        contains characters not of the given ``encoding``. By default, it is
         'strict', meaning that a UnicodeDecodeError will be raised. Other
         values are 'ignore' and 'replace'.
 
@@ -686,7 +686,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
 
     decode_error : {'strict', 'ignore', 'replace'}
         Instruction on what to do if a byte sequence is given to analyze that
-        contains characters not of the given `encoding`. By default, it is
+        contains characters not of the given ``encoding``. By default, it is
         'strict', meaning that a UnicodeDecodeError will be raised. Other
         values are 'ignore' and 'replace'.
 
@@ -790,9 +790,9 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
     stop_words_ : set
         Terms that were ignored because they either:
 
-          - occurred in too many documents (`max_df`)
-          - occurred in too few documents (`min_df`)
-          - were cut off by feature selection (`max_features`).
+          - occurred in too many documents (``max_df``)
+          - occurred in too few documents (``min_df``)
+          - were cut off by feature selection (``max_features``).
 
         This is only available if no vocabulary was given.
 
@@ -1334,7 +1334,7 @@ class TfidfVectorizer(CountVectorizer):
 
     decode_error : {'strict', 'ignore', 'replace'} (default='strict')
         Instruction on what to do if a byte sequence is given to analyze that
-        contains characters not of the given `encoding`. By default, it is
+        contains characters not of the given ``encoding``. By default, it is
         'strict', meaning that a UnicodeDecodeError will be raised. Other
         values are 'ignore' and 'replace'.
 
@@ -1461,9 +1461,9 @@ class TfidfVectorizer(CountVectorizer):
     stop_words_ : set
         Terms that were ignored because they either:
 
-          - occurred in too many documents (`max_df`)
-          - occurred in too few documents (`min_df`)
-          - were cut off by feature selection (`max_features`).
+          - occurred in too many documents (``max_df``)
+          - occurred in too few documents (``min_df``)
+          - were cut off by feature selection (``max_features``).
 
         This is only available if no vocabulary was given.
 

--- a/sklearn/feature_selection/mutual_info_.py
+++ b/sklearn/feature_selection/mutual_info_.py
@@ -229,7 +229,7 @@ def _estimate_mi(X, y, discrete_features='auto', discrete_target=False,
         random_state is the seed used by the random number generator; If
         RandomState instance, random_state is the random number generator; If
         None, the random number generator is the RandomState instance used by
-        `np.random`.
+        ``np.random``.
 
     Returns
     -------
@@ -336,7 +336,7 @@ def mutual_info_regression(X, y, discrete_features='auto', n_neighbors=3,
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Returns
     -------
@@ -415,7 +415,7 @@ def mutual_info_classif(X, y, discrete_features='auto', n_neighbors=3,
         random_state is the seed used by the random number generator; If
         RandomState instance, random_state is the random number generator; If
         None, the random number generator is the RandomState instance used by
-        `np.random`.
+        ``np.random``.
 
     Returns
     -------

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -56,7 +56,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         attribute or through a ``feature_importances_`` attribute.
 
     n_features_to_select : int or None (default=None)
-        The number of features to select. If `None`, half of the features
+        The number of features to select. If ``None``, half of the features
         are selected.
 
     step : int or float, optional (default=1)

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -387,7 +387,7 @@ class SelectPercentile(_BaseFilter):
         Scores of features.
 
     pvalues_ : array-like, shape=(n_features,)
-        p-values of feature scores, None if `score_func` returned only scores.
+        p-values of feature scores, None if ``score_func`` returned only scores.
 
     Examples
     --------
@@ -471,7 +471,7 @@ class SelectKBest(_BaseFilter):
         Scores of features.
 
     pvalues_ : array-like, shape=(n_features,)
-        p-values of feature scores, None if `score_func` returned only scores.
+        p-values of feature scores, None if ``score_func`` returned only scores.
 
     Examples
     --------
@@ -751,7 +751,7 @@ class GenericUnivariateSelect(_BaseFilter):
         Scores of features.
 
     pvalues_ : array-like, shape=(n_features,)
-        p-values of feature scores, None if `score_func` returned scores only.
+        p-values of feature scores, None if ``score_func`` returned scores only.
 
     Examples
     --------

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -387,7 +387,8 @@ class SelectPercentile(_BaseFilter):
         Scores of features.
 
     pvalues_ : array-like, shape=(n_features,)
-        p-values of feature scores, None if ``score_func`` returned only scores.
+        p-values of feature scores, None if ``score_func`` returned only
+        scores.
 
     Examples
     --------
@@ -471,7 +472,8 @@ class SelectKBest(_BaseFilter):
         Scores of features.
 
     pvalues_ : array-like, shape=(n_features,)
-        p-values of feature scores, None if ``score_func`` returned only scores.
+        p-values of feature scores, None if ``score_func`` returned only
+        scores.
 
     Examples
     --------
@@ -751,7 +753,8 @@ class GenericUnivariateSelect(_BaseFilter):
         Scores of features.
 
     pvalues_ : array-like, shape=(n_features,)
-        p-values of feature scores, None if ``score_func`` returned scores only.
+        p-values of feature scores, None if ``score_func`` returned scores
+        only.
 
     Examples
     --------

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -112,7 +112,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         The generator used to initialize the centers. If int, random_state is
         the seed used by the random number generator; If RandomState instance,
         random_state is the random number generator; If None, the random number
-        generator is the RandomState instance used by `np.random`.
+        generator is the RandomState instance used by ``np.random``.
 
     Attributes
     ----------
@@ -521,7 +521,7 @@ class GaussianProcessClassifier(BaseEstimator, ClassifierMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     multi_class : string, default : "one_vs_rest"
         Specifies how multi-class classification problems are handled.

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -110,7 +110,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
         The generator used to initialize the centers. If int, random_state is
         the seed used by the random number generator; If RandomState instance,
         random_state is the random number generator; If None, the random number
-        generator is the RandomState instance used by `np.random`.
+        generator is the RandomState instance used by ``np.random``.
 
     Attributes
     ----------
@@ -365,7 +365,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
             If int, random_state is the seed used by the random number
             generator; If RandomState instance, random_state is the
             random number generator; If None, the random number
-            generator is the RandomState instance used by `np.random`.
+            generator is the RandomState instance used by ``np.random``.
 
         Returns
         -------

--- a/sklearn/impute.py
+++ b/sklearn/impute.py
@@ -138,7 +138,7 @@ class SimpleImputer(BaseEstimator, TransformerMixin):
     copy : boolean, optional (default=True)
         If True, a copy of X will be created. If False, imputation will
         be done in-place whenever possible. Note that, in the following cases,
-        a new copy will always be made, even if `copy=False`:
+        a new copy will always be made, even if ``copy=False``:
 
         - If X is not an array of floating values;
         - If X is encoded as a CSR matrix.
@@ -456,7 +456,7 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
         imputations computed during the final round. A round is a single
         imputation of each feature with missing values. The stopping criterion
         is met once `abs(max(X_t - X_{t-1}))/abs(max(X[known_vals]))` < tol,
-        where `X_t` is `X` at iteration `t. Note that early stopping is only
+        where ``X_t`` is `X` at iteration `t. Note that early stopping is only
         applied if ``sample_posterior=False``.
 
     tol : float, optional (default=1e-3)

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -183,10 +183,10 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
     Attributes
     ----------
     X_min_ : float
-        Minimum value of input array `X_` for left bound.
+        Minimum value of input array ``X_`` for left bound.
 
     X_max_ : float
-        Maximum value of input array `X_` for right bound.
+        Maximum value of input array ``X_`` for right bound.
 
     f_ : function
         The stepwise interpolating function that covers the input domain ``X``.

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -42,7 +42,7 @@ class RBFSampler(BaseEstimator, TransformerMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Examples
     --------
@@ -150,7 +150,7 @@ class SkewedChi2Sampler(BaseEstimator, TransformerMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Examples
     --------
@@ -479,7 +479,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Attributes
     ----------

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -581,7 +581,7 @@ class ElasticNet(LinearModel, RegressorMixin, MultiOutputMixin):
         feature to update.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`. Used when ``selection`` ==
+        RandomState instance used by ``np.random``. Used when ``selection`` ==
         'random'.
 
     selection : str, default 'cyclic'
@@ -863,7 +863,7 @@ class Lasso(ElasticNet):
         feature to update.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`. Used when ``selection`` ==
+        RandomState instance used by ``np.random``. Used when ``selection`` ==
         'random'.
 
     selection : str, default 'cyclic'
@@ -1325,7 +1325,7 @@ class LassoCV(LinearModelCV, RegressorMixin):
         feature to update.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`. Used when ``selection`` ==
+        RandomState instance used by ``np.random``. Used when ``selection`` ==
         'random'.
 
     selection : str, default 'cyclic'
@@ -1498,7 +1498,7 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
         feature to update.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`. Used when ``selection`` ==
+        RandomState instance used by ``np.random``. Used when ``selection`` ==
         'random'.
 
     selection : str, default 'cyclic'
@@ -1677,7 +1677,7 @@ class MultiTaskElasticNet(Lasso):
         feature to update.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`. Used when ``selection`` ==
+        RandomState instance used by ``np.random``. Used when ``selection`` ==
         'random'.
 
     selection : str, default 'cyclic'
@@ -1866,7 +1866,7 @@ class MultiTaskLasso(MultiTaskElasticNet):
         feature to update.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`. Used when ``selection`` ==
+        RandomState instance used by ``np.random``. Used when ``selection`` ==
         'random'.
 
     selection : str, default 'cyclic'
@@ -2033,7 +2033,7 @@ class MultiTaskElasticNetCV(LinearModelCV, RegressorMixin):
         feature to update.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`. Used when ``selection`` ==
+        RandomState instance used by ``np.random``. Used when ``selection`` ==
         'random'.
 
     selection : str, default 'cyclic'
@@ -2212,7 +2212,7 @@ class MultiTaskLassoCV(LinearModelCV, RegressorMixin):
         feature to update.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`. Used when ``selection`` ==
+        RandomState instance used by ``np.random``. Used when ``selection`` ==
         'random'
 
     selection : str, default 'cyclic'

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1898,7 +1898,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         Array of l1_ratio that maps to the best scores across every class. If
         refit is set to False, then for each class, the best l1_ratio is the
         average of the l1_ratio's that correspond to the best scores for each
-        fold.  ``l1_ratio_`` is of shape(n_classes,) when the problem is binary.
+        fold. ``l1_ratio_`` is of shape(n_classes,) when the problem is binary.
 
     n_iter_ : array, shape (n_classes, n_folds, n_cs) or (1, n_folds, n_cs)
         Actual number of iterations for all classes, folds and Cs.

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -601,7 +601,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`. Used when ``solver`` == 'sag' or
+        instance used by ``np.random``. Used when ``solver`` == 'sag' or
         'liblinear'.
 
     check_input : bool, default True
@@ -767,7 +767,7 @@ def _logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`. Used when ``solver`` == 'sag' or
+        instance used by ``np.random``. Used when ``solver`` == 'sag' or
         'liblinear'.
 
     check_input : bool, default True
@@ -1106,7 +1106,7 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`. Used when ``solver`` == 'sag' and
+        instance used by ``np.random``. Used when ``solver`` == 'sag' and
         'liblinear'.
 
     max_squared_sum : float, default None
@@ -1284,7 +1284,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`. Used when ``solver`` == 'sag' or
+        instance used by ``np.random``. Used when ``solver`` == 'sag' or
         'liblinear'.
 
     solver : str, {'newton-cg', 'lbfgs', 'liblinear', 'sag', 'saga'}, \
@@ -1367,15 +1367,15 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
 
         `coef_` is of shape (1, n_features) when the given problem is binary.
         In particular, when `multi_class='multinomial'`, `coef_` corresponds
-        to outcome 1 (True) and `-coef_` corresponds to outcome 0 (False).
+        to outcome 1 (True) and ``-coef_`` corresponds to outcome 0 (False).
 
     intercept_ : array, shape (1,) or (n_classes,)
         Intercept (a.k.a. bias) added to the decision function.
 
-        If `fit_intercept` is set to False, the intercept is set to zero.
-        `intercept_` is of shape (1,) when the given problem is binary.
-        In particular, when `multi_class='multinomial'`, `intercept_`
-        corresponds to outcome 1 (True) and `-intercept_` corresponds to
+        If ``fit_intercept`` is set to False, the intercept is set to zero.
+        ``intercept_`` is of shape (1,) when the given problem is binary.
+        In particular, when `multi_class='multinomial'`, ``intercept_``
+        corresponds to outcome 1 (True) and ``-intercept_`` corresponds to
         outcome 0 (False).
 
     n_iter_ : array, shape (n_classes,) or (1, )
@@ -1832,7 +1832,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     l1_ratios : list of float or None, optional (default=None)
         The list of Elastic-Net mixing parameter, with ``0 <= l1_ratio <= 1``.
@@ -1855,8 +1855,8 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
     intercept_ : array, shape (1,) or (n_classes,)
         Intercept (a.k.a. bias) added to the decision function.
 
-        If `fit_intercept` is set to False, the intercept is set to zero.
-        `intercept_` is of shape(1,) when the problem is binary.
+        If ``fit_intercept`` is set to False, the intercept is set to zero.
+        ``intercept_`` is of shape(1,) when the problem is binary.
 
     Cs_ : array, shape (n_cs)
         Array of C i.e. inverse of regularization parameter values used
@@ -1892,13 +1892,13 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         Array of C that maps to the best scores across every class. If refit is
         set to False, then for each class, the best C is the average of the
         C's that correspond to the best scores for each fold.
-        `C_` is of shape(n_classes,) when the problem is binary.
+        ``C_`` is of shape(n_classes,) when the problem is binary.
 
     l1_ratio_ : array, shape (n_classes,) or (n_classes - 1,)
         Array of l1_ratio that maps to the best scores across every class. If
         refit is set to False, then for each class, the best l1_ratio is the
         average of the l1_ratio's that correspond to the best scores for each
-        fold.  `l1_ratio_` is of shape(n_classes,) when the problem is binary.
+        fold.  ``l1_ratio_`` is of shape(n_classes,) when the problem is binary.
 
     n_iter_ : array, shape (n_classes, n_folds, n_cs) or (1, n_folds, n_cs)
         Actual number of iterations for all classes, folds and Cs.

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -274,7 +274,7 @@ def orthogonal_mp(X, y, n_nonzero_coefs=None, tol=None, precompute=False,
     `n_nonzero_coefs`:
     argmin ||y - X\gamma||^2 subject to ||\gamma||_0 <= n_{nonzero coefs}
 
-    When parametrized by error using the parameter `tol`:
+    When parametrized by error using the parameter ``tol``:
     argmin ||\gamma||_0 subject to ||y - X\gamma||^2 <= tol
 
     Read more in the :ref:`User Guide <omp>`.
@@ -313,7 +313,7 @@ def orthogonal_mp(X, y, n_nonzero_coefs=None, tol=None, precompute=False,
     Returns
     -------
     coef : array, shape (n_features,) or (n_features, n_targets)
-        Coefficients of the OMP solution. If `return_path=True`, this contains
+        Coefficients of the OMP solution. If ``return_path=True``, this contains
         the whole coefficient path. In this case its shape is
         (n_features, n_features) or (n_features, n_targets, n_features) and
         iterating over the last axis yields coefficients in increasing order
@@ -321,7 +321,7 @@ def orthogonal_mp(X, y, n_nonzero_coefs=None, tol=None, precompute=False,
 
     n_iters : array-like or int
         Number of active features across every target. Returned only if
-        `return_n_iter` is set to True.
+        ``return_n_iter`` is set to True.
 
     See also
     --------
@@ -452,7 +452,7 @@ def orthogonal_mp_gram(Gram, Xy, n_nonzero_coefs=None, tol=None,
     Returns
     -------
     coef : array, shape (n_features,) or (n_features, n_targets)
-        Coefficients of the OMP solution. If `return_path=True`, this contains
+        Coefficients of the OMP solution. If ``return_path=True``, this contains
         the whole coefficient path. In this case its shape is
         (n_features, n_features) or (n_features, n_targets, n_features) and
         iterating over the last axis yields coefficients in increasing order
@@ -460,7 +460,7 @@ def orthogonal_mp_gram(Gram, Xy, n_nonzero_coefs=None, tol=None,
 
     n_iters : array-like or int
         Number of active features across every target. Returned only if
-        `return_n_iter` is set to True.
+        ``return_n_iter`` is set to True.
 
     See also
     --------

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -313,11 +313,11 @@ def orthogonal_mp(X, y, n_nonzero_coefs=None, tol=None, precompute=False,
     Returns
     -------
     coef : array, shape (n_features,) or (n_features, n_targets)
-        Coefficients of the OMP solution. If ``return_path=True``, this contains
-        the whole coefficient path. In this case its shape is
+        Coefficients of the OMP solution. If ``return_path=True``, this
+        contains the whole coefficient path. In this case its shape is
         (n_features, n_features) or (n_features, n_targets, n_features) and
-        iterating over the last axis yields coefficients in increasing order
-        of active features.
+        iterating over the last axis yields coefficients in increasing order of
+        active features.
 
     n_iters : array-like or int
         Number of active features across every target. Returned only if
@@ -452,11 +452,11 @@ def orthogonal_mp_gram(Gram, Xy, n_nonzero_coefs=None, tol=None,
     Returns
     -------
     coef : array, shape (n_features,) or (n_features, n_targets)
-        Coefficients of the OMP solution. If ``return_path=True``, this contains
-        the whole coefficient path. In this case its shape is
+        Coefficients of the OMP solution. If ``return_path=True``, this
+        contains the whole coefficient path. In this case its shape is
         (n_features, n_features) or (n_features, n_targets, n_features) and
-        iterating over the last axis yields coefficients in increasing order
-        of active features.
+        iterating over the last axis yields coefficients in increasing order of
+        active features.
 
     n_iters : array-like or int
         Number of active features across every target. Returned only if

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -78,7 +78,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        instance used by ``np.random``.
 
     warm_start : bool, optional
         When set to True, reuse the solution of the previous call to fit as
@@ -196,11 +196,11 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
 
         classes : array, shape = [n_classes]
             Classes across all calls to partial_fit.
-            Can be obtained by via `np.unique(y_all)`, where y_all is the
+            Can be obtained by via ``np.unique(y_all)``, where y_all is the
             target vector of the entire dataset.
             This argument is required for the first call to partial_fit
             and can be omitted in the subsequent calls.
-            Note that y doesn't need to contain all labels in `classes`.
+            Note that y doesn't need to contain all labels in ``classes``.
 
         Returns
         -------
@@ -321,7 +321,7 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        instance used by ``np.random``.
 
     warm_start : bool, optional
         When set to True, reuse the solution of the previous call to fit as

--- a/sklearn/linear_model/perceptron.py
+++ b/sklearn/linear_model/perceptron.py
@@ -57,7 +57,7 @@ class Perceptron(BaseSGDClassifier):
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        instance used by ``np.random``.
 
     early_stopping : bool, default=False
         Whether to use early stopping to terminate training when validation.

--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -73,13 +73,13 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin,
 
          * `fit(X, y)`: Fit model to given training data and target values.
          * `score(X, y)`: Returns the mean accuracy on the given test data,
-           which is used for the stop criterion defined by `stop_score`.
+           which is used for the stop criterion defined by ``stop_score``.
            Additionally, the score is used to decide which of two equally
            large consensus sets is chosen as the better one.
-         * `predict(X)`: Returns predicted values using the linear model,
+         * ``predict(X)``: Returns predicted values using the linear model,
            which is used to compute residual error using loss function.
 
-        If `base_estimator` is None, then
+        If ``base_estimator`` is None, then
         ``base_estimator=sklearn.linear_model.LinearRegression()`` is used for
         target values of dtype float.
 
@@ -91,9 +91,9 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin,
         as an absolute number of samples for `min_samples >= 1`, treated as a
         relative number `ceil(min_samples * X.shape[0]`) for
         `min_samples < 1`. This is typically chosen as the minimal number of
-        samples necessary to estimate the given `base_estimator`. By default a
+        samples necessary to estimate the given ``base_estimator``. By default a
         ``sklearn.linear_model.LinearRegression()`` estimator is assumed and
-        `min_samples` is chosen as ``X.shape[1] + 1``.
+        ``min_samples`` is chosen as ``X.shape[1] + 1``.
 
     residual_threshold : float, optional
         Maximum residual for a data sample to be classified as an inlier.
@@ -110,7 +110,7 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin,
         selected data: `is_model_valid(model, X, y)`. If its return value is
         False the current randomly chosen sub-sample is skipped.
         Rejecting samples with this function is computationally costlier than
-        with `is_data_valid`. `is_model_valid` should therefore only be used if
+        with ``is_data_valid``. ``is_model_valid`` should therefore only be used if
         the estimated model is needed for making the rejection decision.
 
     max_trials : int, optional
@@ -157,12 +157,12 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin,
         The generator used to initialize the centers.  If int, random_state is
         the seed used by the random number generator; If RandomState instance,
         random_state is the random number generator; If None, the random number
-        generator is the RandomState instance used by `np.random`.
+        generator is the RandomState instance used by ``np.random``.
 
     Attributes
     ----------
     estimator_ : object
-        Best fitted model (copy of the `base_estimator` object).
+        Best fitted model (copy of the ``base_estimator`` object).
 
     n_trials_ : int
         Number of random selection trials until one of the stop criteria is
@@ -247,8 +247,8 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin,
         ------
         ValueError
             If no valid consensus set could be found. This occurs if
-            `is_data_valid` and `is_model_valid` return False for all
-            `max_trials` randomly chosen sub-samples.
+            ``is_data_valid`` and ``is_model_valid`` return False for all
+            ``max_trials`` randomly chosen sub-samples.
 
         """
         X = check_array(X, accept_sparse='csr')
@@ -271,10 +271,10 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin,
                                  "integer value.")
             min_samples = self.min_samples
         else:
-            raise ValueError("Value for `min_samples` must be scalar and "
+            raise ValueError("Value for ``min_samples`` must be scalar and "
                              "positive.")
         if min_samples > X.shape[0]:
-            raise ValueError("`min_samples` may not be larger than number "
+            raise ValueError("``min_samples`` may not be larger than number "
                              "of samples: n_samples = %d." % (X.shape[0]))
 
         if self.stop_probability < 0 or self.stop_probability > 1:
@@ -434,7 +434,7 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin,
             else:
                 raise ValueError(
                     "RANSAC could not find a valid consensus set. All"
-                    " `max_trials` iterations were skipped because each"
+                    " ``max_trials`` iterations were skipped because each"
                     " randomly chosen sub-sample failed the passing criteria."
                     " See estimator attributes for diagnostics (n_skips*).")
         else:
@@ -456,7 +456,7 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin,
     def predict(self, X):
         """Predict using the estimated model.
 
-        This is a wrapper for `estimator_.predict(X)`.
+        This is a wrapper for ``estimator_.predict(X)``.
 
         Parameters
         ----------

--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -89,9 +89,9 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin,
     min_samples : int (>= 1) or float ([0, 1]), optional
         Minimum number of samples chosen randomly from original data. Treated
         as an absolute number of samples for `min_samples >= 1`, treated as a
-        relative number `ceil(min_samples * X.shape[0]`) for
-        `min_samples < 1`. This is typically chosen as the minimal number of
-        samples necessary to estimate the given ``base_estimator``. By default a
+        relative number `ceil(min_samples * X.shape[0]`) for `min_samples < 1`.
+        This is typically chosen as the minimal number of samples necessary to
+        estimate the given ``base_estimator``. By default a
         ``sklearn.linear_model.LinearRegression()`` estimator is assumed and
         ``min_samples`` is chosen as ``X.shape[1] + 1``.
 
@@ -108,9 +108,9 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin,
     is_model_valid : callable, optional
         This function is called with the estimated model and the randomly
         selected data: `is_model_valid(model, X, y)`. If its return value is
-        False the current randomly chosen sub-sample is skipped.
-        Rejecting samples with this function is computationally costlier than
-        with ``is_data_valid``. ``is_model_valid`` should therefore only be used if
+        False the current randomly chosen sub-sample is skipped. Rejecting
+        samples with this function is computationally costlier than with
+        ``is_data_valid``. ``is_model_valid`` should therefore only be used if
         the estimated model is needed for making the rejection decision.
 
     max_trials : int, optional

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -274,7 +274,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         - 'sparse_cg' uses the conjugate gradient solver as found in
           scipy.sparse.linalg.cg. As an iterative algorithm, this solver is
           more appropriate than 'cholesky' for large-scale data
-          (possibility to set `tol` and `max_iter`).
+          (possibility to set ``tol`` and `max_iter`).
 
         - 'lsqr' uses the dedicated regularized least-squares routine
           scipy.sparse.linalg.lsqr. It is the fastest and uses an iterative
@@ -290,7 +290,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
 
 
         All last five solvers support both dense and sparse data. However, only
-        'sag' and 'sparse_cg' supports sparse input when`fit_intercept` is
+        'sag' and 'sparse_cg' supports sparse input when``fit_intercept`` is
         True.
 
         .. versionadded:: 0.17
@@ -316,10 +316,10 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`. Used when ``solver`` == 'sag'.
+        instance used by ``np.random``. Used when ``solver`` == 'sag'.
 
     return_n_iter : boolean, default False
-        If True, the method also returns `n_iter`, the actual number of
+        If True, the method also returns ``n_iter``, the actual number of
         iteration performed by the solver.
 
         .. versionadded:: 0.17
@@ -339,10 +339,10 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
 
     n_iter : int, optional
         The actual number of iteration performed by the solver.
-        Only returned if `return_n_iter` is True.
+        Only returned if ``return_n_iter`` is True.
 
     intercept : float or array, shape = [n_targets]
-        The intercept of the model. Only returned if `return_intercept`
+        The intercept of the model. Only returned if ``return_intercept``
         is True and if X is a scipy sparse array.
 
     Notes
@@ -638,7 +638,7 @@ class Ridge(_BaseRidge, RegressorMixin):
         - 'sparse_cg' uses the conjugate gradient solver as found in
           scipy.sparse.linalg.cg. As an iterative algorithm, this solver is
           more appropriate than 'cholesky' for large-scale data
-          (possibility to set `tol` and `max_iter`).
+          (possibility to set ``tol`` and `max_iter`).
 
         - 'lsqr' uses the dedicated regularized least-squares routine
           scipy.sparse.linalg.lsqr. It is the fastest and uses an iterative
@@ -653,7 +653,7 @@ class Ridge(_BaseRidge, RegressorMixin):
           scaler from sklearn.preprocessing.
 
         All last five solvers support both dense and sparse data. However, only
-        'sag' and 'sparse_cg' supports sparse input when `fit_intercept` is
+        'sag' and 'sparse_cg' supports sparse input when ``fit_intercept`` is
         True.
 
         .. versionadded:: 0.17
@@ -666,7 +666,7 @@ class Ridge(_BaseRidge, RegressorMixin):
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`. Used when ``solver`` == 'sag'.
+        instance used by ``np.random``. Used when ``solver`` == 'sag'.
 
         .. versionadded:: 0.17
            *random_state* to support Stochastic Average Gradient.
@@ -797,7 +797,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         - 'sparse_cg' uses the conjugate gradient solver as found in
           scipy.sparse.linalg.cg. As an iterative algorithm, this solver is
           more appropriate than 'cholesky' for large-scale data
-          (possibility to set `tol` and `max_iter`).
+          (possibility to set ``tol`` and `max_iter`).
 
         - 'lsqr' uses the dedicated regularized least-squares routine
           scipy.sparse.linalg.lsqr. It is the fastest and uses an iterative
@@ -821,7 +821,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`. Used when ``solver`` == 'sag'.
+        instance used by ``np.random``. Used when ``solver`` == 'sag'.
 
     Attributes
     ----------

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -633,11 +633,11 @@ class BaseSGDClassifier(BaseSGD, LinearClassifierMixin, metaclass=ABCMeta):
 
         classes : array, shape (n_classes,)
             Classes across all calls to partial_fit.
-            Can be obtained by via `np.unique(y_all)`, where y_all is the
+            Can be obtained by via ``np.unique(y_all)``, where y_all is the
             target vector of the entire dataset.
             This argument is required for the first call to partial_fit
             and can be omitted in the subsequent calls.
-            Note that y doesn't need to contain all labels in `classes`.
+            Note that y doesn't need to contain all labels in ``classes``.
 
         sample_weight : array-like, shape (n_samples,), optional
             Weights applied to individual samples.
@@ -780,7 +780,7 @@ class SGDClassifier(BaseSGDClassifier):
         The verbosity level
 
     epsilon : float
-        Epsilon in the epsilon-insensitive loss functions; only if `loss` is
+        Epsilon in the epsilon-insensitive loss functions; only if ``loss`` is
         'huber', 'epsilon_insensitive', or 'squared_epsilon_insensitive'.
         For 'huber', determines the threshold at which it becomes less
         important to get the prediction exactly right.
@@ -799,7 +799,7 @@ class SGDClassifier(BaseSGDClassifier):
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        instance used by ``np.random``.
 
     learning_rate : string, optional
         The learning rate schedule:
@@ -962,7 +962,7 @@ class SGDClassifier(BaseSGDClassifier):
         -------
         array, shape (n_samples, n_classes)
             Returns the probability of the sample for each class in the model,
-            where classes are ordered as they are in `self.classes_`.
+            where classes are ordered as they are in ``self.classes_``.
 
         References
         ----------
@@ -1040,7 +1040,7 @@ class SGDClassifier(BaseSGDClassifier):
         T : array-like, shape (n_samples, n_classes)
             Returns the log-probability of the sample for each class in the
             model, where classes are ordered as they are in
-            `self.classes_`.
+            ``self.classes_``.
         """
         self._check_proba()
         return self._predict_log_proba
@@ -1392,7 +1392,7 @@ class SGDRegressor(BaseSGDRegressor):
         The verbosity level.
 
     epsilon : float
-        Epsilon in the epsilon-insensitive loss functions; only if `loss` is
+        Epsilon in the epsilon-insensitive loss functions; only if ``loss`` is
         'huber', 'epsilon_insensitive', or 'squared_epsilon_insensitive'.
         For 'huber', determines the threshold at which it becomes less
         important to get the prediction exactly right.
@@ -1404,7 +1404,7 @@ class SGDRegressor(BaseSGDRegressor):
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        instance used by ``np.random``.
 
     learning_rate : string, optional
         The learning rate schedule:

--- a/sklearn/linear_model/theil_sen.py
+++ b/sklearn/linear_model/theil_sen.py
@@ -245,7 +245,7 @@ class TheilSenRegressor(LinearModel, RegressorMixin):
         permutations generator.  If int, random_state is the seed used by the
         random number generator; If RandomState instance, random_state is the
         random number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`.
+        RandomState instance used by ``np.random``.
 
     n_jobs : int or None, optional (default=None)
         Number of CPUs to use during the cross validation.

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -202,7 +202,7 @@ class Isomap(BaseEstimator, TransformerMixin):
         """Transform X.
 
         This is implemented by linking the points X into the graph of geodesic
-        distances of the training data. First the `n_neighbors` nearest
+        distances of the training data. First the ``n_neighbors`` nearest
         neighbors of X are found in the training data, and from these the
         shortest geodesic distances from each point in X to each point in
         the training data are computed in order to construct the kernel.

--- a/sklearn/manifold/locally_linear.py
+++ b/sklearn/manifold/locally_linear.py
@@ -147,7 +147,7 @@ def null_space(M, k, k_skip=1, eigen_solver='arpack', tol=1E-6, max_iter=100,
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`. Used when ``solver`` == 'arpack'.
+        by ``np.random``. Used when ``solver`` == 'arpack'.
 
     """
     if eigen_solver == 'auto':
@@ -253,7 +253,7 @@ def locally_linear_embedding(
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`. Used when ``solver`` == 'arpack'.
+        by ``np.random``. Used when ``solver`` == 'arpack'.
 
     n_jobs : int or None, optional (default=None)
         The number of parallel jobs to run for neighbors search.
@@ -585,7 +585,7 @@ class LocallyLinearEmbedding(BaseEstimator, TransformerMixin,
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`. Used when ``eigen_solver`` == 'arpack'.
+        by ``np.random``. Used when ``eigen_solver`` == 'arpack'.
 
     n_jobs : int or None, optional (default=None)
         The number of parallel jobs to run.

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -54,7 +54,7 @@ def _smacof_single(dissimilarities, metric=True, n_components=2, init=None,
         The generator used to initialize the centers.  If int, random_state is
         the seed used by the random number generator; If RandomState instance,
         random_state is the random number generator; If None, the random number
-        generator is the RandomState instance used by `np.random`.
+        generator is the RandomState instance used by ``np.random``.
 
     Returns
     -------
@@ -201,7 +201,7 @@ def smacof(dissimilarities, metric=True, n_components=2, init=None, n_init=8,
         The generator used to initialize the centers.  If int, random_state is
         the seed used by the random number generator; If RandomState instance,
         random_state is the random number generator; If None, the random number
-        generator is the RandomState instance used by `np.random`.
+        generator is the RandomState instance used by ``np.random``.
 
     return_n_iter : bool, optional, default: False
         Whether or not to return the number of iterations.
@@ -317,7 +317,7 @@ class MDS(BaseEstimator):
         The generator used to initialize the centers.  If int, random_state is
         the seed used by the random number generator; If RandomState instance,
         random_state is the random number generator; If None, the random number
-        generator is the RandomState instance used by `np.random`.
+        generator is the RandomState instance used by ``np.random``.
 
     dissimilarity : 'euclidean' | 'precomputed', optional, default: 'euclidean'
         Dissimilarity measure to use:

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -172,7 +172,7 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
         lobpcg eigenvectors decomposition.  If int, random_state is the seed
         used by the random number generator; If RandomState instance,
         random_state is the random number generator; If None, the random number
-        generator is the RandomState instance used by `np.random`. Used when
+        generator is the RandomState instance used by ``np.random``. Used when
         ``solver`` == 'amg'.
 
     eigen_tol : float, optional, default=0.0
@@ -369,7 +369,7 @@ class SpectralEmbedding(BaseEstimator):
         lobpcg eigenvectors.  If int, random_state is the seed used by the
         random number generator; If RandomState instance, random_state is the
         random number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`. Used when ``solver`` ==
+        RandomState instance used by ``np.random``. Used when ``solver`` ==
         'amg'.
 
     eigen_solver : {None, 'arpack', 'lobpcg', or 'amg'}

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -568,7 +568,7 @@ class TSNE(BaseEstimator):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.  Note that different initializations might result in
+        by ``np.random``.  Note that different initializations might result in
         different local minima of the cost function.
 
     method : string (default: 'barnes_hut')

--- a/sklearn/mixture/bayesian_mixture.py
+++ b/sklearn/mixture/bayesian_mixture.py
@@ -85,9 +85,9 @@ class BayesianGaussianMixture(BaseMixture):
     n_components : int, defaults to 1.
         The number of mixture components. Depending on the data and the value
         of the ``weight_concentration_prior`` the model can decide to not use
-        all the components by setting some component ``weights_`` to values very
-        close to zero. The number of effective components is therefore smaller
-        than n_components.
+        all the components by setting some component ``weights_`` to values
+        very close to zero. The number of effective components is therefore
+        smaller than n_components.
 
     covariance_type : {'full', 'tied', 'diag', 'spherical'}, defaults to 'full'
         String describing the type of covariance parameters to use.

--- a/sklearn/mixture/bayesian_mixture.py
+++ b/sklearn/mixture/bayesian_mixture.py
@@ -84,8 +84,8 @@ class BayesianGaussianMixture(BaseMixture):
     ----------
     n_components : int, defaults to 1.
         The number of mixture components. Depending on the data and the value
-        of the `weight_concentration_prior` the model can decide to not use
-        all the components by setting some component `weights_` to values very
+        of the ``weight_concentration_prior`` the model can decide to not use
+        all the components by setting some component ``weights_`` to values very
         close to zero. The number of effective components is therefore smaller
         than n_components.
 
@@ -141,7 +141,7 @@ class BayesianGaussianMixture(BaseMixture):
     mean_precision_prior : float | None, optional.
         The precision prior on the mean distribution (Gaussian).
         Controls the extend to where means can be placed. Smaller
-        values concentrate the means of each clusters around `mean_prior`.
+        values concentrate the means of each clusters around ``mean_prior``.
         The value of the parameter must be greater than 0.
         If it is None, it's set to 1.
 
@@ -156,7 +156,7 @@ class BayesianGaussianMixture(BaseMixture):
     covariance_prior : float or array-like, optional
         The prior on the covariance distribution (Wishart).
         If it is None, the emiprical covariance prior is initialized using the
-        covariance of X. The shape depends on `covariance_type`::
+        covariance of X. The shape depends on ``covariance_type``::
 
                 (n_features, n_features) if 'full',
                 (n_features, n_features) if 'tied',
@@ -167,7 +167,7 @@ class BayesianGaussianMixture(BaseMixture):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     warm_start : bool, default to False.
         If 'warm_start' is True, the solution of the last fitting is used as
@@ -194,7 +194,7 @@ class BayesianGaussianMixture(BaseMixture):
 
     covariances_ : array-like
         The covariance of each mixture component.
-        The shape depends on `covariance_type`::
+        The shape depends on ``covariance_type``::
 
             (n_components,)                        if 'spherical',
             (n_features, n_features)               if 'tied',
@@ -261,7 +261,7 @@ class BayesianGaussianMixture(BaseMixture):
         The precision prior on the mean distribution (Gaussian).
         Controls the extend to where means can be placed.
         Smaller values concentrate the means of each clusters around
-        `mean_prior`.
+        ``mean_prior``.
 
     mean_precision_ : array-like, shape (n_components,)
         The precision of each components on the mean distribution (Gaussian).
@@ -278,7 +278,7 @@ class BayesianGaussianMixture(BaseMixture):
 
     covariance_prior_ : float or array-like
         The prior on the covariance distribution (Wishart).
-        The shape depends on `covariance_type`::
+        The shape depends on ``covariance_type``::
 
             (n_features, n_features) if 'full',
             (n_features, n_features) if 'tied',
@@ -509,7 +509,7 @@ class BayesianGaussianMixture(BaseMixture):
         xk : array-like, shape (n_components, n_features)
 
         sk : array-like
-            The shape depends of `covariance_type`:
+            The shape depends of ``covariance_type``:
             'full' : (n_components, n_features, n_features)
             'tied' : (n_features, n_features)
             'diag' : (n_components, n_features)

--- a/sklearn/mixture/gaussian_mixture.py
+++ b/sklearn/mixture/gaussian_mixture.py
@@ -484,11 +484,11 @@ class GaussianMixture(BaseMixture):
 
     weights_init : array-like, shape (n_components, ), optional
         The user-provided initial weights, defaults to None.
-        If it None, weights are initialized using the `init_params` method.
+        If it None, weights are initialized using the ``init_params`` method.
 
     means_init : array-like, shape (n_components, n_features), optional
         The user-provided initial means, defaults to None,
-        If it None, means are initialized using the `init_params` method.
+        If it None, means are initialized using the ``init_params`` method.
 
     precisions_init : array-like, optional.
         The user-provided initial precisions (inverse of the covariance
@@ -505,7 +505,7 @@ class GaussianMixture(BaseMixture):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     warm_start : bool, default to False.
         If 'warm_start' is True, the solution of the last fitting is used as
@@ -534,7 +534,7 @@ class GaussianMixture(BaseMixture):
 
     covariances_ : array-like
         The covariance of each mixture component.
-        The shape depends on `covariance_type`::
+        The shape depends on ``covariance_type``::
 
             (n_components,)                        if 'spherical',
             (n_features, n_features)               if 'tied',
@@ -548,7 +548,7 @@ class GaussianMixture(BaseMixture):
         equivalently parameterized by the precision matrices. Storing the
         precision matrices instead of the covariance matrices makes it more
         efficient to compute the log-likelihood of new samples at test time.
-        The shape depends on `covariance_type`::
+        The shape depends on ``covariance_type``::
 
             (n_components,)                        if 'spherical',
             (n_features, n_features)               if 'tied',
@@ -562,7 +562,7 @@ class GaussianMixture(BaseMixture):
         Gaussian can be equivalently parameterized by the precision matrices.
         Storing the precision matrices instead of the covariance matrices makes
         it more efficient to compute the log-likelihood of new samples at test
-        time. The shape depends on `covariance_type`::
+        time. The shape depends on ``covariance_type``::
 
             (n_components,)                        if 'spherical',
             (n_features, n_features)               if 'tied',

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1107,13 +1107,13 @@ class GridSearchCV(BaseSearchCV):
     The parameters selected are those that maximize the score of the left out
     data, unless an explicit score is passed in which case it is used instead.
 
-    If ``2*n_jobs`` was set to a value higher than one, the data is copied for each
-    point in the grid (and not ``2*n_jobs`` times). This is done for efficiency
-    reasons if individual jobs take very little time, but may raise errors if
-    the dataset is large and not enough memory is available.  A workaround in
-    this case is to set ``pre_dispatch``. Then, the memory is copied only
-    ``pre_dispatch`` many times. A reasonable value for ``pre_dispatch`` is `2 *
-    n_jobs`.
+    If ``2*n_jobs`` was set to a value higher than one, the data is copied for
+    each point in the grid (and not ``2*n_jobs`` times). This is done for
+    efficiency reasons if individual jobs take very little time, but may raise
+    errors if the dataset is large and not enough memory is available. A
+    workaround in this case is to set ``pre_dispatch``. Then, the memory is
+    copied only ``pre_dispatch`` many times. A reasonable value for
+    ``pre_dispatch`` is `2 * n_jobs`.
 
     See Also
     ---------
@@ -1427,13 +1427,13 @@ class RandomizedSearchCV(BaseSearchCV):
     The parameters selected are those that maximize the score of the held-out
     data, according to the scoring parameter.
 
-    If ``2*n_jobs`` was set to a value higher than one, the data is copied for each
-    parameter setting(and not ``2*n_jobs`` times). This is done for efficiency
-    reasons if individual jobs take very little time, but may raise errors if
-    the dataset is large and not enough memory is available.  A workaround in
-    this case is to set ``pre_dispatch``. Then, the memory is copied only
-    ``pre_dispatch`` many times. A reasonable value for ``pre_dispatch`` is `2 *
-    n_jobs`.
+    If ``2*n_jobs`` was set to a value higher than one, the data is copied for
+    each parameter setting(and not ``2*n_jobs`` times). This is done for
+    efficiency reasons if individual jobs take very little time, but may raise
+    errors if the dataset is large and not enough memory is available. A
+    workaround in this case is to set ``pre_dispatch``. Then, the memory is
+    copied only ``pre_dispatch`` many times. A reasonable value for
+    ``pre_dispatch`` is `2 * n_jobs`.
 
     See Also
     --------

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -215,7 +215,7 @@ class ParameterSampler:
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Returns
     -------
@@ -910,7 +910,7 @@ class GridSearchCV(BaseSearchCV):
         Possible inputs for cv are:
 
         - None, to use the default 3-fold cross validation,
-        - integer, to specify the number of folds in a `(Stratified)KFold`,
+        - integer, to specify the number of folds in a ``(Stratified)KFold``,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
@@ -1107,12 +1107,12 @@ class GridSearchCV(BaseSearchCV):
     The parameters selected are those that maximize the score of the left out
     data, unless an explicit score is passed in which case it is used instead.
 
-    If `n_jobs` was set to a value higher than one, the data is copied for each
-    point in the grid (and not `n_jobs` times). This is done for efficiency
+    If ``2*n_jobs`` was set to a value higher than one, the data is copied for each
+    point in the grid (and not ``2*n_jobs`` times). This is done for efficiency
     reasons if individual jobs take very little time, but may raise errors if
     the dataset is large and not enough memory is available.  A workaround in
-    this case is to set `pre_dispatch`. Then, the memory is copied only
-    `pre_dispatch` many times. A reasonable value for `pre_dispatch` is `2 *
+    this case is to set ``pre_dispatch``. Then, the memory is copied only
+    ``pre_dispatch`` many times. A reasonable value for ``pre_dispatch`` is `2 *
     n_jobs`.
 
     See Also
@@ -1252,7 +1252,7 @@ class RandomizedSearchCV(BaseSearchCV):
         Possible inputs for cv are:
 
         - None, to use the default 3-fold cross validation,
-        - integer, to specify the number of folds in a `(Stratified)KFold`,
+        - integer, to specify the number of folds in a ``(Stratified)KFold``,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
@@ -1303,7 +1303,7 @@ class RandomizedSearchCV(BaseSearchCV):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     error_score : 'raise' or numeric
         Value to assign to the score if an error occurs in estimator fitting.
@@ -1427,12 +1427,12 @@ class RandomizedSearchCV(BaseSearchCV):
     The parameters selected are those that maximize the score of the held-out
     data, according to the scoring parameter.
 
-    If `n_jobs` was set to a value higher than one, the data is copied for each
-    parameter setting(and not `n_jobs` times). This is done for efficiency
+    If ``2*n_jobs`` was set to a value higher than one, the data is copied for each
+    parameter setting(and not ``2*n_jobs`` times). This is done for efficiency
     reasons if individual jobs take very little time, but may raise errors if
     the dataset is large and not enough memory is available.  A workaround in
-    this case is to set `pre_dispatch`. Then, the memory is copied only
-    `pre_dispatch` many times. A reasonable value for `pre_dispatch` is `2 *
+    this case is to set ``pre_dispatch``. Then, the memory is copied only
+    ``pre_dispatch`` many times. A reasonable value for ``pre_dispatch`` is `2 *
     n_jobs`.
 
     See Also

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -382,7 +382,7 @@ class KFold(_BaseKFold):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`. Used when ``shuffle`` == True.
+        by ``np.random``. Used when ``shuffle`` == True.
 
     Examples
     --------
@@ -593,7 +593,7 @@ class StratifiedKFold(_BaseKFold):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`. Used when ``shuffle`` == True.
+        by ``np.random``. Used when ``shuffle`` == True.
 
     Examples
     --------
@@ -1088,7 +1088,7 @@ class _RepeatedSplits(metaclass=ABCMeta):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     **cvargs : additional params
         Constructor parameters for cv. Must not contain random_state
@@ -1190,7 +1190,7 @@ class RepeatedKFold(_RepeatedSplits):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Examples
     --------
@@ -1384,7 +1384,7 @@ class ShuffleSplit(BaseShuffleSplit):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Examples
     --------
@@ -1485,7 +1485,7 @@ class GroupShuffleSplit(ShuffleSplit):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     '''
 
@@ -1651,7 +1651,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     Examples
     --------
@@ -2096,7 +2096,7 @@ def train_test_split(*arrays, **options):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     shuffle : boolean, optional (default=True)
         Whether or not to shuffle the data before splitting. If shuffle=False

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -78,7 +78,7 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv='warn',
         Possible inputs for cv are:
 
         - None, to use the default 3-fold cross validation,
-        - integer, to specify the number of folds in a `(Stratified)KFold`,
+        - integer, to specify the number of folds in a ``(Stratified)KFold``,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
@@ -294,7 +294,7 @@ def cross_val_score(estimator, X, y=None, groups=None, scoring=None, cv='warn',
         Possible inputs for cv are:
 
         - None, to use the default 3-fold cross validation,
-        - integer, to specify the number of folds in a `(Stratified)KFold`,
+        - integer, to specify the number of folds in a ``(Stratified)KFold``,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
@@ -674,7 +674,7 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv='warn',
         Possible inputs for cv are:
 
         - None, to use the default 3-fold cross validation,
-        - integer, to specify the number of folds in a `(Stratified)KFold`,
+        - integer, to specify the number of folds in a ``(Stratified)KFold``,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
@@ -966,7 +966,7 @@ def permutation_test_score(estimator, X, y, groups=None, cv='warn',
         Possible inputs for cv are:
 
         - None, to use the default 3-fold cross validation,
-        - integer, to specify the number of folds in a `(Stratified)KFold`,
+        - integer, to specify the number of folds in a ``(Stratified)KFold``,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
@@ -994,7 +994,7 @@ def permutation_test_score(estimator, X, y, groups=None, cv='warn',
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     verbose : integer, optional
         The verbosity level.
@@ -1118,7 +1118,7 @@ def learning_curve(estimator, X, y, groups=None,
         Possible inputs for cv are:
 
         - None, to use the default 3-fold cross validation,
-        - integer, to specify the number of folds in a `(Stratified)KFold`,
+        - integer, to specify the number of folds in a ``(Stratified)KFold``,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
@@ -1164,7 +1164,7 @@ def learning_curve(estimator, X, y, groups=None,
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`. Used when ``shuffle`` is True.
+        by ``np.random``. Used when ``shuffle`` is True.
 
     error_score : 'raise' | 'raise-deprecating' or numeric
         Value to assign to the score if an error occurs in estimator fitting.
@@ -1369,7 +1369,7 @@ def validation_curve(estimator, X, y, param_name, param_range, groups=None,
         Possible inputs for cv are:
 
         - None, to use the default 3-fold cross validation,
-        - integer, to specify the number of folds in a `(Stratified)KFold`,
+        - integer, to specify the number of folds in a ``(Stratified)KFold``,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -136,7 +136,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin,
 
     Also known as one-vs-all, this strategy consists in fitting one classifier
     per class. For each classifier, the class is fitted against all the other
-    classes. In addition to its computational efficiency (only `n_classes`
+    classes. In addition to its computational efficiency (only ``n_classes``
     classifiers are needed), one advantage of this approach is its
     interpretability. Since each class is represented by one and one classifier
     only, it is possible to gain knowledge about the class by inspecting its
@@ -166,10 +166,10 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin,
 
     Attributes
     ----------
-    estimators_ : list of `n_classes` estimators
+    estimators_ : list of ``n_classes`` estimators
         Estimators used for predictions.
 
-    classes_ : array, shape = [`n_classes`]
+    classes_ : array, shape = [``n_classes``]
         Class labels.
     label_binarizer_ : LabelBinarizer object
         Object used to transform multiclass labels to binary labels and
@@ -235,7 +235,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin,
 
         classes : array, shape (n_classes, )
             Classes across all calls to partial_fit.
-            Can be obtained via `np.unique(y_all)`, where y_all is the
+            Can be obtained via ``np.unique(y_all)``, where y_all is the
             target vector of the entire dataset.
             This argument is only required in the first call of partial_fit
             and can be omitted in the subsequent calls.
@@ -336,7 +336,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin,
         -------
         T : (sparse) array-like, shape = [n_samples, n_classes]
             Returns the probability of the sample for each class in the model,
-            where classes are ordered as they are in `self.classes_`.
+            where classes are ordered as they are in ``self.classes_``.
         """
         check_is_fitted(self, 'estimators_')
         # Y[i, j] gives the probability that sample i has the label j.
@@ -447,7 +447,7 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
     algorithms such as kernel algorithms which don't scale well with
     `n_samples`. This is because each individual learning problem only involves
     a small subset of the data whereas, with one-vs-the-rest, the complete
-    dataset is used `n_classes` times.
+    dataset is used ``n_classes`` times.
 
     Read more in the :ref:`User Guide <ovo_classification>`.
 
@@ -532,7 +532,7 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
 
         classes : array, shape (n_classes, )
             Classes across all calls to partial_fit.
-            Can be obtained via `np.unique(y_all)`, where y_all is the
+            Can be obtained via ``np.unique(y_all)``, where y_all is the
             target vector of the entire dataset.
             This argument is only required in the first call of partial_fit
             and can be omitted in the subsequent calls.
@@ -665,7 +665,7 @@ class OutputCodeClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         The generator used to initialize the codebook.  If int, random_state is
         the seed used by the random number generator; If RandomState instance,
         random_state is the random number generator; If None, the random number
-        generator is the RandomState instance used by `np.random`.
+        generator is the RandomState instance used by ``np.random``.
 
     n_jobs : int or None, optional (default=None)
         The number of jobs to use for the computation.

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -86,7 +86,7 @@ class MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
             target matrix of the entire dataset.
             This argument is required for the first call to partial_fit
             and can be omitted in the subsequent calls.
-            Note that y doesn't need to contain all labels in `classes`.
+            Note that y doesn't need to contain all labels in ``classes``.
 
         sample_weight : array-like, shape = (n_samples) or None
             Sample weights. If None, then samples are equally weighted.
@@ -219,7 +219,7 @@ class MultiOutputRegressor(MultiOutputEstimator, RegressorMixin):
         for more details.
 
         When individual estimators are fast to train or predict
-        using `n_jobs>1` can result in slower performance due
+        using ``n_jobs>1`` can result in slower performance due
         to the overhead of spawning processes.
 
     Attributes
@@ -533,7 +533,7 @@ class ClassifierChain(_BaseChain, ClassifierMixin, MetaEstimatorMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
         The random number generator is used to generate random chain orders.
 
@@ -693,7 +693,7 @@ class RegressorChain(_BaseChain, RegressorMixin, MetaEstimatorMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
         The random number generator is used to generate random chain orders.
 

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -698,7 +698,7 @@ class MultinomialNB(BaseDiscreteNB):
 
     Notes
     -----
-    For the rationale behind the names `coef_` and `intercept_`, i.e.
+    For the rationale behind the names `coef_` and ``intercept_``, i.e.
     naive Bayes as a linear classifier, see J. Rennie et al. (2003),
     Tackling the poor assumptions of naive Bayes text classifiers, ICML.
 

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -110,7 +110,7 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
     .. warning::
 
        Regarding the Nearest Neighbors algorithms, if it is found that two
-       neighbors, neighbor `k+1` and `k`, have identical distances
+       neighbors, neighbor ``k+1`` and ``k``, have identical distances
        but different labels, the results will depend on the ordering of the
        training data.
 

--- a/sklearn/neighbors/graph.py
+++ b/sklearn/neighbors/graph.py
@@ -67,8 +67,9 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity', metric='minkowski',
 
     include_self : bool, default=False.
         Whether or not to mark each sample as the first nearest neighbor to
-        itself. If ``None``, then True is used for mode='connectivity' and False
-        for mode='distance' as this will preserve backwards compatibility.
+        itself. If ``None``, then True is used for mode='connectivity' and
+        False for mode='distance' as this will preserve backwards
+        compatibility.
 
     n_jobs : int or None, optional (default=None)
         The number of parallel jobs to run for neighbors search.
@@ -145,8 +146,9 @@ def radius_neighbors_graph(X, radius, mode='connectivity', metric='minkowski',
 
     include_self : bool, default=False
         Whether or not to mark each sample as the first nearest neighbor to
-        itself. If ``None``, then True is used for mode='connectivity' and False
-        for mode='distance' as this will preserve backwards compatibility.
+        itself. If ``None``, then True is used for mode='connectivity' and
+        False for mode='distance' as this will preserve backwards
+        compatibility.
 
     n_jobs : int or None, optional (default=None)
         The number of parallel jobs to run for neighbors search.

--- a/sklearn/neighbors/graph.py
+++ b/sklearn/neighbors/graph.py
@@ -67,7 +67,7 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity', metric='minkowski',
 
     include_self : bool, default=False.
         Whether or not to mark each sample as the first nearest neighbor to
-        itself. If `None`, then True is used for mode='connectivity' and False
+        itself. If ``None``, then True is used for mode='connectivity' and False
         for mode='distance' as this will preserve backwards compatibility.
 
     n_jobs : int or None, optional (default=None)
@@ -145,7 +145,7 @@ def radius_neighbors_graph(X, radius, mode='connectivity', metric='minkowski',
 
     include_self : bool, default=False
         Whether or not to mark each sample as the first nearest neighbor to
-        itself. If `None`, then True is used for mode='connectivity' and False
+        itself. If ``None``, then True is used for mode='connectivity' and False
         for mode='distance' as this will preserve backwards compatibility.
 
     n_jobs : int or None, optional (default=None)

--- a/sklearn/neighbors/kde.py
+++ b/sklearn/neighbors/kde.py
@@ -210,7 +210,7 @@ class KernelDensity(BaseEstimator):
             If int, random_state is the seed used by the random number
             generator; If RandomState instance, random_state is the random
             number generator; If None, the random number generator is the
-            RandomState instance used by `np.random`.
+            RandomState instance used by ``np.random``.
 
         Returns
         -------

--- a/sklearn/neighbors/lof.py
+++ b/sklearn/neighbors/lof.py
@@ -135,7 +135,7 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin,
 
     offset_ : float
         Offset used to obtain binary labels from the raw scores.
-        Observations having a negative_outlier_factor smaller than `offset_`
+        Observations having a negative_outlier_factor smaller than ``offset_``
         are detected as abnormal.
         The offset is set to -1.5 (inliers score around -1), except when a
         contamination parameter different than "auto" is provided. In that

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -115,7 +115,7 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
     .. warning::
 
        Regarding the Nearest Neighbors algorithms, if it is found that two
-       neighbors, neighbor `k+1` and `k`, have identical distances but
+       neighbors, neighbor ``k+1`` and ``k``, have identical distances but
        different labels, the results will depend on the ordering of the
        training data.
 

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -778,7 +778,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     tol : float, optional, default 1e-4
         Tolerance for the optimization. When the loss or score is not improving
@@ -934,8 +934,8 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         else:
             classes = unique_labels(y)
             if len(np.setdiff1d(classes, self.classes_, assume_unique=True)):
-                raise ValueError("`y` has classes not in `self.classes_`."
-                                 " `self.classes_` has %s. 'y' has %s." %
+                raise ValueError("`y` has classes not in ``self.classes_``."
+                                 " ``self.classes_`` has %s. 'y' has %s." %
                                  (self.classes_, classes))
 
         y = self._label_binarizer.transform(y)
@@ -995,11 +995,11 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
 
         classes : array, shape (n_classes), default None
             Classes across all calls to partial_fit.
-            Can be obtained via `np.unique(y_all)`, where y_all is the
+            Can be obtained via ``np.unique(y_all)``, where y_all is the
             target vector of the entire dataset.
             This argument is required for the first call to partial_fit
             and can be omitted in the subsequent calls.
-            Note that y doesn't need to contain all labels in `classes`.
+            Note that y doesn't need to contain all labels in ``classes``.
 
         Returns
         -------
@@ -1036,7 +1036,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         log_y_prob : array-like, shape (n_samples, n_classes)
             The predicted log-probability of the sample for each class
             in the model, where classes are ordered as they are in
-            `self.classes_`. Equivalent to log(predict_proba(X))
+            ``self.classes_``. Equivalent to log(predict_proba(X))
         """
         y_prob = self.predict_proba(X)
         return np.log(y_prob, out=y_prob)
@@ -1053,7 +1053,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         -------
         y_prob : array-like, shape (n_samples, n_classes)
             The predicted probability of the sample for each class in the
-            model, where classes are ordered as they are in `self.classes_`.
+            model, where classes are ordered as they are in ``self.classes_``.
         """
         check_is_fitted(self, "coefs_")
         y_pred = self._predict(X)
@@ -1162,7 +1162,7 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     tol : float, optional, default 1e-4
         Tolerance for the optimization. When the loss or score is not improving

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -567,7 +567,7 @@ class OneHotEncoder(_BaseEncoder):
             try:
                 n_values = np.asarray(self._n_values, dtype=int)
             except (ValueError, TypeError):
-                raise TypeError("Wrong type for parameter ``n_values``. Expected"
+                raise TypeError("Wrong type for parameter `n_values`. Expected"
                                 " 'auto', int or array of ints, got %r"
                                 % type(self._n_values))
             if n_values.ndim < 1 or n_values.shape[0] != X.shape[1]:

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -150,7 +150,7 @@ class OneHotEncoder(_BaseEncoder):
     returns a sparse matrix or dense array.
 
     By default, the encoder derives the categories based on the unique values
-    in each feature. Alternatively, you can also specify the `categories`
+    in each feature. Alternatively, you can also specify the ``categories``
     manually.
     The OneHotEncoder previously assumed that the input features take on
     values in the range [0, max(values)). This behaviour is deprecated.
@@ -213,8 +213,8 @@ class OneHotEncoder(_BaseEncoder):
                   in ``range(n_values[i])``
 
         .. deprecated:: 0.20
-            The `n_values` keyword was deprecated in version 0.20 and will
-            be removed in 0.22. Use `categories` instead.
+            The ``n_values`` keyword was deprecated in version 0.20 and will
+            be removed in 0.22. Use ``categories`` instead.
 
     categorical_features : 'all' or array of indices or mask, default='all'
         Specify what features are treated as categorical.
@@ -226,7 +226,7 @@ class OneHotEncoder(_BaseEncoder):
         Non-categorical features are always stacked to the right of the matrix.
 
         .. deprecated:: 0.20
-            The `categorical_features` keyword was deprecated in version
+            The ``categorical_features`` keyword was deprecated in version
             0.20 and will be removed in 0.22.
             You can use the ``ColumnTransformer`` instead.
 
@@ -462,7 +462,7 @@ class OneHotEncoder(_BaseEncoder):
         # Prevents new drop functionality from being used in legacy mode
         if self._legacy_mode and self.drop is not None:
             raise ValueError(
-                "The `categorical_features` and `n_values` keywords "
+                "The ``categorical_features`` and ``n_values`` keywords "
                 "are deprecated, and cannot be used together "
                 "with 'drop'.")
 
@@ -567,7 +567,7 @@ class OneHotEncoder(_BaseEncoder):
             try:
                 n_values = np.asarray(self._n_values, dtype=int)
             except (ValueError, TypeError):
-                raise TypeError("Wrong type for parameter `n_values`. Expected"
+                raise TypeError("Wrong type for parameter ``n_values``. Expected"
                                 " 'auto', int or array of ints, got %r"
                                 % type(self._n_values))
             if n_values.ndim < 1 or n_values.shape[0] != X.shape[1]:

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -142,7 +142,7 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
     if sparse.issparse(X):
         if with_mean:
             raise ValueError(
-                "Cannot center sparse matrices: pass ``with_mean=False`` instead"
+                "Cannot center sparse matrices: pass `with_mean=False` instead"
                 " See docstring for motivation and alternatives.")
         if axis != 0:
             raise ValueError("Can only scale sparse matrix on axis=0, "
@@ -792,7 +792,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         if sparse.issparse(X):
             if self.with_mean:
                 raise ValueError(
-                    "Cannot uncenter sparse matrices: pass ``with_mean=False`` "
+                    "Cannot uncenter sparse matrices: pass `with_mean=False` "
                     "instead See docstring for motivation and alternatives.")
             if not sparse.isspmatrix_csr(X):
                 X = X.tocsr()
@@ -1164,7 +1164,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
         if self.with_centering:
             if sparse.issparse(X):
                 raise ValueError(
-                    "Cannot center sparse matrices: use ``with_centering=False``"
+                    "Cannot center sparse matrices: use `with_centering=False`"
                     " instead. See docstring for motivation and alternatives.")
             self.center_ = np.nanmedian(X, axis=0)
         else:
@@ -2539,7 +2539,7 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
     <sphx_glr_auto_examples_preprocessing_plot_all_scaling.py>`.
     """
     if copy == "warn":
-        warnings.warn("The default value of ``copy`` will change from False to "
+        warnings.warn("The default value of `copy` will change from False to "
                       "True in 0.23 in order to make it more consistent with "
                       "the default ``copy`` values of other functions in "
                       ":mod:`sklearn.preprocessing.data` and prevent "

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -113,8 +113,8 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
     program with memory exhaustion problems.
 
     Instead the caller is expected to either set explicitly
-    `with_mean=False` (in that case, only variance scaling will be
-    performed on the features of the CSC matrix) or to call `X.toarray()`
+    ``with_mean=False`` (in that case, only variance scaling will be
+    performed on the features of the CSC matrix) or to call ``X.toarray()``
     if he/she expects the materialized dense array to fit in memory.
 
     To avoid memory copy the caller should pass a CSC matrix.
@@ -123,7 +123,7 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
     and maintained during the data transformation.
 
     We use a biased estimator for the standard deviation, equivalent to
-    `numpy.std(x, ddof=0)`. Note that the choice of `ddof` is unlikely to
+    `numpy.std(x, ddof=0)`. Note that the choice of ``ddof`` is unlikely to
     affect model performance.
 
     For a comparison of the different scalers, transformers, and normalizers,
@@ -142,7 +142,7 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
     if sparse.issparse(X):
         if with_mean:
             raise ValueError(
-                "Cannot center sparse matrices: pass `with_mean=False` instead"
+                "Cannot center sparse matrices: pass ``with_mean=False`` instead"
                 " See docstring for motivation and alternatives.")
         if axis != 0:
             raise ValueError("Can only scale sparse matrix on axis=0, "
@@ -494,7 +494,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
 
         z = (x - u) / s
 
-    where `u` is the mean of the training samples or zero if `with_mean=False`,
+    where `u` is the mean of the training samples or zero if ``with_mean=False``,
     and `s` is the standard deviation of the training samples or one if
     `with_std=False`.
 
@@ -517,7 +517,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
     estimator unable to learn from other features correctly as expected.
 
     This scaler can also be applied to sparse CSR or CSC matrices by passing
-    `with_mean=False` to avoid breaking the sparsity structure of the data.
+    ``with_mean=False`` to avoid breaking the sparsity structure of the data.
 
     Read more in the :ref:`User Guide <preprocessing_scaler>`.
 
@@ -544,7 +544,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
     ----------
     scale_ : ndarray or None, shape (n_features,)
         Per feature relative scaling of the data. This is calculated using
-        `np.sqrt(var_)`. Equal to ``None`` when ``with_std=False``.
+        ``np.sqrt(var_)``. Equal to ``None`` when ``with_std=False``.
 
         .. versionadded:: 0.17
            *scale_*
@@ -555,7 +555,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
 
     var_ : ndarray or None, shape (n_features,)
         The variance for each feature in the training set. Used to compute
-        `scale_`. Equal to ``None`` when ``with_std=False``.
+        ``scale_``. Equal to ``None`` when ``with_std=False``.
 
     n_samples_seen_ : int or array, shape (n_features,)
         The number of samples processed by the estimator for each feature.
@@ -594,7 +594,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
     transform.
 
     We use a biased estimator for the standard deviation, equivalent to
-    `numpy.std(x, ddof=0)`. Note that the choice of `ddof` is unlikely to
+    `numpy.std(x, ddof=0)`. Note that the choice of ``ddof`` is unlikely to
     affect model performance.
 
     For a comparison of the different scalers, transformers, and normalizers,
@@ -662,7 +662,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
                         warn_on_dtype=False, estimator=self,
                         dtype=FLOAT_DTYPES, force_all_finite='allow-nan')
 
-        # Even in the case of `with_mean=False`, we update the mean anyway
+        # Even in the case of ``with_mean=False``, we update the mean anyway
         # This is needed for the incremental computation of the var
         # See incr_mean_variance_axis and _incremental_mean_variance_axis
 
@@ -677,7 +677,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         if sparse.issparse(X):
             if self.with_mean:
                 raise ValueError(
-                    "Cannot center sparse matrices: pass `with_mean=False` "
+                    "Cannot center sparse matrices: pass ``with_mean=False`` "
                     "instead. See docstring for motivation and alternatives.")
 
             sparse_constructor = (sparse.csr_matrix
@@ -760,7 +760,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         if sparse.issparse(X):
             if self.with_mean:
                 raise ValueError(
-                    "Cannot center sparse matrices: pass `with_mean=False` "
+                    "Cannot center sparse matrices: pass ``with_mean=False`` "
                     "instead. See docstring for motivation and alternatives.")
             if self.scale_ is not None:
                 inplace_column_scale(X, 1 / self.scale_)
@@ -792,7 +792,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         if sparse.issparse(X):
             if self.with_mean:
                 raise ValueError(
-                    "Cannot uncenter sparse matrices: pass `with_mean=False` "
+                    "Cannot uncenter sparse matrices: pass ``with_mean=False`` "
                     "instead See docstring for motivation and alternatives.")
             if not sparse.isspmatrix_csr(X):
                 X = X.tocsr()
@@ -1164,7 +1164,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
         if self.with_centering:
             if sparse.issparse(X):
                 raise ValueError(
-                    "Cannot center sparse matrices: use `with_centering=False`"
+                    "Cannot center sparse matrices: use ``with_centering=False``"
                     " instead. See docstring for motivation and alternatives.")
             self.center_ = np.nanmedian(X, axis=0)
         else:
@@ -1287,8 +1287,8 @@ def robust_scale(X, axis=0, with_centering=True, with_scaling=True,
     program with memory exhaustion problems.
 
     Instead the caller is expected to either set explicitly
-    `with_centering=False` (in that case, only variance scaling will be
-    performed on the features of the CSR matrix) or to call `X.toarray()`
+    ``with_centering=False`` (in that case, only variance scaling will be
+    performed on the features of the CSR matrix) or to call ``X.toarray()``
     if he/she expects the materialized dense array to fit in memory.
 
     To avoid memory copy the caller should pass a CSR matrix.
@@ -2203,7 +2203,7 @@ class QuantileTransformer(BaseEstimator, TransformerMixin):
             The data used to scale along the features axis. If a sparse
             matrix is provided, it will be converted into a sparse
             ``csc_matrix``. Additionally, the sparse matrix needs to be
-            nonnegative if `ignore_implicit_zeros` is False.
+            nonnegative if ``ignore_implicit_zeros`` is False.
 
         Returns
         -------
@@ -2389,7 +2389,7 @@ class QuantileTransformer(BaseEstimator, TransformerMixin):
             The data used to scale along the features axis. If a sparse
             matrix is provided, it will be converted into a sparse
             ``csc_matrix``. Additionally, the sparse matrix needs to be
-            nonnegative if `ignore_implicit_zeros` is False.
+            nonnegative if ``ignore_implicit_zeros`` is False.
 
         Returns
         -------
@@ -2410,7 +2410,7 @@ class QuantileTransformer(BaseEstimator, TransformerMixin):
             The data used to scale along the features axis. If a sparse
             matrix is provided, it will be converted into a sparse
             ``csc_matrix``. Additionally, the sparse matrix needs to be
-            nonnegative if `ignore_implicit_zeros` is False.
+            nonnegative if ``ignore_implicit_zeros`` is False.
 
         Returns
         -------
@@ -2495,9 +2495,9 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
         leaving the original `X` unchanged
 
         .. deprecated:: 0.21
-            The default value of parameter `copy` will be changed from False
+            The default value of parameter ``copy`` will be changed from False
             to True in 0.23. The current default of False is being changed to
-            make it more consistent with the default `copy` values of other
+            make it more consistent with the default ``copy`` values of other
             functions in :mod:`sklearn.preprocessing.data`. Furthermore, the
             current default of False may have unexpected side effects by
             modifying the value of `X` inplace
@@ -2539,9 +2539,9 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
     <sphx_glr_auto_examples_preprocessing_plot_all_scaling.py>`.
     """
     if copy == "warn":
-        warnings.warn("The default value of `copy` will change from False to "
+        warnings.warn("The default value of ``copy`` will change from False to "
                       "True in 0.23 in order to make it more consistent with "
-                      "the default `copy` values of other functions in "
+                      "the default ``copy`` values of other functions in "
                       ":mod:`sklearn.preprocessing.data` and prevent "
                       "unexpected side effects by modifying the value of `X` "
                       "inplace. To avoid inplace modifications of `X`, it is "

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -85,8 +85,8 @@ class Imputer(BaseEstimator, TransformerMixin):
     axis : integer, optional (default=0)
         The axis along which to impute.
 
-        - If `axis=0`, then impute along columns.
-        - If `axis=1`, then impute along rows.
+        - If ``axis=0``, then impute along columns.
+        - If ``axis=1``, then impute along rows.
 
     verbose : integer, optional (default=0)
         Controls the verbosity of the imputer.
@@ -94,12 +94,12 @@ class Imputer(BaseEstimator, TransformerMixin):
     copy : boolean, optional (default=True)
         If True, a copy of X will be created. If False, imputation will
         be done in-place whenever possible. Note that, in the following cases,
-        a new copy will always be made, even if `copy=False`:
+        a new copy will always be made, even if ``copy=False``:
 
         - If X is not an array of floating values;
-        - If X is sparse and `missing_values=0`;
-        - If `axis=0` and X is encoded as a CSR matrix;
-        - If `axis=1` and X is encoded as a CSC matrix.
+        - If X is sparse and ``missing_values=0``;
+        - If ``axis=0`` and X is encoded as a CSR matrix;
+        - If ``axis=1`` and X is encoded as a CSC matrix.
 
     Attributes
     ----------

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -787,7 +787,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
     Attributes
     ----------
     classes_ : array of labels
-        A copy of the `classes` parameter where provided,
+        A copy of the ``classes`` parameter where provided,
         or otherwise, the sorted set of classes found when fitting.
 
     Examples
@@ -823,7 +823,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         ----------
         y : iterable of iterables
             A set of labels (any orderable and hashable object) for each
-            sample. If the `classes` parameter is set, `y` will not be
+            sample. If the ``classes`` parameter is set, `y` will not be
             iterated.
 
         Returns
@@ -851,7 +851,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         ----------
         y : iterable of iterables
             A set of labels (any orderable and hashable object) for each
-            sample. If the `classes` parameter is set, `y` will not be
+            sample. If the ``classes`` parameter is set, `y` will not be
             iterated.
 
         Returns
@@ -894,7 +894,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         ----------
         y : iterable of iterables
             A set of labels (any orderable and hashable object) for each
-            sample. If the `classes` parameter is set, `y` will not be
+            sample. If the ``classes`` parameter is set, `y` will not be
             iterated.
 
         Returns

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -173,7 +173,7 @@ def gaussian_random_matrix(n_components, n_features, random_state=None):
         at fit time.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`.
+        RandomState instance used by ``np.random``.
 
     Returns
     -------
@@ -232,7 +232,7 @@ def sparse_random_matrix(n_components, n_features, density='auto',
         at fit time.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`.
+        RandomState instance used by ``np.random``.
 
     Returns
     -------
@@ -452,7 +452,7 @@ class GaussianRandomProjection(BaseRandomProjection):
         at fit time.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`.
+        RandomState instance used by ``np.random``.
 
     Attributes
     ----------
@@ -572,7 +572,7 @@ class SparseRandomProjection(BaseRandomProjection):
         at fit time.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
         number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`.
+        RandomState instance used by ``np.random``.
 
     Attributes
     ----------

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -51,7 +51,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         two classes.
         ``"ovr"`` trains n_classes one-vs-rest classifiers, while
         ``"crammer_singer"`` optimizes a joint objective over all classes.
-        While `crammer_singer` is interesting from a theoretical perspective
+        While ``crammer_singer`` is interesting from a theoretical perspective
         as it is consistent, it is seldom used in practice as it rarely leads
         to better accuracy and is more expensive to compute.
         If ``"crammer_singer"`` is chosen, the options loss, penalty and dual
@@ -94,7 +94,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         int, random_state is the seed used by the random number generator; If
         RandomState instance, random_state is the random number generator; If
         None, the random number generator is the RandomState instance used by
-        `np.random`.
+        ``np.random``.
 
     max_iter : int, (default=1000)
         The maximum number of iterations to be run.
@@ -306,7 +306,7 @@ class LinearSVR(LinearModel, RegressorMixin):
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        instance used by ``np.random``.
 
     max_iter : int, (default=1000)
         The maximum number of iterations to be run.
@@ -317,7 +317,7 @@ class LinearSVR(LinearModel, RegressorMixin):
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
 
-        `coef_` is a readonly property derived from `raw_coef_` that
+        `coef_` is a readonly property derived from ``raw_coef_`` that
         follows the internal memory layout of liblinear.
 
     intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]
@@ -526,7 +526,7 @@ class SVC(BaseSVC):
         the data for probability estimates. If int, random_state is the
         seed used by the random number generator; If RandomState instance,
         random_state is the random number generator; If None, the random
-        number generator is the RandomState instance used by `np.random`.
+        number generator is the RandomState instance used by ``np.random``.
 
     Attributes
     ----------
@@ -550,8 +550,8 @@ class SVC(BaseSVC):
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
 
-        `coef_` is a readonly property derived from `dual_coef_` and
-        `support_vectors_`.
+        `coef_` is a readonly property derived from ``dual_coef_`` and
+        ``support_vectors_``.
 
     intercept_ : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
@@ -712,7 +712,7 @@ class NuSVC(BaseSVC):
         the data for probability estimates. If int, random_state is the seed
         used by the random number generator; If RandomState instance,
         random_state is the random number generator; If None, the random
-        number generator is the RandomState instance used by `np.random`.
+        number generator is the RandomState instance used by ``np.random``.
 
     Attributes
     ----------
@@ -736,8 +736,8 @@ class NuSVC(BaseSVC):
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
 
-        `coef_` is readonly property derived from `dual_coef_` and
-        `support_vectors_`.
+        `coef_` is readonly property derived from ``dual_coef_`` and
+        ``support_vectors_``.
 
     intercept_ : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
@@ -871,8 +871,8 @@ class SVR(BaseLibSVM, RegressorMixin):
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
 
-        `coef_` is readonly property derived from `dual_coef_` and
-        `support_vectors_`.
+        `coef_` is readonly property derived from ``dual_coef_`` and
+        ``support_vectors_``.
 
     intercept_ : array, shape = [1]
         Constants in decision function.
@@ -998,8 +998,8 @@ class NuSVR(BaseLibSVM, RegressorMixin):
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
 
-        `coef_` is readonly property derived from `dual_coef_` and
-        `support_vectors_`.
+        `coef_` is readonly property derived from ``dual_coef_`` and
+        ``support_vectors_``.
 
     intercept_ : array, shape = [1]
         Constants in decision function.
@@ -1128,16 +1128,16 @@ class OneClassSVM(BaseLibSVM, OutlierMixin):
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
 
-        `coef_` is readonly property derived from `dual_coef_` and
-        `support_vectors_`
+        `coef_` is readonly property derived from ``dual_coef_`` and
+        ``support_vectors_``
 
     intercept_ : array, shape = [1,]
         Constant in the decision function.
 
     offset_ : float
         Offset used to define the decision function from the raw scores.
-        We have the relation: decision_function = score_samples - `offset_`.
-        The offset is the opposite of `intercept_` and is provided for
+        We have the relation: decision_function = score_samples - ``offset_``.
+        The offset is the opposite of ``intercept_`` and is provided for
         consistency with other outlier detection algorithms.
 
     """

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -555,8 +555,8 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
 
-        - If int, then consider `min_samples_split` as the minimum number.
-        - If float, then `min_samples_split` is a fraction and
+        - If int, then consider ``min_samples_split`` as the minimum number.
+        - If float, then ``min_samples_split`` is a fraction and
           `ceil(min_samples_split * n_samples)` are the minimum
           number of samples for each split.
 
@@ -570,8 +570,8 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
         right branches.  This may have the effect of smoothing the model,
         especially in regression.
 
-        - If int, then consider `min_samples_leaf` as the minimum number.
-        - If float, then `min_samples_leaf` is a fraction and
+        - If int, then consider ``min_samples_leaf`` as the minimum number.
+        - If float, then ``min_samples_leaf`` is a fraction and
           `ceil(min_samples_leaf * n_samples)` are the minimum
           number of samples for each node.
 
@@ -586,14 +586,14 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
     max_features : int, float, string or None, optional (default=None)
         The number of features to consider when looking for the best split:
 
-            - If int, then consider `max_features` features at each split.
-            - If float, then `max_features` is a fraction and
+            - If int, then consider ``max_features`` features at each split.
+            - If float, then ``max_features`` is a fraction and
               `int(max_features * n_features)` features are considered at each
               split.
-            - If "auto", then `max_features=sqrt(n_features)`.
-            - If "sqrt", then `max_features=sqrt(n_features)`.
-            - If "log2", then `max_features=log2(n_features)`.
-            - If None, then `max_features=n_features`.
+            - If "auto", then ``max_features=sqrt(n_features)``.
+            - If "sqrt", then ``max_features=sqrt(n_features)``.
+            - If "log2", then ``max_features=log2(n_features)``.
+            - If None, then ``max_features=n_features``.
 
         Note: the search for a split does not stop until at least one
         valid partition of the node samples is found, even if it requires to
@@ -603,7 +603,7 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.
@@ -928,8 +928,8 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
 
-        - If int, then consider `min_samples_split` as the minimum number.
-        - If float, then `min_samples_split` is a fraction and
+        - If int, then consider ``min_samples_split`` as the minimum number.
+        - If float, then ``min_samples_split`` is a fraction and
           `ceil(min_samples_split * n_samples)` are the minimum
           number of samples for each split.
 
@@ -943,8 +943,8 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
         right branches.  This may have the effect of smoothing the model,
         especially in regression.
 
-        - If int, then consider `min_samples_leaf` as the minimum number.
-        - If float, then `min_samples_leaf` is a fraction and
+        - If int, then consider ``min_samples_leaf`` as the minimum number.
+        - If float, then ``min_samples_leaf`` is a fraction and
           `ceil(min_samples_leaf * n_samples)` are the minimum
           number of samples for each node.
 
@@ -959,14 +959,14 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
     max_features : int, float, string or None, optional (default=None)
         The number of features to consider when looking for the best split:
 
-        - If int, then consider `max_features` features at each split.
-        - If float, then `max_features` is a fraction and
+        - If int, then consider ``max_features`` features at each split.
+        - If float, then ``max_features`` is a fraction and
           `int(max_features * n_features)` features are considered at each
           split.
-        - If "auto", then `max_features=n_features`.
-        - If "sqrt", then `max_features=sqrt(n_features)`.
-        - If "log2", then `max_features=log2(n_features)`.
-        - If None, then `max_features=n_features`.
+        - If "auto", then ``max_features=n_features``.
+        - If "sqrt", then ``max_features=sqrt(n_features)``.
+        - If "log2", then ``max_features=log2(n_features)``.
+        - If None, then ``max_features=n_features``.
 
         Note: the search for a split does not stop until at least one
         valid partition of the node samples is found, even if it requires to
@@ -976,7 +976,7 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.
@@ -1163,9 +1163,9 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
 
     Extra-trees differ from classic decision trees in the way they are built.
     When looking for the best split to separate the samples of a node into two
-    groups, random splits are drawn for each of the `max_features` randomly
+    groups, random splits are drawn for each of the ``max_features`` randomly
     selected features and the best split among those is chosen. When
-    `max_features` is set 1, this amounts to building a totally random
+    ``max_features`` is set 1, this amounts to building a totally random
     decision tree.
 
     Warning: Extra-trees should only be used within ensemble methods.
@@ -1191,8 +1191,8 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
 
-        - If int, then consider `min_samples_split` as the minimum number.
-        - If float, then `min_samples_split` is a fraction and
+        - If int, then consider ``min_samples_split`` as the minimum number.
+        - If float, then ``min_samples_split`` is a fraction and
           `ceil(min_samples_split * n_samples)` are the minimum
           number of samples for each split.
 
@@ -1206,8 +1206,8 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
         right branches.  This may have the effect of smoothing the model,
         especially in regression.
 
-        - If int, then consider `min_samples_leaf` as the minimum number.
-        - If float, then `min_samples_leaf` is a fraction and
+        - If int, then consider ``min_samples_leaf`` as the minimum number.
+        - If float, then ``min_samples_leaf`` is a fraction and
           `ceil(min_samples_leaf * n_samples)` are the minimum
           number of samples for each node.
 
@@ -1222,14 +1222,14 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
     max_features : int, float, string or None, optional (default="auto")
         The number of features to consider when looking for the best split:
 
-            - If int, then consider `max_features` features at each split.
-            - If float, then `max_features` is a fraction and
+            - If int, then consider ``max_features`` features at each split.
+            - If float, then ``max_features`` is a fraction and
               `int(max_features * n_features)` features are considered at each
               split.
-            - If "auto", then `max_features=sqrt(n_features)`.
-            - If "sqrt", then `max_features=sqrt(n_features)`.
-            - If "log2", then `max_features=log2(n_features)`.
-            - If None, then `max_features=n_features`.
+            - If "auto", then ``max_features=sqrt(n_features)``.
+            - If "sqrt", then ``max_features=sqrt(n_features)``.
+            - If "log2", then ``max_features=log2(n_features)``.
+            - If None, then ``max_features=n_features``.
 
         Note: the search for a split does not stop until at least one
         valid partition of the node samples is found, even if it requires to
@@ -1239,7 +1239,7 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.
@@ -1347,9 +1347,9 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
 
     Extra-trees differ from classic decision trees in the way they are built.
     When looking for the best split to separate the samples of a node into two
-    groups, random splits are drawn for each of the `max_features` randomly
+    groups, random splits are drawn for each of the ``max_features`` randomly
     selected features and the best split among those is chosen. When
-    `max_features` is set 1, this amounts to building a totally random
+    ``max_features`` is set 1, this amounts to building a totally random
     decision tree.
 
     Warning: Extra-trees should only be used within ensemble methods.
@@ -1380,8 +1380,8 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
 
-        - If int, then consider `min_samples_split` as the minimum number.
-        - If float, then `min_samples_split` is a fraction and
+        - If int, then consider ``min_samples_split`` as the minimum number.
+        - If float, then ``min_samples_split`` is a fraction and
           `ceil(min_samples_split * n_samples)` are the minimum
           number of samples for each split.
 
@@ -1395,8 +1395,8 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
         right branches.  This may have the effect of smoothing the model,
         especially in regression.
 
-        - If int, then consider `min_samples_leaf` as the minimum number.
-        - If float, then `min_samples_leaf` is a fraction and
+        - If int, then consider ``min_samples_leaf`` as the minimum number.
+        - If float, then ``min_samples_leaf`` is a fraction and
           `ceil(min_samples_leaf * n_samples)` are the minimum
           number of samples for each node.
 
@@ -1411,14 +1411,14 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
     max_features : int, float, string or None, optional (default="auto")
         The number of features to consider when looking for the best split:
 
-        - If int, then consider `max_features` features at each split.
-        - If float, then `max_features` is a fraction and
+        - If int, then consider ``max_features`` features at each split.
+        - If float, then ``max_features`` is a fraction and
           `int(max_features * n_features)` features are considered at each
           split.
-        - If "auto", then `max_features=n_features`.
-        - If "sqrt", then `max_features=sqrt(n_features)`.
-        - If "log2", then `max_features=log2(n_features)`.
-        - If None, then `max_features=n_features`.
+        - If "auto", then ``max_features=n_features``.
+        - If "sqrt", then ``max_features=sqrt(n_features)``.
+        - If "log2", then ``max_features=log2(n_features)``.
+        - If None, then ``max_features=n_features``.
 
         Note: the search for a split does not stop until at least one
         valid partition of the node samples is found, even if it requires to
@@ -1428,7 +1428,7 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        by ``np.random``.
 
     min_impurity_decrease : float, optional (default=0.)
         A node will be split if this split induces a decrease of the impurity

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -250,7 +250,7 @@ def resample(*arrays, **options):
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        instance used by ``np.random``.
 
     Returns
     -------
@@ -352,7 +352,7 @@ def shuffle(*arrays, **options):
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        instance used by ``np.random``.
 
     n_samples : int, None by default
         Number of samples to generate. If left to None this is

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -161,10 +161,10 @@ def randomized_range_finder(A, size, n_iter,
     power_iteration_normalizer : 'auto' (default), 'QR', 'LU', 'none'
         Whether the power iterations are normalized with step-by-step
         QR factorization (the slowest but most accurate), 'none'
-        (the fastest but numerically unstable when `n_iter` is large, e.g.
+        (the fastest but numerically unstable when ``n_iter`` is large, e.g.
         typically 5 or larger), or 'LU' factorization (numerically stable
         but can lose slightly in accuracy). The 'auto' mode applies no
-        normalization if `n_iter` <= 2 and switches to LU otherwise.
+        normalization if ``n_iter`` <= 2 and switches to LU otherwise.
 
         .. versionadded:: 0.18
 
@@ -173,7 +173,7 @@ def randomized_range_finder(A, size, n_iter,
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        instance used by ``np.random``.
 
     Returns
     -------
@@ -250,7 +250,7 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter='auto',
     n_iter : int or 'auto' (default is 'auto')
         Number of power iterations. It can be used to deal with very noisy
         problems. When 'auto', it is set to 4, unless `n_components` is small
-        (< .1 * min(X.shape)) `n_iter` in which case is set to 7.
+        (< .1 * min(X.shape)) ``n_iter`` in which case is set to 7.
         This improves precision with few components.
 
         .. versionchanged:: 0.18
@@ -258,10 +258,10 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter='auto',
     power_iteration_normalizer : 'auto' (default), 'QR', 'LU', 'none'
         Whether the power iterations are normalized with step-by-step
         QR factorization (the slowest but most accurate), 'none'
-        (the fastest but numerically unstable when `n_iter` is large, e.g.
+        (the fastest but numerically unstable when ``n_iter`` is large, e.g.
         typically 5 or larger), or 'LU' factorization (numerically stable
         but can lose slightly in accuracy). The 'auto' mode applies no
-        normalization if `n_iter` <= 2 and switches to LU otherwise.
+        normalization if ``n_iter`` <= 2 and switches to LU otherwise.
 
         .. versionadded:: 0.18
 
@@ -276,8 +276,8 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter='auto',
 
     flip_sign : boolean, (True by default)
         The output of a singular value decomposition is only unique up to a
-        permutation of the signs of the singular vectors. If `flip_sign` is
-        set to `True`, the sign ambiguity is resolved by making the largest
+        permutation of the signs of the singular vectors. If ``flip_sign`` is
+        set to ``True``, the sign ambiguity is resolved by making the largest
         loadings for each component in the left singular vectors positive.
 
     random_state : int, RandomState instance or None, optional (default=None)
@@ -285,7 +285,7 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter='auto',
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        instance used by ``np.random``.
 
     Notes
     -----
@@ -293,7 +293,7 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter='auto',
     singular value decomposition using randomization to speed up the
     computations. It is particularly fast on large matrices on which
     you wish to extract only a small number of components. In order to
-    obtain further speed up, `n_iter` can be set <=2 (at the cost of
+    obtain further speed up, ``n_iter`` can be set <=2 (at the cost of
     loss of precision).
 
     References

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -117,7 +117,7 @@ def is_multilabel(y):
     Returns
     -------
     out : bool,
-        Return ``True``, if ``y`` is in a multilabel format, else ```False``.
+        Return ``True``, if ``y`` is in a multilabel format, else ``False``.
 
     Examples
     --------

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -521,8 +521,8 @@ class mock_mldata_urlopen:
     ----------
     mock_datasets : dict
         A dictionary of {dataset_name: data_dict}, or
-        {dataset_name: (data_dict, ordering). `data_dict` itself is a
-        dictionary of {column_name: data_array}, and `ordering` is a list of
+        {dataset_name: (data_dict, ordering). ``data_dict`` itself is a
+        dictionary of {column_name: data_array}, and ``ordering`` is a list of
         column_names to determine the ordering in the data set (see
         :func:`fake_mldata` for details).
     """
@@ -561,8 +561,8 @@ def install_mldata_mock(mock_datasets):
     ----------
     mock_datasets : dict
         A dictionary of {dataset_name: data_dict}, or
-        {dataset_name: (data_dict, ordering). `data_dict` itself is a
-        dictionary of {column_name: data_array}, and `ordering` is a list of
+        {dataset_name: (data_dict, ordering). ``data_dict`` itself is a
+        dictionary of {column_name: data_array}, and ``ordering`` is a list of
         column_names to determine the ordering in the data set (see
         :func:`fake_mldata` for details).
     """


### PR DESCRIPTION
This is to fix the `WARNING: 'any' reference target not found` issues while making the documentation.