### PR TITLE
DOC AdaboostRegressor do not require the base estimator to support sample weight

### DIFF
--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -870,7 +870,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
     base_estimator : object, optional (default=None)
         The base estimator from which the boosted ensemble is built.
         If ``None``, then the base estimator is
-        :class:`sklearn.tree.DecisionTreeRegressor(max_depth=3)`.
+        ``DecisionTreeRegressor(max_depth=3)``.
 
     n_estimators : integer, optional (default=50)
         The maximum number of estimators at which boosting is terminated.

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -870,7 +870,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
     base_estimator : object, optional (default=None)
         The base estimator from which the boosted ensemble is built.
         If ``None``, then the base estimator is
-        ``DecisionTreeRegressor(max_depth=3)``.
+        :class:`sklearn.tree.DecisionTreeRegressor(max_depth=3)`.
 
     n_estimators : integer, optional (default=50)
         The maximum number of estimators at which boosting is terminated.

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -869,8 +869,8 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
     ----------
     base_estimator : object, optional (default=None)
         The base estimator from which the boosted ensemble is built.
-        Support for sample weighting is required. If ``None``, then
-        the base estimator is ``DecisionTreeRegressor(max_depth=3)``
+        If ``None``, then the base estimator is
+        ``DecisionTreeRegressor(max_depth=3)``.
 
     n_estimators : integer, optional (default=50)
         The maximum number of estimators at which boosting is terminated.


### PR DESCRIPTION
We sample the training set according to the weight, which is consistent with the reference.