### PR TITLE
[MRG] MAINT Adds tag categorical to OneHotEncoder

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -144,6 +144,9 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
 
         return X_int, X_mask
 
+    def _more_tags(self):
+        return {'X_types': ['categorical']}
+
 
 class OneHotEncoder(_BaseEncoder):
     """Encode categorical integer features as a one-hot numeric array.
@@ -656,6 +659,3 @@ class OrdinalEncoder(_BaseEncoder):
             X_tr[:, i] = self.categories_[i][labels]
 
         return X_tr
-
-    def _more_tags(self):
-        return {'X_types': ['categorical']}

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -673,6 +673,6 @@ def test_categories(density, drop):
     assert ohe_test.drop_idx_.dtype == np.int_
 
 
-@pytest.mark.parametrize('encoder', [OneHotEncoder, OrdinalEncoder])
-def test_encoders_has_categorical_tags(encoder):
-    assert 'categorical' in encoder()._get_tags()['X_types']
+@pytest.mark.parametrize('Encoder', [OneHotEncoder, OrdinalEncoder])
+def test_encoders_has_categorical_tags(Encoder):
+    assert 'categorical' in Encoder()._get_tags()['X_types']

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -671,3 +671,8 @@ def test_categories(density, drop):
             assert cat_list[drop_idx] == drop_cat
     assert isinstance(ohe_test.drop_idx_, np.ndarray)
     assert ohe_test.drop_idx_.dtype == np.int_
+
+
+@pytest.mark.parametrize('encoder', [OneHotEncoder, OrdinalEncoder])
+def test_encoders_has_categorical_tags(encoder):
+    assert 'categorical' in encoder()._get_tags()['X_types']


### PR DESCRIPTION
Gives `OneHotEncoder` the `{'X_types': ['categorical']}` tag.