### PR TITLE
Nicer error in num_samples if shape is not valid and there's no __len__

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -332,7 +332,7 @@ def test_check_array_on_mock_dataframe():
     arr = np.array([[0.2, 0.7], [0.6, 0.5], [0.4, 0.1], [0.7, 0.2]])
     mock_df = MockDataFrame(arr)
     checked_arr = check_array(mock_df)
-    assert (checked_arr.dtype == arr.dtype)
+    assert checked_arr.dtype == arr.dtype
     checked_arr = check_array(mock_df, dtype=np.float32)
     assert checked_arr.dtype == np.dtype(np.float32)
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -332,8 +332,7 @@ def test_check_array_on_mock_dataframe():
     arr = np.array([[0.2, 0.7], [0.6, 0.5], [0.4, 0.1], [0.7, 0.2]])
     mock_df = MockDataFrame(arr)
     checked_arr = check_array(mock_df)
-    assert (checked_arr.dtype ==
-                 arr.dtype)
+    assert (checked_arr.dtype == arr.dtype)
     checked_arr = check_array(mock_df, dtype=np.float32)
     assert checked_arr.dtype == np.dtype(np.float32)
 
@@ -674,8 +673,9 @@ def test_check_consistent_length():
 
     assert_raises(TypeError, check_consistent_length, [1, 2], np.array(1))
     # Despite ensembles having __len__ they must raise TypeError
-    assert_raises_regex(TypeError, 'Expected sequence or array-like', check_consistent_length,
-                        [1, 2], RandomForestRegressor())
+    assert_raises_regex(TypeError, 'Expected sequence or array-like',
+                        check_consistent_length, [1, 2],
+                        RandomForestRegressor())
     # XXX: We should have a test with a string, but what is correct behaviour?
 
 
@@ -822,6 +822,7 @@ def test_retrieve_samples_from_non_standard_shape():
 
     X = TestNonNumericShape()
     assert _num_samples(X) == len(X)
+
     # check that it gives a good error if there's no __len__
     class TestNoLenWeirdShape:
         def __init__(self):
@@ -829,8 +830,6 @@ def test_retrieve_samples_from_non_standard_shape():
 
     with pytest.raises(TypeError, match="Expected sequence or array-like"):
         _num_samples(TestNoLenWeirdShape())
-
-
 
 
 @pytest.mark.parametrize('x, target_type, min_val, max_val',

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -674,7 +674,7 @@ def test_check_consistent_length():
 
     assert_raises(TypeError, check_consistent_length, [1, 2], np.array(1))
     # Despite ensembles having __len__ they must raise TypeError
-    assert_raises_regex(TypeError, 'estimator', check_consistent_length,
+    assert_raises_regex(TypeError, 'Expected sequence or array-like', check_consistent_length,
                         [1, 2], RandomForestRegressor())
     # XXX: We should have a test with a string, but what is correct behaviour?
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -822,6 +822,15 @@ def test_retrieve_samples_from_non_standard_shape():
 
     X = TestNonNumericShape()
     assert _num_samples(X) == len(X)
+    # check that it gives a good error if there's no __len__
+    class TestNoLenWeirdShape:
+        def __init__(self):
+            self.shape = ("not numeric",)
+
+    with pytest.raises(TypeError) as raised_error:
+        _num_samples(TestNoLenWeirdShape())
+
+
 
 
 @pytest.mark.parametrize('x, target_type, min_val, max_val',

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -827,7 +827,7 @@ def test_retrieve_samples_from_non_standard_shape():
         def __init__(self):
             self.shape = ("not numeric",)
 
-    with pytest.raises(TypeError) as raised_error:
+    with pytest.raises(TypeError, match="Expected sequence or array-like"):
         _num_samples(TestNoLenWeirdShape())
 
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -129,7 +129,7 @@ def _is_arraylike(x):
 
 def _num_samples(x):
     """Return number of samples in array-like x."""
-    message =  'Expected sequence or array-like, got %s' % type(x)
+    message = 'Expected sequence or array-like, got %s' % type(x)
     if hasattr(x, 'fit') and callable(x.fit):
         # Don't get num_samples from an ensembles length!
         raise TypeError(message)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -129,17 +129,16 @@ def _is_arraylike(x):
 
 def _num_samples(x):
     """Return number of samples in array-like x."""
+    message =  'Expected sequence or array-like, got %s' % x
     if hasattr(x, 'fit') and callable(x.fit):
         # Don't get num_samples from an ensembles length!
-        raise TypeError('Expected sequence or array-like, got '
-                        'estimator %s' % x)
+        raise TypeError(message)
 
     if not hasattr(x, '__len__') and not hasattr(x, 'shape'):
         if hasattr(x, '__array__'):
             x = np.asarray(x)
         else:
-            raise TypeError("Expected sequence or array-like, got %s" %
-                            type(x))
+            raise TypeError(message)
 
     if hasattr(x, 'shape') and x.shape is not None:
         if len(x.shape) == 0:
@@ -153,8 +152,7 @@ def _num_samples(x):
     if hasattr(x, '__len__'):
         return len(x)
     else:
-        raise TypeError("Expected sequence or array-like, got %s" %
-                        type(x))
+        raise TypeError(message)
 
 
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -149,9 +149,9 @@ def _num_samples(x):
         if isinstance(x.shape[0], numbers.Integral):
             return x.shape[0]
 
-    if hasattr(x, '__len__'):
+    try:
         return len(x)
-    else:
+    except TypeError:
         raise TypeError(message)
 
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -129,7 +129,7 @@ def _is_arraylike(x):
 
 def _num_samples(x):
     """Return number of samples in array-like x."""
-    message =  'Expected sequence or array-like, got %s' % x
+    message =  'Expected sequence or array-like, got %s' % type(x)
     if hasattr(x, 'fit') and callable(x.fit):
         # Don't get num_samples from an ensembles length!
         raise TypeError(message)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -133,13 +133,15 @@ def _num_samples(x):
         # Don't get num_samples from an ensembles length!
         raise TypeError('Expected sequence or array-like, got '
                         'estimator %s' % x)
+
     if not hasattr(x, '__len__') and not hasattr(x, 'shape'):
         if hasattr(x, '__array__'):
             x = np.asarray(x)
         else:
             raise TypeError("Expected sequence or array-like, got %s" %
                             type(x))
-    if hasattr(x, 'shape'):
+
+    if hasattr(x, 'shape') and x.shape is not None:
         if len(x.shape) == 0:
             raise TypeError("Singleton array %r cannot be considered"
                             " a valid collection." % x)
@@ -147,10 +149,13 @@ def _num_samples(x):
         # Dask dataframes may not return numeric shape[0] value
         if isinstance(x.shape[0], numbers.Integral):
             return x.shape[0]
-        else:
-            return len(x)
-    else:
+
+    if hasattr(x, '__len__'):
         return len(x)
+    else:
+        raise TypeError("Expected sequence or array-like, got %s" %
+                        type(x))
+
 
 
 def check_memory(memory):


### PR DESCRIPTION
This refactors ``_num_samples`` to raise a nice error message if X has no ``len``.

This happens apparently with tensorflow symbolic tensors, for example. But generally also seems nicer.