### PR TITLE
MAINT Simplify arguments to csr_set_problem and csr_to_sparse

### DIFF
--- a/sklearn/svm/liblinear.pxd
+++ b/sklearn/svm/liblinear.pxd
@@ -32,9 +32,7 @@ cdef extern from "liblinear_helper.c":
     void copy_w(void *, model *, int)
     parameter *set_parameter(int, double, double, int, char *, char *, int, int, double)
     problem *set_problem (char *, char *, np.npy_intp *, double, char *)
-    problem *csr_set_problem (char *values, np.npy_intp *n_indices,
-        char *indices, np.npy_intp *n_indptr, char *indptr, char *Y,
-        np.npy_intp n_features, double bias, char *)
+    problem *csr_set_problem (char *, char *, char *, char *, int, int, double, char *)
 
     model *set_model(parameter *, char *, np.npy_intp *, char *, double)
 

--- a/sklearn/svm/liblinear.pyx
+++ b/sklearn/svm/liblinear.pyx
@@ -26,12 +26,10 @@ def train_wrap(X, np.ndarray[np.float64_t, ndim=1, mode='c'] Y,
     if is_sparse:
         problem = csr_set_problem(
                 (<np.ndarray[np.float64_t, ndim=1, mode='c']>X.data).data,
-                (<np.ndarray[np.int32_t,   ndim=1, mode='c']>X.indices).shape,
                 (<np.ndarray[np.int32_t,   ndim=1, mode='c']>X.indices).data,
-                (<np.ndarray[np.int32_t,   ndim=1, mode='c']>X.indptr).shape,
                 (<np.ndarray[np.int32_t,   ndim=1, mode='c']>X.indptr).data,
-                Y.data, (<np.int32_t>X.shape[1]), bias,
-                sample_weight.data)
+                Y.data, (<np.int32_t>X.shape[0]), (<np.int32_t>X.shape[1]),
+                bias, sample_weight.data)
     else:
         problem = set_problem(
                 (<np.ndarray[np.float64_t, ndim=2, mode='c']>X).data,

--- a/sklearn/svm/src/liblinear/liblinear_helper.c
+++ b/sklearn/svm/src/liblinear/liblinear_helper.c
@@ -70,19 +70,18 @@ static struct feature_node **dense_to_sparse(double *x, npy_intp *dims,
 /*
  * Convert scipy.sparse.csr to libsvm's sparse data structure
  */
-static struct feature_node **csr_to_sparse(double *values,
-        npy_intp *shape_indices, int *indices, npy_intp *shape_indptr,
-        int *indptr, double bias, int n_features)
+static struct feature_node **csr_to_sparse(double *values, int *indices,
+        int *indptr, int n_samples, int n_features, double bias)
 {
     struct feature_node **sparse, *temp;
     int i, j=0, k=0, n;
     int have_bias = (bias > 0);
 
-    sparse = malloc ((shape_indptr[0]-1)* sizeof(struct feature_node *));
+    sparse = malloc (n_samples * sizeof(struct feature_node *));
     if (sparse == NULL)
         return NULL;
 
-    for (i=0; i<shape_indptr[0]-1; ++i) {
+    for (i=0; i<n_samples; ++i) {
         n = indptr[i+1] - indptr[i]; /* count elements in row i */
 
         sparse[i] = malloc ((n+have_bias+1) * sizeof(struct feature_node));
@@ -140,14 +139,14 @@ struct problem * set_problem(char *X,char *Y, npy_intp *dims, double bias, char*
     return problem;
 }
 
-struct problem * csr_set_problem (char *values, npy_intp *n_indices,
-	char *indices, npy_intp *n_indptr, char *indptr, char *Y,
-        npy_intp n_features, double bias, char *sample_weight) {
+struct problem * csr_set_problem (char *values, char *indices, char *indptr,
+        char *Y, int n_samples, int n_features, double bias,
+        char *sample_weight) {
 
     struct problem *problem;
     problem = malloc (sizeof (struct problem));
     if (problem == NULL) return NULL;
-    problem->l = (int) n_indptr[0] -1;
+    problem->l = n_samples;
     problem->sample_weight = (double *) sample_weight;
 
     if (bias > 0){
@@ -157,8 +156,8 @@ struct problem * csr_set_problem (char *values, npy_intp *n_indices,
     }
 
     problem->y = (double *) Y;
-    problem->x = csr_to_sparse((double *) values, n_indices, (int *) indices,
-			n_indptr, (int *) indptr, bias, n_features);
+    problem->x = csr_to_sparse((double *) values, (int *) indices,
+                        (int *) indptr, n_samples, n_features, bias);
     problem->bias = bias;
     problem->sample_weight = sample_weight;
 


### PR DESCRIPTION
Their arguments are now more like the arguments to set_problem and
dense_to_sparse.

n_indices (a.k.a. shape_indices) was not being used and n_indptr[0]-1 (a.k.a. shape_indptr[0]-1) is just the number of samples.