### PR TITLE
FIX remove lambdas from text preprocessing

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -134,6 +134,13 @@ Changelog
   `predict_proba` give consistent results.
   :pr:`14114` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+:mod:`sklearn.feature_extraction`
+.......................
+
+- |Fix| Functions created by build_preprocessor and build_analyzer of
+  :class:`feature_extraction.text.VectorizerMixin` can now be pickled.
+  :pr:`14430` by :user:`Dillon Niederhut <deniederhut>`.
+
 :mod:`sklearn.gaussian_process`
 ...............................
 
@@ -216,7 +223,7 @@ Changelog
 - |Enhancement| SVM now throws more specific error when fit on non-square data
   and kernel = precomputed.  :class:`svm.BaseLibSVM`
   :pr:`14336` by :user:`Gregory Dexter <gdex1>`.
-  
+
 :mod:`sklearn.preprocessing`
 ............................
 
@@ -225,8 +232,8 @@ Changelog
   :class:`preprocessing.MaxAbsScaler`, :class:`preprocessing.RobustScaler`
   and :class:`preprocessing.QuantileTransformer` which results in a slight
   performance improvement. :pr:`13987` by `Roman Yurchak`_.
- 
-- |Fix| KernelCenterer now throws error when fit on non-square 
+
+- |Fix| KernelCenterer now throws error when fit on non-square
   class:`preprocessing.KernelCenterer`
   :pr:`14336` by :user:`Gregory Dexter <gdex1>`.
 
@@ -258,7 +265,7 @@ Changelog
 
 - |Fix| KNearestRegressor now throws error when fit on non-square data and
   metric = precomputed.  :class:`neighbors.NeighborsBase`
-  :pr:`14336` by :user:`Gregory Dexter <gdex1>`.  
+  :pr:`14336` by :user:`Gregory Dexter <gdex1>`.
 
 :mod:`sklearn.neural_network`
 .............................
@@ -269,7 +276,7 @@ Changelog
   :class:`neural_network.MLPClassifier` to give control over
   maximum number of function evaluation to not meet ``tol`` improvement.
   :issue:`9274` by :user:`Daniel Perry <daniel-perry>`.
-  
+
 
 Miscellaneous
 .............

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -480,7 +480,12 @@ def test_vectorizer():
 
     # ascii preprocessor?
     v3.set_params(strip_accents='ascii', lowercase=False)
-    assert v3.build_preprocessor() == strip_accents_ascii
+    processor = v3.build_preprocessor()
+    text = ("J'ai mangé du kangourou  ce midi, "
+            "c'était pas très bon.")
+    expected = strip_accents_ascii(text)
+    result = processor(text)
+    assert expected == result
 
     # error on bad strip_accents param
     v3.set_params(strip_accents='_gabbledegook_', preprocessor=None)

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -884,6 +884,25 @@ def test_pickling_vectorizer():
                 orig.fit_transform(JUNK_FOOD_DOCS).toarray())
 
 
+@pytest.mark.parametrize('factory', [
+    CountVectorizer.build_analyzer,
+    CountVectorizer.build_preprocessor,
+    CountVectorizer.build_tokenizer,
+])
+def test_pickling_built_processors(factory):
+    """Tokenizers cannot be pickled
+    https://github.com/scikit-learn/scikit-learn/issues/12833
+    """
+    vec = CountVectorizer()
+    function = factory(vec)
+    text = ("J'ai mangé du kangourou  ce midi, "
+            "c'était pas très bon.")
+    roundtripped_function = pickle.loads(pickle.dumps(function))
+    expected = function(text)
+    result = roundtripped_function(text)
+    assert result == expected
+
+
 def test_countvectorizer_vocab_sets_when_pickling():
     # ensure that vocabulary of type set is coerced to a list to
     # preserve iteration ordering after deserialization

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -76,8 +76,8 @@ def _analyze(doc, analyzer=None, tokenizer=None, ngrams=None,
     """Chain together an optional series of text processing steps to go from
     a single document to ngrams, with or without tokenizing or preprocessing.
 
-    If analyzer is used, it happens at the very end, and in this codebase is
-    intended to replace the preprocessor, tokenizer, and ngrams step.
+    If analyzer is used, only the decoder argument is used, as the analyzer is
+    intended to replace the preprocessor, tokenizer, and ngrams steps.
 
     Parameters
     ----------
@@ -93,19 +93,21 @@ def _analyze(doc, analyzer=None, tokenizer=None, ngrams=None,
     ngrams: list
         A sequence of tokens, possibly with pairs, triples, etc.
     """
+
     if decoder is not None:
         doc = decoder(doc)
-    if preprocessor is not None:
-        doc = preprocessor(doc)
-    if tokenizer is not None:
-        doc = tokenizer(doc)
-    if ngrams is not None:
-        if stop_words is not None:
-            doc = ngrams(doc, stop_words)
-        else:
-            doc = ngrams(doc)
     if analyzer is not None:
         doc = analyzer(doc)
+    else:
+        if preprocessor is not None:
+            doc = preprocessor(doc)
+        if tokenizer is not None:
+            doc = tokenizer(doc)
+        if ngrams is not None:
+            if stop_words is not None:
+                doc = ngrams(doc, stop_words)
+            else:
+                doc = ngrams(doc)
     return doc
 
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -312,12 +312,9 @@ class VectorizerMixin:
             raise ValueError('Invalid value for "strip_accents": %s' %
                              self.strip_accents)
 
-        if self.lowercase:
-            return partial(
-                _preprocess, accent_function=strip_accents, lower=True
-            )
-        else:
-            return partial(_preprocess, accent_function=strip_accents)
+        return partial(
+            _preprocess, accent_function=strip_accents, lower=self.lowercase
+        )
 
     def build_tokenizer(self):
         """Return a function that splits a string into a sequence of tokens"""

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -15,6 +15,7 @@ build feature vectors from text documents.
 import array
 from collections import defaultdict
 from collections.abc import Mapping
+from functools import partial
 import numbers
 from operator import itemgetter
 import re
@@ -42,6 +43,70 @@ __all__ = ['HashingVectorizer',
            'strip_accents_ascii',
            'strip_accents_unicode',
            'strip_tags']
+
+
+def _preprocess(doc, accent_function=None, lower=False):
+    """Chain together an optional series of text preprocessing steps to
+    apply to a document.
+
+    Parameters
+    ----------
+    doc: str
+        The string to preprocess
+    accent_function: callable
+        Function for handling accented characters. Common strategies include
+        normalizing and removing.
+    lower: bool
+        Whether to use str.lower to lowercase all fo the text
+
+    Returns
+    -------
+    doc: str
+        preprocessed string
+    """
+    if lower:
+        doc = doc.lower()
+    if accent_function is not None:
+        doc = accent_function(doc)
+    return doc
+
+
+def _analyze(doc, analyzer=None, tokenizer=None, ngrams=None,
+             preprocessor=None, decoder=None, stop_words=None):
+    """Chain together an optional series of text processing steps to go from
+    a single document to ngrams, with or without tokenizing or preprocessing.
+
+    If analyzer is used, it happens at the very end, and in this codebase is
+    intended to replace the preprocessor, tokenizer, and ngrams step.
+
+    Parameters
+    ----------
+    analyzer: callable
+    tokenizer: callable
+    ngrams: callable
+    preprocessor: callable
+    decoder: callable
+    stop_words: list
+
+    Returns
+    -------
+    ngrams: list
+        A sequence of tokens, possibly with pairs, triples, etc.
+    """
+    if decoder is not None:
+        doc = decoder(doc)
+    if preprocessor is not None:
+        doc = preprocessor(doc)
+    if tokenizer is not None:
+        doc = tokenizer(doc)
+    if ngrams is not None:
+        if stop_words is not None:
+            doc = ngrams(doc, stop_words)
+        else:
+            doc = ngrams(doc)
+    if analyzer is not None:
+        doc = analyzer(doc)
+    return doc
 
 
 def strip_accents_unicode(s):
@@ -232,16 +297,9 @@ class VectorizerMixin:
         if self.preprocessor is not None:
             return self.preprocessor
 
-        # unfortunately python functools package does not have an efficient
-        # `compose` function that would have allowed us to chain a dynamic
-        # number of functions. However the cost of a lambda call is a few
-        # hundreds of nanoseconds which is negligible when compared to the
-        # cost of tokenizing a string of 1000 chars for instance.
-        noop = lambda x: x
-
         # accent stripping
         if not self.strip_accents:
-            strip_accents = noop
+            strip_accents = None
         elif callable(self.strip_accents):
             strip_accents = self.strip_accents
         elif self.strip_accents == 'ascii':
@@ -253,16 +311,18 @@ class VectorizerMixin:
                              self.strip_accents)
 
         if self.lowercase:
-            return lambda x: strip_accents(x.lower())
+            return partial(
+                _preprocess, accent_function=strip_accents, lower=True
+            )
         else:
-            return strip_accents
+            return partial(_preprocess, accent_function=strip_accents)
 
     def build_tokenizer(self):
         """Return a function that splits a string into a sequence of tokens"""
         if self.tokenizer is not None:
             return self.tokenizer
         token_pattern = re.compile(self.token_pattern)
-        return lambda doc: token_pattern.findall(doc)
+        return token_pattern.findall
 
     def get_stop_words(self):
         """Build or fetch the effective stop words list"""
@@ -335,24 +395,28 @@ class VectorizerMixin:
         if callable(self.analyzer):
             if self.input in ['file', 'filename']:
                 self._validate_custom_analyzer()
-            return lambda doc: self.analyzer(self.decode(doc))
+            return partial(
+                _analyze, analyzer=self.analyzer, decoder=self.decode
+            )
 
         preprocess = self.build_preprocessor()
 
         if self.analyzer == 'char':
-            return lambda doc: self._char_ngrams(preprocess(self.decode(doc)))
+            return partial(_analyze, ngrams=self._char_ngrams,
+                           preprocessor=preprocess, decoder=self.decode)
 
         elif self.analyzer == 'char_wb':
-            return lambda doc: self._char_wb_ngrams(
-                preprocess(self.decode(doc)))
+            return partial(_analyze, ngrams=self._char_wb_ngrams,
+                           preprocessor=preprocess, decoder=self.decode)
 
         elif self.analyzer == 'word':
             stop_words = self.get_stop_words()
             tokenize = self.build_tokenizer()
             self._check_stop_words_consistency(stop_words, preprocess,
                                                tokenize)
-            return lambda doc: self._word_ngrams(
-                tokenize(preprocess(self.decode(doc))), stop_words)
+            return partial(_analyze, ngrams=self._word_ngrams,
+                           tokenizer=tokenize, preprocessor=preprocess,
+                           decoder=self.decode, stop_words=stop_words)
 
         else:
             raise ValueError('%s is not a valid tokenization scheme/analyzer' %


### PR DESCRIPTION
Lambda functions are non-serializable under the stdlib pickle
module. This commit replaces the lambdas found in three text
preprocessing functions with hidden functions for chaining
a sequence of preprocessing steps that can be partialed where
appropriate.

#### Reference Issues/PRs

Closes #12833

#### What does this implement/fix? Explain your changes.

Instead of composing functions with lambdas, create chains 
of preprocessing steps inside single functions that can 
be decomposed with partialing.
