### PR TITLE
[MRG] Release 0.21.3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,11 @@
 Contributing to scikit-learn
 ============================
 
+The latest contributing guide is available in the repository at
+`doc/developers/contributing.rst`, or online at:
+
+https://scikit-learn.org/dev/developers/contributing.html
+
 There are many ways to contribute to scikit-learn, with the most common ones
 being contribution of code or documentation to the project. Improving the
 documentation is no less important than improving the library itself. If you
@@ -22,15 +27,9 @@ up" on issues that others reported and that are relevant to you. It also helps
 us if you spread the word: reference the project from your blog and articles,
 link to it from your website, or simply star it in GitHub to say "I use it".
 
-Guideline
----------
+Quick links
+-----------
 
-Full contribution guidelines are available in the repository at
-`doc/developers/contributing.rst`, or online at:
-
-http://scikit-learn.org/dev/developers/contributing.html
-
-Quick links to:
 * [Submitting a bug report or feature request](http://scikit-learn.org/dev/developers/contributing.html#submitting-a-bug-report-or-a-feature-request)
 * [Contributing code](http://scikit-learn.org/dev/developers/contributing.html#contributing-code)
 * [Coding guidelines](http://scikit-learn.org/dev/developers/contributing.html#coding-guidelines)

--- a/README.rst
+++ b/README.rst
@@ -58,13 +58,6 @@ Scikit-learn 0.21 and later require Python 3.5 or newer.
 For running the examples Matplotlib >= 1.5.1 is required. A few examples
 require scikit-image >= 0.12.3, a few examples require pandas >= 0.18.0.
 
-scikit-learn also uses CBLAS, the C interface to the Basic Linear Algebra
-Subprograms library. scikit-learn comes with a reference implementation, but
-the system CBLAS will be detected by the build system and used if present.
-CBLAS exists in many implementations; see `Linear algebra libraries
-<http://scikit-learn.org/stable/modules/computing#linear-algebra-libraries>`_
-for known issues.
-
 User installation
 ~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -104,8 +104,10 @@ You can check the latest sources with the command::
 
 Contributing
 ~~~~~~~~~~~~
-To learn more about making a contribution to scikit-learn, please view the contributing document: 
-https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md
+
+To learn more about making a contribution to scikit-learn, please see our
+`Contributing guide
+<https://scikit-learn.org/dev/developers/contributing.html>`_.
 
 Testing
 ~~~~~~~

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -1,3 +1,5 @@
+.. _about:
+
 About us
 ========
 
@@ -13,6 +15,11 @@ Michel of INRIA took leadership of the project and made the first public
 release, February the 1st 2010. Since then, several releases have appeared
 following a ~3 month cycle, and a thriving international community has
 been leading the development.
+
+Governance
+----------
+The decision making process and governance structure of scikit-learn is laid
+out in the :ref:`governance document <governance>`.
 
 Authors
 -------
@@ -68,11 +75,6 @@ The following people have been active contributors in the past, but are no longe
 - Vincent Michel
 - Virgile Fritsch
 - Wei Li
-
-Governance
-----------
-The decision making process and governance structure of scikit-learn is laid
-out in the :ref:`governance document <governance>`.
 
 .. _citing-scikit-learn:
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -148,6 +148,30 @@ Then you need to set the following environment variables::
 
 Finally you can build the package using the standard command.
 
+FreeBSD
+-------
+
+The clang compiler included in FreeBSD 12.0 and 11.2 base systems does not 
+include OpenMP support. You need to install the `openmp` library from packages 
+(or ports)::
+
+    sudo pkg install openmp
+    
+This will install header files in ``/usr/local/include`` and libs in 
+``/usr/local/lib``. Since these directories are not searched by default, you 
+can set the environment variables to these locations::
+
+    export CFLAGS="$CFLAGS -I/usr/local/include"
+    export CXXFLAGS="$CXXFLAGS -I/usr/local/include"
+    export LDFLAGS="$LDFLAGS -L/usr/local/lib -lomp"
+    export DYLD_LIBRARY_PATH=/usr/local/lib
+
+Finally you can build the package using the standard command.
+
+For the upcomming FreeBSD 12.1 and 11.3 versions, OpenMP will be included in 
+the base system and these steps will not be necessary.
+
+
 Installing build dependencies
 =============================
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -154,56 +154,38 @@ Installing build dependencies
 Linux
 -----
 
-Installing from source requires you to have installed the scikit-learn runtime
-dependencies, Python development headers and a working C/C++ compiler.
-Under Debian-based operating systems, which include Ubuntu::
+Installing from source without conda requires you to have installed the
+scikit-learn runtime dependencies, Python development headers and a working
+C/C++ compiler. Under Debian-based operating systems, which include Ubuntu::
 
     sudo apt-get install build-essential python3-dev python3-setuptools \
-                     python3-numpy python3-scipy \
-                     libatlas-dev libatlas3-base
+                     python3-pip
+    
+and then::
 
-On recent Debian and Ubuntu (e.g. Ubuntu 14.04 or later) make sure that ATLAS
-is used to provide the implementation of the BLAS and LAPACK linear algebra
-routines::
-
-    sudo update-alternatives --set libblas.so.3 \
-        /usr/lib/atlas-base/atlas/libblas.so.3
-    sudo update-alternatives --set liblapack.so.3 \
-        /usr/lib/atlas-base/atlas/liblapack.so.3
+    pip3 install numpy scipy cython
 
 .. note::
 
     In order to build the documentation and run the example code contains in
     this documentation you will need matplotlib::
 
-        sudo apt-get install python-matplotlib
+        pip3 install matplotlib
 
-.. note::
+When precompiled wheels are not avalaible for your architecture, you can
+install the system versions::
 
-    The above installs the ATLAS implementation of BLAS
-    (the Basic Linear Algebra Subprograms library).
-    Ubuntu 11.10 and later, and recent (testing) versions of Debian,
-    offer an alternative implementation called OpenBLAS.
-
-    Using OpenBLAS can give speedups in some scikit-learn modules,
-    but can freeze joblib/multiprocessing prior to OpenBLAS version 0.2.8-4,
-    so using it is not recommended unless you know what you're doing.
-
-    If you do want to use OpenBLAS, then replacing ATLAS only requires a couple
-    of commands. ATLAS has to be removed, otherwise NumPy may not work::
-
-        sudo apt-get remove libatlas3gf-base libatlas-dev
-        sudo apt-get install libopenblas-dev
-
-        sudo update-alternatives  --set libblas.so.3 \
-            /usr/lib/openblas-base/libopenblas.so.0
-        sudo update-alternatives --set liblapack.so.3 \
-            /usr/lib/lapack/liblapack.so.3
+    sudo apt-get install cython3 python3-numpy python3-scipy python3-matplotlib
 
 On Red Hat and clones (e.g. CentOS), install the dependencies using::
 
-    sudo yum -y install gcc gcc-c++ numpy python-devel scipy
+    sudo yum -y install gcc gcc-c++ python-devel numpy scipy
 
+.. note::
+
+    To use a high performance BLAS library (e.g. OpenBlas) see 
+    `scipy installation instructions
+    <https://docs.scipy.org/doc/scipy/reference/building/linux.html>`_.
 
 Windows
 -------

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -44,11 +44,26 @@ basis to help users test bleeding edge features or bug fixes::
 Building from source
 =====================
 
+In the vast majority of cases, building scikit-learn for development purposes
+can be done with::
+
+    pip install cython pytest flake8
+
+Then, in the main repository::
+
+    pip install --editable .
+
+Please read below for details and more advanced instructions.
+
+Dependencies
+------------
+
 Scikit-learn requires:
 
 - Python (>= 3.5),
 - NumPy (>= 1.11),
-- SciPy (>= 0.17).
+- SciPy (>= 0.17),
+- Joblib (>= 0.11).
 
 .. note::
 
@@ -93,12 +108,12 @@ If you want to build a stable version, you can ``git checkout <VERSION>``
 to get the code for that particular version, or download an zip archive of
 the version from github.
 
-If you have all the build requirements installed (see below for details), you
-can build and install the package in the following way.
+Once you have all the build requirements installed (see below for details),
+you can build and install the package in the following way.
 
 If you run the development version, it is cumbersome to reinstall the
 package each time you update the sources. Therefore it's recommended that you
-install in editable, which allows you to edit the code in-place. This
+install in editable mode, which allows you to edit the code in-place. This
 builds the extension in place and creates a link to the development directory
 (see `the pip docs <https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs>`_)::
 
@@ -112,16 +127,16 @@ builds the extension in place and creates a link to the development directory
 
 .. note::
 
-    If you decide to do an editable install you have to rerun::
+    You will have to re-run::
 
         pip install --editable .
 
-    every time the source code of a compiled extension is
-    changed (for instance when switching branches or pulling changes from upstream).
+    every time the source code of a compiled extension is changed (for
+    instance when switching branches or pulling changes from upstream).
+    Compiled extensions are Cython files (ending in `.pyx` or `.pxd`).
 
-On Unix-like systems, you can simply type ``make`` in the top-level folder to
-build in-place and launch all the tests. Have a look at the ``Makefile`` for
-additional utilities.
+On Unix-like systems, you can equivalently type ``make in`` from the
+top-level folder. Have a look at the ``Makefile`` for additional utilities.
 
 Mac OSX
 -------
@@ -266,58 +281,3 @@ build step::
     python setup.py build --compiler=my_compiler install
 
 where ``my_compiler`` should be one of ``mingw32`` or ``msvc``.
-
-
-.. _testing:
-
-Testing
-=======
-
-Testing scikit-learn once installed
------------------------------------
-
-Testing requires having `pytest <https://docs.pytest.org>`_ >=\ |PytestMinVersion|\ .
-Some tests also require having `pandas <https://pandas.pydata.org/>` installed.
-After installation, the package can be tested by executing *from outside* the
-source directory::
-
-    $ pytest sklearn
-
-This should give you a lot of output (and some warnings) but
-eventually should finish with a message similar to::
-
-    =========== 8304 passed, 26 skipped, 4659 warnings in 557.76 seconds ===========
-
-Otherwise, please consider posting an issue into the `GitHub issue tracker
-<https://github.com/scikit-learn/scikit-learn/issues>`_ or to the
-:ref:`mailing_lists` including the traceback of the individual failures
-and errors. Please include your operating system, your version of NumPy, SciPy
-and scikit-learn, and how you installed scikit-learn.
-
-
-Testing scikit-learn from within the source folder
---------------------------------------------------
-
-Scikit-learn can also be tested without having the package
-installed. For this you must compile the sources inplace from the
-source directory::
-
-    python setup.py build_ext --inplace
-
-Test can now be run using pytest::
-
-    pytest sklearn
-
-This is automated by the commands::
-
-    make in
-
-and::
-
-    make test
-
-
-You can also install a symlink named ``site-packages/scikit-learn.egg-link``
-to the development folder of scikit-learn with::
-
-    pip install --editable .

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -9,6 +9,9 @@ contribute.
 
 The project is hosted on https://github.com/scikit-learn/scikit-learn
 
+The decision making process and governance structure of scikit-learn is laid
+out in the governance document: :ref:`governance`.
+
 Scikit-learn is somewhat :ref:`selective <selectiveness>` when it comes to
 adding new algorithms, and the best way to contribute and to help the project
 is to start working on known issues.
@@ -32,18 +35,12 @@ See :ref:`new_contributors` to get started.
     others of the Python Software Foundation:
     https://www.python.org/psf/codeofconduct/
 
-|
-
 
 In case you experience issues using this package, do not hesitate to submit a
 ticket to the
-`GitHub issue tracker <https://github.com/scikit-learn/scikit-learn/issues>`_. You are
-also welcome to post feature requests or pull requests.
-
-Governance
-==========
-The decision making process and governance structure of scikit-learn is laid
-out in the governance document: :ref:`governance`.
+`GitHub issue tracker
+<https://github.com/scikit-learn/scikit-learn/issues>`_. You are also
+welcome to post feature requests or pull requests.
 
 Ways to contribute
 ==================
@@ -210,37 +207,31 @@ then submit a "pull request" (PR):
        $ git clone git@github.com:YourLogin/scikit-learn.git
        $ cd scikit-learn
 
-4. Install library in editable mode::
+4. Install the development dependencies::
+
+       $ pip install cython pytest flake8
+
+5. Install scikit-learn in editable mode::
 
        $ pip install --editable .
 
    for more details about advanced installation, see the
    :ref:`install_bleeding_edge` section.
 
-5. Create a branch to hold your development changes::
+6. Add the ``upstream`` remote. This saves a reference to the main
+   scikit-learn repository, which you can use to keep your repository
+   synchronized with the latest changes::
 
-       $ git checkout -b my-feature
+    $ git remote add upstream https://github.com/scikit-learn/scikit-learn.git
 
-   and start making changes. Always use a ``feature`` branch. It's good practice to
-   never work on the ``master`` branch!
+7. Create a branch to hold your development changes::
 
-   .. note::
+       $ git checkout -b my-feature upstream/master
 
-     In the above setup, your ``origin`` remote repository points to
-     ``YourLogin/scikit-learn.git``. If you wish to fetch/merge from the main
-     repository instead of your forked one, you will need to add another remote
-     to use instead of ``origin``. If we choose the name ``upstream`` for it, the
-     command will be::
+   and start making changes. Always use a ``feature`` branch. It's good
+   practice to never work on the ``master`` branch!
 
-         $ git remote add upstream https://github.com/scikit-learn/scikit-learn.git
-
-     And in order to fetch the new remote and base your work on the latest changes
-     of it you can::
-
-         $ git fetch upstream
-         $ git checkout -b my-feature upstream/master
-
-6. Develop the feature on your feature branch on your computer, using Git to do the
+8. Develop the feature on your feature branch on your computer, using Git to do the
    version control. When you're done editing, add changed files using ``git add``
    and then ``git commit`` files::
 
@@ -251,7 +242,7 @@ then submit a "pull request" (PR):
 
        $ git push -u origin my-feature
 
-7. Follow `these
+9. Follow `these
    <https://help.github.com/articles/creating-a-pull-request-from-a-fork>`_
    instructions to create a pull request from your fork. This will send an
    email to the committers. You may want to consider sending an email to the
@@ -259,111 +250,131 @@ then submit a "pull request" (PR):
 
 .. note::
 
-  If you are modifying a Cython module, you have to re-run step 4 after modifications
+  If you are modifying a Cython module, you have to re-run step 5 after modifications
   and before testing them.
 
+It is often helpful to keep your local branch synchronized with the latest
+changes of the main scikit-learn repository::
 
-If any of the above seems like magic to you, then look up the `Git documentation
-<https://git-scm.com/documentation>`_ and the `Git development workflow
-<http://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html>`_ on the
-web, or ask a friend or another contributor for help.
+    $ git fetch upstream
+    $ git merge upstream/master
 
-If some conflicts arise between your branch and the ``master`` branch, you need
-to merge ``master``. For that, you first need to fetch the ``upstream``, and
-then merge its ``master`` into your branch::
-
-  $ git fetch upstream
-  $ git merge upstream/master
-
-Subsequently, you need to solve the conflicts. You can refer to the `Git
-documentation related to resolving merge conflict using the command line
+Subsequently, you might need to solve the conflicts. You can refer to the
+`Git documentation related to resolving merge conflict using the command
+line
 <https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line/>`_.
 
-.. note::
+.. topic:: Learning git:
 
-   In the past, the policy to resolve conflicts was to rebase your branch on
-   ``master``. GitHub interface deals with merging ``master`` better than in
-   the past.
+    The `Git documentation <https://git-scm.com/documentation>`_ and
+    http://try.github.io are excellent resources to get started with git,
+    and understanding all of the commands shown here.
 
+Pull request checklist
+----------------------
 
-Contributing pull requests
---------------------------
+Before a PR can be merged, it needs to be approved by two core developers.
+Please prefix the title of your pull request with ``[MRG]`` if the
+contribution is complete and should be subjected to a detailed review. An
+incomplete contribution -- where you expect to do more work before receiving
+a full review -- should be prefixed ``[WIP]`` (to indicate a work in
+progress) and changed to ``[MRG]`` when it matures. WIPs may be useful to:
+indicate you are working on something to avoid duplicated work, request
+broad review of functionality or API, or seek collaborators. WIPs often
+benefit from the inclusion of a `task list
+<https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments>`_ in
+the PR description.
 
-We recommend that your contribution complies with the following
-rules before submitting a pull request:
+In order to ease the reviewing process, we recommend that your contribution
+complies with the following rules before marking a PR as ``[MRG]``. The
+**bolded** ones are especially important:
 
-* Follow the `coding-guidelines`_ (see below). To make sure that
-  your PR does not add PEP8 violations you can run
-  `./build_tools/circle/flake8_diff.sh` or `make flake8-diff` on a
-  Unix-like system.
+1. **Give your pull request a helpful title** that summarises what your
+   contribution does. This title will often become the commit message once
+   merged so it should summarise your contribution for posterity. In some
+   cases "Fix <ISSUE TITLE>" is enough. "Fix #<ISSUE NUMBER>" is never a
+   good title.
 
-* When applicable, use the validation tools and scripts in the
-  ``sklearn.utils`` submodule.  A list of utility routines available
-  for developers can be found in the :ref:`developers-utils` page.
+2. **Make sure your code passes the tests**. The whole test suite can be run
+   with `pytest`, but it is usually not recommended since it takes a long
+   time. It is often enough to only run the test related to your changes:
+   for example, if you changed something in
+   `sklearn/linear_model/logistic.py`, running the following commands will
+   usually be enough:
 
-* Give your pull request a helpful title that summarises what your
-  contribution does. In some cases "Fix <ISSUE TITLE>" is enough.
-  "Fix #<ISSUE NUMBER>" is not enough.
+   - `pytest sklearn/linear_model/logistic.py` to make sure the doctest
+     examples are correct
+   - `pytest sklearn/linear_model/tests/test_logistic.py` to run the tests
+     specific to the file
+   - `pytest sklearn/linear_model` to test the whole `linear_model` module
+   - `pytest sklearn/doc/linear_model.rst` to make sure the user guide
+     examples are correct.
+   - `pytest sklearn/tests/test_common.py -k LogisticRegression` to run all our
+     estimator checks (specifically for `LogisticRegression`, if that's the
+     estimator you changed).
 
-* Often pull requests resolve one or more other issues (or pull requests).
-  If merging your pull request means that some other issues/PRs should
-  be closed, you should `use keywords to create link to them
-  <https://github.com/blog/1506-closing-issues-via-pull-requests/>`_
-  (e.g., ``Fixes #1234``; multiple issues/PRs are allowed as long as each
-  one is preceded by a keyword). Upon merging, those issues/PRs will
-  automatically be closed by GitHub. If your pull request is simply
-  related to some other issues/PRs, create a link to them without using
-  the keywords (e.g., ``See also #1234``).
+   There may be other failing tests, but they will be caught by the CI so
+   you don't need to run the whole test suite locally. You can read more in
+   :ref:`testing_coverage`.
 
-* All public methods should have informative docstrings with sample
-  usage presented as doctests when appropriate.
+3. **Make sure your code is properly commented and documented**, and **make
+   sure the documentation renders properly**. To build the documentation, please
+   refer to our :ref:`contribute_documentation` guidelines. The CI will also
+   build the docs: please refer to :ref:`generated_doc_CI`.
 
-* Please prefix the title of your pull request with ``[MRG]`` if the
-  contribution is complete and should be subjected to a detailed review.
-  Two core developers will review your code and change the prefix of the pull
-  request to ``[MRG + 1]`` and ``[MRG + 2]`` on approval, making it eligible
-  for merging. An incomplete contribution -- where you expect to do more
-  work before receiving a full review -- should be prefixed ``[WIP]`` (to
-  indicate a work in progress) and changed to ``[MRG]`` when it matures.
-  WIPs may be useful to: indicate you are working on something to avoid
-  duplicated work, request broad review of functionality or API, or seek
-  collaborators. WIPs often benefit from the inclusion of a
-  `task list
-  <https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments>`_
-  in the PR description.
+4. **Tests are necessary for enhancements to be
+   accepted**. Bug-fixes or new features should be provided with
+   `non-regression tests
+   <https://en.wikipedia.org/wiki/Non-regression_testing>`_. These tests
+   verify the correct behavior of the fix or feature. In this manner, further
+   modifications on the code base are granted to be consistent with the
+   desired behavior. In the case of bug fixes, at the time of the PR, the
+   non-regression tests should fail for the code base in the master branch
+   and pass for the PR code.
 
-* All other tests pass when everything is rebuilt from scratch. On
-  Unix-like systems, check with (from the toplevel source folder)::
+5. **Make sure that your PR does not add PEP8 violations**. On a Unix-like
+   system, you can run `make flake8-diff`. `flake8 path_to_file`, would work
+   for any system, but please avoid reformatting parts of the file that your
+   pull request doesn't change, as it distracts from code review.
 
-    $ make
+6. Follow the `coding-guidelines`_ (see below).
 
-* When adding additional functionality, provide at least one example script
-  in the ``examples/`` folder. Have a look at other examples for reference.
-  Examples should demonstrate why the new functionality is useful in
-  practice and, if possible, compare it to other methods available in
-  scikit-learn.
+7. When applicable, use the validation tools and scripts in the
+   ``sklearn.utils`` submodule.  A list of utility routines available
+   for developers can be found in the :ref:`developers-utils` page.
 
-* Documentation and high-coverage tests are necessary for enhancements to be
-  accepted. Bug-fixes or new features should be provided with
-  `non-regression tests
-  <https://en.wikipedia.org/wiki/Non-regression_testing>`_. These tests
-  verify the correct behavior of the fix or feature. In this manner, further
-  modifications on the code base are granted to be consistent with the
-  desired behavior. For the case of bug fixes, at the time of the PR, the
-  non-regression tests should fail for the code base in the master branch
-  and pass for the PR code.
+8. Often pull requests resolve one or more other issues (or pull requests).
+   If merging your pull request means that some other issues/PRs should
+   be closed, you should `use keywords to create link to them
+   <https://github.com/blog/1506-closing-issues-via-pull-requests/>`_
+   (e.g., ``Fixes #1234``; multiple issues/PRs are allowed as long as each
+   one is preceded by a keyword). Upon merging, those issues/PRs will
+   automatically be closed by GitHub. If your pull request is simply
+   related to some other issues/PRs, create a link to them without using
+   the keywords (e.g., ``See also #1234``).
 
-* At least one paragraph of narrative documentation with links to
-  references in the literature (with PDF links when possible) and
-  the example. For more details on writing and building the
-  documentation, see the :ref:`contribute_documentation` section.
+9. PRs should often substantiate the change, through benchmarks of
+   performance and efficiency or through examples of usage. Examples also
+   illustrate the features and intricacies of the library to users. Have a
+   look at other examples in the `examples/
+   <https://github.com/scikit-learn/scikit-learn/tree/master/examples>`_
+   directory for reference. Examples should demonstrate why the new
+   functionality is useful in practice and, if possible, compare it to other
+   methods available in scikit-learn.
 
-* The documentation should also include expected time and space complexity
-  of the algorithm and scalability, e.g. "this algorithm can scale to a
-  large number of samples > 100000, but does not scale in dimensionality:
-  n_features is expected to be lower than 100".
+10. New features often need to be illustrated with narrative documentation in
+    the user guide, with small code snipets. If relevant, please also add
+    references in the literature, with PDF links when possible.
 
-You can also check for common programming errors with the following tools:
+11. The user guide should also include expected time and space complexity
+    of the algorithm and scalability, e.g. "this algorithm can scale to a
+    large number of samples > 100000, but does not scale in dimensionality:
+    n_features is expected to be lower than 100".
+
+You can also check our :ref:`code_review` to get an idea of what reviewers
+will expect.
+
+You can check for common programming errors with the following tools:
 
 * Code with a good unittest coverage (at least 80%, better 100%), check
   with::
@@ -373,17 +384,12 @@ You can also check for common programming errors with the following tools:
 
   see also :ref:`testing_coverage`
 
-* No flake8 warnings, check with::
-
-    $ pip install flake8
-    $ flake8 path/to/module.py
-
 Bonus points for contributions that include a performance analysis with
 a benchmark script and profiling output (please report on the mailing
 list or on the GitHub issue).
 
-Also check out the :ref:`performance-howto` guide for more details on profiling
-and Cython optimizations.
+Also check out the :ref:`performance-howto` guide for more details on
+profiling and Cython optimizations.
 
 .. note::
 
@@ -404,10 +410,10 @@ and Cython optimizations.
 Continuous Integration (CI)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* Travis is used for testing on Linux platforms
-* Appveyor is used for testing on Windows platforms
+* Azure pipelines are used for testing scikit-learn on Linux, Mac and Windows,
+  with different dependencies and settings.
 * CircleCI is used to build the docs for viewing, for linting with flake8, and
-    for testing with PyPy on Linux
+  for testing with PyPy on Linux
 
 Please note that if one of the following markers appear in the latest commit
 message, the following actions are taken.
@@ -498,50 +504,51 @@ underestimate how easy an issue is to solve!
 .. _contribute_documentation:
 
 Documentation
--------------
+=============
 
 We are glad to accept any sort of documentation: function docstrings,
 reStructuredText documents (like this one), tutorials, etc. reStructuredText
 documents live in the source code repository under the ``doc/`` directory.
 
 You can edit the documentation using any text editor, and then generate the
-HTML output by typing ``make html`` from the ``doc/`` directory. Alternatively,
-``make`` can be used to quickly generate the documentation without the example
-gallery. The resulting HTML files will be placed in ``_build/html/stable`` and are viewable
-in a web browser. See the ``README`` file in the ``doc/`` directory for more information.
+HTML output by typing ``make`` from the ``doc/`` directory. Alternatively,
+``make html`` may be used to generate the documentation **with** the example
+gallery (which takes quite some time). The resulting HTML files will be
+placed in ``_build/html/stable`` and are viewable in a web browser.
 
 
 Building the documentation
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------
+
+First, make sure you have :ref:`properly installed <install_bleeding_edge>`
+the development version.
 
 Building the documentation requires installing some additional packages::
 
-    pip install sphinx sphinx-gallery numpydoc matplotlib Pillow pandas scikit-image joblib
+    pip install sphinx sphinx-gallery numpydoc matplotlib Pillow pandas scikit-image
 
 To build the documentation, you need to be in the ``doc`` folder::
 
     cd doc
 
-It also requires having the version of scikit-learn installed that corresponds
-to the documentation, e.g.::
+In the vast majority of cases, you only need to generate the full web site,
+without the example gallery::
 
-    pip install --editable ..
+    make
 
-To generate the full web site, including the example gallery::
+The documentation will be generated in the ``_build/html/stable`` directory.
+To also generate the example gallery you can use::
 
     make html
 
-Generating the example gallery will run all our examples which takes a
-while. To save some time, you can use:
+This will run all the examples, which takes a while. If you only want to
+generate a few examples, you can use::
 
-- ``make html-noplot``: this will generate the documentation without the
-  example gallery. This is useful when changing a docstring for example.
-- ``EXAMPLES_PATTERN=your_regex_goes_here make html``: only the examples
-  matching ``your_regex_goes_here`` will be run. This is particularly
-  useful if you are modifying a few examples.
+    EXAMPLES_PATTERN=your_regex_goes_here make html
 
-That should create all the documentation in the ``_build/html/stable``
-directory.  Set the environment variable `NO_MATHJAX=1` if you intend to view
+This is particularly useful if you are modifying a few examples.
+
+Set the environment variable `NO_MATHJAX=1` if you intend to view
 the documentation in an offline setting.
 
 To build the PDF manual, run::
@@ -558,7 +565,7 @@ To build the PDF manual, run::
    to know the exact version.
 
 Guidelines for writing documentation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------------
 
 It is important to keep a good compromise between mathematical and algorithmic
 details, and give intuition to the reader on what the algorithm does.
@@ -602,8 +609,10 @@ Finally, follow the formatting rules below to make it consistently good:
 * When editing reStructuredText (``.rst``) files, try to keep line length under
   80 characters when possible (exceptions include links and tables).
 
+.. _generated_doc_CI:
+
 Generated documentation on CircleCI
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------------
 
 When you change the documentation in a pull request, CircleCI automatically
 builds it. To view the documentation generated by CircleCI:
@@ -626,7 +635,7 @@ reviewing pull requests, you may find :ref:`this tip
 .. _testing_coverage:
 
 Testing and improving test coverage
------------------------------------
+===================================
 
 High-quality `unit testing <https://en.wikipedia.org/wiki/Unit_testing>`_
 is a corner-stone of the scikit-learn development process. For this
@@ -645,7 +654,7 @@ For guidelines on how to use ``pytest`` efficiently, see the
 :ref:`pytest_tips`.
 
 Writing matplotlib related tests
-................................
+--------------------------------
 
 Test fixtures ensure that a set of tests will be executing with the appropriate
 initialization and cleanup. The scikit-learn test suite implements a fixture
@@ -665,7 +674,7 @@ argument::
         # you can now safely use matplotlib
 
 Workflow to improve test coverage
-.................................
+---------------------------------
 
 To test code coverage, you need to install the `coverage
 <https://pypi.org/project/coverage/>`_ package in addition to pytest.
@@ -677,12 +686,6 @@ To test code coverage, you need to install the `coverage
     write or adapt a test specifically for these lines.
 
 3. Loop.
-
-Developers web site
--------------------
-
-More information can be found on the `developer's wiki
-<https://github.com/scikit-learn/scikit-learn/wiki>`_.
 
 
 Issue Tracker Tags
@@ -1450,13 +1453,6 @@ Inheriting from ``ClassifierMixin``, ``RegressorMixin`` or ``ClusterMixin``
 will set the attribute automatically.  When a meta-estimator needs to distinguish
 among estimator types, instead of checking ``_estimator_type`` directly, helpers
 like :func:`base.is_classifier` should be used.
-
-Working notes
--------------
-
-For unresolved issues, TODOs, and remarks on ongoing work, developers are
-advised to maintain notes on the `GitHub wiki
-<https://github.com/scikit-learn/scikit-learn/wiki>`__.
 
 Specific models
 ---------------

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -224,8 +224,10 @@ then submit a "pull request" (PR):
 
     $ git remote add upstream https://github.com/scikit-learn/scikit-learn.git
 
-7. Create a branch to hold your development changes::
+7. Fetch the ``upstream`` and then create a branch to hold your development
+   changes::
 
+       $ git fetch upstream
        $ git checkout -b my-feature upstream/master
 
    and start making changes. Always use a ``feature`` branch. It's good

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -41,7 +41,7 @@ ticket to the
 also welcome to post feature requests or pull requests.
 
 Governance
-----------
+==========
 The decision making process and governance structure of scikit-learn is laid
 out in the governance document: :ref:`governance`.
 

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -201,3 +201,6 @@ For the docs to render properly, please also import
 ``enable_my_experimental_feature`` in ``doc/conf.py``, else sphinx won't be
 able to import the corresponding modules. Note that using ``from
 sklearn.experimental import *`` **does not work**.
+
+Note that some experimental classes / functions are not included in the
+:mod:`sklearn.experimental` module: ``sklearn.datasets.fetch_openml``.

--- a/doc/developers/performance.rst
+++ b/doc/developers/performance.rst
@@ -360,26 +360,16 @@ directly as Cython extension), the default Python profiler is useless:
 we need a dedicated tool to introspect what's happening inside the
 compiled extension it-self.
 
-Using yep and google-perftools
---------------------------------
+Using yep and gperftools
+------------------------
 
 Easy profiling without special compilation options use yep:
 
 - https://pypi.org/project/yep/
 - http://fa.bianp.net/blog/2011/a-profiler-for-python-extensions
 
-.. note::
-
-  google-perftools provides a nice 'line by line' report mode that
-  can be triggered with the ``--lines`` option. However this
-  does not seem to work correctly at the time of writing. This
-  issue can be tracked on the `project issue tracker
-  <https://github.com/gperftools/gperftools>`_.
-
-
-
 Using gprof
--------------
+-----------
 
 In order to profile compiled Python extensions one could use ``gprof``
 after having recompiled the project with ``gcc -pg`` and using the
@@ -390,12 +380,25 @@ with ``-pg`` which is rather complicated to get working.
 Fortunately there exist two alternative profilers that don't require you to
 recompile everything.
 
-
 Using valgrind / callgrind / kcachegrind
 ----------------------------------------
 
-TODO
+kcachegrind
+~~~~~~~~~~~
 
+``yep`` can be used to create a profiling report.
+``kcachegrind`` provides a graphical environment to visualize this report::
+
+  # Run yep to profile some python script
+  python -m yep -c my_file.py
+
+  # open my_file.py.callgrin with kcachegrind
+  kcachegrind my_file.py.prof
+
+.. note::
+
+   ``yep`` can be executed with the argument ``--lines`` or ``-l`` to compile
+   a profiling report 'line by line'.
 
 Multi-core parallelism using ``joblib.Parallel``
 ================================================

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -106,5 +106,12 @@ Documentation of scikit-learn |version|
                     <blockquote>Roadmap of the project.
                     </blockquote>
                 </div>
+            </div>
+            <div class="row-fluid">
+                <div class="span4 box">
+                    <h2><a href="about.html">About us</a></h2>
+                    <blockquote>About the scikit-learn project.
+                    </blockquote>
+                </div>
 
             </div>

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1412,7 +1412,12 @@ functions or non-estimator constructors.
         ``class_weight='balanced'`` can be used to give all classes
         equal weight by giving each sample a weight inversely related
         to its class's prevalence in the training data:
-        ``n_samples / (n_classes * np.bincount(y))``.
+        ``n_samples / (n_classes * np.bincount(y))``. Class weights will be
+        used differently depending on the algorithm: for linear models (such
+        as linear SVM or logistic regression), the class weights will alter the
+        loss function by weighting the loss of each sample by its class weight.
+        For tree-based algorithms, the class weights will be used for
+        reweighting the splitting criterion.
         **Note** however that this rebalancing does not take the weight of
         samples in each class into account.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -209,7 +209,7 @@
                     </li>
                     <li><strong>Scikit-learn from 0.21 requires Python 3.5 or greater.</strong>
                     </li>
-                    <li><em>July 2019.</em> scikit-learn 0.21.3 and 0.20.4 are available for download (<a href="whats_new.html#version-0-21">Changelog</a>).
+                    <li><em>July 2019.</em> scikit-learn 0.21.3 (<a href="whats_new.html#version-0-21-3">Changelog</a>) and 0.20.4 (<a href="whats_new.html#version-0-20-4">Changelog</a>) are available for download.
                     </li>
                     <li><em>May 2019.</em> scikit-learn 0.21.0 to 0.21.2 are available for download (<a href="whats_new.html#version-0-21">Changelog</a>).
                     </li>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -209,13 +209,11 @@
                     </li>
                     <li><strong>Scikit-learn from 0.21 requires Python 3.5 or greater.</strong>
                     </li>
+                    <li><em>July 2019.</em> scikit-learn 0.21.3 and 0.20.4 are available for download (<a href="whats_new.html#version-0-21">Changelog</a>).
+                    </li>
                     <li><em>May 2019.</em> scikit-learn 0.21.0 to 0.21.2 are available for download (<a href="whats_new.html#version-0-21">Changelog</a>).
                     </li>
                     <li><em>March 2019.</em> scikit-learn 0.20.3 is available for download (<a href="whats_new.html#version-0-20-3">Changelog</a>).
-                    </li>
-                    <li><em>December 2018.</em> scikit-learn 0.20.2 is available for download (<a href="whats_new.html#version-0-20-2">Changelog</a>)
-                    </li>
-                    <li><em>November 2018.</em> scikit-learn 0.20.1 is available for download (<a href="whats_new.html#version-0-20-1">Changelog</a>).
                     </li>
                     <li><em>September 2018.</em> scikit-learn 0.20.0 is available for download (<a href="whats_new.html#version-0-20-0">Changelog</a>).
                     </li>

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -128,16 +128,23 @@ Random Forests
 --------------
 
 In random forests (see :class:`RandomForestClassifier` and
-:class:`RandomForestRegressor` classes), each tree in the ensemble is
-built from a sample drawn with replacement (i.e., a bootstrap sample)
-from the training set. In addition, when splitting a node during the
-construction of the tree, the split that is chosen is no longer the
-best split among all features. Instead, the split that is picked is the
-best split among a random subset of the features. As a result of this
-randomness, the bias of the forest usually slightly increases (with
-respect to the bias of a single non-random tree) but, due to averaging,
-its variance also decreases, usually more than compensating for the
-increase in bias, hence yielding an overall better model.
+:class:`RandomForestRegressor` classes), each tree in the ensemble is built
+from a sample drawn with replacement (i.e., a bootstrap sample) from the
+training set.
+
+Furthermore, when splitting each node during the construction of a tree, the
+best split is found either from all input features or a random subset of size
+``max_features``. (See the :ref:`parameter tuning guidelines
+<random_forest_parameters>` for more details).
+
+The purpose of these two sources of randomness is to decrease the variance of
+the forest estimator. Indeed, individual decision trees typically exhibit high
+variance and tend to overfit. The injected randomness in forests yield decision
+trees with somewhat decoupled prediction errors. By taking an average of those
+predictions, some errors can cancel out. Random forests achieve a reduced
+variance by combining diverse trees, sometimes at the cost of a slight increase
+in bias. In practice the variance reduction is often significant hence yielding
+an overall better model.
 
 In contrast to the original publication [B2001]_, the scikit-learn
 implementation combines classifiers by averaging their probabilistic
@@ -188,30 +195,31 @@ in bias::
     :align: center
     :scale: 75%
 
+.. _random_forest_parameters:
+
 Parameters
 ----------
 
-The main parameters to adjust when using these methods is ``n_estimators``
-and ``max_features``. The former is the number of trees in the forest. The
-larger the better, but also the longer it will take to compute. In
-addition, note that results will stop getting significantly better
-beyond a critical number of trees. The latter is the size of the random
-subsets of features to consider when splitting a node. The lower the
-greater the reduction of variance, but also the greater the increase in
-bias. Empirical good default values are ``max_features=n_features``
-for regression problems, and ``max_features=sqrt(n_features)`` for
-classification tasks (where ``n_features`` is the number of features
-in the data). Good results are often achieved when setting ``max_depth=None``
-in combination with ``min_samples_split=2`` (i.e., when fully developing the
-trees). Bear in mind though that these values are usually not optimal, and
-might result in models that consume a lot of RAM. The best parameter values
-should always be cross-validated. In addition, note that in random forests,
-bootstrap samples are used by default (``bootstrap=True``)
-while the default strategy for extra-trees is to use the whole dataset
-(``bootstrap=False``).
-When using bootstrap sampling the generalization accuracy can be estimated
-on the left out or out-of-bag samples. This can be enabled by
-setting ``oob_score=True``.
+The main parameters to adjust when using these methods is ``n_estimators`` and
+``max_features``. The former is the number of trees in the forest. The larger
+the better, but also the longer it will take to compute. In addition, note that
+results will stop getting significantly better beyond a critical number of
+trees. The latter is the size of the random subsets of features to consider
+when splitting a node. The lower the greater the reduction of variance, but
+also the greater the increase in bias. Empirical good default values are
+``max_features=None`` (always considering all features instead of a random
+subset) for regression problems, and ``max_features="sqrt"`` (using a random
+subset of size ``sqrt(n_features)``) for classification tasks (where
+``n_features`` is the number of features in the data). Good results are often
+achieved when setting ``max_depth=None`` in combination with
+``min_samples_split=2`` (i.e., when fully developing the trees). Bear in mind
+though that these values are usually not optimal, and might result in models
+that consume a lot of RAM. The best parameter values should always be
+cross-validated. In addition, note that in random forests, bootstrap samples
+are used by default (``bootstrap=True``) while the default strategy for
+extra-trees is to use the whole dataset (``bootstrap=False``). When using
+bootstrap sampling the generalization accuracy can be estimated on the left out
+or out-of-bag samples. This can be enabled by setting ``oob_score=True``.
 
 .. note::
 

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -744,7 +744,14 @@ of a single trial are modeled using a
 Logistic regression is implemented in :class:`LogisticRegression`. 
 This implementation can fit binary, One-vs-Rest, or multinomial logistic 
 regression with optional :math:`\ell_1`, :math:`\ell_2` or Elastic-Net 
-regularization. Note that regularization is applied by default.
+regularization.
+
+.. note::
+
+    Regularization is applied by default, which is common in machine
+    learning but not in statistics. Another advantage of regularization is
+    that it improves numerical stability. No regularization amounts to
+    setting C to a very high value.
 
 As an optimization problem, binary class :math:`\ell_2` penalized logistic
 regression minimizes the following cost function:

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -71,7 +71,7 @@ The least squares solution is computed using the singular value
 decomposition of X. If X is a matrix of shape `(n_samples, n_features)`
 this method has a cost of 
 :math:`O(n_{\text{samples}} n_{\text{features}}^2)`, assuming that
-:math:`n_{\text{samples} \geq n_{\text{features}}}`.
+:math:`n_{\text{samples}} \geq n_{\text{features}}`.
 
 .. _ridge_regression:
 

--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -509,7 +509,7 @@ The disadvantages to using t-SNE are roughly:
 * The algorithm is stochastic and multiple restarts with different seeds can
   yield different embeddings. However, it is perfectly legitimate to pick the
   embedding with the least error.
-* Global structure is not explicitly preserved. This is problem is mitigated by
+* Global structure is not explicitly preserved. This problem is mitigated by
   initializing points with PCA (using `init='pca'`).
 
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -223,7 +223,7 @@ the following two rules:
     importing it from another module will be a more robust approach and work
     independently of the joblib backend.
 
-    For example, to use, ``n_jobs`` greater than 1 in the example below,
+    For example, to use ``n_jobs`` greater than 1 in the example below,
     ``custom_scoring_function`` function is saved in a user-created module
     (``custom_scorer_module.py``) and imported::
 

--- a/doc/sphinxext/custom_references_resolver.py
+++ b/doc/sphinxext/custom_references_resolver.py
@@ -90,8 +90,6 @@ class CustomReferencesResolver(ReferencesResolver):
                         result = ('%s:%s' % (domain.name, role), res)
                         return self.create_node(result)
 
-        self.warn_missing_reference(refdoc, 'any', target, node, domain)
-
         # no results considered to be <code>
         contnode['classes'] = []
         return contnode

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -91,6 +91,7 @@
             <li><a href="{{ pathto('faq') }}">FAQ</a></li>
             <li><a href="{{ pathto('developers/index') }}">Development</a></li>
             <li><a href="{{ pathto('roadmap') }}">Roadmap</a></li>
+            <li><a href="{{ pathto('about') }}">About us</a></li>
             <li class="divider"></li>
                 <script>if (VERSION_SUBDIR != "stable") document.write('<li><a href="http://scikit-learn.org/stable/documentation.html">Stable version</a></li>')</script>
                 <script>if (VERSION_SUBDIR != "dev") document.write('<li><a href="http://scikit-learn.org/dev/documentation.html">Development version</a></li>')</script>

--- a/doc/themes/scikit-learn/static/nature.css_t
+++ b/doc/themes/scikit-learn/static/nature.css_t
@@ -779,6 +779,14 @@ th.field-name {
     white-space: nowrap;
 }
 
+@media screen and (max-width: 780px) {
+    /* field lists aren't shown as a table in small screens */
+
+    th.field-name, td.field-body {
+        display: block;
+    }
+}
+
 
 /* -------- warning header for old versions --------------------------------*/
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -30,7 +30,7 @@ Changelog
   :issue:`12946` by :user:`Pierre Tallotte <pierretallotte>`.
 
 :mod:`sklearn.covariance`
-......................
+.........................
 
 - |Fix| Fixed a regression in :func:`covariance.graphical_lasso` so that
   the case `n_features=2` is handled correctly. :issue:`13276` by

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -2,7 +2,51 @@
 
 .. currentmodule:: sklearn
 
-.. _changes_0_20_3:
+ .. _changes_0_20_4:
+
+Version 0.20.4
+==============
+
+**July 30, 2019**
+
+This is a bug-fix release with some bug fixes applied to version 0.20.3.
+
+Changelog
+---------
+
+The bundled version of joblib was upgraded from 0.13.0 to 0.13.2.
+
+:mod:`sklearn.cluster`
+..............................
+
+- |Fix| Fixed a bug in :class:`cluster.KMeans` where KMeans++ initialisation
+  could rarely result in an IndexError. :issue:`11756` by `Joel Nothman`_.
+
+:mod:`sklearn.compose`
+.....................
+
+- |Fix| Fixed an issue in :class:`compose.ColumnTransformer` where using
+  DataFrames whose column order differs between :func:``fit`` and
+  :func:``transform`` could lead to silently passing incorrect columns to the
+  ``remainder`` transformer.
+  :pr:`14237` by `Andreas Schuderer <schuderer>`.
+
+:mod:`sklearn.model_selection`
+..............................
+
+- |Fix| Fixed a bug where :class:`model_selection.StratifiedKFold`
+  shuffles each class's samples with the same ``random_state``,
+  making ``shuffle=True`` ineffective.
+  :issue:`13124` by :user:`Hanmin Qin <qinhanmin2014>`.
+
+:mod:`sklearn.neighbors`
+......................
+
+- |Fix| Fixed a bug in :class:`neighbors.KernelDensity` which could not be
+  restored from a pickle if ``sample_weight`` had been used.
+  :issue:`13772` by :user:`Aditya Vyas <aditya1702>`.
+
+ .. _changes_0_20_3:
 
 Version 0.20.3
 ==============
@@ -174,12 +218,12 @@ Code and Documentation Contributors
 
 With thanks to:
 
+
 adanhawth, Adrin Jalali, Albert Thomas, Andreas Mueller, Dan Stine, Feda Curic,
 Hanmin Qin, Jan S, jeremiedbb, Joel Nothman, Joris Van den Bossche,
 josephsalmon, Katrin Leinweber, Loic Esteve, Muhammad Hassaan Rafique, Nicolas
 Hug, Olivier Grisel, Paul Paczuski, Reshama Shaikh, Sam Waterbury, Shivam
 Kotwalia, Thomas Fan
-
 
 .. _changes_0_20_1:
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -27,82 +27,6 @@ Changelog
 ---------
 
 :mod:`sklearn.cluster`
-.....................
-
-- |Fix| Fixed a bug in :class:`cluster.KMeans` where computation was single
-  threaded when `n_jobs > 1` or `n_jobs = -1`.
-  :pr:`12955` by :user:`Prabakaran Kumaresshan <nixphix>`.
-
-- |Fix| Fixed a bug in :class:`cluster.OPTICS` where users were unable to pass
-  float `min_samples` and `min_cluster_size`. :pr:`14496` by
-  :user:`Fabian Klopfer <someusername1>`
-  and :user:`Hanmin Qin <qinhanmin2014>`.
-
-:mod:`sklearn.inspection`
-.....................
-
-- |Fix| Fixed a bug in :func:`inspection.plot_partial_dependence` where 
-  ``target`` parameter was not being taken into account for multiclass problems.
-  :pr:`14393` by :user:`Guillem G. Subies <guillemgsubies>`.
-
-:mod:`sklearn.datasets`
-.......................
-
-- |Fix| :func:`datasets.fetch_california_housing`,
-  :func:`datasets.fetch_covtype`,
-  :func:`datasets.fetch_kddcup99`, :func:`datasets.fetch_olivetti_faces`,
-  :func:`datasets.fetch_rcv1`, and :func:`datasets.fetch_species_distributions`
-  try to persist the previously cache using the new ``joblib`` if the cahced
-  data was persisted using the deprecated ``sklearn.externals.joblib``. This
-  behavior is set to be deprecated and removed in v0.23.
-  :pr:`14197` by `Adrin Jalali`_.
-
-:mod:`sklearn.impute`
-.....................
-
-- |Fix| Fixed a bug in :class:`impute.SimpleImputer` and
-  :class:`impute.IterativeImputer` so that no errors are thrown when there are
-  missing values in training data. :pr:`13974` by `Frank Hoang <fhoang7>`.
-
-:mod:`sklearn.linear_model`
-...........................
-- |Fix| Fixed a bug in :class:`linear_model.LogisticRegressionCV` where
-  ``refit=False`` would fail depending on the ``'multiclass'`` and
-  ``'penalty'`` parameters (regression introduced in 0.21). :pr:`14087` by
-  `Nicolas Hug`_.
-- |Fix| Compatibility fix for :class:`linear_model.ARDRegression` and
-  Scipy>=1.3.0. Adapts to upstream changes to the default `pinvh` cutoff
-  threshold which otherwise results in poor accuracy in some cases.
-  :pr:`14067` by :user:`Tim Staley <timstaley>`.
-
-:mod:`sklearn.tree`
-...................
-
-- |Fix| Fixed bug in :func:`tree.export_text` when the tree has one feature and 
-  a single feature name is passed in. :pr:`14053` by `Thomas Fan`
-
-- |Fix| Fixed an issue with :func:`plot_tree` where it display
-  entropy calculations even for `gini` criterion in DecisionTreeClassifiers.
-  :pr:`13947` by :user:`Frank Hoang <fhoang7>`.
-
-:mod:`sklearn.neighbors`
-........................
-
-- |Fix| Fixed a bug in :class:`neighbors.NeighborhoodComponentsAnalysis` where
-  the validation of initial parameters ``n_components``, ``max_iter`` and
-  ``tol`` required too strict types. :pr:`14092` by
-  :user:`Jérémie du Boisberranger <jeremiedbb>`.
-
-:mod:`sklearn.compose`
-.....................
-
-- |Fix| Fixed an issue in :class:`compose.ColumnTransformer` where using
-  DataFrames whose column order differs between :func:``fit`` and
-  :func:``transform`` could lead to silently passing incorrect columns to the
-  ``remainder`` transformer.
-  :pr:`14237` by `Andreas Schuderer <schuderer>`.
-
-:mod:`sklearn.cluster`
 ......................
 
 - |Fix| Fixed a bug in :class:`cluster.KMeans` where computation was single
@@ -145,7 +69,7 @@ Changelog
 :mod:`sklearn.inspection`
 .........................
 
-- |Fix| Fixed a bug in :func:`inspection.plot_partial_dependence` where
+- |Fix| Fixed a bug in :func:`inspection.plot_partial_dependence` where 
   ``target`` parameter was not being taken into account for multiclass problems.
   :pr:`14393` by :user:`Guillem G. Subies <guillemgsubies>`.
 
@@ -173,7 +97,7 @@ Changelog
 :mod:`sklearn.tree`
 ...................
 
-- |Fix| Fixed bug in :func:`tree.export_text` when the tree has one feature and
+- |Fix| Fixed bug in :func:`tree.export_text` when the tree has one feature and 
   a single feature name is passed in. :pr:`14053` by `Thomas Fan`.
 
 .. _changes_0_21_2:
@@ -206,6 +130,13 @@ Changelog
 - |Fix| Fixed a bug in :class:`preprocessing.OneHotEncoder` where the new
   `drop` parameter was not reflected in `get_feature_names`. :pr:`13894`
   by :user:`James Myatt <jamesmyatt>`.
+
+:mod:`sklearn.tree`
+...................
+
+- |Fix| Fixed an issue with :func:`plot_tree` where it display
+  entropy calculations even for `gini` criterion in DecisionTreeClassifiers.
+  :pr:`13947` by :user:`Frank Hoang <fhoang7>`.
 
 :mod:`sklearn.utils.sparsefuncs`
 ................................
@@ -262,7 +193,7 @@ Changelog
 Version 0.21.0
 ==============
 
-**10 May 2019**
+**May 2019**
 
 Changed models
 --------------
@@ -863,6 +794,7 @@ Support for Python 3.4 and below has been officially dropped.
   ``fit.predict`` were not equivalent. :pr:`13142` by
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+
 :mod:`sklearn.model_selection`
 ..............................
 
@@ -1102,7 +1034,7 @@ Miscellaneous
 
 - |Enhancement| Joblib is no longer vendored in scikit-learn, and becomes a
   dependency. Minimal supported version is joblib 0.11, however using
-  version >= 0.13 is strongly recommended. 
+  version >= 0.13 is strongly recommended.
   :pr:`13531` by :user:`Roman Yurchak <rth>`.
 
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -7,7 +7,7 @@
 Version 0.21.3
 ==============
 
-**In development**
+**July 30, 2019**
 
 Changed models
 --------------

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -12,6 +12,13 @@ Version 0.21.3
 Changelog
 ---------
 
+:mod:`sklearn.impute`
+.....................
+
+- |Fix| Fixed a bug in :class:`SimpleImputer` and :class:`IterativeImputer`
+  so that no errors are thrown when there are missing values in training data.
+  :pr:`13974` by `Frank Hoang <fhoang7>`.
+
 :mod:`sklearn.linear_model`
 ...........................
 - |Fix| Fixed a bug in :class:`linear_model.LogisticRegressionCV` where

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -33,6 +33,13 @@ Changelog
   `drop` parameter was not reflected in `get_feature_names`. :pr:`13894`
   by :user:`James Myatt <jamesmyatt>`.
 
+:mod:`sklearn.tree`
+................................
+
+- |Fix| Fixed an issue with :func:`plot_tree` where it display
+  entropy calculations even for `gini` criterion in DecisionTreeClassifiers.
+  :pr:`13947` by :user:`Frank Hoang <fhoang7>`.
+
 :mod:`sklearn.utils.sparsefuncs`
 ................................
 
@@ -954,8 +961,8 @@ Baibak, daten-kieker, Denis Kataev, Didi Bar-Zev, Dillon Gardner, Dmitry Mottl,
 Dmitry Vukolov, Dougal J. Sutherland, Dowon, drewmjohnston, Dror Atariah,
 Edward J Brown, Ekaterina Krivich, Elizabeth Sander, Emmanuel Arias, Eric
 Chang, Eric Larson, Erich Schubert, esvhd, Falak, Feda Curic, Federico Caselli,
-Fibinse Xavier`, Finn O'Shea, Gabriel Marzinotto, Gabriel Vacaliuc, Gabriele
-Calvo, Gael Varoquaux, GauravAhlawat, Giuseppe Vettigli, Greg Gandenberger,
+Frank Hoang, Fibinse Xavier`, Finn O'Shea, Gabriel Marzinotto, Gabriel Vacaliuc, 
+Gabriele Calvo, Gael Varoquaux, GauravAhlawat, Giuseppe Vettigli, Greg Gandenberger,
 Guillaume Fournier, Guillaume Lemaitre, Gustavo De Mari Pereira, Hanmin Qin,
 haroldfox, hhu-luqi, Hunter McGushion, Ian Sanders, JackLangerman, Jacopo
 Notarstefano, jakirkham, James Bourbeau, Jan Koch, Jan S, janvanrijn, Jarrod

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -49,9 +49,9 @@ Changelog
 :mod:`sklearn.impute`
 .....................
 
-- |Fix| Fixed a bug in :class:`SimpleImputer` and :class:`IterativeImputer`
-  so that no errors are thrown when there are missing values in training data.
-  :pr:`13974` by `Frank Hoang <fhoang7>`.
+- |Fix| Fixed a bug in :class:`impute.SimpleImputer` and
+  :class:`impute.IterativeImputer` so that no errors are thrown when there are
+  missing values in training data. :pr:`13974` by `Frank Hoang <fhoang7>`.
 
 :mod:`sklearn.linear_model`
 ...........................
@@ -59,6 +59,10 @@ Changelog
   ``refit=False`` would fail depending on the ``'multiclass'`` and
   ``'penalty'`` parameters (regression introduced in 0.21). :pr:`14087` by
   `Nicolas Hug`_.
+- |Fix| Compatibility fix for :class:`linear_model.ARDRegression` and
+  Scipy>=1.3.0. Adapts to upstream changes to the default `pinvh` cutoff
+  threshold which otherwise results in poor accuracy in some cases.
+  :pr:`14067` by :user:`Tim Staley <timstaley>`.
 
 :mod:`sklearn.tree`
 ...................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -25,6 +25,14 @@ Changelog
 - |Fix| Fixed bug in :func:`tree.export_text` when the tree has one feature and 
   a single feature name is passed in. :pr:`14053` by `Thomas Fan`
 
+:mod:`sklearn.neighbors`
+........................
+
+- |Fix| Fixed a bug in :class:`neighbors.NeighborhoodComponentsAnalysis` where
+  the validation of initial parameters ``n_components``, ``max_iter`` and
+  ``tol`` required too strict types. :pr:`14092` by
+  :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 .. _changes_0_21_2:
 
 Version 0.21.2

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -2,8 +2,6 @@
 
 .. currentmodule:: sklearn
 
-<<<<<<< HEAD
-=======
 .. _changes_0_21_3:
 
 Version 0.21.3
@@ -21,7 +19,12 @@ Changelog
   ``'penalty'`` parameters (regression introduced in 0.21). :pr:`14087` by
   `Nicolas Hug`_.
 
->>>>>>> 36b688eb04... [MRG] fix refit=False error in LogisticRegressionCV (#14087)
+:mod:`sklearn.tree`
+...................
+
+- |Fix| Fixed bug in :func:`tree.export_text` when the tree has one feature and 
+  a single feature name is passed in. :pr:`14053` by `Thomas Fan`
+
 .. _changes_0_21_2:
 
 Version 0.21.2

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -12,6 +12,18 @@ Version 0.21.3
 Changelog
 ---------
 
+:mod:`sklearn.datasets`
+.......................
+
+- |Fix| :func:`datasets.fetch_california_housing`,
+  :func:`datasets.fetch_covtype`,
+  :func:`datasets.fetch_kddcup99`, :func:`datasets.fetch_olivetti_faces`,
+  :func:`datasets.fetch_rcv1`, and :func:`datasets.fetch_species_distributions`
+  try to persist the previously cache using the new ``joblib`` if the cahced
+  data was persisted using the deprecated ``sklearn.externals.joblib``. This
+  behavior is set to be deprecated and removed in v0.23.
+  :pr:`14197` by `Adrin Jalali`_.
+
 :mod:`sklearn.impute`
 .....................
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -29,8 +29,8 @@ Changelog
 :mod:`sklearn.cluster`
 ......................
 
-- |Fix| Fixed a bug in :class:`cluster.KMeans` where computation was single
-  threaded when `n_jobs > 1` or `n_jobs = -1`.
+- |Fix| Fixed a bug in :class:`cluster.KMeans` where computation with
+  `init='random'` was single threaded for `n_jobs > 1` or `n_jobs = -1`.
   :pr:`12955` by :user:`Prabakaran Kumaresshan <nixphix>`.
 
 - |Fix| Fixed a bug in :class:`cluster.OPTICS` where users were unable to pass
@@ -54,10 +54,17 @@ Changelog
   :func:`datasets.fetch_covtype`,
   :func:`datasets.fetch_kddcup99`, :func:`datasets.fetch_olivetti_faces`,
   :func:`datasets.fetch_rcv1`, and :func:`datasets.fetch_species_distributions`
-  try to persist the previously cache using the new ``joblib`` if the cahced
+  try to persist the previously cache using the new ``joblib`` if the cached
   data was persisted using the deprecated ``sklearn.externals.joblib``. This
   behavior is set to be deprecated and removed in v0.23.
   :pr:`14197` by `Adrin Jalali`_.
+
+:mod:`sklearn.ensemble`
+.......................
+
+- |Fix| Fix zero division error in :func:`HistGradientBoostingClassifier` and
+  :func:`HistGradientBoostingRegressor`.
+  :pr:`14024` by `Nicolas Hug <NicolasHug>`.
 
 :mod:`sklearn.impute`
 .....................
@@ -100,6 +107,10 @@ Changelog
 - |Fix| Fixed bug in :func:`tree.export_text` when the tree has one feature and 
   a single feature name is passed in. :pr:`14053` by `Thomas Fan`.
 
+- |Fix| Fixed an issue with :func:`plot_tree` where it displayed
+  entropy calculations even for `gini` criterion in DecisionTreeClassifiers.
+  :pr:`13947` by :user:`Frank Hoang <fhoang7>`.
+
 .. _changes_0_21_2:
 
 Version 0.21.2
@@ -131,12 +142,6 @@ Changelog
   `drop` parameter was not reflected in `get_feature_names`. :pr:`13894`
   by :user:`James Myatt <jamesmyatt>`.
 
-:mod:`sklearn.tree`
-...................
-
-- |Fix| Fixed an issue with :func:`plot_tree` where it display
-  entropy calculations even for `gini` criterion in DecisionTreeClassifiers.
-  :pr:`13947` by :user:`Frank Hoang <fhoang7>`.
 
 :mod:`sklearn.utils.sparsefuncs`
 ................................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -26,6 +26,14 @@ random sampling procedures.
 Changelog
 ---------
 
+
+:mod:`sklearn.inspection`
+.....................
+
+- |Fix| Fixed a bug in :func:`inspection.plot_partial_dependence` where 
+  ``target`` parameter was not being taken into account for multiclass problems.
+  :pr:`14393` by :user:`Guillem G. Subies <guillemgsubies>`.
+
 :mod:`sklearn.datasets`
 .......................
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -32,6 +32,10 @@ Changelog
 - |Fix| Fixed bug in :func:`tree.export_text` when the tree has one feature and 
   a single feature name is passed in. :pr:`14053` by `Thomas Fan`
 
+- |Fix| Fixed an issue with :func:`plot_tree` where it display
+  entropy calculations even for `gini` criterion in DecisionTreeClassifiers.
+  :pr:`13947` by :user:`Frank Hoang <fhoang7>`.
+
 :mod:`sklearn.neighbors`
 ........................
 
@@ -70,13 +74,6 @@ Changelog
 - |Fix| Fixed a bug in :class:`preprocessing.OneHotEncoder` where the new
   `drop` parameter was not reflected in `get_feature_names`. :pr:`13894`
   by :user:`James Myatt <jamesmyatt>`.
-
-:mod:`sklearn.tree`
-...................
-
-- |Fix| Fixed an issue with :func:`plot_tree` where it display
-  entropy calculations even for `gini` criterion in DecisionTreeClassifiers.
-  :pr:`13947` by :user:`Frank Hoang <fhoang7>`.
 
 :mod:`sklearn.utils.sparsefuncs`
 ................................

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -44,6 +44,15 @@ Changelog
   ``tol`` required too strict types. :pr:`14092` by
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+:mod:`sklearn.compose`
+.....................
+
+- |Fix| Fixed an issue in :class:`compose.ColumnTransformer` where using
+  DataFrames whose column order differs between :func:``fit`` and
+  :func:``transform`` could lead to silently passing incorrect columns to the
+  ``remainder`` transformer.
+  :pr:`14237` by `Andreas Schuderer <schuderer>`.
+
 .. _changes_0_21_2:
 
 Version 0.21.2

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -117,6 +117,13 @@ This is a bug-fix release to primarily resolve some packaging issues in version
 Changelog
 ---------
 
+:mod:`sklearn.inspection`
+.........................
+
+- |Fix| Fixed a bug in :func:`inspection.partial_dependence` to only check
+  classifier and not regressor for the multiclass-multioutput case.
+  :pr:`14309` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -26,6 +26,17 @@ random sampling procedures.
 Changelog
 ---------
 
+:mod:`sklearn.cluster`
+.....................
+
+- |Fix| Fixed a bug in :class:`cluster.KMeans` where computation was single
+  threaded when `n_jobs > 1` or `n_jobs = -1`.
+  :pr:`12955` by :user:`Prabakaran Kumaresshan <nixphix>`.
+
+- |Fix| Fixed a bug in :class:`cluster.OPTICS` where users were unable to pass
+  float `min_samples` and `min_cluster_size`. :pr:`14496` by
+  :user:`Fabian Klopfer <someusername1>`
+  and :user:`Hanmin Qin <qinhanmin2014>`.
 
 :mod:`sklearn.inspection`
 .....................
@@ -90,6 +101,80 @@ Changelog
   :func:``transform`` could lead to silently passing incorrect columns to the
   ``remainder`` transformer.
   :pr:`14237` by `Andreas Schuderer <schuderer>`.
+
+:mod:`sklearn.cluster`
+......................
+
+- |Fix| Fixed a bug in :class:`cluster.KMeans` where computation was single
+  threaded when `n_jobs > 1` or `n_jobs = -1`.
+  :pr:`12955` by :user:`Prabakaran Kumaresshan <nixphix>`.
+
+- |Fix| Fixed a bug in :class:`cluster.OPTICS` where users were unable to pass
+  float `min_samples` and `min_cluster_size`. :pr:`14496` by
+  :user:`Fabian Klopfer <someusername1>`
+  and :user:`Hanmin Qin <qinhanmin2014>`.
+
+:mod:`sklearn.compose`
+......................
+
+- |Fix| Fixed an issue in :class:`compose.ColumnTransformer` where using
+  DataFrames whose column order differs between :func:``fit`` and
+  :func:``transform`` could lead to silently passing incorrect columns to the
+  ``remainder`` transformer.
+  :pr:`14237` by `Andreas Schuderer <schuderer>`.
+
+:mod:`sklearn.datasets`
+.......................
+
+- |Fix| :func:`datasets.fetch_california_housing`,
+  :func:`datasets.fetch_covtype`,
+  :func:`datasets.fetch_kddcup99`, :func:`datasets.fetch_olivetti_faces`,
+  :func:`datasets.fetch_rcv1`, and :func:`datasets.fetch_species_distributions`
+  try to persist the previously cache using the new ``joblib`` if the cahced
+  data was persisted using the deprecated ``sklearn.externals.joblib``. This
+  behavior is set to be deprecated and removed in v0.23.
+  :pr:`14197` by `Adrin Jalali`_.
+
+:mod:`sklearn.impute`
+.....................
+
+- |Fix| Fixed a bug in :class:`impute.SimpleImputer` and
+  :class:`impute.IterativeImputer` so that no errors are thrown when there are
+  missing values in training data. :pr:`13974` by `Frank Hoang <fhoang7>`.
+
+:mod:`sklearn.inspection`
+.........................
+
+- |Fix| Fixed a bug in :func:`inspection.plot_partial_dependence` where
+  ``target`` parameter was not being taken into account for multiclass problems.
+  :pr:`14393` by :user:`Guillem G. Subies <guillemgsubies>`.
+
+:mod:`sklearn.linear_model`
+...........................
+
+- |Fix| Fixed a bug in :class:`linear_model.LogisticRegressionCV` where
+  ``refit=False`` would fail depending on the ``'multiclass'`` and
+  ``'penalty'`` parameters (regression introduced in 0.21). :pr:`14087` by
+  `Nicolas Hug`_.
+
+- |Fix| Compatibility fix for :class:`linear_model.ARDRegression` and
+  Scipy>=1.3.0. Adapts to upstream changes to the default `pinvh` cutoff
+  threshold which otherwise results in poor accuracy in some cases.
+  :pr:`14067` by :user:`Tim Staley <timstaley>`.
+
+:mod:`sklearn.neighbors`
+........................
+
+- |Fix| Fixed a bug in :class:`neighbors.NeighborhoodComponentsAnalysis` where
+  the validation of initial parameters ``n_components``, ``max_iter`` and
+  ``tol`` required too strict types. :pr:`14092` by
+  :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
+:mod:`sklearn.tree`
+...................
+
+- |Fix| Fixed bug in :func:`tree.export_text` when the tree has one feature and
+  a single feature name is passed in. :pr:`14053` by `Thomas Fan`.
 
 .. _changes_0_21_2:
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -34,7 +34,7 @@ Changelog
   by :user:`James Myatt <jamesmyatt>`.
 
 :mod:`sklearn.tree`
-................................
+...................
 
 - |Fix| Fixed an issue with :func:`plot_tree` where it display
   entropy calculations even for `gini` criterion in DecisionTreeClassifiers.
@@ -76,7 +76,7 @@ Changelog
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 :mod:`sklearn.neighbors`
-......................
+........................
 
 - |Fix| Fixed a bug in :class:`neighbors.KernelDensity` which could not be
   restored from a pickle if ``sample_weight`` had been used.
@@ -355,6 +355,7 @@ Support for Python 3.4 and below has been officially dropped.
   - all the single node trees in feature importance calculation are ignored
   - in case all trees have only one single node (i.e. a root node),
     feature importances will be an array of all zeros.
+
   :pr:`13636` and :pr:`13620` by `Adrin Jalali`_.
 
 - |Fix| Fixed a bug in :class:`ensemble.GradientBoostingClassifier` and
@@ -494,7 +495,7 @@ Support for Python 3.4 and below has been officially dropped.
 ...........................
 
 - |Enhancement| :class:`linear_model.Ridge` now preserves ``float32`` and
-  ``float64`` dtypes. :issues:`8769` and :issues:`11000` by
+  ``float64`` dtypes. :issue:`8769` and :issue:`11000` by
   :user:`Guillaume Lemaitre <glemaitre>`, and :user:`Joan Massich <massich>`
 
 - |Feature| :class:`linear_model.LogisticRegression` and

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -9,6 +9,20 @@ Version 0.21.3
 
 **In development**
 
+Changed models
+--------------
+
+The following estimators and functions, when fit with the same data and
+parameters, may produce different models from the previous version. This often
+occurs due to changes in the modelling logic (bug fixes or enhancements), or in
+random sampling procedures.
+
+- The v0.20.0 release notes failed to mention a backwards incompatibility in
+  :func:`metrics.make_scorer` when `needs_proba=True` and `y_true` is binary.
+  Now, the scorer function is supposed to accept a 1D `y_pred` (i.e.,
+  probability of the positive class, shape `(n_samples,)`), instead of a 2D
+  `y_pred` (i.e., shape `(n_samples, 2)`).
+
 Changelog
 ---------
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -2,6 +2,26 @@
 
 .. currentmodule:: sklearn
 
+<<<<<<< HEAD
+=======
+.. _changes_0_21_3:
+
+Version 0.21.3
+==============
+
+**In development**
+
+Changelog
+---------
+
+:mod:`sklearn.linear_model`
+...........................
+- |Fix| Fixed a bug in :class:`linear_model.LogisticRegressionCV` where
+  ``refit=False`` would fail depending on the ``'multiclass'`` and
+  ``'penalty'`` parameters (regression introduced in 0.21). :pr:`14087` by
+  `Nicolas Hug`_.
+
+>>>>>>> 36b688eb04... [MRG] fix refit=False error in LogisticRegressionCV (#14087)
 .. _changes_0_21_2:
 
 Version 0.21.2

--- a/examples/classification/plot_lda_qda.py
+++ b/examples/classification/plot_lda_qda.py
@@ -130,6 +130,8 @@ def plot_qda_cov(qda, splot):
 
 
 plt.figure(figsize=(10, 8), facecolor='white')
+plt.suptitle('Linear Discriminant Analysis vs Quadratic Discriminant Analysis',
+             y=0.98, fontsize=15)
 for i, (X, y) in enumerate([dataset_fixed_cov(), dataset_cov()]):
     # Linear Discriminant Analysis
     lda = LinearDiscriminantAnalysis(solver="svd", store_covariance=True)
@@ -144,7 +146,6 @@ for i, (X, y) in enumerate([dataset_fixed_cov(), dataset_cov()]):
     splot = plot_data(qda, X, y, y_pred, fig_index=2 * i + 2)
     plot_qda_cov(qda, splot)
     plt.axis('tight')
-plt.suptitle('Linear Discriminant Analysis vs Quadratic Discriminant Analysis',
-             y=1.02, fontsize=15)
 plt.tight_layout()
+plt.subplots_adjust(top=0.92)
 plt.show()

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -138,7 +138,9 @@ target = np.array(dataset.feature_names) == "DIS"
 X = dataset.data[:, np.logical_not(target)]
 y = dataset.data[:, target].squeeze()
 y_trans = quantile_transform(dataset.data[:, target],
-                             output_distribution='normal').squeeze()
+                             n_quantiles=300,
+                             output_distribution='normal',
+                             copy=True).squeeze()
 
 ###############################################################################
 # A :class:`sklearn.preprocessing.QuantileTransformer` is used such that the
@@ -184,7 +186,8 @@ ax0.set_ylim([0, 10])
 
 regr_trans = TransformedTargetRegressor(
     regressor=RidgeCV(),
-    transformer=QuantileTransformer(output_distribution='normal'))
+    transformer=QuantileTransformer(n_quantiles=300,
+                                    output_distribution='normal'))
 regr_trans.fit(X_train, y_train)
 y_pred = regr_trans.predict(X_test)
 

--- a/examples/linear_model/plot_omp.py
+++ b/examples/linear_model/plot_omp.py
@@ -18,7 +18,6 @@ n_components, n_features = 512, 100
 n_nonzero_coefs = 17
 
 # generate the data
-###################
 
 # y = Xw
 # |x|_0 = n_nonzero_coefs
@@ -32,11 +31,9 @@ y, X, w = make_sparse_coded_signal(n_samples=1,
 idx, = w.nonzero()
 
 # distort the clean signal
-##########################
 y_noisy = y + 0.05 * np.random.randn(len(y))
 
 # plot the sparse signal
-########################
 plt.figure(figsize=(7, 7))
 plt.subplot(4, 1, 1)
 plt.xlim(0, 512)
@@ -44,8 +41,6 @@ plt.title("Sparse signal")
 plt.stem(idx, w[idx])
 
 # plot the noise-free reconstruction
-####################################
-
 omp = OrthogonalMatchingPursuit(n_nonzero_coefs=n_nonzero_coefs)
 omp.fit(X, y)
 coef = omp.coef_
@@ -56,7 +51,6 @@ plt.title("Recovered signal from noise-free measurements")
 plt.stem(idx_r, coef[idx_r])
 
 # plot the noisy reconstruction
-###############################
 omp.fit(X, y_noisy)
 coef = omp.coef_
 idx_r, = coef.nonzero()
@@ -66,7 +60,6 @@ plt.title("Recovered signal from noisy measurements")
 plt.stem(idx_r, coef[idx_r])
 
 # plot the noisy reconstruction with number of non-zeros set by CV
-##################################################################
 omp_cv = OrthogonalMatchingPursuitCV(cv=5)
 omp_cv.fit(X, y_noisy)
 coef = omp_cv.coef_

--- a/examples/neural_networks/plot_mlp_alpha.py
+++ b/examples/neural_networks/plot_mlp_alpha.py
@@ -36,7 +36,8 @@ names = ['alpha ' + str(i) for i in alphas]
 
 classifiers = []
 for i in alphas:
-    classifiers.append(MLPClassifier(alpha=i, random_state=1))
+    classifiers.append(MLPClassifier(solver='lbfgs', alpha=i, random_state=1,
+                                     hidden_layer_sizes=[100, 100]))
 
 X, y = make_classification(n_features=2, n_redundant=0, n_informative=2,
                            random_state=0, n_clusters_per_class=1)

--- a/examples/neural_networks/plot_mlp_training_curves.py
+++ b/examples/neural_networks/plot_mlp_training_curves.py
@@ -14,10 +14,15 @@ Note that those results can be highly dependent on the value of
 """
 
 print(__doc__)
+
+import warnings
+
 import matplotlib.pyplot as plt
+
 from sklearn.neural_network import MLPClassifier
 from sklearn.preprocessing import MinMaxScaler
 from sklearn import datasets
+from sklearn.exceptions import ConvergenceWarning
 
 # different learning rate schedules and momentum parameters
 params = [{'solver': 'sgd', 'learning_rate': 'constant', 'momentum': 0,
@@ -52,6 +57,7 @@ def plot_on_dataset(X, y, ax, name):
     # for each dataset, plot learning for each learning strategy
     print("\nlearning on dataset %s" % name)
     ax.set_title(name)
+
     X = MinMaxScaler().fit_transform(X)
     mlps = []
     if name == "digits":
@@ -64,12 +70,19 @@ def plot_on_dataset(X, y, ax, name):
         print("training: %s" % label)
         mlp = MLPClassifier(verbose=0, random_state=0,
                             max_iter=max_iter, **param)
-        mlp.fit(X, y)
+
+        # some parameter combinations will not converge as can be seen on the
+        # plots so they are ignored here
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=ConvergenceWarning,
+                                    module="sklearn")
+            mlp.fit(X, y)
+
         mlps.append(mlp)
         print("Training set score: %f" % mlp.score(X, y))
         print("Training set loss: %f" % mlp.loss_)
     for mlp, label, args in zip(mlps, labels, plot_args):
-            ax.plot(mlp.loss_curve_, label=label, **args)
+        ax.plot(mlp.loss_curve_, label=label, **args)
 
 
 fig, axes = plt.subplots(2, 2, figsize=(15, 10))

--- a/examples/plot_isotonic_regression.py
+++ b/examples/plot_isotonic_regression.py
@@ -50,7 +50,7 @@ lc.set_linewidths(np.full(n, 0.5))
 
 fig = plt.figure()
 plt.plot(x, y, 'r.', markersize=12)
-plt.plot(x, y_, 'g.-', markersize=12)
+plt.plot(x, y_, 'b.-', markersize=12)
 plt.plot(x, lr.predict(x[:, np.newaxis]), 'b-')
 plt.gca().add_collection(lc)
 plt.legend(('Data', 'Isotonic Fit', 'Linear Fit'), loc='lower right')

--- a/examples/preprocessing/plot_map_data_to_normal.py
+++ b/examples/preprocessing/plot_map_data_to_normal.py
@@ -53,7 +53,10 @@ BINS = 30
 rng = np.random.RandomState(304)
 bc = PowerTransformer(method='box-cox')
 yj = PowerTransformer(method='yeo-johnson')
-qt = QuantileTransformer(output_distribution='normal', random_state=rng)
+# n_quantiles is set to the training set size rather than the default value
+# to avoid a warning being raised by this example
+qt = QuantileTransformer(n_quantiles=500, output_distribution='normal',
+                         random_state=rng)
 size = (N_SAMPLES, 1)
 
 

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -45,7 +45,7 @@ warnings.filterwarnings('always', category=DeprecationWarning,
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.21.2'
+__version__ = '0.21.3'
 
 
 # On OSX, we can get a runtime error due to multiple OpenMP libraries loaded

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -9,38 +9,12 @@ import os
 
 from distutils.version import LooseVersion
 
-from numpy.distutils.system_info import get_info
-
 from .openmp_helpers import check_openmp_support
 
 
 DEFAULT_ROOT = 'sklearn'
 # on conda, this is the latest for python 3.5
 CYTHON_MIN_VERSION = '0.28.5'
-
-
-def get_blas_info():
-    def atlas_not_found(blas_info_):
-        def_macros = blas_info.get('define_macros', [])
-        for x in def_macros:
-            if x[0] == "NO_ATLAS_INFO":
-                # if x[1] != 1 we should have lapack
-                # how do we do that now?
-                return True
-            if x[0] == "ATLAS_INFO":
-                if "None" in x[1]:
-                    # this one turned up on FreeBSD
-                    return True
-        return False
-
-    blas_info = get_info('blas_opt', 0)
-    if (not blas_info) or atlas_not_found(blas_info):
-        cblas_libs = ['cblas']
-        blas_info.pop('libraries', None)
-    else:
-        cblas_libs = blas_info.pop('libraries', [])
-
-    return cblas_libs, blas_info
 
 
 def build_from_c_and_cpp_files(extensions):

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -17,6 +17,11 @@ def get_config():
     -------
     config : dict
         Keys are parameter names that can be passed to :func:`set_config`.
+
+    See Also
+    --------
+    config_context: Context manager for global scikit-learn configuration
+    set_config: Set global scikit-learn configuration
     """
     return _global_config.copy()
 
@@ -53,6 +58,11 @@ def set_config(assume_finite=None, working_memory=None,
         all the non-changed parameters.
 
         .. versionadded:: 0.21
+
+    See Also
+    --------
+    config_context: Context manager for global scikit-learn configuration
+    get_config: Retrieve current values of the global configuration
     """
     if assume_finite is not None:
         _global_config['assume_finite'] = assume_finite
@@ -99,6 +109,11 @@ def config_context(**new_config):
     Traceback (most recent call last):
     ...
     ValueError: Input contains NaN, ...
+
+    See Also
+    --------
+    set_config: Set global scikit-learn configuration
+    get_config: Retrieve current values of the global configuration
     """
     old_config = get_config().copy()
     set_config(**new_config)

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -109,6 +109,9 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
         rand_vals = random_state.random_sample(n_local_trials) * current_pot
         candidate_ids = np.searchsorted(stable_cumsum(closest_dist_sq),
                                         rand_vals)
+        # XXX: numerical imprecision can result in a candidate_id out of range
+        np.clip(candidate_ids, None, closest_dist_sq.size - 1,
+                out=candidate_ids)
 
         # Compute distances to center candidates
         distance_to_candidates = euclidean_distances(

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -44,7 +44,7 @@ class OPTICS(BaseEstimator, ClusterMixin):
 
     Parameters
     ----------
-    min_samples : int > 1 or float between 0 and 1 (default=None)
+    min_samples : int > 1 or float between 0 and 1 (default=5)
         The number of samples in a neighborhood for a point to be considered as
         a core point. Also, up and down steep regions can't have more then
         ``min_samples`` consecutive non-steep points. Expressed as an absolute
@@ -341,7 +341,7 @@ if metric=’precomputed’.
         A feature array, or array of distances between samples if
         metric='precomputed'
 
-    min_samples : int (default=5)
+    min_samples : int > 1 or float between 0 and 1
         The number of samples in a neighborhood for a point to be considered
         as a core point. Expressed as an absolute number or a fraction of the
         number of samples (rounded to be at least 2).
@@ -437,7 +437,7 @@ if metric=’precomputed’.
     n_samples = X.shape[0]
     _validate_size(min_samples, n_samples, 'min_samples')
     if min_samples <= 1:
-        min_samples = max(2, min_samples * n_samples)
+        min_samples = max(2, int(min_samples * n_samples))
 
     # Start all points as 'unprocessed' ##
     reachability_ = np.empty(n_samples)
@@ -582,7 +582,7 @@ def cluster_optics_xi(reachability, predecessor, ordering, min_samples,
     ordering : array, shape (n_samples,)
         OPTICS ordered point indices (`ordering_`)
 
-    min_samples : int > 1 or float between 0 and 1 (default=None)
+    min_samples : int > 1 or float between 0 and 1
         The same as the min_samples given to OPTICS. Up and down steep regions
         can't have more then ``min_samples`` consecutive non-steep points.
         Expressed as an absolute number or a fraction of the number of samples
@@ -619,12 +619,12 @@ def cluster_optics_xi(reachability, predecessor, ordering, min_samples,
     n_samples = len(reachability)
     _validate_size(min_samples, n_samples, 'min_samples')
     if min_samples <= 1:
-        min_samples = max(2, min_samples * n_samples)
+        min_samples = max(2, int(min_samples * n_samples))
     if min_cluster_size is None:
         min_cluster_size = min_samples
     _validate_size(min_cluster_size, n_samples, 'min_cluster_size')
     if min_cluster_size <= 1:
-        min_cluster_size = max(2, min_cluster_size * n_samples)
+        min_cluster_size = max(2, int(min_cluster_size * n_samples))
 
     clusters = _xi_cluster(reachability[ordering], predecessor[ordering],
                            ordering, xi,
@@ -753,16 +753,12 @@ def _xi_cluster(reachability_plot, predecessor_plot, ordering, xi, min_samples,
         reachability plot is defined by the ratio from one point to its
         successor being at most 1-xi.
 
-    min_samples : int > 1 or float between 0 and 1 (default=None)
+    min_samples : int > 1
         The same as the min_samples given to OPTICS. Up and down steep regions
         can't have more then ``min_samples`` consecutive non-steep points.
-        Expressed as an absolute number or a fraction of the number of samples
-        (rounded to be at least 2).
 
-    min_cluster_size : int > 1 or float between 0 and 1
-        Minimum number of samples in an OPTICS cluster, expressed as an
-        absolute number or a fraction of the number of samples (rounded
-        to be at least 2).
+    min_cluster_size : int > 1
+        Minimum number of samples in an OPTICS cluster.
 
     predecessor_correction : bool
         Correct clusters based on the calculated predecessors.

--- a/sklearn/cluster/tests/test_mean_shift.py
+++ b/sklearn/cluster/tests/test_mean_shift.py
@@ -36,7 +36,7 @@ def test_estimate_bandwidth_1sample():
     # Test estimate_bandwidth when n_samples=1 and quantile<1, so that
     # n_neighbors is set to 1.
     bandwidth = estimate_bandwidth(X, n_samples=1, quantile=0.3)
-    assert bandwidth == 0.
+    assert bandwidth == pytest.approx(0., abs=1e-5)
 
 
 @pytest.mark.parametrize("bandwidth, cluster_all, expected, "

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -111,7 +111,7 @@ def test_extract_xi():
 
     clust = OPTICS(min_samples=3, min_cluster_size=3,
                    max_eps=20, cluster_method='xi',
-                   xi=0.1).fit(X)
+                   xi=0.3).fit(X)
     # this may fail if the predecessor correction is not at work!
     assert_array_equal(clust.labels_, expected_labels)
 

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -102,6 +102,12 @@ def test_extract_xi():
                    xi=0.4).fit(X)
     assert_array_equal(clust.labels_, expected_labels)
 
+    # check float min_samples and min_cluster_size
+    clust = OPTICS(min_samples=0.1, min_cluster_size=0.08,
+                   max_eps=20, cluster_method='xi',
+                   xi=0.4).fit(X)
+    assert_array_equal(clust.labels_, expected_labels)
+
     X = np.vstack((C1, C2, C3, C4, C5, np.array([[100, 100]] * 2), C6))
     expected_labels = np.r_[[1] * 5, [3] * 5, [2] * 5, [0] * 5, [2] * 5,
                             -1, -1, [4] * 5]

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -79,6 +79,8 @@ boolean mask array or callable
         By setting ``remainder`` to be an estimator, the remaining
         non-specified columns will use the ``remainder`` estimator. The
         estimator must support :term:`fit` and :term:`transform`.
+        Note that using this feature requires that the DataFrame columns
+        input at :term:`fit` and :term:`transform` have identical order.
 
     sparse_threshold : float, default = 0.3
         If the output of the different transformers contains sparse matrices,
@@ -302,11 +304,17 @@ boolean mask array or callable
                 "'passthrough', or estimator. '%s' was passed instead" %
                 self.remainder)
 
-        n_columns = X.shape[1]
+        # Make it possible to check for reordered named columns on transform
+        if (hasattr(X, 'columns') and
+                any(_check_key_type(cols, str) for cols in self._columns)):
+            self._df_columns = X.columns
+
+        self._n_features = X.shape[1]
         cols = []
         for columns in self._columns:
             cols.extend(_get_column_indices(X, columns))
-        remaining_idx = sorted(list(set(range(n_columns)) - set(cols))) or None
+        remaining_idx = list(set(range(self._n_features)) - set(cols))
+        remaining_idx = sorted(remaining_idx) or None
 
         self._remainder = ('remainder', self.remainder, remaining_idx)
 
@@ -507,8 +515,27 @@ boolean mask array or callable
 
         """
         check_is_fitted(self, 'transformers_')
-
         X = _check_X(X)
+
+        if self._n_features > X.shape[1]:
+            raise ValueError('Number of features of the input must be equal '
+                             'to or greater than that of the fitted '
+                             'transformer. Transformer n_features is {0} '
+                             'and input n_features is {1}.'
+                             .format(self._n_features, X.shape[1]))
+
+        # No column reordering allowed for named cols combined with remainder
+        if (self._remainder[2] is not None and
+                hasattr(self, '_df_columns') and
+                hasattr(X, 'columns')):
+            n_cols_fit = len(self._df_columns)
+            n_cols_transform = len(X.columns)
+            if (n_cols_transform >= n_cols_fit and
+                    any(X.columns[:n_cols_fit] != self._df_columns)):
+                raise ValueError('Column ordering must be equal for fit '
+                                 'and for transform when using the '
+                                 'remainder keyword')
+
         Xs = self._fit_transform(X, None, _transform_one, fitted=True)
         self._validate_output(Xs)
 

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -494,6 +494,17 @@ def test_column_transformer_invalid_columns(remainder):
         assert_raise_message(ValueError, "Specifying the columns",
                              ct.fit, X_array)
 
+    # transformed n_features does not match fitted n_features
+    col = [0, 1]
+    ct = ColumnTransformer([('trans', Trans(), col)], remainder=remainder)
+    ct.fit(X_array)
+    X_array_more = np.array([[0, 1, 2], [2, 4, 6], [3, 6, 9]]).T
+    ct.transform(X_array_more)  # Should accept added columns
+    X_array_fewer = np.array([[0, 1, 2], ]).T
+    err_msg = 'Number of features'
+    with pytest.raises(ValueError, match=err_msg):
+        ct.transform(X_array_fewer)
+
 
 def test_column_transformer_invalid_transformer():
 
@@ -1083,3 +1094,40 @@ def test_column_transformer_negative_column_indexes():
     tf_1 = ColumnTransformer([('ohe', ohe, [-1])], remainder='passthrough')
     tf_2 = ColumnTransformer([('ohe', ohe,  [2])], remainder='passthrough')
     assert_array_equal(tf_1.fit_transform(X), tf_2.fit_transform(X))
+
+
+@pytest.mark.parametrize("explicit_colname", ['first', 'second'])
+def test_column_transformer_reordered_column_names_remainder(explicit_colname):
+    """Regression test for issue #14223: 'Named col indexing fails with
+       ColumnTransformer remainder on changing DataFrame column ordering'
+
+       Should raise error on changed order combined with remainder.
+       Should allow for added columns in `transform` input DataFrame
+       as long as all preceding columns match.
+    """
+    pd = pytest.importorskip('pandas')
+
+    X_fit_array = np.array([[0, 1, 2], [2, 4, 6]]).T
+    X_fit_df = pd.DataFrame(X_fit_array, columns=['first', 'second'])
+
+    X_trans_array = np.array([[2, 4, 6], [0, 1, 2]]).T
+    X_trans_df = pd.DataFrame(X_trans_array, columns=['second', 'first'])
+
+    tf = ColumnTransformer([('bycol', Trans(), explicit_colname)],
+                           remainder=Trans())
+
+    tf.fit(X_fit_df)
+    err_msg = 'Column ordering must be equal'
+    with pytest.raises(ValueError, match=err_msg):
+        tf.transform(X_trans_df)
+
+    # No error for added columns if ordering is identical
+    X_extended_df = X_fit_df.copy()
+    X_extended_df['third'] = [3, 6, 9]
+    tf.transform(X_extended_df)  # No error should be raised
+
+    # No 'columns' AttributeError when transform input is a numpy array
+    X_array = X_fit_array.copy()
+    err_msg = 'Specifying the columns'
+    with pytest.raises(ValueError, match=err_msg):
+        tf.transform(X_array)

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -10,6 +10,7 @@ import os
 import csv
 import sys
 import shutil
+import warnings
 from collections import namedtuple
 from os import environ, listdir, makedirs
 from os.path import dirname, exists, expanduser, isdir, join, splitext
@@ -919,3 +920,31 @@ def _fetch_remote(remote, dirname=None):
                       "file may be corrupted.".format(file_path, checksum,
                                                       remote.checksum))
     return file_path
+
+
+def _refresh_cache(files, compress):
+    # TODO: REMOVE in v0.23
+    import joblib
+    msg = "sklearn.externals.joblib is deprecated in 0.21"
+    with warnings.catch_warnings(record=True) as warns:
+        data = tuple([joblib.load(f) for f in files])
+
+    refresh_needed = any([str(x.message).startswith(msg) for x in warns])
+
+    other_warns = [w for w in warns if not str(w.message).startswith(msg)]
+    for w in other_warns:
+        warnings.warn(message=w.message, category=w.category)
+
+    if refresh_needed:
+        try:
+            for value, path in zip(data, files):
+                joblib.dump(value, path, compress=compress)
+        except IOError:
+            message = ("This dataset will stop being loadable in scikit-learn "
+                       "version 0.23 because it references a deprecated "
+                       "import path. Consider removing the following files "
+                       "and allowing it to be cached anew:\n%s"
+                       % ("\n".join(files)))
+            warnings.warn(message=message, category=DeprecationWarning)
+
+    return data[0] if len(data) == 1 else data

--- a/sklearn/datasets/california_housing.py
+++ b/sklearn/datasets/california_housing.py
@@ -32,6 +32,7 @@ from .base import get_data_home
 from .base import _fetch_remote
 from .base import _pkl_filepath
 from .base import RemoteFileMetadata
+from .base import _refresh_cache
 from ..utils import Bunch
 from ..utils import _joblib
 
@@ -128,7 +129,9 @@ def fetch_california_housing(data_home=None, download_if_missing=True,
         remove(archive_path)
 
     else:
-        cal_housing = _joblib.load(filepath)
+        cal_housing = _refresh_cache([filepath], 6)
+        # TODO: Revert to the following line in v0.23
+        # cal_housing = joblib.load(filepath)
 
     feature_names = ["MedInc", "HouseAge", "AveRooms", "AveBedrms",
                      "Population", "AveOccup", "Latitude", "Longitude"]

--- a/sklearn/datasets/covtype.py
+++ b/sklearn/datasets/covtype.py
@@ -24,6 +24,7 @@ import numpy as np
 from .base import get_data_home
 from .base import _fetch_remote
 from .base import RemoteFileMetadata
+from .base import _refresh_cache
 from ..utils import Bunch
 from .base import _pkl_filepath
 from ..utils import _joblib
@@ -125,8 +126,10 @@ def fetch_covtype(data_home=None, download_if_missing=True,
     try:
         X, y
     except NameError:
-        X = _joblib.load(samples_path)
-        y = _joblib.load(targets_path)
+        X, y = _refresh_cache([samples_path, targets_path], 9)
+        # TODO: Revert to the following two lines in v0.23
+        # X = joblib.load(samples_path)
+        # y = joblib.load(targets_path)
 
     if shuffle:
         ind = np.arange(X.shape[0])

--- a/sklearn/datasets/kddcup99.py
+++ b/sklearn/datasets/kddcup99.py
@@ -20,6 +20,7 @@ import numpy as np
 from .base import _fetch_remote
 from .base import get_data_home
 from .base import RemoteFileMetadata
+from .base import _refresh_cache
 from ..utils import Bunch
 from ..utils import _joblib
 from ..utils import check_random_state
@@ -293,8 +294,10 @@ def _fetch_brute_kddcup99(data_home=None,
     try:
         X, y
     except NameError:
-        X = _joblib.load(samples_path)
-        y = _joblib.load(targets_path)
+        X, y = _refresh_cache([samples_path, targets_path], 0)
+        # TODO: Revert to the following two lines in v0.23
+        # X = joblib.load(samples_path)
+        # y = joblib.load(targets_path)
 
     return Bunch(data=X, target=y)
 

--- a/sklearn/datasets/olivetti_faces.py
+++ b/sklearn/datasets/olivetti_faces.py
@@ -24,6 +24,7 @@ from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from .base import _pkl_filepath
 from ..utils import _joblib
+from .base import _refresh_cache
 from ..utils import check_random_state, Bunch
 
 # The original data can be found at:
@@ -107,7 +108,9 @@ def fetch_olivetti_faces(data_home=None, shuffle=False, random_state=0,
         _joblib.dump(faces, filepath, compress=6)
         del mfile
     else:
-        faces = _joblib.load(filepath)
+        faces = _refresh_cache([filepath], 6)
+        # TODO: Revert to the following line in v0.23
+        # faces = joblib.load(filepath)
 
     # We want floating point data, but float32 is enough (there is only
     # one byte of precision in the original uint8s anyway)

--- a/sklearn/datasets/rcv1.py
+++ b/sklearn/datasets/rcv1.py
@@ -22,6 +22,7 @@ from .base import _pkl_filepath
 from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from ..utils import _joblib
+from .base import _refresh_cache
 from .svmlight_format import load_svmlight_files
 from ..utils import shuffle as shuffle_
 from ..utils import Bunch
@@ -189,8 +190,10 @@ def fetch_rcv1(data_home=None, subset='all', download_if_missing=True,
             f.close()
             remove(f.name)
     else:
-        X = _joblib.load(samples_path)
-        sample_id = _joblib.load(sample_id_path)
+        X, sample_id = _refresh_cache([samples_path, sample_id_path], 9)
+        # TODO: Revert to the following two lines in v0.23
+        # X = joblib.load(samples_path)
+        # sample_id = joblib.load(sample_id_path)
 
     # load target (y), categories, and sample_id_bis
     if download_if_missing and (not exists(sample_topics_path) or
@@ -243,8 +246,10 @@ def fetch_rcv1(data_home=None, subset='all', download_if_missing=True,
         _joblib.dump(y, sample_topics_path, compress=9)
         _joblib.dump(categories, topics_path, compress=9)
     else:
-        y = _joblib.load(sample_topics_path)
-        categories = _joblib.load(topics_path)
+        y, categories = _refresh_cache([sample_topics_path, topics_path], 9)
+        # TODO: Revert to the following two lines in v0.23
+        # y = joblib.load(sample_topics_path)
+        # categories = joblib.load(topics_path)
 
     if subset == 'all':
         pass

--- a/sklearn/datasets/species_distributions.py
+++ b/sklearn/datasets/species_distributions.py
@@ -51,6 +51,7 @@ from .base import RemoteFileMetadata
 from ..utils import Bunch
 from .base import _pkl_filepath
 from ..utils import _joblib
+from .base import _refresh_cache
 
 # The original data can be found at:
 # https://biodiversityinformatics.amnh.org/open_source/maxent/samples.zip
@@ -259,6 +260,8 @@ def fetch_species_distributions(data_home=None,
                       **extra_params)
         _joblib.dump(bunch, archive_path, compress=9)
     else:
-        bunch = _joblib.load(archive_path)
+        bunch = _refresh_cache([archive_path], 9)
+        # TODO: Revert to the following line in v0.23
+        # bunch = joblib.load(archive_path)
 
     return bunch

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -8,6 +8,7 @@ from pickle import dumps
 from functools import partial
 
 import pytest
+import joblib
 
 import numpy as np
 from sklearn.datasets import get_data_home
@@ -23,6 +24,7 @@ from sklearn.datasets import load_breast_cancer
 from sklearn.datasets import load_boston
 from sklearn.datasets import load_wine
 from sklearn.datasets.base import Bunch
+from sklearn.datasets.base import _refresh_cache
 from sklearn.datasets.tests.test_common import check_return_X_y
 
 from sklearn.externals._pilutil import pillow_installed
@@ -272,3 +274,55 @@ def test_bunch_dir():
     # check that dir (important for autocomplete) shows attributes
     data = load_iris()
     assert "data" in dir(data)
+
+
+def test_refresh_cache(monkeypatch):
+    # uses pytests monkeypatch fixture
+    # https://docs.pytest.org/en/latest/monkeypatch.html
+
+    def _load_warn(*args, **kwargs):
+        # raise the warning from "externals.joblib.__init__.py"
+        # this is raised when a file persisted by the old joblib is loaded now
+        msg = ("sklearn.externals.joblib is deprecated in 0.21 and will be "
+               "removed in 0.23. Please import this functionality directly "
+               "from joblib, which can be installed with: pip install joblib. "
+               "If this warning is raised when loading pickled models, you "
+               "may need to re-serialize those models with scikit-learn "
+               "0.21+.")
+        warnings.warn(msg, DeprecationWarning)
+        return 0
+
+    def _load_warn_unrelated(*args, **kwargs):
+        warnings.warn("unrelated warning", DeprecationWarning)
+        return 0
+
+    def _dump_safe(*args, **kwargs):
+        pass
+
+    def _dump_raise(*args, **kwargs):
+        # this happens if the file is read-only and joblib.dump fails to write
+        # on it.
+        raise IOError()
+
+    # test if the dataset spesific warning is raised if load raises the joblib
+    # warning, and dump fails to dump with new joblib
+    monkeypatch.setattr(joblib, "load", _load_warn)
+    monkeypatch.setattr(joblib, "dump", _dump_raise)
+    msg = "This dataset will stop being loadable in scikit-learn"
+    with pytest.warns(DeprecationWarning, match=msg):
+        _refresh_cache('test', 0)
+
+    # make sure no warning is raised if load raises the warning, but dump
+    # manages to dump the new data
+    monkeypatch.setattr(joblib, "load", _load_warn)
+    monkeypatch.setattr(joblib, "dump", _dump_safe)
+    with pytest.warns(None) as warns:
+        _refresh_cache('test', 0)
+    assert len(warns) == 0
+
+    # test if an unrelated warning is still passed through and not suppressed
+    # by _refresh_cache
+    monkeypatch.setattr(joblib, "load", _load_warn_unrelated)
+    monkeypatch.setattr(joblib, "dump", _dump_safe)
+    with pytest.warns(DeprecationWarning, match="unrelated warning"):
+        _refresh_cache('test', 0)

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -678,7 +678,7 @@ class HistGradientBoostingClassifier(BaseHistGradientBoosting,
         generalizes to 'categorical_crossentropy' for multiclass
         classification. 'auto' will automatically choose either loss depending
         on the nature of the problem.
-    learning_rate : float, optional (default=1)
+    learning_rate : float, optional (default=0.1)
         The learning rate, also known as *shrinkage*. This is used as a
         multiplicative factor for the leaves values. Use ``1`` for no
         shrinkage.

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -15,6 +15,11 @@ from .splitting import Splitter
 from .histogram import HistogramBuilder
 from .predictor import TreePredictor, PREDICTOR_RECORD_DTYPE
 from .utils import sum_parallel
+from .types import PREDICTOR_RECORD_DTYPE
+from .types import Y_DTYPE
+
+
+EPS = np.finfo(Y_DTYPE).eps  # to avoid zero division errors
 
 
 class TreeNode:
@@ -397,7 +402,7 @@ class TreeGrower:
         https://arxiv.org/abs/1603.02754
         """
         node.value = -self.shrinkage * node.sum_gradients / (
-            node.sum_hessians + self.splitter.l2_regularization)
+            node.sum_hessians + self.splitter.l2_regularization + EPS)
         self.finalized_leaves.append(node)
 
     def _finalize_splittable_nodes(self):

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -15,7 +15,6 @@ from .splitting import Splitter
 from .histogram import HistogramBuilder
 from .predictor import TreePredictor, PREDICTOR_RECORD_DTYPE
 from .utils import sum_parallel
-from .types import PREDICTOR_RECORD_DTYPE
 from .types import Y_DTYPE
 
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -145,3 +145,46 @@ def test_should_stop(scores, n_iter_no_change, tol, stopping):
         n_iter_no_change=n_iter_no_change, tol=tol
     )
     assert gbdt._should_stop(scores) == stopping
+
+
+def test_binning_train_validation_are_separated():
+    # Make sure training and validation data are binned separately.
+    # See issue 13926
+
+    rng = np.random.RandomState(0)
+    validation_fraction = .2
+    gb = HistGradientBoostingClassifier(
+        n_iter_no_change=5,
+        validation_fraction=validation_fraction,
+        random_state=rng
+    )
+    gb.fit(X_classification, y_classification)
+    mapper_training_data = gb.bin_mapper_
+
+    # Note that since the data is small there is no subsampling and the
+    # random_state doesn't matter
+    mapper_whole_data = _BinMapper(random_state=0)
+    mapper_whole_data.fit(X_classification)
+
+    n_samples = X_classification.shape[0]
+    assert np.all(mapper_training_data.actual_n_bins_ ==
+                  int((1 - validation_fraction) * n_samples))
+    assert np.all(mapper_training_data.actual_n_bins_ !=
+                  mapper_whole_data.actual_n_bins_)
+
+
+@pytest.mark.parametrize('data', [
+    make_classification(random_state=0, n_classes=2),
+    make_classification(random_state=0, n_classes=3, n_informative=3)
+], ids=['binary_crossentropy', 'categorical_crossentropy'])
+def test_zero_division_hessians(data):
+    # non regression test for issue #14018
+    # make sure we avoid zero division errors when computing the leaves values.
+
+    # If the learning rate is too high, the raw predictions are bad and will
+    # saturate the softmax (or sigmoid in binary classif). This leads to
+    # probabilities being exactly 0 or 1, gradients being constant, and
+    # hessians being zero.
+    X, y = data
+    gb = HistGradientBoostingClassifier(learning_rate=100, max_iter=10)
+    gb.fit(X, y)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -147,32 +147,6 @@ def test_should_stop(scores, n_iter_no_change, tol, stopping):
     assert gbdt._should_stop(scores) == stopping
 
 
-def test_binning_train_validation_are_separated():
-    # Make sure training and validation data are binned separately.
-    # See issue 13926
-
-    rng = np.random.RandomState(0)
-    validation_fraction = .2
-    gb = HistGradientBoostingClassifier(
-        n_iter_no_change=5,
-        validation_fraction=validation_fraction,
-        random_state=rng
-    )
-    gb.fit(X_classification, y_classification)
-    mapper_training_data = gb.bin_mapper_
-
-    # Note that since the data is small there is no subsampling and the
-    # random_state doesn't matter
-    mapper_whole_data = _BinMapper(random_state=0)
-    mapper_whole_data.fit(X_classification)
-
-    n_samples = X_classification.shape[0]
-    assert np.all(mapper_training_data.actual_n_bins_ ==
-                  int((1 - validation_fraction) * n_samples))
-    assert np.all(mapper_training_data.actual_n_bins_ !=
-                  mapper_whole_data.actual_n_bins_)
-
-
 @pytest.mark.parametrize('data', [
     make_classification(random_state=0, n_classes=2),
     make_classification(random_state=0, n_classes=3, n_informative=3)

--- a/sklearn/ensemble/partial_dependence.py
+++ b/sklearn/ensemble/partial_dependence.py
@@ -100,11 +100,11 @@ def partial_dependence(gbrt, target_variables, grid=None, X=None,
     gbrt : BaseGradientBoosting
         A fitted gradient boosting model.
     target_variables : array-like, dtype=int
-        The target features for which the partial dependecy should be
+        The target features for which the partial dependency should be
         computed (size should be smaller than 3 for visual renderings).
     grid : array-like, shape=(n_points, len(target_variables))
         The grid of ``target_variables`` values for which the
-        partial dependecy should be evaluated (either ``grid`` or ``X``
+        partial dependency should be evaluated (either ``grid`` or ``X``
         must be specified).
     X : array-like, shape=(n_samples, n_features)
         The data on which ``gbrt`` was trained. It is used to generate

--- a/sklearn/externals/_scipy_linalg.py
+++ b/sklearn/externals/_scipy_linalg.py
@@ -1,0 +1,118 @@
+# This should remained pinned to version 1.2 and not updated like other
+# externals.
+"""Copyright (c) 2001-2002 Enthought, Inc.  2003-2019, SciPy Developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided
+   with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+import numpy as np
+import scipy.linalg.decomp as decomp
+
+
+def pinvh(a, cond=None, rcond=None, lower=True, return_rank=False,
+          check_finite=True):
+    """
+    Compute the (Moore-Penrose) pseudo-inverse of a Hermitian matrix.
+
+    Copied in from scipy==1.2.2, in order to preserve the default choice of the
+    `cond` and `above_cutoff` values which determine which values of the matrix
+    inversion lie below threshold and are so set to zero. Changes in scipy 1.3
+    resulted in a smaller default threshold and thus slower convergence of
+    dependent algorithms in some cases (see Sklearn github issue #14055).
+
+    Calculate a generalized inverse of a Hermitian or real symmetric matrix
+    using its eigenvalue decomposition and including all eigenvalues with
+    'large' absolute value.
+
+    Parameters
+    ----------
+    a : (N, N) array_like
+        Real symmetric or complex hermetian matrix to be pseudo-inverted
+    cond, rcond : float or None
+        Cutoff for 'small' eigenvalues.
+        Singular values smaller than rcond * largest_eigenvalue are considered
+        zero.
+
+        If None or -1, suitable machine precision is used.
+    lower : bool, optional
+        Whether the pertinent array data is taken from the lower or upper
+        triangle of a. (Default: lower)
+    return_rank : bool, optional
+        if True, return the effective rank of the matrix
+    check_finite : bool, optional
+        Whether to check that the input matrix contains only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination) if the inputs do contain infinities or NaNs.
+
+    Returns
+    -------
+    B : (N, N) ndarray
+        The pseudo-inverse of matrix `a`.
+    rank : int
+        The effective rank of the matrix.  Returned if return_rank == True
+
+    Raises
+    ------
+    LinAlgError
+        If eigenvalue does not converge
+
+    Examples
+    --------
+    >>> from scipy.linalg import pinvh
+    >>> a = np.random.randn(9, 6)
+    >>> a = np.dot(a, a.T)
+    >>> B = pinvh(a)
+    >>> np.allclose(a, np.dot(a, np.dot(B, a)))
+    True
+    >>> np.allclose(B, np.dot(B, np.dot(a, B)))
+    True
+
+    """
+    a = decomp._asarray_validated(a, check_finite=check_finite)
+    s, u = decomp.eigh(a, lower=lower, check_finite=False)
+
+    if rcond is not None:
+        cond = rcond
+    if cond in [None, -1]:
+        t = u.dtype.char.lower()
+        factor = {'f': 1E3, 'd': 1E6}
+        cond = factor[t] * np.finfo(t).eps
+
+    # For Hermitian matrices, singular values equal abs(eigenvalues)
+    above_cutoff = (abs(s) > cond * np.max(abs(s)))
+    psigma_diag = 1.0 / s[above_cutoff]
+    u = u[:, above_cutoff]
+
+    B = np.dot(u * psigma_diag, np.conjugate(u).T)
+
+    if return_rank:
+        return B, len(psigma_diag)
+    else:
+        return B

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -476,7 +476,8 @@ class RFECV(RFE, MetaEstimatorMixin):
 
         groups : array-like, shape = [n_samples], optional
             Group labels for the samples used while splitting the dataset into
-            train/test set.
+            train/test set. Only used in conjunction with a "Group" `cv`
+            instance (e.g., `GroupKFold`).
         """
         X, y = check_X_y(X, y, "csr", ensure_min_features=2)
 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -269,7 +269,7 @@ class SimpleImputer(BaseEstimator, TransformerMixin):
 
         if self.add_indicator:
             self.indicator_ = MissingIndicator(
-                missing_values=self.missing_values)
+                missing_values=self.missing_values, error_on_new=False)
             self.indicator_.fit(X)
         else:
             self.indicator_ = None

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -672,4 +672,4 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
 
     def _more_tags(self):
         return {'allow_nan': True,
-                'X_types': ['2darray', 'str']}
+                'X_types': ['2darray', 'string']}

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -520,7 +520,7 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
 
         if self.add_indicator:
             self.indicator_ = MissingIndicator(
-                missing_values=self.missing_values)
+                missing_values=self.missing_values, error_on_new=False)
             X_trans_indicator = self.indicator_.fit_transform(X)
         else:
             self.indicator_ = None

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -430,7 +430,11 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
         if (self.n_nearest_features is None or
                 self.n_nearest_features >= n_features):
             return None
-        abs_corr_mat = np.abs(np.corrcoef(X_filled.T))
+        with np.errstate(invalid='ignore'):
+            # if a feature in the neighboorhood has only a single value
+            # (e.g., categorical feature), the std. dev. will be null and
+            # np.corrcoef will raise a warning due to a division by zero
+            abs_corr_mat = np.abs(np.corrcoef(X_filled.T))
         # np.corrcoef is not defined for features with zero std
         abs_corr_mat[np.isnan(abs_corr_mat)] = tolerance
         # ensures exploration, i.e. at least some probability of sampling

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -445,6 +445,16 @@ def test_imputation_constant_pandas(dtype):
     assert_array_equal(X_trans, X_true)
 
 
+@pytest.mark.parametrize('Imputer', (SimpleImputer, IterativeImputer))
+def test_imputation_missing_value_in_test_array(Imputer):
+    # [Non Regression Test for issue #13968] Missing value in test set should
+    # not throw an error and return a finite dataset
+    train = [[1], [2]]
+    test = [[3], [np.nan]]
+    imputer = Imputer(add_indicator=True)
+    imputer.fit(train).transform(test)
+
+
 @pytest.mark.filterwarnings('ignore: The default of the `iid`')  # 0.22
 @pytest.mark.filterwarnings('ignore: The default value of cv')  # 0.22
 def test_imputation_pipeline_grid_search():

--- a/sklearn/inspection/partial_dependence.py
+++ b/sklearn/inspection/partial_dependence.py
@@ -289,9 +289,15 @@ def partial_dependence(estimator, X, features, response_method='auto',
         raise ValueError(
             "'estimator' must be a fitted regressor or classifier.")
 
-    if (hasattr(estimator, 'classes_') and
-            isinstance(estimator.classes_[0], np.ndarray)):
-        raise ValueError('Multiclass-multioutput estimators are not supported')
+    if is_classifier(estimator):
+        if not hasattr(estimator, 'classes_'):
+            raise ValueError(
+                "'estimator' parameter must be a fitted estimator"
+            )
+        if isinstance(estimator.classes_[0], np.ndarray):
+            raise ValueError(
+                'Multiclass-multioutput estimators are not supported'
+            )
 
     X = check_array(X)
 

--- a/sklearn/inspection/partial_dependence.py
+++ b/sklearn/inspection/partial_dependence.py
@@ -580,8 +580,6 @@ def plot_partial_dependence(estimator, X, features, feature_names=None,
             raise ValueError(
                 'target must be in [0, n_tasks], got {}.'.format(target))
         target_idx = target
-    else:
-        target_idx = 0
 
     # get global min and max values of PD grouped by plot type
     pdp_lim = {}

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -437,12 +437,12 @@ def test_plot_partial_dependence(pyplot):
 
 
 def test_plot_partial_dependence_multiclass(pyplot):
-    # Test partial dependence plot function on multi-class input.
-    iris = load_iris()
-    clf = GradientBoostingClassifier(n_estimators=10, random_state=1)
-    clf.fit(iris.data, iris.target)
-
     grid_resolution = 25
+    clf = GradientBoostingClassifier(n_estimators=10, random_state=1)
+    iris = load_iris()
+
+    # Test partial dependence plot function on multi-class input.
+    clf.fit(iris.data, iris.target)
     plot_partial_dependence(clf, iris.data, [0, 1],
                             target=0,
                             grid_resolution=grid_resolution)
@@ -453,17 +453,25 @@ def test_plot_partial_dependence_multiclass(pyplot):
 
     # now with symbol labels
     target = iris.target_names[iris.target]
-    clf = GradientBoostingClassifier(n_estimators=10, random_state=1)
     clf.fit(iris.data, target)
-
-    grid_resolution = 25
     plot_partial_dependence(clf, iris.data, [0, 1],
                             target='setosa',
                             grid_resolution=grid_resolution)
-    fig = pyplot.gcf()
-    axs = fig.get_axes()
-    assert len(axs) == 2
-    assert all(ax.has_data for ax in axs)
+    fig2 = pyplot.gcf()
+    axs2 = fig2.get_axes()
+    assert len(axs2) == 2
+    assert all(ax.has_data for ax in axs2)
+
+    # check that the pd plots are the same for 0 and "setosa"
+    assert all(axs[0].lines[0]._y == axs2[0].lines[0]._y)
+    # check that the pd plots are different for another target
+    clf.fit(iris.data, iris.target)
+    plot_partial_dependence(clf, iris.data, [0, 1],
+                            target=1,
+                            grid_resolution=grid_resolution)
+    fig3 = pyplot.gcf()
+    axs3 = fig3.get_axes()
+    assert any(axs[0].lines[0]._y != axs3[0].lines[0]._y)
 
 
 def test_plot_partial_dependence_multioutput(pyplot):

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -18,6 +18,7 @@ from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.linear_model import LinearRegression
 from sklearn.linear_model import LogisticRegression
 from sklearn.linear_model import MultiTaskLasso
+from sklearn.tree import DecisionTreeRegressor
 from sklearn.datasets import load_boston, load_iris
 from sklearn.datasets import make_classification, make_regression
 from sklearn.cluster import KMeans
@@ -52,6 +53,7 @@ multioutput_regression_data = (make_regression(n_targets=2, random_state=0), 2)
     (GradientBoostingClassifier, 'brute', multiclass_classification_data),
     (GradientBoostingRegressor, 'recursion', regression_data),
     (GradientBoostingRegressor, 'brute', regression_data),
+    (DecisionTreeRegressor, 'brute', regression_data),
     (LinearRegression, 'brute', regression_data),
     (LinearRegression, 'brute', multioutput_regression_data),
     (LogisticRegression, 'brute', binary_classification_data),
@@ -244,7 +246,6 @@ def test_partial_dependence_easy_target(est, power):
     assert r2 > .99
 
 
-@pytest.mark.filterwarnings('ignore:The default value of ')  # 0.22
 @pytest.mark.parametrize('Estimator',
                          (sklearn.tree.DecisionTreeClassifier,
                           sklearn.tree.ExtraTreeClassifier,
@@ -271,6 +272,8 @@ def test_multiclass_multioutput(Estimator):
 
 class NoPredictProbaNoDecisionFunction(BaseEstimator, ClassifierMixin):
     def fit(self, X, y):
+        # simulate that we have some classes
+        self.classes_ = [0, 1]
         return self
 
 

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -28,6 +28,7 @@ from sklearn.dummy import DummyClassifier
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import ignore_warnings
 
 
 # toy sample
@@ -262,7 +263,8 @@ def test_multiclass_multioutput(Estimator):
     y = np.array([y, y]).T
 
     est = Estimator()
-    est.fit(X, y)
+    with ignore_warnings(DeprecationWarning):
+        est.fit(X, y)
 
     with pytest.raises(
             ValueError,

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -263,7 +263,7 @@ def test_multiclass_multioutput(Estimator):
     y = np.array([y, y]).T
 
     est = Estimator()
-    with ignore_warnings(category=DeprecationWarning):
+    with ignore_warnings(category=FutureWarning):
         est.fit(X, y)
 
     with pytest.raises(

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -263,7 +263,7 @@ def test_multiclass_multioutput(Estimator):
     y = np.array([y, y]).T
 
     est = Estimator()
-    with ignore_warnings(DeprecationWarning):
+    with ignore_warnings(category=DeprecationWarning):
         est.fit(X, y)
 
     with pytest.raises(

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -8,12 +8,12 @@ Various bayesian regression
 from math import log
 import numpy as np
 from scipy import linalg
-from scipy.linalg import pinvh
 
 from .base import LinearModel, _rescale_data
 from ..base import RegressorMixin
 from ..utils.extmath import fast_logdet
 from ..utils import check_X_y
+from ..utils.fixes import pinvh
 
 
 ###############################################################################

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -2186,7 +2186,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
                 # Take the best scores across every fold and the average of
                 # all coefficients corresponding to the best scores.
                 best_indices = np.argmax(scores, axis=1)
-                if self.multi_class == 'ovr':
+                if multi_class == 'ovr':
                     w = np.mean([coefs_paths[i, best_indices[i], :]
                                  for i in range(len(folds))], axis=0)
                 else:
@@ -2196,8 +2196,11 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
                 best_indices_C = best_indices % len(self.Cs_)
                 self.C_.append(np.mean(self.Cs_[best_indices_C]))
 
-                best_indices_l1 = best_indices // len(self.Cs_)
-                self.l1_ratio_.append(np.mean(l1_ratios_[best_indices_l1]))
+                if self.penalty == 'elasticnet':
+                    best_indices_l1 = best_indices // len(self.Cs_)
+                    self.l1_ratio_.append(np.mean(l1_ratios_[best_indices_l1]))
+                else:
+                    self.l1_ratio_.append(None)
 
             if multi_class == 'multinomial':
                 self.C_ = np.tile(self.C_, n_classes)

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -1441,8 +1441,7 @@ class SGDRegressor(BaseSGDRegressor):
 
     eta0 : double
         The initial learning rate for the 'constant', 'invscaling' or
-        'adaptive' schedules. The default value is 0.0 as eta0 is not used by
-        the default schedule 'optimal'.
+        'adaptive' schedules. The default value is 0.01.
 
     power_t : double
         The exponent for inverse scaling learning rate [default 0.5].

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -188,6 +188,24 @@ def test_toy_ard_object():
     assert_array_almost_equal(clf.predict(test), [1, 3, 4], 2)
 
 
+def test_ard_accuracy_on_easy_problem():
+    # Check that ARD converges with reasonable accuracy on an easy problem
+    # (Github issue #14055)
+    # This particular seed seems to converge poorly in the failure-case
+    # (scipy==1.3.0, sklearn==0.21.2)
+    seed = 45
+    X = np.random.RandomState(seed=seed).normal(size=(250, 3))
+    y = X[:, 1]
+
+    regressor = ARDRegression()
+    regressor.fit(X, y)
+
+    abs_coef_error = np.abs(1 - regressor.coef_[1])
+    # Expect an accuracy of better than 1E-4 in most cases -
+    # Failure-case produces 0.16!
+    assert abs_coef_error < 0.01
+
+
 def test_return_std():
     # Test return_std option for both Bayesian regressors
     def f(X):

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1580,8 +1580,9 @@ def test_LogisticRegressionCV_GridSearchCV_elastic_net_ovr():
     assert (lrcv.predict(X_test) == gs.predict(X_test)).mean() >= .8
 
 
-@pytest.mark.parametrize('multi_class', ('ovr', 'multinomial'))
-def test_LogisticRegressionCV_no_refit(multi_class):
+@pytest.mark.parametrize('penalty', ('l2', 'elasticnet'))
+@pytest.mark.parametrize('multi_class', ('ovr', 'multinomial', 'auto'))
+def test_LogisticRegressionCV_no_refit(penalty, multi_class):
     # Test LogisticRegressionCV attribute shapes when refit is False
 
     n_classes = 3
@@ -1591,10 +1592,13 @@ def test_LogisticRegressionCV_no_refit(multi_class):
                                random_state=0)
 
     Cs = np.logspace(-4, 4, 3)
-    l1_ratios = np.linspace(0, 1, 2)
+    if penalty == 'elasticnet':
+        l1_ratios = np.linspace(0, 1, 2)
+    else:
+        l1_ratios = None
 
-    lrcv = LogisticRegressionCV(penalty='elasticnet', Cs=Cs, solver='saga',
-                                cv=5, l1_ratios=l1_ratios, random_state=0,
+    lrcv = LogisticRegressionCV(penalty=penalty, Cs=Cs, solver='saga',
+                                l1_ratios=l1_ratios, random_state=0, cv=5,
                                 multi_class=multi_class, refit=False)
     lrcv.fit(X, y)
     assert lrcv.C_.shape == (n_classes,)

--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -18,7 +18,7 @@ from sklearn.linear_model import (orthogonal_mp, orthogonal_mp_gram,
 from sklearn.utils import check_random_state
 from sklearn.datasets import make_sparse_coded_signal
 
-n_samples, n_features, n_nonzero_coefs, n_targets = 20, 30, 5, 3
+n_samples, n_features, n_nonzero_coefs, n_targets = 25, 35, 5, 3
 y, X, gamma = make_sparse_coded_signal(n_targets, n_features, n_samples,
                                        n_nonzero_coefs, random_state=0)
 # Make X not of norm 1 for testing

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1,4 +1,3 @@
-import sys
 import numpy as np
 import scipy.sparse as sp
 from scipy import linalg

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1090,11 +1090,7 @@ def test_dtype_match(solver):
     assert coef_64.dtype == X_64.dtype
     assert ridge_32.predict(X_32).dtype == X_32.dtype
     assert ridge_64.predict(X_64).dtype == X_64.dtype
-    if solver == "sparse_cg" and sys.platform == "darwin":
-        pytest.xfail(
-            "Known failures on MacOS, See "
-            "https://github.com/scikit-learn/scikit-learn/issues/13868")
-    assert_allclose(ridge_32.coef_, ridge_64.coef_, rtol=1e-4)
+    assert_allclose(ridge_32.coef_, ridge_64.coef_, rtol=1e-4, atol=5e-4)
 
 
 def test_dtype_match_cholesky():

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1074,13 +1074,14 @@ def test_dtype_match(solver):
     X_32 = X_64.astype(np.float32)
     y_32 = y_64.astype(np.float32)
 
+    tol = 2 * np.finfo(np.float32).resolution
     # Check type consistency 32bits
-    ridge_32 = Ridge(alpha=alpha, solver=solver, max_iter=500, tol=1e-10,)
+    ridge_32 = Ridge(alpha=alpha, solver=solver, max_iter=500, tol=tol)
     ridge_32.fit(X_32, y_32)
     coef_32 = ridge_32.coef_
 
     # Check type consistency 64 bits
-    ridge_64 = Ridge(alpha=alpha, solver=solver, max_iter=500, tol=1e-10,)
+    ridge_64 = Ridge(alpha=alpha, solver=solver, max_iter=500, tol=tol)
     ridge_64.fit(X_64, y_64)
     coef_64 = ridge_64.coef_
 

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -423,10 +423,18 @@ def make_scorer(score_func, greater_is_better=True, needs_proba=False,
         Whether score_func requires predict_proba to get probability estimates
         out of a classifier.
 
+        If True, for binary `y_true`, the score function is supposed to accept
+        a 1D `y_pred` (i.e., probability of the positive class, shape
+        `(n_samples,)`).
+
     needs_threshold : boolean, default=False
         Whether score_func takes a continuous decision certainty.
         This only works for binary classification using estimators that
         have either a decision_function or predict_proba method.
+
+        If True, for binary `y_true`, the score function is supposed to accept
+        a 1D `y_pred` (i.e., probability of the positive class or the decision
+        function, shape `(n_samples,)`).
 
         For example ``average_precision`` or the area under the roc curve
         can not be computed using discrete predictions alone.

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -596,7 +596,8 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
 
         groups : array-like, with shape (n_samples,), optional
             Group labels for the samples used while splitting the dataset into
-            train/test set.
+            train/test set. Only used in conjunction with a "Group" `cv`
+            instance (e.g., `GroupKFold`).
 
         **fit_params : dict of string -> object
             Parameters passed to the ``fit`` method of the estimator

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2124,6 +2124,11 @@ def train_test_split(*arrays, **options):
                                      safe_indexing(a, test)) for a in arrays))
 
 
+# Tell nose that train_test_split is not a test.
+# (Needed for external libraries that may use nose.)
+train_test_split.__test__ = False
+
+
 def _build_repr(self):
     # XXX This is copied from BaseEstimator's get_params
     cls = self.__class__

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -56,7 +56,8 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv='warn',
 
     groups : array-like, with shape (n_samples,), optional
         Group labels for the samples used while splitting the dataset into
-        train/test set.
+        train/test set. Only used in conjunction with a "Group" `cv` instance
+        (e.g., `GroupKFold`).
 
     scoring : string, callable, list/tuple, dict or None, default: None
         A single string (see :ref:`scoring_parameter`) or a callable
@@ -276,7 +277,8 @@ def cross_val_score(estimator, X, y=None, groups=None, scoring=None, cv='warn',
 
     groups : array-like, with shape (n_samples,), optional
         Group labels for the samples used while splitting the dataset into
-        train/test set.
+        train/test set. Only used in conjunction with a "Group" `cv` instance
+        (e.g., `GroupKFold`).
 
     scoring : string, callable or None, optional, default: None
         A string (see model evaluation documentation) or
@@ -666,7 +668,8 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv='warn',
 
     groups : array-like, with shape (n_samples,), optional
         Group labels for the samples used while splitting the dataset into
-        train/test set.
+        train/test set. Only used in conjunction with a "Group" `cv` instance
+        (e.g., `GroupKFold`).
 
     cv : int, cross-validation generator or an iterable, optional
         Determines the cross-validation splitting strategy.
@@ -1147,7 +1150,8 @@ def learning_curve(estimator, X, y, groups=None,
 
     groups : array-like, with shape (n_samples,), optional
         Group labels for the samples used while splitting the dataset into
-        train/test set.
+        train/test set. Only used in conjunction with a "Group" `cv` instance
+        (e.g., `GroupKFold`).
 
     train_sizes : array-like, shape (n_ticks,), dtype float or int
         Relative or absolute numbers of training examples that will be used to
@@ -1408,7 +1412,8 @@ def validation_curve(estimator, X, y, param_name, param_range, groups=None,
 
     groups : array-like, with shape (n_samples,), optional
         Group labels for the samples used while splitting the dataset into
-        train/test set.
+        train/test set. Only used in conjunction with a "Group" `cv` instance
+        (e.g., `GroupKFold`).
 
     cv : int, cross-validation generator or an iterable, optional
         Determines the cross-validation splitting strategy.

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -649,8 +649,14 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv='warn',
                       pre_dispatch='2*n_jobs', method='predict'):
     """Generate cross-validated estimates for each input data point
 
-    It is not appropriate to pass these predictions into an evaluation
-    metric. Use :func:`cross_validate` to measure generalization error.
+    The data is split according to the cv parameter. Each sample belongs
+    to exactly one test set, and its prediction is computed with an
+    estimator fitted on the corresponding training set.
+
+    Passing these predictions into an evaluation metric may not be a valid
+    way to measure generalization performance. Results can differ from
+    `cross_validate` and `cross_val_score` unless all tests sets have equal
+    size and the metric decomposes over samples.
 
     Read more in the :ref:`User Guide <cross_validation>`.
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1745,7 +1745,7 @@ def test_empty_cv_iterator_error():
 
     train_size = 100
     ridge = RandomizedSearchCV(Ridge(), {'alpha': [1e-3, 1e-2, 1e-1]},
-                               cv=cv, n_jobs=-1)
+                               cv=cv, n_jobs=4)
 
     # assert that this raises an error
     with pytest.raises(ValueError,
@@ -1767,7 +1767,7 @@ def test_random_search_bad_cv():
 
     train_size = 100
     ridge = RandomizedSearchCV(Ridge(), {'alpha': [1e-3, 1e-2, 1e-1]},
-                               cv=cv, n_jobs=-1)
+                               cv=cv, n_jobs=4)
 
     # assert that this raises an error
     with pytest.raises(ValueError,

--- a/sklearn/neighbors/nca.py
+++ b/sklearn/neighbors/nca.py
@@ -13,6 +13,7 @@ from warnings import warn
 import numpy as np
 import sys
 import time
+import numbers
 from scipy.optimize import minimize
 from ..utils.extmath import softmax
 from ..metrics import pairwise_distances
@@ -299,7 +300,8 @@ class NeighborhoodComponentsAnalysis(BaseEstimator, TransformerMixin):
 
         # Check the preferred dimensionality of the projected space
         if self.n_components is not None:
-            check_scalar(self.n_components, 'n_components', int, 1)
+            check_scalar(
+                self.n_components, 'n_components', numbers.Integral, 1)
 
             if self.n_components > X.shape[1]:
                 raise ValueError('The preferred dimensionality of the '
@@ -318,9 +320,9 @@ class NeighborhoodComponentsAnalysis(BaseEstimator, TransformerMixin):
                                  .format(X.shape[1],
                                          self.components_.shape[1]))
 
-        check_scalar(self.max_iter, 'max_iter', int, 1)
-        check_scalar(self.tol, 'tol', float, 0.)
-        check_scalar(self.verbose, 'verbose', int, 0)
+        check_scalar(self.max_iter, 'max_iter', numbers.Integral, 1)
+        check_scalar(self.tol, 'tol', numbers.Real, 0.)
+        check_scalar(self.verbose, 'verbose', numbers.Integral, 0)
 
         if self.callback is not None:
             if not callable(self.callback):

--- a/sklearn/neighbors/tests/test_nca.py
+++ b/sklearn/neighbors/tests/test_nca.py
@@ -129,7 +129,7 @@ def test_params_validation():
     # TypeError
     assert_raises(TypeError, NCA(max_iter='21').fit, X, y)
     assert_raises(TypeError, NCA(verbose='true').fit, X, y)
-    assert_raises(TypeError, NCA(tol=1).fit, X, y)
+    assert_raises(TypeError, NCA(tol='1').fit, X, y)
     assert_raises(TypeError, NCA(n_components='invalid').fit, X, y)
     assert_raises(TypeError, NCA(warm_start=1).fit, X, y)
 
@@ -518,3 +518,17 @@ def test_convergence_warning():
     assert_warns_message(ConvergenceWarning,
                          '[{}] NCA did not converge'.format(cls_name),
                          nca.fit, iris_data, iris_target)
+
+
+@pytest.mark.parametrize('param, value', [('n_components', np.int32(3)),
+                                          ('max_iter', np.int32(100)),
+                                          ('tol', np.float32(0.0001))])
+def test_parameters_valid_types(param, value):
+    # check that no error is raised when parameters have numpy integer or
+    # floating types.
+    nca = NeighborhoodComponentsAnalysis(**{param: value})
+
+    X = iris_data
+    y = iris_target
+
+    nca.fit(X, y)

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -757,7 +757,7 @@ def test_encoder_dtypes_pandas():
     assert_array_equal(enc.transform(X).toarray(), exp)
 
     X = pd.DataFrame({'A': [1, 2], 'B': ['a', 'b'], 'C': [3., 4.]})
-    X_type = [int, object, float]
+    X_type = [X['A'].dtype, X['B'].dtype, X['C'].dtype]
     enc.fit(X)
     assert all([enc.categories_[i].dtype == X_type[i] for i in range(3)])
     assert_array_equal(enc.transform(X).toarray(), exp)

--- a/sklearn/setup.py
+++ b/sklearn/setup.py
@@ -5,11 +5,7 @@ from sklearn._build_utils import maybe_cythonize_extensions
 
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
-    from numpy.distutils.system_info import get_info
     import numpy
-
-    # needs to be called during build otherwise show_version may fail sometimes
-    get_info('blas_opt', 0)
 
     libraries = []
     if os.name == 'posix':

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -1140,6 +1140,15 @@ class OneClassSVM(BaseLibSVM, OutlierMixin):
         The offset is the opposite of `intercept_` and is provided for
         consistency with other outlier detection algorithms.
 
+    Examples
+    --------
+    >>> from sklearn.svm import OneClassSVM
+    >>> X = [[0], [0.44], [0.45], [0.46], [1]]
+    >>> clf = OneClassSVM(gamma='auto').fit(X)
+    >>> clf.predict(X)
+    array([-1,  1,  1,  1, -1])
+    >>> clf.score_samples(X)  # doctest: +ELLIPSIS
+    array([1.7798..., 2.0547..., 2.0556..., 2.0561..., 1.7332...])
     """
 
     _impl = 'one_class'

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -891,7 +891,8 @@ def export_text(decision_tree, feature_names=None, max_depth=10,
         value_fmt = "{}{} value: {}\n"
 
     if feature_names:
-        feature_names_ = [feature_names[i] for i in tree_.feature]
+        feature_names_ = [feature_names[i] if i != _tree.TREE_UNDEFINED
+                          else None for i in tree_.feature]
     else:
         feature_names_ = ["feature_{}".format(i) for i in tree_.feature]
 

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -547,16 +547,16 @@ class _MPLTreeExporter(_BaseTreeExporter):
 
         self.arrow_args = dict(arrowstyle="<-")
 
-    def _make_tree(self, node_id, et, depth=0):
+    def _make_tree(self, node_id, et, criterion, depth=0):
         # traverses _tree.Tree recursively, builds intermediate
         # "_reingold_tilford.Tree" object
-        name = self.node_to_str(et, node_id, criterion='entropy')
+        name = self.node_to_str(et, node_id, criterion=criterion)
         if (et.children_left[node_id] != _tree.TREE_LEAF
                 and (self.max_depth is None or depth <= self.max_depth)):
             children = [self._make_tree(et.children_left[node_id], et,
-                                        depth=depth + 1),
+                                        criterion, depth=depth + 1),
                         self._make_tree(et.children_right[node_id], et,
-                                        depth=depth + 1)]
+                                        criterion, depth=depth + 1)]
         else:
             return Tree(name, node_id)
         return Tree(name, node_id, *children)
@@ -568,7 +568,8 @@ class _MPLTreeExporter(_BaseTreeExporter):
             ax = plt.gca()
         ax.clear()
         ax.set_axis_off()
-        my_tree = self._make_tree(0, decision_tree.tree_)
+        my_tree = self._make_tree(0, decision_tree.tree_,
+                                  decision_tree.criterion)
         draw_tree = buchheim(my_tree)
 
         # important to make sure we're still

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -398,6 +398,21 @@ def test_export_text():
     assert export_text(reg, decimals=1) == expected_report
     assert export_text(reg, decimals=1, show_weights=True) == expected_report
 
+    X_single = [[-2], [-1], [-1], [1], [1], [2]]
+    reg = DecisionTreeRegressor(max_depth=2, random_state=0)
+    reg.fit(X_single, y_mo)
+
+    expected_report = dedent("""
+    |--- first <= 0.0
+    |   |--- value: [-1.0, -1.0]
+    |--- first >  0.0
+    |   |--- value: [1.0, 1.0]
+    """).lstrip()
+    assert export_text(reg, decimals=1,
+                       feature_names=['first']) == expected_report
+    assert export_text(reg, decimals=1, show_weights=True,
+                       feature_names=['first']) == expected_report
+
 
 def test_plot_tree_entropy(pyplot):
     # mostly smoke tests

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -399,9 +399,28 @@ def test_export_text():
     assert export_text(reg, decimals=1, show_weights=True) == expected_report
 
 
-def test_plot_tree(pyplot):
+def test_plot_tree_entropy(pyplot):
     # mostly smoke tests
-    # Check correctness of export_graphviz
+    # Check correctness of export_graphviz for criterion = entropy
+    clf = DecisionTreeClassifier(max_depth=3,
+                                 min_samples_split=2,
+                                 criterion="entropy",
+                                 random_state=2)
+    clf.fit(X, y)
+
+    # Test export code
+    feature_names = ['first feat', 'sepal_width']
+    nodes = plot_tree(clf, feature_names=feature_names)
+    assert len(nodes) == 3
+    assert nodes[0].get_text() == ("first feat <= 0.0\nentropy = 1.0\n"
+                                   "samples = 6\nvalue = [3, 3]")
+    assert nodes[1].get_text() == "entropy = 0.0\nsamples = 3\nvalue = [3, 0]"
+    assert nodes[2].get_text() == "entropy = 0.0\nsamples = 3\nvalue = [0, 3]"
+
+
+def test_plot_tree_gini(pyplot):
+    # mostly smoke tests
+    # Check correctness of export_graphviz for criterion = gini
     clf = DecisionTreeClassifier(max_depth=3,
                                  min_samples_split=2,
                                  criterion="gini",
@@ -412,7 +431,7 @@ def test_plot_tree(pyplot):
     feature_names = ['first feat', 'sepal_width']
     nodes = plot_tree(clf, feature_names=feature_names)
     assert len(nodes) == 3
-    assert nodes[0].get_text() == ("first feat <= 0.0\nentropy = 0.5\n"
+    assert nodes[0].get_text() == ("first feat <= 0.0\ngini = 0.5\n"
                                    "samples = 6\nvalue = [3, 3]")
-    assert nodes[1].get_text() == "entropy = 0.0\nsamples = 3\nvalue = [3, 0]"
-    assert nodes[2].get_text() == "entropy = 0.0\nsamples = 3\nvalue = [0, 3]"
+    assert nodes[1].get_text() == "gini = 0.0\nsamples = 3\nvalue = [3, 0]"
+    assert nodes[2].get_text() == "gini = 0.0\nsamples = 3\nvalue = [0, 3]"

--- a/sklearn/utils/_show_versions.py
+++ b/sklearn/utils/_show_versions.py
@@ -68,47 +68,14 @@ def _get_deps_info():
     return deps_info
 
 
-def _get_blas_info():
-    """Information on system BLAS
-
-    Uses the `scikit-learn` builtin method
-    :func:`sklearn._build_utils.get_blas_info` which may fail from time to time
-
-    Returns
-    -------
-    blas_info: dict
-        system BLAS information
-
-    """
-    from .._build_utils import get_blas_info
-
-    cblas_libs, blas_dict = get_blas_info()
-
-    macros = ['{key}={val}'.format(key=a, val=b)
-              for (a, b) in blas_dict.get('define_macros', [])]
-
-    blas_blob = [
-        ('macros', ', '.join(macros)),
-        ('lib_dirs', ':'.join(blas_dict.get('library_dirs', ''))),
-        ('cblas_libs', ', '.join(cblas_libs)),
-    ]
-
-    return dict(blas_blob)
-
-
 def show_versions():
     "Print useful debugging information"
 
     sys_info = _get_sys_info()
     deps_info = _get_deps_info()
-    blas_info = _get_blas_info()
 
     print('\nSystem:')
     for k, stat in sys_info.items():
-        print("{k:>10}: {stat}".format(k=k, stat=stat))
-
-    print('\nBLAS:')
-    for k, stat in blas_info.items():
         print("{k:>10}: {stat}".format(k=k, stat=stat))
 
     print('\nPython deps:')

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -651,7 +651,7 @@ def check_dtype_object(name, estimator_orig):
             raise
 
     tags = _safe_tags(estimator)
-    if 'str' not in tags['X_types']:
+    if 'string' not in tags['X_types']:
         X[0, 0] = {'foo': 'bar'}
         msg = "argument must be a string.* number"
         assert_raises_regex(TypeError, msg, estimator.fit, X, y)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2382,8 +2382,11 @@ def check_decision_proba_consistency(name, estimator_orig):
             hasattr(estimator, "predict_proba")):
 
         estimator.fit(X, y)
-        a = estimator.predict_proba(X_test)[:, 1]
-        b = estimator.decision_function(X_test)
+        # Since the link function from decision_function() to predict_proba()
+        # is sometimes not precise enough (typically expit), we round to the
+        # 10th decimal to avoid numerical issues.
+        a = estimator.predict_proba(X_test)[:, 1].round(decimals=10)
+        b = estimator.decision_function(X_test).round(decimals=10)
         assert_array_equal(rankdata(a), rankdata(b))
 
 

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -39,6 +39,13 @@ except ImportError:
     from scipy.misc import comb, logsumexp  # noqa
 
 
+if sp_version >= (1, 3):
+    # Preserves earlier default choice of pinvh cutoff `cond` value.
+    # Can be removed once issue #14055 is fully addressed.
+    from ..externals._scipy_linalg import pinvh
+else:
+    from scipy.linalg import pinvh # noqa
+
 if sp_version >= (0, 19):
     def _argmax(arr_or_spmatrix, axis=None):
         return arr_or_spmatrix.argmax(axis=axis)

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -978,10 +978,14 @@ def assert_run_python_script(source_code, timeout=60):
         cmd = [sys.executable, source_file]
         cwd = op.normpath(op.join(op.dirname(sklearn.__file__), '..'))
         env = os.environ.copy()
+        try:
+            env["PYTHONPATH"] = os.pathsep.join([cwd, env["PYTHONPATH"]])
+        except KeyError:
+            env["PYTHONPATH"] = cwd
         kwargs = {
             'cwd': cwd,
             'stderr': STDOUT,
-            'env': env,
+            'env': env
         }
         # If coverage is running, pass the config file to the subprocess
         coverage_rc = os.environ.get("COVERAGE_PROCESS_START")

--- a/sklearn/utils/tests/test_show_versions.py
+++ b/sklearn/utils/tests/test_show_versions.py
@@ -32,4 +32,3 @@ def test_show_versions_with_blas(capsys):
         out, err = capsys.readouterr()
         assert 'python' in out
         assert 'numpy' in out
-        assert 'BLAS' in out

--- a/sklearn/utils/tests/test_show_versions.py
+++ b/sklearn/utils/tests/test_show_versions.py
@@ -2,6 +2,7 @@
 from sklearn.utils._show_versions import _get_sys_info
 from sklearn.utils._show_versions import _get_deps_info
 from sklearn.utils._show_versions import show_versions
+from sklearn.utils.testing import ignore_warnings
 
 
 def test_get_sys_info():
@@ -13,20 +14,22 @@ def test_get_sys_info():
 
 
 def test_get_deps_info():
-    deps_info = _get_deps_info()
+    with ignore_warnings():
+        deps_info = _get_deps_info()
 
-    assert 'pip' in deps_info
-    assert 'setuptools' in deps_info
-    assert 'sklearn' in deps_info
-    assert 'numpy' in deps_info
-    assert 'scipy' in deps_info
-    assert 'Cython' in deps_info
-    assert 'pandas' in deps_info
+        assert 'pip' in deps_info
+        assert 'setuptools' in deps_info
+        assert 'sklearn' in deps_info
+        assert 'numpy' in deps_info
+        assert 'scipy' in deps_info
+        assert 'Cython' in deps_info
+        assert 'pandas' in deps_info
 
 
 def test_show_versions_with_blas(capsys):
-    show_versions()
-    out, err = capsys.readouterr()
-    assert 'python' in out
-    assert 'numpy' in out
-    assert 'BLAS' in out
+    with ignore_warnings():
+        show_versions()
+        out, err = capsys.readouterr()
+        assert 'python' in out
+        assert 'numpy' in out
+        assert 'BLAS' in out


### PR DESCRIPTION
To be merged without squashing.

I thought we should consider if 0.21.3 should be released at some point soon (early July). It's one month since 0.21.2 was released. This branch currently just includes https://github.com/scikit-learn/scikit-learn/milestone/30?closed=1 and https://github.com/scikit-learn/scikit-learn/milestone/34?closed=1. We should review documentation commits that should also be included.

The initial commit selection is:
```
drop 0b3aa5e466 DOC bump version
drop 10249939e5 DOC move 0.20 to previous releases
drop e7bd8a33e5 FIX Optics paper typo which resulted in undersized clusters (#13750)
drop 384c8ad3d3 ENH add a break_ties parameter to SVC and NuSVC (#12557)
drop 13981bdce9 STY Remove variable renaming (#13731)
drop 19192c0427 MAINT Replace manual checks with `check_is_fitted`  (#13013)
drop 905dedc635 DEP remove random_state from OneClassSVM (#13802)
drop 28480f4cb2 DEP change the default of gamma in SVM (#13801)
drop d0a94fea74 DEP remove graph lasso (#13795)
drop 7896b21562 MNT change default of solver in LogisiticRegression (#13805)
drop 6525a39dd6 MNT Remove Imputer in preprocessing (#13796)
drop 43f85020c5 DEP remove correlation and regression models from GaussianProcess (#13819)
drop 2b7a69baca DEP remove the batch_size parameter from pariwise_distance_argmin (#13822)
drop 53624e8c26 DEP remove public function download_20newsgroups (#13829)
drop 9631a67388 DEP remove scale_face function from lfw (#13830)
drop 777f91f114 [MRG] DEP Removed the reorder parameter from the auc function (#13827)
drop 7166ae8ece MNT Updated adjusted_mutual_info_score and normalized_mutual_info_score default to 'arithmetic' (#13814)
drop 91e019df5e DEP remove precomputed parameter in t_sne.trustworthiness (#13820)
drop 69eb4d4678 [MRG] DEP change default and deprecate iid in SearchCV (#13834)
drop c7566ea232 disallow input as sparse matrix in affinity propagation function, Aff… (#13828)
drop 95339a677e [MRG] DEP remove pooling_func in AgglomerativeClustering (#13821)
drop 7fdac52c19 MNT Remove backward compatibility of param order in make_column_transformer (#13831)
drop 8a8e21b2a3 MNT Change the default value of n_estimators in forests (#13803)
drop 83656484a8 MNT Remove raises and with_setup requiring nose (#13842)
drop da9e680996 DOC fix the docstring of AMI MNI regarding new default (#13837)
drop eec7614a1f Small fixes to maintainer commands
drop b243c6aa43 DEP change default of contamination in LOF (#13815)
drop 75967ef20e DEP remove deprecated parameters in EllipticEnvelope (#13818)
drop 11de9d60f2 Updating MissingIndicator User Guide section (#13849)
drop 4e65827b5c [MRG] RidgeCV minor refactor to improve readability (#13832)
drop 5d240c6a0b MAINT Fixes coverage reporting on pylatest_conda (#13895)
drop af4247b152 DEP remove utilities related to mldata (#13798)
drop 0bfa52dad7 DEP Change default of error_score in cross-validation (#13840)
drop 911792b008 ENH Avoid calling _encode_check_unknown() twice in BaseEncoder.transform (#13810)
drop 57c04f4e8d ENH Allows setting of initial hyperparameters for BayesianRidge (#13618)
drop 778b11904e [MRG] DEP remove threshold_, change contamination, deprecate behaviour in iforest (#13811)
drop c28ef9ef2a DEP change the default of multi_class to 'auto' in logistic regression (#13807)
drop e0532cdea5 MAINT increase numerical gradient check tolerance to make the test stable (#13885)
drop 8f378ca684 DOC Fix bracket typo in linear_model.rst (#13932)
drop e747376eef [MRG] MAINT Fixes apt by removing the ubuntu-toolchain-r/test repo (#13934)
drop 22b0eabfd0 DOC add 0.21.3 entry
pick f3a6a1a6c8 TST avoid nose collecting train_test_split as a test (#13951)
drop db48ebce60 ENH add n_components kwarg to SpectralClustering. See #13698 (#13726)
pick fa383a4aca FIX plot_tree now displays correct criterion (#13947)
drop cebefd4f01 DOC adds instructions for building on FreeBSD (#13953)
drop 69dd9a54e2 DOC correct headline level in contributor docs (#13959)
drop 57726672b5 CLN Remove parent negative loss calculation from for loop to improve performance (#13955)
drop 2a7194de7a FIX Bin training and validation data separately in GBDTs (#13933)
drop be03467b9c FIX Changed VarianceThreshold behaviour when threshold is zero. See #13691 (#13704)
drop 9f7e8671dc PERF Free problem and param sooner in liblinear.train_wrap
drop f283ed6b40 CLN Removed max_bins from splitter in GBDT (#13927)
drop 54e6c720de CLN Refactors code (#13966)
pick 7ea7284f22 MAINT: use explicit value of n_jobs to avoid hangs on Windows (#13970)
drop b271e20570 DEP remove positive parameter for lars solver (#13863)
drop a98db9a4d6 DEP change default and deprecate normalize_components in SparsePCA (#13838)
drop 9ee164baa3 [MRG] DEP remove legacy mode from OneHotEncoder (#13855)
drop 9328581ec5 FIX use CD solver in face decomposition to use postive parameter (#13975)
drop 9adba491a2 [MRG] DEP change the default of cv and n_splits (#13839)
drop 7ee46f1717 FIX Lazy cython import for pytest to work without cython
drop 3ed200292f Added matplotlib to show_versions() (#13983)
drop 233fd6df32 DOC add doc example to OneClassSVM
drop ccd6399cad CLN GBDTs: don't split on last bin (explicitly) (#13919)
drop 896a76eb22 [MRG][DOC] Fix inconsistencies in clustering doc. (#13946)
drop e871a56d44 DOC Fixed documentation typos (#13993)
drop 5e0d1a1f04 DOC Fix typo: omit comma (#13999)
drop 9661a64fae ENH Avoid uncessary copies in sklearn.preprocessing (#13987)
drop 2e7e06b78f [MRG] Doctest with print change only adjusts default options for doctest (#13991)
pick 162216af26 MAINT: test_encoder_dtypes_pandas reads expected dtype from DF (#13997)
drop 15b54340ee [MRG] CLN Only one function for parallel predict (#14003)
drop ccd3331f7e MNT remove unused imports (#14021)
drop 6675c9e342 MAINT pass n_samples instead of sample_indices in GBDT (#14017)
drop ec35ed226c EHN Add function score_samples to Pipeline (#13806)
drop 2b571c039d MNT better message for pillow import error (#14027)
drop abf7721904 TST fix a part of Gradient Boosting test which wasn't running (#14032)
drop 69dbdf4f9b MNT DOC don't warn if a ref with single backtick is not found (#14040)
drop 0f801d7ba8 DOC link set_config and config_context in docstrings (#14030)
pick a80d679ff7 MNT DOC fix some sphinx warnings on what's new files (#14049)
drop b3d716c924 DOC Fixes default value for eta0 in SGDRegressor (#14047)
drop 8342548ae1 EXA Remove useless sections in omp example (#14019)
drop 61f6f5bcd1 TST add test to check that all ridge solver give the same results (#13914)
drop c315bf9314 MNT Ignore setup.py in the coverage report (#14052)
drop 9d7b804603 MAINT: adjustments to test_logistic.py::test_dtype_match (#13645)
drop d84a8d17af ENH Binary only estimator checks for classification (#13875)
drop 4c58057dda DOC Add what's new for binary only estimator checks (#13875)
drop 9c732e15a8 DOC Fix typo in manifold documentation (#14073)
drop 227ebc4815 DOC fix the default value of learning_rate in docstring of HistGBC. (#14072)
drop e669a89aa4 CLN Removed some unused imports (#14074)
drop 05b12cfcfd PERF Shrink arrays to size in liblinear helper dense_to_sparse (#14026)
drop 2fc3a85b3f MAINT Use isinstance(x, numbers.Integral) to check for integer dtype (#14004)
drop 73caac258c MAINT Fixes lgtm errors (#14041)
drop 50425e1dfe MAINT Remove sudo tag in travis (#14050)
drop d91b0f324b MNT refactor naive Bayes tests (#14064)
pick 8fe89ea524 FIX wrong usage and occurrence of string tag (#14043)
drop fd1d210362 DOC add kcachegrind visualization docs (#8016)
drop 4a6264db68 TST add test for pipeline in partial dependence (#14079)
drop 76ce7c5b63 DEP change default validate in FunctionTransformer to False(#13817)
drop a5743ed36f TST add test for LAD-loss and quantile loss equivalence (old GBDT code) (#14086)
pick b580ad5dfd BUG Fix zero division error in GBDTs (#14024)
drop bec83089f7 MAINT Uses pytest-xdist to parallelize tests (#13041)
drop e2a69b7376 DOC use train/test split in GaussianNB example (#14080)
drop df7dd83911 ENH allow sparse input to incremental PCA (#13960)
drop 3ec339a58f Added colorblind compatibility (#14091)
pick 36b688eb04 [MRG] fix refit=False error in LogisticRegressionCV (#14087)
drop b28aadf6ef Added fit and score times for learning_curve (#13938)
drop eed5cba610 TST Check that estimators are not cloned during pipeline construction (#7633)
pick cb12053c57 DOC Make parameter, etc listings use small screen width better (#9503)
drop 6ab8c86c38 [MRG] DOC DOC sklearn.manifold.t_sne.trustworthiness added to classes.rst (#9747)
drop 0eedf99eee MAINT Don't use clean_warnings_registry in tests (#14085)
drop 120009b12a DOC fix user guide for learning_curve (#14099)
drop b7c4163690 FIX Fix off-by-one error in liblinear helper dense_to_sparse (#14103)
pick e2b6bff0ac BUG Fixes export_text with single feature (#14053)
drop 1015caf54d MAINT Remove imports from sklearn.utils._joblib (#13676)
drop 7ce8b21cd1 PERF Don't allocate space for bias element if there isn't one (#14108)
pick 197f448eed [MRG] Fix NCA parameter type check (#14092)
drop 4a325353ef MNT Fix some typos in README (#14122)
drop f9f8974216 DOC updated class_weight explanation in glossary (#14121)
drop 801cca8e73 MNT fix suppressing matplotlib warning issue while making docs (#14115)
drop b3030f046f minor fix in gaussian_mixture.py (#14120)
drop 0c110701f9 TST Fixed typo in test_column_transformer (#14128)
drop 8632775c23 FIX Fix memory leak in liblinear helper csr_to_sparse error path (#14118)
drop 842df6f60e MAINT Faster linear_model tests (#14105)
drop ab4b4ec5eb DOC add clarification on random forest default params (#13248)
pick 6b811ac2c3 DOC add missing what's new to pr 14092 (#14133)
drop 214def06a3 DOC Contributing guide update (#13961)
drop cf2e60bc1b MAINT Simplify arguments to csr_set_problem and csr_to_sparse (#14135)
drop c0d77d4d37 DOC: document resulting NaN in SimpleImputer.statistics_ (#14129)
drop da96da96f0 EHN Add warm_start parameter to HistGradientBoosting (#14012)
drop 3d997697fd [MRG] Error for cosine affinity when zero vectors present (#7943)
drop e94f5de906 FIX remove action of normalize_components in SparsePCA (#14134)
drop ee8bdd0b61 ENH Add joblib to the list of dependencies in show_versions (#14141)
drop 8681ece373 ENH Fix unfriendly error message for documentation checks (#11967)
drop 5674122c97 MAINT More test runtime optimizations (#14136)
drop 5b8b6277a3 DOC fixing the missing fetch upstream in contributing docs (#14142)
drop d710f73096 DOC Fix suptitle in LDA_QDA example (#14130)
drop 27bffe63dd CI _changed.html now provides links to compare PR to dev and stable (#14165)
drop a31676b948 EXA Readability of plot_isotonic_regression.py for color blind persons (#14154)
drop 59612a22b3 DOC Fixed Future Warnings by explicitly defining n_estimators = 100 in for the Regressor. (#14159)
drop 9bdcf25fda EXA Fixed Convergence Warnings by changing solver to 'lbfgs' in plot_mlp_alpha.py (#14158)
drop 8b002f2714 MAINT Fix test_fit_csr_matrix failure on master (#14171)
drop 55a7752f2e EXA remove warnings by setting n_quantiles in plot_transformed_target (#14156)
drop f41cd1e856 EXA Use n_quantiles=500 in plot_map_data_to_normal.py (#14149)
drop 0bdd92036d [MRG] MAINT Adds tag categorical to OneHotEncoder (#14068)
drop 62d11120c4 DOC make more obvious that logistic regression is regularized by default (#14093)
drop a717619b8b EXA more color blind friendly colors in plot_map_data_to_normal.py (#wimlds) (#14173)
drop 78ac1ab026 TST Add requires_positive_y estimator tag (#14095)
pick 7f50e82663 FIX Initialize MissingIndicator with error_on_new = False (#13974)
drop be17713d85 MAINT Upgrade CI to PyPy 7.1.1, fix CI failure on master (#13912)
drop eade48eaa2 TST refactor test_truncated_svd (#14140)
drop 24d4b2c2f3 EXA Fixed Convergence Warnings On MLP Training Curves (#14144)
drop a413f88fea TST Fix test_truncated_svd.py::test_explained_variance_compone… (#14178)
drop 11d2539444 MAINT Enable ccache in CircleCI / fix CI on master (#14172)
drop 1dc7b1d84a DOC Add use_line_collection=True to plt.stem to remove warning (#14146)
drop f6923a2971 Fixes #10548 random state description in feature-extraction (#14155)
```