### PR TITLE
[MRG]Documented attributes in QuadraticDiscriminantAnalysis, RadiusNeighborsClassifier and KNeighborsClassifier, 

### DIFF
--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -610,7 +610,6 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
         For each class k an array of shape [n_k]. It contains the scaling
         of the Gaussian distributions along its principal axes, i.e. the
         variance in the rotated coordinate system.
-        
     classes_ : array-like, shape (n_classes,)
         Unique class labels.    
 

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -611,7 +611,7 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
         of the Gaussian distributions along its principal axes, i.e. the
         variance in the rotated coordinate system.
     classes_ : array-like, shape (n_classes,)
-        Unique class labels.    
+        Unique class labels.
 
     Examples
     --------
@@ -630,6 +630,7 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
     sklearn.discriminant_analysis.LinearDiscriminantAnalysis: Linear
         Discriminant Analysis
     """
+    
     def __init__(self, priors=None, reg_param=0., store_covariance=False,
                  tol=1.0e-4):
         self.priors = np.asarray(priors) if priors is not None else None

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -630,7 +630,6 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
     sklearn.discriminant_analysis.LinearDiscriminantAnalysis: Linear
         Discriminant Analysis
     """
-
     def __init__(self, priors=None, reg_param=0., store_covariance=False,
                  tol=1.0e-4):
         self.priors = np.asarray(priors) if priors is not None else None

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -610,6 +610,9 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
         For each class k an array of shape [n_k]. It contains the scaling
         of the Gaussian distributions along its principal axes, i.e. the
         variance in the rotated coordinate system.
+        
+    classes_ : array-like, shape (n_classes,)
+        Unique class labels.    
 
     Examples
     --------

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -610,6 +610,7 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
         For each class k an array of shape [n_k]. It contains the scaling
         of the Gaussian distributions along its principal axes, i.e. the
         variance in the rotated coordinate system.
+
     classes_ : array-like, shape (n_classes,)
         Unique class labels.
 

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -630,7 +630,7 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
     sklearn.discriminant_analysis.LinearDiscriminantAnalysis: Linear
         Discriminant Analysis
     """
-    
+ 
     def __init__(self, priors=None, reg_param=0., store_covariance=False,
                  tol=1.0e-4):
         self.priors = np.asarray(priors) if priors is not None else None

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -630,7 +630,7 @@ class QuadraticDiscriminantAnalysis(BaseEstimator, ClassifierMixin):
     sklearn.discriminant_analysis.LinearDiscriminantAnalysis: Linear
         Discriminant Analysis
     """
- 
+
     def __init__(self, priors=None, reg_param=0., store_covariance=False,
                  tol=1.0e-4):
         self.priors = np.asarray(priors) if priors is not None else None

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -101,7 +101,7 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         'minkowski'. 
         
     outputs_2d_ : boolean depending on y in fit,
-        True if the output at fit is 2d, else false.
+        True if the output 'y' at fit is 2d, else false.
 
     Examples
     --------
@@ -336,7 +336,7 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         'minkowski'.    
         
     outputs_2d_ : boolean depending on y in fit,
-        True if the output at fit is 2d, else false.
+        True if the output 'y' at fit is 2d, else false.
 
     Examples
     --------

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -88,7 +88,7 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         Class labels known to the classifier
         
     effective_metric_ : string or callble
-        The distance metric to use. It will be same as
+        The distance metric used. It will be same as
         the `metric` parameter or a synonym of it, e.g.
         'euclidean' if the `metric` parameter set to
         'minkowski' and `p` parameter set to 2.

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -100,7 +100,8 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         if the `effective_metric_` attribute is set to
         'minkowski'. 
         
-    outputs_2d_ : boolean depending on y in fit 
+    outputs_2d_ : boolean depending on y in fit,
+        True if the output at fit is 2d, else false.
 
     Examples
     --------

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -81,6 +81,7 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
         Doesn't affect :meth:`fit` method.
+        
     Attributes
     ----------
     classes_ : array of shape = (n_classes,)
@@ -311,6 +312,7 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
+        
     Attributes
     ----------
     classes_ : array of shape = (n_classes,)

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -336,7 +336,8 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         'minkowski'.    
         
     outputs_2d_ : boolean depending on y in fit,
-        True if the output 'y' at fit is 2d, else false.
+        False when `y`'s shape is (n_samples, ) or (n_samples, 1) during fit
+        otherwise True.
 
     Examples
     --------

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -90,7 +90,6 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         The distance metric used. It will be same as the `metric` parameter 
         or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
         'minkowski' and `p` parameter set to 2.
-        
     effective_metric_params_ : dict
         Additional keyword arguments for the metric function. For most metrics 
         will be same with `metric_params` parameter, but may also contain the

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -325,7 +325,6 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         will be same with `metric_params` parameter, but may also contain the
         `p` parameter value if the `effective_metric_` attribute is set to
         'minkowski'.    
-        
     outputs_2d_ : bool
         False when `y`'s shape is (n_samples, ) or (n_samples, 1) during fit
         otherwise True.

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -81,7 +81,7 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
         Doesn't affect :meth:`fit` method.
-        
+
     Attributes
     ----------
     classes_ : array of shape = (n_classes,)
@@ -312,7 +312,7 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
-        
+
     Attributes
     ----------
     classes_ : array of shape = (n_classes,)

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -335,7 +335,8 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         if the `effective_metric_` attribute is set to
         'minkowski'.    
         
-    outputs_2d_ : boolean depending on y in fit   
+    outputs_2d_ : boolean depending on y in fit,
+        True if the output at fit is 2d, else false.
 
     Examples
     --------

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -100,7 +100,7 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         if the `effective_metric_` attribute is set to
         'minkowski'. 
         
-    outputs_2d_ : array of shape = (n_samples,1) or (n_samples,) 
+    outputs_2d_ : boolean depending on y in fit 
 
     Examples
     --------
@@ -334,7 +334,7 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         if the `effective_metric_` attribute is set to
         'minkowski'.    
         
-    outputs_2d_ : array of shape = (n_samples,1) or (n_samples,)    
+    outputs_2d_ : boolean depending on y in fit   
 
     Examples
     --------

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -86,14 +86,14 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
     classes_ : array of shape = (n_classes,)
         Class labels known to the classifier
     effective_metric_ : string or callble
-        The distance metric used. It will be same as the `metric` parameter 
+        The distance metric used. It will be same as the `metric` parameter
         or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
         'minkowski' and `p` parameter set to 2.
     effective_metric_params_ : dict
-        Additional keyword arguments for the metric function. For most metrics 
+        Additional keyword arguments for the metric function. For most metrics
         will be same with `metric_params` parameter, but may also contain the
         `p` parameter value if the `effective_metric_` attribute is set to
-        'minkowski'. 
+        'minkowski'.
     outputs_2d_ : bool
         False when `y`'s shape is (n_samples, ) or (n_samples, 1) during fit
         otherwise True.
@@ -316,14 +316,14 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
     classes_ : array of shape = (n_classes,)
         Class labels known to the classifier.
     effective_metric_ : string or callble
-        The distance metric used. It will be same as the `metric` parameter 
+        The distance metric used. It will be same as the `metric` parameter
         or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
         'minkowski' and `p` parameter set to 2.
     effective_metric_params_ : dict
         Additional keyword arguments for the metric function. For most metrics
         will be same with `metric_params` parameter, but may also contain the
         `p` parameter value if the `effective_metric_` attribute is set to
-        'minkowski'.    
+        'minkowski'.
     outputs_2d_ : bool
         False when `y`'s shape is (n_samples, ) or (n_samples, 1) during fit
         otherwise True.

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -81,7 +81,6 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
         Doesn't affect :meth:`fit` method.
-        
     Attributes
     ----------
     classes_ : array of shape = (n_classes,)

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -316,7 +316,6 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
     ----------
     classes_ : array of shape = (n_classes,)
         Class labels known to the classifier.
-        
     effective_metric_ : string or callble
         The distance metric used. It will be same as the `metric` parameter 
         or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -312,7 +312,6 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
-        
     Attributes
     ----------
     classes_ : array of shape = (n_classes,)

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -95,7 +95,6 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         will be same with `metric_params` parameter, but may also contain the
         `p` parameter value if the `effective_metric_` attribute is set to
         'minkowski'. 
-        
     outputs_2d_ : bool
         False when `y`'s shape is (n_samples, ) or (n_samples, 1) during fit
         otherwise True.

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -101,7 +101,8 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         'minkowski'. 
         
     outputs_2d_ : bool
-        True if the output 'y' at fit is 2d, else false.
+        False when `y`'s shape is (n_samples, ) or (n_samples, 1) during fit
+        otherwise True.
 
     Examples
     --------

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -322,7 +322,7 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         Class labels known to the classifier.
         
     effective_metric_ : string or callble
-        The distance metric to use. It will be same as
+        The distance metric used. It will be same as
         the `metric` parameter or a synonym of it, e.g.
         'euclidean' if the `metric` parameter set to
         'minkowski' and `p` parameter set to 2.

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -100,7 +100,7 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         if the `effective_metric_` attribute is set to
         'minkowski'. 
         
-    outputs_2d_ : boolean depending on y in fit,
+    outputs_2d_ : bool
         True if the output 'y' at fit is 2d, else false.
 
     Examples

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -88,16 +88,14 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         Class labels known to the classifier
         
     effective_metric_ : string or callble
-        The distance metric used. It will be same as
-        the `metric` parameter or a synonym of it, e.g.
-        'euclidean' if the `metric` parameter set to
+        The distance metric used. It will be same as the `metric` parameter 
+        or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
         'minkowski' and `p` parameter set to 2.
         
     effective_metric_params_ : dict
-        Additional keyword arguments for the metric function.
-        For most metrics will be same with `metric_params`
-        parameter, but may also contain the `p` parameter value
-        if the `effective_metric_` attribute is set to
+        Additional keyword arguments for the metric function. For most metrics 
+        will be same with `metric_params` parameter, but may also contain the
+        `p` parameter value if the `effective_metric_` attribute is set to
         'minkowski'. 
         
     outputs_2d_ : bool
@@ -324,16 +322,14 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         Class labels known to the classifier.
         
     effective_metric_ : string or callble
-        The distance metric used. It will be same as
-        the `metric` parameter or a synonym of it, e.g.
-        'euclidean' if the `metric` parameter set to
+        The distance metric used. It will be same as the `metric` parameter 
+        or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
         'minkowski' and `p` parameter set to 2.
         
     effective_metric_params_ : dict
-        Additional keyword arguments for the metric function.
-        For most metrics will be same with `metric_params`
-        parameter, but may also contain the `p` parameter value
-        if the `effective_metric_` attribute is set to
+        Additional keyword arguments for the metric function. For most metrics
+        will be same with `metric_params` parameter, but may also contain the
+        `p` parameter value if the `effective_metric_` attribute is set to
         'minkowski'.    
         
     outputs_2d_ : bool

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -85,7 +85,6 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
     ----------
     classes_ : array of shape = (n_classes,)
         Class labels known to the classifier
-        
     effective_metric_ : string or callble
         The distance metric used. It will be same as the `metric` parameter 
         or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -335,7 +335,7 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         if the `effective_metric_` attribute is set to
         'minkowski'.    
         
-    outputs_2d_ : boolean depending on y in fit,
+    outputs_2d_ : bool
         False when `y`'s shape is (n_samples, ) or (n_samples, 1) during fit
         otherwise True.
 

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -86,15 +86,18 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
     ----------
     classes_ : array of shape = (n_classes,)
         Class labels known to the classifier
+
     effective_metric_ : string or callble
         The distance metric used. It will be same as the `metric` parameter
         or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
         'minkowski' and `p` parameter set to 2.
+
     effective_metric_params_ : dict
         Additional keyword arguments for the metric function. For most metrics
         will be same with `metric_params` parameter, but may also contain the
         `p` parameter value if the `effective_metric_` attribute is set to
         'minkowski'.
+
     outputs_2d_ : bool
         False when `y`'s shape is (n_samples, ) or (n_samples, 1) during fit
         otherwise True.
@@ -317,15 +320,18 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
     ----------
     classes_ : array of shape = (n_classes,)
         Class labels known to the classifier.
+
     effective_metric_ : string or callble
         The distance metric used. It will be same as the `metric` parameter
         or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
         'minkowski' and `p` parameter set to 2.
+
     effective_metric_params_ : dict
         Additional keyword arguments for the metric function. For most metrics
         will be same with `metric_params` parameter, but may also contain the
         `p` parameter value if the `effective_metric_` attribute is set to
         'minkowski'.
+
     outputs_2d_ : bool
         False when `y`'s shape is (n_samples, ) or (n_samples, 1) during fit
         otherwise True.

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -81,6 +81,26 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
         Doesn't affect :meth:`fit` method.
+        
+    Attributes
+    ----------
+    classes_ : array of shape = (n_classes,)
+        Class labels known to the classifier
+        
+    effective_metric_ : string or callble
+        The distance metric to use. It will be same as
+        the `metric` parameter or a synonym of it, e.g.
+        'euclidean' if the `metric` parameter set to
+        'minkowski' and `p` parameter set to 2.
+        
+    effective_metric_params_ : dict
+        Additional keyword arguments for the metric function.
+        For most metrics will be same with `metric_params`
+        parameter, but may also contain the `p` parameter value
+        if the `effective_metric_` attribute is set to
+        'minkowski'. 
+        
+    outputs_2d_ : array of shape = (n_samples,1) or (n_samples,) 
 
     Examples
     --------
@@ -295,6 +315,26 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
+        
+    Attributes
+    ----------
+    classes_ : array of shape = (n_classes,)
+        Class labels known to the classifier.
+        
+    effective_metric_ : string or callble
+        The distance metric to use. It will be same as
+        the `metric` parameter or a synonym of it, e.g.
+        'euclidean' if the `metric` parameter set to
+        'minkowski' and `p` parameter set to 2.
+        
+    effective_metric_params_ : dict
+        Additional keyword arguments for the metric function.
+        For most metrics will be same with `metric_params`
+        parameter, but may also contain the `p` parameter value
+        if the `effective_metric_` attribute is set to
+        'minkowski'.    
+        
+    outputs_2d_ : array of shape = (n_samples,1) or (n_samples,)    
 
     Examples
     --------

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -320,7 +320,6 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         The distance metric used. It will be same as the `metric` parameter 
         or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
         'minkowski' and `p` parameter set to 2.
-        
     effective_metric_params_ : dict
         Additional keyword arguments for the metric function. For most metrics
         will be same with `metric_params` parameter, but may also contain the


### PR DESCRIPTION
Partially address [#14312](https://github.com/scikit-learn/scikit-learn/issues/14312) 

Covering QuadraticDiscriminantAnalysis, [classes_, covariance_] inside 
sklearn/discriminant_analysis.py

added  RadiusNeighborsClassifier, [classes_, effective_metric_, effective_metric_params_, outputs_2d_]
KNeighborsClassifier, [classes_, effective_metric_, effective_metric_params_, outputs_2d_]