### PR TITLE
MAINT Improve stacklevel for warnings in helpers

### DIFF
--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -227,7 +227,7 @@ def _check_optimize_result(solver, result, max_iter=None):
             warnings.warn("{} failed to converge (status={}): {}. "
                           "Increase the number of iterations."
                           .format(solver, result.status, result.message),
-                          ConvergenceWarning)
+                          ConvergenceWarning, stacklevel=2)
         if max_iter is not None:
             # In scipy <= 1.0.0, nit may exceed maxiter for lbfgs.
             # See https://github.com/scipy/scipy/issues/7854

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -313,7 +313,7 @@ def _ensure_sparse_format(spmatrix, accept_sparse, dtype, copy,
     if force_all_finite:
         if not hasattr(spmatrix, "data"):
             warnings.warn("Can't check %s sparse matrix for nan or inf."
-                          % spmatrix.format)
+                          % spmatrix.format, stacklevel=2)
         else:
             _assert_all_finite(spmatrix.data,
                                allow_nan=force_all_finite == 'allow-nan')
@@ -428,7 +428,7 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
             "'warn_on_dtype' is deprecated in version 0.21 and will be "
             "removed in 0.23. Don't set `warn_on_dtype` to remove this "
             "warning.",
-            DeprecationWarning)
+            DeprecationWarning, stacklevel=2)
 
     # store reference to original array to check if copy is needed when
     # function returns
@@ -528,7 +528,7 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
                 "a float dtype before using it in scikit-learn, "
                 "for example by using "
                 "your_array = your_array.astype(np.float64).",
-                FutureWarning)
+                FutureWarning, stacklevel=2)
 
         # make sure we actually converted to numeric:
         if dtype_numeric and array.dtype.kind == "O":
@@ -559,7 +559,7 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
     if warn_on_dtype and dtype_orig is not None and array.dtype != dtype_orig:
         msg = ("Data with input dtype %s was converted to %s%s."
                % (dtype_orig, array.dtype, context))
-        warnings.warn(msg, DataConversionWarning)
+        warnings.warn(msg, DataConversionWarning, stacklevel=2)
 
     if copy and np.may_share_memory(array, array_orig):
         array = np.array(array, dtype=dtype, order=order)
@@ -852,7 +852,8 @@ def check_symmetric(array, tol=1E-10, raise_warning=True,
             raise ValueError("Array must be symmetric")
         if raise_warning:
             warnings.warn("Array is not symmetric, and will be converted "
-                          "to symmetric by average with its transpose.")
+                          "to symmetric by average with its transpose.",
+                          stacklevel=2)
         if sp.issparse(array):
             conversion = 'to' + array.format
             array = getattr(0.5 * (array + array.T), conversion)()


### PR DESCRIPTION
Helper functions should raise warnings with `stacklevel=2` (or higher) so that it's easier to know where the warning originated from.

E.g.,
```
sklearn/linear_model/_glm/glm.py:356: ConvergenceWarning: lbfgs failed to converge (status=1): b'STOP: TOTAL NO. of ITERATIONS REACHED LIMIT'. Increase the number of iterations.
```
instead of,
```
sklearn/utils/optimize.py:230: ConvergenceWarning: lbfgs failed to converge (status=1): b'STOP: TOTAL NO. of ITERATIONS REACHED LIMIT'. Increase the number of iterations.
``` 
(that just points to the helper function).

This fixes it for a few helpers in `utils.validation`