### PR TITLE
[MRG] fix cluster ordering in k-means example

### DIFF
--- a/examples/cluster/plot_mini_batch_kmeans.py
+++ b/examples/cluster/plot_mini_batch_kmeans.py
@@ -59,12 +59,13 @@ colors = ['#4EACC5', '#FF9C34', '#4E9A06']
 # We want to have the same colors for the same cluster from the
 # MiniBatchKMeans and the KMeans algorithm. Let's pair the cluster centers per
 # closest one.
-k_means_cluster_centers = np.sort(k_means.cluster_centers_, axis=0)
-mbk_means_cluster_centers = np.sort(mbk.cluster_centers_, axis=0)
+k_means_cluster_centers = k_means.cluster_centers_
+order = pairwise_distances_argmin(k_means.cluster_centers_,
+                                  mbk.cluster_centers_)
+mbk_means_cluster_centers = mbk.cluster_centers_[order]
+
 k_means_labels = pairwise_distances_argmin(X, k_means_cluster_centers)
 mbk_means_labels = pairwise_distances_argmin(X, mbk_means_cluster_centers)
-order = pairwise_distances_argmin(k_means_cluster_centers,
-                                  mbk_means_cluster_centers)
 
 # KMeans
 ax = fig.add_subplot(1, 3, 1)
@@ -84,8 +85,8 @@ plt.text(-3.5, 1.8,  'train time: %.2fs\ninertia: %f' % (
 # MiniBatchKMeans
 ax = fig.add_subplot(1, 3, 2)
 for k, col in zip(range(n_clusters), colors):
-    my_members = mbk_means_labels == order[k]
-    cluster_center = mbk_means_cluster_centers[order[k]]
+    my_members = mbk_means_labels == k
+    cluster_center = mbk_means_cluster_centers[k]
     ax.plot(X[my_members, 0], X[my_members, 1], 'w',
             markerfacecolor=col, marker='.')
     ax.plot(cluster_center[0], cluster_center[1], 'o', markerfacecolor=col,
@@ -101,7 +102,7 @@ different = (mbk_means_labels == 4)
 ax = fig.add_subplot(1, 3, 3)
 
 for k in range(n_clusters):
-    different += ((k_means_labels == k) != (mbk_means_labels == order[k]))
+    different += ((k_means_labels == k) != (mbk_means_labels == k))
 
 identic = np.logical_not(different)
 ax.plot(X[identic, 0], X[identic, 1], 'w',


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #14504 

#### What does this implement/fix? Explain your changes.
1. Avoid incorrect use of `np.sort` on cluster centers.
2. Order clusters in one place and replace `order[k]` with `k`.

#### Any other comments?
There is not much visual change in the output, which looked correct by coincidence.

I'm not sure if there are any test required to run when changing examples?