### PR TITLE
DOC Add comment about scipy.stats.mstats.mode for SimpleImputer(strategy=most_frequent)

### DIFF
--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -338,6 +338,10 @@ class SimpleImputer(BaseEstimator, TransformerMixin):
 
         # Most frequent
         elif strategy == "most_frequent":
+            # Avoid use of scipy.stats.mstats.mode due to the required
+            # additional overhead and slow benchmarking performance.
+            # See #14399 for full discussion.
+
             # To be able access the elements by columns
             X = X.transpose()
             mask = mask.transpose()

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -344,11 +344,11 @@ class SimpleImputer(BaseEstimator, TransformerMixin):
             # See https://github.com/scipy/scipy/issues/2636
 
             if np.issubdtype(X.dtype, np.number):
-                mode_masked, count_masked  = stats.mstats.mode(masked_X, axis=0)
+                mode_masked, count_masked = stats.mstats.mode(masked_X, axis=0)
                 most_frequent = mode_masked.data.flatten()
                 counts = count_masked.data.flatten().astype(int)
                 most_frequent[np.where(counts == 0)] = np.nan
-            
+
             # stats.mstats.mode requires that array elements are
             # able to be cast as to floats
             else:
@@ -356,10 +356,7 @@ class SimpleImputer(BaseEstimator, TransformerMixin):
                 X = X.transpose()
                 mask = mask.transpose()
 
-                if X.dtype.kind == "O":
-                    most_frequent = np.empty(X.shape[0], dtype=object)
-                else:
-                    most_frequent = np.empty(X.shape[0])
+                most_frequent = np.empty(X.shape[0], dtype=object)
 
                 for i, (row, row_mask) in enumerate(zip(X[:], mask[:])):
                     row_mask = np.logical_not(row_mask).astype(np.bool)

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -338,30 +338,19 @@ class SimpleImputer(BaseEstimator, TransformerMixin):
 
         # Most frequent
         elif strategy == "most_frequent":
-            # scipy.stats.mstats.mode cannot be used because it will no work
-            # properly if the first element is masked and if its frequency
-            # is equal to the frequency of the most frequent valid element
-            # See https://github.com/scipy/scipy/issues/2636
+            # To be able access the elements by columns
+            X = X.transpose()
+            mask = mask.transpose()
 
-            if np.issubdtype(X.dtype, np.number):
-                mode_masked, count_masked = stats.mstats.mode(masked_X, axis=0)
-                most_frequent = mode_masked.data.flatten()
-                counts = count_masked.data.flatten().astype(int)
-                most_frequent[np.where(counts == 0)] = np.nan
-
-            # stats.mstats.mode requires that array elements are
-            # able to be cast as to floats
-            else:
-                # To be able access the elements by columns
-                X = X.transpose()
-                mask = mask.transpose()
-
+            if X.dtype.kind == "O":
                 most_frequent = np.empty(X.shape[0], dtype=object)
+            else:
+                most_frequent = np.empty(X.shape[0])
 
-                for i, (row, row_mask) in enumerate(zip(X[:], mask[:])):
-                    row_mask = np.logical_not(row_mask).astype(np.bool)
-                    row = row[row_mask]
-                    most_frequent[i] = _most_frequent(row, np.nan, 0)
+            for i, (row, row_mask) in enumerate(zip(X[:], mask[:])):
+                row_mask = np.logical_not(row_mask).astype(np.bool)
+                row = row[row_mask]
+                most_frequent[i] = _most_frequent(row, np.nan, 0)
 
             return most_frequent
 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -340,7 +340,7 @@ class SimpleImputer(BaseEstimator, TransformerMixin):
         elif strategy == "most_frequent":
             # Avoid use of scipy.stats.mstats.mode due to the required
             # additional overhead and slow benchmarking performance.
-            # See #14399 for full discussion.
+            # See Issue 14325 and PR 14399 for full discussion.
 
             # To be able access the elements by columns
             X = X.transpose()

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -343,19 +343,28 @@ class SimpleImputer(BaseEstimator, TransformerMixin):
             # is equal to the frequency of the most frequent valid element
             # See https://github.com/scipy/scipy/issues/2636
 
-            # To be able access the elements by columns
-            X = X.transpose()
-            mask = mask.transpose()
-
-            if X.dtype.kind == "O":
-                most_frequent = np.empty(X.shape[0], dtype=object)
+            if np.issubdtype(X.dtype, np.number):
+                mode_masked, count_masked  = stats.mstats.mode(masked_X, axis=0)
+                most_frequent = mode_masked.data.flatten()
+                counts = count_masked.data.flatten().astype(int)
+                most_frequent[np.where(counts == 0)] = np.nan
+            
+            # stats.mstats.mode requires that array elements are
+            # able to be cast as to floats
             else:
-                most_frequent = np.empty(X.shape[0])
+                # To be able access the elements by columns
+                X = X.transpose()
+                mask = mask.transpose()
 
-            for i, (row, row_mask) in enumerate(zip(X[:], mask[:])):
-                row_mask = np.logical_not(row_mask).astype(np.bool)
-                row = row[row_mask]
-                most_frequent[i] = _most_frequent(row, np.nan, 0)
+                if X.dtype.kind == "O":
+                    most_frequent = np.empty(X.shape[0], dtype=object)
+                else:
+                    most_frequent = np.empty(X.shape[0])
+
+                for i, (row, row_mask) in enumerate(zip(X[:], mask[:])):
+                    row_mask = np.logical_not(row_mask).astype(np.bool)
+                    row = row[row_mask]
+                    most_frequent[i] = _most_frequent(row, np.nan, 0)
 
             return most_frequent
 


### PR DESCRIPTION
#### Reference Issues/PRs
Attempts to make use of `scipy.stats.mstats.mode` within`SimpleImputer(strategy='most_frequent')`. This was suggested in #14325 since a previous bug within the `mstats.mode` function [has been fixed](https://github.com/scipy/scipy/pull/2672).

#### What does this implement/fix? Explain your changes.
I'm currently using the updated `mstats.mode` function to impute values for numeric inputs. 

However, it seems that `mstats.mode` will not work with alpha inputs because it requires that the inputs can be cast to floats. This happens [here](https://github.com/scipy/scipy/blob/master/scipy/stats/mstats_basic.py#L151) when `mstats.mode` internally calls `find_repeats`.

#### Any other comments?
My initial assumption was that `mstats.mode` would be able to handle all input types (since `scipy.stats.mode` can) and that the code block for `strategy == 'most_frequent'` could be cleanly handled with this single function.

My current understanding is that any non-numeric inputs would have to be handled separately by passing them off to `scipy.stats.mode` -- however this is already the current behavior for all cases (numeric and otherwise). Data are being passed into the internal function `_most_frequent`, which is using `scipy.stats.mode`. I could be overlooking something obvious but for now it seems to me that using `mstats.mode` might introduce more complexity into the code.

#### Request for feedback
What do you think is the best way forward? Do you think there is a simpler way that I could continue on  with `mstats.mode` that I might be missing or does it not seem worth it to include `mstats.mode`?
