### PR TITLE
ENH: add normalize parameter to metrics.classification.confusion_matrix

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -184,7 +184,7 @@ def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
     return _weighted_sum(score, sample_weight, normalize)
 
 
-def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
+def confusion_matrix(y_true, y_pred, labels=None, normalize=False, sample_weight=None):
     """Compute confusion matrix to evaluate the accuracy of a classification
 
     By definition a confusion matrix :math:`C` is such that :math:`C_{i, j}`
@@ -210,6 +210,10 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
         or select a subset of labels.
         If none is given, those that appear at least once
         in ``y_true`` or ``y_pred`` are used in sorted order.
+
+    normalize : bool, optional (default=False)
+        If True, , return the fraction of classified samples (float),
+        else returns the number of classified samples (int).
 
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
@@ -290,6 +294,10 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
     CM = coo_matrix((sample_weight, (y_true, y_pred)),
                     shape=(n_labels, n_labels), dtype=dtype,
                     ).toarray()
+
+    # Normalize matrix if normalize=True
+    if normalize:
+        CM = CM.astype('float') / CM.sum(axis=1)[:, np.newaxis]
 
     return CM
 

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -184,7 +184,8 @@ def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
     return _weighted_sum(score, sample_weight, normalize)
 
 
-def confusion_matrix(y_true, y_pred, labels=None, normalize=False, sample_weight=None):
+def confusion_matrix(y_true, y_pred, labels=None,
+                     normalize=False, sample_weight=None):
     """Compute confusion matrix to evaluate the accuracy of a classification
 
     By definition a confusion matrix :math:`C` is such that :math:`C_{i, j}`


### PR DESCRIPTION
Allows to get a normalized confusion matrix directly from the function
call. I use `confusion_matrix` frequently and find the need to always
normalize the matrix manually maybe unnecessary.

I am aware of the fact that other functions like `accuracy_score` already
have this exact functionality implemented, so probably the lack of the
`normalize` parameter is intentional and I'm missing the why. But in case
its not intentional you might find this contribution useful :).
