### PR TITLE
[MRG] Relaxed criterion specification so tree plot does not force calculate entropy for any DecisionTreeClassifier

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -885,6 +885,10 @@ Support for Python 3.4 and below has been officially dropped.
   ``max_depth`` were both specified by the user. Please note that this also
   affects all ensemble methods using decision trees.
   :pr:`12344` by :user:`Adrin Jalali <adrinjalali>`.
+  
+- |Fix| Fixed an issue with :class:`MLPTreeExporter` where it display
+  entropy calculations even for `gini` criterion in DecisionTreeClassifiers.
+  :pr:`13947` by :user:`Frank Hoang <fhoang7>`.
 
 :mod:`sklearn.utils`
 ....................
@@ -965,8 +969,8 @@ Baibak, daten-kieker, Denis Kataev, Didi Bar-Zev, Dillon Gardner, Dmitry Mottl,
 Dmitry Vukolov, Dougal J. Sutherland, Dowon, drewmjohnston, Dror Atariah,
 Edward J Brown, Ekaterina Krivich, Elizabeth Sander, Emmanuel Arias, Eric
 Chang, Eric Larson, Erich Schubert, esvhd, Falak, Feda Curic, Federico Caselli,
-Fibinse Xavier`, Finn O'Shea, Gabriel Marzinotto, Gabriel Vacaliuc, Gabriele
-Calvo, Gael Varoquaux, GauravAhlawat, Giuseppe Vettigli, Greg Gandenberger,
+Frank Hoang, Fibinse Xavier`, Finn O'Shea, Gabriel Marzinotto, Gabriel Vacaliuc, 
+Gabriele Calvo, Gael Varoquaux, GauravAhlawat, Giuseppe Vettigli, Greg Gandenberger,
 Guillaume Fournier, Guillaume Lemaitre, Gustavo De Mari Pereira, Hanmin Qin,
 haroldfox, hhu-luqi, Hunter McGushion, Ian Sanders, JackLangerman, Jacopo
 Notarstefano, jakirkham, James Bourbeau, Jan Koch, Jan S, janvanrijn, Jarrod

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -44,6 +44,13 @@ Changelog
   `drop` parameter was not reflected in `get_feature_names`. :pr:`13894`
   by :user:`James Myatt <jamesmyatt>`.
 
+:mod:`sklearn.tree`
+................................
+
+- |Fix| Fixed an issue with :func:`plot_tree` where it display
+  entropy calculations even for `gini` criterion in DecisionTreeClassifiers.
+  :pr:`13947` by :user:`Frank Hoang <fhoang7>`.
+
 :mod:`sklearn.utils.sparsefuncs`
 ................................
 
@@ -885,10 +892,6 @@ Support for Python 3.4 and below has been officially dropped.
   ``max_depth`` were both specified by the user. Please note that this also
   affects all ensemble methods using decision trees.
   :pr:`12344` by :user:`Adrin Jalali <adrinjalali>`.
-  
-- |Fix| Fixed an issue with :class:`MLPTreeExporter` where it display
-  entropy calculations even for `gini` criterion in DecisionTreeClassifiers.
-  :pr:`13947` by :user:`Frank Hoang <fhoang7>`.
 
 :mod:`sklearn.utils`
 ....................

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -435,7 +435,7 @@ cdef class Splitter:
         best_split.gain = -1.
         sum_gradient_left, sum_hessian_left = 0., 0.
         n_samples_left = 0
-        gain = -negative_loss(sum_gradients, sum_hessians, self.l2_regularization)
+        gain = -negative_loss(sum_gradients, sum_hessians, l2_regularization)
 
         for bin_idx in range(self.actual_n_bins[feature_idx]):
             n_samples_left += histograms[feature_idx, bin_idx].count

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -435,7 +435,7 @@ cdef class Splitter:
         best_split.gain = -1.
         sum_gradient_left, sum_hessian_left = 0., 0.
         n_samples_left = 0
-        gain = -negative_loss(sum_gradients, sum_hessians, l2_regularization)
+        gain = -negative_loss(sum_gradients, sum_hessians, self.l2_regularization)
 
         for bin_idx in range(self.actual_n_bins[feature_idx]):
             n_samples_left += histograms[feature_idx, bin_idx].count

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -435,6 +435,7 @@ cdef class Splitter:
         best_split.gain = -1.
         sum_gradient_left, sum_hessian_left = 0., 0.
         n_samples_left = 0
+        gain = -negative_loss(sum_gradients, sum_hessians, l2_regularization)
 
         for bin_idx in range(self.actual_n_bins[feature_idx]):
             n_samples_left += histograms[feature_idx, bin_idx].count
@@ -462,7 +463,7 @@ cdef class Splitter:
                 # won't get any better (hessians are > 0 since loss is convex)
                 break
 
-            gain = _split_gain(sum_gradient_left, sum_hessian_left,
+            gain += _split_gain(sum_gradient_left, sum_hessian_left,
                                sum_gradient_right, sum_hessian_right,
                                sum_gradients, sum_hessians,
                                self.l2_regularization)
@@ -500,11 +501,10 @@ cdef inline Y_DTYPE_C _split_gain(
     """
     cdef:
         Y_DTYPE_C gain
-    gain = negative_loss(sum_gradient_left, sum_hessian_left,
+    gain += negative_loss(sum_gradient_left, sum_hessian_left,
                          l2_regularization)
     gain += negative_loss(sum_gradient_right, sum_hessian_right,
                           l2_regularization)
-    gain -= negative_loss(sum_gradients, sum_hessians, l2_regularization)
     return gain
 
 cdef inline Y_DTYPE_C negative_loss(

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -435,7 +435,6 @@ cdef class Splitter:
         best_split.gain = -1.
         sum_gradient_left, sum_hessian_left = 0., 0.
         n_samples_left = 0
-        gain = -negative_loss(sum_gradients, sum_hessians, l2_regularization)
 
         for bin_idx in range(self.actual_n_bins[feature_idx]):
             n_samples_left += histograms[feature_idx, bin_idx].count
@@ -463,7 +462,7 @@ cdef class Splitter:
                 # won't get any better (hessians are > 0 since loss is convex)
                 break
 
-            gain += _split_gain(sum_gradient_left, sum_hessian_left,
+            gain = _split_gain(sum_gradient_left, sum_hessian_left,
                                sum_gradient_right, sum_hessian_right,
                                sum_gradients, sum_hessians,
                                self.l2_regularization)
@@ -501,10 +500,11 @@ cdef inline Y_DTYPE_C _split_gain(
     """
     cdef:
         Y_DTYPE_C gain
-    gain += negative_loss(sum_gradient_left, sum_hessian_left,
+    gain = negative_loss(sum_gradient_left, sum_hessian_left,
                          l2_regularization)
     gain += negative_loss(sum_gradient_right, sum_hessian_right,
                           l2_regularization)
+    gain -= negative_loss(sum_gradients, sum_hessians, l2_regularization)
     return gain
 
 cdef inline Y_DTYPE_C negative_loss(

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -553,10 +553,10 @@ class _MPLTreeExporter(_BaseTreeExporter):
         name = self.node_to_str(et, node_id, criterion=criterion)
         if (et.children_left[node_id] != _tree.TREE_LEAF
                 and (self.max_depth is None or depth <= self.max_depth)):
-            children = [self._make_tree(et.children_left[node_id], et, criterion,
-                                        depth=depth + 1),
-                        self._make_tree(et.children_right[node_id], et, criterion,
-                                        depth=depth + 1)]
+            children = [self._make_tree(et.children_left[node_id], et,
+                                        criterion, depth=depth + 1),
+                        self._make_tree(et.children_right[node_id], et,
+                                        criterion, depth=depth + 1)]
         else:
             return Tree(name, node_id)
         return Tree(name, node_id, *children)

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -568,7 +568,8 @@ class _MPLTreeExporter(_BaseTreeExporter):
             ax = plt.gca()
         ax.clear()
         ax.set_axis_off()
-        my_tree = self._make_tree(0, decision_tree.tree_, decision_tree.criterion)
+        my_tree = self._make_tree(0, decision_tree.tree_,
+                                  decision_tree.criterion)
         draw_tree = buchheim(my_tree)
 
         # important to make sure we're still

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -553,10 +553,10 @@ class _MPLTreeExporter(_BaseTreeExporter):
         name = self.node_to_str(et, node_id, criterion=criterion)
         if (et.children_left[node_id] != _tree.TREE_LEAF
                 and (self.max_depth is None or depth <= self.max_depth)):
-            children = [self._make_tree(et.children_left[node_id], et,
-                                        criterion, depth=depth + 1),
-                        self._make_tree(et.children_right[node_id], et,
-                                        criterion, depth=depth + 1)]
+            children = [self._make_tree(et.children_left[node_id], et, criterion,
+                                        depth=depth + 1),
+                        self._make_tree(et.children_right[node_id], et, criterion,
+                                        depth=depth + 1)]
         else:
             return Tree(name, node_id)
         return Tree(name, node_id, *children)

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -547,15 +547,15 @@ class _MPLTreeExporter(_BaseTreeExporter):
 
         self.arrow_args = dict(arrowstyle="<-")
 
-    def _make_tree(self, node_id, et, depth=0):
+    def _make_tree(self, node_id, et, criterion, depth=0):
         # traverses _tree.Tree recursively, builds intermediate
         # "_reingold_tilford.Tree" object
-        name = self.node_to_str(et, node_id, criterion='entropy')
+        name = self.node_to_str(et, node_id, criterion=criterion)
         if (et.children_left[node_id] != _tree.TREE_LEAF
                 and (self.max_depth is None or depth <= self.max_depth)):
-            children = [self._make_tree(et.children_left[node_id], et,
+            children = [self._make_tree(et.children_left[node_id], et, criterion,
                                         depth=depth + 1),
-                        self._make_tree(et.children_right[node_id], et,
+                        self._make_tree(et.children_right[node_id], et, criterion,
                                         depth=depth + 1)]
         else:
             return Tree(name, node_id)
@@ -568,7 +568,7 @@ class _MPLTreeExporter(_BaseTreeExporter):
             ax = plt.gca()
         ax.clear()
         ax.set_axis_off()
-        my_tree = self._make_tree(0, decision_tree.tree_)
+        my_tree = self._make_tree(0, decision_tree.tree_, decision_tree.criterion)
         draw_tree = buchheim(my_tree)
 
         # important to make sure we're still

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -399,9 +399,28 @@ def test_export_text():
     assert export_text(reg, decimals=1, show_weights=True) == expected_report
 
 
-def test_plot_tree(pyplot):
+def test_plot_tree_entropy(pyplot):
     # mostly smoke tests
-    # Check correctness of export_graphviz
+    # Check correctness of export_graphviz for criterion = entropy
+    clf = DecisionTreeClassifier(max_depth=3,
+                                 min_samples_split=2,
+                                 criterion="entropy",
+                                 random_state=2)
+    clf.fit(X, y)
+
+    # Test export code
+    feature_names = ['first feat', 'sepal_width']
+    nodes = plot_tree(clf, feature_names=feature_names)
+    assert len(nodes) == 3
+    assert nodes[0].get_text() == ("first feat <= 0.0\nentropy = 1.0\n"
+                                   "samples = 6\nvalue = [3, 3]")
+    assert nodes[1].get_text() == "entropy = 0.0\nsamples = 3\nvalue = [3, 0]"
+    assert nodes[2].get_text() == "entropy = 0.0\nsamples = 3\nvalue = [0, 3]"
+
+
+def test_plot_tree_gini(pyplot):
+    # mostly smoke tests
+    # Check correctness of export_graphviz for criterion = gini
     clf = DecisionTreeClassifier(max_depth=3,
                                  min_samples_split=2,
                                  criterion="gini",

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -412,7 +412,7 @@ def test_plot_tree(pyplot):
     feature_names = ['first feat', 'sepal_width']
     nodes = plot_tree(clf, feature_names=feature_names)
     assert len(nodes) == 3
-    assert nodes[0].get_text() == ("first feat <= 0.0\nentropy = 0.5\n"
+    assert nodes[0].get_text() == ("first feat <= 0.0\ngini = 0.5\n"
                                    "samples = 6\nvalue = [3, 3]")
-    assert nodes[1].get_text() == "entropy = 0.0\nsamples = 3\nvalue = [3, 0]"
-    assert nodes[2].get_text() == "entropy = 0.0\nsamples = 3\nvalue = [0, 3]"
+    assert nodes[1].get_text() == "gini = 0.0\nsamples = 3\nvalue = [3, 0]"
+    assert nodes[2].get_text() == "gini = 0.0\nsamples = 3\nvalue = [0, 3]"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #13944 


#### What does this implement/fix? Explain your changes.
Removed hard coding of criterion in tree making function. Instead, passed in criterion as an additional input into the function and modified subsequent function calls accordingly. export.py test file was modified to ensure that all tests passed as a result of this change. 

#### Any other comments?
Need feedback on my approach and potential next steps. I would assume that the next thing to do would be to write a separate test to ensure that the proper decision tree criteria will be printed when entropy is the desired metric. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
