### PR TITLE
[MRG] MAINT Uses another regex to get versions

### DIFF
--- a/build_tools/circle/list_versions.py
+++ b/build_tools/circle/list_versions.py
@@ -51,7 +51,7 @@ print()
 ROOT_URL = 'https://api.github.com/repos/scikit-learn/scikit-learn.github.io/contents/'  # noqa
 RAW_FMT = 'https://raw.githubusercontent.com/scikit-learn/scikit-learn.github.io/master/%s/documentation.html'  # noqa
 VERSION_RE = re.compile(r"\bVERSION:\s*'([^']+)'")
-NAMED_DIRS = ['dev', 'stable', 'circle']
+NAMED_DIRS = ['dev', 'stable']
 
 # Gather data for each version directory, including symlinks
 dirs = {}

--- a/build_tools/circle/list_versions.py
+++ b/build_tools/circle/list_versions.py
@@ -50,7 +50,7 @@ print()
 
 ROOT_URL = 'https://api.github.com/repos/scikit-learn/scikit-learn.github.io/contents/'  # noqa
 RAW_FMT = 'https://raw.githubusercontent.com/scikit-learn/scikit-learn.github.io/master/%s/documentation.html'  # noqa
-VERSION_RE = re.compile(r"\bVERSION:\s*'([^']+)'")
+VERSION_RE = re.compile(r"scikit-learn ([\w\.]+) documentation</title>")
 NAMED_DIRS = ['dev', 'stable']
 
 # Gather data for each version directory, including symlinks

--- a/build_tools/circle/list_versions.py
+++ b/build_tools/circle/list_versions.py
@@ -50,7 +50,7 @@ print()
 
 ROOT_URL = 'https://api.github.com/repos/scikit-learn/scikit-learn.github.io/contents/'  # noqa
 RAW_FMT = 'https://raw.githubusercontent.com/scikit-learn/scikit-learn.github.io/master/%s/documentation.html'  # noqa
-VERSION_RE = re.compile(r"scikit-learn ([\w\.]+) documentation</title>")
+VERSION_RE = re.compile(r"scikit-learn ([\w\.\-]+) documentation</title>")
 NAMED_DIRS = ['dev', 'stable']
 
 # Gather data for each version directory, including symlinks


### PR DESCRIPTION
Since [sphinx 1.7 moved](https://github.com/sphinx-doc/sphinx/blob/a498960de9039b0d0c8d24f75f32fa4acd5b75e1/CHANGES#L1317) the `documentation_options` to a seperate file, this PR uses another regex to get the version from the `documentation.html` file.