### PR TITLE
[MRG] DOC Adds link to User Guide for SVC's probability parameter

### DIFF
--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -487,9 +487,9 @@ class SVC(BaseSVC):
 
     probability : boolean, optional (default=False)
         Whether to enable probability estimates. This must be enabled prior
-        to calling `fit`, and will slow down that method. When enabled,
-        `predict_proba` may be inconsistent with `predict` and will slow down
-        fitting as it internally uses 5-fold cross-validation. Read more in the
+        to calling `fit` and will slow down that method as it internally uses
+        5-fold cross-validation. When enabled, `predict_proba` may be
+        inconsistent with `predict`. Read more in the
         :ref:`User Guide <scores_probabilities>`.
 
     tol : float, optional (default=1e-3)
@@ -689,9 +689,9 @@ class NuSVC(BaseSVC):
 
     probability : boolean, optional (default=False)
         Whether to enable probability estimates. This must be enabled prior
-        to calling `fit`, and will slow down that method. When enabled,
-        `predict_proba` may be inconsistent with `predict` and will slow down
-        fitting as it internally uses 5-fold cross-validation. Read more in the
+        to calling `fit` and will slow down that method as it internally uses
+        5-fold cross-validation. When enabled, `predict_proba` may be
+        inconsistent with `predict`. Read more in the
         :ref:`User Guide <scores_probabilities>`.
 
     tol : float, optional (default=1e-3)

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -487,10 +487,9 @@ class SVC(BaseSVC):
 
     probability : boolean, optional (default=False)
         Whether to enable probability estimates. This must be enabled prior
-        to calling `fit` and will slow down that method as it internally uses
-        5-fold cross-validation. When enabled, `predict_proba` may be
-        inconsistent with `predict`. Read more in the
-        :ref:`User Guide <scores_probabilities>`.
+        to calling `fit`, will slow down that method as it internally uses
+        5-fold cross-validation, and `predict_proba` may be inconsistent with
+        `predict`. Read more in the :ref:`User Guide <scores_probabilities>`.
 
     tol : float, optional (default=1e-3)
         Tolerance for stopping criterion.
@@ -689,10 +688,9 @@ class NuSVC(BaseSVC):
 
     probability : boolean, optional (default=False)
         Whether to enable probability estimates. This must be enabled prior
-        to calling `fit` and will slow down that method as it internally uses
-        5-fold cross-validation. When enabled, `predict_proba` may be
-        inconsistent with `predict`. Read more in the
-        :ref:`User Guide <scores_probabilities>`.
+        to calling `fit`, will slow down that method as it internally uses
+        5-fold cross-validation, and `predict_proba` may be inconsistent with
+        `predict`. Read more in the :ref:`User Guide <scores_probabilities>`.
 
     tol : float, optional (default=1e-3)
         Tolerance for stopping criterion.

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -488,7 +488,8 @@ class SVC(BaseSVC):
     probability : boolean, optional (default=False)
         Whether to enable probability estimates. This must be enabled prior
         to calling `fit`, and will slow down that method. When enabled,
-        `predict_proba` may be inconsistent with `predict`. Read more in the
+        `predict_proba` may be inconsistent with `predict` and will slow down
+        fitting as it internally uses 5-fold cross-validation. Read more in the
         :ref:`User Guide <scores_probabilities>`.
 
     tol : float, optional (default=1e-3)

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -487,7 +487,9 @@ class SVC(BaseSVC):
 
     probability : boolean, optional (default=False)
         Whether to enable probability estimates. This must be enabled prior
-        to calling `fit`, and will slow down that method.
+        to calling `fit`, and will slow down that method. When enabled,
+        `predict_proba` may be inconsistent with `predict`. Read more in the
+        :ref:`User Guide <scores_probabilities>`.
 
     tol : float, optional (default=1e-3)
         Tolerance for stopping criterion.
@@ -686,7 +688,9 @@ class NuSVC(BaseSVC):
 
     probability : boolean, optional (default=False)
         Whether to enable probability estimates. This must be enabled prior
-        to calling `fit`, and will slow down that method.
+        to calling `fit`, and will slow down that method. When enabled,
+        `predict_proba` may be inconsistent with `predict`. Read more in the
+        :ref:`User Guide <scores_probabilities>`.
 
     tol : float, optional (default=1e-3)
         Tolerance for stopping criterion.

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -689,7 +689,8 @@ class NuSVC(BaseSVC):
     probability : boolean, optional (default=False)
         Whether to enable probability estimates. This must be enabled prior
         to calling `fit`, and will slow down that method. When enabled,
-        `predict_proba` may be inconsistent with `predict`. Read more in the
+        `predict_proba` may be inconsistent with `predict` and will slow down
+        fitting as it internally uses 5-fold cross-validation. Read more in the
         :ref:`User Guide <scores_probabilities>`.
 
     tol : float, optional (default=1e-3)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to #13211


#### What does this implement/fix? Explain your changes.
Adds link to user guide regarding inconsistent behavior between `predict_proba` and `predict`.

CC: @amueller 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
