### PR TITLE
MNT remove unused imports

### DIFF
--- a/benchmarks/bench_saga.py
+++ b/benchmarks/bench_saga.py
@@ -7,7 +7,7 @@ import json
 import time
 import os
 
-from joblib import delayed, Parallel, Memory
+from joblib import delayed, Parallel
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/sklearn/covariance/elliptic_envelope.py
+++ b/sklearn/covariance/elliptic_envelope.py
@@ -3,7 +3,6 @@
 # License: BSD 3 clause
 
 import numpy as np
-import warnings
 from . import MinCovDet
 from ..utils.validation import check_is_fitted, check_array
 from ..metrics import accuracy_score

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -19,7 +19,6 @@ from .empirical_covariance_ import (empirical_covariance, EmpiricalCovariance,
 
 from ..exceptions import ConvergenceWarning
 from ..utils.validation import check_random_state, check_array
-from ..utils import deprecated
 from ..linear_model import cd_fast
 from ..linear_model import lars_path_gram
 from ..model_selection import check_cv, cross_val_score

--- a/sklearn/covariance/tests/test_elliptic_envelope.py
+++ b/sklearn/covariance/tests/test_elliptic_envelope.py
@@ -7,7 +7,7 @@ from sklearn.covariance import EllipticEnvelope
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_array_equal, assert_warns_message
+from sklearn.utils.testing import assert_array_equal
 from sklearn.exceptions import NotFittedError
 
 

--- a/sklearn/covariance/tests/test_graphical_lasso.py
+++ b/sklearn/covariance/tests/test_graphical_lasso.py
@@ -4,7 +4,6 @@ import sys
 
 import numpy as np
 from scipy import linalg
-import pytest
 
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_less

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -9,7 +9,7 @@ from scipy.sparse import csc_matrix
 
 import pytest
 
-from sklearn.utils.testing import assert_raise_message, assert_no_warnings
+from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -9,7 +9,6 @@ import numpy as np
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_allclose
-from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import if_safe_multiprocessing_with_blas
 
 from sklearn.decomposition import SparsePCA, MiniBatchSparsePCA, PCA

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -50,7 +50,6 @@ from . import _gb_losses
 
 from ..utils import check_random_state
 from ..utils import check_array
-from ..utils import check_X_y
 from ..utils import column_or_1d
 from ..utils import check_consistent_length
 from ..utils import deprecated

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -5,7 +5,6 @@ Testing for the bagging ensemble module (sklearn.ensemble.bagging).
 # Author: Gilles Louppe
 # License: BSD 3 clause
 
-import pytest
 import numpy as np
 
 from sklearn.base import BaseEstimator

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -37,7 +37,6 @@ from sklearn.utils.testing import assert_greater_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
-from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import skip_if_no_parallel
 

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -13,7 +13,6 @@ import numpy as np
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -1,6 +1,5 @@
 """Testing for the boost module (sklearn.ensemble.boost)."""
 
-import pytest
 import numpy as np
 
 from sklearn.utils.testing import assert_array_equal, assert_array_less

--- a/sklearn/ensemble/voting.py
+++ b/sklearn/ensemble/voting.py
@@ -22,7 +22,7 @@ from ..base import TransformerMixin
 from ..base import clone
 from ..preprocessing import LabelEncoder
 from ..utils._joblib import Parallel, delayed
-from ..utils.validation import has_fit_parameter, check_is_fitted
+from ..utils.validation import check_is_fitted
 from ..utils.metaestimators import _BaseComposition
 from ..utils import Bunch
 

--- a/sklearn/feature_extraction/hashing.py
+++ b/sklearn/feature_extraction/hashing.py
@@ -2,7 +2,6 @@
 # License: BSD 3 clause
 
 import numbers
-import warnings
 
 import numpy as np
 import scipy.sparse as sp

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -34,7 +34,7 @@ from sklearn.utils.testing import (assert_equal, assert_not_equal,
                                    assert_almost_equal, assert_in,
                                    assert_less, assert_greater,
                                    assert_warns_message, assert_raise_message,
-                                   clean_warning_registry, ignore_warnings,
+                                   clean_warning_registry,
                                    SkipTest, assert_raises, assert_no_warnings,
                                    fails_if_pypy, assert_allclose_dense_sparse,
                                    skip_if_32bit)

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -2,7 +2,6 @@
 Testing Recursive feature elimination
 """
 
-import pytest
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from scipy import sparse

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -26,7 +26,6 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_warns_message
-from sklearn.utils.testing import assert_no_warnings
 from sklearn.linear_model import SGDClassifier
 from sklearn.preprocessing import scale
 from sklearn.utils.testing import skip_if_no_parallel

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -14,8 +14,6 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils.testing import assert_warns
-from sklearn.utils.testing import assert_warns_message
-from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import ignore_warnings
 
 from sklearn import linear_model, datasets, metrics

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -8,7 +8,6 @@
 # * Fast Optimization for t-SNE:
 #   https://cseweb.ucsd.edu/~lvdmaaten/workshops/nips2010/papers/vandermaaten.pdf
 
-import warnings
 from time import time
 import numpy as np
 from scipy import linalg

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -16,8 +16,6 @@ from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils.testing import assert_in
-from sklearn.utils.testing import assert_warns
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import skip_if_32bit
 from sklearn.utils import check_random_state
 from sklearn.manifold.t_sne import _joint_probabilities

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -16,7 +16,6 @@ better.
 
 
 from math import log
-import warnings
 
 import numpy as np
 from scipy import sparse as sp

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -17,7 +17,7 @@ from sklearn.metrics.cluster.supervised import _generalized_average
 from sklearn.utils import assert_all_finite
 from sklearn.utils.testing import (
         assert_equal, assert_almost_equal, assert_raise_message,
-        assert_warns_message, ignore_warnings
+        ignore_warnings
 )
 from numpy.testing import assert_array_almost_equal
 

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -20,7 +20,6 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils.testing import ignore_warnings
-from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_raise_message
 
 from sklearn.metrics.pairwise import euclidean_distances

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -18,7 +18,6 @@ from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
-from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -19,7 +19,6 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import ignore_warnings
-from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.validation import _num_samples
 from sklearn.utils.mocking import MockDataFrame
 

--- a/sklearn/neighbors/tests/test_lof.py
+++ b/sklearn/neighbors/tests/test_lof.py
@@ -4,7 +4,6 @@
 
 from math import sqrt
 
-import pytest
 import numpy as np
 from sklearn import neighbors
 

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -2,20 +2,14 @@
 #          Joris Van den Bossche <jorisvandenbossche@gmail.com>
 # License: BSD 3 clause
 
-import numbers
-import warnings
-
 import numpy as np
 from scipy import sparse
 
-from .. import get_config as _get_config
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_array
-from ..utils import deprecated
-from ..utils.fixes import _argmax, _object_dtype_isnan
+from ..utils.fixes import _argmax
 from ..utils.validation import check_is_fitted
 
-from .base import _transform_selected
 from .label import _encode, _encode_check_unknown
 
 

--- a/sklearn/preprocessing/tests/test_base.py
+++ b/sklearn/preprocessing/tests/test_base.py
@@ -4,7 +4,7 @@ from scipy import sparse
 
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raise_message
-from sklearn.preprocessing._encoders import _transform_selected
+from sklearn.preprocessing.base import _transform_selected
 from sklearn.preprocessing.data import Binarizer
 
 

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -8,14 +8,8 @@ import pytest
 
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.testing import assert_allclose
-from sklearn.utils.testing import ignore_warnings
-from sklearn.utils.testing import assert_warns
-from sklearn.utils.testing import assert_warns_message
-from sklearn.utils.testing import assert_no_warnings
 
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.preprocessing import OrdinalEncoder

--- a/sklearn/tests/test_metaestimators.py
+++ b/sklearn/tests/test_metaestimators.py
@@ -1,5 +1,4 @@
 """Common tests for metaestimators"""
-import pytest
 import functools
 
 import numpy as np

--- a/sklearn/tests/test_site_joblib.py
+++ b/sklearn/tests/test_site_joblib.py
@@ -1,6 +1,5 @@
-import os
-import pytest
-from sklearn.utils._joblib import Parallel, delayed, Memory, parallel_backend
+from sklearn.utils._joblib import Parallel, delayed  # noqa
+from sklearn.utils._joblib import Memory, parallel_backend # noqa
 
 
 def test_old_pickle(tmpdir):

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -1,8 +1,6 @@
 """
 Testing for export functions of decision trees (sklearn.tree.export).
 """
-import pytest
-
 from re import finditer, search
 from textwrap import dedent
 

--- a/sklearn/utils/_joblib.py
+++ b/sklearn/utils/_joblib.py
@@ -1,4 +1,3 @@
-import os as _os
 import warnings as _warnings
 
 with _warnings.catch_warnings():

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -21,16 +21,11 @@ import tempfile
 from subprocess import check_output, STDOUT, CalledProcessError
 from subprocess import TimeoutExpired
 
-
 import scipy as sp
-import scipy.io
 from functools import wraps
 from operator import itemgetter
 from inspect import signature
-from urllib.request import urlopen
-from urllib.error import HTTPError
 
-import tempfile
 import shutil
 import atexit
 import unittest

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from sklearn.linear_model import LogisticRegression
 from sklearn.datasets import make_blobs

--- a/sklearn/utils/tests/test_fixes.py
+++ b/sklearn/utils/tests/test_fixes.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_allclose
 
 from sklearn.utils.fixes import MaskedArray
 from sklearn.utils.fixes import _joblib_parallel_args


### PR DESCRIPTION
The current linting approach of applying flake8 to the git diff fails to catch unused imports, that can be found with e.g.,
```
flake8 --select=F401 sklearn
```

this removes those.

A number of these were likely introduced during the deprecation removal lately.