### PR TITLE
TST refactor test for PCA

### DIFF
--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -262,10 +262,6 @@ def test_pca_validation(svd_solver, data, n_components, err_msg):
     with pytest.raises(ValueError, match=err_msg):
         pca_fitted.fit(data)
 
-    pca = PCA(n_components=n_components, svd_solver=svd_solver)
-    assert pca_fitted.n_components == pca.n_components
-    assert pca_fitted.svd_solver == pca.svd_solver
-
     # Additional case for arpack
     if svd_solver == 'arpack':
         n_components = smallest_d

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -18,7 +18,7 @@ from sklearn.decomposition.pca import _assess_dimension_
 from sklearn.decomposition.pca import _infer_dimension_
 
 iris = datasets.load_iris()
-solver_list = ['full', 'arpack', 'randomized', 'auto']
+PCA_SOLVERS = ['full', 'arpack', 'randomized', 'auto']
 
 
 @pytest.mark.parametrize(
@@ -39,7 +39,7 @@ def test_pca_internal_state(svd_solver, n_components, err_msg):
     assert pca_fitted.svd_solver == pca.svd_solver
 
 
-@pytest.mark.parametrize('svd_solver', solver_list)
+@pytest.mark.parametrize('svd_solver', PCA_SOLVERS)
 @pytest.mark.parametrize('n_components', range(1, iris.data.shape[1]))
 def test_pca(svd_solver, n_components):
     X = iris.data
@@ -91,7 +91,7 @@ def test_whitening():
     # the component-wise variance is thus highly varying:
     assert_greater(X.std(axis=0).std(), 43.8)
 
-    for solver, copy in product(solver_list, (True, False)):
+    for solver, copy in product(PCA_SOLVERS, (True, False)):
         # whiten the data while projecting to the lower dim subspace
         X_ = X.copy()  # make sure we keep an original across iterations.
         pca = PCA(n_components=n_components, whiten=True, copy=copy,
@@ -149,7 +149,7 @@ def test_pca_explained_variance_equivalence_solver(svd_solver):
                                   random_state=0)[0]],
     ids=['random-data', 'correlated-data']
 )
-@pytest.mark.parametrize('svd_solver', solver_list)
+@pytest.mark.parametrize('svd_solver', PCA_SOLVERS)
 def test_pca_explained_variance_empirical(X, svd_solver):
     pca = PCA(n_components=2, svd_solver=svd_solver, random_state=0)
     X_pca = pca.fit_transform(X)
@@ -177,7 +177,7 @@ def test_pca_singular_values_consistency(svd_solver):
     )
 
 
-@pytest.mark.parametrize("svd_solver", solver_list)
+@pytest.mark.parametrize("svd_solver", PCA_SOLVERS)
 def test_pca_singular_values(svd_solver):
     rng = np.random.RandomState(0)
     n_samples, n_features = 100, 80
@@ -209,7 +209,7 @@ def test_pca_singular_values(svd_solver):
     assert_allclose(pca.singular_values_, [3.142, 2.718, 1.0])
 
 
-@pytest.mark.parametrize("svd_solver", solver_list)
+@pytest.mark.parametrize("svd_solver", PCA_SOLVERS)
 def test_pca_check_projection(svd_solver):
     # Test that the projection of data is correct
     rng = np.random.RandomState(0)
@@ -224,7 +224,7 @@ def test_pca_check_projection(svd_solver):
     assert_allclose(np.abs(Yt[0][0]), 1., atol=1e-3)
 
 
-@pytest.mark.parametrize("svd_solver", solver_list)
+@pytest.mark.parametrize("svd_solver", PCA_SOLVERS)
 def test_pca_check_projection_list(svd_solver):
     # Test that the projection of data is correct
     X = [[1.0, 0.0], [0.0, 1.0]]
@@ -253,7 +253,7 @@ def test_pca_inverse(svd_solver, whiten):
     assert_allclose(X, Y_inverse, atol=1e-4)
 
 
-@pytest.mark.parametrize('solver', solver_list)
+@pytest.mark.parametrize('solver', PCA_SOLVERS)
 @pytest.mark.parametrize(
     'data',
     [np.array([[0, 1, 0], [1, 0, 0]]), np.array([[0, 1, 0], [1, 0, 0]]).T]
@@ -380,19 +380,20 @@ def test_infer_dim_3():
 
 
 @pytest.mark.parametrize(
-    "X, n_components, n_components_",
+    "X, n_components, n_components_validated",
     [(iris.data, 0.95, 2),  # row > col
      (iris.data, 0.01, 1),  # row > col
      (np.random.RandomState(0).rand(5, 20), 0.5, 2)]  # row < col
 )
-def test_infer_dim_by_explained_variance(X, n_components, n_components_):
+def test_infer_dim_by_explained_variance(X, n_components,
+                                         n_components_validated):
     pca = PCA(n_components=n_components, svd_solver='full')
     pca.fit(X)
     assert pca.n_components == pytest.approx(n_components)
-    assert pca.n_components_ == n_components_
+    assert pca.n_components_ == n_components_validated
 
 
-@pytest.mark.parametrize("svd_solver", solver_list)
+@pytest.mark.parametrize("svd_solver", PCA_SOLVERS)
 def test_pca_score(svd_solver):
     # Test that probabilistic PCA scoring yields a reasonable score
     n, p = 1000, 3
@@ -431,7 +432,7 @@ def test_pca_score3():
     assert ll.argmax() == 1
 
 
-@pytest.mark.parametrize("svd_solver", solver_list)
+@pytest.mark.parametrize("svd_solver", PCA_SOLVERS)
 def test_pca_sanity_noise_variance(svd_solver):
     # Sanity check for the noise_variance_. For more details see
     # https://github.com/scikit-learn/scikit-learn/issues/7568
@@ -493,7 +494,7 @@ def test_pca_svd_solver_auto(data, n_components, expected_solver):
     assert_allclose(pca_auto.components_, pca_test.components_)
 
 
-@pytest.mark.parametrize('svd_solver', solver_list)
+@pytest.mark.parametrize('svd_solver', PCA_SOLVERS)
 def test_pca_sparse_input(svd_solver):
     X = np.random.RandomState(0).rand(5, 4)
     X = sp.sparse.csr_matrix(X)
@@ -511,7 +512,7 @@ def test_pca_bad_solver():
         pca.fit(X)
 
 
-@pytest.mark.parametrize("svd_solver", solver_list)
+@pytest.mark.parametrize("svd_solver", PCA_SOLVERS)
 def test_pca_deterministic_output(svd_solver):
     rng = np.random.RandomState(0)
     X = rng.rand(10, 10)
@@ -525,7 +526,7 @@ def test_pca_deterministic_output(svd_solver):
     )
 
 
-@pytest.mark.parametrize('svd_solver', solver_list)
+@pytest.mark.parametrize('svd_solver', PCA_SOLVERS)
 def test_pca_dtype_preservation(svd_solver):
     check_pca_float_dtype_preservation(svd_solver)
     check_pca_int_dtype_upcast_to_double(svd_solver)

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -1,5 +1,3 @@
-from itertools import product
-
 import numpy as np
 import scipy as sp
 

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -133,12 +133,12 @@ def test_pca_explained_variance_equivalence_solver(svd_solver):
     assert_allclose(
         pca_full.explained_variance_,
         pca_other.explained_variance_,
-        atol=1e-2
+        rtol=5e-2
     )
     assert_allclose(
         pca_full.explained_variance_ratio_,
         pca_other.explained_variance_ratio_,
-        atol=1e-4
+        rtol=5e-2
     )
 
 
@@ -157,7 +157,7 @@ def test_pca_explained_variance_empirical(X, svd_solver):
 
     expected_result = np.linalg.eig(np.cov(X, rowvar=False))[0]
     expected_result = sorted(expected_result, reverse=True)[:2]
-    assert_allclose(pca.explained_variance_, expected_result, atol=1e-2)
+    assert_allclose(pca.explained_variance_, expected_result, rtol=5e-3)
 
 
 @pytest.mark.parametrize("svd_solver", ['arpack', 'randomized'])
@@ -173,7 +173,7 @@ def test_pca_singular_values_consistency(svd_solver):
     pca_other.fit(X)
 
     assert_allclose(
-        pca_full.singular_values_, pca_other.singular_values_, atol=1e-1
+        pca_full.singular_values_, pca_other.singular_values_, rtol=5e-3
     )
 
 
@@ -221,7 +221,7 @@ def test_pca_check_projection(svd_solver):
     Yt = PCA(n_components=2, svd_solver=svd_solver).fit(X).transform(Xt)
     Yt /= np.sqrt((Yt ** 2).sum())
 
-    assert_allclose(np.abs(Yt[0][0]), 1., atol=1e-3)
+    assert_allclose(np.abs(Yt[0][0]), 1., rtol=5e-3)
 
 
 @pytest.mark.parametrize("svd_solver", solver_list)
@@ -231,8 +231,8 @@ def test_pca_check_projection_list(svd_solver):
     pca = PCA(n_components=1, svd_solver=svd_solver, random_state=0)
     X_trans = pca.fit_transform(X)
     assert X_trans.shape, (2, 1)
-    assert_allclose(X_trans.mean(), 0.00, atol=1e-2)
-    assert_allclose(X_trans.std(), 0.71, atol=1e-2)
+    assert_allclose(X_trans.mean(), 0.00, atol=1e-12)
+    assert_allclose(X_trans.std(), 0.71, rtol=5e-3)
 
 
 @pytest.mark.parametrize("svd_solver", ['full', 'arpack', 'randomized'])
@@ -250,7 +250,7 @@ def test_pca_inverse(svd_solver, whiten):
     pca = PCA(n_components=2, svd_solver=svd_solver, whiten=whiten).fit(X)
     Y = pca.transform(X)
     Y_inverse = pca.inverse_transform(Y)
-    assert_allclose(X, Y_inverse, atol=1e-4)
+    assert_allclose(X, Y_inverse, rtol=5e-6)
 
 
 @pytest.mark.parametrize('solver', solver_list)
@@ -403,7 +403,7 @@ def test_pca_score(svd_solver):
 
     ll1 = pca.score(X)
     h = -0.5 * np.log(2 * np.pi * np.exp(1) * 0.1 ** 2) * p
-    assert_allclose(ll1 / h, 1, atol=1e-1)
+    assert_allclose(ll1 / h, 1, rtol=5e-2)
 
     ll2 = pca.score(rng.randn(n, p) * .2 + np.array([3, 4, 5]))
     assert ll1 > ll2
@@ -451,7 +451,7 @@ def test_pca_score_consistency_solvers(svd_solver):
     pca_other = PCA(n_components=30, svd_solver=svd_solver, random_state=0)
     pca_full.fit(X)
     pca_other.fit(X)
-    assert_allclose(pca_full.score(X), pca_other.score(X), atol=1e-3)
+    assert_allclose(pca_full.score(X), pca_other.score(X), rtol=5e-6)
 
 
 # arpack raises ValueError for n_components == min(n_samples,  n_features)
@@ -547,7 +547,7 @@ def check_pca_float_dtype_preservation(svd_solver):
     assert pca_64.transform(X_64).dtype == np.float64
     assert pca_32.transform(X_32).dtype == np.float32
 
-    assert_allclose(pca_64.components_, pca_32.components_, atol=1e-4)
+    assert_allclose(pca_64.components_, pca_32.components_, rtol=1e-4)
 
 
 def check_pca_int_dtype_upcast_to_double(svd_solver):
@@ -566,4 +566,4 @@ def check_pca_int_dtype_upcast_to_double(svd_solver):
     assert pca_64.transform(X_i64).dtype == np.float64
     assert pca_32.transform(X_i32).dtype == np.float64
 
-    assert_allclose(pca_64.components_, pca_32.components_, atol=1e-4)
+    assert_allclose(pca_64.components_, pca_32.components_, rtol=1e-4)

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -225,7 +225,7 @@ def test_pca_check_projection(svd_solver):
 
 
 @pytest.mark.parametrize("svd_solver", solver_list)
-def test_pca_check_projection(svd_solver):
+def test_pca_check_projection_list(svd_solver):
     # Test that the projection of data is correct
     X = [[1.0, 0.0], [0.0, 1.0]]
     pca = PCA(n_components=1, svd_solver=svd_solver, random_state=0)
@@ -381,8 +381,8 @@ def test_infer_dim_3():
 
 @pytest.mark.parametrize(
     "X, n_components, n_components_",
-    [(iris.data, 0.95, 2), # row > col
-     (iris.data, 0.01, 1), # row > col
+    [(iris.data, 0.95, 2),  # row > col
+     (iris.data, 0.01, 1),  # row > col
      (np.random.RandomState(0).rand(5, 20), 0.5, 2)]  # row < col
 )
 def test_infer_dim_by_explained_variance(X, n_components, n_components_):


### PR DESCRIPTION
To ease implementing the tests in #12319, I am refactoring some of the tests in `test_pca.py` using pytest parametrization. This can be useful even if #12319 is not merged.