### PR TITLE
DOC Fix typo: omit comma

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -222,7 +222,7 @@ the following two rules:
     importing it from another module will be a more robust approach and work
     independently of the joblib backend.
 
-    For example, to use, ``n_jobs`` greater than 1 in the example below,
+    For example, to use ``n_jobs`` greater than 1 in the example below,
     ``custom_scoring_function`` function is saved in a user-created module
     (``custom_scorer_module.py``) and imported::
 


### PR DESCRIPTION
This PR removes a comma in the documentation. No issue was filed since it's a small change. Low-priority. Please feel free to notify me if I should file an issue for this.
