### PR TITLE
[WIP] Providing built-in DummyRegression support for series based Xs …

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1988,12 +1988,14 @@ probably means that something went wrong: features are not helpful, a
 hyperparameter is not correctly tuned, the classifier is suffering from class
 imbalance, etc...
 
-:class:`DummyRegressor` also implements four simple rules of thumb for regression:
+:class:`DummyRegressor` also implements six simple rules of thumb for regression:
 
 - ``mean`` always predicts the mean of the training targets.
 - ``median`` always predicts the median of the training targets.
 - ``quantile`` always predicts a user provided quantile of the training targets.
 - ``constant`` always predicts a constant value that is provided by the user.
+- ``series_mean`` always predicts the mean of a testing sample.
+- ``series_last`` always predicts the last element of a testing sample.
 
-In all these strategies, the ``predict`` method completely ignores
+In all but the ``series`` strategies, the ``predict`` method completely ignores
 the input data.

--- a/examples/model_selection/defining_a_dummy_estimators_as_baseline.py
+++ b/examples/model_selection/defining_a_dummy_estimators_as_baseline.py
@@ -24,11 +24,13 @@ from sklearn.datasets import make_regression
 print("*" * 80)
 print("Regression example")
 print("*" * 80)
-print("Since all features are informative the LinearRegression model should capture perfect score")
-print("while the DummyRegressor should give a near non-X dependent result (a poor 0 score)")
+print("Since all features are informative the LinearRegression model should")
+print("capture perfect score while the DummyRegressor should give a near")
+print("non-X dependent result (a poor 0 score)")
 
 
-X, y = make_regression(random_state=0, n_samples=1000, n_features=100,n_informative=100)
+X, y = make_regression(random_state=0, n_samples=1000, n_features=100,
+                       n_informative=100)
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
@@ -44,17 +46,19 @@ print("Linear regression score {}".format(clf.score(X_test, y_test)))
 print("*" * 80)
 print("Time series regression example")
 print("*" * 80)
-print("Since this is a fibonnaci alike series, the last element is a good predictor of the next one,")
-print("giving the dummy regressor an informative score (in this case a score between 0 and 1).")
-print("But the linear regression should capture the full relationship between N and its two previous")
-print("elements (score near 1).")
+print("Since this is a fibonnaci alike series, the last element is a good")
+print("predictor of the next one, giving the dummy regressor an informative")
+print("score (in this case a score between 0 and 1).")
+print("But the linear regression should capture the full relationship")
+print("between N and its two previous elements (score near 1).")
 
 # sample time series with a linear relationship N = (N-1) + (N-2)
 full_time_series = [1, 2, 3, 5, 8, 13, 21, 34, 55, 87, 142]
 
 # splits the time series in a rolling window of size 2
 steps_for_prediction = 2
-X = [full_time_series[i:i+steps_for_prediction] for i in range(len(full_time_series) - steps_for_prediction)]
+count = len(full_time_series) - steps_for_prediction
+X = [full_time_series[i:i+steps_for_prediction] for i in range(count)]
 
 # y is the next step
 y = full_time_series[steps_for_prediction:]
@@ -70,17 +74,19 @@ clf.fit(X_train, y_train)
 print("Linear regression score {}".format(clf.score(X_test, y_test)))
 
 
-
 print("*" * 80)
 print("Classification example")
 print("*" * 80)
-print("Since the relationship between y and X is linear (X > 500 => 1), logistic regression")
-print("should give a near perfect score (1) while the default DummyClassifier will give a near 0.5 result.")
+print("Since the relationship between y and X is linear ")
+print("(X > 500 => 1), logistic regression should give a")
+print("near perfect score (1) while the default")
+print("DummyClassifier will give a near 0.5 result.")
 
 X = [[x] for x in range(1000)]
 y = np.array([x > 500 for x in range(1000)]) * 1
 
-X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0, stratify = y)
+X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0,
+                                                    stratify=y)
 
 clf = DummyClassifier(random_state=0)
 clf.fit(X_train, y_train)

--- a/examples/model_selection/defining_a_dummy_estimators_as_baseline.py
+++ b/examples/model_selection/defining_a_dummy_estimators_as_baseline.py
@@ -1,0 +1,91 @@
+"""
+==============================
+Dummy baselines usage examples
+==============================
+
+Example of DummyClassifier and DummyRegression.
+
+A model or pipeline's result will typically be compared to a baseline. Simple
+baselines are provided for both classification and regression problems through
+the DummyClassifier and DummyRegression estimators.
+Therefore it is expected that a good model or pipeline should beat the dummy
+heuristics implemented here. The only way to find it out is to run those
+dummy estimators prior to modelling your pipeline.
+
+"""
+print(__doc__)
+
+import numpy as np
+from sklearn.model_selection import train_test_split
+from sklearn.dummy import DummyRegressor, DummyClassifier
+from sklearn.linear_model import LinearRegression, LogisticRegression
+from sklearn.datasets import make_regression
+
+print("*" * 80)
+print("Regression example")
+print("*" * 80)
+print("Since all features are informative the LinearRegression model should capture perfect score")
+print("while the DummyRegressor should give a near non-X dependent result (a poor 0 score)")
+
+
+X, y = make_regression(random_state=0, n_samples=1000, n_features=100,n_informative=100)
+
+X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+clf = DummyRegressor(strategy="mean")
+clf.fit(X_train, y_train)
+print("Dummy mean score {}".format(clf.score(X_test, y_test)))
+
+clf = LinearRegression()
+clf.fit(X_train, y_train)
+print("Linear regression score {}".format(clf.score(X_test, y_test)))
+
+
+print("*" * 80)
+print("Time series regression example")
+print("*" * 80)
+print("Since this is a fibonnaci alike series, the last element is a good predictor of the next one,")
+print("giving the dummy regressor an informative score (in this case a score between 0 and 1).")
+print("But the linear regression should capture the full relationship between N and its two previous")
+print("elements (score near 1).")
+
+# sample time series with a linear relationship N = (N-1) + (N-2)
+full_time_series = [1, 2, 3, 5, 8, 13, 21, 34, 55, 87, 142]
+
+# splits the time series in a rolling window of size 2
+steps_for_prediction = 2
+X = [full_time_series[i:i+steps_for_prediction] for i in range(len(full_time_series) - steps_for_prediction)]
+
+# y is the next step
+y = full_time_series[steps_for_prediction:]
+
+X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+clf = DummyRegressor(strategy="series_last")
+clf.fit(X_train, y_train)
+print("Dummy score {}".format(clf.score(X_test, y_test)))
+
+clf = LinearRegression()
+clf.fit(X_train, y_train)
+print("Linear regression score {}".format(clf.score(X_test, y_test)))
+
+
+
+print("*" * 80)
+print("Classification example")
+print("*" * 80)
+print("Since the relationship between y and X is linear (X > 500 => 1), logistic regression")
+print("should give a near perfect score (1) while the default DummyClassifier will give a near 0.5 result.")
+
+X = [[x] for x in range(1000)]
+y = np.array([x > 500 for x in range(1000)]) * 1
+
+X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0, stratify = y)
+
+clf = DummyClassifier(random_state=0)
+clf.fit(X_train, y_train)
+print("Dummy score {}".format(clf.score(X_test, y_test)))
+
+clf = LogisticRegression(random_state=0)
+clf.fit(X_train, y_train)
+print("Logistic regression score {}".format(clf.score(X_test, y_test)))

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -375,7 +375,7 @@ class DummyRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
         * "constant": always predicts a constant value that is provided by
           the user.
         * "series_last": Predicts the last element of x for each series x in X.
-        * "series_average": Predicts the average of x for each series x in X.
+        * "series_mean": Predicts the mean of x for each series x in X.
 
     constant : int or float or array of shape = [n_outputs]
         The explicit constant as predicted by the "constant" strategy. This
@@ -420,7 +420,7 @@ class DummyRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
         self : object
         """
         allowed_strategies = ("mean", "median", "quantile", "constant",
-                              "series_last", "series_average")
+                              "series_last", "series_mean")
         if self.strategy not in allowed_strategies:
             raise ValueError("Unknown strategy type: %s, expected one of %s."
                              % (self.strategy, allowed_strategies))
@@ -509,7 +509,7 @@ class DummyRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
             X = check_array(X, allow_nd=True)
             return X[:, -1]
 
-        elif self.strategy == "series_average":
+        elif self.strategy == "series_mean":
             return np.mean(X, axis=1)
 
         check_is_fitted(self, "constant_")

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -738,3 +738,57 @@ def test_dtype_of_classifier_probas(strategy):
     probas = model.fit(X, y).predict_proba(X)
 
     assert probas.dtype == np.float64
+
+
+def test_series_last_strategy():
+    X = [[0]] * 5  # ignored
+    y = [1, 2, 3, 4, 5]  # ignored
+    clf = DummyRegressor(strategy="series_last")
+    clf.fit(X, y)
+
+    X = [[1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]]
+    y_pred = clf.predict(X)
+
+    y_expected = [3, 4, 5, 6]
+    assert_array_almost_equal(y_expected, y_pred)
+
+
+def test_series_last_strategy_with_extra_dimension():
+    X = [[0]] * 5  # ignored
+    y = [1, 2, 3, 4, 5]  # ignored
+    clf = DummyRegressor(strategy="series_last")
+    clf.fit(X, y)
+
+    X = [[[1, 1], [2, 2], [3, 3]], [[2, 2], [3, 3], [4, 4]],
+         [[3, 3], [4, 4], [5, 5]], [[4, 4], [5, 5], [6, 6]]]
+    y_pred = clf.predict(X)
+
+    y_expected = [[3, 3], [4, 4], [5, 5], [6, 6]]
+    assert_array_almost_equal(y_expected, y_pred)
+
+
+def test_series_average_strategy():
+    X = [[0]] * 5  # ignored
+    y = [1, 2, 3, 4, 5]  # ignored
+    clf = DummyRegressor(strategy="series_average")
+    clf.fit(X, y)
+
+    X = [[1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]]
+    y_pred = clf.predict(X)
+
+    y_expected = [2, 3, 4, 5]
+    assert_array_almost_equal(y_expected, y_pred)
+
+
+def test_series_average_strategy_with_extra_dimension():
+    X = [[0]] * 5  # ignored
+    y = [1, 2, 3, 4, 5]  # ignored
+    clf = DummyRegressor(strategy="series_average")
+    clf.fit(X, y)
+
+    X = [[[1, 1], [2, 2], [9, 9]], [[2, 2], [3, 3], [10, 10]],
+         [[3, 3], [4, 4], [11, 11]], [[4, 4], [5, 5], [12, 12]]]
+    y_pred = clf.predict(X)
+
+    y_expected = [[4, 4], [5, 5], [6, 6], [7, 7]]
+    assert_array_almost_equal(y_expected, y_pred)

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -767,10 +767,10 @@ def test_series_last_strategy_with_extra_dimension():
     assert_array_almost_equal(y_expected, y_pred)
 
 
-def test_series_average_strategy():
+def test_series_mean_strategy():
     X = [[0]] * 5  # ignored
     y = [1, 2, 3, 4, 5]  # ignored
-    clf = DummyRegressor(strategy="series_average")
+    clf = DummyRegressor(strategy="series_mean")
     clf.fit(X, y)
 
     X = [[1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]]
@@ -780,10 +780,10 @@ def test_series_average_strategy():
     assert_array_almost_equal(y_expected, y_pred)
 
 
-def test_series_average_strategy_with_extra_dimension():
+def test_series_mean_strategy_with_extra_dimension():
     X = [[0]] * 5  # ignored
     y = [1, 2, 3, 4, 5]  # ignored
-    clf = DummyRegressor(strategy="series_average")
+    clf = DummyRegressor(strategy="series_mean")
     clf.fit(X, y)
 
     X = [[[1, 1], [2, 2], [9, 9]], [[2, 2], [3, 3], [10, 10]],


### PR DESCRIPTION
When evaluating time series two common dummy strategies are to repeat the last value of the series or to take the average of the series.
Since there is splitting support tailored for time series for folding strategies (TimeSeriesSplit,, I thought it would be helpful to provide default dummy regressors for them.

Example usage:

```
X = [[0]] * 5 # ignored
y = [1, 2, 3, 4, 5] # ignored
clf = DummyRegressor(strategy="series_last")
clf.fit(X, y)

X = [[1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]]
y_pred = clf.predict(X)

y_expected = [3, 4, 5, 6]
assert_array_almost_equal(y_expected, y_pred)
```

There seems to be no rule (in the documentation) that a dummy classifier must not use X. Examples of the persistence strategy in the literature:
- https://towardsdatascience.com/the-best-forecast-techniques-or-how-to-predict-from-time-series-data-967221811981
- https://arxiv.org/abs/1708.08376
    
Since it's my first attempt, please let me know if it makes sense to the project and what to improve prior to finishing it.

- [X] support dummy series average and last element
- [X] regression tests
- [X] function documentation
- [X] examples
- [X] user guide under "Dummy estimators (3.3.6)

#### Reference Issues/PRs
This is the pull request itself.

#### What does this implement/fix? Explain your changes.
DummyRegressor now supports two approaches. Both assumes x in X is a (part of a) time series.
'series_last' is a dummy regressor which returns the last element while 'series_average' returns the average of x.

Changes
[X] Both were added as options while creating a new instance of DummyRegressor
[X] DummyRegressor does not need to pre-cache a constant if one of those options is selected
[X] DummyRegressor returns the last element of x for each x in X when selecting 'series_last'
[X] DummyRegressor returns the average of x for each x in X when selecting 'series_average'

#### Any other comments?

DummyRegressor and DummyClassifier are important for baseline definitions.

While an intermediate/advanced sklearn user will easily implement a dummy regression/classifier alike estimator to compare its results, DummyClassifier and DummyRegressor existence makes it much easier for newcomers and simpler to current users.

Adding series support with two simple and common approaches for time series makes it easier for those dealing with time series for baseline comparison as the TimeSeriesSplit did for cross validation.