### PR TITLE
[MRG] DOC Added version information for PCA.singular_values_

### DIFF
--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -222,6 +222,8 @@ class PCA(_BasePCA):
         The singular values corresponding to each of the selected components.
         The singular values are equal to the 2-norms of the ``n_components``
         variables in the lower-dimensional space.
+        
+        .. versionadded:: 0.19
 
     mean_ : array, shape (n_features,)
         Per-feature empirical mean, estimated from the training set.

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -222,7 +222,7 @@ class PCA(_BasePCA):
         The singular values corresponding to each of the selected components.
         The singular values are equal to the 2-norms of the ``n_components``
         variables in the lower-dimensional space.
-        
+
         .. versionadded:: 0.19
 
     mean_ : array, shape (n_features,)


### PR DESCRIPTION
`PCA.singular_values_` is added in 0.19; adding this information to the documentation.

#### Reference Issues/PRs
The feature `PCA.singular_values_` has originally been implemented in #7685, however, the version information (0.19) is absent from the documentation.

#### What does this implement/fix? Explain your changes.
Adding information about the versioning, especially suitable for the users of older versions.

#### Any other comments?
