### PR TITLE
FIX Lazy cython import for pytest to work without cython

### DIFF
--- a/sklearn/linear_model/setup.py
+++ b/sklearn/linear_model/setup.py
@@ -2,8 +2,6 @@ import os
 
 import numpy
 
-from Cython import Tempita
-
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
 
@@ -32,6 +30,7 @@ def configuration(parent_package='', top_path=None):
 
         with open(sag_cython_file, "r") as f:
             tmpl = f.read()
+        from Cython import Tempita # noqa
         tmpl_ = Tempita.sub(tmpl)
 
         with open(sag_file, "w") as f:


### PR DESCRIPTION
Present of import atop the test file caused pytest to fail collecting
tests if the testing environment did not have cython installed.

@ogrisel @jeremiedbb 