### PR TITLE
TST Fix atol in test_estimate_bandwidth_1sample

### DIFF
--- a/sklearn/cluster/tests/test_mean_shift.py
+++ b/sklearn/cluster/tests/test_mean_shift.py
@@ -36,7 +36,7 @@ def test_estimate_bandwidth_1sample():
     # Test estimate_bandwidth when n_samples=1 and quantile<1, so that
     # n_neighbors is set to 1.
     bandwidth = estimate_bandwidth(X, n_samples=1, quantile=0.3)
-    assert bandwidth == 0.
+    assert bandwidth == pytest.approx(0., abs=1e-5)
 
 
 @pytest.mark.parametrize("bandwidth, cluster_all, expected, "


### PR DESCRIPTION
This re-applies the fix from https://github.com/scikit-learn/scikit-learn/pull/13130 that got accidentally reverted in https://github.com/scikit-learn/scikit-learn/pull/13179 (likely due to a merge conflict resolution).

Currently, this was causing test failures on ARM in https://github.com/conda-forge/scikit-learn-feedstock/pull/98

This should also be backported to 0.21.X