### PR TITLE
FIX Bin training and validation data separately in GBDTs

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -45,7 +45,7 @@ Changelog
 - |Fix| :class:`ensemble.HistGradientBoostingClassifier` and
   :class:`ensemble.HistGradientBoostingRegressor` now bin the training and
   validation data separately to avoid any data leak. :pr:`13933` by
-  :user:`NicolasHug`_.
+  `NicolasHug`_.
 
 :mod:`sklearn.linear_model`
 ..................

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -39,6 +39,14 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
+:mod:`sklearn.ensemble`
+.......................
+
+- |Fix| :class:`ensemble.HistGradientBoostingClassifier` and
+  :class:`ensemble.HistGradientBoostingRegressor` now bin the training and
+  validation data separately to avoid any data leak. :pr:`13933` by
+  :user:`NicolasHug`_.
+
 :mod:`sklearn.linear_model`
 ..................
 

--- a/sklearn/ensemble/_hist_gradient_boosting/binning.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/binning.py
@@ -140,7 +140,7 @@ class _BinMapper(BaseEstimator, TransformerMixin):
         Returns
         -------
         X_binned : array-like, shape (n_samples, n_features)
-            The binned data.
+            The binned data (fortran-aligned).
         """
         X = check_array(X, dtype=[X_DTYPE])
         check_is_fitted(self, ['bin_thresholds_', 'actual_n_bins_'])

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -112,17 +112,6 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         # data.
         self._in_fit = True
 
-        # bin the data
-        if self.verbose:
-            print("Binning {:.3f} GB of data: ".format(X.nbytes / 1e9), end="",
-                  flush=True)
-        tic = time()
-        self.bin_mapper_ = _BinMapper(max_bins=self.max_bins, random_state=rng)
-        X_binned = self.bin_mapper_.fit_transform(X)
-        toc = time()
-        if self.verbose:
-            duration = toc - tic
-            print("{:.3f} s".format(duration))
 
         self.loss_ = self._get_loss()
 
@@ -135,17 +124,19 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
             # stratify for classification
             stratify = y if hasattr(self.loss_, 'predict_proba') else None
 
-            X_binned_train, X_binned_val, y_train, y_val = train_test_split(
-                X_binned, y, test_size=self.validation_fraction,
-                stratify=stratify, random_state=rng)
-
-            # Predicting is faster of C-contiguous arrays, training is faster
-            # on Fortran arrays.
-            X_binned_val = np.ascontiguousarray(X_binned_val)
-            X_binned_train = np.asfortranarray(X_binned_train)
+            X_train, X_val, y_train, y_val = train_test_split(
+                X, y, test_size=self.validation_fraction, stratify=stratify,
+                random_state=rng)
         else:
-            X_binned_train, y_train = X_binned, y
-            X_binned_val, y_val = None, None
+            X_train, y_train = X, y
+            X_val, y_val = None, None
+
+        # Bin the data
+        X_binned_train = self._bin_data(X_train, rng, is_training_data=True)
+        if X_val is not None:
+            X_binned_val = self._bin_data(X_val, rng, is_training_data=False)
+        else:
+            X_binned_val = None
 
         if self.verbose:
             print("Fitting gradient boosted rounds:")
@@ -386,6 +377,34 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         recent_improvements = [score > reference_score
                                for score in recent_scores]
         return not any(recent_improvements)
+
+    def _bin_data(self, X, rng, is_training_data):
+        """Bin data X.
+
+        If is_training_data, then set the bin_mapper_ attribute.
+        Else, the binned data is converted to a C-contiguous array.
+        """
+
+        description = 'training' if is_training_data else 'validation'
+        if self.verbose:
+            print("Binning {:.3f} GB of {} data: ".format(
+                X.nbytes / 1e9, description), end="", flush=True)
+        tic = time()
+        bin_mapper = _BinMapper(max_bins=self.max_bins, random_state=rng)
+        X_binned = bin_mapper.fit_transform(X)  # F-aligned array
+        toc = time()
+        if self.verbose:
+            duration = toc - tic
+            print("{:.3f} s".format(duration))
+
+        if is_training_data:
+            self.bin_mapper_ = bin_mapper
+        else:
+            # Validation data. We convert the array to C-contiguous since
+            # predicting is faster with this layout (training is faster on
+            # F-arrays though)
+            X_binned = np.ascontiguousarray(X_binned)
+        return X_binned
 
     def _print_iteration_stats(self, iteration_start_time):
         """Print info about the current fitting iteration."""

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -153,9 +153,12 @@ def test_binning_train_validation_are_separated():
     # See issue 13926
 
     rng = np.random.RandomState(0)
-    gb = HistGradientBoostingClassifier(n_iter_no_change=5,
-                                        validation_fraction=.2,
-                                        random_state=rng)
+    validation_fraction = .2
+    gb = HistGradientBoostingClassifier(
+        n_iter_no_change=5,
+        validation_fraction=validation_fraction,
+        random_state=rng
+    )
     gb.fit(X_classification, y_classification)
     mapper_training_data = gb.bin_mapper_
 
@@ -164,5 +167,8 @@ def test_binning_train_validation_are_separated():
     mapper_whole_data = _BinMapper(random_state=0)
     mapper_whole_data.fit(X_classification)
 
+    n_samples = X_classification.shape[0]
+    assert np.all(mapper_training_data.actual_n_bins_ ==
+                  int((1 - validation_fraction) * n_samples))
     assert np.all(mapper_training_data.actual_n_bins_ !=
                   mapper_whole_data.actual_n_bins_)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -150,6 +150,7 @@ def test_should_stop(scores, n_iter_no_change, tol, stopping):
 
 def test_binning_train_validation_are_separated():
     # Make sure training and validation data are binned separately.
+    # See issue 13926
 
     rng = np.random.RandomState(0)
     gb = HistGradientBoostingClassifier(n_iter_no_change=5,
@@ -163,7 +164,5 @@ def test_binning_train_validation_are_separated():
     mapper_whole_data = _BinMapper(random_state=0)
     mapper_whole_data.fit(X_classification)
 
-    for feature_idx in range(X_classification.shape[1]):
-        n_bins_training = mapper_training_data.actual_n_bins_[feature_idx]
-        n_bins_whole = mapper_whole_data.actual_n_bins_[feature_idx]
-        assert n_bins_training != n_bins_whole
+    assert np.all(mapper_training_data.actual_n_bins_ !=
+                  mapper_whole_data.actual_n_bins_)


### PR DESCRIPTION
Closes #13926

Instead of binning the whole data before the train/validation split, we now bin the training and validation data separately.

Not sure if that's worth a whatsnew entry, since it's all experimental still?