### PR TITLE
[MRG] Updated adjusted_mutual_info_score and normalized_mutual_info_score default to 'arithmetic'

### DIFF
--- a/examples/cluster/plot_adjusted_for_chance_measures.py
+++ b/examples/cluster/plot_adjusted_for_chance_measures.py
@@ -56,8 +56,7 @@ def uniform_labelings_scores(score_func, n_samples, n_clusters_range,
 
 
 def ami_score(U, V):
-    return metrics.adjusted_mutual_info_score(U, V,
-                                              average_method='arithmetic')
+    return metrics.adjusted_mutual_info_score(U, V)
 
 score_funcs = [
     metrics.adjusted_rand_score,

--- a/examples/cluster/plot_affinity_propagation.py
+++ b/examples/cluster/plot_affinity_propagation.py
@@ -35,8 +35,7 @@ print("V-measure: %0.3f" % metrics.v_measure_score(labels_true, labels))
 print("Adjusted Rand Index: %0.3f"
       % metrics.adjusted_rand_score(labels_true, labels))
 print("Adjusted Mutual Information: %0.3f"
-      % metrics.adjusted_mutual_info_score(labels_true, labels,
-                                           average_method='arithmetic'))
+      % metrics.adjusted_mutual_info_score(labels_true, labels))
 print("Silhouette Coefficient: %0.3f"
       % metrics.silhouette_score(X, labels, metric='sqeuclidean'))
 

--- a/examples/cluster/plot_dbscan.py
+++ b/examples/cluster/plot_dbscan.py
@@ -44,8 +44,7 @@ print("V-measure: %0.3f" % metrics.v_measure_score(labels_true, labels))
 print("Adjusted Rand Index: %0.3f"
       % metrics.adjusted_rand_score(labels_true, labels))
 print("Adjusted Mutual Information: %0.3f"
-      % metrics.adjusted_mutual_info_score(labels_true, labels,
-                                           average_method='arithmetic'))
+      % metrics.adjusted_mutual_info_score(labels_true, labels))
 print("Silhouette Coefficient: %0.3f"
       % metrics.silhouette_score(X, labels))
 

--- a/examples/cluster/plot_kmeans_digits.py
+++ b/examples/cluster/plot_kmeans_digits.py
@@ -65,8 +65,7 @@ def bench_k_means(estimator, name, data):
              metrics.completeness_score(labels, estimator.labels_),
              metrics.v_measure_score(labels, estimator.labels_),
              metrics.adjusted_rand_score(labels, estimator.labels_),
-             metrics.adjusted_mutual_info_score(labels,  estimator.labels_,
-                                                average_method='arithmetic'),
+             metrics.adjusted_mutual_info_score(labels,  estimator.labels_),
              metrics.silhouette_score(data, estimator.labels_,
                                       metric='euclidean',
                                       sample_size=sample_size)))

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -128,8 +128,6 @@ def test_agglomerative_clustering_wrong_arg_memory():
     assert_raises(ValueError, clustering.fit, X)
 
 
-@pytest.mark.filterwarnings("ignore:the behavior of nmi will "
-                            "change in version 0.22")
 def test_agglomerative_clustering():
     # Check that we obtain the correct number of clusters with
     # agglomerative clustering.
@@ -238,8 +236,6 @@ def test_ward_agglomeration():
     assert_raises(ValueError, agglo.fit, X[:0])
 
 
-@pytest.mark.filterwarnings("ignore:the behavior of nmi will "
-                            "change in version 0.22")
 def test_single_linkage_clustering():
     # Check that we get the correct result in two emblematic cases
     moons, moon_labels = make_moons(noise=0.05, random_state=42)
@@ -301,8 +297,6 @@ def test_scikit_vs_scipy():
     assert_raises(ValueError, _hc_cut, n_leaves + 1, children, n_leaves)
 
 
-@pytest.mark.filterwarnings("ignore:the behavior of nmi will "
-                            "change in version 0.22")
 def test_identical_points():
     # Ensure identical points are handled correctly when using mst with
     # a sparse connectivity matrix

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -86,8 +86,6 @@ def test_sparse_graph_connected_component():
         assert_array_equal(component_1, component_2)
 
 
-@pytest.mark.filterwarnings("ignore:the behavior of nmi will "
-                            "change in version 0.22")
 def test_spectral_embedding_two_components(seed=36):
     # Test spectral embedding with two components
     random_state = np.random.RandomState(seed)
@@ -181,8 +179,6 @@ def test_spectral_embedding_amg_solver(seed=36):
     assert _check_with_col_sign_flipping(embed_amg, embed_arpack, 0.05)
 
 
-@pytest.mark.filterwarnings("ignore:the behavior of nmi will "
-                            "change in version 0.22")
 def test_pipeline_spectral_clustering(seed=36):
     # Test using pipeline to do spectral clustering
     random_state = np.random.RandomState(seed)

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -690,7 +690,6 @@ def adjusted_mutual_info_score(labels_true, labels_pred,
     average_method : string, optional (default: 'arithmetic')
         How to compute the normalizer in the denominator. Possible options
         are 'min', 'geometric', 'arithmetic', and 'max'.
-        If 'warn', 'max' will be used.
 
         .. versionadded:: 0.20
 
@@ -738,8 +737,6 @@ def adjusted_mutual_info_score(labels_true, labels_pred,
        <https://en.wikipedia.org/wiki/Adjusted_Mutual_Information>`_
 
     """
-    if average_method == 'warn':
-        average_method = 'arithmetic'
     labels_true, labels_pred = check_clusterings(labels_true, labels_pred)
     n_samples = labels_true.shape[0]
     classes = np.unique(labels_true)

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -771,7 +771,7 @@ def adjusted_mutual_info_score(labels_true, labels_pred,
 
 
 def normalized_mutual_info_score(labels_true, labels_pred,
-                                 average_method='warn'):
+                                 average_method='arithmetic'):
     """Normalized Mutual Information between two clusterings.
 
     Normalized Mutual Information (NMI) is a normalization of the Mutual
@@ -805,8 +805,6 @@ def normalized_mutual_info_score(labels_true, labels_pred,
     average_method : string, optional (default: 'warn')
         How to compute the normalizer in the denominator. Possible options
         are 'min', 'geometric', 'arithmetic', and 'max'.
-        If 'warn', 'geometric' will be used. The default will change to
-        'arithmetic' in version 0.22.
 
         .. versionadded:: 0.20
 
@@ -844,12 +842,6 @@ def normalized_mutual_info_score(labels_true, labels_pred,
       0.0
 
     """
-    if average_method == 'warn':
-        warnings.warn("The behavior of NMI will change in version 0.22. "
-                      "To match the behavior of 'v_measure_score', NMI will "
-                      "use average_method='arithmetic' by default.",
-                      FutureWarning)
-        average_method = 'geometric'
     labels_true, labels_pred = check_clusterings(labels_true, labels_pred)
     classes = np.unique(labels_true)
     clusters = np.unique(labels_pred)

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -654,7 +654,7 @@ def mutual_info_score(labels_true, labels_pred, contingency=None):
 
 
 def adjusted_mutual_info_score(labels_true, labels_pred,
-                               average_method='warn'):
+                               average_method='arithmetic'):
     """Adjusted Mutual Information between two clusterings.
 
     Adjusted Mutual Information (AMI) is an adjustment of the Mutual
@@ -687,11 +687,10 @@ def adjusted_mutual_info_score(labels_true, labels_pred,
     labels_pred : array, shape = [n_samples]
         A clustering of the data into disjoint subsets.
 
-    average_method : string, optional (default: 'warn')
+    average_method : string, optional (default: 'arithmetic')
         How to compute the normalizer in the denominator. Possible options
         are 'min', 'geometric', 'arithmetic', and 'max'.
-        If 'warn', 'max' will be used. The default will change to
-        'arithmetic' in version 0.22.
+        If 'warn', 'max' will be used.
 
         .. versionadded:: 0.20
 
@@ -740,11 +739,7 @@ def adjusted_mutual_info_score(labels_true, labels_pred,
 
     """
     if average_method == 'warn':
-        warnings.warn("The behavior of AMI will change in version 0.22. "
-                      "To match the behavior of 'v_measure_score', AMI will "
-                      "use average_method='arithmetic' by default.",
-                      FutureWarning)
-        average_method = 'max'
+        average_method = 'arithmetic'
     labels_true, labels_pred = check_clusterings(labels_true, labels_pred)
     n_samples = labels_true.shape[0]
     classes = np.unique(labels_true)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -32,16 +32,6 @@ score_funcs = [
 ]
 
 
-def test_future_warning():
-    score_funcs_with_changing_means = [
-        normalized_mutual_info_score
-    ]
-    warning_msg = "The behavior of "
-    args = [0, 0, 0], [0, 0, 0]
-    for score_func in score_funcs_with_changing_means:
-        assert_warns_message(FutureWarning, warning_msg, score_func, *args)
-
-
 @ignore_warnings(category=FutureWarning)
 def test_error_messages_on_wrong_input():
     for score_func in score_funcs:

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -229,8 +229,7 @@ def test_adjusted_mutual_info_score():
     a110 = np.array([list(labels_a) * 110]).flatten()
     b110 = np.array([list(labels_b) * 110]).flatten()
     ami = adjusted_mutual_info_score(a110, b110)
-    # This is not accurate to more than 2 places
-    assert_almost_equal(ami, 0.37, 2)
+    assert_almost_equal(ami, 0.38, 2)
 
 
 def test_expected_mutual_info_overflow():

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -34,8 +34,7 @@ score_funcs = [
 
 def test_future_warning():
     score_funcs_with_changing_means = [
-        normalized_mutual_info_score,
-        adjusted_mutual_info_score,
+        normalized_mutual_info_score
     ]
     warning_msg = "The behavior of "
     args = [0, 0, 0], [0, 0, 0]
@@ -223,7 +222,7 @@ def test_adjusted_mutual_info_score():
     assert_almost_equal(emi, 0.15042, 5)
     # Adjusted mutual information
     ami = adjusted_mutual_info_score(labels_a, labels_b)
-    assert_almost_equal(ami, 0.27502, 5)
+    assert_almost_equal(ami, 0.27821, 5)
     ami = adjusted_mutual_info_score([1, 1, 2, 2], [2, 2, 3, 3])
     assert_equal(ami, 1.0)
     # Test with a very large array

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -190,7 +190,6 @@ def test_adjustment_for_chance():
     assert_array_almost_equal(max_abs_scores, [0.02, 0.03, 0.03, 0.02], 2)
 
 
-@ignore_warnings(category=FutureWarning)
 def test_adjusted_mutual_info_score():
     # Compute the Adjusted Mutual Information and test against known values
     labels_a = np.array([1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3])

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -433,8 +433,6 @@ def test_thresholded_scorers_multilabel_indicator_data():
     assert_almost_equal(score1, score2)
 
 
-@pytest.mark.filterwarnings("ignore:the behavior of ")
-# AMI and NMI changes for 0.22
 def test_supervised_cluster_scorers():
     # Test clustering scorers against gold standard labeling.
     X, y = make_blobs(random_state=0, centers=2)


### PR DESCRIPTION
#### Reference Issues/PRs

This was raised by @glemaitre in issue #13797 as issues to resolve before the v0.22 release.

#### What does this implement/fix? Explain your changes.

In `adjusted_mutual_info_score()` and ` normalized_mutual_info_score()` function from `sklearn.metrics.cluster`:
- [x] changed default to `arithmetic`
- [x] removed deprecation warning
- [x] removed logical structure for when `warn` is passed

In test for both functions:
- [x] updated expected returned values
- [x] removed `test_future_warning()`altogether

In other parts of the codebase calling either functions:
- [x] Removed explicit passing of `average_method='arithmetic'`