### PR TITLE
Fix nan problem in precision_recall_curve (affecting average_precision_score)

### DIFF
--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -500,6 +500,7 @@ def precision_recall_curve(y_true, probas_pred, pos_label=None,
     precision = tps / (tps + fps)
     precision[np.isnan(precision)] = 0
     recall = tps / tps[-1]
+    recall[np.isnan(recall)] = 0
 
     # stop when full recall attained
     # and reverse the outputs so recall is decreasing

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1,4 +1,3 @@
-
 import pytest
 import numpy as np
 import warnings
@@ -491,6 +490,7 @@ def test_binary_clf_curve():
     assert_raise_message(ValueError, msg, precision_recall_curve,
                          y_true, y_pred)
 
+
 def test_precision_recall_curve():
     y_true, _, probas_pred = make_prediction(binary=True)
     _test_precision_recall_curve(y_true, probas_pred)
@@ -510,6 +510,7 @@ def test_precision_recall_curve():
     assert_equal(p.size, r.size)
     assert_equal(p.size, t.size + 1)
 
+
 def test_precision_recall_curve_nan():
     y_true, _, probas_pred = make_prediction(binary=True)
     _test_precision_recall_curve(y_true, probas_pred)
@@ -527,10 +528,11 @@ def test_precision_recall_curve_nan():
     p, r, t = precision_recall_curve(labels, predict_probas)
     assert_array_almost_equal(p, np.array([0., 1.]))
     assert_array_almost_equal(r, np.array([0., 0.]))
-    #it should return 0 instead of nan
+    # it should return 0 instead of nan
     assert_array_almost_equal(t, np.array([4]))
     assert_equal(p.size, r.size)
     assert_equal(p.size, t.size + 1)
+
 
 def _test_precision_recall_curve(y_true, probas_pred):
     # Test Precision-Recall and aread under PR curve
@@ -572,7 +574,7 @@ def test_precision_recall_curve_toydata():
         p, r, _ = precision_recall_curve(y_true, y_score)
         auc_prc = average_precision_score(y_true, y_score)
         assert_array_almost_equal(p, [0.5, 0., 1.])
-        assert_array_almost_equal(r, [1., 0.,  0.])
+        assert_array_almost_equal(r, [1., 0., 0.])
         # Here we are doing a terrible prediction: we are always getting
         # it wrong, hence the average_precision_score is the accuracy at
         # chance: 50%
@@ -622,9 +624,9 @@ def test_precision_recall_curve_toydata():
         assert_raises(Exception, average_precision_score, y_true, y_score,
                       average="weighted")
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="samples"), 1.)
+                                                    average="samples"), 1.)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="micro"), 1.)
+                                                    average="micro"), 1.)
 
         y_true = np.array([[0, 1], [0, 1]])
         y_score = np.array([[0, 1], [1, 0]])
@@ -633,31 +635,31 @@ def test_precision_recall_curve_toydata():
         assert_raises(Exception, average_precision_score, y_true, y_score,
                       average="weighted")
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="samples"), 0.75)
+                                                    average="samples"), 0.75)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="micro"), 0.5)
+                                                    average="micro"), 0.5)
 
         y_true = np.array([[1, 0], [0, 1]])
         y_score = np.array([[0, 1], [1, 0]])
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="macro"), 0.5)
+                                                    average="macro"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="weighted"), 0.5)
+                                                    average="weighted"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="samples"), 0.5)
+                                                    average="samples"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="micro"), 0.5)
+                                                    average="micro"), 0.5)
 
         y_true = np.array([[1, 0], [0, 1]])
         y_score = np.array([[0.5, 0.5], [0.5, 0.5]])
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="macro"), 0.5)
+                                                    average="macro"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="weighted"), 0.5)
+                                                    average="weighted"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="samples"), 0.5)
+                                                    average="samples"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                            average="micro"), 0.5)
+                                                    average="micro"), 0.5)
 
 
 def test_average_precision_constant_values():
@@ -859,7 +861,7 @@ def _my_lrap(y_true, y_score):
     y_true = check_array(y_true)
     y_score = check_array(y_score)
     n_samples, n_labels = y_true.shape
-    score = np.empty((n_samples, ))
+    score = np.empty((n_samples,))
     for i in range(n_samples):
         # The best rank correspond to 1. Rank higher than 1 are worse.
         # The best inverse ranking correspond to n_labels.
@@ -919,14 +921,14 @@ def check_alternative_lrap_implementation(lrap_score, n_classes=5,
 
 
 @pytest.mark.parametrize(
-        'check',
-        (check_lrap_toy,
-         check_lrap_without_tie_and_increasing_score,
-         check_lrap_only_ties,
-         check_zero_or_all_relevant_labels))
+    'check',
+    (check_lrap_toy,
+     check_lrap_without_tie_and_increasing_score,
+     check_lrap_only_ties,
+     check_zero_or_all_relevant_labels))
 @pytest.mark.parametrize(
-        'func',
-        (label_ranking_average_precision_score, _my_lrap))
+    'func',
+    (label_ranking_average_precision_score, _my_lrap))
 def test_label_ranking_avp(check, func):
     check(func)
 
@@ -939,10 +941,9 @@ def test_lrap_error_raised():
 @pytest.mark.parametrize('n_classes', (2, 5, 10))
 @pytest.mark.parametrize('random_state', range(1))
 def test_alternative_lrap_implementation(n_samples, n_classes, random_state):
-
     check_alternative_lrap_implementation(
-               label_ranking_average_precision_score,
-               n_classes, n_samples, random_state)
+        label_ranking_average_precision_score,
+        n_classes, n_samples, random_state)
 
 
 def test_lrap_sample_weighting_zero_labels():
@@ -1120,7 +1121,7 @@ def test_partial_roc_auc_score():
     with pytest.raises(ValueError):
         assert roc_auc_score(y_true, y_true, max_fpr=0)
 
-    y_scores = np.array([0.1,  0,  0.1, 0.01])
+    y_scores = np.array([0.1, 0, 0.1, 0.01])
     roc_auc_with_max_fpr_one = roc_auc_score(y_true, y_scores, max_fpr=1)
     unconstrained_roc_auc = roc_auc_score(y_true, y_scores)
     assert roc_auc_with_max_fpr_one == unconstrained_roc_auc

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -488,6 +488,7 @@ def test_binary_clf_curve():
     assert_raise_message(ValueError, msg, precision_recall_curve,
                          y_true, y_pred)
 
+
 def test_precision_recall_curve():
     y_true, _, probas_pred = make_prediction(binary=True)
     _test_precision_recall_curve(y_true, probas_pred)
@@ -506,6 +507,7 @@ def test_precision_recall_curve():
     assert_array_almost_equal(t, np.array([1, 2, 3, 4]))
     assert_equal(p.size, r.size)
     assert_equal(p.size, t.size + 1)
+
 
 def test_precision_recall_curve_nan():
     y_true, _, probas_pred = make_prediction(binary=True)
@@ -528,6 +530,7 @@ def test_precision_recall_curve_nan():
     assert_array_almost_equal(t, np.array([4]))
     assert_equal(p.size, r.size)
     assert_equal(p.size, t.size + 1)
+
 
 def _test_precision_recall_curve(y_true, probas_pred):
     # Test Precision-Recall and aread under PR curve

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1,3 +1,4 @@
+
 import pytest
 import numpy as np
 import warnings
@@ -37,7 +38,6 @@ from sklearn.exceptions import UndefinedMetricWarning
 
 def make_prediction(dataset=None, binary=False):
     """Make some classification predictions on a toy dataset using a SVC
-
     If binary is True restrict to a binary classification problem instead of a
     multiclass classification problem
     """
@@ -100,7 +100,6 @@ def _auc(y_true, y_score):
 def _average_precision(y_true, y_score):
     """Alternative implementation to check for correctness of
     `average_precision_score`.
-
     Note that this implementation fails on some edge cases.
     For example, for constant predictions e.g. [0.5, 0.5, 0.5],
     y_true = [1, 0, 0] returns an average precision of 0.33...
@@ -131,7 +130,6 @@ def _average_precision_slow(y_true, y_score):
     """A second alternative implementation of average precision that closely
     follows the Wikipedia article's definition (see References). This should
     give identical results as `average_precision_score` for all inputs.
-
     References
     ----------
     .. [1] `Wikipedia entry for the Average precision
@@ -490,7 +488,6 @@ def test_binary_clf_curve():
     assert_raise_message(ValueError, msg, precision_recall_curve,
                          y_true, y_pred)
 
-
 def test_precision_recall_curve():
     y_true, _, probas_pred = make_prediction(binary=True)
     _test_precision_recall_curve(y_true, probas_pred)
@@ -509,7 +506,6 @@ def test_precision_recall_curve():
     assert_array_almost_equal(t, np.array([1, 2, 3, 4]))
     assert_equal(p.size, r.size)
     assert_equal(p.size, t.size + 1)
-
 
 def test_precision_recall_curve_nan():
     y_true, _, probas_pred = make_prediction(binary=True)
@@ -532,7 +528,6 @@ def test_precision_recall_curve_nan():
     assert_array_almost_equal(t, np.array([4]))
     assert_equal(p.size, r.size)
     assert_equal(p.size, t.size + 1)
-
 
 def _test_precision_recall_curve(y_true, probas_pred):
     # Test Precision-Recall and aread under PR curve
@@ -574,7 +569,7 @@ def test_precision_recall_curve_toydata():
         p, r, _ = precision_recall_curve(y_true, y_score)
         auc_prc = average_precision_score(y_true, y_score)
         assert_array_almost_equal(p, [0.5, 0., 1.])
-        assert_array_almost_equal(r, [1., 0., 0.])
+        assert_array_almost_equal(r, [1., 0.,  0.])
         # Here we are doing a terrible prediction: we are always getting
         # it wrong, hence the average_precision_score is the accuracy at
         # chance: 50%
@@ -624,9 +619,9 @@ def test_precision_recall_curve_toydata():
         assert_raises(Exception, average_precision_score, y_true, y_score,
                       average="weighted")
         assert_almost_equal(average_precision_score(y_true, y_score,
-                                                    average="samples"), 1.)
+                            average="samples"), 1.)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                                                    average="micro"), 1.)
+                            average="micro"), 1.)
 
         y_true = np.array([[0, 1], [0, 1]])
         y_score = np.array([[0, 1], [1, 0]])
@@ -635,31 +630,31 @@ def test_precision_recall_curve_toydata():
         assert_raises(Exception, average_precision_score, y_true, y_score,
                       average="weighted")
         assert_almost_equal(average_precision_score(y_true, y_score,
-                                                    average="samples"), 0.75)
+                            average="samples"), 0.75)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                                                    average="micro"), 0.5)
+                            average="micro"), 0.5)
 
         y_true = np.array([[1, 0], [0, 1]])
         y_score = np.array([[0, 1], [1, 0]])
         assert_almost_equal(average_precision_score(y_true, y_score,
-                                                    average="macro"), 0.5)
+                            average="macro"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                                                    average="weighted"), 0.5)
+                            average="weighted"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                                                    average="samples"), 0.5)
+                            average="samples"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                                                    average="micro"), 0.5)
+                            average="micro"), 0.5)
 
         y_true = np.array([[1, 0], [0, 1]])
         y_score = np.array([[0.5, 0.5], [0.5, 0.5]])
         assert_almost_equal(average_precision_score(y_true, y_score,
-                                                    average="macro"), 0.5)
+                            average="macro"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                                                    average="weighted"), 0.5)
+                            average="weighted"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                                                    average="samples"), 0.5)
+                            average="samples"), 0.5)
         assert_almost_equal(average_precision_score(y_true, y_score,
-                                                    average="micro"), 0.5)
+                            average="micro"), 0.5)
 
 
 def test_average_precision_constant_values():
@@ -861,7 +856,7 @@ def _my_lrap(y_true, y_score):
     y_true = check_array(y_true)
     y_score = check_array(y_score)
     n_samples, n_labels = y_true.shape
-    score = np.empty((n_samples,))
+    score = np.empty((n_samples, ))
     for i in range(n_samples):
         # The best rank correspond to 1. Rank higher than 1 are worse.
         # The best inverse ranking correspond to n_labels.
@@ -921,14 +916,14 @@ def check_alternative_lrap_implementation(lrap_score, n_classes=5,
 
 
 @pytest.mark.parametrize(
-    'check',
-    (check_lrap_toy,
-     check_lrap_without_tie_and_increasing_score,
-     check_lrap_only_ties,
-     check_zero_or_all_relevant_labels))
+        'check',
+        (check_lrap_toy,
+         check_lrap_without_tie_and_increasing_score,
+         check_lrap_only_ties,
+         check_zero_or_all_relevant_labels))
 @pytest.mark.parametrize(
-    'func',
-    (label_ranking_average_precision_score, _my_lrap))
+        'func',
+        (label_ranking_average_precision_score, _my_lrap))
 def test_label_ranking_avp(check, func):
     check(func)
 
@@ -941,9 +936,10 @@ def test_lrap_error_raised():
 @pytest.mark.parametrize('n_classes', (2, 5, 10))
 @pytest.mark.parametrize('random_state', range(1))
 def test_alternative_lrap_implementation(n_samples, n_classes, random_state):
+
     check_alternative_lrap_implementation(
-        label_ranking_average_precision_score,
-        n_classes, n_samples, random_state)
+               label_ranking_average_precision_score,
+               n_classes, n_samples, random_state)
 
 
 def test_lrap_sample_weighting_zero_labels():
@@ -1121,7 +1117,7 @@ def test_partial_roc_auc_score():
     with pytest.raises(ValueError):
         assert roc_auc_score(y_true, y_true, max_fpr=0)
 
-    y_scores = np.array([0.1, 0, 0.1, 0.01])
+    y_scores = np.array([0.1,  0,  0.1, 0.01])
     roc_auc_with_max_fpr_one = roc_auc_score(y_true, y_scores, max_fpr=1)
     unconstrained_roc_auc = roc_auc_score(y_true, y_scores)
     assert roc_auc_with_max_fpr_one == unconstrained_roc_auc

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -510,6 +510,27 @@ def test_precision_recall_curve():
     assert_equal(p.size, r.size)
     assert_equal(p.size, t.size + 1)
 
+def test_precision_recall_curve_nan():
+    y_true, _, probas_pred = make_prediction(binary=True)
+    _test_precision_recall_curve(y_true, probas_pred)
+
+    # Use {-1, 1} for labels; make sure original labels aren't modified
+    y_true[np.where(y_true == 0)] = -1
+    y_true_copy = y_true.copy()
+    _test_precision_recall_curve(y_true, probas_pred)
+    assert_array_equal(y_true_copy, y_true)
+
+    labels = [0, 0, 0, 0]
+    predict_probas = [1, 2, 3, 4]
+    # In this case, recall is going to be [nan 0] but it should be set to [0 0]
+    # in order to mean average precision not being set to nan too.
+    p, r, t = precision_recall_curve(labels, predict_probas)
+    assert_array_almost_equal(p, np.array([0., 1.]))
+    assert_array_almost_equal(r, np.array([0., 0.]))
+    #it should return 0 instead of nan
+    assert_array_almost_equal(t, np.array([4]))
+    assert_equal(p.size, r.size)
+    assert_equal(p.size, t.size + 1)
 
 def _test_precision_recall_curve(y_true, probas_pred):
     # Test Precision-Recall and aread under PR curve


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #8245
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
I was using _average_precision_score_ for multilabel classification problems and I was getting nan result in many datasets, I found a similar issue in #8245 and I checked the code for the function.
I found a bug in _precision_recall_curve_ function, precision is set to 0 in case a nan is obtained but the same is not done for recall, so I added that, because it is needed for average_precision_score to  work properly.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
