### PR TITLE
Fixed typo in test_column_transformer

### DIFF
--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -241,8 +241,8 @@ def test_column_transformer_dataframe():
     X_df2 = X_df.copy()
     X_df2.columns = [1, 0]
     ct = ColumnTransformer([('trans', Trans(), 0)], remainder='drop')
-    assert_array_equal(ct.fit_transform(X_df), X_res_first)
-    assert_array_equal(ct.fit(X_df).transform(X_df), X_res_first)
+    assert_array_equal(ct.fit_transform(X_df2), X_res_first)
+    assert_array_equal(ct.fit(X_df2).transform(X_df2), X_res_first)
 
     assert len(ct.transformers_) == 2
     assert ct.transformers_[-1][0] == 'remainder'


### PR DESCRIPTION


#### Reference Issues/PRs
Was original part of #14048, but have separated it into its own PR.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

In test_column_transformer_dataframe(), X_df2 was created but never used. X_df was mistakenly used in its place. This PR fixes that typo.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
