### PR TITLE
disallow input as sparse matrix in affinity propagation function, Aff…

### DIFF
--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -105,6 +105,7 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
     Brendan J. Frey and Delbert Dueck, "Clustering by Passing Messages
     Between Data Points", Science Feb. 2007
     """
+    S = check_array(S, accept_sparse=False)
     S = as_float_array(S, copy=copy)
     n_samples = S.shape[0]
 

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -105,7 +105,6 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
     Brendan J. Frey and Delbert Dueck, "Clustering by Passing Messages
     Between Data Points", Science Feb. 2007
     """
-    S = check_array(S, accept_sparse=False)
     S = as_float_array(S, copy=copy)
     n_samples = S.shape[0]
 
@@ -365,7 +364,11 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         y : Ignored
 
         """
-        X = check_array(X, accept_sparse='csr')
+        if(self.affinity == "precomputed"):
+            accept_sparse = False
+        else:
+            accept_sparse = 'csr'
+        X = check_array(X, accept_sparse=accept_sparse)
         if self.affinity == "precomputed":
             self.affinity_matrix_ = X
         elif self.affinity == "euclidean":

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -364,7 +364,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         y : Ignored
 
         """
-        if(self.affinity == "precomputed"):
+        if self.affinity == "precomputed":
             accept_sparse = False
         else:
             accept_sparse = 'csr'

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -63,7 +63,8 @@ def test_affinity_propagation():
     assert_raises(ValueError, affinity_propagation, S, damping=0)
     af = AffinityPropagation(affinity="unknown")
     assert_raises(ValueError, af.fit, X)
-
+    af_2 = AffinityPropagation(affinity='precomputed')
+    assert_raises(TypeError, af_2.fit, csr_matrix((3, 3)))
 
 def test_affinity_propagation_predict():
     # Test AffinityPropagation.predict


### PR DESCRIPTION
disallow input as sparse matrix in affinity propagation function, Affinity(precomputed="Euclidean").fit(sparse_matrix) is still supported

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
See #13812 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fix #13812

