### PR TITLE
[MRG][DOC] Fix inconsistencies in clustering doc.

### DIFF
--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -402,7 +402,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         Returns
         -------
         labels : ndarray, shape (n_samples,)
-            Index of the cluster each sample belongs to.
+            Cluster labels.
         """
         check_is_fitted(self, "cluster_centers_indices_")
         if not hasattr(self, "cluster_centers_"):
@@ -434,7 +434,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
 
         Returns
         -------
-        y : ndarray, shape (n_samples,)
-            Index of the cluster each sample belongs to.
+        labels : ndarray, shape (n_samples,)
+            Cluster labels.
         """
         return super().fit_predict(X, y)

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -397,7 +397,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         ----------
         X : array-like or sparse matrix, shape (n_samples, n_features)
             New data to predict. If a sparse matrix is provided, it will be
-            converted into a sparse ``csr_matrix`̀ .
+            converted into a sparse ``csr_matrix``.
 
         Returns
         -------

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -364,6 +364,10 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         y : Ignored
             Not used, present here for API consistency by convention.
 
+        Returns
+        -------
+        self
+
         """
         if self.affinity == "precomputed":
             accept_sparse = False

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -359,7 +359,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
             array-like, shape (n_samples, n_samples)
             Training instances to cluster, or similarities / affinities between
             instances if ``affinity='precomputed'``. If a sparse feature matrix
-            is provided, it will be converted into a sparse ``csr_matrix`̀ .
+            is provided, it will be converted into a sparse ``csr_matrix``.
 
         y : Ignored
             Not used, present here for API consistency by convention.
@@ -427,7 +427,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
             array-like, shape (n_samples, n_samples)
             Training instances to cluster, or similarities / affinities between
             instances if ``affinity='precomputed'``. If a sparse feature matrix
-            is provided, it will be converted into a sparse ``csr_matrix`̀ .
+            is provided, it will be converted into a sparse ``csr_matrix``.
 
         y : Ignored
             Not used, present here for API consistency by convention.

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -357,7 +357,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         ----------
         X : array-like or sparse matrix, shape (n_samples, n_features), or \
             array-like, shape (n_samples, n_samples)
-            Training instances to cluster or similarities / affinities between
+            Training instances to cluster, or similarities / affinities between
             instances if ``affinity='precomputed'``. If a sparse feature matrix
             is provided, it will be converted into a sparse ``csr_matrix`̀ .
 
@@ -425,7 +425,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         ----------
         X : array-like or sparse matrix, shape (n_samples, n_features), or \
             array-like, shape (n_samples, n_samples)
-            Training instances to cluster or similarities / affinities between
+            Training instances to cluster, or similarities / affinities between
             instances if ``affinity='precomputed'``. If a sparse feature matrix
             is provided, it will be converted into a sparse ``csr_matrix`̀ .
 

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -351,7 +351,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         return self.affinity == "precomputed"
 
     def fit(self, X, y=None):
-        """Fit the clustering from features or affinity matrix.
+        """Fit the clustering from features, or affinity matrix.
 
         Parameters
         ----------

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -351,17 +351,18 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         return self.affinity == "precomputed"
 
     def fit(self, X, y=None):
-        """ Create affinity matrix from negative euclidean distances, then
-        apply affinity propagation clustering.
+        """Fit the clustering from features or affinity matrix.
 
         Parameters
         ----------
-
-        X : array-like, shape (n_samples, n_features) or (n_samples, n_samples)
-            Data matrix or, if affinity is ``precomputed``, matrix of
-            similarities / affinities.
+        X : array-like or sparse matrix, shape (n_samples, n_features), or \
+            array-like, shape (n_samples, n_samples)
+            Training instances to cluster or similarities / affinities between
+            instances if ``affinity='precomputed'``. If a sparse feature matrix
+            is provided, it will be converted into a sparse ``csr_matrix`̀ .
 
         y : Ignored
+            Not used, present here for API consistency by convention.
 
         """
         if self.affinity == "precomputed":
@@ -394,12 +395,13 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape (n_samples, n_features)
-            New data to predict.
+        X : array-like or sparse matrix, shape (n_samples, n_features)
+            New data to predict. If a sparse matrix is provided, it will be
+            converted into a sparse ``csr_matrix`̀ .
 
         Returns
         -------
-        labels : array, shape (n_samples,)
+        labels : ndarray, shape (n_samples,)
             Index of the cluster each sample belongs to.
         """
         check_is_fitted(self, "cluster_centers_indices_")
@@ -414,3 +416,25 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
                           "because affinity propagation did not converge. "
                           "Labeling every sample as '-1'.", ConvergenceWarning)
             return np.array([-1] * X.shape[0])
+
+    def fit_predict(self, X, y=None, sample_weight=None):
+        """Fit the clustering from features or affinity matrix, and return
+        cluster labels.
+
+        Parameters
+        ----------
+        X : array-like or sparse matrix, shape (n_samples, n_features), or \
+            array-like, shape (n_samples, n_samples)
+            Training instances to cluster or similarities / affinities between
+            instances if ``affinity='precomputed'``. If a sparse feature matrix
+            is provided, it will be converted into a sparse ``csr_matrix`̀ .
+
+        y : Ignored
+            Not used, present here for API consistency by convention.
+
+        Returns
+        -------
+        y : ndarray, shape (n_samples,)
+            Index of the cluster each sample belongs to.
+        """
+        return super().fit_predict(X, y)

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -417,7 +417,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
                           "Labeling every sample as '-1'.", ConvergenceWarning)
             return np.array([-1] * X.shape[0])
 
-    def fit_predict(self, X, y=None, sample_weight=None):
+    def fit_predict(self, X, y=None):
         """Fit the clustering from features or affinity matrix, and return
         cluster labels.
 

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -329,7 +329,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         self.n_jobs = n_jobs
 
     def fit(self, X, y=None, sample_weight=None):
-        """Perform DBSCAN clustering from features or distance matrix.
+        """Perform DBSCAN clustering from features, or distance matrix.
 
         Parameters
         ----------

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -333,17 +333,20 @@ class DBSCAN(BaseEstimator, ClusterMixin):
 
         Parameters
         ----------
-        X : array or sparse (CSR) matrix of shape (n_samples, n_features), or \
-                array of shape (n_samples, n_samples)
-            A feature array, or array of distances between samples if
-            ``metric='precomputed'``.
+        X : array-like or sparse matrix, shape (n_samples, n_features), or \
+            (n_samples, n_samples)
+            Training instances to cluster or distances between instances if
+            ``metric='precomputed'``. If a sparse matrix is provided, it will
+            be converted into a sparse ``csr_matrix`̀ .
+
         sample_weight : array, shape (n_samples,), optional
             Weight of each sample, such that a sample with a weight of at least
-            ``min_samples`` is by itself a core sample; a sample with negative
-            weight may inhibit its eps-neighbor from being core.
+            ``min_samples`` is by itself a core sample; a sample with a
+            negative weight may inhibit its eps-neighbor from being core.
             Note that weights are absolute, and default to 1.
 
         y : Ignored
+            Not used, present here for API consistency by convention.
 
         """
         X = check_array(X, accept_sparse='csr')
@@ -359,26 +362,30 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         return self
 
     def fit_predict(self, X, y=None, sample_weight=None):
-        """Performs clustering on X and returns cluster labels.
+        """Perform DBSCAN clustering from features or distance matrix,
+        and return cluster labels.
 
         Parameters
         ----------
-        X : array or sparse (CSR) matrix of shape (n_samples, n_features), or \
-                array of shape (n_samples, n_samples)
-            A feature array, or array of distances between samples if
-            ``metric='precomputed'``.
+        X : array-like or sparse matrix, shape (n_samples, n_features), or \
+            (n_samples, n_samples)
+            Training instances to cluster or distances between instances if
+            ``metric='precomputed'``. If a sparse matrix is provided, it will
+            be converted into a sparse ``csr_matrix`̀ .
+
         sample_weight : array, shape (n_samples,), optional
             Weight of each sample, such that a sample with a weight of at least
-            ``min_samples`` is by itself a core sample; a sample with negative
-            weight may inhibit its eps-neighbor from being core.
+            ``min_samples`` is by itself a core sample; a sample with a
+            negative weight may inhibit its eps-neighbor from being core.
             Note that weights are absolute, and default to 1.
 
         y : Ignored
+            Not used, present here for API consistency by convention.
 
         Returns
         -------
         y : ndarray, shape (n_samples,)
-            cluster labels
+            Cluster labels.
         """
         self.fit(X, sample_weight=sample_weight)
         return self.labels_

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -337,7 +337,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
             (n_samples, n_samples)
             Training instances to cluster, or distances between instances if
             ``metric='precomputed'``. If a sparse matrix is provided, it will
-            be converted into a sparse ``csr_matrix`̀ .
+            be converted into a sparse ``csr_matrix``.
 
         sample_weight : array, shape (n_samples,), optional
             Weight of each sample, such that a sample with a weight of at least
@@ -371,7 +371,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
             (n_samples, n_samples)
             Training instances to cluster, or distances between instances if
             ``metric='precomputed'``. If a sparse matrix is provided, it will
-            be converted into a sparse ``csr_matrix`̀ .
+            be converted into a sparse ``csr_matrix``.
 
         sample_weight : array, shape (n_samples,), optional
             Weight of each sample, such that a sample with a weight of at least

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -384,8 +384,8 @@ class DBSCAN(BaseEstimator, ClusterMixin):
 
         Returns
         -------
-        y : ndarray, shape (n_samples,)
-            Cluster labels.
+        labels : ndarray, shape (n_samples,)
+            Cluster labels. Noisy samples are given the label -1.
         """
         self.fit(X, sample_weight=sample_weight)
         return self.labels_

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -348,6 +348,10 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         y : Ignored
             Not used, present here for API consistency by convention.
 
+        Returns
+        -------
+        self
+
         """
         X = check_array(X, accept_sparse='csr')
         clust = dbscan(X, sample_weight=sample_weight,

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -335,7 +335,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         ----------
         X : array-like or sparse matrix, shape (n_samples, n_features), or \
             (n_samples, n_samples)
-            Training instances to cluster or distances between instances if
+            Training instances to cluster, or distances between instances if
             ``metric='precomputed'``. If a sparse matrix is provided, it will
             be converted into a sparse ``csr_matrix`̀ .
 
@@ -369,7 +369,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         ----------
         X : array-like or sparse matrix, shape (n_samples, n_features), or \
             (n_samples, n_samples)
-            Training instances to cluster or distances between instances if
+            Training instances to cluster, or distances between instances if
             ``metric='precomputed'``. If a sparse matrix is provided, it will
             be converted into a sparse ``csr_matrix`̀ .
 

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -891,7 +891,7 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
 
         Returns
         -------
-        y : ndarray, shape (n_samples,)
+        labels : ndarray, shape (n_samples,)
             Cluster labels.
         """
         return super().fit_predict(X, y)

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -667,7 +667,7 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
         Metric used to compute the linkage. Can be "euclidean", "l1", "l2",
         "manhattan", "cosine", or "precomputed".
         If linkage is "ward", only "euclidean" is accepted.
-        If "precomputed", a distance matrix (instead of a similarity matrix)
+        If "precomputed", a distance matrix (instead of a feature matrix)
         is needed as input for the fit method.
 
     memory : None, str or object with the joblib.Memory interface, optional

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -773,15 +773,16 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
         return self.n_connected_components_
 
     def fit(self, X, y=None):
-        """Fit the hierarchical clustering on the data
+        """Fit the hierarchical clustering from features or distance matrix.
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
-            Training data. Shape [n_samples, n_features], or [n_samples,
-            n_samples] if affinity=='precomputed'.
+        X : array-like, shape (n_samples, n_features) or (n_samples, n_samples)
+            Training instances to cluster or distances between instances if
+            ``affinity='precomputed'``.
 
         y : Ignored
+            Not used, present here for API consistency by convention.
 
         Returns
         -------
@@ -874,6 +875,26 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
             # Reassign cluster numbers
             self.labels_ = np.searchsorted(np.unique(labels), labels)
         return self
+
+    def fit_predict(self, X, y=None, sample_weight=None):
+        """Fit the hierarchical clustering from features or distance matrix,
+        and return cluster labels.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features) or (n_samples, n_samples)
+            Training instances to cluster or distances between instances if
+            ``affinity='precomputed'``.
+
+        y : Ignored
+            Not used, present here for API consistency by convention.
+
+        Returns
+        -------
+        y : ndarray, shape (n_samples,)
+            Cluster labels.
+        """
+        return super().fit_predict(X, y)
 
 
 class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -667,7 +667,7 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
         Metric used to compute the linkage. Can be "euclidean", "l1", "l2",
         "manhattan", "cosine", or "precomputed".
         If linkage is "ward", only "euclidean" is accepted.
-        If "precomputed", a distance matrix (instead of a feature matrix)
+        If "precomputed", a distance matrix (instead of a similarity matrix)
         is needed as input for the fit method.
 
     memory : None, str or object with the joblib.Memory interface, optional

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -773,7 +773,7 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
         return self.n_connected_components_
 
     def fit(self, X, y=None):
-        """Fit the hierarchical clustering from features or distance matrix.
+        """Fit the hierarchical clustering from features, or distance matrix.
 
         Parameters
         ----------

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -876,7 +876,7 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
             self.labels_ = np.searchsorted(np.unique(labels), labels)
         return self
 
-    def fit_predict(self, X, y=None, sample_weight=None):
+    def fit_predict(self, X, y=None):
         """Fit the hierarchical clustering from features or distance matrix,
         and return cluster labels.
 

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -778,7 +778,7 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
         Parameters
         ----------
         X : array-like, shape (n_samples, n_features) or (n_samples, n_samples)
-            Training instances to cluster or distances between instances if
+            Training instances to cluster, or distances between instances if
             ``affinity='precomputed'``.
 
         y : Ignored

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -883,7 +883,7 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
         Parameters
         ----------
         X : array-like, shape (n_samples, n_features) or (n_samples, n_samples)
-            Training instances to cluster or distances between instances if
+            Training instances to cluster, or distances between instances if
             ``affinity='precomputed'``.
 
         y : Ignored

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -448,16 +448,24 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
         self.n_jobs = n_jobs
 
     def fit(self, X, y=None):
-        """Creates an affinity matrix for X using the selected affinity,
-        then applies spectral clustering to this affinity matrix.
+        """Perform spectral clustering from features, or affinity matrix.
 
         Parameters
         ----------
-        X : array-like or sparse matrix, shape (n_samples, n_features)
-            OR, if affinity==`precomputed`, a precomputed affinity
-            matrix of shape (n_samples, n_samples)
+        X : array-like or sparse matrix, shape (n_samples, n_features), or \
+            array-like, shape (n_samples, n_samples)
+            Training instances to cluster, or similarities / affinities between
+            instances if ``affinity='precomputed'``. If a sparse matrix is
+            provided in a format other than ``csr_matrix``, ``csc_matrix``,
+            or ``coo_matrix``, it will be converted into a sparse
+            ``csr_matrix``.
 
         y : Ignored
+            Not used, present here for API consistency by convention.
+
+        Returns
+        -------
+        self
 
         """
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'],
@@ -497,6 +505,30 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
                                            eigen_tol=self.eigen_tol,
                                            assign_labels=self.assign_labels)
         return self
+
+    def fit_predict(self, X, y=None):
+        """Perform spectral clustering from features, or affinity matrix,
+        and return cluster labels.
+
+        Parameters
+        ----------
+        X : array-like or sparse matrix, shape (n_samples, n_features), or \
+            array-like, shape (n_samples, n_samples)
+            Training instances to cluster, or similarities / affinities between
+            instances if ``affinity='precomputed'``. If a sparse matrix is
+            provided in a format other than ``csr_matrix``, ``csc_matrix``,
+            or ``coo_matrix``, it will be converted into a sparse
+            ``csr_matrix``.
+
+        y : Ignored
+            Not used, present here for API consistency by convention.
+
+        Returns
+        -------
+        labels : ndarray, shape (n_samples,)
+            Cluster labels.
+        """
+        return super().fit_predict(X, y)
 
     @property
     def _pairwise(self):


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This pull request concerns only the clustering algorithms that can take as input
affinity or distance matrices. It could be extended to the other clustering algorithms.

* fit and fit_predict have now the same descriptions for their input
arguments X and y.
* The commit follows the documentation conventions detailed in issue #3791.
* The documentation now indicates the preferred sparse matrix format if relevant.
* `AgglomerativeClustering`.  The parameter affinity is misleading (see issue #13945).
The documentation of the fit method now clarifies that a distance matrix is expected (not an affinity / similarity matrix).

#### A few questions about documentation conventions
* Does the documentation of the `fit` methods should indicate that `self` is returned ? In this case, what is the returned type ? `object` ?
* How should be called the object returned by `predict` of clustering algorithms ? `y` or `labels` ? What bout the description ? "Cluster labels" or "Index of the cluster each sample belongs to." ?