### PR TITLE
DOC More notes about the difference between the three base scorers

### DIFF
--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -452,13 +452,13 @@ def make_scorer(score_func, greater_is_better=True, needs_proba=False,
 
     Notes
     -----
-    If ``needs_proba is False`` and ``needs_threshold is False``, the score
-    function is supposed to accept the output of ``predict``. If
-    ``needs_proba is True``, the score function is supposed to accept the
-    output of ``predict_proba`` (For binary y_true, the score function is
+    If `needs_proba=False` and `needs_threshold=False`, the score
+    function is supposed to accept the output of `predict`. If
+    `needs_proba=True`, the score function is supposed to accept the
+    output of `predict_proba` (For binary `y_true`, the score function is
     supposed to accept probability of the positive class). If
-    ``needs_threshold is True``, the score function is supposed to accept the
-    output of ``decision_function``.
+    `needs_threshold=True`, the score function is supposed to accept the
+    output of `decision_function`.
     """
     sign = 1 if greater_is_better else -1
     if needs_proba and needs_threshold:

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -455,7 +455,7 @@ def make_scorer(score_func, greater_is_better=True, needs_proba=False,
     If ``needs_proba is False`` and ``needs_threshold is False``, the score
     function is supposed to accept the output of ``predict``. If
     ``needs_proba is True``, the score function is supposed to accept the
-    output of ``predict_proba``(For binary y_true, the score function is
+    output of ``predict_proba`` (For binary y_true, the score function is
     supposed to accept probability of the positive class). If
     ``needs_threshold is True``, the score function is supposed to accept the
     output of ``decision_function``.

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -449,6 +449,16 @@ def make_scorer(score_func, greater_is_better=True, needs_proba=False,
     >>> from sklearn.svm import LinearSVC
     >>> grid = GridSearchCV(LinearSVC(), param_grid={'C': [1, 10]},
     ...                     scoring=ftwo_scorer)
+
+    Notes
+    -----
+    If ``needs_proba is False`` and ``needs_threshold is False``, the score
+    function is supposed to accept the output of ``predict``. If
+    ``needs_proba is True``, the score function is supposed to accept the
+    output of ``predict_proba``(For binary y_true, the score function is
+    supposed to accept probability of the positive class). If
+    ``needs_threshold is True``, the score function is supposed to accept the
+    output of ``decision_function``.
     """
     sign = 1 if greater_is_better else -1
     if needs_proba and needs_threshold:


### PR DESCRIPTION
Closes #10247
summarize the difference of the three base scorers, though this is not always the case (e.g., when needs_threshold is True, we'll still accept the output of predict_proba when decision_function is not available, but in this case, users can set needs_proba to True instead)