### PR TITLE
[MRG] Avoid calling _encode_check_unknown() twice in BaseEncoder.transform

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -134,6 +134,8 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
                         Xi = Xi.copy()
 
                     Xi[~valid_mask] = self.categories_[i][0]
+            # We use check_unkown=False, since _encode_check_unknown was
+            # already called above.
             _, encoded = _encode(Xi, self.categories_[i], encode=True,
                                  check_unknown=False)
             X_int[:, i] = encoded

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -134,7 +134,7 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
                         Xi = Xi.copy()
 
                     Xi[~valid_mask] = self.categories_[i][0]
-            # We use check_unkown=False, since _encode_check_unknown was
+            # We use check_unknown=False, since _encode_check_unknown was
             # already called above.
             _, encoded = _encode(Xi, self.categories_[i], encode=True,
                                  check_unknown=False)

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -134,7 +134,8 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
                         Xi = Xi.copy()
 
                     Xi[~valid_mask] = self.categories_[i][0]
-            _, encoded = _encode(Xi, self.categories_[i], encode=True)
+            _, encoded = _encode(Xi, self.categories_[i], encode=True,
+                                 check_unknown=False)
             X_int[:, i] = encoded
 
         return X_int, X_mask

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -47,7 +47,7 @@ def _encode_numpy(values, uniques=None, encode=False, check_unknown=True):
             diff = _encode_check_unknown(values, uniques)
             if diff:
                 raise ValueError("y contains previously unseen labels: %s"
-                                % str(diff))
+                                 % str(diff))
         encoded = np.searchsorted(uniques, values)
         return uniques, encoded
     else:

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -92,10 +92,11 @@ def _encode(values, uniques=None, encode=False, check_unknown=True):
     encode : bool, default False
         If True, also encode the values into integer codes based on `uniques`.
     check_unknown : bool, default True
-        If True, check for values in values that are not in unique and raise an
-        error. Ignored for object dtype (equivalent to True in this case). This
-        set to False in _BaseEncoder._transform() to avoid calling
-        _encode_check_unknown() twice.
+        If True, check for values in ``values`` that are not in ``unique``
+        and raise an error. This is ignored for object dtype and treated as
+        True in this case). This parameter is useful for
+        _BaseEncoder._transform() to avoid calling _encode_check_unknown()
+        twice.
 
     Returns
     -------

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -93,8 +93,8 @@ def _encode(values, uniques=None, encode=False, check_unknown=True):
         If True, also encode the values into integer codes based on `uniques`.
     check_unknown : bool, default True
         If True, check for values in ``values`` that are not in ``unique``
-        and raise an error. This is ignored for object dtype and treated as
-        True in this case). This parameter is useful for
+        and raise an error. This is ignored for object dtype, and treated as
+        True in this case. This parameter is useful for
         _BaseEncoder._transform() to avoid calling _encode_check_unknown()
         twice.
 

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -605,3 +605,24 @@ def test_encode_util(values, expected):
     assert_array_equal(encoded, np.array([1, 0, 2, 0, 2]))
     _, encoded = _encode(values, uniques, encode=True)
     assert_array_equal(encoded, np.array([1, 0, 2, 0, 2]))
+
+
+def test_encode_check_unknown():
+    # test for the check_unknown parameter of _encode()
+    uniques = np.array([1, 2, 3])
+    values = np.array([1, 2, 3, 4])
+
+    # Default is True, raise error
+    with pytest.raises(ValueError,
+                       match='y contains previously unseen labels'):
+        _encode(values, uniques, encode=True, check_unknown=True)
+
+    # dont raise error if False
+    _encode(values, uniques, encode=True, check_unknown=False)
+
+    # parameter is ignored for object dtype
+    uniques = np.array(['a', 'b', 'c'], dtype=object)
+    values = np.array(['a', 'b', 'c', 'd'], dtype=object)
+    with pytest.raises(ValueError,
+                       match='y contains previously unseen labels'):
+        _encode(values, uniques, encode=True, check_unknown=False)


### PR DESCRIPTION
`_BaseEncoder._transform()` currently calls `_encode_check_unknown()`, and then calls `_encode()` which will call `_encode_check_unknown()` a second time (if the dtype is compatible with numpy)

Since `_encode_check_unknown()` calls `np.unique()` on a given column, its complexity is O(n_samples) which is not negligible on large training sets.

This PR avoids this by adding a `check_unknown` parameter to `_encode()` which defaults to True.