### PR TITLE
[MRG] MAINT Pins pytest version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,6 @@ jobs:
         DISTRIB: 'ubuntu'
         PYTHON_VERSION: '3.5'
         JOBLIB_VERSION: '0.11'
-        PYTEST_VERSION: '3.8.1'
         SKLEARN_NO_OPENMP: 'True'
       # Linux + Python 3.5 build with OpenBLAS and without SITE_JOBLIB
       py35_conda_openblas:
@@ -23,7 +22,6 @@ jobs:
         SCIPY_VERSION: '0.17.0'
         CYTHON_VERSION: '*'
         PILLOW_VERSION: '4.0.0'
-        PYTEST_VERSION: '3.8.1'
         MATPLOTLIB_VERSION: '1.5.1'
         # later version of joblib are not packaged in conda for Python 3.5
         JOBLIB_VERSION: '0.12.3'
@@ -41,6 +39,7 @@ jobs:
         PYAMG_VERSION: '*'
         PILLOW_VERSION: '*'
         JOBLIB_VERSION: '*'
+        PYTEST_VERSION: '4.6.2'
         MATPLOTLIB_VERSION: '*'
         COVERAGE: 'true'
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
@@ -71,6 +70,7 @@ jobs:
         SCIPY_VERSION: '*'
         CYTHON_VERSION: '*'
         PILLOW_VERSION: '*'
+        PYTEST_VERSION: '4.6.2'
         JOBLIB_VERSION: '*'
         COVERAGE: 'true'
 
@@ -83,6 +83,7 @@ jobs:
         PYTHON_VERSION: '3.7'
         CHECK_WARNINGS: 'true'
         PYTHON_ARCH: '64'
+        PYTEST_VERSION: '4.6.2'
         COVERAGE: 'true'
       py35_32:
         PYTHON_VERSION: '3.5'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ jobs:
         DISTRIB: 'ubuntu'
         PYTHON_VERSION: '3.5'
         JOBLIB_VERSION: '0.11'
+        PYTEST_VERSION: '3.8.1'
         SKLEARN_NO_OPENMP: 'True'
       # Linux + Python 3.5 build with OpenBLAS and without SITE_JOBLIB
       py35_conda_openblas:
@@ -22,6 +23,7 @@ jobs:
         SCIPY_VERSION: '0.17.0'
         CYTHON_VERSION: '*'
         PILLOW_VERSION: '4.0.0'
+        PYTEST_VERSION: '3.8.1'
         MATPLOTLIB_VERSION: '1.5.1'
         # later version of joblib are not packaged in conda for Python 3.5
         JOBLIB_VERSION: '0.12.3'

--- a/build_tools/azure/install.cmd
+++ b/build_tools/azure/install.cmd
@@ -11,7 +11,7 @@ IF "%PYTHON_ARCH%"=="64" (
     call deactivate
     @rem Clean up any left-over from a previous build
     conda remove --all -q -y -n %VIRTUALENV%
-    conda create -n %VIRTUALENV% -q -y python=%PYTHON_VERSION% numpy scipy cython matplotlib pytest wheel pillow joblib pytest-xdist
+    conda create -n %VIRTUALENV% -q -y python=%PYTHON_VERSION% numpy scipy cython matplotlib pytest=%PYTEST_VERSION% wheel pillow joblib pytest-xdist
 
     call activate %VIRTUALENV%
 ) else (

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -25,7 +25,7 @@ make_conda() {
 }
 
 if [[ "$DISTRIB" == "conda" ]]; then
-    TO_INSTALL="python=$PYTHON_VERSION pip pytest pytest-cov \
+    TO_INSTALL="python=$PYTHON_VERSION pip pytest=$PYTEST_VERSION pytest-cov \
                 numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
                 cython=$CYTHON_VERSION joblib=$JOBLIB_VERSION"
 
@@ -62,13 +62,13 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     sudo apt-get install python3-scipy python3-matplotlib libatlas3-base libatlas-base-dev libatlas-dev python3-virtualenv
     python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
     source $VIRTUALENV/bin/activate
-    python -m pip install pytest pytest-cov cython joblib==$JOBLIB_VERSION
+    python -m pip install pytest==$PYTEST_VERSION pytest-cov cython joblib==$JOBLIB_VERSION
 elif [[ "$DISTRIB" == "ubuntu-32" ]]; then
     apt-get update
     apt-get install -y python3-dev python3-scipy python3-matplotlib libatlas3-base libatlas-base-dev libatlas-dev python3-virtualenv
     python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
     source $VIRTUALENV/bin/activate
-    python -m pip install pytest pytest-cov cython joblib==$JOBLIB_VERSION
+    python -m pip install pytest==$PYTEST_VERSION pytest-cov cython joblib==$JOBLIB_VERSION
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -11,6 +11,7 @@ jobs:
     TEST_DIR: '$(Agent.WorkFolder)/tmp_folder'
     JUNITXML: 'test-data.xml'
     OMP_NUM_THREADS: '4'
+    PYTEST_VERSION: '4.6.2'
     OPENBLAS_NUM_THREADS: '4'
     SKLEARN_SKIP_NETWORK_TESTS: '1'
   strategy:
@@ -33,6 +34,7 @@ jobs:
         -e JUNITXML=$JUNITXML
         -e VIRTUALENV=testvenv
         -e JOBLIB_VERSION=$JOBLIB_VERSION
+        -e PYTEST_VERSION=$PYTEST_VERSION
         -e SKLEARN_NO_OPENMP=$SKLEARN_NO_OPENMP
         -e OMP_NUM_THREADS=$OMP_NUM_THREADS
         -e OPENBLAS_NUM_THREADS=$OPENBLAS_NUM_THREADS

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -11,7 +11,7 @@ jobs:
     TEST_DIR: '$(Agent.WorkFolder)/tmp_folder'
     JUNITXML: 'test-data.xml'
     OMP_NUM_THREADS: '4'
-    PYTEST_VERSION: '4.6.2'
+    PYTEST_VERSION: '3.8.1'
     OPENBLAS_NUM_THREADS: '4'
     SKLEARN_SKIP_NETWORK_TESTS: '1'
   strategy:

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -11,6 +11,7 @@ jobs:
     TEST_DIR: '$(Agent.WorkFolder)/tmp_folder'
     VIRTUALENV: 'testvenv'
     JUNITXML: 'test-data.xml'
+    PYTEST_VERSION: '4.6.2'
     OMP_NUM_THREADS: '4'
     OPENBLAS_NUM_THREADS: '4'
     SKLEARN_SKIP_NETWORK_TESTS: '1'

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -11,7 +11,7 @@ jobs:
     TEST_DIR: '$(Agent.WorkFolder)/tmp_folder'
     VIRTUALENV: 'testvenv'
     JUNITXML: 'test-data.xml'
-    PYTEST_VERSION: '4.6.2'
+    PYTEST_VERSION: '3.8.1'
     OMP_NUM_THREADS: '4'
     OPENBLAS_NUM_THREADS: '4'
     SKLEARN_SKIP_NETWORK_TESTS: '1'

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -12,7 +12,7 @@ jobs:
     VIRTUALENV: 'testvenv'
     JUNITXML: 'test-data.xml'
     SKLEARN_SKIP_NETWORK_TESTS: '1'
-    PYTEST_VERSION: '4.6.2'
+    PYTEST_VERSION: '3.8.1'
     TMP_FOLDER: '$(Agent.WorkFolder)\tmp_folder'
   strategy:
     matrix:

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -12,6 +12,7 @@ jobs:
     VIRTUALENV: 'testvenv'
     JUNITXML: 'test-data.xml'
     SKLEARN_SKIP_NETWORK_TESTS: '1'
+    PYTEST_VERSION: '4.6.2'
     TMP_FOLDER: '$(Agent.WorkFolder)\tmp_folder'
   strategy:
     matrix:


### PR DESCRIPTION
After pytest was updated to `5.0.0` there has been errors such as: https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=4635

This happened before when pytest was updated from `3.*` to `4.*`. This PR pins the pytest version to `3.*` for python 3.5 (the newest version available on conda) and `4.*` on the latest python version.