### PR TITLE
MAINT More test runtime optimizations

### DIFF
--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -63,6 +63,8 @@ def test_connect_regions():
         # Newer versions of scipy have face in misc
         from scipy import misc
         face = misc.face(gray=True)
+    # subsample by 4 to reduce run time
+    face = face[::4, ::4]
     for thr in (50, 150):
         mask = face > thr
         graph = img_to_graph(face, mask)
@@ -77,6 +79,10 @@ def test_connect_regions_with_grid():
         # Newer versions of scipy have face in misc
         from scipy import misc
         face = misc.face(gray=True)
+
+    # subsample by 4 to reduce run time
+    face = face[::4, ::4]
+
     mask = face > 50
     graph = grid_to_graph(*face.shape, mask=mask)
     assert_equal(ndimage.label(mask)[1], connected_components(graph)[0])

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -113,12 +113,12 @@ def test_random_starts():
 @pytest.mark.parametrize('kernel', non_fixed_kernels)
 def test_custom_optimizer(kernel):
     # Test that GPC can use externally defined optimizers.
-    # Define a dummy optimizer that simply tests 50 random hyperparameters
+    # Define a dummy optimizer that simply tests 10 random hyperparameters
     def optimizer(obj_func, initial_theta, bounds):
         rng = np.random.RandomState(0)
         theta_opt, func_min = \
             initial_theta, obj_func(initial_theta, eval_gradient=False)
-        for _ in range(50):
+        for _ in range(10):
             theta = np.atleast_1d(rng.uniform(np.maximum(-2, bounds[:, 0]),
                                               np.minimum(1, bounds[:, 1])))
             f = obj_func(theta, eval_gradient=False)

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -796,7 +796,7 @@ def test_iterative_imputer_no_missing():
 
 def test_iterative_imputer_rank_one():
     rng = np.random.RandomState(0)
-    d = 100
+    d = 50
     A = rng.rand(d, 1)
     B = rng.rand(1, d)
     X = np.dot(A, B)
@@ -808,7 +808,7 @@ def test_iterative_imputer_rank_one():
                                verbose=1,
                                random_state=rng)
     X_filled = imputer.fit_transform(X_missing)
-    assert_allclose(X_filled, X, atol=0.01)
+    assert_allclose(X_filled, X, atol=0.02)
 
 
 @pytest.mark.parametrize(
@@ -817,8 +817,8 @@ def test_iterative_imputer_rank_one():
 )
 def test_iterative_imputer_transform_recovery(rank):
     rng = np.random.RandomState(0)
-    n = 100
-    d = 100
+    n = 70
+    d = 70
     A = rng.rand(n, rank)
     B = rng.rand(rank, d)
     X_filled = np.dot(A, B)
@@ -832,7 +832,7 @@ def test_iterative_imputer_transform_recovery(rank):
     X_test_filled = X_filled[n:]
     X_test = X_missing[n:]
 
-    imputer = IterativeImputer(max_iter=10,
+    imputer = IterativeImputer(max_iter=5,
                                verbose=1,
                                random_state=rng).fit(X_train)
     X_test_est = imputer.transform(X_test)
@@ -890,7 +890,7 @@ def test_iterative_imputer_early_stopping():
     X_missing[nan_mask] = np.nan
 
     imputer = IterativeImputer(max_iter=100,
-                               tol=1e-3,
+                               tol=1e-2,
                                sample_posterior=False,
                                verbose=1,
                                random_state=rng)

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -37,12 +37,15 @@ y = [-1, -1, -1, 1, 1, 1]
 
 
 # (X, y), n_targets  <-- as expected in the output of partial_dep()
-binary_classification_data = (make_classification(random_state=0), 1)
-multiclass_classification_data = (make_classification(n_classes=3,
+binary_classification_data = (make_classification(n_samples=50,
+                                                  random_state=0), 1)
+multiclass_classification_data = (make_classification(n_samples=50,
+                                                      n_classes=3,
                                                       n_clusters_per_class=1,
                                                       random_state=0), 3)
-regression_data = (make_regression(random_state=0), 1)
-multioutput_regression_data = (make_regression(n_targets=2, random_state=0), 2)
+regression_data = (make_regression(n_samples=50, random_state=0), 1)
+multioutput_regression_data = (make_regression(n_samples=50, n_targets=2,
+                                               random_state=0), 2)
 
 
 @pytest.mark.parametrize('Estimator, method, data', [

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -247,7 +247,7 @@ def test_preserve_trustworthiness_approximately(method, init):
     n_components = 2
     X = random_state.randn(50, n_components).astype(np.float32)
     tsne = TSNE(n_components=n_components, init=init, random_state=0,
-		method=method, n_iter=700)
+                method=method, n_iter=700)
     X_embedded = tsne.fit_transform(X)
     t = trustworthiness(X, X_embedded, n_neighbors=1)
     assert t > 0.85

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -126,7 +126,7 @@ def test_binary_search_neighbors():
     # Binary perplexity search approximation.
     # Should be approximately equal to the slow method when we use
     # all points as neighbors.
-    n_samples = 500
+    n_samples = 200
     desired_perplexity = 25.0
     random_state = check_random_state(0)
     distances = random_state.randn(n_samples, 2).astype(np.float32)
@@ -248,7 +248,7 @@ def test_preserve_trustworthiness_approximately():
     for init in ('random', 'pca'):
         for method in methods:
             tsne = TSNE(n_components=n_components, init=init, random_state=0,
-                        method=method)
+                        method=method, n_iter=500)
             X_embedded = tsne.fit_transform(X)
             t = trustworthiness(X, X_embedded, n_neighbors=1)
             assert_greater(t, 0.85, msg='Trustworthiness={:0.3f} < 0.85 '
@@ -273,11 +273,11 @@ def test_optimization_minimizes_kl_divergence():
 def test_fit_csr_matrix():
     # X can be a sparse matrix.
     random_state = check_random_state(0)
-    X = random_state.randn(100, 2)
-    X[(np.random.randint(0, 100, 50), np.random.randint(0, 2, 50))] = 0.0
+    X = random_state.randn(50, 2)
+    X[(np.random.randint(0, 50, 25), np.random.randint(0, 2, 25))] = 0.0
     X_csr = sp.csr_matrix(X)
     tsne = TSNE(n_components=2, perplexity=10, learning_rate=100.0,
-                random_state=0, method='exact')
+                random_state=0, method='exact', n_iter=500)
     X_embedded = tsne.fit_transform(X_csr)
     assert_almost_equal(trustworthiness(X_csr, X_embedded, n_neighbors=1), 1.0,
                         decimal=1)
@@ -287,11 +287,11 @@ def test_preserve_trustworthiness_approximately_with_precomputed_distances():
     # Nearest neighbors should be preserved approximately.
     random_state = check_random_state(0)
     for i in range(3):
-        X = random_state.randn(100, 2)
+        X = random_state.randn(80, 2)
         D = squareform(pdist(X), "sqeuclidean")
         tsne = TSNE(n_components=2, perplexity=2, learning_rate=100.0,
                     early_exaggeration=2.0, metric="precomputed",
-                    random_state=i, verbose=0)
+                    random_state=i, verbose=0, n_iter=500)
         X_embedded = tsne.fit_transform(D)
         t = trustworthiness(D, X_embedded, n_neighbors=1, metric="precomputed")
         assert t > .95
@@ -420,11 +420,11 @@ def test_early_exaggeration_used():
     for method in methods:
         tsne = TSNE(n_components=n_components, perplexity=1,
                     learning_rate=100.0, init="pca", random_state=0,
-                    method=method, early_exaggeration=1.0)
+                    method=method, early_exaggeration=1.0, n_iter=250)
         X_embedded1 = tsne.fit_transform(X)
         tsne = TSNE(n_components=n_components, perplexity=1,
                     learning_rate=100.0, init="pca", random_state=0,
-                    method=method, early_exaggeration=10.0)
+                    method=method, early_exaggeration=10.0, n_iter=250)
         X_embedded2 = tsne.fit_transform(X)
 
         assert not np.allclose(X_embedded1, X_embedded2)
@@ -586,9 +586,10 @@ def test_64bit(method, dt):
     # Ensure 64bit arrays are handled correctly.
     random_state = check_random_state(0)
 
-    X = random_state.randn(50, 2).astype(dt, copy=False)
+    X = random_state.randn(10, 2).astype(dt, copy=False)
     tsne = TSNE(n_components=2, perplexity=2, learning_rate=100.0,
-                random_state=0, method=method, verbose=0)
+                random_state=0, method=method, verbose=0,
+                n_iter=300)
     X_embedded = tsne.fit_transform(X)
     effective_type = X_embedded.dtype
 
@@ -605,7 +606,7 @@ def test_kl_divergence_not_nan(method):
 
     X = random_state.randn(50, 2)
     tsne = TSNE(n_components=2, perplexity=2, learning_rate=100.0,
-                random_state=0, method=method, verbose=0, n_iter=1003)
+                random_state=0, method=method, verbose=0, n_iter=503)
     tsne.fit_transform(X)
 
     assert not np.isnan(tsne.kl_divergence_)
@@ -722,9 +723,10 @@ def test_min_grad_norm():
 def test_accessible_kl_divergence():
     # Ensures that the accessible kl_divergence matches the computed value
     random_state = check_random_state(0)
-    X = random_state.randn(100, 2)
+    X = random_state.randn(50, 2)
     tsne = TSNE(n_iter_without_progress=2, verbose=2,
-                random_state=0, method='exact')
+                random_state=0, method='exact',
+                n_iter=500)
 
     old_stdout = sys.stdout
     sys.stdout = StringIO()
@@ -746,7 +748,8 @@ def test_accessible_kl_divergence():
     assert_almost_equal(tsne.kl_divergence_, float(error), decimal=5)
 
 
-def check_uniform_grid(method, seeds=[0, 1, 2], n_iter=1000):
+@pytest.mark.parametrize('method', ['barnes_hut', 'exact'])
+def test_uniform_grid(method):
     """Make sure that TSNE can approximately recover a uniform 2D grid
 
     Due to ties in distances between point in X_2d_grid, this test is platform
@@ -758,6 +761,8 @@ def check_uniform_grid(method, seeds=[0, 1, 2], n_iter=1000):
     we re-run t-SNE from the final point when the convergence is not good
     enough.
     """
+    seeds = [0, 1, 2]
+    n_iter = 500
     for seed in seeds:
         tsne = TSNE(n_components=2, init='random', random_state=seed,
                     perplexity=20, n_iter=n_iter, method=method)
@@ -789,11 +794,6 @@ def assert_uniform_grid(Y, try_name=None):
 
     assert_greater(smallest_to_mean, .5, msg=try_name)
     assert_less(largest_to_mean, 2, msg=try_name)
-
-
-@pytest.mark.parametrize('method', ['barnes_hut', 'exact'])
-def test_uniform_grid(method):
-    check_uniform_grid(method)
 
 
 def test_bh_match_exact():
@@ -829,8 +829,8 @@ def test_tsne_with_different_distance_metrics():
     for metric, dist_func in zip(metrics, dist_funcs):
         X_transformed_tsne = TSNE(
             metric=metric, n_components=n_components_embedding,
-            random_state=0).fit_transform(X)
+            random_state=0, n_iter=300).fit_transform(X)
         X_transformed_tsne_precomputed = TSNE(
             metric='precomputed', n_components=n_components_embedding,
-            random_state=0).fit_transform(dist_func(X))
+            random_state=0, n_iter=300).fit_transform(dist_func(X))
         assert_array_equal(X_transformed_tsne, X_transformed_tsne_precomputed)

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -239,21 +239,18 @@ def test_trustworthiness():
     assert_almost_equal(trustworthiness(X, X_embedded, n_neighbors=1), 0.2)
 
 
-def test_preserve_trustworthiness_approximately():
+@pytest.mark.parametrize("method", ['exact', 'barnes_hut'])
+@pytest.mark.parametrize("init", ('random', 'pca'))
+def test_preserve_trustworthiness_approximately(method, init):
     # Nearest neighbors should be preserved approximately.
     random_state = check_random_state(0)
     n_components = 2
-    methods = ['exact', 'barnes_hut']
     X = random_state.randn(50, n_components).astype(np.float32)
-    for init in ('random', 'pca'):
-        for method in methods:
-            tsne = TSNE(n_components=n_components, init=init, random_state=0,
-                        method=method, n_iter=500)
-            X_embedded = tsne.fit_transform(X)
-            t = trustworthiness(X, X_embedded, n_neighbors=1)
-            assert_greater(t, 0.85, msg='Trustworthiness={:0.3f} < 0.85 '
-                                        'for method={} and '
-                                        'init={}'.format(t, method, init))
+    tsne = TSNE(n_components=n_components, init=init, random_state=0,
+		method=method, n_iter=700)
+    X_embedded = tsne.fit_transform(X)
+    t = trustworthiness(X, X_embedded, n_neighbors=1)
+    assert t > 0.85
 
 
 def test_optimization_minimizes_kl_divergence():

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -678,7 +678,7 @@ def test_matthews_corrcoef_multiclass():
     assert_almost_equal(mcc, 0.)
 
 
-@pytest.mark.parametrize('n_points', [100, 10000, 1000000])
+@pytest.mark.parametrize('n_points', [100, 10000])
 def test_matthews_corrcoef_overflow(n_points):
     # https://github.com/scikit-learn/scikit-learn/issues/9622
     rng = np.random.RandomState(20170906)

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1197,11 +1197,11 @@ def test_multiclass_sample_weight_invariance(name):
 def test_multilabel_sample_weight_invariance(name):
     # multilabel indicator
     random_state = check_random_state(0)
-    _, ya = make_multilabel_classification(n_features=1, n_classes=20,
-                                           random_state=0, n_samples=100,
+    _, ya = make_multilabel_classification(n_features=1, n_classes=10,
+                                           random_state=0, n_samples=50,
                                            allow_unlabeled=False)
-    _, yb = make_multilabel_classification(n_features=1, n_classes=20,
-                                           random_state=1, n_samples=100,
+    _, yb = make_multilabel_classification(n_features=1, n_classes=10,
+                                           random_state=1, n_samples=50,
                                            allow_unlabeled=False)
     y_true = np.vstack([ya, yb])
     y_pred = np.vstack([ya, ya])

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -558,7 +558,7 @@ def test_pairwise_distances_chunked():
     # Test the pairwise_distance helper function.
     rng = np.random.RandomState(0)
     # Euclidean distance should be equivalent to calling the function.
-    X = rng.random_sample((400, 4))
+    X = rng.random_sample((200, 4))
     check_pairwise_distances_chunked(X, None, working_memory=1,
                                      metric='euclidean')
     # Test small amounts of memory
@@ -569,7 +569,7 @@ def test_pairwise_distances_chunked():
     check_pairwise_distances_chunked(X.tolist(), None, working_memory=1,
                                      metric='euclidean')
     # Euclidean distance, with Y != X.
-    Y = rng.random_sample((200, 4))
+    Y = rng.random_sample((100, 4))
     check_pairwise_distances_chunked(X, Y, working_memory=1,
                                      metric='euclidean')
     check_pairwise_distances_chunked(X.tolist(), Y.tolist(), working_memory=1,
@@ -1103,9 +1103,9 @@ def test_pairwise_distances_data_derived_params(n_jobs, metric, dist_function,
                                                 y_is_x):
     # check that pairwise_distances give the same result in sequential and
     # parallel, when metric has data-derived parameters.
-    with config_context(working_memory=1):  # to have more than 1 chunk
+    with config_context(working_memory=0.1):  # to have more than 1 chunk
         rng = np.random.RandomState(0)
-        X = rng.random_sample((1000, 10))
+        X = rng.random_sample((100, 10))
 
         if y_is_x:
             Y = X
@@ -1115,7 +1115,7 @@ def test_pairwise_distances_data_derived_params(n_jobs, metric, dist_function,
             else:
                 params = {'VI': np.linalg.inv(np.cov(X.T)).T}
         else:
-            Y = rng.random_sample((1000, 10))
+            Y = rng.random_sample((100, 10))
             expected_dist_default_params = cdist(X, Y, metric=metric)
             if metric == "seuclidean":
                 params = {'V': np.var(np.vstack([X, Y]), axis=0, ddof=1)}

--- a/sklearn/mixture/tests/test_bayesian_mixture.py
+++ b/sklearn/mixture/tests/test_bayesian_mixture.py
@@ -296,7 +296,7 @@ def test_monotonic_likelihood():
             bgmm = BayesianGaussianMixture(
                 weight_concentration_prior_type=prior_type,
                 n_components=2 * n_components, covariance_type=covar_type,
-                warm_start=True, max_iter=1, random_state=rng, tol=1e-4)
+                warm_start=True, max_iter=1, random_state=rng, tol=1e-3)
             current_lower_bound = -np.infty
             # Do one training iteration at a time so we can make sure that the
             # training log likelihood increases after each iteration.
@@ -435,7 +435,7 @@ def test_invariant_translation():
 ])
 def test_bayesian_mixture_fit_predict(seed, max_iter, tol):
     rng = np.random.RandomState(seed)
-    rand_data = RandomData(rng, scale=7)
+    rand_data = RandomData(rng, n_samples=50, scale=7)
     n_components = 2 * rand_data.n_components
 
     for covar_type in COVARIANCE_TYPE:
@@ -453,7 +453,7 @@ def test_bayesian_mixture_fit_predict(seed, max_iter, tol):
 
 def test_bayesian_mixture_fit_predict_n_init():
     # Check that fit_predict is equivalent to fit.predict, when n_init > 1
-    X = np.random.RandomState(0).randn(1000, 5)
+    X = np.random.RandomState(0).randn(50, 5)
     gm = BayesianGaussianMixture(n_components=5, n_init=10, random_state=0)
     y_pred1 = gm.fit_predict(X)
     y_pred2 = gm.predict(X)

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -69,7 +69,7 @@ def generate_data(n_samples, n_features, weights, means, precisions,
 
 
 class RandomData:
-    def __init__(self, rng, n_samples=500, n_components=2, n_features=2,
+    def __init__(self, rng, n_samples=200, n_components=2, n_features=2,
                  scale=50):
         self.n_samples = n_samples
         self.n_components = n_components
@@ -652,7 +652,7 @@ def test_gaussian_mixture_fit():
             ecov = EmpiricalCovariance()
             ecov.covariance_ = prec_test[h]
             # the accuracy depends on the number of data and randomness, rng
-            assert_allclose(ecov.error_norm(prec_pred[k]), 0, atol=0.1)
+            assert_allclose(ecov.error_norm(prec_pred[k]), 0, atol=0.15)
 
 
 def test_gaussian_mixture_fit_best_params():
@@ -1031,8 +1031,9 @@ def test_sample():
 @ignore_warnings(category=ConvergenceWarning)
 def test_init():
     # We check that by increasing the n_init number we have a better solution
-    for random_state in range(25):
-        rand_data = RandomData(np.random.RandomState(random_state), scale=1)
+    for random_state in range(15):
+        rand_data = RandomData(np.random.RandomState(random_state),
+                               n_samples=50, scale=1)
         n_components = rand_data.n_components
         X = rand_data.X['full']
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -737,8 +737,8 @@ def test_pandas_input():
 
 def test_unsupervised_grid_search():
     # test grid-search with unsupervised estimator
-    X, y = make_blobs(random_state=0)
-    km = KMeans(random_state=0)
+    X, y = make_blobs(n_samples=50, random_state=0)
+    km = KMeans(random_state=0, init="random", n_init=1)
 
     # Multi-metric evaluation unsupervised
     scoring = ['adjusted_rand_score', 'fowlkes_mallows_score']
@@ -1099,15 +1099,19 @@ def test_random_search_cv_results_multimetric():
     scoring = ('accuracy', 'recall')
 
     # Scipy 0.12's stats dists do not accept seed, hence we use param grid
-    params = dict(C=np.logspace(-10, 1), gamma=np.logspace(-5, 0, base=0.1))
+    params = dict(C=np.logspace(-4, 1, 3),
+                  gamma=np.logspace(-5, 0, 3, base=0.1))
     for iid in (True, False):
         for refit in (True, False):
             random_searches = []
             for scoring in (('accuracy', 'recall'), 'accuracy', 'recall'):
                 # If True, for multi-metric pass refit='accuracy'
                 if refit:
+                    probability = True
                     refit = 'accuracy' if isinstance(scoring, tuple) else refit
-                clf = SVC(probability=True, random_state=42)
+                else:
+                    probability = False
+                clf = SVC(probability=probability, random_state=42)
                 random_search = RandomizedSearchCV(clf, n_iter=n_search_iter,
                                                    cv=n_splits, iid=iid,
                                                    param_distributions=params,

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1477,7 +1477,7 @@ def test_nested_cv():
            StratifiedShuffleSplit(n_splits=3, random_state=0)]
 
     for inner_cv, outer_cv in combinations_with_replacement(cvs, 2):
-        gs = GridSearchCV(Ridge(), param_grid={'alpha': [1, .1]},
+        gs = GridSearchCV(Ridge(solver="eigen"), param_grid={'alpha': [1, .1]},
                           cv=inner_cv, error_score='raise')
         cross_val_score(gs, X=X, y=y, groups=groups, cv=outer_cv,
                         fit_params={'groups': groups})

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -812,20 +812,21 @@ def test_cross_val_predict():
                        'not match total number of classes (3). '
                        'Results may not be appropriate for your use case.')
     assert_warns_message(RuntimeWarning, warning_message,
-                         cross_val_predict, LogisticRegression(),
+                         cross_val_predict,
+                         LogisticRegression(solver="liblinear"),
                          X, y, method='predict_proba', cv=KFold(2))
 
 
 def test_cross_val_predict_decision_function_shape():
     X, y = make_classification(n_classes=2, n_samples=50, random_state=0)
 
-    preds = cross_val_predict(LogisticRegression(), X, y,
+    preds = cross_val_predict(LogisticRegression(solver="liblinear"), X, y,
                               method='decision_function')
     assert_equal(preds.shape, (50,))
 
     X, y = load_iris(return_X_y=True)
 
-    preds = cross_val_predict(LogisticRegression(), X, y,
+    preds = cross_val_predict(LogisticRegression(solver="liblinear"), X, y,
                               method='decision_function')
     assert_equal(preds.shape, (150, 3))
 
@@ -866,13 +867,13 @@ def test_cross_val_predict_decision_function_shape():
 def test_cross_val_predict_predict_proba_shape():
     X, y = make_classification(n_classes=2, n_samples=50, random_state=0)
 
-    preds = cross_val_predict(LogisticRegression(), X, y,
+    preds = cross_val_predict(LogisticRegression(solver="liblinear"), X, y,
                               method='predict_proba')
     assert_equal(preds.shape, (50, 2))
 
     X, y = load_iris(return_X_y=True)
 
-    preds = cross_val_predict(LogisticRegression(), X, y,
+    preds = cross_val_predict(LogisticRegression(solver="liblinear"), X, y,
                               method='predict_proba')
     assert_equal(preds.shape, (150, 3))
 
@@ -880,13 +881,13 @@ def test_cross_val_predict_predict_proba_shape():
 def test_cross_val_predict_predict_log_proba_shape():
     X, y = make_classification(n_classes=2, n_samples=50, random_state=0)
 
-    preds = cross_val_predict(LogisticRegression(), X, y,
+    preds = cross_val_predict(LogisticRegression(solver="liblinear"), X, y,
                               method='predict_log_proba')
     assert_equal(preds.shape, (50, 2))
 
     X, y = load_iris(return_X_y=True)
 
-    preds = cross_val_predict(LogisticRegression(), X, y,
+    preds = cross_val_predict(LogisticRegression(solver="liblinear"), X, y,
                               method='predict_log_proba')
     assert_equal(preds.shape, (150, 3))
 
@@ -923,9 +924,11 @@ def test_cross_val_predict_input_types():
     predictions = cross_val_predict(clf, X, y.tolist())
 
     # test with X and y as list and non empty method
-    predictions = cross_val_predict(LogisticRegression(), X.tolist(),
+    predictions = cross_val_predict(LogisticRegression(solver="liblinear"),
+                                    X.tolist(),
                                     y.tolist(), method='decision_function')
-    predictions = cross_val_predict(LogisticRegression(), X,
+    predictions = cross_val_predict(LogisticRegression(solver="liblinear"),
+                                    X,
                                     y.tolist(), method='decision_function')
 
     # test with 3d X and
@@ -961,7 +964,7 @@ def test_cross_val_predict_unbalanced():
                                random_state=1)
     # Change the first sample to a new class
     y[0] = 2
-    clf = LogisticRegression(random_state=1)
+    clf = LogisticRegression(random_state=1, solver="liblinear")
     cv = StratifiedKFold(n_splits=2, random_state=1)
     train, test = list(cv.split(X, y))
     yhat_proba = cross_val_predict(clf, X, y, cv=cv, method="predict_proba")
@@ -1385,7 +1388,7 @@ def check_cross_val_predict_multilabel(est, X, y, method):
 def check_cross_val_predict_with_method_binary(est):
     # This test includes the decision_function with two classes.
     # This is a special case: it has only one column of output.
-    X, y = make_classification(n_classes=2, random_state=0)
+    X, y = make_classification(n_classes=2,  random_state=0)
     for method in ['decision_function', 'predict_proba', 'predict_log_proba']:
         check_cross_val_predict_binary(est, X, y, method)
 
@@ -1399,8 +1402,10 @@ def check_cross_val_predict_with_method_multiclass(est):
 
 
 def test_cross_val_predict_with_method():
-    check_cross_val_predict_with_method_binary(LogisticRegression())
-    check_cross_val_predict_with_method_multiclass(LogisticRegression())
+    check_cross_val_predict_with_method_binary(
+            LogisticRegression(solver="liblinear"))
+    check_cross_val_predict_with_method_multiclass(
+            LogisticRegression(solver="liblinear"))
 
 
 @pytest.mark.filterwarnings('ignore: max_iter and tol parameters')
@@ -1419,7 +1424,7 @@ def test_gridsearchcv_cross_val_predict_with_method():
     iris = load_iris()
     X, y = iris.data, iris.target
     X, y = shuffle(X, y, random_state=0)
-    est = GridSearchCV(LogisticRegression(random_state=42),
+    est = GridSearchCV(LogisticRegression(random_state=42, solver="liblinear"),
                        {'C': [0.1, 1]},
                        cv=2)
     for method in ['decision_function', 'predict_proba', 'predict_log_proba']:
@@ -1435,7 +1440,8 @@ def test_cross_val_predict_with_method_multilabel_ovr():
     X, y = make_multilabel_classification(n_samples=n_samp, n_labels=3,
                                           n_classes=n_classes, n_features=5,
                                           random_state=42)
-    est = OneVsRestClassifier(LogisticRegression(random_state=0))
+    est = OneVsRestClassifier(LogisticRegression(solver="liblinear",
+                                                 random_state=0))
     for method in ['predict_proba', 'decision_function']:
         check_cross_val_predict_binary(est, X, y, method=method)
 
@@ -1475,7 +1481,7 @@ def test_cross_val_predict_with_method_rare_class():
     rng = np.random.RandomState(0)
     X = rng.normal(0, 1, size=(14, 10))
     y = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 3])
-    est = LogisticRegression()
+    est = LogisticRegression(solver="liblinear")
     for method in ['predict_proba', 'predict_log_proba', 'decision_function']:
         with warnings.catch_warnings():
             # Suppress warning about too few examples of a class
@@ -1533,7 +1539,7 @@ def test_cross_val_predict_class_subset():
 
     methods = ['decision_function', 'predict_proba', 'predict_log_proba']
     for method in methods:
-        est = LogisticRegression()
+        est = LogisticRegression(solver="liblinear")
 
         # Test with n_splits=3
         predictions = cross_val_predict(est, X, y, method=method,


### PR DESCRIPTION
Optimizes the test runtime of a few more modules.

For the changed modules, this PR reduces the runtime by 40% (or 30s),
```
pytest sklearn/feature_extraction sklearn/feature_selection sklearn/gaussian_process sklearn/impute sklearn/inspection/ sklearn/manifold sklearn/metrics/ sklearn/mixture sklearn/model_selection/
```