### PR TITLE
Fixes #13609: Fixing y_score initialization so that it is not initialized as a column …

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -173,6 +173,13 @@ Changelog
   maximum number of function evaluation to not meet ``tol`` improvement.
   :issue:`9274` by :user:`Daniel Perry <daniel-perry>`.
 
+:mod:`sklearn.cross_decomposition`
+..................................
+
+- |Fix| Fixed a bug where :class:`cross_decomposition.PLSCanonical` and
+  :class:`cross_decomposition.PLSRegression` were raising an error when fitted
+  with a target matrix `Y` in which the first column was constant.
+  :issue:`13609` by :user:`Camila Williamson <camilaagw>`.
 
 Miscellaneous
 .............
@@ -183,7 +190,7 @@ Miscellaneous
 
 - |Fix| Port `lobpcg` from SciPy which implement some bug fixes but only
   available in 1.3+.
-  :pr:`14195` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`13609` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Changes to estimator checks
 ---------------------------

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -31,7 +31,11 @@ def _nipals_twoblocks_inner_loop(X, Y, mode="A", max_iter=500, tol=1e-06,
     similar to the Power method for determining the eigenvectors and
     eigenvalues of a X'Y.
     """
-    y_score = Y[:, [0]]
+    for col in Y.T:
+        if np.any(np.abs(col) > np.finfo(np.double).eps):
+            y_score = col.reshape(len(col), 1)
+            break
+
     x_weights_old = 0
     ite = 1
     X_pinv = Y_pinv = None

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -261,6 +261,47 @@ def test_pls():
     check_ortho(pls_ca.x_scores_, "x scores are not orthogonal")
     check_ortho(pls_ca.y_scores_, "y scores are not orthogonal")
 
+    # 4) Another "Non regression test" of PLS Regression (PLS2):
+    #    Checking behavior when the first column of Y is constant
+    # ===============================================
+    # The results were compared against a modified version of plsreg2
+    # from the R-package plsdepot
+    X = d.data
+    Y = d.target
+    Y[:, 0] = 1
+    pls_2 = pls_.PLSRegression(n_components=X.shape[1])
+    pls_2.fit(X, Y)
+
+    x_weights = np.array(
+        [[-0.6273573, 0.007081799, 0.7786994],
+         [-0.7493417, -0.277612681, -0.6011807],
+         [-0.2119194, 0.960666981, -0.1794690]])
+    x_weights_sign_flip = pls_2.x_weights_ / x_weights
+
+    x_loadings = np.array(
+        [[-0.6273512, -0.22464538, 0.7786994],
+         [-0.6643156, -0.09871193, -0.6011807],
+         [-0.5125877, 1.01407380, -0.1794690]])
+    x_loadings_sign_flip = pls_2.x_loadings_ / x_loadings
+
+    y_loadings = np.array(
+        [[0.0000000, 0.0000000, 0.0000000],
+         [0.4357300, 0.5828479, 0.2174802],
+         [-0.1353739, -0.2486423, -0.1810386]])
+
+    # R/python sign flip should be the same in x_weight and x_rotation
+    assert_array_almost_equal(x_loadings_sign_flip, x_weights_sign_flip, 4)
+
+    # This test that R / python give the same result up to column
+    # sign indeterminacy
+    assert_array_almost_equal(np.abs(x_loadings_sign_flip), 1, 4)
+    assert_array_almost_equal(np.abs(x_weights_sign_flip), 1, 4)
+
+    # For the PLSRegression with default parameters, it holds that
+    # y_loadings==y_weights. In this case we only test that R/python
+    # give the same result for the y_loadings irrespective of the sign
+    assert_array_almost_equal(np.abs(pls_2.y_loadings_), np.abs(y_loadings), 4)
+
 
 def test_convergence_fail():
     d = load_linnerud()


### PR DESCRIPTION
…containing only zeros

#### Reference Issues/PRs
Fixes #13609

#### What does this implement/fix? Explain your changes.
Changing y_score initialization so that it is not initialized by default as the first column of Y. This is problematic when the first column Y is constant as it leads to numerical problems (division by zero)

The change was implemented based on slide 15 from 
http://www.eigenvector.com/Docs/Wise_pls_properties.pdf 
Choose `u_1=y` or one column of **Y**