### PR TITLE
CLN: remove collinearity warning from LDA

### DIFF
--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -383,8 +383,6 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
         U, S, V = linalg.svd(X, full_matrices=False)
 
         rank = np.sum(S > self.tol)
-        if rank < n_features:
-            warnings.warn("Variables are collinear.")
         # Scaling of within covariance is: V' 1/S
         scalings = (V[:rank] / std).T / S[:rank]
 


### PR DESCRIPTION
It is apparently not warned about anywhere else, and may only be
creating noise for people using it.

Closes #14361

#### Reference Issues/PRs

Fixes #14361 
Supercedes #14335

#### What does this implement/fix? Explain your changes.

Removes a warning about matrix rank during fitting.
