### PR TITLE
DOC Fix missing newline in DistanceMetric docs

### DIFF
--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -120,6 +120,7 @@ cdef class DistanceMetric:
            [ 5.19615242,  0.        ]])
 
     Available Metrics
+
     The following lists the string metric identifiers and the associated
     distance metric classes:
 


### PR DESCRIPTION
Currently, the [DistanceMetric docs](https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.DistanceMetric.html) look like this:

> Available Metrics The following lists the string metric identifiers and the associated distance metric classes:

With this PR, they should look like:

> Available Metrics 
>
> The following lists the string metric identifiers and the associated distance metric classes: