### PR TITLE
MNT Redundant statement in AdaBoostClassifier

### DIFF
--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -590,8 +590,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         if not iboost == self.n_estimators - 1:
             # Only boost positive weights
             sample_weight *= np.exp(estimator_weight * incorrect *
-                                    ((sample_weight > 0) |
-                                     (estimator_weight < 0)))
+                                    (sample_weight > 0))
 
         return sample_weight, estimator_weight, estimator_error
 


### PR DESCRIPTION
In SAMME
We make sure that ``learning_rate > 0``
We also make sure that ``estimator_error < 1 - 1/n_classes`` (otherwise we discard current estimator and stop the iteration)
```python
estimator_weight = self.learning_rate * (
            np.log((1. - estimator_error) / estimator_error) +
            np.log(n_classes - 1.))
```
It's easy to prove that estimator_weight > 0 (the right part is monotonically decreasing)