### PR TITLE
Fix more formatting inconsistencies

### DIFF
--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -44,7 +44,7 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
     """Init n_clusters seeds according to k-means++
 
     Parameters
-    -----------
+    ----------
     X : array or sparse matrix, shape (n_samples, n_features)
         The data to pick seeds for. To avoid memory copy, the input data
         should be double precision (dtype=np.float64).
@@ -887,7 +887,7 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         probably much faster than the default batch implementation.
 
     Notes
-    ------
+    -----
     The k-means problem is solved using either Lloyd's or Elkan's algorithm.
 
     The average complexity is given by O(k n T), were n is the number of

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -409,7 +409,7 @@ class MeanShift(BaseEstimator, ClusterMixin):
         """Perform clustering.
 
         Parameters
-        -----------
+        ----------
         X : array-like, shape=[n_samples, n_features]
             Samples to cluster.
 

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -173,7 +173,7 @@ def spectral_clustering(affinity, n_clusters=8, n_components=None,
     Read more in the :ref:`User Guide <spectral_clustering>`.
 
     Parameters
-    -----------
+    ----------
     affinity : array-like or sparse matrix, shape: (n_samples, n_samples)
         The affinity matrix describing the relationship of the samples to
         embed. **Must be symmetric**.
@@ -240,7 +240,7 @@ def spectral_clustering(affinity, n_clusters=8, n_components=None,
       https://www1.icsi.berkeley.edu/~stellayu/publication/doc/2003kwayICCV.pdf
 
     Notes
-    ------
+    -----
     The graph should contain only one connect component, elsewhere
     the results make little sense.
 
@@ -298,7 +298,7 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
     Read more in the :ref:`User Guide <spectral_clustering>`.
 
     Parameters
-    -----------
+    ----------
     n_clusters : integer, optional
         The dimension of the projection subspace.
 

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -810,7 +810,7 @@ def load_sample_image(image_name):
     Read more in the :ref:`User Guide <sample_images>`.
 
     Parameters
-    -----------
+    ----------
     image_name : {`china.jpg`, `flower.jpg`}
         The name of the sample image loaded
 
@@ -820,7 +820,7 @@ def load_sample_image(image_name):
         The image as a numpy array: height x width x color
 
     Examples
-    ---------
+    --------
 
     >>> from sklearn.datasets import load_sample_image
     >>> china = load_sample_image('china.jpg')   # doctest: +SKIP
@@ -895,7 +895,7 @@ def _fetch_remote(remote, dirname=None):
     downloaded file.
 
     Parameters
-    -----------
+    ----------
     remote : RemoteFileMetadata
         Named tuple containing remote dataset meta information: url, filename
         and checksum

--- a/sklearn/datasets/california_housing.py
+++ b/sklearn/datasets/california_housing.py
@@ -97,7 +97,7 @@ def fetch_california_housing(data_home=None, download_if_missing=True,
         .. versionadded:: 0.20
 
     Notes
-    ------
+    -----
 
     This dataset consists of 20,640 samples and 9 features.
     """

--- a/sklearn/datasets/species_distributions.py
+++ b/sklearn/datasets/species_distributions.py
@@ -154,7 +154,7 @@ def fetch_species_distributions(data_home=None,
         instead of trying to download the data from the source site.
 
     Returns
-    --------
+    -------
     The data is returned as a Bunch object with the following attributes:
 
     coverages : array, shape = [14, 1592, 1212]

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -101,7 +101,7 @@ class TreeNode:
         priority).
 
         Parameters
-        -----------
+        ----------
         other_node : TreeNode
             The node to compare with.
         """

--- a/sklearn/ensemble/voting.py
+++ b/sklearn/ensemble/voting.py
@@ -281,7 +281,7 @@ class VotingClassifier(_BaseVoting, ClassifierMixin):
             The input samples.
 
         Returns
-        ----------
+        -------
         maj : array-like, shape (n_samples,)
             Predicted class labels.
         """
@@ -325,7 +325,7 @@ class VotingClassifier(_BaseVoting, ClassifierMixin):
             The input samples.
 
         Returns
-        ----------
+        -------
         avg : array-like, shape (n_samples, n_classes)
             Weighted average probability for each class per sample.
         """

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -32,7 +32,7 @@ def _make_edges_3d(n_x, n_y, n_z=1):
     """Returns a list of edges for a 3D image.
 
     Parameters
-    -----------
+    ----------
     n_x : integer
         The size of the grid in the x direction.
     n_y : integer

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -32,7 +32,7 @@ def _make_edges_3d(n_x, n_y, n_z=1):
     """Returns a list of edges for a 3D image.
 
     Parameters
-    ===========
+    -----------
     n_x : integer
         The size of the grid in the x direction.
     n_y : integer

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1156,7 +1156,7 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
     .. versionadded:: 0.18
 
     Parameters
-    -----------
+    ----------
     length_scale : float or array with shape (n_features,), default: 1.0
         The length scale of the kernel. If a float, an isotropic kernel is
         used. If an array, an anisotropic kernel is used where each dimension
@@ -1269,7 +1269,7 @@ class Matern(RBF):
     .. versionadded:: 0.18
 
     Parameters
-    -----------
+    ----------
     length_scale : float or array with shape (n_features,), default: 1.0
         The length scale of the kernel. If a float, an isotropic kernel is
         used. If an array, an anisotropic kernel is used where each dimension

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -224,7 +224,7 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
     values output by lars_path
 
     Examples
-    ---------
+    --------
 
     Comparing lasso_path and lars_path with interpolation:
 
@@ -661,7 +661,7 @@ class ElasticNet(LinearModel, RegressorMixin, MultiOutputMixin):
         """Fit model with coordinate descent.
 
         Parameters
-        -----------
+        ----------
         X : ndarray or scipy.sparse matrix, (n_samples, n_features)
             Data
 
@@ -1747,7 +1747,7 @@ class MultiTaskElasticNet(Lasso):
         """Fit MultiTaskElasticNet model with coordinate descent
 
         Parameters
-        -----------
+        ----------
         X : ndarray, shape (n_samples, n_features)
             Data
         y : ndarray, shape (n_samples, n_tasks)

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -42,7 +42,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500, alpha_min=0,
     Read more in the :ref:`User Guide <least_angle_regression>`.
 
     Parameters
-    -----------
+    ----------
     X : None or array, shape (n_samples, n_features)
         Input data. Note that if X is None then the Gram matrix must be
         specified, i.e., cannot be None or False.
@@ -112,7 +112,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500, alpha_min=0,
         solution of the coordinate descent lasso_path function.
 
     Returns
-    --------
+    -------
     alphas : array, shape (n_alphas + 1,)
         Maximum of covariances (in absolute value) at each iteration.
         ``n_alphas`` is either ``max_iter``, ``n_features`` or the
@@ -179,7 +179,7 @@ def lars_path_gram(Xy, Gram, n_samples, max_iter=500, alpha_min=0,
     Read more in the :ref:`User Guide <least_angle_regression>`.
 
     Parameters
-    -----------
+    ----------
     Xy : array-like, shape (n_samples,) or (n_samples, n_targets)
         Xy = np.dot(X.T, y).
 
@@ -231,7 +231,7 @@ def lars_path_gram(Xy, Gram, n_samples, max_iter=500, alpha_min=0,
         solution of the coordinate descent lasso_path function.
 
     Returns
-    --------
+    -------
     alphas : array, shape (n_alphas + 1,)
         Maximum of covariances (in absolute value) at each iteration.
         ``n_alphas`` is either ``max_iter``, ``n_features`` or the
@@ -295,7 +295,7 @@ def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
     Read more in the :ref:`User Guide <least_angle_regression>`.
 
     Parameters
-    -----------
+    ----------
     X : None or ndarray, shape (n_samples, n_features)
         Input data. Note that if X is None then Gram must be specified,
         i.e., cannot be None or False.
@@ -358,7 +358,7 @@ def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
         solution of the coordinate descent lasso_path function.
 
     Returns
-    --------
+    -------
     alphas : array, shape (n_alphas + 1,)
         Maximum of covariances (in absolute value) at each iteration.
         ``n_alphas`` is either ``max_iter``, ``n_features`` or the
@@ -1128,7 +1128,7 @@ def _lars_path_residues(X_train, y_train, X_test, y_test, Gram=None,
     """Compute the residues on left-out data for a full LARS path
 
     Parameters
-    -----------
+    ----------
     X_train : array, shape (n_samples, n_features)
         The data to fit the LARS on
 
@@ -1189,7 +1189,7 @@ def _lars_path_residues(X_train, y_train, X_test, y_test, Gram=None,
 
 
     Returns
-    --------
+    -------
     alphas : array, shape (n_alphas,)
         Maximum of covariances (in absolute value) at each iteration.
         ``n_alphas`` is either ``max_iter`` or ``n_features``, whichever

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -681,7 +681,7 @@ def _omp_path_residues(X_train, y_train, X_test, y_test, copy=True,
     """Compute the residues on left-out data for a full LARS path
 
     Parameters
-    -----------
+    ----------
     X_train : array, shape (n_samples, n_features)
         The data to fit the LARS on
 

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -145,7 +145,7 @@ class Isomap(BaseEstimator, TransformerMixin):
         reconstruction_error : float
 
         Notes
-        -------
+        -----
         The cost function of an isomap embedding is
 
         ``E = frobenius_norm[K(D) - K(D_fit)] / n_samples``

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -348,7 +348,7 @@ class SpectralEmbedding(BaseEstimator):
     Read more in the :ref:`User Guide <spectral_embedding>`.
 
     Parameters
-    -----------
+    ----------
     n_components : integer, default: 2
         The dimension of the projected subspace.
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -749,7 +749,7 @@ def paired_cosine_distances(X, Y):
     distances : ndarray, shape (n_samples, )
 
     Notes
-    ------
+    -----
     The cosine distance is equivalent to the half the squared
     euclidean distance if each sample is normalized to unit norm
     """

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -447,7 +447,7 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
         ``predict``.
 
         Parameters
-        -----------
+        ----------
         X : indexable, length n_samples
             Must fulfill the input assumptions of the
             underlying estimator.
@@ -464,7 +464,7 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
         ``predict_proba``.
 
         Parameters
-        -----------
+        ----------
         X : indexable, length n_samples
             Must fulfill the input assumptions of the
             underlying estimator.
@@ -481,7 +481,7 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
         ``predict_log_proba``.
 
         Parameters
-        -----------
+        ----------
         X : indexable, length n_samples
             Must fulfill the input assumptions of the
             underlying estimator.
@@ -498,7 +498,7 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
         ``decision_function``.
 
         Parameters
-        -----------
+        ----------
         X : indexable, length n_samples
             Must fulfill the input assumptions of the
             underlying estimator.
@@ -515,7 +515,7 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
         ``refit=True``.
 
         Parameters
-        -----------
+        ----------
         X : indexable, length n_samples
             Must fulfill the input assumptions of the
             underlying estimator.
@@ -532,7 +532,7 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
         ``inverse_transform`` and ``refit=True``.
 
         Parameters
-        -----------
+        ----------
         Xt : indexable, length n_samples
             Must fulfill the input assumptions of the
             underlying estimator.
@@ -1105,7 +1105,7 @@ class GridSearchCV(BaseSearchCV):
         This is present only if ``refit`` is not False.
 
     Notes
-    ------
+    -----
     The parameters selected are those that maximize the score of the left out
     data, unless an explicit score is passed in which case it is used instead.
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -853,7 +853,7 @@ class LeaveOneGroupOut(BaseCrossValidator):
     >>> logo = LeaveOneGroupOut()
     >>> logo.get_n_splits(X, y, groups)
     2
-    >>> logo.get_n_splits(groups=groups) # 'groups' is always required
+    >>> logo.get_n_splits(groups=groups)  # 'groups' is always required
     2
     >>> print(logo)
     LeaveOneGroupOut()

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -62,14 +62,14 @@ def _get_weights(dist, weights):
     """Get the weights from an array of distances and a parameter ``weights``
 
     Parameters
-    ===========
+    -----------
     dist : ndarray
         The input distances
     weights : {'uniform', 'distance' or a callable}
         The kind of weighting used
 
     Returns
-    ========
+    --------
     weights_arr : array of the same shape as ``dist``
         if ``weights == 'uniform'``, then returns None
     """

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -62,14 +62,14 @@ def _get_weights(dist, weights):
     """Get the weights from an array of distances and a parameter ``weights``
 
     Parameters
-    -----------
+    ----------
     dist : ndarray
         The input distances
     weights : {'uniform', 'distance' or a callable}
         The kind of weighting used
 
     Returns
-    --------
+    -------
     weights_arr : array of the same shape as ``dist``
         if ``weights == 'uniform'``, then returns None
     """

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1683,7 +1683,7 @@ class Normalizer(BaseEstimator, TransformerMixin):
     >>> X = [[4, 1, 2, 2],
     ...      [1, 3, 9, 3],
     ...      [5, 7, 5, 1]]
-    >>> transformer = Normalizer().fit(X) # fit does nothing.
+    >>> transformer = Normalizer().fit(X)  # fit does nothing.
     >>> transformer
     Normalizer(copy=True, norm='l2')
     >>> transformer.transform(X)
@@ -1819,7 +1819,7 @@ class Binarizer(BaseEstimator, TransformerMixin):
     >>> X = [[ 1., -1.,  2.],
     ...      [ 2.,  0.,  0.],
     ...      [ 0.,  1., -1.]]
-    >>> transformer = Binarizer().fit(X) # fit does nothing.
+    >>> transformer = Binarizer().fit(X)  # fit does nothing.
     >>> transformer
     Binarizer(copy=True, threshold=0.0)
     >>> transformer.transform(X)

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -126,7 +126,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
         self : object
 
         Notes
-        ------
+        -----
         If X and y are not C-ordered and contiguous arrays of np.float64 and
         X is not a scipy.sparse.csr_matrix, X and/or y may be copied.
 
@@ -542,7 +542,7 @@ class BaseSVC(BaseLibSVM, ClassifierMixin, metaclass=ABCMeta):
             n_classes).
 
         Notes
-        ------
+        -----
         If decision_function_shape='ovo', the function values are proportional
         to the distance of the samples X to the separating hyperplane. If the
         exact distances are required, divide the function values by the norm of

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -839,7 +839,7 @@ def export_text(decision_tree, feature_names=None, max_depth=10,
         Text summary of all the rules in the decision tree.
 
     Examples
-    -------
+    --------
 
     >>> from sklearn.datasets import load_iris
     >>> from sklearn.tree import DecisionTreeClassifier

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -392,7 +392,7 @@ def weighted_mode(a, w, axis=0):
     The value 4 appears three times: with uniform weights, the result is
     simply the mode of the distribution.
 
-    >>> weights = [1, 3, 0.5, 1.5, 1, 2] # deweight the 4's
+    >>> weights = [1, 3, 0.5, 1.5, 1, 2]  # deweight the 4's
     >>> weighted_mode(x, weights)
     (array([2.]), array([3.5]))
 

--- a/sklearn/utils/mocking.py
+++ b/sklearn/utils/mocking.py
@@ -108,7 +108,7 @@ class CheckingClassifier(BaseEstimator, ClassifierMixin):
     def predict(self, T):
         """
         Parameters
-        -----------
+        ----------
         T : indexable, length n_samples
         """
         if self.check_X is not None:


### PR DESCRIPTION
Not sure how people feel about these kinds of changes, but I've just been writing a script to find inconsistencies in the code formatting.

All changes here are not super important, but because I am fixing things that only occur in a few places, it's obvious it is wrong.

### Examples
#### Incorrect header delimiter
```
Parameters
==========
```
to 
```
Parameters
----------
```

#### Incorrect number of header delimiters
```
Parameters
-------
```
to 
```
Parameters
----------
```

#### Insufficient spaces before inline comment
See https://www.python.org/dev/peps/pep-0008/#inline-comments
> Inline comments should be separated by at least two spaces from the statement.
```
logo.get_n_splits(groups=groups) # 'groups' is always required
```
to
```
logo.get_n_splits(groups=groups)  # 'groups' is always required
```
####