### PR TITLE
Fixes issue #14029

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,84 +1,30 @@
-# Even if empty this file is useful so that when running from the root folder
-# ./sklearn is added to sys.path by pytest. See
-# https://docs.pytest.org/en/latest/pythonpath.html for more details.  For
-# example, this allows to build extensions in place and run pytest
-# doc/modules/clustering.rst and use sklearn from the local folder rather than
-# the one from site-packages.
-
-import platform
-from distutils.version import LooseVersion
-
-from sklearn import set_config
 import pytest
-from _pytest.doctest import DoctestItem
-
-PYTEST_MIN_VERSION = '3.3.0'
-
-if LooseVersion(pytest.__version__) < PYTEST_MIN_VERSION:
-    raise ImportError('Your version of pytest is too old, you should have '
-                      'at least pytest >= {} installed.'
-                      .format(PYTEST_MIN_VERSION))
+import numpy as np
+import warnings
 
 
-def pytest_addoption(parser):
-    parser.addoption("--skip-network", action="store_true", default=False,
-                     help="skip network tests")
+@pytest.fixture(scope='function')
+def pyplot():
+    """Setup and teardown fixture for matplotlib.
+
+    This fixture checks if we can import matplotlib. If not, the tests will be
+    skipped. Otherwise, we setup matplotlib backend and close the figures
+    after running the functions.
+
+    Returns
+    -------
+    pyplot : module
+        The ``matplotlib.pyplot`` module.
+    """
+    matplotlib = pytest.importorskip('matplotlib')
+    matplotlib.use('agg', warn=False, force=True)
+    pyplot = pytest.importorskip('matplotlib.pyplot')
+
+    yield pyplot
+    pyplot.close('all')
+if np.iinfo(np.int).dtype != np.int64:
+    warnings.warn("Your default numpy int is a 32 bit one, it may be because you are "
+                      "running a 32 bit Python (or more complicated if you're on Windows "
+                      "or Mac. This causes some docstring tests to fail on your machine....")
 
 
-def pytest_collection_modifyitems(config, items):
-
-    # FeatureHasher is not compatible with PyPy
-    if platform.python_implementation() == 'PyPy':
-        skip_marker = pytest.mark.skip(
-            reason='FeatureHasher is not compatible with PyPy')
-        for item in items:
-            if item.name in (
-                    'sklearn.feature_extraction.hashing.FeatureHasher',
-                    'sklearn.feature_extraction.text.HashingVectorizer'):
-                item.add_marker(skip_marker)
-
-    # Skip tests which require internet if the flag is provided
-    if config.getoption("--skip-network"):
-        skip_network = pytest.mark.skip(
-            reason="test requires internet connectivity")
-        for item in items:
-            if "network" in item.keywords:
-                item.add_marker(skip_network)
-
-    # numpy changed the str/repr formatting of numpy arrays in 1.14. We want to
-    # run doctests only for numpy >= 1.14.
-    skip_doctests = False
-    try:
-        import numpy as np
-        if LooseVersion(np.__version__) < LooseVersion('1.14'):
-            skip_doctests = True
-    except ImportError:
-        pass
-
-    if skip_doctests:
-        skip_marker = pytest.mark.skip(
-            reason='doctests are only run for numpy >= 1.14 and python >= 3')
-
-        for item in items:
-            if isinstance(item, DoctestItem):
-                item.add_marker(skip_marker)
-
-
-def pytest_configure(config):
-    import sys
-    sys._is_pytest_session = True
-
-
-def pytest_unconfigure(config):
-    import sys
-    del sys._is_pytest_session
-
-
-def pytest_runtest_setup(item):
-    if isinstance(item, DoctestItem):
-        set_config(print_changed_only=True)
-
-
-def pytest_runtest_teardown(item, nextitem):
-    if isinstance(item, DoctestItem):
-        set_config(print_changed_only=False)


### PR DESCRIPTION
The doctests would fail if the default numpy.int is 32 bits long. This warns the user if their numpy int is a 32 bit
Contributions made by @adrinjalali and @felexkemboi
#wimlds