### PR TITLE
MAINT: n_jobs=-1 replaced with n_jobs=4 in tests

### DIFF
--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -106,10 +106,10 @@ def test_dict_learning_reconstruction():
 
 
 def test_dict_learning_reconstruction_parallel():
-    # regression test that parallel reconstruction works with n_jobs=-1
+    # regression test that parallel reconstruction works with n_jobs>1
     n_components = 12
     dico = DictionaryLearning(n_components, transform_algorithm='omp',
-                              transform_alpha=0.001, random_state=0, n_jobs=-1)
+                              transform_alpha=0.001, random_state=0, n_jobs=4)
     code = dico.fit(X).transform(X)
     assert_array_almost_equal(np.dot(code, dico.components_), X)
 
@@ -123,7 +123,7 @@ def test_dict_learning_lassocd_readonly_data():
     with TempMemmap(X) as X_read_only:
         dico = DictionaryLearning(n_components, transform_algorithm='lasso_cd',
                                   transform_alpha=0.001, random_state=0,
-                                  n_jobs=-1)
+                                  n_jobs=4)
         with ignore_warnings(category=ConvergenceWarning):
             code = dico.fit(X_read_only).transform(X_read_only)
         assert_array_almost_equal(np.dot(code, dico.components_), X_read_only,

--- a/sklearn/linear_model/tests/test_theil_sen.py
+++ b/sklearn/linear_model/tests/test_theil_sen.py
@@ -259,7 +259,7 @@ def test_theil_sen_parallel():
     lstq = LinearRegression().fit(X, y)
     assert_greater(norm(lstq.coef_ - w), 1.0)
     # Check that Theil-Sen works
-    theil_sen = TheilSenRegressor(n_jobs=-1,
+    theil_sen = TheilSenRegressor(n_jobs=4,
                                   random_state=0,
                                   max_subpopulation=2e3).fit(X, y)
     assert_array_almost_equal(theil_sen.coef_, w, 1)

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -166,7 +166,7 @@ classes = list(map(np.unique, (y1, y2, y3)))
 
 def test_multi_output_classification_partial_fit_parallelism():
     sgd_linear_clf = SGDClassifier(loss='log', random_state=1, max_iter=5)
-    mor = MultiOutputClassifier(sgd_linear_clf, n_jobs=-1)
+    mor = MultiOutputClassifier(sgd_linear_clf, n_jobs=4)
     mor.partial_fit(X, y, classes)
     est1 = mor.estimators_[0]
     mor.partial_fit(X, y)


### PR DESCRIPTION
This change is to work around the hang

 https://github.com/scikit-learn/scikit-learn/issues/12263

afflicting Windows on machines with > 62 hyper-threads.

@jnothman 
