### PR TITLE
Fix attribute mismatches in documentation strings.

### DIFF
--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -436,6 +436,9 @@ class FastICA(BaseEstimator, TransformerMixin):
     mixing_ : array, shape (n_features, n_components)
         The mixing matrix.
 
+    mean_ : array, shape(n_features)
+        The mean over features. Only set if `self.whiten` is True.
+
     n_iter_ : int
         If the algorithm is "deflation", n_iter is the
         maximum number of iterations run across all components. Else

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -444,7 +444,7 @@ class FastICA(BaseEstimator, TransformerMixin):
         maximum number of iterations run across all components. Else
         they are just the number of iterations taken to converge.
 
-    whitening_ : array, shape (n_components, n_features) or None.
+    whitening_ : array, shape (n_components, n_features)
         Only set if whiten is 'True'. This is the pre-whitening matrix that projects
         data onto the first `n_components` principal components.
     

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -447,7 +447,7 @@ class FastICA(BaseEstimator, TransformerMixin):
     whitening_ : array, shape (n_components, n_features)
         Only set if whiten is 'True'. This is the pre-whitening matrix that projects
         data onto the first `n_components` principal components.
-    
+
     Examples
     --------
     >>> from sklearn.datasets import load_digits

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -444,6 +444,10 @@ class FastICA(BaseEstimator, TransformerMixin):
         maximum number of iterations run across all components. Else
         they are just the number of iterations taken to converge.
 
+    whitening_ : array, shape (n_components, n_features) or None.
+        Only set if whiten is 'True'. This is the pre-whitening matrix that projects
+        data onto the first `n_components` principal components.
+    
     Examples
     --------
     >>> from sklearn.datasets import load_digits

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -445,8 +445,8 @@ class FastICA(BaseEstimator, TransformerMixin):
         they are just the number of iterations taken to converge.
 
     whitening_ : array, shape (n_components, n_features)
-        Only set if whiten is 'True'. This is the pre-whitening matrix that projects
-        data onto the first `n_components` principal components.
+        Only set if whiten is 'True'. This is the pre-whitening matrix
+        that projects data onto the first `n_components` principal components.
 
     Examples
     --------

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -1193,7 +1193,7 @@ class NMF(BaseEstimator, TransformerMixin):
         Factorization matrix, sometimes called 'dictionary'.
 
     n_components_ : integer
-        The number of components. It is same to the `n_components` parameter
+        The number of components. It is same as the `n_components` parameter
         if it was given. Otherwise, it will be same with the number of
         features.
 

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -1194,7 +1194,7 @@ class NMF(BaseEstimator, TransformerMixin):
 
     n_components_ : integer
         The number of components. It is same as the `n_components` parameter
-        if it was given. Otherwise, it will be same with the number of
+        if it was given. Otherwise, it will be same as the number of
         features.
 
     reconstruction_err_ : number

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -1192,6 +1192,11 @@ class NMF(BaseEstimator, TransformerMixin):
     components_ : array, [n_components, n_features]
         Factorization matrix, sometimes called 'dictionary'.
 
+    n_components_ : integer
+        The number of components. It is same to the `n_components` parameter
+        if it was given. Otherwise, it will be same with the number of
+        features.
+
     reconstruction_err_ : number
         Frobenius norm of the matrix difference, or beta-divergence, between
         the training data ``X`` and the reconstructed data ``WH`` from

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -238,12 +238,10 @@ class PCA(_BasePCA):
         if n_components is None.
 
     n_features_ : int
-        The number of features in the data matrix the PCA transformer was
-        fitted on.
+        Number of features in the training data.
 
     n_samples_ : int
-        The number of samples in the data matrix the PCA transformer was
-        fitted on.
+        Number of samples in the training data.
 
     noise_variance_ : float
         The estimated noise covariance following the Probabilistic PCA model

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -236,6 +236,14 @@ class PCA(_BasePCA):
         number is estimated from input data. Otherwise it equals the parameter
         n_components, or the lesser value of n_features and n_samples
         if n_components is None.
+        
+    n_features_ : int
+        The number of features in the data matrix the PCA transformed was
+        fitted on.
+
+    n_samples_ : int
+        The number of samples in the data matrix the PCA transformed was
+        fitted on.
 
     noise_variance_ : float
         The estimated noise covariance following the Probabilistic PCA model

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -236,13 +236,13 @@ class PCA(_BasePCA):
         number is estimated from input data. Otherwise it equals the parameter
         n_components, or the lesser value of n_features and n_samples
         if n_components is None.
-        
+
     n_features_ : int
-        The number of features in the data matrix the PCA transformed was
+        The number of features in the data matrix the PCA transformer was
         fitted on.
 
     n_samples_ : int
-        The number of samples in the data matrix the PCA transformed was
+        The number of samples in the data matrix the PCA transformer was
         fitted on.
 
     noise_variance_ : float

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -453,7 +453,7 @@ class GaussianRandomProjection(BaseRandomProjection):
 
     Attributes
     ----------
-    n_component_ : int
+    n_components_ : int
         Concrete number of components computed when n_components="auto".
 
     components_ : numpy array of shape [n_components, n_features]

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -573,7 +573,7 @@ class SparseRandomProjection(BaseRandomProjection):
 
     Attributes
     ----------
-    n_component_ : int
+    n_components_ : int
         Concrete number of components computed when n_components="auto".
 
     components_ : CSR matrix with shape [n_components, n_features]


### PR DESCRIPTION
Partially fixes #14312

Fixes the following items:

- [X] FastICA, [whitening_]
  The matrix projecting data onto the first principal components.

- [X] FastICA, [mean_]
 The mean over features

- [X] NMF, [n_components_]
  This attribute is same to the `n_components` parameter if it was set. Otherwise,
  it is same with `n_features`

- [X] GaussianRandomProjection, [n_components_]
  Just a typo fixed: `n_component_` -> `n_components_`

- [X] SparseRandomProjection, [n_components_]
  Just a typo fixed: `n_component_` -> `n_components_`

- [X] PCA, [n_features_]
  The number of features in the data matrix the PCA transformer was fitted on.

- [X] PCA, [n_samples_]
  The number of samples in the data matrix the PCA transformer was fitted on.
