### PR TITLE
MAINT Mark for removal deprecated LinearSVC loss options in 0.23

### DIFF
--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -206,7 +206,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         -------
         self : object
         """
-        # FIXME Remove l1/l2 support in 0.22 ----------------------------------
+        # FIXME Remove l1/l2 support in 0.23 ----------------------------------
         msg = ("loss='%s' has been deprecated in favor of "
                "loss='%s' as of 0.16. Backward compatibility"
                " for the loss='%s' will be removed in %s")
@@ -214,7 +214,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         if self.loss in ('l1', 'l2'):
             old_loss = self.loss
             self.loss = {'l1': 'hinge', 'l2': 'squared_hinge'}.get(self.loss)
-            warnings.warn(msg % (old_loss, self.loss, old_loss, '0.22'),
+            warnings.warn(msg % (old_loss, self.loss, old_loss, '0.23'),
                           DeprecationWarning)
         # ---------------------------------------------------------------------
 
@@ -390,7 +390,7 @@ class LinearSVR(LinearModel, RegressorMixin):
         -------
         self : object
         """
-        # FIXME Remove l1/l2 support in 0.22 ----------------------------------
+        # FIXME Remove l1/l2 support in 0.23 ----------------------------------
         msg = ("loss='%s' has been deprecated in favor of "
                "loss='%s' as of 0.16. Backward compatibility"
                " for the loss='%s' will be removed in %s")
@@ -400,7 +400,7 @@ class LinearSVR(LinearModel, RegressorMixin):
             self.loss = {'l1': 'epsilon_insensitive',
                          'l2': 'squared_epsilon_insensitive'
                          }.get(self.loss)
-            warnings.warn(msg % (old_loss, self.loss, old_loss, '0.22'),
+            warnings.warn(msg % (old_loss, self.loss, old_loss, '0.23'),
                           DeprecationWarning)
         # ---------------------------------------------------------------------
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -206,7 +206,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         -------
         self : object
         """
-        # FIXME Remove l1/l2 support in 1.0 -----------------------------------
+        # FIXME Remove l1/l2 support in 0.23 ----------------------------------
         msg = ("loss='%s' has been deprecated in favor of "
                "loss='%s' as of 0.16. Backward compatibility"
                " for the loss='%s' will be removed in %s")
@@ -214,7 +214,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         if self.loss in ('l1', 'l2'):
             old_loss = self.loss
             self.loss = {'l1': 'hinge', 'l2': 'squared_hinge'}.get(self.loss)
-            warnings.warn(msg % (old_loss, self.loss, old_loss, '1.0'),
+            warnings.warn(msg % (old_loss, self.loss, old_loss, '0.23'),
                           DeprecationWarning)
         # ---------------------------------------------------------------------
 
@@ -390,7 +390,7 @@ class LinearSVR(LinearModel, RegressorMixin):
         -------
         self : object
         """
-        # FIXME Remove l1/l2 support in 1.0 -----------------------------------
+        # FIXME Remove l1/l2 support in 0.23 ----------------------------------
         msg = ("loss='%s' has been deprecated in favor of "
                "loss='%s' as of 0.16. Backward compatibility"
                " for the loss='%s' will be removed in %s")
@@ -400,7 +400,7 @@ class LinearSVR(LinearModel, RegressorMixin):
             self.loss = {'l1': 'epsilon_insensitive',
                          'l2': 'squared_epsilon_insensitive'
                          }.get(self.loss)
-            warnings.warn(msg % (old_loss, self.loss, old_loss, '1.0'),
+            warnings.warn(msg % (old_loss, self.loss, old_loss, '0.23'),
                           DeprecationWarning)
         # ---------------------------------------------------------------------
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -206,7 +206,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         -------
         self : object
         """
-        # FIXME Remove l1/l2 support in 0.23 ----------------------------------
+        # FIXME Remove l1/l2 support in 0.22 ----------------------------------
         msg = ("loss='%s' has been deprecated in favor of "
                "loss='%s' as of 0.16. Backward compatibility"
                " for the loss='%s' will be removed in %s")
@@ -214,7 +214,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         if self.loss in ('l1', 'l2'):
             old_loss = self.loss
             self.loss = {'l1': 'hinge', 'l2': 'squared_hinge'}.get(self.loss)
-            warnings.warn(msg % (old_loss, self.loss, old_loss, '0.23'),
+            warnings.warn(msg % (old_loss, self.loss, old_loss, '0.22'),
                           DeprecationWarning)
         # ---------------------------------------------------------------------
 
@@ -390,7 +390,7 @@ class LinearSVR(LinearModel, RegressorMixin):
         -------
         self : object
         """
-        # FIXME Remove l1/l2 support in 0.23 ----------------------------------
+        # FIXME Remove l1/l2 support in 0.22 ----------------------------------
         msg = ("loss='%s' has been deprecated in favor of "
                "loss='%s' as of 0.16. Backward compatibility"
                " for the loss='%s' will be removed in %s")
@@ -400,7 +400,7 @@ class LinearSVR(LinearModel, RegressorMixin):
             self.loss = {'l1': 'epsilon_insensitive',
                          'l2': 'squared_epsilon_insensitive'
                          }.get(self.loss)
-            warnings.warn(msg % (old_loss, self.loss, old_loss, '0.23'),
+            warnings.warn(msg % (old_loss, self.loss, old_loss, '0.22'),
                           DeprecationWarning)
         # ---------------------------------------------------------------------
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -577,7 +577,7 @@ def test_linearsvc_parameters():
                          svm.LinearSVC(loss="l3").fit, X, y)
 
 
-# FIXME remove in 1.0
+# FIXME remove in 0.22
 def test_linearsvx_loss_penalty_deprecations():
     X, y = [[0.0], [1.0]], [0, 1]
 
@@ -588,25 +588,25 @@ def test_linearsvx_loss_penalty_deprecations():
     # LinearSVC
     # loss l1 --> hinge
     assert_warns_message(DeprecationWarning,
-                         msg % ("l1", "hinge", "loss='l1'", "1.0"),
+                         msg % ("l1", "hinge", "loss='l1'", "0.22"),
                          svm.LinearSVC(loss="l1").fit, X, y)
 
     # loss l2 --> squared_hinge
     assert_warns_message(DeprecationWarning,
-                         msg % ("l2", "squared_hinge", "loss='l2'", "1.0"),
+                         msg % ("l2", "squared_hinge", "loss='l2'", "0.22"),
                          svm.LinearSVC(loss="l2").fit, X, y)
 
     # LinearSVR
     # loss l1 --> epsilon_insensitive
     assert_warns_message(DeprecationWarning,
                          msg % ("l1", "epsilon_insensitive", "loss='l1'",
-                                "1.0"),
+                                "0.22"),
                          svm.LinearSVR(loss="l1").fit, X, y)
 
     # loss l2 --> squared_epsilon_insensitive
     assert_warns_message(DeprecationWarning,
                          msg % ("l2", "squared_epsilon_insensitive",
-                                "loss='l2'", "1.0"),
+                                "loss='l2'", "0.22"),
                          svm.LinearSVR(loss="l2").fit, X, y)
 
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -577,7 +577,7 @@ def test_linearsvc_parameters():
                          svm.LinearSVC(loss="l3").fit, X, y)
 
 
-# FIXME remove in 0.22
+# FIXME remove in 0.23
 def test_linearsvx_loss_penalty_deprecations():
     X, y = [[0.0], [1.0]], [0, 1]
 
@@ -588,25 +588,25 @@ def test_linearsvx_loss_penalty_deprecations():
     # LinearSVC
     # loss l1 --> hinge
     assert_warns_message(DeprecationWarning,
-                         msg % ("l1", "hinge", "loss='l1'", "0.22"),
+                         msg % ("l1", "hinge", "loss='l1'", "0.23"),
                          svm.LinearSVC(loss="l1").fit, X, y)
 
     # loss l2 --> squared_hinge
     assert_warns_message(DeprecationWarning,
-                         msg % ("l2", "squared_hinge", "loss='l2'", "0.22"),
+                         msg % ("l2", "squared_hinge", "loss='l2'", "0.23"),
                          svm.LinearSVC(loss="l2").fit, X, y)
 
     # LinearSVR
     # loss l1 --> epsilon_insensitive
     assert_warns_message(DeprecationWarning,
                          msg % ("l1", "epsilon_insensitive", "loss='l1'",
-                                "0.22"),
+                                "0.23"),
                          svm.LinearSVR(loss="l1").fit, X, y)
 
     # loss l2 --> squared_epsilon_insensitive
     assert_warns_message(DeprecationWarning,
                          msg % ("l2", "squared_epsilon_insensitive",
-                                "loss='l2'", "0.22"),
+                                "loss='l2'", "0.23"),
                          svm.LinearSVR(loss="l2").fit, X, y)
 
 


### PR DESCRIPTION
The l1 / l2 loss options in LinearSVC were renamed to `hinge` and `squared_hinge` in 0.16 and marked for removal in 1.0.

Since it's unclear when 1.0 will happen this moves the removal date to ~~0.23~~ ~~0.22~~ 0.23.