### PR TITLE
[MRG] BLD Do not get version from circle

### DIFF
--- a/build_tools/circle/list_versions.py
+++ b/build_tools/circle/list_versions.py
@@ -51,7 +51,7 @@ print()
 ROOT_URL = 'https://api.github.com/repos/scikit-learn/scikit-learn.github.io/contents/'  # noqa
 RAW_FMT = 'https://raw.githubusercontent.com/scikit-learn/scikit-learn.github.io/master/%s/documentation.html'  # noqa
 VERSION_RE = re.compile(r"\bVERSION:\s*'([^']+)'")
-NAMED_DIRS = ['dev', 'stable']
+NAMED_DIRS = ['dev', 'stable', 'circle']
 
 # Gather data for each version directory, including symlinks
 dirs = {}


### PR DESCRIPTION
This should fix https://circleci.com/gh/scikit-learn/scikit-learn/66274

The https://api.github.com/repos/scikit-learn/scikit-learn.github.io/contents/ json seems to have a `name=circle` with `type=dir`. This will try to download `documentation.html` that [does not exists](https://github.com/scikit-learn/scikit-learn.github.io/tree/master/circle).