### PR TITLE
FIX silence warning in IterativeImputer when constant feature in data

### DIFF
--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -430,7 +430,11 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
         if (self.n_nearest_features is None or
                 self.n_nearest_features >= n_features):
             return None
-        abs_corr_mat = np.abs(np.corrcoef(X_filled.T))
+        with np.errstate(invalid='ignore'):
+            # if a feature in the neighboorhood has only a single value
+            # (e.g., categorical feature), the std. dev. will be null and
+            # np.corrcoef will raise a warning due to a division by zero
+            abs_corr_mat = np.abs(np.corrcoef(X_filled.T))
         # np.corrcoef is not defined for features with zero std
         abs_corr_mat[np.isnan(abs_corr_mat)] = tolerance
         # ensures exploration, i.e. at least some probability of sampling

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -16,6 +16,7 @@ from sklearn.utils.testing import assert_array_almost_equal
 # make IterativeImputer available
 from sklearn.experimental import enable_iterative_imputer  # noqa
 
+from sklearn.datasets import load_boston
 from sklearn.impute import MissingIndicator
 from sklearn.impute import SimpleImputer, IterativeImputer
 from sklearn.dummy import DummyRegressor
@@ -922,6 +923,32 @@ def test_iterative_imputer_early_stopping():
                                random_state=rng)
     imputer.fit(X_missing)
     assert imputer.n_iter_ == imputer.max_iter
+
+
+def test_iterative_imputer_catch_warning():
+    # check that we catch a RuntimeWarning due to a division by zero when a
+    # feature is constant in the dataset
+    X, y = load_boston(return_X_y=True)
+    n_samples, n_features = X.shape
+
+    # simulate that a feature only contain one category during fit
+    X[:, 3] = 1
+
+    # add some missing values
+    rng = np.random.RandomState(0)
+    missing_rate = 0.15
+    for feat in range(n_features):
+        sample_idx = rng.choice(
+            np.arange(n_samples), size=int(n_samples * missing_rate),
+            replace=False
+        )
+        X[sample_idx, feat] = np.nan
+
+    imputer = IterativeImputer(n_nearest_features=5, sample_posterior=True)
+    with pytest.warns(None) as record:
+        X_fill = imputer.fit_transform(X, y)
+    assert not record.list
+    assert not np.any(np.isnan(X_fill))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Follow-up on #14148

If a feature is constant, a `true_divide` `RuntimeWarning` is raised. This PR silent it.

ping @jnothman @sergeyf @adrinjalali 