### PR TITLE
[MRG] Add clone_kernel option to make gaussian process models faster

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -117,6 +117,18 @@ Changelog
   `predict_proba` give consistent results.
   :pr:`14114` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+:mod:`sklearn.gaussian_process`
+...............................
+
+- |Feature| :func:`gaussian_process.GaussianProcessClassifier.log_marginal_likelihood`
+  and :func:`gaussian_process.GaussianProcessRegressor.log_marginal_likelihood` now
+  accept a ``clone_kernel=True`` keyword argument. When set to ``False``,
+  the kernel attribute is modified, but may result in a performance improvement.
+  :func:`gaussian_process.GaussianProcessClassifier.fit` and
+  :func:`gaussian_process.GaussianProcessRegressor.fit` call
+  ``log_marginal_likelihood`` method with ``clone_kernel=False`` now.
+  :pr:`14378` by :user:`Masashi Shibata <c-bata>`.
+
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -141,9 +141,6 @@ Changelog
   and :func:`gaussian_process.GaussianProcessRegressor.log_marginal_likelihood` now
   accept a ``clone_kernel=True`` keyword argument. When set to ``False``,
   the kernel attribute is modified, but may result in a performance improvement.
-  :func:`gaussian_process.GaussianProcessClassifier.fit` and
-  :func:`gaussian_process.GaussianProcessRegressor.fit` call
-  ``log_marginal_likelihood`` method with ``clone_kernel=False`` now.
   :pr:`14378` by :user:`Masashi Shibata <c-bata>`.
 
 - |API| From version 0.24 :meth:`Kernel.get_params` will raise an

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -321,8 +321,8 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
             additionally. If True, theta must not be None.
 
         clone_kernel : bool, default=True
-            If True, the kernel attribute is copied. Please specify False if
-            you want to make this method call faster.
+            If True, the kernel attribute is copied. If False, the kernel
+            attribute is modified, but may result in a performance improvement.
 
         Returns
         -------
@@ -722,8 +722,8 @@ class GaussianProcessClassifier(BaseEstimator, ClassifierMixin):
             for non-binary classification. If True, theta must not be None.
 
         clone_kernel : bool, default=True
-            If True, the kernel attribute is copied. Please specify False if
-            you want to make this method call faster.
+            If True, the kernel attribute is copied. If False, the kernel
+            attribute is modified, but may result in a performance improvement.
 
         Returns
         -------

--- a/sklearn/gaussian_process/gpc.py
+++ b/sklearn/gaussian_process/gpc.py
@@ -320,7 +320,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
             to the kernel hyperparameters at position theta is returned
             additionally. If True, theta must not be None.
 
-        clone_kernel : bool, default: True
+        clone_kernel : bool, default=True
             If True, the kernel attribute is copied. Please specify False if
             you want to make this method call faster.
 
@@ -721,7 +721,7 @@ class GaussianProcessClassifier(BaseEstimator, ClassifierMixin):
             additionally. Note that gradient computation is not supported
             for non-binary classification. If True, theta must not be None.
 
-        clone_kernel : bool, default: True
+        clone_kernel : bool, default=True
             If True, the kernel attribute is copied. Please specify False if
             you want to make this method call faster.
 

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -404,7 +404,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
             to the kernel hyperparameters at position theta is returned
             additionally. If True, theta must not be None.
 
-        clone_kernel : bool, default: True
+        clone_kernel : bool, default=True
             If True, the kernel attribute is copied. Please specify False if
             you want to make this method call faster.
 

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -405,8 +405,8 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
             additionally. If True, theta must not be None.
 
         clone_kernel : bool, default=True
-            If True, the kernel attribute is copied. Please specify False if
-            you want to make this method call faster.
+            If True, the kernel attribute is copied. If False, the kernel
+            attribute is modified, but may result in a performance improvement.
 
         Returns
         -------

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -210,10 +210,11 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
             def obj_func(theta, eval_gradient=True):
                 if eval_gradient:
                     lml, grad = self.log_marginal_likelihood(
-                        theta, eval_gradient=True)
+                        theta, eval_gradient=True, clone_kernel=False)
                     return -lml, -grad
                 else:
-                    return -self.log_marginal_likelihood(theta)
+                    return -self.log_marginal_likelihood(theta,
+                                                         clone_kernel=False)
 
             # First optimize starting from theta specified in kernel
             optima = [(self._constrained_optimization(obj_func,
@@ -241,7 +242,8 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
             self.log_marginal_likelihood_value_ = -np.min(lml_values)
         else:
             self.log_marginal_likelihood_value_ = \
-                self.log_marginal_likelihood(self.kernel_.theta)
+                self.log_marginal_likelihood(self.kernel_.theta,
+                                             clone_kernel=False)
 
         # Precompute quantities required for predictions which are independent
         # of actual query points
@@ -386,7 +388,8 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
             y_samples = np.hstack(y_samples)
         return y_samples
 
-    def log_marginal_likelihood(self, theta=None, eval_gradient=False):
+    def log_marginal_likelihood(self, theta=None, eval_gradient=False,
+                                clone_kernel=True):
         """Returns log-marginal likelihood of theta for training data.
 
         Parameters
@@ -400,6 +403,10 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
             If True, the gradient of the log-marginal likelihood with respect
             to the kernel hyperparameters at position theta is returned
             additionally. If True, theta must not be None.
+
+        clone_kernel : bool, default: True
+            If True, the kernel attribute is copied. Please specify False if
+            you want to make this method call faster.
 
         Returns
         -------
@@ -417,7 +424,11 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
                     "Gradient can only be evaluated for theta!=None")
             return self.log_marginal_likelihood_value_
 
-        kernel = self.kernel_.clone_with_theta(theta)
+        if clone_kernel:
+            kernel = self.kernel_.clone_with_theta(theta)
+        else:
+            kernel = self.kernel_
+            kernel.theta = theta
 
         if eval_gradient:
             K, K_gradient = kernel(self.X_train_, eval_gradient=True)

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -60,6 +60,16 @@ def test_lml_precomputed(kernel):
                         gpc.log_marginal_likelihood(), 7)
 
 
+@pytest.mark.parametrize('kernel', kernels)
+def test_lml_without_cloning_kernel(kernel):
+    # Test that clone_kernel=False has side-effects of kernel.theta.
+    gpc = GaussianProcessClassifier(kernel=kernel).fit(X, y)
+    input_theta = np.ones(gpc.kernel_.theta.shape, dtype=np.float64)
+
+    gpc.log_marginal_likelihood(input_theta, clone_kernel=False)
+    assert_almost_equal(gpc.kernel_.theta, input_theta, 7)
+
+
 @pytest.mark.parametrize('kernel', non_fixed_kernels)
 def test_converged_to_local_maximum(kernel):
     # Test that we are in local maximum after hyperparameter-optimization.

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -69,6 +69,16 @@ def test_lml_precomputed(kernel):
                  gpr.log_marginal_likelihood())
 
 
+@pytest.mark.parametrize('kernel', kernels)
+def test_lml_without_cloning_kernel(kernel):
+    # Test that lml of optimized kernel is stored correctly.
+    gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
+    input_theta = np.ones(gpr.kernel_.theta.shape, dtype=np.float64)
+
+    gpr.log_marginal_likelihood(input_theta, clone_kernel=False)
+    assert_almost_equal(gpr.kernel_.theta, input_theta, 7)
+
+
 @pytest.mark.parametrize('kernel', non_fixed_kernels)
 def test_converged_to_local_maximum(kernel):
     # Test that we are in local maximum after hyperparameter-optimization.


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.

**Problems**

I want to make GaussianProcessRegressor faster. I profiled `GaussianProcessRegressor#fit` using cProfile and generated the graph to find bottlenecks. The result is below:

![output](https://user-images.githubusercontent.com/5564044/61235963-c6cd5800-a771-11e9-8ee3-daf4600ba6ee.png)

This result shows `Kernel#clone_with_theta` accounts for 55.18% of the whole.

**Solutions**

Basically, I think we don't need to clone kernels. It seems to be enough that we just replace `theta` attribute. From my benchmark of [this gist](https://gist.github.com/c-bata/7eb7738c829c9858f4955dab5ac851e3), `GaussianProcessRegressor#fit` will be 26.4% faster by applying this patch.

*Before:*

```
$ python examples/gpr_bench.py 
elapsed: 3.620s
elapsed: 4.616s
elapsed: 3.892s
elapsed: 3.784s
elapsed: 3.908s
elapsed: 4.280s
elapsed: 2.884s
elapsed: 2.543s
elapsed: 2.502s
elapsed: 4.946s
score: 3.6975975036621094 0.7911395580877181
```

*After:*

```
$ python examples/gpr_bench.py 
elapsed: 2.642s
elapsed: 2.423s
elapsed: 2.921s
elapsed: 2.704s
elapsed: 2.856s
elapsed: 3.667s
elapsed: 2.737s
elapsed: 2.397s
elapsed: 2.292s
elapsed: 2.590s
score: 2.722917938232422 0.36802930790866245
```

#### Any other comments?

To confirm this PR doesn't break the logic, I generate the graph of model prediction results (I might need to design more suitable kernel functions).

| before | after (exactly the same with before's one) |
| ---  | --- |
| ![gpr_predict](https://user-images.githubusercontent.com/5564044/61236018-ef555200-a771-11e9-841e-aa6602ddaa7e.png) | ![gpr_predict2](https://user-images.githubusercontent.com/5564044/61236019-efede880-a771-11e9-8957-93a1b5d81ee7.png) |
