### PR TITLE
Use LaTeX for phi in KernelCenterer documentation

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -250,10 +250,10 @@ Centering kernel matrices
 -------------------------
 
 If you have a kernel matrix of a kernel :math:`K` that computes a dot product
-in a feature space defined by function :math:`phi`,
+in a feature space defined by function :math:`\phi`,
 a :class:`KernelCenterer` can transform the kernel matrix
 so that it contains inner products in the feature space
-defined by :math:`phi` followed by removal of the mean in that space.
+defined by :math:`\phi` followed by removal of the mean in that space.
 
 .. _preprocessing_transformer:
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This small PR brings small changes to the docstring and documentation section of `KernelCenterer` for a better rendition using LaTeX.
