### PR TITLE
MAINT Use isinstance(x, numbers.Integral) to check for integer dtype

### DIFF
--- a/benchmarks/bench_plot_nmf.py
+++ b/benchmarks/bench_plot_nmf.py
@@ -240,7 +240,8 @@ class _PGNMF(NMF):
                 n_components <= 0):
             raise ValueError("Number of components must be a positive integer;"
                              " got (n_components=%r)" % n_components)
-        if not isinstance(self.max_iter, numbers.Integral) or self.max_iter < 0:
+        if (not isinstance(self.max_iter, numbers.Integral) or
+                self.max_iter < 0):
             raise ValueError("Maximum number of iterations must be a positive "
                              "integer; got (max_iter=%r)" % self.max_iter)
         if not isinstance(self.tol, numbers.Number) or self.tol < 0:

--- a/benchmarks/bench_plot_nmf.py
+++ b/benchmarks/bench_plot_nmf.py
@@ -21,7 +21,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.decomposition.nmf import NMF
 from sklearn.decomposition.nmf import _initialize_nmf
 from sklearn.decomposition.nmf import _beta_divergence
-from sklearn.decomposition.nmf import INTEGER_TYPES, _check_init
+from sklearn.decomposition.nmf import _check_init
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils.extmath import safe_sparse_dot, squared_norm
 from sklearn.utils import check_array
@@ -236,11 +236,11 @@ class _PGNMF(NMF):
         if n_components is None:
             n_components = n_features
 
-        if (not isinstance(n_components, INTEGER_TYPES) or
+        if (not isinstance(n_components, numbers.Integral) or
                 n_components <= 0):
             raise ValueError("Number of components must be a positive integer;"
                              " got (n_components=%r)" % n_components)
-        if not isinstance(self.max_iter, INTEGER_TYPES) or self.max_iter < 0:
+        if not isinstance(self.max_iter, numbers.Integral) or self.max_iter < 0:
             raise ValueError("Maximum number of iterations must be a positive "
                              "integer; got (max_iter=%r)" % self.max_iter)
         if not isinstance(self.tol, numbers.Number) or self.tol < 0:

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -24,8 +24,6 @@ from .cdnmf_fast import _update_cdnmf_fast
 
 EPSILON = np.finfo(np.float32).eps
 
-INTEGER_TYPES = (numbers.Integral, np.integer)
-
 
 def norm(x):
     """Dot product-based Euclidean norm implementation
@@ -1011,10 +1009,10 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
     if n_components is None:
         n_components = n_features
 
-    if not isinstance(n_components, INTEGER_TYPES) or n_components <= 0:
+    if not isinstance(n_components, numbers.Integral) or n_components <= 0:
         raise ValueError("Number of components must be a positive integer;"
                          " got (n_components=%r)" % n_components)
-    if not isinstance(max_iter, INTEGER_TYPES) or max_iter < 0:
+    if not isinstance(max_iter, numbers.Integral) or max_iter < 0:
         raise ValueError("Maximum number of iterations must be a positive "
                          "integer; got (max_iter=%r)" % max_iter)
     if not isinstance(tol, numbers.Number) or tol < 0:

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -425,7 +425,7 @@ class PCA(_BasePCA):
                              "svd_solver='full'"
                              % (n_components, min(n_samples, n_features)))
         elif n_components >= 1:
-            if not isinstance(n_components, (numbers.Integral, np.integer)):
+            if not isinstance(n_components, numbers.Integral):
                 raise ValueError("n_components=%r must be of type int "
                                  "when greater than or equal to 1, "
                                  "was of type=%r"
@@ -490,7 +490,7 @@ class PCA(_BasePCA):
                              "svd_solver='%s'"
                              % (n_components, min(n_samples, n_features),
                                 svd_solver))
-        elif not isinstance(n_components, (numbers.Integral, np.integer)):
+        elif not isinstance(n_components, numbers.Integral):
             raise ValueError("n_components=%r must be of type int "
                              "when greater than or equal to 1, was of type=%r"
                              % (n_components, type(n_components)))

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -298,7 +298,7 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
         # Validate max_samples
         if max_samples is None:
             max_samples = self.max_samples
-        elif not isinstance(max_samples, (numbers.Integral, np.integer)):
+        elif not isinstance(max_samples, numbers.Integral):
             max_samples = int(max_samples * X.shape[0])
 
         if not (0 < max_samples <= X.shape[0]):
@@ -308,7 +308,7 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
         self._max_samples = max_samples
 
         # Validate max_features
-        if isinstance(self.max_features, (numbers.Integral, np.integer)):
+        if isinstance(self.max_features, numbers.Integral):
             max_features = self.max_features
         elif isinstance(self.max_features, np.float):
             max_features = self.max_features * self.n_features_

--- a/sklearn/ensemble/base.py
+++ b/sklearn/ensemble/base.py
@@ -101,7 +101,7 @@ class BaseEnsemble(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
     def _validate_estimator(self, default=None):
         """Check the estimator and the n_estimator attribute, set the
         `base_estimator_` attribute."""
-        if not isinstance(self.n_estimators, (numbers.Integral, np.integer)):
+        if not isinstance(self.n_estimators, numbers.Integral):
             raise ValueError("n_estimators must be an integer, "
                              "got {0}.".format(type(self.n_estimators)))
 

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1315,7 +1315,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                                  "or 'log2'." % self.max_features)
         elif self.max_features is None:
             max_features = self.n_features_
-        elif isinstance(self.max_features, (numbers.Integral, np.integer)):
+        elif isinstance(self.max_features, numbers.Integral):
             max_features = self.max_features
         else:  # float
             if 0. < self.max_features <= 1.:
@@ -1327,7 +1327,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         self.max_features_ = max_features
 
         if not isinstance(self.n_iter_no_change,
-                          (numbers.Integral, np.integer, type(None))):
+                          (numbers.Integral, type(None))):
             raise ValueError("n_iter_no_change should either be None or an "
                              "integer. %r was passed"
                              % self.n_iter_no_change)

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -23,8 +23,6 @@ from .bagging import BaseBagging
 
 __all__ = ["IsolationForest"]
 
-INTEGER_TYPES = (numbers.Integral, np.integer)
-
 
 class IsolationForest(BaseBagging, OutlierMixin):
     """Isolation Forest Algorithm
@@ -256,7 +254,7 @@ class IsolationForest(BaseBagging, OutlierMixin):
                                  'Valid choices are: "auto", int or'
                                  'float' % self.max_samples)
 
-        elif isinstance(self.max_samples, INTEGER_TYPES):
+        elif isinstance(self.max_samples, numbers.Integral):
             if self.max_samples > n_samples:
                 warn("max_samples (%s) is greater than the "
                      "total number of samples (%s). max_samples "

--- a/sklearn/feature_extraction/hashing.py
+++ b/sklearn/feature_extraction/hashing.py
@@ -97,7 +97,7 @@ class FeatureHasher(BaseEstimator, TransformerMixin):
     def _validate_params(n_features, input_type):
         # strangely, np.int16 instances are not instances of Integral,
         # while np.int64 instances are...
-        if not isinstance(n_features, (numbers.Integral, np.integer)):
+        if not isinstance(n_features, numbers.Integral):
             raise TypeError("n_features must be integral, got %r (%s)."
                             % (n_features, type(n_features)))
         elif n_features < 1 or n_features >= 2 ** 31:

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -15,6 +15,7 @@ from collections import defaultdict
 from collections.abc import Mapping, Sequence, Iterable
 from functools import partial, reduce
 from itertools import product
+import numbers
 import operator
 import time
 import warnings
@@ -693,7 +694,7 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
             # parameter set.
             if callable(self.refit):
                 self.best_index_ = self.refit(results)
-                if not isinstance(self.best_index_, (int, np.integer)):
+                if not isinstance(self.best_index_, numbers.Integral):
                     raise TypeError('best_index_ returned is not an integer')
                 if (self.best_index_ < 0 or
                    self.best_index_ >= len(results["params"])):

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1075,7 +1075,7 @@ class _RepeatedSplits(metaclass=ABCMeta):
         and shuffle.
     """
     def __init__(self, cv, n_repeats=10, random_state=None, **cvargs):
-        if not isinstance(n_repeats, (np.integer, numbers.Integral)):
+        if not isinstance(n_repeats, numbers.Integral):
             raise ValueError("Number of repetitions must be of Integral type.")
 
         if n_repeats <= 0:

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -11,6 +11,7 @@ from distutils.version import LooseVersion
 
 import warnings
 from abc import ABCMeta, abstractmethod
+import numbers
 
 import numpy as np
 from scipy.sparse import csr_matrix, issparse
@@ -268,7 +269,7 @@ class NeighborsBase(BaseEstimator, MultiOutputMixin, metaclass=ABCMeta):
                     self.n_neighbors
                 )
             else:
-                if not np.issubdtype(type(self.n_neighbors), np.integer):
+                if not isinstance(self.n_neighbors, numbers.Integral):
                     raise TypeError(
                         "n_neighbors does not take %s value, "
                         "enter integer value" %
@@ -391,7 +392,7 @@ class KNeighborsMixin:
                 n_neighbors
             )
         else:
-            if not np.issubdtype(type(n_neighbors), np.integer):
+            if not isinstance(n_neighbors, numbers.Integral):
                 raise TypeError(
                     "n_neighbors does not take %s value, "
                     "enter integer value" %

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -211,7 +211,7 @@ class KBinsDiscretizer(BaseEstimator, TransformerMixin):
         """
         orig_bins = self.n_bins
         if isinstance(orig_bins, numbers.Number):
-            if not isinstance(orig_bins, (numbers.Integral, np.integer)):
+            if not isinstance(orig_bins, numbers.Integral):
                 raise ValueError("{} received an invalid n_bins type. "
                                  "Received {}, expected int."
                                  .format(KBinsDiscretizer.__name__,

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -9,6 +9,7 @@
 
 
 from itertools import chain, combinations
+import numbers
 import warnings
 from itertools import combinations_with_replacement as combinations_w_r
 
@@ -670,7 +671,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         # transform it to a NumPy array of shape (n_features,) required by
         # incr_mean_variance_axis and _incremental_variance_axis
         if (hasattr(self, 'n_samples_seen_') and
-                isinstance(self.n_samples_seen_, (int, np.integer))):
+                isinstance(self.n_samples_seen_, numbers.Integral)):
             self.n_samples_seen_ = np.repeat(
                 self.n_samples_seen_, X.shape[1]).astype(np.int64, copy=False)
 

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -14,8 +14,6 @@ randomized trees. Single and multi-output problems are both handled.
 #
 # License: BSD 3 clause
 
-
-
 import numbers
 import warnings
 from abc import ABCMeta
@@ -187,7 +185,7 @@ class BaseDecisionTree(BaseEstimator, MultiOutputMixin, metaclass=ABCMeta):
         max_leaf_nodes = (-1 if self.max_leaf_nodes is None
                           else self.max_leaf_nodes)
 
-        if isinstance(self.min_samples_leaf, (numbers.Integral, np.integer)):
+        if isinstance(self.min_samples_leaf, numbers.Integral):
             if not 1 <= self.min_samples_leaf:
                 raise ValueError("min_samples_leaf must be at least 1 "
                                  "or in (0, 0.5], got %s"
@@ -200,7 +198,7 @@ class BaseDecisionTree(BaseEstimator, MultiOutputMixin, metaclass=ABCMeta):
                                  % self.min_samples_leaf)
             min_samples_leaf = int(ceil(self.min_samples_leaf * n_samples))
 
-        if isinstance(self.min_samples_split, (numbers.Integral, np.integer)):
+        if isinstance(self.min_samples_split, numbers.Integral):
             if not 2 <= self.min_samples_split:
                 raise ValueError("min_samples_split must be an integer "
                                  "greater than 1 or a float in (0.0, 1.0]; "
@@ -234,7 +232,7 @@ class BaseDecisionTree(BaseEstimator, MultiOutputMixin, metaclass=ABCMeta):
                     'values are "auto", "sqrt" or "log2".')
         elif self.max_features is None:
             max_features = self.n_features_
-        elif isinstance(self.max_features, (numbers.Integral, np.integer)):
+        elif isinstance(self.max_features, numbers.Integral):
             max_features = self.max_features
         else:  # float
             if self.max_features > 0.0:
@@ -254,7 +252,7 @@ class BaseDecisionTree(BaseEstimator, MultiOutputMixin, metaclass=ABCMeta):
             raise ValueError("max_depth must be greater than zero. ")
         if not (0 < max_features <= self.n_features_):
             raise ValueError("max_features must be in (0, n_features]")
-        if not isinstance(max_leaf_nodes, (numbers.Integral, np.integer)):
+        if not isinstance(max_leaf_nodes, numbers.Integral):
             raise ValueError("max_leaf_nodes must be integral number but was "
                              "%r" % max_leaf_nodes)
         if -1 < max_leaf_nodes < 2:

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -773,7 +773,7 @@ def check_random_state(seed):
     """
     if seed is None or seed is np.random:
         return np.random.mtrand._rand
-    if isinstance(seed, (numbers.Integral, np.integer)):
+    if isinstance(seed, numbers.Integral):
         return np.random.RandomState(seed)
     if isinstance(seed, np.random.RandomState):
         return seed


### PR DESCRIPTION
Closes https://github.com/scikit-learn/scikit-learn/issues/5786

On the discussion whether,
 - isinstance(x, (numbers.Integral, np.integer)) 
 - isinstance(x, six.integer_types)

should be used for testing integer dtype (including `np.integer`), a better choice is to use `isinstance(x, numbers.Integral)` as mentionned in  https://github.com/scikit-learn/scikit-learn/issues/5786#issuecomment-182034421

```py
>>> import numpy as np
>>> import numbers
>>> x = np.int64(2)
>>> x
2
>>> type(x)
<class 'numpy.int64'>
>>> isinstance(x, numbers.Integral)
True
```