### PR TITLE
[MRG] ENH Uses debian stretch for circleci doc building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   doc-min-dependencies:
     docker:
-      - image: continuumio/miniconda3:4.5.12
+      - image: circleci/python:3.7.3-stretch
     environment:
       - MINICONDA_PATH: ~/miniconda
       - CONDA_ENV_NAME: testenv
@@ -32,7 +32,7 @@ jobs:
 
   doc:
     docker:
-      - image: continuumio/miniconda3:4.5.12
+      - image: circleci/python:3.7.3-stretch
     environment:
       - MINICONDA_PATH: ~/miniconda
       - CONDA_ENV_NAME: testenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   doc-min-dependencies:
     docker:
-      - image: circleci/python:3.6
+      - image: continuumio/miniconda3:4.5.12
     environment:
       - MINICONDA_PATH: ~/miniconda
       - CONDA_ENV_NAME: testenv
@@ -32,7 +32,7 @@ jobs:
 
   doc:
     docker:
-      - image: circleci/python:3.6
+      - image: continuumio/miniconda3:4.5.12
     environment:
       - MINICONDA_PATH: ~/miniconda
       - CONDA_ENV_NAME: testenv

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -96,9 +96,9 @@ make_args="SPHINXOPTS=-T $make_args"  # show full traceback on exception
 
 # Installing required system packages to support the rendering of math
 # notation in the HTML documentation
-sudo -E apt-get -yq update
-sudo -E apt-get -yq remove texlive-binaries --purge
-sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes \
+apt-get -yq update
+apt-get -yq remove texlive-binaries --purge
+apt-get -yq --no-install-suggests --no-install-recommends --force-yes \
     install dvipng texlive-latex-base texlive-latex-extra \
     texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended\
     latexmk gsfonts
@@ -107,13 +107,6 @@ sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes \
 if [[ `type -t deactivate` ]]; then
   deactivate
 fi
-
-# Install dependencies with miniconda
-wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-   -O miniconda.sh
-chmod +x miniconda.sh && ./miniconda.sh -b -p $MINICONDA_PATH
-export PATH="$MINICONDA_PATH/bin:$PATH"
-conda update --yes --quiet conda
 
 # Configure the conda environment and put it in the path using the
 # provided versions

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -98,9 +98,9 @@ make_args="SPHINXOPTS=-T $make_args"  # show full traceback on exception
 # notation in the HTML documentation
 apt-get -yq update
 apt-get -yq remove texlive-binaries --purge
-apt-get -yq --no-install-suggests --no-install-recommends --force-yes \
+apt-get -yq --no-install-suggests --no-install-recommends \
     install dvipng texlive-latex-base texlive-latex-extra \
-    texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended\
+    texlive-latex-recommended texlive-fonts-recommended \
     latexmk gsfonts build-essential
 
 # deactivate circleci virtualenv and setup a miniconda env instead

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -101,7 +101,7 @@ apt-get -yq remove texlive-binaries --purge
 apt-get -yq --no-install-suggests --no-install-recommends --force-yes \
     install dvipng texlive-latex-base texlive-latex-extra \
     texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended\
-    latexmk gsfonts
+    latexmk gsfonts build-essential
 
 # deactivate circleci virtualenv and setup a miniconda env instead
 if [[ `type -t deactivate` ]]; then

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -96,17 +96,23 @@ make_args="SPHINXOPTS=-T $make_args"  # show full traceback on exception
 
 # Installing required system packages to support the rendering of math
 # notation in the HTML documentation
-apt-get -yq update
-apt-get -yq remove texlive-binaries --purge
-apt-get -yq --no-install-suggests --no-install-recommends \
+sudo -E apt-get -yq update
+sudo -E apt-get -yq remove texlive-binaries --purge
+sudo -E apt-get -yq --no-install-suggests --no-install-recommends \
     install dvipng texlive-latex-base texlive-latex-extra \
     texlive-latex-recommended texlive-fonts-recommended \
-    latexmk gsfonts build-essential
+    latexmk gsfonts
 
 # deactivate circleci virtualenv and setup a miniconda env instead
 if [[ `type -t deactivate` ]]; then
   deactivate
 fi
+
+# Install dependencies with miniconda
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+   -O miniconda.sh
+chmod +x miniconda.sh && ./miniconda.sh -b -p $MINICONDA_PATH
+export PATH="$MINICONDA_PATH/bin:$PATH"
 
 # Configure the conda environment and put it in the path using the
 # provided versions


### PR DESCRIPTION
This PR uses debian stretch as the base image **explicitly** for doc building.

(jessie had apt bugs https://discuss.circleci.com/t/convenience-images-update-changes-to-debian-mirror-for-browsers-tagged-image-variants/29293)