### PR TITLE
Replaced shutil and tempfile packages with joblib in caching transformers 

### DIFF
--- a/examples/compose/plot_compare_reduction.py
+++ b/examples/compose/plot_compare_reduction.py
@@ -103,6 +103,7 @@ plt.show()
 #     of a transformer is costly.
 
 from joblib import Memory
+from shutil import rmtree
 
 # Create a temporary folder to store the transformers of the pipeline
 location = 'cachedir'
@@ -118,7 +119,7 @@ grid.fit(digits.data, digits.target)
 
 # Delete the temporary cache before exiting
 memory.clear(warn=False)
-memory.store_backend.clear_location(location)
+rmtree(location)
 
 ###############################################################################
 # The ``PCA`` fitting is only computed at the evaluation of the first

--- a/examples/compose/plot_compare_reduction.py
+++ b/examples/compose/plot_compare_reduction.py
@@ -102,13 +102,11 @@ plt.show()
 #     cache. Hence, use the ``memory`` constructor parameter when the fitting
 #     of a transformer is costly.
 
-from tempfile import mkdtemp
-from shutil import rmtree
 from joblib import Memory
 
 # Create a temporary folder to store the transformers of the pipeline
-cachedir = mkdtemp()
-memory = Memory(location=cachedir, verbose=10)
+location = './cachedir'
+memory = Memory(location=location, verbose=10)
 cached_pipe = Pipeline([('reduce_dim', PCA()),
                         ('classify', LinearSVC(dual=False, max_iter=10000))],
                        memory=memory)
@@ -119,7 +117,7 @@ digits = load_digits()
 grid.fit(digits.data, digits.target)
 
 # Delete the temporary cache before exiting
-rmtree(cachedir)
+memory.clear(warn=False)
 
 ###############################################################################
 # The ``PCA`` fitting is only computed at the evaluation of the first

--- a/examples/compose/plot_compare_reduction.py
+++ b/examples/compose/plot_compare_reduction.py
@@ -105,7 +105,7 @@ plt.show()
 from joblib import Memory
 
 # Create a temporary folder to store the transformers of the pipeline
-location = './cachedir'
+location = 'cachedir'
 memory = Memory(location=location, verbose=10)
 cached_pipe = Pipeline([('reduce_dim', PCA()),
                         ('classify', LinearSVC(dual=False, max_iter=10000))],
@@ -118,6 +118,7 @@ grid.fit(digits.data, digits.target)
 
 # Delete the temporary cache before exiting
 memory.clear(warn=False)
+memory.store_backend.clear_location(location)
 
 ###############################################################################
 # The ``PCA`` fitting is only computed at the evaluation of the first


### PR DESCRIPTION
Replaced shutil and tempfile packages with joblib functions according to Memory usage in [official documentation](https://joblib.readthedocs.io/en/latest/auto_examples/memory_basic_usage.html)

#### What does this implement/fix? Explain your changes.
This PR simplifies using of caching transformers within a Pipeline. 

#### Any other comments?
This is my first PR.


