### PR TITLE
[MRG] Bugfix for precision_recall_curve when all labels are negative

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -678,7 +678,7 @@ def precision_recall_curve(y_true, probas_pred, *, pos_label=None,
 
     precision = tps / (tps + fps)
     precision[np.isnan(precision)] = 0
-    recall = tps / tps[-1]
+    recall = np.ones(tps.size) if tps[-1] == 0 else tps / tps[-1]
 
     # stop when full recall attained
     # and reverse the outputs so recall is decreasing

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -807,6 +807,11 @@ def test_precision_recall_curve_toydata():
             precision_recall_curve(y_true, y_score)
         with pytest.raises(Exception):
             average_precision_score(y_true, y_score)
+        # p, r, _ = precision_recall_curve(y_true, y_score)
+        # auc_prc = average_precision_score(y_true, y_score)
+        # assert_array_almost_equal(p, [0, 1])
+        # assert_array_almost_equal(r, [1, 0.])
+        # assert_almost_equal(auc_prc, 0.)
 
         y_true = [1, 1]
         y_score = [0.25, 0.75]
@@ -822,6 +827,10 @@ def test_precision_recall_curve_toydata():
             average_precision_score(y_true, y_score, average="macro")
         with pytest.raises(Exception):
             average_precision_score(y_true, y_score, average="weighted")
+        # assert_almost_equal(average_precision_score(y_true, y_score,
+        #                     average="macro"), 0.5)
+        # assert_almost_equal(average_precision_score(y_true, y_score,
+        #                     average="weighted"), 1.)
         assert_almost_equal(average_precision_score(y_true, y_score,
                             average="samples"), 1.)
         assert_almost_equal(average_precision_score(y_true, y_score,
@@ -833,6 +842,10 @@ def test_precision_recall_curve_toydata():
             average_precision_score(y_true, y_score, average="macro")
         with pytest.raises(Exception):
             average_precision_score(y_true, y_score, average="weighted")
+        # assert_almost_equal(average_precision_score(y_true, y_score,
+        #                     average="macro"), 0.5)
+        # assert_almost_equal(average_precision_score(y_true, y_score,
+        #                     average="weighted"), 1.)
         assert_almost_equal(average_precision_score(y_true, y_score,
                             average="samples"), 0.75)
         assert_almost_equal(average_precision_score(y_true, y_score,
@@ -860,12 +873,36 @@ def test_precision_recall_curve_toydata():
         assert_almost_equal(average_precision_score(y_true, y_score,
                             average="micro"), 0.5)
 
+<<<<<<< HEAD
     with np.errstate(all="ignore"):
         # if one class is never present weighted should not be NaN
         y_true = np.array([[0, 0], [0, 1]])
         y_score = np.array([[0, 0], [0, 1]])
         assert_almost_equal(average_precision_score(y_true, y_score,
                             average="weighted"), 1)
+=======
+        y_true = np.array([[0, 0], [0, 0]])
+        y_score = np.array([[0, 1], [0, 1]])
+        assert_almost_equal(average_precision_score(y_true, y_score,
+                            average="macro"), 0.)
+        assert_almost_equal(average_precision_score(y_true, y_score,
+                            average="weighted"), 0.)
+        assert_almost_equal(average_precision_score(y_true, y_score,
+                            average="samples"), 0.)
+        assert_almost_equal(average_precision_score(y_true, y_score,
+                            average="micro"), 0.)
+
+        y_true = np.array([[1, 1], [1, 1]])
+        y_score = np.array([[0, 1], [0, 1]])
+        assert_almost_equal(average_precision_score(y_true, y_score,
+                            average="macro"), 1.)
+        assert_almost_equal(average_precision_score(y_true, y_score,
+                            average="weighted"), 1.)
+        assert_almost_equal(average_precision_score(y_true, y_score,
+                            average="samples"), 1.)
+        assert_almost_equal(average_precision_score(y_true, y_score,
+                            average="micro"), 1.)
+>>>>>>> fixed bug for precision recall curve when all labels are negative
 
 
 def test_average_precision_constant_values():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #8245 

#### What does this implement/fix? Explain your changes.
When all the `y_true` labels are negative, `precision_recall_curve` returns `nan` because of `recall` being set to `nan` instead of `1`. This is because of the direction division of the `tps` vector by `tps[-1]` which happens to be `0`.

This fix checks if `tps[-1]` is `0` and if yes, sets the recall to `1` directly since there are no True Positives or False Negatives, else we calculate `recall` as normal.


#### Any other comments?
I had to update `test_precision_recall_curve_toydata` since this test was expecting the `TrueDivide` exception to be raised which is no longer the case as a result of this fix. I added 2 test cases, one to check when all truth labels are negative and the other to check when all truth labels are positive to ensure precision calculation is accurate.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
