### PR TITLE
Fix  warnings in examples #14117 - fixed warning messages in plot_transformed_target.py

### DIFF
--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -137,8 +137,8 @@ dataset = load_boston()
 target = np.array(dataset.feature_names) == "DIS"
 X = dataset.data[:, np.logical_not(target)]
 y = dataset.data[:, target].squeeze()
-y_trans = quantile_transform(dataset.data[:, target], 
-                             n_quantiles=300, 
+y_trans = quantile_transform(dataset.data[:, target],
+                             n_quantiles=300,
                              output_distribution='normal',
                              copy=True).squeeze()
 
@@ -186,8 +186,8 @@ ax0.set_ylim([0, 10])
 
 regr_trans = TransformedTargetRegressor(
     regressor=RidgeCV(),
-    transformer=QuantileTransformer(n_quantiles=300, 
-    output_distribution='normal'))
+    transformer=QuantileTransformer(n_quantiles=300,
+                                    output_distribution='normal'))
 regr_trans.fit(X_train, y_train)
 y_pred = regr_trans.predict(X_test)
 

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -137,8 +137,8 @@ dataset = load_boston()
 target = np.array(dataset.feature_names) == "DIS"
 X = dataset.data[:, np.logical_not(target)]
 y = dataset.data[:, target].squeeze()
-y_trans = quantile_transform(dataset.data[:, target], n_quantiles = len(dataset.data[:]),
-                             output_distribution='normal', copy = True).squeeze()
+y_trans = quantile_transform(dataset.data[:, target], n_quantiles=len(dataset.data[:]),
+                             output_distribution='normal', copy=True).squeeze()
 
 ###############################################################################
 # A :class:`sklearn.preprocessing.QuantileTransformer` is used such that the
@@ -184,7 +184,7 @@ ax0.set_ylim([0, 10])
 
 regr_trans = TransformedTargetRegressor(
     regressor=RidgeCV(),
-    transformer=QuantileTransformer(n_quantiles = len(X_train), output_distribution='normal'))
+    transformer=QuantileTransformer(n_quantiles=len(X_train), output_distribution='normal'))
 regr_trans.fit(X_train, y_train)
 y_pred = regr_trans.predict(X_test)
 

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -137,8 +137,9 @@ dataset = load_boston()
 target = np.array(dataset.feature_names) == "DIS"
 X = dataset.data[:, np.logical_not(target)]
 y = dataset.data[:, target].squeeze()
-y_trans = quantile_transform(dataset.data[:, target], n_quantiles=len(dataset.data[:]),
-                             output_distribution='normal', copy=True).squeeze()
+y_trans = quantile_transform(dataset.data[:, target], 
+    n_quantiles=len(dataset.data[:]), output_distribution='normal',
+     copy=True).squeeze()
 
 ###############################################################################
 # A :class:`sklearn.preprocessing.QuantileTransformer` is used such that the
@@ -184,7 +185,8 @@ ax0.set_ylim([0, 10])
 
 regr_trans = TransformedTargetRegressor(
     regressor=RidgeCV(),
-    transformer=QuantileTransformer(n_quantiles=len(X_train), output_distribution='normal'))
+    transformer=QuantileTransformer(n_quantiles=len(X_train), 
+        output_distribution='normal'))
 regr_trans.fit(X_train, y_train)
 y_pred = regr_trans.predict(X_test)
 

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -137,8 +137,8 @@ dataset = load_boston()
 target = np.array(dataset.feature_names) == "DIS"
 X = dataset.data[:, np.logical_not(target)]
 y = dataset.data[:, target].squeeze()
-y_trans = quantile_transform(dataset.data[:, target],
-                             output_distribution='normal').squeeze()
+y_trans = quantile_transform(dataset.data[:, target], n_quantiles = len(dataset.data[:]),
+                             output_distribution='normal', copy = True).squeeze()
 
 ###############################################################################
 # A :class:`sklearn.preprocessing.QuantileTransformer` is used such that the
@@ -184,7 +184,7 @@ ax0.set_ylim([0, 10])
 
 regr_trans = TransformedTargetRegressor(
     regressor=RidgeCV(),
-    transformer=QuantileTransformer(output_distribution='normal'))
+    transformer=QuantileTransformer(n_quantiles = len(X_train), output_distribution='normal'))
 regr_trans.fit(X_train, y_train)
 y_pred = regr_trans.predict(X_test)
 

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -138,8 +138,9 @@ target = np.array(dataset.feature_names) == "DIS"
 X = dataset.data[:, np.logical_not(target)]
 y = dataset.data[:, target].squeeze()
 y_trans = quantile_transform(dataset.data[:, target], 
-    n_quantiles=len(dataset.data[:]), output_distribution='normal',
-     copy=True).squeeze()
+                             n_quantiles=300, 
+                             output_distribution='normal',
+                             copy=True).squeeze()
 
 ###############################################################################
 # A :class:`sklearn.preprocessing.QuantileTransformer` is used such that the
@@ -185,8 +186,8 @@ ax0.set_ylim([0, 10])
 
 regr_trans = TransformedTargetRegressor(
     regressor=RidgeCV(),
-    transformer=QuantileTransformer(n_quantiles=len(X_train), 
-        output_distribution='normal'))
+    transformer=QuantileTransformer(n_quantiles=300, 
+    output_distribution='normal'))
 regr_trans.fit(X_train, y_train)
 y_pred = regr_trans.predict(X_test)
 


### PR DESCRIPTION
@babatunde-abdulquddus and I fixed warnings in examples/compose/plot_transformed_target.py at scikit learn  workshop hosted at Nairobi, Kenya by  @#WiMLDS_Nairobi.

 Related to #14117 