### PR TITLE
Use common convergence checks for lbfgs solver

### DIFF
--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -4,12 +4,11 @@
 #
 # License: BSD 3 clause
 
-import warnings
 from operator import itemgetter
 
 import numpy as np
 from scipy.linalg import cholesky, cho_solve, solve
-from scipy.optimize import fmin_l_bfgs_b
+from scipy import optimize
 from scipy.special import erf, expit
 
 from ..base import BaseEstimator, ClassifierMixin, clone
@@ -17,9 +16,9 @@ from .kernels \
     import RBF, CompoundKernel, ConstantKernel as C
 from ..utils.validation import check_X_y, check_is_fitted, check_array
 from ..utils import check_random_state
+from ..utils.optimize import _check_optimize_result
 from ..preprocessing import LabelEncoder
 from ..multiclass import OneVsRestClassifier, OneVsOneClassifier
-from ..exceptions import ConvergenceWarning
 
 
 # Values required for approximating the logistic sigmoid by
@@ -426,12 +425,11 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
     def _constrained_optimization(self, obj_func, initial_theta, bounds):
         if self.optimizer == "fmin_l_bfgs_b":
-            theta_opt, func_min, convergence_dict = \
-                fmin_l_bfgs_b(obj_func, initial_theta, bounds=bounds)
-            if convergence_dict["warnflag"] != 0:
-                warnings.warn("fmin_l_bfgs_b terminated abnormally with the "
-                              " state: %s" % convergence_dict,
-                              ConvergenceWarning)
+            opt_res = optimize.minimize(
+                obj_func, initial_theta, method="L-BFGS-B", jac=True,
+                bounds=bounds)
+            _check_optimize_result("lbfgs", opt_res)
+            theta_opt, func_min = opt_res.x, opt_res.fun
         elif callable(self.optimizer):
             theta_opt, func_min = \
                 self.optimizer(obj_func, initial_theta, bounds=bounds)
@@ -482,7 +480,7 @@ class GaussianProcessClassifier(BaseEstimator, ClassifierMixin):
                 # the corresponding value of the target function.
                 return theta_opt, func_min
 
-        Per default, the 'fmin_l_bfgs_b' algorithm from scipy.optimize
+        Per default, the 'L-BFGS-B' algorithm from scipy.optimize.minimize
         is used. If None is passed, the kernel's parameters are kept fixed.
         Available internal optimizers are::
 

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -8,7 +8,7 @@ from operator import itemgetter
 
 import numpy as np
 from scipy.linalg import cholesky, cho_solve, solve
-from scipy import optimize
+import scipy.optimize
 from scipy.special import erf, expit
 
 from ..base import BaseEstimator, ClassifierMixin, clone
@@ -73,7 +73,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
                 # the corresponding value of the target function.
                 return theta_opt, func_min
 
-        Per default, the 'fmin_l_bfgs_b' algorithm from scipy.optimize
+        Per default, the 'L-BFGS-B' algorithm from scipy.optimize.maximize
         is used. If None is passed, the kernel's parameters are kept fixed.
         Available internal optimizers are::
 
@@ -425,7 +425,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
     def _constrained_optimization(self, obj_func, initial_theta, bounds):
         if self.optimizer == "fmin_l_bfgs_b":
-            opt_res = optimize.minimize(
+            opt_res = scipy.optimize.minimize(
                 obj_func, initial_theta, method="L-BFGS-B", jac=True,
                 bounds=bounds)
             _check_optimize_result("lbfgs", opt_res)

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -73,7 +73,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
                 # the corresponding value of the target function.
                 return theta_opt, func_min
 
-        Per default, the 'L-BFGS-B' algorithm from scipy.optimize.maximize
+        Per default, the 'L-BFGS-B' algorithm from scipy.optimize.minimize
         is used. If None is passed, the kernel's parameters are kept fixed.
         Available internal optimizers are::
 

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -9,13 +9,14 @@ from operator import itemgetter
 
 import numpy as np
 from scipy.linalg import cholesky, cho_solve, solve_triangular
-from scipy.optimize import fmin_l_bfgs_b
+from scipy import optimize
 
 from ..base import BaseEstimator, RegressorMixin, clone
 from ..base import MultiOutputMixin
 from .kernels import RBF, ConstantKernel as C
 from ..utils import check_random_state
 from ..utils.validation import check_X_y, check_array
+from ..utils.optimize import _check_optimize_result
 from ..exceptions import ConvergenceWarning
 
 
@@ -77,7 +78,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
                 # the corresponding value of the target function.
                 return theta_opt, func_min
 
-        Per default, the 'fmin_l_bfgs_b' algorithm from scipy.optimize
+        Per default, the 'L-BGFS-B' algorithm from scipy.optimize.maximize
         is used. If None is passed, the kernel's parameters are kept fixed.
         Available internal optimizers are::
 
@@ -461,12 +462,11 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
 
     def _constrained_optimization(self, obj_func, initial_theta, bounds):
         if self.optimizer == "fmin_l_bfgs_b":
-            theta_opt, func_min, convergence_dict = \
-                fmin_l_bfgs_b(obj_func, initial_theta, bounds=bounds)
-            if convergence_dict["warnflag"] != 0:
-                warnings.warn("fmin_l_bfgs_b terminated abnormally with the "
-                              " state: %s" % convergence_dict,
-                              ConvergenceWarning)
+            opt_res = optimize.minimize(
+                obj_func, initial_theta, method="L-BFGS-B", jac=True,
+                bounds=bounds)
+            _check_optimize_result("lbfgs", opt_res)
+            theta_opt, func_min = opt_res.x, opt_res.fun
         elif callable(self.optimizer):
             theta_opt, func_min = \
                 self.optimizer(obj_func, initial_theta, bounds=bounds)

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -9,7 +9,7 @@ from operator import itemgetter
 
 import numpy as np
 from scipy.linalg import cholesky, cho_solve, solve_triangular
-from scipy import optimize
+import scipy.optimize
 
 from ..base import BaseEstimator, RegressorMixin, clone
 from ..base import MultiOutputMixin
@@ -17,7 +17,6 @@ from .kernels import RBF, ConstantKernel as C
 from ..utils import check_random_state
 from ..utils.validation import check_X_y, check_array
 from ..utils.optimize import _check_optimize_result
-from ..exceptions import ConvergenceWarning
 
 
 class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
@@ -78,7 +77,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
                 # the corresponding value of the target function.
                 return theta_opt, func_min
 
-        Per default, the 'L-BGFS-B' algorithm from scipy.optimize.maximize
+        Per default, the 'L-BGFS-B' algorithm from scipy.optimize.minimize
         is used. If None is passed, the kernel's parameters are kept fixed.
         Available internal optimizers are::
 
@@ -462,7 +461,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
 
     def _constrained_optimization(self, obj_func, initial_theta, bounds):
         if self.optimizer == "fmin_l_bfgs_b":
-            opt_res = optimize.minimize(
+            opt_res = scipy.optimize.minimize(
                 obj_func, initial_theta, method="L-BFGS-B", jac=True,
                 bounds=bounds)
             _check_optimize_result("lbfgs", opt_res)

--- a/sklearn/linear_model/huber.py
+++ b/sklearn/linear_model/huber.py
@@ -11,6 +11,7 @@ from ..utils import check_X_y
 from ..utils import check_consistent_length
 from ..utils import axis0_safe_slice
 from ..utils.extmath import safe_sparse_dot
+from ..utils.optimize import _check_optimize_result
 
 
 def _huber_loss_and_gradient(w, X, y, epsilon, alpha, sample_weight=None):
@@ -147,8 +148,8 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
         to outliers.
 
     max_iter : int, default 100
-        Maximum number of iterations that scipy.optimize.fmin_l_bfgs_b
-        should run for.
+        Maximum number of iterations that
+        ``scipy.optimize.minimize(method="L-BFGS-B")`` should run for.
 
     alpha : float, default 0.0001
         Regularization parameter.
@@ -180,7 +181,8 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
         The value by which ``|y - X'w - c|`` is scaled down.
 
     n_iter_ : int
-        Number of iterations that fmin_l_bfgs_b has run for.
+        Number of iterations that
+        ``scipy.optimize.minimize(method="L-BFGS-B")`` has run for.
 
         .. versionchanged:: 0.20
 
@@ -282,18 +284,19 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
         bounds = np.tile([-np.inf, np.inf], (parameters.shape[0], 1))
         bounds[-1][0] = np.finfo(np.float64).eps * 10
 
-        parameters, f, dict_ = optimize.fmin_l_bfgs_b(
-            _huber_loss_and_gradient, parameters,
+        opt_res = optimize.minimize(
+            _huber_loss_and_gradient, parameters, method="L-BFGS-B", jac=True,
             args=(X, y, self.epsilon, self.alpha, sample_weight),
-            maxiter=self.max_iter, pgtol=self.tol, bounds=bounds,
-            iprint=0)
-        if dict_['warnflag'] == 2:
+            options={"maxiter": self.max_iter, "gtol": self.tol, "iprint": -1},
+            bounds=bounds)
+
+        parameters = opt_res.x
+
+        if opt_res.status == 2:
             raise ValueError("HuberRegressor convergence failed:"
                              " l-BFGS-b solver terminated with %s"
-                             % dict_['task'].decode('ascii'))
-        # In scipy <= 1.0.0, nit may exceed maxiter.
-        # See https://github.com/scipy/scipy/issues/7854.
-        self.n_iter_ = min(dict_['nit'], self.max_iter)
+                             % opt_res.message)
+        self.n_iter_ = _check_optimize_result("lbfgs", opt_res, self.max_iter)
         self.scale_ = parameters[-1]
         if self.fit_intercept:
             self.intercept_ = parameters[-2]

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -9,8 +9,9 @@
 import numpy as np
 
 from abc import ABCMeta, abstractmethod
-from scipy.optimize import fmin_l_bfgs_b
 import warnings
+
+import scipy.optimize
 
 from ..base import BaseEstimator, ClassifierMixin, RegressorMixin
 from ..base import is_classifier
@@ -26,6 +27,7 @@ from ..utils.extmath import safe_sparse_dot
 from ..utils.validation import check_is_fitted
 from ..utils.multiclass import _check_partial_fit_first_call, unique_labels
 from ..utils.multiclass import type_of_target
+from ..utils.optimize import _check_optimize_result
 
 
 _STOCHASTIC_SOLVERS = ['sgd', 'adam']
@@ -458,34 +460,19 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         else:
             iprint = -1
 
-        optimal_parameters, self.loss_, d = fmin_l_bfgs_b(
-            x0=packed_coef_inter,
-            func=self._loss_grad_lbfgs,
-            maxfun=self.max_fun,
-            maxiter=self.max_iter,
-            iprint=iprint,
-            pgtol=self.tol,
-            args=(X, y, activations, deltas, coef_grads, intercept_grads))
-        self.n_iter_ = d['nit']
-        if d['warnflag'] == 1:
-            if d['nit'] >= self.max_iter:
-                warnings.warn(
-                    "LBFGS Optimizer: Maximum iterations (%d) "
-                    "reached and the optimization hasn't converged yet."
-                    % self.max_iter, ConvergenceWarning)
-            if d['funcalls'] >= self.max_fun:
-                warnings.warn(
-                    "LBFGS Optimizer: Maximum function evaluations (%d) "
-                    "reached and the optimization hasn't converged yet."
-                    % self.max_fun, ConvergenceWarning)
-        elif d['warnflag'] == 2:
-            warnings.warn(
-                "LBFGS Optimizer: Optimization hasn't converged yet, "
-                "cause of LBFGS stopping: %s."
-                % d['task'], ConvergenceWarning)
-
-
-        self._unpack(optimal_parameters)
+        opt_res = scipy.optimize.minimize(
+                self._loss_grad_lbfgs, packed_coef_inter,
+                method="L-BFGS-B", jac=True,
+                options={
+                    "maxfun": self.max_fun,
+                    "maxiter": self.max_iter,
+                    "iprint": iprint,
+                    "pgtol": self.tol
+                },
+                args=(X, y, activations, deltas, coef_grads, intercept_grads))
+        self.n_iter_ = _check_optimize_result("lbfgs", opt_res, self.max_iter)
+        self.loss_ = opt_res.fun
+        self._unpack(opt_res.x)
 
     def _fit_stochastic(self, X, y, activations, deltas, coef_grads,
                         intercept_grads, layer_units, incremental):

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -467,7 +467,7 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
                     "maxfun": self.max_fun,
                     "maxiter": self.max_iter,
                     "iprint": iprint,
-                    "pgtol": self.tol
+                    "gtol": self.tol
                 },
                 args=(X, y, activations, deltas, coef_grads, intercept_grads))
         self.n_iter_ = _check_optimize_result("lbfgs", opt_res, self.max_iter)

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -202,3 +202,27 @@ def newton_cg(grad_hess, func, grad, x0, args=(), tol=1e-4,
         warnings.warn("newton-cg failed to converge. Increase the "
                       "number of iterations.", ConvergenceWarning)
     return xk, k
+
+
+def _check_optimize_result(solver, result):
+    """Check the OptimizeResult for successful convergence
+
+    Parameters
+    ----------
+    solver: str
+       solver name. Currently only `lbfgs` (or `L-BFGS-B`) is supported.
+    result: OptimizeResult
+       result of the scipy.optimize.minimize function
+
+    Returns
+    -------
+    n_iter: int
+       number of iterations
+    """
+    # handle both scipy and scikit-learn solver names
+    if solver in ["lbfgs", "L-BFGS-B"]:
+        if result.status != 0:
+            warnings.warn("{} failed to converge. Increase the number "
+                          "of iterations.".format(solver), ConvergenceWarning)
+    else:
+        raise NotImplementedError

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -204,7 +204,7 @@ def newton_cg(grad_hess, func, grad, x0, args=(), tol=1e-4,
     return xk, k
 
 
-def _check_optimize_result(solver, result):
+def _check_optimize_result(solver, result, max_iter):
     """Check the OptimizeResult for successful convergence
 
     Parameters
@@ -224,5 +224,10 @@ def _check_optimize_result(solver, result):
         if result.status != 0:
             warnings.warn("{} failed to converge. Increase the number "
                           "of iterations.".format(solver), ConvergenceWarning)
+        # In scipy <= 1.0.0, nit may exceed maxiter.
+        # See https://github.com/scipy/scipy/issues/7854.
+        n_iter_i = min(result.nit, max_iter)
     else:
         raise NotImplementedError
+
+    return n_iter_i


### PR DESCRIPTION
First step toward https://github.com/scikit-learn/scikit-learn/issues/14248

This replaces to calls to `fmin_l_bfgs_b` with `scipy.optimize.minimize(method="L-BFGS-B")` and uses a common helper to check for convergence (for instance previously no warnings were shown in Gaussian process models). It also consistently applies the fix for `max_iter`,
```py
   	 # In scipy <= 1.0.0, nit may exceed maxiter.
     # See https://github.com/scipy/scipy/issues/7854.
     self.n_iter_ = min(dict_['nit'], self.max_iter)
```
that was not done in neural_network module. Follow up on https://github.com/scikit-learn/scikit-learn/pull/9274#pullrequestreview-256748375.

Although this PR is mostly an internal refactoring, it also fixes the above mentioned issues, and could be considered a bug fix.

The message in case of a `ConvergenceWarning` is changed, so in that sense its somewhat non backward compatible change, but because the warning type is very specific I don't know how much that matters.

**Note:** `fmin_l_bfgs_b` is now marked as [a legacy function in scipy](https://docs.scipy.org/doc/scipy/reference/optimize.html#legacy-functions),
> The functions below are not recommended for use in new scripts; all of these methods are accessible via a newer, more consistent interfaces, provided by the interfaces above.

The mapping between legacy and new parameters for the optimization result can be found [here](https://github.com/scipy/scipy/blob/v1.3.0/scipy/optimize/lbfgsb.py#L200)