### PR TITLE
[MRG] Correct the default value of learning_rate in docstring of HistGBC.

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -696,7 +696,7 @@ class HistGradientBoostingClassifier(BaseHistGradientBoosting,
         generalizes to 'categorical_crossentropy' for multiclass
         classification. 'auto' will automatically choose either loss depending
         on the nature of the problem.
-    learning_rate : float, optional (default=1)
+    learning_rate : float, optional (default=0.1)
         The learning rate, also known as *shrinkage*. This is used as a
         multiplicative factor for the leaves values. Use ``1`` for no
         shrinkage.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The default value of `learning_rate` in the docstring of [HistGradientBoostingClassifier](https://scikit-learn.org/dev/modules/generated/sklearn.ensemble.HistGradientBoostingClassifier.html#sklearn.ensemble.HistGradientBoostingClassifier) is wrong (`1` instead of `0.1`). This PR fixes this very small typo.