### PR TITLE
[MRG] allow child classes to override parents' tags

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -339,7 +339,6 @@ class BaseEstimator:
         collected_tags = {}
         _resolve_tags(self.__class__)
 
-
         collected_tags.update(overridden_tags)
 
         tags = _DEFAULT_TAGS.copy()

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -319,7 +319,6 @@ class BaseEstimator:
         else:
             overridden_tags = {}
 
-        collected_tags = {}
         def _resolve_tags(c):
             nonlocal collected_tags
             if c is BaseEstimator or c is object:
@@ -329,13 +328,17 @@ class BaseEstimator:
                 _resolve_tags(direct_parent_class)
                 if '_more_tags' in direct_parent_class.__dict__:
                     more_tags = direct_parent_class._more_tags(self)
+
+                    # filter-out tags that will be overridden in child class
                     more_tags = {key: val for (key, val) in more_tags.items()
                                  if key not in overridden_tags.keys()}
 
                     collected_tags = _update_if_consistent(collected_tags,
                                                            more_tags)
 
+        collected_tags = {}
         _resolve_tags(self.__class__)
+
 
         collected_tags.update(overridden_tags)
 


### PR DESCRIPTION
Fixes #14044

This PR relaxes the current constraint on the tags and implements the solution proposed in https://github.com/scikit-learn/scikit-learn/issues/14044#issuecomment-500426242

That is:

- any child is allowed to override its parent's tags
- if D inherits from B and C, then B and C must agree on their tags (else there's no way to know the tags of D). This constraint is dismissed if D overrides the inconsistent tags.

waiting to see if CI goes green