### PR TITLE
MAINT Don't use clean_warnings_registry in tests

### DIFF
--- a/sklearn/feature_selection/tests/test_chi2.py
+++ b/sklearn/feature_selection/tests/test_chi2.py
@@ -14,7 +14,6 @@ from sklearn.feature_selection.univariate_selection import _chisquare
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import clean_warning_registry
 
 # Feature 0 is highly informative for class 1;
 # feature 1 is the same everywhere;
@@ -72,7 +71,6 @@ def test_chi2_negative():
 def test_chi2_unused_feature():
     # Unused feature should evaluate to NaN
     # and should issue no runtime warning
-    clean_warning_registry()
     with warnings.catch_warnings(record=True) as warned:
         warnings.simplefilter('always')
         chi, p = chi2([[1, 0], [0, 0]], [1, 0])

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -13,7 +13,7 @@ from sklearn import svm
 from sklearn.datasets import make_multilabel_classification
 from sklearn.preprocessing import label_binarize, LabelBinarizer
 from sklearn.utils.validation import check_random_state
-from sklearn.utils.testing import assert_raises, clean_warning_registry
+from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_almost_equal
@@ -1598,7 +1598,6 @@ def test_prf_warnings():
            'being set to 0.0 due to no true samples.')
     my_assert(w, msg, f, [-1, -1], [1, 1], average='binary')
 
-    clean_warning_registry()
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter('always')
         precision_recall_fscore_support([0, 0], [0, 0], average="binary")
@@ -1615,7 +1614,6 @@ def test_recall_warnings():
                        np.array([[1, 1], [1, 1]]),
                        np.array([[0, 0], [0, 0]]),
                        average='micro')
-    clean_warning_registry()
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter('always')
         recall_score(np.array([[0, 0], [0, 0]]),
@@ -1631,7 +1629,6 @@ def test_recall_warnings():
 
 
 def test_precision_warnings():
-    clean_warning_registry()
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter('always')
         precision_score(np.array([[1, 1], [1, 1]]),
@@ -1652,7 +1649,6 @@ def test_precision_warnings():
 
 
 def test_fscore_warnings():
-    clean_warning_registry()
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter('always')
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -462,7 +462,6 @@ def test_auc_score_non_binary_class():
     assert_raise_message(ValueError, "multiclass format is not supported",
                          roc_auc_score, y_true, y_pred)
 
-    clean_warning_registry()
     with warnings.catch_warnings(record=True):
         rng = check_random_state(404)
         y_pred = rng.rand(10)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -18,7 +18,6 @@ from sklearn.utils import gen_batches
 
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_almost_equal
-from sklearn.utils.testing import clean_warning_registry
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_less
@@ -941,26 +940,22 @@ def test_scaler_int():
     X_csc = sparse.csc_matrix(X)
 
     null_transform = StandardScaler(with_mean=False, with_std=False, copy=True)
-    clean_warning_registry()
     with warnings.catch_warnings(record=True):
         X_null = null_transform.fit_transform(X_csr)
     assert_array_equal(X_null.data, X_csr.data)
     X_orig = null_transform.inverse_transform(X_null)
     assert_array_equal(X_orig.data, X_csr.data)
 
-    clean_warning_registry()
     with warnings.catch_warnings(record=True):
         scaler = StandardScaler(with_mean=False).fit(X)
         X_scaled = scaler.transform(X, copy=True)
     assert not np.any(np.isnan(X_scaled))
 
-    clean_warning_registry()
     with warnings.catch_warnings(record=True):
         scaler_csr = StandardScaler(with_mean=False).fit(X_csr)
         X_csr_scaled = scaler_csr.transform(X_csr, copy=True)
     assert not np.any(np.isnan(X_csr_scaled.data))
 
-    clean_warning_registry()
     with warnings.catch_warnings(record=True):
         scaler_csc = StandardScaler(with_mean=False).fit(X_csc)
         X_csc_scaled = scaler_csc.transform(X_csc, copy=True)

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -15,7 +15,6 @@ import functools
 
 import pytest
 
-from sklearn.utils.testing import clean_warning_registry
 from sklearn.utils.testing import all_estimators
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_in
@@ -155,7 +154,6 @@ def test_configure():
         old_env = os.getenv('SKLEARN_NO_OPENMP')
         os.environ['SKLEARN_NO_OPENMP'] = "True"
 
-        clean_warning_registry()
         with warnings.catch_warnings():
             # The configuration spits out warnings when not finding
             # Blas/Atlas development headers
@@ -174,7 +172,6 @@ def test_configure():
 def _tested_linear_classifiers():
     classifiers = all_estimators(type_filter='classifier')
 
-    clean_warning_registry()
     with warnings.catch_warnings(record=True):
         for name, clazz in classifiers:
             required_parameters = getattr(clazz, "_required_parameters", [])

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -604,8 +604,9 @@ except ImportError:
 def clean_warning_registry():
     """Clean Python warning registry for easier testing of warning messages.
 
-    We may not need to do this any more when getting rid of Python 2, not
-    entirely sure. See https://bugs.python.org/issue4180 and
+    When changing warning filters this function is not necessary with
+    Python3.5+, as __warningregistry__ will be re-set internally.
+    See https://bugs.python.org/issue4180 and
     https://bugs.python.org/issue21724 for more details.
 
     """

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -111,7 +111,6 @@ def assert_warns(warning_class, func, *args, **kw):
     result : the return value of `func`
 
     """
-    clean_warning_registry()
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
@@ -160,7 +159,6 @@ def assert_warns_message(warning_class, message, func, *args, **kw):
     result : the return value of `func`
 
     """
-    clean_warning_registry()
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
@@ -236,7 +234,6 @@ def assert_no_warnings(func, *args, **kw):
     **kw
     """
     # very important to avoid uncontrolled state propagation
-    clean_warning_registry()
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
 
@@ -319,7 +316,6 @@ class _IgnoreWarnings:
         """Decorator to catch and hide warnings without visual nesting."""
         @wraps(fn)
         def wrapper(*args, **kwargs):
-            clean_warning_registry()
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", self.category)
                 return fn(*args, **kwargs)
@@ -342,7 +338,6 @@ class _IgnoreWarnings:
         self._filters = self._module.filters
         self._module.filters = self._filters[:]
         self._showwarning = self._module.showwarning
-        clean_warning_registry()
         warnings.simplefilter("ignore", self.category)
 
     def __exit__(self, *exc_info):
@@ -351,7 +346,6 @@ class _IgnoreWarnings:
         self._module.filters = self._filters
         self._module.showwarning = self._showwarning
         self.log[:] = []
-        clean_warning_registry()
 
 
 def assert_raise_message(exceptions, message, function, *args, **kwargs):
@@ -615,10 +609,10 @@ def clean_warning_registry():
     https://bugs.python.org/issue21724 for more details.
 
     """
-    reg = "__warningregistry__"
-    for mod_name, mod in list(sys.modules.items()):
-        if hasattr(mod, reg):
-            getattr(mod, reg).clear()
+    for mod in sys.modules.values():
+        registry = getattr(mod, "__warningregistry__", None)
+        if registry is not None:
+            registry.clear()
 
 
 def check_skip_network():


### PR DESCRIPTION
`clean_warnings_registry` previously needed to be called because of a CPython bug (https://bugs.python.org/issue4180) were `warnings.simplefilter("always")` failed to work as expected. This [was fixed in Python 3.4](https://bugs.python.org/issue4180#msg227018) as far as I can tell.

The function itself can still be useful, but we no longer need it when changing warning filters.

Removing calls to `clean_warnings_registry()` reduces the runtime of common tests by ~30% and of the complete test suite by ~6%.

I have left this function in two places where we don't update the warning filters. Those two cases can probably be replaced with pytest utils, in which case the function can be deprecated. Though that could be done in a follow-up PR, here I'm mostly interested in test run time.
