### PR TITLE
[MRG] Document attributes of regressor classes within neighbors submodule.

### DIFF
--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -263,7 +263,7 @@ class RadiusNeighborsRegressor(NeighborsBase, RadiusNeighborsMixin,
 
     Attributes
     ----------
-    effective_metric_ : string or callble
+    effective_metric_ : string or callable
         The distance metric to use. It will be same as
         the `metric` parameter or a synonym of it, e.g.
         'euclidean' if the `metric` parameter set to

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -89,6 +89,21 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
         for more details.
         Doesn't affect :meth:`fit` method.
 
+    Attributes
+    ----------
+    effective_metric_ : string or callble
+        The distance metric to use. It will be same as
+        the `metric` parameter or a synonym of it, e.g.
+        'euclidean' if the `metric` parameter set to
+        'minkowski' and `p` parameter set to 2.
+
+    effective_metric_params_ : dict
+        Additional keyword arguments for the metric function.
+        For most metrics will be same with `metric_params`
+        parameter, but may also contain the `p` parameter value
+        if the `effective_metric_` attribute is set to
+        'minkowski'.
+
     Examples
     --------
     >>> X = [[0], [1], [2], [3]]

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -92,16 +92,14 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
     Attributes
     ----------
     effective_metric_ : string or callable
-        The distance metric to use. It will be same as
-        the `metric` parameter or a synonym of it, e.g.
-        'euclidean' if the `metric` parameter set to
+        The distance metric to use. It will be same as the `metric` parameter
+        or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
         'minkowski' and `p` parameter set to 2.
 
     effective_metric_params_ : dict
-        Additional keyword arguments for the metric function.
-        For most metrics will be same with `metric_params`
-        parameter, but may also contain the `p` parameter value
-        if the `effective_metric_` attribute is set to
+        Additional keyword arguments for the metric function. For most metrics
+        will be same with `metric_params` parameter, but may also contain the
+        `p` parameter value if the `effective_metric_` attribute is set to
         'minkowski'.
 
     Examples
@@ -264,16 +262,14 @@ class RadiusNeighborsRegressor(NeighborsBase, RadiusNeighborsMixin,
     Attributes
     ----------
     effective_metric_ : string or callable
-        The distance metric to use. It will be same as
-        the `metric` parameter or a synonym of it, e.g.
-        'euclidean' if the `metric` parameter set to
+        The distance metric to use. It will be same as the `metric` parameter
+        or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
         'minkowski' and `p` parameter set to 2.
 
     effective_metric_params_ : dict
-        Additional keyword arguments for the metric function.
-        For most metrics will be same with `metric_params`
-        parameter, but may also contain the `p` parameter value
-        if the `effective_metric_` attribute is set to
+        Additional keyword arguments for the metric function. For most metrics
+        will be same with `metric_params` parameter, but may also contain the
+        `p` parameter value if the `effective_metric_` attribute is set to
         'minkowski'.
 
     Examples

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -261,6 +261,21 @@ class RadiusNeighborsRegressor(NeighborsBase, RadiusNeighborsMixin,
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
+    Attributes
+    ----------
+    effective_metric_ : string or callble
+        The distance metric to use. It will be same as
+        the `metric` parameter or a synonym of it, e.g.
+        'euclidean' if the `metric` parameter set to
+        'minkowski' and `p` parameter set to 2.
+
+    effective_metric_params_ : dict
+        Additional keyword arguments for the metric function.
+        For most metrics will be same with `metric_params`
+        parameter, but may also contain the `p` parameter value
+        if the `effective_metric_` attribute is set to
+        'minkowski'.
+
     Examples
     --------
     >>> X = [[0], [1], [2], [3]]

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -91,7 +91,7 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
 
     Attributes
     ----------
-    effective_metric_ : string or callble
+    effective_metric_ : string or callable
         The distance metric to use. It will be same as
         the `metric` parameter or a synonym of it, e.g.
         'euclidean' if the `metric` parameter set to


### PR DESCRIPTION
Partially address #14312 

Document the following attributes of the `KNeighborsRegressor` and `RadiusNeighborsRegressor` classes.

- [X] KNeighborsRegressor, [effective_metric_, effective_metric_params_]
- [X] RadiusNeighborsRegressor, [effective_metric_, effective_metric_params_]
