### PR TITLE
FIX broken sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include *.rst
 recursive-include doc *
 recursive-include examples *
-recursive-include sklearn *.c *.h *.pyx *.pxd *.pxi
+recursive-include sklearn *.c *.h *.pyx *.pxd *.pxi *.tp
 recursive-include sklearn/datasets *.csv *.csv.gz *.rst *.jpg *.txt *.arff.gz *.json.gz
 include COPYING
 include README.rst


### PR DESCRIPTION
- missing *.tp files (cython templates) from MANIFST.in
- missing `__init__.py` file to turn a tests folder into a package to
  be shipped with the tarball

Fix #13859.

Note: we probably need to improve our CI to also test for the installation of the generated tarball.