### PR TITLE
[MRG] DEP Removed the reorder parameter from the auc function

### DIFF
--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -37,7 +37,7 @@ from ..preprocessing import label_binarize
 from .base import _average_binary_score
 
 
-def auc(x, y, reorder='deprecated'):
+def auc(x, y):
     """Compute Area Under the Curve (AUC) using the trapezoidal rule
 
     This is a general function, given points on a curve.  For computing the
@@ -52,19 +52,6 @@ def auc(x, y, reorder='deprecated'):
         decreasing.
     y : array, shape = [n]
         y coordinates.
-    reorder : boolean, optional (default='deprecated')
-        Whether to sort x before computing. If False, assume that x must be
-        either monotonic increasing or monotonic decreasing. If True, y is
-        used to break ties when sorting x. Make sure that y has a monotonic
-        relation to x when setting reorder to True.
-
-        .. deprecated:: 0.20
-           Parameter ``reorder`` has been deprecated in version 0.20 and will
-           be removed in 0.22. It's introduced for roc_auc_score (not for
-           general use) and is no longer used there. What's more, the result
-           from auc will be significantly influenced if x is sorted
-           unexpectedly due to slight floating point error (See issue #9786).
-           Future (and default) behavior is equivalent to ``reorder=False``.
 
     Returns
     -------
@@ -95,27 +82,14 @@ def auc(x, y, reorder='deprecated'):
         raise ValueError('At least 2 points are needed to compute'
                          ' area under curve, but x.shape = %s' % x.shape)
 
-    if reorder != 'deprecated':
-        warnings.warn("The 'reorder' parameter has been deprecated in "
-                      "version 0.20 and will be removed in 0.22. It is "
-                      "recommended not to set 'reorder' and ensure that x "
-                      "is monotonic increasing or monotonic decreasing.",
-                      DeprecationWarning)
-
     direction = 1
-    if reorder is True:
-        # reorder the data points according to the x axis and using y to
-        # break ties
-        order = np.lexsort((y, x))
-        x, y = x[order], y[order]
-    else:
-        dx = np.diff(x)
-        if np.any(dx < 0):
-            if np.all(dx <= 0):
-                direction = -1
-            else:
-                raise ValueError("x is neither increasing nor decreasing "
-                                 ": {}.".format(x))
+    dx = np.diff(x)
+    if np.any(dx < 0):
+        if np.all(dx <= 0):
+            direction = -1
+        else:
+            raise ValueError("x is neither increasing nor decreasing "
+                             ": {}.".format(x))
 
     area = direction * np.trapz(y, x)
     if isinstance(area, np.memmap):

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -427,24 +427,6 @@ def test_auc():
     assert_array_almost_equal(auc(x, y), 0.5)
 
 
-def test_auc_duplicate_values():
-    # Test Area Under Curve (AUC) computation with duplicate values
-
-    # auc() was previously sorting the x and y arrays according to the indices
-    # from numpy.argsort(x), which was reordering the tied 0's in this example
-    # and resulting in an incorrect area computation. This test detects the
-    # error.
-
-    # This will not work again in the future! so regression?
-    x = [-2.0, 0.0, 0.0, 0.0, 1.0]
-    y1 = [2.0, 0.0, 0.5, 1.0, 1.0]
-    y2 = [2.0, 1.0, 0.0, 0.5, 1.0]
-    y3 = [2.0, 1.0, 0.5, 0.0, 1.0]
-
-    for y in (y1, y2, y3):
-        assert_array_almost_equal(auc(x, y), 3.0)
-
-
 def test_auc_errors():
     # Incompatible shapes
     assert_raises(ValueError, auc, [0.0, 0.5, 1.0], [0.1, 0.2])

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -427,7 +427,6 @@ def test_auc():
     assert_array_almost_equal(auc(x, y), 0.5)
 
 
-@pytest.mark.filterwarnings("ignore: The 'reorder' parameter")  # 0.22
 def test_auc_duplicate_values():
     # Test Area Under Curve (AUC) computation with duplicate values
 
@@ -443,7 +442,7 @@ def test_auc_duplicate_values():
     y3 = [2.0, 1.0, 0.5, 0.0, 1.0]
 
     for y in (y1, y2, y3):
-        assert_array_almost_equal(auc(x, y, reorder=True), 3.0)
+        assert_array_almost_equal(auc(x, y), 3.0)
 
 
 def test_auc_errors():
@@ -459,15 +458,6 @@ def test_auc_errors():
     error_message = ("x is neither increasing nor decreasing : "
                      "{}".format(np.array(x)))
     assert_raise_message(ValueError, error_message, auc, x, y)
-
-
-def test_deprecated_auc_reorder():
-    depr_message = ("The 'reorder' parameter has been deprecated in version "
-                    "0.20 and will be removed in 0.22. It is recommended not "
-                    "to set 'reorder' and ensure that x is monotonic "
-                    "increasing or monotonic decreasing.")
-    assert_warns_message(DeprecationWarning, depr_message, auc,
-                         [1, 2], [2, 3], reorder=True)
 
 
 def test_auc_score_non_binary_class():


### PR DESCRIPTION
#### Reference Issues/PRs

This was raised by @glemaitre in issue #13797 as issues to resolve before the v0.22 release.

#### What does this implement/fix? Explain your changes.

In `auc()` function removed:
- [x] docstring for reorder parameter
- [x]  deprecation warning for when reorder is passed
- [x] control structure for when reorder is passed

In test removed:
- [x] warning ignore for deprecation warning for reorder parameter
- [x] removed `reorder=True` from `test_auc_duplicate_values()`
- [x] removed `test_deprecated_auc_reorder()` test
- [x] removed `test_auc_duplicate_values()`