### PR TITLE
Correct scaling in PLSRegression when using predict()

### DIFF
--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -434,7 +434,7 @@ class _PLS(BaseEstimator, TransformerMixin, RegressorMixin, MultiOutputMixin,
         X -= self.x_mean_
         X /= self.x_std_
         Ypred = np.dot(X, self.coef_)
-        return Ypred + self.y_mean_
+        return Ypred / self.y_std_ + self.y_mean_
 
     def fit_transform(self, X, y=None):
         """Learn and apply the dimension reduction on the train data.

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -434,7 +434,7 @@ class _PLS(BaseEstimator, TransformerMixin, RegressorMixin, MultiOutputMixin,
         X -= self.x_mean_
         X /= self.x_std_
         Ypred = np.dot(X, self.coef_)
-        return Ypred / self.y_std_ + self.y_mean_
+        return Ypred * self.y_std_ + self.y_mean_
 
     def fit_transform(self, X, y=None):
         """Learn and apply the dimension reduction on the train data.


### PR DESCRIPTION
#### Reference Issues/PRs

This doesn't reference an open issue. It might be related to #6002.

#### What does this implement/fix? Explain your changes.

When making a prediction using PLSRegression, the prediction needs to be converted back to the original scaling based on the scaling used during fitting. Currently that is done with the mean centering, but not for the variance scaling of y.
