### PR TITLE
DOC Fix bracket typo in linear_model.rst

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -71,7 +71,7 @@ The least squares solution is computed using the singular value
 decomposition of X. If X is a matrix of shape `(n_samples, n_features)`
 this method has a cost of 
 :math:`O(n_{\text{samples}} n_{\text{features}}^2)`, assuming that
-:math:`n_{\text{samples} \geq n_{\text{features}}}`.
+:math:`n_{\text{samples}} \geq n_{\text{features}}`.
 
 .. _ridge_regression:
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

There is a typo with the brackets in the [Ordinary Least Squares Complexity](https://scikit-learn.org/stable/modules/linear_model.html#ordinary-least-squares-complexity) subsection in the Generalized Linear Models documentation. This very small PR fixes this typo.