### PR TITLE
[WIP] OrdinalEncoder functionality for unknown categories when transforming

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -883,6 +883,16 @@ class OrdinalEncoder(_BaseEncoder):
         The categories of each feature determined during fitting
         (in order of the features in X and corresponding with the output
         of ``transform``).
+    handle_unknown : 'error', 'ignore' or 'treat_as_rare', default='error'.
+        Whether to raise an error or ignore if an unknown categorical feature
+        is present during transform (default is to raise). When this parameter
+        is set to 'ignore' and an unknown category is encountered during
+        transform, the resulting one-hot encoded columns for this feature
+        will be all zeros. In the inverse transform, an unknown category
+        will be denoted as None.
+    rare_category : default='unknown'
+    dtype : number type, default=np.float64
+        Desired dtype of output.
 
     Examples
     --------
@@ -914,11 +924,11 @@ class OrdinalEncoder(_BaseEncoder):
     """
 
     def __init__(self, categories='auto', handle_unknown='error',
-                 rare_category='rare_value', dtype=np.float64):
+                 unknown_category='unknown', dtype=np.float64):
         self.categories = categories
         self.dtype = dtype
         self.handle_unknown = handle_unknown
-        self.rare_category = rare_category
+        self.unknown_category = unknown_category
 
     def fit(self, X, y=None):
         """Fit the OrdinalEncoder to X.
@@ -960,7 +970,7 @@ class OrdinalEncoder(_BaseEncoder):
                 # iterate over columns with unseen categories
                 for i in np.where(~np.all(X_mask, axis=0))[0]:
                     # check if  "rare_category" is already a known category
-                    idx = np.argwhere(self.categories_[0] == self.rare_category)
+                    idx = np.argwhere(self.categories_[0] == self.unknown_category)
                     if idx.size > 0:
                         # replace unknown by index of known category
                         X_int[~X_mask[:, i], i] = int(idx)
@@ -968,7 +978,7 @@ class OrdinalEncoder(_BaseEncoder):
                         # replace unkown category by index of "rare_category"
                         X_int[~X_mask[:, i], i] = len(self.categories_[i])
                         # add "rare_category" to categories list
-                        self.categories_[i] = np.append(self.categories_[i], self.rare_category)
+                        self.categories_[i] = np.append(self.categories_[i], self.unknown_category)
             if self.handle_unknown == 'ignore':
                 idx = np.where(~np.all(X_mask, axis=1))[0]
                 X_int = np.delete(X_int, idx, axis=0)

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -966,7 +966,7 @@ class OrdinalEncoder(_BaseEncoder):
         """
         X_int, X_mask = self._transform(X, handle_unknown=self.handle_unknown)
         if not np.all(X_mask):  # are there any unseen categories
-            if self.handle_unknown == 'treat_as_rare':
+            if self.handle_unknown == 'keep':
                 # iterate over columns with unseen categories
                 for i in np.where(~np.all(X_mask, axis=0))[0]:
                     # check if  "rare_category" is already a known category

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -966,7 +966,7 @@ class OrdinalEncoder(_BaseEncoder):
         """
         X_int, X_mask = self._transform(X, handle_unknown=self.handle_unknown)
         if not np.all(X_mask):  # are there any unseen categories
-            if self.handle_unknown == 'keep':
+            if self.handle_unknown == 'cast':
                 # iterate over columns with unseen categories
                 for i in np.where(~np.all(X_mask, axis=0))[0]:
                     # check if  "rare_category" is already a known category

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -970,7 +970,7 @@ class OrdinalEncoder(_BaseEncoder):
                 # iterate over columns with unseen categories
                 for i in np.where(~np.all(X_mask, axis=0))[0]:
                     # check if  "rare_category" is already a known category
-                    idx = np.argwhere(self.categories_[0] == self.unknown_category)
+                    idx = np.argwhere(self.categories_[i] == self.unknown_category)
                     if idx.size > 0:
                         # replace unknown by index of known category
                         X_int[~X_mask[:, i], i] = int(idx)

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -970,15 +970,17 @@ class OrdinalEncoder(_BaseEncoder):
                 # iterate over columns with unseen categories
                 for i in np.where(~np.all(X_mask, axis=0))[0]:
                     # check if  "rare_category" is already a known category
-                    idx = np.argwhere(self.categories_[i] == self.unknown_category)
+                    categories = self.categories_[i]
+                    idx = np.argwhere(categories == self.unknown_category)
                     if idx.size > 0:
                         # replace unknown by index of known category
                         X_int[~X_mask[:, i], i] = int(idx)
                     else:
                         # replace unkown category by index of "rare_category"
-                        X_int[~X_mask[:, i], i] = len(self.categories_[i])
+                        X_int[~X_mask[:, i], i] = len(categories)
                         # add "rare_category" to categories list
-                        self.categories_[i] = np.append(self.categories_[i], self.unknown_category)
+                        self.categories_[i] = np.append(categories,
+                                                        self.unknown_category)
             if self.handle_unknown == 'ignore':
                 idx = np.where(~np.all(X_mask, axis=1))[0]
                 X_int = np.delete(X_int, idx, axis=0)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #13488, see also #12153

#### What does this implement/fix? Explain your changes.
Currently `OrdinalEncoder` breaks if encounters unknown/unseen categories during transform. This PR adds two functionalities:
- `handle_unknown = 'cast'`, which as discussed in #13488 adds a new category given by the user via `unknown_category` (defaults to `'unknown'`). It will also add this category to the `categories_` attribute where necessary in order for `inverse_transform` to work accordingly.

- `handle_unknown = 'ignore'`, which will remove the observation (row), keeping valid observations across the different features (columns). 

#### Any other comments?
In #13488 it was discussed to introduce `min_frequency` or an extra base class as mentioned in #12153, which I think is an overkill, at least to start. In my opinion if that much complicated logic is necessary it should be the user doing it with a customize pipeline, a user cannot expect sklearn to tackle such specific case in my opinion. 
This PR is only a few lines of code and I believe it can easily be extended if indeed `min_frequency` is desirable since the only change will be in the base class and in the return of the mask from `_transform`.

Example:

```
df = pd.DataFrame({
    'col_0': ['dog', 'horse', 'cat', 'cat', 'dog', 'cat', 'horse'],
    'col_1': ['A', 'A', 'C', 'B', 'Z', 'C', 'C']
})
df_test = pd.DataFrame({
    'col_0': ['dog', 'horse', 'cat', 'cat', 'dog', 'cat', 'horse'],
    'col_1': ['A', 'A', 'something_else', 'B', 'Z', 'C', 'SOMETHING']
})

# cast 
b = OrdinalEncoder(handle_unknown='cast')
b.fit(df)
x = b.transform(df_test)
print(x)
>>>
[[1. 0.]
 [2. 0.]
 [0. 4.]
 [0. 1.]
 [1. 3.]
 [0. 2.]
 [2. 4.]]

print(b.inverse_transform(x))
>>>
[['dog' 'A']
 ['horse' 'A']
 ['cat' 'unknown']
 ['cat' 'B']
 ['dog' 'Z']
 ['cat' 'C']
 ['horse' 'unknown']]

print(b.categories_)
>>>
[array(['cat', 'dog', 'horse'], dtype=object), array(['A', 'B', 'C', 'Z', 'unknown'], dtype=object)]

# ignore 
b = OrdinalEncoder(handle_unknown='ignore')
b.fit(df)
x = b.transform(df_test)
print(x)
>>>
[[1. 0.]
 [2. 0.]
 [0. 1.]
 [1. 3.]
 [0. 2.]]

print(b.inverse_transform(x))
>>>
[['dog' 'A']
 ['horse' 'A']
 ['cat' 'B']
 ['dog' 'Z']
 ['cat' 'C']]

print(b.categories_)
>>> [array(['cat', 'dog', 'horse'], dtype=object), array(['A', 'B', 'C', 'Z'], dtype=object)]

```

I know I have not comply with PEP8 nor wrote tests yet but I want to first get your opinion on this PR before putting more effort.