### PR TITLE
[MRG] Add function score_samples to Pipeline (fix issue #12542)

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -47,6 +47,12 @@ Changelog
   of the maximization procedure in :term:`fit`.
   :pr:`13618` by :user:`Yoshihiro Uchida <c56pony>`.
 
+:mod:`sklearn.pipeline`
+..................
+
+- |Enhancement| :class:`pipeline.Pipeline` now supports :term:`score_samples` if
+  the final estimator does.
+  :pr:`13806` by :user:`Anaël Beaugnon <ab-anssi>`.
 
 :mod:`sklearn.svm`
 ..................

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -48,7 +48,7 @@ Changelog
   :pr:`13618` by :user:`Yoshihiro Uchida <c56pony>`.
 
 :mod:`sklearn.pipeline`
-..................
+.......................
 
 - |Enhancement| :class:`pipeline.Pipeline` now supports :term:`score_samples` if
   the final estimator does.

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -507,23 +507,6 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
         return self.best_estimator_.decision_function(X)
 
     @if_delegate_has_method(delegate=('best_estimator_', 'estimator'))
-    def score_samples(self, X):
-        """Call score_samples on the estimator with the best found parameters.
-
-        Only available if ``refit=True`` and the underlying estimator supports
-        ``score_samples``.
-
-        Parameters
-        ----------
-        X : indexable, length n_samples
-            Must fulfill the input assumptions of the
-            underlying estimator.
-
-        """
-        self._check_is_fitted('score_samples')
-        return self.best_estimator_.score_samples(X)
-
-    @if_delegate_has_method(delegate=('best_estimator_', 'estimator'))
     def transform(self, X):
         """Call transform on the estimator with the best found parameters.
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -507,6 +507,23 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
         return self.best_estimator_.decision_function(X)
 
     @if_delegate_has_method(delegate=('best_estimator_', 'estimator'))
+    def score_samples(self, X):
+        """Call score_samples on the estimator with the best found parameters.
+
+        Only available if ``refit=True`` and the underlying estimator supports
+        ``score_samples``.
+
+        Parameters
+        ----------
+        X : indexable, length n_samples
+            Must fulfill the input assumptions of the
+            underlying estimator.
+
+        """
+        self._check_is_fitted('score_samples')
+        return self.best_estimator_.score_samples(X)
+
+    @if_delegate_has_method(delegate=('best_estimator_', 'estimator'))
     def transform(self, X):
         """Call transform on the estimator with the best found parameters.
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -506,8 +506,8 @@ class Pipeline(_BaseComposition):
         y_score : ndarray, shape (n_samples,)
         """
         Xt = X
-        for _, name, transform in self._iter(with_final=False):
-            Xt = transform.transform(Xt)
+        for _, _, transformer in self._iter(with_final=False):
+            Xt = transformer.transform(Xt)
         return self.steps[-1][-1].score_samples(Xt)
 
     @if_delegate_has_method(delegate='_final_estimator')

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -493,7 +493,7 @@ class Pipeline(_BaseComposition):
 
     @if_delegate_has_method(delegate='_final_estimator')
     def score_samples(self, X):
-        """Apply transforms, and score_samples of the final estimator
+        """Apply transforms, and score_samples of the final estimator.
 
         Parameters
         ----------
@@ -503,7 +503,7 @@ class Pipeline(_BaseComposition):
 
         Returns
         -------
-        y_score : array-like, shape = [n_samples, n_classes]
+        y_score : array-like, shape (n_samples, n_classes)
         """
         Xt = X
         for _, name, transform in self._iter(with_final=False):

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -492,6 +492,25 @@ class Pipeline(_BaseComposition):
         return self.steps[-1][-1].decision_function(Xt)
 
     @if_delegate_has_method(delegate='_final_estimator')
+    def score_samples(self, X):
+        """Apply transforms, and score_samples of the final estimator
+
+        Parameters
+        ----------
+        X : iterable
+            Data to predict on. Must fulfill input requirements of first step
+            of the pipeline.
+
+        Returns
+        -------
+        y_score : array-like, shape = [n_samples, n_classes]
+        """
+        Xt = X
+        for _, name, transform in self._iter(with_final=False):
+            Xt = transform.transform(Xt)
+        return self.steps[-1][-1].score_samples(Xt)
+
+    @if_delegate_has_method(delegate='_final_estimator')
     def predict_log_proba(self, X):
         """Apply transforms, and predict_log_proba of the final estimator
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -503,7 +503,7 @@ class Pipeline(_BaseComposition):
 
         Returns
         -------
-        y_score : array-like, shape (n_samples, n_classes)
+        y_score : array-like, shape (n_samples,)
         """
         Xt = X
         for _, name, transform in self._iter(with_final=False):

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -503,7 +503,7 @@ class Pipeline(_BaseComposition):
 
         Returns
         -------
-        y_score : array-like, shape (n_samples,)
+        y_score : ndarray, shape (n_samples,)
         """
         Xt = X
         for _, name, transform in self._iter(with_final=False):

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -339,7 +339,7 @@ def test_pipeline_score_samples_pca_lof():
     # Test with PCA + OneClassSVM
     lof = LocalOutlierFactor(novelty=True)
     pca = PCA(svd_solver='full', n_components='mle', whiten=True)
-    pipe = Pipeline([('pca', pca), ('lof', clf)])
+    pipe = Pipeline([('pca', pca), ('lof', lof)])
     pipe.fit(X)
     assert_allclose(pipe.score_samples(X[:2]),
                     [-0.9564705258081416, -1.0371487183896932])

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -351,15 +351,19 @@ def test_pipeline_score_samples_pca_lof():
 
 
 def test_score_samples_on_pipeline_without_score_samples():
+    iris = load_iris()
+    X = iris.data
+    y = iris.target
     # Test that a pipeline does not have score_samples method when the final
     # step of the pipeline does not have score_samples defined.
     pca = PCA(svd_solver='full', n_components='mle', whiten=True)
     clf = LogisticRegression()
     pipe = Pipeline([('pca', pca), ('clf', clf)])
-    assert_raises_regex(
-            AttributeError,
-            "'LogisticRegression' object has no attribute 'score_samples'",
-            getattr, pipe, 'score_samples')
+    pipe.fit(X, y)
+    with pytest.raises(AttributeError,
+                       match="'LogisticRegression' object has no attribute "
+                             "'score_samples'"):
+        pipe.score_samples(X)
 
 
 def test_pipeline_methods_preprocessing_svm():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -336,9 +336,11 @@ def test_pipeline_methods_pca_svm():
 def test_pipeline_score_samples_pca_lof():
     iris = load_iris()
     X = iris.data
-    # Test with PCA + OneClassSVM
-    lof = LocalOutlierFactor(novelty=True)
+    # Test that the score_samples method is implemented on a pipeline.
+    # Test that the score_samples method on pipeline yields same results as
+    # applying transform and score_samples steps separately.
     pca = PCA(svd_solver='full', n_components='mle', whiten=True)
+    lof = LocalOutlierFactor(novelty=True)
     pipe = Pipeline([('pca', pca), ('lof', lof)])
     pipe.fit(X)
     # Check the shapes
@@ -346,6 +348,18 @@ def test_pipeline_score_samples_pca_lof():
     # Check the values
     lof.fit(pca.fit_transform(X))
     assert_allclose(pipe.score_samples(X), lof.score_samples(pca.transform(X)))
+
+
+def test_score_samples_on_pipeline_without_score_samples():
+    # Test that a pipeline does not have score_samples method when the final
+    # step of the pipeline does not have score_samples defined.
+    pca = PCA(svd_solver='full', n_components='mle', whiten=True)
+    clf = LogisticRegression()
+    pipe = Pipeline([('pca', pca), ('clf', clf)])
+    assert_raises_regex(
+            AttributeError,
+            "'LogisticRegression' object has no attribute 'score_samples'",
+            getattr, pipe, 'score_samples')
 
 
 def test_pipeline_methods_preprocessing_svm():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -351,14 +351,11 @@ def test_pipeline_score_samples_pca_lof():
 
 
 def test_score_samples_on_pipeline_without_score_samples():
-    iris = load_iris()
-    X = iris.data
-    y = iris.target
+    X = np.array([[1], [2]])
+    y = np.array([1, 2])
     # Test that a pipeline does not have score_samples method when the final
     # step of the pipeline does not have score_samples defined.
-    pca = PCA(svd_solver='full', n_components='mle', whiten=True)
-    clf = LogisticRegression()
-    pipe = Pipeline([('pca', pca), ('clf', clf)])
+    pipe = make_pipeline(LogisticRegression())
     pipe.fit(X, y)
     with pytest.raises(AttributeError,
                        match="'LogisticRegression' object has no attribute "

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -340,8 +340,8 @@ def test_pipeline_score_samples_pca_lof():
     pca = PCA(svd_solver='full', n_components='mle', whiten=True)
     pipe = Pipeline([('pca', pca), ('lof', clf)])
     pipe.fit(X)
-    assert_equal(list(pipe.score_samples(X[:2])),
-                 [-0.9564705258081416, -1.0371487183896932])
+    assert_array_almost_equal(pipe.score_samples(X[:2]),
+                              [-0.9564705258081416, -1.0371487183896932])
 
 
 def test_pipeline_methods_preprocessing_svm():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -344,7 +344,7 @@ def test_pipeline_score_samples_pca_lof():
     pipe = Pipeline([('pca', pca), ('lof', lof)])
     pipe.fit(X)
     # Check the shapes
-    assert_equal(pipe.score_samples(X).shape, (X.shape[0],))
+    assert pipe.score_samples(X).shape == (X.shape[0],)
     # Check the values
     lof.fit(pca.fit_transform(X))
     assert_allclose(pipe.score_samples(X), lof.score_samples(pca.transform(X)))

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -23,7 +23,8 @@ from sklearn.utils.testing import assert_no_warnings
 
 from sklearn.base import clone, BaseEstimator
 from sklearn.pipeline import Pipeline, FeatureUnion, make_pipeline, make_union
-from sklearn.svm import OneClassSVM, SVC
+from sklearn.svm import SVC
+from sklearn.neighbors import LocalOutlierFactor
 from sklearn.linear_model import LogisticRegression, Lasso
 from sklearn.linear_model import LinearRegression
 from sklearn.cluster import KMeans
@@ -330,13 +331,13 @@ def test_pipeline_methods_pca_svm():
     pipe.score(X, y)
 
 
-def test_pipeline_score_samples_pca_oneclass_svm():
+def test_pipeline_score_samples_pca_lof():
     iris = load_iris()
     X = iris.data
     # Test with PCA + OneClassSVM
-    clf = OneClassSVM()
+    clf = LocalOutlierFactor(novelty=True)
     pca = PCA(svd_solver='full', n_components='mle', whiten=True)
-    pipe = Pipeline([('pca', pca), ('oneclass_svm', clf)])
+    pipe = Pipeline([('pca', pca), ('lof', clf)])
     pipe.fit(X)
     pipe.score_samples(X)
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -340,7 +340,8 @@ def test_pipeline_score_samples_pca_lof():
     pca = PCA(svd_solver='full', n_components='mle', whiten=True)
     pipe = Pipeline([('pca', pca), ('lof', clf)])
     pipe.fit(X)
-    pipe.score_samples(X)
+    assert_equal(list(pipe.score_samples(X[:2])),
+                 [-0.9564705258081416, -1.0371487183896932])
 
 
 def test_pipeline_methods_preprocessing_svm():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -331,6 +331,7 @@ def test_pipeline_methods_pca_svm():
     pipe.score(X, y)
 
 
+@pytest.mark.filterwarnings('ignore: default contamination parameter')  # 0.22
 def test_pipeline_score_samples_pca_lof():
     iris = load_iris()
     X = iris.data

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -23,7 +23,7 @@ from sklearn.utils.testing import assert_no_warnings
 
 from sklearn.base import clone, BaseEstimator
 from sklearn.pipeline import Pipeline, FeatureUnion, make_pipeline, make_union
-from sklearn.svm import SVC
+from sklearn.svm import OneClassSVM, SVC
 from sklearn.linear_model import LogisticRegression, Lasso
 from sklearn.linear_model import LinearRegression
 from sklearn.cluster import KMeans
@@ -328,6 +328,17 @@ def test_pipeline_methods_pca_svm():
     pipe.predict_proba(X)
     pipe.predict_log_proba(X)
     pipe.score(X, y)
+
+
+def test_pipeline_score_samples_pca_oneclass_svm():
+    iris = load_iris()
+    X = iris.data
+    # Test with PCA + OneClassSVM
+    clf = OneClassSVM()
+    pca = PCA(svd_solver='full', n_components='mle', whiten=True)
+    pipe = Pipeline([('pca', pca), ('oneclass_svm', clf)])
+    pipe.fit(X)
+    pipe.score_samples(X)
 
 
 def test_pipeline_methods_preprocessing_svm():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -16,6 +16,7 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_dict_equal
@@ -340,8 +341,8 @@ def test_pipeline_score_samples_pca_lof():
     pca = PCA(svd_solver='full', n_components='mle', whiten=True)
     pipe = Pipeline([('pca', pca), ('lof', clf)])
     pipe.fit(X)
-    assert_array_almost_equal(pipe.score_samples(X[:2]),
-                              [-0.9564705258081416, -1.0371487183896932])
+    assert_allclose(pipe.score_samples(X[:2]),
+                    [-0.9564705258081416, -1.0371487183896932])
 
 
 def test_pipeline_methods_preprocessing_svm():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -332,7 +332,6 @@ def test_pipeline_methods_pca_svm():
     pipe.score(X, y)
 
 
-@pytest.mark.filterwarnings('ignore: default contamination parameter')  # 0.22
 def test_pipeline_score_samples_pca_lof():
     iris = load_iris()
     X = iris.data

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -337,7 +337,7 @@ def test_pipeline_score_samples_pca_lof():
     iris = load_iris()
     X = iris.data
     # Test with PCA + OneClassSVM
-    clf = LocalOutlierFactor(novelty=True)
+    lof = LocalOutlierFactor(novelty=True)
     pca = PCA(svd_solver='full', n_components='mle', whiten=True)
     pipe = Pipeline([('pca', pca), ('lof', clf)])
     pipe.fit(X)

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -341,8 +341,11 @@ def test_pipeline_score_samples_pca_lof():
     pca = PCA(svd_solver='full', n_components='mle', whiten=True)
     pipe = Pipeline([('pca', pca), ('lof', lof)])
     pipe.fit(X)
-    assert_allclose(pipe.score_samples(X[:2]),
-                    [-0.9564705258081416, -1.0371487183896932])
+    # Check the shapes
+    assert_equal(pipe.score_samples(X).shape, (X.shape[0],))
+    # Check the values
+    lof.fit(pca.fit_transform(X))
+    assert_allclose(pipe.score_samples(X), lof.score_samples(pca.transform(X)))
 
 
 def test_pipeline_methods_preprocessing_svm():


### PR DESCRIPTION
#### Reference Issues/PRs
Fix issue #12542.

#### What does this implement/fix? Explain your changes.
The pull request adds a function `score_samples` to the `Pipeline`,  `GridSearchCV`, and `RandomizedSearchCV`classes (code very similar to the functions `predict_proba`, `decision_function`, `predict_log_proba`).