### PR TITLE
MAINT DOC Fix CircleCI on master

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -925,7 +925,7 @@ trees. Building a traditional decision tree (as in the other GBDTs
 requires sorting the samples at each node (for
 each feature). Sorting is needed so that the potential gain of a split point
 can be computed efficiently. Splitting a single node has thus a complexity
-of :math:`\mathcal{O}(\text{n_features} * n \log(n))` where :math:`n` is the
+of :math:`\mathcal{O}(\text{n\_features} * n \log(n))` where :math:`n` is the
 number of samples at the node.
 
 :class:`HistGradientBoostingClassifier` and
@@ -933,7 +933,7 @@ number of samples at the node.
 feature values and instead use a data-structure called a histogram, where the
 samples are implicitly ordered. Building a histogram has a
 :math:`\mathcal{O}(n)` complexity, so the node splitting procedure has a
-:math:`\mathcal{O}(\text{n_features} * n)` complexity, much smaller than the
+:math:`\mathcal{O}(\text{n\_features} * n)` complexity, much smaller than the
 previous one. In addition, instead of considering :math:`n` split points, we
 here consider only ``max_bins`` split points, which is much smaller.
 

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -925,7 +925,7 @@ trees. Building a traditional decision tree (as in the other GBDTs
 requires sorting the samples at each node (for
 each feature). Sorting is needed so that the potential gain of a split point
 can be computed efficiently. Splitting a single node has thus a complexity
-of :math:`\mathcal{O}(\text{n-features} \times n \log(n))` where :math:`n`
+of :math:`\mathcal{O}(n_\text{features} \times n \log(n))` where :math:`n`
 is the number of samples at the node.
 
 :class:`HistGradientBoostingClassifier` and
@@ -933,7 +933,7 @@ is the number of samples at the node.
 feature values and instead use a data-structure called a histogram, where the
 samples are implicitly ordered. Building a histogram has a
 :math:`\mathcal{O}(n)` complexity, so the node splitting procedure has a
-:math:`\mathcal{O}(\text{n-features} \times n)` complexity, much smaller
+:math:`\mathcal{O}(n_\text{features} \times n)` complexity, much smaller
 than the previous one. In addition, instead of considering :math:`n` split
 points, we here consider only ``max_bins`` split points, which is much
 smaller.

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -925,17 +925,18 @@ trees. Building a traditional decision tree (as in the other GBDTs
 requires sorting the samples at each node (for
 each feature). Sorting is needed so that the potential gain of a split point
 can be computed efficiently. Splitting a single node has thus a complexity
-of :math:`\mathcal{O}(\text{n\_features} * n \log(n))` where :math:`n` is the
-number of samples at the node.
+of :math:`\mathcal{O}(\text{n-features} \times n \log(n))` where :math:`n`
+is the number of samples at the node.
 
 :class:`HistGradientBoostingClassifier` and
 :class:`HistGradientBoostingRegressor`, in contrast, do not require sorting the
 feature values and instead use a data-structure called a histogram, where the
 samples are implicitly ordered. Building a histogram has a
 :math:`\mathcal{O}(n)` complexity, so the node splitting procedure has a
-:math:`\mathcal{O}(\text{n\_features} * n)` complexity, much smaller than the
-previous one. In addition, instead of considering :math:`n` split points, we
-here consider only ``max_bins`` split points, which is much smaller.
+:math:`\mathcal{O}(\text{n-features} \times n)` complexity, much smaller
+than the previous one. In addition, instead of considering :math:`n` split
+points, we here consider only ``max_bins`` split points, which is much
+smaller.
 
 In order to build histograms, the input data `X` needs to be binned into
 integer-valued bins. This binning procedure does require sorting the feature


### PR DESCRIPTION
Following https://github.com/scikit-learn/scikit-learn/pull/14525 latex generation fails on master with,
```
! Missing $ inserted.
<inserted text> 
                $
l.23893 of \(\mathcal{O}(\text{n_features}
                                           * n \log(n))\) where \(n\) is the
!  ==> Fatal error occurred, no output PDF file produced!
```
likely due to the use of underscore in text mode. This tries to fix it.

cc @NicolasHug 