### PR TITLE
Change documentation cross_val_predict

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -625,12 +625,10 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv=None,
                       pre_dispatch='2*n_jobs', method='predict'):
     """Generate cross-validated estimates for each input data point
 
-    Using these predictions to measure the generalization performance of the model 
-    can lead to different results than `cross_val` due to the aggregation of the 
-    predictions. 
-    
-    Moreover only metrics compatible with pooling have to be considered and test
-    sets have to present similar caracteristics.
+    Passing these predictions into an evaluation metric may not be a valid way 
+    to measure generalization performance. Results can differ from `cross_validate`
+    and `cross_val_score` unless all tests sets have equal size and the metric 
+    decomposes over samples.
 
     Read more in the :ref:`User Guide <cross_validation>`.
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -625,10 +625,10 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv=None,
                       pre_dispatch='2*n_jobs', method='predict'):
     """Generate cross-validated estimates for each input data point
 
-    Passing these predictions into an evaluation metric may not be a valid way
-    to measure generalization performance. Results can differ from `cross_validate`
-    and `cross_val_score` unless all tests sets have equal size and the metric
-    decomposes over samples.
+    Passing these predictions into an evaluation metric may not be a valid
+    way to measure generalization performance. Results can differ from
+    `cross_validate` and `cross_val_score` unless all tests sets have equal
+    size and the metric decomposes over samples.
 
     Read more in the :ref:`User Guide <cross_validation>`.
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -625,8 +625,12 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv=None,
                       pre_dispatch='2*n_jobs', method='predict'):
     """Generate cross-validated estimates for each input data point
 
-    It is not appropriate to pass these predictions into an evaluation
-    metric. Use :func:`cross_validate` to measure generalization error.
+    Using these predictions to measure the generalization performance of the model 
+    can lead to different results than `cross_val` due to the aggregation of the 
+    predictions. 
+    
+    Moreover only metrics compatible with pooling have to be considered and test
+    sets have to present similar caracteristics.
 
     Read more in the :ref:`User Guide <cross_validation>`.
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -625,6 +625,10 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv=None,
                       pre_dispatch='2*n_jobs', method='predict'):
     """Generate cross-validated estimates for each input data point
 
+    The data is split according to the cv parameter. Each sample belongs
+    to exactly one test set, and its prediction is computed with an 
+    estimator fitted on the corresponding training set.
+
     Passing these predictions into an evaluation metric may not be a valid
     way to measure generalization performance. Results can differ from
     `cross_validate` and `cross_val_score` unless all tests sets have equal

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -626,7 +626,7 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv=None,
     """Generate cross-validated estimates for each input data point
 
     The data is split according to the cv parameter. Each sample belongs
-    to exactly one test set, and its prediction is computed with an 
+    to exactly one test set, and its prediction is computed with an
     estimator fitted on the corresponding training set.
 
     Passing these predictions into an evaluation metric may not be a valid

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -625,9 +625,9 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv=None,
                       pre_dispatch='2*n_jobs', method='predict'):
     """Generate cross-validated estimates for each input data point
 
-    Passing these predictions into an evaluation metric may not be a valid way 
+    Passing these predictions into an evaluation metric may not be a valid way
     to measure generalization performance. Results can differ from `cross_validate`
-    and `cross_val_score` unless all tests sets have equal size and the metric 
+    and `cross_val_score` unless all tests sets have equal size and the metric
     decomposes over samples.
 
     Read more in the :ref:`User Guide <cross_validation>`.


### PR DESCRIPTION
closes #14199

Change of the cross_val_predict documentation in order to recommend the user to be careful for computing performances on the predictions provided by this function which can lead to different results than cross_val due to a pooling instead of an averaging strategy.