### PR TITLE
TST test_k_means_fit_predict: do not test fit determinism together with predict/labels_ equality

### DIFF
--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -342,10 +342,12 @@ def test_k_means_fit_predict(algo, dtype, constructor, seed, max_iter, tol):
         kmeans = KMeans(algorithm=algo, n_clusters=10, random_state=seed,
                         tol=tol, max_iter=max_iter, n_jobs=1)
 
-        labels_1 = kmeans.fit(X).predict(X)
-        labels_2 = kmeans.fit_predict(X)
+        labels_1 = kmeans.fit_predict(X)
+        labels_2 = kmeans.predict(X)
+        labels_3 = kmeans.labels_
 
         assert_array_equal(labels_1, labels_2)
+        assert_array_equal(labels_1, labels_3)
 
 
 def test_mb_kmeans_verbose():

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -328,7 +328,7 @@ def test_k_means_fortran_aligned_data():
     (4, 300, 1e-1),  # loose convergence
 ])
 def test_k_means_fit_predict(algo, dtype, constructor, seed, max_iter, tol):
-    # check that fit.predict gives same result as fit_predict
+    # check that predict gives same result as fit_predict or labels_
     # There's a very small chance of failure with elkan on unstructured dataset
     # because predict method uses fast euclidean distances computation which
     # may cause small numerical instabilities.


### PR DESCRIPTION
I think this might fix #12644.

The comments there suggest the failure is due to `fit` and `fit_predict` learning permuted clusters. I don't think the intention of this test is to check the determinism / idempotence of `fit`/`fit_predict`, even if that would also be a good thing to ensure and to test.

The intention of the test here is:

```
    # check that fit.predict gives same result as fit_predict
    # There's a very small chance of failure with elkan on unstructured dataset
    # because predict method uses fast euclidean distances computation which
    # may cause small numerical instabilities.
```

therefore this should not call `fit` twice, but rather check that calling `predict` after `fit_predict` gives the same labels. This is what we now test in the present PR.