### PR TITLE
Added undefined behavior of partial_fit to glossary

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1272,6 +1272,8 @@ Methods
         To clear the model, a new estimator should be constructed, for instance
         with :func:`base.clone`.
 
+        NOTE: Using ``partial_fit`` after ``fit`` results in undefined behavior.
+
     ``predict``
         Makes a prediction for each sample, usually only taking :term:`X` as
         input (but see under regressor output conventions below). In a


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

The issue #14107 points out that the behavior of 'partial_fit' is not as expected when called after 'fit'. This undefined behavior is not documented anywhere. In this PR, I have mentioned in this undefined behavior in the glossary of partial_fit.

Fixes #14107.  

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
