### PR TITLE
2D sample weight for MultiOutputEstimator

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -90,7 +90,7 @@ class MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
 
         sample_weight : array-like, shape = (n_samples) or (n_samples, n_outputs) or None
             Sample weights. If None, then samples are equally weighted.
-            Only supported if the underlying regressor supports sample
+            Only supported if the underlying estimator supports sample
             weights.
 
         Returns
@@ -103,7 +103,7 @@ class MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
 
         if y.ndim == 1:
             raise ValueError("y must have at least two dimensions for "
-                             "multi-output regression but has only one.")
+                             "multi-output estimator but has only one.")
 
         if (sample_weight is not None and
                 not has_fit_parameter(self.estimator, 'sample_weight')):
@@ -116,7 +116,7 @@ class MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
             sample_weight = sample_weight.T
         else:
             raise ValueError("sample weight must have at most two dimensions "
-                             "for multi-output regression but has more than "
+                             "for multi-output estimator but has more than "
                              "two.")
 
         first_time = not hasattr(self, 'estimators_')
@@ -144,7 +144,7 @@ class MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
 
         sample_weight : array-like, shape = (n_samples) or (n_samples, n_outputs) or None
             Sample weights. If None, then samples are equally weighted.
-            Only supported if the underlying regressor supports sample
+            Only supported if the underlying estimator supports sample
             weights.
 
         Returns
@@ -165,7 +165,7 @@ class MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
 
         if y.ndim == 1:
             raise ValueError("y must have at least two dimensions for "
-                             "multi-output regression but has only one.")
+                             "multi-output estimator but has only one.")
 
         if (sample_weight is not None and
                 not has_fit_parameter(self.estimator, 'sample_weight')):
@@ -178,7 +178,7 @@ class MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
             sample_weight = sample_weight.T
         else:
             raise ValueError("sample weight must have at most two dimensions "
-                             "for multi-output regression but has more than "
+                             "for multi-output estimator but has more than "
                              "two.")
 
         self.estimators_ = Parallel(n_jobs=self.n_jobs)(

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -88,7 +88,8 @@ class MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
             and can be omitted in the subsequent calls.
             Note that y doesn't need to contain all labels in `classes`.
 
-        sample_weight : array-like, shape = (n_samples) or (n_samples, n_outputs) or None
+        sample_weight : array-like, shape = (n_samples) or \
+                        (n_samples, n_outputs) or None
             Sample weights. If None, then samples are equally weighted.
             Only supported if the underlying estimator supports sample
             weights.
@@ -110,6 +111,8 @@ class MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
             raise ValueError("Underlying estimator does not support"
                              " sample weights.")
 
+        if sample_weight is not None:
+            sample_weight = np.asarray(sample_weight)
         if sample_weight is None or sample_weight.ndim == 1:
             sample_weight = [sample_weight] * y.shape[1]
         elif sample_weight.ndim == 2:
@@ -142,7 +145,8 @@ class MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
             Multi-output targets. An indicator matrix turns on multilabel
             estimation.
 
-        sample_weight : array-like, shape = (n_samples) or (n_samples, n_outputs) or None
+        sample_weight : array-like, shape = (n_samples) or \
+                        (n_samples, n_outputs) or None
             Sample weights. If None, then samples are equally weighted.
             Only supported if the underlying estimator supports sample
             weights.
@@ -172,6 +176,8 @@ class MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
             raise ValueError("Underlying estimator does not support"
                              " sample weights.")
 
+        if sample_weight is not None:
+            sample_weight = np.asarray(sample_weight)
         if sample_weight is None or sample_weight.ndim == 1:
             sample_weight = [sample_weight] * y.shape[1]
         elif sample_weight.ndim == 2:


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10912.

#### What does this implement/fix? Explain your changes.
The original issue #10912 is about 2D sample weight for MultiOutputRegressor.
I made modifications in MultiOutputEstimator, so that this feature is available for not only MultiOutputRegressor but also MultiOutputClassifier.

#### Any other comments?
2D sample weight is useful in my use case, because different outputs have different numerical ranges.
