### PR TITLE
[MRG] TST add more iteration in randomized SVD test

### DIFF
--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -114,8 +114,8 @@ def test_explained_variance(X_sparse, kind, n_components, solver):
 @pytest.mark.parametrize('solver', SVD_SOLVERS)
 def test_explained_variance_components_10_20(X_sparse, kind, solver):
     X = X_sparse if kind == 'sparse' else X_sparse.toarray()
-    svd_10 = TruncatedSVD(10, algorithm=solver).fit(X)
-    svd_20 = TruncatedSVD(20, algorithm=solver).fit(X)
+    svd_10 = TruncatedSVD(10, algorithm=solver, n_iter=10).fit(X)
+    svd_20 = TruncatedSVD(20, algorithm=solver, n_iter=10).fit(X)
 
     # Assert the 1st component is equal
     assert_allclose(


### PR DESCRIPTION
I got this test failing on some PRs. I tried with 1000 different random state and it failed 12% of the time.
Increasing the number of iterations solved the issue and make it more robust. 