### PR TITLE
FIX silently omitted tests in test_neighbors.py

### DIFF
--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -971,8 +971,8 @@ def test_neighbors_badargs():
         assert_raises(ValueError,
                       nbrs.predict,
                       [[]])
-        if (isinstance(cls(), neighbors.KNeighborsClassifier) or
-                isinstance(cls(), neighbors.KNeighborsRegressor)):
+        if (issubclass(cls, neighbors.KNeighborsClassifier) or
+                issubclass(cls, neighbors.KNeighborsRegressor)):
             nbrs = cls(n_neighbors=-1)
             assert_raises(ValueError, nbrs.fit, X, y)
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -971,8 +971,8 @@ def test_neighbors_badargs():
         assert_raises(ValueError,
                       nbrs.predict,
                       [[]])
-        if (isinstance(cls, neighbors.KNeighborsClassifier) or
-                isinstance(cls, neighbors.KNeighborsRegressor)):
+        if (isinstance(cls(), neighbors.KNeighborsClassifier) or
+                isinstance(cls(), neighbors.KNeighborsRegressor)):
             nbrs = cls(n_neighbors=-1)
             assert_raises(ValueError, nbrs.fit, X, y)
 
@@ -1215,9 +1215,9 @@ def test_k_and_radius_neighbors_X_None():
         rng = nn.radius_neighbors_graph(None, radius=1.5)
         kng = nn.kneighbors_graph(None)
         for graph in [rng, kng]:
-            assert_array_equal(rng.A, [[0, 1], [1, 0]])
-            assert_array_equal(rng.data, [1, 1])
-            assert_array_equal(rng.indices, [1, 0])
+            assert_array_equal(graph.A, [[0, 1], [1, 0]])
+            assert_array_equal(graph.data, [1, 1])
+            assert_array_equal(graph.indices, [1, 0])
 
         X = [[0, 1], [0, 1], [1, 1]]
         nn = neighbors.NearestNeighbors(n_neighbors=2, algorithm=algorithm)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
None


#### What does this implement/fix? Explain your changes.
Two tests in the `neighbors.tests.test_neighbors.py` don't work as expected, i.e. tests are silently omitted.
 - `test_neighbors_badargs` contains unreachable code: `isinstance(class, class)` instead of `isinstance(obj, class)`
(see also [codecov](https://codecov.io/gh/scikit-learn/scikit-learn/src/master/sklearn/neighbors/tests/test_neighbors.py))
- in `test_k_and_radius_neighbors_X_None` not all elements of an iterable are used in a loop, but the same one over again

#### Any other comments?
None

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.


Thanks for contributing!
-->
