### PR TITLE
DOC fixing the missing fetch upstream in contributing docs

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -224,8 +224,10 @@ then submit a "pull request" (PR):
 
     $ git remote add upstream https://github.com/scikit-learn/scikit-learn.git
 
-7. Create a branch to hold your development changes::
+7. Fetch the ``upstream`` and then create a branch to hold your development
+   changes::
 
+       $ git fetch upstream
        $ git checkout -b my-feature upstream/master
 
    and start making changes. Always use a ``feature`` branch. It's good


### PR DESCRIPTION
The contributing docs is missing a `git fetch upstream` for the `checout -b branchname upstream/master` to actually work.

#WiDSML