### PR TITLE
[MRG] Implementation of score_samples without saving the precision matrix i…

### DIFF
--- a/sklearn/decomposition/base.py
+++ b/sklearn/decomposition/base.py
@@ -25,9 +25,9 @@ class _BasePCA(BaseEstimator, TransformerMixin, metaclass=ABCMeta):
     Use derived classes instead.
     """
     def _get_mat_inv_lemma_diag(self):
-        """returns diagonal terms of the D matrix as a 1xn array. This is given by
-        inverse of 1/noise_variance + inv(S**2 - noise_variance) or
-        inverse of S**2/noise_variance + inv(S**2 - noise_variance) if whiten is True
+        """returns diagonal terms of the D matrix as a 1xn array.
+        This is given by inverse of
+        1/noise_variance + inv(S**2 - noise_variance)
         S**2 is the first n_components of explained_variance.
         """
         exp_var = self.explained_variance_

--- a/sklearn/decomposition/base.py
+++ b/sklearn/decomposition/base.py
@@ -25,32 +25,32 @@ class _BasePCA(BaseEstimator, TransformerMixin, metaclass=ABCMeta):
     Use derived classes instead.
     """
     def _get_mat_inv_lemma_diag(self):
-        '''
-        returns diagonal terms of the D matrix as a 1xn array. This is given by 
+        """returns diagonal terms of the D matrix as a 1xn array. This is given by
         inverse of 1/noise_variance + inv(S**2 - noise_variance) or
         inverse of S**2/noise_variance + inv(S**2 - noise_variance) if whiten is True
         S**2 is the first n_components of explained_variance.
-        '''
+        """
         exp_var = self.explained_variance_
         exp_var_diff = np.maximum(exp_var - self.noise_variance_, 0.)
         pre_precision = 1 / self.noise_variance_
-        '''old implementation for whiten==True is wrong. 
-        Uncomment to obtain same output as old implementation.'''
+        """old implementation for whiten==True is wrong
+        Uncomment to obtain same output as old implementation.
+        """
 #        if self.whiten:
 #            pre_precision *= exp_var
-        
+
         pre_precision += 1 / exp_var_diff
 
         return (1 / pre_precision).reshape(1, -1)
-		
-        
+
     def _get_logdet_precision(self):
         n_features = self.mean_.shape[0]
         noise_var = self.noise_variance_
 
         exp_var = self.explained_variance_
-        '''old implementation for whiten==True is wrong. 
-        Uncomment to obtain same output as old implementation.'''
+        """old implementation for whiten==True is wrong
+        Uncomment to obtain same output as old implementation.
+        """
 #        if self.whiten:
 #            exp_var = exp_var * (exp_var - noise_var) + noise_var
 

--- a/sklearn/decomposition/base.py
+++ b/sklearn/decomposition/base.py
@@ -10,6 +10,7 @@
 
 import numpy as np
 from scipy import linalg
+from math import log
 
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_array
@@ -23,7 +24,6 @@ class _BasePCA(BaseEstimator, TransformerMixin, metaclass=ABCMeta):
     Warning: This class should not be used directly.
     Use derived classes instead.
     """
-
     def _get_mat_inv_lemma_diag(self):
         '''
         returns diagonal terms of the D matrix as a 1xn array. This is given by 
@@ -31,11 +31,12 @@ class _BasePCA(BaseEstimator, TransformerMixin, metaclass=ABCMeta):
         inverse of S**2/noise_variance + inv(S**2 - noise_variance) if whiten is True
         S**2 is the first n_components of explained_variance.
         '''
-        
         exp_var = self.explained_variance_
         exp_var_diff = np.maximum(exp_var - self.noise_variance_, 0.)
         pre_precision = 1 / self.noise_variance_
-#        if self.whiten: #old implementation for whiten==True is wrong. Uncomment to obtain same output as old implementation.
+        '''old implementation for whiten==True is wrong. 
+        Uncomment to obtain same output as old implementation.'''
+#        if self.whiten:
 #            pre_precision *= exp_var
         
         pre_precision += 1 / exp_var_diff
@@ -48,14 +49,15 @@ class _BasePCA(BaseEstimator, TransformerMixin, metaclass=ABCMeta):
         noise_var = self.noise_variance_
 
         exp_var = self.explained_variance_
-#        if self.whiten: #old implementation for whiten==True is wrong. Uncomment to obtain same output as old implementation.
+        '''old implementation for whiten==True is wrong. 
+        Uncomment to obtain same output as old implementation.'''
+#        if self.whiten:
 #            exp_var = exp_var * (exp_var - noise_var) + noise_var
 
         logdet = - np.sum(np.log(exp_var))
-        logdet -= math.log(noise_var) * (n_features - self.n_components_)
+        logdet -= log(noise_var) * (n_features - self.n_components_)
 
         return logdet
-		
 
     @abstractmethod
     def fit(X, y=None):

--- a/sklearn/decomposition/base.py
+++ b/sklearn/decomposition/base.py
@@ -24,6 +24,60 @@ class _BasePCA(BaseEstimator, TransformerMixin, metaclass=ABCMeta):
     Warning: This class should not be used directly.
     Use derived classes instead.
     """
+    def get_covariance(self):
+        """Compute data covariance with the generative model.
+
+        ``cov = components_.T * S**2 * components_ + sigma2 * eye(n_features)``
+        where  S**2 contains the explained variances, and sigma2 contains the
+        noise variances.
+
+        Returns
+        -------
+        cov : array, shape=(n_features, n_features)
+            Estimated covariance of data.
+        """
+        components_ = self.components_
+        exp_var = self.explained_variance_
+        if self.whiten:
+            components_ = components_ * np.sqrt(exp_var[:, np.newaxis])
+        exp_var_diff = np.maximum(exp_var - self.noise_variance_, 0.)
+        cov = np.dot(components_.T * exp_var_diff, components_)
+        cov.flat[::len(cov) + 1] += self.noise_variance_  # modify diag inplace
+        return cov
+
+    def get_precision(self):
+        """Compute data precision matrix with the generative model.
+
+        Equals the inverse of the covariance but computed with
+        the matrix inversion lemma for efficiency.
+
+        Returns
+        -------
+        precision : array, shape=(n_features, n_features)
+            Estimated precision of data.
+        """
+        n_features = self.components_.shape[1]
+
+        # handle corner cases first
+        if self.n_components_ == 0:
+            return np.eye(n_features) / self.noise_variance_
+        if self.n_components_ == n_features:
+            return linalg.inv(self.get_covariance())
+
+        # Get precision using matrix inversion lemma
+        components_ = self.components_
+        exp_var = self.explained_variance_
+        if self.whiten:
+            components_ = components_ * np.sqrt(exp_var[:, np.newaxis])
+        exp_var_diff = np.maximum(exp_var - self.noise_variance_, 0.)
+        precision = np.dot(components_, components_.T) / self.noise_variance_
+        precision.flat[::len(precision) + 1] += 1. / exp_var_diff
+        precision = np.dot(components_.T,
+                           np.dot(linalg.inv(precision), components_))
+        precision /= -(self.noise_variance_ ** 2)
+        precision.flat[::len(precision) + 1] += 1. / self.noise_variance_
+        return precision
+
     def _get_mat_inv_lemma_diag(self):
         """returns diagonal terms of the D matrix as a 1xn array.
         This is given by inverse of

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -567,7 +567,7 @@ class PCA(_BasePCA):
         Using matrix inversion lemma, it can be written as
         a - a**2 components_.T * D * components,
         where D is a diagonal matrix
-        
+
         During the calculation of log-likelihood, the precision matrix
         is multiplied on the left side by a row vector.
         Hence, it is not needed to save the whole precision matrix
@@ -610,10 +610,9 @@ class PCA(_BasePCA):
 
             log_like_row = Xr / noise_var
             logdet = self._get_logdet_precision()
-            log_like_row -= \
-            np.dot(np.dot(Xr, components.T),
-                   components * self._get_mat_inv_lemma_diag().T) \
-                   / noise_var **2
+            log_like_row -= np.dot(np.dot(Xr, components.T), components *                                 
+                                   self._get_mat_inv_lemma_diag().T)
+            log_like_row /= noise_var ** 2
 
         log_like = -.5 * (Xr * log_like_row).sum(axis=1)
         log_like -= .5 * (n_features * log(2. * np.pi) -

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -611,8 +611,8 @@ class PCA(_BasePCA):
             log_like_row = Xr / noise_var
             logdet = self._get_logdet_precision()
             log_like_row -= np.dot(np.dot(Xr, components.T), components
-                                   * self._get_mat_inv_lemma_diag().T)
-            log_like_row /= noise_var ** 2
+                                   * self._get_mat_inv_lemma_diag().T) \
+                                   / noise_var ** 2
 
         log_like = -.5 * (Xr * log_like_row).sum(axis=1)
         log_like -= .5 * (n_features * log(2. * np.pi) -

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -612,7 +612,7 @@ class PCA(_BasePCA):
             logdet = self._get_logdet_precision()
             log_like_row -= np.dot(np.dot(Xr, components.T), components
                                    * self._get_mat_inv_lemma_diag().T) \
-                                   / noise_var ** 2
+                            / noise_var ** 2
 
         log_like = -.5 * (Xr * log_like_row).sum(axis=1)
         log_like -= .5 * (n_features * log(2. * np.pi) -

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -545,7 +545,6 @@ class PCA(_BasePCA):
 
         return U, S, V
 
-
     def score_samples(self, X):
         """Return the log-likelihood of each sample.
 
@@ -563,13 +562,16 @@ class PCA(_BasePCA):
         ll : array, shape (n_samples,)
             Log-likelihood of each sample under the current model
         """
-	
+
         """precision matrix is defined as the inverse of covariance matrix.
         Using matrix inversion lemma, it can be written as
-        a - a**2 components_.T * D * components, where D is a diagonal matrix
-        During the calculation of log-likelihood, the precision matrix is multiplied
-        on the left side by a row vector. Hence, it is not needed to save the whole
-        precision matrix on memory. In fact, only the diagonal terms of D is needed.
+        a - a**2 components_.T * D * components,
+        where D is a diagonal matrix
+        
+        During the calculation of log-likelihood, the precision matrix
+        is multiplied on the left side by a row vector.
+        Hence, it is not needed to save the whole precision matrix
+        on memory. In fact, only the diagonal terms of D is needed.
         """
         check_is_fitted(self, 'mean_')
 
@@ -608,8 +610,10 @@ class PCA(_BasePCA):
 
             log_like_row = Xr / noise_var
             logdet = self._get_logdet_precision()
-            log_like_row -= np.dot(np.dot(Xr, components.T),
-                               components * self._get_mat_inv_lemma_diag().T) / noise_var **2
+            log_like_row -= \
+            np.dot(np.dot(Xr, components.T),
+                   components * self._get_mat_inv_lemma_diag().T) \
+                   / noise_var **2
 
         log_like = -.5 * (Xr * log_like_row).sum(axis=1)
         log_like -= .5 * (n_features * log(2. * np.pi) -

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -612,7 +612,7 @@ class PCA(_BasePCA):
             logdet = self._get_logdet_precision()
             log_like_row -= np.dot(np.dot(Xr, components.T), components
                                    * self._get_mat_inv_lemma_diag().T) \
-                            / noise_var ** 2
+                           / noise_var ** 2
 
         log_like = -.5 * (Xr * log_like_row).sum(axis=1)
         log_like -= .5 * (n_features * log(2. * np.pi) -

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -610,9 +610,9 @@ class PCA(_BasePCA):
 
             log_like_row = Xr / noise_var
             logdet = self._get_logdet_precision()
-            log_like_row -= np.dot(np.dot(Xr, components.T), components
-                                   * self._get_mat_inv_lemma_diag().T) \
-            / noise_var ** 2
+            log_like_row -= \
+            np.dot(np.dot(Xr, components.T), components
+                   * self._get_mat_inv_lemma_diag().T) / noise_var ** 2
 
         log_like = -.5 * (Xr * log_like_row).sum(axis=1)
         log_like -= .5 * (n_features * log(2. * np.pi) -

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -612,7 +612,7 @@ class PCA(_BasePCA):
             logdet = self._get_logdet_precision()
             log_like_row -= np.dot(np.dot(Xr, components.T), components
                                    * self._get_mat_inv_lemma_diag().T) \
-                           / noise_var ** 2
+            / noise_var ** 2
 
         log_like = -.5 * (Xr * log_like_row).sum(axis=1)
         log_like -= .5 * (n_features * log(2. * np.pi) -

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -564,32 +564,32 @@ class PCA(_BasePCA):
             Log-likelihood of each sample under the current model
         """
 	
-        '''
-        precision matrix is defined as the inverse of covariance matrix.
-        Using matrix inversion lemma, it can be written as 
+        """precision matrix is defined as the inverse of covariance matrix.
+        Using matrix inversion lemma, it can be written as
         a - a**2 components_.T * D * components, where D is a diagonal matrix
         During the calculation of log-likelihood, the precision matrix is multiplied
         on the left side by a row vector. Hence, it is not needed to save the whole
         precision matrix on memory. In fact, only the diagonal terms of D is needed.
-        '''
+        """
         check_is_fitted(self, 'mean_')
 
         X = check_array(X)
-        
+
         n_features = X.shape[1]
         components = self.components_
         exp_var = self.explained_variance_
         noise_var = self.noise_variance_
 
         Xr = X - self.mean_
-        
+
         # handle corner cases first
         if self.n_components_ == n_features:
-            '''old implementation for whiten==True is wrong. 
-            Uncomment to obtain same output as old implementation.'''
+            """old implementation for whiten==True is wrong
+            Uncomment to obtain same output as old implementation.
+            """
 #            if self.whiten:
 #                exp_var = exp_var * exp_var
-                
+
             logdet = - np.sum(np.log(exp_var))
             inv_exp_var = 1 / exp_var.reshape(-1, 1)
             log_like_row = np.dot(np.dot(Xr, components.T),
@@ -598,23 +598,23 @@ class PCA(_BasePCA):
         elif self.n_components_ == 0:
             log_like_row = Xr / noise_var
             logdet = - log(noise_var) * n_features
-             
+
         else:
-            '''old implementation for whiten==True is wrong. 
-            Uncomment to obtain same output as old implementation.'''
+            """old implementation for whiten==True is wrong
+            Uncomment to obtain same output as old implementation.
+            """
 #            if self.whiten:
 #                components = components * np.sqrt(exp_var[:, np.newaxis])
-            
+
             log_like_row = Xr / noise_var
             logdet = self._get_logdet_precision()
             log_like_row -= np.dot(np.dot(Xr, components.T),
                                components * self._get_mat_inv_lemma_diag().T) / noise_var **2
-                           
+
         log_like = -.5 * (Xr * log_like_row).sum(axis=1)
         log_like -= .5 * (n_features * log(2. * np.pi) -
                           logdet)
         return log_like
-		
 
     def score(self, X, y=None):
         """Return the average log-likelihood of all samples.

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -585,8 +585,10 @@ class PCA(_BasePCA):
         
         # handle corner cases first
         if self.n_components_ == n_features:
-            if self.whiten: #this should be commented out, sklearn is wrong
-                exp_var = exp_var * exp_var
+            '''old implementation for whiten==True is wrong. 
+            Uncomment to obtain same output as old implementation.'''
+#            if self.whiten:
+#                exp_var = exp_var * exp_var
                 
             logdet = - np.sum(np.log(exp_var))
             inv_exp_var = 1 / exp_var.reshape(-1, 1)
@@ -595,10 +597,12 @@ class PCA(_BasePCA):
 
         elif self.n_components_ == 0:
             log_like_row = Xr / noise_var
-            logdet = - math.log(noise_var) * n_features
+            logdet = - log(noise_var) * n_features
              
         else:
-#            if self.whiten: #old implementation for whiten==True is wrong. Uncomment to obtain same output as old implementation.
+            '''old implementation for whiten==True is wrong. 
+            Uncomment to obtain same output as old implementation.'''
+#            if self.whiten:
 #                components = components * np.sqrt(exp_var[:, np.newaxis])
             
             log_like_row = Xr / noise_var
@@ -607,7 +611,7 @@ class PCA(_BasePCA):
                                components * self._get_mat_inv_lemma_diag().T) / noise_var **2
                            
         log_like = -.5 * (Xr * log_like_row).sum(axis=1)
-        log_like -= .5 * (n_features * math.log(2. * np.pi) -
+        log_like -= .5 * (n_features * log(2. * np.pi) -
                           logdet)
         return log_like
 		

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -610,7 +610,7 @@ class PCA(_BasePCA):
 
             log_like_row = Xr / noise_var
             logdet = self._get_logdet_precision()
-            log_like_row -= np.dot(np.dot(Xr, components.T), components                                
+            log_like_row -= np.dot(np.dot(Xr, components.T), components
                                    * self._get_mat_inv_lemma_diag().T)
             log_like_row /= noise_var ** 2
 

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -610,8 +610,8 @@ class PCA(_BasePCA):
 
             log_like_row = Xr / noise_var
             logdet = self._get_logdet_precision()
-            log_like_row -= np.dot(np.dot(Xr, components.T), components *                                 
-                                   self._get_mat_inv_lemma_diag().T)
+            log_like_row -= np.dot(np.dot(Xr, components.T), components                                
+                                   * self._get_mat_inv_lemma_diag().T)
             log_like_row /= noise_var ** 2
 
         log_like = -.5 * (Xr * log_like_row).sum(axis=1)

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -22,7 +22,7 @@ from scipy.sparse.linalg import svds
 from .base import _BasePCA
 from ..utils import check_random_state
 from ..utils import check_array
-from ..utils.extmath import fast_logdet, randomized_svd, svd_flip
+from ..utils.extmath import randomized_svd, svd_flip
 from ..utils.extmath import stable_cumsum
 from ..utils.validation import check_is_fitted
 
@@ -611,8 +611,8 @@ class PCA(_BasePCA):
             log_like_row = Xr / noise_var
             logdet = self._get_logdet_precision()
             log_like_row -= \
-            np.dot(np.dot(Xr, components.T), components
-                   * self._get_mat_inv_lemma_diag().T) / noise_var ** 2
+                np.dot(np.dot(Xr, components.T), components
+                       * self._get_mat_inv_lemma_diag().T) / noise_var ** 2
 
         log_like = -.5 * (Xr * log_like_row).sum(axis=1)
         log_like -= .5 * (n_features * log(2. * np.pi) -


### PR DESCRIPTION
…n memory. This reduces memory usage problems when n_features is large and can speed up calculation. Also contains a fix for score_samples implementation when whiten==True.

#### Reference Issues/PRs
Please refer to Issue #13898 
_PCA implementation of score_samples calculates the wrong precision matrix when whiten is True_

#### What does this implement/fix? Explain your changes.
This fix the issue raised in Issue #13898, and also implement the following changes for fast score_samples computation when n_features is large.

Original implementation of score_samples calculates the precision matrix, which is a n_features x n_features matrix, and does Xr * P * Xr.T as part of the score_samples calculation. The precision matrix is the inverse of covariance matrix, by the use of matrix inversion lemma it can be simplified as (matrix multiplication implied below):
**P = (1 / noise_variance) - (1 / noise_variance^2) * components_.T * (M^-1) * components_,**
where M is a diagonal matrix. As all we want to calculate is Xr * P * Xr.T, it is not necessary to save P in memory: only the diagonal elements of matrix M is needed.

The calculation of log determinant doesn't need the precision matrix either, as we have the identity (matrix multiplication implied below):
**det(COV^-1) = 1 / det(COV) = 1 / det(C.T * D * C) = 1 / det(D)**
where C is the square matrix that diagonalizes COV and D is the diagonalized covariance matrix.
