### PR TITLE
[MRG] Remove dead code from BaseGradientBoosting

### DIFF
--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1571,13 +1571,6 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         n_inbag = max(1, int(self.subsample * n_samples))
         loss_ = self.loss_
 
-        # Set min_weight_leaf from min_weight_fraction_leaf
-        if self.min_weight_fraction_leaf != 0. and sample_weight is not None:
-            min_weight_leaf = (self.min_weight_fraction_leaf *
-                               np.sum(sample_weight))
-        else:
-            min_weight_leaf = 0.
-
         if self.verbose:
             verbose_reporter = VerboseReporter(self.verbose)
             verbose_reporter.init(self, begin_at_stage)


### PR DESCRIPTION
This pull request removes dead code from `BaseGradientBoosting` related to `min_weight_leaf` that is not used anymore.

It was originally introduced in commit 6f335af7ee3107b5007ee232c6f05342bebe09c6, but it seems it is unused since commit 02c0029baa449499e2814c03e987f9a7f33c7c0b.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->
