### PR TITLE
DOC make_scorer now requires score function to accpet 1d y_pred when needs_proba is True

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -18,7 +18,7 @@ occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
 - The v0.20.0 release notes failed to mention a backwards incompatibility in
-  `:func:`metrics.make_scorer` when `needs_proba=True` and `y_true` is binary.
+  :func:`metrics.make_scorer` when `needs_proba=True` and `y_true` is binary.
   Now, the scorer function is supposed to accept a 1D `y_pred` (i.e.,
   probability of the positive class, shape `(n_samples,)`), instead of a 2D
   `y_pred` (i.e., shape `(n_samples, 2)`).

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -9,6 +9,20 @@ Version 0.21.3
 
 **In development**
 
+Changed models
+--------------
+
+The following estimators and functions, when fit with the same data and
+parameters, may produce different models from the previous version. This often
+occurs due to changes in the modelling logic (bug fixes or enhancements), or in
+random sampling procedures.
+
+- The v0.20.0 release notes failed to mention a backwards incompatibility in
+  `:func:`metrics.make_scorer` when `needs_proba=True` and `y_true` is binary.
+  Now, the scorer function is supposed to accept a 1D `y_pred` (i.e.,
+  probability of the positive class, shape `(n_samples,)`), instead of a 2D
+  `y_pred` (i.e., shape `(n_samples, 2)`).
+
 Changelog
 ---------
 

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -423,18 +423,18 @@ def make_scorer(score_func, greater_is_better=True, needs_proba=False,
         Whether score_func requires predict_proba to get probability estimates
         out of a classifier.
 
-        If True, for binary y_true, the score function is supposed to accept
-        1d y_pred (i.e., probability of the positive class, shape
-        ``(n_samples,)``).
+        If True, for binary `y_true`, the score function is supposed to accept
+        a 1D `y_pred` (i.e., probability of the positive class, shape
+        `(n_samples,)`).
 
     needs_threshold : boolean, default=False
         Whether score_func takes a continuous decision certainty.
         This only works for binary classification using estimators that
         have either a decision_function or predict_proba method.
 
-        If True, for binary y_true, the score function is supposed to accept
-        1d y_pred (i.e., probability of the positive class or the decision
-        function, shape ``(n_samples,)``).
+        If True, for binary `y_true`, the score function is supposed to accept
+        a 1D `y_pred` (i.e., probability of the positive class or the decision
+        function, shape `(n_samples,)`).
 
         For example ``average_precision`` or the area under the roc curve
         can not be computed using discrete predictions alone.

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -423,10 +423,18 @@ def make_scorer(score_func, greater_is_better=True, needs_proba=False,
         Whether score_func requires predict_proba to get probability estimates
         out of a classifier.
 
+        If True, for binary y_true, the score function is supposed to accpet
+        1d y_pred (i.e., probability of the positive class, shape
+        ``(n_samples,)``).
+
     needs_threshold : boolean, default=False
         Whether score_func takes a continuous decision certainty.
         This only works for binary classification using estimators that
         have either a decision_function or predict_proba method.
+
+        If True, for binary y_true, the score function is supposed to accpet
+        1d y_pred (i.e., probability of the positive class or the decision
+        function, shape ``(n_samples,)``).
 
         For example ``average_precision`` or the area under the roc curve
         can not be computed using discrete predictions alone.

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -423,7 +423,7 @@ def make_scorer(score_func, greater_is_better=True, needs_proba=False,
         Whether score_func requires predict_proba to get probability estimates
         out of a classifier.
 
-        If True, for binary y_true, the score function is supposed to accpet
+        If True, for binary y_true, the score function is supposed to accept
         1d y_pred (i.e., probability of the positive class, shape
         ``(n_samples,)``).
 
@@ -432,7 +432,7 @@ def make_scorer(score_func, greater_is_better=True, needs_proba=False,
         This only works for binary classification using estimators that
         have either a decision_function or predict_proba method.
 
-        If True, for binary y_true, the score function is supposed to accpet
+        If True, for binary y_true, the score function is supposed to accept
         1d y_pred (i.e., probability of the positive class or the decision
         function, shape ``(n_samples,)``).
 


### PR DESCRIPTION
Closes #12848
In #9521, we change the behavior of make_scorer when needs_proba is True and y_true is binary. Previously, we requires score function to accept 2d y_pred (i.e., the output of predict_proba), now we require the score function to accpet 1d y_pred (probability of the positive class).
I think the change is trivial (maybe more reasonable?) and it has been a long time, so I choose to update the doc instead of mention it in what's new.