### PR TITLE
EXA Use n_quantiles=500 in plot_map_data_to_normal.py

### DIFF
--- a/examples/preprocessing/plot_map_data_to_normal.py
+++ b/examples/preprocessing/plot_map_data_to_normal.py
@@ -53,7 +53,8 @@ BINS = 30
 rng = np.random.RandomState(304)
 bc = PowerTransformer(method='box-cox')
 yj = PowerTransformer(method='yeo-johnson')
-qt = QuantileTransformer(n_quantiles=500, output_distribution='normal', random_state=rng)
+qt = QuantileTransformer(n_quantiles=500, output_distribution='normal',
+                         random_state=rng)
 size = (N_SAMPLES, 1)
 
 
@@ -135,3 +136,4 @@ for distribution, color, axes in zip(distributions, colors, axes_list):
 
 plt.tight_layout()
 plt.show()
+

--- a/examples/preprocessing/plot_map_data_to_normal.py
+++ b/examples/preprocessing/plot_map_data_to_normal.py
@@ -53,7 +53,7 @@ BINS = 30
 rng = np.random.RandomState(304)
 bc = PowerTransformer(method='box-cox')
 yj = PowerTransformer(method='yeo-johnson')
-qt = QuantileTransformer(output_distribution='normal', random_state=rng)
+qt = QuantileTransformer(n_quantiles=500, output_distribution='normal', random_state=rng)
 size = (N_SAMPLES, 1)
 
 

--- a/examples/preprocessing/plot_map_data_to_normal.py
+++ b/examples/preprocessing/plot_map_data_to_normal.py
@@ -136,4 +136,3 @@ for distribution, color, axes in zip(distributions, colors, axes_list):
 
 plt.tight_layout()
 plt.show()
-

--- a/examples/preprocessing/plot_map_data_to_normal.py
+++ b/examples/preprocessing/plot_map_data_to_normal.py
@@ -53,9 +53,8 @@ BINS = 30
 rng = np.random.RandomState(304)
 bc = PowerTransformer(method='box-cox')
 yj = PowerTransformer(method='yeo-johnson')
-# n_quantiles is set to the training set size.
-# A larger number of n_quantiles does not give a better approximation of the
-# cumulative distribution function estimator
+# n_quantiles is set to the training set size rather than the default value
+# to avoid a warning being raised by this example
 qt = QuantileTransformer(n_quantiles=500, output_distribution='normal',
                          random_state=rng)
 size = (N_SAMPLES, 1)

--- a/examples/preprocessing/plot_map_data_to_normal.py
+++ b/examples/preprocessing/plot_map_data_to_normal.py
@@ -53,6 +53,9 @@ BINS = 30
 rng = np.random.RandomState(304)
 bc = PowerTransformer(method='box-cox')
 yj = PowerTransformer(method='yeo-johnson')
+# n_quantiles is set to the training set size.
+# A larger number of n_quantiles does not give a better approximation of the
+# cumulative distribution function estimator
 qt = QuantileTransformer(n_quantiles=500, output_distribution='normal',
                          random_state=rng)
 size = (N_SAMPLES, 1)


### PR DESCRIPTION
We are having warning since we are using n_quantiles default values. Fix this by assigning a value to n_quantiles during class initialization.

Related to issue #14117

#WiMLDS
@MaggieChege
@dominicondigo