### PR TITLE
TST avoid nose collecting train_test_split as a test

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2124,6 +2124,11 @@ def train_test_split(*arrays, **options):
                                      safe_indexing(a, test)) for a in arrays))
 
 
+# Tell nose that train_test_split is not a test.
+# (Needed for external libraries that may use nose.)
+train_test_split.__test__ = False
+
+
 def _build_repr(self):
     # XXX This is copied from BaseEstimator's get_params
     cls = self.__class__


### PR DESCRIPTION
Reinstates #10223 and fixes #13943. Thanks @trevorstephens 