### PR TITLE
BLD Enable parallel cythonization

### DIFF
--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -86,10 +86,14 @@ def maybe_cythonize_extensions(top_path, config):
             exc.args += (message,)
             raise
 
+        n_jobs = 1
         try:
             import joblib
-            n_jobs = getattr(joblib, "effective_n_jobs")()
-        except (ImportError, AttributeError):
+            if LooseVersion(joblib.__version__) > LooseVersion("0.13.0"):
+                # earlier joblib versions can over-estimate the number of
+                # available CPU in some cases
+                n_jobs = joblib.effective_n_jobs()
+        except ImportError:
             n_jobs = 1
 
         config.ext_modules = cythonize(

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -90,8 +90,9 @@ def maybe_cythonize_extensions(top_path, config):
         try:
             import joblib
             if LooseVersion(joblib.__version__) > LooseVersion("0.13.0"):
-                # earlier joblib versions can over-estimate the number of
-                # available CPU in some cases
+                # earlier joblib versions don't account for CPU affinity
+                # constraints, and may over-estimate the number of available
+                # CPU particularly in CI (cf loky#114)
                 n_jobs = joblib.effective_n_jobs()
         except ImportError:
             pass

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -8,6 +8,7 @@ Utilities useful during the build.
 import os
 
 from distutils.version import LooseVersion
+import contextlib
 
 from numpy.distutils.system_info import get_info
 
@@ -87,15 +88,13 @@ def maybe_cythonize_extensions(top_path, config):
             raise
 
         n_jobs = 1
-        try:
+        with contextlib.suppress(ImportError):
             import joblib
             if LooseVersion(joblib.__version__) > LooseVersion("0.13.0"):
                 # earlier joblib versions don't account for CPU affinity
                 # constraints, and may over-estimate the number of available
                 # CPU particularly in CI (cf loky#114)
                 n_jobs = joblib.effective_n_jobs()
-        except ImportError:
-            pass
 
         config.ext_modules = cythonize(
             config.ext_modules,

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -86,7 +86,14 @@ def maybe_cythonize_extensions(top_path, config):
             exc.args += (message,)
             raise
 
+        try:
+            import joblib
+            n_jobs = getattr(joblib, "effective_n_jobs")()
+        except (ImportError, AttributeError):
+            n_jobs = 1
+
         config.ext_modules = cythonize(
             config.ext_modules,
+            nthreads=n_jobs,
             compile_time_env={'SKLEARN_OPENMP_SUPPORTED': with_openmp},
             compiler_directives={'language_level': 3})

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -94,7 +94,7 @@ def maybe_cythonize_extensions(top_path, config):
                 # available CPU in some cases
                 n_jobs = joblib.effective_n_jobs()
         except ImportError:
-            n_jobs = 1
+            pass
 
         config.ext_modules = cythonize(
             config.ext_modules,


### PR DESCRIPTION
Cythonization during build takes a while (~1 min on my laptop). This enables parallel cythonization by default when `joblib.effective_n_jobs` is available (older versions don't have it, and we don't want to make it a mandatory build dependency).

The scaling with CPU cores is almost ideal (I imagine up to 8-10 cores).

This should improve CI build time a bit, since most CI agents have 2 CPU cores that we can use.