### PR TITLE
[MRG] Ridge memory error

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -281,6 +281,7 @@ def make_carousel_thumbs(app, exception):
 
 # we use the issues path for PRs since the issues URL will forward
 issues_github_path = 'scikit-learn/scikit-learn'
+issues_user_uri = 'https://github.com/{user}'
 
 
 def setup(app):

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -976,12 +976,12 @@ class _RidgeGCV(LinearModel):
         # even if X is very sparse, K is usually very dense
         try:
             K = safe_sparse_dot(X, X.T, dense_output=True)
-        except MemoryError:
+        except MemoryError as e:
             msg = ("Setting gcv_mode='eigen' with a sparse X creates a "
                    "n_samples**2 dense matrix, setting "
                    "gcv_mode='svd' may help because it would create a "
                    "n_samples * n_features dense matrix")
-            raise MemoryError(msg)
+            raise MemoryError(msg) from e
         # the following emulates an additional constant regressor
         # corresponding to fit_intercept=True
         # but this is done only when the features have been centered
@@ -1034,12 +1034,12 @@ class _RidgeGCV(LinearModel):
         if sparse.issparse(X):
             try:
                 X = X.toarray()
-            except MemoryError:
+            except MemoryError as e:
                 msg = ("Setting gcv_mode='svd' with a sparse X creates a "
                        "n_samples * n_features dense matrix, setting "
                        "gcv_mode='eigen' may help because it would create a "
                        "n_samples**2 dense matrix")
-                raise MemoryError(msg)
+                raise MemoryError(msg) from e
         if centered_kernel:
             X = np.hstack((X, np.ones((X.shape[0], 1))))
         # to emulate fit_intercept=True situation, add a column on ones

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -978,9 +978,9 @@ class _RidgeGCV(LinearModel):
             K = safe_sparse_dot(X, X.T, dense_output=True)
         except MemoryError:
             msg = ("Setting gcv_mode='eigen' with a sparse X creates a "
-                   "n_samples * n_samples dense matrix, setting "
+                   "n_samples**2 dense matrix, setting "
                    "gcv_mode='svd' may help because it would create a "
-                   "n_samples**2 dense matrix")
+                   "n_samples * n_features dense matrix")
             raise MemoryError(msg)
         # the following emulates an additional constant regressor
         # corresponding to fit_intercept=True

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1027,8 +1027,9 @@ def test_ridge_X_sparse_auto_memory_error(monkeypatch, gcv_mode):
     ridgecv = RidgeCV(gcv_mode=gcv_mode)
 
     msg = (r"Setting gcv_mode='eigen' with a sparse X creates a "
-           r"n_samples \* n_samples dense matrix, setting gcv_mode='svd' "
-           r"may help because it would create a n_samples\*\*2 dense matrix")
+           r"n_samples\*\*2 dense matrix, setting gcv_mode='svd' "
+           r"may help because it would create a n_samples \* n_features "
+           r"dense matrix")
 
     with pytest.raises(MemoryError, match=msg):
         ridgecv.fit(X, y_diabetes)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #2354


#### What does this implement/fix? Explain your changes.
The change made in https://github.com/scikit-learn/scikit-learn/commit/daf527735ae8a76a251da9703f29bd7dace9ec7a disables sparse support for svd. The example in #2354, does fit in memory, which would work with svd. This PR informs the user of this behavior when gcv_mode='auto' or 'eigen'.

#### Any other comments?
The original reason to disable sparse support: https://github.com/scikit-learn/scikit-learn/issues/1921 was based on a stackoverflow question with a `(183576, 101507)` sparse matrix. In that case, we would need to investigation how to  include `spasrse_cg` or `lsqr` into RidgeCV. (Or better yet, think about generalized CV problem https://github.com/scikit-learn/scikit-learn/pull/8230) 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->