### PR TITLE
DOC Minor fixes for parameter documentation in ridge

### DIFF
--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1590,17 +1590,14 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
 
     Parameters
     ----------
-    alphas : numpy array of shape [n_alphas], list or tuple
+    alphas : numpy array of shape [n_alphas], default (0.1, 1.0, 10.0)
         Array of alpha values to try.
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.
         Alpha corresponds to ``C^-1`` in other linear models such as
         LogisticRegression or LinearSVC.
-        Default value is (0.1, 1.0, 10.0)
         If using generalized cross-validation, alphas must be positive.
-        Note: the `alphas` feature will be of `np.ndarray` type even if the
-        constructor parameter was a list or a tuple.
 
     fit_intercept : bool, default True
         Whether to calculate the intercept for this model. If set
@@ -1707,16 +1704,13 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
     Parameters
     ----------
-    alphas : numpy array of shape [n_alphas], list or tuple
+    alphas : numpy array of shape [n_alphas], default (0.1, 1.0, 10.0)
         Array of alpha values to try.
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.
         Alpha corresponds to ``C^-1`` in other linear models such as
         LogisticRegression or LinearSVC.
-        Default value is (0.1, 1.0, 10.0)
-        Note: the `alphas` feature will be of `np.ndarray` type even if the
-        constructor parameter was a list or a tuple.
 
     fit_intercept : bool, default True
         Whether to calculate the intercept for this model. If set

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -633,7 +633,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default=False
+    normalize : bool, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -641,7 +641,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    copy_X : boolean, optional, default=True
+    copy_X : bool, default=True
         If True, X will be copied; else, it may be overwritten.
 
     max_iter : int, optional
@@ -783,7 +783,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         intercept will be used in calculations (e.g. data is expected to be
         already centered).
 
-    normalize : boolean, optional, default=False
+    normalize : bool, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -791,7 +791,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    copy_X : boolean, optional, default=True
+    copy_X : bool, default=True
         If True, X will be copied; else, it may be overwritten.
 
     max_iter : int, optional
@@ -843,7 +843,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
           .. versionadded:: 0.19
            SAGA solver.
 
-    random_state : int, RandomState instance or None, optional, default=None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator to use when shuffling
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
@@ -1604,7 +1604,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default=False
+    normalize : bool, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -1612,7 +1612,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    scoring : string, callable or None, optional, default=None
+    scoring : string, callable or None, default=None
         A string (see model evaluation documentation) or
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
@@ -1717,7 +1717,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default=False
+    normalize : bool, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -1725,7 +1725,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    scoring : string, callable or None, optional, default=None
+    scoring : string, callable or None, default=None
         A string (see model evaluation documentation) or
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -262,7 +262,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         assumed to be specific to the targets. Hence they must correspond in
         number.
 
-    sample_weight : float or numpy array of shape [n_samples], default None
+    sample_weight : float or numpy array of shape [n_samples], default=None
         Individual weights for each sample. If sample_weight is not None and
         solver='auto', the solver will be set to 'cholesky'.
 
@@ -314,10 +314,10 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         by scipy.sparse.linalg. For 'sag' and saga solver, the default value is
         1000.
 
-    tol : float, default 1e-3
+    tol : float, default=1e-3
         Precision of the solution.
 
-    verbose : int, default 0
+    verbose : int, default=0
         Verbosity level. Setting verbose > 0 will display additional
         information depending on the solver used.
 
@@ -328,13 +328,13 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         generator; If None, the random number generator is the RandomState
         instance used by `np.random`. Used when ``solver`` == 'sag'.
 
-    return_n_iter : boolean, default False
+    return_n_iter : boolean, default=False
         If True, the method also returns `n_iter`, the actual number of
         iteration performed by the solver.
 
         .. versionadded:: 0.17
 
-    return_intercept : boolean, default False
+    return_intercept : boolean, default=False
         If True and if X is sparse, the method also returns the intercept,
         and the solver is automatically changed to 'sag'. This is only a
         temporary fix for fitting the intercept with sparse data. For dense
@@ -342,7 +342,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
 
         .. versionadded:: 0.17
 
-    check_input : boolean, default True
+    check_input : boolean, default=True
         If False, the input arrays X and y will not be checked.
 
         .. versionadded:: 0.21
@@ -619,7 +619,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
 
     Parameters
     ----------
-    alpha : {float, array-like}, shape (n_targets), default 1.0
+    alpha : {float, array-like}, shape (n_targets), default=1.0
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.
@@ -628,12 +628,12 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         assumed to be specific to the targets. Hence they must correspond in
         number.
 
-    fit_intercept : bool, default True
+    fit_intercept : bool, default=True
         Whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : boolean, optional, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -641,7 +641,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    copy_X : boolean, optional, default True
+    copy_X : boolean, optional, default=True
         If True, X will be copied; else, it may be overwritten.
 
     max_iter : int, optional
@@ -649,7 +649,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         For 'sparse_cg' and 'lsqr' solvers, the default value is determined
         by scipy.sparse.linalg. For 'sag' solver, the default value is 1000.
 
-    tol : float, default 1e-3
+    tol : float, default=1e-3
         Precision of the solution.
 
     solver : {'auto', 'svd', 'cholesky', 'lsqr', 'sparse_cg', 'sag', 'saga'}
@@ -771,19 +771,19 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
 
     Parameters
     ----------
-    alpha : float, default 1.0
+    alpha : float, default=1.0
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.
         Alpha corresponds to ``C^-1`` in other linear models such as
         LogisticRegression or LinearSVC.
 
-    fit_intercept : bool, default True
+    fit_intercept : bool, default=True
         Whether to calculate the intercept for this model. If set to false, no
         intercept will be used in calculations (e.g. data is expected to be
         already centered).
 
-    normalize : boolean, optional, default False
+    normalize : boolean, optional, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -791,14 +791,14 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    copy_X : boolean, optional, default True
+    copy_X : boolean, optional, default=True
         If True, X will be copied; else, it may be overwritten.
 
     max_iter : int, optional
         Maximum number of iterations for conjugate gradient solver.
         The default value is determined by scipy.sparse.linalg.
 
-    tol : float, default 1e-3
+    tol : float, default=1e-3
         Precision of the solution.
 
     class_weight : dict or 'balanced', optional
@@ -843,7 +843,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
           .. versionadded:: 0.19
            SAGA solver.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, optional, default=None
         The seed of the pseudo random number generator to use when shuffling
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
@@ -909,7 +909,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         y : array-like of shape (n_samples,)
             Target values
 
-        sample_weight : {float, numpy array}, shape (n_samples), default None
+        sample_weight : {float, numpy array}, shape (n_samples), default=None
             Sample weight.
 
             .. versionadded:: 0.17
@@ -1590,7 +1590,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
 
     Parameters
     ----------
-    alphas : numpy array of shape [n_alphas], default (0.1, 1.0, 10.0)
+    alphas : numpy array of shape [n_alphas], default=(0.1, 1.0, 10.0)
         Array of alpha values to try.
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
@@ -1599,12 +1599,12 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         LogisticRegression or LinearSVC.
         If using generalized cross-validation, alphas must be positive.
 
-    fit_intercept : bool, default True
+    fit_intercept : bool, default=True
         Whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : boolean, optional, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -1612,7 +1612,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    scoring : string, callable or None, optional, default: None
+    scoring : string, callable or None, optional, default=None
         A string (see model evaluation documentation) or
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
@@ -1704,7 +1704,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
     Parameters
     ----------
-    alphas : numpy array of shape [n_alphas], default (0.1, 1.0, 10.0)
+    alphas : numpy array of shape [n_alphas], default=(0.1, 1.0, 10.0)
         Array of alpha values to try.
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
@@ -1712,12 +1712,12 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         Alpha corresponds to ``C^-1`` in other linear models such as
         LogisticRegression or LinearSVC.
 
-    fit_intercept : bool, default True
+    fit_intercept : bool, default=True
         Whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : boolean, optional, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -1725,7 +1725,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    scoring : string, callable or None, optional, default: None
+    scoring : string, callable or None, optional, default=None
         A string (see model evaluation documentation) or
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
@@ -1823,7 +1823,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         y : array-like, shape (n_samples,)
             Target values. Will be cast to X's dtype if necessary
 
-        sample_weight : {float, numpy array}, shape (n_samples), default None
+        sample_weight : {float, numpy array}, shape (n_samples), default=None
             Sample weight.
 
         Returns

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -314,10 +314,10 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         by scipy.sparse.linalg. For 'sag' and saga solver, the default value is
         1000.
 
-    tol : float
+    tol : float, default 1e-3
         Precision of the solution.
 
-    verbose : int
+    verbose : int, default 0
         Verbosity level. Setting verbose > 0 will display additional
         information depending on the solver used.
 
@@ -619,7 +619,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
 
     Parameters
     ----------
-    alpha : {float, array-like}, shape (n_targets)
+    alpha : {float, array-like}, shape (n_targets), default 1.0
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.
@@ -649,7 +649,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         For 'sparse_cg' and 'lsqr' solvers, the default value is determined
         by scipy.sparse.linalg. For 'sag' solver, the default value is 1000.
 
-    tol : float
+    tol : float, default 1e-3
         Precision of the solution.
 
     solver : {'auto', 'svd', 'cholesky', 'lsqr', 'sparse_cg', 'sag', 'saga'}
@@ -771,14 +771,14 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
 
     Parameters
     ----------
-    alpha : float
+    alpha : float, default 1.0
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.
         Alpha corresponds to ``C^-1`` in other linear models such as
         LogisticRegression or LinearSVC.
 
-    fit_intercept : boolean
+    fit_intercept : boolean, default True
         Whether to calculate the intercept for this model. If set to false, no
         intercept will be used in calculations (e.g. data is expected to be
         already centered).
@@ -798,7 +798,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         Maximum number of iterations for conjugate gradient solver.
         The default value is determined by scipy.sparse.linalg.
 
-    tol : float
+    tol : float, default 1e-3
         Precision of the solution.
 
     class_weight : dict or 'balanced', optional
@@ -1590,14 +1590,17 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
 
     Parameters
     ----------
-    alphas : numpy array of shape [n_alphas]
+    alphas : numpy array of shape [n_alphas], list or tuple
         Array of alpha values to try.
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.
         Alpha corresponds to ``C^-1`` in other linear models such as
         LogisticRegression or LinearSVC.
+        Default value is (0.1, 1.0, 10.0)
         If using generalized cross-validation, alphas must be positive.
+        Note: the `alphas` feature will be of `np.ndarray` type even if the
+        constructor parameter was a list or a tuple.
 
     fit_intercept : bool, default True
         Whether to calculate the intercept for this model. If set
@@ -1704,15 +1707,18 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
     Parameters
     ----------
-    alphas : numpy array of shape [n_alphas]
+    alphas : numpy array of shape [n_alphas], list or tuple
         Array of alpha values to try.
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.
         Alpha corresponds to ``C^-1`` in other linear models such as
         LogisticRegression or LinearSVC.
+        Default value is (0.1, 1.0, 10.0)
+        Note: the `alphas` feature will be of `np.ndarray` type even if the
+        constructor parameter was a list or a tuple.
 
-    fit_intercept : boolean
+    fit_intercept : boolean, default True
         Whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -909,7 +909,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         y : array-like of shape (n_samples,)
             Target values
 
-        sample_weight : {float, numpy array}, shape (n_samples), default=None
+        sample_weight : {float, numpy array of shape (n_samples,)}, default=None
             Sample weight.
 
             .. versionadded:: 0.17

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -262,7 +262,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         assumed to be specific to the targets. Hence they must correspond in
         number.
 
-    sample_weight : float or numpy array of shape [n_samples], default=None
+    sample_weight : float or numpy array of shape (n_samples,), default=None
         Individual weights for each sample. If sample_weight is not None and
         solver='auto', the solver will be set to 'cholesky'.
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -262,7 +262,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         assumed to be specific to the targets. Hence they must correspond in
         number.
 
-    sample_weight : float or numpy array of shape [n_samples]
+    sample_weight : float or numpy array of shape [n_samples], default None
         Individual weights for each sample. If sample_weight is not None and
         solver='auto', the solver will be set to 'cholesky'.
 
@@ -909,7 +909,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         y : array-like of shape (n_samples,)
             Target values
 
-        sample_weight : float or numpy array of shape (n_samples,)
+        sample_weight : float or numpy array of shape (n_samples,), default None
             Sample weight.
 
             .. versionadded:: 0.17
@@ -1823,7 +1823,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         y : array-like, shape (n_samples,)
             Target values. Will be cast to X's dtype if necessary
 
-        sample_weight : float or numpy array of shape (n_samples,)
+        sample_weight : float or numpy array of shape (n_samples,), default None
             Sample weight.
 
         Returns

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1590,7 +1590,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
 
     Parameters
     ----------
-    alphas : numpy array of shape [n_alphas], default=(0.1, 1.0, 10.0)
+    alphas : numpy array of shape (n_alphas,), default=(0.1, 1.0, 10.0)
         Array of alpha values to try.
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -909,7 +909,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         y : array-like of shape (n_samples,)
             Target values
 
-        sample_weight : {float, numpy array of shape (n_samples,)}, default=None
+        sample_weight : {float, array-like of shape (n_samples,)}, default=None
             Sample weight.
 
             .. versionadded:: 0.17
@@ -1823,7 +1823,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         y : array-like, shape (n_samples,)
             Target values. Will be cast to X's dtype if necessary
 
-        sample_weight : {float, numpy array of shape (n_samples,)}, default=None
+        sample_weight : {float, array-like of shape (n_samples,)}, default=None
             Sample weight.
 
         Returns

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -328,13 +328,13 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         generator; If None, the random number generator is the RandomState
         instance used by `np.random`. Used when ``solver`` == 'sag'.
 
-    return_n_iter : boolean, default=False
+    return_n_iter : bool, default=False
         If True, the method also returns `n_iter`, the actual number of
         iteration performed by the solver.
 
         .. versionadded:: 0.17
 
-    return_intercept : boolean, default=False
+    return_intercept : bool, default=False
         If True and if X is sparse, the method also returns the intercept,
         and the solver is automatically changed to 'sag'. This is only a
         temporary fix for fitting the intercept with sparse data. For dense
@@ -342,7 +342,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
 
         .. versionadded:: 0.17
 
-    check_input : boolean, default=True
+    check_input : bool, default=True
         If False, the input arrays X and y will not be checked.
 
         .. versionadded:: 0.21

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -778,7 +778,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         Alpha corresponds to ``C^-1`` in other linear models such as
         LogisticRegression or LinearSVC.
 
-    fit_intercept : boolean, default True
+    fit_intercept : bool, default True
         Whether to calculate the intercept for this model. If set to false, no
         intercept will be used in calculations (e.g. data is expected to be
         already centered).
@@ -1718,7 +1718,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         Note: the `alphas` feature will be of `np.ndarray` type even if the
         constructor parameter was a list or a tuple.
 
-    fit_intercept : boolean, default True
+    fit_intercept : bool, default True
         Whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1704,7 +1704,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
     Parameters
     ----------
-    alphas : numpy array of shape [n_alphas], default=(0.1, 1.0, 10.0)
+    alphas : numpy array of shape (n_alphas,), default=(0.1, 1.0, 10.0)
         Array of alpha values to try.
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -909,7 +909,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         y : array-like of shape (n_samples,)
             Target values
 
-        sample_weight : float or numpy array of shape (n_samples,), default None
+        sample_weight : {float, numpy array}, shape (n_samples), default None
             Sample weight.
 
             .. versionadded:: 0.17
@@ -1823,7 +1823,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         y : array-like, shape (n_samples,)
             Target values. Will be cast to X's dtype if necessary
 
-        sample_weight : float or numpy array of shape (n_samples,), default None
+        sample_weight : {float, numpy array}, shape (n_samples), default None
             Sample weight.
 
         Returns

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -619,7 +619,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
 
     Parameters
     ----------
-    alpha : {float, array-like}, shape (n_targets), default=1.0
+    alpha : {float, array-like of shape (n_targets,)}, default=1.0
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1823,7 +1823,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         y : array-like, shape (n_samples,)
             Target values. Will be cast to X's dtype if necessary
 
-        sample_weight : {float, numpy array}, shape (n_samples), default=None
+        sample_weight : {float, numpy array of shape (n_samples,)}, default=None
             Sample weight.
 
         Returns


### PR DESCRIPTION
Address #14452 

- [x] Document default values for `alpha` and `tol` parameters for `Ridge` class
- [x] Document default values for `alpha`, `fit_intercept` and `tol` parameters for `RidgeClassifier` class
- [x] Document default values for `alphas` parameter for `RidgeCV` class
- [x] Document default values for `alphas` and `fit_intercept` parameters for `RidgeClassifierCV` class