### PR TITLE
[MRG] Fix typo: Remove space in "cross-entropy"

### DIFF
--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1204,8 +1204,8 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
     """Logistic Regression (aka logit, MaxEnt) classifier.
 
     In the multiclass case, the training algorithm uses the one-vs-rest (OvR)
-    scheme if the 'multi_class' option is set to 'ovr', and uses the cross-
-    entropy loss if the 'multi_class' option is set to 'multinomial'.
+    scheme if the 'multi_class' option is set to 'ovr', and uses the
+    cross-entropy loss if the 'multi_class' option is set to 'multinomial'.
     (Currently the 'multinomial' option is supported only by the 'lbfgs',
     'sag', 'saga' and 'newton-cg' solvers.)
 


### PR DESCRIPTION
#### Reference Issues/PRs
none


#### What does this implement/fix? Explain your changes.
Removes unnecessary space in "cross-entropy"

Appears bad in
https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html
and makes greping for "cross-entropy" hard.