### PR TITLE
[MRG] DEP change the default of gamma in SVM

### DIFF
--- a/doc/modules/compose.rst
+++ b/doc/modules/compose.rst
@@ -216,12 +216,12 @@ object::
      >>> from sklearn.datasets import load_digits
      >>> digits = load_digits()
      >>> pca1 = PCA()
-     >>> svm1 = SVC(gamma='scale')
+     >>> svm1 = SVC()
      >>> pipe = Pipeline([('reduce_dim', pca1), ('clf', svm1)])
      >>> pipe.fit(digits.data, digits.target)
      ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
      Pipeline(memory=None,
-              steps=[('reduce_dim', PCA(...)), ('clf', SVC(...))], 
+              steps=[('reduce_dim', PCA(...)), ('clf', SVC(...))],
               verbose=False)
      >>> # The pca instance can be inspected directly
      >>> print(pca1.components_) # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
@@ -238,7 +238,7 @@ object::
 
      >>> cachedir = mkdtemp()
      >>> pca2 = PCA()
-     >>> svm2 = SVC(gamma='scale')
+     >>> svm2 = SVC()
      >>> cached_pipe = Pipeline([('reduce_dim', pca2), ('clf', svm2)],
      ...                        memory=cachedir)
      >>> cached_pipe.fit(digits.data, digits.target)

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -947,7 +947,7 @@ Vector Machine, a Decision Tree, and a K-nearest neighbor classifier::
    >>> # Training classifiers
    >>> clf1 = DecisionTreeClassifier(max_depth=4)
    >>> clf2 = KNeighborsClassifier(n_neighbors=7)
-   >>> clf3 = SVC(gamma='scale', kernel='rbf', probability=True)
+   >>> clf3 = SVC(kernel='rbf', probability=True)
    >>> eclf = VotingClassifier(estimators=[('dt', clf1), ('knn', clf2), ('svc', clf3)],
    ...                         voting='soft', weights=[2, 1, 2])
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -100,7 +100,7 @@ Usage examples:
     >>> from sklearn.model_selection import cross_val_score
     >>> iris = datasets.load_iris()
     >>> X, y = iris.data, iris.target
-    >>> clf = svm.SVC(gamma='scale', random_state=0)
+    >>> clf = svm.SVC(random_state=0)
     >>> cross_val_score(clf, X, y, scoring='recall_macro',
     ...                 cv=5)  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     array([0.96..., 0.96..., 0.96..., 0.93..., 1.        ])
@@ -1964,7 +1964,7 @@ Next, let's compare the accuracy of ``SVC`` and ``most_frequent``::
 We see that ``SVC`` doesn't do much better than a dummy classifier. Now, let's
 change the kernel::
 
-  >>> clf = SVC(gamma='scale', kernel='rbf', C=1).fit(X_train, y_train)
+  >>> clf = SVC(kernel='rbf', C=1).fit(X_train, y_train)
   >>> clf.score(X_test, y_test)  # doctest: +ELLIPSIS
   0.94...
 

--- a/doc/modules/model_persistence.rst
+++ b/doc/modules/model_persistence.rst
@@ -23,7 +23,7 @@ persistence model, namely `pickle <https://docs.python.org/2/library/pickle.html
 
   >>> from sklearn import svm
   >>> from sklearn import datasets
-  >>> clf = svm.SVC(gamma='scale')
+  >>> clf = svm.SVC()
   >>> iris = datasets.load_iris()
   >>> X, y = iris.data, iris.target
   >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -75,7 +75,7 @@ n_features]`` holding the training samples, and an array y of class labels
     >>> from sklearn import svm
     >>> X = [[0, 0], [1, 1]]
     >>> y = [0, 1]
-    >>> clf = svm.SVC(gamma='scale')
+    >>> clf = svm.SVC()
     >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
     SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
         decision_function_shape='ovr', degree=3, gamma='scale', kernel='rbf',
@@ -119,7 +119,7 @@ n_classes)``.
 
     >>> X = [[0], [1], [2], [3]]
     >>> Y = [0, 1, 2, 3]
-    >>> clf = svm.SVC(gamma='scale', decision_function_shape='ovo')
+    >>> clf = svm.SVC(decision_function_shape='ovo')
     >>> clf.fit(X, Y) # doctest: +NORMALIZE_WHITESPACE
     SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
         decision_function_shape='ovo', degree=3, gamma='scale', kernel='rbf',

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -542,7 +542,7 @@ test vectors must be provided.
     >>> gram = np.dot(X, X.T)
     >>> clf.fit(gram, y) # doctest: +NORMALIZE_WHITESPACE
     SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
-        decision_function_shape='ovr', degree=3, gamma='auto_deprecated',
+        decision_function_shape='ovr', degree=3, gamma='scale',
         kernel='precomputed', max_iter=-1,
         probability=False, random_state=None, shrinking=True, tol=0.001,
         verbose=False)

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -314,8 +314,8 @@ Vector Regression depends only on a subset of the training data,
 because the cost function for building the model ignores any training
 data close to the model prediction.
 
-There are three different implementations of Support Vector Regression: 
-:class:`SVR`, :class:`NuSVR` and :class:`LinearSVR`. :class:`LinearSVR` 
+There are three different implementations of Support Vector Regression:
+:class:`SVR`, :class:`NuSVR` and :class:`LinearSVR`. :class:`LinearSVR`
 provides a faster implementation than :class:`SVR` but only considers
 linear kernels, while :class:`NuSVR` implements a slightly different
 formulation than :class:`SVR` and :class:`LinearSVR`. See
@@ -331,7 +331,7 @@ floating point values instead of integer values::
     >>> clf = svm.SVR()
     >>> clf.fit(X, y) # doctest: +NORMALIZE_WHITESPACE
     SVR(C=1.0, cache_size=200, coef0=0.0, degree=3, epsilon=0.1,
-        gamma='auto_deprecated', kernel='rbf', max_iter=-1, shrinking=True,
+        gamma='scale', kernel='rbf', max_iter=-1, shrinking=True,
         tol=0.001, verbose=False)
     >>> clf.predict([[1, 1]])
     array([1.5])
@@ -349,7 +349,7 @@ Density estimation, novelty detection
 =======================================
 
 The class :class:`OneClassSVM` implements a One-Class SVM which is used in
-outlier detection. 
+outlier detection.
 
 See :ref:`outlier_detection` for the description and usage of OneClassSVM.
 

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -329,7 +329,7 @@ once will overwrite what was learned by any previous ``fit()``::
   >>> clf = SVC()
   >>> clf.set_params(kernel='linear').fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
   SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
-    decision_function_shape='ovr', degree=3, gamma='auto_deprecated',
+    decision_function_shape='ovr', degree=3, gamma='scale',
     kernel='linear', max_iter=-1,
     probability=False, random_state=None, shrinking=True, tol=0.001,
     verbose=False)

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -216,7 +216,7 @@ persistence model, `pickle <https://docs.python.org/2/library/pickle.html>`_::
 
   >>> from sklearn import svm
   >>> from sklearn import datasets
-  >>> clf = svm.SVC(gamma='scale')
+  >>> clf = svm.SVC()
   >>> iris = datasets.load_iris()
   >>> X, y = iris.data, iris.target
   >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
@@ -291,7 +291,7 @@ maintained::
     >>> from sklearn import datasets
     >>> from sklearn.svm import SVC
     >>> iris = datasets.load_iris()
-    >>> clf = SVC(gamma='scale')
+    >>> clf = SVC()
     >>> clf.fit(iris.data, iris.target)  # doctest: +NORMALIZE_WHITESPACE
     SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
       decision_function_shape='ovr', degree=3, gamma='scale', kernel='rbf',
@@ -336,7 +336,7 @@ once will overwrite what was learned by any previous ``fit()``::
   >>> clf.predict(X[:5])
   array([0, 0, 0, 0, 0])
 
-  >>> clf.set_params(kernel='rbf', gamma='scale').fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+  >>> clf.set_params(kernel='rbf').fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
   SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
     decision_function_shape='ovr', degree=3, gamma='scale', kernel='rbf',
     max_iter=-1, probability=False,
@@ -363,8 +363,7 @@ the target data fit upon::
     >>> X = [[1, 2], [2, 4], [4, 5], [3, 2], [3, 1]]
     >>> y = [0, 0, 1, 1, 2]
 
-    >>> classif = OneVsRestClassifier(estimator=SVC(gamma='scale',
-    ...                                             random_state=0))
+    >>> classif = OneVsRestClassifier(estimator=SVC(random_state=0))
     >>> classif.fit(X, y).predict(X)
     array([0, 0, 1, 1, 2])
 

--- a/doc/tutorial/statistical_inference/supervised_learning.rst
+++ b/doc/tutorial/statistical_inference/supervised_learning.rst
@@ -463,7 +463,7 @@ classification --:class:`SVC` (Support Vector Classification).
     >>> svc = svm.SVC(kernel='linear')
     >>> svc.fit(iris_X_train, iris_y_train)    # doctest: +NORMALIZE_WHITESPACE
     SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
-        decision_function_shape='ovr', degree=3, gamma='auto_deprecated',
+        decision_function_shape='ovr', degree=3, gamma='scale',
         kernel='linear', max_iter=-1,
         probability=False, random_state=None, shrinking=True, tol=0.001,
         verbose=False)

--- a/examples/preprocessing/plot_discretization_classification.py
+++ b/examples/preprocessing/plot_discretization_classification.py
@@ -83,7 +83,7 @@ classifiers = [
     (GradientBoostingClassifier(n_estimators=50, random_state=0), {
         'learning_rate': np.logspace(-4, 0, 10)
     }),
-    (SVC(random_state=0, gamma='scale'), {
+    (SVC(random_state=0), {
         'C': np.logspace(-2, 7, 10)
     }),
 ]

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -71,7 +71,7 @@ def test_classification():
                            Perceptron(tol=1e-3),
                            DecisionTreeClassifier(),
                            KNeighborsClassifier(),
-                           SVC(gamma="scale")]:
+                           SVC()]:
         for params in grid:
             BaggingClassifier(base_estimator=base_estimator,
                               random_state=rng,
@@ -117,8 +117,7 @@ def test_sparse_classification():
             for f in ['predict', 'predict_proba', 'predict_log_proba', 'decision_function']:
                 # Trained on sparse format
                 sparse_classifier = BaggingClassifier(
-                    base_estimator=CustomSVC(gamma='scale',
-                                             decision_function_shape='ovr'),
+                    base_estimator=CustomSVC(decision_function_shape='ovr'),
                     random_state=1,
                     **params
                 ).fit(X_train_sparse, y_train)
@@ -126,8 +125,7 @@ def test_sparse_classification():
 
                 # Trained on dense format
                 dense_classifier = BaggingClassifier(
-                    base_estimator=CustomSVC(gamma='scale',
-                                             decision_function_shape='ovr'),
+                    base_estimator=CustomSVC(decision_function_shape='ovr'),
                     random_state=1,
                     **params
                 ).fit(X_train, y_train)
@@ -155,7 +153,7 @@ def test_regression():
                            DummyRegressor(),
                            DecisionTreeRegressor(),
                            KNeighborsRegressor(),
-                           SVR(gamma='scale')]:
+                           SVR()]:
         for params in grid:
             BaggingRegressor(base_estimator=base_estimator,
                              random_state=rng,
@@ -201,7 +199,7 @@ def test_sparse_regression():
 
             # Trained on sparse format
             sparse_classifier = BaggingRegressor(
-                base_estimator=CustomSVR(gamma='scale'),
+                base_estimator=CustomSVR(),
                 random_state=1,
                 **params
             ).fit(X_train_sparse, y_train)
@@ -209,7 +207,7 @@ def test_sparse_regression():
 
             # Trained on dense format
             dense_results = BaggingRegressor(
-                base_estimator=CustomSVR(gamma='scale'),
+                base_estimator=CustomSVR(),
                 random_state=1,
                 **params
             ).fit(X_train, y_train).predict(X_test)
@@ -334,7 +332,7 @@ def test_oob_score_classification():
                                                         iris.target,
                                                         random_state=rng)
 
-    for base_estimator in [DecisionTreeClassifier(), SVC(gamma="scale")]:
+    for base_estimator in [DecisionTreeClassifier(), SVC()]:
         clf = BaggingClassifier(base_estimator=base_estimator,
                                 n_estimators=100,
                                 bootstrap=True,
@@ -464,8 +462,7 @@ def test_parallel_classification():
     assert_array_almost_equal(y1, y3)
 
     # decision_function
-    ensemble = BaggingClassifier(SVC(gamma='scale',
-                                     decision_function_shape='ovr'),
+    ensemble = BaggingClassifier(SVC(decision_function_shape='ovr'),
                                  n_jobs=3,
                                  random_state=0).fit(X_train, y_train)
 
@@ -482,8 +479,7 @@ def test_parallel_classification():
                          "".format(X_test.shape[1], X_err.shape[1]),
                          ensemble.decision_function, X_err)
 
-    ensemble = BaggingClassifier(SVC(gamma='scale',
-                                     decision_function_shape='ovr'),
+    ensemble = BaggingClassifier(SVC(decision_function_shape='ovr'),
                                  n_jobs=1,
                                  random_state=0).fit(X_train, y_train)
 
@@ -529,7 +525,7 @@ def test_gridsearch():
     parameters = {'n_estimators': (1, 2),
                   'base_estimator__C': (1, 2)}
 
-    GridSearchCV(BaggingClassifier(SVC(gamma="scale")),
+    GridSearchCV(BaggingClassifier(SVC()),
                  parameters,
                  scoring="roc_auc").fit(X, y)
 
@@ -578,7 +574,7 @@ def test_base_estimator():
 
     assert isinstance(ensemble.base_estimator_, DecisionTreeRegressor)
 
-    ensemble = BaggingRegressor(SVR(gamma='scale'),
+    ensemble = BaggingRegressor(SVR(),
                                 n_jobs=3,
                                 random_state=0).fit(X_train, y_train)
     assert isinstance(ensemble.base_estimator_, SVR)

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -325,7 +325,7 @@ def test_sample_weight():
     """Tests sample_weight parameter of VotingClassifier"""
     clf1 = LogisticRegression(random_state=123)
     clf2 = RandomForestClassifier(random_state=123)
-    clf3 = SVC(gamma='scale', probability=True, random_state=123)
+    clf3 = SVC(probability=True, random_state=123)
     eclf1 = VotingClassifier(estimators=[
         ('lr', clf1), ('rf', clf2), ('svc', clf3)],
         voting='soft').fit(X, y, sample_weight=np.ones((len(y),)))

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -291,7 +291,7 @@ def test_base_estimator():
     clf = AdaBoostClassifier(RandomForestClassifier())
     clf.fit(X, y_regr)
 
-    clf = AdaBoostClassifier(SVC(gamma="scale"), algorithm="SAMME")
+    clf = AdaBoostClassifier(SVC(), algorithm="SAMME")
     clf.fit(X, y_class)
 
     from sklearn.ensemble import RandomForestRegressor
@@ -299,13 +299,13 @@ def test_base_estimator():
     clf = AdaBoostRegressor(RandomForestRegressor(), random_state=0)
     clf.fit(X, y_regr)
 
-    clf = AdaBoostRegressor(SVR(gamma='scale'), random_state=0)
+    clf = AdaBoostRegressor(SVR(), random_state=0)
     clf.fit(X, y_regr)
 
     # Check that an empty discrete ensemble fails in fit, not predict.
     X_fail = [[1, 1], [1, 1], [1, 1], [1, 1]]
     y_fail = ["foo", "bar", 1, 2]
-    clf = AdaBoostClassifier(SVC(gamma="scale"), algorithm="SAMME")
+    clf = AdaBoostClassifier(SVC(), algorithm="SAMME")
     assert_raises_regexp(ValueError, "worse than random",
                          clf.fit, X_fail, y_fail)
 
@@ -347,14 +347,14 @@ def test_sparse_classification():
 
         # Trained on sparse format
         sparse_classifier = AdaBoostClassifier(
-            base_estimator=CustomSVC(gamma='scale', probability=True),
+            base_estimator=CustomSVC(probability=True),
             random_state=1,
             algorithm="SAMME"
         ).fit(X_train_sparse, y_train)
 
         # Trained on dense format
         dense_classifier = AdaBoostClassifier(
-            base_estimator=CustomSVC(gamma='scale', probability=True),
+            base_estimator=CustomSVC(probability=True),
             random_state=1,
             algorithm="SAMME"
         ).fit(X_train, y_train)
@@ -441,13 +441,13 @@ def test_sparse_regression():
 
         # Trained on sparse format
         sparse_classifier = AdaBoostRegressor(
-            base_estimator=CustomSVR(gamma='scale'),
+            base_estimator=CustomSVR(),
             random_state=1
         ).fit(X_train_sparse, y_train)
 
         # Trained on dense format
         dense_classifier = dense_results = AdaBoostRegressor(
-            base_estimator=CustomSVR(gamma='scale'),
+            base_estimator=CustomSVR(),
             random_state=1
         ).fit(X_train, y_train)
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -978,7 +978,7 @@ class GridSearchCV(BaseSearchCV):
     >>> from sklearn.model_selection import GridSearchCV
     >>> iris = datasets.load_iris()
     >>> parameters = {'kernel':('linear', 'rbf'), 'C':[1, 10]}
-    >>> svc = svm.SVC(gamma="scale")
+    >>> svc = svm.SVC()
     >>> clf = GridSearchCV(svc, parameters, cv=5)
     >>> clf.fit(iris.data, iris.target)
     ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -443,7 +443,7 @@ def test_grid_search_bad_param_grid():
         GridSearchCV, clf, param_dict)
 
     param_dict = {"C": []}
-    clf = SVC(gamma="scale")
+    clf = SVC()
     assert_raise_message(
         ValueError,
         "Parameter values for parameter (C) need to be a non-empty sequence.",
@@ -458,7 +458,7 @@ def test_grid_search_bad_param_grid():
         GridSearchCV, clf, param_dict)
 
     param_dict = {"C": np.ones((3, 2))}
-    clf = SVC(gamma="scale")
+    clf = SVC()
     assert_raises(ValueError, GridSearchCV, clf, param_dict)
 
 
@@ -886,7 +886,7 @@ def test_grid_search_cv_results():
     n_candidates = n_grid_points
 
     for iid in (False, True):
-        search = GridSearchCV(SVC(gamma='scale'), cv=n_splits, iid=iid,
+        search = GridSearchCV(SVC(), cv=n_splits, iid=iid,
                               param_grid=params, return_train_score=True)
         search.fit(X, y)
         assert_equal(iid, search.iid)
@@ -936,7 +936,7 @@ def test_random_search_cv_results():
     n_cand = n_search_iter
 
     for iid in (False, True):
-        search = RandomizedSearchCV(SVC(gamma='scale'), n_iter=n_search_iter,
+        search = RandomizedSearchCV(SVC(), n_iter=n_search_iter,
                                     cv=n_splits, iid=iid,
                                     param_distributions=params,
                                     return_train_score=True)
@@ -1061,7 +1061,7 @@ def test_grid_search_cv_results_multimetric():
         for scoring in ({'accuracy': make_scorer(accuracy_score),
                          'recall': make_scorer(recall_score)},
                         'accuracy', 'recall'):
-            grid_search = GridSearchCV(SVC(gamma='scale'), cv=n_splits,
+            grid_search = GridSearchCV(SVC(), cv=n_splits,
                                        iid=iid, param_grid=params,
                                        scoring=scoring, refit=False)
             grid_search.fit(X, y)
@@ -1160,9 +1160,9 @@ def test_search_cv_results_rank_tie_breaking():
     # which would result in a tie of their mean cv-scores
     param_grid = {'C': [1, 1.001, 0.001]}
 
-    grid_search = GridSearchCV(SVC(gamma="scale"), param_grid=param_grid,
+    grid_search = GridSearchCV(SVC(), param_grid=param_grid,
                                return_train_score=True)
-    random_search = RandomizedSearchCV(SVC(gamma="scale"), n_iter=3,
+    random_search = RandomizedSearchCV(SVC(), n_iter=3,
                                        param_distributions=param_grid,
                                        return_train_score=True)
 
@@ -1364,7 +1364,7 @@ def test_predict_proba_disabled():
     # Test predict_proba when disabled on estimator.
     X = np.arange(20).reshape(5, -1)
     y = [0, 0, 1, 1, 1]
-    clf = SVC(gamma='scale', probability=False)
+    clf = SVC(probability=False)
     gs = GridSearchCV(clf, {}, cv=2).fit(X, y)
     assert not hasattr(gs, "predict_proba")
 
@@ -1712,22 +1712,22 @@ def test_deprecated_grid_search_iid():
     depr_message = ("The default of the `iid` parameter will change from True "
                     "to False in version 0.22")
     X, y = make_blobs(n_samples=54, random_state=0, centers=2)
-    grid = GridSearchCV(SVC(gamma='scale', random_state=0),
+    grid = GridSearchCV(SVC(random_state=0),
                         param_grid={'C': [10]}, cv=3)
     # no warning with equally sized test sets
     assert_no_warnings(grid.fit, X, y)
 
-    grid = GridSearchCV(SVC(gamma='scale', random_state=0),
+    grid = GridSearchCV(SVC(random_state=0),
                         param_grid={'C': [10]}, cv=5)
     # warning because 54 % 5 != 0
     assert_warns_message(DeprecationWarning, depr_message, grid.fit, X, y)
 
-    grid = GridSearchCV(SVC(gamma='scale', random_state=0),
+    grid = GridSearchCV(SVC(random_state=0),
                         param_grid={'C': [10]}, cv=2)
     # warning because stratification into two classes and 27 % 2 != 0
     assert_warns_message(DeprecationWarning, depr_message, grid.fit, X, y)
 
-    grid = GridSearchCV(SVC(gamma='scale', random_state=0),
+    grid = GridSearchCV(SVC(random_state=0),
                         param_grid={'C': [10]}, cv=KFold(2))
     # no warning because no stratification and 54 % 2 == 0
     assert_no_warnings(grid.fit, X, y)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -350,10 +350,10 @@ def test_cross_validate_invalid_scoring_param():
 
     # Multiclass Scorers that return multiple values are not supported yet
     assert_raises_regex(ValueError, "scoring must return a number, got",
-                        cross_validate, SVC(gamma='scale'), X, y,
+                        cross_validate, SVC(), X, y,
                         scoring=multivalued_scorer)
     assert_raises_regex(ValueError, "scoring must return a number, got",
-                        cross_validate, SVC(gamma='scale'), X, y,
+                        cross_validate, SVC(), X, y,
                         scoring={"foo": multivalued_scorer})
 
     assert_raises_regex(ValueError, "'mse' is not a valid scoring value.",
@@ -567,7 +567,7 @@ def test_cross_val_score_precomputed():
     assert_array_almost_equal(score_precomputed, score_linear)
 
     # test with callable
-    svm = SVC(gamma='scale', kernel=lambda x, y: np.dot(x, y.T))
+    svm = SVC(kernel=lambda x, y: np.dot(x, y.T))
     score_callable = cross_val_score(svm, X, y)
     assert_array_almost_equal(score_precomputed, score_callable)
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2089,8 +2089,7 @@ def test_cv_pipeline_precomputed():
     y_true = np.ones((4,))
     K = X.dot(X.T)
     kcent = KernelCenterer()
-    pipeline = Pipeline([("kernel_centerer", kcent), ("svr",
-                        SVR(gamma='scale'))])
+    pipeline = Pipeline([("kernel_centerer", kcent), ("svr", SVR())])
 
     # did the pipeline set the _pairwise attribute?
     assert pipeline._pairwise

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -171,7 +171,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
             if self.gamma == 'scale':
                 # var = E[X^2] - E[X]^2 if sparse
                 X_var = ((X.multiply(X)).mean() - (X.mean()) ** 2
-                          if sparse else X.var())
+                         if sparse else X.var())
                 self._gamma = 1.0 / (X.shape[1] * X_var) if X_var != 0 else 1.0
             elif self.gamma == 'auto':
                 self._gamma = 1.0 / X.shape[1]

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -1,5 +1,3 @@
-import numbers
-
 import numpy as np
 import scipy.sparse as sp
 import warnings
@@ -173,7 +171,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
             if self.gamma == 'scale':
                 # var = E[X^2] - E[X]^2 if sparse
                 X_var = ((X.multiply(X)).mean() - (X.mean()) ** 2
-                        if sparse else X.var())
+                          if sparse else X.var())
                 self._gamma = 1.0 / (X.shape[1] * X_var) if X_var != 0 else 1.0
             elif self.gamma == 'auto':
                 self._gamma = 1.0 / X.shape[1]

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -167,31 +167,11 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
                              "boolean masks (use `indices=True` in CV)."
                              % (sample_weight.shape, X.shape))
 
-        if self.gamma in ('scale', 'auto_deprecated'):
-            if sparse:
-                # var = E[X^2] - E[X]^2
-                X_var = (X.multiply(X)).mean() - (X.mean()) ** 2
-            else:
-                X_var = X.var()
-            if self.gamma == 'scale':
-                if X_var != 0:
-                    self._gamma = 1.0 / (X.shape[1] * X_var)
-                else:
-                    self._gamma = 1.0
-            else:
-                kernel_uses_gamma = (not callable(self.kernel) and self.kernel
-                                     not in ('linear', 'precomputed'))
-                if kernel_uses_gamma and not np.isclose(X_var, 1.0):
-                    # NOTE: when deprecation ends we need to remove explicitly
-                    # setting `gamma` in examples (also in tests). See
-                    # https://github.com/scikit-learn/scikit-learn/pull/10331
-                    # for the examples/tests that need to be reverted.
-                    warnings.warn("The default value of gamma will change "
-                                  "from 'auto' to 'scale' in version 0.22 to "
-                                  "account better for unscaled features. Set "
-                                  "gamma explicitly to 'auto' or 'scale' to "
-                                  "avoid this warning.", FutureWarning)
-                self._gamma = 1.0 / X.shape[1]
+        if self.gamma == 'scale':
+            # var = E[X^2] - E[X]^2 if sparse
+            X_var = ((X.multiply(X)).mean() - (X.mean()) ** 2
+                     if sparse else X.var())
+            self._gamma = 1.0 / (X.shape[1] * X_var) if X_var != 0 else 1.0
         elif self.gamma == 'auto':
             self._gamma = 1.0 / X.shape[1]
         else:

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -1,3 +1,5 @@
+import numbers
+
 import numpy as np
 import scipy.sparse as sp
 import warnings
@@ -167,13 +169,19 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
                              "boolean masks (use `indices=True` in CV)."
                              % (sample_weight.shape, X.shape))
 
-        if self.gamma == 'scale':
-            # var = E[X^2] - E[X]^2 if sparse
-            X_var = ((X.multiply(X)).mean() - (X.mean()) ** 2
-                     if sparse else X.var())
-            self._gamma = 1.0 / (X.shape[1] * X_var) if X_var != 0 else 1.0
-        elif self.gamma == 'auto':
-            self._gamma = 1.0 / X.shape[1]
+        if isinstance(self.gamma, str):
+            if self.gamma == 'scale':
+                # var = E[X^2] - E[X]^2 if sparse
+                X_var = ((X.multiply(X)).mean() - (X.mean()) ** 2
+                        if sparse else X.var())
+                self._gamma = 1.0 / (X.shape[1] * X_var) if X_var != 0 else 1.0
+            elif self.gamma == 'auto':
+                self._gamma = 1.0 / X.shape[1]
+            else:
+                raise ValueError(
+                    "When 'gamma' is a string, it should be either 'scale' or "
+                    "'auto'. Got '{}' instead.".format(self.gamma)
+                )
         else:
             self._gamma = self.gamma
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -470,8 +470,7 @@ class SVC(BaseSVC):
         - if 'auto', uses 1 / n_features.
 
         .. versionchanged:: 0.22
-           The default value of ``gamma`` changed from ``'auto'`` to
-           ``'scale'``.
+           The default value of ``gamma`` changed from 'auto' to 'scale'.
 
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
@@ -670,8 +669,7 @@ class NuSVC(BaseSVC):
         - if 'auto', uses 1 / n_features.
 
         .. versionchanged:: 0.22
-           The default value of ``gamma`` changed from ``'auto'`` to
-           ``'scale'``.
+           The default value of ``gamma`` changed from 'auto' to 'scale'.
 
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
@@ -848,8 +846,7 @@ class SVR(BaseLibSVM, RegressorMixin):
         - if 'auto', uses 1 / n_features.
 
         .. versionchanged:: 0.22
-           The default value of ``gamma`` changed from ``'auto'`` to
-           ``'scale'``.
+           The default value of ``gamma`` changed from 'auto' to 'scale'.
 
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
@@ -985,8 +982,7 @@ class NuSVR(BaseLibSVM, RegressorMixin):
         - if 'auto', uses 1 / n_features.
 
         .. versionchanged:: 0.22
-           The default value of ``gamma`` changed from ``'auto'`` to
-           ``'scale'``.
+           The default value of ``gamma`` changed from 'auto' to 'scale'.
 
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
@@ -1103,8 +1099,7 @@ class OneClassSVM(BaseLibSVM, OutlierMixin):
         - if 'auto', uses 1 / n_features.
 
         .. versionchanged:: 0.22
-           The default value of ``gamma`` changed from ``'auto'`` to
-           ``'scale'``.
+           The default value of ``gamma`` changed from 'auto' to 'scale'.
 
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -462,15 +462,12 @@ class SVC(BaseSVC):
         Degree of the polynomial kernel function ('poly').
         Ignored by all other kernels.
 
-    gamma : float, optional (default='auto')
+    gamma : {'scale', 'auto'} or float, optional (default='scale')
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
 
-        Current default is 'auto' which uses 1 / n_features,
-        if ``gamma='scale'`` is passed then it uses 1 / (n_features * X.var())
-        as value of gamma. The current default of gamma, 'auto', will change
-        to 'scale' in version 0.22. 'auto_deprecated', a deprecated version of
-        'auto' is used as a default indicating that no explicit value of gamma
-        was passed.
+        - if ``gamma='scale'`` (default) is passed then it uses
+          1 / (n_features * X.var()) as value of gamma,
+        - if 'auto', uses 1 / n_features.
 
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
@@ -616,7 +613,7 @@ class SVC(BaseSVC):
 
     _impl = 'c_svc'
 
-    def __init__(self, C=1.0, kernel='rbf', degree=3, gamma='auto_deprecated',
+    def __init__(self, C=1.0, kernel='rbf', degree=3, gamma='scale',
                  coef0=0.0, shrinking=True, probability=False,
                  tol=1e-3, cache_size=200, class_weight=None,
                  verbose=False, max_iter=-1, decision_function_shape='ovr',
@@ -661,15 +658,12 @@ class NuSVC(BaseSVC):
         Degree of the polynomial kernel function ('poly').
         Ignored by all other kernels.
 
-    gamma : float, optional (default='auto')
+    gamma : {'scale', 'auto'} or float, optional (default='scale')
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
 
-        Current default is 'auto' which uses 1 / n_features,
-        if ``gamma='scale'`` is passed then it uses 1 / (n_features * X.var())
-        as value of gamma. The current default of gamma, 'auto', will change
-        to 'scale' in version 0.22. 'auto_deprecated', a deprecated version of
-        'auto' is used as a default indicating that no explicit value of gamma
-        was passed.
+        - if ``gamma='scale'`` (default) is passed then it uses
+          1 / (n_features * X.var()) as value of gamma,
+        - if 'auto', uses 1 / n_features.
 
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
@@ -768,7 +762,7 @@ class NuSVC(BaseSVC):
     >>> X = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1]])
     >>> y = np.array([1, 1, 2, 2])
     >>> from sklearn.svm import NuSVC
-    >>> clf = NuSVC(gamma='scale')
+    >>> clf = NuSVC()
     >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
     NuSVC(break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
           decision_function_shape='ovr', degree=3, gamma='scale', kernel='rbf',
@@ -795,7 +789,7 @@ class NuSVC(BaseSVC):
 
     _impl = 'nu_svc'
 
-    def __init__(self, nu=0.5, kernel='rbf', degree=3, gamma='auto_deprecated',
+    def __init__(self, nu=0.5, kernel='rbf', degree=3, gamma='scale',
                  coef0=0.0, shrinking=True, probability=False, tol=1e-3,
                  cache_size=200, class_weight=None, verbose=False, max_iter=-1,
                  decision_function_shape='ovr', break_ties=False,
@@ -838,15 +832,12 @@ class SVR(BaseLibSVM, RegressorMixin):
         Degree of the polynomial kernel function ('poly').
         Ignored by all other kernels.
 
-    gamma : float, optional (default='auto')
+    gamma : {'scale', 'auto'} or float, optional (default='scale')
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
 
-        Current default is 'auto' which uses 1 / n_features,
-        if ``gamma='scale'`` is passed then it uses 1 / (n_features * X.var())
-        as value of gamma. The current default of gamma, 'auto', will change
-        to 'scale' in version 0.22. 'auto_deprecated', a deprecated version of
-        'auto' is used as a default indicating that no explicit value of gamma
-        was passed.
+        - if ``gamma='scale'`` (default) is passed then it uses
+          1 / (n_features * X.var()) as value of gamma,
+        - if 'auto', uses 1 / n_features.
 
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
@@ -907,7 +898,7 @@ class SVR(BaseLibSVM, RegressorMixin):
     >>> rng = np.random.RandomState(0)
     >>> y = rng.randn(n_samples)
     >>> X = rng.randn(n_samples, n_features)
-    >>> clf = SVR(gamma='scale', C=1.0, epsilon=0.2)
+    >>> clf = SVR(C=1.0, epsilon=0.2)
     >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
     SVR(C=1.0, cache_size=200, coef0=0.0, degree=3, epsilon=0.2, gamma='scale',
         kernel='rbf', max_iter=-1, shrinking=True, tol=0.001, verbose=False)
@@ -931,7 +922,7 @@ class SVR(BaseLibSVM, RegressorMixin):
 
     _impl = 'epsilon_svr'
 
-    def __init__(self, kernel='rbf', degree=3, gamma='auto_deprecated',
+    def __init__(self, kernel='rbf', degree=3, gamma='scale',
                  coef0=0.0, tol=1e-3, C=1.0, epsilon=0.1, shrinking=True,
                  cache_size=200, verbose=False, max_iter=-1):
 
@@ -974,15 +965,12 @@ class NuSVR(BaseLibSVM, RegressorMixin):
         Degree of the polynomial kernel function ('poly').
         Ignored by all other kernels.
 
-    gamma : float, optional (default='auto')
+    gamma : {'scale', 'auto'} or float, optional (default='scale')
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
 
-        Current default is 'auto' which uses 1 / n_features,
-        if ``gamma='scale'`` is passed then it uses 1 / (n_features * X.var())
-        as value of gamma. The current default of gamma, 'auto', will change
-        to 'scale' in version 0.22. 'auto_deprecated', a deprecated version of
-        'auto' is used as a default indicating that no explicit value of gamma
-        was passed.
+        - if ``gamma='scale'`` (default) is passed then it uses
+          1 / (n_features * X.var()) as value of gamma,
+        - if 'auto', uses 1 / n_features.
 
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
@@ -1034,7 +1022,7 @@ class NuSVR(BaseLibSVM, RegressorMixin):
     >>> np.random.seed(0)
     >>> y = np.random.randn(n_samples)
     >>> X = np.random.randn(n_samples, n_features)
-    >>> clf = NuSVR(gamma='scale', C=1.0, nu=0.1)
+    >>> clf = NuSVR(C=1.0, nu=0.1)
     >>> clf.fit(X, y)  #doctest: +NORMALIZE_WHITESPACE
     NuSVR(C=1.0, cache_size=200, coef0=0.0, degree=3, gamma='scale',
           kernel='rbf', max_iter=-1, nu=0.1, shrinking=True, tol=0.001,
@@ -1059,7 +1047,7 @@ class NuSVR(BaseLibSVM, RegressorMixin):
     _impl = 'nu_svr'
 
     def __init__(self, nu=0.5, C=1.0, kernel='rbf', degree=3,
-                 gamma='auto_deprecated', coef0=0.0, shrinking=True,
+                 gamma='scale', coef0=0.0, shrinking=True,
                  tol=1e-3, cache_size=200, verbose=False, max_iter=-1):
 
         super().__init__(
@@ -1091,15 +1079,12 @@ class OneClassSVM(BaseLibSVM, OutlierMixin):
         Degree of the polynomial kernel function ('poly').
         Ignored by all other kernels.
 
-    gamma : float, optional (default='auto')
+    gamma : {'scale', 'auto'} or float, optional (default='scale')
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
 
-        Current default is 'auto' which uses 1 / n_features,
-        if ``gamma='scale'`` is passed then it uses 1 / (n_features * X.var())
-        as value of gamma. The current default of gamma, 'auto', will change
-        to 'scale' in version 0.22. 'auto_deprecated', a deprecated version of
-        'auto' is used as a default indicating that no explicit value of gamma
-        was passed.
+        - if ``gamma='scale'`` (default) is passed then it uses
+          1 / (n_features * X.var()) as value of gamma,
+        - if 'auto', uses 1 / n_features.
 
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
@@ -1166,7 +1151,7 @@ class OneClassSVM(BaseLibSVM, OutlierMixin):
 
     _impl = 'one_class'
 
-    def __init__(self, kernel='rbf', degree=3, gamma='auto_deprecated',
+    def __init__(self, kernel='rbf', degree=3, gamma='scale',
                  coef0=0.0, tol=1e-3, nu=0.5, shrinking=True, cache_size=200,
                  verbose=False, max_iter=-1, random_state=None):
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -469,6 +469,10 @@ class SVC(BaseSVC):
           1 / (n_features * X.var()) as value of gamma,
         - if 'auto', uses 1 / n_features.
 
+        .. versionchanged:: 0.22
+           The default value of ``gamma`` changed from ``'auto'`` to
+           ``'scale'``.
+
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
         It is only significant in 'poly' and 'sigmoid'.
@@ -665,6 +669,10 @@ class NuSVC(BaseSVC):
           1 / (n_features * X.var()) as value of gamma,
         - if 'auto', uses 1 / n_features.
 
+        .. versionchanged:: 0.22
+           The default value of ``gamma`` changed from ``'auto'`` to
+           ``'scale'``.
+
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
         It is only significant in 'poly' and 'sigmoid'.
@@ -839,6 +847,10 @@ class SVR(BaseLibSVM, RegressorMixin):
           1 / (n_features * X.var()) as value of gamma,
         - if 'auto', uses 1 / n_features.
 
+        .. versionchanged:: 0.22
+           The default value of ``gamma`` changed from ``'auto'`` to
+           ``'scale'``.
+
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
         It is only significant in 'poly' and 'sigmoid'.
@@ -972,6 +984,10 @@ class NuSVR(BaseLibSVM, RegressorMixin):
           1 / (n_features * X.var()) as value of gamma,
         - if 'auto', uses 1 / n_features.
 
+        .. versionchanged:: 0.22
+           The default value of ``gamma`` changed from ``'auto'`` to
+           ``'scale'``.
+
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
         It is only significant in 'poly' and 'sigmoid'.
@@ -1085,6 +1101,10 @@ class OneClassSVM(BaseLibSVM, OutlierMixin):
         - if ``gamma='scale'`` (default) is passed then it uses
           1 / (n_features * X.var()) as value of gamma,
         - if 'auto', uses 1 / n_features.
+
+        .. versionchanged:: 0.22
+           The default value of ``gamma`` changed from ``'auto'`` to
+           ``'scale'``.
 
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -141,15 +141,15 @@ def test_svc_with_custom_kernel():
     def kfunc(x, y):
         return safe_sparse_dot(x, y.T)
     clf_lin = svm.SVC(kernel='linear').fit(X_sp, Y)
-    clf_mylin = svm.SVC(gamma='scale', kernel=kfunc).fit(X_sp, Y)
+    clf_mylin = svm.SVC(kernel=kfunc).fit(X_sp, Y)
     assert_array_equal(clf_lin.predict(X_sp), clf_mylin.predict(X_sp))
 
 
 def test_svc_iris():
     # Test the sparse SVC with the iris dataset
     for k in ('linear', 'poly', 'rbf'):
-        sp_clf = svm.SVC(gamma='scale', kernel=k).fit(iris.data, iris.target)
-        clf = svm.SVC(gamma='scale', kernel=k).fit(iris.data.toarray(),
+        sp_clf = svm.SVC(kernel=k).fit(iris.data, iris.target)
+        clf = svm.SVC(kernel=k).fit(iris.data.toarray(),
                                                    iris.target)
 
         assert_array_almost_equal(clf.support_vectors_,
@@ -190,16 +190,16 @@ def test_sparse_decision_function():
 def test_error():
     # Test that it gives proper exception on deficient input
     # impossible value of C
-    assert_raises(ValueError, svm.SVC(gamma='scale', C=-1).fit, X, Y)
+    assert_raises(ValueError, svm.SVC(C=-1).fit, X, Y)
 
     # impossible value of nu
-    clf = svm.NuSVC(gamma='scale', nu=0.0)
+    clf = svm.NuSVC(nu=0.0)
     assert_raises(ValueError, clf.fit, X_sp, Y)
 
     Y2 = Y[:-1]  # wrong dimensions for labels
     assert_raises(ValueError, clf.fit, X_sp, Y2)
 
-    clf = svm.SVC(gamma="scale")
+    clf = svm.SVC()
     clf.fit(X_sp, Y)
     assert_array_equal(clf.predict(T), true_result)
 
@@ -258,7 +258,7 @@ def test_weight():
     X_ = sparse.csr_matrix(X_)
     for clf in (linear_model.LogisticRegression(),
                 svm.LinearSVC(random_state=0),
-                svm.SVC(gamma="scale")):
+                svm.SVC()):
         clf.set_params(class_weight={0: 5})
         clf.fit(X_[:180], y_[:180])
         y_pred = clf.predict(X_[180:])
@@ -267,7 +267,7 @@ def test_weight():
 
 def test_sample_weights():
     # Test weights on individual samples
-    clf = svm.SVC(gamma="scale")
+    clf = svm.SVC()
     clf.fit(X_sp, Y)
     assert_array_equal(clf.predict([X[2]]), [1.])
 
@@ -330,7 +330,7 @@ def test_sparse_realdata():
 def test_sparse_svc_clone_with_callable_kernel():
     # Test that the "dense_fit" is called even though we use sparse input
     # meaning that everything works fine.
-    a = svm.SVC(gamma='scale', C=1, kernel=lambda x, y: x * y.T,
+    a = svm.SVC(C=1, kernel=lambda x, y: x * y.T,
                 probability=True, random_state=0)
     b = base.clone(a)
 
@@ -338,7 +338,7 @@ def test_sparse_svc_clone_with_callable_kernel():
     pred = b.predict(X_sp)
     b.predict_proba(X_sp)
 
-    dense_svm = svm.SVC(gamma='scale', C=1, kernel=lambda x, y: np.dot(x, y.T),
+    dense_svm = svm.SVC(C=1, kernel=lambda x, y: np.dot(x, y.T),
                         probability=True, random_state=0)
     pred_dense = dense_svm.fit(X, Y).predict(X)
     assert_array_equal(pred_dense, pred)
@@ -346,17 +346,17 @@ def test_sparse_svc_clone_with_callable_kernel():
 
 
 def test_timeout():
-    sp = svm.SVC(gamma='scale', C=1, kernel=lambda x, y: x * y.T,
+    sp = svm.SVC(C=1, kernel=lambda x, y: x * y.T,
                  probability=True, random_state=0, max_iter=1)
 
     assert_warns(ConvergenceWarning, sp.fit, X_sp, Y)
 
 
 def test_consistent_proba():
-    a = svm.SVC(gamma='scale', probability=True, max_iter=1, random_state=0)
+    a = svm.SVC(probability=True, max_iter=1, random_state=0)
     with ignore_warnings(category=ConvergenceWarning):
         proba_1 = a.fit(X, Y).predict_proba(X)
-    a = svm.SVC(gamma='scale', probability=True, max_iter=1, random_state=0)
+    a = svm.SVC(probability=True, max_iter=1, random_state=0)
     with ignore_warnings(category=ConvergenceWarning):
         proba_2 = a.fit(X, Y).predict_proba(X)
     assert_array_almost_equal(proba_1, proba_2)

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -518,7 +518,6 @@ def test_bad_input():
     assert_raises(ValueError, clf.predict, Xt)
 
 
-
 @pytest.mark.parametrize(
     'Estimator, data',
     [(svm.SVC, datasets.load_iris(return_X_y=True)),

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -56,7 +56,7 @@ def test_libsvm_iris():
 
     # shuffle the dataset so that labels are not ordered
     for k in ('linear', 'rbf'):
-        clf = svm.SVC(gamma='scale', kernel=k).fit(iris.data, iris.target)
+        clf = svm.SVC(kernel=k).fit(iris.data, iris.target)
         assert_greater(np.mean(clf.predict(iris.data) == iris.target), 0.9)
         assert hasattr(clf, "coef_") == (k == 'linear')
 
@@ -121,7 +121,7 @@ def test_precomputed():
     # matrix. kernel is just a linear kernel
 
     kfunc = lambda x, y: np.dot(x, y.T)
-    clf = svm.SVC(gamma='scale', kernel=kfunc)
+    clf = svm.SVC(kernel=kfunc)
     clf.fit(X, Y)
     pred = clf.predict(T)
 
@@ -153,7 +153,7 @@ def test_precomputed():
     pred = clf.predict(K)
     assert_almost_equal(np.mean(pred == iris.target), .99, decimal=2)
 
-    clf = svm.SVC(gamma='scale', kernel=kfunc)
+    clf = svm.SVC(kernel=kfunc)
     clf.fit(iris.data, iris.target)
     assert_almost_equal(np.mean(pred == iris.target), .99, decimal=2)
 
@@ -166,14 +166,13 @@ def test_svr():
                 svm.NuSVR(kernel='linear', nu=.4, C=10.),
                 svm.SVR(kernel='linear', C=10.),
                 svm.LinearSVR(C=10.),
-                svm.LinearSVR(C=10.),
-                ):
+                svm.LinearSVR(C=10.)):
         clf.fit(diabetes.data, diabetes.target)
         assert_greater(clf.score(diabetes.data, diabetes.target), 0.02)
 
     # non-regression test; previously, BaseLibSVM would check that
     # len(np.unique(y)) < 2, which must only be done for SVC
-    svm.SVR(gamma='scale').fit(diabetes.data, np.ones(len(diabetes.data)))
+    svm.SVR()).fit(diabetes.data, np.ones(len(diabetes.data)))
     svm.LinearSVR().fit(diabetes.data, np.ones(len(diabetes.data)))
 
 
@@ -232,14 +231,14 @@ def test_svr_errors():
     y = [0.0, 0.5]
 
     # Bad kernel
-    clf = svm.SVR(gamma='scale', kernel=lambda x, y: np.array([[1.0]]))
+    clf = svm.SVR(kernel=lambda x, y: np.array([[1.0]]))
     clf.fit(X, y)
     assert_raises(ValueError, clf.predict, X)
 
 
 def test_oneclass():
     # Test OneClassSVM
-    clf = svm.OneClassSVM(gamma='scale')
+    clf = svm.OneClassSVM()
     clf.fit(X)
     pred = clf.predict(T)
 
@@ -308,9 +307,8 @@ def test_probability():
     # Predict probabilities using SVC
     # This uses cross validation, so we use a slightly bigger testing set.
 
-    for clf in (svm.SVC(gamma='scale', probability=True, random_state=0,
-                C=1.0), svm.NuSVC(gamma='scale', probability=True,
-                                  random_state=0)):
+    for clf in (svm.SVC(probability=True, random_state=0, C=1.0),
+                svm.NuSVC(probability=True, random_state=0)):
         clf.fit(iris.data, iris.target)
 
         prob_predict = clf.predict_proba(iris.data)
@@ -408,7 +406,7 @@ def test_svr_predict():
 @pytest.mark.filterwarnings('ignore: Default multi_class will')  # 0.22
 def test_weight():
     # Test class weights
-    clf = svm.SVC(gamma='scale', class_weight={1: 0.1})
+    clf = svm.SVC(class_weight={1: 0.1})
     # we give a small weights to class 1
     clf.fit(X, Y)
     # so all predicted values belong to class 2
@@ -418,7 +416,7 @@ def test_weight():
                                  weights=[0.833, 0.167], random_state=2)
 
     for clf in (linear_model.LogisticRegression(),
-                svm.LinearSVC(random_state=0), svm.SVC(gamma="scale")):
+                svm.LinearSVC(random_state=0), svm.SVC()):
         clf.set_params(class_weight={0: .1, 1: 10})
         clf.fit(X_[:100], y_[:100])
         y_pred = clf.predict(X_[100:])
@@ -428,7 +426,7 @@ def test_weight():
 def test_sample_weights():
     # Test weights on individual samples
     # TODO: check on NuSVR, OneClass, etc.
-    clf = svm.SVC(gamma="scale")
+    clf = svm.SVC()
     clf.fit(X, Y)
     assert_array_equal(clf.predict([X[2]]), [1.])
 
@@ -437,7 +435,7 @@ def test_sample_weights():
     assert_array_equal(clf.predict([X[2]]), [2.])
 
     # test that rescaling all samples is the same as changing C
-    clf = svm.SVC(gamma="scale")
+    clf = svm.SVC()
     clf.fit(X, Y)
     dual_coef_no_weight = clf.dual_coef_
     clf.set_params(C=100)
@@ -479,17 +477,17 @@ def test_auto_weight():
 def test_bad_input():
     # Test that it gives proper exception on deficient input
     # impossible value of C
-    assert_raises(ValueError, svm.SVC(gamma='scale', C=-1).fit, X, Y)
+    assert_raises(ValueError, svm.SVC(C=-1).fit, X, Y)
 
     # impossible value of nu
-    clf = svm.NuSVC(gamma='scale', nu=0.0)
+    clf = svm.NuSVC(nu=0.0)
     assert_raises(ValueError, clf.fit, X, Y)
 
     Y2 = Y[:-1]  # wrong dimensions for labels
     assert_raises(ValueError, clf.fit, X, Y2)
 
     # Test with arrays that are non-contiguous.
-    for clf in (svm.SVC(gamma="scale"), svm.LinearSVC(random_state=0)):
+    for clf in (svm.SVC(), svm.LinearSVC(random_state=0)):
         Xf = np.asfortranarray(X)
         assert not Xf.flags['C_CONTIGUOUS']
         yf = np.ascontiguousarray(np.tile(Y, (2, 1)).T)
@@ -504,25 +502,25 @@ def test_bad_input():
     assert_raises(ValueError, clf.fit, X, Y)
 
     # sample_weight bad dimensions
-    clf = svm.SVC(gamma="scale")
+    clf = svm.SVC()
     assert_raises(ValueError, clf.fit, X, Y, sample_weight=range(len(X) - 1))
 
     # predict with sparse input when trained with dense
-    clf = svm.SVC(gamma="scale").fit(X, Y)
+    clf = svm.SVC().fit(X, Y)
     assert_raises(ValueError, clf.predict, sparse.lil_matrix(X))
 
     Xt = np.array(X).T
     clf.fit(np.dot(X, Xt), Y)
     assert_raises(ValueError, clf.predict, X)
 
-    clf = svm.SVC(gamma="scale")
+    clf = svm.SVC()
     clf.fit(X, Y)
     assert_raises(ValueError, clf.predict, Xt)
 
 
 def test_unicode_kernel():
     # Test that a unicode kernel name does not cause a TypeError
-    clf = svm.SVC(gamma='scale', kernel='linear', probability=True)
+    clf = svm.SVC(kernel='linear', probability=True)
     clf.fit(X, Y)
     clf.predict_proba(T)
     svm.libsvm.cross_validation(iris.data,
@@ -810,7 +808,7 @@ def test_linearsvc_verbose():
 def test_svc_clone_with_callable_kernel():
     # create SVM with callable linear kernel, check that results are the same
     # as with built-in linear kernel
-    svm_callable = svm.SVC(gamma='scale', kernel=lambda x, y: np.dot(x, y.T),
+    svm_callable = svm.SVC(kernel=lambda x, y: np.dot(x, y.T),
                            probability=True, random_state=0,
                            decision_function_shape='ovr')
     # clone for checking clonability with lambda functions..
@@ -836,7 +834,7 @@ def test_svc_clone_with_callable_kernel():
 
 
 def test_svc_bad_kernel():
-    svc = svm.SVC(gamma='scale', kernel=lambda x, y: x)
+    svc = svm.SVC(kernel=lambda x, y: x)
     assert_raises(ValueError, svc.fit, X, Y)
 
 
@@ -849,11 +847,11 @@ def test_timeout():
 def test_unfitted():
     X = "foo!"  # input validation not required when SVM not fitted
 
-    clf = svm.SVC(gamma="scale")
+    clf = svm.SVC()
     assert_raises_regexp(Exception, r".*\bSVC\b.*\bnot\b.*\bfitted\b",
                          clf.predict, X)
 
-    clf = svm.NuSVR(gamma='scale')
+    clf = svm.NuSVR()
     assert_raises_regexp(Exception, r".*\bNuSVR\b.*\bnot\b.*\bfitted\b",
                          clf.predict, X)
 
@@ -916,12 +914,12 @@ def test_hasattr_predict_proba():
     # Method must be (un)available before or after fit, switched by
     # `probability` param
 
-    G = svm.SVC(gamma='scale', probability=True)
+    G = svm.SVC(probability=True)
     assert hasattr(G, 'predict_proba')
     G.fit(iris.data, iris.target)
     assert hasattr(G, 'predict_proba')
 
-    G = svm.SVC(gamma='scale', probability=False)
+    G = svm.SVC(probability=False)
     assert not hasattr(G, 'predict_proba')
     G.fit(iris.data, iris.target)
     assert not hasattr(G, 'predict_proba')
@@ -938,8 +936,8 @@ def test_decision_function_shape_two_class():
     for n_classes in [2, 3]:
         X, y = make_blobs(centers=n_classes, random_state=0)
         for estimator in [svm.SVC, svm.NuSVC]:
-            clf = OneVsRestClassifier(estimator(gamma='scale',
-                decision_function_shape="ovr")).fit(X, y)
+            clf = OneVsRestClassifier(
+                estimator(decision_function_shape="ovr")).fit(X, y)
             assert_equal(len(clf.predict(X)), len(y))
 
 
@@ -1023,12 +1021,6 @@ def test_svc_ovr_tie_breaking(SVCClass):
 def test_gamma_auto():
     X, y = [[0.0, 1.2], [1.0, 1.3]], [0, 1]
 
-    msg = ("The default value of gamma will change from 'auto' to 'scale' in "
-           "version 0.22 to account better for unscaled features. Set gamma "
-           "explicitly to 'auto' or 'scale' to avoid this warning.")
-
-    assert_warns_message(FutureWarning, msg,
-                         svm.SVC().fit, X, y)
     assert_no_warnings(svm.SVC(kernel='linear').fit, X, y)
     assert_no_warnings(svm.SVC(kernel='precomputed').fit, X, y)
 
@@ -1036,7 +1028,7 @@ def test_gamma_auto():
 def test_gamma_scale():
     X, y = [[0.], [1.]], [0, 1]
 
-    clf = svm.SVC(gamma='scale')
+    clf = svm.SVC()
     assert_no_warnings(clf.fit, X, y)
     assert_almost_equal(clf._gamma, 4)
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -172,7 +172,7 @@ def test_svr():
 
     # non-regression test; previously, BaseLibSVM would check that
     # len(np.unique(y)) < 2, which must only be done for SVC
-    svm.SVR()).fit(diabetes.data, np.ones(len(diabetes.data)))
+    svm.SVR().fit(diabetes.data, np.ones(len(diabetes.data)))
     svm.LinearSVR().fit(diabetes.data, np.ones(len(diabetes.data)))
 
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -518,6 +518,23 @@ def test_bad_input():
     assert_raises(ValueError, clf.predict, Xt)
 
 
+
+@pytest.mark.parametrize(
+    'Estimator, data',
+    [(svm.SVC, datasets.load_iris(return_X_y=True)),
+     (svm.NuSVC, datasets.load_iris(return_X_y=True)),
+     (svm.SVR, datasets.load_diabetes(return_X_y=True)),
+     (svm.NuSVR, datasets.load_diabetes(return_X_y=True)),
+     (svm.OneClassSVM, datasets.load_iris(return_X_y=True))]
+)
+def test_svm_gamma_error(Estimator, data):
+    X, y = data
+    est = Estimator(gamma='auto_deprecated')
+    err_msg = "When 'gamma' is a string, it should be either 'scale' or 'auto'"
+    with pytest.raises(ValueError, match=err_msg):
+        est.fit(X, y)
+
+
 def test_unicode_kernel():
     # Test that a unicode kernel name does not cause a TypeError
     clf = svm.SVC(kernel='linear', probability=True)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -180,7 +180,7 @@ def test_ovr_fit_predict_sparse():
         assert_array_equal(pred, Y_pred_sprs.toarray())
 
         # Test decision_function
-        clf = svm.SVC(gamma="scale")
+        clf = svm.SVC()
         clf_sprs = OneVsRestClassifier(clf).fit(X_train, sparse(Y_train))
         dec_pred = (clf_sprs.decision_function(X_test) > 0).astype(int)
         assert_array_equal(dec_pred, clf_sprs.predict(X_test).toarray())
@@ -280,7 +280,7 @@ def test_ovr_binary():
                      Ridge(), ElasticNet()):
         conduct_test(base_clf)
 
-    for base_clf in (MultinomialNB(), SVC(gamma='scale', probability=True),
+    for base_clf in (MultinomialNB(), SVC(probability=True),
                      LogisticRegression()):
         conduct_test(base_clf, test_predict_proba=True)
 
@@ -304,7 +304,7 @@ def test_ovr_multilabel():
 
 
 def test_ovr_fit_predict_svc():
-    ovr = OneVsRestClassifier(svm.SVC(gamma="scale"))
+    ovr = OneVsRestClassifier(svm.SVC())
     ovr.fit(iris.data, iris.target)
     assert_equal(len(ovr.estimators_), 3)
     assert_greater(ovr.score(iris.data, iris.target), .9)
@@ -351,20 +351,18 @@ def test_ovr_multilabel_predict_proba():
         clf = OneVsRestClassifier(base_clf).fit(X_train, Y_train)
 
         # Decision function only estimator.
-        decision_only = OneVsRestClassifier(svm.SVR(gamma='scale')
-                                            ).fit(X_train, Y_train)
+        decision_only = OneVsRestClassifier(svm.SVR()).fit(X_train, Y_train)
         assert not hasattr(decision_only, 'predict_proba')
 
         # Estimator with predict_proba disabled, depending on parameters.
-        decision_only = OneVsRestClassifier(svm.SVC(gamma='scale',
-                                                    probability=False))
+        decision_only = OneVsRestClassifier(svm.SVC(probability=False))
         assert not hasattr(decision_only, 'predict_proba')
         decision_only.fit(X_train, Y_train)
         assert not hasattr(decision_only, 'predict_proba')
         assert hasattr(decision_only, 'decision_function')
 
         # Estimator which can get predict_proba enabled after fitting
-        gs = GridSearchCV(svm.SVC(gamma='scale', probability=False),
+        gs = GridSearchCV(svm.SVC(probability=False),
                           param_grid={'probability': [True]})
         proba_after_fit = OneVsRestClassifier(gs)
         assert not hasattr(proba_after_fit, 'predict_proba')
@@ -388,8 +386,7 @@ def test_ovr_single_label_predict_proba():
     clf = OneVsRestClassifier(base_clf).fit(X_train, Y_train)
 
     # Decision function only estimator.
-    decision_only = OneVsRestClassifier(svm.SVR(gamma='scale')
-                                        ).fit(X_train, Y_train)
+    decision_only = OneVsRestClassifier(svm.SVR()).fit(X_train, Y_train)
     assert not hasattr(decision_only, 'predict_proba')
 
     Y_pred = clf.predict(X_test)
@@ -412,7 +409,7 @@ def test_ovr_multilabel_decision_function():
                                                    random_state=0)
     X_train, Y_train = X[:80], Y[:80]
     X_test = X[80:]
-    clf = OneVsRestClassifier(svm.SVC(gamma="scale")).fit(X_train, Y_train)
+    clf = OneVsRestClassifier(svm.SVC()).fit(X_train, Y_train)
     assert_array_equal((clf.decision_function(X_test) > 0).astype(int),
                        clf.predict(X_test))
 
@@ -423,7 +420,7 @@ def test_ovr_single_label_decision_function():
                                         random_state=0)
     X_train, Y_train = X[:80], Y[:80]
     X_test = X[80:]
-    clf = OneVsRestClassifier(svm.SVC(gamma="scale")).fit(X_train, Y_train)
+    clf = OneVsRestClassifier(svm.SVC()).fit(X_train, Y_train)
     assert_array_equal(clf.decision_function(X_test).ravel() > 0,
                        clf.predict(X_test))
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -322,7 +322,7 @@ def test_pipeline_methods_pca_svm():
     X = iris.data
     y = iris.target
     # Test with PCA + SVC
-    clf = SVC(gamma='scale', probability=True, random_state=0)
+    clf = SVC(probability=True, random_state=0)
     pca = PCA(svd_solver='full', n_components='mle', whiten=True)
     pipe = Pipeline([('pca', pca), ('svc', clf)])
     pipe.fit(X, y)
@@ -341,8 +341,7 @@ def test_pipeline_methods_preprocessing_svm():
     n_classes = len(np.unique(y))
     scaler = StandardScaler()
     pca = PCA(n_components=2, svd_solver='randomized', whiten=True)
-    clf = SVC(gamma='scale', probability=True, random_state=0,
-              decision_function_shape='ovr')
+    clf = SVC(probability=True, random_state=0, decision_function_shape='ovr')
 
     for preprocessing in [scaler, pca]:
         pipe = Pipeline([('preprocess', preprocessing), ('svc', clf)])
@@ -1007,7 +1006,7 @@ def test_pipeline_memory():
         else:
             memory = Memory(location=cachedir, verbose=10)
         # Test with Transformer + SVC
-        clf = SVC(gamma='scale', probability=True, random_state=0)
+        clf = SVC(probability=True, random_state=0)
         transf = DummyTransf()
         pipe = Pipeline([('transf', clone(transf)), ('svc', clf)])
         cached_pipe = Pipeline([('transf', transf), ('svc', clf)],
@@ -1041,7 +1040,7 @@ def test_pipeline_memory():
         assert_equal(ts, cached_pipe.named_steps['transf'].timestamp_)
         # Create a new pipeline with cloned estimators
         # Check that even changing the name step does not affect the cache hit
-        clf_2 = SVC(gamma='scale', probability=True, random_state=0)
+        clf_2 = SVC(probability=True, random_state=0)
         transf_2 = DummyTransf()
         cached_pipe_2 = Pipeline([('transf_2', transf_2), ('svc', clf_2)],
                                  memory=memory)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -636,7 +636,7 @@ def test_check_is_fitted():
     assert_raises(TypeError, check_is_fitted, "SVR", "support_")
 
     ard = ARDRegression()
-    svr = SVR(gamma='scale')
+    svr = SVR()
 
     try:
         assert_raises(NotFittedError, check_is_fitted, ard, "coef_")


### PR DESCRIPTION
Change the default from `'auto_deprecated'` to `'scale'` on all SVMs.
Revert the changes from https://github.com/scikit-learn/scikit-learn/pull/10331/files where `gamma='scale'` was added explicitly.