### PR TITLE
[MRG] BUG Adds space to error message in plot_roc_curve

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -200,6 +200,9 @@ Changelog
 :mod:`sklearn.metrics`
 ......................
 
+- |Feature| :func:`metrics.plot_roc_curve` has been added to plot roc
+  curves. :pr:`14357` by `Thomas Fan`_.
+
 - |Feature| Added multiclass support to :func:`metrics.roc_auc_score`.
   :issue:`12789` by :user:`Kathy Chen <kathyxchen>`,
   :user:`Mohamed Maskani <maskani-moh>`, and :user:`Thomas Fan <thomasjpfan>`.

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -200,8 +200,9 @@ Changelog
 :mod:`sklearn.metrics`
 ......................
 
-- |Feature| :func:`metrics.plot_roc_curve` has been added to plot roc
-  curves. :pr:`14357` by `Thomas Fan`_.
+- |MajorFeature| :func:`metrics.plot_roc_curve` has been added to plot roc
+  curves. This function introduces the visualization API described in
+  the :ref:`User Guide <visualizations>`. :pr:`14357` by `Thomas Fan`_.
 
 - |Feature| Added multiclass support to :func:`metrics.roc_auc_score`.
   :issue:`12789` by :user:`Kathy Chen <kathyxchen>`,

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -146,7 +146,7 @@ def plot_roc_curve(estimator, X, y, pos_label=None, sample_weight=None,
 
     if y_pred.ndim != 1:
         if y_pred.shape[1] > 2:
-            raise ValueError("Estimator should solve a"
+            raise ValueError("Estimator should solve a "
                              "binary classification problem")
         y_pred = y_pred[:, 1]
     fpr, tpr, _ = roc_curve(y, y_pred, pos_label=pos_label,


### PR DESCRIPTION
This PR cleans up: https://github.com/scikit-learn/scikit-learn/pull/14357

- Adds whats new
- Updates error message with space.

CC: @qinhanmin2014