### PR TITLE
Bug in LinearClassifierMixin.decision_function()

### DIFF
--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -266,9 +266,12 @@ class LinearClassifierMixin(ClassifierMixin):
         if X.shape[1] != n_features:
             raise ValueError("X has %d features per sample; expecting %d"
                              % (X.shape[1], n_features))
-
-        scores = safe_sparse_dot(X, self.coef_.T,
+        
+        projection = safe_sparse_dot(X, self.coef_.T,
                                  dense_output=True) + self.intercept_
+        
+        norms = np.linalg.norm(self.coef_, axis=1)
+        scores = np.divide(projection, norms)
         return scores.ravel() if scores.shape[1] == 1 else scores
 
     def predict(self, X):


### PR DESCRIPTION
This function is suppoed to calculate the signed distance from a point to various hyperplanes (i.e. the decision boundaries). However, the current formula used to calculate the score is incorrect as it does not divide the projection of the point on the hyperplane by the magnitude of the normal vector to the hyperplane. Since each hyperplane can have a different magnitude, this can affect LinearClassifierMixin.predict() and LinearClassifierMixin.predict_proba_lr() causing an incorrect prediction. This is a fairly major bug affecting all downstream classifiers (e.g. LinearSVC and LogisticRegressuib). Happy to provide an example if more information is needed.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
