### PR TITLE
FIX feature importances in random forests should sum up to 1

### DIFF
--- a/doc/whats_new/_contributors.rst
+++ b/doc/whats_new/_contributors.rst
@@ -169,3 +169,5 @@
 .. _Roman Yurchak: https://github.com/rth
 
 .. _Hanmin Qin: https://github.com/qinhanmin2014
+
+.. _Adrin Jalali: https://github.com/adrinjalali

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -194,6 +194,20 @@ Support for Python 3.4 and below has been officially dropped.
   prediction step, thus capping the memory usage. :issue:`13283` by
   `Nicolas Goix`_.
 
+- |Fix| The values of ``feature_importances_`` in all random forest based
+  models (i.e.
+  :class:`ensemble.RandomForestClassifier`,
+  :class:`ensemble.RandomForestRegressor`,
+  :class:`ensemble.ExtraTreesClassifier`,
+  :class:`ensemble.ExtraTreesRegressor`, and
+  :class:`ensemble.RandomTreesEmbedding`) now:
+
+  - sum up to ``1``
+  - all the single node trees in feature importance calculation are ignored
+  - in case all trees have only one single node (i.e. a root node),
+    feature importances will be an array of all zeros.
+  :issue:`13636` by `Adrin Jalali`_.
+
 - |Fix| Fixed a bug in :class:`ensemble.GradientBoostingClassifier` and
   :class:`ensemble.GradientBoostingRegressor`, which didn't support
   scikit-learn estimators as the initial estimator. Also added support of

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -366,6 +366,9 @@ class BaseForest(BaseEnsemble, MultiOutputMixin, metaclass=ABCMeta):
         Returns
         -------
         feature_importances_ : array, shape = [n_features]
+            The values of this array sum to 1, unless all trees are single node
+            trees consisting of only the root node, in which case it will be an
+            array of zeros.
         """
         check_is_fitted(self, 'estimators_')
 

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -9,6 +9,7 @@ Testing for the forest module (sklearn.ensemble.forest).
 # License: BSD 3 clause
 
 import pickle
+import math
 from collections import defaultdict
 from distutils.version import LooseVersion
 import itertools
@@ -42,6 +43,7 @@ from sklearn.utils.testing import skip_if_no_parallel
 
 from sklearn import datasets
 from sklearn.decomposition import TruncatedSVD
+from sklearn.datasets import make_classification
 from sklearn.ensemble import ExtraTreesClassifier
 from sklearn.ensemble import ExtraTreesRegressor
 from sklearn.ensemble import RandomForestClassifier
@@ -1359,3 +1361,19 @@ def test_multi_target(name, oob_score):
     # Try to fit and predict.
     clf.fit(X, y)
     clf.predict(X)
+
+
+def test_forest_feature_importances_sum():
+    X, y = make_classification(n_samples=15, n_informative=3, random_state=1,
+                               n_classes=3)
+    clf = RandomForestClassifier(min_samples_leaf=5,random_state=42,
+                                 n_estimators=200).fit(X, y)
+    assert math.isclose(1, clf.feature_importances_.sum(), abs_tol=1e-7)
+
+
+def test_forest_degenerate_feature_importances():
+    X = np.zeros((10, 10))
+    y = np.ones((10,))
+    gbr = RandomForestRegressor().fit(X, y)
+    assert_array_equal(gbr.feature_importances_,
+                       np.zeros(10, dtype=np.float64))

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1372,6 +1372,7 @@ def test_forest_feature_importances_sum():
 
 
 def test_forest_degenerate_feature_importances():
+    # build a forest of single node trees. See #13636
     X = np.zeros((10, 10))
     y = np.ones((10,))
     gbr = RandomForestRegressor(n_estimators=10).fit(X, y)

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1374,6 +1374,6 @@ def test_forest_feature_importances_sum():
 def test_forest_degenerate_feature_importances():
     X = np.zeros((10, 10))
     y = np.ones((10,))
-    gbr = RandomForestRegressor().fit(X, y)
+    gbr = RandomForestRegressor(n_estimators=10).fit(X, y)
     assert_array_equal(gbr.feature_importances_,
                        np.zeros(10, dtype=np.float64))

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1366,7 +1366,7 @@ def test_multi_target(name, oob_score):
 def test_forest_feature_importances_sum():
     X, y = make_classification(n_samples=15, n_informative=3, random_state=1,
                                n_classes=3)
-    clf = RandomForestClassifier(min_samples_leaf=5,random_state=42,
+    clf = RandomForestClassifier(min_samples_leaf=5, random_state=42,
                                  n_estimators=200).fit(X, y)
     assert math.isclose(1, clf.feature_importances_.sum(), abs_tol=1e-7)
 


### PR DESCRIPTION
Same as the discussion in #7406 and #13620, the feature importances of random forest based mdoels should sum up to 1, and root only trees should be ignored.