### PR TITLE
[MRG] BLD Adds conda free channel for python 3.5 on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
       - NUMPY_VERSION: 1.11.0
       - SCIPY_VERSION: 0.17.0
       - MATPLOTLIB_VERSION: 1.5.1
+      - CYTHON_VERSION: 0.28.5
       - SCIKIT_IMAGE_VERSION: 0.12.3
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - NUMPY_VERSION: 1.11.0
       - SCIPY_VERSION: 0.17.0
       - MATPLOTLIB_VERSION: 1.5.1
-      - SCIKIT_IMAGE_VERSION: 0.12.3
+      - SCIKIT_IMAGE_VERSION: 0.14.0
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - NUMPY_VERSION: 1.11.0
       - SCIPY_VERSION: 0.17.0
       - MATPLOTLIB_VERSION: 1.5.1
-      - SCIKIT_IMAGE_VERSION: 0.14.0
+      - SCIKIT_IMAGE_VERSION: 0.12.3
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -121,7 +121,7 @@ export CCACHE_COMPRESS=1
 # provided versions
 
 # Adds older packages for python 3.5
-if [ $PYTHON_VERSION = "3.5"]; then
+if [[ "$PYTHON_VERSION" == "3.5" ]]; then
     conda config --set restore_free_channel true
 fi
 

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -119,6 +119,12 @@ export CCACHE_COMPRESS=1
 
 # Configure the conda environment and put it in the path using the
 # provided versions
+
+# Adds older packages for python 3.5
+if [ $PYTHON_VERSION = "3.5"]; then
+    conda config --set restore_free_channel true
+fi
+
 conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
   numpy="${NUMPY_VERSION:-*}" scipy="${SCIPY_VERSION:-*}" cython \
   pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=2.1.2 pillow \

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -126,8 +126,9 @@ if [[ "$PYTHON_VERSION" == "3.5" ]]; then
 fi
 
 conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
-  numpy="${NUMPY_VERSION:-*}" scipy="${SCIPY_VERSION:-*}" cython \
-  pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=2.1.2 pillow \
+  numpy="${NUMPY_VERSION:-*}" scipy="${SCIPY_VERSION:-*}" \
+  cython="${CYTHON_VERSION:-*}" pytest coverage \
+  matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=2.1.2 pillow \
   scikit-image="${SCIKIT_IMAGE_VERSION:-*}" pandas="${PANDAS_VERSION:-*}" \
   joblib
 


### PR DESCRIPTION
This PR updates version of scikit-image to work with 3.5-3.7. `scikit-image=0.12.3` is not on conda anymore.