### PR TITLE
[DOC] lambda_ in PowerTransformer.inverse_transform docstring

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2738,20 +2738,20 @@ class PowerTransformer(BaseEstimator, TransformerMixin):
 
         The inverse of the Box-Cox transformation is given by::
 
-            if lambda == 0:
+            if lambda_ == 0:
                 X = exp(X_trans)
             else:
-                X = (X_trans * lambda + 1) ** (1 / lambda)
+                X = (X_trans * lambda_ + 1) ** (1 / lambda_)
 
         The inverse of the Yeo-Johnson transformation is given by::
 
-            if X >= 0 and lambda == 0:
+            if X >= 0 and lambda_ == 0:
                 X = exp(X_trans) - 1
-            elif X >= 0 and lambda != 0:
-                X = (X_trans * lambda + 1) ** (1 / lambda) - 1
-            elif X < 0 and lambda != 2:
-                X = 1 - (-(2 - lambda) * X_trans + 1) ** (1 / (2 - lambda))
-            elif X < 0 and lambda == 2:
+            elif X >= 0 and lambda_ != 0:
+                X = (X_trans * lambda_ + 1) ** (1 / lambda_) - 1
+            elif X < 0 and lambda_ != 2:
+                X = 1 - (-(2 - lambda_) * X_trans + 1) ** (1 / (2 - lambda_))
+            elif X < 0 and lambda_ == 2:
                 X = 1 - exp(-X_trans)
 
         Parameters


### PR DESCRIPTION
#### Reference Issues/PRs
None yet, but i'm happy to create one if needed.


#### What does this implement/fix? Explain your changes.
The current docstring of `PowerTransformer.inverse_transform` contains syntax errors.
`lambda` is a reserved keyword in Python, used to express anonymous functions (as in Church-Turing "lambda-calculus").

This PR replaces `lambda` by `lambda_` in order to circumvent this reserved keyword.


#### Any other comments?
Note that `scipy.stats.boxcox` uses `lmbda` (without the "a"), but the trailing underscore in `lambda_` is more consistent with the attribute of sklearn's `PowerTransformer` class (`lambdas_`). It's also PEP8-compliant.

Quoting from PEP 8: (https://www.python.org/dev/peps/pep-0008/#id36)
> `single_trailing_underscore_`: used by convention to avoid conflicts with Python keyword, e.g. `Tkinter.Toplevel(master, class_='ClassName')`
