### PR TITLE
Remove tolerance paramter from Perceptron

### DIFF
--- a/benchmarks/bench_covertype.py
+++ b/benchmarks/bench_covertype.py
@@ -101,7 +101,7 @@ ESTIMATORS = {
     'ExtraTrees': ExtraTreesClassifier(n_estimators=20),
     'RandomForest': RandomForestClassifier(n_estimators=20),
     'CART': DecisionTreeClassifier(min_samples_split=5),
-    'SGD': SGDClassifier(alpha=0.001, max_iter=1000),
+    'SGD': SGDClassifier(alpha=0.001),
     'GaussianNB': GaussianNB(),
     'liblinear': LinearSVC(loss="l2", penalty="l2", C=1000, dual=False,
                            tol=1e-3),

--- a/doc/tutorial/text_analytics/solutions/exercise_01_language_train_model.py
+++ b/doc/tutorial/text_analytics/solutions/exercise_01_language_train_model.py
@@ -37,7 +37,7 @@ vectorizer = TfidfVectorizer(ngram_range=(1, 3), analyzer='char',
 # the pipeline instance should stored in a variable named clf
 clf = Pipeline([
     ('vec', vectorizer),
-    ('clf', Perceptron(tol=1e-3)),
+    ('clf', Perceptron()),
 ])
 
 # TASK: Fit the pipeline on the training set

--- a/examples/applications/plot_out_of_core_classification.py
+++ b/examples/applications/plot_out_of_core_classification.py
@@ -208,7 +208,7 @@ positive_class = 'acq'
 # Here are some classifiers that support the `partial_fit` method
 partial_fit_classifiers = {
     'SGD': SGDClassifier(max_iter=5),
-    'Perceptron': Perceptron(tol=1e-3),
+    'Perceptron': Perceptron(),
     'NB Multinomial': MultinomialNB(alpha=0.01),
     'Passive-Aggressive': PassiveAggressiveClassifier(tol=1e-3),
 }

--- a/examples/linear_model/plot_sgd_comparison.py
+++ b/examples/linear_model/plot_sgd_comparison.py
@@ -26,7 +26,7 @@ X, y = datasets.load_digits(return_X_y=True)
 classifiers = [
     ("SGD", SGDClassifier(max_iter=100)),
     ("ASGD", SGDClassifier(average=True, max_iter=1000)),
-    ("Perceptron", Perceptron(tol=1e-3)),
+    ("Perceptron", Perceptron()),
     ("Passive-Aggressive I", PassiveAggressiveClassifier(loss='hinge',
                                                          C=1.0, tol=1e-4)),
     ("Passive-Aggressive II", PassiveAggressiveClassifier(loss='squared_hinge',

--- a/examples/linear_model/plot_sgd_comparison.py
+++ b/examples/linear_model/plot_sgd_comparison.py
@@ -25,7 +25,7 @@ X, y = datasets.load_digits(return_X_y=True)
 
 classifiers = [
     ("SGD", SGDClassifier(max_iter=100)),
-    ("ASGD", SGDClassifier(average=True, max_iter=1000)),
+    ("ASGD", SGDClassifier(average=True)),
     ("Perceptron", Perceptron()),
     ("Passive-Aggressive I", PassiveAggressiveClassifier(loss='hinge',
                                                          C=1.0, tol=1e-4)),

--- a/examples/text/plot_document_classification_20newsgroups.py
+++ b/examples/text/plot_document_classification_20newsgroups.py
@@ -247,7 +247,7 @@ def benchmark(clf):
 results = []
 for clf, name in (
         (RidgeClassifier(tol=1e-2, solver="sag"), "Ridge Classifier"),
-        (Perceptron(max_iter=50, tol=1e-3), "Perceptron"),
+        (Perceptron(max_iter=50), "Perceptron"),
         (PassiveAggressiveClassifier(max_iter=50, tol=1e-3),
          "Passive-Aggressive"),
         (KNeighborsClassifier(n_neighbors=10), "kNN"),

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -64,7 +64,7 @@ def test_classification():
 
     for base_estimator in [None,
                            DummyClassifier(),
-                           Perceptron(tol=1e-3),
+                           Perceptron(),
                            DecisionTreeClassifier(),
                            KNeighborsClassifier(),
                            SVC()]:
@@ -543,7 +543,7 @@ def test_base_estimator():
 
     assert isinstance(ensemble.base_estimator_, DecisionTreeClassifier)
 
-    ensemble = BaggingClassifier(Perceptron(tol=1e-3),
+    ensemble = BaggingClassifier(Perceptron(),
                                  n_jobs=3,
                                  random_state=0).fit(X_train, y_train)
 

--- a/sklearn/ensemble/tests/test_base.py
+++ b/sklearn/ensemble/tests/test_base.py
@@ -22,7 +22,7 @@ from sklearn.feature_selection import SelectFromModel
 def test_base():
     # Check BaseEnsemble methods.
     ensemble = BaggingClassifier(
-        base_estimator=Perceptron(tol=1e-3, random_state=None), n_estimators=3)
+        base_estimator=Perceptron(random_state=None), n_estimators=3)
 
     iris = load_iris()
     ensemble.fit(iris.data, iris.target)
@@ -43,7 +43,7 @@ def test_base():
     assert isinstance(ensemble[2].random_state, int)
     assert ensemble[1].random_state != ensemble[2].random_state
 
-    np_int_ensemble = BaggingClassifier(base_estimator=Perceptron(tol=1e-3),
+    np_int_ensemble = BaggingClassifier(base_estimator=Perceptron(),
                                         n_estimators=np.int32(3))
     np_int_ensemble.fit(iris.data, iris.target)
 
@@ -51,7 +51,7 @@ def test_base():
 def test_base_zero_n_estimators():
     # Check that instantiating a BaseEnsemble with n_estimators<=0 raises
     # a ValueError.
-    ensemble = BaggingClassifier(base_estimator=Perceptron(tol=1e-3),
+    ensemble = BaggingClassifier(base_estimator=Perceptron(),
                                  n_estimators=0)
     iris = load_iris()
     assert_raise_message(ValueError,
@@ -62,13 +62,13 @@ def test_base_zero_n_estimators():
 def test_base_not_int_n_estimators():
     # Check that instantiating a BaseEnsemble with a string as n_estimators
     # raises a ValueError demanding n_estimators to be supplied as an integer.
-    string_ensemble = BaggingClassifier(base_estimator=Perceptron(tol=1e-3),
+    string_ensemble = BaggingClassifier(base_estimator=Perceptron(),
                                         n_estimators='3')
     iris = load_iris()
     assert_raise_message(ValueError,
                          "n_estimators must be an integer",
                          string_ensemble.fit, iris.data, iris.target)
-    float_ensemble = BaggingClassifier(base_estimator=Perceptron(tol=1e-3),
+    float_ensemble = BaggingClassifier(base_estimator=Perceptron(),
                                        n_estimators=3.0)
     assert_raise_message(ValueError,
                          "n_estimators must be an integer",
@@ -79,7 +79,7 @@ def test_set_random_states():
     # Linear Discriminant Analysis doesn't have random state: smoke test
     _set_random_states(LinearDiscriminantAnalysis(), random_state=17)
 
-    clf1 = Perceptron(tol=1e-3, random_state=None)
+    clf1 = Perceptron(random_state=None)
     assert clf1.random_state is None
     # check random_state is None still sets
     _set_random_states(clf1, None)
@@ -88,16 +88,15 @@ def test_set_random_states():
     # check random_state fixes results in consistent initialisation
     _set_random_states(clf1, 3)
     assert isinstance(clf1.random_state, int)
-    clf2 = Perceptron(tol=1e-3, random_state=None)
+    clf2 = Perceptron(random_state=None)
     _set_random_states(clf2, 3)
     assert clf1.random_state == clf2.random_state
 
     # nested random_state
 
     def make_steps():
-        return [('sel', SelectFromModel(Perceptron(tol=1e-3,
-                                                   random_state=None))),
-                ('clf', Perceptron(tol=1e-3, random_state=None))]
+        return [('sel', SelectFromModel(Perceptron(random_state=None))),
+                ('clf', Perceptron(random_state=None))]
 
     est1 = Pipeline(make_steps())
     _set_random_states(est1, 3)


### PR DESCRIPTION
Partially address #14351

**What does this implement/fix? Explain your changes.**
Removing redundant parameter assignment in examples

Any other comments?
Removed redundant paramater `tol=1e-3` for `Perceptron` in the tests.
