### PR TITLE
TST dtype dependent rtol, atol in assert_allclose_dense_sparse

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2449,11 +2449,11 @@ def check_fit_idempotent(name, estimator_orig):
         if hasattr(estimator, method):
             new_result = getattr(estimator, method)(X_test)
             if np.issubdtype(new_result.dtype, np.floating):
-                tol = np.finfo(new_result.dtype).eps
+                tol = 2*np.finfo(new_result.dtype).eps
             else:
-                tol = np.finfo(np.float64).eps
+                tol = 2*np.finfo(np.float64).eps
             assert_allclose_dense_sparse(
                 result[method], new_result,
-                atol=tol, rtol=tol,
+                atol=max(tol, 1e-9), rtol=max(tol, 1e-7),
                 err_msg="Idempotency check failed for method {}".format(method)
             )

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2449,11 +2449,11 @@ def check_fit_idempotent(name, estimator_orig):
         if hasattr(estimator, method):
             new_result = getattr(estimator, method)(X_test)
             if np.issubdtype(new_result.dtype, np.floating):
-                atol = 2*np.finfo(new_result.dtype).eps
+                tol = np.finfo(new_result.dtype).eps
             else:
-                atol = 2*np.finfo(np.float64).eps
+                tol = np.finfo(np.float64).eps
             assert_allclose_dense_sparse(
                 result[method], new_result,
-                atol=atol,
+                atol=tol, rtol=tol,
                 err_msg="Idempotency check failed for method {}".format(method)
             )

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2448,4 +2448,12 @@ def check_fit_idempotent(name, estimator_orig):
     for method in check_methods:
         if hasattr(estimator, method):
             new_result = getattr(estimator, method)(X_test)
-            assert_allclose_dense_sparse(result[method], new_result)
+            if np.issubdtype(new_result.dtype, np.floating):
+                atol = 2*np.finfo(new_result.dtype).eps
+            else:
+                atol = 2*np.finfo(np.float64).eps
+            assert_allclose_dense_sparse(
+                result[method], new_result,
+                atol=atol,
+                err_msg="Idempotency check failed for method {}".format(method)
+            )


### PR DESCRIPTION
Check for closeness of new_result and the previously computed result
in `check_fit_idempotent` should depend on the dtype of the result, and 
cannot be less than that precision's epsilon.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

Closes #13977 

#### What does this implement/fix? Explain your changes.

This change sets `atol` keyword in the call to `assert_allclose_dense_sparse` in 
`check_fit_idempotent` estimator checker.

#### Any other comments?


@amueller @jeremiedbb 