### PR TITLE
MNT DOC don't warn if a ref with single backtick is not found

### DIFF
--- a/doc/sphinxext/custom_references_resolver.py
+++ b/doc/sphinxext/custom_references_resolver.py
@@ -90,8 +90,6 @@ class CustomReferencesResolver(ReferencesResolver):
                         result = ('%s:%s' % (domain.name, role), res)
                         return self.create_node(result)
 
-        self.warn_missing_reference(refdoc, 'any', target, node, domain)
-
         # no results considered to be <code>
         contnode['classes'] = []
         return contnode


### PR DESCRIPTION
Closes #13542

It seems the latest consensus on single backticks and warnings/errors is not to warn. This PR removes the line which results in the warnings.

As a result, double backtick would behave the same as a single backtick which does not resolve to an existing reference.

This removes a few hundred warnings currently raised during doc build.

Ping @thomasjpfan @jnothman 