### PR TITLE
[MRG] TST Increases tolerance to match float32 resolution

### DIFF
--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1099,7 +1099,7 @@ def test_dtype_match(solver):
     X_32 = X_64.astype(np.float32)
     y_32 = y_64.astype(np.float32)
 
-    tol = np.finfo(np.float32).resolution
+    tol = 2 * np.finfo(np.float32).resolution
     # Check type consistency 32bits
     ridge_32 = Ridge(alpha=alpha, solver=solver, max_iter=500, tol=tol)
     ridge_32.fit(X_32, y_32)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1099,13 +1099,14 @@ def test_dtype_match(solver):
     X_32 = X_64.astype(np.float32)
     y_32 = y_64.astype(np.float32)
 
+    tol = np.finfo(np.float32).resolution
     # Check type consistency 32bits
-    ridge_32 = Ridge(alpha=alpha, solver=solver, max_iter=500, tol=1e-6)
+    ridge_32 = Ridge(alpha=alpha, solver=solver, max_iter=500, tol=tol)
     ridge_32.fit(X_32, y_32)
     coef_32 = ridge_32.coef_
 
     # Check type consistency 64 bits
-    ridge_64 = Ridge(alpha=alpha, solver=solver, max_iter=500, tol=1e-6)
+    ridge_64 = Ridge(alpha=alpha, solver=solver, max_iter=500, tol=tol)
     ridge_64.fit(X_64, y_64)
     coef_64 = ridge_64.coef_
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1100,12 +1100,12 @@ def test_dtype_match(solver):
     y_32 = y_64.astype(np.float32)
 
     # Check type consistency 32bits
-    ridge_32 = Ridge(alpha=alpha, solver=solver, max_iter=500, tol=1e-10,)
+    ridge_32 = Ridge(alpha=alpha, solver=solver, max_iter=500, tol=1e-6)
     ridge_32.fit(X_32, y_32)
     coef_32 = ridge_32.coef_
 
     # Check type consistency 64 bits
-    ridge_64 = Ridge(alpha=alpha, solver=solver, max_iter=500, tol=1e-10,)
+    ridge_64 = Ridge(alpha=alpha, solver=solver, max_iter=500, tol=1e-6)
     ridge_64.fit(X_64, y_64)
     coef_64 = ridge_64.coef_
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/13868
Fixes https://github.com/scikit-learn/scikit-learn/pull/13876


#### What does this implement/fix? Explain your changes.
Changes `tol` to `np.finfo(np.float32).resolution`

#### Any other comments?
I suspect that float64 found a better (and different) solution because it can resolve `1e-10` better than float32 can.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
