### PR TITLE
[MRG] decision_path and apply for all tree-based ensemble model classes.

### DIFF
--- a/sklearn/ensemble/base.py
+++ b/sklearn/ensemble/base.py
@@ -159,14 +159,14 @@ class ForestMixin:
 
         Parameters
         ----------
-        X : array-like or sparse matrix, shape = [n_samples, n_features]
+        X : array-like or sparse matrix, shape (n_samples, n_features)
             The input samples. Internally, its dtype will be converted to
             ``dtype=np.float32``. If a sparse matrix is provided, it will be
             converted into a sparse ``csr_matrix``.
 
         Returns
         -------
-        X_leaves : array_like, shape = [n_samples, n_estimators]
+        X_leaves : ndarray, shape (n_samples, n_estimators)
             For each datapoint x in X and for each tree in the forest,
             return the index of the leaf x ends up in.
         """
@@ -185,20 +185,20 @@ class ForestMixin:
 
         Parameters
         ----------
-        X : array-like or sparse matrix, shape = [n_samples, n_features]
+        X : array-like or sparse matrix, shape (n_samples, n_features)
             The input samples. Internally, its dtype will be converted to
             ``dtype=np.float32``. If a sparse matrix is provided, it will be
             converted into a sparse ``csr_matrix``.
 
         Returns
         -------
-        indicator : sparse csr array, shape = [n_samples, n_nodes]
+        indicator : sparse ``csr_matrix``, shape (n_samples, n_nodes)
             Return a node indicator matrix where non zero elements
-            indicates that the samples goes through the nodes.
+            indicate that the sample goes through the nodes.
 
-        n_nodes_ptr : array of size (n_estimators + 1, )
+        n_nodes_ptr : ndarray, shape (n_estimators + 1, )
             The columns from indicator[n_nodes_ptr[i]:n_nodes_ptr[i+1]]
-            gives the indicator value for the i-th estimator.
+            give the indicator value for the i-th estimator.
 
         """
         X = self._validate_X_predict(X)

--- a/sklearn/ensemble/base.py
+++ b/sklearn/ensemble/base.py
@@ -7,12 +7,14 @@ Base class for ensemble-based estimators.
 
 import numpy as np
 import numbers
+from scipy.sparse import hstack as sparse_hstack
 
 from ..base import clone
 from ..base import BaseEstimator
 from ..base import MetaEstimatorMixin
 from ..utils import check_random_state
-from ..utils._joblib import effective_n_jobs
+from ..utils.fixes import parallel_helper, _joblib_parallel_args
+from ..utils._joblib import Parallel, delayed, effective_n_jobs
 from abc import ABCMeta, abstractmethod
 
 MAX_RAND_SEED = np.iinfo(np.int32).max
@@ -146,6 +148,46 @@ class BaseEnsemble(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
     def __iter__(self):
         """Returns iterator over estimators in the ensemble."""
         return iter(self.estimators_)
+
+
+class ForestMixin:
+    """ Mixin class for all tree-based ensemble model classes in scikit-learn."""
+
+    def decision_path(self, X):
+        """Return the decision path in the forest
+
+        .. versionadded:: 0.18
+
+        Parameters
+        ----------
+        X : array-like or sparse matrix, shape = [n_samples, n_features]
+            The input samples. Internally, its dtype will be converted to
+            ``dtype=np.float32``. If a sparse matrix is provided, it will be
+            converted into a sparse ``csr_matrix``.
+
+        Returns
+        -------
+        indicator : sparse csr array, shape = [n_samples, n_nodes]
+            Return a node indicator matrix where non zero elements
+            indicates that the samples goes through the nodes.
+
+        n_nodes_ptr : array of size (n_estimators + 1, )
+            The columns from indicator[n_nodes_ptr[i]:n_nodes_ptr[i+1]]
+            gives the indicator value for the i-th estimator.
+
+        """
+        X = self._validate_X_predict(X)
+        indicators = Parallel(n_jobs=self.n_jobs, verbose=self.verbose,
+                              **_joblib_parallel_args(prefer='threads'))(
+            delayed(parallel_helper)(tree, 'decision_path', X,
+                                     check_input=False)
+            for tree in self.estimators_)
+
+        n_nodes = [0]
+        n_nodes.extend([i.shape[1] for i in indicators])
+        n_nodes_ptr = np.array(n_nodes).cumsum()
+
+        return sparse_hstack(indicators).tocsr(), n_nodes_ptr
 
 
 def _partition_estimators(n_estimators, n_jobs):

--- a/sklearn/ensemble/base.py
+++ b/sklearn/ensemble/base.py
@@ -151,7 +151,8 @@ class BaseEnsemble(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
 
 
 class ForestMixin:
-    """ Mixin class for all tree-based ensemble model classes in scikit-learn."""
+    """ Mixin class for all tree-based ensemble model classes in
+    scikit-learn."""
 
     def decision_path(self, X):
         """Return the decision path in the forest

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -154,30 +154,6 @@ class BaseForest(BaseEnsemble, MultiOutputMixin, ForestMixin,
         self.warm_start = warm_start
         self.class_weight = class_weight
 
-    def apply(self, X):
-        """Apply trees in the forest to X, return leaf indices.
-
-        Parameters
-        ----------
-        X : array-like or sparse matrix, shape = [n_samples, n_features]
-            The input samples. Internally, its dtype will be converted to
-            ``dtype=np.float32``. If a sparse matrix is provided, it will be
-            converted into a sparse ``csr_matrix``.
-
-        Returns
-        -------
-        X_leaves : array_like, shape = [n_samples, n_estimators]
-            For each datapoint x in X and for each tree in the forest,
-            return the index of the leaf x ends up in.
-        """
-        X = self._validate_X_predict(X)
-        results = Parallel(n_jobs=self.n_jobs, verbose=self.verbose,
-                           **_joblib_parallel_args(prefer="threads"))(
-            delayed(parallel_helper)(tree, 'apply', X, check_input=False)
-            for tree in self.estimators_)
-
-        return np.array(results).T
-
     def fit(self, X, y, sample_weight=None):
         """Build a forest of trees from the training set (X, y).
 

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -515,7 +515,6 @@ class ForestClassifier(BaseForest, ClassifierMixin, metaclass=ABCMeta):
             The class probabilities of the input samples. The order of the
             classes corresponds to that in the attribute `classes_`.
         """
-        check_is_fitted(self, 'estimators_')
         # Check data
         X = self._validate_X_predict(X)
 
@@ -620,7 +619,6 @@ class ForestRegressor(BaseForest, RegressorMixin, metaclass=ABCMeta):
         y : array of shape = [n_samples] or [n_samples, n_outputs]
             The predicted values.
         """
-        check_is_fitted(self, 'estimators_')
         # Check data
         X = self._validate_X_predict(X)
 

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -121,7 +121,8 @@ def _parallel_build_trees(tree, forest, X, y, sample_weight, tree_idx, n_trees,
     return tree
 
 
-class BaseForest(BaseEnsemble, MultiOutputMixin, ForestMixin, metaclass=ABCMeta):
+class BaseForest(BaseEnsemble, MultiOutputMixin, ForestMixin,
+                 metaclass=ABCMeta):
     """Base class for forests of trees.
 
     Warning: This class should not be used directly. Use derived classes

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -23,7 +23,7 @@ The module structure is the following:
 from abc import ABCMeta
 from abc import abstractmethod
 
-from .base import BaseEnsemble
+from .base import BaseEnsemble, ForestMixin
 from ..base import ClassifierMixin
 from ..base import RegressorMixin
 from ..base import BaseEstimator
@@ -1163,7 +1163,7 @@ class VerboseReporter(object):
                 self.verbose_mod *= 10
 
 
-class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
+class BaseGradientBoosting(BaseEnsemble, ForestMixin, metaclass=ABCMeta):
     """Abstract base class for Gradient Boosting. """
 
     @abstractmethod

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -38,6 +38,7 @@ import numpy as np
 
 from scipy.sparse import csc_matrix
 from scipy.sparse import csr_matrix
+from scipy.sparse import hstack as sparse_hstack
 from scipy.sparse import issparse
 from scipy.special import expit
 
@@ -1751,7 +1752,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+        X : array-like or sparse matrix, shape (n_samples, n_features)
             The input samples. Internally, its dtype will be converted to
             ``dtype=np.float32``. If a sparse matrix is provided, it will
             be converted to a sparse ``csr_matrix``.
@@ -1786,25 +1787,40 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
 
         Parameters
         ----------
-        X : array-like or sparse matrix, shape = [n_samples, n_features]
+        X : array-like or sparse matrix, shape (n_samples, n_features)
             The input samples. Internally, its dtype will be converted to
             ``dtype=np.float32``. If a sparse matrix is provided, it will be
             converted into a sparse ``csr_matrix``.
 
         Returns
         -------
-        indicator : sparse csr array, shape = [n_samples, n_nodes]
-            Return a node indicator matrix where non zero elements
-            indicates that the samples goes through the nodes.
+        indicator : list of sparse csr matrices, n_classes_ elements of shape \
+                (n_samples, n_nodes)
+            Return a list of node indicator matrices of size `n_classes_`.
+            Non zero elements of indicator matrices indicate that the samples
+            go through the nodes.
 
-        n_nodes_ptr : array of size (n_estimators + 1, )
-            The columns from indicator[n_nodes_ptr[i]:n_nodes_ptr[i+1]]
-            gives the indicator value for the i-th estimator.
+        n_nodes_ptr : ndarray, shape (n_classes_, n_estimators + 1)
+            The columns from indicator[c][n_nodes_ptr[i]:n_nodes_ptr[i+1]]
+            give the indicator value for the i-th estimator of the class c.
 
         """
         X = self._validate_X_predict(X)
 
-        return 'TO BE IMPLEMENTED'
+        # n_classes will be equal to 1 in the binary classification or the
+        # regression case.
+        n_estimators, n_classes = self.estimators_.shape
+        indicators = [None for _ in range(n_classes)]
+        n_nodes_ptr = np.zeros((n_classes, n_estimators + 1))
+
+        for c in range(n_classes):
+            indicators[c] = [tree.decision_path(X, check_input=False)
+                             for tree in self.estimators_[:, c]]
+            n_nodes = [0]
+            n_nodes.extend([i.shape[1] for i in indicators[c]])
+            n_nodes_ptr[c, :] = np.array(n_nodes).cumsum()
+        indicators = [sparse_hstack(indic).tocsr() for indic in indicators]
+        return indicators, n_nodes_ptr
 
 
 class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
@@ -2591,14 +2607,14 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+        X : array-like or sparse matrix, shape (n_samples, n_features)
             The input samples. Internally, its dtype will be converted to
             ``dtype=np.float32``. If a sparse matrix is provided, it will
-            be converted to a sparse ``csr_matrix``.
+            be converted into a sparse ``csr_matrix``.
 
         Returns
         -------
-        X_leaves : array-like, shape (n_samples, n_estimators)
+        X_leaves : ndarray, shape (n_samples, n_estimators)
             For each datapoint x in X and for each tree in the ensemble,
             return the index of the leaf x ends up in each estimator.
         """
@@ -2606,3 +2622,31 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
         leaves = super().apply(X)
         leaves = leaves.reshape(X.shape[0], self.estimators_.shape[0])
         return leaves
+
+    def decision_path(self, X):
+        """Return the decision path in the forest.
+
+        .. versionadded:: 0.22
+
+        Parameters
+        ----------
+        X : array-like or sparse matrix, shape (n_samples, n_features)
+            The input samples. Internally, its dtype will be converted to
+            ``dtype=np.float32``. If a sparse matrix is provided, it will be
+            converted into a sparse ``csr_matrix``.
+
+        Returns
+        -------
+        indicator : sparse ``csr_matrix``, shape (n_samples, n_nodes)
+            Return a node indicator matrix where non zero elements
+            indicate that the sample goes through the nodes.
+
+        n_nodes_ptr : ndarray, shape (n_estimators + 1, )
+            The columns from indicator[n_nodes_ptr[i]:n_nodes_ptr[i+1]]
+            give the indicator value for the i-th estimator.
+
+        """
+
+        indicators, n_nodes_ptr = super().decision_path(X)
+        n_estimators = self.estimators_.shape[0]
+        return indicators[0], n_nodes_ptr.reshape(n_estimators + 1)

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -20,13 +20,14 @@ from ..utils.validation import check_is_fitted, _num_samples
 from ..base import OutlierMixin
 
 from .bagging import BaseBagging
+from .base import ForestMixin
 
 __all__ = ["IsolationForest"]
 
 INTEGER_TYPES = (numbers.Integral, np.integer)
 
 
-class IsolationForest(BaseBagging, OutlierMixin):
+class IsolationForest(BaseBagging, OutlierMixin, ForestMixin):
     """Isolation Forest Algorithm
 
     Return the anomaly score of each sample using the IsolationForest algorithm

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -306,8 +306,7 @@ class IsolationForest(BaseBagging, OutlierMixin, ForestMixin):
             For each observation, tells whether or not (+1 or -1) it should
             be considered as an inlier according to the fitted model.
         """
-        check_is_fitted(self, ["offset_"])
-        X = check_array(X, accept_sparse='csr')
+        X = self._validate_X_predict(X)
         is_inlier = np.ones(X.shape[0], dtype=int)
         is_inlier[self.decision_function(X) < 0] = -1
         return is_inlier
@@ -381,6 +380,11 @@ class IsolationForest(BaseBagging, OutlierMixin, ForestMixin):
         # Take the opposite of the scores as bigger is better (here less
         # abnormal)
         return -self._compute_chunked_score_samples(X)
+
+    def _validate_X_predict(self, X):
+        """Validate X whenever one tries to predict, apply, predict_proba"""
+        check_is_fitted(self, ["offset_"])
+        return check_array(X, accept_sparse='csr')
 
     def _compute_chunked_score_samples(self, X):
 

--- a/sklearn/ensemble/tests/test_base.py
+++ b/sklearn/ensemble/tests/test_base.py
@@ -156,8 +156,7 @@ def check_decision_path(name):
     X, y = hastie_X, hastie_y
     n_samples = X.shape[0]
     ForestEstimator = FOREST_CLASSIFIERS_REGRESSORS[name]
-    est = ForestEstimator(n_estimators=5, max_depth=1, warm_start=False,
-                          random_state=1)
+    est = ForestEstimator(n_estimators=5, warm_start=False, random_state=1)
     est.fit(X, y)
     indicator, n_nodes_ptr = est.decision_path(X)
 

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -37,7 +37,6 @@ from sklearn.utils.testing import assert_greater_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
-from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import skip_if_no_parallel
 
@@ -1216,33 +1215,6 @@ def test_dtype_convert(n_classes=15):
     result = classifier.fit(X, y).predict(X)
     assert_array_equal(classifier.classes_, y)
     assert_array_equal(result, y)
-
-
-def check_decision_path(name):
-    X, y = hastie_X, hastie_y
-    n_samples = X.shape[0]
-    ForestEstimator = FOREST_ESTIMATORS[name]
-    est = ForestEstimator(n_estimators=5, max_depth=1, warm_start=False,
-                          random_state=1)
-    est.fit(X, y)
-    indicator, n_nodes_ptr = est.decision_path(X)
-
-    assert_equal(indicator.shape[1], n_nodes_ptr[-1])
-    assert_equal(indicator.shape[0], n_samples)
-    assert_array_equal(np.diff(n_nodes_ptr),
-                       [e.tree_.node_count for e in est.estimators_])
-
-    # Assert that leaves index are correct
-    leaves = est.apply(X)
-    for est_id in range(leaves.shape[1]):
-        leave_indicator = [indicator[i, n_nodes_ptr[est_id] + j]
-                           for i, j in enumerate(leaves[:, est_id])]
-        assert_array_almost_equal(leave_indicator, np.ones(shape=n_samples))
-
-
-@pytest.mark.parametrize('name', FOREST_CLASSIFIERS_REGRESSORS)
-def test_decision_path(name):
-    check_decision_path(name)
 
 
 def test_min_impurity_split():

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1233,16 +1233,15 @@ def check_sparse_input(EstimatorClass, X, X_sparse, y):
                             presort=False).fit(X_sparse, y)
     auto = EstimatorClass(n_estimators=10, random_state=0, max_depth=2,
                           presort='auto').fit(X_sparse, y)
-
     assert_array_almost_equal(sparse.apply(X), dense.apply(X))
     dense_indicator, dense_nodes_ptr = dense.decision_path(X)
     sparse_indicator, sparse_nodes_prt = sparse.decision_path(X)
     assert_array_equal(dense_nodes_ptr, sparse_nodes_prt)
-    if isinstance(EstimatorClass, GradientBoostingClassifier):
+    if issubclass(EstimatorClass, GradientBoostingClassifier):
         assert len(dense_indicator) == len(sparse_indicator)
         for dense_ind, sparse_ind in zip(dense_indicator, sparse_indicator):
             assert_array_equal(dense_ind.toarray(), sparse_ind.toarray())
-    elif isinstance(EstimatorClass, GradientBoostingRegressor):
+    elif issubclass(EstimatorClass, GradientBoostingRegressor):
         assert_array_equal(dense_indicator.toarray(),
                            sparse_indicator.toarray())
     assert_array_almost_equal(sparse.predict(X), dense.predict(X))
@@ -1252,11 +1251,11 @@ def check_sparse_input(EstimatorClass, X, X_sparse, y):
     assert_array_almost_equal(sparse.apply(X), auto.apply(X))
     auto_indicator, auto_nodes_ptr = auto.decision_path(X)
     assert_array_equal(auto_nodes_ptr, sparse_nodes_prt)
-    if isinstance(EstimatorClass, GradientBoostingClassifier):
+    if issubclass(EstimatorClass, GradientBoostingClassifier):
         assert len(auto_indicator) == len(sparse_indicator)
         for auto_ind, sparse_ind in zip(auto_indicator, sparse_indicator):
             assert_array_equal(auto_ind.toarray(), sparse_ind.toarray())
-    elif isinstance(EstimatorClass, GradientBoostingRegressor):
+    elif issubclass(EstimatorClass, GradientBoostingRegressor):
         assert_array_equal(auto_indicator.toarray(),
                            sparse_indicator.toarray())
     assert_array_almost_equal(sparse.predict(X), auto.predict(X))
@@ -1267,11 +1266,11 @@ def check_sparse_input(EstimatorClass, X, X_sparse, y):
     assert_array_almost_equal(dense.predict(X_sparse), sparse.predict(X))
     sparse_indicator, sparse_nodes_prt = dense.decision_path(X_sparse)
     assert_array_equal(dense_nodes_ptr, sparse_nodes_prt)
-    if isinstance(EstimatorClass, GradientBoostingClassifier):
+    if issubclass(EstimatorClass, GradientBoostingClassifier):
         assert len(dense_indicator) == len(sparse_indicator)
         for dense_ind, sparse_ind in zip(dense_indicator, sparse_indicator):
             assert_array_equal(dense_ind.toarray(), sparse_ind.toarray())
-    elif isinstance(EstimatorClass, GradientBoostingRegressor):
+    elif issubclass(EstimatorClass, GradientBoostingRegressor):
         assert_array_equal(dense_indicator.toarray(),
                            sparse_indicator.toarray())
     assert_array_almost_equal(sparse.predict(X), dense.predict(X))


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The `decision_path` method is currently available only for `RandomForest`/`ExtraTrees` Classifier/Regressor, but not for `IsolationForest` and `GradientBoosting` Classifier/Regressor. 
The `apply` method is currently available only for `RandomForest`/`ExtraTrees`/`Gradient Boosting` Classifier/Regressor but not for `IsolationForest` or the `Histogram`-variants of gradient boosting.

I have added a mixin, `ForestMixin`, in `sklearn.ensemble.base` to provide a common implementation of the methods `decision_path` and `apply` for `RandomForest`/`ExtraTrees` Classifier/Regressor and `IsolationForest`.
However, `Gradient Boosting` Classifier/Regressor require specific implementations of the methods `decision_path` and `apply`. The `apply` method is already available. Work in progress for `decision_path` ...