### PR TITLE
DOC make explicit that groups required *Group* splitter

### DIFF
--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -476,7 +476,8 @@ class RFECV(RFE, MetaEstimatorMixin):
 
         groups : array-like, shape = [n_samples], optional
             Group labels for the samples used while splitting the dataset into
-            train/test set.
+            train/test set. Only used in conjunction with a "Group" `cv`
+            instance (e.g., `GroupKFold`).
         """
         X, y = check_X_y(X, y, "csr", ensure_min_features=2)
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -596,7 +596,8 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
 
         groups : array-like, with shape (n_samples,), optional
             Group labels for the samples used while splitting the dataset into
-            train/test set.
+            train/test set. Only used in conjunction with a "Group" `cv`
+            instance (e.g., `GroupKFold`).
 
         **fit_params : dict of string -> object
             Parameters passed to the ``fit`` method of the estimator

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -56,7 +56,8 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv=None,
 
     groups : array-like, with shape (n_samples,), optional
         Group labels for the samples used while splitting the dataset into
-        train/test set.
+        train/test set. Only used in conjunction with a "Group" `cv` instance
+        (e.g., `GroupKFold`).
 
     scoring : string, callable, list/tuple, dict or None, default: None
         A single string (see :ref:`scoring_parameter`) or a callable
@@ -271,7 +272,8 @@ def cross_val_score(estimator, X, y=None, groups=None, scoring=None, cv=None,
 
     groups : array-like, with shape (n_samples,), optional
         Group labels for the samples used while splitting the dataset into
-        train/test set.
+        train/test set. Only used in conjunction with a "Group" `cv` instance
+        (e.g., `GroupKFold`).
 
     scoring : string, callable or None, optional, default: None
         A string (see model evaluation documentation) or
@@ -644,7 +646,8 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv=None,
 
     groups : array-like, with shape (n_samples,), optional
         Group labels for the samples used while splitting the dataset into
-        train/test set.
+        train/test set. Only used in conjunction with a "Group" `cv` instance
+        (e.g., `GroupKFold`).
 
     cv : int, cross-validation generator or an iterable, optional
         Determines the cross-validation splitting strategy.
@@ -1123,7 +1126,8 @@ def learning_curve(estimator, X, y, groups=None,
 
     groups : array-like, with shape (n_samples,), optional
         Group labels for the samples used while splitting the dataset into
-        train/test set.
+        train/test set. Only used in conjunction with a "Group" `cv` instance
+        (e.g., `GroupKFold`).
 
     train_sizes : array-like, shape (n_ticks,), dtype float or int
         Relative or absolute numbers of training examples that will be used to
@@ -1409,7 +1413,8 @@ def validation_curve(estimator, X, y, param_name, param_range, groups=None,
 
     groups : array-like, with shape (n_samples,), optional
         Group labels for the samples used while splitting the dataset into
-        train/test set.
+        train/test set. Only used in conjunction with a "Group" `cv` instance
+        (e.g., `GroupKFold`).
 
     cv : int, cross-validation generator or an iterable, optional
         Determines the cross-validation splitting strategy.


### PR DESCRIPTION
closes #11406

Make explicit that the parameter `groups` requires *Group* splitter from `model_selection`.