### PR TITLE
DOC: trivial rst fix

### DIFF
--- a/examples/impute/plot_iterative_imputer_variants_comparison.py
+++ b/examples/impute/plot_iterative_imputer_variants_comparison.py
@@ -8,13 +8,13 @@ used with a variety of estimators to do round-robin regression, treating every
 variable as an output in turn.
 
 In this example we compare some estimators for the purpose of missing feature
-imputation with :class:`sklearn.imputeIterativeImputer`::
+imputation with :class:`sklearn.imputeIterativeImputer`:
 
-    :class:`~sklearn.linear_model.BayesianRidge`: regularized linear regression
-    :class:`~sklearn.tree.DecisionTreeRegressor`: non-linear regression
-    :class:`~sklearn.ensemble.ExtraTreesRegressor`: similar to missForest in R
-    :class:`~sklearn.neighbors.KNeighborsRegressor`: comparable to other KNN
-    imputation approaches
+* :class:`~sklearn.linear_model.BayesianRidge`: regularized linear regression
+* :class:`~sklearn.tree.DecisionTreeRegressor`: non-linear regression
+* :class:`~sklearn.ensemble.ExtraTreesRegressor`: similar to missForest in R
+* :class:`~sklearn.neighbors.KNeighborsRegressor`: comparable to other KNN
+  imputation approaches
 
 Of particular interest is the ability of
 :class:`sklearn.impute.IterativeImputer` to mimic the behavior of missForest, a


### PR DESCRIPTION
A trivial fix for restructured text not rendering well in the docsring of an example (as visible on https://scikit-learn.org/dev/auto_examples/impute/plot_iterative_imputer_variants_comparison.html)