### PR TITLE
[MRG] Fix eulidean distances (float32) batch management

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -2,6 +2,23 @@
 
 .. currentmodule:: sklearn
 
+.. _changes_0_21_2:
+
+Version 0.21.2
+==============
+
+**June 2019**
+
+Changelog
+---------
+
+:mod:`sklearn.metrics`
+......................
+
+- |Fix| Fixed a bug in :func:`euclidean_distances` where a part of the distance
+  matrix was left un-instanciated for suffiently large datasets. :issue:`13910`
+  by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 .. _changes_0_21_1:
 
 Version 0.21.1
@@ -18,20 +35,16 @@ Changelog
 :mod:`sklearn.metrics`
 ......................
 
-- |Fix| Fixed a bug in :func:`metrics.pairwise_distances` where it would raise
+- |Fix| Fixed a bug in :class:`metrics.pairwise_distances` where it would raise
   ``AttributeError`` for boolean metrics when ``X`` had a boolean dtype and
   ``Y == None``.
   :issue:`13864` by :user:`Paresh Mathur <rick2047>`.
 
-- |Fix| Fixed two bugs in :func:`metrics.pairwise_distances` when
+- |Fix| Fixed two bugs in :class:`metrics.pairwise_distances` when
   ``n_jobs > 1``. First it used to return a distance matrix with same dtype as
   input, even for integer dtype. Then the diagonal was not zeros for euclidean
   metric when ``Y`` is ``X``. :issue:`13877` by
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
-
-- |Fix| Fixed a bug in :func:`euclidean_distances` where a part of the distance
-  matrix was left un-instanciated for suffiently large datasets. :issue:`13910`
-  by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 :mod:`sklearn.neighbors`
 ......................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -18,16 +18,20 @@ Changelog
 :mod:`sklearn.metrics`
 ......................
 
-- |Fix| Fixed a bug in :class:`metrics.pairwise_distances` where it would raise
+- |Fix| Fixed a bug in :func:`metrics.pairwise_distances` where it would raise
   ``AttributeError`` for boolean metrics when ``X`` had a boolean dtype and
   ``Y == None``.
   :issue:`13864` by :user:`Paresh Mathur <rick2047>`.
 
-- |Fix| Fixed two bugs in :class:`metrics.pairwise_distances` when
+- |Fix| Fixed two bugs in :func:`metrics.pairwise_distances` when
   ``n_jobs > 1``. First it used to return a distance matrix with same dtype as
   input, even for integer dtype. Then the diagonal was not zeros for euclidean
   metric when ``Y`` is ``X``. :issue:`13877` by
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
+- |Fix| Fixed a bug in :func:`euclidean_distances` where a part of the distance
+  matrix was left un-instanciated for suffiently large datasets. :issue:`13910`
+  by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 :mod:`sklearn.neighbors`
 ......................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -16,7 +16,8 @@ Changelog
 ......................
 
 - |Fix| Fixed a bug in :func:`euclidean_distances` where a part of the distance
-  matrix was left un-instanciated for suffiently large datasets. :issue:`13910`
+  matrix was left un-instanciated for suffiently large float32 datasets
+  (regression introduced in 0.21) :issue:`13910`
   by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 .. _changes_0_21_1:

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -283,7 +283,7 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
     return distances if squared else np.sqrt(distances, out=distances)
 
 
-def _euclidean_distances_upcast(X, XX=None, Y=None, YY=None):
+def _euclidean_distances_upcast(X, XX=None, Y=None, YY=None, batch_size=None):
     """Euclidean distances between X and Y
 
     Assumes X and Y have float32 dtype.
@@ -298,27 +298,28 @@ def _euclidean_distances_upcast(X, XX=None, Y=None, YY=None):
 
     distances = np.empty((n_samples_X, n_samples_Y), dtype=np.float32)
 
-    x_density = X.nnz / np.prod(X.shape) if issparse(X) else 1
-    y_density = Y.nnz / np.prod(Y.shape) if issparse(Y) else 1
+    if batch_size is None:
+        x_density = X.nnz / np.prod(X.shape) if issparse(X) else 1
+        y_density = Y.nnz / np.prod(Y.shape) if issparse(Y) else 1
 
-    # Allow 10% more memory than X, Y and the distance matrix take (at least
-    # 10MiB)
-    maxmem = max(
-        ((x_density * n_samples_X + y_density * n_samples_Y) * n_features
-         + (x_density * n_samples_X * y_density * n_samples_Y)) / 10,
-        10 * 2 ** 17)
+        # Allow 10% more memory than X, Y and the distance matrix take (at
+        # least 10MiB)
+        maxmem = max(
+            ((x_density * n_samples_X + y_density * n_samples_Y) * n_features
+             + (x_density * n_samples_X * y_density * n_samples_Y)) / 10,
+            10 * 2 ** 17)
 
-    # The increase amount of memory in 8-byte blocks is:
-    # - x_density * batch_size * n_features (copy of chunk of X)
-    # - y_density * batch_size * n_features (copy of chunk of Y)
-    # - batch_size * batch_size (chunk of distance matrix)
-    # Hence x² + (xd+yd)kx = M, where x=batch_size, k=n_features, M=maxmem
-    #                                 xd=x_density and yd=y_density
-    tmp = (x_density + y_density) * n_features
-    batch_size = (-tmp + np.sqrt(tmp ** 2 + 4 * maxmem)) / 2
-    batch_size = max(int(batch_size), 1)
+        # The increase amount of memory in 8-byte blocks is:
+        # - x_density * batch_size * n_features (copy of chunk of X)
+        # - y_density * batch_size * n_features (copy of chunk of Y)
+        # - batch_size * batch_size (chunk of distance matrix)
+        # Hence x² + (xd+yd)kx = M, where x=batch_size, k=n_features, M=maxmem
+        #                                 xd=x_density and yd=y_density
+        tmp = (x_density + y_density) * n_features
+        batch_size = (-tmp + np.sqrt(tmp ** 2 + 4 * maxmem)) / 2
+        batch_size = max(int(batch_size), 1)
 
-    x_batches = gen_batches(X.shape[0], batch_size)
+    x_batches = gen_batches(n_samples_X, batch_size)
 
     for i, x_slice in enumerate(x_batches):
         X_chunk = X[x_slice].astype(np.float64)
@@ -327,7 +328,7 @@ def _euclidean_distances_upcast(X, XX=None, Y=None, YY=None):
         else:
             XX_chunk = XX[x_slice]
 
-        y_batches = gen_batches(Y.shape[0], batch_size)
+        y_batches = gen_batches(n_samples_Y, batch_size)
 
         for j, y_slice in enumerate(y_batches):
             if X is Y and j < i:

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -319,7 +319,6 @@ def _euclidean_distances_upcast(X, XX=None, Y=None, YY=None):
     batch_size = max(int(batch_size), 1)
 
     x_batches = gen_batches(X.shape[0], batch_size)
-    y_batches = gen_batches(Y.shape[0], batch_size)
 
     for i, x_slice in enumerate(x_batches):
         X_chunk = X[x_slice].astype(np.float64)
@@ -327,6 +326,8 @@ def _euclidean_distances_upcast(X, XX=None, Y=None, YY=None):
             XX_chunk = row_norms(X_chunk, squared=True)[:, np.newaxis]
         else:
             XX_chunk = XX[x_slice]
+
+        y_batches = gen_batches(Y.shape[0], batch_size)
 
         for j, y_slice in enumerate(y_batches):
             if X is Y and j < i:

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -714,7 +714,7 @@ def test_euclidean_distances_upcast(batch_size, x_array_constr,
     assert_allclose(distances, expected, rtol=1e-6)
 
 
-@pytest.mark.parametrize("batch_size", [None, 10, 11, 101])
+@pytest.mark.parametrize("batch_size", [None, 5, 7, 101])
 @pytest.mark.parametrize("x_array_constr", [np.array, csr_matrix],
                          ids=["dense", "sparse"])
 def test_euclidean_distances_upcast_sym(batch_size, x_array_constr):

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -48,6 +48,7 @@ from sklearn.metrics.pairwise import check_paired_arrays
 from sklearn.metrics.pairwise import paired_distances
 from sklearn.metrics.pairwise import paired_euclidean_distances
 from sklearn.metrics.pairwise import paired_manhattan_distances
+from sklearn.metrics.pairwise import _euclidean_distances_upcast
 from sklearn.preprocessing import normalize
 from sklearn.exceptions import DataConversionWarning
 
@@ -649,9 +650,9 @@ def test_euclidean_distances(dtype, x_array_constr, y_array_constr):
     # check that euclidean distances gives same result as scipy cdist
     # when X and Y != X are provided
     rng = np.random.RandomState(0)
-    X = rng.random_sample((110, 10000)).astype(dtype, copy=False)
+    X = rng.random_sample((100, 10)).astype(dtype, copy=False)
     X[X < 0.8] = 0
-    Y = rng.random_sample((100, 10000)).astype(dtype, copy=False)
+    Y = rng.random_sample((10, 10)).astype(dtype, copy=False)
     Y[Y < 0.8] = 0
 
     expected = cdist(X, Y)
@@ -673,7 +674,7 @@ def test_euclidean_distances_sym(dtype, x_array_constr):
     # check that euclidean distances gives same result as scipy pdist
     # when only X is provided
     rng = np.random.RandomState(0)
-    X = rng.random_sample((100, 10000)).astype(dtype, copy=False)
+    X = rng.random_sample((100, 10)).astype(dtype, copy=False)
     X[X < 0.8] = 0
 
     expected = squareform(pdist(X))
@@ -685,6 +686,52 @@ def test_euclidean_distances_sym(dtype, x_array_constr):
     # and fails due too rounding errors.
     assert_allclose(distances, expected, rtol=1e-6)
     assert distances.dtype == dtype
+
+
+@pytest.mark.parametrize("batch_size", [None, 5, 7, 101])
+@pytest.mark.parametrize("x_array_constr", [np.array, csr_matrix],
+                         ids=["dense", "sparse"])
+@pytest.mark.parametrize("y_array_constr", [np.array, csr_matrix],
+                         ids=["dense", "sparse"])
+def test_euclidean_distances_upcast(batch_size, x_array_constr,
+                                    y_array_constr):
+    # check batches handling when Y != X (#13910)
+    rng = np.random.RandomState(0)
+    X = rng.random_sample((100, 10)).astype(np.float32)
+    X[X < 0.8] = 0
+    Y = rng.random_sample((10, 10)).astype(np.float32)
+    Y[Y < 0.8] = 0
+
+    expected = cdist(X, Y)
+
+    X = x_array_constr(X)
+    Y = y_array_constr(Y)
+    distances = _euclidean_distances_upcast(X, Y=Y, batch_size=batch_size)
+    distances = np.sqrt(np.maximum(distances, 0))
+
+    # the default rtol=1e-7 is too close to the float32 precision
+    # and fails due too rounding errors.
+    assert_allclose(distances, expected, rtol=1e-6)
+
+
+@pytest.mark.parametrize("batch_size", [None, 10, 11, 101])
+@pytest.mark.parametrize("x_array_constr", [np.array, csr_matrix],
+                         ids=["dense", "sparse"])
+def test_euclidean_distances_upcast_sym(batch_size, x_array_constr):
+    # check batches handling when X is Y (#13910)
+    rng = np.random.RandomState(0)
+    X = rng.random_sample((100, 10)).astype(np.float32)
+    X[X < 0.8] = 0
+
+    expected = squareform(pdist(X))
+
+    X = x_array_constr(X)
+    distances = _euclidean_distances_upcast(X, Y=X, batch_size=batch_size)
+    distances = np.sqrt(np.maximum(distances, 0))
+
+    # the default rtol=1e-7 is too close to the float32 precision
+    # and fails due too rounding errors.
+    assert_allclose(distances, expected, rtol=1e-6)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -649,9 +649,9 @@ def test_euclidean_distances(dtype, x_array_constr, y_array_constr):
     # check that euclidean distances gives same result as scipy cdist
     # when X and Y != X are provided
     rng = np.random.RandomState(0)
-    X = rng.random_sample((100, 10)).astype(dtype, copy=False)
+    X = rng.random_sample((110, 10000)).astype(dtype, copy=False)
     X[X < 0.8] = 0
-    Y = rng.random_sample((10, 10)).astype(dtype, copy=False)
+    Y = rng.random_sample((100, 10000)).astype(dtype, copy=False)
     Y[Y < 0.8] = 0
 
     expected = cdist(X, Y)
@@ -673,7 +673,7 @@ def test_euclidean_distances_sym(dtype, x_array_constr):
     # check that euclidean distances gives same result as scipy pdist
     # when only X is provided
     rng = np.random.RandomState(0)
-    X = rng.random_sample((100, 10)).astype(dtype, copy=False)
+    X = rng.random_sample((100, 10000)).astype(dtype, copy=False)
     X[X < 0.8] = 0
 
     expected = squareform(pdist(X))


### PR DESCRIPTION
Fixes #13905

Silly mistake: the Y batch generator was consumed after the first step of the X loop. It needs to be reset at each step. 

The tests didn't not cover the case of > 1 batch. I updated them by taking larger datasets.