### PR TITLE
DOC: fix convergence warning in iterative example

### DIFF
--- a/examples/impute/plot_iterative_imputer_variants_comparison.py
+++ b/examples/impute/plot_iterative_imputer_variants_comparison.py
@@ -105,7 +105,7 @@ estimators = [
 score_iterative_imputer = pd.DataFrame()
 for impute_estimator in estimators:
     estimator = make_pipeline(
-        IterativeImputer(random_state=0, estimator=impute_estimator),
+        IterativeImputer(random_state=0, estimator=impute_estimator, tol=1),
         br_estimator
     )
     score_iterative_imputer[impute_estimator.__class__.__name__] = \


### PR DESCRIPTION

#### Reference Issues/PRs

Resolves on check box from https://github.com/scikit-learn/scikit-learn/issues/14117

#### What does this implement/fix? Explain your changes.

The estimator fails to converge reliably even with 1e4
iterations. We can keep the default max_iter and avoid
convergence warnings by increasing the tolerance.

#### Any other comments?

Before change:

<img width="1392" alt="Screenshot 2019-07-13 11 35 49" src="https://user-images.githubusercontent.com/6868396/61174225-0ffb8d00-a563-11e9-8d3f-48effb5545a4.png">

After change:

<img width="1392" alt="Screenshot 2019-07-13 11 36 05" src="https://user-images.githubusercontent.com/6868396/61174228-15f16e00-a563-11e9-8793-cd96436529f0.png">
