### PR TITLE
CI Enable parallel builds

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -90,4 +90,5 @@ except ImportError:
     print('pandas not installed')
 "
 pip list
+python setup.py build_ext --inplace -j 3
 python setup.py develop

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -30,6 +30,7 @@ export PATH=/usr/lib/ccache:$PATH
 export LOKY_MAX_CPU_COUNT="2"
 export OMP_NUM_THREADS="1"
 
+python setup.py build_ext --inplace -j 3
 pip install -e .
 
 # Check that Python implementation is PyPy


### PR DESCRIPTION
As illustrated in https://github.com/scikit-learn/scikit-learn/issues/12676#issuecomment-508088691 by @dimrozakis, parallel build does seem to work (despite earlier reports that they weren't).

This attempts to enable those in CI. The typical strategy for multi-core compilation is to use `CPU_CORES + 1` to compensate for I/O.

Let's see if this helps with run time. I haven't found a way to pass the `-j` flag to the `setup.py bdist_wheels` yet (that is used e.g. for Windows builds on Azure).

A better improvement would be to use ccache. Caching was just added to Azure Pipelines https://github.com/Microsoft/azure-pipelines-yaml/pull/113 but it doesn't sound like it's as good as in Circle CI. Might be worth investigating.

FYI @jeremiedbb @thomasjpfan 