### PR TITLE
[MRG] Fix typo in RFE example

### DIFF
--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -87,7 +87,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
 
     Examples
     --------
-    The following example shows how to retrieve the 5 right informative
+    The following example shows how to retrieve the 5 most informative
     features in the Friedman #1 dataset.
 
     >>> from sklearn.datasets import make_friedman1


### PR DESCRIPTION
####  Reference Issues/PRs

None

#### What does this implement/fix? Explain your changes.

Changes documentation to read "retrieve 5 most informative" instead of "5 right informative".

#### Any other comments?

No