### PR TITLE
DOC: silences collinearity warnings in LDA example

### DIFF
--- a/examples/neighbors/plot_nca_dim_reduction.py
+++ b/examples/neighbors/plot_nca_dim_reduction.py
@@ -39,6 +39,7 @@ from sklearn.neighbors import (KNeighborsClassifier,
                                NeighborhoodComponentsAnalysis)
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
+import warnings
 
 print(__doc__)
 
@@ -81,8 +82,12 @@ for i, (name, model) in enumerate(dim_reduction_methods):
     plt.figure()
     # plt.subplot(1, 3, i + 1, aspect=1)
 
-    # Fit the method's model
-    model.fit(X_train, y_train)
+    # There are some hard to avoid collinearity warnings that get raised
+    # by the LinearDiscriminantAnalysis
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        # Fit the method's model
+        model.fit(X_train, y_train)
 
     # Fit a nearest neighbor classifier on the embedded training set
     knn.fit(model.transform(X_train), y_train)


### PR DESCRIPTION
These pop up from using the digits dataset. In lieu of
using an example dataset with no collinear data, suppress
the user warning from LinearDiscriminantAnalysis.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes one of the check boxes in https://github.com/scikit-learn/scikit-learn/issues/14117

#### What does this implement/fix? Explain your changes.

Temporarly suppresses the UserWarnings raised by LinearDiscriminantAnalysis when fit on the digits dataset.

#### Any other comments?

Hello from #SciPy2019!
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
