### PR TITLE
Refactor BaseEstimator's and Kernel's get_params and set_params

### DIFF
--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -4,6 +4,7 @@ classes used across scikit-learn.
 """
 
 __all__ = ['NotFittedError',
+           'SignatureError',
            'ChangedBehaviorWarning',
            'ConvergenceWarning',
            'DataConversionWarning',
@@ -35,6 +36,13 @@ class NotFittedError(ValueError, AttributeError):
     .. versionchanged:: 0.18
        Moved from sklearn.utils.validation.
     """
+
+
+class SignatureError(RuntimeError):
+    """ TODO
+    """
+    def __init__(self, signature):
+        self.signature = signature
 
 
 class ChangedBehaviorWarning(UserWarning):

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -4,6 +4,7 @@ classes used across scikit-learn.
 """
 
 __all__ = ['NotFittedError',
+           'InvalidParameterError',
            'SignatureError',
            'ChangedBehaviorWarning',
            'ConvergenceWarning',
@@ -36,6 +37,14 @@ class NotFittedError(ValueError, AttributeError):
     .. versionchanged:: 0.18
        Moved from sklearn.utils.validation.
     """
+
+
+class InvalidParameterError(ValueError):
+    """ TODO
+    """
+
+    def __init__(self, param_name):
+        self.param_name = param_name
 
 
 class SignatureError(RuntimeError):

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -4,8 +4,6 @@ classes used across scikit-learn.
 """
 
 __all__ = ['NotFittedError',
-           'InvalidParameterError',
-           'SignatureError',
            'ChangedBehaviorWarning',
            'ConvergenceWarning',
            'DataConversionWarning',
@@ -37,21 +35,6 @@ class NotFittedError(ValueError, AttributeError):
     .. versionchanged:: 0.18
        Moved from sklearn.utils.validation.
     """
-
-
-class InvalidParameterError(ValueError):
-    """ TODO
-    """
-
-    def __init__(self, param_name):
-        self.param_name = param_name
-
-
-class SignatureError(RuntimeError):
-    """ TODO
-    """
-    def __init__(self, signature):
-        self.signature = signature
 
 
 class ChangedBehaviorWarning(UserWarning):

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -795,9 +795,11 @@ class GenericUnivariateSelect(_BaseFilter):
 
         # Now perform some acrobatics to set the right named parameter in
         # the selector
-        possible_params = selector._get_param_names()
-        possible_params.remove('score_func')
-        selector.set_params(**{possible_params[0]: self.param})
+        possible_params = selector.get_params(deep=False)
+        possible_params.pop('score_func')
+        param_name = list(possible_params.keys())[0]
+        params = {param_name: self.param}
+        selector.set_params(**params)
 
         return selector
 

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -28,7 +28,6 @@ from scipy.special import kv, gamma
 from scipy.spatial.distance import pdist, cdist, squareform
 
 from ..base import clone, GetSetParamsMixin
-from ..exceptions import InvalidParameterError, SignatureError
 from ..metrics.pairwise import pairwise_kernels
 
 
@@ -136,13 +135,12 @@ class Kernel(GetSetParamsMixin, metaclass=ABCMeta):
         try:
             # for Kernels, get_params is always shallow
             return super().get_params(deep=False)
-        except SignatureError as e:
-            raise SignatureError("scikit-learn kernels should always "
-                                 "specify their parameters in the signature"
-                                 " of their __init__ (no varargs)."
-                                 " %s with constructor %s doesn't "
-                                 " follow this convention."
-                                 % (self.__class__, e.signature))
+        except RuntimeError as e:
+            raise RuntimeError("scikit-learn kernels should always "
+                               "specify their parameters in the signature"
+                               " of their __init__ (no varargs)."
+                               " %s doesn't follow this convention."
+                               % self.__class__) from e
 
     def set_params(self, **params):
         """Set the parameters of this kernel.
@@ -155,13 +153,7 @@ class Kernel(GetSetParamsMixin, metaclass=ABCMeta):
         -------
         self
         """
-        try:
-            return super().set_params(**params)
-        except InvalidParameterError as e:
-            raise InvalidParameterError('Invalid parameter %s for kernel %s. '
-                                        'Check the list of available parameters '
-                                        'with `kernel.get_params().keys()`.' %
-                                        (e.param_name, self))
+        return super().set_params(**params)
 
     def clone_with_theta(self, theta):
         """Returns a clone of self with given hyperparameters theta.

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -301,9 +301,9 @@ def test_pipeline_raise_set_params_error():
     pipe = Pipeline([('cls', LinearRegression())])
 
     # expected error message
-    error_msg = ('Invalid parameter %s for estimator %s. '
+    error_msg = ('Invalid parameter %s for object %s. '
                  'Check the list of available parameters '
-                 'with `estimator.get_params().keys()`.')
+                 'with `object.get_params().keys()`.')
 
     assert_raise_message(ValueError,
                          error_msg % ('fake', pipe),

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -18,7 +18,7 @@ from scipy.sparse import issparse
 from .murmurhash import murmurhash3_32
 from .class_weight import compute_class_weight, compute_sample_weight
 from . import _joblib
-from ..exceptions import DataConversionWarning, SignatureError
+from ..exceptions import DataConversionWarning
 from .deprecation import deprecated
 from .fixes import np_version
 from .validation import (as_float_array,
@@ -124,15 +124,22 @@ class Bunch(dict):
 
 
 def get_param_names_from_constructor(cls):
-    """ TODO
+    """ Get the parameter names a given class from its constructor.
 
     Parameters
     ----------
-    cls
+    cls : type
+        Class to get the parameter names from.
 
     Returns
     -------
+    param_names : list of strings
+        Parameter names of the given class.
 
+    Raises
+    ------
+    RuntimeError
+        If the class constructor contains varargs.
     """
     # fetch the constructor or the original constructor before
     # deprecation wrapping if any
@@ -149,7 +156,8 @@ def get_param_names_from_constructor(cls):
                   if p.name != 'self' and p.kind != p.VAR_KEYWORD]
     for p in parameters:
         if p.kind == p.VAR_POSITIONAL:
-            raise SignatureError(init_signature)
+            raise RuntimeError("%s with constructor %s contains varargs."
+                               % (cls, init_signature))
     # Extract and sort argument names excluding 'self'
     return sorted([p.name for p in parameters])
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Hi there, this is a PR for #13555 .

#### What does this implement/fix? Explain your changes.
- Moved `_get_param_names` out of `BaseEstimator` as utility function now called `get_param_names_from_constructor`.
    - This is meant for reuse in `gaussian_process.kernels.Kernel` .
    - Added a `SignatureError` class to pass the signature from the utility function up to the appropriate exception message in `BaseEstimator` and `gaussian_process.kernels.Kernel`.
- Modified `gaussian_process.kernels.Kernel` to use the new utility function and remove duplication.
- Changed `GenericUnivariateSelect._make_selector` to use `get_params` instead of the new utility function so that it raises the proper error in case of a selector with inappropriate signature.
- Also refactored `get_params` to call from a new `_get_params_from` method. This is so `get_params` can be easily overridden to take a signature of, for example, the parent class in custom subclasses of client code.

#### Any other comments?
- Docstrings will be added later.
- Other that raising `SignatureError` (subclassed from `RuntimeError`) these changes don't add or change current behavior, so I haven't added any new tests. If new tests might seem necessary, please let me know.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
