### PR TITLE
MNT fix suppressing matplotlib warning issue while making docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -303,7 +303,6 @@ linkcode_resolve = make_linkcode_resolve('sklearn',
                                          '{package}/{path}#L{lineno}')
 
 warnings.filterwarnings("ignore", category=UserWarning,
-                        module="matplotlib",
                         message='Matplotlib is currently using agg, which is a'
                                 ' non-GUI backend, so cannot show the figure.')
 


### PR DESCRIPTION
For some reason now the `UserWarning` which we were ignoring, is not under the `matplotlib` module and the warnings were shown again, hence removing the line from the config to still suppress it.