### PR TITLE
MAINT Fix test_fit_csr_matrix failure on master

### DIFF
--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -1,6 +1,7 @@
 import sys
 from io import StringIO
 import numpy as np
+from numpy.testing import assert_allclose
 import scipy.sparse as sp
 
 import pytest
@@ -274,10 +275,10 @@ def test_fit_csr_matrix():
     X[(np.random.randint(0, 50, 25), np.random.randint(0, 2, 25))] = 0.0
     X_csr = sp.csr_matrix(X)
     tsne = TSNE(n_components=2, perplexity=10, learning_rate=100.0,
-                random_state=0, method='exact', n_iter=500)
+                random_state=0, method='exact', n_iter=750)
     X_embedded = tsne.fit_transform(X_csr)
-    assert_almost_equal(trustworthiness(X_csr, X_embedded, n_neighbors=1), 1.0,
-                        decimal=1)
+    assert_allclose(trustworthiness(X_csr, X_embedded, n_neighbors=1),
+                    1.0, rtol=1.1e-1)
 
 
 def test_preserve_trustworthiness_approximately_with_precomputed_distances():


### PR DESCRIPTION
Closes https://github.com/scikit-learn/scikit-learn/issues/14168

test_fit_csr_matrix is sometimes failing on Linux py35_conda_openblas likely to the dataset size reduction recently cf https://github.com/scikit-learn/scikit-learn/issues/14168#issuecomment-504755401 (and the reduction in `n_iter` from 1000 (default) to 500).

This increases `n_iter` back to 750, and increases the relative tolerance from 0.10 to 0.11.