### PR TITLE
[MRG] DEP change default and deprecate normalize_components in SparsePCA

### DIFF
--- a/examples/decomposition/plot_faces_decomposition.py
+++ b/examples/decomposition/plot_faces_decomposition.py
@@ -81,8 +81,7 @@ estimators = [
     ('Sparse comp. - MiniBatchSparsePCA',
      decomposition.MiniBatchSparsePCA(n_components=n_components, alpha=0.8,
                                       n_iter=100, batch_size=3,
-                                      random_state=rng,
-                                      normalize_components=True),
+                                      random_state=rng),
      True),
 
     ('MiniBatchDictionaryLearning',

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -24,9 +24,8 @@ def _check_normalize_components(normalize_components, estimator_name):
             )
         else:
             raise NotImplementedError(
-                "Not normalizing the components in {} is not supported "
-                "since 0.22. Remove this parameter from the constructor."
-                .format(estimator_name)
+                "normalize_components=False is not supported starting from "
+                "0.22. Remove this parameter from the constructor."
             )
 
 

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -13,6 +13,23 @@ from ..base import BaseEstimator, TransformerMixin
 from .dict_learning import dict_learning, dict_learning_online
 
 
+# FIXME: remove in 0.24
+def _check_normalize_components(normalize_components, estimator_name):
+    if normalize_components != 'deprecated':
+        if normalize_components:
+            warnings.warn(
+                "'normalize_components' has been deprecated in 0.22 and "
+                "will be removed in 0.24. Remove the parameter from the "
+                " constructor.", DeprecationWarning
+            )
+        else:
+            raise NotImplementedError(
+                "Not normalizing the components in {} is not supported "
+                "since 0.22. Remove this parameter from the constructor."
+                .format(estimator_name)
+            )
+
+
 class SparsePCA(BaseEstimator, TransformerMixin):
     """Sparse Principal Components Analysis (SparsePCA)
 
@@ -69,20 +86,15 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    normalize_components : boolean, optional (default=False)
-        - if False, use a version of Sparse PCA without components
-          normalization and without data centering. This is likely a bug and
-          even though it's the default for backward compatibility,
-          this should not be used.
-        - if True, use a version of Sparse PCA with components normalization
-          and data centering.
+    normalize_components : True, optional (default='deprecated')
+        This parameter does not have any effect. The components are always
+        normalized.
 
         .. versionadded:: 0.20
 
         .. deprecated:: 0.22
-           ``normalize_components`` was added and set to ``False`` for
-           backward compatibility. It would be set to ``True`` from 0.22
-           onwards.
+           ``normalize_components`` si deprecated in 0.22 and will be removed
+           in 0.24.
 
     Attributes
     ----------
@@ -105,9 +117,7 @@ class SparsePCA(BaseEstimator, TransformerMixin):
     >>> from sklearn.datasets import make_friedman1
     >>> from sklearn.decomposition import SparsePCA
     >>> X, _ = make_friedman1(n_samples=200, n_features=30, random_state=0)
-    >>> transformer = SparsePCA(n_components=5,
-    ...         normalize_components=True,
-    ...         random_state=0)
+    >>> transformer = SparsePCA(n_components=5, random_state=0)
     >>> transformer.fit(X) # doctest: +ELLIPSIS
     SparsePCA(...)
     >>> X_transformed = transformer.transform(X)
@@ -126,7 +136,7 @@ class SparsePCA(BaseEstimator, TransformerMixin):
     def __init__(self, n_components=None, alpha=1, ridge_alpha=0.01,
                  max_iter=1000, tol=1e-8, method='lars', n_jobs=None,
                  U_init=None, V_init=None, verbose=False, random_state=None,
-                 normalize_components=False):
+                 normalize_components='deprecated'):
         self.n_components = n_components
         self.alpha = alpha
         self.ridge_alpha = ridge_alpha
@@ -159,15 +169,12 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         random_state = check_random_state(self.random_state)
         X = check_array(X)
 
-        if self.normalize_components:
-            self.mean_ = X.mean(axis=0)
-            X = X - self.mean_
-        else:
-            warnings.warn("normalize_components=False is a "
-                          "backward-compatible setting that implements a "
-                          "non-standard definition of sparse PCA. This "
-                          "compatibility mode will be removed in 0.22.",
-                          DeprecationWarning)
+        _check_normalize_components(
+            self.normalize_components, self.__class__.__name__
+        )
+
+        self.mean_ = X.mean(axis=0)
+        X = X - self.mean_
 
         if self.n_components is None:
             n_components = X.shape[1]
@@ -184,15 +191,12 @@ class SparsePCA(BaseEstimator, TransformerMixin):
                                                random_state=random_state,
                                                code_init=code_init,
                                                dict_init=dict_init,
-                                               return_n_iter=True
-                                               )
+                                               return_n_iter=True)
         self.components_ = Vt.T
-
-        if self.normalize_components:
-            components_norm = \
-                    np.linalg.norm(self.components_, axis=1)[:, np.newaxis]
-            components_norm[components_norm == 0] = 1
-            self.components_ /= components_norm
+        components_norm = np.linalg.norm(
+            self.components_, axis=1)[:, np.newaxis]
+        components_norm[components_norm == 0] = 1
+        self.components_ /= components_norm
 
         self.error_ = E
         return self
@@ -292,20 +296,15 @@ class MiniBatchSparsePCA(SparsePCA):
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    normalize_components : boolean, optional (default=False)
-        - if False, use a version of Sparse PCA without components
-          normalization and without data centering. This is likely a bug and
-          even though it's the default for backward compatibility,
-          this should not be used.
-        - if True, use a version of Sparse PCA with components normalization
-          and data centering.
+    normalize_components : True, optional (default='deprecated')
+        This parameter does not have any effect. The components are always
+        normalized.
 
         .. versionadded:: 0.20
 
         .. deprecated:: 0.22
-           ``normalize_components`` was added and set to ``False`` for
-           backward compatibility. It would be set to ``True`` from 0.22
-           onwards.
+           ``normalize_components`` si deprecated in 0.22 and will be removed
+           in 0.24.
 
     Attributes
     ----------
@@ -325,10 +324,8 @@ class MiniBatchSparsePCA(SparsePCA):
     >>> from sklearn.datasets import make_friedman1
     >>> from sklearn.decomposition import MiniBatchSparsePCA
     >>> X, _ = make_friedman1(n_samples=200, n_features=30, random_state=0)
-    >>> transformer = MiniBatchSparsePCA(n_components=5,
-    ...         batch_size=50,
-    ...         normalize_components=True,
-    ...         random_state=0)
+    >>> transformer = MiniBatchSparsePCA(n_components=5, batch_size=50,
+    ...                                  random_state=0)
     >>> transformer.fit(X) # doctest: +ELLIPSIS
     MiniBatchSparsePCA(...)
     >>> X_transformed = transformer.transform(X)
@@ -347,7 +344,7 @@ class MiniBatchSparsePCA(SparsePCA):
     def __init__(self, n_components=None, alpha=1, ridge_alpha=0.01,
                  n_iter=100, callback=None, batch_size=3, verbose=False,
                  shuffle=True, n_jobs=None, method='lars', random_state=None,
-                 normalize_components=False):
+                 normalize_components='deprecated'):
         super().__init__(
             n_components=n_components, alpha=alpha, verbose=verbose,
             ridge_alpha=ridge_alpha, n_jobs=n_jobs, method=method,
@@ -377,15 +374,12 @@ class MiniBatchSparsePCA(SparsePCA):
         random_state = check_random_state(self.random_state)
         X = check_array(X)
 
-        if self.normalize_components:
-            self.mean_ = X.mean(axis=0)
-            X = X - self.mean_
-        else:
-            warnings.warn("normalize_components=False is a "
-                          "backward-compatible setting that implements a "
-                          "non-standard definition of sparse PCA. This "
-                          "compatibility mode will be removed in 0.22.",
-                          DeprecationWarning)
+        _check_normalize_components(
+            self.normalize_components, self.__class__.__name__
+        )
+
+        self.mean_ = X.mean(axis=0)
+        X = X - self.mean_
 
         if self.n_components is None:
             n_components = X.shape[1]
@@ -403,10 +397,9 @@ class MiniBatchSparsePCA(SparsePCA):
             return_n_iter=True)
         self.components_ = Vt.T
 
-        if self.normalize_components:
-            components_norm = \
-                    np.linalg.norm(self.components_, axis=1)[:, np.newaxis]
-            components_norm[components_norm == 0] = 1
-            self.components_ /= components_norm
+        components_norm = np.linalg.norm(
+            self.components_, axis=1)[:, np.newaxis]
+        components_norm[components_norm == 0] = 1
+        self.components_ /= components_norm
 
         return self

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -295,7 +295,7 @@ class MiniBatchSparsePCA(SparsePCA):
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    normalize_components : True, optional (default='deprecated')
+    normalize_components : 'deprecated'
         This parameter does not have any effect. The components are always
         normalized.
 

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -86,14 +86,14 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    normalize_components : True, optional (default='deprecated')
+    normalize_components : 'deprecated'
         This parameter does not have any effect. The components are always
         normalized.
 
         .. versionadded:: 0.20
 
         .. deprecated:: 0.22
-           ``normalize_components`` si deprecated in 0.22 and will be removed
+           ``normalize_components`` is deprecated in 0.22 and will be removed
            in 0.24.
 
     Attributes
@@ -303,7 +303,7 @@ class MiniBatchSparsePCA(SparsePCA):
         .. versionadded:: 0.20
 
         .. deprecated:: 0.22
-           ``normalize_components`` si deprecated in 0.22 and will be removed
+           ``normalize_components`` is deprecated in 0.22 and will be removed
            in 0.24.
 
     Attributes

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -207,8 +207,6 @@ def test_spca_error_unormalized_components(spca):
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)
 
-    err_msg = "Not normalizing the components in {} is not supported".format(
-        spca.__name__
-    )
+    err_msg = "normalize_components=False is not supported starting "
     with pytest.raises(NotImplementedError, match=err_msg):
         spca(normalize_components=False).fit(Y)

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -41,115 +41,92 @@ def generate_toy_data(n_components, n_samples, image_size, random_state=None):
 # test different aspects of the code in the same test
 
 
-@pytest.mark.filterwarnings("ignore:normalize_components")
-@pytest.mark.parametrize("norm_comp", [False, True])
-def test_correct_shapes(norm_comp):
+def test_correct_shapes():
     rng = np.random.RandomState(0)
     X = rng.randn(12, 10)
-    spca = SparsePCA(n_components=8, random_state=rng,
-                     normalize_components=norm_comp)
+    spca = SparsePCA(n_components=8, random_state=rng)
     U = spca.fit_transform(X)
     assert_equal(spca.components_.shape, (8, 10))
     assert_equal(U.shape, (12, 8))
     # test overcomplete decomposition
-    spca = SparsePCA(n_components=13, random_state=rng,
-                     normalize_components=norm_comp)
+    spca = SparsePCA(n_components=13, random_state=rng)
     U = spca.fit_transform(X)
     assert_equal(spca.components_.shape, (13, 10))
     assert_equal(U.shape, (12, 13))
 
 
-@pytest.mark.filterwarnings("ignore:normalize_components")
-@pytest.mark.parametrize("norm_comp", [False, True])
-def test_fit_transform(norm_comp):
+def test_fit_transform():
     alpha = 1
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)  # wide array
     spca_lars = SparsePCA(n_components=3, method='lars', alpha=alpha,
-                          random_state=0, normalize_components=norm_comp)
+                          random_state=0)
     spca_lars.fit(Y)
 
     # Test that CD gives similar results
     spca_lasso = SparsePCA(n_components=3, method='cd', random_state=0,
-                           alpha=alpha, normalize_components=norm_comp)
+                           alpha=alpha)
     spca_lasso.fit(Y)
     assert_array_almost_equal(spca_lasso.components_, spca_lars.components_)
 
 
-@pytest.mark.filterwarnings("ignore:normalize_components")
-@pytest.mark.parametrize("norm_comp", [False, True])
 @if_safe_multiprocessing_with_blas
-def test_fit_transform_parallel(norm_comp):
+def test_fit_transform_parallel():
     alpha = 1
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)  # wide array
     spca_lars = SparsePCA(n_components=3, method='lars', alpha=alpha,
-                          random_state=0, normalize_components=norm_comp)
+                          random_state=0)
     spca_lars.fit(Y)
     U1 = spca_lars.transform(Y)
     # Test multiple CPUs
     spca = SparsePCA(n_components=3, n_jobs=2, method='lars', alpha=alpha,
-                     random_state=0, normalize_components=norm_comp).fit(Y)
+                     random_state=0).fit(Y)
     U2 = spca.transform(Y)
     assert not np.all(spca_lars.components_ == 0)
     assert_array_almost_equal(U1, U2)
 
 
-@pytest.mark.filterwarnings("ignore:normalize_components")
-@pytest.mark.parametrize("norm_comp", [False, True])
-def test_transform_nan(norm_comp):
+def test_transform_nan():
     # Test that SparsePCA won't return NaN when there is 0 feature in all
     # samples.
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)  # wide array
     Y[:, 0] = 0
-    estimator = SparsePCA(n_components=8, normalize_components=norm_comp)
+    estimator = SparsePCA(n_components=8)
     assert not np.any(np.isnan(estimator.fit_transform(Y)))
 
 
-@pytest.mark.filterwarnings("ignore:normalize_components")
-@pytest.mark.parametrize("norm_comp", [False, True])
-def test_fit_transform_tall(norm_comp):
+def test_fit_transform_tall():
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 65, (8, 8), random_state=rng)  # tall array
-    spca_lars = SparsePCA(n_components=3, method='lars',
-                          random_state=rng, normalize_components=norm_comp)
+    spca_lars = SparsePCA(n_components=3, method='lars', random_state=rng)
     U1 = spca_lars.fit_transform(Y)
-    spca_lasso = SparsePCA(n_components=3, method='cd',
-                           random_state=rng, normalize_components=norm_comp)
+    spca_lasso = SparsePCA(n_components=3, method='cd', random_state=rng)
     U2 = spca_lasso.fit(Y).transform(Y)
     assert_array_almost_equal(U1, U2)
 
 
-@pytest.mark.filterwarnings("ignore:normalize_components")
-@pytest.mark.parametrize("norm_comp", [False, True])
-def test_initialization(norm_comp):
+def test_initialization():
     rng = np.random.RandomState(0)
     U_init = rng.randn(5, 3)
     V_init = rng.randn(3, 4)
     model = SparsePCA(n_components=3, U_init=U_init, V_init=V_init, max_iter=0,
-                      random_state=rng, normalize_components=norm_comp)
+                      random_state=rng)
     model.fit(rng.randn(5, 4))
-    if norm_comp:
-        assert_allclose(model.components_,
-                        V_init / np.linalg.norm(V_init, axis=1)[:, None])
-    else:
-        assert_allclose(model.components_, V_init)
+    assert_allclose(model.components_,
+                    V_init / np.linalg.norm(V_init, axis=1)[:, None])
 
 
-@pytest.mark.filterwarnings("ignore:normalize_components")
-@pytest.mark.parametrize("norm_comp", [False, True])
-def test_mini_batch_correct_shapes(norm_comp):
+def test_mini_batch_correct_shapes():
     rng = np.random.RandomState(0)
     X = rng.randn(12, 10)
-    pca = MiniBatchSparsePCA(n_components=8, random_state=rng,
-                             normalize_components=norm_comp)
+    pca = MiniBatchSparsePCA(n_components=8, random_state=rng)
     U = pca.fit_transform(X)
     assert_equal(pca.components_.shape, (8, 10))
     assert_equal(U.shape, (12, 8))
     # test overcomplete decomposition
-    pca = MiniBatchSparsePCA(n_components=13, random_state=rng,
-                             normalize_components=norm_comp)
+    pca = MiniBatchSparsePCA(n_components=13, random_state=rng)
     U = pca.fit_transform(X)
     assert_equal(pca.components_.shape, (13, 10))
     assert_equal(U.shape, (12, 13))
@@ -157,15 +134,12 @@ def test_mini_batch_correct_shapes(norm_comp):
 
 # XXX: test always skipped
 @pytest.mark.skipif(True, reason="skipping mini_batch_fit_transform.")
-@pytest.mark.filterwarnings("ignore:normalize_components")
-@pytest.mark.parametrize("norm_comp", [False, True])
-def test_mini_batch_fit_transform(norm_comp):
+def test_mini_batch_fit_transform():
     alpha = 1
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)  # wide array
     spca_lars = MiniBatchSparsePCA(n_components=3, random_state=0,
-                                   alpha=alpha,
-                                   normalize_components=norm_comp).fit(Y)
+                                   alpha=alpha).fit(Y)
     U1 = spca_lars.transform(Y)
     # Test multiple CPUs
     if sys.platform == 'win32':  # fake parallelism for win32
@@ -174,22 +148,19 @@ def test_mini_batch_fit_transform(norm_comp):
         joblib_par.multiprocessing = None
         try:
             spca = MiniBatchSparsePCA(n_components=3, n_jobs=2, alpha=alpha,
-                                      random_state=0,
-                                      normalize_components=norm_comp)
+                                      random_state=0)
             U2 = spca.fit(Y).transform(Y)
         finally:
             joblib_par.multiprocessing = _mp
     else:  # we can efficiently use parallelism
         spca = MiniBatchSparsePCA(n_components=3, n_jobs=2, alpha=alpha,
-                                  random_state=0,
-                                  normalize_components=norm_comp)
+                                  random_state=0)
         U2 = spca.fit(Y).transform(Y)
     assert not np.all(spca_lars.components_ == 0)
     assert_array_almost_equal(U1, U2)
     # Test that CD gives similar results
     spca_lasso = MiniBatchSparsePCA(n_components=3, method='cd', alpha=alpha,
-                                    random_state=0,
-                                    normalize_components=norm_comp).fit(Y)
+                                    random_state=0).fit(Y)
     assert_array_almost_equal(spca_lasso.components_, spca_lars.components_)
 
 
@@ -198,7 +169,7 @@ def test_scaling_fit_transform():
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 1000, (8, 8), random_state=rng)
     spca_lars = SparsePCA(n_components=3, method='lars', alpha=alpha,
-                          random_state=rng, normalize_components=True)
+                          random_state=rng)
     results_train = spca_lars.fit_transform(Y)
     results_test = spca_lars.transform(Y[:10])
     assert_allclose(results_train[0], results_test[0])
@@ -208,8 +179,7 @@ def test_pca_vs_spca():
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 1000, (8, 8), random_state=rng)
     Z, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)
-    spca = SparsePCA(alpha=0, ridge_alpha=0, n_components=2,
-                     normalize_components=True)
+    spca = SparsePCA(alpha=0, ridge_alpha=0, n_components=2)
     pca = PCA(n_components=2)
     pca.fit(Y)
     spca.fit(Y)
@@ -226,6 +196,19 @@ def test_pca_vs_spca():
 def test_spca_deprecation_warning(spca):
     rng = np.random.RandomState(0)
     Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)
-    warn_message = "normalize_components"
-    assert_warns_message(DeprecationWarning, warn_message,
-                         spca(normalize_components=False).fit, Y)
+
+    warn_msg = "'normalize_components' has been deprecated in 0.22"
+    with pytest.warns(DeprecationWarning, match=warn_msg):
+        spca(normalize_components=True).fit(Y)
+
+
+@pytest.mark.parametrize("spca", [SparsePCA, MiniBatchSparsePCA])
+def test_spca_error_unormalized_components(spca):
+    rng = np.random.RandomState(0)
+    Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)
+
+    err_msg = "Not normalizing the components in {} is not supported".format(
+        spca.__name__
+    )
+    with pytest.raises(NotImplementedError, match=err_msg):
+        spca(normalize_components=False).fit(Y)


### PR DESCRIPTION
Change the default to normalize the components in SparsePCA. The parameter has been deprecated and will be removed.