### PR TITLE
[MRG] Fix missing 'const' in a few memoryview declaration in trees.

### DIFF
--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -8,6 +8,7 @@ Testing for the forest module (sklearn.ensemble.forest).
 #          Arnaud Joly
 # License: BSD 3 clause
 
+import os
 import pickle
 from collections import defaultdict
 from distutils.version import LooseVersion
@@ -1367,6 +1368,7 @@ def test_random_forest_memmap():
     X_orig = np.random.RandomState(0).random_sample((10, 2)).astype(np.float32)
 
     with NamedTemporaryFile() as tmp:
+        tmp.close()  # necessary under windows
         mmap = np.memmap(tmp.name, dtype='float32', mode='w+', shape=(10, 2))
         mmap[...] = X_orig[...]
 
@@ -1374,3 +1376,5 @@ def test_random_forest_memmap():
         y = np.zeros(10)
 
         RandomForestClassifier(n_estimators=2).fit(X_mmap, y)
+
+        os.remove(tmp.name)  # necessary since it's been closed manually

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -8,14 +8,12 @@ Testing for the forest module (sklearn.ensemble.forest).
 #          Arnaud Joly
 # License: BSD 3 clause
 
-import os
 import pickle
 from collections import defaultdict
 from distutils.version import LooseVersion
 import itertools
 from itertools import combinations
 from itertools import product
-from tempfile import NamedTemporaryFile
 
 import numpy as np
 from scipy.sparse import csr_matrix
@@ -1361,21 +1359,3 @@ def test_multi_target(name, oob_score):
     # Try to fit and predict.
     clf.fit(X, y)
     clf.predict(X)
-
-
-def test_random_forest_memmap():
-    # check that random forest supports read-only buffer (#13626)
-    X_orig = np.random.RandomState(0).random_sample((10, 2)).astype(np.float32)
-
-    with NamedTemporaryFile() as tmp:
-        tmp.close()  # necessary under windows
-        mmap = np.memmap(tmp.name, dtype='float32', mode='w+', shape=(10, 2))
-        mmap[...] = X_orig[...]
-
-        X_mmap = np.memmap(tmp.name, dtype='float32', mode='r', shape=(10, 2))
-        y = np.zeros(10)
-
-        RandomForestClassifier(n_estimators=2).fit(X_mmap, y)
-
-        del mmap, X_mmap
-        os.remove(tmp.name)  # necessary since it's been closed manually

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1377,4 +1377,5 @@ def test_random_forest_memmap():
 
         RandomForestClassifier(n_estimators=2).fit(X_mmap, y)
 
+        del mmap, X_mmap
         os.remove(tmp.name)  # necessary since it's been closed manually

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -117,7 +117,7 @@ cdef class Splitter:
 
     cdef int init(self,
                    object X,
-                   DOUBLE_t[:, ::1] y,
+                   const DOUBLE_t[:, ::1] y,
                    DOUBLE_t* sample_weight,
                    np.ndarray X_idx_sorted=None) except -1:
         """Initialize the splitter.
@@ -237,7 +237,7 @@ cdef class Splitter:
 
 
 cdef class BaseDenseSplitter(Splitter):
-    cdef DTYPE_t[:, :] X
+    cdef const DTYPE_t[:, :] X
 
     cdef np.ndarray X_idx_sorted
     cdef INT32_t* X_idx_sorted_ptr
@@ -261,7 +261,7 @@ cdef class BaseDenseSplitter(Splitter):
 
     cdef int init(self,
                   object X,
-                  DOUBLE_t[:, ::1] y,
+                  const DOUBLE_t[:, ::1] y,
                   DOUBLE_t* sample_weight,
                   np.ndarray X_idx_sorted=None) except -1:
         """Initialize the splitter
@@ -877,7 +877,7 @@ cdef class BaseSparseSplitter(Splitter):
 
     cdef int init(self,
                   object X,
-                  DOUBLE_t[:, ::1] y,
+                  const DOUBLE_t[:, ::1] y,
                   DOUBLE_t* sample_weight,
                   np.ndarray X_idx_sorted=None) except -1:
         """Initialize the splitter

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -33,6 +33,7 @@ from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_raise_message
+from sklearn.utils.testing import TempMemmap
 
 from sklearn.utils.validation import check_random_state
 
@@ -1848,3 +1849,12 @@ def test_multi_target(name):
     # Try to fit and predict.
     clf.fit(X, y)
     clf.predict(X)
+
+
+def test_decision_tree_memmap():
+    # check that decision trees supports read-only buffer (#13626)
+    X = np.random.RandomState(0).random_sample((10, 2)).astype(np.float32)
+    y = np.zeros(10)
+
+    with TempMemmap(X) as X_read_only:
+        DecisionTreeClassifier().fit(X_read_only, y)

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1856,5 +1856,5 @@ def test_decision_tree_memmap():
     X = np.random.RandomState(0).random_sample((10, 2)).astype(np.float32)
     y = np.zeros(10)
 
-    with TempMemmap(X) as X_read_only:
-        DecisionTreeClassifier().fit(X_read_only, y)
+    with TempMemmap((X, y)) as (X_read_only, y_read_only):
+        DecisionTreeClassifier().fit(X_read_only, y_read_only)


### PR DESCRIPTION
Memory views were introduced in trees in #12886.
It misses the `const` keyword in a few declarations.

A typical use case is doing cross validation on a `RandomForest`:
```python
import numpy as np
from sklearn.ensemble import RandomForestClassifier
from sklearn.model_selection import cross_val_score

X = np.random.random_sample((10000, 1000))
y = np.random.randint(2, size=10000)
rf = RandomForestClassifier(n_jobs=-1)

cross_val_score(rf, X, y)
```

Here X is more than 1Mb, which means it's mem-mapped by joblib in `cross_val_score`. This code breaks on master.

What's happening is that for `cross_val_score`, the joblib backend is the sequential backend (as expected) but for the random forest it's loky backend, ignoring `prefer='threads'`. So it seems that even if this PR fixes the bug in sklearn, there's also a bug in joblib. @ogrisel 