### PR TITLE
MRG add dendrogram example

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -603,6 +603,18 @@ Single linkage can also perform well on non-globular data.
  * :ref:`sphx_glr_auto_examples_cluster_plot_digits_linkage.py`: exploration of the
    different linkage strategies in a real dataset.
 
+Visualization of cluster hierarchy
+----------------------------------
+
+It's possible to visualize the tree representing the hierarchical merging of clusters
+as a dendrogram. Visual inspection can often be useful for understanding the structure
+of the data, though more so in the case of small sample sizes.
+
+.. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_dendrogram_001.png
+    :target: ../auto_examples/cluster/plot_agglomerative_dendrogram.html
+    :scale: 42
+
+
 
 Adding connectivity constraints
 -------------------------------

--- a/examples/cluster/plot_agglomerative_dendrogram.py
+++ b/examples/cluster/plot_agglomerative_dendrogram.py
@@ -19,16 +19,16 @@ from sklearn.cluster import AgglomerativeClustering
 def plot_dendrogram(model, **kwargs):
     # Create linkage matrix and then plot the dendrogram
 
-    # create the counts of samples in each node
+    # create the counts of samples under each node
     counts = np.zeros(model.children_.shape[0])
     n_samples = len(model.labels_)
     for i, merge in enumerate(model.children_):
         current_count = 0
-        for j in [0, 1]:
-            if merge[j] < n_samples:
-                current_count += 1
+        for child_idx in merge:
+            if child_idx < n_samples:
+                current_count += 1  # leaf node
             else:
-                current_count += counts[merge[j] - n_samples]
+                current_count += counts[child_idx - n_samples]
         counts[i] = current_count
 
     linkage_matrix = np.column_stack([model.children_, model.distances_,

--- a/examples/cluster/plot_agglomerative_dendrogram.py
+++ b/examples/cluster/plot_agglomerative_dendrogram.py
@@ -45,7 +45,6 @@ X = iris.data
 model = AgglomerativeClustering(distance_threshold=0, n_clusters=None)
 
 model = model.fit(X)
-fig = plt.figure(figsize=(25, 10))
 plt.title('Hierarchical Clustering Dendrogram')
 # plot the top three levels of the dendrogram
 plot_dendrogram(model, truncate_mode='level', p=3)

--- a/examples/cluster/plot_agglomerative_dendrogram.py
+++ b/examples/cluster/plot_agglomerative_dendrogram.py
@@ -1,0 +1,53 @@
+# Authors: Mathew Kallada, Andreas Mueller
+# License: BSD 3 clause
+"""
+=========================================
+Plot Hierarachical Clustering Dendrogram
+=========================================
+This example plots the corresponding dendrogram of a hierarchical clustering
+using AgglomerativeClustering and the dendrogram method available in scipy.
+"""
+
+import numpy as np
+
+from matplotlib import pyplot as plt
+from scipy.cluster.hierarchy import dendrogram
+from sklearn.datasets import load_iris
+from sklearn.cluster import AgglomerativeClustering
+
+
+def plot_dendrogram(model, **kwargs):
+    # Create linkage matrix and then plot the dendrogram
+
+    # create the counts of samples in each node
+    counts = np.zeros(model.children_.shape[0])
+    n_samples = len(model.labels_)
+    for i, merge in enumerate(model.children_):
+        current_count = 0
+        for j in [0, 1]:
+            if merge[j] < n_samples:
+                current_count += 1
+            else:
+                current_count += counts[merge[j] - n_samples]
+        counts[i] = current_count
+
+    linkage_matrix = np.column_stack([model.children_, model.distances_,
+                                      counts]).astype(float)
+
+    # Plot the corresponding dendrogram
+    dendrogram(linkage_matrix, **kwargs)
+
+
+iris = load_iris()
+X = iris.data
+
+# setting distance_threshold=0 ensures we compute the full tree.
+model = AgglomerativeClustering(distance_threshold=0, n_clusters=None)
+
+model = model.fit(X)
+fig = plt.figure(figsize=(25, 10))
+plt.title('Hierarchical Clustering Dendrogram')
+# plot the top three levels of the dendrogram
+plot_dendrogram(model, truncate_mode='level', p=3)
+plt.xlabel("Number of points in node (or index of point if no parenthesis).")
+plt.show()

--- a/examples/cluster/plot_agglomerative_dendrogram.py
+++ b/examples/cluster/plot_agglomerative_dendrogram.py
@@ -2,7 +2,7 @@
 # License: BSD 3 clause
 """
 =========================================
-Plot Hierarachical Clustering Dendrogram
+Plot Hierarchical Clustering Dendrogram
 =========================================
 This example plots the corresponding dendrogram of a hierarchical clustering
 using AgglomerativeClustering and the dendrogram method available in scipy.

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -990,6 +990,10 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
         at the i-th iteration, children[i][0] and children[i][1]
         are merged to form node `n_features + i`
 
+    distances_ : array-like, shape (n_nodes-1,)
+        Distances between nodes in the corresponding place in `children_`.
+        Only computed if distance_threshold is not None.
+
     Examples
     --------
     >>> import numpy as np

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -859,10 +859,10 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
          self.n_leaves_,
          parents) = out[:4]
 
-        if distance_threshold is not None:
-            distances = out[-1]
+        if return_distance:
+            self.distances_ = out[-1]
             self.n_clusters_ = np.count_nonzero(
-                distances >= distance_threshold) + 1
+                self.distances_ >= distance_threshold) + 1
         else:
             self.n_clusters_ = self.n_clusters
 


### PR DESCRIPTION
Fixes #6788, fixes #3464.

This PR stores the distances in the AgglomerativeClustering object if they are computed, and adds an example to plot the corresponding dendrogram.
It's based on #3464 with some fixes.

We don't have access to the number of data points per node, but that is easy to compute. If there's a better vectorized way I'm all ears! But I assume this is mostly useful for smaller datasets anyway.