### PR TITLE
EXA Avoid overlapping subplots in plot_kernel_pca.py

### DIFF
--- a/examples/decomposition/plot_kernel_pca.py
+++ b/examples/decomposition/plot_kernel_pca.py
@@ -76,6 +76,5 @@ plt.title("Original space after inverse transform")
 plt.xlabel("$x_1$")
 plt.ylabel("$x_2$")
 
-plt.subplots_adjust(0.02, 0.10, 0.98, 0.94, 0.04, 0.35)
-
+plt.tight_layout()
 plt.show()


### PR DESCRIPTION
before:
![sphx_glr_plot_kernel_pca_001 (1)](https://user-images.githubusercontent.com/12003569/57618915-32027e80-75b7-11e9-9718-a184586444fd.png)
after:
![sphx_glr_plot_kernel_pca_001](https://user-images.githubusercontent.com/12003569/57618921-3464d880-75b7-11e9-9ac4-9acead83cf8c.png)
