### PR TITLE
Fixed documentation for mean_precision_prior.  Smaller->Larger

### DIFF
--- a/sklearn/mixture/bayesian_mixture.py
+++ b/sklearn/mixture/bayesian_mixture.py
@@ -140,7 +140,7 @@ class BayesianGaussianMixture(BaseMixture):
 
     mean_precision_prior : float | None, optional.
         The precision prior on the mean distribution (Gaussian).
-        Controls the extend to where means can be placed. Smaller
+        Controls the extend to where means can be placed. Larger
         values concentrate the means of each clusters around `mean_prior`.
         The value of the parameter must be greater than 0.
         If it is None, it's set to 1.
@@ -260,7 +260,7 @@ class BayesianGaussianMixture(BaseMixture):
     mean_precision_prior : float
         The precision prior on the mean distribution (Gaussian).
         Controls the extend to where means can be placed.
-        Smaller values concentrate the means of each clusters around
+        Larger values concentrate the means of each clusters around
         `mean_prior`.
 
     mean_precision_ : array-like, shape (n_components,)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #13740.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Documentation for parameter mean_precision_prior in BayesianGuassianMixture was incorrect.  "Smaller" values concentrate means of each cluster around mean_prior should be "Larger" values concentrate.

#### Any other comments?
Thank you for the guidance on how to contribute and open a pull request.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
