### PR TITLE
[MRG] EHN add parameter axis in safe_indexing to slice rows and columns

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -96,7 +96,16 @@ Changelog
   remove constant features due to numerical instability, by using range
   rather than variance in this case.
   :pr:`13704` by `Roddy MacSween <rlms>`.
-  
+
+
+:mod:`sklearn.utils`
+....................
+
+- |Enhancement| :func:`utils.safe_indexing` accepts an ``axis`` parameter to
+  index array-like across rows and columns. The column indexing can be done on
+  NumPy array, SciPy sparse matrix, and Pandas DataFrame.
+  :pr:`14035` by `Guillaume Lemaitre <glemaitre>`.
+
 Miscellaneous
 .............
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -17,6 +17,8 @@ from ..utils._joblib import Parallel, delayed
 from ..pipeline import _fit_transform_one, _transform_one, _name_estimators
 from ..preprocessing import FunctionTransformer
 from ..utils import Bunch
+from ..utils import safe_indexing
+from ..utils import _get_column_indices
 from ..utils.metaestimators import _BaseComposition
 from ..utils.validation import check_array, check_is_fitted
 
@@ -402,7 +404,7 @@ boolean mask array or callable
             return Parallel(n_jobs=self.n_jobs)(
                 delayed(func)(
                     transformer=clone(trans) if not fitted else trans,
-                    X=_get_column(X, column),
+                    X=safe_indexing(X, column, axis=1),
                     y=y,
                     weight=weight,
                     message_clsname='ColumnTransformer',
@@ -551,132 +553,6 @@ def _check_X(X):
     if hasattr(X, '__array__') or sparse.issparse(X):
         return X
     return check_array(X, force_all_finite='allow-nan', dtype=np.object)
-
-
-def _check_key_type(key, superclass):
-    """
-    Check that scalar, list or slice is of a certain type.
-
-    This is only used in _get_column and _get_column_indices to check
-    if the `key` (column specification) is fully integer or fully string-like.
-
-    Parameters
-    ----------
-    key : scalar, list, slice, array-like
-        The column specification to check
-    superclass : int or str
-        The type for which to check the `key`
-
-    """
-    if isinstance(key, superclass):
-        return True
-    if isinstance(key, slice):
-        return (isinstance(key.start, (superclass, type(None))) and
-                isinstance(key.stop, (superclass, type(None))))
-    if isinstance(key, list):
-        return all(isinstance(x, superclass) for x in key)
-    if hasattr(key, 'dtype'):
-        if superclass is int:
-            return key.dtype.kind == 'i'
-        else:
-            # superclass = str
-            return key.dtype.kind in ('O', 'U', 'S')
-    return False
-
-
-def _get_column(X, key):
-    """
-    Get feature column(s) from input data X.
-
-    Supported input types (X): numpy arrays, sparse arrays and DataFrames
-
-    Supported key types (key):
-    - scalar: output is 1D
-    - lists, slices, boolean masks: output is 2D
-    - callable that returns any of the above
-
-    Supported key data types:
-
-    - integer or boolean mask (positional):
-        - supported for arrays, sparse matrices and dataframes
-    - string (key-based):
-        - only supported for dataframes
-        - So no keys other than strings are allowed (while in principle you
-          can use any hashable object as key).
-
-    """
-    # check whether we have string column names or integers
-    if _check_key_type(key, int):
-        column_names = False
-    elif _check_key_type(key, str):
-        column_names = True
-    elif hasattr(key, 'dtype') and np.issubdtype(key.dtype, np.bool_):
-        # boolean mask
-        column_names = False
-        if hasattr(X, 'loc'):
-            # pandas boolean masks don't work with iloc, so take loc path
-            column_names = True
-    else:
-        raise ValueError("No valid specification of the columns. Only a "
-                         "scalar, list or slice of all integers or all "
-                         "strings, or boolean mask is allowed")
-
-    if column_names:
-        if hasattr(X, 'loc'):
-            # pandas dataframes
-            return X.loc[:, key]
-        else:
-            raise ValueError("Specifying the columns using strings is only "
-                             "supported for pandas DataFrames")
-    else:
-        if hasattr(X, 'iloc'):
-            # pandas dataframes
-            return X.iloc[:, key]
-        else:
-            # numpy arrays, sparse arrays
-            return X[:, key]
-
-
-def _get_column_indices(X, key):
-    """
-    Get feature column indices for input data X and key.
-
-    For accepted values of `key`, see the docstring of _get_column
-
-    """
-    n_columns = X.shape[1]
-
-    if (_check_key_type(key, int)
-            or hasattr(key, 'dtype') and np.issubdtype(key.dtype, np.bool_)):
-        # Convert key into positive indexes
-        idx = np.arange(n_columns)[key]
-        return np.atleast_1d(idx).tolist()
-    elif _check_key_type(key, str):
-        try:
-            all_columns = list(X.columns)
-        except AttributeError:
-            raise ValueError("Specifying the columns using strings is only "
-                             "supported for pandas DataFrames")
-        if isinstance(key, str):
-            columns = [key]
-        elif isinstance(key, slice):
-            start, stop = key.start, key.stop
-            if start is not None:
-                start = all_columns.index(start)
-            if stop is not None:
-                # pandas indexing with strings is endpoint included
-                stop = all_columns.index(stop) + 1
-            else:
-                stop = n_columns + 1
-            return list(range(n_columns)[slice(start, stop)])
-        else:
-            columns = list(key)
-
-        return [all_columns.index(col) for col in columns]
-    else:
-        raise ValueError("No valid specification of the columns. Only a "
-                         "scalar, list or slice of all integers or all "
-                         "strings, or boolean mask is allowed")
 
 
 def _is_empty_column_selection(column):

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -191,7 +191,6 @@ def safe_indexing(X, indices, axis=0):
             - Supported key types (key):
                 - scalar: output is 1D
                 - lists, slices, boolean masks: output is 2D
-                - callable that returns any of the above
             - Supported key data types:
                 - integer or boolean mask (positional): supported for
                   arrays, sparse matrices and dataframes
@@ -308,8 +307,7 @@ def _safe_indexing_column(X, key):
 
     Supported key types (key):
     - scalar: output is 1D;
-    - lists, slices, boolean masks: output is 2D;
-    - callable that returns any of the above.
+    - lists, slices, boolean masks: output is 2D.
 
     Supported key data types:
     - integer or boolean mask (positional):

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -283,6 +283,8 @@ def _check_key_type(key, superclass):
     if hasattr(key, 'dtype'):
         if superclass is int:
             return key.dtype.kind == 'i'
+        elif superclass is bool:
+            return key.dtype.kind == 'b'
         else:
             # superclass = str
             return key.dtype.kind in ('O', 'U', 'S')

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -183,7 +183,7 @@ def safe_indexing(X, indices, axis=0):
 
     Parameters
     ----------
-    X : array-like, sparse-matrix, list, pandas.DataFrame, pandas.Series.
+    X : array-like, sparse-matrix, list, pandas.DataFrame, pandas.Series
         Data from which to sample rows, items or columns.
     indices : see below
         When ``axis=0``, indices need to be an array of integer.
@@ -220,7 +220,7 @@ def _safe_indexing_row(X, indices):
 
     Parameters
     ----------
-    X : array-like, sparse-matrix, list, pandas.DataFrame, pandas.Series.
+    X : array-like, sparse-matrix, list, pandas.DataFrame, pandas.Series
         Data from which to sample rows or items.
     indices : array-like of int
         Indices according to which X will be subsampled.
@@ -235,6 +235,7 @@ def _safe_indexing_row(X, indices):
     CSR, CSC, and LIL sparse matrices are supported. COO sparse matrices are
     not supported.
     """
+    indices = np.asarray(indices)
     if hasattr(X, "iloc"):
         # Work-around for indexing with read-only indices in pandas
         indices = indices if indices.flags.writeable else indices.copy()
@@ -261,7 +262,7 @@ def _safe_indexing_row(X, indices):
 def _check_key_type(key, superclass):
     """Check that scalar, list or slice is of a certain type.
 
-    This is only used in _get_column and _get_column_indices to check
+    This is only used in _safe_indexing_column and _get_column_indices to check
     if the ``key`` (column specification) is fully integer or fully
     string-like.
 

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -185,7 +185,7 @@ def safe_indexing(X, indices, axis=0):
     ----------
     X : array-like, sparse-matrix, list, pandas.DataFrame, pandas.Series
         Data from which to sample rows, items or columns.
-    indices : see below
+    indices : array-like
         - When ``axis=0``, indices need to be an array of integer.
         - When ``axis=1``, indices can be one of:
             - Supported key types (key):

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -235,9 +235,9 @@ def _safe_indexing_row(X, indices):
     CSR, CSC, and LIL sparse matrices are supported. COO sparse matrices are
     not supported.
     """
-    indices = np.asarray(indices)
     if hasattr(X, "iloc"):
         # Work-around for indexing with read-only indices in pandas
+        indices = np.asarray(indices)
         indices = indices if indices.flags.writeable else indices.copy()
         # Pandas Dataframes and Series
         try:

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -188,7 +188,11 @@ def safe_indexing(X, indices, axis=0):
     indices : array-like
         - When ``axis=0``, indices need to be an array of integer.
         - When ``axis=1``, indices can be one of:
-            - integer: output is 1D, unless `X` is sparse.
+            - scalar: output is 1D, unless `X` is sparse.
+              Supported data types for scalars:
+                - integer: supported for arrays, sparse matrices and
+                  dataframes.
+                - string (key-based): only supported for dataframes.
             - container: lists, slices, boolean masks: output is 2D.
               Supported data types for containers:
                 - integer or boolean (positional): supported for

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -188,17 +188,15 @@ def safe_indexing(X, indices, axis=0):
     indices : array-like
         - When ``axis=0``, indices need to be an array of integer.
         - When ``axis=1``, indices can be one of:
-            - Supported key types (key):
-                - scalar: output is 1D
-                - lists, slices, boolean masks: output is 2D
-            - Supported key data types:
-                - integer or boolean mask (positional): supported for
+            - integer: output is 1D, unless `X` is sparse.
+            - container: lists, slices, boolean masks: output is 2D.
+              Supported data types for containers:
+                - integer or boolean (positional): supported for
                   arrays, sparse matrices and dataframes
-                - string (key-based): only supported for dataframes. So no keys
-                  other than strings are allowed (while in principle you can
-                  use any hashable object as key).
+                - string (key-based): only supported for dataframes. No keys
+                  other than strings are allowed.
     axis : int, default=0
-        The axis along which the X will be subsampled. ``axis=0`` will select
+        The axis along which `X` will be subsampled. ``axis=0`` will select
         rows while ``axis=1`` will select columns.
 
     Returns

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -315,6 +315,13 @@ def _safe_indexing_column(X, key):
         - So no keys other than strings are allowed (while in principle you
           can use any hashable object as key).
     """
+    # check that X is a 2D structure
+    if X.ndim != 2:
+        raise ValueError(
+            "'X' should be a 2D NumPy array, 2D sparse matrix or pandas "
+            "dataframe when indexing the columns (i.e. 'axis=1'). "
+            "Got {} instead with {} dimension(s).".format(type(X), X.ndim)
+        )
     # check whether we have string column names or integers
     if _check_key_type(key, int):
         column_names = False

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -210,7 +210,13 @@ def safe_indexing(X, indices, axis=0):
     """
     if axis == 0:
         return _safe_indexing_row(X, indices)
-    return _safe_indexing_column(X, indices)
+    elif axis == 1:
+        return _safe_indexing_column(X, indices)
+    else:
+        raise ValueError(
+            "'axis' should be either 0 (to index rows) or 1 (to index "
+            " column). Got {} instead.".format(axis)
+        )
 
 
 def _safe_indexing_row(X, indices):

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -186,22 +186,26 @@ def safe_indexing(X, indices, axis=0):
     X : array-like, sparse-matrix, list, pandas.DataFrame, pandas.Series
         Data from which to sample rows, items or columns.
     indices : see below
-        When ``axis=0``, indices need to be an array of integer.
-        When ``axis=1``, indices can be one of:
-            Supported key types (key):
-            - scalar: output is 1D
-            - lists, slices, boolean masks: output is 2D
-            - callable that returns any of the above
-            Supported key data types:
-            - integer or boolean mask (positional):
-                - supported for arrays, sparse matrices and dataframes
-            - string (key-based):
-                - only supported for dataframes
-                - So no keys other than strings are allowed (while in principle
-                  you can use any hashable object as key).
+        - When ``axis=0``, indices need to be an array of integer.
+        - When ``axis=1``, indices can be one of:
+            - Supported key types (key):
+                - scalar: output is 1D
+                - lists, slices, boolean masks: output is 2D
+                - callable that returns any of the above
+            - Supported key data types:
+                - integer or boolean mask (positional): supported for
+                  arrays, sparse matrices and dataframes
+                - string (key-based): only supported for dataframes. So no keys
+                  other than strings are allowed (while in principle you can
+                  use any hashable object as key).
     axis : int, default=0
         The axis along which the X will be subsampled. ``axis=0`` will select
         rows while ``axis=1`` will select columns.
+
+    Returns
+    -------
+    subset
+        Subset of X on axis 0 or 1.
 
     Notes
     -----
@@ -398,7 +402,7 @@ def _get_column_indices(X, key):
         except ValueError as e:
             if 'not in list' in str(e):
                 raise ValueError(
-                    "A given feature is not a column of the dataframe"
+                    "A given column is not a column of the dataframe"
                 ) from e
             raise
 

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -350,7 +350,7 @@ def test_get_column_indices_error(key, err_msg):
 @pytest.mark.parametrize("asarray", [True, False], ids=["array-like", "array"])
 def test_safe_indexing_pandas_series(idx, asarray):
     pd = pytest.importorskip("pandas")
-    idx = np.asarray(idx) if asarray and isinstance(idx, Iterable) else idx
+    idx = np.asarray(idx) if asarray else idx
     serie = pd.Series(np.arange(3))
     assert_array_equal(safe_indexing(serie, idx).values, [0, 1])
 

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -307,6 +307,12 @@ def test_safe_indexing_axis_1_error(X, key, err_msg):
         safe_indexing(X, key, axis=1)
 
 
+@pytest.mark.parametrize("axis", [None, 3])
+def test_safe_indexing_error_axis(axis):
+    with pytest.raises(ValueError, match="'axis' should be either 0"):
+        safe_indexing(X_toy, [0, 1], axis=axis)
+
+
 @pytest.mark.parametrize(
     "key, err_msg",
     [(10, r"all features must be in \[0, 2\]"),

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -206,6 +206,10 @@ def test_safe_indexing_axis_0():
 def test_safe_indexing_axis_1_sparse(idx):
     X_true = safe_indexing(X_toy, idx, axis=1)
 
+    # scipy matrix will always return a 2D array
+    if X_true.ndim == 1:
+        X_true = X_true[:, np.newaxis]
+
     X_sparse = sp.csc_matrix(X_toy)
     assert_array_equal(
         safe_indexing(X_sparse, idx, axis=1).toarray(), X_true
@@ -230,7 +234,6 @@ def test_safe_indexing_axis_1_pandas(idx_array, idx_df):
     assert_array_equal(
         safe_indexing(X_df, idx_df, axis=1).values, X_true
     )
-    print(safe_indexing(X_df, idx_df, axis=1).values)
 
 
 def test_safe_indexing_pandas():

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -332,7 +332,7 @@ def test_safe_indexing_1d_array_error(X_constructor):
 @pytest.mark.parametrize(
     "key, err_msg",
     [(10, r"all features must be in \[0, 2\]"),
-     ('whatever', 'A given feature is not a column of the dataframe')]
+     ('whatever', 'A given column is not a column of the dataframe')]
 )
 def test_get_column_indices_error(key, err_msg):
     pd = pytest.importorskip("pandas")

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -345,7 +345,7 @@ def test_get_column_indices_error(key, err_msg):
 @pytest.mark.parametrize(
     "idx",
     [[0, 1],
-     [True, True, False, False]]
+     [True, True, False]]
 )
 @pytest.mark.parametrize("asarray", [True, False], ids=["array-like", "array"])
 def test_safe_indexing_pandas_series(idx, asarray):

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -313,6 +313,22 @@ def test_safe_indexing_error_axis(axis):
         safe_indexing(X_toy, [0, 1], axis=axis)
 
 
+@pytest.mark.parametrize("X_constructor", ['array', 'series'])
+def test_safe_indexing_1d_array_error(X_constructor):
+    # check that we are raising an error if the array-like passed is 1D and
+    # we try to index on the 2nd dimension
+    X = list(range(5))
+    if X_constructor == 'array':
+        X_constructor = np.asarray(X)
+    elif X_constructor == 'series':
+        pd = pytest.importorskip("pandas")
+        X_constructor = pd.Series(X)
+
+    err_msg = "'X' should be a 2D NumPy array, 2D sparse matrix or pandas"
+    with pytest.raises(ValueError, match=err_msg):
+        safe_indexing(X_constructor, [0, 1], axis=1)
+
+
 @pytest.mark.parametrize(
     "key, err_msg",
     [(10, r"all features must be in \[0, 2\]"),

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -9,7 +9,7 @@ import scipy.sparse as sp
 
 from sklearn.utils.testing import (assert_equal, assert_raises,
                                    assert_array_equal,
-                                   SkipTest, assert_raises_regex,
+                                   assert_raises_regex,
                                    assert_warns_message, assert_no_warnings)
 from sklearn.utils import check_random_state
 from sklearn.utils import deprecated
@@ -26,7 +26,7 @@ from sklearn.utils.mocking import MockDataFrame
 from sklearn import config_context
 
 # toy array
-X = np.arange(9).reshape((3, 3))
+X_toy = np.arange(9).reshape((3, 3))
 
 
 def test_make_rng():
@@ -204,29 +204,33 @@ def test_safe_indexing_axis_0():
 
 @pytest.mark.parametrize("idx", [0, [0, 1]], ids=['scalar', 'list'])
 def test_safe_indexing_axis_1_sparse(idx):
-    X_true = safe_indexing(X, idx, axis=1)
+    X_true = safe_indexing(X_toy, idx, axis=1)
 
-    X_sparse = sp.csc_matrix(X)
+    X_sparse = sp.csc_matrix(X_toy)
     assert_array_equal(
-        safe_indexing(X_sparse.toarray(), idx, axis=1), X_true
+        safe_indexing(X_sparse, idx, axis=1).toarray(), X_true
     )
 
 
 @pytest.mark.parametrize(
-    "idx_true, idx_df",
-    [(0, 0), (0, 'col_0'),
-     ([0, 1], [0, 1]), ([0, 1], ['col_0', 'col_1']),
-     ([0, 1], slice(0, 2)), ([0, 1], [True, True, False])],
+    "idx_array, idx_df",
+    [(0, 0),
+     (0, 'col_0'),
+     ([0, 1], [0, 1]),
+     ([0, 1], ['col_0', 'col_1']),
+     ([0, 1], slice(0, 2)),
+     ([0, 1], [True, True, False])],
     ids=['scalar-int', 'scalar-str', 'list-int', 'list-str', 'slice', 'mask']
 )
-def test_safe_indexing_axis_1_pandas(idx_true, idx_df):
+def test_safe_indexing_axis_1_pandas(idx_array, idx_df):
     pd = pytest.importorskip('pandas')
 
-    X_true = safe_indexing(X, idx_true, axis=1)
-    X_df = pd.DataFrame(X, columns=['col_{}'.format(i) for i in range(3)])
+    X_true = safe_indexing(X_toy, idx_array, axis=1)
+    X_df = pd.DataFrame(X_toy, columns=['col_{}'.format(i) for i in range(3)])
     assert_array_equal(
         safe_indexing(X_df, idx_df, axis=1).values, X_true
     )
+    print(safe_indexing(X_df, idx_df, axis=1).values)
 
 
 def test_safe_indexing_pandas():


### PR DESCRIPTION
Allows to index columns as well as rows using the code from `ColumnTransformer`.
Added some tests for the supported type.

This PR should simplify the review of #14028 

NB: the functions have been moved and renamed but not modified.