### PR TITLE
Fix: SVR example - change 'scale' to 'auto'

### DIFF
--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -885,7 +885,7 @@ class SVR(BaseLibSVM, RegressorMixin):
     >>> rng = np.random.RandomState(0)
     >>> y = rng.randn(n_samples)
     >>> X = rng.randn(n_samples, n_features)
-    >>> clf = SVR(gamma='scale', C=1.0, epsilon=0.2)
+    >>> clf = SVR(gamma='auto', C=1.0, epsilon=0.2)
     >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
     SVR(C=1.0, cache_size=200, coef0=0.0, degree=3, epsilon=0.2, gamma='scale',
         kernel='rbf', max_iter=-1, shrinking=True, tol=0.001, verbose=False)


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Running given SVR example:
```
from sklearn.svm import SVR
import numpy as np
n_samples, n_features = 150, 130
np.random.seed(0)
y = np.random.randn(n_samples)
X = np.random.randn(n_samples, n_features)
clf = SVR(gamma='scale', C=0.9, epsilon=0.2)
clf.fit(X, y) 
```
Returns TypeError:

> /site-packages/sklearn/svm/base.py in _dense_fit(self, X, y, sample_weight, solver_type, kernel, random_seed)
>     252                 cache_size=self.cache_size, coef0=self.coef0,
>     253                 gamma=self._gamma, epsilon=self.epsilon,
> --> 254                 max_iter=self.max_iter, random_seed=random_seed)
>  
> sklearn/svm/libsvm.pyx in sklearn.svm.libsvm.fit()
> TypeError: a float is required

Change gamma='scale' to 'auto' because 'scale' deprecated:

> The current default of gamma, 'auto', will change to 'scale' in version 0.22. 'auto_deprecated', a deprecated version of 'auto' is used as a default indicating that no explicit value of gamma was passed.

#### Any other comments?


