### PR TITLE
[MRG] Ensure model convergence in Balancing Model Complexity example

### DIFF
--- a/examples/model_selection/plot_grid_search_refit_callable.py
+++ b/examples/model_selection/plot_grid_search_refit_callable.py
@@ -27,6 +27,7 @@ from sklearn.datasets import load_digits
 from sklearn.decomposition import PCA
 from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import MinMaxScaler
 from sklearn.svm import LinearSVC
 
 
@@ -76,12 +77,13 @@ def best_low_complexity(cv_results):
 
 
 pipe = Pipeline([
+        ('standard_scaler', MinMaxScaler()),
         ('reduce_dim', PCA(random_state=42)),
-        ('classify', LinearSVC(random_state=42)),
+        ('classify', LinearSVC(random_state=42, tol=1e-1)),
 ])
 
 param_grid = {
-    'reduce_dim__n_components': [2, 4, 6, 8]
+    'reduce_dim__n_components': [2, 4, 8, 10]
 }
 
 grid = GridSearchCV(pipe, cv=10, n_jobs=1, param_grid=param_grid,

--- a/examples/model_selection/plot_grid_search_refit_callable.py
+++ b/examples/model_selection/plot_grid_search_refit_callable.py
@@ -93,9 +93,10 @@ grid.fit(digits.data, digits.target)
 
 n_components = grid.cv_results_['param_reduce_dim__n_components']
 test_scores = grid.cv_results_['mean_test_score']
+component_locations = [2, 4, 6, 8]
 
 plt.figure()
-plt.bar(n_components, test_scores, width=1.3, color='b')
+plt.bar(component_locations, test_scores, width=1.3, color='b')
 
 lower = lower_bound(grid.cv_results_)
 plt.axhline(np.max(test_scores), linestyle='--', color='y',
@@ -105,7 +106,7 @@ plt.axhline(lower, linestyle='--', color='.5', label='Best score - 1 std')
 plt.title("Balance model complexity and cross-validated score")
 plt.xlabel('Number of PCA components used')
 plt.ylabel('Digit classification accuracy')
-plt.xticks(n_components.tolist())
+plt.xticks(ticks=component_locations, labels=n_components.tolist())
 plt.ylim((0, 1.0))
 plt.legend(loc='upper left')
 

--- a/examples/model_selection/plot_grid_search_refit_callable.py
+++ b/examples/model_selection/plot_grid_search_refit_callable.py
@@ -106,7 +106,7 @@ plt.axhline(lower, linestyle='--', color='.5', label='Best score - 1 std')
 plt.title("Balance model complexity and cross-validated score")
 plt.xlabel('Number of PCA components used')
 plt.ylabel('Digit classification accuracy')
-plt.xticks(ticks=component_locations, labels=n_components.tolist())
+plt.xticks(component_locations, n_components.tolist())
 plt.ylim((0, 1.0))
 plt.legend(loc='upper left')
 

--- a/examples/model_selection/plot_grid_search_refit_callable.py
+++ b/examples/model_selection/plot_grid_search_refit_callable.py
@@ -8,7 +8,7 @@ finding a decent accuracy within 1 standard deviation of the best accuracy
 score while minimising the number of PCA components [1].
 
 The figure shows the trade-off between cross-validated score and the number
-of PCA components. The balanced case is when n_components=6 and accuracy=0.80,
+of PCA components. The balanced case is when n_components=8 and accuracy=0.87,
 which falls into the range within 1 standard deviation of the best accuracy
 score.
 


### PR DESCRIPTION
#### Reference Issues/PRs
As described in #14117, convergence warnings are raised within `examples/model_selection/plot_grid_search_refit_callable.py` while fitting a `LinearSVC()` on the `digits` dataset.
>scikit-learn/sklearn/svm/base.py:927: ConvergenceWarning: Liblinear failed to converge, increase the number of iterations.


#### What does this implement/fix? Explain your changes.
The fix contains three pieces:
* Adds a `MinMaxScaler()` into the pipeline.
* Relaxes the `tol` for the SVC to `1e-1`.
* Changes the parameter grid of PCs from `[2, 4, 6, 8]` to `[2, 4, 6, 10]`.
  * Necessary because the first two steps removed the convergence warning, but resulted in the most complex PC being chosen as the best model. The latter set of PCs still allow for the instructive example of having lower complexity model within the 1 std accuracy tolerance.

#### Any other comments?
An extra plotting variable was introduced in order to ensure even spacing between the PC bars. See updated plot below.

<img width="569" alt="Screen Shot 2019-07-13 at 12 54 50 PM" src="https://user-images.githubusercontent.com/21250871/61174512-3fb09200-a56f-11e9-9f12-c09223faa0e0.png">

This work is being done at the SciPy 2019 Sprints.