### PR TITLE
Fix warnings in examples/decomposition/plot_faces_decomposition.py #14117

### DIFF
--- a/examples/decomposition/plot_faces_decomposition.py
+++ b/examples/decomposition/plot_faces_decomposition.py
@@ -80,6 +80,7 @@ estimators = [
     ('Sparse comp. - MiniBatchSparsePCA',
      decomposition.MiniBatchSparsePCA(n_components=n_components, alpha=0.8,
                                       n_iter=100, batch_size=3,
+                                      normalize_components=True,
                                       random_state=rng),
      True),
 


### PR DESCRIPTION
I have parsed an argument to the decomposition.MiniBatchSparsePCA of normalize_components=True since the default of normalize_components=False will be iccompatibile for version 0.22                  