### PR TITLE
TST Fix test_truncated_svd.py::test_explained_variance_components_10_20

### DIFF
--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -121,7 +121,7 @@ def test_explained_variance_components_10_20(X_sparse, kind, solver):
     assert_allclose(
         svd_10.explained_variance_ratio_,
         svd_20.explained_variance_ratio_[:10],
-        rtol=3e-3,
+        rtol=5e-3,
     )
 
     # Assert that 20 components has higher explained variance than 10


### PR DESCRIPTION
`test_truncated_svd.py::test_explained_variance_components_10_20` is occasionally failing on master in one job since https://github.com/scikit-learn/scikit-learn/pull/14140 was merged with,
```py
   def test_explained_variance_components_10_20(X_sparse, kind, solver):
        X = X_sparse if kind == 'sparse' else X_sparse.toarray()
        svd_10 = TruncatedSVD(10, algorithm=solver).fit(X)
        svd_20 = TruncatedSVD(20, algorithm=solver).fit(X)
    
        # Assert the 1st component is equal
        assert_allclose(
            svd_10.explained_variance_ratio_,
            svd_20.explained_variance_ratio_[:10],
>           rtol=3e-3,
        )
E       AssertionError: 
E       Not equal to tolerance rtol=0.003, atol=0
E       
E       (mismatch 10.0%)
E        x: array([ 0.073484,  0.059621,  0.059073,  0.056352,  0.054605,  0.05335 ,
E               0.04774 ,  0.04553 ,  0.042884,  0.040547])
E        y: array([ 0.073484,  0.059609,  0.059087,  0.056357,  0.054615,  0.05333 ,
E               0.047748,  0.045528,  0.042904,  0.040399])
```
this previously it was an `assert_array_almost_equal(..., decimal=5)` which given the scale of the data should correspond approximately `assert_allclose(..., rtol=a few 1e-3)`.

That's the annoying part of moving from  `assert_array_almost_equal` to `assert_allclose` but I still think it's worth it to understand the actual tolerance used in tests.

cc @thomasjpfan 