### PR TITLE
[MRG] DOC: fix contributing guide section ordering

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -41,7 +41,7 @@ ticket to the
 also welcome to post feature requests or pull requests.
 
 Governance
-----------
+==========
 The decision making process and governance structure of scikit-learn is laid
 out in the governance document: :ref:`governance`.
 


### PR DESCRIPTION
The [current contributing](https://scikit-learn.org/stable/developers/contributing.html) guide is a mess. For example, the [coding guidelines](https://scikit-learn.org/stable/developers/contributing.html#coding-guidelines) section is a subsection of the *Issue Tracker Tags* section, which makes no sense.

This PR fixes the ordering.


I'm planning to re-arrange this whole guide a bit and try to make it more straightforward for beginners and new contributors, in another PR.