### PR TITLE
TST refactor test_truncated_svd

### DIFF
--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -7,98 +7,106 @@ import pytest
 
 from sklearn.decomposition import TruncatedSVD, PCA
 from sklearn.utils import check_random_state
-from sklearn.utils.testing import (assert_array_almost_equal, assert_equal,
-                                   assert_raises, assert_greater,
+from sklearn.utils.testing import (assert_raises,
                                    assert_array_less, assert_allclose)
 
 
-# Make an X that looks somewhat like a small tf-idf matrix.
-# XXX newer versions of SciPy >0.16 have scipy.sparse.rand for this.
-shape = 60, 55
-n_samples, n_features = shape
-rng = check_random_state(42)
-X = rng.randint(-100, 20, np.product(shape)).reshape(shape)
-X = sp.csr_matrix(np.maximum(X, 0), dtype=np.float64)
-X.data[:] = 1 + np.log(X.data)
-Xdense = X.A
+@pytest.fixture(scope='module')
+def X_sparse():
+    # Make an X that looks somewhat like a small tf-idf matrix.
+    # XXX newer versions of SciPy >0.16 have scipy.sparse.rand for this.
+    shape = 60, 55
+    n_samples, n_features = shape
+    rng = check_random_state(42)
+    X = rng.randint(-100, 20, np.product(shape)).reshape(shape)
+    X = sp.csr_matrix(np.maximum(X, 0), dtype=np.float64)
+    X.data[:] = 1 + np.log(X.data)
+    return X
 
 
-def test_algorithms():
+@pytest.mark.parametrize("algorithm", ['randomized'])
+def test_solvers(X_sparse, algorithm):
     svd_a = TruncatedSVD(30, algorithm="arpack")
-    svd_r = TruncatedSVD(30, algorithm="randomized", random_state=42)
+    svd = TruncatedSVD(30, algorithm=algorithm, random_state=42)
 
-    Xa = svd_a.fit_transform(X)[:, :6]
-    Xr = svd_r.fit_transform(X)[:, :6]
-    assert_array_almost_equal(Xa, Xr, decimal=5)
+    Xa = svd_a.fit_transform(X_sparse)[:, :6]
+    Xr = svd.fit_transform(X_sparse)[:, :6]
+    assert_allclose(Xa, Xr, rtol=2e-3)
 
     comp_a = np.abs(svd_a.components_)
-    comp_r = np.abs(svd_r.components_)
+    comp = np.abs(svd.components_)
     # All elements are equal, but some elements are more equal than others.
-    assert_array_almost_equal(comp_a[:9], comp_r[:9])
-    assert_array_almost_equal(comp_a[9:], comp_r[9:], decimal=2)
+    assert_allclose(comp_a[:9], comp[:9], rtol=1e-3)
+    assert_allclose(comp_a[9:], comp[9:], rtol=2e-1, atol=1e-2)
 
 
-def test_attributes():
-    for n_components in (10, 25, 41):
-        tsvd = TruncatedSVD(n_components).fit(X)
-        assert_equal(tsvd.n_components, n_components)
-        assert_equal(tsvd.components_.shape, (n_components, n_features))
+@pytest.mark.parametrize("n_components", (10, 25, 41))
+def test_attributes(n_components, X_sparse):
+    n_features = X_sparse.shape[1]
+    tsvd = TruncatedSVD(n_components).fit(X_sparse)
+    assert tsvd.n_components == n_components
+    assert tsvd.components_.shape == (n_components, n_features)
 
 
 @pytest.mark.parametrize('algorithm', ("arpack", "randomized"))
-def test_too_many_components(algorithm):
+def test_too_many_components(algorithm, X_sparse):
+    n_features = X_sparse.shape[1]
     for n_components in (n_features, n_features + 1):
         tsvd = TruncatedSVD(n_components=n_components, algorithm=algorithm)
-        assert_raises(ValueError, tsvd.fit, X)
+        assert_raises(ValueError, tsvd.fit, X_sparse)
 
 
 @pytest.mark.parametrize('fmt', ("array", "csr", "csc", "coo", "lil"))
-def test_sparse_formats(fmt):
-    Xfmt = Xdense if fmt == "dense" else getattr(X, "to" + fmt)()
+def test_sparse_formats(fmt, X_sparse):
+    n_samples = X_sparse.shape[0]
+    Xfmt = (X_sparse.toarray()
+            if fmt == "dense" else getattr(X_sparse, "to" + fmt)())
     tsvd = TruncatedSVD(n_components=11)
     Xtrans = tsvd.fit_transform(Xfmt)
-    assert_equal(Xtrans.shape, (n_samples, 11))
+    assert Xtrans.shape == (n_samples, 11)
     Xtrans = tsvd.transform(Xfmt)
-    assert_equal(Xtrans.shape, (n_samples, 11))
+    assert Xtrans.shape == (n_samples, 11)
 
 
 @pytest.mark.parametrize('algo', ("arpack", "randomized"))
-def test_inverse_transform(algo):
+def test_inverse_transform(algo, X_sparse):
     # We need a lot of components for the reconstruction to be "almost
     # equal" in all positions. XXX Test means or sums instead?
     tsvd = TruncatedSVD(n_components=52, random_state=42, algorithm=algo)
-    Xt = tsvd.fit_transform(X)
+    Xt = tsvd.fit_transform(X_sparse)
     Xinv = tsvd.inverse_transform(Xt)
-    assert_array_almost_equal(Xinv, Xdense, decimal=1)
+    assert_allclose(Xinv, X_sparse.toarray(), rtol=1e-1, atol=2e-1)
 
 
-def test_integers():
-    Xint = X.astype(np.int64)
+def test_integers(X_sparse):
+    n_samples = X_sparse.shape[0]
+    Xint = X_sparse.astype(np.int64)
     tsvd = TruncatedSVD(n_components=6)
     Xtrans = tsvd.fit_transform(Xint)
-    assert_equal(Xtrans.shape, (n_samples, tsvd.n_components))
+    assert Xtrans.shape == (n_samples, tsvd.n_components)
 
 
-def test_explained_variance():
+def test_explained_variance(X_sparse):
     # Test sparse data
     svd_a_10_sp = TruncatedSVD(10, algorithm="arpack")
     svd_r_10_sp = TruncatedSVD(10, algorithm="randomized", random_state=42)
     svd_a_20_sp = TruncatedSVD(20, algorithm="arpack")
     svd_r_20_sp = TruncatedSVD(20, algorithm="randomized", random_state=42)
-    X_trans_a_10_sp = svd_a_10_sp.fit_transform(X)
-    X_trans_r_10_sp = svd_r_10_sp.fit_transform(X)
-    X_trans_a_20_sp = svd_a_20_sp.fit_transform(X)
-    X_trans_r_20_sp = svd_r_20_sp.fit_transform(X)
+    X_trans_a_10_sp = svd_a_10_sp.fit_transform(X_sparse)
+    X_trans_r_10_sp = svd_r_10_sp.fit_transform(X_sparse)
+    X_trans_a_20_sp = svd_a_20_sp.fit_transform(X_sparse)
+    X_trans_r_20_sp = svd_r_20_sp.fit_transform(X_sparse)
 
     # Test dense data
+    X_dense = X_sparse.toarray()
     svd_a_10_de = TruncatedSVD(10, algorithm="arpack")
     svd_r_10_de = TruncatedSVD(10, algorithm="randomized", random_state=42)
     svd_a_20_de = TruncatedSVD(20, algorithm="arpack")
     svd_r_20_de = TruncatedSVD(20, algorithm="randomized", random_state=42)
-    X_trans_a_10_de = svd_a_10_de.fit_transform(X.toarray())
-    X_trans_r_10_de = svd_r_10_de.fit_transform(X.toarray())
-    X_trans_a_20_de = svd_a_20_de.fit_transform(X.toarray())
-    X_trans_r_20_de = svd_r_20_de.fit_transform(X.toarray())
+    X_trans_a_10_de = svd_a_10_de.fit_transform(X_dense)
+    X_trans_r_10_de = svd_r_10_de.fit_transform(X_dense)
+    X_trans_a_20_de = svd_a_20_de.fit_transform(X_dense)
+    X_trans_r_20_de = svd_r_20_de.fit_transform(X_dense)
 
     # helper arrays for tests below
     svds = (svd_a_10_sp, svd_r_10_sp, svd_a_20_sp, svd_r_20_sp, svd_a_10_de,
@@ -128,17 +136,17 @@ def test_explained_variance():
 
     # Assert the 1st component is equal
     for svd_10, svd_20 in svds_10_v_20:
-        assert_array_almost_equal(
+        assert_allclose(
             svd_10.explained_variance_ratio_,
             svd_20.explained_variance_ratio_[:10],
-            decimal=5,
+            rtol=1e-3,
         )
 
     # Assert that 20 components has higher explained variance than 10
     for svd_10, svd_20 in svds_10_v_20:
-        assert_greater(
-            svd_20.explained_variance_ratio_.sum(),
-            svd_10.explained_variance_ratio_.sum(),
+        assert (
+            svd_20.explained_variance_ratio_.sum() >
+            svd_10.explained_variance_ratio_.sum()
         )
 
     # Assert that all the values are greater than 0
@@ -151,22 +159,23 @@ def test_explained_variance():
 
     # Compare sparse vs. dense
     for svd_sparse, svd_dense in svds_sparse_v_dense:
-        assert_array_almost_equal(svd_sparse.explained_variance_ratio_,
-                                  svd_dense.explained_variance_ratio_)
+        assert_allclose(svd_sparse.explained_variance_ratio_,
+                        svd_dense.explained_variance_ratio_)
 
     # Test that explained_variance is correct
     for svd, transformed in svds_trans:
-        total_variance = np.var(X.toarray(), axis=0).sum()
+        total_variance = np.var(X_dense, axis=0).sum()
         variances = np.var(transformed, axis=0)
         true_explained_variance_ratio = variances / total_variance
 
-        assert_array_almost_equal(
+        assert_allclose(
             svd.explained_variance_ratio_,
             true_explained_variance_ratio,
         )
 
 
-def test_singular_values():
+@pytest.mark.parametrize('solver', ['randomized'])
+def test_singular_values_solvers(solver):
     # Check that the TruncatedSVD output has the correct singular values
 
     rng = np.random.RandomState(0)
@@ -177,24 +186,27 @@ def test_singular_values():
 
     apca = TruncatedSVD(n_components=2, algorithm='arpack',
                         random_state=rng).fit(X)
-    rpca = TruncatedSVD(n_components=2, algorithm='arpack',
-                        random_state=rng).fit(X)
-    assert_array_almost_equal(apca.singular_values_, rpca.singular_values_, 12)
+    pca = TruncatedSVD(n_components=2, algorithm='randomized',
+                       random_state=rng).fit(X)
+    assert_allclose(apca.singular_values_, pca.singular_values_, rtol=1e-2)
 
     # Compare to the Frobenius norm
     X_apca = apca.transform(X)
-    X_rpca = rpca.transform(X)
-    assert_array_almost_equal(np.sum(apca.singular_values_**2.0),
-                              np.linalg.norm(X_apca, "fro")**2.0, 12)
-    assert_array_almost_equal(np.sum(rpca.singular_values_**2.0),
-                              np.linalg.norm(X_rpca, "fro")**2.0, 12)
+    X_pca = pca.transform(X)
+    assert_allclose(np.sum(apca.singular_values_**2.0),
+                    np.linalg.norm(X_apca, "fro")**2.0, rtol=1e-2)
+    assert_allclose(np.sum(pca.singular_values_**2.0),
+                    np.linalg.norm(X_pca, "fro")**2.0, rtol=1e-2)
 
     # Compare to the 2-norms of the score vectors
-    assert_array_almost_equal(apca.singular_values_,
-                              np.sqrt(np.sum(X_apca**2.0, axis=0)), 12)
-    assert_array_almost_equal(rpca.singular_values_,
-                              np.sqrt(np.sum(X_rpca**2.0, axis=0)), 12)
+    assert_allclose(apca.singular_values_,
+                    np.sqrt(np.sum(X_apca**2.0, axis=0)), rtol=1e-2)
+    assert_allclose(pca.singular_values_,
+                    np.sqrt(np.sum(X_pca**2.0, axis=0)), rtol=1e-2)
 
+
+@pytest.mark.parametrize('solver', ['randomized'])
+def test_singular_values_expected(solver):
     # Set the singular values and see what we get back
     rng = np.random.RandomState(0)
     n_samples = 100
@@ -204,30 +216,32 @@ def test_singular_values():
 
     apca = TruncatedSVD(n_components=3, algorithm='arpack',
                         random_state=rng)
-    rpca = TruncatedSVD(n_components=3, algorithm='randomized',
-                        random_state=rng)
+    pca = TruncatedSVD(n_components=3, algorithm=solver,
+                       random_state=rng)
     X_apca = apca.fit_transform(X)
-    X_rpca = rpca.fit_transform(X)
+    X_pca = pca.fit_transform(X)
 
     X_apca /= np.sqrt(np.sum(X_apca**2.0, axis=0))
-    X_rpca /= np.sqrt(np.sum(X_rpca**2.0, axis=0))
+    X_pca /= np.sqrt(np.sum(X_pca**2.0, axis=0))
     X_apca[:, 0] *= 3.142
     X_apca[:, 1] *= 2.718
-    X_rpca[:, 0] *= 3.142
-    X_rpca[:, 1] *= 2.718
+    X_pca[:, 0] *= 3.142
+    X_pca[:, 1] *= 2.718
 
     X_hat_apca = np.dot(X_apca, apca.components_)
-    X_hat_rpca = np.dot(X_rpca, rpca.components_)
+    X_hat_rpca = np.dot(X_pca, pca.components_)
     apca.fit(X_hat_apca)
-    rpca.fit(X_hat_rpca)
-    assert_array_almost_equal(apca.singular_values_, [3.142, 2.718, 1.0], 14)
-    assert_array_almost_equal(rpca.singular_values_, [3.142, 2.718, 1.0], 14)
+    pca.fit(X_hat_rpca)
+    assert_allclose(apca.singular_values_, [3.142, 2.718, 1.0], 14)
+    assert_allclose(pca.singular_values_, [3.142, 2.718, 1.0], 14)
 
 
-def test_truncated_svd_eq_pca():
+def test_truncated_svd_eq_pca(X_sparse):
     # TruncatedSVD should be equal to PCA on centered data
 
-    X_c = X - X.mean(axis=0)
+    X_dense = X_sparse.toarray()
+
+    X_c = X_dense - X_dense.mean(axis=0)
 
     params = dict(n_components=10, random_state=42)
 

--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -36,7 +36,7 @@ def test_solvers(X_sparse, solver, kind):
     comp = np.abs(svd.components_)
     # All elements are equal, but some elements are more equal than others.
     assert_allclose(comp_a[:9], comp[:9], rtol=1e-3)
-    assert_allclose(comp_a[9:], comp[9:], rtol=2e-1, atol=1e-2)
+    assert_allclose(comp_a[9:], comp[9:], atol=1e-2)
 
 
 @pytest.mark.parametrize("n_components", (10, 25, 41))
@@ -121,7 +121,7 @@ def test_explained_variance_components_10_20(X_sparse, kind, solver):
     assert_allclose(
         svd_10.explained_variance_ratio_,
         svd_20.explained_variance_ratio_[:10],
-        rtol=2e-3,
+        rtol=3e-3,
     )
 
     # Assert that 20 components has higher explained variance than 10

--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -232,8 +232,8 @@ def test_singular_values_expected(solver):
     X_hat_rpca = np.dot(X_pca, pca.components_)
     apca.fit(X_hat_apca)
     pca.fit(X_hat_rpca)
-    assert_allclose(apca.singular_values_, [3.142, 2.718, 1.0], 14)
-    assert_allclose(pca.singular_values_, [3.142, 2.718, 1.0], 14)
+    assert_allclose(apca.singular_values_, [3.142, 2.718, 1.0], rtol=1e-14)
+    assert_allclose(pca.singular_values_, [3.142, 2.718, 1.0], rtol=1e-14)
 
 
 def test_truncated_svd_eq_pca(X_sparse):

--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -15,12 +15,8 @@ SVD_SOLVERS = ['arpack', 'randomized']
 @pytest.fixture(scope='module')
 def X_sparse():
     # Make an X that looks somewhat like a small tf-idf matrix.
-    # XXX newer versions of SciPy >0.16 have scipy.sparse.rand for this.
-    shape = (60, 55)
-    n_samples, n_features = shape
     rng = check_random_state(42)
-    X = rng.randint(-100, 20, np.product(shape)).reshape(shape)
-    X = sp.csr_matrix(np.maximum(X, 0), dtype=np.float64)
+    X = sp.random(60, 55, density=0.2, format="csr", random_state=rng)
     X.data[:] = 1 + np.log(X.data)
     return X
 
@@ -125,7 +121,7 @@ def test_explained_variance_components_10_20(X_sparse, kind, solver):
     assert_allclose(
         svd_10.explained_variance_ratio_,
         svd_20.explained_variance_ratio_[:10],
-        rtol=1e-3,
+        rtol=2e-3,
     )
 
     # Assert that 20 components has higher explained variance than 10

--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -16,7 +16,7 @@ SVD_SOLVERS = ['arpack', 'randomized']
 def X_sparse():
     # Make an X that looks somewhat like a small tf-idf matrix.
     # XXX newer versions of SciPy >0.16 have scipy.sparse.rand for this.
-    shape = 60, 55
+    shape = (60, 55)
     n_samples, n_features = shape
     rng = check_random_state(42)
     X = rng.randint(-100, 20, np.product(shape)).reshape(shape)
@@ -25,12 +25,12 @@ def X_sparse():
     return X
 
 
-@pytest.mark.parametrize("algorithm", ['randomized'])
+@pytest.mark.parametrize("solver", ['randomized'])
 @pytest.mark.parametrize('kind', ('dense', 'sparse'))
-def test_solvers(X_sparse, algorithm, kind):
+def test_solvers(X_sparse, solver, kind):
     X = X_sparse if kind == 'sparse' else X_sparse.toarray()
     svd_a = TruncatedSVD(30, algorithm="arpack")
-    svd = TruncatedSVD(30, algorithm=algorithm, random_state=42)
+    svd = TruncatedSVD(30, algorithm=solver, random_state=42)
 
     Xa = svd_a.fit_transform(X)[:, :6]
     Xr = svd.fit_transform(X)[:, :6]
@@ -118,8 +118,8 @@ def test_explained_variance(X_sparse, kind, n_components, solver):
 @pytest.mark.parametrize('solver', SVD_SOLVERS)
 def test_explained_variance_components_10_20(X_sparse, kind, solver):
     X = X_sparse if kind == 'sparse' else X_sparse.toarray()
-    svd_10 = TruncatedSVD(10, algorithm="arpack").fit(X)
-    svd_20 = TruncatedSVD(20, algorithm="arpack").fit(X)
+    svd_10 = TruncatedSVD(10, algorithm=solver).fit(X)
+    svd_20 = TruncatedSVD(20, algorithm=solver).fit(X)
 
     # Assert the 1st component is equal
     assert_allclose(


### PR DESCRIPTION
Similarly to https://github.com/scikit-learn/scikit-learn/pull/14138 refactor `test_truncated_svd` to make them more parametrized and avoid `assert_array_almost_equal`. 

This would help for adding a new solver in https://github.com/scikit-learn/scikit-learn/pull/12319

Should be fairly easy to review.