### PR TITLE
[MRG] FIX convert F-ordered array in Ridge with SAG solver

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -131,7 +131,7 @@ Changelog
 
 - |Fix| :class:`linear_model.Ridge` now accepts Fortran arrays and make a
   conversion instead of failing.
-  :pr:`xx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`14458` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.metrics`
 ......................

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -115,7 +115,7 @@ Changelog
 :mod:`sklearn.linear_model`
 ...........................
 
-- |Enhancement| :class:`linearmodel.BayesianRidge` now accepts hyperparameters
+- |Enhancement| :class:`linear_model.BayesianRidge` now accepts hyperparameters
   ``alpha_init`` and ``lambda_init`` which can be used to set the initial value
   of the maximization procedure in :term:`fit`.
   :pr:`13618` by :user:`Yoshihiro Uchida <c56pony>`.
@@ -127,7 +127,11 @@ Changelog
 
 - |Efficiency| The 'liblinear' logistic regression solver is now faster and
   requires less memory.
-  :pr:`14108`, pr:`14170` by :user:`Alex Henrie <alexhenrie>`.
+  :pr:`14108`, :pr:`14170` by :user:`Alex Henrie <alexhenrie>`.
+
+- |Fix| :class:`linear_model.Ridge` now accepts Fortran arrays and make a
+  conversion instead of failing.
+  :pr:`xx` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.metrics`
 ......................

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -130,7 +130,7 @@ Changelog
   :pr:`14108`, :pr:`14170` by :user:`Alex Henrie <alexhenrie>`.
 
 - |Fix| :class:`linear_model.Ridge` with `solver='sag'` now accepts F-ordered
-  arrays and make a conversion instead of failing.
+  and noon-contiguous arrays and make a conversion instead of failing.
   :pr:`14458` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.metrics`

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -130,7 +130,7 @@ Changelog
   :pr:`14108`, :pr:`14170` by :user:`Alex Henrie <alexhenrie>`.
 
 - |Fix| :class:`linear_model.Ridge` with `solver='sag'` now accepts F-ordered
-  and noon-contiguous arrays and make a conversion instead of failing.
+  and non-contiguous arrays and makes a conversion instead of failing.
   :pr:`14458` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.metrics`

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -129,8 +129,8 @@ Changelog
   requires less memory.
   :pr:`14108`, :pr:`14170` by :user:`Alex Henrie <alexhenrie>`.
 
-- |Fix| :class:`linear_model.Ridge` now accepts Fortran arrays and make a
-  conversion instead of failing.
+- |Fix| :class:`linear_model.Ridge` with `solver='sag'` now accepts F-ordered
+  arrays and make a conversion instead of failing.
   :pr:`14458` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.metrics`

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -91,6 +91,7 @@ def make_dataset(X, y, sample_weight, random_state=None):
                           seed=seed)
         intercept_decay = SPARSE_INTERCEPT_DECAY
     else:
+        X = np.ascontiguousarray(X)
         dataset = ArrayData(X, y, sample_weight, seed=seed)
         intercept_decay = 1.0
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -409,7 +409,7 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         _accept_sparse = _get_valid_accept_sparse(sparse.issparse(X), solver)
         X = check_array(X, accept_sparse=_accept_sparse, dtype=_dtype,
                         order="C")
-        y = check_array(y, dtype=X.dtype, ensure_2d=False, order="C")
+        y = check_array(y, dtype=X.dtype, ensure_2d=False, order=None)
     check_consistent_length(X, y)
 
     n_samples, n_features = X.shape

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1210,3 +1210,10 @@ def test_ridge_regression_dtype_stability(solver, seed):
     assert results[np.float32].dtype == np.float32
     assert results[np.float64].dtype == np.float64
     assert_allclose(results[np.float32], results[np.float64], atol=atol)
+
+
+def test_ridge_sag_with_X_fortran():
+    # check that Fortran array are converted when using SAG solver
+    X, y = make_regression(random_state=42)
+    X = np.asfortranarray(X)
+    Ridge(solver='sag').fit(X, y)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1215,5 +1215,8 @@ def test_ridge_regression_dtype_stability(solver, seed):
 def test_ridge_sag_with_X_fortran():
     # check that Fortran array are converted when using SAG solver
     X, y = make_regression(random_state=42)
+    # for the order of X and y to not be C-ordered arrays
     X = np.asfortranarray(X)
+    X = X[::2, :]
+    y = y[::2]
     Ridge(solver='sag').fit(X, y)


### PR DESCRIPTION
closes #14457 

Make an implicit conversion when array is not C-ordered in `make_dataset`.