### PR TITLE
Fix warnings in examples/neighbors/plot_nca_illustration.py #14117 

### DIFF
--- a/examples/impute/plot_missing_values.py
+++ b/examples/impute/plot_missing_values.py
@@ -32,22 +32,10 @@ from sklearn.pipeline import make_pipeline, make_union
 from sklearn.impute import SimpleImputer, IterativeImputer, MissingIndicator
 from sklearn.model_selection import cross_val_score
 
-# Importing warnings library
-import warnings
-from sklearn.exceptions import ConvergenceWarning
-
-warnings.filterwarnings("ignore",
-                        category=ConvergenceWarning,
-                        module="sklearn")
-
-# Filtering runtime warnings invalid value encountered in true_divide
-np.seterr(invalid='ignore')
-
 rng = np.random.RandomState(0)
 
 N_SPLITS = 5
-# Initialising with estimators using a default 100
-REGRESSOR = RandomForestRegressor(random_state=0, n_estimators=100)
+REGRESSOR = RandomForestRegressor(random_state=0)
 
 
 def get_scores_for_imputer(imputer, X_missing, y_missing):

--- a/examples/impute/plot_missing_values.py
+++ b/examples/impute/plot_missing_values.py
@@ -31,7 +31,8 @@ from sklearn.ensemble import RandomForestRegressor
 from sklearn.pipeline import make_pipeline, make_union
 from sklearn.impute import SimpleImputer, IterativeImputer, MissingIndicator
 from sklearn.model_selection import cross_val_score
-#Importing warnings library
+
+# Importing warnings library
 import warnings
 from sklearn.exceptions import ConvergenceWarning
 
@@ -39,13 +40,13 @@ warnings.filterwarnings("ignore",
                         category=ConvergenceWarning,
                         module="sklearn")
 
-#Filtering runtime warnings invalid value encountered in true_divide
+# Filtering runtime warnings invalid value encountered in true_divide
 np.seterr(invalid='ignore')
 
 rng = np.random.RandomState(0)
 
 N_SPLITS = 5
-#Initialising with estimators using a default 100
+# Initialising with estimators using a default 100
 REGRESSOR = RandomForestRegressor(random_state=0, n_estimators=100)
 
 

--- a/examples/impute/plot_missing_values.py
+++ b/examples/impute/plot_missing_values.py
@@ -31,11 +31,22 @@ from sklearn.ensemble import RandomForestRegressor
 from sklearn.pipeline import make_pipeline, make_union
 from sklearn.impute import SimpleImputer, IterativeImputer, MissingIndicator
 from sklearn.model_selection import cross_val_score
+#Importing warnings library
+import warnings
+from sklearn.exceptions import ConvergenceWarning
+
+warnings.filterwarnings("ignore",
+                        category=ConvergenceWarning,
+                        module="sklearn")
+
+#Filtering runtime warnings invalid value encountered in true_divide
+np.seterr(invalid='ignore')
 
 rng = np.random.RandomState(0)
 
 N_SPLITS = 5
-REGRESSOR = RandomForestRegressor(random_state=0)
+#Initialising with estimators using a default 100
+REGRESSOR = RandomForestRegressor(random_state=0, n_estimators=100)
 
 
 def get_scores_for_imputer(imputer, X_missing, y_missing):

--- a/examples/neighbors/plot_nca_illustration.py
+++ b/examples/neighbors/plot_nca_illustration.py
@@ -35,7 +35,7 @@ ax = plt.gca()
 # Draw the graph nodes
 for i in range(X.shape[0]):
     ax.text(X[i, 0], X[i, 1], str(i), va='center', ha='center')
-    ax.scatter(X[i, 0], X[i, 1], s=300, c=cm.Set1(y[i]), alpha=0.4)
+    ax.scatter(X[i, 0], X[i, 1], s=300, alpha=0.4)
 
 
 def p_i(X, i):
@@ -87,7 +87,7 @@ relate_point(X_embedded, i, ax2)
 for i in range(len(X)):
     ax2.text(X_embedded[i, 0], X_embedded[i, 1], str(i),
              va='center', ha='center')
-    ax2.scatter(X_embedded[i, 0], X_embedded[i, 1], s=300, c=cm.Set1(y[i]),
+    ax2.scatter(X_embedded[i, 0], X_embedded[i, 1], s=300,
                 alpha=0.4)
 
 # Make axes equal so that boundaries are displayed correctly as circles

--- a/examples/neighbors/plot_nca_illustration.py
+++ b/examples/neighbors/plot_nca_illustration.py
@@ -35,8 +35,7 @@ ax = plt.gca()
 # Draw the graph nodes
 for i in range(X.shape[0]):
     ax.text(X[i, 0], X[i, 1], str(i), va='center', ha='center')
-    ax.scatter(X[i, 0], X[i, 1], s=300,
-                c=np.array([cm.Set1(y[i])]), alpha=0.4)
+    ax.scatter(X[i, 0], X[i, 1], s=300,c=np.array([cm.Set1(y[i])]), alpha=0.4)
 
 def p_i(X, i):
     diff_embedded = X[i] - X
@@ -57,8 +56,7 @@ def relate_point(X, i, ax):
         thickness = p_i(X, i)
         if i != j:
             line = ([pt_i[0], pt_j[0]], [pt_i[1], pt_j[1]])
-            ax.plot(*line, c=cm.Set1(y[j]),
-                    linewidth=5*thickness[j])
+            ax.plot(*line, c=cm.Set1(y[j]),linewidth=5*thickness[j])
 
 
 # we consider only point 3
@@ -87,9 +85,8 @@ relate_point(X_embedded, i, ax2)
 for i in range(len(X)):
     ax2.text(X_embedded[i, 0], X_embedded[i, 1], str(i),
              va='center', ha='center')
-    ax2.scatter(X_embedded[i, 0], X_embedded[i, 1], s=300,
-                c=np.array([cm.Set1(y[i])]),
-                alpha=0.4)
+    ax2.scatter(X_embedded[i, 0], X_embedded[i, 1],s=300,
+                    c=np.array([cm.Set1(y[i])]),alpha=0.4)
 
 # Make axes equal so that boundaries are displayed correctly as circles
 ax2.set_title("NCA embedding")

--- a/examples/neighbors/plot_nca_illustration.py
+++ b/examples/neighbors/plot_nca_illustration.py
@@ -85,7 +85,8 @@ relate_point(X_embedded, i, ax2)
 for i in range(len(X)):
     ax2.text(X_embedded[i, 0], X_embedded[i, 1], str(i),
              va='center', ha='center')
-    ax2.scatter(X_embedded[i, 0], X_embedded[i, 1], s=300, c=np.array([cm.Set1(y[i])]), alpha=0.4)
+    ax2.scatter(X_embedded[i, 0], X_embedded[i, 1], s=300, 
+                c=np.array([cm.Set1(y[i])]), alpha=0.4)
 
 # Make axes equal so that boundaries are displayed correctly as circles
 ax2.set_title("NCA embedding")

--- a/examples/neighbors/plot_nca_illustration.py
+++ b/examples/neighbors/plot_nca_illustration.py
@@ -35,7 +35,7 @@ ax = plt.gca()
 # Draw the graph nodes
 for i in range(X.shape[0]):
     ax.text(X[i, 0], X[i, 1], str(i), va='center', ha='center')
-    ax.scatter(X[i, 0], X[i, 1], s=300, c=np.array([cm.Set1(y[i])]), alpha=0.4)
+    ax.scatter(X[i, 0], X[i, 1], s=300, c=cm.Set1(y[[i]]), alpha=0.4)
 
 def p_i(X, i):
     diff_embedded = X[i] - X
@@ -56,7 +56,8 @@ def relate_point(X, i, ax):
         thickness = p_i(X, i)
         if i != j:
             line = ([pt_i[0], pt_j[0]], [pt_i[1], pt_j[1]])
-            ax.plot(*line, c=cm.Set1(y[j]), linewidth=5*thickness[j])
+            ax.plot(*line, c=cm.Set1(y[j]),
+                    linewidth=5*thickness[j])
 
 
 # we consider only point 3
@@ -85,8 +86,8 @@ relate_point(X_embedded, i, ax2)
 for i in range(len(X)):
     ax2.text(X_embedded[i, 0], X_embedded[i, 1], str(i),
              va='center', ha='center')
-    ax2.scatter(X_embedded[i, 0], X_embedded[i, 1], s=300,
-                c=np.array([cm.Set1(y[i])]), alpha=0.4)
+    ax2.scatter(X_embedded[i, 0], X_embedded[i, 1], s=300, c=cm.Set1(y[[i]]),
+                alpha=0.4)
 
 # Make axes equal so that boundaries are displayed correctly as circles
 ax2.set_title("NCA embedding")

--- a/examples/neighbors/plot_nca_illustration.py
+++ b/examples/neighbors/plot_nca_illustration.py
@@ -35,8 +35,8 @@ ax = plt.gca()
 # Draw the graph nodes
 for i in range(X.shape[0]):
     ax.text(X[i, 0], X[i, 1], str(i), va='center', ha='center')
-    ax.scatter(X[i, 0], X[i, 1], s=300, alpha=0.4)
-
+    ax.scatter(X[i, 0], X[i, 1], s=300,
+                c=np.array([cm.Set1(y[i])]), alpha=0.4)
 
 def p_i(X, i):
     diff_embedded = X[i] - X
@@ -88,6 +88,7 @@ for i in range(len(X)):
     ax2.text(X_embedded[i, 0], X_embedded[i, 1], str(i),
              va='center', ha='center')
     ax2.scatter(X_embedded[i, 0], X_embedded[i, 1], s=300,
+                c=np.array([cm.Set1(y[i])]),
                 alpha=0.4)
 
 # Make axes equal so that boundaries are displayed correctly as circles

--- a/examples/neighbors/plot_nca_illustration.py
+++ b/examples/neighbors/plot_nca_illustration.py
@@ -35,7 +35,7 @@ ax = plt.gca()
 # Draw the graph nodes
 for i in range(X.shape[0]):
     ax.text(X[i, 0], X[i, 1], str(i), va='center', ha='center')
-    ax.scatter(X[i, 0], X[i, 1], s=300,c=np.array([cm.Set1(y[i])]), alpha=0.4)
+    ax.scatter(X[i, 0], X[i, 1], s=300, c=np.array([cm.Set1(y[i])]), alpha=0.4)
 
 def p_i(X, i):
     diff_embedded = X[i] - X
@@ -56,7 +56,7 @@ def relate_point(X, i, ax):
         thickness = p_i(X, i)
         if i != j:
             line = ([pt_i[0], pt_j[0]], [pt_i[1], pt_j[1]])
-            ax.plot(*line, c=cm.Set1(y[j]),linewidth=5*thickness[j])
+            ax.plot(*line, c=cm.Set1(y[j]), linewidth=5*thickness[j])
 
 
 # we consider only point 3
@@ -85,8 +85,7 @@ relate_point(X_embedded, i, ax2)
 for i in range(len(X)):
     ax2.text(X_embedded[i, 0], X_embedded[i, 1], str(i),
              va='center', ha='center')
-    ax2.scatter(X_embedded[i, 0], X_embedded[i, 1],s=300,
-                    c=np.array([cm.Set1(y[i])]),alpha=0.4)
+    ax2.scatter(X_embedded[i, 0], X_embedded[i, 1], s=300, c=np.array([cm.Set1(y[i])]), alpha=0.4)
 
 # Make axes equal so that boundaries are displayed correctly as circles
 ax2.set_title("NCA embedding")

--- a/examples/neighbors/plot_nca_illustration.py
+++ b/examples/neighbors/plot_nca_illustration.py
@@ -85,7 +85,7 @@ relate_point(X_embedded, i, ax2)
 for i in range(len(X)):
     ax2.text(X_embedded[i, 0], X_embedded[i, 1], str(i),
              va='center', ha='center')
-    ax2.scatter(X_embedded[i, 0], X_embedded[i, 1], s=300, 
+    ax2.scatter(X_embedded[i, 0], X_embedded[i, 1], s=300,
                 c=np.array([cm.Set1(y[i])]), alpha=0.4)
 
 # Make axes equal so that boundaries are displayed correctly as circles


### PR DESCRIPTION
### I was able to fix the warnings try transforming the colour argument to an array. It was intially a tuple
#### The error was
```sh
'c' argument looks like a single numeric RGB or RGBA sequence, which should be avoided as value-mapping will have precedence in case its length matches with 'x' & 'y'.  Please use a 2-D array with a single row if you really want to specify the same RGB or RGBA value for all points.
```
### Before the change
![2019-06-22](https://user-images.githubusercontent.com/28790446/59963321-2bdab880-94fa-11e9-817a-6a99a5c84dad.png)

### After the change
![2019-06-22 (3)](https://user-images.githubusercontent.com/28790446/59963323-3301c680-94fa-11e9-9d5a-788d5e1db40f.png)

### The plotting still remains the same
#WiDSML
@adrinjalali