### PR TITLE
[MRG] DEP remove precomputed parameter in t_sne.trustworthiness

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -392,8 +392,7 @@ def _gradient_descent(objective, p0, it, n_iter,
     return p, error, i
 
 
-def trustworthiness(X, X_embedded, n_neighbors=5,
-                    precomputed=False, metric='euclidean'):
+def trustworthiness(X, X_embedded, n_neighbors=5, metric='euclidean'):
     r"""Expresses to what extent the local structure is retained.
 
     The trustworthiness is within [0, 1]. It is defined as
@@ -427,13 +426,6 @@ def trustworthiness(X, X_embedded, n_neighbors=5,
     n_neighbors : int, optional (default: 5)
         Number of neighbors k that will be considered.
 
-    precomputed : bool, optional (default: False)
-        Set this flag if X is a precomputed square distance matrix.
-
-        ..deprecated:: 0.20
-            ``precomputed`` has been deprecated in version 0.20 and will be
-            removed in version 0.22. Use ``metric`` instead.
-
     metric : string, or callable, optional, default 'euclidean'
         Which metric to use for computing pairwise distances between samples
         from the original input space. If metric is 'precomputed', X must be a
@@ -446,11 +438,6 @@ def trustworthiness(X, X_embedded, n_neighbors=5,
     trustworthiness : float
         Trustworthiness of the low-dimensional embedding.
     """
-    if precomputed:
-        warnings.warn("The flag 'precomputed' has been deprecated in version "
-                      "0.20 and will be removed in 0.22. See 'metric' "
-                      "parameter instead.", DeprecationWarning)
-        metric = 'precomputed'
     dist_X = pairwise_distances(X, metric=metric)
     if metric == 'precomputed':
         dist_X = dist_X.copy()

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -299,25 +299,6 @@ def test_preserve_trustworthiness_approximately_with_precomputed_distances():
         assert t > .95
 
 
-def test_trustworthiness_precomputed_deprecation():
-    # FIXME: Remove this test in v0.23
-
-    # Use of the flag `precomputed` in trustworthiness parameters has been
-    # deprecated, but will still work until v0.23.
-    random_state = check_random_state(0)
-    X = random_state.randn(100, 2)
-    assert_equal(assert_warns(DeprecationWarning, trustworthiness,
-                              pairwise_distances(X), X, precomputed=True), 1.)
-    assert_equal(assert_warns(DeprecationWarning, trustworthiness,
-                              pairwise_distances(X), X, metric='precomputed',
-                              precomputed=True), 1.)
-    assert_raises(ValueError, assert_warns, DeprecationWarning,
-                  trustworthiness, X, X, metric='euclidean', precomputed=True)
-    assert_equal(assert_warns(DeprecationWarning, trustworthiness,
-                              pairwise_distances(X), X, metric='euclidean',
-                              precomputed=True), 1.)
-
-
 def test_trustworthiness_not_euclidean_metric():
     # Test trustworthiness with a metric different from 'euclidean' and
     # 'precomputed'


### PR DESCRIPTION
Remove `precomputed` parameter from `t_sne.trustworthness`.