### PR TITLE
Remove MetaEstimatorMixin from RFECV parents

### DIFF
--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -329,7 +329,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         return {'poor_score': True}
 
 
-class RFECV(RFE, MetaEstimatorMixin):
+class RFECV(RFE):
     """Feature ranking with recursive feature elimination and cross-validated
     selection of the best number of features.
 


### PR DESCRIPTION
Fixes #14343

RFE inherits MetaEstimatorMixin already, so RFECV may inherit only RFE, not both RFE and MetaEstimatorMixin.