### PR TITLE
Mention intel conda channel in installation doc

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -230,6 +230,25 @@ library for Windows, Mac OSX and Linux.
 Anaconda offers scikit-learn as part of its free distribution.
 
 
+Intel conda channel
+-------------------
+
+Intel maintains a dedicated conda channel that ships scikit-learn::
+
+    $ conda install -c scikit-learn
+
+This version of scikit-learn comes with alternative solvers for some common
+estimators. Those solvers come from the DAAL C++ library and are optimized for
+multi-core CPUs.
+
+Note that those solvers are not enabled by default, please refer to the
+[daal4py](https://intelpython.github.io/daal4py/sklearn.html) documentation for
+more details.
+
+Compatibility with the standard scikit-learn solvers is checked via automated
+continuous integration as reported on https://github.com/IntelPython/daal4py.
+
+
 WinPython for Windows
 -----------------------
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -235,7 +235,7 @@ Intel conda channel
 
 Intel maintains a dedicated conda channel that ships scikit-learn::
 
-    $ conda install -c scikit-learn
+    $ conda install -c intel scikit-learn
 
 This version of scikit-learn comes with alternative solvers for some common
 estimators. Those solvers come from the DAAL C++ library and are optimized for

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -242,8 +242,8 @@ estimators. Those solvers come from the DAAL C++ library and are optimized for
 multi-core CPUs.
 
 Note that those solvers are not enabled by default, please refer to the
-[daal4py](https://intelpython.github.io/daal4py/sklearn.html) documentation for
-more details.
+`daal4py <https://intelpython.github.io/daal4py/sklearn.html>`_ documentation
+for more details.
 
 Compatibility with the standard scikit-learn solvers is checked by running the
 full scikit-learn test suite via automated continuous integration as reported

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -239,7 +239,7 @@ Intel maintains a dedicated conda channel that ships scikit-learn::
 
 This version of scikit-learn comes with alternative solvers for some common
 estimators. Those solvers come from the DAAL C++ library and are optimized for
-multi-core CPUs.
+multi-core Intel CPUs.
 
 Note that those solvers are not enabled by default, please refer to the
 `daal4py <https://intelpython.github.io/daal4py/sklearn.html>`_ documentation

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -245,8 +245,9 @@ Note that those solvers are not enabled by default, please refer to the
 [daal4py](https://intelpython.github.io/daal4py/sklearn.html) documentation for
 more details.
 
-Compatibility with the standard scikit-learn solvers is checked via automated
-continuous integration as reported on https://github.com/IntelPython/daal4py.
+Compatibility with the standard scikit-learn solvers is checked by running the
+full scikit-learn test suite via automated continuous integration as reported
+on https://github.com/IntelPython/daal4py.
 
 
 WinPython for Windows


### PR DESCRIPTION
Update the scikit-learn installation doc to mention the intel conda channel maintained by @oleksandr-pavlyk and his colleagues. This channel ships a scikit-learn version with the daal4py solvers.

https://intelpython.github.io/daal4py/sklearn.html

For information the daal4py solvers often bring significant speed ups on Xeon machines with many cores, in particular for K-Means and SVMs:

https://github.com/IntelPython/scikit-learn_bench

The speed difference for K-Means should be reduced once #11950 is merged. The speed difference for SVM might be reduced if we add multi-threading to the libsvm solvers potentially via openmp.