### PR TITLE
Fix plot_coin_segamentation speed issue #13383

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -126,6 +126,7 @@ conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
 source activate testenv
 pip install "sphinx-gallery>=0.2,<0.3"
 pip install numpydoc==0.8
+pip install --upgrade pyamg
 
 # Build and install scikit-learn in dev mode
 python setup.py develop

--- a/examples/cluster/plot_coin_segmentation.py
+++ b/examples/cluster/plot_coin_segmentation.py
@@ -72,7 +72,8 @@ N_REGIONS = 25
 for assign_labels in ('kmeans', 'discretize'):
     t0 = time.time()
     labels = spectral_clustering(graph, n_clusters=N_REGIONS,
-                                 assign_labels=assign_labels, random_state=42)
+                                 assign_labels=assign_labels, random_state=42,
+                                 eigen_solver='amg')
     t1 = time.time()
     labels = labels.reshape(rescaled_coins.shape)
 


### PR DESCRIPTION

I changed the eigen_solver to 'amg' in the function sklearn.cluster.SpectralClustering. The runtime on CircleCI is 4.4 sec after the change.

