### PR TITLE
PERF Fix off-by-one error in liblinear helper dense_to_sparse

### DIFF
--- a/sklearn/svm/src/liblinear/liblinear_helper.c
+++ b/sklearn/svm/src/liblinear/liblinear_helper.c
@@ -32,7 +32,7 @@ static struct feature_node **dense_to_sparse(double *x, npy_intp *dims,
         /* allocate stack for nonzero elements */
         T = sparse[i] = malloc((dims[1]+2) * sizeof(struct feature_node));
         if (T == NULL) {
-            for (j=0; j<i-1; j++)
+            for (j=0; j<i; j++)
                 free(sparse[j]);
             free(sparse);
             return NULL;


### PR DESCRIPTION
I accidentally introduced this error while working on 05b12cfcfdc1f1b557591ddcda734521fcaa96f2. Sorry!