### PR TITLE
[MRG]  FIX only check classifier for multiclass-multioutput rejection in PDP 

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -99,6 +99,13 @@ This is a bug-fix release to primarily resolve some packaging issues in version
 Changelog
 ---------
 
+:mod:`sklearn.inspection`
+.........................
+
+- |Fix| Fixed a bug in :func:`inspection.partial_dependence` to only check
+  classifier and not regressor for the multiclass-multioutput case.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -104,7 +104,7 @@ Changelog
 
 - |Fix| Fixed a bug in :func:`inspection.partial_dependence` to only check
   classifier and not regressor for the multiclass-multioutput case.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`14309` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.metrics`
 ......................

--- a/sklearn/inspection/partial_dependence.py
+++ b/sklearn/inspection/partial_dependence.py
@@ -286,9 +286,15 @@ def partial_dependence(estimator, X, features, response_method='auto',
         raise ValueError(
             "'estimator' must be a fitted regressor or classifier.")
 
-    if (hasattr(estimator, 'classes_') and
-            isinstance(estimator.classes_[0], np.ndarray)):
-        raise ValueError('Multiclass-multioutput estimators are not supported')
+    if is_classifier(estimator):
+        if not hasattr(estimator, 'classes_'):
+            raise ValueError(
+                "'estimator' parameter must be a fitted estimator"
+            )
+        if isinstance(estimator.classes_[0], np.ndarray):
+            raise ValueError(
+                'Multiclass-multioutput estimators are not supported'
+            )
 
     X = check_array(X)
 

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -21,6 +21,7 @@ from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.linear_model import LinearRegression
 from sklearn.linear_model import LogisticRegression
 from sklearn.linear_model import MultiTaskLasso
+from sklearn.tree import DecisionTreeRegressor
 from sklearn.datasets import load_boston, load_iris
 from sklearn.datasets import make_classification, make_regression
 from sklearn.cluster import KMeans
@@ -58,6 +59,7 @@ multioutput_regression_data = (make_regression(n_samples=50, n_targets=2,
     (GradientBoostingClassifier, 'brute', multiclass_classification_data),
     (GradientBoostingRegressor, 'recursion', regression_data),
     (GradientBoostingRegressor, 'brute', regression_data),
+    (DecisionTreeRegressor, 'brute', regression_data),
     (LinearRegression, 'brute', regression_data),
     (LinearRegression, 'brute', multioutput_regression_data),
     (LogisticRegression, 'brute', binary_classification_data),
@@ -261,7 +263,6 @@ def test_partial_dependence_easy_target(est, power):
     assert r2 > .99
 
 
-@pytest.mark.filterwarnings('ignore:The default value of ')  # 0.22
 @pytest.mark.parametrize('Estimator',
                          (sklearn.tree.DecisionTreeClassifier,
                           sklearn.tree.ExtraTreeClassifier,
@@ -288,6 +289,8 @@ def test_multiclass_multioutput(Estimator):
 
 class NoPredictProbaNoDecisionFunction(BaseEstimator, ClassifierMixin):
     def fit(self, X, y):
+        # simulate that we have some classes
+        self.classes_ = [0, 1]
         return self
 
 


### PR DESCRIPTION
closes #14272 

I don't think that we should not change `DecisionTreeRegressor`. We should rather modified slightly the PDP.