### PR TITLE
[MRG] Remove parent negative loss calculation from for loop to improve performance

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -463,7 +463,7 @@ cdef class Splitter:
                 # won't get any better (hessians are > 0 since loss is convex)
                 break
 
-            gain = _split_gain(sum_gradient_left, sum_hessian_left,
+            gain += _split_gain(sum_gradient_left, sum_hessian_left,
                                sum_gradient_right, sum_hessian_right,
                                sum_gradients, sum_hessians,
                                self.l2_regularization)

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -435,7 +435,7 @@ cdef class Splitter:
         best_split.gain = -1.
         sum_gradient_left, sum_hessian_left = 0., 0.
         n_samples_left = 0
-        gain = -negative_loss(sum_gradients, sum_hessians, l2_regularization)
+        gain = -negative_loss(sum_gradients, sum_hessians, self.l2_regularization)
 
         for bin_idx in range(self.actual_n_bins[feature_idx]):
             n_samples_left += histograms[feature_idx, bin_idx].count

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -436,7 +436,7 @@ cdef class Splitter:
         best_split.gain = -1.
         sum_gradient_left, sum_hessian_left = 0., 0.
         n_samples_left = 0
-        negative_loss_current_node = -negative_loss(sum_gradients,
+        negative_loss_current_node = negative_loss(sum_gradients,
             sum_hessians, self.l2_regularization)
 
         for bin_idx in range(self.actual_n_bins[feature_idx]):

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -429,13 +429,15 @@ cdef class Splitter:
             Y_DTYPE_C sum_hessian_right
             Y_DTYPE_C sum_gradient_left
             Y_DTYPE_C sum_gradient_right
+            Y_DTYPE_C negative_loss_current_node
             Y_DTYPE_C gain
             split_info_struct best_split
 
         best_split.gain = -1.
         sum_gradient_left, sum_hessian_left = 0., 0.
         n_samples_left = 0
-        gain = -negative_loss(sum_gradients, sum_hessians, self.l2_regularization)
+        negative_loss_current_node = -negative_loss(sum_gradients,
+            sum_hessians, self.l2_regularization)
 
         for bin_idx in range(self.actual_n_bins[feature_idx]):
             n_samples_left += histograms[feature_idx, bin_idx].count
@@ -463,9 +465,10 @@ cdef class Splitter:
                 # won't get any better (hessians are > 0 since loss is convex)
                 break
 
-            gain += _split_gain(sum_gradient_left, sum_hessian_left,
+            gain = _split_gain(sum_gradient_left, sum_hessian_left,
                                sum_gradient_right, sum_hessian_right,
                                sum_gradients, sum_hessians,
+                               negative_loss_current_node,
                                self.l2_regularization)
 
             if gain > best_split.gain and gain > self.min_gain_to_split:
@@ -489,6 +492,7 @@ cdef inline Y_DTYPE_C _split_gain(
         Y_DTYPE_C sum_hessian_right,
         Y_DTYPE_C sum_gradients,
         Y_DTYPE_C sum_hessians,
+        Y_DTYPE_C negative_loss_current_node,
         Y_DTYPE_C l2_regularization) nogil:
     """Loss reduction
 
@@ -501,10 +505,11 @@ cdef inline Y_DTYPE_C _split_gain(
     """
     cdef:
         Y_DTYPE_C gain
-    gain += negative_loss(sum_gradient_left, sum_hessian_left,
+    gain = negative_loss(sum_gradient_left, sum_hessian_left,
                          l2_regularization)
     gain += negative_loss(sum_gradient_right, sum_hessian_right,
                           l2_regularization)
+    gain -= negative_loss_current_node
     return gain
 
 cdef inline Y_DTYPE_C negative_loss(

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -435,6 +435,7 @@ cdef class Splitter:
         best_split.gain = -1.
         sum_gradient_left, sum_hessian_left = 0., 0.
         n_samples_left = 0
+        gain = -negative_loss(sum_gradients, sum_hessians, l2_regularization)
 
         for bin_idx in range(self.actual_n_bins[feature_idx]):
             n_samples_left += histograms[feature_idx, bin_idx].count
@@ -500,11 +501,10 @@ cdef inline Y_DTYPE_C _split_gain(
     """
     cdef:
         Y_DTYPE_C gain
-    gain = negative_loss(sum_gradient_left, sum_hessian_left,
+    gain += negative_loss(sum_gradient_left, sum_hessian_left,
                          l2_regularization)
     gain += negative_loss(sum_gradient_right, sum_hessian_right,
                           l2_regularization)
-    gain -= negative_loss(sum_gradients, sum_hessians, l2_regularization)
     return gain
 
 cdef inline Y_DTYPE_C negative_loss(

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -467,7 +467,6 @@ cdef class Splitter:
 
             gain = _split_gain(sum_gradient_left, sum_hessian_left,
                                sum_gradient_right, sum_hessian_right,
-                               sum_gradients, sum_hessians,
                                negative_loss_current_node,
                                self.l2_regularization)
 
@@ -490,8 +489,6 @@ cdef inline Y_DTYPE_C _split_gain(
         Y_DTYPE_C sum_hessian_left,
         Y_DTYPE_C sum_gradient_right,
         Y_DTYPE_C sum_hessian_right,
-        Y_DTYPE_C sum_gradients,
-        Y_DTYPE_C sum_hessians,
         Y_DTYPE_C negative_loss_current_node,
         Y_DTYPE_C l2_regularization) nogil:
     """Loss reduction


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Resolves #13931 


#### What does this implement/fix? Explain your changes.
Removes parent negative node loss calculation for loop in order to improve performance of histogram gradient boosting 

#### Any other comments?
Still need input on if I need to add test coverage around this or how to gauge measurable performance improvement

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
