### PR TITLE
MAINT increase numerical gradient check tolerance to make the test stable

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 from scipy.optimize import newton
 from sklearn.utils import assert_all_finite
 from sklearn.utils.fixes import sp_version
@@ -130,8 +131,8 @@ def test_numerical_gradients(loss, n_classes, prediction_dim):
     def relative_error(a, b):
         return np.abs(a - b) / np.maximum(np.abs(a), np.abs(b))
 
-    assert np.allclose(numerical_gradients, gradients, rtol=1e-5)
-    assert np.allclose(numerical_hessians, hessians, rtol=1e-5)
+    assert_allclose(numerical_gradients, gradients, atol=1e-5)
+    assert_allclose(numerical_hessians, hessians, atol=1e-5)
 
 
 def test_baseline_least_squares():

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -86,8 +86,7 @@ def test_derivatives(loss, x0, y_true):
 ])
 @pytest.mark.skipif(Y_DTYPE != np.float64,
                     reason='Need 64 bits float precision for numerical checks')
-@pytest.mark.parametrize('seed', range(1))
-def test_numerical_gradients(loss, n_classes, prediction_dim, seed):
+def test_numerical_gradients(loss, n_classes, prediction_dim, seed=0):
     # Make sure gradients and hessians computed in the loss are correct, by
     # comparing with their approximations computed with finite central
     # differences.

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -86,13 +86,14 @@ def test_derivatives(loss, x0, y_true):
 ])
 @pytest.mark.skipif(Y_DTYPE != np.float64,
                     reason='Need 64 bits float precision for numerical checks')
-def test_numerical_gradients(loss, n_classes, prediction_dim):
+@pytest.mark.parametrize('seed', range(1))
+def test_numerical_gradients(loss, n_classes, prediction_dim, seed):
     # Make sure gradients and hessians computed in the loss are correct, by
     # comparing with their approximations computed with finite central
     # differences.
     # See https://en.wikipedia.org/wiki/Finite_difference.
 
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(seed)
     n_samples = 100
     if loss == 'least_squares':
         y_true = rng.normal(size=n_samples).astype(Y_DTYPE)
@@ -131,8 +132,8 @@ def test_numerical_gradients(loss, n_classes, prediction_dim):
     def relative_error(a, b):
         return np.abs(a - b) / np.maximum(np.abs(a), np.abs(b))
 
-    assert_allclose(numerical_gradients, gradients, atol=1e-5)
-    assert_allclose(numerical_hessians, hessians, atol=1e-5)
+    assert_allclose(numerical_gradients, gradients, rtol=1e-4)
+    assert_allclose(numerical_hessians, hessians, rtol=1e-4)
 
 
 def test_baseline_least_squares():


### PR DESCRIPTION
Fix #13882

I have tested with all random seeds in `range(100)` under 32 bit and 64 bit  Python / linux (using docker) and the test is stable if we use absolute tolerance (we could even decrease it to 1e-6).

If I keep `rtol=1e-5`, the tests fails with several random seeds in range(100) even under 64 bit Python / linux.