### PR TITLE
DOC Fix suptitle in LDA_QDA example

### DIFF
--- a/examples/classification/plot_lda_qda.py
+++ b/examples/classification/plot_lda_qda.py
@@ -130,6 +130,8 @@ def plot_qda_cov(qda, splot):
 
 
 plt.figure(figsize=(10, 8), facecolor='white')
+plt.suptitle('Linear Discriminant Analysis vs Quadratic Discriminant Analysis',
+             y=0.98, fontsize=15)
 for i, (X, y) in enumerate([dataset_fixed_cov(), dataset_cov()]):
     # Linear Discriminant Analysis
     lda = LinearDiscriminantAnalysis(solver="svd", store_covariance=True)
@@ -144,7 +146,6 @@ for i, (X, y) in enumerate([dataset_fixed_cov(), dataset_cov()]):
     splot = plot_data(qda, X, y, y_pred, fig_index=2 * i + 2)
     plot_qda_cov(qda, splot)
     plt.axis('tight')
-plt.suptitle('Linear Discriminant Analysis vs Quadratic Discriminant Analysis',
-             y=1.02, fontsize=15)
 plt.tight_layout()
+plt.subplots_adjust(top=0.92)
 plt.show()


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The suptitle in the [Linear and Quadratic Discriminant Analysis with covariance ellipsoid](https://scikit-learn.org/dev/auto_examples/classification/plot_lda_qda.html#sphx-glr-auto-examples-classification-plot-lda-qda-py) example is not displayed properly (it is cut because `y=1.02`).

To fix this, the suptitle is first displayed, then the top of the figure is adjusted with `plt.subplots_adjust()`.
