### PR TITLE
[MRG+1] fix plot_partial_dependence not taking target into account when multiclass

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -17,7 +17,7 @@ Changelog
 .....................
 
 - |Fix| Fixed a bug in :func:`inspection.plot_partial_dependence` where 
-  ``target`` parameter was not being taken into account
+  ``target`` parameter was not being taken into account for multiclass problems.
   :pr:`14393` by :user:`Guillem G. Subies <guillemgsubies>`.
 
 :mod:`sklearn.datasets`

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -12,6 +12,14 @@ Version 0.21.3
 Changelog
 ---------
 
+
+:mod:`sklearn.inspection`
+.....................
+
+- |Fix| Fixed a bug in :func:`inspection.plot_partial_dependence` where 
+  ``target`` parameter was not being taken into account
+  :pr:`14393` by :user:`Guillem G. Subies <guillemgsubies>`.
+
 :mod:`sklearn.datasets`
 .......................
 

--- a/sklearn/inspection/partial_dependence.py
+++ b/sklearn/inspection/partial_dependence.py
@@ -586,8 +586,6 @@ def plot_partial_dependence(estimator, X, features, feature_names=None,
             raise ValueError(
                 'target must be in [0, n_tasks], got {}.'.format(target))
         target_idx = target
-    else:
-        target_idx = 0
 
     # get global min and max values of PD grouped by plot type
     pdp_lim = {}

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -507,6 +507,7 @@ def test_plot_partial_dependence_multiclass(pyplot):
     # check that the pd plots are the same for 0 and "setosa"
     assert all(axs[0].lines[0]._y == axs2[0].lines[0]._y)
     # check that the pd plots are different for another target
+    clf.fit(iris.data, iris.target)
     plot_partial_dependence(clf, iris.data, [0, 1],
                             target=1,
                             grid_resolution=grid_resolution)

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -502,10 +502,23 @@ def test_plot_partial_dependence_multiclass(pyplot):
     plot_partial_dependence(clf, iris.data, [0, 1],
                             target='setosa',
                             grid_resolution=grid_resolution)
-    fig = pyplot.gcf()
-    axs = fig.get_axes()
-    assert len(axs) == 2
-    assert all(ax.has_data for ax in axs)
+    fig2 = pyplot.gcf()
+    axs2 = fig2.get_axes()
+    assert len(axs2) == 2
+    assert all(ax.has_data for ax in axs2)
+
+    # 0 is setosa
+    assert all(axs[0].lines[0]._y == axs2[0].lines[0]._y)
+    # 1 is not
+    clf = GradientBoostingClassifier(n_estimators=10, random_state=1)
+    clf.fit(iris.data, iris.target)
+    grid_resolution = 25
+    plot_partial_dependence(clf, iris.data, [0, 1],
+                            target=1,
+                            grid_resolution=grid_resolution)
+    fig3 = plt.gcf()
+    axs3 = fig3.get_axes()
+    assert any(axs[0].lines[0]._y != axs3[0].lines[0]._y)
 
 
 def test_plot_partial_dependence_multioutput(pyplot):

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -479,12 +479,12 @@ def test_plot_partial_dependence(pyplot):
 
 
 def test_plot_partial_dependence_multiclass(pyplot):
-    # Test partial dependence plot function on multi-class input.
-    iris = load_iris()
-    clf = GradientBoostingClassifier(n_estimators=10, random_state=1)
-    clf.fit(iris.data, iris.target)
-
     grid_resolution = 25
+    clf = GradientBoostingClassifier(n_estimators=10, random_state=1)
+    iris = load_iris()
+
+    # Test partial dependence plot function on multi-class input.
+    clf.fit(iris.data, iris.target)
     plot_partial_dependence(clf, iris.data, [0, 1],
                             target=0,
                             grid_resolution=grid_resolution)
@@ -495,10 +495,7 @@ def test_plot_partial_dependence_multiclass(pyplot):
 
     # now with symbol labels
     target = iris.target_names[iris.target]
-    clf = GradientBoostingClassifier(n_estimators=10, random_state=1)
     clf.fit(iris.data, target)
-
-    grid_resolution = 25
     plot_partial_dependence(clf, iris.data, [0, 1],
                             target='setosa',
                             grid_resolution=grid_resolution)
@@ -510,9 +507,7 @@ def test_plot_partial_dependence_multiclass(pyplot):
     # check that the pd plots are the same for 0 and "setosa"
     assert all(axs[0].lines[0]._y == axs2[0].lines[0]._y)
     # check that the pd plots are different for another target
-    clf = GradientBoostingClassifier(n_estimators=10, random_state=1)
     clf.fit(iris.data, iris.target)
-    grid_resolution = 25
     plot_partial_dependence(clf, iris.data, [0, 1],
                             target=1,
                             grid_resolution=grid_resolution)

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -516,7 +516,7 @@ def test_plot_partial_dependence_multiclass(pyplot):
     plot_partial_dependence(clf, iris.data, [0, 1],
                             target=1,
                             grid_resolution=grid_resolution)
-    fig3 = plt.gcf()
+    fig3 = pyplot.gcf()
     axs3 = fig3.get_axes()
     assert any(axs[0].lines[0]._y != axs3[0].lines[0]._y)
 

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -507,7 +507,6 @@ def test_plot_partial_dependence_multiclass(pyplot):
     # check that the pd plots are the same for 0 and "setosa"
     assert all(axs[0].lines[0]._y == axs2[0].lines[0]._y)
     # check that the pd plots are different for another target
-    clf.fit(iris.data, iris.target)
     plot_partial_dependence(clf, iris.data, [0, 1],
                             target=1,
                             grid_resolution=grid_resolution)

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -507,9 +507,9 @@ def test_plot_partial_dependence_multiclass(pyplot):
     assert len(axs2) == 2
     assert all(ax.has_data for ax in axs2)
 
-    # 0 is setosa
+    # check that the pd plots are the same for 0 and "setosa"
     assert all(axs[0].lines[0]._y == axs2[0].lines[0]._y)
-    # 1 is not
+    # check that the pd plots are different for another target
     clf = GradientBoostingClassifier(n_estimators=10, random_state=1)
     clf.fit(iris.data, iris.target)
     grid_resolution = 25


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #14301

#### What does this implement/fix? Explain your changes.

I just took out an else so `target_idx` does not get overwritten.

#### Any other comments?

I didn't know what was the optimal way to test it. Right now I check the y axis and make sure that they are not the same (the bug made them equals all the time).

Also, I have a question: Here it should be int or str, shouldn't it?
https://github.com/scikit-learn/scikit-learn/blob/c0c53137cec61a4d6cd72d8a43bbe0321476e440/sklearn/inspection/partial_dependence.py#L404
