### PR TITLE
[MRG] DOC: Fixes for latest numpydoc

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -125,7 +125,7 @@ conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
 
 source activate testenv
 pip install "sphinx-gallery>=0.2,<0.3"
-pip install numpydoc==0.8
+pip install numpydoc==0.9
 
 # Build and install scikit-learn in dev mode
 python setup.py develop

--- a/doc/governance.rst
+++ b/doc/governance.rst
@@ -1,4 +1,3 @@
-
 .. _governance:
 
 ===========================================
@@ -71,12 +70,12 @@ the core developers which will stay open for a week. TC membership votes are
 subject to a two-third majority of all cast votes as well as a simple majority
 approval of all the current TC members. TC members who do not actively engage
 with the TC duties are expected to resign.
- 
+
 The initial Technical Committee of scikit-learn consists of :user:`Alexandre Gramfort <agramfort>`,
 :user:`Olivier Grisel <ogrisel>`, :user:`Andreas Müller <amueller>`, :user:`Joel Nothman <jnothman>`,
 :user:`Hanmin Qin <qinhanmin2014>`, :user:`Gaël Varoquaux <GaelVaroquaux>`, and
 :user:`Roman Yurchak <rth>`.
- 
+
 Decision Making Process
 =======================
 Decisions about the future of the project are made through discussion with all
@@ -110,11 +109,11 @@ are made according to the following rules:
   consensus), happens on the issue of pull-request page.
 
 * **Changes to the API principles and changes to dependencies or supported
-  versions** happen via a :ref:`slep` and follows the decision-making process outlined above. 
+  versions** happen via a :ref:`slep` and follows the decision-making process outlined above.
 
 * **Changes to the governance model** use the same decision process outlined above.
 
- 
+
 If a veto -1 vote is cast on a lazy consensus, the proposer can appeal to the
 community and core developers and the change can be approved or rejected using
 the decision making procedure outlined above.

--- a/doc/other_distributions.rst
+++ b/doc/other_distributions.rst
@@ -1,4 +1,3 @@
-
 .. _install_by_distribution:
 
 Third party distributions of scikit-learn

--- a/doc/preface.rst
+++ b/doc/preface.rst
@@ -28,5 +28,7 @@ Welcome to scikit-learn
     about
     testimonials/testimonials
     whats_new
+    roadmap
+    governance
 
 |

--- a/sklearn/datasets/svmlight_format.py
+++ b/sklearn/datasets/svmlight_format.py
@@ -133,7 +133,8 @@ def load_svmlight_file(f, n_features=None, dtype=np.float64,
     See also
     --------
     load_svmlight_files: similar function for loading multiple files in this
-    format, enforcing the same number of features/columns on all of them.
+                         format, enforcing the same number of features/columns
+                         on all of them.
 
     Examples
     --------

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -537,7 +537,7 @@ def cosine_distances(X, Y=None):
     See also
     --------
     sklearn.metrics.pairwise.cosine_similarity
-    scipy.spatial.distance.cosine (dense matrices only)
+    scipy.spatial.distance.cosine : dense matrices only
     """
     # 1.0 - cosine_similarity(X, Y) without copy
     S = cosine_similarity(X, Y)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Fixes:

1. ~~Warnings about a few files missing from toctrees with `:orphan:`~~
2. Errors in `See also` blocks due to latest `numpydoc` getting more strict.
3. Bump to latest `numpydoc`

cc @jnothman 