### PR TITLE
[MRG] Fixes get_feature_names results when using drop functionality

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -15,10 +15,17 @@ Changelog
 :mod:`sklearn.metrics`
 ......................
 
-- |Fix| Fixed a bug in :func:`euclidean_distances` where a part of the distance
-  matrix was left un-instanciated for suffiently large float32 datasets
-  (regression introduced in 0.21) :issue:`13910`
-  by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+- |Fix| Fixed a bug in :func:`metrics.euclidean_distances` where a part of the
+  distance matrix was left un-instanciated for suffiently large float32
+  datasets (regression introduced in 0.21). :pr:`13910` by :user:`Jérémie du
+  Boisberranger <jeremiedbb>`.
+
+:mod:`sklearn.preprocessing`
+......................
+
+- |Fix| Fixed a bug in :class:`preprocessing.OneHotEncoder` where the new
+  `drop` parameter was not reflected in `get_feature_names`. :pr:`13894`
+  by :user:`James Myatt <jamesmyatt>`.
 
 .. _changes_0_21_1:
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -21,7 +21,7 @@ Changelog
   Boisberranger <jeremiedbb>`.
 
 :mod:`sklearn.preprocessing`
-......................
+............................
 
 - |Fix| Fixed a bug in :class:`preprocessing.OneHotEncoder` where the new
   `drop` parameter was not reflected in `get_feature_names`. :pr:`13894`

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -847,6 +847,8 @@ class OneHotEncoder(_BaseEncoder):
         for i in range(len(cats)):
             names = [
                 input_features[i] + '_' + str(t) for t in cats[i]]
+            if self.drop is not None:
+                names.pop(self.drop_idx_[i])
             feature_names.extend(names)
 
         return np.array(feature_names, dtype=object)

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -590,36 +590,18 @@ def test_one_hot_encoder_feature_names_unicode():
     assert_array_equal(['n👍me_c❤t1', 'n👍me_dat2'], feature_names)
 
 
-@pytest.mark.parametrize("drop", ['first',
-                                  ['c', 2, 'b']],
+@pytest.mark.parametrize("drop, expected_names",
+                         [('first', ['x0_c', 'x2_b']),
+                          (['c', 2, 'b'], ['x0_b', 'x2_a'])],
                          ids=['first', 'manual'])
-def test_one_hot_encoder_feature_names_drop(drop):
+def test_one_hot_encoder_feature_names_drop(drop, expected_names):
     X = [['c', 2, 'a'],
          ['b', 2, 'b']]
 
-    # Assume "drop=None" version has the right names in the right order
-    ohe_base = OneHotEncoder()
-    ohe_base.fit(X)
-
-    if drop == 'first':
-        drop_cats = [x[0] for x in ohe_base.categories_]
-    else:
-        drop_cats = drop
-
-    expected_names = list(ohe_base.get_feature_names())
-    for i, cat_drop in enumerate(drop_cats):
-        feat_drop = "x{}_{}".format(i, cat_drop)
-        expected_names.remove(feat_drop)
-
-    ohe_test = OneHotEncoder(drop=drop)
-
-    # Act
-    ohe_test.fit(X)
-
-    # Assert
-    feature_names = ohe_test.get_feature_names()
+    ohe = OneHotEncoder(drop=drop)
+    ohe.fit(X)
+    feature_names = ohe.get_feature_names()
     assert isinstance(feature_names, np.ndarray)
-
     assert_array_equal(expected_names, feature_names)
 
 

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -590,6 +590,25 @@ def test_one_hot_encoder_feature_names_unicode():
     assert_array_equal(['n👍me_c❤t1', 'n👍me_dat2'], feature_names)
 
 
+def test_one_hot_encoder_feature_names_drop():
+    # Assume that this is OK for manual drop, if OK for first
+    # since other tests will fail if drop_idx_ is not correct
+    enc = OneHotEncoder(drop='first')
+    X = [['Male', 1, 'girl', 2, 3],
+         ['Female', 41, 'girl', 2, 10],
+         ['Male', 51, 'boy', 2, 3],
+         ['Male', 91, 'girl', 2, 30]]
+
+    enc.fit(X)
+    feature_names = enc.get_feature_names()
+    assert isinstance(feature_names, np.ndarray)
+
+    assert_array_equal(['x0_Male',
+                        'x1_41', 'x1_51', 'x1_91',
+                        'x2_girl',
+                        'x4_10', 'x4_30'], feature_names)
+
+
 @pytest.mark.parametrize("X", [np.array([[1, np.nan]]).T,
                                np.array([['a', np.nan]], dtype=object).T],
                          ids=['numeric', 'object'])


### PR DESCRIPTION
The new "drop" functionality in OneHotEncoder from v0.21 is not taken into account in the "get_feature_names" method. This fixes that problem.