### PR TITLE
Updating MissingIndicator User Guide section

### DIFF
--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -196,7 +196,10 @@ The :class:`MissingIndicator` transformer is useful to transform a dataset into
 corresponding binary matrix indicating the presence of missing values in the
 dataset. This transformation is useful in conjunction with imputation. When
 using imputation, preserving the information about which values had been
-missing can be informative.
+missing can be informative. Note that both the :class:`SimpleImputer` and 
+:class:`IterativeImputer` have the boolean parameter ``add_indicator``
+(default=False) which when set to True provides a convenient way of stacking a 
+:class:`MissingIndicator` transform onto output of the imputer’s transform.
 
 ``NaN`` is usually used as the placeholder for missing values. However, it
 enforces the data type to be float. The parameter ``missing_values`` allows to

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -196,10 +196,11 @@ The :class:`MissingIndicator` transformer is useful to transform a dataset into
 corresponding binary matrix indicating the presence of missing values in the
 dataset. This transformation is useful in conjunction with imputation. When
 using imputation, preserving the information about which values had been
-missing can be informative. Note that both the :class:`SimpleImputer` and 
+missing can be informative. Note that both the :class:`SimpleImputer` and
 :class:`IterativeImputer` have the boolean parameter ``add_indicator``
-(default=False) which when set to True provides a convenient way of stacking a 
-:class:`MissingIndicator` transform onto output of the imputer’s transform.
+(``False`` by default) which when set to ``True`` provides a convenient way of
+stacking the output of the :class:`MissingIndicator` transformer with the
+output of the imputer.
 
 ``NaN`` is usually used as the placeholder for missing values. However, it
 enforces the data type to be float. The parameter ``missing_values`` allows to
@@ -226,7 +227,7 @@ mask of the features containing missing values at ``fit`` time::
 
 The ``features`` parameter can be set to ``'all'`` to returned all features
 whether or not they contain missing values::
-    
+
   >>> indicator = MissingIndicator(missing_values=-1, features="all")
   >>> mask_all = indicator.fit_transform(X)
   >>> mask_all


### PR DESCRIPTION
An add_indicator parameter was added to SimpleImputer and IterativeImputer as an easy way to stack a MissingIndicator. This addition is now mentioned in the MissingIndicator section of the User Guide.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #13825
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Updates the User Guide according to the ref issue and the comment above.


#### Any other comments?
No

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
