### PR TITLE
Fix test_omp_cv test for MKL with AVX512

### DIFF
--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -17,7 +17,7 @@ from sklearn.linear_model import (orthogonal_mp, orthogonal_mp_gram,
 from sklearn.utils import check_random_state
 from sklearn.datasets import make_sparse_coded_signal
 
-n_samples, n_features, n_nonzero_coefs, n_targets = 20, 30, 5, 3
+n_samples, n_features, n_nonzero_coefs, n_targets = 25, 35, 5, 3
 y, X, gamma = make_sparse_coded_signal(n_targets, n_features, n_samples,
                                        n_nonzero_coefs, random_state=0)
 # Make X not of norm 1 for testing


### PR DESCRIPTION
Closes https://github.com/scikit-learn/scikit-learn/issues/12676

As suggested by @agramfort increasing the data size can help making `OrthogonalMatchingPursuitCV` more stable and indeed I can confirm that,
```diff
- n_samples, n_features, n_nonzero_coefs, n_targets = 20, 30, 5, 3
+ n_samples, n_features, n_nonzero_coefs, n_targets = 25, 35, 5, 3
```
does fix the `test_omp_cv` test on a machine with AVX512 and MKL.