### PR TITLE
MNT DOC fix some sphinx warnings on what's new files

### DIFF
--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -30,7 +30,7 @@ Changelog
   :issue:`12946` by :user:`Pierre Tallotte <pierretallotte>`.
 
 :mod:`sklearn.covariance`
-......................
+.........................
 
 - |Fix| Fixed a regression in :func:`covariance.graphical_lasso` so that
   the case `n_features=2` is handled correctly. :issue:`13276` by

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -45,7 +45,7 @@ Changelog
   by :user:`James Myatt <jamesmyatt>`.
 
 :mod:`sklearn.tree`
-................................
+...................
 
 - |Fix| Fixed an issue with :func:`plot_tree` where it display
   entropy calculations even for `gini` criterion in DecisionTreeClassifiers.
@@ -87,7 +87,7 @@ Changelog
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 :mod:`sklearn.neighbors`
-......................
+........................
 
 - |Fix| Fixed a bug in :class:`neighbors.KernelDensity` which could not be
   restored from a pickle if ``sample_weight`` had been used.
@@ -366,6 +366,7 @@ Support for Python 3.4 and below has been officially dropped.
   - all the single node trees in feature importance calculation are ignored
   - in case all trees have only one single node (i.e. a root node),
     feature importances will be an array of all zeros.
+
   :pr:`13636` and :pr:`13620` by `Adrin Jalali`_.
 
 - |Fix| Fixed a bug in :class:`ensemble.GradientBoostingClassifier` and
@@ -505,7 +506,7 @@ Support for Python 3.4 and below has been officially dropped.
 ...........................
 
 - |Enhancement| :class:`linear_model.Ridge` now preserves ``float32`` and
-  ``float64`` dtypes. :issues:`8769` and :issues:`11000` by
+  ``float64`` dtypes. :issue:`8769` and :issue:`11000` by
   :user:`Guillaume Lemaitre <glemaitre>`, and :user:`Joan Massich <massich>`
 
 - |Feature| :class:`linear_model.LogisticRegression` and

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -45,10 +45,10 @@ Changelog
 - |Fix| :class:`ensemble.HistGradientBoostingClassifier` and
   :class:`ensemble.HistGradientBoostingRegressor` now bin the training and
   validation data separately to avoid any data leak. :pr:`13933` by
-  `NicolasHug`_.
+  `Nicolas Hug`_.
 
 :mod:`sklearn.linear_model`
-..................
+...........................
 
 - |Enhancement| :class:`linearmodel.BayesianRidge` now accepts hyperparameters
   ``alpha_init`` and ``lambda_init`` which can be used to set the initial value
@@ -73,7 +73,7 @@ Changelog
 
 
 :mod:`sklearn.preprocessing`
-..................
+............................
 
 - |Enhancement| Avoid unnecessary data copy when fitting preprocessors
   :class:`preprocessing.StandardScaler`, :class:`preprocessing.MinMaxScaler`,
@@ -83,7 +83,7 @@ Changelog
 
 
 :mod:`sklearn.cluster`
-..................
+......................
 
 - |Enhancement| :class:`cluster.SpectralClustering` now accepts a ``n_components`` 
   parameter. This parameter extends `SpectralClustering` class functionality to


### PR DESCRIPTION
This fixes some of the sphinx warnings on whats_new files.

(reducing the warnings and issues on the doc build for people to work on the rest during a sprint in two weeks)