### PR TITLE
DOC specify default of error_score in cross_validate

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -146,7 +146,7 @@ def cross_validate(estimator, X, y=None, *, groups=None, scoring=None, cv=None,
 
         .. versionadded:: 0.20
 
-    error_score : 'raise' or numeric
+    error_score : 'raise' or numeric, default=np.nan
         Value to assign to the score if an error occurs in estimator fitting.
         If set to 'raise', the error is raised.
         If a numeric value is given, FitFailedWarning is raised. This parameter

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -382,15 +382,7 @@ def cross_val_score(estimator, X, y=None, *, groups=None, scoring=None,
     fit_params : dict, default=None
         Parameters to pass to the fit method of the estimator.
 
-<<<<<<< HEAD
-<<<<<<< HEAD
     pre_dispatch : int or str, default='2*n_jobs'
-=======
-    pre_dispatch : int, or str, default='2*n_jobs'
->>>>>>> More parameter documentation improved in model_selection._validation submodule.
-=======
-    pre_dispatch : int or str, default='2*n_jobs'
->>>>>>> Update _validation.py
         Controls the number of jobs that get dispatched during parallel
         execution. Reducing this number can be useful to avoid an
         explosion of memory consumption when more jobs get dispatched

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -111,11 +111,7 @@ def cross_validate(estimator, X, y=None, *, groups=None, scoring=None, cv=None,
     fit_params : dict, default=None
         Parameters to pass to the fit method of the estimator.
 
-<<<<<<< HEAD
     pre_dispatch : int or str, default='2*n_jobs'
-=======
-    pre_dispatch : int, or str, default='2*n_jobs'
->>>>>>> More parameter documentation improved in model_selection._validation submodule.
         Controls the number of jobs that get dispatched during parallel
         execution. Reducing this number can be useful to avoid an
         explosion of memory consumption when more jobs get dispatched
@@ -387,10 +383,14 @@ def cross_val_score(estimator, X, y=None, *, groups=None, scoring=None,
         Parameters to pass to the fit method of the estimator.
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     pre_dispatch : int or str, default='2*n_jobs'
 =======
     pre_dispatch : int, or str, default='2*n_jobs'
 >>>>>>> More parameter documentation improved in model_selection._validation submodule.
+=======
+    pre_dispatch : int or str, default='2*n_jobs'
+>>>>>>> Update _validation.py
         Controls the number of jobs that get dispatched during parallel
         execution. Reducing this number can be useful to avoid an
         explosion of memory consumption when more jobs get dispatched

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -111,7 +111,11 @@ def cross_validate(estimator, X, y=None, *, groups=None, scoring=None, cv=None,
     fit_params : dict, default=None
         Parameters to pass to the fit method of the estimator.
 
+<<<<<<< HEAD
     pre_dispatch : int or str, default='2*n_jobs'
+=======
+    pre_dispatch : int, or str, default='2*n_jobs'
+>>>>>>> More parameter documentation improved in model_selection._validation submodule.
         Controls the number of jobs that get dispatched during parallel
         execution. Reducing this number can be useful to avoid an
         explosion of memory consumption when more jobs get dispatched
@@ -382,7 +386,11 @@ def cross_val_score(estimator, X, y=None, *, groups=None, scoring=None,
     fit_params : dict, default=None
         Parameters to pass to the fit method of the estimator.
 
+<<<<<<< HEAD
     pre_dispatch : int or str, default='2*n_jobs'
+=======
+    pre_dispatch : int, or str, default='2*n_jobs'
+>>>>>>> More parameter documentation improved in model_selection._validation submodule.
         Controls the number of jobs that get dispatched during parallel
         execution. Reducing this number can be useful to avoid an
         explosion of memory consumption when more jobs get dispatched


### PR DESCRIPTION
Added default value documentation for some parameters of `KFold`, `StratifiedKFold` and `cross_validate`, just like it was previously done for parameters of some linear models (see #14452).