### PR TITLE
[MRG] DOC Fix missing space after backquotes

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -497,7 +497,7 @@ You can edit the documentation using any text editor, and then generate the
 HTML output by typing ``make html`` from the ``doc/`` directory. Alternatively,
 ``make`` can be used to quickly generate the documentation without the example
 gallery. The resulting HTML files will be placed in ``_build/html/stable`` and are viewable
-in a web browser. See the ``README``file in the ``doc/`` directory for more information.
+in a web browser. See the ``README`` file in the ``doc/`` directory for more information.
 
 
 Building the documentation

--- a/doc/whats_new/v0.17.rst
+++ b/doc/whats_new/v0.17.rst
@@ -376,7 +376,7 @@ Bug fixes
 
 - Fixed a bug in :class:`linear_model.LogisticRegression` and
   :class:`linear_model.LogisticRegressionCV` when using
-  ``class_weight='balanced'```or ``class_weight='auto'``.
+  ``class_weight='balanced'`` or ``class_weight='auto'``.
   By `Tom Dupre la Tour`_.
 
 - Fixed bug :issue:`5495` when
@@ -508,4 +508,3 @@ Unterthiner, Tiago Freitas Pereira, Tian Wang, Tim Head, Timothy Hopper,
 tokoroten, Tom Dupré la Tour, Trevor Stephens, Valentin Stolbunov, Vighnesh
 Birodkar, Vinayak Mehta, Vincent, Vincent Michel, vstolbunov, wangz10, Wei Xue,
 Yucheng Low, Yury Zhauniarovich, Zac Stewart, zhai_pro, Zichen Wang
-


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

None

#### What does this implement/fix? Explain your changes.

One missing space after the double backquotes makes the inline markup for code samples to expend to the next one. Then, the sentence is incorrectly formatted as:
<img width="276" alt="before" src="https://user-images.githubusercontent.com/1850174/55292390-afd04900-53c0-11e9-9d13-87f92f579cd5.png">

Instead of:
<img width="286" alt="after" src="https://user-images.githubusercontent.com/1850174/55292392-b363d000-53c0-11e9-96ca-7699743b92ba.png">



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
