### PR TITLE
[MRG] Use sphinx-gallery 0.3.1 in doc build

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -133,7 +133,7 @@ conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
   joblib
 
 source activate testenv
-pip install "sphinx-gallery>=0.2,<0.3"
+pip install sphinx-gallery==0.3.1
 pip install numpydoc==0.9
 
 # Build and install scikit-learn in dev mode


### PR DESCRIPTION
I don't really understand why sphinx-gallery version was restricted in https://github.com/scikit-learn/scikit-learn/pull/13422#issuecomment-516043280. I can build locally with sphinx-gallery 0.4 without problem.

Of course if anyone remembers why this was done, comments and objections more than welcome!

Once the doc is built I'll have a look at a few pages and check that the output is similar on the dev doc and on this PR doc.