### PR TITLE
[MRG] Let fbeta_score accept beta = 0

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1409,7 +1409,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     In such cases, the metric will be set to 0, as will f-score, and
     ``UndefinedMetricWarning`` will be raised.
     """
-    if beta <= 0:
+    if beta < 0:
         raise ValueError("beta should be >0 in the F-beta score")
     labels = _check_set_wise_labels(y_true, y_pred, average, labels,
                                     pos_label)

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1428,20 +1428,22 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         pred_sum = np.array([pred_sum.sum()])
         true_sum = np.array([true_sum.sum()])
 
-    # Finally, we have all our sufficient statistics. Divide! #
-    beta2 = beta ** 2
-
     # Divide, and on zero-division, set scores to 0 and warn:
 
     precision = _prf_divide(tp_sum, pred_sum,
                             'precision', 'predicted', average, warn_for)
     recall = _prf_divide(tp_sum, true_sum,
                          'recall', 'true', average, warn_for)
+
     # Don't need to warn for F: either P or R warned, or tp == 0 where pos
     # and true are nonzero, in which case, F is well-defined and zero
-    denom = beta2 * precision + recall
-    denom[denom == 0.] = 1  # avoid division by 0
-    f_score = (1 + beta2) * precision * recall / denom
+    if beta < np.inf:
+        beta2 = beta ** 2
+        denom = beta2 * precision + recall
+        denom[denom == 0.] = 1  # avoid division by 0
+        f_score = (1 + beta2) * precision * recall / denom
+    else:
+        f_score = recall
 
     # Average the results
     if average == 'weighted':

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1410,7 +1410,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     ``UndefinedMetricWarning`` will be raised.
     """
     if beta < 0:
-        raise ValueError("beta should be >0 in the F-beta score")
+        raise ValueError("beta should be >=0 in the F-beta score")
     labels = _check_set_wise_labels(y_true, y_pred, average, labels,
                                     pos_label)
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1327,11 +1327,11 @@ def test_precision_recall_f1_score_multilabel_1():
     assert_array_almost_equal(r, [0.0, 1.0, 1.0, 0.0], 2)
     assert_array_almost_equal(f, [0.0, 1 / 1.5, 1, 0.0], 2)
     assert_array_almost_equal(s, [1, 1, 1, 1], 2)
-    
+
     f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
     support = s
     assert_array_almost_equal(f2, [0, 0.83, 1, 0], 2)
-    
+
     f3 = fbeta_score(y_true, y_pred, beta=np.inf, average=None)
     assert_array_almost_equal(f3, r, 2)
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -198,6 +198,9 @@ def test_precision_recall_f1_score_binary():
                                       **kwargs),
                             (1 + 2 ** 2) * ps * rs / (2 ** 2 * ps + rs), 2)
 
+        assert_almost_equal(my_assert(fbeta_score, y_true, y_pred, beta=np.inf,
+                                      **kwargs), rs)
+
 
 @ignore_warnings
 def test_precision_recall_f_binary_single_class():
@@ -1324,10 +1327,13 @@ def test_precision_recall_f1_score_multilabel_1():
     assert_array_almost_equal(r, [0.0, 1.0, 1.0, 0.0], 2)
     assert_array_almost_equal(f, [0.0, 1 / 1.5, 1, 0.0], 2)
     assert_array_almost_equal(s, [1, 1, 1, 1], 2)
-
+    
     f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
     support = s
     assert_array_almost_equal(f2, [0, 0.83, 1, 0], 2)
+    
+    f3 = fbeta_score(y_true, y_pred, beta=np.inf, average=None)
+    assert_array_almost_equal(f3, r, 2)
 
     # Check macro
     p, r, f, s = precision_recall_fscore_support(y_true, y_pred,

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -329,7 +329,7 @@ def test_precision_recall_fscore_support_errors():
 
     # Bad beta
     assert_raises(ValueError, precision_recall_fscore_support,
-                  y_true, y_pred, beta=0.0)
+                  y_true, y_pred, beta=-1.0)
 
     # Bad pos_label
     assert_raises(ValueError, precision_recall_fscore_support,


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
See also #13224

#### What does this implement/fix? Explain your changes.

Previously would raise a ValueError if beta = 0 in metrics.fbeta_score(). However, beta = 0 should be an admissible value for computing a harmonic mean.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
