### PR TITLE
EXA Remove useless sections in omp example

### DIFF
--- a/examples/linear_model/plot_omp.py
+++ b/examples/linear_model/plot_omp.py
@@ -17,7 +17,6 @@ from sklearn.datasets import make_sparse_coded_signal
 n_components, n_features = 512, 100
 n_nonzero_coefs = 17
 
-# #############################################################################
 # generate the data
 
 # y = Xw
@@ -31,11 +30,9 @@ y, X, w = make_sparse_coded_signal(n_samples=1,
 
 idx, = w.nonzero()
 
-# #############################################################################
 # distort the clean signal
 y_noisy = y + 0.05 * np.random.randn(len(y))
 
-# #############################################################################
 # plot the sparse signal
 plt.figure(figsize=(7, 7))
 plt.subplot(4, 1, 1)
@@ -43,7 +40,6 @@ plt.xlim(0, 512)
 plt.title("Sparse signal")
 plt.stem(idx, w[idx])
 
-# #############################################################################
 # plot the noise-free reconstruction
 omp = OrthogonalMatchingPursuit(n_nonzero_coefs=n_nonzero_coefs)
 omp.fit(X, y)
@@ -54,7 +50,6 @@ plt.xlim(0, 512)
 plt.title("Recovered signal from noise-free measurements")
 plt.stem(idx_r, coef[idx_r])
 
-# #############################################################################
 # plot the noisy reconstruction
 omp.fit(X, y_noisy)
 coef = omp.coef_
@@ -64,7 +59,6 @@ plt.xlim(0, 512)
 plt.title("Recovered signal from noisy measurements")
 plt.stem(idx_r, coef[idx_r])
 
-# #############################################################################
 # plot the noisy reconstruction with number of non-zeros set by CV
 omp_cv = OrthogonalMatchingPursuitCV(cv=5)
 omp_cv.fit(X, y_noisy)

--- a/examples/linear_model/plot_omp.py
+++ b/examples/linear_model/plot_omp.py
@@ -17,8 +17,8 @@ from sklearn.datasets import make_sparse_coded_signal
 n_components, n_features = 512, 100
 n_nonzero_coefs = 17
 
+# #############################################################################
 # generate the data
-###################
 
 # y = Xw
 # |x|_0 = n_nonzero_coefs
@@ -31,21 +31,20 @@ y, X, w = make_sparse_coded_signal(n_samples=1,
 
 idx, = w.nonzero()
 
+# #############################################################################
 # distort the clean signal
-##########################
 y_noisy = y + 0.05 * np.random.randn(len(y))
 
+# #############################################################################
 # plot the sparse signal
-########################
 plt.figure(figsize=(7, 7))
 plt.subplot(4, 1, 1)
 plt.xlim(0, 512)
 plt.title("Sparse signal")
 plt.stem(idx, w[idx])
 
+# #############################################################################
 # plot the noise-free reconstruction
-####################################
-
 omp = OrthogonalMatchingPursuit(n_nonzero_coefs=n_nonzero_coefs)
 omp.fit(X, y)
 coef = omp.coef_
@@ -55,8 +54,8 @@ plt.xlim(0, 512)
 plt.title("Recovered signal from noise-free measurements")
 plt.stem(idx_r, coef[idx_r])
 
+# #############################################################################
 # plot the noisy reconstruction
-###############################
 omp.fit(X, y_noisy)
 coef = omp.coef_
 idx_r, = coef.nonzero()
@@ -65,8 +64,8 @@ plt.xlim(0, 512)
 plt.title("Recovered signal from noisy measurements")
 plt.stem(idx_r, coef[idx_r])
 
+# #############################################################################
 # plot the noisy reconstruction with number of non-zeros set by CV
-##################################################################
 omp_cv = OrthogonalMatchingPursuitCV(cv=5)
 omp_cv.fit(X, y_noisy)
 coef = omp_cv.coef_


### PR DESCRIPTION
FIx the problem:
 - Comments mismatch: latter block's comments appear at the end of the previous one
 - Plot broken into subplots