### PR TITLE
[MRG] issue #13383: Made plot_compare_reduction.py faster

### DIFF
--- a/examples/compose/plot_compare_reduction.py
+++ b/examples/compose/plot_compare_reduction.py
@@ -29,6 +29,7 @@ fitting of a transformer is costly.
 
 # Authors: Robert McGibbon, Joel Nothman, Guillaume Lemaitre
 
+
 import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.datasets import load_digits
@@ -39,7 +40,6 @@ from sklearn.decomposition import PCA, NMF
 from sklearn.feature_selection import SelectKBest, chi2
 
 print(__doc__)
-
 
 pipe = Pipeline([
     # the reduce_dim stage is populated by the param_grid
@@ -128,4 +128,3 @@ rmtree(location)
 # estimator data, leading to save processing time. Therefore, the use of
 # caching the pipeline using ``memory`` is highly beneficial when fitting
 # a transformer is costly.
-

--- a/examples/compose/plot_compare_reduction.py
+++ b/examples/compose/plot_compare_reduction.py
@@ -29,7 +29,6 @@ fitting of a transformer is costly.
 
 # Authors: Robert McGibbon, Joel Nothman, Guillaume Lemaitre
 
-
 import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.datasets import load_digits
@@ -40,6 +39,7 @@ from sklearn.decomposition import PCA, NMF
 from sklearn.feature_selection import SelectKBest, chi2
 
 print(__doc__)
+
 
 pipe = Pipeline([
     # the reduce_dim stage is populated by the param_grid
@@ -63,7 +63,7 @@ param_grid = [
 ]
 reducer_labels = ['PCA', 'NMF', 'KBest(chi2)']
 
-grid = GridSearchCV(pipe, cv=5, n_jobs=1, param_grid=param_grid)
+grid = GridSearchCV(pipe, cv=3, n_jobs=1, param_grid=param_grid)
 digits = load_digits()
 grid.fit(digits.data, digits.target)
 
@@ -113,7 +113,7 @@ cached_pipe = Pipeline([('reduce_dim', PCA()),
                        memory=memory)
 
 # This time, a cached pipeline will be used within the grid search
-grid = GridSearchCV(cached_pipe, cv=5, n_jobs=1, param_grid=param_grid)
+grid = GridSearchCV(cached_pipe, cv=3, n_jobs=1, param_grid=param_grid)
 digits = load_digits()
 grid.fit(digits.data, digits.target)
 
@@ -128,3 +128,4 @@ rmtree(location)
 # estimator data, leading to save processing time. Therefore, the use of
 # caching the pipeline using ``memory`` is highly beneficial when fitting
 # a transformer is costly.
+


### PR DESCRIPTION
Addressed in [#13383](https://github.com/scikit-learn/scikit-learn/issues/13383)
Changed cv in line 66 and line 116 to 3. It was 5 before. It reduced CPU time in my computer from 32.5 sec to 18 sec.
Using previously defined cv = 5

                  precision    recall  f1-score   support
           0          1.00         0.99         0.99        178
           1          0.83         0.84         0.83        182
           2          0.98         0.98         0.98        177
           3          0.80         0.82         0.81        183
           4          0.96         0.93         0.95        181
           5          0.90         0.97         0.93        182
           6          0.98         0.98         0.98        181
           7          0.87         0.97         0.92        179
           8          0.83         0.77         0.80        174
           9          0.79         0.69         0.74        180
       accuracy                                  0.89       1797
    macro avg   0.89         0.89         0.89       1797
weighted avg  0.89         0.89          0.89       1797
CPU times: user 32.5 s, sys: 553 ms, total: 33 s
Wall time: 5.89 s


![image](https://user-images.githubusercontent.com/48491625/61179226-2dad0e80-a5c4-11e9-84e6-7e86b3295ac6.png)


Using cv = 3

	               precision    recall  f1-score   support

                  0       1.00      0.99      0.99       178
                  1       0.83      0.84      0.83       182
                  2       0.98      0.98      0.98       177
                  3       0.80      0.82      0.81       183
                  4       0.96      0.93      0.95       181
                  5       0.90      0.97      0.93       182
                  6       0.98      0.98      0.98       181
                  7       0.87      0.97      0.92       179
                  8       0.83      0.77      0.80       174
                  9       0.79      0.69      0.74       180
       accuracy                                0.89      1797
    macro avg       0.89      0.89      0.89      1797
weighted avg       0.89      0.89     0.89       1797


CPU times: user 18 s, sys: 227 ms, total: 18.3 s
Wall time: 3.19 s

![image](https://user-images.githubusercontent.com/48491625/61179225-25ed6a00-a5c4-11e9-9c88-46c04f6de1f9.png)

