### PR TITLE
MAINT Remove sudo tag in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 # make it explicit that we favor the new container-based travis workers
-sudo: false
-
 language: python
 
 cache:


### PR DESCRIPTION
Travis are now recommending removing the sudo tag.
Check out [this](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).
