### PR TITLE
MAINT Faster linear_model tests

### DIFF
--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1897,7 +1897,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
     >>> from sklearn.datasets import load_iris
     >>> from sklearn.linear_model import LogisticRegressionCV
     >>> X, y = load_iris(return_X_y=True)
-    >>> clf = LogisticRegressionCV(Cs=6, cv=5, random_state=0).fit(X, y)
+    >>> clf = LogisticRegressionCV(cv=5, random_state=0).fit(X, y)
     >>> clf.predict(X[:2, :])
     array([0, 0])
     >>> clf.predict_proba(X[:2, :]).shape

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1897,7 +1897,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
     >>> from sklearn.datasets import load_iris
     >>> from sklearn.linear_model import LogisticRegressionCV
     >>> X, y = load_iris(return_X_y=True)
-    >>> clf = LogisticRegressionCV(cv=5, random_state=0).fit(X, y)
+    >>> clf = LogisticRegressionCV(Cs=6, cv=5, random_state=0).fit(X, y)
     >>> clf.predict(X[:2, :])
     array([0, 0])
     >>> clf.predict_proba(X[:2, :]).shape

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1660,7 +1660,7 @@ def test_logistic_regression_path_coefs_multinomial():
                          [LogisticRegression(random_state=0),
                           LogisticRegressionCV(random_state=0, cv=3,
                                                Cs=3, tol=1e-3)],
-                         ids=lambda x: x.__class__)
+                         ids=lambda x: x.__class__.__name__)
 @pytest.mark.parametrize('solver', ['liblinear', 'lbfgs', 'newton-cg', 'sag',
                                     'saga'])
 def test_logistic_regression_multi_class_auto(est, solver):

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -851,20 +851,22 @@ def test_logistic_regression_sample_weights():
     # Test the above for l1 penalty and l2 penalty with dual=True.
     # since the patched liblinear code is different.
     clf_cw = LogisticRegression(
-        solver="liblinear", class_weight={0: 1, 1: 2},
-        penalty="l1", tol=1e-5, **kw)
+        solver="liblinear", fit_intercept=False, class_weight={0: 1, 1: 2},
+        penalty="l1", tol=1e-5, random_state=42, multi_class='ovr')
     clf_cw.fit(X, y)
     clf_sw = LogisticRegression(
-        solver="liblinear", penalty="l1", tol=1e-5, **kw)
+        solver="liblinear", fit_intercept=False, penalty="l1", tol=1e-5,
+        random_state=42, multi_class='ovr')
     clf_sw.fit(X, y, sample_weight)
     assert_array_almost_equal(clf_cw.coef_, clf_sw.coef_, decimal=4)
 
     clf_cw = LogisticRegression(
-        solver="liblinear", class_weight={0: 1, 1: 2},
-        penalty="l2", dual=True, **kw)
+        solver="liblinear", fit_intercept=False, class_weight={0: 1, 1: 2},
+        penalty="l2", dual=True, random_state=42, multi_class='ovr')
     clf_cw.fit(X, y)
     clf_sw = LogisticRegression(
-        solver="liblinear", penalty="l2", dual=True, **kw)
+        solver="liblinear", fit_intercept=False, penalty="l2", dual=True,
+        random_state=42, multi_class='ovr')
     clf_sw.fit(X, y, sample_weight)
     assert_array_almost_equal(clf_cw.coef_, clf_sw.coef_, decimal=4)
 

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -802,23 +802,17 @@ def test_logistic_regression_sample_weights():
                                n_classes=2, random_state=0)
     sample_weight = y + 1
 
-    def _set_cv_C(estimator):
-        # use smaller than the default number of Cs in LogisticRegressionCV
-        # for faster test time
-        if isinstance(estimator, LogisticRegressionCV):
-            estimator.set_params(Cs=3, cv=3)
-
     for LR in [LogisticRegression, LogisticRegressionCV]:
+
+        kw = {'random_state': 42, 'fit_intercept': False, 'multi_class': 'ovr'}
+        if LR is LogisticRegressionCV:
+            kw.update({'Cs': 3, 'cv': 3})
 
         # Test that passing sample_weight as ones is the same as
         # not passing them at all (default None)
         for solver in ['lbfgs', 'liblinear']:
-            clf_sw_none = LR(solver=solver, fit_intercept=False,
-                             random_state=42, multi_class='ovr')
-            clf_sw_ones = LR(solver=solver, fit_intercept=False,
-                             random_state=42, multi_class='ovr')
-            _set_cv_C(clf_sw_none)
-            _set_cv_C(clf_sw_ones)
+            clf_sw_none = LR(solver=solver, **kw)
+            clf_sw_ones = LR(solver=solver, **kw)
             clf_sw_none.fit(X, y)
             clf_sw_ones.fit(X, y, sample_weight=np.ones(y.shape[0]))
             assert_array_almost_equal(
@@ -826,22 +820,15 @@ def test_logistic_regression_sample_weights():
 
         # Test that sample weights work the same with the lbfgs,
         # newton-cg, and 'sag' solvers
-        clf_sw_lbfgs = LR(fit_intercept=False, random_state=42,
-                          multi_class='ovr')
-        _set_cv_C(clf_sw_lbfgs)
+        clf_sw_lbfgs = LR(**kw)
         clf_sw_lbfgs.fit(X, y, sample_weight=sample_weight)
-        clf_sw_n = LR(solver='newton-cg', fit_intercept=False, random_state=42,
-                      multi_class='ovr')
-        _set_cv_C(clf_sw_n)
+        clf_sw_n = LR(solver='newton-cg', **kw)
         clf_sw_n.fit(X, y, sample_weight=sample_weight)
-        clf_sw_sag = LR(solver='sag', fit_intercept=False, tol=1e-10,
-                        random_state=42, multi_class='ovr')
-        _set_cv_C(clf_sw_sag)
+        clf_sw_sag = LR(solver='sag', tol=1e-10, **kw)
         # ignore convergence warning due to small dataset
         with ignore_warnings():
             clf_sw_sag.fit(X, y, sample_weight=sample_weight)
-        clf_sw_liblinear = LR(solver='liblinear', fit_intercept=False,
-                              random_state=42, multi_class='ovr')
+        clf_sw_liblinear = LR(solver='liblinear', **kw)
         clf_sw_liblinear.fit(X, y, sample_weight=sample_weight)
         assert_array_almost_equal(
             clf_sw_lbfgs.coef_, clf_sw_n.coef_, decimal=4)
@@ -854,14 +841,9 @@ def test_logistic_regression_sample_weights():
         # passing class weight = [1,1] but adjusting sample weights
         # to be 2 for all instances of class 2
         for solver in ['lbfgs', 'liblinear']:
-            clf_cw_12 = LR(solver=solver, fit_intercept=False,
-                           class_weight={0: 1, 1: 2}, random_state=42,
-                           multi_class='ovr')
-            _set_cv_C(clf_cw_12)
+            clf_cw_12 = LR(solver=solver, class_weight={0: 1, 1: 2}, **kw)
             clf_cw_12.fit(X, y)
-            clf_sw_12 = LR(solver=solver, fit_intercept=False, random_state=42,
-                           multi_class='ovr')
-            _set_cv_C(clf_sw_12)
+            clf_sw_12 = LR(solver=solver, **kw)
             clf_sw_12.fit(X, y, sample_weight=sample_weight)
             assert_array_almost_equal(
                 clf_cw_12.coef_, clf_sw_12.coef_, decimal=4)
@@ -869,22 +851,20 @@ def test_logistic_regression_sample_weights():
     # Test the above for l1 penalty and l2 penalty with dual=True.
     # since the patched liblinear code is different.
     clf_cw = LogisticRegression(
-        solver="liblinear", fit_intercept=False, class_weight={0: 1, 1: 2},
-        penalty="l1", tol=1e-5, random_state=42, multi_class='ovr')
+        solver="liblinear", class_weight={0: 1, 1: 2},
+        penalty="l1", tol=1e-5, **kw)
     clf_cw.fit(X, y)
     clf_sw = LogisticRegression(
-        solver="liblinear", fit_intercept=False, penalty="l1", tol=1e-5,
-        random_state=42, multi_class='ovr')
+        solver="liblinear", penalty="l1", tol=1e-5, **kw)
     clf_sw.fit(X, y, sample_weight)
     assert_array_almost_equal(clf_cw.coef_, clf_sw.coef_, decimal=4)
 
     clf_cw = LogisticRegression(
-        solver="liblinear", fit_intercept=False, class_weight={0: 1, 1: 2},
-        penalty="l2", dual=True, random_state=42, multi_class='ovr')
+        solver="liblinear", class_weight={0: 1, 1: 2},
+        penalty="l2", dual=True, **kw)
     clf_cw.fit(X, y)
     clf_sw = LogisticRegression(
-        solver="liblinear", fit_intercept=False, penalty="l2", dual=True,
-        random_state=42, multi_class='ovr')
+        solver="liblinear", penalty="l2", dual=True, **kw)
     clf_sw.fit(X, y, sample_weight)
     assert_array_almost_equal(clf_cw.coef_, clf_sw.coef_, decimal=4)
 

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -13,7 +13,7 @@ from sklearn.metrics.scorer import get_scorer
 from sklearn.model_selection import StratifiedKFold
 from sklearn.model_selection import GridSearchCV
 from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import LabelEncoder
+from sklearn.preprocessing import LabelEncoder, StandardScaler
 from sklearn.utils import compute_class_weight, _IS_32BIT
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_allclose
@@ -566,9 +566,9 @@ def test_multinomial_logistic_regression_string_inputs():
     y = np.array(y) - 1
     # Test for string labels
     lr = LogisticRegression(multi_class='multinomial')
-    lr_cv = LogisticRegressionCV(multi_class='multinomial')
+    lr_cv = LogisticRegressionCV(multi_class='multinomial', Cs=3)
     lr_str = LogisticRegression(multi_class='multinomial')
-    lr_cv_str = LogisticRegressionCV(multi_class='multinomial')
+    lr_cv_str = LogisticRegressionCV(multi_class='multinomial', Cs=3)
 
     lr.fit(X_ref, y)
     lr_cv.fit(X_ref, y)
@@ -576,22 +576,20 @@ def test_multinomial_logistic_regression_string_inputs():
     lr_cv_str.fit(X_ref, y_str)
 
     assert_array_almost_equal(lr.coef_, lr_str.coef_)
-    assert_equal(sorted(lr_str.classes_), ['bar', 'baz', 'foo'])
+    assert sorted(lr_str.classes_) == ['bar', 'baz', 'foo']
     assert_array_almost_equal(lr_cv.coef_, lr_cv_str.coef_)
-    assert_equal(sorted(lr_str.classes_), ['bar', 'baz', 'foo'])
-    assert_equal(sorted(lr_cv_str.classes_), ['bar', 'baz', 'foo'])
+    assert sorted(lr_str.classes_) == ['bar', 'baz', 'foo']
+    assert sorted(lr_cv_str.classes_) == ['bar', 'baz', 'foo']
 
     # The predictions should be in original labels
-    assert_equal(sorted(np.unique(lr_str.predict(X_ref))),
-                 ['bar', 'baz', 'foo'])
-    assert_equal(sorted(np.unique(lr_cv_str.predict(X_ref))),
-                 ['bar', 'baz', 'foo'])
+    assert sorted(np.unique(lr_str.predict(X_ref))) == ['bar', 'baz', 'foo']
+    assert sorted(np.unique(lr_cv_str.predict(X_ref))) == ['bar', 'baz', 'foo']
 
     # Make sure class weights can be given with string labels
     lr_cv_str = LogisticRegression(
         class_weight={'bar': 1, 'baz': 2, 'foo': 0},
         multi_class='multinomial').fit(X_ref, y_str)
-    assert_equal(sorted(np.unique(lr_cv_str.predict(X_ref))), ['bar', 'baz'])
+    assert sorted(np.unique(lr_cv_str.predict(X_ref))) == ['bar', 'baz']
 
 
 def test_logistic_cv_sparse():
@@ -666,40 +664,39 @@ def test_ovr_multinomial_iris():
 
     # Ensure that what OvR learns for class2 is same regardless of whether
     # classes 0 and 1 are separated or not
-    assert_array_almost_equal(clf.scores_[2], clf1.scores_[2])
-    assert_array_almost_equal(clf.intercept_[2:], clf1.intercept_)
-    assert_array_almost_equal(clf.coef_[2][np.newaxis, :], clf1.coef_)
+    assert_allclose(clf.scores_[2], clf1.scores_[2])
+    assert_allclose(clf.intercept_[2:], clf1.intercept_)
+    assert_allclose(clf.coef_[2][np.newaxis, :], clf1.coef_)
 
     # Test the shape of various attributes.
-    assert_equal(clf.coef_.shape, (3, n_features))
+    assert clf.coef_.shape == (3, n_features)
     assert_array_equal(clf.classes_, [0, 1, 2])
     coefs_paths = np.asarray(list(clf.coefs_paths_.values()))
-    assert_array_almost_equal(coefs_paths.shape, (3, n_cv, 10, n_features + 1))
-    assert_equal(clf.Cs_.shape, (10,))
+    assert coefs_paths.shape == (3, n_cv, 10, n_features + 1)
+    assert clf.Cs_.shape == (10,)
     scores = np.asarray(list(clf.scores_.values()))
-    assert_equal(scores.shape, (3, n_cv, 10))
+    assert scores.shape == (3, n_cv, 10)
 
     # Test that for the iris data multinomial gives a better accuracy than OvR
     for solver in ['lbfgs', 'newton-cg', 'sag', 'saga']:
-        max_iter = 2000 if solver in ['sag', 'saga'] else 15
+        max_iter = 500 if solver in ['sag', 'saga'] else 15
         clf_multi = LogisticRegressionCV(
             solver=solver, multi_class='multinomial', max_iter=max_iter,
-            random_state=42, tol=1e-5 if solver in ['sag', 'saga'] else 1e-2,
+            random_state=42, tol=1e-3 if solver in ['sag', 'saga'] else 1e-2,
             cv=2)
         clf_multi.fit(train, target)
         multi_score = clf_multi.score(train, target)
         ovr_score = clf.score(train, target)
-        assert_greater(multi_score, ovr_score)
+        assert multi_score > ovr_score
 
         # Test attributes of LogisticRegressionCV
-        assert_equal(clf.coef_.shape, clf_multi.coef_.shape)
+        assert clf.coef_.shape == clf_multi.coef_.shape
         assert_array_equal(clf_multi.classes_, [0, 1, 2])
         coefs_paths = np.asarray(list(clf_multi.coefs_paths_.values()))
-        assert_array_almost_equal(coefs_paths.shape, (3, n_cv, 10,
-                                                      n_features + 1))
-        assert_equal(clf_multi.Cs_.shape, (10,))
+        assert coefs_paths.shape == (3, n_cv, 10, n_features + 1)
+        assert clf_multi.Cs_.shape == (10,)
         scores = np.asarray(list(clf_multi.scores_.values()))
-        assert_equal(scores.shape, (3, n_cv, 10))
+        assert scores.shape == (3, n_cv, 10)
 
 
 def test_logistic_regression_solvers():
@@ -805,6 +802,12 @@ def test_logistic_regression_sample_weights():
                                n_classes=2, random_state=0)
     sample_weight = y + 1
 
+    def _set_cv_C(estimator):
+        # use smaller than the default number of Cs in LogisticRegressionCV
+        # for faster test time
+        if isinstance(estimator, LogisticRegressionCV):
+            estimator.set_params(Cs=3, cv=3)
+
     for LR in [LogisticRegression, LogisticRegressionCV]:
 
         # Test that passing sample_weight as ones is the same as
@@ -812,9 +815,11 @@ def test_logistic_regression_sample_weights():
         for solver in ['lbfgs', 'liblinear']:
             clf_sw_none = LR(solver=solver, fit_intercept=False,
                              random_state=42, multi_class='ovr')
-            clf_sw_none.fit(X, y)
             clf_sw_ones = LR(solver=solver, fit_intercept=False,
                              random_state=42, multi_class='ovr')
+            _set_cv_C(clf_sw_none)
+            _set_cv_C(clf_sw_ones)
+            clf_sw_none.fit(X, y)
             clf_sw_ones.fit(X, y, sample_weight=np.ones(y.shape[0]))
             assert_array_almost_equal(
                 clf_sw_none.coef_, clf_sw_ones.coef_, decimal=4)
@@ -823,12 +828,15 @@ def test_logistic_regression_sample_weights():
         # newton-cg, and 'sag' solvers
         clf_sw_lbfgs = LR(fit_intercept=False, random_state=42,
                           multi_class='ovr')
+        _set_cv_C(clf_sw_lbfgs)
         clf_sw_lbfgs.fit(X, y, sample_weight=sample_weight)
         clf_sw_n = LR(solver='newton-cg', fit_intercept=False, random_state=42,
                       multi_class='ovr')
+        _set_cv_C(clf_sw_n)
         clf_sw_n.fit(X, y, sample_weight=sample_weight)
         clf_sw_sag = LR(solver='sag', fit_intercept=False, tol=1e-10,
                         random_state=42, multi_class='ovr')
+        _set_cv_C(clf_sw_sag)
         # ignore convergence warning due to small dataset
         with ignore_warnings():
             clf_sw_sag.fit(X, y, sample_weight=sample_weight)
@@ -849,9 +857,11 @@ def test_logistic_regression_sample_weights():
             clf_cw_12 = LR(solver=solver, fit_intercept=False,
                            class_weight={0: 1, 1: 2}, random_state=42,
                            multi_class='ovr')
+            _set_cv_C(clf_cw_12)
             clf_cw_12.fit(X, y)
             clf_sw_12 = LR(solver=solver, fit_intercept=False, random_state=42,
                            multi_class='ovr')
+            _set_cv_C(clf_sw_12)
             clf_sw_12.fit(X, y, sample_weight=sample_weight)
             assert_array_almost_equal(
                 clf_cw_12.coef_, clf_sw_12.coef_, decimal=4)
@@ -929,6 +939,8 @@ def test_logistic_regression_multinomial():
                                n_informative=10,
                                n_classes=n_classes, random_state=0)
 
+    X = StandardScaler(with_mean=False).fit_transform(X)
+
     # 'lbfgs' is used as a referenced
     solver = 'lbfgs'
     ref_i = LogisticRegression(solver=solver, multi_class='multinomial')
@@ -936,8 +948,8 @@ def test_logistic_regression_multinomial():
                                fit_intercept=False)
     ref_i.fit(X, y)
     ref_w.fit(X, y)
-    assert_array_equal(ref_i.coef_.shape, (n_classes, n_features))
-    assert_array_equal(ref_w.coef_.shape, (n_classes, n_features))
+    assert ref_i.coef_.shape == (n_classes, n_features)
+    assert ref_w.coef_.shape == (n_classes, n_features)
     for solver in ['sag', 'saga', 'newton-cg']:
         clf_i = LogisticRegression(solver=solver, multi_class='multinomial',
                                    random_state=42, max_iter=2000, tol=1e-7,
@@ -947,13 +959,13 @@ def test_logistic_regression_multinomial():
                                    fit_intercept=False)
         clf_i.fit(X, y)
         clf_w.fit(X, y)
-        assert_array_equal(clf_i.coef_.shape, (n_classes, n_features))
-        assert_array_equal(clf_w.coef_.shape, (n_classes, n_features))
+        assert clf_i.coef_.shape == (n_classes, n_features)
+        assert clf_w.coef_.shape == (n_classes, n_features)
 
         # Compare solutions between lbfgs and the other solvers
-        assert_almost_equal(ref_i.coef_, clf_i.coef_, decimal=3)
-        assert_almost_equal(ref_w.coef_, clf_w.coef_, decimal=3)
-        assert_almost_equal(ref_i.intercept_, clf_i.intercept_, decimal=3)
+        assert_allclose(ref_i.coef_, clf_i.coef_, rtol=1e-2)
+        assert_allclose(ref_w.coef_, clf_w.coef_, rtol=1e-2)
+        assert_allclose(ref_i.intercept_, clf_i.intercept_, rtol=1e-2)
 
     # Test that the path give almost the same results. However since in this
     # case we take the average of the coefs after fitting across all the
@@ -962,8 +974,8 @@ def test_logistic_regression_multinomial():
         clf_path = LogisticRegressionCV(solver=solver, max_iter=2000, tol=1e-6,
                                         multi_class='multinomial', Cs=[1.])
         clf_path.fit(X, y)
-        assert_array_almost_equal(clf_path.coef_, ref_i.coef_, decimal=3)
-        assert_almost_equal(clf_path.intercept_, ref_i.intercept_, decimal=3)
+        assert_allclose(clf_path.coef_, ref_i.coef_, rtol=2e-2)
+        assert_allclose(clf_path.intercept_, ref_i.intercept_, rtol=2e-2)
 
 
 def test_multinomial_grad_hess():
@@ -1125,13 +1137,13 @@ def test_logistic_regression_cv_refit(random_seed, penalty):
     # logistic regression loss is convex, we should still recover exactly
     # the same solution as long as the stopping criterion is strict enough (and
     # that there are no exactly duplicated features when penalty='l1').
-    X, y = make_classification(n_samples=50, n_features=20,
+    X, y = make_classification(n_samples=100, n_features=20,
                                random_state=random_seed)
     common_params = dict(
         solver='saga',
         penalty=penalty,
         random_state=random_seed,
-        max_iter=10000,
+        max_iter=1000,
         tol=1e-12,
     )
     lr_cv = LogisticRegressionCV(Cs=[1.0], refit=True, **common_params)
@@ -1186,6 +1198,7 @@ def test_max_iter():
 def test_n_iter(solver):
     # Test that self.n_iter_ has the correct format.
     X, y = iris.data, iris.target
+
     y_bin = y.copy()
     y_bin[y_bin == 2] = 0
 
@@ -1264,8 +1277,8 @@ def test_warm_start(solver, warm_start, fit_intercept, multi_class):
 def test_saga_vs_liblinear():
     iris = load_iris()
     X, y = iris.data, iris.target
-    X = np.concatenate([X] * 10)
-    y = np.concatenate([y] * 10)
+    X = np.concatenate([X] * 3)
+    y = np.concatenate([y] * 3)
 
     X_bin = X[y <= 1]
     y_bin = y[y <= 1] * 2 - 1
@@ -1477,13 +1490,13 @@ def test_LogisticRegressionCV_GridSearchCV_elastic_net(multi_class):
         # test_LogisticRegressionCV_GridSearchCV_elastic_net_ovr
         X, y = make_classification(random_state=0)
     else:
-        X, y = make_classification(n_samples=200, n_classes=3, n_informative=3,
+        X, y = make_classification(n_samples=100, n_classes=3, n_informative=3,
                                    random_state=0)
 
     cv = StratifiedKFold(5, random_state=0)
 
-    l1_ratios = np.linspace(0, 1, 5)
-    Cs = np.logspace(-4, 4, 5)
+    l1_ratios = np.linspace(0, 1, 3)
+    Cs = np.logspace(-4, 4, 3)
 
     lrcv = LogisticRegressionCV(penalty='elasticnet', Cs=Cs, solver='saga',
                                 cv=cv, l1_ratios=l1_ratios, random_state=0,
@@ -1508,13 +1521,13 @@ def test_LogisticRegressionCV_GridSearchCV_elastic_net_ovr():
     # l1_param for each class, while LogisticRegression will share the
     # parameters over the *n_classes* classifiers.
 
-    X, y = make_classification(n_samples=200, n_classes=3, n_informative=3,
+    X, y = make_classification(n_samples=100, n_classes=3, n_informative=3,
                                random_state=0)
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
     cv = StratifiedKFold(5, random_state=0)
 
-    l1_ratios = np.linspace(0, 1, 5)
-    Cs = np.logspace(-4, 4, 5)
+    l1_ratios = np.linspace(0, 1, 3)
+    Cs = np.logspace(-4, 4, 3)
 
     lrcv = LogisticRegressionCV(penalty='elasticnet', Cs=Cs, solver='saga',
                                 cv=cv, l1_ratios=l1_ratios, random_state=0,
@@ -1661,9 +1674,11 @@ def test_logistic_regression_path_coefs_multinomial():
         assert_array_almost_equal(coefs[1], coefs[2], decimal=1)
 
 
-@pytest.mark.parametrize('est', [LogisticRegression(random_state=0),
-                                 LogisticRegressionCV(random_state=0, cv=3),
-                                 ])
+@pytest.mark.parametrize('est',
+                         [LogisticRegression(random_state=0),
+                          LogisticRegressionCV(random_state=0, cv=3,
+                                               Cs=3, tol=1e-3)],
+                         ids=lambda x: x.__class__)
 @pytest.mark.parametrize('solver', ['liblinear', 'lbfgs', 'newton-cg', 'sag',
                                     'saga'])
 def test_logistic_regression_multi_class_auto(est, solver):
@@ -1678,16 +1693,16 @@ def test_logistic_regression_multi_class_auto(est, solver):
     y_bin = y_multi == 0
     est_auto_bin = fit(X, y_bin, multi_class='auto', solver=solver)
     est_ovr_bin = fit(X, y_bin, multi_class='ovr', solver=solver)
-    assert np.allclose(est_auto_bin.coef_, est_ovr_bin.coef_)
-    assert np.allclose(est_auto_bin.predict_proba(X2),
-                       est_ovr_bin.predict_proba(X2))
+    assert_allclose(est_auto_bin.coef_, est_ovr_bin.coef_)
+    assert_allclose(est_auto_bin.predict_proba(X2),
+                    est_ovr_bin.predict_proba(X2))
 
     est_auto_multi = fit(X, y_multi, multi_class='auto', solver=solver)
     if solver == 'liblinear':
         est_ovr_multi = fit(X, y_multi, multi_class='ovr', solver=solver)
-        assert np.allclose(est_auto_multi.coef_, est_ovr_multi.coef_)
-        assert np.allclose(est_auto_multi.predict_proba(X2),
-                           est_ovr_multi.predict_proba(X2))
+        assert_allclose(est_auto_multi.coef_, est_ovr_multi.coef_)
+        assert_allclose(est_auto_multi.predict_proba(X2),
+                        est_ovr_multi.predict_proba(X2))
     else:
         est_multi_multi = fit(X, y_multi, multi_class='multinomial',
                               solver=solver)
@@ -1695,9 +1710,9 @@ def test_logistic_regression_multi_class_auto(est, solver):
             pytest.xfail('Issue #11924: LogisticRegressionCV(solver="lbfgs", '
                          'multi_class="multinomial") is nondterministic on '
                          'MacOS.')  # pragma: no cover
-        assert np.allclose(est_auto_multi.coef_, est_multi_multi.coef_)
-        assert np.allclose(est_auto_multi.predict_proba(X2),
-                           est_multi_multi.predict_proba(X2))
+        assert_allclose(est_auto_multi.coef_, est_multi_multi.coef_)
+        assert_allclose(est_auto_multi.predict_proba(X2),
+                        est_multi_multi.predict_proba(X2))
 
         # Make sure multi_class='ovr' is distinct from ='multinomial'
         assert not np.allclose(est_auto_bin.coef_,

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -1564,9 +1564,10 @@ def test_multi_core_gridsearch_and_early_stopping():
         'alpha': np.logspace(-4, 4, 9),
         'n_iter_no_change': [5, 10, 50],
     }
-    clf = SGDClassifier(tol=1e-3, max_iter=1000, early_stopping=True,
+
+    clf = SGDClassifier(tol=1e-2, max_iter=1000, early_stopping=True,
                         random_state=0)
-    search = RandomizedSearchCV(clf, param_grid, n_iter=10, n_jobs=2,
+    search = RandomizedSearchCV(clf, param_grid, n_iter=3, n_jobs=2,
                                 random_state=0)
     search.fit(iris.data, iris.target)
     assert search.best_score_ > 0.8
@@ -1602,9 +1603,9 @@ def test_SGDClassifier_fit_for_all_backends(backend):
     # Create a classification problem with 50000 features and 20 classes. Using
     # loky or multiprocessing this make the clf.coef_ exceed the threshold
     # above which memmaping is used in joblib and loky (1MB as of 2018/11/1).
-    X = sp.random(1000, 50000, density=0.01, format='csr',
+    X = sp.random(500, 2000, density=0.02, format='csr',
                   random_state=random_state)
-    y = random_state.choice(20, 1000)
+    y = random_state.choice(20, 500)
 
     # Begin by fitting a SGD classifier sequentially
     clf_sequential = SGDClassifier(tol=1e-3, max_iter=1000, n_jobs=1,

--- a/sklearn/linear_model/tests/test_theil_sen.py
+++ b/sklearn/linear_model/tests/test_theil_sen.py
@@ -259,7 +259,7 @@ def test_theil_sen_parallel():
     lstq = LinearRegression().fit(X, y)
     assert_greater(norm(lstq.coef_ - w), 1.0)
     # Check that Theil-Sen works
-    theil_sen = TheilSenRegressor(n_jobs=4,
+    theil_sen = TheilSenRegressor(n_jobs=2,
                                   random_state=0,
                                   max_subpopulation=2e3).fit(X, y)
     assert_array_almost_equal(theil_sen.coef_, w, 1)


### PR DESCRIPTION
Makes unit tests of `linear_model` module faster by ~35% or 10sec.

Mostly slow tests are due to SAG/SAGA not converging that well on tiny datasets, and due to computing cross-validation on large grid sizes.