### PR TITLE
DOC adds instructions for building on FreeBSD

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -148,6 +148,24 @@ Then you need to set the following environment variables::
 
 Finally you can build the package using the standard command.
 
+FreeBSD
+-------
+
+You first need to have OpenMP library installed::
+
+    sudo pkg install openmp
+    
+This will install headers files in ``/usr/local/include`` and libs in ``/usr/local/lib``.
+Then set the environment variables to this locations::
+
+    export CFLAGS="$CFLAGS -I/usr/local/include"
+    export CXXFLAGS="$CXXFLAGS -I/usr/local/include"
+    export LDFLAGS="$LDFLAGS -L/usr/local/lib -lomp"
+    export DYLD_LIBRARY_PATH=/usr/local/lib
+
+Finally you can build the package using the standard command.
+
+
 Installing build dependencies
 =============================
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -156,7 +156,7 @@ You first need to have OpenMP library installed::
     sudo pkg install openmp
     
 This will install headers files in ``/usr/local/include`` and libs in ``/usr/local/lib``.
-Then set the environment variables to this locations::
+Then set the environment variables to these locations::
 
     export CFLAGS="$CFLAGS -I/usr/local/include"
     export CXXFLAGS="$CXXFLAGS -I/usr/local/include"

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -151,12 +151,13 @@ Finally you can build the package using the standard command.
 FreeBSD
 -------
 
-You first need to have OpenMP library installed::
+The clang compiler included in FreeBSD 12.0 and 11.2 base systems does not include OpenMP support.
+You need to install the `openmp` library from packages (or ports)::
 
     sudo pkg install openmp
     
-This will install headers files in ``/usr/local/include`` and libs in ``/usr/local/lib``.
-Then set the environment variables to these locations::
+This will install header files in ``/usr/local/include`` and libs in ``/usr/local/lib``.
+Since these directories are not searched by default, you can set the environment variables to these locations::
 
     export CFLAGS="$CFLAGS -I/usr/local/include"
     export CXXFLAGS="$CXXFLAGS -I/usr/local/include"
@@ -164,6 +165,8 @@ Then set the environment variables to these locations::
     export DYLD_LIBRARY_PATH=/usr/local/lib
 
 Finally you can build the package using the standard command.
+
+For the upcomming FreeBSD 12.1 and 11.3 versions, OpenMP will be included in the base system and these steps will not be necessary.
 
 
 Installing build dependencies

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -151,13 +151,15 @@ Finally you can build the package using the standard command.
 FreeBSD
 -------
 
-The clang compiler included in FreeBSD 12.0 and 11.2 base systems does not include OpenMP support.
-You need to install the `openmp` library from packages (or ports)::
+The clang compiler included in FreeBSD 12.0 and 11.2 base systems does not 
+include OpenMP support. You need to install the `openmp` library from packages 
+(or ports)::
 
     sudo pkg install openmp
     
-This will install header files in ``/usr/local/include`` and libs in ``/usr/local/lib``.
-Since these directories are not searched by default, you can set the environment variables to these locations::
+This will install header files in ``/usr/local/include`` and libs in 
+``/usr/local/lib``. Since these directories are not searched by default, you 
+can set the environment variables to these locations::
 
     export CFLAGS="$CFLAGS -I/usr/local/include"
     export CXXFLAGS="$CXXFLAGS -I/usr/local/include"
@@ -166,7 +168,8 @@ Since these directories are not searched by default, you can set the environment
 
 Finally you can build the package using the standard command.
 
-For the upcomming FreeBSD 12.1 and 11.3 versions, OpenMP will be included in the base system and these steps will not be necessary.
+For the upcomming FreeBSD 12.1 and 11.3 versions, OpenMP will be included in 
+the base system and these steps will not be necessary.
 
 
 Installing build dependencies


### PR DESCRIPTION
Closes https://github.com/scikit-learn/scikit-learn/issues/13950

#### What does this implement/fix? Explain your changes.

Installing using pip on FreeBSD fails because OpenMP headers and libs can not be located.
This PR adds instructions for building on FreeBSD.
