### PR TITLE
Include `use_line_collection` argument

### DIFF
--- a/examples/linear_model/plot_lasso_and_elasticnet.py
+++ b/examples/linear_model/plot_lasso_and_elasticnet.py
@@ -60,13 +60,15 @@ print(enet)
 print("r^2 on test data : %f" % r2_score_enet)
 
 m, s, _ = plt.stem(np.where(enet.coef_)[0], enet.coef_[enet.coef_ != 0],
-                   markerfmt='x', label='Elastic net coefficients')
+                   markerfmt='x', label='Elastic net coefficients',
+                   use_line_collection=True)
 plt.setp([m, s], color="#2ca02c")
 m, s, _ = plt.stem(np.where(lasso.coef_)[0], lasso.coef_[lasso.coef_ != 0],
-                   markerfmt='x', label='Lasso coefficients')
+                   markerfmt='x', label='Lasso coefficients',
+                   use_line_collection=True)
 plt.setp([m, s], color='#ff7f0e')
 plt.stem(np.where(coef)[0], coef[coef != 0], label='true coefficients',
-         markerfmt='bx')
+         markerfmt='bx', use_line_collection=True)
 
 plt.legend(loc='best')
 plt.title("Lasso $R^2$: %.3f, Elastic Net $R^2$: %.3f"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Avoids raising a warning for `examples/linear_model/plot_lasso_and_elasticnet.py`, as described in #14117.

#### What does this implement/fix? Explain your changes.
As described by the warning message,
>UserWarning: In Matplotlib 3.3 individual lines on a stem plot will be added as a LineCollection instead of individual lines. This significantly improves the performance of a stem plot. To remove this warning and switch to the new behaviour, set the "use_line_collection" keyword argument to True.

the addition of `use_line_collection=True` to all three `plt.stem()` plots removed the warning.

#### Any other comments?
This work is being done at the SciPy2019 sprints.
