### PR TITLE
FIX remove action of normalize_components in SparsePCA

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -17,8 +17,8 @@ parameters, may produce different models from the previous version. This often
 occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
-..
-    TO FILL IN AS WE GO
+- :class:`decomposition.SparsePCA` where `normalize_components` has no effect
+  due to deprecation.
 
 Details are listed in the changelog below.
 

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -224,17 +224,10 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         check_is_fitted(self, 'components_')
 
         X = check_array(X)
-
-        if self.normalize_components:
-            X = X - self.mean_
+        X = X - self.mean_
 
         U = ridge_regression(self.components_.T, X.T, self.ridge_alpha,
                              solver='cholesky')
-
-        if not self.normalize_components:
-            s = np.sqrt((U ** 2).sum(axis=0))
-            s[s == 0] = 1
-            U /= s
 
         return U
 


### PR DESCRIPTION
I forgot to remove the following line when dealing with the deprecation.
Note that `normalize_components` should not have any effect and the algorithm behave like if `normalize_components=True`