### PR TITLE
PERF Only call malloc twice in liblinear to_sparse helpers

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -68,9 +68,9 @@ Changelog
   of the maximization procedure in :term:`fit`.
   :pr:`13618` by :user:`Yoshihiro Uchida <c56pony>`.
 
-- |Efficiency| The 'liblinear' logistic regression solver now consumes less
-  memory if ``fit_intercept=False`` and ``X`` is a CSR sparse matrix.
-  :pr:`14108` by :user:`Alex Henrie <alexhenrie>`.
+- |Efficiency| The 'liblinear' logistic regression solver is now faster and
+  requires less memory.
+  :pr:`14108`, pr:`14170` by :user:`Alex Henrie <alexhenrie>`.
 
 :mod:`sklearn.model_selection`
 ..................

--- a/sklearn/svm/liblinear.pxd
+++ b/sklearn/svm/liblinear.pxd
@@ -31,8 +31,8 @@ cdef extern from "linear.h":
 cdef extern from "liblinear_helper.c":
     void copy_w(void *, model *, int)
     parameter *set_parameter(int, double, double, int, char *, char *, int, int, double)
-    problem *set_problem (char *, char *, np.npy_intp *, double, char *)
-    problem *csr_set_problem (char *, char *, char *, char *, int, int, double, char *)
+    problem *set_problem (char *, char *, np.npy_intp *, int, double, char *)
+    problem *csr_set_problem (char *, char *, char *, char *, int, int, int, double, char *)
 
     model *set_model(parameter *, char *, np.npy_intp *, char *, double)
 

--- a/sklearn/svm/liblinear.pyx
+++ b/sklearn/svm/liblinear.pyx
@@ -29,13 +29,13 @@ def train_wrap(X, np.ndarray[np.float64_t, ndim=1, mode='c'] Y,
                 (<np.ndarray[np.int32_t,   ndim=1, mode='c']>X.indices).data,
                 (<np.ndarray[np.int32_t,   ndim=1, mode='c']>X.indptr).data,
                 Y.data, (<np.int32_t>X.shape[0]), (<np.int32_t>X.shape[1]),
-                bias, sample_weight.data)
+                (<np.int32_t>X.nnz), bias, sample_weight.data)
     else:
         problem = set_problem(
                 (<np.ndarray[np.float64_t, ndim=2, mode='c']>X).data,
                 Y.data,
                 (<np.ndarray[np.float64_t, ndim=2, mode='c']>X).shape,
-                bias, sample_weight.data)
+                (<np.int32_t>np.count_nonzero(X)), bias, sample_weight.data)
 
     cdef np.ndarray[np.int32_t, ndim=1, mode='c'] \
         class_weight_label = np.arange(class_weight.shape[0], dtype=np.intc)

--- a/sklearn/svm/src/liblinear/liblinear_helper.c
+++ b/sklearn/svm/src/liblinear/liblinear_helper.c
@@ -3,40 +3,39 @@
 #include "linear.h"
 
 /*
- * Convert matrix to sparse representation suitable for libsvm. x is
- * expected to be an array of length nrow*ncol.
+ * Convert matrix to sparse representation suitable for liblinear. x is
+ * expected to be an array of length dims[0]*dims[1].
  *
- * Typically the matrix will be dense, so we speed up the routine for
- * this case. We create an array big enough to hold the largest possible
- * number of non-zero elements and after collecting them we just call
- * realloc to shrink the array and reclaim any unused memory.
+ * Whether the matrix is densely or sparsely populated, the fastest way to
+ * convert it to liblinear's sparse format is to calculate the amount of memory
+ * needed and allocate a single big block.
  *
- * Special care must be taken with indices, since libsvm indices start
- * at 1 and not at 0.
+ * Special care must be taken with indices, since liblinear indices start at 1
+ * and not at 0.
  *
  * If bias is > 0, we append an item at the end.
  */
 static struct feature_node **dense_to_sparse(double *x, npy_intp *dims,
-                                             double bias)
+                                             int n_nonzero, double bias)
 {
     struct feature_node **sparse;
     int i, j;                           /* number of nonzero elements in row i */
     struct feature_node *T;             /* pointer to the top of the stack */
-    int count;
+    int have_bias = (bias > 0);
 
     sparse = malloc (dims[0] * sizeof(struct feature_node *));
     if (sparse == NULL)
         return NULL;
 
+    n_nonzero += (have_bias+1) * dims[0];
+    T = malloc (n_nonzero * sizeof(struct feature_node));
+    if (T == NULL) {
+        free(sparse);
+        return NULL;
+    }
+
     for (i=0; i<dims[0]; ++i) {
-        /* allocate stack for nonzero elements */
-        T = sparse[i] = malloc((dims[1]+2) * sizeof(struct feature_node));
-        if (T == NULL) {
-            for (j=0; j<i; j++)
-                free(sparse[j]);
-            free(sparse);
-            return NULL;
-        }
+        sparse[i] = T;
 
         for (j=1; j<=dims[1]; ++j) {
             if (*x != 0) {
@@ -48,7 +47,7 @@ static struct feature_node **dense_to_sparse(double *x, npy_intp *dims,
         }
 
         /* set bias element */
-        if (bias > 0) {
+        if (have_bias) {
                 T->value = bias;
                 T->index = j;
                 ++ T;
@@ -57,10 +56,6 @@ static struct feature_node **dense_to_sparse(double *x, npy_intp *dims,
         /* set sentinel */
         T->index = -1;
         ++ T;
-
-        /* shrink stack to size */
-        count = T - sparse[i];
-        sparse[i] = realloc(sparse[i], count * sizeof(struct feature_node));
     }
 
     return sparse;
@@ -71,48 +66,52 @@ static struct feature_node **dense_to_sparse(double *x, npy_intp *dims,
  * Convert scipy.sparse.csr to libsvm's sparse data structure
  */
 static struct feature_node **csr_to_sparse(double *values, int *indices,
-        int *indptr, int n_samples, int n_features, double bias)
+        int *indptr, int n_samples, int n_features, int n_nonzero, double bias)
 {
-    struct feature_node **sparse, *temp;
+    struct feature_node **sparse;
     int i, j=0, k=0, n;
+    struct feature_node *T;
     int have_bias = (bias > 0);
 
     sparse = malloc (n_samples * sizeof(struct feature_node *));
     if (sparse == NULL)
         return NULL;
 
+    n_nonzero += (have_bias+1) * n_samples;
+    T = malloc (n_nonzero * sizeof(struct feature_node));
+    if (T == NULL) {
+        free(sparse);
+        return NULL;
+    }
+
     for (i=0; i<n_samples; ++i) {
+        sparse[i] = T;
         n = indptr[i+1] - indptr[i]; /* count elements in row i */
 
-        sparse[i] = malloc ((n+have_bias+1) * sizeof(struct feature_node));
-        if (sparse[i] == NULL) {
-            for (j=0; j<i; ++j)
-                free(sparse[j]);
-            free(sparse);
-            return NULL;
-        }
-
-        temp = sparse[i];
         for (j=0; j<n; ++j) {
-            temp[j].value = values[k];
-            temp[j].index = indices[k] + 1; /* libsvm uses 1-based indexing */
+            T->value = values[k];
+            T->index = indices[k] + 1; /* libsvm uses 1-based indexing */
+            ++T;
             ++k;
         }
 
         if (have_bias) {
-            temp[j].value = bias;
-            temp[j].index = n_features + 1;
+            T->value = bias;
+            T->index = n_features + 1;
+            ++T;
             ++j;
         }
 
         /* set sentinel */
-        temp[j].index = -1;
+        T->index = -1;
+        ++T;
     }
 
     return sparse;
 }
 
-struct problem * set_problem(char *X,char *Y, npy_intp *dims, double bias, char* sample_weight)
+struct problem * set_problem(char *X, char *Y, npy_intp *dims, int n_nonzero,
+        double bias, char* sample_weight)
 {
     struct problem *problem;
     /* not performant but simple */
@@ -128,7 +127,7 @@ struct problem * set_problem(char *X,char *Y, npy_intp *dims, double bias, char*
 
     problem->y = (double *) Y;
     problem->sample_weight = (double *) sample_weight;
-    problem->x = dense_to_sparse((double *) X, dims, bias);
+    problem->x = dense_to_sparse((double *) X, dims, n_nonzero, bias);
     problem->bias = bias;
     problem->sample_weight = sample_weight;
     if (problem->x == NULL) { 
@@ -140,7 +139,7 @@ struct problem * set_problem(char *X,char *Y, npy_intp *dims, double bias, char*
 }
 
 struct problem * csr_set_problem (char *values, char *indices, char *indptr,
-        char *Y, int n_samples, int n_features, double bias,
+        char *Y, int n_samples, int n_features, int n_nonzero, double bias,
         char *sample_weight) {
 
     struct problem *problem;
@@ -157,7 +156,7 @@ struct problem * csr_set_problem (char *values, char *indices, char *indptr,
 
     problem->y = (double *) Y;
     problem->x = csr_to_sparse((double *) values, (int *) indices,
-                        (int *) indptr, n_samples, n_features, bias);
+                        (int *) indptr, n_samples, n_features, n_nonzero, bias);
     problem->bias = bias;
     problem->sample_weight = sample_weight;
 
@@ -204,8 +203,7 @@ double get_bias(struct model *model)
 
 void free_problem(struct problem *problem)
 {
-    int i;
-    for(i=problem->l-1; i>=0; --i) free(problem->x[i]);
+    free(problem->x[0]);
     free(problem->x);
     free(problem);
 }


### PR DESCRIPTION
By my benchmarks, this way takes 1% less time and 1% less memory. Plus, it makes error handling a lot easier.