### PR TITLE
[MRG] DOC use train/test split in GaussianNB example

### DIFF
--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -90,14 +90,17 @@ classification. The likelihood of the features is assumed to be Gaussian:
 The parameters :math:`\sigma_y` and :math:`\mu_y`
 are estimated using maximum likelihood.
 
-    >>> from sklearn import datasets
-    >>> iris = datasets.load_iris()
-    >>> from sklearn.naive_bayes import GaussianNB
-    >>> gnb = GaussianNB()
-    >>> y_pred = gnb.fit(iris.data, iris.target).predict(iris.data)
-    >>> print("Number of mislabeled points out of a total %d points : %d"
-    ...       % (iris.data.shape[0],(iris.target != y_pred).sum()))
-    Number of mislabeled points out of a total 150 points : 6
+   >>> from sklearn import datasets
+   >>> iris = datasets.load_iris()
+   >>> X, y = iris.data, iris.target
+   >>> from sklearn.model_selection import train_test_split
+   >>> X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=21)
+   >>> from sklearn.naive_bayes import GaussianNB
+   >>> gnb = GaussianNB()
+   >>> y_pred = gnb.fit(X_train, y_train).predict(X_test)
+   >>> print("Number of mislabeled points out of a total %d points : %d"
+   ...       % (iris.data.shape[0],(y_test != y_pred).sum()))
+   Number of mislabeled points out of a total 150 points : 4
 
 .. _multinomial_naive_bayes:
 

--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -90,11 +90,11 @@ classification. The likelihood of the features is assumed to be Gaussian:
 The parameters :math:`\sigma_y` and :math:`\mu_y`
 are estimated using maximum likelihood.
 
-   >>> from sklearn import datasets
-   >>> X, y = datasets.load_iris(return_X_y=True)
+   >>> from sklearn.datasets import load_iris
    >>> from sklearn.model_selection import train_test_split
-   >>> X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=21)
    >>> from sklearn.naive_bayes import GaussianNB
+   >>> X, y = load_iris(return_X_y=True)
+   >>> X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=0)
    >>> gnb = GaussianNB()
    >>> y_pred = gnb.fit(X_train, y_train).predict(X_test)
    >>> print("Number of mislabeled points out of a total %d points : %d"

--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -92,14 +92,14 @@ are estimated using maximum likelihood.
 
    >>> from sklearn import datasets
    >>> iris = datasets.load_iris()
-   >>> X, y = iris.data, iris.target
+   >>> X, y = load_iris(return_X_y=True)
    >>> from sklearn.model_selection import train_test_split
    >>> X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=21)
    >>> from sklearn.naive_bayes import GaussianNB
    >>> gnb = GaussianNB()
    >>> y_pred = gnb.fit(X_train, y_train).predict(X_test)
    >>> print("Number of mislabeled points out of a total %d points : %d"
-   ...       % (iris.data.shape[0],(y_test != y_pred).sum()))
+   ...       % (X_test.shape[0], (y_test != y_pred).sum()))
    Number of mislabeled points out of a total 150 points : 4
 
 .. _multinomial_naive_bayes:

--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -91,8 +91,7 @@ The parameters :math:`\sigma_y` and :math:`\mu_y`
 are estimated using maximum likelihood.
 
    >>> from sklearn import datasets
-   >>> iris = datasets.load_iris()
-   >>> X, y = load_iris(return_X_y=True)
+   >>> X, y = datasets.load_iris(return_X_y=True)
    >>> from sklearn.model_selection import train_test_split
    >>> X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=21)
    >>> from sklearn.naive_bayes import GaussianNB

--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -99,7 +99,7 @@ are estimated using maximum likelihood.
    >>> y_pred = gnb.fit(X_train, y_train).predict(X_test)
    >>> print("Number of mislabeled points out of a total %d points : %d"
    ...       % (X_test.shape[0], (y_test != y_pred).sum()))
-   Number of mislabeled points out of a total 150 points : 4
+   Number of mislabeled points out of a total 75 points : 4
 
 .. _multinomial_naive_bayes:
 


### PR DESCRIPTION
Change GNB example to follow the common practice of train-test split

<!--
\-
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
\-
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
The current example for GNB includes fitting the full dataset and then predicting on the full dataset. It is good practice to split the datasets into train and test sets, therefore I propose to change the example to incorporate that.

#### Any other comments?
\-

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
