### PR TITLE
Fix joblib is imported with both import and import from

### DIFF
--- a/sklearn/datasets/lfw.py
+++ b/sklearn/datasets/lfw.py
@@ -16,7 +16,7 @@ from distutils.version import LooseVersion
 
 import numpy as np
 import joblib
-from joblib import Memory
+
 
 from .base import get_data_home, _fetch_remote, RemoteFileMetadata
 from ..utils import Bunch
@@ -305,9 +305,9 @@ def fetch_lfw_people(data_home=None, funneled=True, resize=0.5,
     # arrays for optimal memory usage
     if LooseVersion(joblib.__version__) < LooseVersion('0.12'):
         # Deal with change of API in joblib
-        m = Memory(cachedir=lfw_home, compress=6, verbose=0)
+        m = joblib.Memory(cachedir=lfw_home, compress=6, verbose=0)
     else:
-        m = Memory(location=lfw_home, compress=6, verbose=0)
+        m = joblib.Memory(location=lfw_home, compress=6, verbose=0)
     load_func = m.cache(_fetch_lfw_people)
 
     # load and memoize the pairs as np arrays
@@ -476,9 +476,9 @@ def fetch_lfw_pairs(subset='train', data_home=None, funneled=True, resize=0.5,
     # arrays for optimal memory usage
     if LooseVersion(joblib.__version__) < LooseVersion('0.12'):
         # Deal with change of API in joblib
-        m = Memory(cachedir=lfw_home, compress=6, verbose=0)
+        m = joblib.Memory(cachedir=lfw_home, compress=6, verbose=0)
     else:
-        m = Memory(location=lfw_home, compress=6, verbose=0)
+        m = joblib.Memory(location=lfw_home, compress=6, verbose=0)
     load_func = m.cache(_fetch_lfw_pairs)
 
     # select the right metadata file according to the requested subset


### PR DESCRIPTION
#### Reference Issues/PRs
#12167

Fixes Module 'joblib' is imported with both 'import' and 'import from' in 
Source root/sklearn/datasets/lfw.py

 #### What does this implement/fix? Explain your changes.
Deleted line 19 (`from joblib import Memory`) 
updated all instance of `Memory` to `joblib.Memory`

#### Any other comments?
#WiMDS 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
