### PR TITLE
FIX wrong usage and occurrence of string tag

### DIFF
--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -668,4 +668,4 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
 
     def _more_tags(self):
         return {'allow_nan': True,
-                'X_types': ['2darray', 'str']}
+                'X_types': ['2darray', 'string']}

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -663,8 +663,7 @@ def check_dtype_object(name, estimator_orig):
         if "Unknown label type" not in str(e):
             raise
 
-    tags = _safe_tags(estimator)
-    if 'string' not in tags['X_types']:
+    if 'string' not in _safe_tags(estimator, 'X_types'):
         X[0, 0] = {'foo': 'bar'}
         msg = "argument must be a string.* number"
         assert_raises_regex(TypeError, msg, estimator.fit, X, y)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -663,7 +663,7 @@ def check_dtype_object(name, estimator_orig):
         if "Unknown label type" not in str(e):
             raise
 
-    if 'string' not in _safe_tags(estimator, 'X_types'):
+    if 'string' not in tags['X_types']:
         X[0, 0] = {'foo': 'bar'}
         msg = "argument must be a string.* number"
         assert_raises_regex(TypeError, msg, estimator.fit, X, y)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -650,7 +650,7 @@ def check_dtype_object(name, estimator_orig):
             raise
 
     tags = _safe_tags(estimator)
-    if 'str' not in tags['X_types']:
+    if 'string' not in tags['X_types']:
         X[0, 0] = {'foo': 'bar'}
         msg = "argument must be a string.* number"
         assert_raises_regex(TypeError, msg, estimator.fit, X, y)


### PR DESCRIPTION
The right tag to use should be `string` and not `str`. However, there are 2 occurrences within the code base.

I am unsure if we should backport this in 0.21.3