### PR TITLE
EXA Readability of plot_isotonic_regression.py for color blind persons

### DIFF
--- a/examples/plot_isotonic_regression.py
+++ b/examples/plot_isotonic_regression.py
@@ -50,7 +50,7 @@ lc.set_linewidths(np.full(n, 0.5))
 
 fig = plt.figure()
 plt.plot(x, y, 'r.', markersize=12)
-plt.plot(x, y_, 'g.-', markersize=12)
+plt.plot(x, y_, 'b.-', markersize=12)
 plt.plot(x, lr.predict(x[:, np.newaxis]), 'b-')
 plt.gca().add_collection(lc)
 plt.legend(('Data', 'Isotonic Fit', 'Linear Fit'), loc='lower right')


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs: 
<!--
Fix:  #5435
Convert the output image contrasting options for different color-blind readability. 

#### What does this implement/fix? Explain your changes.
It enables readability of the image by both normal as well as different color-blind groups including the red-blind, green-blind, blue-blind.  

#### Collaborators
@martinoywa, mcecily, @felexkemboi, @toopurity


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
