### PR TITLE
Inconsistency of the code and its annotation in plot_ols.py

### DIFF
--- a/examples/linear_model/plot_ols.py
+++ b/examples/linear_model/plot_ols.py
@@ -12,8 +12,8 @@ to draw a straight line that will best minimize the residual sum of squares
 between the observed responses in the dataset, and the responses predicted by
 the linear approximation.
 
-The coefficients, the residual sum of squares and the variance score are also
-calculated.
+The coefficients, the residual sum of squares and the coefficient of
+determination are also calculated.
 
 """
 print(__doc__)
@@ -26,7 +26,7 @@ print(__doc__)
 import matplotlib.pyplot as plt
 import numpy as np
 from sklearn import datasets, linear_model
-from sklearn.metrics import mean_squared_error, explained_variance_score
+from sklearn.metrics import mean_squared_error, r2_score
 
 # Load the diabetes dataset
 diabetes = datasets.load_diabetes()
@@ -57,9 +57,9 @@ print('Coefficients: \n', regr.coef_)
 # The mean squared error
 print('Mean squared error: %.2f'
       % mean_squared_error(diabetes_y_test, diabetes_y_pred))
-# Explained variance score: 1 is perfect prediction
-print('Variance score: %.2f'
-      % explained_variance_score(diabetes_y_test, diabetes_y_pred))
+# The coefficient of determination: 1 is perfect prediction
+print('Coefficient of determination: %.2f'
+      % r2_score(diabetes_y_test, diabetes_y_pred))
 
 # Plot outputs
 plt.scatter(diabetes_X_test, diabetes_y_test,  color='black')

--- a/examples/linear_model/plot_ols.py
+++ b/examples/linear_model/plot_ols.py
@@ -58,7 +58,8 @@ print('Coefficients: \n', regr.coef_)
 print("Mean squared error: %.2f"
       % mean_squared_error(diabetes_y_test, diabetes_y_pred))
 # Explained variance score: 1 is perfect prediction
-print('Variance score: %.2f' % explained_variance_score(diabetes_y_test, diabetes_y_pred))
+print('Variance score: %.2f' % explained_variance_score( \
+        diabetes_y_test, diabetes_y_pred))
 
 # Plot outputs
 plt.scatter(diabetes_X_test, diabetes_y_test,  color='black')

--- a/examples/linear_model/plot_ols.py
+++ b/examples/linear_model/plot_ols.py
@@ -12,8 +12,8 @@ to draw a straight line that will best minimize the residual sum of squares
 between the observed responses in the dataset, and the responses predicted by
 the linear approximation.
 
-The coefficients, the residual sum of squares and the coefficient of
-determination are also calculated.
+The coefficients, the residual sum of squares and the coefficient of determination
+are also calculated.
 
 """
 print(__doc__)

--- a/examples/linear_model/plot_ols.py
+++ b/examples/linear_model/plot_ols.py
@@ -55,11 +55,11 @@ diabetes_y_pred = regr.predict(diabetes_X_test)
 # The coefficients
 print('Coefficients: \n', regr.coef_)
 # The mean squared error
-print("Mean squared error: %.2f"
+print('Mean squared error: %.2f'
       % mean_squared_error(diabetes_y_test, diabetes_y_pred))
 # Explained variance score: 1 is perfect prediction
-print('Variance score: %.2f' % explained_variance_score \
-        (diabetes_y_test, diabetes_y_pred))
+print('Variance score: %.2f'
+      % explained_variance_score(diabetes_y_test, diabetes_y_pred))
 
 # Plot outputs
 plt.scatter(diabetes_X_test, diabetes_y_test,  color='black')

--- a/examples/linear_model/plot_ols.py
+++ b/examples/linear_model/plot_ols.py
@@ -58,8 +58,8 @@ print('Coefficients: \n', regr.coef_)
 print("Mean squared error: %.2f"
       % mean_squared_error(diabetes_y_test, diabetes_y_pred))
 # Explained variance score: 1 is perfect prediction
-print('Variance score: %.2f' % explained_variance_score( \
-        diabetes_y_test, diabetes_y_pred))
+print('Variance score: %.2f' % explained_variance_score \
+        (diabetes_y_test, diabetes_y_pred))
 
 # Plot outputs
 plt.scatter(diabetes_X_test, diabetes_y_test,  color='black')

--- a/examples/linear_model/plot_ols.py
+++ b/examples/linear_model/plot_ols.py
@@ -26,7 +26,7 @@ print(__doc__)
 import matplotlib.pyplot as plt
 import numpy as np
 from sklearn import datasets, linear_model
-from sklearn.metrics import mean_squared_error, r2_score
+from sklearn.metrics import mean_squared_error, explained_variance_score
 
 # Load the diabetes dataset
 diabetes = datasets.load_diabetes()
@@ -58,7 +58,7 @@ print('Coefficients: \n', regr.coef_)
 print("Mean squared error: %.2f"
       % mean_squared_error(diabetes_y_test, diabetes_y_pred))
 # Explained variance score: 1 is perfect prediction
-print('Variance score: %.2f' % r2_score(diabetes_y_test, diabetes_y_pred))
+print('Variance score: %.2f' % explained_variance_score(diabetes_y_test, diabetes_y_pred))
 
 # Plot outputs
 plt.scatter(diabetes_X_test, diabetes_y_test,  color='black')

--- a/examples/linear_model/plot_ols.py
+++ b/examples/linear_model/plot_ols.py
@@ -12,8 +12,8 @@ to draw a straight line that will best minimize the residual sum of squares
 between the observed responses in the dataset, and the responses predicted by
 the linear approximation.
 
-The coefficients, the residual sum of squares and the coefficient of determination
-are also calculated.
+The coefficients, the residual sum of squares and the coefficient
+of determination are also calculated.
 
 """
 print(__doc__)


### PR DESCRIPTION
The code in ` examples/linear_model/plot_ols.py`  was not in accordance with its annotation. Although `r2_score` and `explained_variance_score` are mutually replaceable and they even have the same value in some models, they are not the same thing.