### PR TITLE
Run itrees in parallel during prediction.

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -47,6 +47,10 @@ Changelog
   validation data separately to avoid any data leak. :pr:`13933` by
   `NicolasHug`_.
 
+- |Fix| :class:`ensemble.IsolationForest` now runs parallel jobs
+  during :term:`predict`. :pr:`14001` by :user:`Sérgio Pereira
+  <sergiormpereira>`.
+
 :mod:`sklearn.linear_model`
 ..................
 

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -418,22 +418,24 @@ class IsolationForest(BaseBagging, OutlierMixin):
     def _compute_score_samples(self, X, subsample_features):
         """Compute the score of each samples in X going through the extra
         trees.
+
         Parameters
         ----------
         X : array-like or sparse matrix
         subsample_features : bool,
             whether features should be subsampled
+
         Returns
         -------
         ndarray
             The anomaly scores for each sample
         """
-        def get_depths(X, trees, trees_features, subsample_features):
-            n = X.shape[0]
+        def get_depths(_X, trees, trees_features, _subsample_features):
+            n = _X.shape[0]
             batch_depths = np.zeros(n, order="f")
 
             for tree, features in zip(trees, trees_features):
-                X_subset = X[:, features] if subsample_features else X
+                X_subset = _X[:, features] if _subsample_features else _X
 
                 leaves_index = tree.apply(X_subset)
                 node_indicator = tree.decision_path(X_subset)
@@ -450,10 +452,10 @@ class IsolationForest(BaseBagging, OutlierMixin):
         par_exec = Parallel(n_jobs=n_jobs, **self._parallel_args())
         par_results = par_exec(
             delayed(get_depths)(
-                X=X, trees=self.estimators_[starts[i]: starts[i + 1]],
+                _X=X, trees=self.estimators_[starts[i]: starts[i + 1]],
                 trees_features=self.estimators_features_[
                                starts[i]: starts[i + 1]],
-                subsample_features=subsample_features)
+                _subsample_features=subsample_features)
             for i in range(n_jobs))
 
         n_samples = X.shape[0]

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -451,7 +451,7 @@ class IsolationForest(BaseBagging, OutlierMixin):
 
         par_exec = Parallel(n_jobs=n_jobs, **self._parallel_args())
         par_results = par_exec(
-            delayed(get_depths)(
+            delayed(get_depths, check_pickle=False)(
                 _X=X, trees=self.estimators_[starts[i]: starts[i + 1]],
                 trees_features=self.estimators_features_[
                                starts[i]: starts[i + 1]],

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -21,6 +21,7 @@ from ..utils.validation import check_is_fitted, _num_samples
 from ..base import OutlierMixin
 
 from .bagging import BaseBagging
+from .base import _partition_estimators
 
 __all__ = ["IsolationForest"]
 
@@ -417,39 +418,46 @@ class IsolationForest(BaseBagging, OutlierMixin):
     def _compute_score_samples(self, X, subsample_features):
         """Compute the score of each samples in X going through the extra
         trees.
-
         Parameters
         ----------
         X : array-like or sparse matrix
         subsample_features : bool,
             whether features should be subsampled
-
         Returns
         -------
         ndarray
             The anomaly scores for each sample
         """
-        def get_score(_X, _tree, _features, _subsample_features):
-            X_subset = _X[:, _features] if _subsample_features else _X
+        def get_depths(X, trees, trees_features, subsample_features):
+            n = X.shape[0]
+            batch_depths = np.zeros(n, order="f")
 
-            leaves_index = _tree.apply(X_subset)
-            node_indicator = _tree.decision_path(X_subset)
-            n_samples_leaf = _tree.tree_.n_node_samples[leaves_index]
+            for tree, features in zip(trees, trees_features):
+                X_subset = X[:, features] if subsample_features else X
 
-            return np.ravel(node_indicator.sum(axis=1)) + _average_path_length(
-                n_samples_leaf) - 1.0
+                leaves_index = tree.apply(X_subset)
+                node_indicator = tree.decision_path(X_subset)
+                n_samples_leaf = tree.tree_.n_node_samples[leaves_index]
+
+                batch_depths += np.ravel(node_indicator.sum(axis=1)) \
+                    + _average_path_length(n_samples_leaf) - 1.0
+
+            return batch_depths
+
+        n_jobs, n_estimators, starts = _partition_estimators(
+            self.n_estimators, self.n_jobs)
+
+        par_exec = Parallel(n_jobs=n_jobs, **self._parallel_args())
+        par_results = par_exec(
+            delayed(get_depths)(
+                X=X, trees=self.estimators_[starts[i]: starts[i + 1]],
+                trees_features=self.estimators_features_[
+                               starts[i]: starts[i + 1]],
+                subsample_features=subsample_features)
+            for i in range(n_jobs))
 
         n_samples = X.shape[0]
-
         depths = np.zeros(n_samples, order="f")
-
-        par_exec = Parallel(n_jobs=self.n_jobs, prefer="threads",
-                            require='sharedmem')
-        par_results = par_exec(
-            delayed(get_score)(_X=X, _tree=tree, _features=features,
-                               _subsample_features=subsample_features)
-            for tree, features in zip(self.estimators_,
-                                      self.estimators_features_))
 
         for result in par_results:
             depths += result

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -2,7 +2,9 @@
 #          Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 # License: BSD 3 clause
 
+from distutils.version import LooseVersion
 
+import joblib
 from joblib import Parallel, delayed
 import numbers
 import numpy as np
@@ -449,9 +451,12 @@ class IsolationForest(BaseBagging, OutlierMixin):
         n_jobs, n_estimators, starts = _partition_estimators(
             self.n_estimators, self.n_jobs)
 
+        old_joblib = LooseVersion(joblib.__version__) < LooseVersion('0.12')
+        check_pickle = False if old_joblib else None
+
         par_exec = Parallel(n_jobs=n_jobs, **self._parallel_args())
         par_results = par_exec(
-            delayed(get_depths, check_pickle=False)(
+            delayed(get_depths, check_pickle=check_pickle)(
                 _X=X, trees=self.estimators_[starts[i]: starts[i + 1]],
                 trees_features=self.estimators_features_[
                                starts[i]: starts[i + 1]],

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -463,11 +463,7 @@ class IsolationForest(BaseBagging, OutlierMixin):
                 _subsample_features=subsample_features)
             for i in range(n_jobs))
 
-        n_samples = X.shape[0]
-        depths = np.zeros(n_samples, order="f")
-
-        for result in par_results:
-            depths += result
+        depths = np.sum(par_results, axis=0)
 
         scores = 2 ** (-depths / (len(self.estimators_)
                                   * _average_path_length([self.max_samples_])))

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -169,15 +169,20 @@ def test_iforest_parallel_regression():
 
     ensemble.set_params(n_jobs=1)
     y1 = ensemble.predict(X_test)
+    scores1 = ensemble.score_samples(X_test)
     ensemble.set_params(n_jobs=2)
     y2 = ensemble.predict(X_test)
+    scores2 = ensemble.score_samples(X_test)
     assert_array_almost_equal(y1, y2)
+    assert_array_almost_equal(scores1, scores2)
 
     ensemble = IsolationForest(n_jobs=1,
                                random_state=0).fit(X_train)
 
     y3 = ensemble.predict(X_test)
+    scores3 = ensemble.score_samples(X_test)
     assert_array_almost_equal(y1, y3)
+    assert_array_almost_equal(scores1, scores3)
 
 
 def test_iforest_performance():


### PR DESCRIPTION
#### Reference Issues/PRs
https://github.com/scikit-learn/scikit-learn/issues/14000

#### What does this implement/fix? Explain your changes.
Isolation Forest is executed in parallel during fitting. But, during prediction it is running single-threaded.

In this PR, I parallelised the execution during prediction, more precisely in the _compute_score_samples method. Each ITree was being called in sequence, using a for loop. I created an auxiliary internal function that executes each tree, and this function can be run in parallel. I used joblib for parallelisation.

#### Any other comments?
I run the tests for Isolation Forest and it passed.

