### PR TITLE
MNT Minor clean up in OneVsOneClassifier

### DIFF
--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -471,9 +471,7 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
     classes_ : numpy array of shape [n_classes]
         Array containing labels.
 
-    pairwise_indices_ : list, length = ``n_classes * (n_classes - 1) / 2``,
-        or ``None``.
-
+    pairwise_indices_ : list, length = ``len(estimators_)``, or ``None``.
         Indices of samples used when training the estimators.
         ``None`` when ``estimator`` does not have ``_pairwise`` attribute.
     """

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -475,7 +475,7 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         or ``None``
 
         Indices of samples used when training the estimators.
-        ``None`` when ``estomator`` does not have ``_pairwise`` attribute.
+        ``None`` when ``estimator`` does not have ``_pairwise`` attribute.
     """
 
     def __init__(self, estimator, n_jobs=None):

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -465,14 +465,14 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
 
     Attributes
     ----------
-    estimators_ : list of `n_classes * (n_classes - 1) / 2` estimators
+    estimators_ : list of ``n_classes * (n_classes - 1) / 2`` estimators
         Estimators used for predictions.
 
     classes_ : numpy array of shape [n_classes]
         Array containing labels.
 
-    pairwise_indices_: list, length = `n_classes * (n_classes - 1) / 2`,
-        or ``None``
+    pairwise_indices_ : list, length = ``n_classes * (n_classes - 1) / 2``,
+        or ``None``.
 
         Indices of samples used when training the estimators.
         ``None`` when ``estimator`` does not have ``_pairwise`` attribute.

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -470,6 +470,12 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
 
     classes_ : numpy array of shape [n_classes]
         Array containing labels.
+
+    pairwise_indices_: list, length = `n_classes * (n_classes - 1) / 2`,
+        or ``None``
+
+        Indices of samples used when training the estimators.
+        ``None`` when ``estomator`` does not have ``_pairwise`` attribute.
     """
 
     def __init__(self, estimator, n_jobs=None):

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -505,11 +505,8 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             for i in range(n_classes) for j in range(i + 1, n_classes)))))
 
         self.estimators_ = estimators_indices[0]
-        try:
-            self.pairwise_indices_ = (
-                estimators_indices[1] if self._pairwise else None)
-        except AttributeError:
-            self.pairwise_indices_ = None
+        self.pairwise_indices_ = (
+            estimators_indices[1] if self._pairwise else None)
 
         return self
 
@@ -629,10 +626,6 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
     def _pairwise(self):
         """Indicate if wrapped estimator is using a precomputed Gram matrix"""
         return getattr(self.estimator, "_pairwise", False)
-
-    def _more_tags(self):
-        # FIXME Remove once #10440 is merged
-        return {'_skip_test': True}
 
 
 class OutputCodeClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -471,7 +471,7 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
     classes_ : numpy array of shape [n_classes]
         Array containing labels.
 
-    pairwise_indices_ : list, length = ``len(estimators_)``, or ``None``.
+    pairwise_indices_ : list, length = ``len(estimators_)``, or ``None``
         Indices of samples used when training the estimators.
         ``None`` when ``estimator`` does not have ``_pairwise`` attribute.
     """


### PR DESCRIPTION
We use getattr to get _pairwise so we won't get AttributeError.