### PR TITLE
MNT use relative imports in hist-gradient-boosting

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -5,13 +5,13 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 from timeit import default_timer as time
-from sklearn.base import BaseEstimator, RegressorMixin, ClassifierMixin
-from sklearn.utils import check_X_y, check_random_state, check_array
-from sklearn.utils.validation import check_is_fitted
-from sklearn.utils.multiclass import check_classification_targets
-from sklearn.metrics import check_scoring
-from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import LabelEncoder
+from ...base import BaseEstimator, RegressorMixin, ClassifierMixin
+from ...utils import check_X_y, check_random_state, check_array
+from ...utils.validation import check_is_fitted
+from ...utils.multiclass import check_classification_targets
+from ...metrics import check_scoring
+from ...model_selection import train_test_split
+from ...preprocessing import LabelEncoder
 from ._gradient_boosting import _update_raw_predictions
 from .types import Y_DTYPE, X_DTYPE, X_BINNED_DTYPE
 


### PR DESCRIPTION
This is just a cleanup, I noticed the absolute imports in `sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py`, and the other files in the module seem fine in this regard.