### PR TITLE
[MRG] add support for lists of dictionaries to RandomizedSearchCV

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -210,6 +210,9 @@ Changelog
   plot model scalability (see learning_curve example).
   :pr:`13938` by :user:`Hadrien Reboul <H4dr1en>`.
 
+- |Enhancement| :class:`model_selection.RandomizedSearchCV` now accepts lists
+  of parameter distributions. :pr:`14549` by `Andreas Müller`_.
+
 :mod:`sklearn.pipeline`
 .......................
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -269,9 +269,9 @@ class ParameterSampler:
     def __iter__(self):
         # check if all distributions are given as lists
         # in this case we want to sample without replacement
-        all_lists = all(all(not hasattr(v, "rvs")
-                            for v in dist.values())
-                            for dist in self.param_distributions)
+        all_lists = all(
+            all(not hasattr(v, "rvs") for v in dist.values())
+            for dist in self.param_distributions)
         rnd = check_random_state(self.random_state)
 
         if all_lists:

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -272,7 +272,7 @@ class ParameterSampler:
         all_lists = all(
             all(not hasattr(v, "rvs") for v in dist.values())
             for dist in self.param_distributions)
-        rnd = check_random_state(self.random_state)
+        rng = check_random_state(self.random_state)
 
         if all_lists:
             # look up sampled parameter settings in parameter grid
@@ -288,21 +288,20 @@ class ParameterSampler:
                     % (grid_size, self.n_iter, grid_size), UserWarning)
                 n_iter = grid_size
             for i in sample_without_replacement(grid_size, n_iter,
-                                                random_state=rnd):
+                                                random_state=rng):
                 yield param_grid[i]
 
         else:
             for _ in range(self.n_iter):
-                dist = self.param_distributions[
-                    rnd.randint(len(self.param_distributions))]
+                dist = rng.choice(self.param_distributions)
                 # Always sort the keys of a dictionary, for reproducibility
                 items = sorted(dist.items())
                 params = dict()
                 for k, v in items:
                     if hasattr(v, "rvs"):
-                        params[k] = v.rvs(random_state=rnd)
+                        params[k] = v.rvs(random_state=rng)
                     else:
-                        params[k] = v[rnd.randint(len(v))]
+                        params[k] = v[rng.randint(len(v))]
                 yield params
 
     def __len__(self):

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -3,6 +3,7 @@
 from collections.abc import Iterable, Sized
 from io import StringIO
 from itertools import chain, product
+from functools import partial
 import pickle
 import sys
 from types import GeneratorType
@@ -121,17 +122,18 @@ y = np.array([1, 1, 2, 2])
 def assert_grid_iter_equals_getitem(grid):
     assert list(grid) == [grid[i] for i in range(len(grid))]
 
-
+@pytest.mark.parametrize("klass", [ParameterGrid,
+                                   partial(ParameterSampler, n_iter=10)])
 @pytest.mark.parametrize(
     "input, error_type, error_message",
-    [(0, TypeError, r'Parameter grid is not a dict or a list \(0\)'),
-     ([{'foo': [0]}, 0], TypeError, r'Parameter grid is not a dict \(0\)'),
-     ({'foo': 0}, TypeError, "Parameter grid value is not iterable "
+    [(0, TypeError, r'Parameter .* is not a dict or a list \(0\)'),
+     ([{'foo': [0]}, 0], TypeError, r'Parameter .* is not a dict \(0\)'),
+     ({'foo': 0}, TypeError, "Parameter.* value is not iterable .*"
       r"\(key='foo', value=0\)")]
 )
-def test_validate_parameter_grid_input(input, error_type, error_message):
+def test_validate_parameter_input(klass, input, error_type, error_message):
     with pytest.raises(error_type, match=error_message):
-        ParameterGrid(input)
+        klass(input)
 
 
 def test_parameter_grid():


### PR DESCRIPTION
Follow up on #12759 with a slightly simplified interface.
This makes the API of RandomizedSearchCV a superset of GridSearchCV which makes it more convenient to use.