### PR TITLE
add an autogenerated sitemap

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -127,6 +127,7 @@ conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
 
 source activate testenv
 pip install "sphinx-gallery>=0.2,<0.3"
+pip install sphinx-sitemap
 pip install numpydoc==0.9
 
 # Build and install scikit-learn in dev mode

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,8 +37,12 @@ extensions = [
     'sphinx.ext.imgconverter',
     'sphinx_gallery.gen_gallery',
     'sphinx_issues',
-    'custom_references_resolver'
+    'custom_references_resolver',
+    'sphinx_sitemap'
 ]
+
+# This tells scphinx_sitemap where to find the main documentation
+html_baseurl = 'https://scikit-learn.org/stable/'
 
 # this is needed for some reason...
 # see https://github.com/numpy/numpydoc/issues/69

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -527,7 +527,7 @@ the development version.
 
 Building the documentation requires installing some additional packages::
 
-    pip install sphinx sphinx-gallery numpydoc matplotlib Pillow pandas scikit-image
+    pip install sphinx sphinx-gallery sphinx-sitemap numpydoc matplotlib Pillow pandas scikit-image
 
 To build the documentation, you need to be in the ``doc`` folder::
 


### PR DESCRIPTION
Fixes #13518.

Uses [`sphinx-sitemap`](https://github.com/jdillard/sphinx-sitemap) to generate a sitemap from the stable version only.