### PR TITLE
Export_graphviz() defaults "Helvetica" font

### DIFF
--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -137,7 +137,7 @@ def plot_tree(decision_tree, max_depth=None, feature_names=None,
 
     rounded : bool, optional (default=False)
         When set to ``True``, draw node boxes with rounded corners and use
-        Helvetica fonts instead of Times-Roman.
+        sans fonts instead of Times-Roman.
 
     precision : int, optional (default=3)
         Number of digits of precision for floating point in the values of
@@ -183,7 +183,7 @@ class _BaseTreeExporter(object):
                  class_names=None, label='all', filled=False,
                  impurity=True, node_ids=False,
                  proportion=False, rotate=False, rounded=False,
-                 precision=3, fontsize=None):
+                 precision=3, fontsize=None, fontname='sans'):
         self.max_depth = max_depth
         self.feature_names = feature_names
         self.class_names = class_names
@@ -196,6 +196,7 @@ class _BaseTreeExporter(object):
         self.rounded = rounded
         self.precision = precision
         self.fontsize = fontsize
+        self.fontname = fontname
 
     def get_color(self, value):
         # Find the appropriate color & intensity for a node
@@ -355,7 +356,7 @@ class _DOTTreeExporter(_BaseTreeExporter):
                  feature_names=None, class_names=None, label='all',
                  filled=False, leaves_parallel=False, impurity=True,
                  node_ids=False, proportion=False, rotate=False, rounded=False,
-                 special_characters=False, precision=3):
+                 special_characters=False, precision=3, fontname='sans'):
 
         super().__init__(
             max_depth=max_depth, feature_names=feature_names,
@@ -363,7 +364,7 @@ class _DOTTreeExporter(_BaseTreeExporter):
             impurity=impurity,
             node_ids=node_ids, proportion=proportion, rotate=rotate,
             rounded=rounded,
-            precision=precision)
+            precision=precision, fontname=fontname)
         self.leaves_parallel = leaves_parallel
         self.out_file = out_file
         self.special_characters = special_characters
@@ -434,7 +435,7 @@ class _DOTTreeExporter(_BaseTreeExporter):
                 ', style="%s", color="black"'
                 % ", ".join(rounded_filled))
         if self.rounded:
-            self.out_file.write(', fontname=helvetica')
+            self.out_file.write(', fontname=%s'%self.fontname)
         self.out_file.write('] ;\n')
 
         # Specify graph & edge aesthetics
@@ -442,7 +443,7 @@ class _DOTTreeExporter(_BaseTreeExporter):
             self.out_file.write(
                 'graph [ranksep=equally, splines=polyline] ;\n')
         if self.rounded:
-            self.out_file.write('edge [fontname=helvetica] ;\n')
+            self.out_file.write('edge [fontname=%s] ;\n'%self.fontname)
         if self.rotate:
             self.out_file.write('rankdir=LR ;\n')
 
@@ -656,7 +657,7 @@ def export_graphviz(decision_tree, out_file=None, max_depth=None,
                     feature_names=None, class_names=None, label='all',
                     filled=False, leaves_parallel=False, impurity=True,
                     node_ids=False, proportion=False, rotate=False,
-                    rounded=False, special_characters=False, precision=3):
+                    rounded=False, special_characters=False, precision=3, fontname='sans'):
     """Export a decision tree in DOT format.
 
     This function generates a GraphViz representation of the decision tree,
@@ -723,7 +724,7 @@ def export_graphviz(decision_tree, out_file=None, max_depth=None,
 
     rounded : bool, optional (default=False)
         When set to ``True``, draw node boxes with rounded corners and use
-        Helvetica fonts instead of Times-Roman.
+        sans fonts instead of Times-Roman.
 
     special_characters : bool, optional (default=False)
         When set to ``False``, ignore special characters for PostScript
@@ -772,7 +773,7 @@ def export_graphviz(decision_tree, out_file=None, max_depth=None,
             filled=filled, leaves_parallel=leaves_parallel, impurity=impurity,
             node_ids=node_ids, proportion=proportion, rotate=rotate,
             rounded=rounded, special_characters=special_characters,
-            precision=precision)
+            precision=precision, fontname=fontname)
         exporter.export(decision_tree)
 
         if return_string:


### PR DESCRIPTION
Non-English character text cannot be displayed

fontname ='sans'is set to "sans" to represent the font family and can display any character set as long as the system exists font

Signed-off-by: wstates <states@yeah.net>

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
