### PR TITLE
Avoid memory copies in linear_model when fit_intercept=False

### DIFF
--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -97,7 +97,7 @@ def make_dataset(X, y, sample_weight, random_state=None):
     return dataset, intercept_decay
 
 
-def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
+def _preprocess_data(X, y, fit_intercept, normalize=False, copy=None,
                      sample_weight=None, return_mean=False, check_input=True):
     """
     Centers data to have mean zero along axis 0. If fit_intercept=False or if
@@ -121,17 +121,17 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
         sample_weight = None
 
     if check_input:
-        X = check_array(X, copy=copy, accept_sparse=['csr', 'csc'],
+        X = check_array(X, accept_sparse=['csr', 'csc'],
                         dtype=FLOAT_DTYPES)
-    elif copy:
-        if sp.issparse(X):
-            X = X.copy()
-        else:
-            X = X.copy(order='K')
 
     y = np.asarray(y, dtype=X.dtype)
 
     if fit_intercept:
+        if copy is None or copy:
+            if sp.issparse(X):
+                X = X.copy()
+            else:
+                X = X.copy(order='K')
         if sp.issparse(X):
             X_offset, X_var = mean_variance_axis(X, axis=0)
             if not return_mean:

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -413,12 +413,6 @@ def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
         Gram = None
         if X is None:
             raise ValueError('X and Gram cannot both be unspecified.')
-        if copy_X:
-            # force copy. setting the array to be fortran-ordered
-            # speeds up the calculation of the (partial) Gram matrix
-            # and allows to easily swap columns
-            X = X.copy('F')
-
     elif isinstance(Gram, str) and Gram == 'auto' or Gram is True:
         if Gram is True or X.shape[0] > X.shape[1]:
             Gram = np.dot(X.T, X)
@@ -426,6 +420,12 @@ def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
             Gram = None
     elif copy_Gram:
         Gram = Gram.copy()
+
+    if X is not None and copy_X:
+        # force copy. setting the array to be fortran-ordered
+        # speeds up the calculation of the (partial) Gram matrix
+        # and allows to easily swap columns
+        X = X.copy('F')
 
     if Gram is None:
         n_features = X.shape[1]


### PR DESCRIPTION
Partially addresses #13986 and #13923 

This avoids one memory copy in linear models when `copy_X=True` (default) and `fit_intercept=False`.

For instance, this makes `Ridge(fit_intercept=False)` around 10% faster on the following dataset,
```py
from sklearn.datasets import make_blobs
  
X, y = make_blobs(n_samples=100000, n_features=10, random_state=42)
```

Maybe we should change the default value of `copy_X` from `True` to `None` but I'm not sure it's worth a deprecation cycle.

I have checked that this doesn't break anything with the following common test,
<details>

```diff
diff --git a/sklearn/utils/estimator_checks.py b/sklearn/utils/estimator_checks.py
index 3b09ec287..72961bd73 100644
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -124,6 +124,11 @@ def _yield_classifier_checks(name, classifier):
     # basic consistency testing
     yield check_classifiers_train
     yield partial(check_classifiers_train, readonly_memmap=True)
+
+    sig = signature(classifier.__class__.__init__)
+    if "copy_X" in sig.parameters:
+        yield check_extra_copy_fit_intercept
+
     yield check_classifiers_regression_target
     if not tags["no_validation"]:
         yield check_supervised_y_no_nan
@@ -171,6 +176,11 @@ def _yield_regressor_checks(name, regressor):
     yield check_regressor_data_not_an_array
     yield check_estimators_partial_fit_n_features
     yield check_regressors_no_decision_function
+
+    sig = signature(regressor.__class__.__init__)
+    if "copy_X" in sig.parameters:
+        yield check_extra_copy_fit_intercept
+
     if not tags["no_validation"]:
         yield check_supervised_y_2d
     yield check_supervised_y_no_nan
@@ -190,6 +200,7 @@ def _yield_transformer_checks(name, transformer):
     yield check_transformer_general
     yield partial(check_transformer_general, readonly_memmap=True)
 
+
     if not _safe_tags(transformer, "stateless"):
         yield check_transformers_unfitted
     # Dependent on external solvers and hence accessing the iter
@@ -956,6 +967,25 @@ def check_transformer_general(name, transformer, readonly_memmap=False):
     _check_transformer(name, transformer, X.tolist(), y.tolist())
 
 
+@ignore_warnings(category=(DeprecationWarning, FutureWarning))
+def check_extra_copy_fit_intercept(name, transformer):
+    """Check linear models work on RO arrays when fit_transform=False"""
+
+    X, y = make_blobs(n_samples=30, centers=[[0, 0, 0], [1, 1, 1]],
+                      random_state=0, n_features=2, cluster_std=0.1)
+    X = StandardScaler().fit_transform(X)
+    X -= X.min()
+
+    X, y = create_memmap_backed_data([X, y])
+
+    estimator = clone(transformer)
+    estimator.set_params(copy_X=False)
+    sig = signature(estimator.__class__.__init__)
+    if "fit_intercept" in sig.parameters:
+        estimator.set_params(fit_intercept=False)
+    estimator.fit(X, y)
+
+
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))
 def check_transformer_data_not_an_array(name, transformer):
     X, y = make_blobs(n_samples=30, centers=[[0, 0, 0], [1, 1, 1]],
```
</details>

but of course this only checks the default solver and parameters (and we don't yet have a way to programmatically check all solvers I think?). I'm not sure it's worth adding it in this PR.