### PR TITLE
[MRG] Adds handle unknown option to ordinal encoder

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -481,8 +481,9 @@ new feature of integers (0 to n_categories - 1)::
 
     >>> enc = preprocessing.OrdinalEncoder()
     >>> X = [['male', 'from US', 'uses Safari'], ['female', 'from Europe', 'uses Firefox']]
-    >>> enc.fit(X)  # doctest: +ELLIPSIS
-    OrdinalEncoder(categories='auto', dtype=<... 'numpy.float64'>)
+    >>> enc.fit(X)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    OrdinalEncoder(categories='auto', dtype=<class 'numpy.float64'>,
+                   handle_unknown='error', unknown_category=None, unknown_value=-1)
     >>> enc.transform([['female', 'from US', 'uses Safari']])
     array([[0., 1., 1.]])
 
@@ -561,8 +562,8 @@ parameter allows the user to specify a category for each feature to be dropped.
 This is useful to avoid co-linearity in the input matrix in some classifiers.
 Such functionality is useful, for example, when using non-regularized
 regression (:class:`LinearRegression <sklearn.linear_model.LinearRegression>`),
-since co-linearity would cause the covariance matrix to be non-invertible. 
-When this paramenter is not None, ``handle_unknown`` must be set to 
+since co-linearity would cause the covariance matrix to be non-invertible.
+When this paramenter is not None, ``handle_unknown`` must be set to
 ``error``::
 
     >>> X = [['male', 'from US', 'uses Safari'], ['female', 'from Europe', 'uses Firefox']]

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -913,7 +913,7 @@ class OrdinalEncoder(_BaseEncoder):
     >>> enc.fit(X)
     ... # doctest: +ELLIPSIS
     OrdinalEncoder(categories='auto', dtype=<... 'numpy.float64'>,
-                   handle_unknown='error')
+                   handle_unknown='error', unknown_category=None, unknown_value=-1)
     >>> enc.categories_
     [array(['Female', 'Male'], dtype=object), array([1, 2, 3], dtype=object)]
     >>> enc.transform([['Female', 3], ['Male', 1]])
@@ -933,7 +933,8 @@ class OrdinalEncoder(_BaseEncoder):
     >>> enc.fit(X)
     ... # doctest: +ELLIPSIS
     OrdinalEncoder(categories='auto', dtype=<... 'numpy.float64'>,
-                   handle_unknown='ignore')
+                   handle_unknown='ignore', unknown_category=None,
+                   unknown_value=-1)
     >>> enc.transform([['Female', 4], ['Other', 1]])
     array([[ 0., -1.],
            [-1.,  0.]])

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -883,11 +883,11 @@ class OrdinalEncoder(_BaseEncoder):
         is set to 'ignore' and an unknown category is encountered during
         transform, a numeric ``-1`` category is returned. In the inverse
         transform, an unknown category will be denoted as None.
-    
+
     unknown_category : object
         Desired value that will take unknown value in
         :meth:`~OrdinalEncoder.inverse_transform`.
-    
+
     unknown_value : integer
         Desired value that will take unknown value in
         :meth:`~OrdinalEncoder.transform`. Warning that if this value

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -913,7 +913,7 @@ class OrdinalEncoder(_BaseEncoder):
     >>> enc.fit(X)
     ... # doctest: +ELLIPSIS
     OrdinalEncoder(categories='auto', dtype=<... 'numpy.float64'>,
-                   handle_unknown='error', unknown_category=None, unknown_value=-1)
+                   handle_unknown='error', ...)
     >>> enc.categories_
     [array(['Female', 'Male'], dtype=object), array([1, 2, 3], dtype=object)]
     >>> enc.transform([['Female', 3], ['Male', 1]])
@@ -933,8 +933,7 @@ class OrdinalEncoder(_BaseEncoder):
     >>> enc.fit(X)
     ... # doctest: +ELLIPSIS
     OrdinalEncoder(categories='auto', dtype=<... 'numpy.float64'>,
-                   handle_unknown='ignore', unknown_category=None,
-                   unknown_value=-1)
+                   handle_unknown='ignore', ...)
     >>> enc.transform([['Female', 4], ['Other', 1]])
     array([[ 0., -1.],
            [-1.,  0.]])

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -876,13 +876,23 @@ class OrdinalEncoder(_BaseEncoder):
 
     dtype : number type, default np.float64
         Desired dtype of output.
-    
+
     handle_unknown : 'error' or 'ignore', default='error'.
         Whether to raise an error or ignore if an unknown categorical feature
         is present during transform (default is to raise). When this parameter
         is set to 'ignore' and an unknown category is encountered during
         transform, a numeric ``-1`` category is returned. In the inverse
         transform, an unknown category will be denoted as None.
+    
+    unknown_category : object
+        Desired value that will take unknown value in
+        :meth:`~OrdinalEncoder.inverse_transform`.
+    
+    unknown_value : integer
+        Desired value that will take unknown value in
+        :meth:`~OrdinalEncoder.transform`. Warning that if this value
+        is in :math:`[0, N-1]`, where N is the number of categories,
+        it will be indistiguishable from the original category.
 
 
     Attributes
@@ -913,7 +923,7 @@ class OrdinalEncoder(_BaseEncoder):
     >>> enc.inverse_transform([[1, 0], [0, 1]])
     array([['Male', 1],
            ['Female', 2]], dtype=object)
-    
+
     The ordinal encoding can be set to handle unknown categories at
     transform time.
 
@@ -940,12 +950,13 @@ class OrdinalEncoder(_BaseEncoder):
     """
 
     def __init__(self, categories='auto', dtype=np.float64,
-                 handle_unknown='error'):
+                 handle_unknown='error', unknown_category=None,
+                 unknown_value=-1):
         self.categories = categories
         self.dtype = dtype
         self.handle_unknown = handle_unknown
-        self.unknown_category = None
-        self.unknown_value = -1
+        self.unknown_category = unknown_category
+        self.unknown_value = unknown_value
 
     def fit(self, X, y=None):
         """Fit the OrdinalEncoder to X.

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -687,7 +687,7 @@ def test_ordinal_encoder_specified_categories(X, X2, cats, cat_dtype):
      [np.array(['a', 'b', 'c'])], np.object_),
     ], ids=['object', 'numeric', 'object-string-cat'])
 def test_ordinal_encoder_specified_categories_handle_unknown(X, cats,
-        cat_dtype):
+                                                             cat_dtype):
     enc = OrdinalEncoder(categories=cats, handle_unknown='ignore')
     exp = np.array([[-1.], [1.]])
     assert_array_equal(enc.fit_transform(X), exp)
@@ -752,6 +752,7 @@ def test_ordinal_encoder_raise_categories_shape():
 
     with pytest.raises(ValueError, match=msg):
         enc.fit(X)
+
 
 def test_encoder_dtypes():
     # check that dtypes are preserved when determining categories


### PR DESCRIPTION
#### Reference Issues/PRs
Handles new values when encountered after fit. This has been referenced in issue #10465 and #11997. Although it does no passthrough NaNs or None.


#### What does this implement/fix? Explain your changes.
This PR uses the basic features implemented for one hot encoding to add the same functionality to OrdinalEncoder. This handles both the transform and inverse_transform. In transform category -1 is returned for new values, and None is returned in the inverse transform for -1 values.

#### Any other comments?
This PR might be conflicting with the work of PR #12045.

The unknown category and unknow value could be configured at intanciation.