### PR TITLE
[MRG] Removed synonyms in docs linear_model

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -296,7 +296,7 @@ features are the same for all the regression problems, also called tasks.
 
 The following figure compares the location of the non-zero entries in the
 coefficient matrix W obtained with a simple Lasso or a MultiTaskLasso.
-The Lasso estimates yields scattered non-zeros while the non-zeros of
+The Lasso estimates yield scattered non-zeros while the non-zeros of
 the MultiTaskLasso are full columns.
 
 .. |multi_task_lasso_1| image:: ../auto_examples/linear_model/images/sphx_glr_plot_multi_task_lasso_support_001.png

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -19,7 +19,6 @@ Across the module, we designate the vector :math:`w = (w_1,
 To perform classification with generalized linear models, see
 :ref:`Logistic_regression`.
 
-
 .. _ordinary_least_squares:
 
 Ordinary Least Squares
@@ -27,8 +26,8 @@ Ordinary Least Squares
 
 :class:`LinearRegression` fits a linear model with coefficients
 :math:`w = (w_1, ..., w_p)` to minimize the residual sum
-of squares between the observed responses in the dataset, and the
-responses predicted by the linear approximation. Mathematically it
+of squares between the observed targets in the dataset, and the
+targets predicted by the linear approximation. Mathematically it
 solves a problem of the form:
 
 .. math:: \min_{w} || X w - y||_2^2
@@ -56,7 +55,7 @@ independence of the features. When features are correlated and the
 columns of the design matrix :math:`X` have an approximate linear
 dependence, the design matrix becomes close to singular
 and as a result, the least-squares estimate becomes highly sensitive
-to random errors in the observed response, producing a large
+to random errors in the observed target, producing a large
 variance. This situation of *multicollinearity* can arise, for
 example, when data are collected without an experimental design.
 
@@ -163,7 +162,7 @@ Lasso
 The :class:`Lasso` is a linear model that estimates sparse coefficients.
 It is useful in some contexts due to its tendency to prefer solutions
 with fewer non-zero coefficients, effectively reducing the number of
-variables upon which the given solution is dependent. For this reason, the
+features upon which the given solution is dependent. For this reason, the
 Lasso and its variants are fundamental to the field of compressed sensing.
 Under certain conditions, it can recover the exact set of non-zero
 coefficients (see
@@ -172,7 +171,7 @@ coefficients (see
 Mathematically, it consists of a linear model with an added regularization term.
 The objective function to minimize is:
 
-.. math::  \min_{w} { \frac{1}{2n_{samples}} ||X w - y||_2 ^ 2 + \alpha ||w||_1}
+.. math::  \min_{w} { \frac{1}{2n_{\text{samples}}} ||X w - y||_2 ^ 2 + \alpha ||w||_1}
 
 The lasso estimate thus solves the minimization of the
 least-squares penalty with :math:`\alpha ||w||_1` added, where
@@ -225,7 +224,7 @@ the duality gap computation used for convergence control.
 Setting regularization parameter
 --------------------------------
 
-The ``alpha`` parameter controls the degree of sparsity of the esimated
+The ``alpha`` parameter controls the degree of sparsity of the estimated
 coefficients.
 
 Using cross-validation
@@ -423,7 +422,7 @@ Least-angle regression (LARS) is a regression algorithm for
 high-dimensional data, developed by Bradley Efron, Trevor Hastie, Iain
 Johnstone and Robert Tibshirani. LARS is similar to forward stepwise
 regression. At each step, it finds the feature most correlated with the
-response. When there are multiple features having equal correlation, instead
+target. When there are multiple features having equal correlation, instead
 of continuing along the same feature, it proceeds in a direction equiangular
 between the features.
 
@@ -439,7 +438,7 @@ The advantages of LARS are:
   - It produces a full piecewise linear solution path, which is
     useful in cross-validation or similar attempts to tune the model.
 
-  - If two variables are almost equally correlated with the response,
+  - If two features are almost equally correlated with the target,
     then their coefficients should increase at approximately the same
     rate. The algorithm thus behaves as intuition would expect, and
     also is more stable.
@@ -496,7 +495,7 @@ Mathematical formulation
 ------------------------
 
 The algorithm is similar to forward stepwise regression, but instead
-of including variables at each step, the estimated parameters are
+of including features at each step, the estimated coefficients are
 increased in a direction equiangular to each one's correlations with
 the residual.
 
@@ -592,7 +591,6 @@ The disadvantages of Bayesian regression include:
 
     - Inference of the model can be time consuming.
 
-
 .. topic:: References
 
  * A good introduction to Bayesian methods is given in C. Bishop: Pattern
@@ -654,7 +652,6 @@ After being fitted, the model can then be used to predict new values::
 
     >>> reg.predict([[1, 0.]])
     array([0.50000013])
-
 
 The coefficients :math:`w` of the model can be accessed::
 
@@ -724,7 +721,6 @@ ARD is also known in the literature as *Sparse Bayesian Learning* and
     .. [4] Tristan Fletcher: `Relevance Vector Machines explained <http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.651.8603&rep=rep1&type=pdf>`_
 
 
-
 .. _Logistic_regression:
 
 Logistic regression
@@ -742,8 +738,8 @@ class :class:`LogisticRegression`. This implementation can fit binary, One-vs-
 Rest, or multinomial logistic regression with optional :math:`\ell_1`, :math:`\ell_2`
 or Elastic-Net regularization. Note that regularization is applied by default.
 
-As an optimization problem, binary class :math:`\ell_2` penalized logistic regression
-minimizes the following cost function:
+As an optimization problem, binary class :math:`\ell_2` penalized logistic
+regression minimizes the following cost function:
 
 .. math:: \min_{w, c} \frac{1}{2}w^T w + C \sum_{i=1}^n \log(\exp(- y_i (X_i^T w + c)) + 1) .
 
@@ -760,7 +756,7 @@ Elastic-Net regularization is a combination of :math:`\ell_1` and
 where :math:`\rho` controls the strength of :math:`\ell_1` regularization vs.
 :math:`\ell_2` regularization (it corresponds to the `l1_ratio` parameter).
 
-Note that, in this notation, it's assumed that the observation :math:`y_i` takes
+Note that, in this notation, it's assumed that the target :math:`y_i` takes
 values in the set :math:`{-1, 1}` at trial :math:`i`. We can also see that
 Elastic-Net is equivalent to :math:`\ell_1` when :math:`\rho = 1` and equivalent
 to :math:`\ell_2` when :math:`\rho=0`.
@@ -782,7 +778,7 @@ weights to zero) model.
 
 The "lbfgs", "sag" and "newton-cg" solvers only support :math:`\ell_2`
 regularization or no regularization, and are found to converge faster for some
-high dimensional data. Setting `multi_class` to "multinomial" with these solvers
+high-dimensional data. Setting `multi_class` to "multinomial" with these solvers
 learns a true multinomial logistic regression model [5]_, which means that its
 probability estimates should be better calibrated than the default "one-vs-rest"
 setting.
@@ -1028,7 +1024,7 @@ in these settings.
 
   * :ref:`Theil Sen <theil_sen_regression>` will cope better with
     medium-size outliers in the X direction, but this property will
-    disappear in large dimensional settings.
+    disappear in high-dimensional settings.
 
  When in doubt, use :ref:`RANSAC <ransac_regression>`.
 
@@ -1250,7 +1246,7 @@ the features in second-order polynomials, so that the model looks like this:
 .. math::    \hat{y}(w, x) = w_0 + w_1 x_1 + w_2 x_2 + w_3 x_1 x_2 + w_4 x_1^2 + w_5 x_2^2
 
 The (sometimes surprising) observation is that this is *still a linear model*:
-to see this, imagine creating a new variable
+to see this, imagine creating a new set of features
 
 .. math::  z = [x_1, x_2, x_1 x_2, x_1^2, x_2^2]
 

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -7,8 +7,8 @@ Generalized Linear Models
 .. currentmodule:: sklearn.linear_model
 
 The following are a set of methods intended for regression in which
-the target value is expected to be a linear combination of the input
-variables. In mathematical notion, if :math:`\hat{y}` is the predicted
+the target value is expected to be a linear combination of the features.
+In mathematical notation, if :math:`\hat{y}` is the predicted
 value.
 
 .. math::    \hat{y}(w, x) = w_0 + w_1 x_1 + ... + w_p x_p
@@ -31,7 +31,7 @@ of squares between the observed responses in the dataset, and the
 responses predicted by the linear approximation. Mathematically it
 solves a problem of the form:
 
-.. math:: \min_{w} {|| X w - y||_2}^2
+.. math:: \min_{w} || X w - y||_2^2
 
 .. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_ols_001.png
    :target: ../auto_examples/linear_model/plot_ols.html
@@ -51,8 +51,8 @@ and will store the coefficients :math:`w` of the linear model in its
     >>> reg.coef_
     array([0.5, 0.5])
 
-However, coefficient estimates for Ordinary Least Squares rely on the
-independence of the model terms. When terms are correlated and the
+The coefficient estimates for Ordinary Least Squares rely on the
+independence of the features. When features are correlated and the
 columns of the design matrix :math:`X` have an approximate linear
 dependence, the design matrix becomes close to singular
 and as a result, the least-squares estimate becomes highly sensitive
@@ -68,8 +68,8 @@ example, when data are collected without an experimental design.
 Ordinary Least Squares Complexity
 ---------------------------------
 
-This method computes the least squares solution using a singular value
-decomposition of X. If X is a matrix of size (n, p) this method has a
+The least squares solution is computed using the singular value
+decomposition of X. If X is a matrix of shape (n, p) this method has a
 cost of :math:`O(n p^2)`, assuming that :math:`n \geq p`.
 
 .. _ridge_regression:
@@ -78,17 +78,17 @@ Ridge Regression
 ================
 
 :class:`Ridge` regression addresses some of the problems of
-:ref:`ordinary_least_squares` by imposing a penalty on the size of
+:ref:`ordinary_least_squares` by imposing a penalty on the size of the
 coefficients. The ridge coefficients minimize a penalized residual sum
-of squares,
+of squares.
 
 
 .. math::
 
-   \min_{w} {{|| X w - y||_2}^2 + \alpha {||w||_2}^2}
+   \min_{w} || X w - y||_2^2 + \alpha ||w||_2^2
 
 
-Here, :math:`\alpha \geq 0` is a complexity parameter that controls the amount
+The complexity parameter :math:`\alpha \geq 0` controls the amount
 of shrinkage: the larger the value of :math:`\alpha`, the greater the amount
 of shrinkage and thus the coefficients become more robust to collinearity.
 
@@ -122,7 +122,7 @@ its ``coef_`` member::
 Ridge Complexity
 ----------------
 
-This method has the same order of complexity than an
+This method has the same order of complexity as
 :ref:`ordinary_least_squares`.
 
 .. FIXME:
@@ -162,22 +162,22 @@ Lasso
 
 The :class:`Lasso` is a linear model that estimates sparse coefficients.
 It is useful in some contexts due to its tendency to prefer solutions
-with fewer parameter values, effectively reducing the number of variables
-upon which the given solution is dependent. For this reason, the Lasso
-and its variants are fundamental to the field of compressed sensing.
+with fewer non-zero coefficients, effectively reducing the number of
+variables upon which the given solution is dependent. For this reason, the
+Lasso and its variants are fundamental to the field of compressed sensing.
 Under certain conditions, it can recover the exact set of non-zero
-weights (see
+coefficients (see
 :ref:`sphx_glr_auto_examples_applications_plot_tomography_l1_reconstruction.py`).
 
-Mathematically, it consists of a linear model trained with :math:`\ell_1` prior
-as regularizer. The objective function to minimize is:
+Mathematically, it consists of a linear model with an added regularization term.
+The objective function to minimize is:
 
 .. math::  \min_{w} { \frac{1}{2n_{samples}} ||X w - y||_2 ^ 2 + \alpha ||w||_1}
 
 The lasso estimate thus solves the minimization of the
 least-squares penalty with :math:`\alpha ||w||_1` added, where
 :math:`\alpha` is a constant and :math:`||w||_1` is the :math:`\ell_1`-norm of
-the parameter vector.
+the coefficient vector.
 
 The implementation in the class :class:`Lasso` uses coordinate descent as
 the algorithm to fit the coefficients. See :ref:`least_angle_regression`
@@ -192,7 +192,7 @@ for another implementation::
     >>> reg.predict([[1, 1]])
     array([0.8])
 
-Also useful for lower-level tasks is the function :func:`lasso_path` that
+The function :func:`lasso_path` is useful for lower-level tasks, as it
 computes the coefficients along the full path of possible values.
 
 .. topic:: Examples:
@@ -225,8 +225,8 @@ the duality gap computation used for convergence control.
 Setting regularization parameter
 --------------------------------
 
-The ``alpha`` parameter controls the degree of sparsity of the coefficients
-estimated.
+The ``alpha`` parameter controls the degree of sparsity of the esimated
+coefficients.
 
 Using cross-validation
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -236,7 +236,7 @@ cross-validation: :class:`LassoCV` and :class:`LassoLarsCV`.
 :class:`LassoLarsCV` is based on the :ref:`least_angle_regression` algorithm
 explained below.
 
-For high-dimensional datasets with many collinear regressors,
+For high-dimensional datasets with many collinear features,
 :class:`LassoCV` is most often preferable. However, :class:`LassoLarsCV` has
 the advantage of exploring more relevant values of `alpha` parameter, and
 if the number of samples is very small compared to the number of
@@ -295,10 +295,10 @@ coefficients for multiple regression problems jointly: ``y`` is a 2D array,
 of shape ``(n_samples, n_tasks)``. The constraint is that the selected
 features are the same for all the regression problems, also called tasks.
 
-The following figure compares the location of the non-zeros in W obtained
-with a simple Lasso or a MultiTaskLasso. The Lasso estimates yields
-scattered non-zeros while the non-zeros of the MultiTaskLasso are full
-columns.
+The following figure compares the location of the non-zero entries in the
+coefficient matrix W obtained with a simple Lasso or a MultiTaskLasso.
+The Lasso estimates yields scattered non-zeros while the non-zeros of
+the MultiTaskLasso are full columns.
 
 .. |multi_task_lasso_1| image:: ../auto_examples/linear_model/images/sphx_glr_plot_multi_task_lasso_support_001.png
     :target: ../auto_examples/linear_model/plot_multi_task_lasso_support.html
@@ -318,46 +318,47 @@ columns.
 
 
 Mathematically, it consists of a linear model trained with a mixed
-:math:`\ell_1` :math:`\ell_2` prior as regularizer.
+:math:`\ell_1` :math:`\ell_2`-norm for regularization.
 The objective function to minimize is:
 
-.. math::  \min_{w} { \frac{1}{2n_{samples}} ||X W - Y||_{Fro} ^ 2 + \alpha ||W||_{21}}
+.. math::  \min_{w} { \frac{1}{2n_{\text{samples}}} ||X W - Y||_{\text{Fro}} ^ 2 + \alpha ||W||_{21}}
 
-where :math:`Fro` indicates the Frobenius norm:
+where :math:`\text{Fro}` indicates the Frobenius norm
 
-.. math:: ||A||_{Fro} = \sqrt{\sum_{ij} a_{ij}^2}
+.. math:: ||A||_{\text{Fro}} = \sqrt{\sum_{ij} a_{ij}^2}
 
-and :math:`\ell_1` :math:`\ell_2` reads:
+and :math:`\ell_1` :math:`\ell_2` reads
 
-.. math:: ||A||_{2 1} = \sum_i \sqrt{\sum_j a_{ij}^2}
+.. math:: ||A||_{2 1} = \sum_i \sqrt{\sum_j a_{ij}^2}.
 
-
-The implementation in the class :class:`MultiTaskLasso` uses coordinate descent as
-the algorithm to fit the coefficients.
+The implementation in the class :class:`MultiTaskLasso` uses
+coordinate descent as the algorithm to fit the coefficients.
 
 
 .. _elastic_net:
 
 Elastic-Net
 ===========
-:class:`ElasticNet` is a linear regression model trained with L1 and L2 prior
-as regularizer. This combination allows for learning a sparse model where
-few of the weights are non-zero like :class:`Lasso`, while still maintaining
+:class:`ElasticNet` is a linear regression model trained with both
+:math:`\ell_1` and :math:`\ell_2`-norm regularization of the coefficients.
+This combination  allows for learning a sparse model where few of
+the weights are non-zero like :class:`Lasso`, while still maintaining
 the regularization properties of :class:`Ridge`. We control the convex
-combination of L1 and L2 using the ``l1_ratio`` parameter.
+combination of :math:`\ell_1` and :math:`\ell_2` using the ``l1_ratio``
+parameter.
 
 Elastic-net is useful when there are multiple features which are
 correlated with one another. Lasso is likely to pick one of these
 at random, while elastic-net is likely to pick both.
 
-A practical advantage of trading-off between Lasso and Ridge is it allows
-Elastic-Net to inherit some of Ridge's stability under rotation.
+A practical advantage of trading-off between Lasso and Ridge is that it
+allows Elastic-Net to inherit some of Ridge's stability under rotation.
 
 The objective function to minimize is in this case
 
 .. math::
 
-    \min_{w} { \frac{1}{2n_{samples}} ||X w - y||_2 ^ 2 + \alpha \rho ||w||_1 +
+    \min_{w} { \frac{1}{2n_{\text{samples}}} ||X w - y||_2 ^ 2 + \alpha \rho ||w||_1 +
     \frac{\alpha(1-\rho)}{2} ||w||_2 ^ 2}
 
 
@@ -394,25 +395,24 @@ Multi-task Elastic-Net
 ======================
 
 The :class:`MultiTaskElasticNet` is an elastic-net model that estimates sparse
-coefficients for multiple regression problems jointly: ``Y`` is a 2D array,
+coefficients for multiple regression problems jointly: ``Y`` is a 2D array
 of shape ``(n_samples, n_tasks)``. The constraint is that the selected
 features are the same for all the regression problems, also called tasks.
 
 Mathematically, it consists of a linear model trained with a mixed
-:math:`\ell_1` :math:`\ell_2` prior and :math:`\ell_2` prior as regularizer.
+:math:`\ell_1` :math:`\ell_2`-norm and :math:`\ell_2`-norm for regularization.
 The objective function to minimize is:
 
 .. math::
 
-    \min_{W} { \frac{1}{2n_{samples}} ||X W - Y||_{Fro}^2 + \alpha \rho ||W||_{2 1} +
-    \frac{\alpha(1-\rho)}{2} ||W||_{Fro}^2}
+    \min_{W} { \frac{1}{2n_{\text{samples}}} ||X W - Y||_{\text{Fro}}^2 + \alpha \rho ||W||_{2 1} +
+    \frac{\alpha(1-\rho)}{2} ||W||_{\text{Fro}}^2}
 
 The implementation in the class :class:`MultiTaskElasticNet` uses coordinate descent as
 the algorithm to fit the coefficients.
 
 The class :class:`MultiTaskElasticNetCV` can be used to set the parameters
 ``alpha`` (:math:`\alpha`) and ``l1_ratio`` (:math:`\rho`) by cross-validation.
-
 
 .. _least_angle_regression:
 
@@ -422,19 +422,19 @@ Least Angle Regression
 Least-angle regression (LARS) is a regression algorithm for
 high-dimensional data, developed by Bradley Efron, Trevor Hastie, Iain
 Johnstone and Robert Tibshirani. LARS is similar to forward stepwise
-regression. At each step, it finds the predictor most correlated with the
-response. When there are multiple predictors having equal correlation, instead
-of continuing along the same predictor, it proceeds in a direction equiangular
-between the predictors.
+regression. At each step, it finds the feature most correlated with the
+response. When there are multiple features having equal correlation, instead
+of continuing along the same feature, it proceeds in a direction equiangular
+between the features.
 
 The advantages of LARS are:
 
   - It is numerically efficient in contexts where p >> n (i.e., when the
-    number of dimensions is significantly greater than the number of
-    points)
+    number of features is significantly greater than the number of
+    samples)
 
   - It is computationally just as fast as forward selection and has
-    the same order of complexity as an ordinary least squares.
+    the same order of complexity as ordinary least squares.
 
   - It produces a full piecewise linear solution path, which is
     useful in cross-validation or similar attempts to tune the model.
@@ -463,7 +463,7 @@ LARS Lasso
 ==========
 
 :class:`LassoLars` is a lasso model implemented using the LARS
-algorithm, and unlike the implementation based on coordinate_descent,
+algorithm, and unlike the implementation based on coordinate descent,
 this yields the exact solution, which is piecewise linear as a
 function of the norm of its coefficients.
 
@@ -489,8 +489,8 @@ function of the norm of its coefficients.
 
 The Lars algorithm provides the full path of the coefficients along
 the regularization parameter almost for free, thus a common operation
-consist of retrieving the path with function :func:`lars_path` or 
-:func:`lars_path_gram`
+consist of retrieving the path with one of the functions :func:`lars_path`
+or :func:`lars_path_gram`.
 
 Mathematical formulation
 ------------------------
@@ -501,7 +501,7 @@ increased in a direction equiangular to each one's correlations with
 the residual.
 
 Instead of giving a vector result, the LARS solution consists of a
-curve denoting the solution for each value of the L1 norm of the
+curve denoting the solution for each value of the :math:`\ell_1` norm of the
 parameter vector. The full coefficients path is stored in the array
 ``coef_path_``, which has size (n_features, max_features+1). The first
 column is always zero.
@@ -519,14 +519,14 @@ Orthogonal Matching Pursuit (OMP)
 =================================
 :class:`OrthogonalMatchingPursuit` and :func:`orthogonal_mp` implements the OMP
 algorithm for approximating the fit of a linear model with constraints imposed
-on the number of non-zero coefficients (ie. the L :sub:`0` pseudo-norm).
+on the number of non-zero coefficients (ie. the :math:`\ell_0` pseudo-norm).
 
 Being a forward feature selection method like :ref:`least_angle_regression`,
 orthogonal matching pursuit can approximate the optimum solution vector with a
 fixed number of non-zero elements:
 
 .. math::
-    \underset{\gamma}{\operatorname{arg\,min\,}}  ||y - X\gamma||_2^2 \text{ subject to } ||\gamma||_0 \leq n_{nonzero\_coefs}
+    \underset{\gamma}{\operatorname{arg\,min\,}}  ||y - X\gamma||_2^2 \text{ subject to } ||\gamma||_0 \leq n_{\text{nonzero\_coefs}}
 
 Alternatively, orthogonal matching pursuit can target a specific error instead
 of a specific number of non-zero coefficients. This can be expressed as:
@@ -569,7 +569,7 @@ This can be done by introducing `uninformative priors
 over the hyper parameters of the model.
 The :math:`\ell_{2}` regularization used in `Ridge Regression`_ is equivalent
 to finding a maximum a posteriori estimation under a Gaussian prior over the
-parameters :math:`w` with precision :math:`\lambda^{-1}`.  Instead of setting
+coefficients :math:`w` with precision :math:`\lambda^{-1}`.  Instead of setting
 `\lambda` manually, it is possible to treat it as a random variable to be
 estimated from the data.
 
@@ -608,7 +608,7 @@ Bayesian Ridge Regression
 
 :class:`BayesianRidge` estimates a probabilistic model of the
 regression problem as described above.
-The prior for the parameter :math:`w` is given by a spherical Gaussian:
+The prior for the coefficient :math:`w` is given by a spherical Gaussian:
 
 .. math:: p(w|\lambda) =
     \mathcal{N}(w|0,\lambda^{-1}\mathbf{I}_{p})
@@ -656,14 +656,14 @@ After being fitted, the model can then be used to predict new values::
     array([0.50000013])
 
 
-The weights :math:`w` of the model can be access::
+The coefficients :math:`w` of the model can be accessed::
 
     >>> reg.coef_
     array([0.49999993, 0.49999993])
 
 Due to the Bayesian framework, the weights found are slightly different to the
 ones found by :ref:`ordinary_least_squares`. However, Bayesian Ridge Regression
-is more robust to ill-posed problem.
+is more robust to ill-posed problems.
 
 .. topic:: Examples:
 
@@ -682,19 +682,19 @@ Automatic Relevance Determination - ARD
 ---------------------------------------
 
 :class:`ARDRegression` is very similar to `Bayesian Ridge Regression`_,
-but can lead to sparser weights :math:`w` [1]_ [2]_.
+but can lead to sparser coefficients :math:`w` [1]_ [2]_.
 :class:`ARDRegression` poses a different prior over :math:`w`, by dropping the
 assumption of the Gaussian being spherical.
 
 Instead, the distribution over :math:`w` is assumed to be an axis-parallel,
 elliptical Gaussian distribution.
 
-This means each weight :math:`w_{i}` is drawn from a Gaussian distribution,
+This means each coefficient :math:`w_{i}` is drawn from a Gaussian distribution,
 centered on zero and with a precision :math:`\lambda_{i}`:
 
 .. math:: p(w|\lambda) = \mathcal{N}(w|0,A^{-1})
 
-with :math:`diag \; (A) = \lambda = \{\lambda_{1},...,\lambda_{p}\}`.
+with :math:`\diag \; (A) = \lambda = \{\lambda_{1},...,\lambda_{p}\}`.
 
 In contrast to `Bayesian Ridge Regression`_, each coordinate of :math:`w_{i}`
 has its own standard deviation :math:`\lambda_i`. The prior over all
@@ -732,36 +732,38 @@ Logistic regression
 
 Logistic regression, despite its name, is a linear model for classification
 rather than regression. Logistic regression is also known in the literature as
-logit regression, maximum-entropy classification (MaxEnt)
-or the log-linear classifier. In this model, the probabilities describing the possible outcomes of a single trial are modeled using a `logistic function <https://en.wikipedia.org/wiki/Logistic_function>`_.
+logit regression, maximum-entropy classification (MaxEnt) or the log-linear
+classifier. In this model, the probabilities describing the possible outcomes
+of a single trial are modeled using a
+`logistic function <https://en.wikipedia.org/wiki/Logistic_function>`_.
 
-The implementation of logistic regression in scikit-learn can be accessed from
+The implementation of logistic regression in scikit-learn can be accessed from the
 class :class:`LogisticRegression`. This implementation can fit binary, One-vs-
-Rest, or multinomial logistic regression with optional L2, L1 or Elastic-Net
-regularization. Note that regularization is applied by default.
+Rest, or multinomial logistic regression with optional :math:`\ell_1`, :math:`\ell_2`
+or Elastic-Net regularization. Note that regularization is applied by default.
 
-As an optimization problem, binary class L2 penalized logistic regression
+As an optimization problem, binary class :math:`\ell_2` penalized logistic regression
 minimizes the following cost function:
 
 .. math:: \min_{w, c} \frac{1}{2}w^T w + C \sum_{i=1}^n \log(\exp(- y_i (X_i^T w + c)) + 1) .
 
-Similarly, L1 regularized logistic regression solves the following
+Similarly, :math:`\ell_1` regularized logistic regression solves the following
 optimization problem:
 
 .. math:: \min_{w, c} \|w\|_1 + C \sum_{i=1}^n \log(\exp(- y_i (X_i^T w + c)) + 1).
 
-Elastic-Net regularization is a combination of L1 and L2, and minimizes the
-following cost function:
+Elastic-Net regularization is a combination of :math:`\ell_1` and
+:math:`\ell_2`, and minimizes the following cost function:
 
 .. math:: \min_{w, c} \frac{1 - \rho}{2}w^T w + \rho \|w\|_1 + C \sum_{i=1}^n \log(\exp(- y_i (X_i^T w + c)) + 1),
 
-where :math:`\rho` controls the strengh of L1 regularization vs L2
-regularization (it corresponds to the `l1_ratio` parameter).
+where :math:`\rho` controls the strength of :math:`\ell_1` regularization vs.
+:math:`\ell_2` regularization (it corresponds to the `l1_ratio` parameter).
 
-Note that, in this notation, it's assumed that the observation :math:`y_i` takes values in the set
-:math:`{-1, 1}` at trial :math:`i`. We can also see that Elastic-Net is
-equivalent to L1 when :math:`\rho = 1` and equivalent to L2 when
-:math:`\rho=0`.
+Note that, in this notation, it's assumed that the observation :math:`y_i` takes
+values in the set :math:`{-1, 1}` at trial :math:`i`. We can also see that
+Elastic-Net is equivalent to :math:`\ell_1` when :math:`\rho = 1` and equivalent
+to :math:`\ell_2` when :math:`\rho=0`.
 
 The solvers implemented in the class :class:`LogisticRegression`
 are "liblinear", "newton-cg", "lbfgs", "sag" and "saga":
@@ -774,17 +776,18 @@ a true multinomial (multiclass) model; instead, the optimization problem is
 decomposed in a "one-vs-rest" fashion so separate binary classifiers are
 trained for all classes. This happens under the hood, so
 :class:`LogisticRegression` instances using this solver behave as multiclass
-classifiers. For L1 penalization :func:`sklearn.svm.l1_min_c` allows to
+classifiers. For :math:`\ell_1` regularization :func:`sklearn.svm.l1_min_c` allows to
 calculate the lower bound for C in order to get a non "null" (all feature
 weights to zero) model.
 
-The "lbfgs", "sag" and "newton-cg" solvers only support L2 penalization or no
-regularization, and are found to converge faster for some high dimensional
-data. Setting `multi_class` to "multinomial" with these solvers learns a true
-multinomial logistic regression model [5]_, which means that its probability
-estimates should be better calibrated than the default "one-vs-rest" setting.
+The "lbfgs", "sag" and "newton-cg" solvers only support :math:`\ell_2`
+regularization or no regularization, and are found to converge faster for some
+high dimensional data. Setting `multi_class` to "multinomial" with these solvers
+learns a true multinomial logistic regression model [5]_, which means that its
+probability estimates should be better calibrated than the default "one-vs-rest"
+setting.
 
-The "sag" solver uses a Stochastic Average Gradient descent [6]_. It is faster
+The "sag" solver uses Stochastic Average Gradient descent [6]_. It is faster
 than other solvers for large datasets, when both the number of samples and the
 number of features are large.
 
@@ -793,7 +796,7 @@ non-smooth `penalty="l1"`. This is therefore the solver of choice for sparse
 multinomial logistic regression. It is also the only solver that supports
 `penalty="elasticnet"`.
 
-The "lbfgs" is an optimization algorithm that approximates the 
+The "lbfgs" is an optimization algorithm that approximates the
 Broyden–Fletcher–Goldfarb–Shanno algorithm [8]_, which belongs to
 quasi-Newton methods. The "lbfgs" solver is recommended for use for
 small data-sets but for larger datasets its performance suffers. [9]_
@@ -860,7 +863,7 @@ with 'log' loss, which might be even faster but requires more tuning.
 
 .. note:: **Feature selection with sparse logistic regression**
 
-   A logistic regression with L1 penalty yields sparse models, and can
+   A logistic regression with :math:`\ell_1` penalty yields sparse models, and can
    thus be used to perform feature selection, as detailed in
    :ref:`l1_feature_selection`.
 
@@ -948,7 +951,7 @@ For classification, :class:`PassiveAggressiveClassifier` can be used with
 Robustness regression: outliers and modeling errors
 =====================================================
 
-Robust regression is interested in fitting a regression model in the
+Robust regression aims to fit a regression model in the
 presence of corrupt data: either outliers, or error in the model.
 
 .. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_theilsen_001.png
@@ -1007,7 +1010,7 @@ in these settings.
   Scikit-learn provides 3 robust regression estimators:
   :ref:`RANSAC <ransac_regression>`,
   :ref:`Theil Sen <theil_sen_regression>` and
-  :ref:`HuberRegressor <huber_regression>`
+  :ref:`HuberRegressor <huber_regression>`.
 
   * :ref:`HuberRegressor <huber_regression>` should be faster than
     :ref:`RANSAC <ransac_regression>` and :ref:`Theil Sen <theil_sen_regression>`
@@ -1018,16 +1021,16 @@ in these settings.
     :ref:`HuberRegressor <huber_regression>` for the default parameters.
 
   * :ref:`RANSAC <ransac_regression>` is faster than :ref:`Theil Sen <theil_sen_regression>`
-    and scales much better with the number of samples
+    and scales much better with the number of samples.
 
   * :ref:`RANSAC <ransac_regression>` will deal better with large
-    outliers in the y direction (most common situation)
+    outliers in the y direction (most common situation).
 
   * :ref:`Theil Sen <theil_sen_regression>` will cope better with
     medium-size outliers in the X direction, but this property will
     disappear in large dimensional settings.
 
- When in doubt, use :ref:`RANSAC <ransac_regression>`
+ When in doubt, use :ref:`RANSAC <ransac_regression>`.
 
 .. _ransac_regression:
 
@@ -1040,7 +1043,7 @@ inliers from the complete data set.
 RANSAC is a non-deterministic algorithm producing only a reasonable result with
 a certain probability, which is dependent on the number of iterations (see
 `max_trials` parameter). It is typically used for linear and non-linear
-regression problems and is especially popular in the fields of photogrammetric
+regression problems and is especially popular in the field of photogrammetric
 computer vision.
 
 The algorithm splits the complete input sample data into a set of inliers,
@@ -1106,7 +1109,7 @@ Theil-Sen estimator: generalized-median-based estimator
 The :class:`TheilSenRegressor` estimator uses a generalization of the median in
 multiple dimensions. It is thus robust to multivariate outliers. Note however
 that the robustness of the estimator decreases quickly with the dimensionality
-of the problem. It looses its robustness properties and becomes no
+of the problem. It loses its robustness properties and becomes no
 better than an ordinary least squares in high dimension.
 
 .. topic:: Examples:
@@ -1144,7 +1147,7 @@ dimensions [#f2]_.
 In terms of time and space complexity, Theil-Sen scales according to
 
 .. math::
-    \binom{n_{samples}}{n_{subsamples}}
+    \binom{n_{\text{samples}}}{n_{\text{subsamples}}}
 
 which makes it infeasible to be applied exhaustively to problems with a
 large number of samples and features. Therefore, the magnitude of a
@@ -1217,7 +1220,7 @@ in the following ways.
 
   * Peter J. Huber, Elvezio M. Ronchetti: Robust Statistics, Concomitant scale estimates, pg 172
 
-Also, this estimator is different from the R implementation of Robust Regression
+Note that this estimator is different from the R implementation of Robust Regression
 (http://www.ats.ucla.edu/stat/r/dae/rreg.htm) because the R implementation does a weighted least
 squares implementation with weights given to each sample on the basis of how much the residual is
 greater than a certain threshold.
@@ -1253,10 +1256,10 @@ to see this, imagine creating a new variable
 
 With this re-labeling of the data, our problem can be written
 
-.. math::    \hat{y}(w, x) = w_0 + w_1 z_1 + w_2 z_2 + w_3 z_3 + w_4 z_4 + w_5 z_5
+.. math::    \hat{y}(w, z) = w_0 + w_1 z_1 + w_2 z_2 + w_3 z_3 + w_4 z_4 + w_5 z_5
 
 We see that the resulting *polynomial regression* is in the same class of
-linear models we'd considered above (i.e. the model is linear in :math:`w`)
+linear models we considered above (i.e. the model is linear in :math:`w`)
 and can be solved by the same techniques.  By considering linear fits within
 a higher-dimensional space built with these basis functions, the model has the
 flexibility to fit a much broader range of data.
@@ -1269,9 +1272,9 @@ polynomial features of varying degrees:
    :align: center
    :scale: 50%
 
-This figure is created using the :class:`PolynomialFeatures` preprocessor.
-This preprocessor transforms an input data matrix into a new data matrix
-of a given degree.  It can be used as follows::
+This figure is created using the :class:`PolynomialFeatures` transformer, which
+transforms an input data matrix into a new data matrix of a given degree.
+It can be used as follows::
 
     >>> from sklearn.preprocessing import PolynomialFeatures
     >>> import numpy as np

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -68,8 +68,10 @@ Ordinary Least Squares Complexity
 ---------------------------------
 
 The least squares solution is computed using the singular value
-decomposition of X. If X is a matrix of shape (n, p) this method has a
-cost of :math:`O(n p^2)`, assuming that :math:`n \geq p`.
+decomposition of X. If X is a matrix of shape `(n_samples, n_features)`
+this method has a cost of 
+:math:`O(n_{\text{samples}} n_{\text{features}}^2)`, assuming that
+:math:`n_{\text{samples} \geq n_{\text{features}}}`.
 
 .. _ridge_regression:
 
@@ -79,7 +81,7 @@ Ridge Regression
 :class:`Ridge` regression addresses some of the problems of
 :ref:`ordinary_least_squares` by imposing a penalty on the size of the
 coefficients. The ridge coefficients minimize a penalized residual sum
-of squares.
+of squares:
 
 
 .. math::
@@ -162,7 +164,7 @@ Lasso
 The :class:`Lasso` is a linear model that estimates sparse coefficients.
 It is useful in some contexts due to its tendency to prefer solutions
 with fewer non-zero coefficients, effectively reducing the number of
-features upon which the given solution is dependent. For this reason, the
+features upon which the given solution is dependent. For this reason
 Lasso and its variants are fundamental to the field of compressed sensing.
 Under certain conditions, it can recover the exact set of non-zero
 coefficients (see
@@ -428,9 +430,8 @@ between the features.
 
 The advantages of LARS are:
 
-  - It is numerically efficient in contexts where p >> n (i.e., when the
-    number of features is significantly greater than the number of
-    samples)
+  - It is numerically efficient in contexts where the number of features 
+    is significantly greater than the number of samples.
 
   - It is computationally just as fast as forward selection and has
     the same order of complexity as ordinary least squares.
@@ -488,7 +489,7 @@ function of the norm of its coefficients.
 
 The Lars algorithm provides the full path of the coefficients along
 the regularization parameter almost for free, thus a common operation
-consist of retrieving the path with one of the functions :func:`lars_path`
+is to retrieve the path with one of the functions :func:`lars_path`
 or :func:`lars_path_gram`.
 
 Mathematical formulation
@@ -733,10 +734,10 @@ classifier. In this model, the probabilities describing the possible outcomes
 of a single trial are modeled using a
 `logistic function <https://en.wikipedia.org/wiki/Logistic_function>`_.
 
-The implementation of logistic regression in scikit-learn can be accessed from the
-class :class:`LogisticRegression`. This implementation can fit binary, One-vs-
-Rest, or multinomial logistic regression with optional :math:`\ell_1`, :math:`\ell_2`
-or Elastic-Net regularization. Note that regularization is applied by default.
+Logistic regression is implemented in :class:`LogisticRegression`. 
+This implementation can fit binary, One-vs-Rest, or multinomial logistic 
+regression with optional :math:`\ell_1`, :math:`\ell_2` or Elastic-Net 
+regularization. Note that regularization is applied by default.
 
 As an optimization problem, binary class :math:`\ell_2` penalized logistic
 regression minimizes the following cost function:


### PR DESCRIPTION
There are quite a few synonyms in use in the docs. In this PR I read through `linear_model.rst` and:

- Replaced "regressors", "variables", "predictors", etc with **features**.
- Replaced "observations", "points", etc with **samples**.
- Used `\text{word}` instead of `word` in LaTeX.
- Changed some other stuff as I read through.

Some of this is a bit opinionated, so I would appreciate feedback. This PR closes #13639.

