### PR TITLE
[MRG] Improve speed of plot_pca_vs_fa_model_selection.py example

### DIFF
--- a/examples/decomposition/plot_pca_vs_fa_model_selection.py
+++ b/examples/decomposition/plot_pca_vs_fa_model_selection.py
@@ -94,6 +94,7 @@ for X, title in [(X_homo, 'Homoscedastic Noise'),
     pca.fit(X)
     n_components_pca_mle = pca.n_components_
 
+    print("%s:" % title)
     print("best n_components by PCA CV = %d" % n_components_pca)
     print("best n_components by FactorAnalysis CV = %d" % n_components_fa)
     print("best n_components by PCA MLE = %d" % n_components_pca_mle)

--- a/examples/decomposition/plot_pca_vs_fa_model_selection.py
+++ b/examples/decomposition/plot_pca_vs_fa_model_selection.py
@@ -57,12 +57,12 @@ X_hetero = X + rng.randn(n_samples, n_features) * sigmas
 # #############################################################################
 # Fit the models
 
-n_components = np.arange(0, n_features, 5)  # options for n_components
+n_components = np.arange(0, n_features - 5, 5)  # options for n_components
 
 
 def compute_scores(X):
     pca = PCA(svd_solver='full')
-    fa = FactorAnalysis()
+    fa = FactorAnalysis(tol = 1)
 
     pca_scores, fa_scores = [], []
     for n in n_components:

--- a/examples/decomposition/plot_pca_vs_fa_model_selection.py
+++ b/examples/decomposition/plot_pca_vs_fa_model_selection.py
@@ -57,7 +57,8 @@ X_hetero = X + rng.randn(n_samples, n_features) * sigmas
 # #############################################################################
 # Fit the models
 
-n_components = np.arange(0, n_features - 5, 5)  # options for n_components
+# options for n_components (45 removed for speed)
+n_components = np.arange(0, n_features - 5, 5)
 
 
 def compute_scores(X):

--- a/examples/decomposition/plot_pca_vs_fa_model_selection.py
+++ b/examples/decomposition/plot_pca_vs_fa_model_selection.py
@@ -64,6 +64,8 @@ n_components = np.arange(0, n_features - 5, 5)
 def compute_scores(X):
     pca = PCA(svd_solver='full')
     fa = FactorAnalysis(tol=1)
+    # Tolerance set to 1 to quickly generate the example. However, you probably
+    # want to use the default value or a much smaller one.
 
     pca_scores, fa_scores = [], []
     for n in n_components:

--- a/examples/decomposition/plot_pca_vs_fa_model_selection.py
+++ b/examples/decomposition/plot_pca_vs_fa_model_selection.py
@@ -63,7 +63,7 @@ n_components = np.arange(0, n_features - 5, 5)
 
 def compute_scores(X):
     pca = PCA(svd_solver='full')
-    fa = FactorAnalysis(tol = 1)
+    fa = FactorAnalysis(tol=1)
 
     pca_scores, fa_scores = [], []
     for n in n_components:

--- a/examples/decomposition/plot_pca_vs_fa_model_selection.py
+++ b/examples/decomposition/plot_pca_vs_fa_model_selection.py
@@ -6,11 +6,11 @@ Model selection with Probabilistic PCA and Factor Analysis (FA)
 Probabilistic PCA and Factor Analysis are probabilistic models.
 The consequence is that the likelihood of new data can be used
 for model selection and covariance estimation.
-Here we compare PCA and FA with cross-validation on low rank data corrupted
-with homoscedastic noise (noise variance
-is the same for each feature) or heteroscedastic noise (noise variance
-is the different for each feature). In a second step we compare the model
-likelihood to the likelihoods obtained from shrinkage covariance estimators.
+Here we compare PCA and FA with cross-validation on low rank data
+corrupted with homoscedastic noise (noise variance is the same for each
+feature) or heteroscedastic noise (noise variance is the different for
+each feature). In a second step we compare the model likelihood to the
+likelihoods obtained from shrinkage covariance estimators.
 
 One can observe that with homoscedastic noise both FA and PCA succeed
 in recovering the size of the low rank subspace. The likelihood with PCA
@@ -21,7 +21,6 @@ circumstances the low rank models are more likely than shrinkage models.
 The automatic estimation from
 Automatic Choice of Dimensionality for PCA. NIPS 2000: 598-604
 by Thomas P. Minka is also compared.
-
 """
 
 # Authors: Alexandre Gramfort

--- a/examples/neural_networks/plot_rbm_logistic_classification.py
+++ b/examples/neural_networks/plot_rbm_logistic_classification.py
@@ -87,6 +87,8 @@ X_train, X_test, Y_train, Y_test = train_test_split(
 # Models we will use
 logistic = linear_model.LogisticRegression(solver='newton-cg', tol=1,
                                            multi_class='multinomial')
+# Tolerance set to 1 to quickly generate the example. However, you probably
+# want to use the default value or a much smaller one.
 rbm = BernoulliRBM(random_state=0, verbose=True)
 
 rbm_features_classifier = Pipeline(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

Partial fix to #13383

#### What does this implement/fix? Explain your changes.

I propose two modifications to the example `examples/decomposition/plot_pca_vs_fa_model_selection.py` mentioned in #13383 : 

- Increase the tolerance of the FactorAnalysis: `FactorAnalysis(tol=1)`
- Do not run CV for `n_components = 45`.

The build time (on my computer) decreases from 11.846 to 3.437 seconds.

These modifications are motivated by the fact that among the 3 dimensional reduction techniques trained, only Factor Analysis for 40 and 45 components takes some significant time to fit:

```
Total running time of the script: ( 0 minutes 11.846 seconds)

I - Homoscedastic noise
0 components...
    Time PCA: 0:00:00.022663
    Time FA: 0:00:00.042642
5 components...
    Time PCA: 0:00:00.018533
    Time FA: 0:00:00.042504
10 components...
    Time PCA: 0:00:00.017095
    Time FA: 0:00:00.056470
15 components...
    Time PCA: 0:00:00.023689
    Time FA: 0:00:00.079793
20 components...
    Time PCA: 0:00:00.018067
    Time FA: 0:00:00.089906
25 components...
    Time PCA: 0:00:00.016740
    Time FA: 0:00:00.105046
30 components...
    Time PCA: 0:00:00.017797
    Time FA: 0:00:00.120986
35 components...
    Time PCA: 0:00:00.017244
    Time FA: 0:00:00.188839
40 components...
    Time PCA: 0:00:00.017586
    Time FA: 0:00:02.802308
45 components...
    Time PCA: 0:00:00.017656
    Time FA: 0:00:01.555045
Time PCA MLE: 0:00:00.000007

II - Heteroscedastic noise
0 components...
    Time PCA: 0:00:00.016803
    Time FA: 0:00:00.026970
5 components...
    Time PCA: 0:00:00.016859
    Time FA: 0:00:00.069176
10 components...
    Time PCA: 0:00:00.016116
    Time FA: 0:00:00.080635
15 components...
    Time PCA: 0:00:00.016484
    Time FA: 0:00:00.101170
20 components...
    Time PCA: 0:00:00.016745
    Time FA: 0:00:00.116705
25 components...
    Time PCA: 0:00:00.015989
    Time FA: 0:00:00.123466
30 components...
    Time PCA: 0:00:00.016480
    Time FA: 0:00:00.126200
35 components...
    Time PCA: 0:00:00.016477
    Time FA: 0:00:00.158986
40 components...
    Time PCA: 0:00:00.017423
    Time FA: 0:00:02.712774
45 components...
    Time PCA: 0:00:00.015865
    Time FA: 0:00:01.289101
Time PCA MLE: 0:00:00.000016
```

After applying the 2 modifications mentioned above, we achieve significant speed improvements:

```
I - Homoscedastic noise
0 components...
    Time PCA: 0:00:00.025566
    Time FA: 0:00:00.036936
5 components...
    Time PCA: 0:00:00.021508
    Time FA: 0:00:00.045077
10 components...
    Time PCA: 0:00:00.020512
    Time FA: 0:00:00.043922
15 components...
    Time PCA: 0:00:00.015972
    Time FA: 0:00:00.072845
20 components...
    Time PCA: 0:00:00.016356
    Time FA: 0:00:00.088447
25 components...
    Time PCA: 0:00:00.017344
    Time FA: 0:00:00.096822
30 components...
    Time PCA: 0:00:00.016814
    Time FA: 0:00:00.112733
35 components...
    Time PCA: 0:00:00.016290
    Time FA: 0:00:00.185826
40 components...
    Time PCA: 0:00:00.016499
    Time FA: 0:00:00.325999
Time PCA MLE: 0:00:00.000008

II - Heteroscedastic noise
0 components...
    Time PCA: 0:00:00.015870
    Time FA: 0:00:00.028239
5 components...
    Time PCA: 0:00:00.018323
    Time FA: 0:00:00.065301
10 components...
    Time PCA: 0:00:00.015181
    Time FA: 0:00:00.074517
15 components...
    Time PCA: 0:00:00.018003
    Time FA: 0:00:00.102947
20 components...
    Time PCA: 0:00:00.016931
    Time FA: 0:00:00.112086
25 components...
    Time PCA: 0:00:00.017937
    Time FA: 0:00:00.114989
30 components...
    Time PCA: 0:00:00.017200
    Time FA: 0:00:00.126424
35 components...
    Time PCA: 0:00:00.017375
    Time FA: 0:00:00.140677
40 components...
    Time PCA: 0:00:00.016992
    Time FA: 0:00:00.270111
Time PCA MLE: 0:00:00.000014
```

The printed chosen best numbers of components remain unchanged (I added the nature of the noise to improve its readability):

```
Homoscedastic Noise:
best n_components by PCA CV = 10
best n_components by FactorAnalysis CV = 10
best n_components by PCA MLE = 10
Heteroscedastic Noise:
best n_components by PCA CV = 35
best n_components by FactorAnalysis CV = 10
best n_components by PCA MLE = 38
```

However the 2 plots changed a bit:

**Homoscedastic Noise**

*Original plot*
![homo](https://user-images.githubusercontent.com/1850174/56464272-aaf52880-63b3-11e9-82e3-218d2111b609.png)

*Modified plot*
![homo_tol=1_loop_to_40](https://user-images.githubusercontent.com/1850174/56464292-edb70080-63b3-11e9-8fca-f3856fd1cfcf.png)

**Heteroscedastic Noise**

*Original plot*
![hetero](https://user-images.githubusercontent.com/1850174/56464300-07f0de80-63b4-11e9-970f-aa6ec765232d.png)

*Modified plot*
![hetero_tol=1_loop_to_40](https://user-images.githubusercontent.com/1850174/56464303-0c1cfc00-63b4-11e9-83fd-53aa1e83752d.png)

As you can see, estimated FA scores (average log-likelihood) are different for 40 components for both noises (and the points for 45 components are removed from the 2 plots). However I think that the plots are ok, because the interpretation is left unchanged as this part of the plot isn't important in the example.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
