### PR TITLE
[MRG] Improve performance of the plot_rbm_logistic_classification.py example (#13383)

### DIFF
--- a/examples/neural_networks/plot_rbm_logistic_classification.py
+++ b/examples/neural_networks/plot_rbm_logistic_classification.py
@@ -85,7 +85,7 @@ X_train, X_test, Y_train, Y_test = train_test_split(
     X, Y, test_size=0.2, random_state=0)
 
 # Models we will use
-logistic = linear_model.LogisticRegression(solver='newton-cg',
+logistic = linear_model.LogisticRegression(solver='newton-cg', tol=1,
                                            multi_class='multinomial')
 rbm = BernoulliRBM(random_state=0, verbose=True)
 

--- a/examples/neural_networks/plot_rbm_logistic_classification.py
+++ b/examples/neural_networks/plot_rbm_logistic_classification.py
@@ -85,7 +85,7 @@ X_train, X_test, Y_train, Y_test = train_test_split(
     X, Y, test_size=0.2, random_state=0)
 
 # Models we will use
-logistic = linear_model.LogisticRegression(solver='lbfgs', max_iter=10000,
+logistic = linear_model.LogisticRegression(solver='newton-cg', max_iter=10000,
                                            multi_class='multinomial')
 rbm = BernoulliRBM(random_state=0, verbose=True)
 

--- a/examples/neural_networks/plot_rbm_logistic_classification.py
+++ b/examples/neural_networks/plot_rbm_logistic_classification.py
@@ -85,7 +85,7 @@ X_train, X_test, Y_train, Y_test = train_test_split(
     X, Y, test_size=0.2, random_state=0)
 
 # Models we will use
-logistic = linear_model.LogisticRegression(solver='newton-cg', max_iter=10000,
+logistic = linear_model.LogisticRegression(solver='newton-cg',
                                            multi_class='multinomial')
 rbm = BernoulliRBM(random_state=0, verbose=True)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Partial fix to #13383 

#### What does this implement/fix? Explain your changes.

The example `examples/neural_networks/plot_rbm_logistic_classification.py` mentioned in #13383 takes a total of 32.5 seconds to build in html (on my computer). By replacing the solver used in the logistic regression from `lbfgs` to `newton-cg`, the example took 22.0 seconds to build.

The LogisticRegression is trained twice, once on RBM features in a pipeline and once on raw pixel features, but only the first one is time-consuming because of a slow convergence. `lbfgs` took 4474 iterations to converge, whereas `newton-cg` converges in 43 iterations. 

The performance metrics are exactly similar for the logistic regression using RBM features (at the reported precision). Only very slight differences occur in metrics of the logistic regression trained on raw pixel features (highlighted below).

```
Solver: newton-cg
Logistic regression using RBM features:
              precision    recall  f1-score   support

           0       0.98      0.98      0.98       174
           1       0.93      0.92      0.93       184
           2       0.93      0.97      0.95       166
           3       0.95      0.92      0.93       194
           4       0.95      0.94      0.95       186
           5       0.93      0.94      0.93       181
           6       0.98      0.97      0.97       207
           7       0.93      0.98      0.95       154
           8       0.92      0.88      0.90       182
           9       0.91      0.93      0.92       169

    accuracy                           0.94      1797
   macro avg       0.94      0.94      0.94      1797
weighted avg       0.94      0.94      0.94      1797

Solver: lbfgs
Logistic regression using RBM features:
              precision    recall  f1-score   support

           0       0.98      0.98      0.98       174
           1       0.93      0.92      0.93       184
           2       0.93      0.97      0.95       166
           3       0.95      0.92      0.93       194
           4       0.95      0.94      0.95       186
           5       0.93      0.94      0.93       181
           6       0.98      0.97      0.97       207
           7       0.93      0.98      0.95       154
           8       0.92      0.88      0.90       182
           9       0.91      0.93      0.92       169

    accuracy                           0.94      1797
   macro avg       0.94      0.94      0.94      1797
weighted avg       0.94      0.94      0.94      1797
```

```
Solver: newton-cg
Logistic regression using raw pixel features:
              precision    recall  f1-score   support

           0       0.90      0.93      0.91       174
           1       0.60      0.59      0.59       184
           2       0.75      0.85      0.80       166
           3      *0.77*     0.79      0.78       194
           4       0.81      0.84      0.82       186
           5       0.77      0.75      0.76       181
           6       0.90      0.87      0.89       207
           7       0.86      0.88      0.87       154
           8       0.67     *0.58*   *0.62*       182
           9       0.75      0.76      0.76       169

    accuracy                           0.78      1797
   macro avg       0.78      0.78      0.78      1797
weighted avg       0.78      0.78      0.78      1797

Solver: lbfgs
Logistic regression using raw pixel features:
              precision    recall  f1-score   support

           0       0.90      0.93      0.91       174
           1       0.60      0.59      0.59       184
           2       0.75      0.85      0.80       166
           3      *0.78*     0.79      0.78       194
           4       0.81      0.84      0.82       186
           5       0.77      0.75      0.76       181
           6       0.90      0.87      0.89       207
           7       0.86      0.88      0.87       154
           8       0.67     *0.59*    *0.63*     182
           9       0.75      0.76      0.76       169

    accuracy                           0.78      1797
   macro avg       0.78      0.78      0.78      1797
weighted avg       0.78      0.78      0.78      1797
```


#### Any other comments?

`newton-cg` was the quicker compatible solver to trained the logistic regression on RBM features. Below are the times it took to train it:
 - newton-cg: 00:14.096810
 - lbfgs: 00:22.904742
 - sag: 01:38.606006
 - saga: 02:13.611261

I welcome any other idea that may save more time on this example.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
