### PR TITLE
ENH Binary only estimator checks for classification

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1550,6 +1550,10 @@ poor_score
 multioutput_only
     whether estimator supports only multi-output classification or regression.
 
+binary_only
+    whether estimator supports binary classification but lacks multilabel
+    support.
+
 _skip_test
     whether to skip common tests entirely. Don't use this unless you have a *very good* reason.
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1551,8 +1551,8 @@ multioutput_only
     whether estimator supports only multi-output classification or regression.
 
 binary_only
-    whether estimator supports binary classification but lacks multilabel
-    support.
+    whether estimator supports binary classification but lacks multi-class
+    classification support.
 
 _skip_test
     whether to skip common tests entirely. Don't use this unless you have a *very good* reason.

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -27,6 +27,7 @@ _DEFAULT_TAGS = {
     'multilabel': False,
     '_skip_test': False,
     'multioutput_only': False,
+    'binary_only': False,
     'requires_fit': True}
 
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -829,7 +829,7 @@ def _apply_on_subsets(func, X):
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))
 def check_methods_subset_invariance(name, estimator_orig):
     # check that method gives invariant results if applied
-    # on mini bathes or the whole set
+    # on mini batches or the whole set
     tags = _safe_tags(estimator_orig)
     rnd = np.random.RandomState(0)
     X = 3 * rnd.uniform(size=(20, 3))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1911,6 +1911,7 @@ def check_regressors_no_decision_function(name, regressor_orig):
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))
 def check_class_weight_classifiers(name, classifier_orig):
+    tags = _safe_tags(classifier_orig)
     if name == "NuSVC":
         # the sparse version has a parameter that doesn't do anything
         raise SkipTest("Not testing NuSVC class weight as it is ignored.")
@@ -1919,7 +1920,12 @@ def check_class_weight_classifiers(name, classifier_orig):
         # FIXME SOON!
         raise SkipTest
 
-    for n_centers in [2, 3]:
+    if tags['binary_only']:
+        problems = [2]
+    else:
+        problems = [2, 3]
+
+    for n_centers in problems:
         # create a very noisy dataset
         X, y = make_blobs(centers=n_centers, random_state=0, cluster_std=20)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=.5,

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -277,25 +277,19 @@ class SparseTransformer(BaseEstimator):
         return sp.csr_matrix(X)
 
 
-class BinaryDecisionTreeClassifier(DecisionTreeClassifier):
-    # Toy classifier that only supports binary classification.
-    def _more_tags(self):
-        return {'binary_only': True}
-
-    def fit(self, X, y, sample_weight=None):
-        super().fit(X, y, sample_weight)
-        if self.n_classes_ > 2:
-            raise ValueError('Only 2 classes are supported')
-        return self
-
-
-class UntaggedBinaryDecisionTreeClassifier(DecisionTreeClassifier):
+class UntaggedBinaryClassifier(DecisionTreeClassifier):
     # Toy classifier that only supports binary classification, will fail tests.
     def fit(self, X, y, sample_weight=None):
         super().fit(X, y, sample_weight)
         if self.n_classes_ > 2:
             raise ValueError('Only 2 classes are supported')
         return self
+
+
+class TaggedBinaryClassifier(UntaggedBinaryClassifier):
+    # Toy classifier that only supports binary classification.
+    def _more_tags(self):
+        return {'binary_only': True}
 
 
 def test_check_fit_score_takes_y_works_on_deprecated_fit():
@@ -408,12 +402,12 @@ def test_check_estimator():
     check_estimator(MultiTaskElasticNet())
 
     # doesn't error on binary_only tagged estimator
-    check_estimator(BinaryDecisionTreeClassifier)
+    check_estimator(TaggedBinaryClassifier)
 
     # does error on binary_only untagged estimator
     msg = 'Only 2 classes are supported'
     assert_raises_regex(ValueError, msg, check_estimator,
-                        UntaggedBinaryDecisionTreeClassifier)
+                        UntaggedBinaryClassifier)
 
 
 def test_check_outlier_corruption():

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -285,9 +285,16 @@ class BinaryDecisionTreeClassifier(DecisionTreeClassifier):
     def fit(self, X, y, sample_weight=None):
         super().fit(X, y, sample_weight)
         if self.n_classes_ != 2:
-            raise ValueError("y contains %d class after sample_weight "
-                             "trimmed classes with zero weights, while 2 "
-                             "classes are required." % self.n_classes_)
+            raise ValueError('Only 2 classes are supported')
+        return self
+
+
+class UntaggedBinaryDecisionTreeClassifier(DecisionTreeClassifier):
+    # Toy classifier that only supports binary classification, will fail tests.
+    def fit(self, X, y, sample_weight=None):
+        super().fit(X, y, sample_weight)
+        if self.n_classes_ != 2:
+            raise ValueError('Only 2 classes are supported')
         return self
 
 
@@ -402,6 +409,11 @@ def test_check_estimator():
 
     # doesn't error on binary_only tagged estimator
     check_estimator(BinaryDecisionTreeClassifier)
+
+    # does error on binary_only untagged estimator
+    msg = 'Only 2 classes are supported'
+    assert_raises_regex(ValueError, msg, check_estimator,
+                        UntaggedBinaryDecisionTreeClassifier)
 
 
 def test_check_outlier_corruption():

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -279,26 +279,17 @@ class SparseTransformer(BaseEstimator):
 
 
 class BinaryDecisionTreeClassifier(DecisionTreeClassifier):
+    # Toy classifier that only supports binary classification.
     def _more_tags(self):
         return {'binary_only': True}
 
     def fit(self, X, y, sample_weight=None):
         super().fit(X, y, sample_weight)
-        X, y = check_X_y(X, y, y_numeric=False)
-        check_classification_targets(y)
-        self.classes_, y = np.unique(y, return_inverse=True)
-        n_trim_classes = np.count_nonzero(np.bincount(y, sample_weight))
-        if n_trim_classes != 2:
+        if self.n_classes_ != 2:
             raise ValueError("y contains %d class after sample_weight "
                              "trimmed classes with zero weights, while 2 "
-                             "classes are required." % n_trim_classes)
+                             "classes are required." % self.n_classes_)
         return self
-
-    def predict_proba(self, X):
-        return super().predict_proba(X)
-
-    def predict(self, X):
-        return super().predict(X)
 
 
 def test_check_fit_score_takes_y_works_on_deprecated_fit():

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -20,7 +20,6 @@ from sklearn.utils.estimator_checks import set_checking_parameters
 from sklearn.utils.estimator_checks import check_estimators_unfitted
 from sklearn.utils.estimator_checks import check_fit_score_takes_y
 from sklearn.utils.estimator_checks import check_no_attributes_set_in_init
-from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_is_fitted
 from sklearn.utils.estimator_checks import check_outlier_corruption
 from sklearn.ensemble import AdaBoostClassifier, RandomForestClassifier

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -284,7 +284,7 @@ class BinaryDecisionTreeClassifier(DecisionTreeClassifier):
 
     def fit(self, X, y, sample_weight=None):
         super().fit(X, y, sample_weight)
-        if self.n_classes_ != 2:
+        if self.n_classes_ > 2:
             raise ValueError('Only 2 classes are supported')
         return self
 
@@ -293,7 +293,7 @@ class UntaggedBinaryDecisionTreeClassifier(DecisionTreeClassifier):
     # Toy classifier that only supports binary classification, will fail tests.
     def fit(self, X, y, sample_weight=None):
         super().fit(X, y, sample_weight)
-        if self.n_classes_ != 2:
+        if self.n_classes_ > 2:
             raise ValueError('Only 2 classes are supported')
         return self
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
See also https://github.com/scikit-learn/scikit-learn/issues/6715#issuecomment-476087371

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
I don't think this closes the reference issue entirely, but might help it out in some cases such as mine. I maintain `gplearn`, a niche package that implements genetic programming with a scikit-learn API. I try to stick to scikit-learn standards and be "compatible" as much as possible, but the estimator checks will not pass due to my classifier currently only supporting binary classification as a first-pass MVP. Due to these requirements I currently have thousands of lines of re-written test code in my project that I'd love to lose. I don't think that multiclass should be a requirement to be a scikit-learn compatible estimator as an external package, though open to being challenged on that front.

Changes to the test suite re-frame tests that have multiple classes to be binary if the "binary_only" flag exists within the `more_tags` attribute of the classifier.

#### Any other comments?

Need to write a test to ensure future tests respect this flag, will remove WIP from title when ready. Happy to chat before then :-) 
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->