### PR TITLE
DOC link set_config and config_context in docstrings

### DIFF
--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -17,6 +17,11 @@ def get_config():
     -------
     config : dict
         Keys are parameter names that can be passed to :func:`set_config`.
+
+    See also
+    --------
+    config_context: Context manager for global scikit-learn configuration
+    set_config: Set global scikit-learn configuration
     """
     return _global_config.copy()
 
@@ -56,8 +61,8 @@ def set_config(assume_finite=None, working_memory=None,
 
     See also
     --------
-    config_context
-    get_config
+    config_context: Context manager for global scikit-learn configuration
+    get_config: Retrieve current values of the global configuration
     """
     if assume_finite is not None:
         _global_config['assume_finite'] = assume_finite
@@ -106,8 +111,8 @@ def config_context(**new_config):
 
     See also
     --------
-    set_config
-    get_config
+    set_config: Set global scikit-learn configuration
+    get_config: Retrieve current values of the global configuration
     """
     old_config = get_config().copy()
     set_config(**new_config)

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -18,7 +18,7 @@ def get_config():
     config : dict
         Keys are parameter names that can be passed to :func:`set_config`.
 
-    See also
+    See Also
     --------
     config_context: Context manager for global scikit-learn configuration
     set_config: Set global scikit-learn configuration
@@ -59,7 +59,7 @@ def set_config(assume_finite=None, working_memory=None,
 
         .. versionadded:: 0.21
 
-    See also
+    See Also
     --------
     config_context: Context manager for global scikit-learn configuration
     get_config: Retrieve current values of the global configuration
@@ -109,7 +109,7 @@ def config_context(**new_config):
     ...
     ValueError: Input contains NaN, ...
 
-    See also
+    See Also
     --------
     set_config: Set global scikit-learn configuration
     get_config: Retrieve current values of the global configuration

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -53,9 +53,11 @@ def set_config(assume_finite=None, working_memory=None,
         all the non-changed parameters.
 
         .. versionadded:: 0.21
+
     See also
     --------
     config_context
+    get_config
     """
     if assume_finite is not None:
         _global_config['assume_finite'] = assume_finite
@@ -105,6 +107,7 @@ def config_context(**new_config):
     See also
     --------
     set_config
+    get_config
     """
     old_config = get_config().copy()
     set_config(**new_config)

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -53,6 +53,9 @@ def set_config(assume_finite=None, working_memory=None,
         all the non-changed parameters.
 
         .. versionadded:: 0.21
+    See also
+    --------
+    config_context
     """
     if assume_finite is not None:
         _global_config['assume_finite'] = assume_finite
@@ -98,6 +101,10 @@ def config_context(**new_config):
     Traceback (most recent call last):
     ...
     ValueError: Input contains NaN, ...
+
+    See also
+    --------
+    set_config
     """
     old_config = get_config().copy()
     set_config(**new_config)


### PR DESCRIPTION
Link `sklearn.set_config` and `sklearn.config_context` in their docstrings, as I keep forgetting what's the context manager for `set_config`, and searching for the former currently doesn't help to find the latter.