### PR TITLE
Warn if default numpy.int is 32bits, while running tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,9 +8,11 @@
 import platform
 from distutils.version import LooseVersion
 
-from sklearn import set_config
 import pytest
 from _pytest.doctest import DoctestItem
+
+from sklearn import set_config
+from sklearn.utils import _IS_32BIT
 
 PYTEST_MIN_VERSION = '3.3.0'
 
@@ -51,13 +53,17 @@ def pytest_collection_modifyitems(config, items):
     try:
         import numpy as np
         if LooseVersion(np.__version__) < LooseVersion('1.14'):
+            reason = 'doctests are only run for numpy >= 1.14'
+            skip_doctests = True
+        elif _IS_32BIT:
+            reason = ('doctest are only run when the default numpy int is '
+                      '64 bits.')
             skip_doctests = True
     except ImportError:
         pass
 
     if skip_doctests:
-        skip_marker = pytest.mark.skip(
-            reason='doctests are only run for numpy >= 1.14 and python >= 3')
+        skip_marker = pytest.mark.skip(reason=reason)
 
         for item in items:
             if isinstance(item, DoctestItem):

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -23,8 +23,8 @@ def pyplot():
     yield pyplot
     pyplot.close('all')
 if np.iinfo(np.int).dtype != np.int64:
-    warnings.warn("Your default numpy int is a 32 bit one, it may be because you are "
+    warnings.warn(UserWarning("Your default numpy int is a 32 bit one, it may be because you are "
                       "running a 32 bit Python (or more complicated if you're on Windows "
-                      "or Mac. This causes some docstring tests to fail on your machine....")
+                      "or Mac. This causes some docstring tests to fail on your machine...."))
 
 

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -4,9 +4,11 @@ import pytest
 @pytest.fixture(scope='function')
 def pyplot():
     """Setup and teardown fixture for matplotlib.
+
     This fixture checks if we can import matplotlib. If not, the tests will be
     skipped. Otherwise, we setup matplotlib backend and close the figures
     after running the functions.
+
     Returns
     -------
     pyplot : module

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -1,16 +1,12 @@
 import pytest
-import numpy as np
-import warnings
 
 
 @pytest.fixture(scope='function')
 def pyplot():
     """Setup and teardown fixture for matplotlib.
-
     This fixture checks if we can import matplotlib. If not, the tests will be
     skipped. Otherwise, we setup matplotlib backend and close the figures
     after running the functions.
-
     Returns
     -------
     pyplot : module
@@ -19,12 +15,5 @@ def pyplot():
     matplotlib = pytest.importorskip('matplotlib')
     matplotlib.use('agg', warn=False, force=True)
     pyplot = pytest.importorskip('matplotlib.pyplot')
-
     yield pyplot
     pyplot.close('all')
-if np.iinfo(np.int).dtype != np.int64:
-    warnings.warn(UserWarning("Your default numpy int is a 32 bit one, it may be because you are "
-                      "running a 32 bit Python (or more complicated if you're on Windows "
-                      "or Mac. This causes some docstring tests to fail on your machine...."))
-
-

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+import numpy as np
+import warnings
 
 
 @pytest.fixture(scope='function')
@@ -17,5 +19,12 @@ def pyplot():
     matplotlib = pytest.importorskip('matplotlib')
     matplotlib.use('agg', warn=False, force=True)
     pyplot = pytest.importorskip('matplotlib.pyplot')
+
     yield pyplot
     pyplot.close('all')
+if np.iinfo(np.int).dtype != np.int64:
+    warnings.warn("Your default numpy int is a 32 bit one, it may be because you are "
+                      "running a 32 bit Python (or more complicated if you're on Windows "
+                      "or Mac. This causes some docstring tests to fail on your machine....")
+
+


### PR DESCRIPTION
Fixes #14029

The doctests would fail if the default numpy.int is 32 bits long. This warns the user if their numpy int is a 32 bit
Contributions made by @adrinjalali and @felexkemboi
#wimlds