### PR TITLE
MAINT Deprecate utils.extmath.safe_min

### DIFF
--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -17,7 +17,6 @@ import scipy.sparse as sp
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_random_state, check_array
 from ..utils.extmath import randomized_svd, safe_sparse_dot, squared_norm
-from ..utils.extmath import safe_min
 from ..utils.validation import check_is_fitted, check_non_negative
 from ..exceptions import ConvergenceWarning
 from .cdnmf_fast import _update_cdnmf_fast
@@ -1000,7 +999,7 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
     check_non_negative(X, "NMF (input X)")
     beta_loss = _check_string_param(solver, regularization, beta_loss, init)
 
-    if safe_min(X) == 0 and beta_loss <= 0:
+    if X.min() == 0 and beta_loss <= 0:
         raise ValueError("When beta_loss <= 0 and X contains zeros, "
                          "the solver may diverge. Please add small values to "
                          "X, or use a positive beta_loss.")

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -610,6 +610,8 @@ def safe_min(X):
 
     Adapated from https://stackoverflow.com/q/13426580
 
+    .. deprecated:: 0.21.0
+
     Parameters
     ----------
     X : array_like

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -610,7 +610,7 @@ def safe_min(X):
 
     Adapated from https://stackoverflow.com/q/13426580
 
-    .. deprecated:: 0.21.0
+    .. deprecated:: 0.22.0
 
     Parameters
     ----------

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -604,7 +604,7 @@ def softmax(X, copy=True):
 
 
 @deprecated("safe_min is deprecated in version 0.22 and will be removed "
-            " in version 0.24.")
+            "in version 0.24.")
 def safe_min(X):
     """Returns the minimum value of a dense or a CSR/CSC matrix.
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -20,6 +20,7 @@ from . import check_random_state
 from ._logistic_sigmoid import _log_logistic_sigmoid
 from .sparsefuncs_fast import csr_row_norms
 from .validation import check_array
+from .deprecation import deprecated
 
 
 def squared_norm(x):
@@ -602,6 +603,8 @@ def softmax(X, copy=True):
     return X
 
 
+@deprecated("safe_min is deprecated in version 0.22 and will be removed "
+            " in version 0.24.")
 def safe_min(X):
     """Returns the minimum value of a dense or a CSR/CSC matrix.
 
@@ -646,7 +649,7 @@ def make_nonnegative(X, min_value=0):
     ValueError
         When X is sparse
     """
-    min_ = safe_min(X)
+    min_ = X.min()
     if min_ < min_value:
         if sparse.issparse(X):
             raise ValueError("Cannot make the data matrix"

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -645,6 +645,6 @@ def test_stable_cumsum():
 
 def test_safe_min():
     msg = ("safe_min is deprecated in version 0.22 and will be removed "
-           " in version 0.24.")
+           "in version 0.24.")
     with pytest.warns(DeprecationWarning, match=msg):
         safe_min(np.ones(10))

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -31,6 +31,7 @@ from sklearn.utils.extmath import _incremental_mean_and_var
 from sklearn.utils.extmath import _deterministic_vector_sign_flip
 from sklearn.utils.extmath import softmax
 from sklearn.utils.extmath import stable_cumsum
+from sklearn.utils.extmath import safe_min
 from sklearn.datasets.samples_generator import make_low_rank_matrix
 
 
@@ -640,3 +641,10 @@ def test_stable_cumsum():
     assert_array_equal(stable_cumsum(A, axis=0), np.cumsum(A, axis=0))
     assert_array_equal(stable_cumsum(A, axis=1), np.cumsum(A, axis=1))
     assert_array_equal(stable_cumsum(A, axis=2), np.cumsum(A, axis=2))
+
+
+def test_safe_min():
+    msg = ("safe_min is deprecated in version 0.22 and will be removed "
+           " in version 0.24.")
+    with pytest.warns(DeprecationWarning, match=msg):
+        safe_min(np.ones(10))


### PR DESCRIPTION
`utils.extmath.safe_min` implements a min function that also works for sparse arrays, however it should no longer be necessary with the scipy versions we support. 