### PR TITLE
[MRG] Remove BLAS infos from show_versions and build log

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,13 +58,6 @@ scikit-learn 0.21 and later require Python 3.5 or newer.
 For running the examples Matplotlib >= 1.5.1 is required. A few examples
 require scikit-image >= 0.12.3, a few examples require pandas >= 0.18.0.
 
-scikit-learn also uses CBLAS, the C interface to the Basic Linear Algebra
-Subprograms library. scikit-learn comes with a reference implementation, but
-the system CBLAS will be detected by the build system and used if present.
-CBLAS exists in many implementations; see `Linear algebra libraries
-<http://scikit-learn.org/stable/modules/computing#linear-algebra-libraries>`_
-for known issues.
-
 User installation
 ~~~~~~~~~~~~~~~~~
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -223,7 +223,8 @@ On Red Hat and clones (e.g. CentOS), install the dependencies using::
 .. note::
 
     To use a high performance BLAS library (e.g. OpenBlas) see 
-    `scipy installation instructions <https://docs.scipy.org/doc/scipy/reference/building/linux.html>`_.
+    `scipy installation instructions
+    <https://docs.scipy.org/doc/scipy/reference/building/linux.html>`_.
 
 Windows
 -------

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -220,6 +220,10 @@ On Red Hat and clones (e.g. CentOS), install the dependencies using::
 
     sudo yum -y install gcc gcc-c++ python-devel numpy scipy
 
+.. note::
+
+    To use a high performance BLAS library (e.g. OpenBlas) see 
+    `scipy installation instructions <https://docs.scipy.org/doc/scipy/reference/building/linux.html>`_.
 
 Windows
 -------

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -193,22 +193,12 @@ Installing build dependencies
 Linux
 -----
 
-Installing from source requires you to have installed the scikit-learn runtime
-dependencies, Python development headers and a working C/C++ compiler.
-Under Debian-based operating systems, which include Ubuntu::
+Installing from source without conda or pip requires you to have installed the
+scikit-learn runtime dependencies, Python development headers and a working
+C/C++ compiler. Under Debian-based operating systems, which include Ubuntu::
 
     sudo apt-get install build-essential python3-dev python3-setuptools \
-                     python3-numpy python3-scipy \
-                     libatlas-dev libatlas3-base
-
-On recent Debian and Ubuntu (e.g. Ubuntu 14.04 or later) make sure that ATLAS
-is used to provide the implementation of the BLAS and LAPACK linear algebra
-routines::
-
-    sudo update-alternatives --set libblas.so.3 \
-        /usr/lib/atlas-base/atlas/libblas.so.3
-    sudo update-alternatives --set liblapack.so.3 \
-        /usr/lib/atlas-base/atlas/liblapack.so.3
+                     python3-numpy python3-scipy cython3
 
 .. note::
 
@@ -217,31 +207,9 @@ routines::
 
         sudo apt-get install python-matplotlib
 
-.. note::
-
-    The above installs the ATLAS implementation of BLAS
-    (the Basic Linear Algebra Subprograms library).
-    Ubuntu 11.10 and later, and recent (testing) versions of Debian,
-    offer an alternative implementation called OpenBLAS.
-
-    Using OpenBLAS can give speedups in some scikit-learn modules,
-    but can freeze joblib/multiprocessing prior to OpenBLAS version 0.2.8-4,
-    so using it is not recommended unless you know what you're doing.
-
-    If you do want to use OpenBLAS, then replacing ATLAS only requires a couple
-    of commands. ATLAS has to be removed, otherwise NumPy may not work::
-
-        sudo apt-get remove libatlas3gf-base libatlas-dev
-        sudo apt-get install libopenblas-dev
-
-        sudo update-alternatives  --set libblas.so.3 \
-            /usr/lib/openblas-base/libopenblas.so.0
-        sudo update-alternatives --set liblapack.so.3 \
-            /usr/lib/lapack/liblapack.so.3
-
 On Red Hat and clones (e.g. CentOS), install the dependencies using::
 
-    sudo yum -y install gcc gcc-c++ numpy python-devel scipy
+    sudo yum -y install gcc gcc-c++ python-devel numpy scipy
 
 
 Windows

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -209,7 +209,12 @@ and then::
     In order to build the documentation and run the example code contains in
     this documentation you will need matplotlib::
 
-        sudo apt-get install python3-matplotlib
+        pip3 install matplotlib
+
+When precompiled wheels are not avalaible for your architecture, you can
+install the system versions::
+
+    sudo apt-get install cython3 python3-numpy python3-scipy python3-matplotlib
 
 On Red Hat and clones (e.g. CentOS), install the dependencies using::
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -193,19 +193,23 @@ Installing build dependencies
 Linux
 -----
 
-Installing from source without conda or pip requires you to have installed the
+Installing from source without conda requires you to have installed the
 scikit-learn runtime dependencies, Python development headers and a working
 C/C++ compiler. Under Debian-based operating systems, which include Ubuntu::
 
     sudo apt-get install build-essential python3-dev python3-setuptools \
-                     python3-numpy python3-scipy cython3
+                     python3-pip
+    
+and then::
+
+    pip3 install numpy scipy cython
 
 .. note::
 
     In order to build the documentation and run the example code contains in
     this documentation you will need matplotlib::
 
-        sudo apt-get install python-matplotlib
+        sudo apt-get install python3-matplotlib
 
 On Red Hat and clones (e.g. CentOS), install the dependencies using::
 

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -9,38 +9,12 @@ import os
 
 from distutils.version import LooseVersion
 
-from numpy.distutils.system_info import get_info
-
 from .openmp_helpers import check_openmp_support
 
 
 DEFAULT_ROOT = 'sklearn'
 # on conda, this is the latest for python 3.5
 CYTHON_MIN_VERSION = '0.28.5'
-
-
-def get_blas_info():
-    def atlas_not_found(blas_info_):
-        def_macros = blas_info.get('define_macros', [])
-        for x in def_macros:
-            if x[0] == "NO_ATLAS_INFO":
-                # if x[1] != 1 we should have lapack
-                # how do we do that now?
-                return True
-            if x[0] == "ATLAS_INFO":
-                if "None" in x[1]:
-                    # this one turned up on FreeBSD
-                    return True
-        return False
-
-    blas_info = get_info('blas_opt', 0)
-    if (not blas_info) or atlas_not_found(blas_info):
-        cblas_libs = ['cblas']
-        blas_info.pop('libraries', None)
-    else:
-        cblas_libs = blas_info.pop('libraries', [])
-
-    return cblas_libs, blas_info
 
 
 def build_from_c_and_cpp_files(extensions):

--- a/sklearn/setup.py
+++ b/sklearn/setup.py
@@ -5,11 +5,7 @@ from sklearn._build_utils import maybe_cythonize_extensions
 
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
-    from numpy.distutils.system_info import get_info
     import numpy
-
-    # needs to be called during build otherwise show_version may fail sometimes
-    get_info('blas_opt', 0)
 
     libraries = []
     if os.name == 'posix':

--- a/sklearn/utils/_show_versions.py
+++ b/sklearn/utils/_show_versions.py
@@ -70,47 +70,14 @@ def _get_deps_info():
     return deps_info
 
 
-def _get_blas_info():
-    """Information on system BLAS
-
-    Uses the `scikit-learn` builtin method
-    :func:`sklearn._build_utils.get_blas_info` which may fail from time to time
-
-    Returns
-    -------
-    blas_info: dict
-        system BLAS information
-
-    """
-    from .._build_utils import get_blas_info
-
-    cblas_libs, blas_dict = get_blas_info()
-
-    macros = ['{key}={val}'.format(key=a, val=b)
-              for (a, b) in blas_dict.get('define_macros', [])]
-
-    blas_blob = [
-        ('macros', ', '.join(macros)),
-        ('lib_dirs', ':'.join(blas_dict.get('library_dirs', ''))),
-        ('cblas_libs', ', '.join(cblas_libs)),
-    ]
-
-    return dict(blas_blob)
-
-
 def show_versions():
     "Print useful debugging information"
 
     sys_info = _get_sys_info()
     deps_info = _get_deps_info()
-    blas_info = _get_blas_info()
 
     print('\nSystem:')
     for k, stat in sys_info.items():
-        print("{k:>10}: {stat}".format(k=k, stat=stat))
-
-    print('\nBLAS:')
-    for k, stat in blas_info.items():
         print("{k:>10}: {stat}".format(k=k, stat=stat))
 
     print('\nPython deps:')

--- a/sklearn/utils/_show_versions.py
+++ b/sklearn/utils/_show_versions.py
@@ -8,6 +8,8 @@ adapted from :func:`pandas.show_versions`
 import platform
 import sys
 import importlib
+import numpy
+import scipy
 
 
 def _get_sys_info():
@@ -83,3 +85,9 @@ def show_versions():
     print('\nPython deps:')
     for k, stat in deps_info.items():
         print("{k:>10}: {stat}".format(k=k, stat=stat))
+
+    print('\nNumpy BLAS/LAPACK:')
+    numpy.show_config()
+
+    print('\nScipy BLAS/LAPACK:')
+    scipy.show_config()

--- a/sklearn/utils/_show_versions.py
+++ b/sklearn/utils/_show_versions.py
@@ -8,8 +8,6 @@ adapted from :func:`pandas.show_versions`
 import platform
 import sys
 import importlib
-import numpy
-import scipy
 
 
 def _get_sys_info():

--- a/sklearn/utils/_show_versions.py
+++ b/sklearn/utils/_show_versions.py
@@ -85,9 +85,3 @@ def show_versions():
     print('\nPython deps:')
     for k, stat in deps_info.items():
         print("{k:>10}: {stat}".format(k=k, stat=stat))
-
-    print('\nNumpy BLAS/LAPACK:')
-    numpy.show_config()
-
-    print('\nScipy BLAS/LAPACK:')
-    scipy.show_config()

--- a/sklearn/utils/tests/test_show_versions.py
+++ b/sklearn/utils/tests/test_show_versions.py
@@ -26,9 +26,8 @@ def test_get_deps_info():
     assert 'joblib' in deps_info
 
 
-def test_show_versions_with_blas(capsys):
+def test_show_versions(capsys):
     show_versions()
     out, err = capsys.readouterr()
     assert 'python' in out
     assert 'numpy' in out
-    assert 'BLAS' in out

--- a/sklearn/utils/tests/test_show_versions.py
+++ b/sklearn/utils/tests/test_show_versions.py
@@ -26,8 +26,9 @@ def test_get_deps_info():
     assert 'joblib' in deps_info
 
 
-def test_show_versions(capsys):
+def test_show_versions_with_blas(capsys):
     show_versions()
     out, err = capsys.readouterr()
     assert 'python' in out
     assert 'numpy' in out
+    assert 'BLAS' in out


### PR DESCRIPTION
Fixes  #14096

- remove BLAS infos from `show_versions()`
- remove BLAS from the dependencies in advanced installations doc
- remove BLAS infos displayed in the build log

