### PR TITLE
RandomizedSearchCV.best_estimator_ can not be a dictionary

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1350,7 +1350,7 @@ class RandomizedSearchCV(BaseSearchCV):
         scorer's name (``'_<scorer_name>'``) instead of ``'_score'`` shown
         above. ('split0_test_precision', 'mean_train_precision' etc.)
 
-    best_estimator_ : estimator or dict
+    best_estimator_ : estimator
         Estimator that was chosen by the search, i.e. estimator
         which gave highest score (or smallest loss if specified)
         on the left out data. Not available if ``refit=False``.


### PR DESCRIPTION
Fixes #14551 

The `best_estimator_` attribute of `RandomizedSearchCV` is always an estimator, not a dictionary.