### PR TITLE
[MRG] DEP remove backward compatibility of param order in make_column_transformer

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -10,7 +10,6 @@ different columns.
 from itertools import chain
 
 import numpy as np
-import warnings
 from scipy import sparse
 
 from ..base import clone, TransformerMixin

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -697,62 +697,12 @@ def _is_empty_column_selection(column):
         return False
 
 
-def _validate_transformers(transformers):
-    """Checks if given transformers are valid.
-
-    This is a helper function to support the deprecated tuple order.
-    XXX Remove in v0.22
-    """
-    if not transformers:
-        return True
-
-    for t in transformers:
-        if isinstance(t, str) and t in ('drop', 'passthrough'):
-            continue
-        if (not (hasattr(t, "fit") or hasattr(t, "fit_transform")) or not
-                hasattr(t, "transform")):
-            return False
-
-    return True
-
-
-def _is_deprecated_tuple_order(tuples):
-    """Checks if the input follows the deprecated tuple order.
-
-    Returns
-    -------
-    Returns true if (transformer, columns) is not a valid assumption for the
-    input, but (columns, transformer) is valid. The latter is deprecated and
-    its support will stop in v0.22.
-
-    XXX Remove in v0.22
-    """
-    transformers, columns = zip(*tuples)
-    if (not _validate_transformers(transformers)
-            and _validate_transformers(columns)):
-        return True
-
-    return False
-
-
 def _get_transformer_list(estimators):
     """
     Construct (name, trans, column) tuples from list
 
     """
-    message = ('`make_column_transformer` now expects (transformer, columns) '
-               'as input tuples instead of (columns, transformer). This '
-               'has been introduced in v0.20.1. `make_column_transformer` '
-               'will stop accepting the deprecated (columns, transformer) '
-               'order in v0.22.')
-
     transformers, columns = zip(*estimators)
-
-    # XXX Remove in v0.22
-    if _is_deprecated_tuple_order(estimators):
-        transformers, columns = columns, transformers
-        warnings.warn(message, DeprecationWarning)
-
     names, _ = zip(*_name_estimators(transformers))
 
     transformer_list = list(zip(names, transformers, columns))

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -519,34 +519,13 @@ def test_make_column_transformer():
     assert_equal(transformers, (scaler, norm))
     assert_equal(columns, ('first', ['second']))
 
-    # XXX remove in v0.22
-    with pytest.warns(DeprecationWarning,
-                      match='`make_column_transformer` now expects'):
-        ct1 = make_column_transformer(([0], norm))
-    ct2 = make_column_transformer((norm, [0]))
-    X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
-    assert_almost_equal(ct1.fit_transform(X_array),
-                        ct2.fit_transform(X_array))
-
-    with pytest.warns(DeprecationWarning,
-                      match='`make_column_transformer` now expects'):
-        make_column_transformer(('first', 'drop'))
-
-    with pytest.warns(DeprecationWarning,
-                      match='`make_column_transformer` now expects'):
-        make_column_transformer(('passthrough', 'passthrough'),
-                                ('first', 'drop'))
-
 
 def test_make_column_transformer_pandas():
     pd = pytest.importorskip('pandas')
     X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
     X_df = pd.DataFrame(X_array, columns=['first', 'second'])
     norm = Normalizer()
-    # XXX remove in v0.22
-    with pytest.warns(DeprecationWarning,
-                      match='`make_column_transformer` now expects'):
-        ct1 = make_column_transformer((X_df.columns, norm))
+    ct1 = ColumnTransformer([('norm', Normalizer(), X_df.columns)])
     ct2 = make_column_transformer((norm, X_df.columns))
     assert_almost_equal(ct1.fit_transform(X_df),
                         ct2.fit_transform(X_df))


### PR DESCRIPTION
Remove the original way to pass parameters in `make_column_transformer` which was inconsistent with `ColumnTransformer`.