### PR TITLE
DOC VotingClassifier example weights incorrect

### DIFF
--- a/examples/ensemble/plot_voting_decision_regions.py
+++ b/examples/ensemble/plot_voting_decision_regions.py
@@ -14,7 +14,7 @@ First, three exemplary classifiers are initialized (`DecisionTreeClassifier`,
 `KNeighborsClassifier`, and `SVC`) and used to initialize a
 soft-voting `VotingClassifier` with weights `[2, 1, 2]`, which means that
 the predicted probabilities of the `DecisionTreeClassifier` and `SVC`
-count 5 times as much as the weights of the `KNeighborsClassifier` classifier
+each count 2 times as much as the weights of the `KNeighborsClassifier` classifier
 when the averaged probability is calculated.
 
 """

--- a/examples/ensemble/plot_voting_decision_regions.py
+++ b/examples/ensemble/plot_voting_decision_regions.py
@@ -14,8 +14,8 @@ First, three exemplary classifiers are initialized (`DecisionTreeClassifier`,
 `KNeighborsClassifier`, and `SVC`) and used to initialize a
 soft-voting `VotingClassifier` with weights `[2, 1, 2]`, which means that
 the predicted probabilities of the `DecisionTreeClassifier` and `SVC`
-each count 2 times as much as the weights of the `KNeighborsClassifier` classifier
-when the averaged probability is calculated.
+each count 2 times as much as the weights of the `KNeighborsClassifier`
+classifier when the averaged probability is calculated.
 
 """
 print(__doc__)


### PR DESCRIPTION
The description of the "weights" parameter in one of the VotingClassifier examples was wrong - it was copied from the other example and not updated even though the actual parameters were different.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

Just a simple typo, no issue created.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Simple update - the description of the "weights" parameter was incorrect, probably because it was copied from the other VotingClassifier example, at `examples/ensemble/plot_voting_probas.py`.  But this example had different values for that parameter, so it needed different text.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
