### PR TITLE
Move threshold condition part inside else block for OneVsRest.predict

### DIFF
--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -286,11 +286,6 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin,
             Predicted multi-class targets.
         """
         check_is_fitted(self, 'estimators_')
-        if (hasattr(self.estimators_[0], "decision_function") and
-                is_classifier(self.estimators_[0])):
-            thresh = 0
-        else:
-            thresh = .5
 
         n_samples = _num_samples(X)
         if self.label_binarizer_.y_type_ == "multiclass":
@@ -303,6 +298,11 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin,
                 argmaxima[maxima == pred] = i
             return self.classes_[argmaxima]
         else:
+            if (hasattr(self.estimators_[0], "decision_function") and
+                    is_classifier(self.estimators_[0])):
+                thresh = 0
+            else:
+                thresh = .5
             indices = array.array('i')
             indptr = array.array('i', [0])
             for e in self.estimators_:


### PR DESCRIPTION
#### Reference Issues/PRs
Move threshold condition part inside else block for OneVsRest.predict

#### What does this implement/fix? Explain your changes.
Threshold (`thresh` in the script) is used only when `self.label_binarizer_.y_type_` is __NOT__ "multiclass". Therefore, moving the threshold condition part (from line 289 to 293 in the original script) inside the else block (in line 305 in the original script) improves the computation cost (although to a negligible amount) when `self.label_binarizer_.y_type_` is multiclass.

#### Any other comments?