### PR TITLE
Fix PCA().fit_transform changing the array order

### DIFF
--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -355,12 +355,12 @@ class PCA(_BasePCA):
 
         Notes
         -----
-        This method returns an f-ordered array.
-        To get the output array in c-order,
-        do a transpose of the result i.e
+        This method returns a Fortran-ordered array.To convert it to a C-ordered array,
+        use 'np.ascontiguousarray' e.g
 
         y = PCA().fit_transform(x)
-        y = y.transpose()
+        y = np.ascontiguousarray(y, dtype=np.float32)
+
 
 
         """

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -353,6 +353,15 @@ class PCA(_BasePCA):
         -------
         X_new : array-like, shape (n_samples, n_components)
 
+
+        ..note:: This method changes a c-order array to an f-order array.
+        To get the output matrix in the original order,
+        do a transpose of the result i.e
+
+        y = PCA().fit_transform(x)
+        y = y.transpose()
+
+
         """
         U, S, V = self._fit(X)
         U = U[:, :self.n_components_]

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -355,8 +355,8 @@ class PCA(_BasePCA):
 
         Notes
         -----
-        This method returns a Fortran-ordered array.To convert it to a C-ordered array,
-        use 'np.ascontiguousarray' e.g
+        This method returns a Fortran-ordered array.To convert it to a
+        C-ordered array, use 'np.ascontiguousarray' e.g
 
         y = PCA().fit_transform(x)
         y = np.ascontiguousarray(y, dtype=np.float32)

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -353,9 +353,10 @@ class PCA(_BasePCA):
         -------
         X_new : array-like, shape (n_samples, n_components)
 
-
-        ..note:: This method changes a c-order array to an f-order array.
-        To get the output matrix in the original order,
+        Notes
+        -----
+        This method returns an f-ordered array.
+        To get the output array in c-order,
         do a transpose of the result i.e
 
         y = PCA().fit_transform(x)


### PR DESCRIPTION
Fixes #5419
closes #12213
closes #12390
follow-up #12858

Fixed PCA().fit_transform changes array order.
by Freshia and muokicaleb at Scikit-learn WiMLDS Nairobi 2019 sprint