### PR TITLE
MNT Exclude test files from the coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,4 +7,3 @@ omit =
     */benchmarks/*
     **/setup.py
     *test_*
-

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,4 @@ omit =
     */sklearn/externals/*
     */benchmarks/*
     */setup.py
+    *test_*

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,4 @@ omit =
     */benchmarks/*
     **/setup.py
     *test_*
+


### PR DESCRIPTION
As mentioned in https://github.com/scikit-learn/scikit-learn/issues/13984

this removes test files form the coverage report. As they are always run by definition, this inflates our coverage score somewhat.