### PR TITLE
[MRG] API use drop a sentinel to disable estimators in voting 

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -319,6 +319,11 @@ Support for Python 3.4 and below has been officially dropped.
   :pr:`12599` by :user:`Trevor Stephens<trevorstephens>` and
   :user:`Nicolas Hug<NicolasHug>`.
 
+- |Fix| :class:`ensemble.VotingClassifier` and
+  :class:`ensemble.VotingRegressor` were failing during ``fit`` in one
+  of the estimators was set to ``None`` and ``sample_weight`` was not ``None``.
+  :pr:`13779` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.externals`
 ........................
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -47,6 +47,12 @@ Changelog
   of the estimators was set to ``None`` and ``sample_weight`` was not ``None``.
   :pr:`13779` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- |API| :class:`ensemble.VotingClassifier` and
+  :class:`ensemble.VotingRegressor` accept ``'drop'`` to disable an estimator
+  in addition to ``None`` to be consistent with other estimators (i.e.,
+  :class:`pipeline.FeatureUnion` and :class:`compose.ColumnTransformer`).
+  :pr:`13780` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Changes to estimator checks
 ---------------------------
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -42,8 +42,8 @@ Changelog
 :mod:`sklearn.ensemble`
 .......................
 
-- |Fix| :class:`sklearn.ensemble.VotingClassifier` and
-  :class:`sklearn.ensemble.VotingRegressor` were failing during ``fit`` in one
+- |Fix| :class:`ensemble.VotingClassifier` and
+  :class:`ensemble.VotingRegressor` were failing during ``fit`` in one
   of the estimators was set to ``None`` and ``sample_weight`` was not ``None``.
   :pr:`13779` by :user:`Guillaume Lemaitre <glemaitre>`.
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -39,6 +39,14 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
+:mod:`sklearn.ensemble`
+.......................
+
+- |Fix| :class:`sklearn.ensemble.VotingClassifier` and
+  :class:`sklearn.ensemble.VotingRegressor` were failing during ``fit`` in one
+  of the estimators was set to ``None`` and ``sample_weight`` was not ``None``.
+  :pr:`13779` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Changes to estimator checks
 ---------------------------
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -39,14 +39,6 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
-:mod:`sklearn.ensemble`
-.......................
-
-- |Fix| :class:`ensemble.VotingClassifier` and
-  :class:`ensemble.VotingRegressor` were failing during ``fit`` in one
-  of the estimators was set to ``None`` and ``sample_weight`` was not ``None``.
-  :pr:`13779` by :user:`Guillaume Lemaitre <glemaitre>`.
-
 Changes to estimator checks
 ---------------------------
 

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -345,8 +345,9 @@ def test_sample_weight():
     clf4 = KNeighborsClassifier()
     eclf3 = VotingClassifier(estimators=[
         ('lr', clf1), ('svc', clf3), ('knn', clf4)],
-        voting='soft')
-    msg = ('Underlying estimator \'knn\' does not support sample weights.')
+        voting='soft', n_jobs=-1)
+    msg = ('Underlying estimator KNeighborsClassifier does not support '
+           'sample weights.')
     assert_raise_message(ValueError, msg, eclf3.fit, X, y, sample_weight)
 
 
@@ -524,12 +525,13 @@ def test_transform():
          [('lr', LinearRegression()),
           ('rf', RandomForestRegressor(n_estimators=5))]))]
 )
-def test_none_estimator_with_weights(X, y, voter):
+@pytest.mark.parametrize("drop", [None, 'drop'])
+def test_none_estimator_with_weights(X, y, voter, drop):
     # check that an estimator can be set to None and passing some weight
     # regression test for
     # https://github.com/scikit-learn/scikit-learn/issues/13777
     voter.fit(X, y, sample_weight=np.ones(y.shape))
-    voter.set_params(lr=None)
+    voter.set_params(lr=drop)
     voter.fit(X, y, sample_weight=np.ones(y.shape))
     y_pred = voter.predict(X)
     assert y_pred.shape == y.shape

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -345,7 +345,7 @@ def test_sample_weight():
     clf4 = KNeighborsClassifier()
     eclf3 = VotingClassifier(estimators=[
         ('lr', clf1), ('svc', clf3), ('knn', clf4)],
-        voting='soft', n_jobs=-1)
+        voting='soft')
     msg = ('Underlying estimator KNeighborsClassifier does not support '
            'sample weights.')
     assert_raise_message(ValueError, msg, eclf3.fit, X, y, sample_weight)

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -404,8 +404,10 @@ def test_set_params():
 @pytest.mark.filterwarnings('ignore: Default solver will be changed')  # 0.22
 @pytest.mark.filterwarnings('ignore: Default multi_class will')  # 0.22
 @pytest.mark.filterwarnings('ignore:The default value of n_estimators')
-def test_set_estimator_none():
-    """VotingClassifier set_params should be able to set estimators as None"""
+@pytest.mark.parametrize("drop", [None, 'drop'])
+def test_set_estimator_none(drop):
+    """VotingClassifier set_params should be able to set estimators as None or
+    drop"""
     # Test predict
     clf1 = LogisticRegression(random_state=123)
     clf2 = RandomForestClassifier(random_state=123)
@@ -417,22 +419,22 @@ def test_set_estimator_none():
     eclf2 = VotingClassifier(estimators=[('lr', clf1), ('rf', clf2),
                                          ('nb', clf3)],
                              voting='hard', weights=[1, 1, 0.5])
-    eclf2.set_params(rf=None).fit(X, y)
+    eclf2.set_params(rf=drop).fit(X, y)
     assert_array_equal(eclf1.predict(X), eclf2.predict(X))
 
-    assert dict(eclf2.estimators)["rf"] is None
+    assert dict(eclf2.estimators)["rf"] is drop
     assert len(eclf2.estimators_) == 2
     assert all(isinstance(est, (LogisticRegression, GaussianNB))
                for est in eclf2.estimators_)
-    assert eclf2.get_params()["rf"] is None
+    assert eclf2.get_params()["rf"] is drop
 
     eclf1.set_params(voting='soft').fit(X, y)
     eclf2.set_params(voting='soft').fit(X, y)
     assert_array_equal(eclf1.predict(X), eclf2.predict(X))
     assert_array_almost_equal(eclf1.predict_proba(X), eclf2.predict_proba(X))
-    msg = 'All estimators are None. At least one is required!'
+    msg = 'All estimators are None or "drop". At least one is required!'
     assert_raise_message(
-        ValueError, msg, eclf2.set_params(lr=None, rf=None, nb=None).fit, X, y)
+        ValueError, msg, eclf2.set_params(lr=drop, rf=drop, nb=drop).fit, X, y)
 
     # Test soft voting transform
     X1 = np.array([[1], [2]])
@@ -444,7 +446,7 @@ def test_set_estimator_none():
     eclf2 = VotingClassifier(estimators=[('rf', clf2), ('nb', clf3)],
                              voting='soft', weights=[1, 0.5],
                              flatten_transform=False)
-    eclf2.set_params(rf=None).fit(X1, y1)
+    eclf2.set_params(rf=drop).fit(X1, y1)
     assert_array_almost_equal(eclf1.transform(X1),
                               np.array([[[0.7, 0.3], [0.3, 0.7]],
                                         [[1., 0.], [0., 1.]]]))

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -435,17 +435,11 @@ def test_set_estimator_none(drop):
     eclf2.set_params(rf=drop).fit(X, y)
     assert_array_equal(eclf1.predict(X), eclf2.predict(X))
 
-    if isinstance(drop, str):
-        assert dict(eclf2.estimators)["rf"] == drop
-    else:
-        assert dict(eclf2.estimators)["rf"] is drop
+    assert dict(eclf2.estimators)["rf"] is drop
     assert len(eclf2.estimators_) == 2
     assert all(isinstance(est, (LogisticRegression, GaussianNB))
                for est in eclf2.estimators_)
-    if isinstance(drop, str):
-        assert eclf2.get_params()["rf"] == drop
-    else:
-        assert eclf2.get_params()["rf"] is drop
+    assert eclf2.get_params()["rf"] is drop
 
     eclf1.set_params(voting='soft').fit(X, y)
     eclf2.set_params(voting='soft').fit(X, y)

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -511,12 +511,16 @@ def test_transform():
     )
 
 
+@pytest.mark.filterwarnings('ignore: Default solver will be changed')  # 0.22
+@pytest.mark.filterwarnings('ignore: Default multi_class will')  # 0.22
 @pytest.mark.parametrize(
     "X, y, voter",
-    [(X, y, VotingClassifier([('lr', LogisticRegression()),
-                              ('rf', RandomForestClassifier())])),
-     (X_r, y_r, VotingRegressor([('lr', LinearRegression()),
-                                 ('rf', RandomForestRegressor())]))]
+    [(X, y, VotingClassifier(
+        [('lr', LogisticRegression()),
+         ('rf', RandomForestClassifier(n_estimators=5))])),
+     (X_r, y_r, VotingRegressor(
+         [('lr', LinearRegression()),
+          ('rf', RandomForestRegressor(n_estimators=5))]))]
 )
 def test_none_estimator_with_weights(X, y, voter):
     # check that an estimator can be set to None and passing some weight

--- a/sklearn/ensemble/voting.py
+++ b/sklearn/ensemble/voting.py
@@ -32,7 +32,7 @@ def _parallel_fit_estimator(estimator, X, y, sample_weight=None):
     if sample_weight is not None:
         try:
             estimator.fit(X, y, sample_weight=sample_weight)
-        except:
+        except TypeError:
             raise ValueError(
                 "Underlying estimator {} does not support sample weights."
                 .format(estimator.__class__.__name__)
@@ -60,7 +60,7 @@ class _BaseVoting(_BaseComposition, TransformerMixin):
         if self.weights is None:
             return None
         return [w for est, w in zip(self.estimators, self.weights)
-                if not est[1] in (None, 'drop')]
+                if est[1] not in (None, 'drop')]
 
     def _predict(self, X):
         """Collect results from clf.predict calls. """
@@ -96,7 +96,7 @@ class _BaseVoting(_BaseComposition, TransformerMixin):
         self.estimators_ = Parallel(n_jobs=self.n_jobs)(
                 delayed(_parallel_fit_estimator)(clone(clf), X, y,
                                                  sample_weight=sample_weight)
-                for clf in clfs if not clf in (None, 'drop')
+                for clf in clfs if clf not in (None, 'drop')
             )
 
         self.named_estimators_ = Bunch()

--- a/sklearn/ensemble/voting.py
+++ b/sklearn/ensemble/voting.py
@@ -32,11 +32,13 @@ def _parallel_fit_estimator(estimator, X, y, sample_weight=None):
     if sample_weight is not None:
         try:
             estimator.fit(X, y, sample_weight=sample_weight)
-        except TypeError:
-            raise ValueError(
-                "Underlying estimator {} does not support sample weights."
-                .format(estimator.__class__.__name__)
-            )
+        except TypeError as exc:
+            if "unexpected keyword argument 'sample_weight'" in str(exc):
+                raise ValueError(
+                    "Underlying estimator {} does not support sample weights."
+                    .format(estimator.__class__.__name__)
+                )
+            raise exc
     else:
         estimator.fit(X, y)
     return estimator

--- a/sklearn/ensemble/voting.py
+++ b/sklearn/ensemble/voting.py
@@ -37,8 +37,8 @@ def _parallel_fit_estimator(estimator, X, y, sample_weight=None):
                 raise ValueError(
                     "Underlying estimator {} does not support sample weights."
                     .format(estimator.__class__.__name__)
-                )
-            raise exc
+                ) from exc
+            raise
     else:
         estimator.fit(X, y)
     return estimator

--- a/sklearn/ensemble/voting.py
+++ b/sklearn/ensemble/voting.py
@@ -78,6 +78,8 @@ class _BaseVoting(_BaseComposition, TransformerMixin):
 
         if sample_weight is not None:
             for name, step in self.estimators:
+                if step is None:
+                    continue
                 if not has_fit_parameter(step, 'sample_weight'):
                     raise ValueError('Underlying estimator \'%s\' does not'
                                      ' support sample weights.' % name)


### PR DESCRIPTION
closes #13771 

For consistency, we should allow `'drop'` to work the same as `None` to disable estimators in Voting estimators.

Need to merge #13777 before to have the bug fix regarding the None and the sample weight.