### PR TITLE
Add mae loss functionality to MLP regressor

### DIFF
--- a/sklearn/neural_network/_base.py
+++ b/sklearn/neural_network/_base.py
@@ -194,6 +194,17 @@ def squared_loss(y_true, y_pred):
     """
     return ((y_true - y_pred) ** 2).mean() / 2
 
+def mae_loss(y_true, y_pred):
+    """Compute the mean absolute error loss
+
+    Parameters
+    ----------
+    y_true : array-like or label indicator matrix
+         Ground truth (correct) labels.
+    y_pred : array-like or label indicator matrix
+         predicted values.
+    """
+    return np.average(np.abs(y_true - y_pred))
 
 def log_loss(y_true, y_prob):
     """Compute Logistic loss for classification.
@@ -246,4 +257,4 @@ def binary_log_loss(y_true, y_prob):
 
 
 LOSS_FUNCTIONS = {'squared_loss': squared_loss, 'log_loss': log_loss,
-                  'binary_log_loss': binary_log_loss}
+                  'binary_log_loss': binary_log_loss, 'mae_loss':mae_loss}

--- a/sklearn/neural_network/_base.py
+++ b/sklearn/neural_network/_base.py
@@ -194,6 +194,7 @@ def squared_loss(y_true, y_pred):
     """
     return ((y_true - y_pred) ** 2).mean() / 2
 
+
 def mae_loss(y_true, y_pred):
     """Compute the mean absolute error loss
 
@@ -204,7 +205,8 @@ def mae_loss(y_true, y_pred):
     y_pred : array-like or label indicator matrix
          predicted values.
     """
-    return np.average(np.abs(y_true - y_pred))
+    return (1/y_true.shape[0]) * np.sum(np.abs(y_true - y_pred)) 
+
 
 def log_loss(y_true, y_prob):
     """Compute Logistic loss for classification.
@@ -257,4 +259,4 @@ def binary_log_loss(y_true, y_prob):
 
 
 LOSS_FUNCTIONS = {'squared_loss': squared_loss, 'log_loss': log_loss,
-                  'binary_log_loss': binary_log_loss, 'mae_loss':mae_loss}
+                  'binary_log_loss': binary_log_loss, 'mae_loss': mae_loss}

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -237,8 +237,15 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         # combinations of output activation and loss function:
         # sigmoid and binary cross entropy, softmax and categorical cross
         # entropy, and identity with squared loss
-        deltas[last] = activations[-1] - y
-
+        if self.loss == 'mae_loss':
+            gradient = np.empty_like(y)
+            gradient[activations[-1] > y] = 1
+            gradient[activations[-1] < y] = -1
+            gradient[activations[-1] == y] = 0
+            deltas[last] = gradient
+        else:
+            deltas[last] = activations[-1] - y
+        
         # Compute gradient for the last layer
         coef_grads, intercept_grads = self._compute_loss_grad(
             last, n_samples, activations, deltas, coef_grads, intercept_grads)

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -1167,13 +1167,12 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
         solvers ('sgd', 'adam'), note that this determines the number of epochs
         (how many times each data point will be used), not the number of
         gradient steps.
-        
-    loss : {'squared_loss', 'mae_loss'}, default 'squared_loss'
-        Loss function for MLP Regressor
 
+    loss : {'squared_loss', 'mae_loss'}, default 'squared_loss'
+        Loss function for MLP Regressor.
         - 'squared_loss' uses `squared_loss` as the loss function.
-        
-        - 'mae_loss' uses `mean absolute error` as the loss function.
+
+        - 'mae_loss' uses `mean_absolute_error` as the loss function.
 
     shuffle : bool, optional, default True
         Whether to shuffle samples in each iteration. Only used when

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -1167,6 +1167,13 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
         solvers ('sgd', 'adam'), note that this determines the number of epochs
         (how many times each data point will be used), not the number of
         gradient steps.
+        
+    loss : {'squared_loss', 'mae_loss'}, default 'squared_loss'
+        Loss function for MLP Regressor
+
+        - 'squared_loss' uses `squared_loss` as the loss function.
+        
+        - 'mae_loss' uses `mean absolute error` as the loss function.
 
     shuffle : bool, optional, default True
         Whether to shuffle samples in each iteration. Only used when
@@ -1297,7 +1304,8 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
                  solver='adam', alpha=0.0001,
                  batch_size='auto', learning_rate="constant",
                  learning_rate_init=0.001,
-                 power_t=0.5, max_iter=200, shuffle=True,
+                 power_t=0.5, max_iter=200,
+                 loss='squared_loss', shuffle=True,
                  random_state=None, tol=1e-4,
                  verbose=False, warm_start=False, momentum=0.9,
                  nesterovs_momentum=True, early_stopping=False,
@@ -1308,7 +1316,7 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
             activation=activation, solver=solver, alpha=alpha,
             batch_size=batch_size, learning_rate=learning_rate,
             learning_rate_init=learning_rate_init, power_t=power_t,
-            max_iter=max_iter, loss='squared_loss', shuffle=shuffle,
+            max_iter=max_iter, loss=loss, shuffle=shuffle,
             random_state=random_state, tol=tol, verbose=verbose,
             warm_start=warm_start, momentum=momentum,
             nesterovs_momentum=nesterovs_momentum,

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -20,6 +20,7 @@ from io import StringIO
 from sklearn.metrics import roc_auc_score
 from sklearn.neural_network import MLPClassifier
 from sklearn.neural_network import MLPRegressor
+from sklearn.neural_network._base import mae_loss
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.preprocessing import StandardScaler, MinMaxScaler
 from scipy.sparse import csr_matrix
@@ -558,6 +559,20 @@ def test_shuffle():
     mlp2.fit(X, y)
 
     assert not np.array_equal(mlp1.coefs_[0], mlp2.coefs_[0])
+
+
+def test_mae_loss():
+    y_true = [3, -0.5, 2, 7]
+    y_pred = [2.5, 0.0, 2, 8]
+    assert mae_loss(y_true,y_pred) == 0.5
+    
+
+def test_mlp_regressor_with_mae_loss():
+    X, y = make_regression(n_samples=50, n_features= 5, random_state=0)
+    mlp = MLPRegressor(hidden_layer_sizes=1,loss='mae_loss',
+    max_iter=1,batch_size=1)
+    mlp.fit(X, y)
+    assert mlp.score(X, y) > 0.80
 
 
 def test_sparse_matrices():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs 14571
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fixes #14571
MLP Regressor only had `squared_loss` as a loss function. This PR adds functionality
for `mae_loss` in addition to the existing `squared_loss`

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
