### PR TITLE
Fix warnings by adding use_line_collection=True to plt.stem

### DIFF
--- a/examples/linear_model/plot_omp.py
+++ b/examples/linear_model/plot_omp.py
@@ -38,7 +38,7 @@ plt.figure(figsize=(7, 7))
 plt.subplot(4, 1, 1)
 plt.xlim(0, 512)
 plt.title("Sparse signal")
-plt.stem(idx, w[idx])
+plt.stem(idx, w[idx], use_line_collection=True)
 
 # plot the noise-free reconstruction
 omp = OrthogonalMatchingPursuit(n_nonzero_coefs=n_nonzero_coefs)
@@ -48,7 +48,7 @@ idx_r, = coef.nonzero()
 plt.subplot(4, 1, 2)
 plt.xlim(0, 512)
 plt.title("Recovered signal from noise-free measurements")
-plt.stem(idx_r, coef[idx_r])
+plt.stem(idx_r, coef[idx_r], use_line_collection=True)
 
 # plot the noisy reconstruction
 omp.fit(X, y_noisy)
@@ -57,7 +57,7 @@ idx_r, = coef.nonzero()
 plt.subplot(4, 1, 3)
 plt.xlim(0, 512)
 plt.title("Recovered signal from noisy measurements")
-plt.stem(idx_r, coef[idx_r])
+plt.stem(idx_r, coef[idx_r], use_line_collection=True)
 
 # plot the noisy reconstruction with number of non-zeros set by CV
 omp_cv = OrthogonalMatchingPursuitCV(cv=5)
@@ -67,7 +67,7 @@ idx_r, = coef.nonzero()
 plt.subplot(4, 1, 4)
 plt.xlim(0, 512)
 plt.title("Recovered signal from noisy measurements with CV")
-plt.stem(idx_r, coef[idx_r])
+plt.stem(idx_r, coef[idx_r], use_line_collection=True)
 
 plt.subplots_adjust(0.06, 0.04, 0.94, 0.90, 0.20, 0.38)
 plt.suptitle('Sparse signal recovery with Orthogonal Matching Pursuit',


### PR DESCRIPTION
In matplotlib v3.3, we can set use_line_collection=True in the StemContainer
Related to #14117

#WiMLDS 
@maggiechege
@dominicondigo