### PR TITLE
[MRG] Added tests to check saving KernelDensity with sample_weights

### DIFF
--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -1138,7 +1138,7 @@ cdef class BinaryTree:
                 int(self.n_splits),
                 int(self.n_calls),
                 self.dist_metric,
-                self.sample_weight)
+                self.sample_weight_arr)
 
     def __setstate__(self, state):
         """

--- a/sklearn/neighbors/tests/test_kde.py
+++ b/sklearn/neighbors/tests/test_kde.py
@@ -207,19 +207,25 @@ def test_kde_sample_weights():
 
 def test_pickling(tmpdir):
     # Make sure that predictions are the same before and after pickling. Used
-    # to be a bug because sample_weights wasn't pickled and the resulting tree
-    # would miss some info.
+    # Check that pickling works even when sample_weights are added
 
     kde = KernelDensity()
+    kde_weighted = kde
     data = np.reshape([1., 2., 3.], (-1, 1))
     kde.fit(data)
+    kde_weighted.fit(data, sample_weight=[0.1, 0.2, 0.3])
 
     X = np.reshape([1.1, 2.1], (-1, 1))
     scores = kde.score_samples(X)
+    scores_weighted = kde_weighted.score_samples(X)
 
     file_path = str(tmpdir.join('dump.pkl'))
+    file_path_weighted = str(tmpdir.join('dump_weighted.pkl'))
     _joblib.dump(kde, file_path)
+    _joblib.dump(kde_weighted, file_path_weighted)
     kde = _joblib.load(file_path)
+    kde_weighted = _joblib.load(file_path_weighted)
     scores_pickled = kde.score_samples(X)
-
+    scores_weighted_pickled = kde_weighted.score_samples(X)
     assert_allclose(scores, scores_pickled)
+    assert_allclose(scores_weighted, scores_weighted_pickled)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fix #13692 by correcting typo (`self.sample_weight` to `self.sample_weight_arr`) in [this file](https://github.com/scikit-learn/scikit-learn/blob/301076e77b648ea3d715eb823ac006ec0d88e8c3/sklearn/neighbors/binary_tree.pxi) and added tests [here](https://github.com/scikit-learn/scikit-learn/blob/301076e77b648ea3d715eb823ac006ec0d88e8c3/sklearn/neighbors/tests/test_kde.py)

#### What does this implement/fix? Explain your changes.
Enable saving `kde = KernelDensity()` models with `sample_weight` parameter

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
