### PR TITLE
correct reference to target in `load_linnerud()` docstring

### DIFF
--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -642,8 +642,8 @@ def load_linnerud(return_X_y=False):
     -------
     data : Bunch
         Dictionary-like object, the interesting attributes are: 'data' and
-        'targets', the two multivariate datasets, with 'data' corresponding to
-        the exercise and 'targets' corresponding to the physiological
+        'target', the two multivariate datasets, with 'data' corresponding to
+        the exercise and 'target' corresponding to the physiological
         measurements, as well as 'feature_names' and 'target_names'.
         In addition, you will also have access to 'data_filename',
         the physical location of linnerud data csv dataset, and


### PR DESCRIPTION
Minor correction to docstring of the function `load_linnerud()` in `base.py`, which was referring to 'targets' instead of 'target'. I know there are multiple targets here but the Bunch object is the same as the other datasets.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
