### PR TITLE
[MRG] less strict check for non-zero diagonal in  silhouette_samples

### DIFF
--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -169,19 +169,22 @@ def test_non_numpy_labels():
 
 
 def test_silhouette_nonzero_diag():
+    # Make sure silhouette_samples requires diagonal to be zero.
+    # Non-regression test for #12178
+
     # Construct a zero-diagonal matrix
     dists = pairwise_distances(
         np.array([[0.2, 0.1, 0.12, 1.34, 1.11, 1.6]]).transpose())
-
-    # Construct a nonzero-diagonal distance matrix
-    diag_dists = dists.copy()
-    np.fill_diagonal(diag_dists, 1)
-
     labels = [0, 0, 0, 1, 1, 1]
 
-    assert_raise_message(ValueError, "distance matrix contains non-zero",
-                         silhouette_samples,
-                         diag_dists, labels, metric='precomputed')
+    # small values on the diagonal are OK
+    dists[2][2] = np.finfo(dists.dtype).eps * 10
+    silhouette_samples(dists, labels, metric='precomputed')
+
+    # values bigger than eps * 100 are not
+    dists[2][2] = np.finfo(dists.dtype).eps * 1000
+    with pytest.raises(ValueError, match='contains non-zero'):
+        silhouette_samples(dists, labels, metric='precomputed')
 
 
 def assert_raises_on_only_one_label(func):

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -168,13 +168,14 @@ def test_non_numpy_labels():
         silhouette_score(list(X), list(y)) == silhouette_score(X, y))
 
 
-def test_silhouette_nonzero_diag():
+@pytest.mark.parametrize('dtype', (np.float32, np.float64))
+def test_silhouette_nonzero_diag(dtype):
     # Make sure silhouette_samples requires diagonal to be zero.
     # Non-regression test for #12178
 
     # Construct a zero-diagonal matrix
     dists = pairwise_distances(
-        np.array([[0.2, 0.1, 0.12, 1.34, 1.11, 1.6]]).transpose())
+        np.array([[0.2, 0.1, 0.12, 1.34, 1.11, 1.6]], dtype=dtype).T)
     labels = [0, 0, 0, 1, 1, 1]
 
     # small values on the diagonal are OK

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -212,9 +212,10 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
     """
     X, labels = check_X_y(X, labels, accept_sparse=['csc', 'csr'])
 
-    # Check for diagonal entries in precomputed distance matrix
+    # Check for non-zero diagonal entries in precomputed distance matrix
     if metric == 'precomputed':
-        if np.any(np.diagonal(X)):
+        atol = np.finfo(X.dtype).eps * 100
+        if np.any(np.abs(np.diagonal(X)) > atol):
             raise ValueError(
                 'The precomputed distance matrix contains non-zero '
                 'elements on the diagonal. Use np.fill_diagonal(X, 0).'


### PR DESCRIPTION
Addresses remaining comments from #12258.

Small non-zero values on the diagonal of a precomputed matrix are OK.