### PR TITLE
[MRG] MAINT more informative azure job names

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ jobs:
       # Linux environment to test that scikit-learn can be built against
       # versions of numpy, scipy with ATLAS that comes with Ubuntu Xenial 16.04
       # i.e. numpy 1.11 and scipy 0.17
-      py35_np_atlas:
+      py35_ubuntu_atlas:
         DISTRIB: 'ubuntu'
         PYTHON_VERSION: '3.5'
         JOBLIB_VERSION: '0.11'
@@ -28,7 +28,7 @@ jobs:
         COVERAGE: 'true'
       # Linux environment to test the latest available dependencies and MKL.
       # It runs tests requiring pandas and PyAMG.
-      pylatest_conda:
+      pylatest_conda_mkl_pandas:
         DISTRIB: 'conda'
         PYTHON_VERSION: '*'
         INSTALL_MKL: 'true'
@@ -51,7 +51,7 @@ jobs:
     name: Linux32
     vmImage: ubuntu-16.04
     matrix:
-      py35_np_atlas_32bit:
+      py35_ubuntu_atlas_32bit:
         DISTRIB: 'ubuntu-32'
         PYTHON_VERSION: '3.5'
         JOBLIB_VERSION: '0.11'
@@ -62,7 +62,7 @@ jobs:
     name: macOS
     vmImage: xcode9-macos10.13
     matrix:
-      pylatest_conda:
+      pylatest_conda_mkl:
         DISTRIB: 'conda'
         PYTHON_VERSION: '*'
         INSTALL_MKL: 'true'
@@ -79,12 +79,12 @@ jobs:
     name: Windows
     vmImage: vs2017-win2016
     matrix:
-      py37_64:
+      py37_conda_mkl:
         PYTHON_VERSION: '3.7'
         CHECK_WARNINGS: 'true'
         PYTHON_ARCH: '64'
         PYTEST_VERSION: '4.6.2'
         COVERAGE: 'true'
-      py35_32:
+      py35_pip_openblas_32bit:
         PYTHON_VERSION: '3.5'
         PYTHON_ARCH: '32'


### PR DESCRIPTION
I just changed the azure pipelines job names to be consistently more informative on all platforms.

Let's see if I did not break anything.