### PR TITLE
EXA Remove redundant tol parameter for SGDClassifier

### DIFF
--- a/benchmarks/bench_covertype.py
+++ b/benchmarks/bench_covertype.py
@@ -101,7 +101,7 @@ ESTIMATORS = {
     'ExtraTrees': ExtraTreesClassifier(n_estimators=20),
     'RandomForest': RandomForestClassifier(n_estimators=20),
     'CART': DecisionTreeClassifier(min_samples_split=5),
-    'SGD': SGDClassifier(alpha=0.001, max_iter=1000, tol=1e-3),
+    'SGD': SGDClassifier(alpha=0.001, max_iter=1000),
     'GaussianNB': GaussianNB(),
     'liblinear': LinearSVC(loss="l2", penalty="l2", C=1000, dual=False,
                            tol=1e-3),

--- a/examples/applications/plot_out_of_core_classification.py
+++ b/examples/applications/plot_out_of_core_classification.py
@@ -207,7 +207,7 @@ positive_class = 'acq'
 
 # Here are some classifiers that support the `partial_fit` method
 partial_fit_classifiers = {
-    'SGD': SGDClassifier(max_iter=5, tol=1e-3),
+    'SGD': SGDClassifier(max_iter=5),
     'Perceptron': Perceptron(tol=1e-3),
     'NB Multinomial': MultinomialNB(alpha=0.01),
     'Passive-Aggressive': PassiveAggressiveClassifier(tol=1e-3),

--- a/examples/applications/wikipedia_principal_eigenvector.py
+++ b/examples/applications/wikipedia_principal_eigenvector.py
@@ -224,6 +224,6 @@ def centrality_scores(X, alpha=0.85, max_iter=100, tol=1e-10):
 
 print("Computing principal eigenvector score using a power iteration method")
 t0 = time()
-scores = centrality_scores(X, max_iter=100, tol=1e-10)
+scores = centrality_scores(X, max_iter=100)
 print("done in %0.3fs" % (time() - t0))
 pprint([names[i] for i in np.abs(scores).argsort()[-10:]])

--- a/examples/linear_model/plot_sgd_comparison.py
+++ b/examples/linear_model/plot_sgd_comparison.py
@@ -24,8 +24,8 @@ rounds = 20
 X, y = datasets.load_digits(return_X_y=True)
 
 classifiers = [
-    ("SGD", SGDClassifier(max_iter=100, tol=1e-3)),
-    ("ASGD", SGDClassifier(average=True, max_iter=1000, tol=1e-3)),
+    ("SGD", SGDClassifier(max_iter=100)),
+    ("ASGD", SGDClassifier(average=True, max_iter=1000)),
     ("Perceptron", Perceptron(tol=1e-3)),
     ("Passive-Aggressive I", PassiveAggressiveClassifier(loss='hinge',
                                                          C=1.0, tol=1e-4)),

--- a/examples/linear_model/plot_sgd_early_stopping.py
+++ b/examples/linear_model/plot_sgd_early_stopping.py
@@ -89,7 +89,7 @@ def fit_and_score(estimator, max_iter, X_train, X_test, y_train, y_test):
 # Define the estimators to compare
 estimator_dict = {
     'No stopping criterion':
-    linear_model.SGDClassifier(tol=1e-3, n_iter_no_change=3),
+    linear_model.SGDClassifier(n_iter_no_change=3),
     'Training loss':
     linear_model.SGDClassifier(early_stopping=False, n_iter_no_change=3,
                                tol=0.1),

--- a/examples/linear_model/plot_sgd_iris.py
+++ b/examples/linear_model/plot_sgd_iris.py
@@ -38,7 +38,7 @@ X = (X - mean) / std
 
 h = .02  # step size in the mesh
 
-clf = SGDClassifier(alpha=0.001, max_iter=100, tol=1e-3).fit(X, y)
+clf = SGDClassifier(alpha=0.001, max_iter=100).fit(X, y)
 
 # create a mesh to plot in
 x_min, x_max = X[:, 0].min() - 1, X[:, 0].max() + 1

--- a/examples/linear_model/plot_sgd_separating_hyperplane.py
+++ b/examples/linear_model/plot_sgd_separating_hyperplane.py
@@ -19,7 +19,7 @@ X, Y = make_blobs(n_samples=50, centers=2, random_state=0, cluster_std=0.60)
 
 # fit the model
 clf = SGDClassifier(loss="hinge", alpha=0.01, max_iter=200,
-                    fit_intercept=True, tol=1e-3)
+                    fit_intercept=True)
 clf.fit(X, Y)
 
 # plot the line, the points, and the nearest vectors to the plane

--- a/examples/linear_model/plot_sgd_weighted_samples.py
+++ b/examples/linear_model/plot_sgd_weighted_samples.py
@@ -27,14 +27,14 @@ plt.scatter(X[:, 0], X[:, 1], c=y, s=sample_weight, alpha=0.9,
             cmap=plt.cm.bone, edgecolor='black')
 
 # fit the unweighted model
-clf = linear_model.SGDClassifier(alpha=0.01, max_iter=100, tol=1e-3)
+clf = linear_model.SGDClassifier(alpha=0.01, max_iter=100)
 clf.fit(X, y)
 Z = clf.decision_function(np.c_[xx.ravel(), yy.ravel()])
 Z = Z.reshape(xx.shape)
 no_weights = plt.contour(xx, yy, Z, levels=[0], linestyles=['solid'])
 
 # fit the weighted model
-clf = linear_model.SGDClassifier(alpha=0.01, max_iter=100, tol=1e-3)
+clf = linear_model.SGDClassifier(alpha=0.01, max_iter=100)
 clf.fit(X, y, sample_weight=sample_weight)
 Z = clf.decision_function(np.c_[xx.ravel(), yy.ravel()])
 Z = Z.reshape(xx.shape)

--- a/examples/model_selection/grid_search_text_feature_extraction.py
+++ b/examples/model_selection/grid_search_text_feature_extraction.py
@@ -87,7 +87,7 @@ print()
 pipeline = Pipeline([
     ('vect', CountVectorizer()),
     ('tfidf', TfidfTransformer()),
-    ('clf', SGDClassifier(tol=1e-3)),
+    ('clf', SGDClassifier()),
 ])
 
 # uncommenting more parameters will give better exploring power but will

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -1420,7 +1420,7 @@ def test_tol_parameter():
     assert model_2.n_iter_ > 3
 
     # Strict tolerance and small max_iter should trigger a warning
-    model_3 = SGDClassifier(max_iter=3, random_state=0)
+    model_3 = SGDClassifier(max_iter=3, tol=1e-3, random_state=0)
     model_3 = assert_warns(ConvergenceWarning, model_3.fit, X, y)
     assert model_3.n_iter_ == 3
 

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -1420,7 +1420,7 @@ def test_tol_parameter():
     assert model_2.n_iter_ > 3
 
     # Strict tolerance and small max_iter should trigger a warning
-    model_3 = SGDClassifier(max_iter=3, tol=1e-3, random_state=0)
+    model_3 = SGDClassifier(max_iter=3, random_state=0)
     model_3 = assert_warns(ConvergenceWarning, model_3.fit, X, y)
     assert model_3.n_iter_ == 3
 
@@ -1603,13 +1603,13 @@ def test_SGDClassifier_fit_for_all_backends(backend):
     y = random_state.choice(20, 500)
 
     # Begin by fitting a SGD classifier sequentially
-    clf_sequential = SGDClassifier(tol=1e-3, max_iter=1000, n_jobs=1,
+    clf_sequential = SGDClassifier(max_iter=1000, n_jobs=1,
                                    random_state=42)
     clf_sequential.fit(X, y)
 
     # Fit a SGDClassifier using the specified backend, and make sure the
     # coefficients are equal to those obtained using a sequential fit
-    clf_parallel = SGDClassifier(tol=1e-3, max_iter=1000, n_jobs=4,
+    clf_parallel = SGDClassifier(max_iter=1000, n_jobs=4,
                                  random_state=42)
     with joblib.parallel_backend(backend=backend):
         clf_parallel.fit(X, y)

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1517,7 +1517,7 @@ def test_stochastic_gradient_loss_param():
     }
     X = np.arange(24).reshape(6, -1)
     y = [0, 0, 0, 1, 1, 1]
-    clf = GridSearchCV(estimator=SGDClassifier(tol=1e-3, loss='hinge'),
+    clf = GridSearchCV(estimator=SGDClassifier(loss='hinge'),
                        param_grid=param_grid, cv=3)
 
     # When the estimator is not fitted, `predict_proba` is not available as the
@@ -1532,7 +1532,7 @@ def test_stochastic_gradient_loss_param():
     param_grid = {
         'loss': ['hinge'],
     }
-    clf = GridSearchCV(estimator=SGDClassifier(tol=1e-3, loss='hinge'),
+    clf = GridSearchCV(estimator=SGDClassifier(loss='hinge'),
                        param_grid=param_grid, cv=3)
     assert not hasattr(clf, "predict_proba")
     clf.fit(X, y)

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -176,7 +176,7 @@ def test_multi_output_classification_partial_fit_parallelism():
 
 # check predict_proba passes
 def test_multi_output_predict_proba():
-    sgd_linear_clf = SGDClassifier(random_state=1, max_iter=5, tol=1e-3)
+    sgd_linear_clf = SGDClassifier(random_state=1, max_iter=5)
     param = {'loss': ('hinge', 'log', 'modified_huber')}
 
     # inner function for custom scoring
@@ -194,7 +194,7 @@ def test_multi_output_predict_proba():
 
     # SGDClassifier defaults to loss='hinge' which is not a probabilistic
     # loss function; therefore it does not expose a predict_proba method
-    sgd_linear_clf = SGDClassifier(random_state=1, max_iter=5, tol=1e-3)
+    sgd_linear_clf = SGDClassifier(random_state=1, max_iter=5)
     multi_target_linear = MultiOutputClassifier(sgd_linear_clf)
     multi_target_linear.fit(X, y)
     err_msg = "The base estimator should implement predict_proba method"


### PR DESCRIPTION
Partially address #14351

What does this implement/fix? Explain your changes.
Removing redundant parameter assignment in examples

Any other comments?
Removed redundant paramater `tol=1e-3` for `SGDClassifier` in the tests.