### PR TITLE
[MRG] add _pairwise property to BaseSearchCV

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -48,6 +48,17 @@ Changelog
   :pr:`13618` by :user:`Yoshihiro Uchida <c56pony>`.
 
 
+:mod:`sklearn.model_selection`
+..................
+
+- |Fix| :class:`model_selection.BaseSearchCV` now supports the
+  :term:`_pairwise` property, which prevents an error during cross-validation
+  for estimators with pairwise inputs (such as
+  :class:`neighbors.KNeighborsClassifier` when :term:`metric` is set to
+  'precomputed').
+  :pr:`13925` by :user:`Isaac S. Robson <isrobson>`.
+
+
 :mod:`sklearn.svm`
 ..................
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -398,6 +398,11 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
     def _estimator_type(self):
         return self.estimator._estimator_type
 
+    @property
+    def _pairwise(self):
+        # this allows cross-validation to recognize 'precomputed' distance metric
+        return getattr(self.estimator, '_pairwise', False)
+
     def score(self, X, y=None):
         """Returns the score on the given data, if the estimator has been refit.
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -400,7 +400,7 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
 
     @property
     def _pairwise(self):
-        # this allows cross-validation to recognize 'precomputed' distance metric
+        # allows cross-validation to see 'precomputed' metrics
         return getattr(self.estimator, '_pairwise', False)
 
     def score(self, X, y=None):

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1787,3 +1787,26 @@ def test_random_search_bad_cv():
                              'inconsistent results. Expected \\d+ '
                              'splits, got \\d+'):
         ridge.fit(X[:train_size], y[:train_size])
+
+def test_search_cv__pairwise_property():
+    """
+    Test implementation of BaseSearchCV has the _pairwise property
+    which matches the _pairwise property of its estimator.
+    """
+
+    class PairwiseCV(BaseSearchCV):
+        def __init__(self, estimator, **kwargs):
+            super().__init__(estimator, **kwargs)
+
+    # simple estimator with _pairwise property
+    est = BaseEstimator()
+
+    attr_message = "BaseSearchCV _pairwise property must match estimator"
+
+    # check estimator with and without _pairwise
+    for _pairwise_setting in [True, False]:
+        setattr(est, '_pairwise', _pairwise_setting)
+        cv = PairwiseCV(est)
+
+        # verity the _pairwise property in cv matches est
+        assert _pairwise_setting == getattr(cv, '_pairwise', False), attr_message

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -59,11 +59,13 @@ from sklearn.tree import DecisionTreeRegressor
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.cluster import KMeans
 from sklearn.neighbors import KernelDensity
+from sklearn.neighbors import KNeighborsClassifier
 from sklearn.metrics import f1_score
 from sklearn.metrics import recall_score
 from sklearn.metrics import accuracy_score
 from sklearn.metrics import make_scorer
 from sklearn.metrics import roc_auc_score
+from sklearn.metrics.pairwise import euclidean_distances
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
 from sklearn.linear_model import Ridge, SGDClassifier
@@ -1794,23 +1796,41 @@ def test_search_cv__pairwise_property():
     Test implementation of BaseSearchCV has the _pairwise property
     which matches the _pairwise property of its estimator.
     """
-
     class PairwiseCV(BaseSearchCV):
         def __init__(self, estimator, **kwargs):
             super().__init__(estimator, **kwargs)
 
-    # simple estimator with _pairwise property
+    # first test: check BaseSearchCV children copy _pairwise
     est = BaseEstimator()
 
     attr_message = "BaseSearchCV _pairwise property must match estimator"
 
-    # check estimator with and without _pairwise
     for _pairwise_setting in [True, False]:
         setattr(est, '_pairwise', _pairwise_setting)
         cv = PairwiseCV(est)
+        assert _pairwise_setting == cv._pairwise, attr_message
 
-        # check if cv is pairwise
-        cv_is_pairwise = getattr(cv, '_pairwise', False)
+    # second test: ensure equivalence of 'precomputed'
+    n_samples = 50
+    n_splits = 2
+    X, y = make_classification(n_samples=n_samples, random_state=0)
+    grid_params = {'n_neighbors': [10]}
 
-        # verity the _pairwise property in cv matches est
-        assert _pairwise_setting == cv_is_pairwise, attr_message
+    # defaults to euclidean metric (minkowski p = 2)
+    clf = KNeighborsClassifier()
+    cv = GridSearchCV(clf, grid_params, cv=n_splits)
+    cv.fit(X, y)
+
+    preds_original = cv.predict(X)
+
+    # precompute euclidean metric to validate _pairwise is working
+    X_precomputed = euclidean_distances(X)
+    clf = KNeighborsClassifier(metric='precomputed')
+    cv = GridSearchCV(clf, grid_params, cv=n_splits)
+    cv.fit(X_precomputed, y)
+
+    preds_precomputed = cv.predict(X_precomputed)
+
+    attr_message = "GridSearchCV not identical with precomputed metric"
+
+    assert (preds_original == preds_precomputed).all(), attr_message

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1808,5 +1808,8 @@ def test_search_cv__pairwise_property():
         setattr(est, '_pairwise', _pairwise_setting)
         cv = PairwiseCV(est)
 
+        # check if cv is pairwise
+        cv_is_pairwise = getattr(cv, '_pairwise', False)
+
         # verity the _pairwise property in cv matches est
-        assert _pairwise_setting == getattr(cv, '_pairwise', False), attr_message
+        assert _pairwise_setting == cv_is_pairwise, attr_message

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1788,6 +1788,7 @@ def test_random_search_bad_cv():
                              'splits, got \\d+'):
         ridge.fit(X[:train_size], y[:train_size])
 
+
 def test_search_cv__pairwise_property():
     """
     Test implementation of BaseSearchCV has the _pairwise property


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #13920 

Previously BaseSearchCV did not support a 'precomputed' distance metric. 

This PR simply adds a _pairwise property to the BaseSearchCV to ensure that some X evaluated with the 'precomputed' distance metric can be properly split during cross-validation by [`_safe_split`](https://github.com/scikit-learn/scikit-learn/blob/b7b4d3e2f1a65bcb6d40431d3b61ed1d563c9dab/sklearn/utils/metaestimators.py)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
