### PR TITLE
MAINT: use explicit value of n_jobs to avoid hangs on Windows

### DIFF
--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1757,7 +1757,7 @@ def test_empty_cv_iterator_error():
 
     train_size = 100
     ridge = RandomizedSearchCV(Ridge(), {'alpha': [1e-3, 1e-2, 1e-1]},
-                               cv=cv, n_jobs=-1)
+                               cv=cv, n_jobs=4)
 
     # assert that this raises an error
     with pytest.raises(ValueError,
@@ -1779,7 +1779,7 @@ def test_random_search_bad_cv():
 
     train_size = 100
     ridge = RandomizedSearchCV(Ridge(), {'alpha': [1e-3, 1e-2, 1e-1]},
-                               cv=cv, n_jobs=-1)
+                               cv=cv, n_jobs=4)
 
     # assert that this raises an error
     with pytest.raises(ValueError,


### PR DESCRIPTION
This is a companion change to #13644 , where a new in 0.21 test uses `n_jobs=-1`, causing test suite run on certain Windows boxes to hang #12263 

The change replaced `n_jobs=-1` with `n_jobs=4`.