### PR TITLE
MAINT Pass liblinear X dimensions around as plain ints

### DIFF
--- a/sklearn/svm/liblinear.pxd
+++ b/sklearn/svm/liblinear.pxd
@@ -31,7 +31,7 @@ cdef extern from "linear.h":
 cdef extern from "liblinear_helper.c":
     void copy_w(void *, model *, int)
     parameter *set_parameter(int, double, double, int, char *, char *, int, int, double)
-    problem *set_problem (char *, char *, np.npy_intp *, int, double, char *)
+    problem *set_problem (char *, char *, int, int, int, double, char *)
     problem *csr_set_problem (char *, char *, char *, char *, int, int, int, double, char *)
 
     model *set_model(parameter *, char *, np.npy_intp *, char *, double)

--- a/sklearn/svm/liblinear.pyx
+++ b/sklearn/svm/liblinear.pyx
@@ -33,8 +33,7 @@ def train_wrap(X, np.ndarray[np.float64_t, ndim=1, mode='c'] Y,
     else:
         problem = set_problem(
                 (<np.ndarray[np.float64_t, ndim=2, mode='c']>X).data,
-                Y.data,
-                (<np.ndarray[np.float64_t, ndim=2, mode='c']>X).shape,
+                Y.data, (<np.int32_t>X.shape[0]), (<np.int32_t>X.shape[1]),
                 (<np.int32_t>np.count_nonzero(X)), bias, sample_weight.data)
 
     cdef np.ndarray[np.int32_t, ndim=1, mode='c'] \


### PR DESCRIPTION
This is much easier to understand, it matches what we're doing in csr_set_problem and csr_to_sparse, and it eliminates the absolutely unnecessary conversion to float64_t.