### PR TITLE
[MRG] MAINT Pins pytest version [scipy-dev]

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -115,7 +115,7 @@ elif [[ "$DISTRIB" == "scipy-dev" ]]; then
     pip install https://github.com/joblib/joblib/archive/master.zip
     echo "Installing pillow master"
     pip install https://github.com/python-pillow/Pillow/archive/master.zip
-    pip install pytest==4.6.2 pytest-cov
+    pip install pytest==4.6.4 pytest-cov
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -115,7 +115,7 @@ elif [[ "$DISTRIB" == "scipy-dev" ]]; then
     pip install https://github.com/joblib/joblib/archive/master.zip
     echo "Installing pillow master"
     pip install https://github.com/python-pillow/Pillow/archive/master.zip
-    pip install pytest pytest-cov
+    pip install pytest==4.6.2 pytest-cov
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then


### PR DESCRIPTION
The `scipy-dev` build has been failing when using pytest `5.0.0`. This PR pins the version to `4.*`.