### PR TITLE
[MRG] MNT  removing assert_equal, etc -- continued

### DIFF
--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -9,8 +9,6 @@ from numpy.testing import assert_array_equal
 
 import pytest
 
-from sklearn.utils.testing import (assert_equal, assert_in)
-
 from sklearn.feature_extraction import DictVectorizer
 from sklearn.feature_selection import SelectKBest, chi2
 

--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -3,8 +3,8 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from sklearn.feature_extraction import FeatureHasher
-from sklearn.utils.testing import (assert_raises, assert_equal,
-                                   ignore_warnings, fails_if_pypy)
+from sklearn.utils.testing import (assert_raises, ignore_warnings,
+                                   fails_if_pypy)
 
 pytestmark = fails_if_pypy
 

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -10,8 +10,7 @@ from scipy.sparse.csgraph import connected_components
 from sklearn.feature_extraction.image import (
     img_to_graph, grid_to_graph, extract_patches_2d,
     reconstruct_from_patches_2d, PatchExtractor, extract_patches)
-from sklearn.utils.testing import (assert_equal, assert_raises,
-                                   ignore_warnings)
+from sklearn.utils.testing import assert_raises, ignore_warnings
 
 
 def test_img_to_graph():

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -30,9 +30,7 @@ from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
 from sklearn.utils import IS_PYPY
 from sklearn.exceptions import ChangedBehaviorWarning
-from sklearn.utils.testing import (assert_equal, assert_not_equal,
-                                   assert_almost_equal, assert_in,
-                                   assert_less, assert_greater,
+from sklearn.utils.testing import (assert_almost_equal,
                                    assert_warns_message, assert_raise_message,
                                    clean_warning_registry,
                                    SkipTest, assert_raises, assert_no_warnings,

--- a/sklearn/feature_selection/tests/test_mutual_info.py
+++ b/sklearn/feature_selection/tests/test_mutual_info.py
@@ -4,8 +4,7 @@ from scipy.sparse import csr_matrix
 
 from sklearn.utils import check_random_state
 from sklearn.utils.testing import (assert_array_equal, assert_almost_equal,
-                                   assert_raises, assert_equal,
-                                   assert_greater)
+                                   assert_raises)
 from sklearn.feature_selection.mutual_info_ import (
     mutual_info_regression, mutual_info_classif, _compute_mi)
 

--- a/sklearn/feature_selection/tests/test_variance_threshold.py
+++ b/sklearn/feature_selection/tests/test_variance_threshold.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pytest
 
-from sklearn.utils.testing import (assert_array_equal, assert_equal,
-                                   assert_raises)
+from sklearn.utils.testing import assert_array_equal, assert_raises
 
 from scipy.sparse import bsr_matrix, csc_matrix, csr_matrix
 

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -12,8 +12,7 @@ import pytest
 from sklearn.gaussian_process import GaussianProcessClassifier
 from sklearn.gaussian_process.kernels import RBF, ConstantKernel as C
 
-from sklearn.utils.testing import (assert_greater, assert_almost_equal,
-                                   assert_array_equal)
+from sklearn.utils.testing import assert_almost_equal, assert_array_equal
 
 
 def f(x):

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -15,8 +15,8 @@ from sklearn.gaussian_process.kernels \
 from sklearn.gaussian_process.kernels import DotProduct
 
 from sklearn.utils.testing \
-    import (assert_greater, assert_array_less,
-            assert_almost_equal, assert_equal, assert_raise_message,
+    import (assert_array_less,
+            assert_almost_equal, assert_raise_message,
             assert_array_almost_equal, assert_array_equal)
 
 

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -17,8 +17,8 @@ from sklearn.gaussian_process.kernels \
             Exponentiation)
 from sklearn.base import clone
 
-from sklearn.utils.testing import (assert_equal, assert_almost_equal,
-                                   assert_not_equal, assert_array_equal,
+from sklearn.utils.testing import (assert_almost_equal,
+                                   assert_array_equal,
                                    assert_array_almost_equal)
 
 

--- a/sklearn/linear_model/tests/test_ransac.py
+++ b/sklearn/linear_model/tests/test_ransac.py
@@ -2,7 +2,6 @@ import pytest
 import numpy as np
 from scipy import sparse
 
-from numpy.testing import assert_equal
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
 

--- a/sklearn/linear_model/tests/test_theil_sen.py
+++ b/sklearn/linear_model/tests/test_theil_sen.py
@@ -16,9 +16,7 @@ from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import LinearRegression, TheilSenRegressor
 from sklearn.linear_model.theil_sen import _spatial_median, _breakdown_point
 from sklearn.linear_model.theil_sen import _modified_weiszfeld_step
-from sklearn.utils.testing import (
-        assert_almost_equal, assert_greater, assert_less, assert_raises,
-)
+from sklearn.utils.testing import assert_almost_equal, assert_raises
 
 
 @contextmanager

--- a/sklearn/manifold/tests/test_isomap.py
+++ b/sklearn/manifold/tests/test_isomap.py
@@ -1,7 +1,6 @@
 from itertools import product
 import numpy as np
-from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
-                           assert_equal)
+from numpy.testing import assert_almost_equal, assert_array_almost_equal
 
 from sklearn import datasets
 from sklearn import manifold

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -16,9 +16,7 @@ from sklearn.metrics.cluster.supervised import _generalized_average
 
 from sklearn.utils import assert_all_finite
 from sklearn.utils.testing import (
-        assert_equal, assert_almost_equal, assert_raise_message,
-        ignore_warnings
-)
+        assert_almost_equal, assert_raise_message, ignore_warnings)
 from numpy.testing import assert_array_almost_equal
 
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1248,7 +1248,7 @@ def test_check_cv():
     cv = check_cv(3, classifier=False)
     # Use numpy.testing.assert_equal which recursively compares
     # lists of lists
-    np.testing.assert_equal(list(KFold(3).split(X)), list(cv.split(X)))
+    assert list(KFold(3).split(X)) ==  list(cv.split(X))
 
     y_binary = np.array([0, 1, 0, 1, 0, 0, 1, 1, 1])
     cv = check_cv(3, y_binary, classifier=True)

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1248,7 +1248,7 @@ def test_check_cv():
     cv = check_cv(3, classifier=False)
     # Use numpy.testing.assert_equal which recursively compares
     # lists of lists
-    assert list(KFold(3).split(X)) ==  list(cv.split(X))
+    np.testing.assert_equal(list(KFold(3).split(X)), list(cv.split(X)))
 
     y_binary = np.array([0, 1, 0, 1, 0, 0, 1, 1, 1])
     cv = check_cv(3, y_binary, classifier=True)

--- a/sklearn/neighbors/tests/test_kde.py
+++ b/sklearn/neighbors/tests/test_kde.py
@@ -2,8 +2,7 @@ import numpy as np
 
 import pytest
 
-from sklearn.utils.testing import (assert_allclose, assert_raises,
-                                   assert_equal)
+from sklearn.utils.testing import assert_allclose, assert_raises
 from sklearn.neighbors import KernelDensity, KDTree, NearestNeighbors
 from sklearn.neighbors.ball_tree import kernel_norm
 from sklearn.pipeline import make_pipeline

--- a/sklearn/neighbors/tests/test_nca.py
+++ b/sklearn/neighbors/tests/test_nca.py
@@ -15,7 +15,7 @@ from scipy.optimize import check_grad
 from sklearn import clone
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils import check_random_state
-from sklearn.utils.testing import (assert_raises, assert_equal,
+from sklearn.utils.testing import (assert_raises,
                                    assert_raise_message, assert_warns_message)
 from sklearn.datasets import load_iris, make_classification, make_blobs
 from sklearn.neighbors.nca import NeighborhoodComponentsAnalysis

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -5,7 +5,6 @@ Testing for the nearest centroid module.
 import numpy as np
 from scipy import sparse as sp
 from numpy.testing import assert_array_equal
-from numpy.testing import assert_equal
 
 from sklearn.neighbors import NearestCentroid
 from sklearn import datasets

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -23,8 +23,7 @@ from sklearn.neural_network import MLPRegressor
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.preprocessing import StandardScaler, MinMaxScaler
 from scipy.sparse import csr_matrix
-from sklearn.utils.testing import (assert_raises, assert_greater,
-                                   assert_equal, ignore_warnings)
+from sklearn.utils.testing import assert_raises, ignore_warnings
 from sklearn.utils.testing import assert_raise_message
 
 

--- a/sklearn/neural_network/tests/test_stochastic_optimizers.py
+++ b/sklearn/neural_network/tests/test_stochastic_optimizers.py
@@ -3,7 +3,7 @@ import numpy as np
 from sklearn.neural_network._stochastic_optimizers import (BaseOptimizer,
                                                            SGDOptimizer,
                                                            AdamOptimizer)
-from sklearn.utils.testing import (assert_array_equal, assert_equal)
+from sklearn.utils.testing import assert_array_equal
 
 
 shapes = [(4, 6), (6, 8), (7, 8, 9)]

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -3,7 +3,7 @@ import numpy as np
 from scipy import sparse
 
 from sklearn.preprocessing import FunctionTransformer
-from sklearn.utils.testing import (assert_equal, assert_array_equal,
+from sklearn.utils.testing import (assert_array_equal,
                                    assert_allclose_dense_sparse)
 from sklearn.utils.testing import assert_warns_message, assert_no_warnings
 
@@ -30,20 +30,11 @@ def test_delegate_to_func():
     )
 
     # The function should only have received X.
-    assert_equal(
-        args_store,
-        [X],
-        'Incorrect positional arguments passed to func: {args}'.format(
-            args=args_store,
-        ),
-    )
-    assert_equal(
-        kwargs_store,
-        {},
-        'Unexpected keyword arguments passed to func: {args}'.format(
-            args=kwargs_store,
-        ),
-    )
+    assert args_store == [X], ('Incorrect positional arguments passed to '
+                               'func: {args}'.format(args=args_store))
+
+    assert not kwargs_store, ('Unexpected keyword arguments passed to '
+                              'func: {args}'.format(args=kwargs_store))
 
     # reset the argument stores.
     args_store[:] = []
@@ -56,20 +47,11 @@ def test_delegate_to_func():
                        err_msg='transform should have returned X unchanged')
 
     # The function should have received X
-    assert_equal(
-        args_store,
-        [X],
-        'Incorrect positional arguments passed to func: {args}'.format(
-            args=args_store,
-        ),
-    )
-    assert_equal(
-        kwargs_store,
-        {},
-        'Unexpected keyword arguments passed to func: {args}'.format(
-            args=kwargs_store,
-        ),
-    )
+    assert args_store == [X], ('Incorrect positional arguments passed '
+                               'to func: {args}'.format(args=args_store))
+
+    assert not kwargs_store, ('Unexpected keyword arguments passed to '
+                              'func: {args}'.format(args=kwargs_store))
 
 
 def test_np_log():

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -381,7 +381,7 @@ class BaseRandomProjection(BaseEstimator, TransformerMixin, metaclass=ABCMeta):
                                                     n_features)
 
         # Check contract
-        assert (self.components_.shape == (self.n_components_, n_features),
+        assert self.components_.shape == (self.n_components_, n_features), (
                 'An error has occurred the self.components_ matrix has '
                 ' not the proper shape.')
 

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -31,7 +31,6 @@ import warnings
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
-from numpy.testing import assert_equal
 import scipy.sparse as sp
 
 from .base import BaseEstimator, TransformerMixin
@@ -382,11 +381,9 @@ class BaseRandomProjection(BaseEstimator, TransformerMixin, metaclass=ABCMeta):
                                                     n_features)
 
         # Check contract
-        assert_equal(
-            self.components_.shape,
-            (self.n_components_, n_features),
-            err_msg=('An error has occurred the self.components_ matrix has '
-                     ' not the proper shape.'))
+        assert (self.components_.shape == (self.n_components_, n_features),
+                'An error has occurred the self.components_ matrix has '
+                ' not the proper shape.')
 
         return self
 

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -1,8 +1,7 @@
 import pytest
 
 import numpy as np
-from numpy.testing import (assert_array_almost_equal, assert_array_equal,
-                           assert_equal)
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 from scipy import sparse
 
 from sklearn import datasets, svm, linear_model, base

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -8,9 +8,8 @@ from scipy import sparse
 from sklearn.base import BaseEstimator
 from sklearn.model_selection import LeaveOneOut
 
-from sklearn.utils.testing import (assert_array_almost_equal, assert_equal,
-                                   assert_greater, assert_almost_equal,
-                                   assert_greater_equal,
+from sklearn.utils.testing import (assert_array_almost_equal,
+                                   assert_almost_equal,
                                    assert_array_equal,
                                    assert_raises, ignore_warnings)
 from sklearn.datasets import make_classification, make_blobs

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -8,7 +8,6 @@ from sklearn.isotonic import (check_increasing, isotonic_regression,
 
 from sklearn.utils.validation import check_array
 from sklearn.utils.testing import (assert_raises, assert_array_equal,
-                                   assert_equal,
                                    assert_array_almost_equal,
                                    assert_warns_message, assert_no_warnings)
 from sklearn.utils import shuffle

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -11,8 +11,8 @@ from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.tree import export_graphviz, plot_tree, export_text
 from io import StringIO
-from sklearn.utils.testing import (assert_in, assert_equal, assert_raises,
-                                   assert_less_equal, assert_raises_regex,
+from sklearn.utils.testing import (assert_raises,
+                                   assert_raises_regex,
                                    assert_raise_message)
 from sklearn.exceptions import NotFittedError
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -16,17 +16,12 @@ from . import IS_PYPY
 from .testing import assert_raises, _get_args
 from .testing import assert_raises_regex
 from .testing import assert_raise_message
-from .testing import assert_equal
-from .testing import assert_not_equal
-from .testing import assert_in
 from .testing import assert_array_equal
 from .testing import assert_array_almost_equal
 from .testing import assert_allclose
 from .testing import assert_allclose_dense_sparse
 from .testing import assert_warns_message
 from .testing import set_random_state
-from .testing import assert_greater
-from .testing import assert_greater_equal
 from .testing import SkipTest
 from .testing import ignore_warnings
 from .testing import assert_dict_equal

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -61,25 +61,22 @@ __all__ = ["assert_equal", "assert_not_equal", "assert_raises",
            "assert_run_python_script", "SkipTest"]
 
 _dummy = TestCase('__init__')
-assert_equal = _dummy.assertEqual
-assert_not_equal = _dummy.assertNotEqual
+deprecation_message = (
+    'This helper is deprecated in version 0.22 and will be removed in version '
+    '0.24. Please use "assert" instead'
+)
+assert_equal = deprecated(deprecation_message)(_dummy.assertEqual)
+assert_not_equal = deprecated(deprecation_message)(_dummy.assertNotEqual)
 assert_raises = _dummy.assertRaises
 SkipTest = unittest.case.SkipTest
 assert_dict_equal = _dummy.assertDictEqual
-assert_in = _dummy.assertIn
-assert_not_in = _dummy.assertNotIn
-assert_less = _dummy.assertLess
-assert_greater = _dummy.assertGreater
-assert_less_equal = _dummy.assertLessEqual
-assert_greater_equal = _dummy.assertGreaterEqual
-
-
-for function_name in ('assert_equal', 'assert_not_equal', 'assert_greater',
-                      'assert_greater_equal', 'assert_less',
-                      'assert_less_equal', 'assert_in', 'assert_not_in'):
-    msg = ('{} is deprecated in version 0.22 ans will be removed in version '
-           '0.24. Please use "assert" instead'.format(function_name))
-    globals()[function_name] = deprecated(msg)(globals()[function_name])
+assert_in = deprecated(deprecation_message)(_dummy.assertIn)
+assert_not_in = deprecated(deprecation_message)(_dummy.assertNotIn)
+assert_less = deprecated(deprecation_message)(_dummy.assertLess)
+assert_greater = deprecated(deprecation_message)(_dummy.assertGreater)
+assert_less_equal = deprecated(deprecation_message)(_dummy.assertLessEqual)
+assert_greater_equal = deprecated(deprecation_message)(
+    _dummy.assertGreaterEqual)
 
 assert_raises_regex = _dummy.assertRaisesRegex
 # assert_raises_regexp is deprecated in Python 3.4 in favor of

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -73,6 +73,13 @@ assert_greater = _dummy.assertGreater
 assert_less_equal = _dummy.assertLessEqual
 assert_greater_equal = _dummy.assertGreaterEqual
 
+for function_name in ('assert_equal', 'assert_not_equal', 'assert_greater',
+                      'assert_greater_equal', 'assert_less',
+                      'assert_less_equal', 'assert_in', 'assert_not_in'):
+    msg = ('{} is deprecated in version 0.22 ans will be removed in version '
+           '0.24. Please use "assert" instead'.format(function_name))
+    globals()[function_name] = deprecated(msg)(globals()[function_name])
+
 assert_raises_regex = _dummy.assertRaisesRegex
 # assert_raises_regexp is deprecated in Python 3.4 in favor of
 # assert_raises_regex but lets keep the backward compat in scikit-learn with

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -73,6 +73,7 @@ assert_greater = _dummy.assertGreater
 assert_less_equal = _dummy.assertLessEqual
 assert_greater_equal = _dummy.assertGreaterEqual
 
+
 for function_name in ('assert_equal', 'assert_not_equal', 'assert_greater',
                       'assert_greater_equal', 'assert_less',
                       'assert_less_equal', 'assert_in', 'assert_not_in'):

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -10,7 +10,7 @@ from io import StringIO
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils import deprecated
 from sklearn.utils.testing import (assert_raises_regex,
-                                   assert_equal, ignore_warnings,
+                                   ignore_warnings,
                                    assert_warns, assert_raises)
 from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.estimator_checks \

--- a/sklearn/utils/tests/test_random.py
+++ b/sklearn/utils/tests/test_random.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_array_almost_equal
 from sklearn.utils.fixes import comb
 from sklearn.utils.random import random_choice_csc, sample_without_replacement
 from sklearn.utils._random import _our_rand_r_py
-from sklearn.utils.testing import (assert_equal, assert_raises)
+from sklearn.utils.testing import assert_raises
 
 
 ###############################################################################

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -3,9 +3,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from scipy import linalg
-from numpy.testing import (assert_array_almost_equal,
-                           assert_array_equal,
-                           assert_equal)
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 from numpy.random import RandomState
 
 from sklearn.datasets import make_classification

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -666,7 +666,7 @@ def test_create_memmap_backed_data(monkeypatch):
     (assert_in, (0, [0])),
     (assert_not_in, (0, [1]))])
 def test_deprecated_helpers(callable, args):
-    msg = ('is deprecated in version 0.22 ans will be removed in version '
+    msg = ('is deprecated in version 0.22 and will be removed in version '
            '0.24. Please use "assert" instead')
     with pytest.warns(DeprecationWarning, match=msg):
         callable(*args)

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -39,22 +39,26 @@ from sklearn.tree import DecisionTreeClassifier
 from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
 
 
+@pytest.mark.filterwarnings("ignore", category=DeprecationWarning)  # 0.24
 def test_assert_less():
     assert 0 < 1
     assert_raises(AssertionError, assert_less, 1, 0)
 
 
+@pytest.mark.filterwarnings("ignore", category=DeprecationWarning)  # 0.24
 def test_assert_greater():
     assert 1 > 0
     assert_raises(AssertionError, assert_greater, 0, 1)
 
 
+@pytest.mark.filterwarnings("ignore", category=DeprecationWarning)  # 0.24
 def test_assert_less_equal():
     assert 0 <= 1
     assert 1 <= 1
     assert_raises(AssertionError, assert_less_equal, 1, 0)
 
 
+@pytest.mark.filterwarnings("ignore", category=DeprecationWarning)  # 0.24
 def test_assert_greater_equal():
     assert 1 >= 0
     assert 1 >= 1

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -20,7 +20,6 @@ from sklearn.utils.testing import (
     assert_greater_equal,
     assert_warns,
     assert_no_warnings,
-    assert_equal,
     set_random_state,
     assert_raise_message,
     ignore_warnings,

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -645,3 +645,24 @@ def test_create_memmap_backed_data(monkeypatch):
     for input_array, data in zip(input_list, mmap_data_list):
         check_memmap(input_array, data)
     assert registration_counter.nb_calls == 4
+
+
+# 0.24
+from sklearn.utils.testing import (assert_equal, assert_not_equal,
+                                   assert_greater, assert_greater_equal,
+                                   assert_less, assert_less_equal,
+                                   assert_in, assert_not_in)
+@pytest.mark.parametrize('callable, args', [
+    (assert_equal, (0, 0)),
+    (assert_not_equal, (0, 1)),
+    (assert_greater, (1, 0)),
+    (assert_greater_equal, (1, 0)),
+    (assert_less, (0, 1)),
+    (assert_less_equal, (0, 1)),
+    (assert_in, (0, [0])),
+    (assert_not_in, (0, [1]))])
+def test_deprecated_helpers(callable, args):
+    msg = ('is deprecated in version 0.22 ans will be removed in version '
+           '0.24. Please use "assert" instead')
+    with pytest.warns(DeprecationWarning, match=msg):
+        callable(*args)

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -20,6 +20,10 @@ from sklearn.utils.testing import (
     assert_greater_equal,
     assert_warns,
     assert_no_warnings,
+    assert_equal,
+    assert_not_equal,
+    assert_in,
+    assert_not_in,
     set_random_state,
     assert_raise_message,
     ignore_warnings,
@@ -648,10 +652,6 @@ def test_create_memmap_backed_data(monkeypatch):
 
 
 # 0.24
-from sklearn.utils.testing import (assert_equal, assert_not_equal,
-                                   assert_greater, assert_greater_equal,
-                                   assert_less, assert_less_equal,
-                                   assert_in, assert_not_in)
 @pytest.mark.parametrize('callable, args', [
     (assert_equal, (0, 0)),
     (assert_not_equal, (0, 1)),

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -7,7 +7,7 @@ import pytest
 import numpy as np
 import scipy.sparse as sp
 
-from sklearn.utils.testing import (assert_equal, assert_raises,
+from sklearn.utils.testing import (assert_raises,
                                    assert_array_equal,
                                    SkipTest, assert_raises_regex,
                                    assert_warns_message, assert_no_warnings)


### PR DESCRIPTION
Addresses (and closes?) https://github.com/scikit-learn/scikit-learn/issues/14215

Follow up to #14222 

There are still a few occurrences of `np.testing.assert_equal` but I guess it's worth keeping: it is used to deeply compare lists.

This PR also deprecates:

- assert_equal
- assert_not_equal
- assert_in
- assert_not_in
- assert_greater
- assert_less
- assert_greater_equal
- assert_less_equal