### PR TITLE
Extended Text Vectorizer constructor to enforce float type

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -878,8 +878,8 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         self.lowercase = lowercase
         self.token_pattern = token_pattern
         self.stop_words = stop_words
-        self.max_df = max_df
-        self.min_df = min_df
+        self.max_df = float(max_df)
+        self.min_df = float(min_df)
         if max_df < 0 or min_df < 0:
             raise ValueError("negative value for max_df or min_df")
         self.max_features = max_features


### PR DESCRIPTION
Currently whenever initialising any type of vectoriser no checking is done for the values input for max_df or min_df which causes no issues whenever creating or using the vectoriser however if you try to save the vectoriser or pipeline containing it with some methods of storing models such as ONNX. By converting the value entered to a python float



