### PR TITLE
Add blurb to landing page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,9 @@
 scikit-learn
 ============
 
-scikit-learn is a Python module for machine learning built on top of
-SciPy and distributed under the 3-Clause BSD license.
+scikit-learn is a Python library for machine learning built on top of SciPy and
+NumPy. scikit-learn contains models for supervised and unsupervised learning, as well as
+tools for preprocessing, model selection and evaluation.
 
 The project was started in 2007 by David Cournapeau as a Google Summer
 of Code project, and since then many volunteers have contributed. See

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -196,12 +196,11 @@
     <div id="intro_to_sklearn_p" class="span6">
       <h1>scikit-learn</h1>
       <h2>Machine Learning in Python</h2>
-      <ul>
-        <li>Simple and efficient tools for data mining and data analysis</li>
-        <li>Accessible to everybody, and reusable in various contexts</li>
-        <li>Built on NumPy, SciPy, and matplotlib</li>
-        <li>Open source, commercially usable - BSD license</li>
-      </ul>
+
+        scikit-learn is a Python library for machine learning built on top of SciPy and
+        NumPy. scikit-learn contains models for supervised and unsupervised learning,
+        as well as tools for preprocessing, model selection and evaluation.
+
     </div>
   </div>
 </div>

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -193,14 +193,14 @@
 	</div>
       </div>
     </div>
-    <div id="intro_to_sklearn_p" class="span6">
+    <div id="intro_to_sklearn_p" class="span5">
       <h1>scikit-learn</h1>
       <h2>Machine Learning in Python</h2>
-
+      <p style="line-height: 1.5">
         scikit-learn is a Python library for machine learning built on top of SciPy and
         NumPy. scikit-learn contains models for supervised and unsupervised learning,
         as well as tools for preprocessing, model selection and evaluation.
-
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This adds a consistent blurb to the landing page and the readme.
This is helpful for people who arrive at either of them and wonder what sklearn is.
It also helps people writing about scikit-learn, or introducing speakers, or in a number of settings where someone might ask "what's scikit-learn".

I removed the BSD license from the sentence in the readme, if we think that's important I would probably change it to "scikit-learn is an open-source Python..."