### PR TITLE
[MRG]Allow Gaussian process kernels on structured data #13936

### DIFF
--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -76,7 +76,7 @@ class SequenceKernel(StructureOrGenericKernelMixin, Kernel):
 
 kernel = SequenceKernel()
 
-seqs = np.array(['AGCT', 'AGC', 'AACT', 'TAA', 'AAA', 'GAACA'])
+X = ['AGCT', 'AGC', 'AACT', 'TAA', 'AAA', 'GAACA']
 vals = np.array([1.0, 1.0, 2.0, 2.0, 3.0, 3.0])
 
 '''

--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -1,6 +1,6 @@
 """
 ==========================================================================
-Gaussian process regression and classification on discrete data structures
+Gaussian processes on discrete data structures
 ==========================================================================
 
 This example illustrates the use of Gaussian processes to carry out

--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -1,0 +1,145 @@
+"""
+==========================================================================
+Gaussian process regression and classification on discrete data structures
+==========================================================================
+
+This example illustrates the use of Gaussian processes to carry out
+regression and classification tasks on data that are not in fixed-length
+feature vector form. This is enabled through the use of kernel functions
+that can directly operate on discrete structures such as variable-length
+sequences, trees, and graphs.
+"""
+print(__doc__)
+
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.gaussian_process.kernels import Kernel, Hyperparameter
+from sklearn.gaussian_process.kernels import StructureOrGenericKernelMixin
+from sklearn.gaussian_process import GaussianProcessRegressor
+from sklearn.gaussian_process import GaussianProcessClassifier
+from sklearn.base import clone
+
+
+class SequenceKernel(StructureOrGenericKernelMixin, Kernel):
+    '''
+    a mimimal (but valid) convolutional kernel for sequences of variable length
+    '''
+    def __init__(self,
+                 baseline_similarity=0.5,
+                 baseline_similarity_bounds=(1e-5, 1)):
+        self.baseline_similarity = baseline_similarity
+        self.baseline_similarity_bounds = baseline_similarity_bounds
+
+    @property
+    def hyperparameter_baseline_similarity(self):
+        return Hyperparameter("baseline_similarity",
+                              "numeric",
+                              self.baseline_similarity_bounds)
+
+    def _f(self, s1, s2):
+        '''
+        kernel value between a pair of sequences
+        '''
+        return sum([1.0 if c1 == c2 else self.baseline_similarity
+                   for c1 in s1
+                   for c2 in s2])
+
+    def _g(self, s1, s2):
+        '''
+        kernel derivative between a pair of sequences
+        '''
+        return sum([0.0 if c1 == c2 else 1.0
+                    for c1 in s1
+                    for c2 in s2])
+
+    def __call__(self, X, Y=None, eval_gradient=False):
+        if Y is None:
+            Y = X
+
+        if eval_gradient:
+            return (np.array([[self._f(x, y) for y in Y] for x in X]),
+                    np.array([[[self._g(x, y)] for y in Y] for x in X]))
+        else:
+            return np.array([[self._f(x, y) for y in Y] for x in X])
+
+    def diag(self, X):
+        return np.array([self._f(x, x) for x in X])
+
+    def is_stationary(self):
+        return False
+
+    def clone_with_theta(self, theta):
+        cloned = clone(self)
+        cloned.theta = theta
+        return cloned
+
+
+kernel = SequenceKernel()
+
+seqs = np.array(['AGCT', 'AGC', 'AACT', 'TAA', 'AAA', 'GAACA'])
+vals = np.array([1.0, 1.0, 2.0, 2.0, 3.0, 3.0])
+
+'''
+Visualize sequence similarity matrix under the kernel
+'''
+
+K = kernel(seqs)
+D = kernel.diag(seqs)
+
+plt.figure(figsize=(8, 5))
+plt.imshow(np.diag(D**-0.5).dot(K).dot(np.diag(D**-0.5)))
+plt.gca().set_xticks(np.arange(len(seqs)))
+plt.gca().set_xticklabels(seqs)
+plt.gca().set_yticks(np.arange(len(seqs)))
+plt.gca().set_yticklabels(seqs)
+plt.title('Sequence similarity under the kernel')
+
+'''
+Regression
+'''
+
+training_idx = [0, 1, 3, 4]
+gp = GaussianProcessRegressor(kernel)
+gp.fit(seqs[training_idx], vals[training_idx])
+
+plt.figure(figsize=(8, 5))
+plt.bar(np.arange(len(seqs)), gp.predict(seqs), color='b', label='prediction')
+plt.bar(training_idx, vals[training_idx], width=0.2, color='r',
+        alpha=0.5, label='training')
+plt.gca().set_xticklabels(seqs)
+plt.title('Regression on sequences')
+plt.legend()
+
+'''
+Classification
+'''
+
+seqs = np.array(['AGCT', 'CGA', 'TAAC', 'TCG', 'CTTT', 'TGCT'])
+# whether there are 'A's in the sequence
+clss = np.array([True, True, True, False, False, False])
+
+gp = GaussianProcessClassifier(kernel)
+gp.fit(seqs, clss)
+
+seqs_test = ['AAA', 'ATAG', 'CTC', 'CT', 'C']
+clss_test = [True, True, False, False, False]
+
+plt.figure(figsize=(8, 5))
+plt.scatter(np.arange(len(seqs)), [1.0 if c else -1.0 for c in clss],
+            s=100, marker='o', edgecolor='none', facecolor=(1, 0.75, 0),
+            label='training')
+plt.scatter(len(seqs) + np.arange(len(seqs_test)),
+            [1.0 if c else -1.0 for c in clss_test],
+            s=100, marker='o', edgecolor='none', facecolor='r', label='truth')
+plt.scatter(len(seqs) + np.arange(len(seqs_test)),
+            [1.0 if c else -1.0 for c in gp.predict(seqs_test)],
+            s=100, marker='x', edgecolor=(0, 1.0, 0.3), linewidth=2,
+            label='prediction')
+plt.gca().set_xticks(np.arange(len(seqs) + len(seqs_test)))
+plt.gca().set_xticklabels(np.concatenate((seqs, seqs_test)))
+plt.gca().set_yticks([-1, 1])
+plt.gca().set_yticklabels([False, True])
+plt.title('Classification on sequences')
+plt.legend()
+
+plt.show()

--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -77,7 +77,7 @@ class SequenceKernel(StructureOrGenericKernelMixin, Kernel):
 kernel = SequenceKernel()
 
 X = ['AGCT', 'AGC', 'AACT', 'TAA', 'AAA', 'GAACA']
-vals = np.array([1.0, 1.0, 2.0, 2.0, 3.0, 3.0])
+y = [1.0, 1.0, 2.0, 2.0, 3.0, 3.0]
 
 '''
 Visualize sequence similarity matrix under the kernel

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -115,8 +115,10 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
     Attributes
     ----------
-    X_train_ : array-like of shape (n_samples, n_features)
-        Feature values in training data (also required for prediction)
+    X_train_ : sequence of length n_samples
+        Feature vectors or other representations of training data (also
+        required for prediction). Could either be array-like with shape =
+        (n_samples, n_features) or a list of objects
 
     y_train_ : array-like of shape (n_samples,)
         Target values in training data (also required for prediction)
@@ -160,8 +162,10 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-            Training data
+        X : sequence of length n_samples
+            Feature vectors or other representations of training data.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         y : array-like of shape (n_samples,)
             Target values, must be binary
@@ -248,7 +252,10 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : sequence of length n_samples
+            Query points where the GP is evaluated for classification.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         Returns
         -------
@@ -270,7 +277,10 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : sequence of length n_samples
+            Query points where the GP is evaluated for classification.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         Returns
         -------
@@ -602,8 +612,10 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-            Training data
+        X : sequence of length n_samples
+            Feature vectors or other representations of training data.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         y : array-like of shape (n_samples,)
             Target values, must be binary
@@ -612,7 +624,11 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         -------
         self : returns an instance of self.
         """
-        X, y = check_X_y(X, y, multi_output=False)
+        if self.kernel is None or self.kernel.vector_X_only():
+            X, y = check_X_y(X, y, multi_output=False)
+        else:
+            X, y = check_X_y(X, y, multi_output=False,
+                             ensure_2d=False, dtype=None)
 
         self.base_estimator_ = _BinaryGaussianProcessClassifierLaplace(
             self.kernel, self.optimizer, self.n_restarts_optimizer,
@@ -656,15 +672,23 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : sequence of length n_samples
+            Query points where the GP is evaluated for classification.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         Returns
         -------
         C : ndarray of shape (n_samples,)
             Predicted target values for X, values are from ``classes_``
         """
-        check_is_fitted(self)
-        X = check_array(X)
+        check_is_fitted(self, ["classes_", "n_classes_"])
+
+        if self.kernel is None or self.kernel.vector_X_only():
+            X = check_array(X)
+        else:
+            X = check_array(X, ensure_2d=False, dtype=None)
+
         return self.base_estimator_.predict(X)
 
     def predict_proba(self, X):
@@ -672,7 +696,10 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : sequence of length n_samples
+            Query points where the GP is evaluated for classification.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         Returns
         -------
@@ -686,7 +713,12 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
             raise ValueError("one_vs_one multi-class mode does not support "
                              "predicting probability estimates. Use "
                              "one_vs_rest mode instead.")
-        X = check_array(X)
+
+        if self.kernel is None or self.kernel.vector_X_only():
+            X = check_array(X)
+        else:
+            X = check_array(X, ensure_2d=False, dtype=None)
+
         return self.base_estimator_.predict_proba(X)
 
     @property

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -624,8 +624,9 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         -------
         self : returns an instance of self.
         """
-        if self.kernel is None or self.kernel.vector_X_only():
-            X, y = check_X_y(X, y, multi_output=False)
+        if self.kernel is None or self.kernel.requires_vector_input():
+            X, y = check_X_y(X, y, multi_output=False,
+                             ensure_2d=True, dtype="numeric")
         else:
             X, y = check_X_y(X, y, multi_output=False,
                              ensure_2d=False, dtype=None)
@@ -684,8 +685,8 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         """
         check_is_fitted(self, ["classes_", "n_classes_"])
 
-        if self.kernel is None or self.kernel.vector_X_only():
-            X = check_array(X)
+        if self.kernel is None or self.kernel.requires_vector_input():
+            X = check_array(X, ensure_2d=True, dtype="numeric")
         else:
             X = check_array(X, ensure_2d=False, dtype=None)
 
@@ -714,8 +715,8 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
                              "predicting probability estimates. Use "
                              "one_vs_rest mode instead.")
 
-        if self.kernel is None or self.kernel.vector_X_only():
-            X = check_array(X)
+        if self.kernel is None or self.kernel.requires_vector_input():
+            X = check_array(X, ensure_2d=True, dtype="numeric")
         else:
             X = check_array(X, ensure_2d=False, dtype=None)
 

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -114,8 +114,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
     Attributes
     ----------
-    X_train_ : array-like of shape (n_samples, n_features)
-        Feature values in training data (also required for prediction)
+    X_train_ : sequence of length n_samples
+        Feature vectors or other representations of training data (also
+        required for prediction). Could either be array-like with shape =
+        (n_samples, n_features) or a list of objects
 
     y_train_ : array-like of shape (n_samples,) or (n_samples, n_targets)
         Target values in training data (also required for prediction)
@@ -164,8 +166,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-            Training data
+        X : sequence of length n_samples
+            Feature vectors or other representations of training data.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         y : array-like of shape (n_samples,) or (n_samples, n_targets)
             Target values
@@ -182,7 +186,11 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         self._rng = check_random_state(self.random_state)
 
-        X, y = check_X_y(X, y, multi_output=True, y_numeric=True)
+        if self.kernel_.vector_X_only():
+            X, y = check_X_y(X, y, multi_output=True, y_numeric=True)
+        else:
+            X, y = check_X_y(X, y, multi_output=True, y_numeric=True,
+                             ensure_2d=False, dtype=None)
 
         # Normalize target value
         if self.normalize_y:
@@ -273,8 +281,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-            Query points where the GP is evaluated
+        X : sequence of length n_samples
+            Query points where the GP is evaluated.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         return_std : bool, default: False
             If True, the standard-deviation of the predictive distribution at
@@ -302,7 +312,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
                 "Not returning standard deviation of predictions when "
                 "returning full covariance.")
 
-        X = check_array(X)
+        if self.kernel is None or self.kernel.vector_X_only():
+            X = check_array(X)
+        else:
+            X = check_array(X, ensure_2d=False, dtype=None)
 
         if not hasattr(self, "X_train_"):  # Unfitted;predict based on GP prior
             if self.kernel is None:
@@ -357,8 +370,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Parameters
         ----------
-        X : array-like of shape (n_samples_X, n_features)
-            Query points where the GP samples are evaluated
+        X : sequence of length n_samples
+            Query points where the GP is evaluated.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         n_samples : int, default: 1
             The number of samples drawn from the Gaussian process

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -186,8 +186,9 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         self._rng = check_random_state(self.random_state)
 
-        if self.kernel_.vector_X_only():
-            X, y = check_X_y(X, y, multi_output=True, y_numeric=True)
+        if self.kernel_.requires_vector_input():
+            X, y = check_X_y(X, y, multi_output=True, y_numeric=True,
+                             ensure_2d=True, dtype="numeric")
         else:
             X, y = check_X_y(X, y, multi_output=True, y_numeric=True,
                              ensure_2d=False, dtype=None)
@@ -312,8 +313,8 @@ class GaussianProcessRegressor(MultiOutputMixin,
                 "Not returning standard deviation of predictions when "
                 "returning full covariance.")
 
-        if self.kernel is None or self.kernel.vector_X_only():
-            X = check_array(X)
+        if self.kernel is None or self.kernel.requires_vector_input():
+            X = check_array(X, ensure_2d=True, dtype="numeric")
         else:
             X = check_array(X, ensure_2d=False, dtype=None)
 

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -31,6 +31,7 @@ from scipy.spatial.distance import pdist, cdist, squareform
 
 from ..metrics.pairwise import pairwise_kernels
 from ..base import clone
+from ..utils.validation import _num_samples
 
 
 def _check_length_scale(X, length_scale):
@@ -352,7 +353,7 @@ class Kernel(metaclass=ABCMeta):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
+        X : sequence of length n_samples
             Left argument of the returned kernel k(X, Y)
 
         Returns
@@ -364,6 +365,10 @@ class Kernel(metaclass=ABCMeta):
     @abstractmethod
     def is_stationary(self):
         """Returns whether the kernel is stationary. """
+
+    @abstractmethod
+    def vector_X_only(self):
+        """Returns whether the kernel is defined on discrete structures. """
 
 
 class NormalizedKernelMixin:
@@ -381,7 +386,7 @@ class NormalizedKernelMixin:
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
+        X : sequence of length n_samples
             Left argument of the returned kernel k(X, Y)
 
         Returns
@@ -401,6 +406,27 @@ class StationaryKernelMixin:
     def is_stationary(self):
         """Returns whether the kernel is stationary. """
         return True
+
+
+class VectorOnlyKernelMixin:
+    """Mixin for kernels which operate on fixed-length feature vectors
+
+    .. versionadded:: TBD
+    """
+    def vector_X_only(self):
+        """whether the kernel only works on fixed-length feature vectors."""
+        return True
+
+
+class StructureOrGenericKernelMixin:
+    """Mixin for kernels which operate on discrete structures
+       such as sequences, trees, and graphs
+
+    .. versionadded:: TBD
+    """
+    def vector_X_only(self):
+        """whether the kernel only works on fixed-length feature vectors."""
+        return False
 
 
 class CompoundKernel(Kernel):
@@ -481,12 +507,15 @@ class CompoundKernel(Kernel):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
+        X : sequence of length n_samples_X
             Left argument of the returned kernel k(X, Y)
+            Could either be array-like with shape = (n_samples_X, n_features)
+            or a list of objects.
 
-        Y : array, shape (n_samples_Y, n_features), (optional, default=None)
+        Y : sequence of length n_samples_Y
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
-            if evaluated instead.
+            is evaluated instead. Y could either be array-like with
+            shape = (n_samples_Y, n_features) or a list of objects.
 
         eval_gradient : bool (optional, default=False)
             Determines whether the gradient with respect to the kernel
@@ -524,6 +553,10 @@ class CompoundKernel(Kernel):
         """Returns whether the kernel is stationary. """
         return np.all([kernel.is_stationary() for kernel in self.kernels])
 
+    def vector_X_only(self):
+        """Returns whether the kernel is defined on discrete structures. """
+        return np.any([kernel.vector_X_only() for kernel in self.kernels])
+
     def diag(self, X):
         """Returns the diagonal of the kernel k(X, X).
 
@@ -533,8 +566,9 @@ class CompoundKernel(Kernel):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
-            Left argument of the returned kernel k(X, Y)
+        X : sequence of length n_samples_X
+            Argument to the kernel. Could either be array-like with
+            shape = (n_samples_X, n_features) or a list of objects.
 
         Returns
         -------
@@ -646,6 +680,10 @@ class KernelOperator(Kernel):
         """Returns whether the kernel is stationary. """
         return self.k1.is_stationary() and self.k2.is_stationary()
 
+    def vector_X_only(self):
+        """Returns whether the kernel is stationary. """
+        return self.k1.vector_X_only() or self.k2.vector_X_only()
+
 
 class Sum(KernelOperator):
     """Sum-kernel k1 + k2 of two kernels k1 and k2.
@@ -670,12 +708,15 @@ class Sum(KernelOperator):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
+        X : sequence of length n_samples_X
             Left argument of the returned kernel k(X, Y)
+            Could either be array-like with shape = (n_samples_X, n_features)
+            or a list of objects.
 
-        Y : array, shape (n_samples_Y, n_features), (optional, default=None)
+        Y : sequence of length n_samples_Y
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
-            if evaluated instead.
+            is evaluated instead. Y could either be array-like with
+            shape = (n_samples_Y, n_features) or a list of objects.
 
         eval_gradient : bool (optional, default=False)
             Determines whether the gradient with respect to the kernel
@@ -707,8 +748,9 @@ class Sum(KernelOperator):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
-            Left argument of the returned kernel k(X, Y)
+        X : sequence of length n_samples_X
+            Argument to the kernel. Could either be array-like with
+            shape = (n_samples_X, n_features) or a list of objects.
 
         Returns
         -------
@@ -744,12 +786,15 @@ class Product(KernelOperator):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
+        X : sequence of length n_samples_X
             Left argument of the returned kernel k(X, Y)
+            Could either be array-like with shape = (n_samples_X, n_features)
+            or a list of objects.
 
-        Y : array, shape (n_samples_Y, n_features), (optional, default=None)
+        Y : sequence of length n_samples_Y
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
-            if evaluated instead.
+            is evaluated instead. Y could either be array-like with
+            shape = (n_samples_Y, n_features) or a list of objects.
 
         eval_gradient : bool (optional, default=False)
             Determines whether the gradient with respect to the kernel
@@ -782,8 +827,9 @@ class Product(KernelOperator):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
-            Left argument of the returned kernel k(X, Y)
+        X : sequence of length n_samples_X
+            Argument to the kernel. Could either be array-like with
+            shape = (n_samples_X, n_features) or a list of objects.
 
         Returns
         -------
@@ -896,12 +942,15 @@ class Exponentiation(Kernel):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
+        X : sequence of length n_samples_X
             Left argument of the returned kernel k(X, Y)
+            Could either be array-like with shape = (n_samples_X, n_features)
+            or a list of objects.
 
-        Y : array, shape (n_samples_Y, n_features), (optional, default=None)
+        Y : sequence of length n_samples_Y
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
-            if evaluated instead.
+            is evaluated instead. Y could either be array-like with
+            shape = (n_samples_Y, n_features) or a list of objects.
 
         eval_gradient : bool (optional, default=False)
             Determines whether the gradient with respect to the kernel
@@ -935,8 +984,9 @@ class Exponentiation(Kernel):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
-            Left argument of the returned kernel k(X, Y)
+        X : sequence of length n_samples_X
+            Argument to the kernel. Could either be array-like with
+            shape = (n_samples_X, n_features) or a list of objects.
 
         Returns
         -------
@@ -952,8 +1002,13 @@ class Exponentiation(Kernel):
         """Returns whether the kernel is stationary. """
         return self.kernel.is_stationary()
 
+    def vector_X_only(self):
+        """Returns whether the kernel is defined on discrete structures. """
+        return self.kernel.vector_X_only()
 
-class ConstantKernel(StationaryKernelMixin, Kernel):
+
+class ConstantKernel(StationaryKernelMixin, StructureOrGenericKernelMixin,
+                     Kernel):
     """Constant kernel.
 
     Can be used as part of a product-kernel where it scales the magnitude of
@@ -988,12 +1043,15 @@ class ConstantKernel(StationaryKernelMixin, Kernel):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
+        X : sequence of length n_samples_X
             Left argument of the returned kernel k(X, Y)
+            Could either be array-like with shape = (n_samples_X, n_features)
+            or a list of objects.
 
-        Y : array, shape (n_samples_Y, n_features), (optional, default=None)
+        Y : sequence of length n_samples_Y
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
-            if evaluated instead.
+            is evaluated instead. Y could either be array-like with
+            shape = (n_samples_Y, n_features) or a list of objects.
 
         eval_gradient : bool (optional, default=False)
             Determines whether the gradient with respect to the kernel
@@ -1009,21 +1067,20 @@ class ConstantKernel(StationaryKernelMixin, Kernel):
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
         """
-        X = np.atleast_2d(X)
         if Y is None:
             Y = X
         elif eval_gradient:
             raise ValueError("Gradient can only be evaluated when Y is None.")
 
-        K = np.full((X.shape[0], Y.shape[0]), self.constant_value,
+        K = np.full((_num_samples(X), _num_samples(Y)), self.constant_value,
                     dtype=np.array(self.constant_value).dtype)
         if eval_gradient:
             if not self.hyperparameter_constant_value.fixed:
-                return (K, np.full((X.shape[0], X.shape[0], 1),
+                return (K, np.full((_num_samples(X), _num_samples(X), 1),
                                    self.constant_value,
                                    dtype=np.array(self.constant_value).dtype))
             else:
-                return K, np.empty((X.shape[0], X.shape[0], 0))
+                return K, np.empty((_num_samples(X), _num_samples(X), 0))
         else:
             return K
 
@@ -1036,22 +1093,24 @@ class ConstantKernel(StationaryKernelMixin, Kernel):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
-            Left argument of the returned kernel k(X, Y)
+        X : sequence of length n_samples_X
+            Argument to the kernel. Could either be array-like with
+            shape = (n_samples_X, n_features) or a list of objects.
 
         Returns
         -------
         K_diag : array, shape (n_samples_X,)
             Diagonal of kernel k(X, X)
         """
-        return np.full(X.shape[0], self.constant_value,
+        return np.full(_num_samples(X), self.constant_value,
                        dtype=np.array(self.constant_value).dtype)
 
     def __repr__(self):
         return "{0:.3g}**2".format(np.sqrt(self.constant_value))
 
 
-class WhiteKernel(StationaryKernelMixin, Kernel):
+class WhiteKernel(StationaryKernelMixin, StructureOrGenericKernelMixin,
+                  Kernel):
     """White kernel.
 
     The main use-case of this kernel is as part of a sum-kernel where it
@@ -1085,12 +1144,15 @@ class WhiteKernel(StationaryKernelMixin, Kernel):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
+        X : sequence of length n_samples_X
             Left argument of the returned kernel k(X, Y)
+            Could either be array-like with shape = (n_samples_X, n_features)
+            or a list of objects.
 
-        Y : array, shape (n_samples_Y, n_features), (optional, default=None)
+        Y : sequence of length n_samples_Y
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
-            if evaluated instead.
+            is evaluated instead. Y could either be array-like with
+            shape = (n_samples_Y, n_features) or a list of objects.
 
         eval_gradient : bool (optional, default=False)
             Determines whether the gradient with respect to the kernel
@@ -1106,22 +1168,21 @@ class WhiteKernel(StationaryKernelMixin, Kernel):
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
         """
-        X = np.atleast_2d(X)
         if Y is not None and eval_gradient:
             raise ValueError("Gradient can only be evaluated when Y is None.")
 
         if Y is None:
-            K = self.noise_level * np.eye(X.shape[0])
+            K = self.noise_level * np.eye(_num_samples(X))
             if eval_gradient:
                 if not self.hyperparameter_noise_level.fixed:
                     return (K, self.noise_level
-                            * np.eye(X.shape[0])[:, :, np.newaxis])
+                            * np.eye(_num_samples(X))[:, :, np.newaxis])
                 else:
-                    return K, np.empty((X.shape[0], X.shape[0], 0))
+                    return K, np.empty((_num_samples(X), _num_samples(X), 0))
             else:
                 return K
         else:
-            return np.zeros((X.shape[0], Y.shape[0]))
+            return np.zeros((_num_samples(X), _num_samples(Y)))
 
     def diag(self, X):
         """Returns the diagonal of the kernel k(X, X).
@@ -1132,15 +1193,16 @@ class WhiteKernel(StationaryKernelMixin, Kernel):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
-            Left argument of the returned kernel k(X, Y)
+        X : sequence of length n_samples_X
+            Argument to the kernel. Could either be array-like with
+            shape = (n_samples_X, n_features) or a list of objects.
 
         Returns
         -------
         K_diag : array, shape (n_samples_X,)
             Diagonal of kernel k(X, X)
         """
-        return np.full(X.shape[0], self.noise_level,
+        return np.full(_num_samples(X), self.noise_level,
                        dtype=np.array(self.noise_level).dtype)
 
     def __repr__(self):
@@ -1148,7 +1210,8 @@ class WhiteKernel(StationaryKernelMixin, Kernel):
                                                  self.noise_level)
 
 
-class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
+class RBF(StationaryKernelMixin, NormalizedKernelMixin, VectorOnlyKernelMixin,
+          Kernel):
     """Radial-basis function kernel (aka squared-exponential kernel).
 
     The RBF kernel is a stationary kernel. It is also known as the
@@ -1412,7 +1475,8 @@ class Matern(RBF):
                 self.nu)
 
 
-class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
+class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin,
+                        VectorOnlyKernelMixin, Kernel):
     """Rational Quadratic kernel.
 
     The RationalQuadratic kernel can be seen as a scale mixture (an infinite
@@ -1528,7 +1592,8 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
             self.__class__.__name__, self.alpha, self.length_scale)
 
 
-class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
+class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin,
+                     VectorOnlyKernelMixin, Kernel):
     r"""Exp-Sine-Squared kernel.
 
     The ExpSineSquared kernel allows modeling periodic functions. It is
@@ -1641,7 +1706,7 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
             self.__class__.__name__, self.length_scale, self.periodicity)
 
 
-class DotProduct(Kernel):
+class DotProduct(VectorOnlyKernelMixin, Kernel):
     r"""Dot-Product kernel.
 
     The DotProduct kernel is non-stationary and can be obtained from linear
@@ -1763,7 +1828,7 @@ def _approx_fprime(xk, f, epsilon, args=()):
     return grad
 
 
-class PairwiseKernel(Kernel):
+class PairwiseKernel(VectorOnlyKernelMixin, Kernel):
     """Wrapper for kernels in sklearn.metrics.pairwise.
 
     A thin wrapper around the functionality of the kernels in

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -367,7 +367,7 @@ class Kernel(metaclass=ABCMeta):
         """Returns whether the kernel is stationary. """
 
     @abstractmethod
-    def vector_X_only(self):
+    def requires_vector_input(self):
         """Returns whether the kernel is defined on discrete structures. """
 
 
@@ -413,7 +413,7 @@ class VectorOnlyKernelMixin:
 
     .. versionadded:: TBD
     """
-    def vector_X_only(self):
+    def requires_vector_input(self):
         """whether the kernel only works on fixed-length feature vectors."""
         return True
 
@@ -424,7 +424,7 @@ class StructureOrGenericKernelMixin:
 
     .. versionadded:: TBD
     """
-    def vector_X_only(self):
+    def requires_vector_input(self):
         """whether the kernel only works on fixed-length feature vectors."""
         return False
 
@@ -553,9 +553,10 @@ class CompoundKernel(Kernel):
         """Returns whether the kernel is stationary. """
         return np.all([kernel.is_stationary() for kernel in self.kernels])
 
-    def vector_X_only(self):
+    def requires_vector_input(self):
         """Returns whether the kernel is defined on discrete structures. """
-        return np.any([kernel.vector_X_only() for kernel in self.kernels])
+        return np.any([kernel.requires_vector_input()
+                       for kernel in self.kernels])
 
     def diag(self, X):
         """Returns the diagonal of the kernel k(X, X).
@@ -680,9 +681,10 @@ class KernelOperator(Kernel):
         """Returns whether the kernel is stationary. """
         return self.k1.is_stationary() and self.k2.is_stationary()
 
-    def vector_X_only(self):
+    def requires_vector_input(self):
         """Returns whether the kernel is stationary. """
-        return self.k1.vector_X_only() or self.k2.vector_X_only()
+        return np.any([self.k1.requires_vector_input(),
+                       self.k2.requires_vector_input()])
 
 
 class Sum(KernelOperator):
@@ -1002,9 +1004,9 @@ class Exponentiation(Kernel):
         """Returns whether the kernel is stationary. """
         return self.kernel.is_stationary()
 
-    def vector_X_only(self):
+    def requires_vector_input(self):
         """Returns whether the kernel is defined on discrete structures. """
-        return self.kernel.vector_X_only()
+        return self.kernel.requires_vector_input()
 
 
 class ConstantKernel(StationaryKernelMixin, StructureOrGenericKernelMixin,

--- a/sklearn/gaussian_process/tests/_mini_sequence_kernel.py
+++ b/sklearn/gaussian_process/tests/_mini_sequence_kernel.py
@@ -1,0 +1,50 @@
+from sklearn.gaussian_process.kernels import Kernel, Hyperparameter
+from sklearn.gaussian_process.kernels import StructureOrGenericKernelMixin
+from sklearn.gaussian_process.kernels import StationaryKernelMixin
+import numpy as np
+from sklearn.base import clone
+
+
+class MiniSeqKernel(StructureOrGenericKernelMixin,
+                    StationaryKernelMixin,
+                    Kernel):
+    '''
+    a mimimal (but valid) convolutional kernel for sequences of variable length
+    '''
+    def __init__(self,
+                 baseline_similarity=0.5,
+                 baseline_similarity_bounds=(1e-5, 1)):
+        self.baseline_similarity = baseline_similarity
+        self.baseline_similarity_bounds = baseline_similarity_bounds
+
+    @property
+    def hyperparameter_baseline_similarity(self):
+        return Hyperparameter("baseline_similarity",
+                              "numeric",
+                              self.baseline_similarity_bounds)
+
+    def _f(self, s1, s2):
+        return sum([1.0 if c1 == c2 else self.baseline_similarity
+                   for c1 in s1
+                   for c2 in s2])
+
+    def _g(self, s1, s2):
+        return sum([0.0 if c1 == c2 else 1.0 for c1 in s1 for c2 in s2])
+
+    def __call__(self, X, Y=None, eval_gradient=False):
+        if Y is None:
+            Y = X
+
+        if eval_gradient:
+            return (np.array([[self._f(x, y) for y in Y] for x in X]),
+                    np.array([[[self._g(x, y)] for y in Y] for x in X]))
+        else:
+            return np.array([[self._f(x, y) for y in Y] for x in X])
+
+    def diag(self, X):
+        return np.array([self._f(x, x) for x in X])
+
+    def clone_with_theta(self, theta):
+        cloned = clone(self)
+        cloned.theta = theta
+        return cloned

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -11,12 +11,15 @@ import pytest
 
 from sklearn.gaussian_process import GaussianProcessClassifier
 from sklearn.gaussian_process.kernels import RBF, ConstantKernel as C
+from sklearn.gaussian_process.tests._mini_sequence_kernel import MiniSeqKernel
 
 from sklearn.utils._testing import assert_almost_equal, assert_array_equal
 
 
 def f(x):
     return np.sin(x)
+
+
 X = np.atleast_2d(np.linspace(0, 10, 30)).T
 X2 = np.atleast_2d([2., 4., 5.5, 6.5, 7.5]).T
 y = np.array(f(X).ravel() > 0, dtype=int)
@@ -38,7 +41,18 @@ non_fixed_kernels = [kernel for kernel in kernels
 
 @pytest.mark.parametrize('kernel', kernels)
 def test_predict_consistent(kernel):
+
     # Check binary predict decision has also predicted probability above 0.5.
+    gpc = GaussianProcessClassifier(kernel=kernel).fit(X, y)
+    assert_array_equal(gpc.predict(X),
+                       gpc.predict_proba(X)[:, 1] >= 0.5)
+
+
+def test_predict_consistent_structured():
+    # Check binary predict decision has also predicted probability above 0.5.
+    X = ['A', 'AB', 'B']
+    y = np.array([True, False, True])
+    kernel = MiniSeqKernel(baseline_similarity_bounds='fixed')
     gpc = GaussianProcessClassifier(kernel=kernel).fit(X, y)
     assert_array_equal(gpc.predict(X),
                        gpc.predict_proba(X)[:, 1] >= 0.5)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -13,6 +13,7 @@ from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels \
     import RBF, ConstantKernel as C, WhiteKernel
 from sklearn.gaussian_process.kernels import DotProduct
+from sklearn.gaussian_process.tests._mini_sequence_kernel import MiniSeqKernel
 
 from sklearn.utils._testing \
     import (assert_array_less,
@@ -49,6 +50,20 @@ def test_gpr_interpolation(kernel):
     gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
     y_pred, y_cov = gpr.predict(X, return_cov=True)
 
+    assert_almost_equal(y_pred, y)
+    assert_almost_equal(np.diag(y_cov), 0.)
+
+
+def test_gpr_interpolation_structured():
+    # Test the interpolating property for different kernels.
+    kernel = MiniSeqKernel(baseline_similarity_bounds='fixed')
+    X = ['A', 'B', 'C']
+    y = np.array([1, 2, 3])
+    gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
+    y_pred, y_cov = gpr.predict(X, return_cov=True)
+
+    assert_almost_equal(kernel(X, eval_gradient=True)[1].ravel(),
+                        (1 - np.eye(len(X))).ravel())
     assert_almost_equal(y_pred, y)
     assert_almost_equal(np.diag(y_cov), 0.)
 

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -188,22 +188,24 @@ def test_kernel_stationary(kernel):
 
 
 @pytest.mark.parametrize('kernel',  kernels)
-def test_kernel_vector_X_only(kernel):
+def test_kernel_input_type(kernel):
     # Test whether kernels is for vectors or structured data
     if isinstance(kernel, Exponentiation):
-        assert_equal(kernel.vector_X_only(), kernel.kernel.vector_X_only())
+        assert_equal(kernel.requires_vector_input(),
+                     kernel.kernel.requires_vector_input())
     if isinstance(kernel, KernelOperator):
-        assert_equal(kernel.vector_X_only(),
-                     kernel.k1.vector_X_only() or kernel.k2.vector_X_only())
+        assert_equal(kernel.requires_vector_input(),
+                     np.any([kernel.k1.requires_vector_input(),
+                             kernel.k2.requires_vector_input()]))
 
 
-def test_kernel_vector_X_only_compound():
+def test_compound_kernel_input_type():
     kernel = CompoundKernel([WhiteKernel(noise_level=3.0)])
-    assert_equal(kernel.vector_X_only(), False)
+    assert_equal(kernel.requires_vector_input(), False)
 
     kernel = CompoundKernel([WhiteKernel(noise_level=3.0),
                              RBF(length_scale=2.0)])
-    assert_equal(kernel.vector_X_only(), True)
+    assert_equal(kernel.requires_vector_input(), True)
 
 
 def check_hyperparameters_equal(kernel1, kernel2):


### PR DESCRIPTION
Fixes #13936.

Made the Gaussian process regressor and classifier compatible with either structure- or vector-based kernels. Specifically:
1. Added an `vector_X_only()` abstract method to the GP kernel base class.
2. Added the `VectorOnlyKernelMixin` and `StructureOrGenericKernelMixin` base classes to overload the `vector_X_only()` method for kernels that can only operate on fixed-length feature vectors and that can work on structured and/or generic data, respectively.
3. Let the GP regressor and classifier use different `check_array` and `check_X_y` parameters for vector/structured input. I.e., do not force the X and Y array to be at least 2D and numeric if the kernel can operate on structured input. Updated documentations accordingly.'
4. Provided a minimal example of GP regression and classification using a sequence kernel on variable-length strings at `plot_gpr_on_structured_data.py`.
