### PR TITLE
TST attempt to fix the variance threshold part of #14192

### DIFF
--- a/sklearn/feature_selection/tests/test_variance_threshold.py
+++ b/sklearn/feature_selection/tests/test_variance_threshold.py
@@ -38,7 +38,9 @@ def test_zero_variance_floating_point_error():
     # See #13691
 
     data = [[-0.13725701]] * 10
-    assert np.var(data) != 0
+    if np.var(data) == 0:
+        pytest.skip('This test is not valid for this platform, as it relies '
+                    'on numerical instabilities.')
     for X in [data, csr_matrix(data), csc_matrix(data), bsr_matrix(data)]:
         msg = "No feature in X meets the variance threshold 0.00000"
         with pytest.raises(ValueError, match=msg):


### PR DESCRIPTION
Nightly builds are failing on this assertion (#14192) which was only intended to prove that the test's primary assertion, below it, is actually valid.