### PR TITLE
[MRG] Adds 32bit linux testing to CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
 
 - template: build_tools/azure/posix-32.yml
   parameters:
-    name: Linux-32
+    name: Linux32
     vmImage: ubuntu-16.04
     matrix:
       py35_np_atlas_32bit:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,49 +1,49 @@
 # Adapted from https://github.com/pandas-dev/pandas/blob/master/azure-pipelines.yml
 jobs:
-# - template: build_tools/azure/posix.yml
-#   parameters:
-#     name: Linux
-#     vmImage: ubuntu-16.04
-#     matrix:
-#       # Linux environment to test that scikit-learn can be built against
-#       # versions of numpy, scipy with ATLAS that comes with Ubuntu Xenial 16.04
-#       # i.e. numpy 1.11 and scipy 0.17
-#       py35_np_atlas:
-#         DISTRIB: 'ubuntu'
-#         PYTHON_VERSION: '3.5'
-#         JOBLIB_VERSION: '0.11'
-#         SKLEARN_NO_OPENMP: 'True'
-#       # Linux + Python 3.5 build with OpenBLAS and without SITE_JOBLIB
-#       py35_conda_openblas:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '3.5'
-#         INSTALL_MKL: 'false'
-#         NUMPY_VERSION: '1.11.0'
-#         SCIPY_VERSION: '0.17.0'
-#         CYTHON_VERSION: '*'
-#         PILLOW_VERSION: '4.0.0'
-#         MATPLOTLIB_VERSION: '1.5.1'
-#         # later version of joblib are not packaged in conda for Python 3.5
-#         JOBLIB_VERSION: '0.12.3'
-#         COVERAGE: 'true'
-#       # Linux environment to test the latest available dependencies and MKL.
-#       # It runs tests requiring pandas and PyAMG.
-#       pylatest_conda:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '*'
-#         INSTALL_MKL: 'true'
-#         NUMPY_VERSION: '*'
-#         SCIPY_VERSION: '*'
-#         PANDAS_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         PYAMG_VERSION: '*'
-#         PILLOW_VERSION: '*'
-#         JOBLIB_VERSION: '*'
-#         MATPLOTLIB_VERSION: '*'
-#         COVERAGE: 'true'
-#         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-#         TEST_DOCSTRINGS: 'true'
-#         CHECK_WARNINGS: 'true'
+- template: build_tools/azure/posix.yml
+  parameters:
+    name: Linux
+    vmImage: ubuntu-16.04
+    matrix:
+      # Linux environment to test that scikit-learn can be built against
+      # versions of numpy, scipy with ATLAS that comes with Ubuntu Xenial 16.04
+      # i.e. numpy 1.11 and scipy 0.17
+      py35_np_atlas:
+        DISTRIB: 'ubuntu'
+        PYTHON_VERSION: '3.5'
+        JOBLIB_VERSION: '0.11'
+        SKLEARN_NO_OPENMP: 'True'
+      # Linux + Python 3.5 build with OpenBLAS and without SITE_JOBLIB
+      py35_conda_openblas:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '3.5'
+        INSTALL_MKL: 'false'
+        NUMPY_VERSION: '1.11.0'
+        SCIPY_VERSION: '0.17.0'
+        CYTHON_VERSION: '*'
+        PILLOW_VERSION: '4.0.0'
+        MATPLOTLIB_VERSION: '1.5.1'
+        # later version of joblib are not packaged in conda for Python 3.5
+        JOBLIB_VERSION: '0.12.3'
+        COVERAGE: 'true'
+      # Linux environment to test the latest available dependencies and MKL.
+      # It runs tests requiring pandas and PyAMG.
+      pylatest_conda:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '*'
+        INSTALL_MKL: 'true'
+        NUMPY_VERSION: '*'
+        SCIPY_VERSION: '*'
+        PANDAS_VERSION: '*'
+        CYTHON_VERSION: '*'
+        PYAMG_VERSION: '*'
+        PILLOW_VERSION: '*'
+        JOBLIB_VERSION: '*'
+        MATPLOTLIB_VERSION: '*'
+        COVERAGE: 'true'
+        CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+        TEST_DOCSTRINGS: 'true'
+        CHECK_WARNINGS: 'true'
 
 - template: build_tools/azure/posix-32.yml
   parameters:
@@ -56,32 +56,32 @@ jobs:
         JOBLIB_VERSION: '0.11'
         SKLEARN_NO_OPENMP: 'True'
 
-# - template: build_tools/azure/posix.yml
-#   parameters:
-#     name: macOS
-#     vmImage: xcode9-macos10.13
-#     matrix:
-#       pylatest_conda:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '*'
-#         INSTALL_MKL: 'true'
-#         NUMPY_VERSION: '*'
-#         SCIPY_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         PILLOW_VERSION: '*'
-#         JOBLIB_VERSION: '*'
-#         COVERAGE: 'true'
+- template: build_tools/azure/posix.yml
+  parameters:
+    name: macOS
+    vmImage: xcode9-macos10.13
+    matrix:
+      pylatest_conda:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '*'
+        INSTALL_MKL: 'true'
+        NUMPY_VERSION: '*'
+        SCIPY_VERSION: '*'
+        CYTHON_VERSION: '*'
+        PILLOW_VERSION: '*'
+        JOBLIB_VERSION: '*'
+        COVERAGE: 'true'
 
-# - template: build_tools/azure/windows.yml
-#   parameters:
-#     name: Windows
-#     vmImage: vs2017-win2016
-#     matrix:
-#       py37_64:
-#         PYTHON_VERSION: '3.7'
-#         CHECK_WARNINGS: 'true'
-#         PYTHON_ARCH: '64'
-#         COVERAGE: 'true'
-#       py35_32:
-#         PYTHON_VERSION: '3.5'
-#         PYTHON_ARCH: '32'
+- template: build_tools/azure/windows.yml
+  parameters:
+    name: Windows
+    vmImage: vs2017-win2016
+    matrix:
+      py37_64:
+        PYTHON_VERSION: '3.7'
+        CHECK_WARNINGS: 'true'
+        PYTHON_ARCH: '64'
+        COVERAGE: 'true'
+      py35_32:
+        PYTHON_VERSION: '3.5'
+        PYTHON_ARCH: '32'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,6 +45,17 @@ jobs:
         TEST_DOCSTRINGS: 'true'
         CHECK_WARNINGS: 'true'
 
+- template: build_tools/azure/posix-32.yml
+  parameters:
+    name: Linux-32
+    vmImage: ubuntu-16.04
+    matrix:
+      py35_np_atlas_32bit:
+        DISTRIB: 'ubuntu-32'
+        PYTHON_VERSION: '3.5'
+        JOBLIB_VERSION: '0.11'
+        SKLEARN_NO_OPENMP: 'True'
+
 - template: build_tools/azure/posix.yml
   parameters:
     name: macOS

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,49 +1,49 @@
 # Adapted from https://github.com/pandas-dev/pandas/blob/master/azure-pipelines.yml
 jobs:
-- template: build_tools/azure/posix.yml
-  parameters:
-    name: Linux
-    vmImage: ubuntu-16.04
-    matrix:
-      # Linux environment to test that scikit-learn can be built against
-      # versions of numpy, scipy with ATLAS that comes with Ubuntu Xenial 16.04
-      # i.e. numpy 1.11 and scipy 0.17
-      py35_np_atlas:
-        DISTRIB: 'ubuntu'
-        PYTHON_VERSION: '3.5'
-        JOBLIB_VERSION: '0.11'
-        SKLEARN_NO_OPENMP: 'True'
-      # Linux + Python 3.5 build with OpenBLAS and without SITE_JOBLIB
-      py35_conda_openblas:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '3.5'
-        INSTALL_MKL: 'false'
-        NUMPY_VERSION: '1.11.0'
-        SCIPY_VERSION: '0.17.0'
-        CYTHON_VERSION: '*'
-        PILLOW_VERSION: '4.0.0'
-        MATPLOTLIB_VERSION: '1.5.1'
-        # later version of joblib are not packaged in conda for Python 3.5
-        JOBLIB_VERSION: '0.12.3'
-        COVERAGE: 'true'
-      # Linux environment to test the latest available dependencies and MKL.
-      # It runs tests requiring pandas and PyAMG.
-      pylatest_conda:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '*'
-        INSTALL_MKL: 'true'
-        NUMPY_VERSION: '*'
-        SCIPY_VERSION: '*'
-        PANDAS_VERSION: '*'
-        CYTHON_VERSION: '*'
-        PYAMG_VERSION: '*'
-        PILLOW_VERSION: '*'
-        JOBLIB_VERSION: '*'
-        MATPLOTLIB_VERSION: '*'
-        COVERAGE: 'true'
-        CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-        TEST_DOCSTRINGS: 'true'
-        CHECK_WARNINGS: 'true'
+# - template: build_tools/azure/posix.yml
+#   parameters:
+#     name: Linux
+#     vmImage: ubuntu-16.04
+#     matrix:
+#       # Linux environment to test that scikit-learn can be built against
+#       # versions of numpy, scipy with ATLAS that comes with Ubuntu Xenial 16.04
+#       # i.e. numpy 1.11 and scipy 0.17
+#       py35_np_atlas:
+#         DISTRIB: 'ubuntu'
+#         PYTHON_VERSION: '3.5'
+#         JOBLIB_VERSION: '0.11'
+#         SKLEARN_NO_OPENMP: 'True'
+#       # Linux + Python 3.5 build with OpenBLAS and without SITE_JOBLIB
+#       py35_conda_openblas:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '3.5'
+#         INSTALL_MKL: 'false'
+#         NUMPY_VERSION: '1.11.0'
+#         SCIPY_VERSION: '0.17.0'
+#         CYTHON_VERSION: '*'
+#         PILLOW_VERSION: '4.0.0'
+#         MATPLOTLIB_VERSION: '1.5.1'
+#         # later version of joblib are not packaged in conda for Python 3.5
+#         JOBLIB_VERSION: '0.12.3'
+#         COVERAGE: 'true'
+#       # Linux environment to test the latest available dependencies and MKL.
+#       # It runs tests requiring pandas and PyAMG.
+#       pylatest_conda:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '*'
+#         INSTALL_MKL: 'true'
+#         NUMPY_VERSION: '*'
+#         SCIPY_VERSION: '*'
+#         PANDAS_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         PYAMG_VERSION: '*'
+#         PILLOW_VERSION: '*'
+#         JOBLIB_VERSION: '*'
+#         MATPLOTLIB_VERSION: '*'
+#         COVERAGE: 'true'
+#         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+#         TEST_DOCSTRINGS: 'true'
+#         CHECK_WARNINGS: 'true'
 
 - template: build_tools/azure/posix-32.yml
   parameters:
@@ -56,32 +56,32 @@ jobs:
         JOBLIB_VERSION: '0.11'
         SKLEARN_NO_OPENMP: 'True'
 
-- template: build_tools/azure/posix.yml
-  parameters:
-    name: macOS
-    vmImage: xcode9-macos10.13
-    matrix:
-      pylatest_conda:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '*'
-        INSTALL_MKL: 'true'
-        NUMPY_VERSION: '*'
-        SCIPY_VERSION: '*'
-        CYTHON_VERSION: '*'
-        PILLOW_VERSION: '*'
-        JOBLIB_VERSION: '*'
-        COVERAGE: 'true'
+# - template: build_tools/azure/posix.yml
+#   parameters:
+#     name: macOS
+#     vmImage: xcode9-macos10.13
+#     matrix:
+#       pylatest_conda:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '*'
+#         INSTALL_MKL: 'true'
+#         NUMPY_VERSION: '*'
+#         SCIPY_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         PILLOW_VERSION: '*'
+#         JOBLIB_VERSION: '*'
+#         COVERAGE: 'true'
 
-- template: build_tools/azure/windows.yml
-  parameters:
-    name: Windows
-    vmImage: vs2017-win2016
-    matrix:
-      py37_64:
-        PYTHON_VERSION: '3.7'
-        CHECK_WARNINGS: 'true'
-        PYTHON_ARCH: '64'
-        COVERAGE: 'true'
-      py35_32:
-        PYTHON_VERSION: '3.5'
-        PYTHON_ARCH: '32'
+# - template: build_tools/azure/windows.yml
+#   parameters:
+#     name: Windows
+#     vmImage: vs2017-win2016
+#     matrix:
+#       py37_64:
+#         PYTHON_VERSION: '3.7'
+#         CHECK_WARNINGS: 'true'
+#         PYTHON_ARCH: '64'
+#         COVERAGE: 'true'
+#       py35_32:
+#         PYTHON_VERSION: '3.5'
+#         PYTHON_ARCH: '32'

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -65,7 +65,7 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     python -m pip install pytest pytest-cov cython joblib==$JOBLIB_VERSION
 elif [[ "$DISTRIB" == "ubuntu-32" ]]; then
     apt-get update
-    apt-get install -y python3-scipy python3-matplotlib libatlas3-base libatlas-base-dev libatlas-dev python3-virtualenv
+    apt-get install -y python3-dev python3-scipy python3-matplotlib libatlas3-base libatlas-base-dev libatlas-dev python3-virtualenv
     python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
     source $VIRTUALENV/bin/activate
     python -m pip install pytest pytest-cov cython joblib==$JOBLIB_VERSION

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -65,7 +65,7 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     python -m pip install pytest pytest-cov cython joblib==$JOBLIB_VERSION
 elif [[ "$DISTRIB" == "ubuntu-32" ]]; then
     apt-get update
-    apt-get install python3-scipy python3-matplotlib libatlas3-base libatlas-base-dev libatlas-dev python3-virtualenv
+    apt-get install -y python3-scipy python3-matplotlib libatlas3-base libatlas-base-dev libatlas-dev python3-virtualenv
     python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
     source $VIRTUALENV/bin/activate
     python -m pip install pytest pytest-cov cython joblib==$JOBLIB_VERSION

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -64,6 +64,12 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     source $VIRTUALENV/bin/activate
     python -m pip install pytest pytest-cov cython joblib==$JOBLIB_VERSION
 fi
+elif [[ "$DISTRIB" == "ubuntu-32" ]]; then
+    apt-get install python3-scipy python3-matplotlib libatlas3-base libatlas-base-dev libatlas-dev python3-virtualenv
+    python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
+    source $VIRTUALENV/bin/activate
+    python -m pip install pytest pytest-cov cython joblib==$JOBLIB_VERSION
+fi
 
 if [[ "$COVERAGE" == "true" ]]; then
     python -m pip install coverage codecov

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -63,8 +63,8 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
     source $VIRTUALENV/bin/activate
     python -m pip install pytest pytest-cov cython joblib==$JOBLIB_VERSION
-fi
 elif [[ "$DISTRIB" == "ubuntu-32" ]]; then
+    apt-get update
     apt-get install python3-scipy python3-matplotlib libatlas3-base libatlas-base-dev libatlas-dev python3-virtualenv
     python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
     source $VIRTUALENV/bin/activate

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -18,12 +18,14 @@ jobs:
       ${{ insert }}: ${{ parameters.matrix }}
 
   steps:
+    # Container is detached and sleeping, allowing steps to run commmands
+    # in the container
     - script: >
         docker container run --rm
         -v $TEST_DIR:/temp_dir
         -v $PWD:/io
         -w /io
-        -d
+        --detach
         --name skcontainer
         -e DISTRIB=ubuntu-32
         -e TEST_DIR=/temp_dir
@@ -36,7 +38,7 @@ jobs:
         -e SKLEARN_SKIP_NETWORK_TESTS=$SKLEARN_SKIP_NETWORK_TESTS
         i386/ubuntu:16.04
         sleep 1000000
-      displayName: 'Start up'
+      displayName: 'Start container'
     - script: >
         docker exec skcontainer ./build_tools/azure/install.sh
       displayName: 'Install'

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -20,11 +20,14 @@ jobs:
 
   steps:
     - script: >
-        docker run -it --rm -v $PWD:/io -d
+        docker run -it --rm
+        -v $TEST_DIR:/temp_dir
+        -v $PWD:/io -d
         -n skcontainer
         -e DISTRIB='ubuntu-32'
+        -w /io
         i386/ubuntu:16.04
-        /io/build_tools/azure/test_script_32.sh
+        build_tools/azure/test_script_32.sh
       displayName: 'Install and Test'
     # - script: |
     #     build_tools/azure/test_script.sh

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -23,7 +23,7 @@ jobs:
         docker run -it --rm
         -v $TEST_DIR:/temp_dir
         -v $PWD:/io -d
-        -n skcontainer
+        --name skcontainer
         -e DISTRIB='ubuntu-32'
         -w /io
         i386/ubuntu:16.04

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -30,7 +30,7 @@ jobs:
         sleep 1000000
       displayName: 'Start up'
     - script: >
-      docker exec -ti skcontainer ./build_tools/azure/install.sh
+        docker exec -ti skcontainer ./build_tools/azure/install.sh
       displayName: 'Install'
     - script: >
         docker container stop skcontainer

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -19,28 +19,25 @@ jobs:
       ${{ insert }}: ${{ parameters.matrix }}
 
   steps:
-    - script: |
-        build_tools/azure/install.sh
-      displayName: 'Install'
-    - script: |
-        build_tools/azure/test_script.sh
-      displayName: 'Test Library'
-    - script: |
-        build_tools/azure/test_docs.sh
-      displayName: 'Test Docs'
-    - script: |
-        build_tools/azure/test_pytest_soft_dependency.sh
-      displayName: 'Test Soft Dependency'
-      condition: and(eq(variables['CHECK_PYTEST_SOFT_DEPENDENCY'], 'true'), eq(variables['DISTRIB'], 'conda'))
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFiles: '$(TEST_DIR)/$(JUNITXML)'
-        testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
-      displayName: 'Publish Test Results'
-      condition: succeededOrFailed()
-    - script: |
-        build_tools/azure/upload_codecov.sh
-      condition: and(succeeded(), eq(variables['COVERAGE'], 'true'), eq(variables['DISTRIB'], 'conda'))
-      displayName: 'Upload To Codecov'
-      env:
-        CODECOV_TOKEN: $(CODECOV_TOKEN)
+    - script: >
+        docker run -it --rm -v $PWD:/io -d
+        -n skcontainer
+        -e DISTRIB='ubuntu-32'
+        i386/ubuntu:16.04
+        /io/build_tools/azure/test_script_32.sh
+      display: 'Install and Test'
+    # - script: |
+    #     build_tools/azure/test_script.sh
+    #   displayName: 'Test Library'
+    # - task: PublishTestResults@2
+    #   inputs:
+    #     testResultsFiles: '$(TEST_DIR)/$(JUNITXML)'
+    #     testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
+    #   displayName: 'Publish Test Results'
+    #   condition: succeededOrFailed()
+    # - script: |
+    #     build_tools/azure/upload_codecov.sh
+    #   condition: and(succeeded(), eq(variables['COVERAGE'], 'true'), eq(variables['DISTRIB'], 'conda'))
+    #   displayName: 'Upload To Codecov'
+    #   env:
+    #     CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -27,7 +27,11 @@ jobs:
         -e TEST_DIR=/temp_dir
         -e JUNITXML=$JUNITXML
         -e VIRTUALENV=testvenv
-        -d
+        -e JOBLIB_VERSION=$JOBLIB_VERSION
+        -e SKLEARN_NO_OPENMP=$SKLEARN_NO_OPENMP
+        -e OMP_NUM_THREADS=$OMP_NUM_THREADS
+        -e OPENBLAS_NUM_THREADS=$OPENBLAS_NUM_THREADS
+        -e SKLEARN_SKIP_NETWORK_TESTS=$SKLEARN_SKIP_NETWORK_TESTS
         -w /io
         i386/ubuntu:16.04
         sleep 1000000

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -24,7 +24,8 @@ jobs:
         -v $TEST_DIR:/temp_dir
         -v $PWD:/io
         --name skcontainer
-        -e DISTRIB='ubuntu-32'
+        -e DISTRIB=ubuntu-32
+        -e TEST_DIR=/temp_dir
         -d
         -w /io
         i386/ubuntu:16.04

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -19,11 +19,12 @@ jobs:
 
   steps:
     # Container is detached and sleeping, allowing steps to run commmands
-    # in the container
+    # in the container. The TEST_DIR is mapped allowing the host to access
+    # the JUNITXML file
     - script: >
         docker container run --rm
-        -v $TEST_DIR:/temp_dir
-        -v $PWD:/io
+        --volume $TEST_DIR:/temp_dir
+        --volume $PWD:/io
         -w /io
         --detach
         --name skcontainer

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -25,6 +25,7 @@ jobs:
         -v $PWD:/io
         --name skcontainer
         -e DISTRIB='ubuntu-32'
+        -d
         -w /io
         i386/ubuntu:16.04
         sleep 1000000

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -20,7 +20,7 @@ jobs:
 
   steps:
     - script: >
-        docker container run -it --rm
+        docker container run --rm
         -v $TEST_DIR:/temp_dir
         -v $PWD:/io
         --name skcontainer
@@ -30,7 +30,7 @@ jobs:
         sleep 1000000
       displayName: 'Start up'
     - script: >
-        docker exec -ti skcontainer ./build_tools/azure/install.sh
+        docker exec skcontainer ./build_tools/azure/install.sh
       displayName: 'Install'
     - script: >
         docker container stop skcontainer

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -22,6 +22,8 @@ jobs:
         docker container run --rm
         -v $TEST_DIR:/temp_dir
         -v $PWD:/io
+        -w /io
+        -d
         --name skcontainer
         -e DISTRIB=ubuntu-32
         -e TEST_DIR=/temp_dir
@@ -32,7 +34,6 @@ jobs:
         -e OMP_NUM_THREADS=$OMP_NUM_THREADS
         -e OPENBLAS_NUM_THREADS=$OPENBLAS_NUM_THREADS
         -e SKLEARN_SKIP_NETWORK_TESTS=$SKLEARN_SKIP_NETWORK_TESTS
-        -w /io
         i386/ubuntu:16.04
         sleep 1000000
       displayName: 'Start up'

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -1,0 +1,46 @@
+parameters:
+  name: ''
+  vmImage: ''
+  matrix: []
+
+jobs:
+- job: ${{ parameters.name }}
+  pool:
+    vmImage: ${{ parameters.vmImage }}
+  variables:
+    TEST_DIR: '$(Agent.WorkFolder)/tmp_folder'
+    VIRTUALENV: 'testvenv'
+    JUNITXML: 'test-data.xml'
+    OMP_NUM_THREADS: '4'
+    OPENBLAS_NUM_THREADS: '4'
+    SKLEARN_SKIP_NETWORK_TESTS: '1'
+  strategy:
+    matrix:
+      ${{ insert }}: ${{ parameters.matrix }}
+
+  steps:
+    - script: |
+        build_tools/azure/install.sh
+      displayName: 'Install'
+    - script: |
+        build_tools/azure/test_script.sh
+      displayName: 'Test Library'
+    - script: |
+        build_tools/azure/test_docs.sh
+      displayName: 'Test Docs'
+    - script: |
+        build_tools/azure/test_pytest_soft_dependency.sh
+      displayName: 'Test Soft Dependency'
+      condition: and(eq(variables['CHECK_PYTEST_SOFT_DEPENDENCY'], 'true'), eq(variables['DISTRIB'], 'conda'))
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: '$(TEST_DIR)/$(JUNITXML)'
+        testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
+      displayName: 'Publish Test Results'
+      condition: succeededOrFailed()
+    - script: |
+        build_tools/azure/upload_codecov.sh
+      condition: and(succeeded(), eq(variables['COVERAGE'], 'true'), eq(variables['DISTRIB'], 'conda'))
+      displayName: 'Upload To Codecov'
+      env:
+        CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -9,7 +9,6 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   variables:
     TEST_DIR: '$(Agent.WorkFolder)/tmp_folder'
-    VIRTUALENV: 'testvenv'
     JUNITXML: 'test-data.xml'
     OMP_NUM_THREADS: '4'
     OPENBLAS_NUM_THREADS: '4'
@@ -26,6 +25,8 @@ jobs:
         --name skcontainer
         -e DISTRIB=ubuntu-32
         -e TEST_DIR=/temp_dir
+        -e JUNITXML=$JUNITXML
+        -e VIRTUALENV=testvenv
         -d
         -w /io
         i386/ubuntu:16.04
@@ -35,21 +36,15 @@ jobs:
         docker exec skcontainer ./build_tools/azure/install.sh
       displayName: 'Install'
     - script: >
+        docker exec skcontainer ./build_tools/azure/test_script.sh
+      displayName: 'Test Library'
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: '$(TEST_DIR)/$(JUNITXML)'
+        testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
+      displayName: 'Publish Test Results'
+      condition: succeededOrFailed()
+    - script: >
         docker container stop skcontainer
       displayName: 'Stop container'
       condition: always()
-    # - script: |
-    #     build_tools/azure/test_script.sh
-    #   displayName: 'Test Library'
-    # - task: PublishTestResults@2
-    #   inputs:
-    #     testResultsFiles: '$(TEST_DIR)/$(JUNITXML)'
-    #     testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
-    #   displayName: 'Publish Test Results'
-    #   condition: succeededOrFailed()
-    # - script: |
-    #     build_tools/azure/upload_codecov.sh
-    #   condition: and(succeeded(), eq(variables['COVERAGE'], 'true'), eq(variables['DISTRIB'], 'conda'))
-    #   displayName: 'Upload To Codecov'
-    #   env:
-    #     CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -25,7 +25,7 @@ jobs:
         -e DISTRIB='ubuntu-32'
         i386/ubuntu:16.04
         /io/build_tools/azure/test_script_32.sh
-      display: 'Install and Test'
+      displayName: 'Install and Test'
     # - script: |
     #     build_tools/azure/test_script.sh
     #   displayName: 'Test Library'

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -20,15 +20,22 @@ jobs:
 
   steps:
     - script: >
-        docker run -it --rm
+        docker container run -it --rm
         -v $TEST_DIR:/temp_dir
-        -v $PWD:/io -d
+        -v $PWD:/io
         --name skcontainer
         -e DISTRIB='ubuntu-32'
         -w /io
         i386/ubuntu:16.04
-        build_tools/azure/test_script_32.sh
-      displayName: 'Install and Test'
+        sleep 1000000
+      displayName: 'Start up'
+    - script: >
+      docker exec -ti skcontainer ./build_tools/azure/install.sh
+      displayName: 'Install'
+    - script: >
+        docker container stop skcontainer
+      displayName: 'Stop container'
+      condition: always()
     # - script: |
     #     build_tools/azure/test_script.sh
     #   displayName: 'Test Library'

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -4,7 +4,7 @@ set -e
 
 if [[ "$DISTRIB" == "conda" ]]; then
     source activate $VIRTUALENV
-elif [[ "$DISTRIB" == "ubuntu" ]]; then
+elif [[ "$DISTRIB" == "ubuntu" ]] || [[ "$DISTRIB" == "ubuntu-32" ]]; then
     source $VIRTUALENV/bin/activate
 fi
 

--- a/build_tools/azure/test_script_32.sh
+++ b/build_tools/azure/test_script_32.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+bash /io/build_tools/azure/install.sh

--- a/build_tools/azure/test_script_32.sh
+++ b/build_tools/azure/test_script_32.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -e
-
-./build_tools/azure/install.sh

--- a/build_tools/azure/test_script_32.sh
+++ b/build_tools/azure/test_script_32.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-bash /io/build_tools/azure/install.sh
+./build_tools/azure/install.sh

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
@@ -6,6 +6,7 @@ from sklearn.ensemble._hist_gradient_boosting.types import G_H_DTYPE
 from sklearn.ensemble._hist_gradient_boosting.types import X_BINNED_DTYPE
 from sklearn.ensemble._hist_gradient_boosting.splitting import Splitter
 from sklearn.ensemble._hist_gradient_boosting.histogram import HistogramBuilder
+from sklearn.utils.testing import skip_if_32bit
 
 
 @pytest.mark.parametrize('n_bins', [3, 32, 256])
@@ -61,6 +62,7 @@ def test_histogram_split(n_bins):
             assert split_info.n_samples_left == split_info.sum_hessian_left
 
 
+@skip_if_32bit
 @pytest.mark.parametrize('constant_hessian', [True, False])
 def test_gradient_and_hessian_sanity(constant_hessian):
     # This test checks that the values of gradients and hessians are


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes https://github.com/scikit-learn/scikit-learn/issues/9352


#### What does this implement/fix? Explain your changes.
Uses docker to run tests on 32bit linux.

#### Any other comments?
Besides the known 32bit failure: `test_extract_xi`. This PR finds another error in `test_gradient_and_hessian_sanity`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
