### PR TITLE
Fix 4/5 todo comments in glossary (issue #13533)

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -811,14 +811,14 @@ Class APIs and Estimator Types
 
     density estimator
         An :term:`unsupervised` estimation of input density without a labeled response.
-        Most commonly used techniques are `Histograms <https://scikit-learn.org/stable/modules/density.html#density-estimation-histograms>`_, 
-        `GaussianMixture`, 
+        Most commonly used techniques are `Histograms <https://scikit-learn.org/stable/modules/density.html#density-estimation-histograms>`_,
+        `GaussianMixture`,
         and `KernelDensity` estimation.
 
         * `Histograms <https://scikit-learn.org/stable/modules/density.html#density-estimation-histograms>`_
           visually represents the density of specific bins.
-        * Gaussian Mixtures are discussed in `Clustering`. 
-        * Kernel density estimation has multiple forms to represent density based on bandwidth.
+        * Gaussian Mixtures are discussed in `Clustering`.
+        * Kernel density estimation has multiple forms to represent density based on the chosen kernel and associated bandwidth.
 
         It can also be performed on a multi-dimensional graph.
 
@@ -1147,11 +1147,11 @@ Methods
             :term:`classes_`.
         multilabel classification
             Scikit-learn is inconsistent in its representation of multilabel
-            decision functions. Multi-output multiclass classifiers 
+            decision functions. Multi-output multiclass classifiers
             (eg. ``RandomForestClassifier``) represent it as a list of 2d arrays.
             Multilabel classifiers (eg. ``OneVsRestClassifier``)
-            represent it as a single 2d array, where columns correspond to the 
-            individual binary classification decisions. These scores should be 
+            represent it as a single 2d array, where columns correspond to the
+            individual binary classification decisions. These scores should be
             threshold at 0.
         multioutput classification
             A list of 2d arrays, corresponding to each multiclass decision
@@ -1341,12 +1341,13 @@ Methods
         often the likelihood of the data under the model.
 
     ``score_samples``
-        A method on an array of data points, which evaluates its predictions on
-        the given dataset, and returns an array consisting of log evaluations
-        for each.
+        A method that returns the likelihood of given samples.
 
-        It returns low values for high-dimensional data since evaluations are
-        normalized to probability densities. 
+        For density estimation, it returns the value (log) of the density of the
+        samples.
+
+        For outlier detection, it returns a score for the sample based on its
+        likelihood (thus if it is an outlier, it's not likely at all).
 
         If the estimator was not already :term:`fitted`, calling this method
         should raise a :class:`exceptions.NotFittedError`.

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -810,16 +810,17 @@ Class APIs and Estimator Types
         * :term:`predict` if :term:`inductive`
 
     density estimator
-        A :term:'unsupervised' :term:'estimator' estimating density of dataset inputs without 
-        labeled response
-        Most commonly used techniques are `Histogram <https://scikit-learn.org/stable/modules/density.html>`_, 
-        `Gaussian Mixtures <https://scikit-learn.org/stable/modules/generated/sklearn.mixture.GaussianMixture.html#sklearn.mixture.GaussianMixture>`_, 
-        and `kernel density estimate <https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KernelDensity.html#sklearn.neighbors.KernelDensity>`_
-        * Histogram- visually represent density of specific bins
-        * Gaussian Mixtures are discussed in `Clustering <https://scikit-learn.org/stable/modules/clustering.html#clustering>`_ 
-        * Kernel density estimate have multiple forms to represent density 
-          based on bandwidth 
-        It can also perform on multi-dimension graph
+        An :term:`unsupervised` estimation of input density without a labeled response.
+        Most commonly used techniques are `Histograms <https://scikit-learn.org/stable/modules/density.html#density-estimation-histograms>`_, 
+        `GaussianMixture`, 
+        and `KernelDensity` estimation.
+
+        * `Histograms <https://scikit-learn.org/stable/modules/density.html#density-estimation-histograms>`_
+          visually represents the density of specific bins.
+        * Gaussian Mixtures are discussed in `Clustering`. 
+        * Kernel density estimation has multiple forms to represent density based on bandwidth.
+
+        It can also be performed on a multi-dimensional graph.
 
     estimator
     estimators

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1137,17 +1137,12 @@ Methods
             :term:`classes_`.
         multilabel classification
             Scikit-learn is inconsistent in its representation of multilabel
-            decision functions.  Some estimators represent it like multiclass
-            multioutput, i.e. a list of 2d arrays, each with two columns. Others
-            represent it with a single 2d array, whose columns correspond to
-            the individual binary classification decisions. The latter
-            representation is ambiguously identical to the multiclass
-            classification format, though its semantics differ: it should be
-            interpreted, like in the binary case, by thresholding at 0.
-
-            TODO: `This gist
-            <https://gist.github.com/jnothman/4807b1b0266613c20ba4d1f88d0f8cf5>`_
-            higlights the use of the different formats for multilabel.
+            decision functions. Multi-output multiclass classifiers 
+            (eg. ``RandomForestClassifier``) represent it as a list of 2d arrays.
+            Multilabel classifiers (eg. ``OneVsRestClassifier``)
+            represent it as a single 2d array, where columns correspond to the 
+            individual binary classification decisions. These scores should be 
+            threshold at 0.
         multioutput classification
             A list of 2d arrays, corresponding to each multiclass decision
             function.

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1336,7 +1336,12 @@ Methods
         often the likelihood of the data under the model.
 
     ``score_samples``
-        TODO
+        A method on an array of data points, which evaluates its predictions on
+        the given dataset, and returns an array consisting of log evaluations
+        for each.
+
+        It returns low values for high-dimensional data since evaluations are
+        normalized to probability densities. 
 
         If the estimator was not already :term:`fitted`, calling this method
         should raise a :class:`exceptions.NotFittedError`.
@@ -1439,7 +1444,7 @@ functions or non-estimator constructors.
         ``cv`` values are validated and interpreted with :func:`utils.check_cv`.
 
     ``kernel``
-        
+
         Kernels refer to a set of functions which are used by a series of algorithms
         called Kernel Methods.
         One such example of a kernel is the Radial Basis Function, `RBF`:

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1439,7 +1439,21 @@ functions or non-estimator constructors.
         ``cv`` values are validated and interpreted with :func:`utils.check_cv`.
 
     ``kernel``
-        TODO
+        
+        Kernels refer to a set of functions which are used by a series of algorithms
+        called Kernel Methods.
+        One such example of a kernel is the Radial Basis Function, `RBF`:
+
+            k(x_i, x_j) = exp(-1 / 2 d(x_i / length_scale, x_j / length_scale)^2)
+
+        Kernels are often set as a parameter of their parent algorithm like `SVC`
+        or `GaussianProcessClassifier` for example.
+
+        In both of these situations, the algorithm provides a ``kernel`` named parameter. For `SVC` this is a string object,
+        and for `GaussianProcessClassifier` this is a kernel object from :ref:`kernels <gp_kernels>`.
+        For Gaussian Process algorithms in particular, these inherit from the `Kernel` class.
+
+        For more infomration on Kernel Methods: https://en.wikipedia.org/wiki/Kernel_method
 
     ``max_iter``
         For estimators involving iterative optimization, this determines the

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -810,7 +810,16 @@ Class APIs and Estimator Types
         * :term:`predict` if :term:`inductive`
 
     density estimator
-        TODO
+        A :term:'unsupervised' :term:'estimator' estimating density of dataset inputs without 
+        labeled response
+        Most commonly used techniques are `Histogram <https://scikit-learn.org/stable/modules/density.html>`_, 
+        `Gaussian Mixtures <https://scikit-learn.org/stable/modules/generated/sklearn.mixture.GaussianMixture.html#sklearn.mixture.GaussianMixture>`_, 
+        and `kernel density estimate <https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KernelDensity.html#sklearn.neighbors.KernelDensity>`_
+        * Histogram- visually represent density of specific bins
+        * Gaussian Mixtures are discussed in `Clustering <https://scikit-learn.org/stable/modules/clustering.html#clustering>`_ 
+        * Kernel density estimate have multiple forms to represent density 
+          based on bandwidth 
+        It can also perform on multi-dimension graph
 
     estimator
     estimators


### PR DESCRIPTION
I found 5 "todo" comments in the Glossary, and added definitions for 4 out of 5 of them.
Partially fixes #13533.

The definitions I've provided come from me and my team and are for the following terms (previously left blank with "todo" comment):
1) Kernel
2) score_samples
3) density_estimator
4) Multilabel classification 