### PR TITLE
[MRG] Bug fix in test_gradient_boosting.py (#14031)

### DIFF
--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1217,7 +1217,7 @@ def check_sparse_input(EstimatorClass, X, X_sparse, y):
     assert_array_almost_equal(sparse.predict(X_sparse), dense.predict(X))
     assert_array_almost_equal(dense.predict(X_sparse), sparse.predict(X))
 
-    if isinstance(EstimatorClass, GradientBoostingClassifier):
+    if issubclass(EstimatorClass, GradientBoostingClassifier):
         assert_array_almost_equal(sparse.predict_proba(X),
                                   dense.predict_proba(X))
         assert_array_almost_equal(sparse.predict_log_proba(X),
@@ -1232,10 +1232,9 @@ def check_sparse_input(EstimatorClass, X, X_sparse, y):
                                   sparse.decision_function(X))
         assert_array_almost_equal(dense.decision_function(X_sparse),
                                   sparse.decision_function(X))
-
-        assert_array_almost_equal(
-            np.array(sparse.staged_decision_function(X_sparse)),
-            np.array(sparse.staged_decision_function(X)))
+        for res_sparse, res in zip(sparse.staged_decision_function(X_sparse),
+                                   sparse.staged_decision_function(X)):
+            assert_array_almost_equal(res_sparse, res)
 
 
 @skip_if_32bit


### PR DESCRIPTION
Solve issue #14031.

`issubclass` instead of `isinstance(EstimatorClass, GradientBoostingClassifier)`.
This way the test is executed.

Update the test to avoid failing.