### PR TITLE
MAINT: adjustments to test_logistic.py::test_dtype_match

### DIFF
--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1312,7 +1312,7 @@ def test_dtype_match(solver, multi_class):
     X_64 = np.array(X).astype(np.float64)
     y_64 = np.array(Y1).astype(np.float64)
     X_sparse_32 = sp.csr_matrix(X, dtype=np.float32)
-    solver_tol = 1e-5
+    solver_tol = 5e-4
 
     lr_templ = LogisticRegression(
         solver=solver, multi_class=multi_class,
@@ -1333,13 +1333,16 @@ def test_dtype_match(solver, multi_class):
     assert_equal(lr_64.coef_.dtype, X_64.dtype)
 
     # solver_tol bounds the norm of the loss gradient
-    # dw ~= inv(H)*grad ==>  |dw| ~= |inv(H)| * solver_tol, where H - hessian
+    # dw ~= inv(H)*grad ==> |dw| ~= |inv(H)| * solver_tol, where H - hessian
+    #
+    # See https://github.com/scikit-learn/scikit-learn/pull/13645
     #
     # with  Z = np.hstack((np.ones((3,1)), np.array(X)))
-    # In [18]: np.linalg.norm(np.linalg.inv(0.25 * Z.T @ Z))
-    # Out[18]: 41.32740565066648
+    # In [8]: np.linalg.norm(np.diag([0,2,2]) + np.linalg.inv((Z.T @ Z)/4))
+    # Out[8]: 1.7193336918135917
 
-    atol = 10*solver_tol
+    # factor of 2 to get the ball diameter
+    atol = 2 * 1.72 * solver_tol
     if os.name == 'nt' and _IS_32BIT:
         # FIXME
         atol = 1e-2


### PR DESCRIPTION
When using Intel (R) DAAL to compute logistic loss and gradient with `solver='newton-cg'` the [test `test_dtype_match`](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/linear_model/tests/test_logistic.py#L1363-1396) would [fail the last assertion](https://github.com/IntelPython/daal4py/issues/86), because coefficients computed in single and double precisions would only agree with relative tolerance of 3e-5, rather than 1e-6.

The change introduces use of `tol=solver_tol` in the logistic regression setup,  and derives absolute tolerance in parameter comparison from the data and the `solver_tol`.

The derivation starts with `dw ~= inv(H).grad`, where `grad` and `H` are the gradient and the Hessian at the solution, and `dw` is the distance to the true minimizer. The `solver_tol` bounds the norm of the gradient, and so one should use absolute tolerance of `norm(inv(H)) * solver_tol` when comparing  single and double precision solutions.

@ogrisel @jeremiedbb 