### PR TITLE
API don't default get_params output to None in the future

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -45,6 +45,14 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
+:mod:`sklearn.base`
+...................
+
+- |API| From version 0.24 :meth:`BaseEstimator.get_params` will raise an
+  AttributeError rather than return None for parameters that are in the
+  estimator's constructor but not stored as attributes on the instance.
+  :pr:`14464` by `Joel Nothman`_.
+
 :mod:`sklearn.calibration`
 ..........................
 
@@ -111,6 +119,14 @@ Changelog
   the decision function as in the literature. Thus, `predict` and
   `predict_proba` give consistent results.
   :pr:`14114` by :user:`Guillaume Lemaitre <glemaitre>`.
+
+:mod:`sklearn.gaussian_process`
+...............................
+
+- |API| From version 0.24 :meth:`Kernel.get_params` will raise an
+  AttributeError rather than return None for parameters that are in the
+  estimator's constructor but not stored as attributes on the instance.
+  :pr:`14464` by `Joel Nothman`_.
 
 :mod:`sklearn.linear_model`
 ...........................

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -196,9 +196,10 @@ class BaseEstimator:
             try:
                 value = getattr(self, key)
             except AttributeError:
-                warnings.warn('From version 0.24, get_params will not return '
-                              'None for parameters not available as '
-                              'attribues. An AttributeError will be raised.',
+                warnings.warn('From version 0.24, get_params will raise an '
+                              'AttributeError if a parameter cannot be '
+                              'retrieved as an instance attribute. Previously '
+                              'it would return None.',
                               FutureWarning)
                 value = None
             if deep and hasattr(value, 'get_params'):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -193,7 +193,14 @@ class BaseEstimator:
         """
         out = dict()
         for key in self._get_param_names():
-            value = getattr(self, key, None)
+            try:
+                value = getattr(self, key)
+            except AttributeError:
+                warnings.warn('From version 0.24, get_params will not return '
+                              'None for parameters not available as '
+                              'attribues. An AttributeError will be raised.',
+                              FutureWarning)
+                value = None
             if deep and hasattr(value, 'get_params'):
                 deep_items = value.get_params().items()
                 out.update((key + '__' + k, val) for k, val in deep_items)

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -161,9 +161,10 @@ class Kernel(metaclass=ABCMeta):
             try:
                 value = getattr(self, arg)
             except AttributeError:
-                warnings.warn('From version 0.24, get_params will not return '
-                              'None for parameters not available as '
-                              'attribues. An AttributeError will be raised.',
+                warnings.warn('From version 0.24, get_params will raise an '
+                              'AttributeError if a parameter cannot be '
+                              'retrieved as an instance attribute. Previously '
+                              'it would return None.',
                               FutureWarning)
                 value = None
             params[arg] = value

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -23,6 +23,7 @@ from abc import ABCMeta, abstractmethod
 from collections import namedtuple
 import math
 from inspect import signature
+import warnings
 
 import numpy as np
 from scipy.special import kv, gamma
@@ -157,7 +158,15 @@ class Kernel(metaclass=ABCMeta):
                                " %s doesn't follow this convention."
                                % (cls, ))
         for arg in args:
-            params[arg] = getattr(self, arg, None)
+            try:
+                value = getattr(self, arg)
+            except AttributeError:
+                warnings.warn('From version 0.24, get_params will not return '
+                              'None for parameters not available as '
+                              'attribues. An AttributeError will be raised.',
+                              FutureWarning)
+                value = None
+            params[arg] = value
         return params
 
     def set_params(self, **params):

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -14,7 +14,7 @@ from sklearn.metrics.pairwise \
 from sklearn.gaussian_process.kernels \
     import (RBF, Matern, RationalQuadratic, ExpSineSquared, DotProduct,
             ConstantKernel, WhiteKernel, PairwiseKernel, KernelOperator,
-            Exponentiation)
+            Exponentiation, Kernel)
 from sklearn.base import clone
 
 from sklearn.utils.testing import (assert_almost_equal,
@@ -323,3 +323,24 @@ def test_repr_kernels(kernel):
     # Smoke-test for repr in kernels.
 
     repr(kernel)
+
+
+def test_warns_on_get_params_non_attribute():
+    class MyKernel(Kernel):
+        def __init__(self, param=5):
+            pass
+
+        def __call__(self, X, Y=None, eval_gradient=False):
+            return X
+
+        def diag(self, X):
+            return np.ones(X.shape[0])
+
+        def is_stationary(self):
+            return False
+
+    est = MyKernel()
+    with pytest.warns(FutureWarning, match='AttributeError'):
+        params = est.get_params()
+
+    assert params['param'] is None

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -127,9 +127,9 @@ class Pipeline(_BaseComposition):
 
     def __init__(self, steps, memory=None, verbose=False):
         self.steps = steps
-        self._validate_steps()
         self.memory = memory
         self.verbose = verbose
+        self._validate_steps()
 
     def get_params(self, deep=True):
         """Get parameters for this estimator.

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -505,3 +505,18 @@ def test_regressormixin_score_multioutput():
            "built-in scorer 'r2' uses "
            "multioutput='uniform_average').")
     assert_warns_message(FutureWarning, msg, reg.score, X, y)
+
+
+def test_warns_on_get_params_non_attribute():
+    class MyEstimator(BaseEstimator):
+        def __init__(self, param=5):
+            pass
+
+        def fit(self, X, y=None):
+            return self
+
+    est = MyEstimator()
+    with pytest.warns(FutureWarning, match='AttributeError'):
+        params = est.get_params()
+
+    assert params['param'] is None


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #14461 

#### What does this implement/fix? Explain your changes.

Previously, the default implementation of `get_params` would use `getattr` to retrieve a parameter value from an estimator, but would default to retrieve None if an AttributeError would otherwise have been raised.

This can lead to surprising behaviour upon `clone` when `__init__` is not correctly defined, as shown in #14461.

I propose that we raise an AttributeError when a param cannot be retrieved by `getattr`. This PR deprecates returning None, and raises a FutureWarning.

#### Any other comments?

TODO: add tests
