### PR TITLE
EXA more color blind friendly colors in plot_map_data_to_normal.py (#wimlds)

### DIFF
--- a/examples/preprocessing/plot_map_data_to_normal.py
+++ b/examples/preprocessing/plot_map_data_to_normal.py
@@ -91,8 +91,8 @@ distributions = [
     ('Bimodal', X_bimodal)
 ]
 
-colors = ['firebrick', 'darkorange', 'goldenrod',
-          'seagreen', 'royalblue', 'darkorchid']
+colors = ['#D81B60', '#0188FF', '#FFC107',
+          '#B7A2FF', '#000000', '#2EC5AC']
 
 fig, axes = plt.subplots(nrows=8, ncols=3, figsize=plt.figaspect(2))
 axes = axes.flatten()


### PR DESCRIPTION
Reference Issues/PRs
Fix: 14154 

Changes in relation to the comments on the link: https://github.com/scikit-learn/scikit-learn/pull/14160

Changes.
Provide unique color options while considering different color-blind categories. 

Closes  #14160


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
