### PR TITLE
[NoMRG] Set OMP_NUM_THREADS=2 on pypy / circle ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,21 +112,21 @@ workflows:
   version: 2
   build-doc-and-deploy:
     jobs:
-      - lint
-      - doc:
-          requires:
-            - lint
-      - doc-min-dependencies:
-          requires:
-            - lint
-#      - pypy3:
+#      - lint
+#      - doc:
+#          requires:
+#            - lint
+#      - doc-min-dependencies:
+#          requires:
+#            - lint
+      - pypy3:
 #          filters:
 #            branches:
 #              only:
 #                - 0.20.X
-      - deploy:
-          requires:
-            - doc
+#      - deploy:
+#          requires:
+#            - doc
   pypy:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,11 +119,11 @@ workflows:
       - doc-min-dependencies:
           requires:
             - lint
-      - pypy3:
-          filters:
-            branches:
-              only:
-                - 0.20.X
+#      - pypy3:
+#          filters:
+#            branches:
+#              only:
+#                - 0.20.X
       - deploy:
           requires:
             - doc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ workflows:
 #      - doc-min-dependencies:
 #          requires:
 #            - lint
-      - pypy3:
+      - pypy3
 #          filters:
 #            branches:
 #              only:

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -28,6 +28,7 @@ ccache -M 512M
 export CCACHE_COMPRESS=1
 export PATH=/usr/lib/ccache:$PATH
 export LOKY_MAX_CPU_COUNT="2"
+export OMP_NUM_THREADS="2"
 
 pip install -vv -e . 
 

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -32,6 +32,6 @@ export OMP_NUM_THREADS="2"
 
 pip install -vv -e . 
 
-python -m pytest sklearn/
-python -m pytest doc/sphinxext/
-python -m pytest $(find doc -name '*.rst' | sort)
+python -m pytest -vl sklearn/
+python -m pytest -vl doc/sphinxext/
+python -m pytest -vl $(find doc -name '*.rst' | sort)

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -29,6 +29,7 @@ export CCACHE_COMPRESS=1
 export PATH=/usr/lib/ccache:$PATH
 export LOKY_MAX_CPU_COUNT="2"
 export OMP_NUM_THREADS="2"
+export PYPY_GC_MAX="2GB"
 
 pip install -vv -e . 
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -65,7 +65,7 @@ def test_early_stopping_regression(scoring, validation_fraction,
 
     max_iter = 200
 
-    X, y = make_regression(random_state=0)
+    X, y = make_regression(n_samples=50, random_state=0)
 
     gb = HistGradientBoostingRegressor(
         verbose=1,  # just for coverage

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -86,8 +86,9 @@ def test_early_stopping_regression(scoring, validation_fraction,
 
 
 @pytest.mark.parametrize('data', (
-    make_classification(random_state=0),
-    make_classification(n_classes=3, n_clusters_per_class=1, random_state=0)
+    make_classification(n_samples=30, random_state=0),
+    make_classification(n_samples=30, n_classes=3, n_clusters_per_class=1,
+                        random_state=0)
 ))
 @pytest.mark.parametrize(
     'scoring, validation_fraction, n_iter_no_change, tol', [


### PR DESCRIPTION
Tentative fix for #13763.

I changed `.circleci/config.yml` to try to test this change directly in the PR.