### PR TITLE
[MRG] enable libsvm file random sampling

### DIFF
--- a/sklearn/datasets/_svmlight_format.pyx
+++ b/sklearn/datasets/_svmlight_format.pyx
@@ -7,6 +7,8 @@
 #
 # cython: boundscheck=False, wraparound=False
 
+from libc.stdlib cimport rand
+
 import array
 from cpython cimport array
 cimport cython
@@ -22,9 +24,12 @@ np.import_array()
 cdef bytes COMMA = u','.encode('ascii')
 cdef bytes COLON = u':'.encode('ascii')
 
+cdef extern from "limits.h":
+    int RAND_MAX
 
 def _load_svmlight_file(f, dtype, bint multilabel, bint zero_based,
-                        bint query_id, long long offset, long long length):
+                        bint query_id, long long offset, long long length,
+                        float sampling_rate, np.ndarray[np.int_t, ndim=1] fis):
     cdef array.array data, indices, indptr
     cdef bytes line
     cdef char *hash_ptr
@@ -34,7 +39,17 @@ def _load_svmlight_file(f, dtype, bint multilabel, bint zero_based,
     cdef bytes qid_prefix = b'qid'
     cdef Py_ssize_t n_features
     cdef long long offset_max = offset + length if length > 0 else -1
+    cdef float sampling_threshold = RAND_MAX * sampling_rate
+    
+    if sampling_rate <= 0.0:
+        raise ValueError("Invalid sampling rate: " % sampling_rate)
+    cdef int sample_p = sampling_rate < 1.0
 
+    if fis is None:
+        index_set = None
+    else:
+        index_set = set(fis)
+    
     # Special-case float32 but use float64 for everything else;
     # the Python code will do further conversions.
     if dtype == np.float32:
@@ -69,6 +84,9 @@ def _load_svmlight_file(f, dtype, bint multilabel, bint zero_based,
         if len(line_parts) == 0:
             continue
 
+        if sample_p and rand() > sampling_threshold:
+            continue
+        
         target, features = line_parts[0], line_parts[1:]
         if multilabel:
             if COLON in target:
@@ -80,7 +98,7 @@ def _load_svmlight_file(f, dtype, bint multilabel, bint zero_based,
         else:
             array.resize_smart(labels, len(labels) + 1)
             labels[len(labels) - 1] = float(target)
-
+            
         prev_idx = -1
         n_features = len(features)
         if n_features and features[0].startswith(qid_prefix):
@@ -101,11 +119,12 @@ def _load_svmlight_file(f, dtype, bint multilabel, bint zero_based,
                 raise ValueError("Feature indices in SVMlight/LibSVM data "
                                  "file should be sorted and unique.")
 
-            array.resize_smart(indices, len(indices) + 1)
-            indices[len(indices) - 1] = idx
+            if index_set is None or idx in index_set:
+                array.resize_smart(indices, len(indices) + 1)
+                indices[len(indices) - 1] = idx
 
-            array.resize_smart(data, len(data) + 1)
-            data[len(data) - 1] = float(value)
+                array.resize_smart(data, len(data) + 1)
+                data[len(data) - 1] = float(value)
 
             prev_idx = idx
 

--- a/sklearn/datasets/tests/test_svmlight_format.py
+++ b/sklearn/datasets/tests/test_svmlight_format.py
@@ -28,6 +28,19 @@ invalidfile2 = os.path.join(currdir, "data", "svmlight_invalid_order.txt")
 pytestmark = fails_if_pypy
 
 
+def test_column_selection():
+    def assert_column_selection(zero_based):
+        fis = [2, 11]
+        X, y = load_svmlight_file(datafile, zero_based=zero_based)
+        X1, y1 = load_svmlight_file(datafile, zero_based=zero_based,
+                                    fis=fis, n_features=X.shape[1])
+        for j in fis:
+            np.testing.assert_array_equal(X.getcol(j).data, X1.getcol(j).data)
+
+    assert_column_selection(True)
+    assert_column_selection(False)
+
+
 def test_load_svmlight_file():
     X, y = load_svmlight_file(datafile)
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

It is sometimes useful to extract statistics and visualize the features in a libsvm file that is too large to be loaded entirely in memory. This PR adds an option to load_svmlight_file cython code to select rows randomly while reading the data from file. It also adds an option to select some features / columns while discarding the other.