### PR TITLE
Fixing warnings in examples/impute/plot_missing_values

### DIFF
--- a/examples/impute/plot_missing_values.py
+++ b/examples/impute/plot_missing_values.py
@@ -35,7 +35,6 @@ from sklearn.model_selection import cross_val_score
 rng = np.random.RandomState(0)
 
 N_SPLITS = 5
-# Initialising with estimators using a default 100
 REGRESSOR = RandomForestRegressor(random_state=0)
 
 

--- a/examples/impute/plot_missing_values.py
+++ b/examples/impute/plot_missing_values.py
@@ -31,7 +31,8 @@ from sklearn.ensemble import RandomForestRegressor
 from sklearn.pipeline import make_pipeline, make_union
 from sklearn.impute import SimpleImputer, IterativeImputer, MissingIndicator
 from sklearn.model_selection import cross_val_score
-#Importing warnings library
+
+# Importing warnings library
 import warnings
 from sklearn.exceptions import ConvergenceWarning
 
@@ -39,13 +40,13 @@ warnings.filterwarnings("ignore",
                         category=ConvergenceWarning,
                         module="sklearn")
 
-#Filtering runtime warnings invalid value encountered in true_divide
+# Filtering runtime warnings invalid value encountered in true_divide
 np.seterr(invalid='ignore')
 
 rng = np.random.RandomState(0)
 
 N_SPLITS = 5
-#Initialising with estimators using a default 100
+# Initialising with estimators using a default 100
 REGRESSOR = RandomForestRegressor(random_state=0, n_estimators=100)
 
 

--- a/examples/impute/plot_missing_values.py
+++ b/examples/impute/plot_missing_values.py
@@ -32,22 +32,11 @@ from sklearn.pipeline import make_pipeline, make_union
 from sklearn.impute import SimpleImputer, IterativeImputer, MissingIndicator
 from sklearn.model_selection import cross_val_score
 
-# Importing warnings library
-import warnings
-from sklearn.exceptions import ConvergenceWarning
-
-warnings.filterwarnings("ignore",
-                        category=ConvergenceWarning,
-                        module="sklearn")
-
-# Filtering runtime warnings invalid value encountered in true_divide
-np.seterr(invalid='ignore')
-
 rng = np.random.RandomState(0)
 
 N_SPLITS = 5
 # Initialising with estimators using a default 100
-REGRESSOR = RandomForestRegressor(random_state=0, n_estimators=100)
+REGRESSOR = RandomForestRegressor(random_state=0)
 
 
 def get_scores_for_imputer(imputer, X_missing, y_missing):

--- a/examples/impute/plot_missing_values.py
+++ b/examples/impute/plot_missing_values.py
@@ -31,11 +31,22 @@ from sklearn.ensemble import RandomForestRegressor
 from sklearn.pipeline import make_pipeline, make_union
 from sklearn.impute import SimpleImputer, IterativeImputer, MissingIndicator
 from sklearn.model_selection import cross_val_score
+#Importing warnings library
+import warnings
+from sklearn.exceptions import ConvergenceWarning
+
+warnings.filterwarnings("ignore",
+                        category=ConvergenceWarning,
+                        module="sklearn")
+
+#Filtering runtime warnings invalid value encountered in true_divide
+np.seterr(invalid='ignore')
 
 rng = np.random.RandomState(0)
 
 N_SPLITS = 5
-REGRESSOR = RandomForestRegressor(random_state=0)
+#Initialising with estimators using a default 100
+REGRESSOR = RandomForestRegressor(random_state=0, n_estimators=100)
 
 
 def get_scores_for_imputer(imputer, X_missing, y_missing):

--- a/examples/impute/plot_missing_values.py
+++ b/examples/impute/plot_missing_values.py
@@ -96,7 +96,8 @@ def get_results(dataset):
     # Estimate the score after iterative imputation of the missing values
     imputer = IterativeImputer(missing_values=0,
                                random_state=0,
-                               n_nearest_features=5)
+                               n_nearest_features=5,
+                               sample_posterior=True)
     iterative_impute_scores = get_scores_for_imputer(imputer,
                                                      X_missing,
                                                      y_missing)


### PR DESCRIPTION
## I was able to fix the following warning
* ensemble warning from random forest class
I included the n_estimators=100 argument
* Runtime warning 
```sh
{parent_dir}\sk-venv\lib\site-packages\numpy\lib\function_base.py:2530: RuntimeWarning: invalid value encountered in true_divide
  c /= stddev[:, None]
```
I fixed it by ignoring the  numpy warning

* Convergence warning
```sh
{parent_dir}\SK\sk-venv\lib\site-packages\sklearn\impute\_iterative.py:599: ConvergenceWarning: [IterativeImputer] Early stopping criterion not reached.
  " reached.", ConvergenceWarning)
```
I fixed it by ignoring all covergence warning

related to #14117
#WiDSML
@adrinjalali 