### PR TITLE
Bonify precision recall fscore support

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1422,8 +1422,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     """
     many_beta = isinstance(beta, Iterable)
 
-    if many_beta :
-        if any([b <= 0 for b in beta]) :
+    if many_beta:
+        if any([b <= 0 for b in beta]):
             raise ValueError("all beta should be >0 in the F-beta scores")
     elif beta <= 0:
         raise ValueError("beta should be >0 in the F-beta score")
@@ -1446,8 +1446,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
     # Finally, we have all our sufficient statistics. Divide! #
     beta2 = (beta ** 2)
-    if many_beta :
-        beta2 = np.reshape(beta2,(-1,1))
+    if many_beta:
+        beta2 = np.reshape(beta2, (-1, 1))
 
     # Divide, and on zero-division, set scores to 0 and warn:
 
@@ -1475,9 +1475,9 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         assert average != 'binary' or len(precision) == 1
         precision = np.average(precision, weights=weights)
         recall = np.average(recall, weights=weights)
-        if many_beta :
-            f_score = np.apply_along_axis(lambda x: np.average(x, weights=weights) , axis=1, arr=f_score)
-        else :
+        if many_beta:
+            f_score = np.apply_along_axis(lambda x: np.average(x, weights=weights), axis=1, arr=f_score)
+        else:
             f_score = np.average(f_score, weights=weights)
         true_sum = None  # return no support
 

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1357,13 +1357,13 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     recall : float (if average is not None) or array of float, shape =\
         [n_unique_labels]
 
-    fbeta_score : 
-                if beta is a float : 
+    fbeta_score :
+                if beta is a float :
                     if average is not None :
                         float
                     else :
                         array of float, shape = [n_unique_labels]
-                
+
                 elif beta is an array of float :
                     if average is not None :
                         array of float, shape = [len(beta)]
@@ -1476,7 +1476,9 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         precision = np.average(precision, weights=weights)
         recall = np.average(recall, weights=weights)
         if many_beta:
-            f_score = np.apply_along_axis(lambda x: np.average(x, weights=weights), axis=1, arr=f_score)
+            f_score = np.apply_along_axis(lambda x:
+                                          np.average(x, weights=weights),
+                                          axis=1, arr=f_score)
         else:
             f_score = np.average(f_score, weights=weights)
         true_sum = None  # return no support

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -331,7 +331,7 @@ def test_precision_recall_fscore_support_errors():
     assert_raises(ValueError, precision_recall_fscore_support,
                   y_true, y_pred, beta=0.0)
     assert_raises(ValueError, precision_recall_fscore_support,
-                  y_true, y_pred, beta=np.array([-1.0,1.0,2.0]))
+                  y_true, y_pred, beta=np.array([-1.0, 1.0, 2.0]))
 
     # Bad pos_label
     assert_raises(ValueError, precision_recall_fscore_support,
@@ -1387,62 +1387,62 @@ def test_precision_recall_f1_score_multilabel_2():
     # fp = [ 1.  0.  0.  2.]
     # fn = [ 1.  1.  1.  0.]
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([1.0,3.0]),
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([1.0, 3.0]),
                                                  average=None)                                       
     assert_array_almost_equal(p, [0.0, 1.0, 0.0, 0.0], 2)
     assert_array_almost_equal(r, [0.0, 0.5, 0.0, 0.0], 2)
-    assert_array_almost_equal(f[0,], [0.0, 0.66, 0.0, 0.0], 2)
-    assert_array_almost_equal(f[1,], [0.0, 0.53, 0.0, 0.0], 2)
+    assert_array_almost_equal(f[0, ], [0.0, 0.66, 0.0, 0.0], 2)
+    assert_array_almost_equal(f[1, ], [0.0, 0.53, 0.0, 0.0], 2)
     assert_array_almost_equal(s, [1, 2, 1, 0], 2)
 
     f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
     support = s
     assert_array_almost_equal(f2, [0, 0.55, 0, 0], 2)
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([1.0,3.0]),
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([1.0, 3.0]),
                                                  average="micro")
     assert_almost_equal(p, 0.25)
     assert_almost_equal(r, 0.25)
-    assert_almost_equal(f[0,], 2 * 0.25 * 0.25 / 0.5)
-    assert_almost_equal(f[1,], 10 * 0.25 * 0.25 / (9 * 0.25 + 0.25))
+    assert_almost_equal(f[0, ], 2 * 0.25 * 0.25 / 0.5)
+    assert_almost_equal(f[1, ], 10 * 0.25 * 0.25 / (9 * 0.25 + 0.25))
     assert_equal(s, None)
     assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                     average="micro"),
                         (1 + 4) * p * r / (4 * p + r))
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([0.5,1.0]),
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([0.5, 1.0]),
                                                  average="macro")
     assert_almost_equal(p, 0.25)
     assert_almost_equal(r, 0.125)
-    assert_almost_equal(f[0,], 1.25 * 0.25 * 0.125 / (0.25 * 0.25 + 0.125))
-    assert_almost_equal(f[1,], 2 / 12)
+    assert_almost_equal(f[0, ], 1.25 * 0.25 * 0.125 / (0.25 * 0.25 + 0.125))
+    assert_almost_equal(f[1, ], 2 / 12)
     assert_equal(s, None)
     assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                     average="macro"),
                         np.mean(f2))
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([0.5,1.0]),
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([0.5, 1.0]),
                                                  average="weighted")
     assert_almost_equal(p, 2 / 4)
     assert_almost_equal(r, 1 / 4)
-    assert_almost_equal(f[0,], 1.25 * 1/8 / (0.25 * 0.5 + 0.25))
-    assert_almost_equal(f[1,], 2 / 3 * 2 / 4)
+    assert_almost_equal(f[0, ], 1.25 * 1/8 / (0.25 * 0.5 + 0.25))
+    assert_almost_equal(f[1, ], 2 / 3 * 2 / 4)
     assert_equal(s, None)
     assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                     average="weighted"),
                         np.average(f2, weights=support))
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([0.5,1.0]),
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([0.5, 1.0]),
                                                  average="samples")
     # Check samples
     # |h(x_i) inter y_i | = [0, 0, 1]
     # |y_i| = [1, 1, 2]
     # |h(x_i)| = [1, 1, 2]
-    
+
     assert_almost_equal(p, 1 / 6)
     assert_almost_equal(r, 1 / 6)
-    assert_almost_equal(f[0,], 2 / 12)
-    assert_almost_equal(f[1,], 2 / 4 * 1 / 3)
+    assert_almost_equal(f[0, ], 2 / 12)
+    assert_almost_equal(f[1, ], 2 / 4 * 1 / 3)
     assert_equal(s, None)
     assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                     average="samples"),
@@ -2048,4 +2048,3 @@ def test_multilabel_jaccard_similarity_score_deprecation():
     assert_equal(jss(y1, np.logical_not(y1)), 0)
     assert_equal(jss(y1, np.zeros(y1.shape)), 0)
     assert_equal(jss(y2, np.zeros(y1.shape)), 0)
-

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1387,8 +1387,9 @@ def test_precision_recall_f1_score_multilabel_2():
     # fp = [ 1.  0.  0.  2.]
     # fn = [ 1.  1.  1.  0.]
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([1.0, 3.0]),
-                                                 average=None)                                       
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                 beta=np.array([1.0, 3.0]),
+                                                 average=None)
     assert_array_almost_equal(p, [0.0, 1.0, 0.0, 0.0], 2)
     assert_array_almost_equal(r, [0.0, 0.5, 0.0, 0.0], 2)
     assert_array_almost_equal(f[0, ], [0.0, 0.66, 0.0, 0.0], 2)
@@ -1399,7 +1400,8 @@ def test_precision_recall_f1_score_multilabel_2():
     support = s
     assert_array_almost_equal(f2, [0, 0.55, 0, 0], 2)
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([1.0, 3.0]),
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                 beta=np.array([1.0, 3.0]),
                                                  average="micro")
     assert_almost_equal(p, 0.25)
     assert_almost_equal(r, 0.25)
@@ -1410,7 +1412,8 @@ def test_precision_recall_f1_score_multilabel_2():
                                     average="micro"),
                         (1 + 4) * p * r / (4 * p + r))
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([0.5, 1.0]),
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                 beta=np.array([0.5, 1.0]),
                                                  average="macro")
     assert_almost_equal(p, 0.25)
     assert_almost_equal(r, 0.125)
@@ -1421,7 +1424,8 @@ def test_precision_recall_f1_score_multilabel_2():
                                     average="macro"),
                         np.mean(f2))
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([0.5, 1.0]),
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                 beta=np.array([0.5, 1.0]),
                                                  average="weighted")
     assert_almost_equal(p, 2 / 4)
     assert_almost_equal(r, 1 / 4)
@@ -1432,7 +1436,8 @@ def test_precision_recall_f1_score_multilabel_2():
                                     average="weighted"),
                         np.average(f2, weights=support))
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([0.5, 1.0]),
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                 beta=np.array([0.5, 1.0]),
                                                  average="samples")
     # Check samples
     # |h(x_i) inter y_i | = [0, 0, 1]

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -330,6 +330,8 @@ def test_precision_recall_fscore_support_errors():
     # Bad beta
     assert_raises(ValueError, precision_recall_fscore_support,
                   y_true, y_pred, beta=0.0)
+    assert_raises(ValueError, precision_recall_fscore_support,
+                  y_true, y_pred, beta=np.array([-1.0,1.0,2.0]))
 
     # Bad pos_label
     assert_raises(ValueError, precision_recall_fscore_support,
@@ -1385,57 +1387,62 @@ def test_precision_recall_f1_score_multilabel_2():
     # fp = [ 1.  0.  0.  2.]
     # fn = [ 1.  1.  1.  0.]
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
-                                                 average=None)
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([1.0,3.0]),
+                                                 average=None)                                       
     assert_array_almost_equal(p, [0.0, 1.0, 0.0, 0.0], 2)
     assert_array_almost_equal(r, [0.0, 0.5, 0.0, 0.0], 2)
-    assert_array_almost_equal(f, [0.0, 0.66, 0.0, 0.0], 2)
+    assert_array_almost_equal(f[0,], [0.0, 0.66, 0.0, 0.0], 2)
+    assert_array_almost_equal(f[1,], [0.0, 0.53, 0.0, 0.0], 2)
     assert_array_almost_equal(s, [1, 2, 1, 0], 2)
 
     f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
     support = s
     assert_array_almost_equal(f2, [0, 0.55, 0, 0], 2)
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([1.0,3.0]),
                                                  average="micro")
     assert_almost_equal(p, 0.25)
     assert_almost_equal(r, 0.25)
-    assert_almost_equal(f, 2 * 0.25 * 0.25 / 0.5)
+    assert_almost_equal(f[0,], 2 * 0.25 * 0.25 / 0.5)
+    assert_almost_equal(f[1,], 10 * 0.25 * 0.25 / (9 * 0.25 + 0.25))
     assert_equal(s, None)
     assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                     average="micro"),
                         (1 + 4) * p * r / (4 * p + r))
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([0.5,1.0]),
                                                  average="macro")
     assert_almost_equal(p, 0.25)
     assert_almost_equal(r, 0.125)
-    assert_almost_equal(f, 2 / 12)
+    assert_almost_equal(f[0,], 1.25 * 0.25 * 0.125 / (0.25 * 0.25 + 0.125))
+    assert_almost_equal(f[1,], 2 / 12)
     assert_equal(s, None)
     assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                     average="macro"),
                         np.mean(f2))
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([0.5,1.0]),
                                                  average="weighted")
     assert_almost_equal(p, 2 / 4)
     assert_almost_equal(r, 1 / 4)
-    assert_almost_equal(f, 2 / 3 * 2 / 4)
+    assert_almost_equal(f[0,], 1.25 * 1/8 / (0.25 * 0.5 + 0.25))
+    assert_almost_equal(f[1,], 2 / 3 * 2 / 4)
     assert_equal(s, None)
     assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                     average="weighted"),
                         np.average(f2, weights=support))
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=np.array([0.5,1.0]),
                                                  average="samples")
     # Check samples
     # |h(x_i) inter y_i | = [0, 0, 1]
     # |y_i| = [1, 1, 2]
     # |h(x_i)| = [1, 1, 2]
-
+    
     assert_almost_equal(p, 1 / 6)
     assert_almost_equal(r, 1 / 6)
-    assert_almost_equal(f, 2 / 4 * 1 / 3)
+    assert_almost_equal(f[0,], 2 / 12)
+    assert_almost_equal(f[1,], 2 / 4 * 1 / 3)
     assert_equal(s, None)
     assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                     average="samples"),
@@ -2041,3 +2048,4 @@ def test_multilabel_jaccard_similarity_score_deprecation():
     assert_equal(jss(y1, np.logical_not(y1)), 0)
     assert_equal(jss(y1, np.zeros(y1.shape)), 0)
     assert_equal(jss(y2, np.zeros(y1.shape)), 0)
+


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Bonification of sklearn.metrics.classification.precision_recall_fscore_support so it can take many beta values in input. If so, it returns an F-score for each beta.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
