### PR TITLE
[MRG] FIX Allow to disable estimator and passing weight in Voting estimators

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -319,6 +319,11 @@ Support for Python 3.4 and below has been officially dropped.
   :pr:`12599` by :user:`Trevor Stephens<trevorstephens>` and
   :user:`Nicolas Hug<NicolasHug>`.
 
+- |Fix| :class:`ensemble.VotingClassifier` and
+  :class:`ensemble.VotingRegressor` were failing during ``fit`` in one
+  of the estimators was set to ``None`` and ``sample_weight`` was not ``None``.
+  :pr:`13779` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.externals`
 ........................
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -42,8 +42,8 @@ Changelog
 :mod:`sklearn.ensemble`
 .......................
 
-- |Fix| :class:`sklearn.ensemble.VotingClassifier` and
-  :class:`sklearn.ensemble.VotingRegressor` were failing during ``fit`` in one
+- |Fix| :class:`ensemble.VotingClassifier` and
+  :class:`ensemble.VotingRegressor` were failing during ``fit`` in one
   of the estimators was set to ``None`` and ``sample_weight`` was not ``None``.
   :pr:`13779` by :user:`Guillaume Lemaitre <glemaitre>`.
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -39,6 +39,14 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
+:mod:`sklearn.ensemble`
+.......................
+
+- |Fix| :class:`sklearn.ensemble.VotingClassifier` and
+  :class:`sklearn.ensemble.VotingRegressor` were failing during ``fit`` in one
+  of the estimators was set to ``None`` and ``sample_weight`` was not ``None``.
+  :pr:`13779` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Changes to estimator checks
 ---------------------------
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -39,14 +39,6 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
-:mod:`sklearn.ensemble`
-.......................
-
-- |Fix| :class:`ensemble.VotingClassifier` and
-  :class:`ensemble.VotingRegressor` were failing during ``fit`` in one
-  of the estimators was set to ``None`` and ``sample_weight`` was not ``None``.
-  :pr:`13779` by :user:`Guillaume Lemaitre <glemaitre>`.
-
 Changes to estimator checks
 ---------------------------
 

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -511,12 +511,16 @@ def test_transform():
     )
 
 
+@pytest.mark.filterwarnings('ignore: Default solver will be changed')  # 0.22
+@pytest.mark.filterwarnings('ignore: Default multi_class will')  # 0.22
 @pytest.mark.parametrize(
     "X, y, voter",
-    [(X, y, VotingClassifier([('lr', LogisticRegression()),
-                              ('rf', RandomForestClassifier())])),
-     (X_r, y_r, VotingRegressor([('lr', LinearRegression()),
-                                 ('rf', RandomForestRegressor())]))]
+    [(X, y, VotingClassifier(
+        [('lr', LogisticRegression()),
+         ('rf', RandomForestClassifier(n_estimators=5))])),
+     (X_r, y_r, VotingRegressor(
+         [('lr', LinearRegression()),
+          ('rf', RandomForestRegressor(n_estimators=5))]))]
 )
 def test_none_estimator_with_weights(X, y, voter):
     # check that an estimator can be set to None and passing some weight

--- a/sklearn/ensemble/voting.py
+++ b/sklearn/ensemble/voting.py
@@ -78,6 +78,8 @@ class _BaseVoting(_BaseComposition, TransformerMixin):
 
         if sample_weight is not None:
             for name, step in self.estimators:
+                if step is None:
+                    continue
                 if not has_fit_parameter(step, 'sample_weight'):
                     raise ValueError('Underlying estimator \'%s\' does not'
                                      ' support sample weights.' % name)


### PR DESCRIPTION
close #13777 

This allows fitting with weights in Voting estimators even when one of then is set to `None`.