### PR TITLE
DOC add a more complex example to gridsearch for nested parameters

### DIFF
--- a/doc/modules/compose.rst
+++ b/doc/modules/compose.rst
@@ -101,6 +101,9 @@ permitted). This is convenient for performing only some of the transformations
     >>> pipe[-1:]
     Pipeline(steps=[('clf', SVC())])
 
+
+.. _pipeline_nested_parameters:
+
 Nested parameters
 .................
 

--- a/doc/modules/compose.rst
+++ b/doc/modules/compose.rst
@@ -128,7 +128,7 @@ ignored by setting them to ``'passthrough'``::
 
 The estimators of the pipeline can be retrieved by index:
 
-    >>> pipe[0] 
+    >>> pipe[0]
     PCA()
 
 or by name::
@@ -147,7 +147,7 @@ or by name::
 
 .. topic:: See also:
 
- * :ref:`grid_search`
+ * :ref:`_composite_grid_search`
 
 
 Notes
@@ -369,7 +369,7 @@ Like ``Pipeline``, individual steps may be replaced using ``set_params``,
 and ignored by setting to ``'drop'``::
 
     >>> combined.set_params(kernel_pca='drop')
-    FeatureUnion(transformer_list=[('linear_pca', PCA()), 
+    FeatureUnion(transformer_list=[('linear_pca', PCA()),
                                    ('kernel_pca', 'drop')])
 
 .. topic:: Examples:
@@ -420,7 +420,7 @@ preprocessing or a specific feature extraction method::
 
 For this data, we might want to encode the ``'city'`` column as a categorical
 variable using :class:`preprocessing.OneHotEncoder
-<sklearn.preprocessing.OneHotEncoder>` but apply a 
+<sklearn.preprocessing.OneHotEncoder>` but apply a
 :class:`feature_extraction.text.CountVectorizer
 <sklearn.feature_extraction.text.CountVectorizer>` to the ``'title'`` column.
 As we might use multiple feature extraction methods on the same column, we give

--- a/doc/modules/compose.rst
+++ b/doc/modules/compose.rst
@@ -147,7 +147,7 @@ or by name::
 
 .. topic:: See also:
 
- * :ref:`_composite_grid_search`
+ * :ref:`composite_grid_search`
 
 
 Notes

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -198,7 +198,7 @@ Composite estimators and parameter spaces
 -----------------------------------------
 `GridSearchCV` and `RandomizedSearchCV` allow searching over parameters of
 composite or nested estimators such as `Pipeline`, `ColumnTransformer`,
-`VotingClasssifier` or `CalibratedClassifierCV`
+`VotingClassifier` or `CalibratedClassifierCV`
 using a dedicated syntax ``<estimator>__<parameter>`` syntax::
 
   >>> from sklearn.model_selection import GridSearchCV

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -213,7 +213,7 @@ using a dedicated syntax ``<estimator>__<parameter>`` syntax::
   >>> search = GridSearchCV(calibrated_forest, param_grid, cv=5)
   >>> search.fit(X, y)
   GridSearchCV(cv=5,
-               estimator=CalibratedClassifierCV(base_estimator=RandomForestClassifier(n_estimators=10)),
+               estimator=CalibratedClassifierCV(...),
                param_grid={'base_estimator__max_depth': [2, 4, 6, 8]})
 
 Here, ``<estimator>`` is the parameter name of the nested estimator,

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -219,7 +219,7 @@ using a dedicated syntax ``<estimator>__<parameter>`` syntax::
 Here, ``<estimator>`` is the parameter name of the nested estimator,
 in this case ``base_estimator``.
 The `Pipeline` class has a slightly different notation, as explained in :ref:`pipeline`,
-where ``<estimators>`` referes to the name of the step in the pipeline.
+where ``<estimators>`` refers to the name of the step in the pipeline.
 In practice, there can be several levels of nesting::
 
   >>> from sklearn.pipeline import Pipeline

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -235,8 +235,7 @@ In practice, there can be several levels of nesting::
   GridSearchCV(cv=5,
                estimator=Pipeline(steps=[('select', SelectKBest()),
                                          ('model',
-                                          CalibratedClassifierCV(
-                                              base_estimator=RandomForestClassifier(n_estimators=10)))]),
+                                          CalibratedClassifierCV(base_estimator=RandomForestClassifier(n_estimators=10)))]),
                param_grid={'model__base_estimator__max_depth': [2, 4, 6, 8],
                            'select__k': [1, 2]})
 

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -219,7 +219,7 @@ using a dedicated syntax ``<estimator>__<parameter>`` syntax::
 Here, ``<estimator>`` is the parameter name of the nested estimator,
 in this case ``base_estimator``.
 If the meta-estimator is constructed as a collection of estimators as in `Pipeline`, then
-``<estimators>`` refers to the name of the estimator, see :ref:`pipeline_nested_parameters`.
+``<estimator>`` refers to the name of the estimator, see :ref:`pipeline_nested_parameters`.
 In practice, there can be several levels of nesting::
 
   >>> from sklearn.pipeline import Pipeline

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -218,8 +218,8 @@ using a dedicated syntax ``<estimator>__<parameter>`` syntax::
 
 Here, ``<estimator>`` is the parameter name of the nested estimator,
 in this case ``base_estimator``.
-The `Pipeline` class has a slightly different notation, as explained in :ref:`pipeline`,
-where ``<estimators>`` refers to the name of the step in the pipeline.
+If the meta-estimator is cunstructed as a collection of estimators as in `Pipeline`, then
+``<estimators>`` refers to the name of the estimator, see :ref:`pipeline_nested_parameters`.
 In practice, there can be several levels of nesting::
 
   >>> from sklearn.pipeline import Pipeline
@@ -230,14 +230,7 @@ In practice, there can be several levels of nesting::
   >>> param_grid = {
   ...    'select__k': [1, 2],
   ...    'model__base_estimator__max_depth': [2, 4, 6, 8]}
-  >>> search = GridSearchCV(pipe, param_grid, cv=5)
-  >>> search.fit(X, y)
-  GridSearchCV(cv=5,
-               estimator=Pipeline(steps=[('select', SelectKBest()),
-                                         ('model',
-                                          CalibratedClassifierCV(base_estimator=RandomForestClassifier(n_estimators=10)))]),
-               param_grid={'model__base_estimator__max_depth': [2, 4, 6, 8],
-                           'select__k': [1, 2]})
+  >>> search = GridSearchCV(pipe, param_grid, cv=5).fit(X, y)
 
 
 Model selection: development and evaluation

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -218,7 +218,7 @@ using a dedicated syntax ``<estimator>__<parameter>`` syntax::
 
 Here, ``<estimator>`` is the parameter name of the nested estimator,
 in this case ``base_estimator``.
-If the meta-estimator is cunstructed as a collection of estimators as in `Pipeline`, then
+If the meta-estimator is constructed as a collection of estimators as in `Pipeline`, then
 ``<estimators>`` refers to the name of the estimator, see :ref:`pipeline_nested_parameters`.
 In practice, there can be several levels of nesting::
 

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -199,7 +199,7 @@ Composite estimators and parameter spaces
 `GridSearchCV` and `RandomizedSearchCV` allow searching over parameters of
 composite or nested estimators such as `pipeline.Pipeline`,
 `ColumnTransformer`, `VotingClassifier` or `CalibratedClassifierCV`
-using a dedicated syntax ``<estimator>__<parameter>`` syntax::
+using a dedicated ``<estimator>__<parameter>`` syntax::
 
   >>> from sklearn.model_selection import GridSearchCV
   >>> from sklearn.calibration import CalibratedClassifierCV

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -213,8 +213,7 @@ using a dedicated syntax ``<estimator>__<parameter>`` syntax::
   >>> search = GridSearchCV(calibrated_forest, param_grid, cv=5)
   >>> search.fit(X, y)
   GridSearchCV(cv=5,
-               estimator=CalibratedClassifierCV(
-                   base_estimator=RandomForestClassifier(n_estimators=10)),
+               estimator=CalibratedClassifierCV(base_estimator=RandomForestClassifier(n_estimators=10)),
                param_grid={'base_estimator__max_depth': [2, 4, 6, 8]})
 
 Here, ``<estimator>`` is the parameter name of the nested estimator,

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -197,8 +197,8 @@ for an example usage.
 Composite estimators and parameter spaces
 -----------------------------------------
 `GridSearchCV` and `RandomizedSearchCV` allow searching over parameters of
-composite or nested estimators such as `Pipeline`, `ColumnTransformer`,
-`VotingClassifier` or `CalibratedClassifierCV`
+composite or nested estimators such as `pipeline.Pipeline`,
+`ColumnTransformer`, `VotingClassifier` or `CalibratedClassifierCV`
 using a dedicated syntax ``<estimator>__<parameter>`` syntax::
 
   >>> from sklearn.model_selection import GridSearchCV

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -192,6 +192,8 @@ result in an error when using multiple metrics.
 See :ref:`sphx_glr_auto_examples_model_selection_plot_multi_metric_evaluation.py`
 for an example usage.
 
+.. _composite_grid_search:
+
 Composite estimators and parameter spaces
 -----------------------------------------
 `GridSearchCV` and `RandomizedSearchCV` allow searching over parameters of
@@ -211,14 +213,15 @@ using a dedicated syntax ``<estimator>__<parameter>`` syntax::
   >>> search = GridSearchCV(calibrated_forest, param_grid, cv=5)
   >>> search.fit(X, y)
   GridSearchCV(cv=5,
-               estimator=CalibratedClassifierCV(base_estimator=RandomForestClassifier(n_estimators=10)),
+               estimator=CalibratedClassifierCV(
+                   base_estimator=RandomForestClassifier(n_estimators=10)),
                param_grid={'base_estimator__max_depth': [2, 4, 6, 8]})
 
 Here, ``<estimator>`` is the parameter name of the nested estimator,
 in this case ``base_estimator``.
 The `Pipeline` class has a slightly different notation, as explained in :ref:`pipeline`,
 where ``<estimators>`` referes to the name of the step in the pipeline.
-In practice, there can be several levels of nesting:
+In practice, there can be several levels of nesting::
 
   >>> from sklearn.pipeline import Pipeline
   >>> from sklearn.feature_selection import SelectKBest
@@ -233,7 +236,8 @@ In practice, there can be several levels of nesting:
   GridSearchCV(cv=5,
                estimator=Pipeline(steps=[('select', SelectKBest()),
                                          ('model',
-                                          CalibratedClassifierCV(base_estimator=RandomForestClassifier(n_estimators=10)))]),
+                                          CalibratedClassifierCV(
+                                              base_estimator=RandomForestClassifier(n_estimators=10)))]),
                param_grid={'model__base_estimator__max_depth': [2, 4, 6, 8],
                            'select__k': [1, 2]})
 

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -218,9 +218,10 @@ using a dedicated syntax ``<estimator>__<parameter>`` syntax::
 
 Here, ``<estimator>`` is the parameter name of the nested estimator,
 in this case ``base_estimator``.
-If the meta-estimator is constructed as a collection of estimators as in `Pipeline`, then
-``<estimators>`` refers to the name of the estimator, see :ref:`pipeline_nested_parameters`.
-In practice, there can be several levels of nesting::
+If the meta-estimator is constructed as a collection of estimators as in
+`pipeline.Pipeline`, then ``<estimators>`` refers to the name of the estimator,
+see :ref:`pipeline_nested_parameters`.  In practice, there can be several
+levels of nesting::
 
   >>> from sklearn.pipeline import Pipeline
   >>> from sklearn.feature_selection import SelectKBest


### PR DESCRIPTION
Related to what was brought up in #8710:
I don't think we explicitly describe how to do grid-searches on meta-estimators, and ``Pipeline`` actually works different from other meta-estimators (it uses the step names, not the parameter names).