### PR TITLE
[MRG] DOC Adds recent core devs to _contributors.rst

### DIFF
--- a/doc/whats_new/_contributors.rst
+++ b/doc/whats_new/_contributors.rst
@@ -169,3 +169,9 @@
 .. _Roman Yurchak: https://github.com/rth
 
 .. _Hanmin Qin: https://github.com/qinhanmin2014
+
+.. _Adrin Jalali: https://github.com/adrinjalali
+
+.. _Thomas Fan: https://github.com/thomasjpfan
+
+.. _Nicolas Hug: https://github.com/NicolasHug


### PR DESCRIPTION
Seeing how @adrinjalali has been adding this to `_contributors.rst` in a few PRs. This PR adds me @NicolasHug and @adrinjalali  to the `_contributors.rst` file.