### PR TITLE
PERF Don't allocate space for bias element if there isn't one

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -63,6 +63,10 @@ Changelog
   of the maximization procedure in :term:`fit`.
   :pr:`13618` by :user:`Yoshihiro Uchida <c56pony>`.
 
+- |Efficiency| The 'liblinear' logistic regression solver now consumes less
+  memory if ``fit_intercept=False`` and ``X`` is a CSR sparse matrix.
+  :pr:`14108` by :user:`Alex Henrie <alexhenrie>`.
+
 :mod:`sklearn.model_selection`
 ..................
 

--- a/sklearn/svm/src/liblinear/liblinear_helper.c
+++ b/sklearn/svm/src/liblinear/liblinear_helper.c
@@ -76,6 +76,7 @@ static struct feature_node **csr_to_sparse(double *values,
 {
     struct feature_node **sparse, *temp;
     int i, j=0, k=0, n;
+    int have_bias = (bias > 0);
 
     sparse = malloc ((shape_indptr[0]-1)* sizeof(struct feature_node *));
     if (sparse == NULL)
@@ -84,7 +85,7 @@ static struct feature_node **csr_to_sparse(double *values,
     for (i=0; i<shape_indptr[0]-1; ++i) {
         n = indptr[i+1] - indptr[i]; /* count elements in row i */
 
-        sparse[i] = malloc ((n+2) * sizeof(struct feature_node));
+        sparse[i] = malloc ((n+have_bias+1) * sizeof(struct feature_node));
         if (sparse[i] == NULL) {
             int l;
             for (l=0; l<i; l++)
@@ -99,7 +100,7 @@ static struct feature_node **csr_to_sparse(double *values,
             ++k;
         }
 
-        if (bias > 0) {
+        if (have_bias) {
             temp[j].value = bias;
             temp[j].index = n_features + 1;
             ++j;


### PR DESCRIPTION
When doing regression with 65 million samples and no bias, this patch saves 780 megabytes of memory.