### PR TITLE
[MRG] MAINT check_estimator raises SkipTest when _require_parameters is not present

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -12,7 +12,6 @@ import sys
 import re
 import pkgutil
 import functools
-from contextlib import suppress
 
 import pytest
 
@@ -63,8 +62,10 @@ def _tested_estimators():
             continue
         # FIXME _skip_test should be used here (if we could)
 
-        with suppress(SkipTest):
+        try:
             estimator = _construct_instance(Estimator)
+        except SkipTest:
+            continue
 
         yield name, estimator
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -60,8 +60,6 @@ def _tested_estimators():
             continue
         if name.startswith("_"):
             continue
-        # FIXME _skip_test should be used here (if we could)
-
         try:
             estimator = _construct_instance(Estimator)
         except SkipTest:

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -12,6 +12,7 @@ import sys
 import re
 import pkgutil
 import functools
+from contextlib import suppress
 
 import pytest
 
@@ -27,9 +28,11 @@ from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
 from sklearn.linear_model.base import LinearClassifierMixin
 from sklearn.linear_model import Ridge
 from sklearn.utils import IS_PYPY
+from sklearn.utils.testing import SkipTest
 from sklearn.utils.estimator_checks import (
     _yield_all_checks,
     _safe_tags,
+    _construct_instance,
     set_checking_parameters,
     check_parameters_default_constructible,
     check_class_weight_balanced_linear_classifier)
@@ -60,21 +63,9 @@ def _tested_estimators():
             continue
         # FIXME _skip_test should be used here (if we could)
 
-        required_parameters = getattr(Estimator, "_required_parameters", [])
-        if len(required_parameters):
-            if required_parameters in (["estimator"], ["base_estimator"]):
-                if issubclass(Estimator, RegressorMixin):
-                    estimator = Estimator(Ridge())
-                else:
-                    estimator = Estimator(LinearDiscriminantAnalysis())
-            else:
-                warnings.warn("Can't instantiate estimator {} which requires "
-                              "parameters {}".format(name,
-                                                     required_parameters),
-                              SkipTestWarning)
-                continue
-        else:
-            estimator = Estimator()
+        with suppress(SkipTest):
+            estimator = _construct_instance(Estimator)
+
         yield name, estimator
 
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2262,7 +2262,6 @@ def check_parameters_default_constructible(name, Estimator):
                     assert param_value is init_param.default, init_param.name
                 else:
                     assert param_value == init_param.default, init_param.name
-    return clone(estimator)
 
 
 def enforce_estimator_tags_y(estimator, y):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -291,8 +291,7 @@ def check_estimator(Estimator):
     if isinstance(Estimator, type):
         # got a class
         name = Estimator.__name__
-        estimator = Estimator()
-        check_parameters_default_constructible(name, Estimator)
+        estimator = check_parameters_default_constructible(name, Estimator)
     else:
         # got an instance
         estimator = Estimator
@@ -2256,6 +2255,7 @@ def check_parameters_default_constructible(name, Estimator):
                     assert param_value is init_param.default, init_param.name
                 else:
                     assert param_value == init_param.default, init_param.name
+    return clone(estimator)
 
 
 def enforce_estimator_tags_y(estimator, y):

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -11,7 +11,8 @@ from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils import deprecated
 from sklearn.utils.testing import (assert_raises_regex,
                                    ignore_warnings,
-                                   assert_warns, assert_raises)
+                                   assert_warns, assert_raises,
+                                   SkipTest)
 from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.estimator_checks \
     import check_class_weight_balanced_linear_classifier
@@ -519,6 +520,19 @@ def test_check_estimator_pairwise():
     # test precomputed metric
     est = KNeighborsRegressor(metric='precomputed')
     check_estimator(est)
+
+
+def test_check_estimator_required_parameters_skip():
+    class MyEstimator(BaseEstimator):
+        _required_parameters = ["special_parameter"]
+
+        def __init__(self, special_parameter):
+            self.special_parameter = special_parameter
+
+    assert_raises_regex(SkipTest, r"Can't instantiate estimator MyEstimator "
+                                  r"which requires parameters "
+                                  r"\['special_parameter'\]",
+                                  check_estimator, MyEstimator)
 
 
 def run_tests_without_pytest():


### PR DESCRIPTION
This PR contains two adjustments:

1. Raises `SkipTest` correctly when `_require_parameters` is not recognized.
2. Defines `_construct_instance` to create an instance of estimator.