### PR TITLE
[MRG] Fix 'SparseSeries deprecated: scipy-dev failing on travis' #14002

### DIFF
--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -15,6 +15,7 @@ from scipy.sparse import dok_matrix
 from scipy.sparse import lil_matrix
 
 import numpy as np
+import pandas as pd
 
 from .validation import check_array, _assert_all_finite
 
@@ -240,9 +241,9 @@ def type_of_target(y):
         raise ValueError('Expected array-like (array or non-string sequence), '
                          'got %r' % y)
 
-    sparseseries = (y.__class__.__name__ == 'SparseSeries')
+    sparseseries = pd.api.types.is_sparse(y)
     if sparseseries:
-        raise ValueError("y cannot be class 'SparseSeries'.")
+        raise ValueError("y cannot be a sparse array.")
 
     if is_multilabel(y):
         return 'multilabel-indicator'

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -300,7 +300,7 @@ def test_type_of_target():
         raise SkipTest("Pandas not found")
 
     y = pd.Series(pd.SparseArray([1, 0, 0, 1, 0]))
-    msg = "y cannot be class 'SparseSeries'."
+    msg = "y cannot be a sparse array."
     assert_raises_regex(ValueError, msg, type_of_target, y)
 
 

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -295,11 +295,11 @@ def test_type_of_target():
         assert_raises_regex(ValueError, msg, type_of_target, example)
 
     try:
-        from pandas import SparseSeries
+        import pandas as pd
     except ImportError:
         raise SkipTest("Pandas not found")
 
-    y = SparseSeries([1, 0, 0, 1, 0])
+    y = pd.Series([1, 0, 0, 1, 0]).to_sparse()
     msg = "y cannot be class 'SparseSeries'."
     assert_raises_regex(ValueError, msg, type_of_target, y)
 

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -299,7 +299,7 @@ def test_type_of_target():
     except ImportError:
         raise SkipTest("Pandas not found")
 
-    y = pd.Series([1, 0, 0, 1, 0]).to_sparse()
+    y = pd.Series(pd.SparseArray([1, 0, 0, 1, 0]))
     msg = "y cannot be class 'SparseSeries'."
     assert_raises_regex(ValueError, msg, type_of_target, y)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #14002
Issue: SparseSeries deprecated: scipy-dev failing on travis
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Use a Series with sparse values instead instead of `SparseSeries`.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
