### PR TITLE
[MRG] Doctest with print change only adjusts default options for doctest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -71,3 +71,9 @@ def pytest_configure(config):
 def pytest_unconfigure(config):
     import sys
     del sys._is_pytest_session
+
+
+def pytest_runtest_setup(item):
+    if isinstance(item, DoctestItem):
+        from sklearn import set_config
+        set_config(print_changed_only=True)

--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,7 @@
 import platform
 from distutils.version import LooseVersion
 
+from sklearn import set_config
 import pytest
 from _pytest.doctest import DoctestItem
 
@@ -75,5 +76,9 @@ def pytest_unconfigure(config):
 
 def pytest_runtest_setup(item):
     if isinstance(item, DoctestItem):
-        from sklearn import set_config
         set_config(print_changed_only=True)
+
+
+def pytest_runtest_teardown(item, nextitem):
+    if isinstance(item, DoctestItem):
+        set_config(print_changed_only=False)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -306,3 +306,6 @@ warnings.filterwarnings("ignore", category=UserWarning,
                         module="matplotlib",
                         message='Matplotlib is currently using agg, which is a'
                                 ' non-GUI backend, so cannot show the figure.')
+
+# Reduces the output of estimators
+sklearn.set_config(print_changed_only=True)

--- a/doc/datasets/index.rst
+++ b/doc/datasets/index.rst
@@ -360,20 +360,20 @@ classes::
   (1080, 77)
   >>> mice.target.shape
   (1080,)
-  >>> np.unique(mice.target) # doctest: +NORMALIZE_WHITESPACE
+  >>> np.unique(mice.target)
   array(['c-CS-m', 'c-CS-s', 'c-SC-m', 'c-SC-s', 't-CS-m', 't-CS-s', 't-SC-m', 't-SC-s'], dtype=object)
 
 You can get more information on the dataset by looking at the ``DESCR``
 and ``details`` attributes::
 
-  >>> print(mice.DESCR) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS +SKIP
+  >>> print(mice.DESCR) # doctest: +SKIP
   **Author**: Clara Higuera, Katheleen J. Gardiner, Krzysztof J. Cios
   **Source**: [UCI](https://archive.ics.uci.edu/ml/datasets/Mice+Protein+Expression) - 2015
   **Please cite**: Higuera C, Gardiner KJ, Cios KJ (2015) Self-Organizing
   Feature Maps Identify Proteins Critical to Learning in a Mouse Model of Down
   Syndrome. PLoS ONE 10(6): e0129126...
 
-  >>> mice.details # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS +SKIP
+  >>> mice.details # doctest: +SKIP
   {'id': '40966', 'name': 'MiceProtein', 'version': '4', 'format': 'ARFF',
   'upload_date': '2017-11-08T16:00:15', 'licence': 'Public',
   'url': 'https://www.openml.org/data/v1/download/17928620/MiceProtein.arff',
@@ -398,7 +398,7 @@ dataset on the openml website::
 The ``data_id`` also uniquely identifies a dataset from OpenML::
 
   >>> mice = fetch_openml(data_id=40966)
-  >>> mice.details # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS +SKIP
+  >>> mice.details # doctest: +SKIP
   {'id': '4550', 'name': 'MiceProtein', 'version': '1', 'format': 'ARFF',
   'creator': ...,
   'upload_date': '2016-02-17T14:32:49', 'licence': 'Public', 'url':

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -1046,21 +1046,21 @@ chance normalization**::
   >>> labels_true = [0, 0, 0, 1, 1, 1]
   >>> labels_pred = [0, 0, 1, 1, 2, 2]
 
-  >>> metrics.adjusted_rand_score(labels_true, labels_pred)  # doctest: +ELLIPSIS
+  >>> metrics.adjusted_rand_score(labels_true, labels_pred)
   0.24...
 
 One can permute 0 and 1 in the predicted labels, rename 2 to 3, and get
 the same score::
 
   >>> labels_pred = [1, 1, 0, 0, 3, 3]
-  >>> metrics.adjusted_rand_score(labels_true, labels_pred)  # doctest: +ELLIPSIS
+  >>> metrics.adjusted_rand_score(labels_true, labels_pred)
   0.24...
 
 Furthermore, :func:`adjusted_rand_score` is **symmetric**: swapping the argument
 does not change the score. It can thus be used as a **consensus
 measure**::
 
-  >>> metrics.adjusted_rand_score(labels_pred, labels_true)  # doctest: +ELLIPSIS
+  >>> metrics.adjusted_rand_score(labels_pred, labels_true)
   0.24...
 
 Perfect labeling is scored 1.0::
@@ -1073,7 +1073,7 @@ Bad (e.g. independent labelings) have negative or close to 0.0 scores::
 
   >>> labels_true = [0, 1, 2, 0, 3, 4, 5, 1]
   >>> labels_pred = [1, 1, 0, 0, 2, 2, 2, 2]
-  >>> metrics.adjusted_rand_score(labels_true, labels_pred)  # doctest: +ELLIPSIS
+  >>> metrics.adjusted_rand_score(labels_true, labels_pred)
   -0.12...
 
 
@@ -1360,16 +1360,16 @@ We can turn those concept as scores :func:`homogeneity_score` and
   >>> labels_true = [0, 0, 0, 1, 1, 1]
   >>> labels_pred = [0, 0, 1, 1, 2, 2]
 
-  >>> metrics.homogeneity_score(labels_true, labels_pred)  # doctest: +ELLIPSIS
+  >>> metrics.homogeneity_score(labels_true, labels_pred)
   0.66...
 
-  >>> metrics.completeness_score(labels_true, labels_pred) # doctest: +ELLIPSIS
+  >>> metrics.completeness_score(labels_true, labels_pred)
   0.42...
 
 Their harmonic mean called **V-measure** is computed by
 :func:`v_measure_score`::
 
-  >>> metrics.v_measure_score(labels_true, labels_pred)    # doctest: +ELLIPSIS
+  >>> metrics.v_measure_score(labels_true, labels_pred)
   0.51...
 
 This function's formula is as follows:::
@@ -1378,12 +1378,12 @@ This function's formula is as follows:::
 
 `beta` defaults to a value of 1.0, but for using a value less than 1 for beta::
 
-  >>> metrics.v_measure_score(labels_true, labels_pred, beta=0.6)    # doctest: +ELLIPSIS
+  >>> metrics.v_measure_score(labels_true, labels_pred, beta=0.6)
   0.54...
 
 more weight will be attributed to homogeneity, and using a value greater than 1::
 
-  >>> metrics.v_measure_score(labels_true, labels_pred, beta=1.8)    # doctest: +ELLIPSIS
+  >>> metrics.v_measure_score(labels_true, labels_pred, beta=1.8)
   0.48...
 
 more weight will be attributed to completeness.
@@ -1395,7 +1395,6 @@ Homogeneity, completeness and V-measure can be computed at once using
 :func:`homogeneity_completeness_v_measure` as follows::
 
   >>> metrics.homogeneity_completeness_v_measure(labels_true, labels_pred)
-  ...                                                      # doctest: +ELLIPSIS
   (0.66..., 0.42..., 0.51...)
 
 The following clustering assignment is slightly better, since it is
@@ -1403,7 +1402,6 @@ homogeneous but not complete::
 
   >>> labels_pred = [0, 0, 0, 1, 2, 2]
   >>> metrics.homogeneity_completeness_v_measure(labels_true, labels_pred)
-  ...                                                      # doctest: +ELLIPSIS
   (1.0, 0.68..., 0.81...)
 
 .. note::
@@ -1533,7 +1531,7 @@ between two clusters.
   >>> labels_true = [0, 0, 0, 1, 1, 1]
   >>> labels_pred = [0, 0, 1, 1, 2, 2]
 
-  >>> metrics.fowlkes_mallows_score(labels_true, labels_pred)  # doctest: +ELLIPSIS
+  >>> metrics.fowlkes_mallows_score(labels_true, labels_pred)
   0.47140...
 
 One can permute 0 and 1 in the predicted labels, rename 2 to 3 and get
@@ -1541,20 +1539,20 @@ the same score::
 
   >>> labels_pred = [1, 1, 0, 0, 3, 3]
 
-  >>> metrics.fowlkes_mallows_score(labels_true, labels_pred)  # doctest: +ELLIPSIS
+  >>> metrics.fowlkes_mallows_score(labels_true, labels_pred)
   0.47140...
 
 Perfect labeling is scored 1.0::
 
   >>> labels_pred = labels_true[:]
-  >>> metrics.fowlkes_mallows_score(labels_true, labels_pred)  # doctest: +ELLIPSIS
+  >>> metrics.fowlkes_mallows_score(labels_true, labels_pred)
   1.0
 
 Bad (e.g. independent labelings) have zero scores::
 
   >>> labels_true = [0, 1, 2, 0, 3, 4, 5, 1]
   >>> labels_pred = [1, 1, 0, 0, 2, 2, 2, 2]
-  >>> metrics.fowlkes_mallows_score(labels_true, labels_pred)  # doctest: +ELLIPSIS
+  >>> metrics.fowlkes_mallows_score(labels_true, labels_pred)
   0.0
 
 Advantages
@@ -1635,7 +1633,6 @@ cluster analysis.
   >>> kmeans_model = KMeans(n_clusters=3, random_state=1).fit(X)
   >>> labels = kmeans_model.labels_
   >>> metrics.silhouette_score(X, labels, metric='euclidean')
-  ...                                                      # doctest: +ELLIPSIS
   0.55...
 
 .. topic:: References
@@ -1712,7 +1709,7 @@ cluster analysis.
   >>> from sklearn.cluster import KMeans
   >>> kmeans_model = KMeans(n_clusters=3, random_state=1).fit(X)
   >>> labels = kmeans_model.labels_
-  >>> metrics.calinski_harabasz_score(X, labels)  # doctest: +ELLIPSIS
+  >>> metrics.calinski_harabasz_score(X, labels)
   561.62...
 
 Advantages
@@ -1780,7 +1777,7 @@ cluster analysis as follows:
   >>> from sklearn.metrics import davies_bouldin_score
   >>> kmeans = KMeans(n_clusters=3, random_state=1).fit(X)
   >>> labels = kmeans.labels_
-  >>> davies_bouldin_score(X, labels)  # doctest: +ELLIPSIS
+  >>> davies_bouldin_score(X, labels)
   0.6619...
 
 

--- a/doc/modules/compose.rst
+++ b/doc/modules/compose.rst
@@ -57,10 +57,8 @@ is an estimator object::
     >>> from sklearn.decomposition import PCA
     >>> estimators = [('reduce_dim', PCA()), ('clf', SVC())]
     >>> pipe = Pipeline(estimators)
-    >>> pipe # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
-    Pipeline(memory=None,
-             steps=[('reduce_dim', PCA(copy=True,...)),
-                    ('clf', SVC(C=1.0,...))], verbose=False)
+    >>> pipe
+    Pipeline(steps=[('reduce_dim', PCA()), ('clf', SVC())])
 
 The utility function :func:`make_pipeline` is a shorthand
 for constructing pipelines;
@@ -70,13 +68,8 @@ filling in the names automatically::
     >>> from sklearn.pipeline import make_pipeline
     >>> from sklearn.naive_bayes import MultinomialNB
     >>> from sklearn.preprocessing import Binarizer
-    >>> make_pipeline(Binarizer(), MultinomialNB()) # doctest: +NORMALIZE_WHITESPACE
-    Pipeline(memory=None,
-             steps=[('binarizer', Binarizer(copy=True, threshold=0.0)),
-                    ('multinomialnb', MultinomialNB(alpha=1.0,
-                                                    class_prior=None,
-                                                    fit_prior=True))],
-             verbose=False)
+    >>> make_pipeline(Binarizer(), MultinomialNB())
+    Pipeline(steps=[('binarizer', Binarizer()), ('multinomialnb', MultinomialNB())])
 
 Accessing steps
 ...............
@@ -85,15 +78,12 @@ The estimators of a pipeline are stored as a list in the ``steps`` attribute,
 but can be accessed by index or name by indexing (with ``[idx]``) the
 Pipeline::
 
-    >>> pipe.steps[0]  # doctest: +NORMALIZE_WHITESPACE
-    ('reduce_dim', PCA(copy=True, iterated_power='auto', n_components=None,
-                       random_state=None, svd_solver='auto', tol=0.0,
-                       whiten=False))
-    >>> pipe[0]  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    PCA(copy=True, iterated_power='auto', n_components=None, random_state=None,
-        svd_solver='auto', tol=0.0, whiten=False)
-    >>> pipe['reduce_dim']  # doctest: +NORMALIZE_WHITESPACE
-    PCA(copy=True, ...)
+    >>> pipe.steps[0]
+    ('reduce_dim', PCA())
+    >>> pipe[0]
+    PCA()
+    >>> pipe['reduce_dim']
+    PCA()
 
 Pipeline's `named_steps` attribute allows accessing steps by name with tab
 completion in interactive environments::
@@ -106,10 +96,10 @@ for Python Sequences such as lists or strings (although only a step of 1 is
 permitted). This is convenient for performing only some of the transformations
 (or their inverse):
 
-    >>> pipe[:1] # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    Pipeline(memory=None, steps=[('reduce_dim', PCA(copy=True, ...))],...)
-    >>> pipe[-1:] # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    Pipeline(memory=None, steps=[('clf', SVC(C=1.0, ...))],...)
+    >>> pipe[:1]
+    Pipeline(steps=[('reduce_dim', PCA())])
+    >>> pipe[-1:]
+    Pipeline(steps=[('clf', SVC())])
 
 Nested parameters
 .................
@@ -117,11 +107,8 @@ Nested parameters
 Parameters of the estimators in the pipeline can be accessed using the
 ``<estimator>__<parameter>`` syntax::
 
-    >>> pipe.set_params(clf__C=10) # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
-    Pipeline(memory=None,
-             steps=[('reduce_dim', PCA(copy=True, iterated_power='auto',...)),
-                    ('clf', SVC(C=10,...))],
-             verbose=False)
+    >>> pipe.set_params(clf__C=10)
+    Pipeline(steps=[('reduce_dim', PCA()), ('clf', SVC(C=10))])
 
 This is particularly important for doing grid searches::
 
@@ -141,13 +128,13 @@ ignored by setting them to ``'passthrough'``::
 
 The estimators of the pipeline can be retrieved by index:
 
-    >>> pipe[0]  # doctest: +ELLIPSIS
-    PCA(copy=True, ...)
+    >>> pipe[0] 
+    PCA()
 
 or by name::
 
-    >>> pipe['reduce_dim']  # doctest: +ELLIPSIS
-    PCA(copy=True, ...)
+    >>> pipe['reduce_dim']
+    PCA()
 
 .. topic:: Examples:
 
@@ -201,10 +188,9 @@ object::
     >>> estimators = [('reduce_dim', PCA()), ('clf', SVC())]
     >>> cachedir = mkdtemp()
     >>> pipe = Pipeline(estimators, memory=cachedir)
-    >>> pipe # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
-    Pipeline(...,
-             steps=[('reduce_dim', PCA(copy=True,...)),
-                    ('clf', SVC(C=1.0,...))], verbose=False)
+    >>> pipe
+    Pipeline(memory=...,
+             steps=[('reduce_dim', PCA()), ('clf', SVC())])
     >>> # Clear the cache directory when you don't need it anymore
     >>> rmtree(cachedir)
 
@@ -219,12 +205,9 @@ object::
      >>> svm1 = SVC()
      >>> pipe = Pipeline([('reduce_dim', pca1), ('clf', svm1)])
      >>> pipe.fit(digits.data, digits.target)
-     ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
-     Pipeline(memory=None,
-              steps=[('reduce_dim', PCA(...)), ('clf', SVC(...))],
-              verbose=False)
+     Pipeline(steps=[('reduce_dim', PCA()), ('clf', SVC())])
      >>> # The pca instance can be inspected directly
-     >>> print(pca1.components_) # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
+     >>> print(pca1.components_)
          [[-1.77484909e-19  ... 4.07058917e-18]]
 
    Enabling caching triggers a clone of the transformers before fitting.
@@ -242,12 +225,9 @@ object::
      >>> cached_pipe = Pipeline([('reduce_dim', pca2), ('clf', svm2)],
      ...                        memory=cachedir)
      >>> cached_pipe.fit(digits.data, digits.target)
-     ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
-      Pipeline(memory=...,
-               steps=[('reduce_dim', PCA(...)), ('clf', SVC(...))],
-               verbose=False)
+     Pipeline(memory=...,
+             steps=[('reduce_dim', PCA()), ('clf', SVC())])
      >>> print(cached_pipe.named_steps['reduce_dim'].components_)
-     ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
          [[-1.77484909e-19  ... 4.07058917e-18]]
      >>> # Remove the cache directory
      >>> rmtree(cachedir)
@@ -281,7 +261,7 @@ variable::
   >>> regr = TransformedTargetRegressor(regressor=regressor,
   ...                                   transformer=transformer)
   >>> X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
-  >>> regr.fit(X_train, y_train) # doctest: +ELLIPSIS
+  >>> regr.fit(X_train, y_train)
   TransformedTargetRegressor(...)
   >>> print('R2 score: {0:.2f}'.format(regr.score(X_test, y_test)))
   R2 score: 0.67
@@ -302,7 +282,7 @@ Subsequently, the object is created as::
   >>> regr = TransformedTargetRegressor(regressor=regressor,
   ...                                   func=func,
   ...                                   inverse_func=inverse_func)
-  >>> regr.fit(X_train, y_train) # doctest: +ELLIPSIS
+  >>> regr.fit(X_train, y_train)
   TransformedTargetRegressor(...)
   >>> print('R2 score: {0:.2f}'.format(regr.score(X_test, y_test)))
   R2 score: 0.65
@@ -317,7 +297,7 @@ each other. However, it is possible to bypass this checking by setting
   ...                                   func=func,
   ...                                   inverse_func=inverse_func,
   ...                                   check_inverse=False)
-  >>> regr.fit(X_train, y_train) # doctest: +ELLIPSIS
+  >>> regr.fit(X_train, y_train)
   TransformedTargetRegressor(...)
   >>> print('R2 score: {0:.2f}'.format(regr.score(X_test, y_test)))
   R2 score: -4.50
@@ -376,11 +356,9 @@ and ``value`` is an estimator object::
     >>> from sklearn.decomposition import KernelPCA
     >>> estimators = [('linear_pca', PCA()), ('kernel_pca', KernelPCA())]
     >>> combined = FeatureUnion(estimators)
-    >>> combined # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
-    FeatureUnion(n_jobs=None,
-                 transformer_list=[('linear_pca', PCA(copy=True,...)),
-                                   ('kernel_pca', KernelPCA(alpha=1.0,...))],
-                 transformer_weights=None, verbose=False)
+    >>> combined
+    FeatureUnion(transformer_list=[('linear_pca', PCA()),
+                                   ('kernel_pca', KernelPCA())])
 
 
 Like pipelines, feature unions have a shorthand constructor called
@@ -391,11 +369,8 @@ Like ``Pipeline``, individual steps may be replaced using ``set_params``,
 and ignored by setting to ``'drop'``::
 
     >>> combined.set_params(kernel_pca='drop')
-    ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
-    FeatureUnion(n_jobs=None,
-                 transformer_list=[('linear_pca', PCA(copy=True,...)),
-                                   ('kernel_pca', 'drop')],
-                 transformer_weights=None, verbose=False)
+    FeatureUnion(transformer_list=[('linear_pca', PCA()), 
+                                   ('kernel_pca', 'drop')])
 
 .. topic:: Examples:
 
@@ -460,13 +435,12 @@ By default, the remaining rating columns are ignored (``remainder='drop'``)::
   ...      ('title_bow', CountVectorizer(), 'title')],
   ...     remainder='drop')
 
-  >>> column_trans.fit(X) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-  ColumnTransformer(n_jobs=None, remainder='drop', sparse_threshold=0.3,
-      transformer_weights=None,
-      transformers=...)
+  >>> column_trans.fit(X)
+  ColumnTransformer(transformers=[('city_category', OneHotEncoder(dtype='int'),
+                                   ['city']),
+                                  ('title_bow', CountVectorizer(), 'title')])
 
   >>> column_trans.get_feature_names()
-  ... # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
   ['city_category__x0_London', 'city_category__x0_Paris', 'city_category__x0_Sallisaw',
   'title_bow__bow', 'title_bow__feast', 'title_bow__grapes', 'title_bow__his',
   'title_bow__how', 'title_bow__last', 'title_bow__learned', 'title_bow__moveable',
@@ -474,7 +448,6 @@ By default, the remaining rating columns are ignored (``remainder='drop'``)::
   'title_bow__wrath']
 
   >>> column_trans.transform(X).toarray()
-  ... # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
   array([[1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0],
          [1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 0],
          [0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
@@ -502,7 +475,6 @@ transformation::
   ...     remainder='passthrough')
 
   >>> column_trans.fit_transform(X)
-  ... # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
   array([[1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 5, 4],
          [1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 0, 3, 5],
          [0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 4, 4],
@@ -519,7 +491,6 @@ the transformation::
   ...     remainder=MinMaxScaler())
 
   >>> column_trans.fit_transform(X)[:, -2:]
-  ... # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
   array([[1. , 0.5],
          [0. , 1. ],
          [0.5, 0.5],
@@ -535,11 +506,11 @@ above example would be::
   ...     (OneHotEncoder(), ['city']),
   ...     (CountVectorizer(), 'title'),
   ...     remainder=MinMaxScaler())
-  >>> column_trans # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-  ColumnTransformer(n_jobs=None, remainder=MinMaxScaler(copy=True, ...),
-           sparse_threshold=0.3,
-           transformer_weights=None,
-           transformers=[('onehotencoder', ...)
+  >>> column_trans
+  ColumnTransformer(remainder=MinMaxScaler(),
+                    transformers=[('onehotencoder', OneHotEncoder(), ['city']),
+                                  ('countvectorizer', CountVectorizer(),
+                                   'title')])
 
 .. topic:: Examples:
 

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -54,7 +54,7 @@ data for testing (evaluating) our classifier::
   ((60, 4), (60,))
 
   >>> clf = svm.SVC(kernel='linear', C=1).fit(X_train, y_train)
-  >>> clf.score(X_test, y_test)                           # doctest: +ELLIPSIS
+  >>> clf.score(X_test, y_test)
   0.96...
 
 When evaluating different settings ("hyperparameters") for estimators,
@@ -118,7 +118,7 @@ time)::
   >>> from sklearn.model_selection import cross_val_score
   >>> clf = svm.SVC(kernel='linear', C=1)
   >>> scores = cross_val_score(clf, iris.data, iris.target, cv=5)
-  >>> scores                                              # doctest: +ELLIPSIS
+  >>> scores
   array([0.96..., 1.  ..., 0.96..., 0.96..., 1.        ])
 
 The mean score and the 95\% confidence interval of the score estimate are hence
@@ -134,7 +134,7 @@ scoring parameter::
   >>> from sklearn import metrics
   >>> scores = cross_val_score(
   ...     clf, iris.data, iris.target, cv=5, scoring='f1_macro')
-  >>> scores                                              # doctest: +ELLIPSIS
+  >>> scores
   array([0.96..., 1.  ..., 0.96..., 0.96..., 1.        ])
 
 See :ref:`scoring_parameter` for details.
@@ -152,7 +152,7 @@ validation iterator instead, for instance::
   >>> from sklearn.model_selection import ShuffleSplit
   >>> n_samples = iris.data.shape[0]
   >>> cv = ShuffleSplit(n_splits=5, test_size=0.3, random_state=0)
-  >>> cross_val_score(clf, iris.data, iris.target, cv=cv)  # doctest: +ELLIPSIS
+  >>> cross_val_score(clf, iris.data, iris.target, cv=cv)
   array([0.977..., 0.977..., 1.  ..., 0.955..., 1.        ])
 
 Another option is to use an iterable yielding (train, test) splits as arrays of
@@ -184,7 +184,7 @@ indices, for example::
       >>> X_train_transformed = scaler.transform(X_train)
       >>> clf = svm.SVC(C=1).fit(X_train_transformed, y_train)
       >>> X_test_transformed = scaler.transform(X_test)
-      >>> clf.score(X_test_transformed, y_test)  # doctest: +ELLIPSIS
+      >>> clf.score(X_test_transformed, y_test)
       0.9333...
 
     A :class:`Pipeline <sklearn.pipeline.Pipeline>` makes it easier to compose
@@ -193,7 +193,6 @@ indices, for example::
       >>> from sklearn.pipeline import make_pipeline
       >>> clf = make_pipeline(preprocessing.StandardScaler(), svm.SVC(C=1))
       >>> cross_val_score(clf, iris.data, iris.target, cv=cv)
-      ...                                                 # doctest: +ELLIPSIS
       array([0.977..., 0.933..., 0.955..., 0.933..., 0.977...])
 
     See :ref:`combining_estimators`.
@@ -237,7 +236,7 @@ predefined scorer names::
     >>> scores = cross_validate(clf, iris.data, iris.target, scoring=scoring)
     >>> sorted(scores.keys())
     ['fit_time', 'score_time', 'test_precision_macro', 'test_recall_macro']
-    >>> scores['test_recall_macro']                       # doctest: +ELLIPSIS
+    >>> scores['test_recall_macro']
     array([0.96..., 1.  ..., 0.96..., 0.96..., 1.        ])
 
 Or as a dict mapping scorer name to a predefined or custom scoring function::
@@ -247,10 +246,10 @@ Or as a dict mapping scorer name to a predefined or custom scoring function::
     ...            'rec_macro': make_scorer(recall_score, average='macro')}
     >>> scores = cross_validate(clf, iris.data, iris.target, scoring=scoring,
     ...                         cv=5, return_train_score=True)
-    >>> sorted(scores.keys())                 # doctest: +NORMALIZE_WHITESPACE
+    >>> sorted(scores.keys())
     ['fit_time', 'score_time', 'test_prec_macro', 'test_rec_macro',
      'train_prec_macro', 'train_rec_macro']
-    >>> scores['train_rec_macro']                         # doctest: +ELLIPSIS
+    >>> scores['train_rec_macro']
     array([0.97..., 0.97..., 0.99..., 0.98..., 0.98...])
 
 Here is an example of ``cross_validate`` using a single metric::
@@ -771,7 +770,7 @@ Example of 3-split time series cross-validation on a dataset with 6 samples::
   >>> X = np.array([[1, 2], [3, 4], [1, 2], [3, 4], [1, 2], [3, 4]])
   >>> y = np.array([1, 2, 3, 4, 5, 6])
   >>> tscv = TimeSeriesSplit(n_splits=3)
-  >>> print(tscv)  # doctest: +NORMALIZE_WHITESPACE
+  >>> print(tscv)
   TimeSeriesSplit(max_train_size=None, n_splits=3)
   >>> for train, test in tscv.split(X):
   ...     print("%s %s" % (train, test))

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -168,13 +168,13 @@ in bias::
     >>> clf = DecisionTreeClassifier(max_depth=None, min_samples_split=2,
     ...     random_state=0)
     >>> scores = cross_val_score(clf, X, y, cv=5)
-    >>> scores.mean()                               # doctest: +ELLIPSIS
+    >>> scores.mean()
     0.98...
 
     >>> clf = RandomForestClassifier(n_estimators=10, max_depth=None,
     ...     min_samples_split=2, random_state=0)
     >>> scores = cross_val_score(clf, X, y, cv=5)
-    >>> scores.mean()                               # doctest: +ELLIPSIS
+    >>> scores.mean()
     0.999...
 
     >>> clf = ExtraTreesClassifier(n_estimators=10, max_depth=None,
@@ -385,7 +385,7 @@ learners::
     >>> iris = load_iris()
     >>> clf = AdaBoostClassifier(n_estimators=100)
     >>> scores = cross_val_score(clf, iris.data, iris.target, cv=5)
-    >>> scores.mean()                             # doctest: +ELLIPSIS
+    >>> scores.mean()
     0.9...
 
 The number of weak learners is controlled by the parameter ``n_estimators``. The
@@ -506,7 +506,7 @@ with 100 decision stumps as weak learners::
 
     >>> clf = GradientBoostingClassifier(n_estimators=100, learning_rate=1.0,
     ...     max_depth=1, random_state=0).fit(X_train, y_train)
-    >>> clf.score(X_test, y_test)                 # doctest: +ELLIPSIS
+    >>> clf.score(X_test, y_test)
     0.913...
 
 The number of weak learners (i.e. regression trees) is controlled by the parameter ``n_estimators``; :ref:`The size of each tree <gradient_boosting_tree_size>` can be controlled either by setting the tree depth via ``max_depth`` or by setting the number of leaf nodes via ``max_leaf_nodes``. The ``learning_rate`` is a hyper-parameter in the range (0.0, 1.0] that controls overfitting via :ref:`shrinkage <gradient_boosting_shrinkage>` .
@@ -540,7 +540,7 @@ for regression which can be specified via the argument
     >>> y_train, y_test = y[:200], y[200:]
     >>> est = GradientBoostingRegressor(n_estimators=100, learning_rate=0.1,
     ...     max_depth=1, random_state=0, loss='ls').fit(X_train, y_train)
-    >>> mean_squared_error(y_test, est.predict(X_test))    # doctest: +ELLIPSIS
+    >>> mean_squared_error(y_test, est.predict(X_test))
     5.00...
 
 The figure below shows the results of applying :class:`GradientBoostingRegressor`
@@ -579,7 +579,7 @@ fitted model.
 
   >>> _ = est.set_params(n_estimators=200, warm_start=True)  # set warm_start and new nr of trees
   >>> _ = est.fit(X_train, y_train) # fit additional 100 trees to est
-  >>> mean_squared_error(y_test, est.predict(X_test))    # doctest: +ELLIPSIS
+  >>> mean_squared_error(y_test, est.predict(X_test))
   3.84...
 
 .. _gradient_boosting_tree_size:
@@ -823,7 +823,7 @@ accessed via the ``feature_importances_`` property::
     >>> X, y = make_hastie_10_2(random_state=0)
     >>> clf = GradientBoostingClassifier(n_estimators=100, learning_rate=1.0,
     ...     max_depth=1, random_state=0).fit(X, y)
-    >>> clf.feature_importances_  # doctest: +ELLIPSIS
+    >>> clf.feature_importances_
     array([0.10..., 0.10..., 0.11..., ...
 
 .. topic:: Examples:

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -85,7 +85,7 @@ suitable for feeding into a classifier (maybe after being piped into a
 
   >>> vec = DictVectorizer()
   >>> pos_vectorized = vec.fit_transform(pos_window)
-  >>> pos_vectorized                # doctest: +NORMALIZE_WHITESPACE  +ELLIPSIS
+  >>> pos_vectorized
   <1x6 sparse matrix of type '<... 'numpy.float64'>'
       with 6 stored elements in Compressed Sparse ... format>
   >>> pos_vectorized.toarray()
@@ -289,7 +289,7 @@ reasonable (please see  the :ref:`reference documentation
 <text_feature_extraction_ref>` for the details)::
 
   >>> vectorizer = CountVectorizer()
-  >>> vectorizer                     # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+  >>> vectorizer
   CountVectorizer()
 
 Let's use it to tokenize and count the word occurrences of a minimalistic
@@ -302,7 +302,7 @@ corpus of text documents::
   ...     'Is this the first document?',
   ... ]
   >>> X = vectorizer.fit_transform(corpus)
-  >>> X                              # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+  >>> X
   <4x9 sparse matrix of type '<... 'numpy.int64'>'
       with 19 stored elements in Compressed Sparse ... format>
 
@@ -324,7 +324,7 @@ interpretation of the columns can be retrieved as follows::
   ...      'second', 'the', 'third', 'this'])
   True
 
-  >>> X.toarray()           # doctest: +ELLIPSIS
+  >>> X.toarray()
   array([[0, 1, 1, 1, 0, 0, 1, 0, 1],
          [0, 1, 0, 1, 0, 2, 1, 0, 1],
          [1, 0, 0, 0, 1, 0, 1, 1, 0],
@@ -340,7 +340,6 @@ Hence words that were not seen in the training corpus will be completely
 ignored in future calls to the transform method::
 
   >>> vectorizer.transform(['Something completely new.']).toarray()
-  ...                           # doctest: +ELLIPSIS
   array([[0, 0, 0, 0, 0, 0, 0, 0, 0]]...)
 
 Note that in the previous corpus, the first and the last documents have
@@ -361,7 +360,6 @@ can now resolve ambiguities encoded in local positioning patterns::
 
   >>> X_2 = bigram_vectorizer.fit_transform(corpus).toarray()
   >>> X_2
-  ...                           # doctest: +ELLIPSIS
   array([[0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0],
          [0, 0, 1, 0, 0, 1, 1, 0, 0, 2, 1, 1, 1, 0, 1, 0, 0, 0, 1, 1, 0],
          [1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 0],
@@ -372,7 +370,7 @@ In particular the interrogative form "Is this" is only present in the
 last document::
 
   >>> feature_index = bigram_vectorizer.vocabulary_.get('is this')
-  >>> X_2[:, feature_index]     # doctest: +ELLIPSIS
+  >>> X_2[:, feature_index]
   array([0, 0, 0, 1]...)
 
 .. _stop_words:
@@ -465,7 +463,7 @@ class::
 
   >>> from sklearn.feature_extraction.text import TfidfTransformer
   >>> transformer = TfidfTransformer(smooth_idf=False)
-  >>> transformer   # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+  >>> transformer
   TfidfTransformer(smooth_idf=False)
 
 Again please see the :ref:`reference documentation
@@ -484,11 +482,11 @@ content of the documents::
   ...           [3, 0, 2]]
   ...
   >>> tfidf = transformer.fit_transform(counts)
-  >>> tfidf                         # doctest: +NORMALIZE_WHITESPACE  +ELLIPSIS
+  >>> tfidf
   <6x3 sparse matrix of type '<... 'numpy.float64'>'
       with 9 stored elements in Compressed Sparse ... format>
 
-  >>> tfidf.toarray()                        # doctest: +ELLIPSIS
+  >>> tfidf.toarray()
   array([[0.81940995, 0.        , 0.57320793],
          [1.        , 0.        , 0.        ],
          [1.        , 0.        , 0.        ],
@@ -560,7 +558,7 @@ The weights of each
 feature computed by the ``fit`` method call are stored in a model
 attribute::
 
-  >>> transformer.idf_                       # doctest: +ELLIPSIS
+  >>> transformer.idf_
   array([1. ..., 2.25..., 1.84...])
 
 
@@ -573,7 +571,6 @@ class called :class:`TfidfVectorizer` that combines all the options of
   >>> from sklearn.feature_extraction.text import TfidfVectorizer
   >>> vectorizer = TfidfVectorizer()
   >>> vectorizer.fit_transform(corpus)
-  ...                                # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
   <4x9 sparse matrix of type '<... 'numpy.float64'>'
       with 19 stored elements in Compressed Sparse ... format>
 
@@ -737,7 +734,6 @@ span across words::
 
   >>> ngram_vectorizer = CountVectorizer(analyzer='char_wb', ngram_range=(5, 5))
   >>> ngram_vectorizer.fit_transform(['jumpy fox'])
-  ...                                # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
   <1x4 sparse matrix of type '<... 'numpy.int64'>'
      with 4 stored elements in Compressed Sparse ... format>
   >>> ngram_vectorizer.get_feature_names() == (
@@ -746,7 +742,6 @@ span across words::
 
   >>> ngram_vectorizer = CountVectorizer(analyzer='char', ngram_range=(5, 5))
   >>> ngram_vectorizer.fit_transform(['jumpy fox'])
-  ...                                # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
   <1x5 sparse matrix of type '<... 'numpy.int64'>'
       with 5 stored elements in Compressed Sparse ... format>
   >>> ngram_vectorizer.get_feature_names() == (
@@ -815,7 +810,6 @@ meaning that you don't have to call ``fit`` on it::
   >>> from sklearn.feature_extraction.text import HashingVectorizer
   >>> hv = HashingVectorizer(n_features=10)
   >>> hv.transform(corpus)
-  ...                                # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
   <4x10 sparse matrix of type '<... 'numpy.float64'>'
       with 16 stored elements in Compressed Sparse ... format>
 
@@ -840,7 +834,6 @@ Let's try again with the default setting::
 
   >>> hv = HashingVectorizer()
   >>> hv.transform(corpus)
-  ...                               # doctest: +NORMALIZE_WHITESPACE  +ELLIPSIS
   <4x1048576 sparse matrix of type '<... 'numpy.float64'>'
       with 19 stored elements in Compressed Sparse ... format>
 
@@ -959,7 +952,7 @@ Some tips and tricks:
         ...         tokenize = super().build_tokenizer()
         ...         return lambda doc: list(to_british(tokenize(doc)))
         ...
-        >>> print(CustomVectorizer().build_analyzer()(u"color colour")) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+        >>> print(CustomVectorizer().build_analyzer()(u"color colour"))
         [...'color', ...'color']
 
     for other styles of preprocessing; examples include stemming, lemmatization,

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -290,12 +290,7 @@ reasonable (please see  the :ref:`reference documentation
 
   >>> vectorizer = CountVectorizer()
   >>> vectorizer                     # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-  CountVectorizer(analyzer=...'word', binary=False, decode_error=...'strict',
-          dtype=<... 'numpy.int64'>, encoding=...'utf-8', input=...'content',
-          lowercase=True, max_df=1.0, max_features=None, min_df=1,
-          ngram_range=(1, 1), preprocessor=None, stop_words=None,
-          strip_accents=None, token_pattern=...'(?u)\\b\\w\\w+\\b',
-          tokenizer=None, vocabulary=None)
+  CountVectorizer()
 
 Let's use it to tokenize and count the word occurrences of a minimalistic
 corpus of text documents::
@@ -471,8 +466,7 @@ class::
   >>> from sklearn.feature_extraction.text import TfidfTransformer
   >>> transformer = TfidfTransformer(smooth_idf=False)
   >>> transformer   # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-  TfidfTransformer(norm=...'l2', smooth_idf=False, sublinear_tf=False,
-                   use_idf=True)
+  TfidfTransformer(smooth_idf=False)
 
 Again please see the :ref:`reference documentation
 <text_feature_extraction_ref>` for the details on all the parameters.

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -45,10 +45,10 @@ that contain the missing values::
     >>> import numpy as np
     >>> from sklearn.impute import SimpleImputer
     >>> imp = SimpleImputer(missing_values=np.nan, strategy='mean')
-    >>> imp.fit([[1, 2], [np.nan, 3], [7, 6]])  # doctest: +NORMALIZE_WHITESPACE
+    >>> imp.fit([[1, 2], [np.nan, 3], [7, 6]])
     SimpleImputer()
     >>> X = [[np.nan, 2], [6, np.nan], [7, 6]]
-    >>> print(imp.transform(X))      # doctest: +NORMALIZE_WHITESPACE  +ELLIPSIS
+    >>> print(imp.transform(X))
     [[4.          2.        ]
      [6.          3.666...]
      [7.          6.        ]]
@@ -58,10 +58,10 @@ The :class:`SimpleImputer` class also supports sparse matrices::
     >>> import scipy.sparse as sp
     >>> X = sp.csc_matrix([[1, 2], [0, -1], [8, 4]])
     >>> imp = SimpleImputer(missing_values=-1, strategy='mean')
-    >>> imp.fit(X)                  # doctest: +NORMALIZE_WHITESPACE
+    >>> imp.fit(X)
     SimpleImputer(missing_values=-1)
     >>> X_test = sp.csc_matrix([[-1, 2], [6, -1], [7, 6]])
-    >>> print(imp.transform(X_test).toarray())  # doctest: +NORMALIZE_WHITESPACE
+    >>> print(imp.transform(X_test).toarray())
     [[3. 2.]
      [6. 3.]
      [7. 6.]]
@@ -81,7 +81,7 @@ string values or pandas categoricals when using the ``'most_frequent'`` or
     ...                    ["b", "y"]], dtype="category")
     ...
     >>> imp = SimpleImputer(strategy="most_frequent")
-    >>> print(imp.fit_transform(df))      # doctest: +NORMALIZE_WHITESPACE
+    >>> print(imp.fit_transform(df))
     [['a' 'x']
      ['a' 'y']
      ['a' 'y']
@@ -115,7 +115,7 @@ imputation round are returned.
     >>> from sklearn.experimental import enable_iterative_imputer
     >>> from sklearn.impute import IterativeImputer
     >>> imp = IterativeImputer(max_iter=10, random_state=0)
-    >>> imp.fit([[1, 2], [3, 6], [4, 8], [np.nan, 3], [7, np.nan]])  # doctest: +NORMALIZE_WHITESPACE
+    >>> imp.fit([[1, 2], [3, 6], [4, 8], [np.nan, 3], [7, np.nan]])
     IterativeImputer(random_state=0)
     >>> X_test = [[np.nan, 2], [6, np.nan], [np.nan, 6]]
     >>> # the model learns that the second feature is double the first

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -46,8 +46,7 @@ that contain the missing values::
     >>> from sklearn.impute import SimpleImputer
     >>> imp = SimpleImputer(missing_values=np.nan, strategy='mean')
     >>> imp.fit([[1, 2], [np.nan, 3], [7, 6]])  # doctest: +NORMALIZE_WHITESPACE
-    SimpleImputer(add_indicator=False, copy=True, fill_value=None,
-                  missing_values=nan, strategy='mean', verbose=0)
+    SimpleImputer()
     >>> X = [[np.nan, 2], [6, np.nan], [7, 6]]
     >>> print(imp.transform(X))      # doctest: +NORMALIZE_WHITESPACE  +ELLIPSIS
     [[4.          2.        ]
@@ -60,8 +59,7 @@ The :class:`SimpleImputer` class also supports sparse matrices::
     >>> X = sp.csc_matrix([[1, 2], [0, -1], [8, 4]])
     >>> imp = SimpleImputer(missing_values=-1, strategy='mean')
     >>> imp.fit(X)                  # doctest: +NORMALIZE_WHITESPACE
-    SimpleImputer(add_indicator=False, copy=True, fill_value=None,
-                  missing_values=-1, strategy='mean', verbose=0)
+    SimpleImputer(missing_values=-1)
     >>> X_test = sp.csc_matrix([[-1, 2], [6, -1], [7, 6]])
     >>> print(imp.transform(X_test).toarray())  # doctest: +NORMALIZE_WHITESPACE
     [[3. 2.]
@@ -118,12 +116,7 @@ imputation round are returned.
     >>> from sklearn.impute import IterativeImputer
     >>> imp = IterativeImputer(max_iter=10, random_state=0)
     >>> imp.fit([[1, 2], [3, 6], [4, 8], [np.nan, 3], [7, np.nan]])  # doctest: +NORMALIZE_WHITESPACE
-    IterativeImputer(add_indicator=False, estimator=None,
-                     imputation_order='ascending', initial_strategy='mean',
-                     max_iter=10, max_value=None, min_value=None,
-                     missing_values=nan, n_nearest_features=None,
-                     random_state=0, sample_posterior=False, tol=0.001,
-                     verbose=0)
+    IterativeImputer(random_state=0)
     >>> X_test = [[np.nan, 2], [6, np.nan], [np.nan, 6]]
     >>> # the model learns that the second feature is double the first
     >>> print(np.round(imp.transform(X_test)))

--- a/doc/modules/kernel_approximation.rst
+++ b/doc/modules/kernel_approximation.rst
@@ -60,7 +60,7 @@ a linear algorithm, for example a linear SVM::
     >>> rbf_feature = RBFSampler(gamma=1, random_state=1)
     >>> X_features = rbf_feature.fit_transform(X)
     >>> clf = SGDClassifier(max_iter=5)
-    >>> clf.fit(X_features, y)   # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X_features, y)
     SGDClassifier(max_iter=5)
     >>> clf.score(X_features, y)
     1.0

--- a/doc/modules/kernel_approximation.rst
+++ b/doc/modules/kernel_approximation.rst
@@ -61,12 +61,7 @@ a linear algorithm, for example a linear SVM::
     >>> X_features = rbf_feature.fit_transform(X)
     >>> clf = SGDClassifier(max_iter=5)
     >>> clf.fit(X_features, y)   # doctest: +NORMALIZE_WHITESPACE
-    SGDClassifier(alpha=0.0001, average=False, class_weight=None,
-           early_stopping=False, epsilon=0.1, eta0=0.0, fit_intercept=True,
-           l1_ratio=0.15, learning_rate='optimal', loss='hinge', max_iter=5,
-           n_iter_no_change=5, n_jobs=None, penalty='l2', power_t=0.5,
-           random_state=None, shuffle=True, tol=0.001, validation_fraction=0.1,
-           verbose=0, warm_start=False)
+    SGDClassifier(max_iter=5)
     >>> clf.score(X_features, y)
     1.0
 

--- a/doc/modules/learning_curve.rst
+++ b/doc/modules/learning_curve.rst
@@ -83,11 +83,11 @@ The function :func:`validation_curve` can help in this case::
   >>> train_scores, valid_scores = validation_curve(Ridge(), X, y, "alpha",
   ...                                               np.logspace(-7, 3, 3),
   ...                                               cv=5)
-  >>> train_scores            # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+  >>> train_scores
   array([[0.93..., 0.94..., 0.92..., 0.91..., 0.92...],
          [0.93..., 0.94..., 0.92..., 0.91..., 0.92...],
          [0.51..., 0.52..., 0.49..., 0.47..., 0.49...]])
-  >>> valid_scores           # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+  >>> valid_scores
   array([[0.90..., 0.84..., 0.94..., 0.96..., 0.93...],
          [0.90..., 0.84..., 0.94..., 0.96..., 0.93...],
          [0.46..., 0.25..., 0.50..., 0.49..., 0.52...]])
@@ -146,13 +146,13 @@ average scores on the validation sets)::
 
   >>> train_sizes, train_scores, valid_scores = learning_curve(
   ...     SVC(kernel='linear'), X, y, train_sizes=[50, 80, 110], cv=5)
-  >>> train_sizes            # doctest: +NORMALIZE_WHITESPACE
+  >>> train_sizes
   array([ 50, 80, 110])
-  >>> train_scores           # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+  >>> train_scores
   array([[0.98..., 0.98 , 0.98..., 0.98..., 0.98...],
          [0.98..., 1.   , 0.98..., 0.98..., 0.98...],
          [0.98..., 1.   , 0.98..., 0.98..., 0.99...]])
-  >>> valid_scores           # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+  >>> valid_scores
   array([[1. ,  0.93...,  1. ,  1. ,  0.96...],
          [1. ,  0.96...,  1. ,  1. ,  0.96...],
          [1. ,  0.96...,  1. ,  1. ,  0.96...]])

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -107,7 +107,7 @@ its ``coef_`` member::
     Ridge(alpha=0.5)
     >>> reg.coef_
     array([0.34545455, 0.34545455])
-    >>> reg.intercept_ #doctest: +ELLIPSIS
+    >>> reg.intercept_
     0.13636...
 
 

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -107,7 +107,7 @@ its ``coef_`` member::
     Ridge(alpha=0.5)
     >>> reg.coef_
     array([0.34545455, 0.34545455])
-    >>> reg.intercept_
+    >>> reg.intercept_ #doctest: +ELLIPSIS
     0.13636...
 
 

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -44,9 +44,7 @@ and will store the coefficients :math:`w` of the linear model in its
     >>> from sklearn import linear_model
     >>> reg = linear_model.LinearRegression()
     >>> reg.fit([[0, 0], [1, 1], [2, 2]], [0, 1, 2])
-    ...                                       # doctest: +NORMALIZE_WHITESPACE
-    LinearRegression(copy_X=True, fit_intercept=True, n_jobs=None,
-                     normalize=False)
+    LinearRegression()
     >>> reg.coef_
     array([0.5, 0.5])
 
@@ -106,8 +104,7 @@ its ``coef_`` member::
     >>> from sklearn import linear_model
     >>> reg = linear_model.Ridge(alpha=.5)
     >>> reg.fit([[0, 0], [0, 0], [1, 1]], [0, .1, 1]) # doctest: +NORMALIZE_WHITESPACE
-    Ridge(alpha=0.5, copy_X=True, fit_intercept=True, max_iter=None,
-          normalize=False, random_state=None, solver='auto', tol=0.001)
+    Ridge(alpha=0.5)
     >>> reg.coef_
     array([0.34545455, 0.34545455])
     >>> reg.intercept_ #doctest: +ELLIPSIS
@@ -145,9 +142,7 @@ as GridSearchCV except that it defaults to Generalized Cross-Validation
     >>> reg = linear_model.RidgeCV(alphas=np.logspace(-6, 6, 13))
     >>> reg.fit([[0, 0], [0, 0], [1, 1]], [0, .1, 1])       # doctest: +NORMALIZE_WHITESPACE
     RidgeCV(alphas=array([1.e-06, 1.e-05, 1.e-04, 1.e-03, 1.e-02, 1.e-01, 1.e+00, 1.e+01,
-          1.e+02, 1.e+03, 1.e+04, 1.e+05, 1.e+06]),
-            cv=None, fit_intercept=True, gcv_mode=None, normalize=False,
-            scoring=None, store_cv_values=False)
+          1.e+02, 1.e+03, 1.e+04, 1.e+05, 1.e+06]))
     >>> reg.alpha_
     0.01
 
@@ -194,9 +189,7 @@ for another implementation::
     >>> from sklearn import linear_model
     >>> reg = linear_model.Lasso(alpha=0.1)
     >>> reg.fit([[0, 0], [1, 1]], [0, 1])  # doctest: +NORMALIZE_WHITESPACE
-    Lasso(alpha=0.1, copy_X=True, fit_intercept=True, max_iter=1000,
-       normalize=False, positive=False, precompute=False, random_state=None,
-       selection='cyclic', tol=0.0001, warm_start=False)
+    Lasso(alpha=0.1)
     >>> reg.predict([[1, 1]])
     array([0.8])
 
@@ -484,9 +477,7 @@ function of the norm of its coefficients.
    >>> from sklearn import linear_model
    >>> reg = linear_model.LassoLars(alpha=.1)
    >>> reg.fit([[0, 0], [1, 1]], [0, 1])  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-   LassoLars(alpha=0.1, copy_X=True, eps=..., fit_intercept=True,
-        fit_path=True, max_iter=500, normalize=True, positive=False,
-        precompute='auto', verbose=False)
+   LassoLars(alpha=0.1)
    >>> reg.coef_    # doctest: +ELLIPSIS
    array([0.717157..., 0.        ])
 
@@ -653,10 +644,7 @@ Bayesian Ridge Regression is used for regression::
     >>> Y = [0., 1., 2., 3.]
     >>> reg = linear_model.BayesianRidge()
     >>> reg.fit(X, Y)  # doctest: +NORMALIZE_WHITESPACE
-    BayesianRidge(alpha_1=1e-06, alpha_2=1e-06, alpha_init=None,
-                  compute_score=False, copy_X=True, fit_intercept=True,
-                  lambda_1=1e-06, lambda_2=1e-06, lambda_init=None, n_iter=300,
-                  normalize=False, tol=0.001, verbose=False)
+    BayesianRidge()
 
 After being fitted, the model can then be used to predict new values::
 

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -103,7 +103,7 @@ its ``coef_`` member::
 
     >>> from sklearn import linear_model
     >>> reg = linear_model.Ridge(alpha=.5)
-    >>> reg.fit([[0, 0], [0, 0], [1, 1]], [0, .1, 1]) # doctest: +NORMALIZE_WHITESPACE
+    >>> reg.fit([[0, 0], [0, 0], [1, 1]], [0, .1, 1])
     Ridge(alpha=0.5)
     >>> reg.coef_
     array([0.34545455, 0.34545455])
@@ -140,7 +140,7 @@ as GridSearchCV except that it defaults to Generalized Cross-Validation
     >>> import numpy as np
     >>> from sklearn import linear_model
     >>> reg = linear_model.RidgeCV(alphas=np.logspace(-6, 6, 13))
-    >>> reg.fit([[0, 0], [0, 0], [1, 1]], [0, .1, 1])       # doctest: +NORMALIZE_WHITESPACE
+    >>> reg.fit([[0, 0], [0, 0], [1, 1]], [0, .1, 1])
     RidgeCV(alphas=array([1.e-06, 1.e-05, 1.e-04, 1.e-03, 1.e-02, 1.e-01, 1.e+00, 1.e+01,
           1.e+02, 1.e+03, 1.e+04, 1.e+05, 1.e+06]))
     >>> reg.alpha_
@@ -188,7 +188,7 @@ for another implementation::
 
     >>> from sklearn import linear_model
     >>> reg = linear_model.Lasso(alpha=0.1)
-    >>> reg.fit([[0, 0], [1, 1]], [0, 1])  # doctest: +NORMALIZE_WHITESPACE
+    >>> reg.fit([[0, 0], [1, 1]], [0, 1])
     Lasso(alpha=0.1)
     >>> reg.predict([[1, 1]])
     array([0.8])
@@ -476,9 +476,9 @@ function of the norm of its coefficients.
 
    >>> from sklearn import linear_model
    >>> reg = linear_model.LassoLars(alpha=.1)
-   >>> reg.fit([[0, 0], [1, 1]], [0, 1])  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+   >>> reg.fit([[0, 0], [1, 1]], [0, 1])
    LassoLars(alpha=0.1)
-   >>> reg.coef_    # doctest: +ELLIPSIS
+   >>> reg.coef_
    array([0.717157..., 0.        ])
 
 .. topic:: Examples:
@@ -643,7 +643,7 @@ Bayesian Ridge Regression is used for regression::
     >>> X = [[0., 0.], [1., 1.], [2., 2.], [3., 3.]]
     >>> Y = [0., 1., 2., 3.]
     >>> reg = linear_model.BayesianRidge()
-    >>> reg.fit(X, Y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> reg.fit(X, Y)
     BayesianRidge()
 
 After being fitted, the model can then be used to predict new values::

--- a/doc/modules/metrics.rst
+++ b/doc/modules/metrics.rst
@@ -193,7 +193,7 @@ It can be computed using :func:`chi2_kernel` and then passed to an
     >>> X = [[0, 1], [1, 0], [.2, .8], [.7, .3]]
     >>> y = [0, 1, 0, 1]
     >>> K = chi2_kernel(X, gamma=.5)
-    >>> K                        # doctest: +ELLIPSIS
+    >>> K
     array([[1.        , 0.36787944, 0.89483932, 0.58364548],
            [0.36787944, 1.        , 0.51341712, 0.83822343],
            [0.89483932, 0.51341712, 1.        , 0.7768366 ],

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -504,7 +504,7 @@ or *informedness*.
 
 .. topic:: References:
 
-  .. [Guyon2015] I. Guyon, K. Bennett, G. Cawley, H.J. Escalante, S. Escalera, T.K. Ho, N. MaciÃ ,
+  .. [Guyon2015] I. Guyon, K. Bennett, G. Cawley, H.J. Escalante, S. Escalera, T.K. Ho, N. Macià,
      B. Ray, M. Saeed, A.R. Statnikov, E. Viegas, `Design of the 2015 ChaLearn AutoML Challenge
      <https://ieeexplore.ieee.org/document/7280767>`_,
      IJCNN 2015.
@@ -757,7 +757,7 @@ binary classification and multilabel indicator format.
 
 .. topic:: References:
 
-  .. [Manning2008] C.D. Manning, P. Raghavan, H. SchÃ¼tze, `Introduction to Information Retrieval
+  .. [Manning2008] C.D. Manning, P. Raghavan, H. Schütze, `Introduction to Information Retrieval
      <https://nlp.stanford.edu/IR-book/html/htmledition/evaluation-of-ranked-retrieval-results-1.html>`_,
      2008.
   .. [Everingham2010] M. Everingham, L. Van Gool, C.K.I. Williams, J. Winn, A. Zisserman,
@@ -1030,7 +1030,7 @@ with a svm classifier in a multiclass problem::
   LinearSVC()
   >>> pred_decision = est.decision_function([[-1], [2], [3]])
   >>> y_true = [0, 2, 3]
-  >>> hinge_loss(y_true, pred_decision, labels)  #doctest: +ELLIPSIS
+  >>> hinge_loss(y_true, pred_decision, labels)
   0.56...
 
 .. _log_loss:
@@ -1570,7 +1570,7 @@ the ranking loss is defined as
 .. math::
   ranking\_loss(y, \hat{f}) =  \frac{1}{n_{\text{samples}}}
     \sum_{i=0}^{n_{\text{samples}} - 1} \frac{1}{||y_i||_0(n_\text{labels} - ||y_i||_0)}
-    \left|\left\{(k, l): \hat{f}_{ik} \leq \hat{f}_{il}, y_{ik} = 1, y_{il} = 0Â \right\}\right|
+    \left|\left\{(k, l): \hat{f}_{ik} \leq \hat{f}_{il}, y_{ik} = 1, y_{il} = 0 \right\}\right|
 
 where :math:`|\cdot|` computes the cardinality of the set (i.e., the number of
 elements in the set) and :math:`||\cdot||_0` is the :math:`\ell_0` "norm"
@@ -1833,27 +1833,27 @@ function::
 
 .. _r2_score:
 
-RÂ² score, the coefficient of determination
+R² score, the coefficient of determination
 -------------------------------------------
 
 The :func:`r2_score` function computes the `coefficient of
 determination <https://en.wikipedia.org/wiki/Coefficient_of_determination>`_,
-usually denoted as RÂ².
+usually denoted as R².
 
 It represents the proportion of variance (of y) that has been explained by the
 independent variables in the model. It provides an indication of goodness of
 fit and therefore a measure of how well unseen samples are likely to be
 predicted by the model, through the proportion of explained variance.
 
-As such variance is dataset dependent, RÂ² may not be meaningfully comparable
+As such variance is dataset dependent, R² may not be meaningfully comparable
 across different datasets. Best possible score is 1.0 and it can be negative
 (because the model can be arbitrarily worse). A constant model that always
 predicts the expected value of y, disregarding the input features, would get a
-RÂ² score of 0.0.
+R² score of 0.0.
 
 If :math:`\hat{y}_i` is the predicted value of the :math:`i`-th sample
 and :math:`y_i` is the corresponding true value for total :math:`n` samples,
-the estimated RÂ² is defined as:
+the estimated R² is defined as:
 
 .. math::
 
@@ -1861,7 +1861,7 @@ the estimated RÂ² is defined as:
 
 where :math:`\bar{y} = \frac{1}{n} \sum_{i=1}^{n} y_i` and :math:`\sum_{i=1}^{n} (y_i - \hat{y}_i)^2 = \sum_{i=1}^{n} \epsilon_i^2`.
 
-Note that :func:`r2_score` calculates unadjusted RÂ² without correcting for
+Note that :func:`r2_score` calculates unadjusted R² without correcting for
 bias in sample variance of y.
 
 Here is a small example of usage of the :func:`r2_score` function::
@@ -1888,7 +1888,7 @@ Here is a small example of usage of the :func:`r2_score` function::
 .. topic:: Example:
 
   * See :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_and_elasticnet.py`
-    for an example of RÂ² score usage to
+    for an example of R² score usage to
     evaluate Lasso and Elastic Net on sparse signals.
 
 .. _clustering_metrics:

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1030,7 +1030,7 @@ with a svm classifier in a multiclass problem::
   LinearSVC()
   >>> pred_decision = est.decision_function([[-1], [2], [3]])
   >>> y_true = [0, 2, 3]
-  >>> hinge_loss(y_true, pred_decision, labels)  #doctest: +ELLIPSIS
+  >>> hinge_loss(y_true, pred_decision, labels)
   0.56...
 
 .. _log_loss:

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -504,7 +504,7 @@ or *informedness*.
 
 .. topic:: References:
 
-  .. [Guyon2015] I. Guyon, K. Bennett, G. Cawley, H.J. Escalante, S. Escalera, T.K. Ho, N. Macià,
+  .. [Guyon2015] I. Guyon, K. Bennett, G. Cawley, H.J. Escalante, S. Escalera, T.K. Ho, N. MaciÃ ,
      B. Ray, M. Saeed, A.R. Statnikov, E. Viegas, `Design of the 2015 ChaLearn AutoML Challenge
      <https://ieeexplore.ieee.org/document/7280767>`_,
      IJCNN 2015.
@@ -757,7 +757,7 @@ binary classification and multilabel indicator format.
 
 .. topic:: References:
 
-  .. [Manning2008] C.D. Manning, P. Raghavan, H. Schütze, `Introduction to Information Retrieval
+  .. [Manning2008] C.D. Manning, P. Raghavan, H. SchÃ¼tze, `Introduction to Information Retrieval
      <https://nlp.stanford.edu/IR-book/html/htmledition/evaluation-of-ranked-retrieval-results-1.html>`_,
      2008.
   .. [Everingham2010] M. Everingham, L. Van Gool, C.K.I. Williams, J. Winn, A. Zisserman,
@@ -1030,7 +1030,7 @@ with a svm classifier in a multiclass problem::
   LinearSVC()
   >>> pred_decision = est.decision_function([[-1], [2], [3]])
   >>> y_true = [0, 2, 3]
-  >>> hinge_loss(y_true, pred_decision, labels)
+  >>> hinge_loss(y_true, pred_decision, labels)  #doctest: +ELLIPSIS
   0.56...
 
 .. _log_loss:
@@ -1570,7 +1570,7 @@ the ranking loss is defined as
 .. math::
   ranking\_loss(y, \hat{f}) =  \frac{1}{n_{\text{samples}}}
     \sum_{i=0}^{n_{\text{samples}} - 1} \frac{1}{||y_i||_0(n_\text{labels} - ||y_i||_0)}
-    \left|\left\{(k, l): \hat{f}_{ik} \leq \hat{f}_{il}, y_{ik} = 1, y_{il} = 0 \right\}\right|
+    \left|\left\{(k, l): \hat{f}_{ik} \leq \hat{f}_{il}, y_{ik} = 1, y_{il} = 0Â \right\}\right|
 
 where :math:`|\cdot|` computes the cardinality of the set (i.e., the number of
 elements in the set) and :math:`||\cdot||_0` is the :math:`\ell_0` "norm"
@@ -1833,27 +1833,27 @@ function::
 
 .. _r2_score:
 
-R² score, the coefficient of determination
+RÂ² score, the coefficient of determination
 -------------------------------------------
 
 The :func:`r2_score` function computes the `coefficient of
 determination <https://en.wikipedia.org/wiki/Coefficient_of_determination>`_,
-usually denoted as R².
+usually denoted as RÂ².
 
 It represents the proportion of variance (of y) that has been explained by the
 independent variables in the model. It provides an indication of goodness of
 fit and therefore a measure of how well unseen samples are likely to be
 predicted by the model, through the proportion of explained variance.
 
-As such variance is dataset dependent, R² may not be meaningfully comparable
+As such variance is dataset dependent, RÂ² may not be meaningfully comparable
 across different datasets. Best possible score is 1.0 and it can be negative
 (because the model can be arbitrarily worse). A constant model that always
 predicts the expected value of y, disregarding the input features, would get a
-R² score of 0.0.
+RÂ² score of 0.0.
 
 If :math:`\hat{y}_i` is the predicted value of the :math:`i`-th sample
 and :math:`y_i` is the corresponding true value for total :math:`n` samples,
-the estimated R² is defined as:
+the estimated RÂ² is defined as:
 
 .. math::
 
@@ -1861,7 +1861,7 @@ the estimated R² is defined as:
 
 where :math:`\bar{y} = \frac{1}{n} \sum_{i=1}^{n} y_i` and :math:`\sum_{i=1}^{n} (y_i - \hat{y}_i)^2 = \sum_{i=1}^{n} \epsilon_i^2`.
 
-Note that :func:`r2_score` calculates unadjusted R² without correcting for
+Note that :func:`r2_score` calculates unadjusted RÂ² without correcting for
 bias in sample variance of y.
 
 Here is a small example of usage of the :func:`r2_score` function::
@@ -1888,7 +1888,7 @@ Here is a small example of usage of the :func:`r2_score` function::
 .. topic:: Example:
 
   * See :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_and_elasticnet.py`
-    for an example of R² score usage to
+    for an example of RÂ² score usage to
     evaluate Lasso and Elastic Net on sparse signals.
 
 .. _clustering_metrics:

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1016,10 +1016,7 @@ with a svm classifier in a binary class problem::
   >>> y = [-1, 1]
   >>> est = svm.LinearSVC(random_state=0)
   >>> est.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-  LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
-       intercept_scaling=1, loss='squared_hinge', max_iter=1000,
-       multi_class='ovr', penalty='l2', random_state=0, tol=0.0001,
-       verbose=0)
+  LinearSVC(random_state=0)
   >>> pred_decision = est.decision_function([[-2], [3], [0.5]])
   >>> pred_decision  # doctest: +ELLIPSIS
   array([-2.18...,  2.36...,  0.09...])
@@ -1034,10 +1031,7 @@ with a svm classifier in a multiclass problem::
   >>> labels = np.array([0, 1, 2, 3])
   >>> est = svm.LinearSVC()
   >>> est.fit(X, Y)  # doctest: +NORMALIZE_WHITESPACE
-  LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
-       intercept_scaling=1, loss='squared_hinge', max_iter=1000,
-       multi_class='ovr', penalty='l2', random_state=None, tol=0.0001,
-       verbose=0)
+  LinearSVC()
   >>> pred_decision = est.decision_function([[-1], [2], [3]])
   >>> y_true = [0, 2, 3]
   >>> hinge_loss(y_true, pred_decision, labels)  #doctest: +ELLIPSIS
@@ -1965,7 +1959,7 @@ Next, let's compare the accuracy of ``SVC`` and ``most_frequent``::
   0.63...
   >>> clf = DummyClassifier(strategy='most_frequent', random_state=0)
   >>> clf.fit(X_train, y_train)
-  DummyClassifier(constant=None, random_state=0, strategy='most_frequent')
+  DummyClassifier(random_state=0, strategy='most_frequent')
   >>> clf.score(X_test, y_test)  # doctest: +ELLIPSIS
   0.57...
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -101,7 +101,7 @@ Usage examples:
     >>> iris = datasets.load_iris()
     >>> X, y = iris.data, iris.target
     >>> clf = svm.SVC(random_state=0)
-    >>> cross_val_score(clf, X, y, cv=5, scoring='recall_macro')  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+    >>> cross_val_score(clf, X, y, cv=5, scoring='recall_macro')
     array([0.96..., 0.96..., 0.96..., 0.93..., 1.        ])
     >>> model = svm.SVC()
     >>> cross_val_score(model, X, y, cv=5, scoring='wrong_choice')
@@ -190,9 +190,9 @@ Here is an example of building custom scorers, and of using the
     >>> from sklearn.dummy import DummyClassifier
     >>> clf = DummyClassifier(strategy='most_frequent', random_state=0)
     >>> clf = clf.fit(X, y)
-    >>> my_custom_loss_func(clf.predict(X), y) # doctest: +ELLIPSIS
+    >>> my_custom_loss_func(clf.predict(X), y)
     0.69...
-    >>> score(clf, X, y) # doctest: +ELLIPSIS
+    >>> score(clf, X, y)
     -0.69...
 
 
@@ -274,10 +274,10 @@ permitted and will require a wrapper to return a single metric::
     ...            'fp': make_scorer(fp), 'fn': make_scorer(fn)}
     >>> cv_results = cross_validate(svm.fit(X, y), X, y, cv=5, scoring=scoring)
     >>> # Getting the test set true positive scores
-    >>> print(cv_results['test_tp'])  # doctest: +NORMALIZE_WHITESPACE
+    >>> print(cv_results['test_tp'])
     [10  9  8  7  8]
     >>> # Getting the test set false negative scores
-    >>> print(cv_results['test_fn'])  # doctest: +NORMALIZE_WHITESPACE
+    >>> print(cv_results['test_fn'])
     [0 1 2 3 2]
 
 .. _classification_metrics:
@@ -814,15 +814,15 @@ Here are some small examples in binary classification::
   1.0
   >>> metrics.recall_score(y_true, y_pred)
   0.5
-  >>> metrics.f1_score(y_true, y_pred)  # doctest: +ELLIPSIS
+  >>> metrics.f1_score(y_true, y_pred)
   0.66...
-  >>> metrics.fbeta_score(y_true, y_pred, beta=0.5)  # doctest: +ELLIPSIS
+  >>> metrics.fbeta_score(y_true, y_pred, beta=0.5)
   0.83...
-  >>> metrics.fbeta_score(y_true, y_pred, beta=1)  # doctest: +ELLIPSIS
+  >>> metrics.fbeta_score(y_true, y_pred, beta=1)
   0.66...
-  >>> metrics.fbeta_score(y_true, y_pred, beta=2) # doctest: +ELLIPSIS
+  >>> metrics.fbeta_score(y_true, y_pred, beta=2)
   0.55...
-  >>> metrics.precision_recall_fscore_support(y_true, y_pred, beta=0.5)  # doctest: +ELLIPSIS
+  >>> metrics.precision_recall_fscore_support(y_true, y_pred, beta=0.5)
   (array([0.66..., 1.        ]), array([1. , 0.5]), array([0.71..., 0.83...]), array([2, 2]))
 
 
@@ -832,13 +832,13 @@ Here are some small examples in binary classification::
   >>> y_true = np.array([0, 0, 1, 1])
   >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
   >>> precision, recall, threshold = precision_recall_curve(y_true, y_scores)
-  >>> precision  # doctest: +ELLIPSIS
+  >>> precision
   array([0.66..., 0.5       , 1.        , 1.        ])
   >>> recall
   array([1. , 0.5, 0.5, 0. ])
   >>> threshold
   array([0.35, 0.4 , 0.8 ])
-  >>> average_precision_score(y_true, y_scores)  # doctest: +ELLIPSIS
+  >>> average_precision_score(y_true, y_scores)
   0.83...
 
 
@@ -894,17 +894,15 @@ Then the metrics are defined as:
   >>> from sklearn import metrics
   >>> y_true = [0, 1, 2, 0, 1, 2]
   >>> y_pred = [0, 2, 1, 0, 0, 1]
-  >>> metrics.precision_score(y_true, y_pred, average='macro')  # doctest: +ELLIPSIS
+  >>> metrics.precision_score(y_true, y_pred, average='macro')
   0.22...
   >>> metrics.recall_score(y_true, y_pred, average='micro')
-  ... # doctest: +ELLIPSIS
   0.33...
-  >>> metrics.f1_score(y_true, y_pred, average='weighted')  # doctest: +ELLIPSIS
+  >>> metrics.f1_score(y_true, y_pred, average='weighted')
   0.26...
-  >>> metrics.fbeta_score(y_true, y_pred, average='macro', beta=0.5)  # doctest: +ELLIPSIS
+  >>> metrics.fbeta_score(y_true, y_pred, average='macro', beta=0.5)
   0.23...
   >>> metrics.precision_recall_fscore_support(y_true, y_pred, beta=0.5, average=None)
-  ... # doctest: +ELLIPSIS
   (array([0.66..., 0.        , 0.        ]), array([1., 0., 0.]), array([0.71..., 0.        , 0.        ]), array([2, 2, 2]...))
 
 For multiclass classification with a "negative class", it is possible to exclude some labels:
@@ -916,7 +914,6 @@ For multiclass classification with a "negative class", it is possible to exclude
 Similarly, labels not present in the data sample may be accounted for in macro-averaging.
 
   >>> metrics.precision_score(y_true, y_pred, labels=[0, 1, 2, 3], average='macro')
-  ... # doctest: +ELLIPSIS
   0.166...
 
 .. _jaccard_similarity_score:
@@ -949,14 +946,14 @@ In the binary case: ::
   ...                    [1, 1, 0]])
   >>> y_pred = np.array([[1, 1, 1],
   ...                    [1, 0, 0]])
-  >>> jaccard_score(y_true[0], y_pred[0])  # doctest: +ELLIPSIS
+  >>> jaccard_score(y_true[0], y_pred[0])
   0.6666...
 
 In the multilabel case with binary label indicators: ::
 
-  >>> jaccard_score(y_true, y_pred, average='samples')  # doctest: +ELLIPSIS
+  >>> jaccard_score(y_true, y_pred, average='samples')
   0.5833...
-  >>> jaccard_score(y_true, y_pred, average='macro')  # doctest: +ELLIPSIS
+  >>> jaccard_score(y_true, y_pred, average='macro')
   0.6666...
   >>> jaccard_score(y_true, y_pred, average=None)
   array([0.5, 0.5, 1. ])
@@ -967,7 +964,6 @@ multilabel problem: ::
   >>> y_pred = [0, 2, 1, 2]
   >>> y_true = [0, 1, 2, 2]
   >>> jaccard_score(y_true, y_pred, average=None)
-  ... # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
   array([1. , 0. , 0.33...])
   >>> jaccard_score(y_true, y_pred, average='macro')
   0.44...
@@ -1015,12 +1011,12 @@ with a svm classifier in a binary class problem::
   >>> X = [[0], [1]]
   >>> y = [-1, 1]
   >>> est = svm.LinearSVC(random_state=0)
-  >>> est.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+  >>> est.fit(X, y)
   LinearSVC(random_state=0)
   >>> pred_decision = est.decision_function([[-2], [3], [0.5]])
-  >>> pred_decision  # doctest: +ELLIPSIS
+  >>> pred_decision
   array([-2.18...,  2.36...,  0.09...])
-  >>> hinge_loss([-1, 1, 1], pred_decision)  # doctest: +ELLIPSIS
+  >>> hinge_loss([-1, 1, 1], pred_decision)
   0.3...
 
 Here is an example demonstrating the use of the :func:`hinge_loss` function
@@ -1030,7 +1026,7 @@ with a svm classifier in a multiclass problem::
   >>> Y = np.array([0, 1, 2, 3])
   >>> labels = np.array([0, 1, 2, 3])
   >>> est = svm.LinearSVC()
-  >>> est.fit(X, Y)  # doctest: +NORMALIZE_WHITESPACE
+  >>> est.fit(X, Y)
   LinearSVC()
   >>> pred_decision = est.decision_function([[-1], [2], [3]])
   >>> y_true = [0, 2, 3]
@@ -1084,7 +1080,7 @@ method.
     >>> from sklearn.metrics import log_loss
     >>> y_true = [0, 0, 1, 1]
     >>> y_pred = [[.9, .1], [.8, .2], [.3, .7], [.01, .99]]
-    >>> log_loss(y_true, y_pred)    # doctest: +ELLIPSIS
+    >>> log_loss(y_true, y_pred)
     0.1738...
 
 The first ``[.9, .1]`` in ``y_pred`` denotes 90% probability that the first
@@ -1149,7 +1145,7 @@ function:
     >>> from sklearn.metrics import matthews_corrcoef
     >>> y_true = [+1, +1, +1, -1]
     >>> y_pred = [+1, -1, +1, +1]
-    >>> matthews_corrcoef(y_true, y_pred)  # doctest: +ELLIPSIS
+    >>> matthews_corrcoef(y_true, y_pred)
     -0.33...
 
 .. _multilabel_confusion_matrix:
@@ -1551,7 +1547,7 @@ Here is a small example of usage of this function::
     >>> from sklearn.metrics import label_ranking_average_precision_score
     >>> y_true = np.array([[1, 0, 0], [0, 0, 1]])
     >>> y_score = np.array([[0.75, 0.5, 1], [1, 0.2, 0.1]])
-    >>> label_ranking_average_precision_score(y_true, y_score) # doctest: +ELLIPSIS
+    >>> label_ranking_average_precision_score(y_true, y_score)
     0.416...
 
 .. _label_ranking_loss:
@@ -1586,7 +1582,7 @@ Here is a small example of usage of this function::
     >>> from sklearn.metrics import label_ranking_loss
     >>> y_true = np.array([[1, 0, 0], [0, 0, 1]])
     >>> y_score = np.array([[0.75, 0.5, 1], [1, 0.2, 0.1]])
-    >>> label_ranking_loss(y_true, y_score) # doctest: +ELLIPSIS
+    >>> label_ranking_loss(y_true, y_score)
     0.75...
     >>> # With the following prediction, we have perfect and minimal loss
     >>> y_score = np.array([[1.0, 0.1, 0.2], [0.1, 0.2, 0.9]])
@@ -1658,15 +1654,13 @@ function::
     >>> from sklearn.metrics import explained_variance_score
     >>> y_true = [3, -0.5, 2, 7]
     >>> y_pred = [2.5, 0.0, 2, 8]
-    >>> explained_variance_score(y_true, y_pred)  # doctest: +ELLIPSIS
+    >>> explained_variance_score(y_true, y_pred)
     0.957...
     >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
     >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
     >>> explained_variance_score(y_true, y_pred, multioutput='raw_values')
-    ... # doctest: +ELLIPSIS
     array([0.967..., 1.        ])
     >>> explained_variance_score(y_true, y_pred, multioutput=[0.3, 0.7])
-    ... # doctest: +ELLIPSIS
     0.990...
 
 .. _max_error:
@@ -1733,7 +1727,6 @@ Here is a small example of usage of the :func:`mean_absolute_error` function::
   >>> mean_absolute_error(y_true, y_pred, multioutput='raw_values')
   array([0.5, 1. ])
   >>> mean_absolute_error(y_true, y_pred, multioutput=[0.3, 0.7])
-  ... # doctest: +ELLIPSIS
   0.85...
 
 .. _mean_squared_error:
@@ -1764,7 +1757,7 @@ function::
   0.375
   >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
   >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
-  >>> mean_squared_error(y_true, y_pred)  # doctest: +ELLIPSIS
+  >>> mean_squared_error(y_true, y_pred)
   0.7083...
 
 .. topic:: Examples:
@@ -1803,11 +1796,11 @@ function::
   >>> from sklearn.metrics import mean_squared_log_error
   >>> y_true = [3, 5, 2.5, 7]
   >>> y_pred = [2.5, 5, 4, 8]
-  >>> mean_squared_log_error(y_true, y_pred)  # doctest: +ELLIPSIS
+  >>> mean_squared_log_error(y_true, y_pred)
   0.039...
   >>> y_true = [[0.5, 1], [1, 2], [7, 6]]
   >>> y_pred = [[0.5, 2], [1, 2.5], [8, 8]]
-  >>> mean_squared_log_error(y_true, y_pred)  # doctest: +ELLIPSIS
+  >>> mean_squared_log_error(y_true, y_pred)
   0.044...
 
 .. _median_absolute_error:
@@ -1876,23 +1869,19 @@ Here is a small example of usage of the :func:`r2_score` function::
   >>> from sklearn.metrics import r2_score
   >>> y_true = [3, -0.5, 2, 7]
   >>> y_pred = [2.5, 0.0, 2, 8]
-  >>> r2_score(y_true, y_pred)  # doctest: +ELLIPSIS
+  >>> r2_score(y_true, y_pred)
   0.948...
   >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
   >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
   >>> r2_score(y_true, y_pred, multioutput='variance_weighted')
-  ... # doctest: +ELLIPSIS
   0.938...
   >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
   >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
   >>> r2_score(y_true, y_pred, multioutput='uniform_average')
-  ... # doctest: +ELLIPSIS
   0.936...
   >>> r2_score(y_true, y_pred, multioutput='raw_values')
-  ... # doctest: +ELLIPSIS
   array([0.965..., 0.908...])
   >>> r2_score(y_true, y_pred, multioutput=[0.3, 0.7])
-  ... # doctest: +ELLIPSIS
   0.925...
 
 
@@ -1955,19 +1944,19 @@ Next, let's compare the accuracy of ``SVC`` and ``most_frequent``::
   >>> from sklearn.dummy import DummyClassifier
   >>> from sklearn.svm import SVC
   >>> clf = SVC(kernel='linear', C=1).fit(X_train, y_train)
-  >>> clf.score(X_test, y_test) # doctest: +ELLIPSIS
+  >>> clf.score(X_test, y_test)
   0.63...
   >>> clf = DummyClassifier(strategy='most_frequent', random_state=0)
   >>> clf.fit(X_train, y_train)
   DummyClassifier(random_state=0, strategy='most_frequent')
-  >>> clf.score(X_test, y_test)  # doctest: +ELLIPSIS
+  >>> clf.score(X_test, y_test)
   0.57...
 
 We see that ``SVC`` doesn't do much better than a dummy classifier. Now, let's
 change the kernel::
 
   >>> clf = SVC(kernel='rbf', C=1).fit(X_train, y_train)
-  >>> clf.score(X_test, y_test)  # doctest: +ELLIPSIS
+  >>> clf.score(X_test, y_test)
   0.94...
 
 We see that the accuracy was boosted to almost 100%.  A cross validation

--- a/doc/modules/model_persistence.rst
+++ b/doc/modules/model_persistence.rst
@@ -26,7 +26,7 @@ persistence model, namely `pickle <https://docs.python.org/2/library/pickle.html
   >>> clf = svm.SVC()
   >>> iris = datasets.load_iris()
   >>> X, y = iris.data, iris.target
-  >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+  >>> clf.fit(X, y)
   SVC()
 
   >>> import pickle

--- a/doc/modules/model_persistence.rst
+++ b/doc/modules/model_persistence.rst
@@ -27,10 +27,7 @@ persistence model, namely `pickle <https://docs.python.org/2/library/pickle.html
   >>> iris = datasets.load_iris()
   >>> X, y = iris.data, iris.target
   >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-  SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
-      decision_function_shape='ovr', degree=3, gamma='scale', kernel='rbf',
-      max_iter=-1, probability=False,
-      random_state=None, shrinking=True, tol=0.001, verbose=False)
+  SVC()
 
   >>> import pickle
   >>> s = pickle.dumps(clf)

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -182,7 +182,7 @@ Below is an example of multiclass learning using OvR::
   >>> from sklearn.svm import LinearSVC
   >>> iris = datasets.load_iris()
   >>> X, y = iris.data, iris.target
-  >>> OneVsRestClassifier(LinearSVC(random_state=0)).fit(X, y).predict(X) # doctest: +NORMALIZE_WHITESPACE
+  >>> OneVsRestClassifier(LinearSVC(random_state=0)).fit(X, y).predict(X)
   array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -240,7 +240,7 @@ Below is an example of multiclass learning using OvO::
   >>> from sklearn.svm import LinearSVC
   >>> iris = datasets.load_iris()
   >>> X, y = iris.data, iris.target
-  >>> OneVsOneClassifier(LinearSVC(random_state=0)).fit(X, y).predict(X) # doctest: +NORMALIZE_WHITESPACE
+  >>> OneVsOneClassifier(LinearSVC(random_state=0)).fit(X, y).predict(X)
   array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -305,7 +305,7 @@ Below is an example of multiclass learning using Output-Codes::
   >>> X, y = iris.data, iris.target
   >>> clf = OutputCodeClassifier(LinearSVC(random_state=0),
   ...                            code_size=2, random_state=0)
-  >>> clf.fit(X, y).predict(X) # doctest: +NORMALIZE_WHITESPACE
+  >>> clf.fit(X, y).predict(X)
   array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1,

--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -475,7 +475,7 @@ for more complex methods that do not make this assumption. Usage of the default
     >>> y = np.array([1, 1, 1, 2, 2, 2])
     >>> clf = NearestCentroid()
     >>> clf.fit(X, y)
-    NearestCentroid(metric='euclidean', shrink_threshold=None)
+    NearestCentroid()
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
 

--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -77,7 +77,7 @@ used:
     >>> X = np.array([[-1, -1], [-2, -1], [-3, -2], [1, 1], [2, 1], [3, 2]])
     >>> nbrs = NearestNeighbors(n_neighbors=2, algorithm='ball_tree').fit(X)
     >>> distances, indices = nbrs.kneighbors(X)
-    >>> indices                                           # doctest: +ELLIPSIS
+    >>> indices
     array([[0, 1],
            [1, 0],
            [2, 1],
@@ -125,7 +125,7 @@ have the same interface; we'll show an example of using the KD Tree here:
     >>> import numpy as np
     >>> X = np.array([[-1, -1], [-2, -1], [-3, -2], [1, 1], [2, 1], [3, 2]])
     >>> kdt = KDTree(X, leaf_size=30, metric='euclidean')
-    >>> kdt.query(X, k=2, return_distance=False)          # doctest: +ELLIPSIS
+    >>> kdt.query(X, k=2, return_distance=False)
     array([[0, 1],
            [1, 0],
            [2, 1],
@@ -579,9 +579,9 @@ classes:
     >>> nca = NeighborhoodComponentsAnalysis(random_state=42)
     >>> knn = KNeighborsClassifier(n_neighbors=3)
     >>> nca_pipe = Pipeline([('nca', nca), ('knn', knn)])
-    >>> nca_pipe.fit(X_train, y_train) # doctest: +ELLIPSIS
+    >>> nca_pipe.fit(X_train, y_train)
     Pipeline(...)
-    >>> print(nca_pipe.score(X_test, y_test)) # doctest: +ELLIPSIS
+    >>> print(nca_pipe.score(X_test, y_test))
     0.96190476...
 
 .. |nca_classification_1| image:: ../auto_examples/neighbors/images/sphx_glr_plot_nca_classification_001.png

--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -90,14 +90,8 @@ training samples::
     ...                     hidden_layer_sizes=(5, 2), random_state=1)
     ...
     >>> clf.fit(X, y)                         # doctest: +NORMALIZE_WHITESPACE
-    MLPClassifier(activation='relu', alpha=1e-05, batch_size='auto',
-                  beta_1=0.9, beta_2=0.999, early_stopping=False,
-                  epsilon=1e-08, hidden_layer_sizes=(5, 2),
-                  learning_rate='constant', learning_rate_init=0.001,
-                  max_iter=200, momentum=0.9, n_iter_no_change=10,
-                  nesterovs_momentum=True, power_t=0.5, random_state=1,
-                  shuffle=True, solver='lbfgs', tol=0.0001,
-                  validation_fraction=0.1, verbose=False, warm_start=False)
+    MLPClassifier(alpha=1e-05, hidden_layer_sizes=(5, 2), random_state=1,
+                  solver='lbfgs')
 
 After fitting (training), the model can predict labels for new samples::
 
@@ -139,14 +133,8 @@ indices where the value is `1` represents the assigned classes of that sample::
     ...                     hidden_layer_sizes=(15,), random_state=1)
     ...
     >>> clf.fit(X, y)                         # doctest: +NORMALIZE_WHITESPACE
-    MLPClassifier(activation='relu', alpha=1e-05, batch_size='auto',
-                  beta_1=0.9, beta_2=0.999, early_stopping=False,
-                  epsilon=1e-08, hidden_layer_sizes=(15,),
-                  learning_rate='constant', learning_rate_init=0.001,
-                  max_iter=200, momentum=0.9, n_iter_no_change=10,
-                  nesterovs_momentum=True, power_t=0.5,  random_state=1,
-                  shuffle=True, solver='lbfgs', tol=0.0001,
-                  validation_fraction=0.1, verbose=False, warm_start=False)
+    MLPClassifier(alpha=1e-05, hidden_layer_sizes=(15,), random_state=1,
+                  solver='lbfgs')
     >>> clf.predict([[1., 2.]])
     array([[1, 1]])
     >>> clf.predict([[0., 0.]])

--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -89,7 +89,7 @@ training samples::
     >>> clf = MLPClassifier(solver='lbfgs', alpha=1e-5,
     ...                     hidden_layer_sizes=(5, 2), random_state=1)
     ...
-    >>> clf.fit(X, y)                         # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     MLPClassifier(alpha=1e-05, hidden_layer_sizes=(5, 2), random_state=1,
                   solver='lbfgs')
 
@@ -113,7 +113,7 @@ gradient descent and the gradients are calculated using Backpropagation. For
 classification, it minimizes the Cross-Entropy loss function, giving a vector
 of probability estimates :math:`P(y|x)` per sample :math:`x`::
 
-    >>> clf.predict_proba([[2., 2.], [1., 2.]])  # doctest: +ELLIPSIS
+    >>> clf.predict_proba([[2., 2.], [1., 2.]])
     array([[1.967...e-04, 9.998...-01],
            [1.967...e-04, 9.998...-01]])
 
@@ -132,7 +132,7 @@ indices where the value is `1` represents the assigned classes of that sample::
     >>> clf = MLPClassifier(solver='lbfgs', alpha=1e-5,
     ...                     hidden_layer_sizes=(15,), random_state=1)
     ...
-    >>> clf.fit(X, y)                         # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     MLPClassifier(alpha=1e-05, hidden_layer_sizes=(15,), random_state=1,
                   solver='lbfgs')
     >>> clf.predict([[1., 2.]])
@@ -350,7 +350,7 @@ or want to do additional monitoring, using ``warm_start=True`` and
     >>> clf = MLPClassifier(hidden_layer_sizes=(15,), random_state=1, max_iter=1, warm_start=True)
     >>> for i in range(10):
     ...     clf.fit(X, y)
-    ...     # additional monitoring / inspection # doctest: +ELLIPSIS
+    ...     # additional monitoring / inspection
     MLPClassifier(...
 
 .. topic:: References:

--- a/doc/modules/partial_dependence.rst
+++ b/doc/modules/partial_dependence.rst
@@ -80,9 +80,9 @@ the plots, you can use the
     >>> from sklearn.inspection import partial_dependence
 
     >>> pdp, axes = partial_dependence(clf, X, [0])
-    >>> pdp  # doctest: +ELLIPSIS
+    >>> pdp
     array([[ 2.466...,  2.466..., ...
-    >>> axes  # doctest: +ELLIPSIS
+    >>> axes
     [array([-1.624..., -1.592..., ...
 
 The values at which the partial dependence should be evaluated are directly

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -80,7 +80,7 @@ This class is hence suitable for use in the early steps of a
 
   >>> scaler = preprocessing.StandardScaler().fit(X_train)
   >>> scaler
-  StandardScaler(copy=True, with_mean=True, with_std=True)
+  StandardScaler()
 
   >>> scaler.mean_                                      # doctest: +ELLIPSIS
   array([1. ..., 0. ..., 0.33...])
@@ -438,7 +438,7 @@ This class is hence suitable for use in the early steps of a
 
   >>> normalizer = preprocessing.Normalizer().fit(X)  # fit does nothing
   >>> normalizer
-  Normalizer(copy=True, norm='l2')
+  Normalizer()
 
 
 The normalizer instance can then be used on sample vectors as any transformer::
@@ -482,7 +482,7 @@ new feature of integers (0 to n_categories - 1)::
     >>> enc = preprocessing.OrdinalEncoder()
     >>> X = [['male', 'from US', 'uses Safari'], ['female', 'from Europe', 'uses Firefox']]
     >>> enc.fit(X)  # doctest: +ELLIPSIS
-    OrdinalEncoder(categories='auto', dtype=<... 'numpy.float64'>)
+    OrdinalEncoder()
     >>> enc.transform([['female', 'from US', 'uses Safari']])
     array([[0., 1., 1.]])
 
@@ -504,8 +504,7 @@ Continuing the example above::
   >>> enc = preprocessing.OneHotEncoder()
   >>> X = [['male', 'from US', 'uses Safari'], ['female', 'from Europe', 'uses Firefox']]
   >>> enc.fit(X)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-  OneHotEncoder(categories='auto', drop=None, dtype=<... 'numpy.float64'>,
-                handle_unknown='error', sparse=True)
+  OneHotEncoder()
   >>> enc.transform([['female', 'from US', 'uses Safari'],
   ...                ['male', 'from Europe', 'uses Safari']]).toarray()
   array([[1., 0., 0., 1., 0., 1.],
@@ -529,8 +528,11 @@ dataset::
     >>> # feature
     >>> X = [['male', 'from US', 'uses Safari'], ['female', 'from Europe', 'uses Firefox']]
     >>> enc.fit(X) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-    OneHotEncoder(categories=[...], drop=None, dtype=<... 'numpy.float64'>,
-                  handle_unknown='error', sparse=True)
+    OneHotEncoder(categories=[['female', 'male'],
+                              ['from Africa', 'from Asia', 'from Europe',
+                               'from US'],
+                              ['uses Chrome', 'uses Firefox', 'uses IE',
+                               'uses Safari']])
     >>> enc.transform([['female', 'from Asia', 'uses Chrome']]).toarray()
     array([[1., 0., 0., 1., 0., 0., 1., 0., 0., 0.]])
 
@@ -545,8 +547,7 @@ columns for this feature will be all zeros
     >>> enc = preprocessing.OneHotEncoder(handle_unknown='ignore')
     >>> X = [['male', 'from US', 'uses Safari'], ['female', 'from Europe', 'uses Firefox']]
     >>> enc.fit(X) # doctest: +ELLIPSIS  +NORMALIZE_WHITESPACE
-    OneHotEncoder(categories='auto', drop=None, dtype=<... 'numpy.float64'>,
-                  handle_unknown='ignore', sparse=True)
+    OneHotEncoder(handle_unknown='ignore')
     >>> enc.transform([['female', 'from Asia', 'uses Chrome']]).toarray()
     array([[1., 0., 0., 0., 0., 0.]])
 
@@ -662,7 +663,7 @@ as each sample is treated independently of others::
 
   >>> binarizer = preprocessing.Binarizer().fit(X)  # fit does nothing
   >>> binarizer
-  Binarizer(copy=True, threshold=0.0)
+  Binarizer()
 
   >>> binarizer.transform(X)
   array([[1., 0., 1.],

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -51,7 +51,7 @@ operation on a single array-like dataset::
   ...                     [ 0.,  1., -1.]])
   >>> X_scaled = preprocessing.scale(X_train)
 
-  >>> X_scaled                                          # doctest: +ELLIPSIS
+  >>> X_scaled
   array([[ 0.  ..., -1.22...,  1.33...],
          [ 1.22...,  0.  ..., -0.26...],
          [-1.22...,  1.22..., -1.06...]])
@@ -82,13 +82,13 @@ This class is hence suitable for use in the early steps of a
   >>> scaler
   StandardScaler()
 
-  >>> scaler.mean_                                      # doctest: +ELLIPSIS
+  >>> scaler.mean_
   array([1. ..., 0. ..., 0.33...])
 
-  >>> scaler.scale_                                       # doctest: +ELLIPSIS
+  >>> scaler.scale_
   array([0.81..., 0.81..., 1.24...])
 
-  >>> scaler.transform(X_train)                           # doctest: +ELLIPSIS
+  >>> scaler.transform(X_train)
   array([[ 0.  ..., -1.22...,  1.33...],
          [ 1.22...,  0.  ..., -0.26...],
          [-1.22...,  1.22..., -1.06...]])
@@ -98,7 +98,7 @@ The scaler instance can then be used on new data to transform it the
 same way it did on the training set::
 
   >>> X_test = [[-1., 1., 0.]]
-  >>> scaler.transform(X_test)                # doctest: +ELLIPSIS
+  >>> scaler.transform(X_test)
   array([[-2.44...,  1.22..., -0.26...]])
 
 It is possible to disable either centering or scaling by either
@@ -143,10 +143,10 @@ applied to be consistent with the transformation performed on the train data::
 It is possible to introspect the scaler attributes to find about the exact
 nature of the transformation learned on the training data::
 
-  >>> min_max_scaler.scale_                             # doctest: +ELLIPSIS
+  >>> min_max_scaler.scale_
   array([0.5       , 0.5       , 0.33...])
 
-  >>> min_max_scaler.min_                               # doctest: +ELLIPSIS
+  >>> min_max_scaler.min_
   array([0.        , 0.5       , 0.33...])
 
 If :class:`MinMaxScaler` is given an explicit ``feature_range=(min, max)`` the
@@ -169,15 +169,15 @@ Here is how to use the toy data from the previous example with this scaler::
   ...
   >>> max_abs_scaler = preprocessing.MaxAbsScaler()
   >>> X_train_maxabs = max_abs_scaler.fit_transform(X_train)
-  >>> X_train_maxabs                # doctest +NORMALIZE_WHITESPACE^
+  >>> X_train_maxabs
   array([[ 0.5, -1. ,  1. ],
          [ 1. ,  0. ,  0. ],
          [ 0. ,  1. , -0.5]])
   >>> X_test = np.array([[ -3., -1.,  4.]])
   >>> X_test_maxabs = max_abs_scaler.transform(X_test)
-  >>> X_test_maxabs                 # doctest: +NORMALIZE_WHITESPACE
+  >>> X_test_maxabs
   array([[-1.5, -1. ,  2. ]])
-  >>> max_abs_scaler.scale_         # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+  >>> max_abs_scaler.scale_
   array([2.,  1.,  2.])
 
 
@@ -304,7 +304,7 @@ transformation applied, those landmarks approach closely the percentiles
 previously defined::
 
   >>> np.percentile(X_train_trans[:, 0], [0, 25, 50, 75, 100])
-  ... # doctest: +ELLIPSIS +SKIP
+  ... # doctest: +SKIP
   array([ 0.00... ,  0.24...,  0.49...,  0.73...,  0.99... ])
 
 This can be confirmed on a independent testing set with similar remarks::
@@ -313,7 +313,7 @@ This can be confirmed on a independent testing set with similar remarks::
   ... # doctest: +SKIP
   array([ 4.4  ,  5.125,  5.75 ,  6.175,  7.3  ])
   >>> np.percentile(X_test_trans[:, 0], [0, 25, 50, 75, 100])
-  ... # doctest: +ELLIPSIS +SKIP
+  ... # doctest: +SKIP
   array([ 0.01...,  0.25...,  0.46...,  0.60... ,  0.94...])
 
 Mapping to a Gaussian distribution
@@ -355,11 +355,11 @@ samples drawn from a lognormal distribution to a normal distribution::
 
   >>> pt = preprocessing.PowerTransformer(method='box-cox', standardize=False)
   >>> X_lognormal = np.random.RandomState(616).lognormal(size=(3, 3))
-  >>> X_lognormal                                         # doctest: +ELLIPSIS
+  >>> X_lognormal
   array([[1.28..., 1.18..., 0.84...],
          [0.94..., 1.60..., 0.38...],
          [1.35..., 0.21..., 1.09...]])
-  >>> pt.fit_transform(X_lognormal)                   # doctest: +ELLIPSIS
+  >>> pt.fit_transform(X_lognormal)
   array([[ 0.49...,  0.17..., -0.15...],
          [-0.05...,  0.58..., -0.57...],
          [ 0.69..., -0.84...,  0.10...]])
@@ -386,7 +386,7 @@ Using the earlier example with the iris dataset::
   >>> quantile_transformer = preprocessing.QuantileTransformer(
   ...     output_distribution='normal', random_state=0)
   >>> X_trans = quantile_transformer.fit_transform(X)
-  >>> quantile_transformer.quantiles_ # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+  >>> quantile_transformer.quantiles_
   array([[4.3, 2. , 1. , 0.1],
          [4.4, 2.2, 1.1, 0.1],
          [4.4, 2.2, 1.2, 0.1],
@@ -423,7 +423,7 @@ norms::
   ...      [ 0.,  1., -1.]]
   >>> X_normalized = preprocessing.normalize(X, norm='l2')
 
-  >>> X_normalized                                      # doctest: +ELLIPSIS
+  >>> X_normalized
   array([[ 0.40..., -0.40...,  0.81...],
          [ 1.  ...,  0.  ...,  0.  ...],
          [ 0.  ...,  0.70..., -0.70...]])
@@ -443,12 +443,12 @@ This class is hence suitable for use in the early steps of a
 
 The normalizer instance can then be used on sample vectors as any transformer::
 
-  >>> normalizer.transform(X)                            # doctest: +ELLIPSIS
+  >>> normalizer.transform(X)
   array([[ 0.40..., -0.40...,  0.81...],
          [ 1.  ...,  0.  ...,  0.  ...],
          [ 0.  ...,  0.70..., -0.70...]])
 
-  >>> normalizer.transform([[-1.,  1., 0.]])             # doctest: +ELLIPSIS
+  >>> normalizer.transform([[-1.,  1., 0.]])
   array([[-0.70...,  0.70...,  0.  ...]])
 
 
@@ -481,7 +481,7 @@ new feature of integers (0 to n_categories - 1)::
 
     >>> enc = preprocessing.OrdinalEncoder()
     >>> X = [['male', 'from US', 'uses Safari'], ['female', 'from Europe', 'uses Firefox']]
-    >>> enc.fit(X)  # doctest: +ELLIPSIS
+    >>> enc.fit(X)
     OrdinalEncoder()
     >>> enc.transform([['female', 'from US', 'uses Safari']])
     array([[0., 1., 1.]])
@@ -503,7 +503,7 @@ Continuing the example above::
 
   >>> enc = preprocessing.OneHotEncoder()
   >>> X = [['male', 'from US', 'uses Safari'], ['female', 'from Europe', 'uses Firefox']]
-  >>> enc.fit(X)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+  >>> enc.fit(X)
   OneHotEncoder()
   >>> enc.transform([['female', 'from US', 'uses Safari'],
   ...                ['male', 'from Europe', 'uses Safari']]).toarray()
@@ -527,7 +527,7 @@ dataset::
     >>> # Note that for there are missing categorical values for the 2nd and 3rd
     >>> # feature
     >>> X = [['male', 'from US', 'uses Safari'], ['female', 'from Europe', 'uses Firefox']]
-    >>> enc.fit(X) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> enc.fit(X)
     OneHotEncoder(categories=[['female', 'male'],
                               ['from Africa', 'from Asia', 'from Europe',
                                'from US'],
@@ -546,7 +546,7 @@ columns for this feature will be all zeros
 
     >>> enc = preprocessing.OneHotEncoder(handle_unknown='ignore')
     >>> X = [['male', 'from US', 'uses Safari'], ['female', 'from Europe', 'uses Firefox']]
-    >>> enc.fit(X) # doctest: +ELLIPSIS  +NORMALIZE_WHITESPACE
+    >>> enc.fit(X)
     OneHotEncoder(handle_unknown='ignore')
     >>> enc.transform([['female', 'from Asia', 'uses Chrome']]).toarray()
     array([[1., 0., 0., 0., 0., 0.]])
@@ -712,12 +712,12 @@ Often it's useful to add complexity to the model by considering nonlinear featur
     >>> import numpy as np
     >>> from sklearn.preprocessing import PolynomialFeatures
     >>> X = np.arange(6).reshape(3, 2)
-    >>> X                                                 # doctest: +ELLIPSIS
+    >>> X
     array([[0, 1],
            [2, 3],
            [4, 5]])
     >>> poly = PolynomialFeatures(2)
-    >>> poly.fit_transform(X)                             # doctest: +ELLIPSIS
+    >>> poly.fit_transform(X)
     array([[ 1.,  0.,  1.,  0.,  0.,  1.],
            [ 1.,  2.,  3.,  4.,  6.,  9.],
            [ 1.,  4.,  5., 16., 20., 25.]])
@@ -727,12 +727,12 @@ The features of X have been transformed from :math:`(X_1, X_2)` to :math:`(1, X_
 In some cases, only interaction terms among features are required, and it can be gotten with the setting ``interaction_only=True``::
 
     >>> X = np.arange(9).reshape(3, 3)
-    >>> X                                                 # doctest: +ELLIPSIS
+    >>> X
     array([[0, 1, 2],
            [3, 4, 5],
            [6, 7, 8]])
     >>> poly = PolynomialFeatures(degree=3, interaction_only=True)
-    >>> poly.fit_transform(X)                             # doctest: +ELLIPSIS
+    >>> poly.fit_transform(X)
     array([[  1.,   0.,   1.,   2.,   0.,   0.,   2.,   0.],
            [  1.,   3.,   4.,   5.,  12.,  15.,  20.,  60.],
            [  1.,   6.,   7.,   8.,  42.,  48.,  56., 336.]])

--- a/doc/modules/preprocessing_targets.rst
+++ b/doc/modules/preprocessing_targets.rst
@@ -20,7 +20,7 @@ matrix from a list of multi-class labels::
     >>> from sklearn import preprocessing
     >>> lb = preprocessing.LabelBinarizer()
     >>> lb.fit([1, 2, 6, 4, 2])
-    LabelBinarizer(neg_label=0, pos_label=1, sparse_output=False)
+    LabelBinarizer()
     >>> lb.classes_
     array([1, 2, 4, 6])
     >>> lb.transform([1, 6])

--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -60,7 +60,7 @@ for the training samples::
     >>> X = [[0., 0.], [1., 1.]]
     >>> y = [0, 1]
     >>> clf = SGDClassifier(loss="hinge", penalty="l2", max_iter=5)
-    >>> clf.fit(X, y)   # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     SGDClassifier(max_iter=5)
 
 
@@ -72,12 +72,12 @@ After being fitted, the model can then be used to predict new values::
 SGD fits a linear model to the training data. The member ``coef_`` holds
 the model parameters::
 
-    >>> clf.coef_                                         # doctest: +ELLIPSIS
+    >>> clf.coef_
     array([[9.9..., 9.9...]])
 
 Member ``intercept_`` holds the intercept (aka offset or bias)::
 
-    >>> clf.intercept_                                    # doctest: +ELLIPSIS
+    >>> clf.intercept_
     array([-9.9...])
 
 Whether or not the model should use an intercept, i.e. a biased
@@ -85,7 +85,7 @@ hyperplane, is controlled by the parameter ``fit_intercept``.
 
 To get the signed distance to the hyperplane use :meth:`SGDClassifier.decision_function`::
 
-    >>> clf.decision_function([[2., 2.]])                 # doctest: +ELLIPSIS
+    >>> clf.decision_function([[2., 2.]])
     array([29.6...])
 
 The concrete loss function can be set via the ``loss``
@@ -106,7 +106,7 @@ Using ``loss="log"`` or ``loss="modified_huber"`` enables the
 :math:`P(y|x)` per sample :math:`x`::
 
     >>> clf = SGDClassifier(loss="log", max_iter=5).fit(X, y)
-    >>> clf.predict_proba([[1., 1.]])                      # doctest: +ELLIPSIS
+    >>> clf.predict_proba([[1., 1.]])
     array([[0.00..., 0.99...]])
 
 The concrete penalty can be set via the ``penalty`` parameter.

--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -61,12 +61,7 @@ for the training samples::
     >>> y = [0, 1]
     >>> clf = SGDClassifier(loss="hinge", penalty="l2", max_iter=5)
     >>> clf.fit(X, y)   # doctest: +NORMALIZE_WHITESPACE
-    SGDClassifier(alpha=0.0001, average=False, class_weight=None,
-               early_stopping=False, epsilon=0.1, eta0=0.0, fit_intercept=True,
-               l1_ratio=0.15, learning_rate='optimal', loss='hinge', max_iter=5,
-               n_iter_no_change=5, n_jobs=None, penalty='l2', power_t=0.5,
-               random_state=None, shuffle=True, tol=0.001,
-               validation_fraction=0.1, verbose=0, warm_start=False)
+    SGDClassifier(max_iter=5)
 
 
 After being fitted, the model can then be used to predict new values::

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -77,10 +77,7 @@ n_features]`` holding the training samples, and an array y of class labels
     >>> y = [0, 1]
     >>> clf = svm.SVC()
     >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-    SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
-        decision_function_shape='ovr', degree=3, gamma='scale', kernel='rbf',
-        max_iter=-1, probability=False,
-        random_state=None, shrinking=True, tol=0.001, verbose=False)
+    SVC()
 
 After being fitted, the model can then be used to predict new values::
 
@@ -121,10 +118,7 @@ n_classes)``.
     >>> Y = [0, 1, 2, 3]
     >>> clf = svm.SVC(decision_function_shape='ovo')
     >>> clf.fit(X, Y) # doctest: +NORMALIZE_WHITESPACE
-    SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
-        decision_function_shape='ovo', degree=3, gamma='scale', kernel='rbf',
-        max_iter=-1, probability=False,
-        random_state=None, shrinking=True, tol=0.001, verbose=False)
+    SVC(decision_function_shape='ovo')
     >>> dec = clf.decision_function([[1]])
     >>> dec.shape[1] # 4 classes: 4*3/2 = 6
     6
@@ -139,10 +133,7 @@ two classes, only one model is trained::
 
     >>> lin_clf = svm.LinearSVC()
     >>> lin_clf.fit(X, Y) # doctest: +NORMALIZE_WHITESPACE
-    LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
-         intercept_scaling=1, loss='squared_hinge', max_iter=1000,
-         multi_class='ovr', penalty='l2', random_state=None, tol=0.0001,
-         verbose=0)
+    LinearSVC()
     >>> dec = lin_clf.decision_function([[1]])
     >>> dec.shape[1]
     4
@@ -330,9 +321,7 @@ floating point values instead of integer values::
     >>> y = [0.5, 2.5]
     >>> clf = svm.SVR()
     >>> clf.fit(X, y) # doctest: +NORMALIZE_WHITESPACE
-    SVR(C=1.0, cache_size=200, coef0=0.0, degree=3, epsilon=0.1,
-        gamma='scale', kernel='rbf', max_iter=-1, shrinking=True,
-        tol=0.001, verbose=False)
+    SVR()
     >>> clf.predict([[1, 1]])
     array([1.5])
 
@@ -541,11 +530,7 @@ test vectors must be provided.
     >>> # linear kernel computation
     >>> gram = np.dot(X, X.T)
     >>> clf.fit(gram, y) # doctest: +NORMALIZE_WHITESPACE
-    SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
-        decision_function_shape='ovr', degree=3, gamma='scale',
-        kernel='precomputed', max_iter=-1,
-        probability=False, random_state=None, shrinking=True, tol=0.001,
-        verbose=False)
+    SVC(kernel='precomputed')
     >>> # predict on training examples
     >>> clf.predict(gram)
     array([0, 1])

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -76,7 +76,7 @@ n_features]`` holding the training samples, and an array y of class labels
     >>> X = [[0, 0], [1, 1]]
     >>> y = [0, 1]
     >>> clf = svm.SVC()
-    >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     SVC()
 
 After being fitted, the model can then be used to predict new values::
@@ -94,10 +94,10 @@ can be found in members ``support_vectors_``, ``support_`` and
     array([[0., 0.],
            [1., 1.]])
     >>> # get indices of support vectors
-    >>> clf.support_ # doctest: +ELLIPSIS
+    >>> clf.support_
     array([0, 1]...)
     >>> # get number of support vectors for each class
-    >>> clf.n_support_ # doctest: +ELLIPSIS
+    >>> clf.n_support_
     array([1, 1]...)
 
 .. _svm_multi_class:
@@ -117,7 +117,7 @@ n_classes)``.
     >>> X = [[0], [1], [2], [3]]
     >>> Y = [0, 1, 2, 3]
     >>> clf = svm.SVC(decision_function_shape='ovo')
-    >>> clf.fit(X, Y) # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, Y)
     SVC(decision_function_shape='ovo')
     >>> dec = clf.decision_function([[1]])
     >>> dec.shape[1] # 4 classes: 4*3/2 = 6
@@ -132,7 +132,7 @@ multi-class strategy, thus training n_class models. If there are only
 two classes, only one model is trained::
 
     >>> lin_clf = svm.LinearSVC()
-    >>> lin_clf.fit(X, Y) # doctest: +NORMALIZE_WHITESPACE
+    >>> lin_clf.fit(X, Y)
     LinearSVC()
     >>> dec = lin_clf.decision_function([[1]])
     >>> dec.shape[1]
@@ -320,7 +320,7 @@ floating point values instead of integer values::
     >>> X = [[0, 0], [2, 2]]
     >>> y = [0.5, 2.5]
     >>> clf = svm.SVR()
-    >>> clf.fit(X, y) # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     SVR()
     >>> clf.predict([[1, 1]])
     array([1.5])
@@ -529,7 +529,7 @@ test vectors must be provided.
     >>> clf = svm.SVC(kernel='precomputed')
     >>> # linear kernel computation
     >>> gram = np.dot(X, X.T)
-    >>> clf.fit(gram, y) # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(gram, y)
     SVC(kernel='precomputed')
     >>> # predict on training examples
     >>> clf.predict(gram)

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -180,10 +180,7 @@ the ``[:-1]`` Python syntax, which produces a new array that contains all but
 the last item from ``digits.data``::
 
   >>> clf.fit(digits.data[:-1], digits.target[:-1])  # doctest: +NORMALIZE_WHITESPACE
-  SVC(C=100.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
-    decision_function_shape='ovr', degree=3, gamma=0.001, kernel='rbf',
-    max_iter=-1, probability=False,
-    random_state=None, shrinking=True, tol=0.001, verbose=False)
+  SVC(C=100.0, gamma=0.001)
 
 Now you can *predict* new values. In this case, you'll predict using the last
 image from ``digits.data``. By predicting, you'll determine the image from the 
@@ -220,10 +217,7 @@ persistence model, `pickle <https://docs.python.org/2/library/pickle.html>`_::
   >>> iris = datasets.load_iris()
   >>> X, y = iris.data, iris.target
   >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-  SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
-    decision_function_shape='ovr', degree=3, gamma='scale', kernel='rbf',
-    max_iter=-1, probability=False,
-    random_state=None, shrinking=True, tol=0.001, verbose=False)
+  SVC()
 
   >>> import pickle
   >>> s = pickle.dumps(clf)
@@ -293,19 +287,13 @@ maintained::
     >>> iris = datasets.load_iris()
     >>> clf = SVC()
     >>> clf.fit(iris.data, iris.target)  # doctest: +NORMALIZE_WHITESPACE
-    SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
-      decision_function_shape='ovr', degree=3, gamma='scale', kernel='rbf',
-      max_iter=-1, probability=False,
-      random_state=None, shrinking=True, tol=0.001, verbose=False)
+    SVC()
 
     >>> list(clf.predict(iris.data[:3]))
     [0, 0, 0]
 
     >>> clf.fit(iris.data, iris.target_names[iris.target])  # doctest: +NORMALIZE_WHITESPACE
-    SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
-      decision_function_shape='ovr', degree=3, gamma='scale', kernel='rbf',
-      max_iter=-1, probability=False,
-      random_state=None, shrinking=True, tol=0.001, verbose=False)
+    SVC()
 
     >>> list(clf.predict(iris.data[:3]))  # doctest: +NORMALIZE_WHITESPACE
     ['setosa', 'setosa', 'setosa']
@@ -328,19 +316,12 @@ once will overwrite what was learned by any previous ``fit()``::
 
   >>> clf = SVC()
   >>> clf.set_params(kernel='linear').fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-  SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
-    decision_function_shape='ovr', degree=3, gamma='scale',
-    kernel='linear', max_iter=-1,
-    probability=False, random_state=None, shrinking=True, tol=0.001,
-    verbose=False)
+  SVC(kernel='linear')
   >>> clf.predict(X[:5])
   array([0, 0, 0, 0, 0])
 
   >>> clf.set_params(kernel='rbf').fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-  SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
-    decision_function_shape='ovr', degree=3, gamma='scale', kernel='rbf',
-    max_iter=-1, probability=False,
-    random_state=None, shrinking=True, tol=0.001, verbose=False)
+  SVC()
   >>> clf.predict(X[:5])
   array([0, 0, 0, 0, 0])
 

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -100,7 +100,7 @@ section <datasets>`.
 For instance, in the case of the digits dataset, ``digits.data`` gives
 access to the features that can be used to classify the digits samples::
 
-  >>> print(digits.data)  # doctest: +NORMALIZE_WHITESPACE
+  >>> print(digits.data)
   [[ 0.   0.   5. ...   0.   0.   0.]
    [ 0.   0.   0. ...  10.   0.   0.]
    [ 0.   0.   0. ...  16.   9.   0.]
@@ -123,7 +123,7 @@ learn::
     digits, each original sample is an image of shape ``(8, 8)`` and can be
     accessed using::
 
-      >>> digits.images[0]  # doctest: +NORMALIZE_WHITESPACE
+      >>> digits.images[0]
       array([[  0.,   0.,   5.,  13.,   9.,   1.,   0.,   0.],
              [  0.,   0.,  13.,  15.,  10.,  15.,   5.,   0.],
              [  0.,   3.,  15.,   2.,   0.,  11.,   8.,   0.],
@@ -179,7 +179,7 @@ image, which we'll reserve for our predicting. We select the training set with
 the ``[:-1]`` Python syntax, which produces a new array that contains all but
 the last item from ``digits.data``::
 
-  >>> clf.fit(digits.data[:-1], digits.target[:-1])  # doctest: +NORMALIZE_WHITESPACE
+  >>> clf.fit(digits.data[:-1], digits.target[:-1])
   SVC(C=100.0, gamma=0.001)
 
 Now you can *predict* new values. In this case, you'll predict using the last
@@ -216,7 +216,7 @@ persistence model, `pickle <https://docs.python.org/2/library/pickle.html>`_::
   >>> clf = svm.SVC()
   >>> iris = datasets.load_iris()
   >>> X, y = iris.data, iris.target
-  >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+  >>> clf.fit(X, y)
   SVC()
 
   >>> import pickle
@@ -286,16 +286,16 @@ maintained::
     >>> from sklearn.svm import SVC
     >>> iris = datasets.load_iris()
     >>> clf = SVC()
-    >>> clf.fit(iris.data, iris.target)  # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(iris.data, iris.target)
     SVC()
 
     >>> list(clf.predict(iris.data[:3]))
     [0, 0, 0]
 
-    >>> clf.fit(iris.data, iris.target_names[iris.target])  # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(iris.data, iris.target_names[iris.target])
     SVC()
 
-    >>> list(clf.predict(iris.data[:3]))  # doctest: +NORMALIZE_WHITESPACE
+    >>> list(clf.predict(iris.data[:3]))
     ['setosa', 'setosa', 'setosa']
 
 Here, the first ``predict()`` returns an integer array, since ``iris.target``
@@ -315,12 +315,12 @@ once will overwrite what was learned by any previous ``fit()``::
   >>> X, y = load_iris(return_X_y=True)
 
   >>> clf = SVC()
-  >>> clf.set_params(kernel='linear').fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+  >>> clf.set_params(kernel='linear').fit(X, y)
   SVC(kernel='linear')
   >>> clf.predict(X[:5])
   array([0, 0, 0, 0, 0])
 
-  >>> clf.set_params(kernel='rbf').fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+  >>> clf.set_params(kernel='rbf').fit(X, y)
   SVC()
   >>> clf.predict(X[:5])
   array([0, 0, 0, 0, 0])

--- a/doc/tutorial/statistical_inference/model_selection.rst
+++ b/doc/tutorial/statistical_inference/model_selection.rst
@@ -38,7 +38,7 @@ data in *folds* that we use for training and testing::
     ...     y_test = y_train.pop(k)
     ...     y_train = np.concatenate(y_train)
     ...     scores.append(svc.fit(X_train, y_train).score(X_test, y_test))
-    >>> print(scores)  # doctest: +ELLIPSIS
+    >>> print(scores)
     [0.934..., 0.956..., 0.939...]
 
 .. currentmodule:: sklearn.model_selection
@@ -73,7 +73,7 @@ This example shows an example usage of the ``split`` method.
 The cross-validation can then be performed easily::
 
     >>> [svc.fit(X_digits[train], y_digits[train]).score(X_digits[test], y_digits[test])
-    ...  for train, test in k_fold.split(X_digits)]  # doctest: +ELLIPSIS
+    ...  for train, test in k_fold.split(X_digits)]
     [0.963..., 0.922..., 0.963..., 0.963..., 0.930...]
 
 The cross-validation score can be directly calculated using the
@@ -267,10 +267,10 @@ parameter automatically by cross-validation::
     >>> diabetes = datasets.load_diabetes()
     >>> X_diabetes = diabetes.data
     >>> y_diabetes = diabetes.target
-    >>> lasso.fit(X_diabetes, y_diabetes)  # doctest: +NORMALIZE_WHITESPACE
+    >>> lasso.fit(X_diabetes, y_diabetes)
     LassoCV()
     >>> # The estimator chose automatically its lambda:
-    >>> lasso.alpha_ # doctest: +ELLIPSIS
+    >>> lasso.alpha_
     0.00375...
 
 These estimators are called similarly to their counterparts, with 'CV'

--- a/doc/tutorial/statistical_inference/model_selection.rst
+++ b/doc/tutorial/statistical_inference/model_selection.rst
@@ -268,10 +268,7 @@ parameter automatically by cross-validation::
     >>> X_diabetes = diabetes.data
     >>> y_diabetes = diabetes.target
     >>> lasso.fit(X_diabetes, y_diabetes)  # doctest: +NORMALIZE_WHITESPACE
-    LassoCV(alphas=None, copy_X=True, cv=None, eps=0.001, fit_intercept=True,
-        max_iter=1000, n_alphas=100, n_jobs=None, normalize=False,
-        positive=False, precompute='auto', random_state=None,
-        selection='cyclic', tol=0.0001, verbose=False)
+    LassoCV()
     >>> # The estimator chose automatically its lambda:
     >>> lasso.alpha_ # doctest: +ELLIPSIS
     0.00375...

--- a/doc/tutorial/statistical_inference/supervised_learning.rst
+++ b/doc/tutorial/statistical_inference/supervised_learning.rst
@@ -93,7 +93,7 @@ Scikit-learn documentation for more information about this type of classifier.)
     >>> # Create and fit a nearest-neighbor classifier
     >>> from sklearn.neighbors import KNeighborsClassifier
     >>> knn = KNeighborsClassifier()
-    >>> knn.fit(iris_X_train, iris_y_train) # doctest: +NORMALIZE_WHITESPACE
+    >>> knn.fit(iris_X_train, iris_y_train)
     KNeighborsClassifier()
     >>> knn.predict(iris_X_test)
     array([1, 2, 1, 0, 0, 0, 2, 1, 2, 0])
@@ -182,13 +182,12 @@ Linear models: :math:`y = X\beta + \epsilon`
 
     >>> # The mean square error
     >>> np.mean((regr.predict(diabetes_X_test) - diabetes_y_test)**2)
-    ...                                                   # doctest: +ELLIPSIS
     2004.56760268...
 
     >>> # Explained variance score: 1 is perfect prediction
     >>> # and 0 means that there is no linear relationship
     >>> # between X and y.
-    >>> regr.score(diabetes_X_test, diabetes_y_test) # doctest: +ELLIPSIS
+    >>> regr.score(diabetes_X_test, diabetes_y_test)
     0.5850753022690...
 
 
@@ -258,7 +257,6 @@ diabetes dataset rather than our synthetic data::
     ...            .fit(diabetes_X_train, diabetes_y_train)
     ...            .score(diabetes_X_test, diabetes_y_test)
     ...        for alpha in alphas])
-    ...                            # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     [0.5851110683883..., 0.5852073015444..., 0.5854677540698...,
      0.5855512036503..., 0.5830717085554..., 0.57058999437...]
 
@@ -330,7 +328,7 @@ application of Occam's razor: *prefer simpler models*.
     >>> regr.alpha = best_alpha
     >>> regr.fit(diabetes_X_train, diabetes_y_train)
     Lasso(alpha=0.025118864315095794)
-    >>> print(regr.coef_)  # doctest: +NORMALIZE_WHITESPACE
+    >>> print(regr.coef_)
     [   0.         -212.43764548  517.19478111  313.77959962 -160.8303982    -0.
      -187.19554705   69.38229038  508.66011217   71.84239008]
 
@@ -369,7 +367,7 @@ function or **logistic** function:
 ::
 
     >>> log = linear_model.LogisticRegression(C=1e5)
-    >>> log.fit(iris_X_train, iris_y_train)  # doctest: +NORMALIZE_WHITESPACE
+    >>> log.fit(iris_X_train, iris_y_train)
     LogisticRegression(C=100000.0)
 
 This is known as :class:`LogisticRegression`.
@@ -450,7 +448,7 @@ classification --:class:`SVC` (Support Vector Classification).
 
     >>> from sklearn import svm
     >>> svc = svm.SVC(kernel='linear')
-    >>> svc.fit(iris_X_train, iris_y_train)    # doctest: +NORMALIZE_WHITESPACE
+    >>> svc.fit(iris_X_train, iris_y_train)
     SVC(kernel='linear')
 
 

--- a/doc/tutorial/statistical_inference/supervised_learning.rst
+++ b/doc/tutorial/statistical_inference/supervised_learning.rst
@@ -94,9 +94,7 @@ Scikit-learn documentation for more information about this type of classifier.)
     >>> from sklearn.neighbors import KNeighborsClassifier
     >>> knn = KNeighborsClassifier()
     >>> knn.fit(iris_X_train, iris_y_train) # doctest: +NORMALIZE_WHITESPACE
-    KNeighborsClassifier(algorithm='auto', leaf_size=30, metric='minkowski',
-               metric_params=None, n_jobs=None, n_neighbors=5, p=2,
-               weights='uniform')
+    KNeighborsClassifier()
     >>> knn.predict(iris_X_test)
     array([1, 2, 1, 0, 0, 0, 2, 1, 2, 0])
     >>> iris_y_test
@@ -176,10 +174,8 @@ Linear models: :math:`y = X\beta + \epsilon`
     >>> from sklearn import linear_model
     >>> regr = linear_model.LinearRegression()
     >>> regr.fit(diabetes_X_train, diabetes_y_train)
-    ...                                       # doctest: +NORMALIZE_WHITESPACE
-    LinearRegression(copy_X=True, fit_intercept=True, n_jobs=None,
-                     normalize=False)
-    >>> print(regr.coef_)
+    LinearRegression()
+    >>> print(regr.coef_)  # doctest: +SKIP
     [   0.30349955 -237.63931533  510.53060544  327.73698041 -814.13170937
       492.81458798  102.84845219  184.60648906  743.51961675   76.09517222]
 
@@ -333,10 +329,7 @@ application of Occam's razor: *prefer simpler models*.
     >>> best_alpha = alphas[scores.index(max(scores))]
     >>> regr.alpha = best_alpha
     >>> regr.fit(diabetes_X_train, diabetes_y_train)
-    ... # doctest: +NORMALIZE_WHITESPACE
-    Lasso(alpha=0.025118864315095794, copy_X=True, fit_intercept=True,
-       max_iter=1000, normalize=False, positive=False, precompute=False,
-       random_state=None, selection='cyclic', tol=0.0001, warm_start=False)
+    Lasso(alpha=0.025118864315095794)
     >>> print(regr.coef_)  # doctest: +NORMALIZE_WHITESPACE
     [   0.         -212.43764548  517.19478111  313.77959962 -160.8303982    -0.
      -187.19554705   69.38229038  508.66011217   71.84239008]
@@ -377,10 +370,7 @@ function or **logistic** function:
 
     >>> log = linear_model.LogisticRegression(C=1e5)
     >>> log.fit(iris_X_train, iris_y_train)  # doctest: +NORMALIZE_WHITESPACE
-    LogisticRegression(C=100000.0, class_weight=None, dual=False,
-        fit_intercept=True, intercept_scaling=1, l1_ratio=None, max_iter=100,
-        multi_class='auto', n_jobs=None, penalty='l2', random_state=None,
-        solver='lbfgs', tol=0.0001, verbose=0, warm_start=False)
+    LogisticRegression(C=100000.0)
 
 This is known as :class:`LogisticRegression`.
 
@@ -461,11 +451,7 @@ classification --:class:`SVC` (Support Vector Classification).
     >>> from sklearn import svm
     >>> svc = svm.SVC(kernel='linear')
     >>> svc.fit(iris_X_train, iris_y_train)    # doctest: +NORMALIZE_WHITESPACE
-    SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
-        decision_function_shape='ovr', degree=3, gamma='scale',
-        kernel='linear', max_iter=-1,
-        probability=False, random_state=None, shrinking=True, tol=0.001,
-        verbose=False)
+    SVC(kernel='linear')
 
 
 .. warning:: **Normalizing data**

--- a/doc/tutorial/statistical_inference/unsupervised_learning.rst
+++ b/doc/tutorial/statistical_inference/unsupervised_learning.rst
@@ -39,7 +39,7 @@ algorithms. The simplest clustering algorithm is
 
     >>> k_means = cluster.KMeans(n_clusters=3)
     >>> k_means.fit(X_iris) # doctest: +ELLIPSIS
-    KMeans(algorithm='auto', copy_x=True, init='k-means++', ...
+    KMeans(n_clusters=3)
     >>> print(k_means.labels_[::10])
     [1 1 1 1 1 0 0 0 0 0 2 2 2 2 2]
     >>> print(y_iris[::10])
@@ -118,7 +118,7 @@ algorithms. The simplest clustering algorithm is
     	>>> X = face.reshape((-1, 1)) # We need an (n_sample, n_feature) array
     	>>> k_means = cluster.KMeans(n_clusters=5, n_init=1)
     	>>> k_means.fit(X) # doctest: +ELLIPSIS
-    	KMeans(algorithm='auto', copy_x=True, init='k-means++', ...
+        KMeans(n_clusters=5, n_init=1)
     	>>> values = k_means.cluster_centers_.squeeze()
     	>>> labels = k_means.labels_
     	>>> face_compressed = np.choose(labels, values)
@@ -215,7 +215,7 @@ transposed data.
    >>> agglo = cluster.FeatureAgglomeration(connectivity=connectivity,
    ...                                      n_clusters=32)
    >>> agglo.fit(X) # doctest: +ELLIPSIS
-   FeatureAgglomeration(affinity='euclidean', compute_full_tree='auto',...
+   FeatureAgglomeration(connectivity=..., n_clusters=32)
    >>> X_reduced = agglo.transform(X)
 
    >>> X_approx = agglo.inverse_transform(X_reduced)
@@ -275,8 +275,7 @@ data by projecting on a principal subspace.
     >>> from sklearn import decomposition
     >>> pca = decomposition.PCA()
     >>> pca.fit(X)  # doctest: +NORMALIZE_WHITESPACE
-    PCA(copy=True, iterated_power='auto', n_components=None, random_state=None,
-      svd_solver='auto', tol=0.0, whiten=False)
+    PCA()
     >>> print(pca.explained_variance_)  # doctest: +SKIP
     [  2.18565811e+00   1.19346747e+00   8.43026679e-32]
 

--- a/doc/tutorial/statistical_inference/unsupervised_learning.rst
+++ b/doc/tutorial/statistical_inference/unsupervised_learning.rst
@@ -38,7 +38,7 @@ algorithms. The simplest clustering algorithm is
     >>> y_iris = iris.target
 
     >>> k_means = cluster.KMeans(n_clusters=3)
-    >>> k_means.fit(X_iris) # doctest: +ELLIPSIS
+    >>> k_means.fit(X_iris)
     KMeans(n_clusters=3)
     >>> print(k_means.labels_[::10])
     [1 1 1 1 1 0 0 0 0 0 2 2 2 2 2]
@@ -117,7 +117,7 @@ algorithms. The simplest clustering algorithm is
         ...    face = misc.face(gray=True)
     	>>> X = face.reshape((-1, 1)) # We need an (n_sample, n_feature) array
     	>>> k_means = cluster.KMeans(n_clusters=5, n_init=1)
-    	>>> k_means.fit(X) # doctest: +ELLIPSIS
+    	>>> k_means.fit(X)
         KMeans(n_clusters=5, n_init=1)
     	>>> values = k_means.cluster_centers_.squeeze()
     	>>> labels = k_means.labels_
@@ -214,7 +214,7 @@ transposed data.
 
    >>> agglo = cluster.FeatureAgglomeration(connectivity=connectivity,
    ...                                      n_clusters=32)
-   >>> agglo.fit(X) # doctest: +ELLIPSIS
+   >>> agglo.fit(X)
    FeatureAgglomeration(connectivity=..., n_clusters=32)
    >>> X_reduced = agglo.transform(X)
 
@@ -274,7 +274,7 @@ data by projecting on a principal subspace.
 
     >>> from sklearn import decomposition
     >>> pca = decomposition.PCA()
-    >>> pca.fit(X)  # doctest: +NORMALIZE_WHITESPACE
+    >>> pca.fit(X)
     PCA()
     >>> print(pca.explained_variance_)  # doctest: +SKIP
     [  2.18565811e+00   1.19346747e+00   8.43026679e-32]

--- a/doc/tutorial/text_analytics/working_with_text_data.rst
+++ b/doc/tutorial/text_analytics/working_with_text_data.rst
@@ -330,7 +330,7 @@ The names ``vect``, ``tfidf`` and ``clf`` (classifier) are arbitrary.
 We will use them to perform grid search for suitable hyperparameters below.
 We can now train the model with a single command::
 
-  >>> text_clf.fit(twenty_train.data, twenty_train.target)  # doctest: +ELLIPSIS
+  >>> text_clf.fit(twenty_train.data, twenty_train.target)
   Pipeline(...)
 
 
@@ -344,7 +344,7 @@ Evaluating the predictive accuracy of the model is equally easy::
   ...     categories=categories, shuffle=True, random_state=42)
   >>> docs_test = twenty_test.data
   >>> predicted = text_clf.predict(docs_test)
-  >>> np.mean(predicted == twenty_test.target)            # doctest: +ELLIPSIS
+  >>> np.mean(predicted == twenty_test.target)
   0.8348...
 
 We achieved 83.5% accuracy. Let's see if we can do better with a
@@ -363,10 +363,10 @@ classifier object into our pipeline::
   ...                           max_iter=5, tol=None)),
   ... ])
 
-  >>> text_clf.fit(twenty_train.data, twenty_train.target)  # doctest: +ELLIPSIS
+  >>> text_clf.fit(twenty_train.data, twenty_train.target)
   Pipeline(...)
   >>> predicted = text_clf.predict(docs_test)
-  >>> np.mean(predicted == twenty_test.target)            # doctest: +ELLIPSIS
+  >>> np.mean(predicted == twenty_test.target)
   0.9101...
 
 We achieved 91.3% accuracy using the SVM. ``scikit-learn`` provides further
@@ -375,7 +375,6 @@ utilities for more detailed performance analysis of the results::
   >>> from sklearn import metrics
   >>> print(metrics.classification_report(twenty_test.target, predicted,
   ...     target_names=twenty_test.target_names))
-  ...                                         # doctest: +NORMALIZE_WHITESPACE
                           precision    recall  f1-score   support
   <BLANKLINE>
              alt.atheism       0.95      0.80      0.87       319
@@ -463,7 +462,7 @@ that we can use to ``predict``::
 The object's ``best_score_`` and ``best_params_`` attributes store the best
 mean score and the parameters setting corresponding to that score::
 
-  >>> gs_clf.best_score_                                  # doctest: +ELLIPSIS
+  >>> gs_clf.best_score_
   0.9...
   >>> for param_name in sorted(parameters.keys()):
   ...     print("%s: %r" % (param_name, gs_clf.best_params_[param_name]))

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ test = pytest
 [tool:pytest]
 # disable-pytest-warnings should be removed once we rewrite tests
 # using yield with parametrize
+doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
 addopts =
     --ignore build_tools
     --ignore benchmarks

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -95,7 +95,6 @@ def config_context(**new_config):
     >>> with sklearn.config_context(assume_finite=True):
     ...     with sklearn.config_context(assume_finite=False):
     ...         assert_all_finite([float('nan')])
-    ... # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
     ValueError: Input contains NaN, ...

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -297,7 +297,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
     >>> X = np.array([[1, 2], [1, 4], [1, 0],
     ...               [4, 2], [4, 4], [4, 0]])
     >>> clustering = AffinityPropagation().fit(X)
-    >>> clustering # doctest: +NORMALIZE_WHITESPACE
+    >>> clustering
     AffinityPropagation()
     >>> clustering.labels_
     array([0, 0, 0, 1, 1, 1])

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -298,8 +298,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
     ...               [4, 2], [4, 4], [4, 0]])
     >>> clustering = AffinityPropagation().fit(X)
     >>> clustering # doctest: +NORMALIZE_WHITESPACE
-    AffinityPropagation(affinity='euclidean', convergence_iter=15, copy=True,
-              damping=0.5, max_iter=200, preference=None, verbose=False)
+    AffinityPropagation()
     >>> clustering.labels_
     array([0, 0, 0, 1, 1, 1])
     >>> clustering.predict([[0, 0], [4, 4]])

--- a/sklearn/cluster/bicluster.py
+++ b/sklearn/cluster/bicluster.py
@@ -265,7 +265,7 @@ class SpectralCoclustering(BaseSpectral):
     array([0, 1, 1, 0, 0, 0], dtype=int32)
     >>> clustering.column_labels_
     array([0, 0], dtype=int32)
-    >>> clustering # doctest: +NORMALIZE_WHITESPACE
+    >>> clustering
     SpectralCoclustering(n_clusters=2, random_state=0)
 
     References
@@ -409,7 +409,7 @@ class SpectralBiclustering(BaseSpectral):
     array([1, 1, 1, 0, 0, 0], dtype=int32)
     >>> clustering.column_labels_
     array([0, 1], dtype=int32)
-    >>> clustering # doctest: +NORMALIZE_WHITESPACE
+    >>> clustering
     SpectralBiclustering(n_clusters=2, random_state=0)
 
     References

--- a/sklearn/cluster/bicluster.py
+++ b/sklearn/cluster/bicluster.py
@@ -266,9 +266,7 @@ class SpectralCoclustering(BaseSpectral):
     >>> clustering.column_labels_
     array([0, 0], dtype=int32)
     >>> clustering # doctest: +NORMALIZE_WHITESPACE
-    SpectralCoclustering(init='k-means++', mini_batch=False, n_clusters=2,
-               n_init=10, n_jobs=None, n_svd_vecs=None, random_state=0,
-               svd_method='randomized')
+    SpectralCoclustering(n_clusters=2, random_state=0)
 
     References
     ----------
@@ -412,10 +410,7 @@ class SpectralBiclustering(BaseSpectral):
     >>> clustering.column_labels_
     array([0, 1], dtype=int32)
     >>> clustering # doctest: +NORMALIZE_WHITESPACE
-    SpectralBiclustering(init='k-means++', method='bistochastic',
-               mini_batch=False, n_best=3, n_clusters=2, n_components=6,
-               n_init=10, n_jobs=None, n_svd_vecs=None, random_state=0,
-               svd_method='randomized')
+    SpectralBiclustering(n_clusters=2, random_state=0)
 
     References
     ----------

--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -390,11 +390,9 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
     --------
     >>> from sklearn.cluster import Birch
     >>> X = [[0, 1], [0.3, 1], [-0.3, 1], [0, -1], [0.3, -1], [-0.3, -1]]
-    >>> brc = Birch(branching_factor=50, n_clusters=None, threshold=0.5,
-    ... compute_labels=True)
+    >>> brc = Birch(n_clusters=None)
     >>> brc.fit(X) # doctest: +NORMALIZE_WHITESPACE
-    Birch(branching_factor=50, compute_labels=True, copy=True, n_clusters=None,
-       threshold=0.5)
+    Birch(n_clusters=None)
     >>> brc.predict(X)
     array([0, 0, 0, 1, 1, 1])
 

--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -391,7 +391,7 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
     >>> from sklearn.cluster import Birch
     >>> X = [[0, 1], [0.3, 1], [-0.3, 1], [0, -1], [0.3, -1], [-0.3, -1]]
     >>> brc = Birch(n_clusters=None)
-    >>> brc.fit(X) # doctest: +NORMALIZE_WHITESPACE
+    >>> brc.fit(X)
     Birch(n_clusters=None)
     >>> brc.predict(X)
     array([0, 0, 0, 1, 1, 1])

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -272,8 +272,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
     >>> clustering.labels_
     array([ 0,  0,  0,  1,  1, -1])
     >>> clustering # doctest: +NORMALIZE_WHITESPACE
-    DBSCAN(algorithm='auto', eps=3, leaf_size=30, metric='euclidean',
-        metric_params=None, min_samples=2, n_jobs=None, p=None)
+    DBSCAN(eps=3, min_samples=2)
 
     See also
     --------

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -271,7 +271,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
     >>> clustering = DBSCAN(eps=3, min_samples=2).fit(X)
     >>> clustering.labels_
     array([ 0,  0,  0,  1,  1, -1])
-    >>> clustering # doctest: +NORMALIZE_WHITESPACE
+    >>> clustering
     DBSCAN(eps=3, min_samples=2)
 
     See also

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -744,7 +744,7 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
     >>> X = np.array([[1, 2], [1, 4], [1, 0],
     ...               [4, 2], [4, 4], [4, 0]])
     >>> clustering = AgglomerativeClustering().fit(X)
-    >>> clustering # doctest: +NORMALIZE_WHITESPACE
+    >>> clustering
     AgglomerativeClustering()
     >>> clustering.labels_
     array([1, 1, 1, 0, 0, 0])
@@ -973,7 +973,7 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
     >>> images = digits.images
     >>> X = np.reshape(images, (len(images), -1))
     >>> agglo = cluster.FeatureAgglomeration(n_clusters=32)
-    >>> agglo.fit(X) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> agglo.fit(X)
     FeatureAgglomeration(n_clusters=32)
     >>> X_reduced = agglo.transform(X)
     >>> X_reduced.shape

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -745,9 +745,7 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
     ...               [4, 2], [4, 4], [4, 0]])
     >>> clustering = AgglomerativeClustering().fit(X)
     >>> clustering # doctest: +NORMALIZE_WHITESPACE
-    AgglomerativeClustering(affinity='euclidean', compute_full_tree='auto',
-                            connectivity=None, distance_threshold=None,
-                            linkage='ward', memory=None, n_clusters=2)
+    AgglomerativeClustering()
     >>> clustering.labels_
     array([1, 1, 1, 0, 0, 0])
 
@@ -976,10 +974,7 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
     >>> X = np.reshape(images, (len(images), -1))
     >>> agglo = cluster.FeatureAgglomeration(n_clusters=32)
     >>> agglo.fit(X) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-    FeatureAgglomeration(affinity='euclidean', compute_full_tree='auto',
-                 connectivity=None, distance_threshold=None, linkage='ward',
-                 memory=None, n_clusters=32,
-                 pooling_func=...)
+    FeatureAgglomeration(n_clusters=32)
     >>> X_reduced = agglo.transform(X)
     >>> X_reduced.shape
     (1797, 32)

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -368,8 +368,7 @@ class MeanShift(BaseEstimator, ClusterMixin):
     >>> clustering.predict([[0, 0], [5, 5]])
     array([1, 0])
     >>> clustering # doctest: +NORMALIZE_WHITESPACE
-    MeanShift(bandwidth=2, bin_seeding=False, cluster_all=True, min_bin_freq=1,
-         n_jobs=None, seeds=None)
+    MeanShift(bandwidth=2)
 
     Notes
     -----

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -367,7 +367,7 @@ class MeanShift(BaseEstimator, ClusterMixin):
     array([1, 1, 1, 0, 0, 0])
     >>> clustering.predict([[0, 0], [5, 5]])
     array([1, 0])
-    >>> clustering # doctest: +NORMALIZE_WHITESPACE
+    >>> clustering
     MeanShift(bandwidth=2)
 
     Notes

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -388,10 +388,8 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
     >>> clustering.labels_
     array([1, 1, 1, 0, 0, 0])
     >>> clustering # doctest: +NORMALIZE_WHITESPACE
-    SpectralClustering(affinity='rbf', assign_labels='discretize', coef0=1,
-              degree=3, eigen_solver=None, eigen_tol=0.0, gamma=1.0,
-              kernel_params=None, n_clusters=2, n_components=None, n_init=10,
-              n_jobs=None, n_neighbors=10, random_state=0)
+    SpectralClustering(assign_labels='discretize', n_clusters=2,
+        random_state=0)
 
     Notes
     -----

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -387,7 +387,7 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
     ...         random_state=0).fit(X)
     >>> clustering.labels_
     array([1, 1, 1, 0, 0, 0])
-    >>> clustering # doctest: +NORMALIZE_WHITESPACE
+    >>> clustering
     SpectralClustering(assign_labels='discretize', n_clusters=2,
         random_state=0)
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -153,7 +153,7 @@ boolean mask array or callable
     >>> # Normalizer scales each row of X to unit norm. A separate scaling
     >>> # is applied for the two first and two last elements of each
     >>> # row independently.
-    >>> ct.fit_transform(X)    # doctest: +NORMALIZE_WHITESPACE
+    >>> ct.fit_transform(X)
     array([[0. , 1. , 0.5, 0.5],
            [0.5, 0.5, 0. , 1. ]])
 
@@ -764,7 +764,6 @@ def make_column_transformer(*transformers, **kwargs):
     >>> make_column_transformer(
     ...     (StandardScaler(), ['numerical_column']),
     ...     (OneHotEncoder(), ['categorical_column']))
-    ...     # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     ColumnTransformer(transformers=[('standardscaler', StandardScaler(...),
                                      ['numerical_column']),
                                     ('onehotencoder', OneHotEncoder(...),

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -765,14 +765,10 @@ def make_column_transformer(*transformers, **kwargs):
     ...     (StandardScaler(), ['numerical_column']),
     ...     (OneHotEncoder(), ['categorical_column']))
     ...     # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    ColumnTransformer(n_jobs=None, remainder='drop', sparse_threshold=0.3,
-             transformer_weights=None,
-             transformers=[('standardscaler',
-                            StandardScaler(...),
-                            ['numerical_column']),
-                           ('onehotencoder',
-                            OneHotEncoder(...),
-                            ['categorical_column'])], verbose=False)
+    ColumnTransformer(transformers=[('standardscaler', StandardScaler(...),
+                                     ['numerical_column']),
+                                    ('onehotencoder', OneHotEncoder(...),
+                                     ['categorical_column'])])
 
     """
     # transformer_weights keyword is not passed through because the user

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -87,7 +87,7 @@ class TransformedTargetRegressor(BaseEstimator, RegressorMixin):
     ...                                 func=np.log, inverse_func=np.exp)
     >>> X = np.arange(4).reshape(-1, 1)
     >>> y = np.exp(2 * X).ravel()
-    >>> tt.fit(X, y) # doctest: +ELLIPSIS
+    >>> tt.fit(X, y)
     TransformedTargetRegressor(...)
     >>> tt.score(X, y)
     1.0

--- a/sklearn/covariance/elliptic_envelope.py
+++ b/sklearn/covariance/elliptic_envelope.py
@@ -82,7 +82,7 @@ class EllipticEnvelope(MinCovDet, OutlierMixin):
     >>> cov.predict([[0, 0],
     ...              [3, 3]])
     array([ 1, -1])
-    >>> cov.covariance_ # doctest: +ELLIPSIS
+    >>> cov.covariance_
     array([[0.7411..., 0.2535...],
            [0.2535..., 0.3053...]])
     >>> cov.location_

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -125,7 +125,7 @@ class EmpiricalCovariance(BaseEstimator):
     ...                             cov=real_cov,
     ...                             size=500)
     >>> cov = EmpiricalCovariance().fit(X)
-    >>> cov.covariance_ # doctest: +ELLIPSIS
+    >>> cov.covariance_
     array([[0.7569..., 0.2818...],
            [0.2818..., 0.3928...]])
     >>> cov.location_

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -591,7 +591,7 @@ class MinCovDet(EmpiricalCovariance):
     ...                                   cov=real_cov,
     ...                                   size=500)
     >>> cov = MinCovDet(random_state=0).fit(X)
-    >>> cov.covariance_ # doctest: +ELLIPSIS
+    >>> cov.covariance_
     array([[0.7411..., 0.2535...],
            [0.2535..., 0.3053...]])
     >>> cov.location_

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -108,7 +108,7 @@ class ShrunkCovariance(EmpiricalCovariance):
     ...                                   cov=real_cov,
     ...                                   size=500)
     >>> cov = ShrunkCovariance().fit(X)
-    >>> cov.covariance_ # doctest: +ELLIPSIS
+    >>> cov.covariance_
     array([[0.7387..., 0.2536...],
            [0.2536..., 0.4110...]])
     >>> cov.location_
@@ -376,7 +376,7 @@ class LedoitWolf(EmpiricalCovariance):
     ...                                   cov=real_cov,
     ...                                   size=50)
     >>> cov = LedoitWolf().fit(X)
-    >>> cov.covariance_ # doctest: +ELLIPSIS
+    >>> cov.covariance_
     array([[0.4406..., 0.1616...],
            [0.1616..., 0.8022...]])
     >>> cov.location_

--- a/sklearn/cross_decomposition/cca_.py
+++ b/sklearn/cross_decomposition/cca_.py
@@ -79,7 +79,6 @@ class CCA(_PLS, _UnstableArchMixin):
     >>> Y = [[0.1, -0.2], [0.9, 1.1], [6.2, 5.9], [11.9, 12.3]]
     >>> cca = CCA(n_components=1)
     >>> cca.fit(X, Y)
-    ... # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     CCA(n_components=1)
     >>> X_c, Y_c = cca.transform(X, Y)
 

--- a/sklearn/cross_decomposition/cca_.py
+++ b/sklearn/cross_decomposition/cca_.py
@@ -80,7 +80,7 @@ class CCA(_PLS, _UnstableArchMixin):
     >>> cca = CCA(n_components=1)
     >>> cca.fit(X, Y)
     ... # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-    CCA(copy=True, max_iter=500, n_components=1, scale=True, tol=1e-06)
+    CCA(n_components=1)
     >>> X_c, Y_c = cca.transform(X, Y)
 
     References

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -579,8 +579,7 @@ class PLSRegression(_PLS):
     >>> pls2 = PLSRegression(n_components=2)
     >>> pls2.fit(X, Y)
     ... # doctest: +NORMALIZE_WHITESPACE
-    PLSRegression(copy=True, max_iter=500, n_components=2, scale=True,
-            tol=1e-06)
+    PLSRegression()
     >>> Y_pred = pls2.predict(X)
 
     References
@@ -721,8 +720,7 @@ class PLSCanonical(_PLS):
     >>> plsca = PLSCanonical(n_components=2)
     >>> plsca.fit(X, Y)
     ... # doctest: +NORMALIZE_WHITESPACE
-    PLSCanonical(algorithm='nipals', copy=True, max_iter=500, n_components=2,
-                 scale=True, tol=1e-06)
+    PLSCanonical()
     >>> X_c, Y_c = plsca.transform(X, Y)
 
     References
@@ -797,7 +795,7 @@ class PLSSVD(BaseEstimator, TransformerMixin):
     ...     [11.9, 12.3]])
     >>> plsca = PLSSVD(n_components=2)
     >>> plsca.fit(X, Y)
-    PLSSVD(copy=True, n_components=2, scale=True)
+    PLSSVD()
     >>> X_c, Y_c = plsca.transform(X, Y)
     >>> X_c.shape, Y_c.shape
     ((4, 2), (4, 2))

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -578,7 +578,6 @@ class PLSRegression(_PLS):
     >>> Y = [[0.1, -0.2], [0.9, 1.1], [6.2, 5.9], [11.9, 12.3]]
     >>> pls2 = PLSRegression(n_components=2)
     >>> pls2.fit(X, Y)
-    ... # doctest: +NORMALIZE_WHITESPACE
     PLSRegression()
     >>> Y_pred = pls2.predict(X)
 
@@ -719,7 +718,6 @@ class PLSCanonical(_PLS):
     >>> Y = [[0.1, -0.2], [0.9, 1.1], [6.2, 5.9], [11.9, 12.3]]
     >>> plsca = PLSCanonical(n_components=2)
     >>> plsca.fit(X, Y)
-    ... # doctest: +NORMALIZE_WHITESPACE
     PLSCanonical()
     >>> X_c, Y_c = plsca.transform(X, Y)
 

--- a/sklearn/datasets/descr/twenty_newsgroups.rst
+++ b/sklearn/datasets/descr/twenty_newsgroups.rst
@@ -113,7 +113,7 @@ The extracted TF-IDF vectors are very sparse, with an average of 159 non-zero
 components by sample in a more than 30000-dimensional space
 (less than .5% non-zero features)::
 
-  >>> vectors.nnz / float(vectors.shape[0])       # doctest: +ELLIPSIS
+  >>> vectors.nnz / float(vectors.shape[0])
   159.01327...
 
 :func:`sklearn.datasets.fetch_20newsgroups_vectorized` is a function which 
@@ -144,7 +144,7 @@ which is fast to train and achieves a decent F-score::
   MultinomialNB(alpha=0.01, class_prior=None, fit_prior=True)
 
   >>> pred = clf.predict(vectors_test)
-  >>> metrics.f1_score(newsgroups_test.target, pred, average='macro')  # doctest: +ELLIPSIS
+  >>> metrics.f1_score(newsgroups_test.target, pred, average='macro')
   0.88213...
 
 (The example :ref:`sphx_glr_auto_examples_text_plot_document_classification_20newsgroups.py` shuffles
@@ -195,7 +195,7 @@ blocks, and quotation blocks respectively.
   ...                                      categories=categories)
   >>> vectors_test = vectorizer.transform(newsgroups_test.data)
   >>> pred = clf.predict(vectors_test)
-  >>> metrics.f1_score(pred, newsgroups_test.target, average='macro')  # doctest: +ELLIPSIS
+  >>> metrics.f1_score(pred, newsgroups_test.target, average='macro')
   0.77310...
 
 This classifier lost over a lot of its F-score, just because we removed
@@ -212,7 +212,7 @@ It loses even more if we also strip this metadata from the training data:
 
   >>> vectors_test = vectorizer.transform(newsgroups_test.data)
   >>> pred = clf.predict(vectors_test)
-  >>> metrics.f1_score(newsgroups_test.target, pred, average='macro')  # doctest: +ELLIPSIS
+  >>> metrics.f1_score(newsgroups_test.target, pred, average='macro')
   0.76995...
 
 Some other classifiers cope better with this harder version of the task. Try

--- a/sklearn/decomposition/base.py
+++ b/sklearn/decomposition/base.py
@@ -119,7 +119,7 @@ class _BasePCA(BaseEstimator, TransformerMixin, metaclass=ABCMeta):
         >>> X = np.array([[-1, -1], [-2, -1], [-3, -2], [1, 1], [2, 1], [3, 2]])
         >>> ipca = IncrementalPCA(n_components=2, batch_size=3)
         >>> ipca.fit(X)
-        IncrementalPCA(batch_size=3, copy=True, n_components=2, whiten=False)
+        IncrementalPCA(batch_size=3, n_components=2)
         >>> ipca.transform(X) # doctest: +SKIP
         """
         check_is_fitted(self, ['mean_', 'components_'], all_or_any=all)

--- a/sklearn/decomposition/incremental_pca.py
+++ b/sklearn/decomposition/incremental_pca.py
@@ -108,7 +108,7 @@ class IncrementalPCA(_BasePCA):
     >>> transformer = IncrementalPCA(n_components=7, batch_size=200)
     >>> # either partially fit on smaller batches of data
     >>> transformer.partial_fit(X[:100, :])
-    IncrementalPCA(batch_size=200, copy=True, n_components=7, whiten=False)
+    IncrementalPCA(batch_size=200, n_components=7)
     >>> # or let the fit function itself divide the data into batches
     >>> X_transformed = transformer.fit_transform(X)
     >>> X_transformed.shape

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -254,7 +254,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
     >>> X, _ = make_multilabel_classification(random_state=0)
     >>> lda = LatentDirichletAllocation(n_components=5,
     ...     random_state=0)
-    >>> lda.fit(X) # doctest: +ELLIPSIS
+    >>> lda.fit(X)
     LatentDirichletAllocation(...)
     >>> # get topics for some given samples:
     >>> lda.transform(X[-2:])

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -277,27 +277,27 @@ class PCA(_BasePCA):
     >>> from sklearn.decomposition import PCA
     >>> X = np.array([[-1, -1], [-2, -1], [-3, -2], [1, 1], [2, 1], [3, 2]])
     >>> pca = PCA(n_components=2)
-    >>> pca.fit(X)  # doctest: +NORMALIZE_WHITESPACE
+    >>> pca.fit(X)
     PCA(n_components=2)
-    >>> print(pca.explained_variance_ratio_)  # doctest: +ELLIPSIS
+    >>> print(pca.explained_variance_ratio_)
     [0.9924... 0.0075...]
-    >>> print(pca.singular_values_)  # doctest: +ELLIPSIS
+    >>> print(pca.singular_values_)
     [6.30061... 0.54980...]
 
     >>> pca = PCA(n_components=2, svd_solver='full')
-    >>> pca.fit(X)                 # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> pca.fit(X)
     PCA(n_components=2, svd_solver='full')
-    >>> print(pca.explained_variance_ratio_)  # doctest: +ELLIPSIS
+    >>> print(pca.explained_variance_ratio_)
     [0.9924... 0.00755...]
-    >>> print(pca.singular_values_)  # doctest: +ELLIPSIS
+    >>> print(pca.singular_values_)
     [6.30061... 0.54980...]
 
     >>> pca = PCA(n_components=1, svd_solver='arpack')
-    >>> pca.fit(X)  # doctest: +NORMALIZE_WHITESPACE
+    >>> pca.fit(X)
     PCA(n_components=1, svd_solver='arpack')
-    >>> print(pca.explained_variance_ratio_)  # doctest: +ELLIPSIS
+    >>> print(pca.explained_variance_ratio_)
     [0.99244...]
-    >>> print(pca.singular_values_)  # doctest: +ELLIPSIS
+    >>> print(pca.singular_values_)
     [6.30061...]
 
     See also

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -278,8 +278,7 @@ class PCA(_BasePCA):
     >>> X = np.array([[-1, -1], [-2, -1], [-3, -2], [1, 1], [2, 1], [3, 2]])
     >>> pca = PCA(n_components=2)
     >>> pca.fit(X)  # doctest: +NORMALIZE_WHITESPACE
-    PCA(copy=True, iterated_power='auto', n_components=2, random_state=None,
-      svd_solver='auto', tol=0.0, whiten=False)
+    PCA(n_components=2)
     >>> print(pca.explained_variance_ratio_)  # doctest: +ELLIPSIS
     [0.9924... 0.0075...]
     >>> print(pca.singular_values_)  # doctest: +ELLIPSIS
@@ -287,8 +286,7 @@ class PCA(_BasePCA):
 
     >>> pca = PCA(n_components=2, svd_solver='full')
     >>> pca.fit(X)                 # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-    PCA(copy=True, iterated_power='auto', n_components=2, random_state=None,
-      svd_solver='full', tol=0.0, whiten=False)
+    PCA(n_components=2, svd_solver='full')
     >>> print(pca.explained_variance_ratio_)  # doctest: +ELLIPSIS
     [0.9924... 0.00755...]
     >>> print(pca.singular_values_)  # doctest: +ELLIPSIS
@@ -296,8 +294,7 @@ class PCA(_BasePCA):
 
     >>> pca = PCA(n_components=1, svd_solver='arpack')
     >>> pca.fit(X)  # doctest: +NORMALIZE_WHITESPACE
-    PCA(copy=True, iterated_power='auto', n_components=1, random_state=None,
-      svd_solver='arpack', tol=0.0, whiten=False)
+    PCA(n_components=1, svd_solver='arpack')
     >>> print(pca.explained_variance_ratio_)  # doctest: +ELLIPSIS
     [0.99244...]
     >>> print(pca.singular_values_)  # doctest: +ELLIPSIS

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -117,13 +117,13 @@ class SparsePCA(BaseEstimator, TransformerMixin):
     >>> from sklearn.decomposition import SparsePCA
     >>> X, _ = make_friedman1(n_samples=200, n_features=30, random_state=0)
     >>> transformer = SparsePCA(n_components=5, random_state=0)
-    >>> transformer.fit(X) # doctest: +ELLIPSIS
+    >>> transformer.fit(X)
     SparsePCA(...)
     >>> X_transformed = transformer.transform(X)
     >>> X_transformed.shape
     (200, 5)
     >>> # most values in the components_ are zero (sparsity)
-    >>> np.mean(transformer.components_ == 0) # doctest: +ELLIPSIS
+    >>> np.mean(transformer.components_ == 0)
     0.9666...
 
     See also
@@ -325,7 +325,7 @@ class MiniBatchSparsePCA(SparsePCA):
     >>> X, _ = make_friedman1(n_samples=200, n_features=30, random_state=0)
     >>> transformer = MiniBatchSparsePCA(n_components=5, batch_size=50,
     ...                                  random_state=0)
-    >>> transformer.fit(X) # doctest: +ELLIPSIS
+    >>> transformer.fit(X)
     MiniBatchSparsePCA(...)
     >>> X_transformed = transformer.transform(X)
     >>> X_transformed.shape

--- a/sklearn/decomposition/truncated_svd.py
+++ b/sklearn/decomposition/truncated_svd.py
@@ -87,13 +87,13 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
     >>> from sklearn.random_projection import sparse_random_matrix
     >>> X = sparse_random_matrix(100, 100, density=0.01, random_state=42)
     >>> svd = TruncatedSVD(n_components=5, n_iter=7, random_state=42)
-    >>> svd.fit(X)  # doctest: +NORMALIZE_WHITESPACE
+    >>> svd.fit(X)
     TruncatedSVD(n_components=5, n_iter=7, random_state=42)
-    >>> print(svd.explained_variance_ratio_)  # doctest: +ELLIPSIS
+    >>> print(svd.explained_variance_ratio_)
     [0.0606... 0.0584... 0.0497... 0.0434... 0.0372...]
-    >>> print(svd.explained_variance_ratio_.sum())  # doctest: +ELLIPSIS
+    >>> print(svd.explained_variance_ratio_.sum())
     0.249...
-    >>> print(svd.singular_values_)  # doctest: +ELLIPSIS
+    >>> print(svd.singular_values_)
     [2.5841... 2.5245... 2.3201... 2.1753... 2.0443...]
 
     See also

--- a/sklearn/decomposition/truncated_svd.py
+++ b/sklearn/decomposition/truncated_svd.py
@@ -88,8 +88,7 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
     >>> X = sparse_random_matrix(100, 100, density=0.01, random_state=42)
     >>> svd = TruncatedSVD(n_components=5, n_iter=7, random_state=42)
     >>> svd.fit(X)  # doctest: +NORMALIZE_WHITESPACE
-    TruncatedSVD(algorithm='randomized', n_components=5, n_iter=7,
-            random_state=42, tol=0.0)
+    TruncatedSVD(n_components=5, n_iter=7, random_state=42)
     >>> print(svd.explained_variance_ratio_)  # doctest: +ELLIPSIS
     [0.0606... 0.0584... 0.0497... 0.0434... 0.0372...]
     >>> print(svd.explained_variance_ratio_.sum())  # doctest: +ELLIPSIS

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -241,7 +241,7 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
     >>> X = np.array([[-1, -1], [-2, -1], [-3, -2], [1, 1], [2, 1], [3, 2]])
     >>> y = np.array([1, 1, 1, 2, 2, 2])
     >>> clf = LinearDiscriminantAnalysis()
-    >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     LinearDiscriminantAnalysis()
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
@@ -619,7 +619,6 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
     >>> y = np.array([1, 1, 1, 2, 2, 2])
     >>> clf = QuadraticDiscriminantAnalysis()
     >>> clf.fit(X, y)
-    ... # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     QuadraticDiscriminantAnalysis()
     >>> print(clf.predict([[-0.8, -1]]))
     [1]

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -242,8 +242,7 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
     >>> y = np.array([1, 1, 1, 2, 2, 2])
     >>> clf = LinearDiscriminantAnalysis()
     >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-    LinearDiscriminantAnalysis(n_components=None, priors=None, shrinkage=None,
-                  solver='svd', store_covariance=False, tol=0.0001)
+    LinearDiscriminantAnalysis()
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
     """
@@ -621,8 +620,7 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
     >>> clf = QuadraticDiscriminantAnalysis()
     >>> clf.fit(X, y)
     ... # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-    QuadraticDiscriminantAnalysis(priors=None, reg_param=0.0,
-                                  store_covariance=False, tol=0.0001)
+    QuadraticDiscriminantAnalysis()
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
 

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -954,12 +954,7 @@ class RandomForestClassifier(ForestClassifier):
     ...                            random_state=0, shuffle=False)
     >>> clf = RandomForestClassifier(max_depth=2, random_state=0)
     >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-    RandomForestClassifier(bootstrap=True, class_weight=None, criterion='gini',
-                max_depth=2, max_features='auto', max_leaf_nodes=None,
-                min_impurity_decrease=0.0, min_impurity_split=None,
-                min_samples_leaf=1, min_samples_split=2,
-                min_weight_fraction_leaf=0.0, n_estimators=100, n_jobs=None,
-                oob_score=False, random_state=0, verbose=0, warm_start=False)
+    RandomForestClassifier(max_depth=2, random_state=0)
     >>> print(clf.feature_importances_)
     [0.14205973 0.76664038 0.0282433  0.06305659]
     >>> print(clf.predict([[0, 0, 0, 0]]))
@@ -1206,12 +1201,7 @@ class RandomForestRegressor(ForestRegressor):
     ...                        random_state=0, shuffle=False)
     >>> regr = RandomForestRegressor(max_depth=2, random_state=0)
     >>> regr.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-    RandomForestRegressor(bootstrap=True, criterion='mse', max_depth=2,
-               max_features='auto', max_leaf_nodes=None,
-               min_impurity_decrease=0.0, min_impurity_split=None,
-               min_samples_leaf=1, min_samples_split=2,
-               min_weight_fraction_leaf=0.0, n_estimators=100, n_jobs=None,
-               oob_score=False, random_state=0, verbose=0, warm_start=False)
+    RandomForestRegressor(max_depth=2, random_state=0)
     >>> print(regr.feature_importances_)
     [0.18146984 0.81473937 0.00145312 0.00233767]
     >>> print(regr.predict([[0, 0, 0, 0]]))

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -953,7 +953,7 @@ class RandomForestClassifier(ForestClassifier):
     ...                            n_informative=2, n_redundant=0,
     ...                            random_state=0, shuffle=False)
     >>> clf = RandomForestClassifier(max_depth=2, random_state=0)
-    >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     RandomForestClassifier(max_depth=2, random_state=0)
     >>> print(clf.feature_importances_)
     [0.14205973 0.76664038 0.0282433  0.06305659]
@@ -1200,7 +1200,7 @@ class RandomForestRegressor(ForestRegressor):
     >>> X, y = make_regression(n_features=4, n_informative=2,
     ...                        random_state=0, shuffle=False)
     >>> regr = RandomForestRegressor(max_depth=2, random_state=0)
-    >>> regr.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> regr.fit(X, y)
     RandomForestRegressor(max_depth=2, random_state=0)
     >>> print(regr.feature_importances_)
     [0.18146984 0.81473937 0.00145312 0.00233767]

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -362,8 +362,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
     ...                            random_state=0, shuffle=False)
     >>> clf = AdaBoostClassifier(n_estimators=100, random_state=0)
     >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-    AdaBoostClassifier(algorithm='SAMME.R', base_estimator=None,
-            learning_rate=1.0, n_estimators=100, random_state=0)
+    AdaBoostClassifier(n_estimators=100, random_state=0)
     >>> clf.feature_importances_  # doctest: +ELLIPSIS
     array([0.28..., 0.42..., 0.14..., 0.16...])
     >>> clf.predict([[0, 0, 0, 0]])
@@ -929,8 +928,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
     ...                        random_state=0, shuffle=False)
     >>> regr = AdaBoostRegressor(random_state=0, n_estimators=100)
     >>> regr.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-    AdaBoostRegressor(base_estimator=None, learning_rate=1.0, loss='linear',
-            n_estimators=100, random_state=0)
+    AdaBoostRegressor(n_estimators=100, random_state=0)
     >>> regr.feature_importances_  # doctest: +ELLIPSIS
     array([0.2788..., 0.7109..., 0.0065..., 0.0036...])
     >>> regr.predict([[0, 0, 0, 0]])  # doctest: +ELLIPSIS

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -361,13 +361,13 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
     ...                            n_informative=2, n_redundant=0,
     ...                            random_state=0, shuffle=False)
     >>> clf = AdaBoostClassifier(n_estimators=100, random_state=0)
-    >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     AdaBoostClassifier(n_estimators=100, random_state=0)
-    >>> clf.feature_importances_  # doctest: +ELLIPSIS
+    >>> clf.feature_importances_
     array([0.28..., 0.42..., 0.14..., 0.16...])
     >>> clf.predict([[0, 0, 0, 0]])
     array([1])
-    >>> clf.score(X, y)  # doctest: +ELLIPSIS
+    >>> clf.score(X, y)
     0.983...
 
     See also
@@ -927,13 +927,13 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
     >>> X, y = make_regression(n_features=4, n_informative=2,
     ...                        random_state=0, shuffle=False)
     >>> regr = AdaBoostRegressor(random_state=0, n_estimators=100)
-    >>> regr.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> regr.fit(X, y)
     AdaBoostRegressor(n_estimators=100, random_state=0)
-    >>> regr.feature_importances_  # doctest: +ELLIPSIS
+    >>> regr.feature_importances_
     array([0.2788..., 0.7109..., 0.0065..., 0.0036...])
-    >>> regr.predict([[0, 0, 0, 0]])  # doctest: +ELLIPSIS
+    >>> regr.predict([[0, 0, 0, 0]])
     array([4.7972...])
-    >>> regr.score(X, y)  # doctest: +ELLIPSIS
+    >>> regr.score(X, y)
     0.9771...
 
     See also

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -29,7 +29,6 @@ class NotFittedError(ValueError, AttributeError):
     ...     LinearSVC().predict([[1, 2], [2, 3], [3, 4]])
     ... except NotFittedError as e:
     ...     print(repr(e))
-    ... # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     NotFittedError("This LinearSVC instance is not fitted yet. Call 'fit' with
     appropriate arguments before using this method.")
 
@@ -119,7 +118,6 @@ class FitFailedWarning(RuntimeWarning):
     ...     except ValueError:
     ...         pass
     ...     print(repr(w[-1].message))
-    ... # doctest: +NORMALIZE_WHITESPACE
     FitFailedWarning('Estimator fit failed. The score on this train-test
     partition for these parameters will be set to 0.000000.
     Details: \\nValueError: Penalty term must be positive; got (C=-2)\\n'...)

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -342,8 +342,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         >>> support = SelectKBest(chi2, k=2).fit(X, [0, 1])
         >>> v.get_feature_names()
         ['bar', 'baz', 'foo']
-        >>> v.restrict(support.get_support()) # doctest: +ELLIPSIS
-        ...                                   # doctest: +NORMALIZE_WHITESPACE
+        >>> v.restrict(support.get_support())
         DictVectorizer()
         >>> v.get_feature_names()
         ['bar', 'foo']

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -344,8 +344,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         ['bar', 'baz', 'foo']
         >>> v.restrict(support.get_support()) # doctest: +ELLIPSIS
         ...                                   # doctest: +NORMALIZE_WHITESPACE
-        DictVectorizer(dtype=..., separator='=', sort=True,
-                sparse=True)
+        DictVectorizer()
         >>> v.get_feature_names()
         ['bar', 'foo']
         """

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -348,12 +348,12 @@ def extract_patches_2d(image, patch_size, max_patches=None, random_state=None):
     >>> print('Patches shape: {}'.format(patches.shape))
     Patches shape: (272214, 2, 2, 3)
     >>> # Here are just two of these patches:
-    >>> print(patches[1]) # doctest: +NORMALIZE_WHITESPACE
+    >>> print(patches[1])
     [[[174 201 231]
       [174 201 231]]
      [[173 200 230]
       [173 200 230]]]
-    >>> print(patches[800])# doctest: +NORMALIZE_WHITESPACE
+    >>> print(patches[800])
     [[[187 214 243]
       [188 215 244]]
      [[187 214 243]

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -844,7 +844,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
     >>> X = vectorizer.fit_transform(corpus)
     >>> print(vectorizer.get_feature_names())
     ['and', 'document', 'first', 'is', 'one', 'second', 'the', 'third', 'this']
-    >>> print(X.toarray())  # doctest: +NORMALIZE_WHITESPACE
+    >>> print(X.toarray())
     [[0 1 1 1 0 0 1 0 1]
      [0 2 0 1 0 1 1 0 1]
      [1 0 0 1 1 0 1 1 1]

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -96,7 +96,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
     >>> estimator = SVR(kernel="linear")
     >>> selector = RFE(estimator, 5, step=1)
     >>> selector = selector.fit(X, y)
-    >>> selector.support_ # doctest: +NORMALIZE_WHITESPACE
+    >>> selector.support_
     array([ True,  True,  True,  True,  True, False, False, False, False,
            False])
     >>> selector.ranking_
@@ -432,7 +432,7 @@ class RFECV(RFE, MetaEstimatorMixin):
     >>> estimator = SVR(kernel="linear")
     >>> selector = RFECV(estimator, step=1, cv=5)
     >>> selector = selector.fit(X, y)
-    >>> selector.support_ # doctest: +NORMALIZE_WHITESPACE
+    >>> selector.support_
     array([ True,  True,  True,  True,  True, False, False, False, False,
            False])
     >>> selector.ranking_

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -567,7 +567,7 @@ class GaussianProcessClassifier(BaseEstimator, ClassifierMixin):
     >>> kernel = 1.0 * RBF(1.0)
     >>> gpc = GaussianProcessClassifier(kernel=kernel,
     ...         random_state=0).fit(X, y)
-    >>> gpc.score(X, y) # doctest: +ELLIPSIS
+    >>> gpc.score(X, y)
     0.9866...
     >>> gpc.predict_proba(X[:2,:])
     array([[0.83548752, 0.03228706, 0.13222543],

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -142,9 +142,9 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
     >>> kernel = DotProduct() + WhiteKernel()
     >>> gpr = GaussianProcessRegressor(kernel=kernel,
     ...         random_state=0).fit(X, y)
-    >>> gpr.score(X, y) # doctest: +ELLIPSIS
+    >>> gpr.score(X, y)
     0.3680...
-    >>> gpr.predict(X[:2,:], return_std=True) # doctest: +ELLIPSIS
+    >>> gpr.predict(X[:2,:], return_std=True)
     (array([653.0..., 592.1...]), array([316.6..., 316.6...]))
 
     """

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -153,8 +153,7 @@ class SimpleImputer(BaseEstimator, TransformerMixin):
     >>> imp_mean = SimpleImputer(missing_values=np.nan, strategy='mean')
     >>> imp_mean.fit([[7, 2, 3], [4, np.nan, 6], [10, 5, 9]])
     ... # doctest: +NORMALIZE_WHITESPACE
-    SimpleImputer(add_indicator=False, copy=True, fill_value=None,
-            missing_values=nan, strategy='mean', verbose=0)
+    SimpleImputer()
     >>> X = [[np.nan, 2, 3], [4, np.nan, 6], [10, np.nan, 9]]
     >>> print(imp_mean.transform(X))
     ... # doctest: +NORMALIZE_WHITESPACE
@@ -490,8 +489,7 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
     ...                [2, 4, 0]])
     >>> indicator = MissingIndicator()
     >>> indicator.fit(X1)  # doctest: +NORMALIZE_WHITESPACE
-    MissingIndicator(error_on_new=True, features='missing-only',
-             missing_values=nan, sparse='auto')
+    MissingIndicator()
     >>> X2_tr = indicator.transform(X2)
     >>> X2_tr
     array([[False,  True],

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -152,11 +152,9 @@ class SimpleImputer(BaseEstimator, TransformerMixin):
     >>> from sklearn.impute import SimpleImputer
     >>> imp_mean = SimpleImputer(missing_values=np.nan, strategy='mean')
     >>> imp_mean.fit([[7, 2, 3], [4, np.nan, 6], [10, 5, 9]])
-    ... # doctest: +NORMALIZE_WHITESPACE
     SimpleImputer()
     >>> X = [[np.nan, 2, 3], [4, np.nan, 6], [10, np.nan, 9]]
     >>> print(imp_mean.transform(X))
-    ... # doctest: +NORMALIZE_WHITESPACE
     [[ 7.   2.   3. ]
      [ 4.   3.5  6. ]
      [10.   3.5  9. ]]
@@ -488,7 +486,7 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
     ...                [np.nan, 2, 3],
     ...                [2, 4, 0]])
     >>> indicator = MissingIndicator()
-    >>> indicator.fit(X1)  # doctest: +NORMALIZE_WHITESPACE
+    >>> indicator.fit(X1)
     MissingIndicator()
     >>> X2_tr = indicator.transform(X2)
     >>> X2_tr

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -216,7 +216,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
     >>> from sklearn.isotonic import IsotonicRegression
     >>> X, y = make_regression(n_samples=10, n_features=1, random_state=41)
     >>> iso_reg = IsotonicRegression().fit(X.flatten(), y)
-    >>> iso_reg.predict([.1, .2])  # doctest: +ELLIPSIS
+    >>> iso_reg.predict([.1, .2])
     array([1.8628..., 3.7256...])
     """
     def __init__(self, y_min=None, y_max=None, increasing=True,

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -54,7 +54,6 @@ class RBFSampler(BaseEstimator, TransformerMixin):
     >>> X_features = rbf_feature.fit_transform(X)
     >>> clf = SGDClassifier(max_iter=5, tol=1e-3)
     >>> clf.fit(X_features, y)
-    ... # doctest: +NORMALIZE_WHITESPACE
     SGDClassifier(max_iter=5)
     >>> clf.score(X_features, y)
     1.0
@@ -158,7 +157,7 @@ class SkewedChi2Sampler(BaseEstimator, TransformerMixin):
     ...                                  random_state=0)
     >>> X_features = chi2_feature.fit_transform(X, y)
     >>> clf = SGDClassifier(max_iter=10, tol=1e-3)
-    >>> clf.fit(X_features, y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X_features, y)
     SGDClassifier(max_iter=10)
     >>> clf.score(X_features, y)
     1.0
@@ -273,9 +272,9 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
     >>> chi2sampler = AdditiveChi2Sampler(sample_steps=2)
     >>> X_transformed = chi2sampler.fit_transform(X, y)
     >>> clf = SGDClassifier(max_iter=5, random_state=0, tol=1e-3)
-    >>> clf.fit(X_transformed, y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X_transformed, y)
     SGDClassifier(max_iter=5, random_state=0)
-    >>> clf.score(X_transformed, y) # doctest: +ELLIPSIS
+    >>> clf.score(X_transformed, y)
     0.9499...
 
     Notes
@@ -490,9 +489,8 @@ class Nystroem(BaseEstimator, TransformerMixin):
     ...                                 n_components=300)
     >>> data_transformed = feature_map_nystroem.fit_transform(data)
     >>> clf.fit(data_transformed, digits.target)
-    ... # doctest: +NORMALIZE_WHITESPACE
     LinearSVC()
-    >>> clf.score(data_transformed, digits.target) # doctest: +ELLIPSIS
+    >>> clf.score(data_transformed, digits.target)
     0.9987...
 
     References

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -55,12 +55,7 @@ class RBFSampler(BaseEstimator, TransformerMixin):
     >>> clf = SGDClassifier(max_iter=5, tol=1e-3)
     >>> clf.fit(X_features, y)
     ... # doctest: +NORMALIZE_WHITESPACE
-    SGDClassifier(alpha=0.0001, average=False, class_weight=None,
-           early_stopping=False, epsilon=0.1, eta0=0.0, fit_intercept=True,
-           l1_ratio=0.15, learning_rate='optimal', loss='hinge', max_iter=5,
-           n_iter_no_change=5, n_jobs=None, penalty='l2', power_t=0.5,
-           random_state=None, shuffle=True, tol=0.001, validation_fraction=0.1,
-           verbose=0, warm_start=False)
+    SGDClassifier(max_iter=5)
     >>> clf.score(X_features, y)
     1.0
 
@@ -164,12 +159,7 @@ class SkewedChi2Sampler(BaseEstimator, TransformerMixin):
     >>> X_features = chi2_feature.fit_transform(X, y)
     >>> clf = SGDClassifier(max_iter=10, tol=1e-3)
     >>> clf.fit(X_features, y)  # doctest: +NORMALIZE_WHITESPACE
-    SGDClassifier(alpha=0.0001, average=False, class_weight=None,
-           early_stopping=False, epsilon=0.1, eta0=0.0, fit_intercept=True,
-           l1_ratio=0.15, learning_rate='optimal', loss='hinge', max_iter=10,
-           n_iter_no_change=5, n_jobs=None, penalty='l2', power_t=0.5,
-           random_state=None, shuffle=True, tol=0.001, validation_fraction=0.1,
-           verbose=0, warm_start=False)
+    SGDClassifier(max_iter=10)
     >>> clf.score(X_features, y)
     1.0
 
@@ -284,12 +274,7 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
     >>> X_transformed = chi2sampler.fit_transform(X, y)
     >>> clf = SGDClassifier(max_iter=5, random_state=0, tol=1e-3)
     >>> clf.fit(X_transformed, y)  # doctest: +NORMALIZE_WHITESPACE
-    SGDClassifier(alpha=0.0001, average=False, class_weight=None,
-           early_stopping=False, epsilon=0.1, eta0=0.0, fit_intercept=True,
-           l1_ratio=0.15, learning_rate='optimal', loss='hinge', max_iter=5,
-           n_iter_no_change=5, n_jobs=None, penalty='l2', power_t=0.5,
-           random_state=0, shuffle=True, tol=0.001, validation_fraction=0.1,
-           verbose=0, warm_start=False)
+    SGDClassifier(max_iter=5, random_state=0)
     >>> clf.score(X_transformed, y) # doctest: +ELLIPSIS
     0.9499...
 
@@ -506,10 +491,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
     >>> data_transformed = feature_map_nystroem.fit_transform(data)
     >>> clf.fit(data_transformed, digits.target)
     ... # doctest: +NORMALIZE_WHITESPACE
-    LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
-         intercept_scaling=1, loss='squared_hinge', max_iter=1000,
-         multi_class='ovr', penalty='l2', random_state=None, tol=0.0001,
-         verbose=0)
+    LinearSVC()
     >>> clf.score(data_transformed, digits.target) # doctest: +ELLIPSIS
     0.9987...
 

--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -101,7 +101,7 @@ class KernelRidge(BaseEstimator, RegressorMixin, MultiOutputMixin):
     >>> y = rng.randn(n_samples)
     >>> X = rng.randn(n_samples, n_features)
     >>> clf = KernelRidge(alpha=1.0)
-    >>> clf.fit(X, y) # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     KernelRidge(alpha=1.0)
     """
     def __init__(self, alpha=1, kernel="linear", gamma=None, degree=3, coef0=1,

--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -102,8 +102,7 @@ class KernelRidge(BaseEstimator, RegressorMixin, MultiOutputMixin):
     >>> X = rng.randn(n_samples, n_features)
     >>> clf = KernelRidge(alpha=1.0)
     >>> clf.fit(X, y) # doctest: +NORMALIZE_WHITESPACE
-    KernelRidge(alpha=1.0, coef0=1, degree=3, gamma=None, kernel='linear',
-                kernel_params=None)
+    KernelRidge(alpha=1.0)
     """
     def __init__(self, alpha=1, kernel="linear", gamma=None, degree=3, coef0=1,
                  kernel_params=None):

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -413,7 +413,7 @@ class LinearRegression(LinearModel, RegressorMixin, MultiOutputMixin):
     1.0
     >>> reg.coef_
     array([1., 2.])
-    >>> reg.intercept_ # doctest: +ELLIPSIS
+    >>> reg.intercept_
     3.0000...
     >>> reg.predict(np.array([[3, 5]]))
     array([16.])

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -128,10 +128,7 @@ class BayesianRidge(LinearModel, RegressorMixin):
     >>> clf = linear_model.BayesianRidge()
     >>> clf.fit([[0,0], [1, 1], [2, 2]], [0, 1, 2])
     ... # doctest: +NORMALIZE_WHITESPACE
-    BayesianRidge(alpha_1=1e-06, alpha_2=1e-06, alpha_init=None,
-                  compute_score=False, copy_X=True, fit_intercept=True,
-                  lambda_1=1e-06, lambda_2=1e-06, lambda_init=None, n_iter=300,
-                  normalize=False, tol=0.001, verbose=False)
+    BayesianRidge()
     >>> clf.predict([[1, 1]])
     array([1.])
 
@@ -469,10 +466,7 @@ class ARDRegression(LinearModel, RegressorMixin):
     >>> clf = linear_model.ARDRegression()
     >>> clf.fit([[0,0], [1, 1], [2, 2]], [0, 1, 2])
     ... # doctest: +NORMALIZE_WHITESPACE
-    ARDRegression(alpha_1=1e-06, alpha_2=1e-06, compute_score=False,
-            copy_X=True, fit_intercept=True, lambda_1=1e-06, lambda_2=1e-06,
-            n_iter=300, normalize=False, threshold_lambda=10000.0, tol=0.001,
-            verbose=False)
+    ARDRegression()
     >>> clf.predict([[1, 1]])
     array([1.])
 

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -127,7 +127,6 @@ class BayesianRidge(LinearModel, RegressorMixin):
     >>> from sklearn import linear_model
     >>> clf = linear_model.BayesianRidge()
     >>> clf.fit([[0,0], [1, 1], [2, 2]], [0, 1, 2])
-    ... # doctest: +NORMALIZE_WHITESPACE
     BayesianRidge()
     >>> clf.predict([[1, 1]])
     array([1.])
@@ -465,7 +464,6 @@ class ARDRegression(LinearModel, RegressorMixin):
     >>> from sklearn import linear_model
     >>> clf = linear_model.ARDRegression()
     >>> clf.fit([[0,0], [1, 1], [2, 2]], [0, 1, 2])
-    ... # doctest: +NORMALIZE_WHITESPACE
     ARDRegression()
     >>> clf.predict([[1, 1]])
     array([1.])

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1695,6 +1695,7 @@ class MultiTaskElasticNet(Lasso):
     >>> from sklearn import linear_model
     >>> clf = linear_model.MultiTaskElasticNet(alpha=0.1)
     >>> clf.fit([[0,0], [1, 1], [2, 2]], [[0, 0], [1, 1], [2, 2]])
+    ... #doctest: +NORMALIZE_WHITESPACE
     MultiTaskElasticNet(alpha=0.1)
     >>> print(clf.coef_)
     [[0.45663524 0.45612256]
@@ -2057,6 +2058,7 @@ class MultiTaskElasticNetCV(LinearModelCV, RegressorMixin):
     >>> clf = linear_model.MultiTaskElasticNetCV(cv=3)
     >>> clf.fit([[0,0], [1, 1], [2, 2]],
     ...         [[0, 0], [1, 1], [2, 2]])
+    ... #doctest: +NORMALIZE_WHITESPACE
     MultiTaskElasticNetCV(cv=3)
     >>> print(clf.coef_)
     [[0.52875032 0.46958558]

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -614,9 +614,7 @@ class ElasticNet(LinearModel, RegressorMixin, MultiOutputMixin):
     >>> X, y = make_regression(n_features=2, random_state=0)
     >>> regr = ElasticNet(random_state=0)
     >>> regr.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-    ElasticNet(alpha=1.0, copy_X=True, fit_intercept=True, l1_ratio=0.5,
-          max_iter=1000, normalize=False, positive=False, precompute=False,
-          random_state=0, selection='cyclic', tol=0.0001, warm_start=False)
+    ElasticNet(random_state=0)
     >>> print(regr.coef_) # doctest: +ELLIPSIS
     [18.83816048 64.55968825]
     >>> print(regr.intercept_) # doctest: +ELLIPSIS
@@ -894,9 +892,7 @@ class Lasso(ElasticNet):
     >>> clf = linear_model.Lasso(alpha=0.1)
     >>> clf.fit([[0,0], [1, 1], [2, 2]], [0, 1, 2])
     ... # doctest: +NORMALIZE_WHITESPACE
-    Lasso(alpha=0.1, copy_X=True, fit_intercept=True, max_iter=1000,
-       normalize=False, positive=False, precompute=False, random_state=None,
-       selection='cyclic', tol=0.0001, warm_start=False)
+    Lasso(alpha=0.1)
     >>> print(clf.coef_)
     [0.85 0.  ]
     >>> print(clf.intercept_)  # doctest: +ELLIPSIS
@@ -1539,10 +1535,7 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
     >>> X, y = make_regression(n_features=2, random_state=0)
     >>> regr = ElasticNetCV(cv=5, random_state=0)
     >>> regr.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-    ElasticNetCV(alphas=None, copy_X=True, cv=5, eps=0.001,
-           fit_intercept=True, l1_ratio=0.5, max_iter=1000, n_alphas=100,
-           n_jobs=None, normalize=False, positive=False, precompute='auto',
-           random_state=0, selection='cyclic', tol=0.0001, verbose=0)
+    ElasticNetCV(cv=5, random_state=0)
     >>> print(regr.alpha_) # doctest: +ELLIPSIS
     0.199...
     >>> print(regr.intercept_) # doctest: +ELLIPSIS
@@ -1704,9 +1697,7 @@ class MultiTaskElasticNet(Lasso):
     >>> clf = linear_model.MultiTaskElasticNet(alpha=0.1)
     >>> clf.fit([[0,0], [1, 1], [2, 2]], [[0, 0], [1, 1], [2, 2]])
     ... #doctest: +NORMALIZE_WHITESPACE
-    MultiTaskElasticNet(alpha=0.1, copy_X=True, fit_intercept=True,
-            l1_ratio=0.5, max_iter=1000, normalize=False, random_state=None,
-            selection='cyclic', tol=0.0001, warm_start=False)
+    MultiTaskElasticNet(alpha=0.1)
     >>> print(clf.coef_)
     [[0.45663524 0.45612256]
      [0.45663524 0.45612256]]
@@ -1892,9 +1883,7 @@ class MultiTaskLasso(MultiTaskElasticNet):
     >>> clf = linear_model.MultiTaskLasso(alpha=0.1)
     >>> clf.fit([[0,0], [1, 1], [2, 2]], [[0, 0], [1, 1], [2, 2]])
     ... # doctest: +NORMALIZE_WHITESPACE
-    MultiTaskLasso(alpha=0.1, copy_X=True, fit_intercept=True, max_iter=1000,
-            normalize=False, random_state=None, selection='cyclic', tol=0.0001,
-            warm_start=False)
+    MultiTaskLasso(alpha=0.1)
     >>> print(clf.coef_)
     [[0.89393398 0.        ]
      [0.89393398 0.        ]]
@@ -2072,10 +2061,7 @@ class MultiTaskElasticNetCV(LinearModelCV, RegressorMixin):
     >>> clf.fit([[0,0], [1, 1], [2, 2]],
     ...         [[0, 0], [1, 1], [2, 2]])
     ... #doctest: +NORMALIZE_WHITESPACE
-    MultiTaskElasticNetCV(alphas=None, copy_X=True, cv=3, eps=0.001,
-           fit_intercept=True, l1_ratio=0.5, max_iter=1000, n_alphas=100,
-           n_jobs=None, normalize=False, random_state=None, selection='cyclic',
-           tol=0.0001, verbose=0)
+    MultiTaskElasticNetCV(cv=3)
     >>> print(clf.coef_)
     [[0.52875032 0.46958558]
      [0.52875032 0.46958558]]

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -613,13 +613,13 @@ class ElasticNet(LinearModel, RegressorMixin, MultiOutputMixin):
 
     >>> X, y = make_regression(n_features=2, random_state=0)
     >>> regr = ElasticNet(random_state=0)
-    >>> regr.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> regr.fit(X, y)
     ElasticNet(random_state=0)
-    >>> print(regr.coef_) # doctest: +ELLIPSIS
+    >>> print(regr.coef_)
     [18.83816048 64.55968825]
-    >>> print(regr.intercept_) # doctest: +ELLIPSIS
+    >>> print(regr.intercept_)
     1.451...
-    >>> print(regr.predict([[0, 0]])) # doctest: +ELLIPSIS
+    >>> print(regr.predict([[0, 0]]))
     [1.451...]
 
 
@@ -891,11 +891,10 @@ class Lasso(ElasticNet):
     >>> from sklearn import linear_model
     >>> clf = linear_model.Lasso(alpha=0.1)
     >>> clf.fit([[0,0], [1, 1], [2, 2]], [0, 1, 2])
-    ... # doctest: +NORMALIZE_WHITESPACE
     Lasso(alpha=0.1)
     >>> print(clf.coef_)
     [0.85 0.  ]
-    >>> print(clf.intercept_)  # doctest: +ELLIPSIS
+    >>> print(clf.intercept_)
     0.15...
 
     See also
@@ -1360,7 +1359,7 @@ class LassoCV(LinearModelCV, RegressorMixin):
     >>> from sklearn.datasets import make_regression
     >>> X, y = make_regression(noise=4, random_state=0)
     >>> reg = LassoCV(cv=5, random_state=0).fit(X, y)
-    >>> reg.score(X, y) # doctest: +ELLIPSIS
+    >>> reg.score(X, y)
     0.9993...
     >>> reg.predict(X[:1,])
     array([-78.4951...])
@@ -1534,13 +1533,13 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
 
     >>> X, y = make_regression(n_features=2, random_state=0)
     >>> regr = ElasticNetCV(cv=5, random_state=0)
-    >>> regr.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> regr.fit(X, y)
     ElasticNetCV(cv=5, random_state=0)
-    >>> print(regr.alpha_) # doctest: +ELLIPSIS
+    >>> print(regr.alpha_)
     0.199...
-    >>> print(regr.intercept_) # doctest: +ELLIPSIS
+    >>> print(regr.intercept_)
     0.398...
-    >>> print(regr.predict([[0, 0]])) # doctest: +ELLIPSIS
+    >>> print(regr.predict([[0, 0]]))
     [0.398...]
 
 
@@ -1882,7 +1881,6 @@ class MultiTaskLasso(MultiTaskElasticNet):
     >>> from sklearn import linear_model
     >>> clf = linear_model.MultiTaskLasso(alpha=0.1)
     >>> clf.fit([[0,0], [1, 1], [2, 2]], [[0, 0], [1, 1], [2, 2]])
-    ... # doctest: +NORMALIZE_WHITESPACE
     MultiTaskLasso(alpha=0.1)
     >>> print(clf.coef_)
     [[0.89393398 0.        ]
@@ -2232,7 +2230,7 @@ class MultiTaskLassoCV(LinearModelCV, RegressorMixin):
     >>> from sklearn.metrics import r2_score
     >>> X, y = make_regression(n_targets=2, noise=4, random_state=0)
     >>> reg = MultiTaskLassoCV(cv=5, random_state=0).fit(X, y)
-    >>> r2_score(y, reg.predict(X)) # doctest: +ELLIPSIS
+    >>> r2_score(y, reg.predict(X))
     0.9994...
     >>> reg.alpha_
     0.5713...

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1695,7 +1695,6 @@ class MultiTaskElasticNet(Lasso):
     >>> from sklearn import linear_model
     >>> clf = linear_model.MultiTaskElasticNet(alpha=0.1)
     >>> clf.fit([[0,0], [1, 1], [2, 2]], [[0, 0], [1, 1], [2, 2]])
-    ... #doctest: +NORMALIZE_WHITESPACE
     MultiTaskElasticNet(alpha=0.1)
     >>> print(clf.coef_)
     [[0.45663524 0.45612256]
@@ -2058,7 +2057,6 @@ class MultiTaskElasticNetCV(LinearModelCV, RegressorMixin):
     >>> clf = linear_model.MultiTaskElasticNetCV(cv=3)
     >>> clf.fit([[0,0], [1, 1], [2, 2]],
     ...         [[0, 0], [1, 1], [2, 2]])
-    ... #doctest: +NORMALIZE_WHITESPACE
     MultiTaskElasticNetCV(cv=3)
     >>> print(clf.coef_)
     [[0.52875032 0.46958558]

--- a/sklearn/linear_model/huber.py
+++ b/sklearn/linear_model/huber.py
@@ -202,7 +202,7 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
     >>> X[:4] = rng.uniform(10, 20, (4, 2))
     >>> y[:4] = rng.uniform(10, 20, 4)
     >>> huber = HuberRegressor().fit(X, y)
-    >>> huber.score(X, y) # doctest: +ELLIPSIS
+    >>> huber.score(X, y)
     -7.284608623514573
     >>> huber.predict(X[:1,])
     array([806.7200...])

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -836,9 +836,7 @@ class Lars(LinearModel, RegressorMixin, MultiOutputMixin):
     >>> reg = linear_model.Lars(n_nonzero_coefs=1)
     >>> reg.fit([[-1, 1], [0, 0], [1, 1]], [-1.1111, 0, -1.1111])
     ... # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-    Lars(copy_X=True, eps=..., fit_intercept=True, fit_path=True,
-       n_nonzero_coefs=1, normalize=True, precompute='auto',
-       verbose=False)
+    Lars(n_nonzero_coefs=1)
     >>> print(reg.coef_) # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     [ 0. -1.11...]
 
@@ -1069,9 +1067,7 @@ class LassoLars(Lars):
     >>> reg = linear_model.LassoLars(alpha=0.01)
     >>> reg.fit([[-1, 1], [0, 0], [1, 1]], [-1, 0, -1])
     ... # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-    LassoLars(alpha=0.01, copy_X=True, eps=..., fit_intercept=True,
-         fit_path=True, max_iter=500, normalize=True, positive=False,
-         precompute='auto', verbose=False)
+    LassoLars(alpha=0.01)
     >>> print(reg.coef_) # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     [ 0.         -0.963257...]
 
@@ -1693,9 +1689,7 @@ class LassoLarsIC(LassoLars):
     >>> reg = linear_model.LassoLarsIC(criterion='bic')
     >>> reg.fit([[-1, 1], [0, 0], [1, 1]], [-1.1111, 0, -1.1111])
     ... # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-    LassoLarsIC(copy_X=True, criterion='bic', eps=..., fit_intercept=True,
-          max_iter=500, normalize=True, positive=False, precompute='auto',
-          verbose=False)
+    LassoLarsIC(criterion='bic')
     >>> print(reg.coef_) # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     [ 0.  -1.11...]
 

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -835,9 +835,8 @@ class Lars(LinearModel, RegressorMixin, MultiOutputMixin):
     >>> from sklearn import linear_model
     >>> reg = linear_model.Lars(n_nonzero_coefs=1)
     >>> reg.fit([[-1, 1], [0, 0], [1, 1]], [-1.1111, 0, -1.1111])
-    ... # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     Lars(n_nonzero_coefs=1)
-    >>> print(reg.coef_) # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+    >>> print(reg.coef_)
     [ 0. -1.11...]
 
     See also
@@ -1066,9 +1065,8 @@ class LassoLars(Lars):
     >>> from sklearn import linear_model
     >>> reg = linear_model.LassoLars(alpha=0.01)
     >>> reg.fit([[-1, 1], [0, 0], [1, 1]], [-1, 0, -1])
-    ... # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     LassoLars(alpha=0.01)
-    >>> print(reg.coef_) # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+    >>> print(reg.coef_)
     [ 0.         -0.963257...]
 
     See also
@@ -1323,7 +1321,7 @@ class LarsCV(Lars):
     >>> from sklearn.datasets import make_regression
     >>> X, y = make_regression(n_samples=200, noise=4.0, random_state=0)
     >>> reg = LarsCV(cv=5).fit(X, y)
-    >>> reg.score(X, y) # doctest: +ELLIPSIS
+    >>> reg.score(X, y)
     0.9996...
     >>> reg.alpha_
     0.0254...
@@ -1549,7 +1547,7 @@ class LassoLarsCV(LarsCV):
     >>> from sklearn.datasets import make_regression
     >>> X, y = make_regression(noise=4.0, random_state=0)
     >>> reg = LassoLarsCV(cv=5).fit(X, y)
-    >>> reg.score(X, y) # doctest: +ELLIPSIS
+    >>> reg.score(X, y)
     0.9992...
     >>> reg.alpha_
     0.0484...
@@ -1688,9 +1686,8 @@ class LassoLarsIC(LassoLars):
     >>> from sklearn import linear_model
     >>> reg = linear_model.LassoLarsIC(criterion='bic')
     >>> reg.fit([[-1, 1], [0, 0], [1, 1]], [-1.1111, 0, -1.1111])
-    ... # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     LassoLarsIC(criterion='bic')
-    >>> print(reg.coef_) # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+    >>> print(reg.coef_)
     [ 0.  -1.11...]
 
     Notes

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1384,7 +1384,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
     >>> clf = LogisticRegression(random_state=0).fit(X, y)
     >>> clf.predict(X[:2, :])
     array([0, 0])
-    >>> clf.predict_proba(X[:2, :]) # doctest: +ELLIPSIS
+    >>> clf.predict_proba(X[:2, :])
     array([[9.8...e-01, 1.8...e-02, 1.4...e-08],
            [9.7...e-01, 2.8...e-02, ...e-08]])
     >>> clf.score(X, y)
@@ -1902,7 +1902,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
     array([0, 0])
     >>> clf.predict_proba(X[:2, :]).shape
     (2, 3)
-    >>> clf.score(X, y) # doctest: +ELLIPSIS
+    >>> clf.score(X, y)
     0.98...
 
     See also

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -589,7 +589,7 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin, MultiOutputMixin):
     >>> from sklearn.datasets import make_regression
     >>> X, y = make_regression(noise=4, random_state=0)
     >>> reg = OrthogonalMatchingPursuit().fit(X, y)
-    >>> reg.score(X, y) # doctest: +ELLIPSIS
+    >>> reg.score(X, y)
     0.9991...
     >>> reg.predict(X[:1,])
     array([-78.3854...])
@@ -833,7 +833,7 @@ class OrthogonalMatchingPursuitCV(LinearModel, RegressorMixin):
     >>> X, y = make_regression(n_features=100, n_informative=10,
     ...                        noise=4, random_state=0)
     >>> reg = OrthogonalMatchingPursuitCV(cv=5).fit(X, y)
-    >>> reg.score(X, y) # doctest: +ELLIPSIS
+    >>> reg.score(X, y)
     0.9991...
     >>> reg.n_nonzero_coefs_
     10

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -133,11 +133,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
     >>> clf = PassiveAggressiveClassifier(max_iter=1000, random_state=0,
     ... tol=1e-3)
     >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-    PassiveAggressiveClassifier(C=1.0, average=False, class_weight=None,
-                  early_stopping=False, fit_intercept=True, loss='hinge',
-                  max_iter=1000, n_iter_no_change=5, n_jobs=None,
-                  random_state=0, shuffle=True, tol=0.001,
-                  validation_fraction=0.1, verbose=0, warm_start=False)
+    PassiveAggressiveClassifier(random_state=0)
     >>> print(clf.coef_)
     [[0.26642044 0.45070924 0.67251877 0.64185414]]
     >>> print(clf.intercept_)
@@ -362,11 +358,7 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
     >>> regr = PassiveAggressiveRegressor(max_iter=100, random_state=0,
     ... tol=1e-3)
     >>> regr.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-    PassiveAggressiveRegressor(C=1.0, average=False, early_stopping=False,
-                  epsilon=0.1, fit_intercept=True, loss='epsilon_insensitive',
-                  max_iter=100, n_iter_no_change=5, random_state=0,
-                  shuffle=True, tol=0.001, validation_fraction=0.1,
-                  verbose=0, warm_start=False)
+    PassiveAggressiveRegressor(max_iter=100, random_state=0)
     >>> print(regr.coef_)
     [20.48736655 34.18818427 67.59122734 87.94731329]
     >>> print(regr.intercept_)

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -132,7 +132,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
     >>> X, y = make_classification(n_features=4, random_state=0)
     >>> clf = PassiveAggressiveClassifier(max_iter=1000, random_state=0,
     ... tol=1e-3)
-    >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     PassiveAggressiveClassifier(random_state=0)
     >>> print(clf.coef_)
     [[0.26642044 0.45070924 0.67251877 0.64185414]]
@@ -357,7 +357,7 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
     >>> X, y = make_regression(n_features=4, random_state=0)
     >>> regr = PassiveAggressiveRegressor(max_iter=100, random_state=0,
     ... tol=1e-3)
-    >>> regr.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> regr.fit(X, y)
     PassiveAggressiveRegressor(max_iter=100, random_state=0)
     >>> print(regr.coef_)
     [20.48736655 34.18818427 67.59122734 87.94731329]

--- a/sklearn/linear_model/perceptron.py
+++ b/sklearn/linear_model/perceptron.py
@@ -122,9 +122,9 @@ class Perceptron(BaseSGDClassifier):
     >>> from sklearn.linear_model import Perceptron
     >>> X, y = load_digits(return_X_y=True)
     >>> clf = Perceptron(tol=1e-3, random_state=0)
-    >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     Perceptron()
-    >>> clf.score(X, y) # doctest: +ELLIPSIS
+    >>> clf.score(X, y)
     0.939...
 
     See also

--- a/sklearn/linear_model/perceptron.py
+++ b/sklearn/linear_model/perceptron.py
@@ -123,10 +123,7 @@ class Perceptron(BaseSGDClassifier):
     >>> X, y = load_digits(return_X_y=True)
     >>> clf = Perceptron(tol=1e-3, random_state=0)
     >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-    Perceptron(alpha=0.0001, class_weight=None, early_stopping=False, eta0=1.0,
-          fit_intercept=True, max_iter=1000, n_iter_no_change=5, n_jobs=None,
-          penalty=None, random_state=0, shuffle=True, tol=0.001,
-          validation_fraction=0.1, verbose=0, warm_start=False)
+    Perceptron()
     >>> clf.score(X, y) # doctest: +ELLIPSIS
     0.939...
 

--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -195,7 +195,7 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin,
     >>> X, y = make_regression(
     ...     n_samples=200, n_features=2, noise=4.0, random_state=0)
     >>> reg = RANSACRegressor(random_state=0).fit(X, y)
-    >>> reg.score(X, y) # doctest: +ELLIPSIS
+    >>> reg.score(X, y)
     0.9885...
     >>> reg.predict(X[:1,])
     array([-31.9417...])

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -712,7 +712,7 @@ class Ridge(_BaseRidge, RegressorMixin):
     >>> y = rng.randn(n_samples)
     >>> X = rng.randn(n_samples, n_features)
     >>> clf = Ridge(alpha=1.0)
-    >>> clf.fit(X, y) # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     Ridge()
 
     """
@@ -853,7 +853,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
     >>> from sklearn.linear_model import RidgeClassifier
     >>> X, y = load_breast_cancer(return_X_y=True)
     >>> clf = RidgeClassifier().fit(X, y)
-    >>> clf.score(X, y) # doctest: +ELLIPSIS
+    >>> clf.score(X, y)
     0.9595...
 
     See also
@@ -1658,7 +1658,7 @@ class RidgeCV(_BaseRidgeCV, RegressorMixin):
     >>> from sklearn.linear_model import RidgeCV
     >>> X, y = load_diabetes(return_X_y=True)
     >>> clf = RidgeCV(alphas=[1e-3, 1e-2, 1e-1, 1]).fit(X, y)
-    >>> clf.score(X, y) # doctest: +ELLIPSIS
+    >>> clf.score(X, y)
     0.5166...
 
     See also
@@ -1761,7 +1761,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
     >>> from sklearn.linear_model import RidgeClassifierCV
     >>> X, y = load_breast_cancer(return_X_y=True)
     >>> clf = RidgeClassifierCV(alphas=[1e-3, 1e-2, 1e-1, 1]).fit(X, y)
-    >>> clf.score(X, y) # doctest: +ELLIPSIS
+    >>> clf.score(X, y)
     0.9630...
 
     See also

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -713,8 +713,7 @@ class Ridge(_BaseRidge, RegressorMixin):
     >>> X = rng.randn(n_samples, n_features)
     >>> clf = Ridge(alpha=1.0)
     >>> clf.fit(X, y) # doctest: +NORMALIZE_WHITESPACE
-    Ridge(alpha=1.0, copy_X=True, fit_intercept=True, max_iter=None,
-          normalize=False, random_state=None, solver='auto', tol=0.001)
+    Ridge()
 
     """
     def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,

--- a/sklearn/linear_model/sag.py
+++ b/sklearn/linear_model/sag.py
@@ -206,7 +206,6 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1., beta=0.,
     >>> y = rng.randn(n_samples)
     >>> clf = linear_model.Ridge(solver='sag')
     >>> clf.fit(X, y)
-    ... #doctest: +NORMALIZE_WHITESPACE
     Ridge(solver='sag')
 
     >>> X = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1]])
@@ -214,7 +213,6 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1., beta=0.,
     >>> clf = linear_model.LogisticRegression(
     ...     solver='sag', multi_class='multinomial')
     >>> clf.fit(X, y)
-    ... #doctest: +NORMALIZE_WHITESPACE
     LogisticRegression(multi_class='multinomial', solver='sag')
 
     References

--- a/sklearn/linear_model/sag.py
+++ b/sklearn/linear_model/sag.py
@@ -207,8 +207,7 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1., beta=0.,
     >>> clf = linear_model.Ridge(solver='sag')
     >>> clf.fit(X, y)
     ... #doctest: +NORMALIZE_WHITESPACE
-    Ridge(alpha=1.0, copy_X=True, fit_intercept=True, max_iter=None,
-          normalize=False, random_state=None, solver='sag', tol=0.001)
+    Ridge(solver='sag')
 
     >>> X = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1]])
     >>> y = np.array([1, 1, 2, 2])
@@ -216,11 +215,7 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1., beta=0.,
     ...     solver='sag', multi_class='multinomial')
     >>> clf.fit(X, y)
     ... #doctest: +NORMALIZE_WHITESPACE
-    LogisticRegression(C=1.0, class_weight=None, dual=False,
-        fit_intercept=True, intercept_scaling=1, l1_ratio=None, max_iter=100,
-        multi_class='multinomial', n_jobs=None, penalty='l2',
-        random_state=None, solver='sag', tol=0.0001, verbose=0,
-        warm_start=False)
+    LogisticRegression(multi_class='multinomial', solver='sag')
 
     References
     ----------

--- a/sklearn/linear_model/sag.py
+++ b/sklearn/linear_model/sag.py
@@ -206,6 +206,7 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1., beta=0.,
     >>> y = rng.randn(n_samples)
     >>> clf = linear_model.Ridge(solver='sag')
     >>> clf.fit(X, y)
+    ... #doctest: +NORMALIZE_WHITESPACE
     Ridge(solver='sag')
 
     >>> X = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1]])
@@ -213,6 +214,7 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1., beta=0.,
     >>> clf = linear_model.LogisticRegression(
     ...     solver='sag', multi_class='multinomial')
     >>> clf.fit(X, y)
+    ... #doctest: +NORMALIZE_WHITESPACE
     LogisticRegression(multi_class='multinomial', solver='sag')
 
     References

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -916,6 +916,7 @@ class SGDClassifier(BaseSGDClassifier):
     >>> Y = np.array([1, 1, 2, 2])
     >>> clf = linear_model.SGDClassifier(max_iter=1000, tol=1e-3)
     >>> clf.fit(X, Y)
+    ... #doctest: +NORMALIZE_WHITESPACE
     SGDClassifier()
 
     >>> print(clf.predict([[-0.8, -1]]))
@@ -1509,6 +1510,7 @@ class SGDRegressor(BaseSGDRegressor):
     >>> X = rng.randn(n_samples, n_features)
     >>> clf = linear_model.SGDRegressor(max_iter=1000, tol=1e-3)
     >>> clf.fit(X, y)
+    ... #doctest: +NORMALIZE_WHITESPACE
     SGDRegressor()
 
     See also

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -916,7 +916,6 @@ class SGDClassifier(BaseSGDClassifier):
     >>> Y = np.array([1, 1, 2, 2])
     >>> clf = linear_model.SGDClassifier(max_iter=1000, tol=1e-3)
     >>> clf.fit(X, Y)
-    ... #doctest: +NORMALIZE_WHITESPACE
     SGDClassifier()
 
     >>> print(clf.predict([[-0.8, -1]]))
@@ -1510,7 +1509,6 @@ class SGDRegressor(BaseSGDRegressor):
     >>> X = rng.randn(n_samples, n_features)
     >>> clf = linear_model.SGDRegressor(max_iter=1000, tol=1e-3)
     >>> clf.fit(X, y)
-    ... #doctest: +NORMALIZE_WHITESPACE
     SGDRegressor()
 
     See also

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -917,12 +917,7 @@ class SGDClassifier(BaseSGDClassifier):
     >>> clf = linear_model.SGDClassifier(max_iter=1000, tol=1e-3)
     >>> clf.fit(X, Y)
     ... #doctest: +NORMALIZE_WHITESPACE
-    SGDClassifier(alpha=0.0001, average=False, class_weight=None,
-           early_stopping=False, epsilon=0.1, eta0=0.0, fit_intercept=True,
-           l1_ratio=0.15, learning_rate='optimal', loss='hinge', max_iter=1000,
-           n_iter_no_change=5, n_jobs=None, penalty='l2', power_t=0.5,
-           random_state=None, shuffle=True, tol=0.001, validation_fraction=0.1,
-           verbose=0, warm_start=False)
+    SGDClassifier()
 
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
@@ -1516,12 +1511,7 @@ class SGDRegressor(BaseSGDRegressor):
     >>> clf = linear_model.SGDRegressor(max_iter=1000, tol=1e-3)
     >>> clf.fit(X, y)
     ... #doctest: +NORMALIZE_WHITESPACE
-    SGDRegressor(alpha=0.0001, average=False, early_stopping=False,
-           epsilon=0.1, eta0=0.01, fit_intercept=True, l1_ratio=0.15,
-           learning_rate='invscaling', loss='squared_loss', max_iter=1000,
-           n_iter_no_change=5, penalty='l2', power_t=0.25, random_state=None,
-           shuffle=True, tol=0.001, validation_fraction=0.1, verbose=0,
-           warm_start=False)
+    SGDRegressor()
 
     See also
     --------

--- a/sklearn/linear_model/theil_sen.py
+++ b/sklearn/linear_model/theil_sen.py
@@ -281,7 +281,7 @@ class TheilSenRegressor(LinearModel, RegressorMixin):
     >>> X, y = make_regression(
     ...     n_samples=200, n_features=2, noise=4.0, random_state=0)
     >>> reg = TheilSenRegressor(random_state=0).fit(X, y)
-    >>> reg.score(X, y) # doctest: +ELLIPSIS
+    >>> reg.score(X, y)
     0.9884...
     >>> reg.predict(X[:1,])
     array([-31.5871...])

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -2235,10 +2235,7 @@ def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None):
     >>> y = [-1, 1]
     >>> est = svm.LinearSVC(random_state=0)
     >>> est.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-    LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
-         intercept_scaling=1, loss='squared_hinge', max_iter=1000,
-         multi_class='ovr', penalty='l2', random_state=0, tol=0.0001,
-         verbose=0)
+    LinearSVC(random_state=0)
     >>> pred_decision = est.decision_function([[-2], [3], [0.5]])
     >>> pred_decision  # doctest: +ELLIPSIS
     array([-2.18...,  2.36...,  0.09...])
@@ -2253,10 +2250,7 @@ def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None):
     >>> labels = np.array([0, 1, 2, 3])
     >>> est = svm.LinearSVC()
     >>> est.fit(X, Y)  # doctest: +NORMALIZE_WHITESPACE
-    LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
-         intercept_scaling=1, loss='squared_hinge', max_iter=1000,
-         multi_class='ovr', penalty='l2', random_state=None, tol=0.0001,
-         verbose=0)
+    LinearSVC()
     >>> pred_decision = est.decision_function([[-1], [2], [3]])
     >>> y_true = [0, 2, 3]
     >>> hinge_loss(y_true, pred_decision, labels)  #doctest: +ELLIPSIS

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -2243,7 +2243,7 @@ def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None):
     LinearSVC()
     >>> pred_decision = est.decision_function([[-1], [2], [3]])
     >>> y_true = [0, 2, 3]
-    >>> hinge_loss(y_true, pred_decision, labels)
+    >>> hinge_loss(y_true, pred_decision, labels)  #doctest: +ELLIPSIS
     0.56...
     """
     check_consistent_length(y_true, pred_decision, sample_weight)

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -2243,7 +2243,7 @@ def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None):
     LinearSVC()
     >>> pred_decision = est.decision_function([[-1], [2], [3]])
     >>> y_true = [0, 2, 3]
-    >>> hinge_loss(y_true, pred_decision, labels)  #doctest: +ELLIPSIS
+    >>> hinge_loss(y_true, pred_decision, labels)
     0.56...
     """
     check_consistent_length(y_true, pred_decision, sample_weight)

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -741,7 +741,7 @@ def jaccard_score(y_true, y_pred, labels=None, pos_label=1,
 
     In the binary case:
 
-    >>> jaccard_score(y_true[0], y_pred[0])  # doctest: +ELLIPSIS
+    >>> jaccard_score(y_true[0], y_pred[0])
     0.6666...
 
     In the multilabel case:
@@ -758,7 +758,6 @@ def jaccard_score(y_true, y_pred, labels=None, pos_label=1,
     >>> y_pred = [0, 2, 1, 2]
     >>> y_true = [0, 1, 2, 2]
     >>> jaccard_score(y_true, y_pred, average=None)
-    ... # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     array([1. , 0. , 0.33...])
     """
     labels = _check_set_wise_labels(y_true, y_pred, average, labels,
@@ -848,7 +847,7 @@ def matthews_corrcoef(y_true, y_pred, sample_weight=None):
     >>> from sklearn.metrics import matthews_corrcoef
     >>> y_true = [+1, +1, +1, -1]
     >>> y_pred = [+1, -1, +1, +1]
-    >>> matthews_corrcoef(y_true, y_pred)  # doctest: +ELLIPSIS
+    >>> matthews_corrcoef(y_true, y_pred)
     -0.33...
     """
     y_type, y_true, y_pred = _check_targets(y_true, y_pred)
@@ -1039,11 +1038,11 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
     >>> from sklearn.metrics import f1_score
     >>> y_true = [0, 1, 2, 0, 1, 2]
     >>> y_pred = [0, 2, 1, 0, 0, 1]
-    >>> f1_score(y_true, y_pred, average='macro')  # doctest: +ELLIPSIS
+    >>> f1_score(y_true, y_pred, average='macro')
     0.26...
-    >>> f1_score(y_true, y_pred, average='micro')  # doctest: +ELLIPSIS
+    >>> f1_score(y_true, y_pred, average='micro')
     0.33...
-    >>> f1_score(y_true, y_pred, average='weighted')  # doctest: +ELLIPSIS
+    >>> f1_score(y_true, y_pred, average='weighted')
     0.26...
     >>> f1_score(y_true, y_pred, average=None)
     array([0.8, 0. , 0. ])
@@ -1155,16 +1154,12 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
     >>> y_true = [0, 1, 2, 0, 1, 2]
     >>> y_pred = [0, 2, 1, 0, 0, 1]
     >>> fbeta_score(y_true, y_pred, average='macro', beta=0.5)
-    ... # doctest: +ELLIPSIS
     0.23...
     >>> fbeta_score(y_true, y_pred, average='micro', beta=0.5)
-    ... # doctest: +ELLIPSIS
     0.33...
     >>> fbeta_score(y_true, y_pred, average='weighted', beta=0.5)
-    ... # doctest: +ELLIPSIS
     0.23...
     >>> fbeta_score(y_true, y_pred, average=None, beta=0.5)
-    ... # doctest: +ELLIPSIS
     array([0.71..., 0.        , 0.        ])
 
     Notes
@@ -1383,13 +1378,10 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     >>> y_true = np.array(['cat', 'dog', 'pig', 'cat', 'dog', 'pig'])
     >>> y_pred = np.array(['cat', 'pig', 'dog', 'cat', 'cat', 'dog'])
     >>> precision_recall_fscore_support(y_true, y_pred, average='macro')
-    ... # doctest: +ELLIPSIS
     (0.22..., 0.33..., 0.26..., None)
     >>> precision_recall_fscore_support(y_true, y_pred, average='micro')
-    ... # doctest: +ELLIPSIS
     (0.33..., 0.33..., 0.33..., None)
     >>> precision_recall_fscore_support(y_true, y_pred, average='weighted')
-    ... # doctest: +ELLIPSIS
     (0.22..., 0.33..., 0.26..., None)
 
     It is possible to compute per-label precisions, recalls, F1-scores and
@@ -1397,7 +1389,6 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
     >>> precision_recall_fscore_support(y_true, y_pred, average=None,
     ... labels=['pig', 'dog', 'cat'])
-    ... # doctest: +ELLIPSIS,+NORMALIZE_WHITESPACE
     (array([0.        , 0.        , 0.66...]),
      array([0., 0., 1.]), array([0. , 0. , 0.8]),
      array([2, 2, 2]))
@@ -1546,14 +1537,13 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
     >>> from sklearn.metrics import precision_score
     >>> y_true = [0, 1, 2, 0, 1, 2]
     >>> y_pred = [0, 2, 1, 0, 0, 1]
-    >>> precision_score(y_true, y_pred, average='macro')  # doctest: +ELLIPSIS
+    >>> precision_score(y_true, y_pred, average='macro')
     0.22...
-    >>> precision_score(y_true, y_pred, average='micro')  # doctest: +ELLIPSIS
+    >>> precision_score(y_true, y_pred, average='micro')
     0.33...
     >>> precision_score(y_true, y_pred, average='weighted')
-    ... # doctest: +ELLIPSIS
     0.22...
-    >>> precision_score(y_true, y_pred, average=None)  # doctest: +ELLIPSIS
+    >>> precision_score(y_true, y_pred, average=None)
     array([0.66..., 0.        , 0.        ])
 
     Notes
@@ -1653,11 +1643,11 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
     >>> from sklearn.metrics import recall_score
     >>> y_true = [0, 1, 2, 0, 1, 2]
     >>> y_pred = [0, 2, 1, 0, 0, 1]
-    >>> recall_score(y_true, y_pred, average='macro')  # doctest: +ELLIPSIS
+    >>> recall_score(y_true, y_pred, average='macro')
     0.33...
-    >>> recall_score(y_true, y_pred, average='micro')  # doctest: +ELLIPSIS
+    >>> recall_score(y_true, y_pred, average='micro')
     0.33...
-    >>> recall_score(y_true, y_pred, average='weighted')  # doctest: +ELLIPSIS
+    >>> recall_score(y_true, y_pred, average='weighted')
     0.33...
     >>> recall_score(y_true, y_pred, average=None)
     array([1., 0., 0.])
@@ -2104,7 +2094,7 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None,
     Examples
     --------
     >>> from sklearn.metrics import log_loss
-    >>> log_loss(["spam", "ham", "ham", "spam"],  # doctest: +ELLIPSIS
+    >>> log_loss(["spam", "ham", "ham", "spam"],
     ...          [[.1, .9], [.9, .1], [.8, .2], [.35, .65]])
     0.21616...
 
@@ -2234,12 +2224,12 @@ def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None):
     >>> X = [[0], [1]]
     >>> y = [-1, 1]
     >>> est = svm.LinearSVC(random_state=0)
-    >>> est.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> est.fit(X, y)
     LinearSVC(random_state=0)
     >>> pred_decision = est.decision_function([[-2], [3], [0.5]])
-    >>> pred_decision  # doctest: +ELLIPSIS
+    >>> pred_decision
     array([-2.18...,  2.36...,  0.09...])
-    >>> hinge_loss([-1, 1, 1], pred_decision)  # doctest: +ELLIPSIS
+    >>> hinge_loss([-1, 1, 1], pred_decision)
     0.30...
 
     In the multiclass case:
@@ -2249,7 +2239,7 @@ def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None):
     >>> Y = np.array([0, 1, 2, 3])
     >>> labels = np.array([0, 1, 2, 3])
     >>> est = svm.LinearSVC()
-    >>> est.fit(X, Y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> est.fit(X, Y)
     LinearSVC()
     >>> pred_decision = est.decision_function([[-1], [2], [3]])
     >>> y_true = [0, 2, 3]
@@ -2346,12 +2336,11 @@ def brier_score_loss(y_true, y_prob, sample_weight=None, pos_label=None):
     >>> y_true = np.array([0, 1, 1, 0])
     >>> y_true_categorical = np.array(["spam", "ham", "ham", "spam"])
     >>> y_prob = np.array([0.1, 0.9, 0.8, 0.3])
-    >>> brier_score_loss(y_true, y_prob)  # doctest: +ELLIPSIS
+    >>> brier_score_loss(y_true, y_prob)
     0.037...
-    >>> brier_score_loss(y_true, 1-y_prob, pos_label=0)  # doctest: +ELLIPSIS
+    >>> brier_score_loss(y_true, 1-y_prob, pos_label=0)
     0.037...
-    >>> brier_score_loss(y_true_categorical, y_prob, \
-                         pos_label="ham")  # doctest: +ELLIPSIS
+    >>> brier_score_loss(y_true_categorical, y_prob, pos_label="ham")
     0.037...
     >>> brier_score_loss(y_true, np.array(y_prob) > 0.5)
     0.0

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -186,13 +186,13 @@ def adjusted_rand_score(labels_true, labels_pred):
     Labelings that assign all classes members to the same clusters
     are complete be not always pure, hence penalized::
 
-      >>> adjusted_rand_score([0, 0, 1, 2], [0, 0, 1, 1])  # doctest: +ELLIPSIS
+      >>> adjusted_rand_score([0, 0, 1, 2], [0, 0, 1, 1])
       0.57...
 
     ARI is symmetric, so labelings that have pure clusters with members
     coming from the same classes but unnecessary splits are penalized::
 
-      >>> adjusted_rand_score([0, 0, 1, 1], [0, 0, 1, 2])  # doctest: +ELLIPSIS
+      >>> adjusted_rand_score([0, 0, 1, 1], [0, 0, 1, 2])
       0.57...
 
     If classes members are completely split across different clusters, the
@@ -375,20 +375,16 @@ def homogeneity_score(labels_true, labels_pred):
     perfectly homogeneous::
 
       >>> print("%.6f" % homogeneity_score([0, 0, 1, 1], [0, 0, 1, 2]))
-      ...                                                  # doctest: +ELLIPSIS
       1.000000
       >>> print("%.6f" % homogeneity_score([0, 0, 1, 1], [0, 1, 2, 3]))
-      ...                                                  # doctest: +ELLIPSIS
       1.000000
 
     Clusters that include samples from different classes do not make for an
     homogeneous labeling::
 
       >>> print("%.6f" % homogeneity_score([0, 0, 1, 1], [0, 1, 0, 1]))
-      ...                                                  # doctest: +ELLIPSIS
       0.0...
       >>> print("%.6f" % homogeneity_score([0, 0, 1, 1], [0, 0, 0, 0]))
-      ...                                                  # doctest: +ELLIPSIS
       0.0...
 
     """
@@ -535,10 +531,8 @@ def v_measure_score(labels_true, labels_pred, beta=1.0):
     are complete be not homogeneous, hence penalized::
 
       >>> print("%.6f" % v_measure_score([0, 0, 1, 2], [0, 0, 1, 1]))
-      ...                                                  # doctest: +ELLIPSIS
       0.8...
       >>> print("%.6f" % v_measure_score([0, 1, 2, 3], [0, 0, 1, 1]))
-      ...                                                  # doctest: +ELLIPSIS
       0.66...
 
     Labelings that have pure clusters with members coming from the same
@@ -546,24 +540,20 @@ def v_measure_score(labels_true, labels_pred, beta=1.0):
     and thus penalize V-measure as well::
 
       >>> print("%.6f" % v_measure_score([0, 0, 1, 1], [0, 0, 1, 2]))
-      ...                                                  # doctest: +ELLIPSIS
       0.8...
       >>> print("%.6f" % v_measure_score([0, 0, 1, 1], [0, 1, 2, 3]))
-      ...                                                  # doctest: +ELLIPSIS
       0.66...
 
     If classes members are completely split across different clusters,
     the assignment is totally incomplete, hence the V-Measure is null::
 
       >>> print("%.6f" % v_measure_score([0, 0, 0, 0], [0, 1, 2, 3]))
-      ...                                                  # doctest: +ELLIPSIS
       0.0...
 
     Clusters that include samples from totally different classes totally
     destroy the homogeneity of the labeling, hence::
 
       >>> print("%.6f" % v_measure_score([0, 0, 1, 1], [0, 0, 0, 0]))
-      ...                                                  # doctest: +ELLIPSIS
       0.0...
 
     """

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1358,7 +1358,7 @@ def pairwise_distances_chunked(X, Y=None, reduce_func=None,
     >>> from sklearn.metrics import pairwise_distances_chunked
     >>> X = np.random.RandomState(0).rand(5, 3)
     >>> D_chunk = next(pairwise_distances_chunked(X))
-    >>> D_chunk  # doctest: +ELLIPSIS
+    >>> D_chunk
     array([[0.  ..., 0.29..., 0.41..., 0.19..., 0.57...],
            [0.29..., 0.  ..., 0.57..., 0.41..., 0.76...],
            [0.41..., 0.57..., 0.  ..., 0.44..., 0.90...],
@@ -1376,7 +1376,7 @@ def pairwise_distances_chunked(X, Y=None, reduce_func=None,
     >>> neigh, avg_dist = next(gen)
     >>> neigh
     [array([0, 3]), array([1]), array([2]), array([0, 3]), array([4])]
-    >>> avg_dist  # doctest: +ELLIPSIS
+    >>> avg_dist
     array([0.039..., 0.        , 0.        , 0.039..., 0.        ])
 
     Where r is defined per sample, we need to make use of ``start``:

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -596,20 +596,20 @@ def manhattan_distances(X, Y=None, sum_over_features=True):
     Examples
     --------
     >>> from sklearn.metrics.pairwise import manhattan_distances
-    >>> manhattan_distances([[3]], [[3]])#doctest:+ELLIPSIS
+    >>> manhattan_distances([[3]], [[3]])
     array([[0.]])
-    >>> manhattan_distances([[3]], [[2]])#doctest:+ELLIPSIS
+    >>> manhattan_distances([[3]], [[2]])
     array([[1.]])
-    >>> manhattan_distances([[2]], [[3]])#doctest:+ELLIPSIS
+    >>> manhattan_distances([[2]], [[3]])
     array([[1.]])
     >>> manhattan_distances([[1, 2], [3, 4]],\
-         [[1, 2], [0, 3]])#doctest:+ELLIPSIS
+         [[1, 2], [0, 3]])
     array([[0., 2.],
            [4., 4.]])
     >>> import numpy as np
     >>> X = np.ones((1, 2))
     >>> y = np.full((2, 2), 2.)
-    >>> manhattan_distances(X, y, sum_over_features=False)#doctest:+ELLIPSIS
+    >>> manhattan_distances(X, y, sum_over_features=False)
     array([[1., 1.],
            [1., 1.]])
     """

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -596,20 +596,20 @@ def manhattan_distances(X, Y=None, sum_over_features=True):
     Examples
     --------
     >>> from sklearn.metrics.pairwise import manhattan_distances
-    >>> manhattan_distances([[3]], [[3]])
+    >>> manhattan_distances([[3]], [[3]])#doctest:+ELLIPSIS
     array([[0.]])
-    >>> manhattan_distances([[3]], [[2]])
+    >>> manhattan_distances([[3]], [[2]])#doctest:+ELLIPSIS
     array([[1.]])
-    >>> manhattan_distances([[2]], [[3]])
+    >>> manhattan_distances([[2]], [[3]])#doctest:+ELLIPSIS
     array([[1.]])
     >>> manhattan_distances([[1, 2], [3, 4]],\
-         [[1, 2], [0, 3]])
+         [[1, 2], [0, 3]])#doctest:+ELLIPSIS
     array([[0., 2.],
            [4., 4.]])
     >>> import numpy as np
     >>> X = np.ones((1, 2))
     >>> y = np.full((2, 2), 2.)
-    >>> manhattan_distances(X, y, sum_over_features=False)
+    >>> manhattan_distances(X, y, sum_over_features=False)#doctest:+ELLIPSIS
     array([[1., 1.],
            [1., 1.]])
     """

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -180,7 +180,7 @@ def average_precision_score(y_true, y_score, average="macro", pos_label=1,
     >>> from sklearn.metrics import average_precision_score
     >>> y_true = np.array([0, 0, 1, 1])
     >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
-    >>> average_precision_score(y_true, y_scores)  # doctest: +ELLIPSIS
+    >>> average_precision_score(y_true, y_scores)
     0.83...
 
     Notes
@@ -485,7 +485,7 @@ def precision_recall_curve(y_true, probas_pred, pos_label=None,
     >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
     >>> precision, recall, thresholds = precision_recall_curve(
     ...     y_true, y_scores)
-    >>> precision  # doctest: +ELLIPSIS
+    >>> precision
     array([0.66666667, 0.5       , 1.        , 1.        ])
     >>> recall
     array([1. , 0.5, 0.5, 0. ])
@@ -676,8 +676,7 @@ def label_ranking_average_precision_score(y_true, y_score, sample_weight=None):
     >>> from sklearn.metrics import label_ranking_average_precision_score
     >>> y_true = np.array([[1, 0, 0], [0, 0, 1]])
     >>> y_score = np.array([[0.75, 0.5, 1], [1, 0.2, 0.1]])
-    >>> label_ranking_average_precision_score(y_true, y_score) \
-        # doctest: +ELLIPSIS
+    >>> label_ranking_average_precision_score(y_true, y_score)
     0.416...
 
     """

--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -165,7 +165,6 @@ def mean_absolute_error(y_true, y_pred,
     >>> mean_absolute_error(y_true, y_pred, multioutput='raw_values')
     array([0.5, 1. ])
     >>> mean_absolute_error(y_true, y_pred, multioutput=[0.3, 0.7])
-    ... # doctest: +ELLIPSIS
     0.85...
     """
     y_type, y_true, y_pred, multioutput = _check_reg_targets(
@@ -227,13 +226,11 @@ def mean_squared_error(y_true, y_pred,
     0.375
     >>> y_true = [[0.5, 1],[-1, 1],[7, -6]]
     >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
-    >>> mean_squared_error(y_true, y_pred)  # doctest: +ELLIPSIS
+    >>> mean_squared_error(y_true, y_pred)
     0.708...
     >>> mean_squared_error(y_true, y_pred, multioutput='raw_values')
-    ... # doctest: +ELLIPSIS
     array([0.41666667, 1.        ])
     >>> mean_squared_error(y_true, y_pred, multioutput=[0.3, 0.7])
-    ... # doctest: +ELLIPSIS
     0.825...
 
     """
@@ -294,17 +291,15 @@ def mean_squared_log_error(y_true, y_pred,
     >>> from sklearn.metrics import mean_squared_log_error
     >>> y_true = [3, 5, 2.5, 7]
     >>> y_pred = [2.5, 5, 4, 8]
-    >>> mean_squared_log_error(y_true, y_pred)  # doctest: +ELLIPSIS
+    >>> mean_squared_log_error(y_true, y_pred)
     0.039...
     >>> y_true = [[0.5, 1], [1, 2], [7, 6]]
     >>> y_pred = [[0.5, 2], [1, 2.5], [8, 8]]
-    >>> mean_squared_log_error(y_true, y_pred)  # doctest: +ELLIPSIS
+    >>> mean_squared_log_error(y_true, y_pred)
     0.044...
     >>> mean_squared_log_error(y_true, y_pred, multioutput='raw_values')
-    ... # doctest: +ELLIPSIS
     array([0.00462428, 0.08377444])
     >>> mean_squared_log_error(y_true, y_pred, multioutput=[0.3, 0.7])
-    ... # doctest: +ELLIPSIS
     0.060...
 
     """
@@ -402,12 +397,11 @@ def explained_variance_score(y_true, y_pred,
     >>> from sklearn.metrics import explained_variance_score
     >>> y_true = [3, -0.5, 2, 7]
     >>> y_pred = [2.5, 0.0, 2, 8]
-    >>> explained_variance_score(y_true, y_pred)  # doctest: +ELLIPSIS
+    >>> explained_variance_score(y_true, y_pred)
     0.957...
     >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
     >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
     >>> explained_variance_score(y_true, y_pred, multioutput='uniform_average')
-    ... # doctest: +ELLIPSIS
     0.983...
 
     """
@@ -514,12 +508,12 @@ def r2_score(y_true, y_pred, sample_weight=None,
     >>> from sklearn.metrics import r2_score
     >>> y_true = [3, -0.5, 2, 7]
     >>> y_pred = [2.5, 0.0, 2, 8]
-    >>> r2_score(y_true, y_pred)  # doctest: +ELLIPSIS
+    >>> r2_score(y_true, y_pred)
     0.948...
     >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
     >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
     >>> r2_score(y_true, y_pred,
-    ...          multioutput='variance_weighted') # doctest: +ELLIPSIS
+    ...          multioutput='variance_weighted')
     0.938...
     >>> y_true = [1, 2, 3]
     >>> y_pred = [1, 2, 3]

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -962,11 +962,9 @@ class GridSearchCV(BaseSearchCV):
     >>> svc = svm.SVC()
     >>> clf = GridSearchCV(svc, parameters)
     >>> clf.fit(iris.data, iris.target)
-    ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     GridSearchCV(estimator=SVC(),
                  param_grid={'C': [1, 10], 'kernel': ('linear', 'rbf')})
     >>> sorted(clf.cv_results_.keys())
-    ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     ['mean_fit_time', 'mean_score_time', 'mean_test_score',...
      'param_C', 'param_kernel', 'params',...
      'rank_test_score', 'split0_test_score',...

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -963,17 +963,8 @@ class GridSearchCV(BaseSearchCV):
     >>> clf = GridSearchCV(svc, parameters)
     >>> clf.fit(iris.data, iris.target)
     ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    GridSearchCV(cv=None, error_score=...,
-           estimator=SVC(C=1.0, break_ties=False, cache_size=...,
-                         class_weight=..., coef0=...,
-                         decision_function_shape='ovr', degree=..., gamma=...,
-                         kernel='rbf', max_iter=-1,
-                         probability=False,
-                         random_state=None, shrinking=True,
-                         tol=..., verbose=False),
-           iid=..., n_jobs=None,
-           param_grid=..., pre_dispatch=..., refit=..., return_train_score=...,
-           scoring=..., verbose=...)
+    GridSearchCV(estimator=SVC(),
+                 param_grid={'C': [1, 10], 'kernel': ('linear', 'rbf')})
     >>> sorted(clf.cv_results_.keys())
     ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     ['mean_fit_time', 'mean_score_time', 'mean_test_score',...

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -385,7 +385,7 @@ class KFold(_BaseKFold):
     >>> kf = KFold(n_splits=2)
     >>> kf.get_n_splits(X)
     2
-    >>> print(kf)  # doctest: +NORMALIZE_WHITESPACE
+    >>> print(kf)
     KFold(n_splits=2, random_state=None, shuffle=False)
     >>> for train_index, test_index in kf.split(X):
     ...    print("TRAIN:", train_index, "TEST:", test_index)
@@ -590,7 +590,7 @@ class StratifiedKFold(_BaseKFold):
     >>> skf = StratifiedKFold(n_splits=2)
     >>> skf.get_n_splits(X, y)
     2
-    >>> print(skf)  # doctest: +NORMALIZE_WHITESPACE
+    >>> print(skf)
     StratifiedKFold(n_splits=2, random_state=None, shuffle=False)
     >>> for train_index, test_index in skf.split(X, y):
     ...    print("TRAIN:", train_index, "TEST:", test_index)
@@ -742,7 +742,7 @@ class TimeSeriesSplit(_BaseKFold):
     >>> X = np.array([[1, 2], [3, 4], [1, 2], [3, 4], [1, 2], [3, 4]])
     >>> y = np.array([1, 2, 3, 4, 5, 6])
     >>> tscv = TimeSeriesSplit()
-    >>> print(tscv)  # doctest: +NORMALIZE_WHITESPACE
+    >>> print(tscv)
     TimeSeriesSplit(max_train_size=None, n_splits=5)
     >>> for train_index, test_index in tscv.split(X):
     ...    print("TRAIN:", train_index, "TEST:", test_index)
@@ -1379,7 +1379,6 @@ class ShuffleSplit(BaseShuffleSplit):
     ShuffleSplit(n_splits=5, random_state=0, test_size=0.25, train_size=None)
     >>> for train_index, test_index in rs.split(X):
     ...    print("TRAIN:", train_index, "TEST:", test_index)
-    ...  # doctest: +ELLIPSIS
     TRAIN: [1 3 0 4] TEST: [5 2]
     TRAIN: [4 0 2 5] TEST: [1 3]
     TRAIN: [1 2 4 0] TEST: [3 5]
@@ -1389,7 +1388,6 @@ class ShuffleSplit(BaseShuffleSplit):
     ...                   random_state=0)
     >>> for train_index, test_index in rs.split(X):
     ...    print("TRAIN:", train_index, "TEST:", test_index)
-    ...  # doctest: +ELLIPSIS
     TRAIN: [1 3 0] TEST: [5 2]
     TRAIN: [4 0 2] TEST: [1 3]
     TRAIN: [1 2 4] TEST: [3 5]
@@ -1573,7 +1571,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     >>> sss = StratifiedShuffleSplit(n_splits=5, test_size=0.5, random_state=0)
     >>> sss.get_n_splits(X, y)
     5
-    >>> print(sss)       # doctest: +ELLIPSIS
+    >>> print(sss)
     StratifiedShuffleSplit(n_splits=5, random_state=0, ...)
     >>> for train_index, test_index in sss.split(X, y):
     ...    print("TRAIN:", train_index, "TEST:", test_index)
@@ -1790,7 +1788,7 @@ class PredefinedSplit(BaseCrossValidator):
     >>> ps = PredefinedSplit(test_fold)
     >>> ps.get_n_splits()
     2
-    >>> print(ps)       # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> print(ps)
     PredefinedSplit(test_fold=array([ 0,  1, -1,  1]))
     >>> for train_index, test_index in ps.split():
     ...    print("TRAIN:", train_index, "TEST:", test_index)

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -179,9 +179,9 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv=None,
     Single metric evaluation using ``cross_validate``
 
     >>> cv_results = cross_validate(lasso, X, y, cv=3)
-    >>> sorted(cv_results.keys())                         # doctest: +ELLIPSIS
+    >>> sorted(cv_results.keys())
     ['fit_time', 'score_time', 'test_score']
-    >>> cv_results['test_score']    # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> cv_results['test_score']
     array([0.33150734, 0.08022311, 0.03531764])
 
     Multiple metric evaluation using ``cross_validate``
@@ -190,9 +190,9 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv=None,
     >>> scores = cross_validate(lasso, X, y, cv=3,
     ...                         scoring=('r2', 'neg_mean_squared_error'),
     ...                         return_train_score=True)
-    >>> print(scores['test_neg_mean_squared_error'])      # doctest: +ELLIPSIS
+    >>> print(scores['test_neg_mean_squared_error'])
     [-3635.5... -3573.3... -6114.7...]
-    >>> print(scores['train_r2'])                         # doctest: +ELLIPSIS
+    >>> print(scores['train_r2'])
     [0.28010158 0.39088426 0.22784852]
 
     See Also
@@ -351,7 +351,7 @@ def cross_val_score(estimator, X, y=None, groups=None, scoring=None, cv=None,
     >>> X = diabetes.data[:150]
     >>> y = diabetes.target[:150]
     >>> lasso = linear_model.Lasso()
-    >>> print(cross_val_score(lasso, X, y, cv=3))  # doctest: +ELLIPSIS
+    >>> print(cross_val_score(lasso, X, y, cv=3))
     [0.33150734 0.08022311 0.03531764]
 
     See Also

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -150,12 +150,12 @@ class GaussianNB(BaseNB):
     >>> from sklearn.naive_bayes import GaussianNB
     >>> clf = GaussianNB()
     >>> clf.fit(X, Y)
-    GaussianNB(priors=None, var_smoothing=1e-09)
+    GaussianNB()
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
     >>> clf_pf = GaussianNB()
     >>> clf_pf.partial_fit(X, Y, np.unique(Y))
-    GaussianNB(priors=None, var_smoothing=1e-09)
+    GaussianNB()
     >>> print(clf_pf.predict([[-0.8, -1]]))
     [1]
     """
@@ -692,7 +692,7 @@ class MultinomialNB(BaseDiscreteNB):
     >>> from sklearn.naive_bayes import MultinomialNB
     >>> clf = MultinomialNB()
     >>> clf.fit(X, y)
-    MultinomialNB(alpha=1.0, class_prior=None, fit_prior=True)
+    MultinomialNB()
     >>> print(clf.predict(X[2:3]))
     [3]
 
@@ -793,7 +793,7 @@ class ComplementNB(BaseDiscreteNB):
     >>> from sklearn.naive_bayes import ComplementNB
     >>> clf = ComplementNB()
     >>> clf.fit(X, y)
-    ComplementNB(alpha=1.0, class_prior=None, fit_prior=True, norm=False)
+    ComplementNB()
     >>> print(clf.predict(X[2:3]))
     [3]
 
@@ -895,7 +895,7 @@ class BernoulliNB(BaseDiscreteNB):
     >>> from sklearn.naive_bayes import BernoulliNB
     >>> clf = BernoulliNB()
     >>> clf.fit(X, Y)
-    BernoulliNB(alpha=1.0, binarize=0.0, class_prior=None, fit_prior=True)
+    BernoulliNB()
     >>> print(clf.predict(X[2:3]))
     [3]
 

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -367,7 +367,7 @@ class KNeighborsMixin:
         >>> from sklearn.neighbors import NearestNeighbors
         >>> neigh = NearestNeighbors(n_neighbors=1)
         >>> neigh.fit(samples) # doctest: +ELLIPSIS
-        NearestNeighbors(algorithm='auto', leaf_size=30, ...)
+        NearestNeighbors(n_neighbors=1)
         >>> print(neigh.kneighbors([[1., 1., 1.]])) # doctest: +ELLIPSIS
         (array([[0.5]]), array([[2]]))
 
@@ -524,7 +524,7 @@ class KNeighborsMixin:
         >>> from sklearn.neighbors import NearestNeighbors
         >>> neigh = NearestNeighbors(n_neighbors=2)
         >>> neigh.fit(X) # doctest: +ELLIPSIS
-        NearestNeighbors(algorithm='auto', leaf_size=30, ...)
+        NearestNeighbors(n_neighbors=2)
         >>> A = neigh.kneighbors_graph(X)
         >>> A.toarray()
         array([[1., 0., 1.],
@@ -664,7 +664,7 @@ class RadiusNeighborsMixin:
         >>> from sklearn.neighbors import NearestNeighbors
         >>> neigh = NearestNeighbors(radius=1.6)
         >>> neigh.fit(samples) # doctest: +ELLIPSIS
-        NearestNeighbors(algorithm='auto', leaf_size=30, ...)
+        NearestNeighbors(radius=1.6)
         >>> rng = neigh.radius_neighbors([[1., 1., 1.]])
         >>> print(np.asarray(rng[0][0])) # doctest: +ELLIPSIS
         [1.5 0.5]
@@ -809,7 +809,7 @@ class RadiusNeighborsMixin:
         >>> from sklearn.neighbors import NearestNeighbors
         >>> neigh = NearestNeighbors(radius=1.5)
         >>> neigh.fit(X) # doctest: +ELLIPSIS
-        NearestNeighbors(algorithm='auto', leaf_size=30, ...)
+        NearestNeighbors(radius=1.5)
         >>> A = neigh.radius_neighbors_graph(X)
         >>> A.toarray()
         array([[1., 0., 1.],

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -366,9 +366,9 @@ class KNeighborsMixin:
         >>> samples = [[0., 0., 0.], [0., .5, 0.], [1., 1., .5]]
         >>> from sklearn.neighbors import NearestNeighbors
         >>> neigh = NearestNeighbors(n_neighbors=1)
-        >>> neigh.fit(samples) # doctest: +ELLIPSIS
+        >>> neigh.fit(samples)
         NearestNeighbors(n_neighbors=1)
-        >>> print(neigh.kneighbors([[1., 1., 1.]])) # doctest: +ELLIPSIS
+        >>> print(neigh.kneighbors([[1., 1., 1.]]))
         (array([[0.5]]), array([[2]]))
 
         As you can see, it returns [[0.5]], and [[2]], which means that the
@@ -376,7 +376,7 @@ class KNeighborsMixin:
         (indexes start at 0). You can also query for multiple points:
 
         >>> X = [[0., 1., 0.], [1., 0., 1.]]
-        >>> neigh.kneighbors(X, return_distance=False) # doctest: +ELLIPSIS
+        >>> neigh.kneighbors(X, return_distance=False)
         array([[1],
                [2]]...)
 
@@ -523,7 +523,7 @@ class KNeighborsMixin:
         >>> X = [[0], [3], [1]]
         >>> from sklearn.neighbors import NearestNeighbors
         >>> neigh = NearestNeighbors(n_neighbors=2)
-        >>> neigh.fit(X) # doctest: +ELLIPSIS
+        >>> neigh.fit(X)
         NearestNeighbors(n_neighbors=2)
         >>> A = neigh.kneighbors_graph(X)
         >>> A.toarray()
@@ -663,12 +663,12 @@ class RadiusNeighborsMixin:
         >>> samples = [[0., 0., 0.], [0., .5, 0.], [1., 1., .5]]
         >>> from sklearn.neighbors import NearestNeighbors
         >>> neigh = NearestNeighbors(radius=1.6)
-        >>> neigh.fit(samples) # doctest: +ELLIPSIS
+        >>> neigh.fit(samples)
         NearestNeighbors(radius=1.6)
         >>> rng = neigh.radius_neighbors([[1., 1., 1.]])
-        >>> print(np.asarray(rng[0][0])) # doctest: +ELLIPSIS
+        >>> print(np.asarray(rng[0][0]))
         [1.5 0.5]
-        >>> print(np.asarray(rng[1][0])) # doctest: +ELLIPSIS
+        >>> print(np.asarray(rng[1][0]))
         [1 2]
 
         The first array returned contains the distances to all points which
@@ -808,7 +808,7 @@ class RadiusNeighborsMixin:
         >>> X = [[0], [3], [1]]
         >>> from sklearn.neighbors import NearestNeighbors
         >>> neigh = NearestNeighbors(radius=1.5)
-        >>> neigh.fit(X) # doctest: +ELLIPSIS
+        >>> neigh.fit(X)
         NearestNeighbors(radius=1.5)
         >>> A = neigh.radius_neighbors_graph(X)
         >>> A.toarray()

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -88,7 +88,7 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
     >>> y = [0, 0, 1, 1]
     >>> from sklearn.neighbors import KNeighborsClassifier
     >>> neigh = KNeighborsClassifier(n_neighbors=3)
-    >>> neigh.fit(X, y) # doctest: +ELLIPSIS
+    >>> neigh.fit(X, y)
     KNeighborsClassifier(...)
     >>> print(neigh.predict([[1.1]]))
     [0]
@@ -302,7 +302,7 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
     >>> y = [0, 0, 1, 1]
     >>> from sklearn.neighbors import RadiusNeighborsClassifier
     >>> neigh = RadiusNeighborsClassifier(radius=1.0)
-    >>> neigh.fit(X, y) # doctest: +ELLIPSIS
+    >>> neigh.fit(X, y)
     RadiusNeighborsClassifier(...)
     >>> print(neigh.predict([[1.5]]))
     [0]

--- a/sklearn/neighbors/nca.py
+++ b/sklearn/neighbors/nca.py
@@ -131,16 +131,16 @@ class NeighborhoodComponentsAnalysis(BaseEstimator, TransformerMixin):
     >>> X_train, X_test, y_train, y_test = train_test_split(X, y,
     ... stratify=y, test_size=0.7, random_state=42)
     >>> nca = NeighborhoodComponentsAnalysis(random_state=42)
-    >>> nca.fit(X_train, y_train) # doctest: +ELLIPSIS
+    >>> nca.fit(X_train, y_train)
     NeighborhoodComponentsAnalysis(...)
     >>> knn = KNeighborsClassifier(n_neighbors=3)
-    >>> knn.fit(X_train, y_train) # doctest: +ELLIPSIS
+    >>> knn.fit(X_train, y_train)
     KNeighborsClassifier(...)
-    >>> print(knn.score(X_test, y_test)) # doctest: +ELLIPSIS
+    >>> print(knn.score(X_test, y_test))
     0.933333...
-    >>> knn.fit(nca.transform(X_train), y_train) # doctest: +ELLIPSIS
+    >>> knn.fit(nca.transform(X_train), y_train)
     KNeighborsClassifier(...)
-    >>> print(knn.score(nca.transform(X_test), y_test)) # doctest: +ELLIPSIS
+    >>> print(knn.score(nca.transform(X_test), y_test))
     0.961904...
 
     References

--- a/sklearn/neighbors/nearest_centroid.py
+++ b/sklearn/neighbors/nearest_centroid.py
@@ -56,7 +56,7 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
     >>> y = np.array([1, 1, 1, 2, 2, 2])
     >>> clf = NearestCentroid()
     >>> clf.fit(X, y)
-    NearestCentroid(metric='euclidean', shrink_threshold=None)
+    NearestCentroid()
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
 

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -95,7 +95,7 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
     >>> y = [0, 0, 1, 1]
     >>> from sklearn.neighbors import KNeighborsRegressor
     >>> neigh = KNeighborsRegressor(n_neighbors=2)
-    >>> neigh.fit(X, y) # doctest: +ELLIPSIS
+    >>> neigh.fit(X, y)
     KNeighborsRegressor(...)
     >>> print(neigh.predict([[1.5]]))
     [0.5]
@@ -252,7 +252,7 @@ class RadiusNeighborsRegressor(NeighborsBase, RadiusNeighborsMixin,
     >>> y = [0, 0, 1, 1]
     >>> from sklearn.neighbors import RadiusNeighborsRegressor
     >>> neigh = RadiusNeighborsRegressor(radius=1.0)
-    >>> neigh.fit(X, y) # doctest: +ELLIPSIS
+    >>> neigh.fit(X, y)
     RadiusNeighborsRegressor(...)
     >>> print(neigh.predict([[1.5]]))
     [0.5]

--- a/sklearn/neighbors/unsupervised.py
+++ b/sklearn/neighbors/unsupervised.py
@@ -87,11 +87,10 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
       >>> samples = [[0, 0, 2], [1, 0, 0], [0, 0, 1]]
 
       >>> neigh = NearestNeighbors(2, 0.4)
-      >>> neigh.fit(samples)  #doctest: +ELLIPSIS
+      >>> neigh.fit(samples)
       NearestNeighbors(...)
 
       >>> neigh.kneighbors([[0, 0, 1.3]], 2, return_distance=False)
-      ... #doctest: +ELLIPSIS
       array([[2, 0]]...)
 
       >>> nbrs = neigh.radius_neighbors([[0, 0, 1.3]], 0.4, return_distance=False)

--- a/sklearn/neighbors/unsupervised.py
+++ b/sklearn/neighbors/unsupervised.py
@@ -87,10 +87,11 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
       >>> samples = [[0, 0, 2], [1, 0, 0], [0, 0, 1]]
 
       >>> neigh = NearestNeighbors(2, 0.4)
-      >>> neigh.fit(samples)
+      >>> neigh.fit(samples)  #doctest: +ELLIPSIS
       NearestNeighbors(...)
 
       >>> neigh.kneighbors([[0, 0, 1.3]], 2, return_distance=False)
+      ... #doctest: +ELLIPSIS
       array([[2, 0]]...)
 
       >>> nbrs = neigh.radius_neighbors([[0, 0, 1.3]], 0.4, return_distance=False)

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -80,7 +80,7 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
     >>> from sklearn.neural_network import BernoulliRBM
     >>> X = np.array([[0, 0, 0], [0, 1, 1], [1, 0, 1], [1, 1, 1]])
     >>> model = BernoulliRBM(n_components=2)
-    >>> model.fit(X)  # doctest: +NORMALIZE_WHITESPACE
+    >>> model.fit(X)
     BernoulliRBM(n_components=2)
 
     References

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -81,8 +81,7 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
     >>> X = np.array([[0, 0, 0], [0, 1, 1], [1, 0, 1], [1, 1, 1]])
     >>> model = BernoulliRBM(n_components=2)
     >>> model.fit(X)  # doctest: +NORMALIZE_WHITESPACE
-    BernoulliRBM(batch_size=10, learning_rate=0.1, n_components=2, n_iter=10,
-           random_state=None, verbose=0)
+    BernoulliRBM(n_components=2)
 
     References
     ----------

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -96,9 +96,7 @@ class Pipeline(_BaseComposition):
     >>> # and a parameter 'C' of the svm
     >>> anova_svm.set_params(anova__k=10, svc__C=.1).fit(X, y)
     ... # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-    Pipeline(memory=None,
-             steps=[('anova', SelectKBest(...)),
-                    ('svc', SVC(...))], verbose=False)
+    Pipeline(steps=[('anova', SelectKBest(...)), ('svc', SVC(...))])
     >>> prediction = anova_svm.predict(X)
     >>> anova_svm.score(X, y)  # doctest: +ELLIPSIS
     0.83
@@ -117,7 +115,7 @@ class Pipeline(_BaseComposition):
     >>> # Indexing can also be used to extract a sub-pipeline.
     >>> sub_pipeline = anova_svm[:1]
     >>> sub_pipeline  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-    Pipeline(memory=None, steps=[('anova', ...)], verbose=False)
+    Pipeline(steps=[('anova', SelectKBest(...))])
     >>> coef = anova_svm[-1].coef_
     >>> anova_svm['svc'] is anova_svm[-1]
     True
@@ -671,12 +669,8 @@ def make_pipeline(*steps, **kwargs):
     >>> from sklearn.preprocessing import StandardScaler
     >>> make_pipeline(StandardScaler(), GaussianNB(priors=None))
     ... # doctest: +NORMALIZE_WHITESPACE
-    Pipeline(memory=None,
-             steps=[('standardscaler',
-                     StandardScaler(copy=True, with_mean=True, with_std=True)),
-                    ('gaussiannb',
-                     GaussianNB(priors=None, var_smoothing=1e-09))],
-             verbose=False)
+    Pipeline(steps=[('standardscaler', StandardScaler()),
+                    ('gaussiannb', GaussianNB())])
 
     Returns
     -------
@@ -1008,16 +1002,8 @@ def make_union(*transformers, **kwargs):
     >>> from sklearn.decomposition import PCA, TruncatedSVD
     >>> from sklearn.pipeline import make_union
     >>> make_union(PCA(), TruncatedSVD())  # doctest: +NORMALIZE_WHITESPACE
-    FeatureUnion(n_jobs=None,
-           transformer_list=[('pca',
-                              PCA(copy=True, iterated_power='auto',
-                                  n_components=None, random_state=None,
-                                  svd_solver='auto', tol=0.0, whiten=False)),
-                             ('truncatedsvd',
-                              TruncatedSVD(algorithm='randomized',
-                              n_components=2, n_iter=5,
-                              random_state=None, tol=0.0))],
-           transformer_weights=None, verbose=False)
+     FeatureUnion(transformer_list=[('pca', PCA()),
+                                   ('truncatedsvd', TruncatedSVD())])
     """
     n_jobs = kwargs.pop('n_jobs', None)
     verbose = kwargs.pop('verbose', False)

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -95,26 +95,23 @@ class Pipeline(_BaseComposition):
     >>> # For instance, fit using a k of 10 in the SelectKBest
     >>> # and a parameter 'C' of the svm
     >>> anova_svm.set_params(anova__k=10, svc__C=.1).fit(X, y)
-    ... # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     Pipeline(steps=[('anova', SelectKBest(...)), ('svc', SVC(...))])
     >>> prediction = anova_svm.predict(X)
-    >>> anova_svm.score(X, y)  # doctest: +ELLIPSIS
+    >>> anova_svm.score(X, y)
     0.83
     >>> # getting the selected features chosen by anova_filter
     >>> anova_svm['anova'].get_support()
-    ... # doctest: +NORMALIZE_WHITESPACE
     array([False, False,  True,  True, False, False,  True,  True, False,
            True, False,  True,  True, False,  True, False,  True,  True,
            False, False])
     >>> # Another way to get selected features chosen by anova_filter
     >>> anova_svm.named_steps.anova.get_support()
-    ... # doctest: +NORMALIZE_WHITESPACE
     array([False, False,  True,  True, False, False,  True,  True, False,
            True, False,  True,  True, False,  True, False,  True,  True,
            False, False])
     >>> # Indexing can also be used to extract a sub-pipeline.
     >>> sub_pipeline = anova_svm[:1]
-    >>> sub_pipeline  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> sub_pipeline
     Pipeline(steps=[('anova', SelectKBest(...))])
     >>> coef = anova_svm[-1].coef_
     >>> anova_svm['svc'] is anova_svm[-1]
@@ -668,7 +665,6 @@ def make_pipeline(*steps, **kwargs):
     >>> from sklearn.naive_bayes import GaussianNB
     >>> from sklearn.preprocessing import StandardScaler
     >>> make_pipeline(StandardScaler(), GaussianNB(priors=None))
-    ... # doctest: +NORMALIZE_WHITESPACE
     Pipeline(steps=[('standardscaler', StandardScaler()),
                     ('gaussiannb', GaussianNB())])
 
@@ -775,7 +771,7 @@ class FeatureUnion(_BaseComposition, TransformerMixin):
     >>> union = FeatureUnion([("pca", PCA(n_components=1)),
     ...                       ("svd", TruncatedSVD(n_components=2))])
     >>> X = [[0., 1., 3], [2., 2., 5]]
-    >>> union.fit_transform(X)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> union.fit_transform(X)
     array([[ 1.5       ,  3.0...,  0.8...],
            [-1.5       ,  5.7..., -0.4...]])
     """
@@ -1001,7 +997,7 @@ def make_union(*transformers, **kwargs):
     --------
     >>> from sklearn.decomposition import PCA, TruncatedSVD
     >>> from sklearn.pipeline import make_union
-    >>> make_union(PCA(), TruncatedSVD())  # doctest: +NORMALIZE_WHITESPACE
+    >>> make_union(PCA(), TruncatedSVD())
      FeatureUnion(transformer_list=[('pca', PCA()),
                                    ('truncatedsvd', TruncatedSVD())])
     """

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -70,7 +70,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
     ...      [ 0, 3, -2,  0.5],
     ...      [ 1, 4, -1,    2]]
     >>> est = KBinsDiscretizer(n_bins=3, encode='ordinal', strategy='uniform')
-    >>> est.fit(X)  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+    >>> est.fit(X)
     KBinsDiscretizer(...)
     >>> Xt = est.transform(X)
     >>> Xt  # doctest: +SKIP

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -233,8 +233,6 @@ class OneHotEncoder(_BaseEncoder):
     >>> enc = OneHotEncoder(handle_unknown='ignore')
     >>> X = [['Male', 1], ['Female', 3], ['Female', 2]]
     >>> enc.fit(X)
-    ... # doctest: +ELLIPSIS
-    ... # doctest: +NORMALIZE_WHITESPACE
     OneHotEncoder(handle_unknown='ignore')
 
     >>> enc.categories_
@@ -572,7 +570,6 @@ class OrdinalEncoder(_BaseEncoder):
     >>> enc = OrdinalEncoder()
     >>> X = [['Male', 1], ['Female', 3], ['Female', 2]]
     >>> enc.fit(X)
-    ... # doctest: +ELLIPSIS
     OrdinalEncoder()
     >>> enc.categories_
     [array(['Female', 'Male'], dtype=object), array([1, 2, 3], dtype=object)]

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -235,8 +235,7 @@ class OneHotEncoder(_BaseEncoder):
     >>> enc.fit(X)
     ... # doctest: +ELLIPSIS
     ... # doctest: +NORMALIZE_WHITESPACE
-    OneHotEncoder(categories='auto', drop=None, dtype=<... 'numpy.float64'>,
-                  handle_unknown='ignore', sparse=True)
+    OneHotEncoder(handle_unknown='ignore')
 
     >>> enc.categories_
     [array(['Female', 'Male'], dtype=object), array([1, 2, 3], dtype=object)]
@@ -574,7 +573,7 @@ class OrdinalEncoder(_BaseEncoder):
     >>> X = [['Male', 1], ['Female', 3], ['Female', 2]]
     >>> enc.fit(X)
     ... # doctest: +ELLIPSIS
-    OrdinalEncoder(categories='auto', dtype=<... 'numpy.float64'>)
+    OrdinalEncoder()
     >>> enc.categories_
     [array(['Female', 'Male'], dtype=object), array([1, 2, 3], dtype=object)]
     >>> enc.transform([['Female', 3], ['Male', 1]])

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -265,7 +265,7 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
     >>> data = [[-1, 2], [-0.5, 6], [0, 10], [1, 18]]
     >>> scaler = MinMaxScaler()
     >>> print(scaler.fit(data))
-    MinMaxScaler(copy=True, feature_range=(0, 1))
+    MinMaxScaler()
     >>> print(scaler.data_max_)
     [ 1. 18.]
     >>> print(scaler.transform(data))
@@ -570,7 +570,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
     >>> data = [[0, 0], [0, 0], [1, 1], [1, 1]]
     >>> scaler = StandardScaler()
     >>> print(scaler.fit(data))
-    StandardScaler(copy=True, with_mean=True, with_std=True)
+    StandardScaler()
     >>> print(scaler.mean_)
     [0.5 0.5]
     >>> print(scaler.transform(data))
@@ -856,7 +856,7 @@ class MaxAbsScaler(BaseEstimator, TransformerMixin):
     ...      [ 0.,  1., -1.]]
     >>> transformer = MaxAbsScaler().fit(X)
     >>> transformer
-    MaxAbsScaler(copy=True)
+    MaxAbsScaler()
     >>> transformer.transform(X)
     array([[ 0.5, -1. ,  1. ],
            [ 1. ,  0. ,  0. ],
@@ -1110,8 +1110,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
     ...      [ 4.,  1., -2.]]
     >>> transformer = RobustScaler().fit(X)
     >>> transformer  # doctest: +NORMALIZE_WHITESPACE
-    RobustScaler(copy=True, quantile_range=(25.0, 75.0), with_centering=True,
-           with_scaling=True)
+    RobustScaler()
     >>> transformer.transform(X)
     array([[ 0. , -2. ,  0. ],
            [-1. ,  0. ,  0.4],
@@ -1685,7 +1684,7 @@ class Normalizer(BaseEstimator, TransformerMixin):
     ...      [5, 7, 5, 1]]
     >>> transformer = Normalizer().fit(X)  # fit does nothing.
     >>> transformer
-    Normalizer(copy=True, norm='l2')
+    Normalizer()
     >>> transformer.transform(X)
     array([[0.8, 0.2, 0.4, 0.4],
            [0.1, 0.3, 0.9, 0.3],
@@ -1821,7 +1820,7 @@ class Binarizer(BaseEstimator, TransformerMixin):
     ...      [ 0.,  1., -1.]]
     >>> transformer = Binarizer().fit(X)  # fit does nothing.
     >>> transformer
-    Binarizer(copy=True, threshold=0.0)
+    Binarizer()
     >>> transformer.transform(X)
     array([[1., 0., 1.],
            [1., 0., 0.],
@@ -2615,7 +2614,7 @@ class PowerTransformer(BaseEstimator, TransformerMixin):
     >>> pt = PowerTransformer()
     >>> data = [[1, 2], [3, 2], [4, 5]]
     >>> print(pt.fit(data))
-    PowerTransformer(copy=True, method='yeo-johnson', standardize=True)
+    PowerTransformer()
     >>> print(pt.lambdas_)
     [ 1.386... -3.100...]
     >>> print(pt.transform(data))

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1109,7 +1109,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
     ...      [ -2.,  1.,  3.],
     ...      [ 4.,  1., -2.]]
     >>> transformer = RobustScaler().fit(X)
-    >>> transformer  # doctest: +NORMALIZE_WHITESPACE
+    >>> transformer
     RobustScaler()
     >>> transformer.transform(X)
     array([[ 0. , -2. ,  0. ],
@@ -2096,7 +2096,7 @@ class QuantileTransformer(BaseEstimator, TransformerMixin):
     >>> rng = np.random.RandomState(0)
     >>> X = np.sort(rng.normal(loc=0.5, scale=0.25, size=(25, 1)), axis=0)
     >>> qt = QuantileTransformer(n_quantiles=10, random_state=0)
-    >>> qt.fit_transform(X) # doctest: +ELLIPSIS
+    >>> qt.fit_transform(X)
     array([...])
 
     See also
@@ -2517,7 +2517,6 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
     >>> rng = np.random.RandomState(0)
     >>> X = np.sort(rng.normal(loc=0.5, scale=0.25, size=(25, 1)), axis=0)
     >>> quantile_transform(X, n_quantiles=10, random_state=0, copy=True)
-    ... # doctest: +ELLIPSIS
     array([...])
 
     See also
@@ -2967,7 +2966,7 @@ def power_transform(X, method='warn', standardize=True, copy=True):
     >>> import numpy as np
     >>> from sklearn.preprocessing import power_transform
     >>> data = [[1, 2], [3, 2], [4, 5]]
-    >>> print(power_transform(data, method='box-cox'))  # doctest: +ELLIPSIS
+    >>> print(power_transform(data, method='box-cox'))
     [[-1.332... -0.707...]
      [ 0.256... -0.707...]
      [ 1.076...  1.414...]]

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -348,7 +348,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
     >>> from sklearn import preprocessing
     >>> lb = preprocessing.LabelBinarizer()
     >>> lb.fit([1, 2, 6, 4, 2])
-    LabelBinarizer(neg_label=0, pos_label=1, sparse_output=False)
+    LabelBinarizer()
     >>> lb.classes_
     array([1, 2, 4, 6])
     >>> lb.transform([1, 6])
@@ -368,7 +368,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
 
     >>> import numpy as np
     >>> lb.fit(np.array([[0, 1, 1], [1, 0, 0]]))
-    LabelBinarizer(neg_label=0, pos_label=1, sparse_output=False)
+    LabelBinarizer()
     >>> lb.classes_
     array([0, 1, 2])
     >>> lb.transform([0, 1, 2, 1])

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -188,7 +188,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     LabelEncoder()
     >>> le.classes_
     array([1, 2, 6])
-    >>> le.transform([1, 1, 2, 6]) #doctest: +ELLIPSIS
+    >>> le.transform([1, 1, 2, 6])
     array([0, 0, 1, 2]...)
     >>> le.inverse_transform([0, 0, 1, 2])
     array([1, 1, 2, 6])
@@ -201,7 +201,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     LabelEncoder()
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
-    >>> le.transform(["tokyo", "tokyo", "paris"]) #doctest: +ELLIPSIS
+    >>> le.transform(["tokyo", "tokyo", "paris"])
     array([2, 2, 1]...)
     >>> list(le.inverse_transform([2, 2, 1]))
     ['tokyo', 'tokyo', 'paris']

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -188,7 +188,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     LabelEncoder()
     >>> le.classes_
     array([1, 2, 6])
-    >>> le.transform([1, 1, 2, 6])
+    >>> le.transform([1, 1, 2, 6]) #doctest: +ELLIPSIS
     array([0, 0, 1, 2]...)
     >>> le.inverse_transform([0, 0, 1, 2])
     array([1, 1, 2, 6])
@@ -201,7 +201,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     LabelEncoder()
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
-    >>> le.transform(["tokyo", "tokyo", "paris"])
+    >>> le.transform(["tokyo", "tokyo", "paris"]) #doctest: +ELLIPSIS
     array([2, 2, 1]...)
     >>> list(le.inverse_transform([2, 2, 1]))
     ['tokyo', 'tokyo', 'paris']

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -596,7 +596,7 @@ class SparseRandomProjection(BaseRandomProjection):
     >>> X_new.shape
     (100, 3947)
     >>> # very few components are non-zero
-    >>> np.mean(transformer.components_ != 0) # doctest: +ELLIPSIS
+    >>> np.mean(transformer.components_ != 0)
     0.0100...
 
     See Also

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -40,7 +40,6 @@ Examples
 >>> labels = np.copy(iris.target)
 >>> labels[random_unlabeled_points] = -1
 >>> label_prop_model.fit(iris.data, labels)
-... # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
 LabelPropagation(...)
 
 Notes
@@ -360,7 +359,6 @@ class LabelPropagation(BaseLabelPropagation):
     >>> labels = np.copy(iris.target)
     >>> labels[random_unlabeled_points] = -1
     >>> label_prop_model.fit(iris.data, labels)
-    ... # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     LabelPropagation(...)
 
     References
@@ -474,7 +472,6 @@ class LabelSpreading(BaseLabelPropagation):
     >>> labels = np.copy(iris.target)
     >>> labels[random_unlabeled_points] = -1
     >>> label_prop_model.fit(iris.data, labels)
-    ... # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     LabelSpreading(...)
 
     References

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -582,7 +582,7 @@ class SVC(BaseSVC):
     >>> y = np.array([1, 1, 2, 2])
     >>> from sklearn.svm import SVC
     >>> clf = SVC(gamma='auto')
-    >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     SVC(gamma='auto')
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
@@ -762,7 +762,7 @@ class NuSVC(BaseSVC):
     >>> y = np.array([1, 1, 2, 2])
     >>> from sklearn.svm import NuSVC
     >>> clf = NuSVC()
-    >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     NuSVC()
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
@@ -898,7 +898,7 @@ class SVR(BaseLibSVM, RegressorMixin):
     >>> y = rng.randn(n_samples)
     >>> X = rng.randn(n_samples, n_features)
     >>> clf = SVR(C=1.0, epsilon=0.2)
-    >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     SVR(epsilon=0.2)
 
     See also
@@ -1024,7 +1024,7 @@ class NuSVR(BaseLibSVM, RegressorMixin):
     >>> y = np.random.randn(n_samples)
     >>> X = np.random.randn(n_samples, n_features)
     >>> clf = NuSVR(C=1.0, nu=0.1)
-    >>> clf.fit(X, y)  #doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     NuSVR(nu=0.1)
 
     See also

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -582,7 +582,7 @@ class SVC(BaseSVC):
     >>> y = np.array([1, 1, 2, 2])
     >>> from sklearn.svm import SVC
     >>> clf = SVC(gamma='auto')
-    >>> clf.fit(X, y)
+    >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
     SVC(gamma='auto')
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
@@ -762,7 +762,7 @@ class NuSVC(BaseSVC):
     >>> y = np.array([1, 1, 2, 2])
     >>> from sklearn.svm import NuSVC
     >>> clf = NuSVC()
-    >>> clf.fit(X, y)
+    >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
     NuSVC()
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
@@ -898,7 +898,7 @@ class SVR(BaseLibSVM, RegressorMixin):
     >>> y = rng.randn(n_samples)
     >>> X = rng.randn(n_samples, n_features)
     >>> clf = SVR(C=1.0, epsilon=0.2)
-    >>> clf.fit(X, y)
+    >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
     SVR(epsilon=0.2)
 
     See also
@@ -1024,7 +1024,7 @@ class NuSVR(BaseLibSVM, RegressorMixin):
     >>> y = np.random.randn(n_samples)
     >>> X = np.random.randn(n_samples, n_features)
     >>> clf = NuSVR(C=1.0, nu=0.1)
-    >>> clf.fit(X, y)
+    >>> clf.fit(X, y)  #doctest: +NORMALIZE_WHITESPACE
     NuSVR(nu=0.1)
 
     See also

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -118,9 +118,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
     >>> X, y = make_classification(n_features=4, random_state=0)
     >>> clf = LinearSVC(random_state=0, tol=1e-5)
     >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-    LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
-         intercept_scaling=1, loss='squared_hinge', max_iter=1000,
-         multi_class='ovr', penalty='l2', random_state=0, tol=1e-05, verbose=0)
+    LinearSVC(random_state=0, tol=1e-05)
     >>> print(clf.coef_)
     [[0.085... 0.394... 0.498... 0.375...]]
     >>> print(clf.intercept_)
@@ -330,9 +328,7 @@ class LinearSVR(LinearModel, RegressorMixin):
     >>> X, y = make_regression(n_features=4, random_state=0)
     >>> regr = LinearSVR(random_state=0, tol=1e-5)
     >>> regr.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
-    LinearSVR(C=1.0, dual=True, epsilon=0.0, fit_intercept=True,
-         intercept_scaling=1.0, loss='epsilon_insensitive', max_iter=1000,
-         random_state=0, tol=1e-05, verbose=0)
+    LinearSVR(random_state=0, tol=1e-05)
     >>> print(regr.coef_)
     [16.35... 26.91... 42.30... 60.47...]
     >>> print(regr.intercept_)
@@ -587,10 +583,7 @@ class SVC(BaseSVC):
     >>> from sklearn.svm import SVC
     >>> clf = SVC(gamma='auto')
     >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
-    SVC(C=1.0, break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
-        decision_function_shape='ovr', degree=3, gamma='auto', kernel='rbf',
-        max_iter=-1, probability=False,
-        random_state=None, shrinking=True, tol=0.001, verbose=False)
+    SVC(gamma='auto')
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
 
@@ -770,10 +763,7 @@ class NuSVC(BaseSVC):
     >>> from sklearn.svm import NuSVC
     >>> clf = NuSVC()
     >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
-    NuSVC(break_ties=False, cache_size=200, class_weight=None, coef0=0.0,
-          decision_function_shape='ovr', degree=3, gamma='scale', kernel='rbf',
-          max_iter=-1, nu=0.5, probability=False,
-          random_state=None, shrinking=True, tol=0.001, verbose=False)
+    NuSVC()
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
 
@@ -909,8 +899,7 @@ class SVR(BaseLibSVM, RegressorMixin):
     >>> X = rng.randn(n_samples, n_features)
     >>> clf = SVR(C=1.0, epsilon=0.2)
     >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
-    SVR(C=1.0, cache_size=200, coef0=0.0, degree=3, epsilon=0.2, gamma='scale',
-        kernel='rbf', max_iter=-1, shrinking=True, tol=0.001, verbose=False)
+    SVR(epsilon=0.2)
 
     See also
     --------
@@ -1036,9 +1025,7 @@ class NuSVR(BaseLibSVM, RegressorMixin):
     >>> X = np.random.randn(n_samples, n_features)
     >>> clf = NuSVR(C=1.0, nu=0.1)
     >>> clf.fit(X, y)  #doctest: +NORMALIZE_WHITESPACE
-    NuSVR(C=1.0, cache_size=200, coef0=0.0, degree=3, gamma='scale',
-          kernel='rbf', max_iter=-1, nu=0.1, shrinking=True, tol=0.001,
-          verbose=False)
+    NuSVR(nu=0.1)
 
     See also
     --------

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -117,7 +117,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
     >>> from sklearn.datasets import make_classification
     >>> X, y = make_classification(n_features=4, random_state=0)
     >>> clf = LinearSVC(random_state=0, tol=1e-5)
-    >>> clf.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> clf.fit(X, y)
     LinearSVC(random_state=0, tol=1e-05)
     >>> print(clf.coef_)
     [[0.085... 0.394... 0.498... 0.375...]]
@@ -327,7 +327,7 @@ class LinearSVR(LinearModel, RegressorMixin):
     >>> from sklearn.datasets import make_regression
     >>> X, y = make_regression(n_features=4, random_state=0)
     >>> regr = LinearSVR(random_state=0, tol=1e-5)
-    >>> regr.fit(X, y)  # doctest: +NORMALIZE_WHITESPACE
+    >>> regr.fit(X, y)
     LinearSVR(random_state=0, tol=1e-05)
     >>> print(regr.coef_)
     [16.35... 26.91... 42.30... 60.47...]

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -859,7 +859,6 @@ def export_text(decision_tree, feature_names=None, max_depth=10,
     |   |   |--- class: 1
     |   |--- petal width (cm) >  1.75
     |   |   |--- class: 2
-    ...
     """
     check_is_fitted(decision_tree, 'tree_')
     tree_ = decision_tree.tree_

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -750,7 +750,7 @@ def export_graphviz(decision_tree, out_file=None, max_depth=None,
     >>> iris = load_iris()
 
     >>> clf = clf.fit(iris.data, iris.target)
-    >>> tree.export_graphviz(clf) # doctest: +ELLIPSIS
+    >>> tree.export_graphviz(clf)
     'digraph Tree {...
     """
 

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -281,7 +281,7 @@ def resample(*arrays, **options):
              [2., 1.],
              [1., 0.]])
 
-      >>> X_sparse                   # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+      >>> X_sparse
       <3x2 sparse matrix of type '<... 'numpy.float64'>'
           with 4 stored elements in Compressed Sparse Row format>
 
@@ -426,7 +426,7 @@ def shuffle(*arrays, **options):
              [2., 1.],
              [1., 0.]])
 
-      >>> X_sparse                   # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+      >>> X_sparse
       <3x2 sparse matrix of type '<... 'numpy.float64'>'
           with 3 stored elements in Compressed Sparse Row format>
 

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -542,9 +542,9 @@ def gen_even_slices(n, n_packs, n_samples=None):
     >>> from sklearn.utils import gen_even_slices
     >>> list(gen_even_slices(10, 1))
     [slice(0, 10, None)]
-    >>> list(gen_even_slices(10, 10))
+    >>> list(gen_even_slices(10, 10))                     #doctest: +ELLIPSIS
     [slice(0, 1, None), slice(1, 2, None), ..., slice(9, 10, None)]
-    >>> list(gen_even_slices(10, 5))
+    >>> list(gen_even_slices(10, 5))                      #doctest: +ELLIPSIS
     [slice(0, 2, None), slice(2, 4, None), ..., slice(8, 10, None)]
     >>> list(gen_even_slices(10, 3))
     [slice(0, 4, None), slice(4, 7, None), slice(7, 10, None)]

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -542,9 +542,9 @@ def gen_even_slices(n, n_packs, n_samples=None):
     >>> from sklearn.utils import gen_even_slices
     >>> list(gen_even_slices(10, 1))
     [slice(0, 10, None)]
-    >>> list(gen_even_slices(10, 10))                     #doctest: +ELLIPSIS
+    >>> list(gen_even_slices(10, 10))
     [slice(0, 1, None), slice(1, 2, None), ..., slice(9, 10, None)]
-    >>> list(gen_even_slices(10, 5))                      #doctest: +ELLIPSIS
+    >>> list(gen_even_slices(10, 5))
     [slice(0, 2, None), slice(2, 4, None), ..., slice(8, 10, None)]
     >>> list(gen_even_slices(10, 3))
     [slice(0, 4, None), slice(4, 7, None), slice(7, 10, None)]

--- a/sklearn/utils/deprecation.py
+++ b/sklearn/utils/deprecation.py
@@ -15,7 +15,7 @@ class deprecated:
     in an empty of parentheses:
 
     >>> from sklearn.utils import deprecated
-    >>> deprecated() # doctest: +ELLIPSIS
+    >>> deprecated()
     <sklearn.utils.deprecation.deprecated object at ...>
 
     >>> @deprecated()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #13985 
Fixes #13564

#### What does this implement/fix? Explain your changes.
This PR changes:
1. Makes `NORMALIZE_WHITESPACE` and `ELLIPSIS` the default options.
2. Changes formatting for estimators by setting `print_changed_only=True` for doctest.

#### Any other comments?
This PR only changes `print_changed_only` on doctests, and not normal tests.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->