### PR TITLE
DOC Fix docstring in MissingIndicator class (#14491)

### DIFF
--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -519,7 +519,7 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
         Returns
         -------
         imputer_mask : {ndarray or sparse matrix}, shape (n_samples, \
-n_features)
+        n_features)
             The imputer mask of the original data.
 
         features_with_missing : ndarray, shape (n_features_with_missing)

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -518,8 +518,8 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        imputer_mask : {ndarray or sparse matrix}, shape (n_samples, \
-        n_features)
+        imputer_mask : {ndarray or sparse matrix}, shape \
+        (n_samples, n_features)
             The imputer mask of the original data.
 
         features_with_missing : ndarray, shape (n_features_with_missing)

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -519,7 +519,7 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
         Returns
         -------
         imputer_mask : {ndarray or sparse matrix}, shape (n_samples, \
-        n_features)
+n_features)
             The imputer mask of the original data.
 
         features_with_missing : ndarray, shape (n_features_with_missing)

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -518,8 +518,8 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        imputer_mask : {ndarray or sparse matrix}, shape \
-(n_samples, n_features) or (n_samples, n_features_with_missing)
+        imputer_mask : {ndarray or sparse matrix}, shape (n_samples, \
+        n_features)
             The imputer mask of the original data.
 
         features_with_missing : ndarray, shape (n_features_with_missing)
@@ -647,7 +647,8 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        Xt : {ndarray or sparse matrix}, shape (n_samples, n_features)
+        Xt : {ndarray or sparse matrix}, shape (n_samples, n_features) \
+        or (n_samples, n_features_with_missing)
             The missing indicator for input data. The data type of ``Xt``
             will be boolean.
 
@@ -683,7 +684,8 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        Xt : {ndarray or sparse matrix}, shape (n_samples, n_features)
+        Xt : {ndarray or sparse matrix}, shape (n_samples, n_features) \
+        or (n_samples, n_features_with_missing)
             The missing indicator for input data. The data type of ``Xt``
             will be boolean.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes issue #14491 

#### What does this implement/fix? Explain your changes.
Fixes docstring of _get_missing_features_info, transform and fir_transform for MissingIndicator class.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->