### PR TITLE
[MRG] FIX ensure equivalence between resampling and sample_weight in AdaBoost

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -19,6 +19,8 @@ random sampling procedures.
 
 - :class:`decomposition.SparsePCA` where `normalize_components` has no effect
   due to deprecation.
+- :class:`ensemble.AdaBoostRegressor` internally changed the way the bootstrap
+  samples were drawn.
 
 Details are listed in the changelog below.
 
@@ -59,6 +61,10 @@ Changelog
   :class:`ensemble.HistGradientBoostingRegressor` have an additional
   parameter called `warm_start` that enables warm starting. :pr:`14012` by
   :user:`Johann Faouzi <johannfaouzi>`.
+
+- |Fix| passing `sample_weight` in `fit` in :class:`ensemble.AdaBoostRegressor`
+  is now equivalent to resampling `X` and `y` beforehand.
+  :pr:`14252` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.linear_model`
 ...........................

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -542,7 +542,7 @@ def test_adaboost_sample_weight_resampling_equivalence(adaboost, data):
     estimator1.fit(X, y=y, sample_weight=sample_weight)
     estimator2.fit(X[indices], y[indices])
 
-    assert_allclose(estimator1.predict(X), estimator2.predict(X))
     assert_allclose(
-        estimator1.estimator_weights_, estimator2.estimator_weights_
+        estimator1.estimator_weights_, estimator2.estimator_weights_,
+        rtol=1e-4
     )

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -940,7 +940,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
     >>> regr.fit(X, y)
     AdaBoostRegressor(n_estimators=100, random_state=0)
     >>> regr.feature_importances_
-    array([0.28..., 0.68..., 0.01..., 0.00...])
+    array([0.2..., 0.6..., 0.0..., 0.0...])
     >>> regr.predict([[0, 0, 0, 0]])
     array([3.0...])
     >>> regr.score(X, y)

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -940,9 +940,9 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
     >>> regr.fit(X, y)
     AdaBoostRegressor(n_estimators=100, random_state=0)
     >>> regr.feature_importances_
-    array([0.2..., 0.7..., 0.0..., 0.0... ])
+    array([0.28..., 0.68..., 0.01..., 0.00...])
     >>> regr.predict([[0, 0, 0, 0]])
-    array([3.2...])
+    array([3.0...])
     >>> regr.score(X, y)
     0.97...
 
@@ -1058,8 +1058,10 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         )
         sample_weight_bootstrap = (np.ones((n_samples,)) *
                                    np.bincount(indices, minlength=n_samples))
+        sample_weight_bootstrap /= sample_weight_bootstrap.sum()
         # combine the bootstrap sample with the original sample_weight
         sample_weight_bootstrap *= sample_weight
+        sample_weight_bootstrap /= sample_weight_bootstrap.sum()
 
         self._fit_estimator(estimator, X, y, sample_weight_bootstrap)
 

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -940,11 +940,11 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
     >>> regr.fit(X, y)
     AdaBoostRegressor(n_estimators=100, random_state=0)
     >>> regr.feature_importances_
-    array([0.284..., 0.703..., 0.006..., 0.005... ])
+    array([0.2..., 0.7..., 0.0..., 0.0... ])
     >>> regr.predict([[0, 0, 0, 0]])
-    array([3.236...])
+    array([3.2...])
     >>> regr.score(X, y)
-    0.9750...
+    0.97...
 
     See also
     --------

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -940,11 +940,11 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
     >>> regr.fit(X, y)
     AdaBoostRegressor(n_estimators=100, random_state=0)
     >>> regr.feature_importances_
-    array([0.2788..., 0.7109..., 0.0065..., 0.0036...])
+    array([0.284..., 0.703..., 0.006..., 0.005... ])
     >>> regr.predict([[0, 0, 0, 0]])
-    array([4.7972...])
+    array([3.236...])
     >>> regr.score(X, y)
-    0.9771...
+    0.9750...
 
     See also
     --------


### PR DESCRIPTION
Toward solving #14191

`AdaBoostRegressor` did not ensure that resampling `X` and `y` was equivalent to using `sample_weight`. The current changes ensure that this is true keeping the rest of the algorithm unchanged. However `AdaBoostRegressor` will now require the `base_estimator` to support `sample_weight` as does `AdaBoostClassifier`. In addition, some additional tests were fixed since they were not checking the right thing.