### PR TITLE
[MRG] Fix overlapped plot in the ICA example

### DIFF
--- a/examples/decomposition/plot_ica_blind_source_separation.py
+++ b/examples/decomposition/plot_ica_blind_source_separation.py
@@ -69,5 +69,5 @@ for ii, (model, name) in enumerate(zip(models, names), 1):
     for sig, color in zip(model.T, colors):
         plt.plot(sig, color=color)
 
-plt.subplots_adjust(0.09, 0.04, 0.94, 0.94, 0.26, 0.46)
+plt.subplots_adjust(0.09, 0.06, 0.94, 0.94, 0.26, 0.70)
 plt.show()

--- a/examples/decomposition/plot_ica_blind_source_separation.py
+++ b/examples/decomposition/plot_ica_blind_source_separation.py
@@ -69,5 +69,5 @@ for ii, (model, name) in enumerate(zip(models, names), 1):
     for sig, color in zip(model.T, colors):
         plt.plot(sig, color=color)
 
-plt.subplots_adjust(0.09, 0.06, 0.94, 0.94, 0.26, 0.70)
+plt.tight_layout()
 plt.show()


### PR DESCRIPTION
The plot headings in the FastICA example are mingled together and the bottom part of the plot is a bit out of view.

### Before:
![Figure_1](https://user-images.githubusercontent.com/3812788/60358758-41fde280-99ec-11e9-8b68-984d2dc5decc.png)

### After:
![Figure_2](https://user-images.githubusercontent.com/3812788/60358874-9c973e80-99ec-11e9-9106-a6c3540b4b5c.png)
