### PR TITLE
[MRG] Add memory measurements in gallery

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -130,7 +130,7 @@ conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
   cython="${CYTHON_VERSION:-*}" pytest coverage \
   matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=2.1.2 pillow \
   scikit-image="${SCIKIT_IMAGE_VERSION:-*}" pandas="${PANDAS_VERSION:-*}" \
-  joblib
+  joblib memory_profiler
 
 source activate testenv
 pip install sphinx-gallery==0.3.1

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -250,6 +250,7 @@ intersphinx_mapping = {
 sphinx_gallery_conf = {
     'doc_module': 'sklearn',
     'backreferences_dir': os.path.join('modules', 'generated'),
+    'show_memory': True,
     'reference_url': {
         'sklearn': None}
 }


### PR DESCRIPTION
Since 0.3 sphinx-gallery supports memory measurements in examples on top of timings.

This is how it looks (from sphinx-gallery doc):
![image](https://user-images.githubusercontent.com/1680079/62208287-aa970100-b396-11e9-8a27-ee8124381763.png)
