### PR TITLE
Fix CBLAS API in 0.20.x

### DIFF
--- a/sklearn/linear_model/cd_fast.pyx
+++ b/sklearn/linear_model/cd_fast.pyx
@@ -95,14 +95,17 @@ cdef floating diff_abs_max(int n, floating* a, floating* b) nogil:
 
 
 cdef extern from "cblas.h":
-    enum CBLAS_ORDER:
+    enum _CBLAS_ORDER:
         CblasRowMajor=101
         CblasColMajor=102
-    enum CBLAS_TRANSPOSE:
+    enum _CBLAS_TRANSPOSE:
         CblasNoTrans=111
         CblasTrans=112
         CblasConjTrans=113
         AtlasConj=114
+
+    ctypedef _CBLAS_ORDER CBLAS_ORDER;
+    ctypedef _CBLAS_TRANSPOSE CBLAS_TRANSPOSE;
 
     void daxpy "cblas_daxpy"(int N, double alpha, double *X, int incX,
                              double *Y, int incY) nogil

--- a/sklearn/src/cblas/ATL_drefgemv.c
+++ b/sklearn/src/cblas/ATL_drefgemv.c
@@ -52,7 +52,7 @@
 
 void ATL_drefgemv
 (
-   const enum ATLAS_TRANS     TRANS,
+   const ATLAS_TRANS     TRANS,
    const int                  M,
    const int                  N,
    const double               ALPHA,
@@ -83,7 +83,7 @@ void ATL_drefgemv
  * Arguments
  * =========
  *
- * TRANS   (input)                       const enum ATLAS_TRANS
+ * TRANS   (input)                       const ATLAS_TRANS
  *         On entry,  TRANS  specifies the  operation to be performed as
  *         follows:
  *

--- a/sklearn/src/cblas/ATL_srefgemv.c
+++ b/sklearn/src/cblas/ATL_srefgemv.c
@@ -52,7 +52,7 @@
 
 void ATL_srefgemv
 (
-   const enum ATLAS_TRANS     TRANS,
+   const ATLAS_TRANS     TRANS,
    const int                  M,
    const int                  N,
    const float                ALPHA,
@@ -83,7 +83,7 @@ void ATL_srefgemv
  * Arguments
  * =========
  *
- * TRANS   (input)                       const enum ATLAS_TRANS
+ * TRANS   (input)                       const ATLAS_TRANS
  *         On entry,  TRANS  specifies the  operation to be performed as
  *         follows:
  *

--- a/sklearn/src/cblas/atlas_aux.h
+++ b/sklearn/src/cblas/atlas_aux.h
@@ -56,7 +56,7 @@ void ATL_sgemove(const int M, const int N, const float alpha,
                  const float *A, const int lda, float *C, const int ldc);
 void ATL_sgemoveT(const int N, const int M, const float alpha,
                   const float *A, const int lda, float *C, const int ldc);
-void ATL_ssyreflect(const enum ATLAS_UPLO Uplo, const int N,
+void ATL_ssyreflect(const ATLAS_UPLO Uplo, const int N,
                     float *C, const int ldc);
 void ATL_sgecopy(const int M, const int N, const float *A, const int lda,
                  float *C, const int ldc);
@@ -64,21 +64,21 @@ void ATL_sgecopy(const int M, const int N, const float *A, const int lda,
 void ATL_sgescal(const int M, const int N, const float beta,
                  float *C, const int ldc);
 void ATL_stradd
-   (const enum ATLAS_UPLO Uplo, ATL_CINT N, const float *A, ATL_CINT lda,
+   (const ATLAS_UPLO Uplo, ATL_CINT N, const float *A, ATL_CINT lda,
     const float beta, float *C, ATL_CINT ldc);
 void ATL_strscal
-   (const enum ATLAS_UPLO Uplo, const int M, const int N, const float alpha,
+   (const ATLAS_UPLO Uplo, const int M, const int N, const float alpha,
     float *A, const int lda);
 void ATL_shescal
-   (const enum ATLAS_UPLO Uplo, const int M, const int N, const float alpha,
+   (const ATLAS_UPLO Uplo, const int M, const int N, const float alpha,
     float *A, const int lda);
 
 void ATL_sgezero(const int M, const int N, float *C, const int ldc);
 void ATL_ssyApAt_NB
-   (const enum ATLAS_UPLO Uplo, ATL_CINT N, const float *A, ATL_CINT lda,
+   (const ATLAS_UPLO Uplo, ATL_CINT N, const float *A, ATL_CINT lda,
     const float beta, float *C, ATL_CINT ldc);
 void ATL_ssyApAt
-   (const enum ATLAS_UPLO Uplo, ATL_CINT N, const float *A, ATL_CINT lda,
+   (const ATLAS_UPLO Uplo, ATL_CINT N, const float *A, ATL_CINT lda,
     const float beta, float *C, ATL_CINT ldc);
 void ATL_sgeApBt_NB
    (ATL_CINT M, ATL_CINT N, const float *A, ATL_CINT lda,
@@ -187,7 +187,7 @@ void ATL_dgemove(const int M, const int N, const double alpha,
                  const double *A, const int lda, double *C, const int ldc);
 void ATL_dgemoveT(const int N, const int M, const double alpha,
                   const double *A, const int lda, double *C, const int ldc);
-void ATL_dsyreflect(const enum ATLAS_UPLO Uplo, const int N,
+void ATL_dsyreflect(const ATLAS_UPLO Uplo, const int N,
                     double *C, const int ldc);
 void ATL_dgecopy(const int M, const int N, const double *A, const int lda,
                  double *C, const int ldc);
@@ -195,21 +195,21 @@ void ATL_dgecopy(const int M, const int N, const double *A, const int lda,
 void ATL_dgescal(const int M, const int N, const double beta,
                  double *C, const int ldc);
 void ATL_dtradd
-   (const enum ATLAS_UPLO Uplo, ATL_CINT N, const double *A, ATL_CINT lda,
+   (const ATLAS_UPLO Uplo, ATL_CINT N, const double *A, ATL_CINT lda,
     const double beta, double *C, ATL_CINT ldc);
 void ATL_dtrscal
-   (const enum ATLAS_UPLO Uplo, const int M, const int N, const double alpha,
+   (const ATLAS_UPLO Uplo, const int M, const int N, const double alpha,
     double *A, const int lda);
 void ATL_dhescal
-   (const enum ATLAS_UPLO Uplo, const int M, const int N, const double alpha,
+   (const ATLAS_UPLO Uplo, const int M, const int N, const double alpha,
     double *A, const int lda);
 
 void ATL_dgezero(const int M, const int N, double *C, const int ldc);
 void ATL_dsyApAt_NB
-   (const enum ATLAS_UPLO Uplo, ATL_CINT N, const double *A, ATL_CINT lda,
+   (const ATLAS_UPLO Uplo, ATL_CINT N, const double *A, ATL_CINT lda,
     const double beta, double *C, ATL_CINT ldc);
 void ATL_dsyApAt
-   (const enum ATLAS_UPLO Uplo, ATL_CINT N, const double *A, ATL_CINT lda,
+   (const ATLAS_UPLO Uplo, ATL_CINT N, const double *A, ATL_CINT lda,
     const double beta, double *C, ATL_CINT ldc);
 void ATL_dgeApBt_NB
    (ATL_CINT M, ATL_CINT N, const double *A, ATL_CINT lda,
@@ -318,7 +318,7 @@ void ATL_cgemove(const int M, const int N, const float *alpha,
                  const float *A, const int lda, float *C, const int ldc);
 void ATL_cgemoveT(const int N, const int M, const float *alpha,
                   const float *A, const int lda, float *C, const int ldc);
-void ATL_csyreflect(const enum ATLAS_UPLO Uplo, const int N,
+void ATL_csyreflect(const ATLAS_UPLO Uplo, const int N,
                     float *C, const int ldc);
 void ATL_cgecopy(const int M, const int N, const float *A, const int lda,
                  float *C, const int ldc);
@@ -326,21 +326,21 @@ void ATL_cgecopy(const int M, const int N, const float *A, const int lda,
 void ATL_cgescal(const int M, const int N, const float *beta,
                  float *C, const int ldc);
 void ATL_ctradd
-   (const enum ATLAS_UPLO Uplo, ATL_CINT N, const float *A, ATL_CINT lda,
+   (const ATLAS_UPLO Uplo, ATL_CINT N, const float *A, ATL_CINT lda,
     const float *beta, float *C, ATL_CINT ldc);
 void ATL_ctrscal
-   (const enum ATLAS_UPLO Uplo, const int M, const int N, const float *alpha,
+   (const ATLAS_UPLO Uplo, const int M, const int N, const float *alpha,
     float *A, const int lda);
 void ATL_chescal
-   (const enum ATLAS_UPLO Uplo, const int M, const int N, const float alpha,
+   (const ATLAS_UPLO Uplo, const int M, const int N, const float alpha,
     float *A, const int lda);
 
 void ATL_cgezero(const int M, const int N, float *C, const int ldc);
 void ATL_csyApAt_NB
-   (const enum ATLAS_UPLO Uplo, ATL_CINT N, const float *A, ATL_CINT lda,
+   (const ATLAS_UPLO Uplo, ATL_CINT N, const float *A, ATL_CINT lda,
     const float *beta, float *C, ATL_CINT ldc);
 void ATL_csyApAt
-   (const enum ATLAS_UPLO Uplo, ATL_CINT N, const float *A, ATL_CINT lda,
+   (const ATLAS_UPLO Uplo, ATL_CINT N, const float *A, ATL_CINT lda,
     const float *beta, float *C, ATL_CINT ldc);
 void ATL_cgeApBt_NB
    (ATL_CINT M, ATL_CINT N, const float *A, ATL_CINT lda,
@@ -449,7 +449,7 @@ void ATL_zgemove(const int M, const int N, const double *alpha,
                  const double *A, const int lda, double *C, const int ldc);
 void ATL_zgemoveT(const int N, const int M, const double *alpha,
                   const double *A, const int lda, double *C, const int ldc);
-void ATL_zsyreflect(const enum ATLAS_UPLO Uplo, const int N,
+void ATL_zsyreflect(const ATLAS_UPLO Uplo, const int N,
                     double *C, const int ldc);
 void ATL_zgecopy(const int M, const int N, const double *A, const int lda,
                  double *C, const int ldc);
@@ -457,21 +457,21 @@ void ATL_zgecopy(const int M, const int N, const double *A, const int lda,
 void ATL_zgescal(const int M, const int N, const double *beta,
                  double *C, const int ldc);
 void ATL_ztradd
-   (const enum ATLAS_UPLO Uplo, ATL_CINT N, const double *A, ATL_CINT lda,
+   (const ATLAS_UPLO Uplo, ATL_CINT N, const double *A, ATL_CINT lda,
     const double *beta, double *C, ATL_CINT ldc);
 void ATL_ztrscal
-   (const enum ATLAS_UPLO Uplo, const int M, const int N, const double *alpha,
+   (const ATLAS_UPLO Uplo, const int M, const int N, const double *alpha,
     double *A, const int lda);
 void ATL_zhescal
-   (const enum ATLAS_UPLO Uplo, const int M, const int N, const double alpha,
+   (const ATLAS_UPLO Uplo, const int M, const int N, const double alpha,
     double *A, const int lda);
 
 void ATL_zgezero(const int M, const int N, double *C, const int ldc);
 void ATL_zsyApAt_NB
-   (const enum ATLAS_UPLO Uplo, ATL_CINT N, const double *A, ATL_CINT lda,
+   (const ATLAS_UPLO Uplo, ATL_CINT N, const double *A, ATL_CINT lda,
     const double *beta, double *C, ATL_CINT ldc);
 void ATL_zsyApAt
-   (const enum ATLAS_UPLO Uplo, ATL_CINT N, const double *A, ATL_CINT lda,
+   (const ATLAS_UPLO Uplo, ATL_CINT N, const double *A, ATL_CINT lda,
     const double *beta, double *C, ATL_CINT ldc);
 void ATL_zgeApBt_NB
    (ATL_CINT M, ATL_CINT N, const double *A, ATL_CINT lda,
@@ -571,10 +571,10 @@ void ATL_zgescal_bX
  */
 
 void ATL_cheApAc_NB
-   (const enum ATLAS_UPLO Uplo, ATL_CINT N, const float *A, ATL_CINT lda,
+   (const ATLAS_UPLO Uplo, ATL_CINT N, const float *A, ATL_CINT lda,
     const float *beta, float *C, ATL_CINT ldc);
 void ATL_cheApAc
-   (const enum ATLAS_UPLO Uplo, ATL_CINT N, const float *A, ATL_CINT lda,
+   (const ATLAS_UPLO Uplo, ATL_CINT N, const float *A, ATL_CINT lda,
     const float *beta, float *C, ATL_CINT ldc);
 void ATL_cgeApBc_NB
    (ATL_CINT M, ATL_CINT N, const float *A, ATL_CINT lda,
@@ -584,7 +584,7 @@ void ATL_ccplxdivide
 void ATL_ccplxinvert
    (const int N, float *X, const int incX, float *Y, const int incY);
 
-void ATL_chereflect(const enum ATLAS_UPLO Uplo, const int N,
+void ATL_chereflect(const ATLAS_UPLO Uplo, const int N,
                     float *C, const int ldc);
 void ATL_cscalConj
    (const int N, const float *alpha, float *X, const int incX);
@@ -727,10 +727,10 @@ void ATL_cgescal_bXi0
    (const int M, const int N, const float *beta, float *C, const int ldc);
 
 void ATL_zheApAc_NB
-   (const enum ATLAS_UPLO Uplo, ATL_CINT N, const double *A, ATL_CINT lda,
+   (const ATLAS_UPLO Uplo, ATL_CINT N, const double *A, ATL_CINT lda,
     const double *beta, double *C, ATL_CINT ldc);
 void ATL_zheApAc
-   (const enum ATLAS_UPLO Uplo, ATL_CINT N, const double *A, ATL_CINT lda,
+   (const ATLAS_UPLO Uplo, ATL_CINT N, const double *A, ATL_CINT lda,
     const double *beta, double *C, ATL_CINT ldc);
 void ATL_zgeApBc_NB
    (ATL_CINT M, ATL_CINT N, const double *A, ATL_CINT lda,
@@ -740,7 +740,7 @@ void ATL_zcplxdivide
 void ATL_zcplxinvert
    (const int N, double *X, const int incX, double *Y, const int incY);
 
-void ATL_zhereflect(const enum ATLAS_UPLO Uplo, const int N,
+void ATL_zhereflect(const ATLAS_UPLO Uplo, const int N,
                     double *C, const int ldc);
 void ATL_zscalConj
    (const int N, const double *alpha, double *X, const int incX);
@@ -891,13 +891,13 @@ void ATL_ezgecollapse(const int M, const int N, ATL_QTYPE *C,
                       const int dldc, const int sldc);
 void ATL_zcgecollapse(const int M, const int N, double *C,
                       const int dldc, const int sldc);
-void ATL_qdtrcollapse(const enum ATLAS_UPLO Uplo, const enum ATLAS_DIAG Diag,
+void ATL_qdtrcollapse(const ATLAS_UPLO Uplo, const ATLAS_DIAG Diag,
                       const int N, ATL_QTYPE *C, const int dldc,const int sldc);
-void ATL_dstrcollapse(const enum ATLAS_UPLO Uplo, const enum ATLAS_DIAG Diag,
+void ATL_dstrcollapse(const ATLAS_UPLO Uplo, const ATLAS_DIAG Diag,
                       const int N, double *C, const int dldc, const int sldc);
-void ATL_zctrcollapse(const enum ATLAS_UPLO Uplo, const enum ATLAS_DIAG Diag,
+void ATL_zctrcollapse(const ATLAS_UPLO Uplo, const ATLAS_DIAG Diag,
                       const int N, double *C, const int dldc, const int sldc);
-void ATL_eztrcollapse(const enum ATLAS_UPLO Uplo, const enum ATLAS_DIAG Diag,
+void ATL_eztrcollapse(const ATLAS_UPLO Uplo, const ATLAS_DIAG Diag,
                       const int N, ATL_QTYPE *C, const int dldc,const int sldc);
 
 /*

--- a/sklearn/src/cblas/atlas_level2.h
+++ b/sklearn/src/cblas/atlas_level2.h
@@ -40,7 +40,7 @@
 /*
  * Routines with standard 4 prefixes (S, D, C, Z)
  */
-void ATL_sgemv(const enum ATLAS_TRANS TransA, const int M, const int N,
+void ATL_sgemv(const ATLAS_TRANS TransA, const int M, const int N,
                const float alpha, const float *A, const int lda,
                const float *X, const int incX, const float beta,
                float *Y, const int incY);
@@ -53,30 +53,30 @@ void ATL_sgemvT_L1
 void ATL_sgemvT
    (ATL_CINT M, ATL_CINT N, const float alpha, const float *A, ATL_CINT lda,
     const float *X, ATL_CINT incX, const float beta, float *Y, ATL_CINT incY);
-void ATL_sgbmv(const enum ATLAS_TRANS TransA, const int M, const int N,
+void ATL_sgbmv(const ATLAS_TRANS TransA, const int M, const int N,
                const int KL, const int KU, const float alpha,
                const float *A, const int lda, const float *X,
                const int incX, const float beta, float *Y, const int incY);
-void ATL_strmv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N,
+void ATL_strmv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N,
                const float *A, const int lda, float *X, const int incX);
-void ATL_stbmv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N, const int K,
+void ATL_stbmv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N, const int K,
                const float *A, const int lda, float *X, const int incX);
-void ATL_stpmv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N, const float *Ap,
+void ATL_stpmv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N, const float *Ap,
                float *X, const int incX);
-void ATL_strsv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N,
+void ATL_strsv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N,
                const float *A, const int lda, float *X, const int incX);
-void ATL_stbsv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N, const int K,
+void ATL_stbsv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N, const int K,
                const float *A, const int lda, float *X, const int incX);
-void ATL_stpsv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N,
+void ATL_stpsv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N,
                const float *Ap, float *X, const int incX);
 
-void ATL_dgemv(const enum ATLAS_TRANS TransA, const int M, const int N,
+void ATL_dgemv(const ATLAS_TRANS TransA, const int M, const int N,
                const double alpha, const double *A, const int lda,
                const double *X, const int incX, const double beta,
                double *Y, const int incY);
@@ -89,30 +89,30 @@ void ATL_dgemvT_L1
 void ATL_dgemvT
    (ATL_CINT M, ATL_CINT N, const double alpha, const double *A, ATL_CINT lda,
     const double *X, ATL_CINT incX, const double beta, double *Y, ATL_CINT incY);
-void ATL_dgbmv(const enum ATLAS_TRANS TransA, const int M, const int N,
+void ATL_dgbmv(const ATLAS_TRANS TransA, const int M, const int N,
                const int KL, const int KU, const double alpha,
                const double *A, const int lda, const double *X,
                const int incX, const double beta, double *Y, const int incY);
-void ATL_dtrmv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N,
+void ATL_dtrmv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N,
                const double *A, const int lda, double *X, const int incX);
-void ATL_dtbmv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N, const int K,
+void ATL_dtbmv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N, const int K,
                const double *A, const int lda, double *X, const int incX);
-void ATL_dtpmv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N, const double *Ap,
+void ATL_dtpmv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N, const double *Ap,
                double *X, const int incX);
-void ATL_dtrsv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N,
+void ATL_dtrsv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N,
                const double *A, const int lda, double *X, const int incX);
-void ATL_dtbsv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N, const int K,
+void ATL_dtbsv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N, const int K,
                const double *A, const int lda, double *X, const int incX);
-void ATL_dtpsv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N,
+void ATL_dtpsv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N,
                const double *Ap, double *X, const int incX);
 
-void ATL_cgemv(const enum ATLAS_TRANS TransA, const int M, const int N,
+void ATL_cgemv(const ATLAS_TRANS TransA, const int M, const int N,
                const float *alpha, const float *A, const int lda,
                const float *X, const int incX, const float *beta,
                float *Y, const int incY);
@@ -125,30 +125,30 @@ void ATL_cgemvT_L1
 void ATL_cgemvT
    (ATL_CINT M, ATL_CINT N, const float *alpha, const float *A, ATL_CINT lda,
     const float *X, ATL_CINT incX, const float *beta, float *Y, ATL_CINT incY);
-void ATL_cgbmv(const enum ATLAS_TRANS TransA, const int M, const int N,
+void ATL_cgbmv(const ATLAS_TRANS TransA, const int M, const int N,
                const int KL, const int KU, const float *alpha,
                const float *A, const int lda, const float *X,
                const int incX, const float *beta, float *Y, const int incY);
-void ATL_ctrmv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N,
+void ATL_ctrmv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N,
                const float *A, const int lda, float *X, const int incX);
-void ATL_ctbmv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N, const int K,
+void ATL_ctbmv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N, const int K,
                const float *A, const int lda, float *X, const int incX);
-void ATL_ctpmv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N, const float *Ap,
+void ATL_ctpmv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N, const float *Ap,
                float *X, const int incX);
-void ATL_ctrsv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N,
+void ATL_ctrsv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N,
                const float *A, const int lda, float *X, const int incX);
-void ATL_ctbsv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N, const int K,
+void ATL_ctbsv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N, const int K,
                const float *A, const int lda, float *X, const int incX);
-void ATL_ctpsv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N,
+void ATL_ctpsv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N,
                const float *Ap, float *X, const int incX);
 
-void ATL_zgemv(const enum ATLAS_TRANS TransA, const int M, const int N,
+void ATL_zgemv(const ATLAS_TRANS TransA, const int M, const int N,
                const double *alpha, const double *A, const int lda,
                const double *X, const int incX, const double *beta,
                double *Y, const int incY);
@@ -161,42 +161,42 @@ void ATL_zgemvT_L1
 void ATL_zgemvT
    (ATL_CINT M, ATL_CINT N, const double *alpha, const double *A, ATL_CINT lda,
     const double *X, ATL_CINT incX, const double *beta, double *Y, ATL_CINT incY);
-void ATL_zgbmv(const enum ATLAS_TRANS TransA, const int M, const int N,
+void ATL_zgbmv(const ATLAS_TRANS TransA, const int M, const int N,
                const int KL, const int KU, const double *alpha,
                const double *A, const int lda, const double *X,
                const int incX, const double *beta, double *Y, const int incY);
-void ATL_ztrmv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N,
+void ATL_ztrmv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N,
                const double *A, const int lda, double *X, const int incX);
-void ATL_ztbmv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N, const int K,
+void ATL_ztbmv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N, const int K,
                const double *A, const int lda, double *X, const int incX);
-void ATL_ztpmv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N, const double *Ap,
+void ATL_ztpmv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N, const double *Ap,
                double *X, const int incX);
-void ATL_ztrsv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N,
+void ATL_ztrsv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N,
                const double *A, const int lda, double *X, const int incX);
-void ATL_ztbsv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N, const int K,
+void ATL_ztbsv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N, const int K,
                const double *A, const int lda, double *X, const int incX);
-void ATL_ztpsv(const enum ATLAS_UPLO Uplo, const enum ATLAS_TRANS TransA,
-               const enum ATLAS_DIAG Diag, const int N,
+void ATL_ztpsv(const ATLAS_UPLO Uplo, const ATLAS_TRANS TransA,
+               const ATLAS_DIAG Diag, const int N,
                const double *Ap, double *X, const int incX);
 
 
 /*
  * Routines with S and D prefixes only
  */
-void ATL_ssymv(const enum ATLAS_UPLO Uplo, const int N,
+void ATL_ssymv(const ATLAS_UPLO Uplo, const int N,
                const float alpha, const float *A, const int lda,
                const float *X, const int incX, const float beta,
                float *Y, const int incY);
-void ATL_ssbmv(const enum ATLAS_UPLO Uplo, const int N, const int K,
+void ATL_ssbmv(const ATLAS_UPLO Uplo, const int N, const int K,
                const float alpha, const float *A, const int lda,
                const float *X, const int incX, const float beta,
                float *Y, const int incY);
-void ATL_sspmv(const enum ATLAS_UPLO Uplo, const int N, const float alpha,
+void ATL_sspmv(const ATLAS_UPLO Uplo, const int N, const float alpha,
                const float *Ap, const float *X, const int incX,
                const float beta, float *Y, const int incY);
 void ATL_sger(const int M, const int N, const float alpha,
@@ -207,26 +207,26 @@ void ATL_sger2(const int M, const int N, const float alpha,
                const float beta,
                const float *W, const int incW, const float *Z, const int incZ,
                float *A, const int lda);
-void ATL_ssyr(const enum ATLAS_UPLO Uplo, const int N, const float alpha,
+void ATL_ssyr(const ATLAS_UPLO Uplo, const int N, const float alpha,
               const float *X, const int incX, float *A, const int lda);
-void ATL_sspr(const enum ATLAS_UPLO Uplo, const int N, const float alpha,
+void ATL_sspr(const ATLAS_UPLO Uplo, const int N, const float alpha,
               const float *X, const int incX, float *Ap);
-void ATL_ssyr2(const enum ATLAS_UPLO Uplo, const int N, const float alpha,
+void ATL_ssyr2(const ATLAS_UPLO Uplo, const int N, const float alpha,
                const float *X, const int incX, const float *Y, const int incY,
                float *A, const int lda);
-void ATL_sspr2(const enum ATLAS_UPLO Uplo, const int N, const float alpha,
+void ATL_sspr2(const ATLAS_UPLO Uplo, const int N, const float alpha,
                const float *X, const int incX, const float *Y, const int incY,
                float *A);
 
-void ATL_dsymv(const enum ATLAS_UPLO Uplo, const int N,
+void ATL_dsymv(const ATLAS_UPLO Uplo, const int N,
                const double alpha, const double *A, const int lda,
                const double *X, const int incX, const double beta,
                double *Y, const int incY);
-void ATL_dsbmv(const enum ATLAS_UPLO Uplo, const int N, const int K,
+void ATL_dsbmv(const ATLAS_UPLO Uplo, const int N, const int K,
                const double alpha, const double *A, const int lda,
                const double *X, const int incX, const double beta,
                double *Y, const int incY);
-void ATL_dspmv(const enum ATLAS_UPLO Uplo, const int N, const double alpha,
+void ATL_dspmv(const ATLAS_UPLO Uplo, const int N, const double alpha,
                const double *Ap, const double *X, const int incX,
                const double beta, double *Y, const int incY);
 void ATL_dger(const int M, const int N, const double alpha,
@@ -237,14 +237,14 @@ void ATL_dger2(const int M, const int N, const double alpha,
                const double beta,
                const double *W, const int incW, const double *Z, const int incZ,
                double *A, const int lda);
-void ATL_dsyr(const enum ATLAS_UPLO Uplo, const int N, const double alpha,
+void ATL_dsyr(const ATLAS_UPLO Uplo, const int N, const double alpha,
               const double *X, const int incX, double *A, const int lda);
-void ATL_dspr(const enum ATLAS_UPLO Uplo, const int N, const double alpha,
+void ATL_dspr(const ATLAS_UPLO Uplo, const int N, const double alpha,
               const double *X, const int incX, double *Ap);
-void ATL_dsyr2(const enum ATLAS_UPLO Uplo, const int N, const double alpha,
+void ATL_dsyr2(const ATLAS_UPLO Uplo, const int N, const double alpha,
                const double *X, const int incX, const double *Y, const int incY,
                double *A, const int lda);
-void ATL_dspr2(const enum ATLAS_UPLO Uplo, const int N, const double alpha,
+void ATL_dspr2(const ATLAS_UPLO Uplo, const int N, const double alpha,
                const double *X, const int incX, const double *Y, const int incY,
                double *A);
 
@@ -252,15 +252,15 @@ void ATL_dspr2(const enum ATLAS_UPLO Uplo, const int N, const double alpha,
 /*
  * Routines with C and Z prefixes only
  */
-void ATL_chemv(const enum ATLAS_UPLO Uplo, const int N,
+void ATL_chemv(const ATLAS_UPLO Uplo, const int N,
                const float *alpha, const float *A, const int lda,
                const float *X, const int incX, const float *beta,
                float *Y, const int incY);
-void ATL_chbmv(const enum ATLAS_UPLO Uplo, const int N, const int K,
+void ATL_chbmv(const ATLAS_UPLO Uplo, const int N, const int K,
                const float *alpha, const float *A, const int lda,
                const float *X, const int incX, const float *beta,
                float *Y, const int incY);
-void ATL_chpmv(const enum ATLAS_UPLO Uplo, const int N,
+void ATL_chpmv(const ATLAS_UPLO Uplo, const int N,
                const float *alpha, const float *Ap,
                const float *X, const int incX, const float *beta,
                float *Y, const int incY);
@@ -282,26 +282,26 @@ void ATL_cger2c(const int M, const int N,
                 const float *beta, const float *W, const int incW,
                 const float *Z, const int incZ,
                 float *A, const int lda);
-void ATL_cher(const enum ATLAS_UPLO Uplo, const int N, const float alpha,
+void ATL_cher(const ATLAS_UPLO Uplo, const int N, const float alpha,
               const float *X, const int incX, float *A, const int lda);
-void ATL_chpr(const enum ATLAS_UPLO Uplo, const int N, const float alpha,
+void ATL_chpr(const ATLAS_UPLO Uplo, const int N, const float alpha,
                    const float *X, const int incX, float *A);
-void ATL_cher2(const enum ATLAS_UPLO Uplo, const int N,
+void ATL_cher2(const ATLAS_UPLO Uplo, const int N,
                const float *alpha, const float *X, const int incX,
                const float *Y, const int incY, float *A, const int lda);
-void ATL_chpr2(const enum ATLAS_UPLO Uplo, const int N,
+void ATL_chpr2(const ATLAS_UPLO Uplo, const int N,
                const float *alpha, const float *X, const int incX,
                const float *Y, const int incY, float *Ap);
 
-void ATL_zhemv(const enum ATLAS_UPLO Uplo, const int N,
+void ATL_zhemv(const ATLAS_UPLO Uplo, const int N,
                const double *alpha, const double *A, const int lda,
                const double *X, const int incX, const double *beta,
                double *Y, const int incY);
-void ATL_zhbmv(const enum ATLAS_UPLO Uplo, const int N, const int K,
+void ATL_zhbmv(const ATLAS_UPLO Uplo, const int N, const int K,
                const double *alpha, const double *A, const int lda,
                const double *X, const int incX, const double *beta,
                double *Y, const int incY);
-void ATL_zhpmv(const enum ATLAS_UPLO Uplo, const int N,
+void ATL_zhpmv(const ATLAS_UPLO Uplo, const int N,
                const double *alpha, const double *Ap,
                const double *X, const int incX, const double *beta,
                double *Y, const int incY);
@@ -323,14 +323,14 @@ void ATL_zger2c(const int M, const int N,
                 const double *beta, const double *W, const int incW,
                 const double *Z, const int incZ,
                 double *A, const int lda);
-void ATL_zher(const enum ATLAS_UPLO Uplo, const int N, const double alpha,
+void ATL_zher(const ATLAS_UPLO Uplo, const int N, const double alpha,
               const double *X, const int incX, double *A, const int lda);
-void ATL_zhpr(const enum ATLAS_UPLO Uplo, const int N, const double alpha,
+void ATL_zhpr(const ATLAS_UPLO Uplo, const int N, const double alpha,
                    const double *X, const int incX, double *A);
-void ATL_zher2(const enum ATLAS_UPLO Uplo, const int N,
+void ATL_zher2(const ATLAS_UPLO Uplo, const int N,
                const double *alpha, const double *X, const int incX,
                const double *Y, const int incY, double *A, const int lda);
-void ATL_zhpr2(const enum ATLAS_UPLO Uplo, const int N,
+void ATL_zhpr2(const ATLAS_UPLO Uplo, const int N,
                const double *alpha, const double *X, const int incX,
                const double *Y, const int incY, double *Ap);
 

--- a/sklearn/src/cblas/atlas_reflevel2.h
+++ b/sklearn/src/cblas/atlas_reflevel2.h
@@ -58,7 +58,7 @@
  */
 void       ATL_srefgbmv
 (
-  const enum ATLAS_TRANS,
+  const ATLAS_TRANS,
   const int,              const int,
   const int,              const int,
   const float,
@@ -70,8 +70,8 @@ void       ATL_srefgbmv
 
 void       ATL_srefgpmv
 (
-  const enum ATLAS_UPLO,
-  const enum ATLAS_TRANS,
+  const ATLAS_UPLO,
+  const ATLAS_TRANS,
   const int,              const int,
   const float,
   const float *,          const int,
@@ -82,7 +82,7 @@ void       ATL_srefgpmv
 
 void       ATL_srefgemv
 (
-  const enum ATLAS_TRANS,
+  const ATLAS_TRANS,
   const int,              const int,
   const float,
   const float *,          const int,
@@ -93,7 +93,7 @@ void       ATL_srefgemv
 
 void       ATL_srefgpr
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,              const int,
   const float,
   const float *,          const int,
@@ -112,7 +112,7 @@ void       ATL_srefger
 
 void       ATL_srefsbmv
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,              const int,
   const float,
   const float *,          const int,
@@ -123,7 +123,7 @@ void       ATL_srefsbmv
 
 void       ATL_srefspmv
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const float,
   const float *,
@@ -134,7 +134,7 @@ void       ATL_srefspmv
 
 void       ATL_srefspr
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const float,
   const float *,          const int,
@@ -143,7 +143,7 @@ void       ATL_srefspr
 
 void       ATL_srefspr2
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const float,
   const float *,          const int,
@@ -153,7 +153,7 @@ void       ATL_srefspr2
 
 void       ATL_srefsymv
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const float,
   const float *,          const int,
@@ -164,7 +164,7 @@ void       ATL_srefsymv
 
 void       ATL_srefsyr
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const float,
   const float *,          const int,
@@ -173,7 +173,7 @@ void       ATL_srefsyr
 
 void       ATL_srefsyr2
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const float,
   const float *,          const int,
@@ -183,7 +183,7 @@ void       ATL_srefsyr2
 
 void       ATL_sreftbmv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,              const int,
   const float *,          const int,
   float *,                const int
@@ -191,7 +191,7 @@ void       ATL_sreftbmv
 
 void       ATL_sreftbsv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,              const int,
   const float *,          const int,
   float *,                const int
@@ -199,7 +199,7 @@ void       ATL_sreftbsv
 
 void       ATL_sreftpmv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,
   const float *,
   float *,                const int
@@ -207,7 +207,7 @@ void       ATL_sreftpmv
 
 void       ATL_sreftpsv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,
   const float *,
   float *,                const int
@@ -215,7 +215,7 @@ void       ATL_sreftpsv
 
 void       ATL_sreftrmv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,
   const float *,          const int,
   float *,                const int
@@ -223,7 +223,7 @@ void       ATL_sreftrmv
 
 void       ATL_sreftrsv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,
   const float *,          const int,
   float *,                const int
@@ -231,7 +231,7 @@ void       ATL_sreftrsv
 
 void       ATL_drefgbmv
 (
-  const enum ATLAS_TRANS,
+  const ATLAS_TRANS,
   const int,              const int,
   const int,              const int,
   const double,
@@ -243,8 +243,8 @@ void       ATL_drefgbmv
 
 void       ATL_drefgpmv
 (
-  const enum ATLAS_UPLO,
-  const enum ATLAS_TRANS,
+  const ATLAS_UPLO,
+  const ATLAS_TRANS,
   const int,              const int,
   const double,
   const double *,         const int,
@@ -255,7 +255,7 @@ void       ATL_drefgpmv
 
 void       ATL_drefgemv
 (
-  const enum ATLAS_TRANS,
+  const ATLAS_TRANS,
   const int,              const int,
   const double,
   const double *,         const int,
@@ -266,7 +266,7 @@ void       ATL_drefgemv
 
 void       ATL_drefgpr
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,              const int,
   const double,
   const double *,         const int,
@@ -285,7 +285,7 @@ void       ATL_drefger
 
 void       ATL_drefsbmv
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,              const int,
   const double,
   const double *,         const int,
@@ -296,7 +296,7 @@ void       ATL_drefsbmv
 
 void       ATL_drefspmv
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const double,
   const double *,
@@ -307,7 +307,7 @@ void       ATL_drefspmv
 
 void       ATL_drefspr
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const double,
   const double *,         const int,
@@ -316,7 +316,7 @@ void       ATL_drefspr
 
 void       ATL_drefspr2
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const double,
   const double *,         const int,
@@ -326,7 +326,7 @@ void       ATL_drefspr2
 
 void       ATL_drefsymv
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const double,
   const double *,         const int,
@@ -337,7 +337,7 @@ void       ATL_drefsymv
 
 void       ATL_drefsyr
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const double,
   const double *,         const int,
@@ -346,7 +346,7 @@ void       ATL_drefsyr
 
 void       ATL_drefsyr2
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const double,
   const double *,         const int,
@@ -356,7 +356,7 @@ void       ATL_drefsyr2
 
 void       ATL_dreftbmv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,              const int,
   const double *,         const int,
   double *,               const int
@@ -364,7 +364,7 @@ void       ATL_dreftbmv
 
 void       ATL_dreftbsv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,              const int,
   const double *,         const int,
   double *,               const int
@@ -372,7 +372,7 @@ void       ATL_dreftbsv
 
 void       ATL_dreftpmv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,
   const double *,
   double *,               const int
@@ -380,7 +380,7 @@ void       ATL_dreftpmv
 
 void       ATL_dreftpsv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,
   const double *,
   double *,               const int
@@ -388,7 +388,7 @@ void       ATL_dreftpsv
 
 void       ATL_dreftrmv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,
   const double *,         const int,
   double *,               const int
@@ -396,7 +396,7 @@ void       ATL_dreftrmv
 
 void       ATL_dreftrsv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,
   const double *,         const int,
   double *,               const int
@@ -404,7 +404,7 @@ void       ATL_dreftrsv
 
 void       ATL_crefgbmv
 (
-  const enum ATLAS_TRANS,
+  const ATLAS_TRANS,
   const int,              const int,
   const int,              const int,
   const float *,
@@ -416,8 +416,8 @@ void       ATL_crefgbmv
 
 void       ATL_crefgpmv
 (
-  const enum ATLAS_UPLO,
-  const enum ATLAS_TRANS,
+  const ATLAS_UPLO,
+  const ATLAS_TRANS,
   const int,              const int,
   const float *,
   const float *,          const int,
@@ -428,7 +428,7 @@ void       ATL_crefgpmv
 
 void       ATL_crefgemv
 (
-  const enum ATLAS_TRANS,
+  const ATLAS_TRANS,
   const int,              const int,
   const float *,
   const float *,          const int,
@@ -439,7 +439,7 @@ void       ATL_crefgemv
 
 void       ATL_crefgprc
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,              const int,
   const float *,
   const float *,          const int,
@@ -449,7 +449,7 @@ void       ATL_crefgprc
 
 void       ATL_crefgpru
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,              const int,
   const float *,
   const float *,          const int,
@@ -477,7 +477,7 @@ void       ATL_crefgeru
 
 void       ATL_crefhbmv
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,              const int,
   const float *,
   const float *,          const int,
@@ -488,7 +488,7 @@ void       ATL_crefhbmv
 
 void       ATL_crefhpmv
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const float *,
   const float *,
@@ -499,7 +499,7 @@ void       ATL_crefhpmv
 
 void       ATL_crefhpr
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const float,
   const float *,          const int,
@@ -508,7 +508,7 @@ void       ATL_crefhpr
 
 void       ATL_crefhpr2
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const float *,
   const float *,          const int,
@@ -518,7 +518,7 @@ void       ATL_crefhpr2
 
 void       ATL_crefhemv
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const float *,
   const float *,          const int,
@@ -529,7 +529,7 @@ void       ATL_crefhemv
 
 void       ATL_crefher
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const float,
   const float *,          const int,
@@ -538,7 +538,7 @@ void       ATL_crefher
 
 void       ATL_crefher2
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const float *,
   const float *,          const int,
@@ -548,7 +548,7 @@ void       ATL_crefher2
 
 void       ATL_creftbmv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,              const int,
   const float *,          const int,
   float *,                const int
@@ -556,7 +556,7 @@ void       ATL_creftbmv
 
 void       ATL_creftbsv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,              const int,
   const float *,          const int,
   float *,                const int
@@ -564,7 +564,7 @@ void       ATL_creftbsv
 
 void       ATL_creftpmv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,
   const float *,
   float *,                const int
@@ -572,7 +572,7 @@ void       ATL_creftpmv
 
 void       ATL_creftpsv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,
   const float *,
   float *,                const int
@@ -580,7 +580,7 @@ void       ATL_creftpsv
 
 void       ATL_creftrmv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,
   const float *,          const int,
   float *,                const int
@@ -588,7 +588,7 @@ void       ATL_creftrmv
 
 void       ATL_creftrsv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,
   const float *,          const int,
   float *,                const int
@@ -596,7 +596,7 @@ void       ATL_creftrsv
 
 void       ATL_zrefgbmv
 (
-  const enum ATLAS_TRANS,
+  const ATLAS_TRANS,
   const int,              const int,
   const int,              const int,
   const double *,
@@ -608,8 +608,8 @@ void       ATL_zrefgbmv
 
 void       ATL_zrefgpmv
 (
-  const enum ATLAS_UPLO,
-  const enum ATLAS_TRANS,
+  const ATLAS_UPLO,
+  const ATLAS_TRANS,
   const int,              const int,
   const double *,
   const double *,         const int,
@@ -620,7 +620,7 @@ void       ATL_zrefgpmv
 
 void       ATL_zrefgemv
 (
-  const enum ATLAS_TRANS,
+  const ATLAS_TRANS,
   const int,              const int,
   const double *,
   const double *,         const int,
@@ -631,7 +631,7 @@ void       ATL_zrefgemv
 
 void       ATL_zrefgprc
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,              const int,
   const double *,
   const double *,         const int,
@@ -641,7 +641,7 @@ void       ATL_zrefgprc
 
 void       ATL_zrefgpru
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,              const int,
   const double *,
   const double *,         const int,
@@ -669,7 +669,7 @@ void       ATL_zrefgeru
 
 void       ATL_zrefhbmv
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,              const int,
   const double *,
   const double *,         const int,
@@ -680,7 +680,7 @@ void       ATL_zrefhbmv
 
 void       ATL_zrefhpmv
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const double *,
   const double *,
@@ -691,7 +691,7 @@ void       ATL_zrefhpmv
 
 void       ATL_zrefhpr
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const double,
   const double *,         const int,
@@ -700,7 +700,7 @@ void       ATL_zrefhpr
 
 void       ATL_zrefhpr2
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const double *,
   const double *,         const int,
@@ -710,7 +710,7 @@ void       ATL_zrefhpr2
 
 void       ATL_zrefhemv
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const double *,
   const double *,         const int,
@@ -721,7 +721,7 @@ void       ATL_zrefhemv
 
 void       ATL_zrefher
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const double,
   const double *,         const int,
@@ -730,7 +730,7 @@ void       ATL_zrefher
 
 void       ATL_zrefher2
 (
-  const enum ATLAS_UPLO,
+  const ATLAS_UPLO,
   const int,
   const double *,
   const double *,         const int,
@@ -740,7 +740,7 @@ void       ATL_zrefher2
 
 void       ATL_zreftbmv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,              const int,
   const double *,         const int,
   double *,               const int
@@ -748,7 +748,7 @@ void       ATL_zreftbmv
 
 void       ATL_zreftbsv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,              const int,
   const double *,         const int,
   double *,               const int
@@ -756,7 +756,7 @@ void       ATL_zreftbsv
 
 void       ATL_zreftpmv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,
   const double *,
   double *,               const int
@@ -764,7 +764,7 @@ void       ATL_zreftpmv
 
 void       ATL_zreftpsv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,
   const double *,
   double *,               const int
@@ -772,7 +772,7 @@ void       ATL_zreftpsv
 
 void       ATL_zreftrmv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,
   const double *,         const int,
   double *,               const int
@@ -780,7 +780,7 @@ void       ATL_zreftrmv
 
 void       ATL_zreftrsv
 (
-  const enum ATLAS_UPLO,  const enum ATLAS_TRANS, const enum ATLAS_DIAG,
+  const ATLAS_UPLO,  const ATLAS_TRANS, const ATLAS_DIAG,
   const int,
   const double *,         const int,
   double *,               const int

--- a/sklearn/src/cblas/cblas.h
+++ b/sklearn/src/cblas/cblas.h
@@ -2,12 +2,12 @@
 
 #ifndef CBLAS_ENUM_DEFINED_H
    #define CBLAS_ENUM_DEFINED_H
-   enum CBLAS_ORDER {CblasRowMajor=101, CblasColMajor=102 };
-   enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113,
-                         AtlasConj=114};
-   enum CBLAS_UPLO  {CblasUpper=121, CblasLower=122};
-   enum CBLAS_DIAG  {CblasNonUnit=131, CblasUnit=132};
-   enum CBLAS_SIDE  {CblasLeft=141, CblasRight=142};
+   typedef enum {CblasRowMajor=101, CblasColMajor=102 } CBLAS_ORDER;
+   typedef enum {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113,
+                         AtlasConj=114} CBLAS_TRANSPOSE;
+   typedef enum {CblasUpper=121, CblasLower=122} CBLAS_UPLO;
+   typedef enum {CblasNonUnit=131, CblasUnit=132} CBLAS_DIAG;
+   typedef enum {CblasLeft=141, CblasRight=142} CBLAS_SIDE;
 #endif
 
 #ifndef CBLAS_ENUM_ONLY
@@ -168,197 +168,197 @@ void cblas_zdrot(const int N, void *X, const int incX, void *Y, const int incY,
 /*
  * Routines with standard 4 prefixes (S, D, C, Z)
  */
-void cblas_sgemv(const enum CBLAS_ORDER Order,
-                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+void cblas_sgemv(const CBLAS_ORDER Order,
+                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
                  const float alpha, const float *A, const int lda,
                  const float *X, const int incX, const float beta,
                  float *Y, const int incY);
-void cblas_sgbmv(const enum CBLAS_ORDER Order,
-                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+void cblas_sgbmv(const CBLAS_ORDER Order,
+                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
                  const int KL, const int KU, const float alpha,
                  const float *A, const int lda, const float *X,
                  const int incX, const float beta, float *Y, const int incY);
-void cblas_strmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_strmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const float *A, const int lda,
                  float *X, const int incX);
-void cblas_stbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_stbmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const int K, const float *A, const int lda,
                  float *X, const int incX);
-void cblas_stpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_stpmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const float *Ap, float *X, const int incX);
-void cblas_strsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_strsv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const float *A, const int lda, float *X,
                  const int incX);
-void cblas_stbsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_stbsv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const int K, const float *A, const int lda,
                  float *X, const int incX);
-void cblas_stpsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_stpsv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const float *Ap, float *X, const int incX);
 
-void cblas_dgemv(const enum CBLAS_ORDER Order,
-                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+void cblas_dgemv(const CBLAS_ORDER Order,
+                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
                  const double alpha, const double *A, const int lda,
                  const double *X, const int incX, const double beta,
                  double *Y, const int incY);
-void cblas_dgbmv(const enum CBLAS_ORDER Order,
-                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+void cblas_dgbmv(const CBLAS_ORDER Order,
+                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
                  const int KL, const int KU, const double alpha,
                  const double *A, const int lda, const double *X,
                  const int incX, const double beta, double *Y, const int incY);
-void cblas_dtrmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_dtrmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const double *A, const int lda,
                  double *X, const int incX);
-void cblas_dtbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_dtbmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const int K, const double *A, const int lda,
                  double *X, const int incX);
-void cblas_dtpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_dtpmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const double *Ap, double *X, const int incX);
-void cblas_dtrsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_dtrsv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const double *A, const int lda, double *X,
                  const int incX);
-void cblas_dtbsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_dtbsv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const int K, const double *A, const int lda,
                  double *X, const int incX);
-void cblas_dtpsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_dtpsv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const double *Ap, double *X, const int incX);
 
-void cblas_cgemv(const enum CBLAS_ORDER Order,
-                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+void cblas_cgemv(const CBLAS_ORDER Order,
+                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
                  const void *alpha, const void *A, const int lda,
                  const void *X, const int incX, const void *beta,
                  void *Y, const int incY);
-void cblas_cgbmv(const enum CBLAS_ORDER Order,
-                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+void cblas_cgbmv(const CBLAS_ORDER Order,
+                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
                  const int KL, const int KU, const void *alpha,
                  const void *A, const int lda, const void *X,
                  const int incX, const void *beta, void *Y, const int incY);
-void cblas_ctrmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_ctrmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const void *A, const int lda,
                  void *X, const int incX);
-void cblas_ctbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_ctbmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const int K, const void *A, const int lda,
                  void *X, const int incX);
-void cblas_ctpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_ctpmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const void *Ap, void *X, const int incX);
-void cblas_ctrsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_ctrsv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const void *A, const int lda, void *X,
                  const int incX);
-void cblas_ctbsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_ctbsv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const int K, const void *A, const int lda,
                  void *X, const int incX);
-void cblas_ctpsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_ctpsv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const void *Ap, void *X, const int incX);
 
-void cblas_zgemv(const enum CBLAS_ORDER Order,
-                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+void cblas_zgemv(const CBLAS_ORDER Order,
+                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
                  const void *alpha, const void *A, const int lda,
                  const void *X, const int incX, const void *beta,
                  void *Y, const int incY);
-void cblas_zgbmv(const enum CBLAS_ORDER Order,
-                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+void cblas_zgbmv(const CBLAS_ORDER Order,
+                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
                  const int KL, const int KU, const void *alpha,
                  const void *A, const int lda, const void *X,
                  const int incX, const void *beta, void *Y, const int incY);
-void cblas_ztrmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_ztrmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const void *A, const int lda,
                  void *X, const int incX);
-void cblas_ztbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_ztbmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const int K, const void *A, const int lda,
                  void *X, const int incX);
-void cblas_ztpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_ztpmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const void *Ap, void *X, const int incX);
-void cblas_ztrsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_ztrsv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const void *A, const int lda, void *X,
                  const int incX);
-void cblas_ztbsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_ztbsv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const int K, const void *A, const int lda,
                  void *X, const int incX);
-void cblas_ztpsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+void cblas_ztpsv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
                  const int N, const void *Ap, void *X, const int incX);
 
 
 /*
  * Routines with S and D prefixes only
  */
-void cblas_ssymv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_ssymv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                  const int N, const float alpha, const float *A,
                  const int lda, const float *X, const int incX,
                  const float beta, float *Y, const int incY);
-void cblas_ssbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_ssbmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                  const int N, const int K, const float alpha, const float *A,
                  const int lda, const float *X, const int incX,
                  const float beta, float *Y, const int incY);
-void cblas_sspmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_sspmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                  const int N, const float alpha, const float *Ap,
                  const float *X, const int incX,
                  const float beta, float *Y, const int incY);
-void cblas_sger(const enum CBLAS_ORDER Order, const int M, const int N,
+void cblas_sger(const CBLAS_ORDER Order, const int M, const int N,
                 const float alpha, const float *X, const int incX,
                 const float *Y, const int incY, float *A, const int lda);
-void cblas_ssyr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_ssyr(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                 const int N, const float alpha, const float *X,
                 const int incX, float *A, const int lda);
-void cblas_sspr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_sspr(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                 const int N, const float alpha, const float *X,
                 const int incX, float *Ap);
-void cblas_ssyr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_ssyr2(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                 const int N, const float alpha, const float *X,
                 const int incX, const float *Y, const int incY, float *A,
                 const int lda);
-void cblas_sspr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_sspr2(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                 const int N, const float alpha, const float *X,
                 const int incX, const float *Y, const int incY, float *A);
 
-void cblas_dsymv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_dsymv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                  const int N, const double alpha, const double *A,
                  const int lda, const double *X, const int incX,
                  const double beta, double *Y, const int incY);
-void cblas_dsbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_dsbmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                  const int N, const int K, const double alpha, const double *A,
                  const int lda, const double *X, const int incX,
                  const double beta, double *Y, const int incY);
-void cblas_dspmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_dspmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                  const int N, const double alpha, const double *Ap,
                  const double *X, const int incX,
                  const double beta, double *Y, const int incY);
-void cblas_dger(const enum CBLAS_ORDER Order, const int M, const int N,
+void cblas_dger(const CBLAS_ORDER Order, const int M, const int N,
                 const double alpha, const double *X, const int incX,
                 const double *Y, const int incY, double *A, const int lda);
-void cblas_dsyr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_dsyr(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                 const int N, const double alpha, const double *X,
                 const int incX, double *A, const int lda);
-void cblas_dspr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_dspr(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                 const int N, const double alpha, const double *X,
                 const int incX, double *Ap);
-void cblas_dsyr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_dsyr2(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                 const int N, const double alpha, const double *X,
                 const int incX, const double *Y, const int incY, double *A,
                 const int lda);
-void cblas_dspr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_dspr2(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                 const int N, const double alpha, const double *X,
                 const int incX, const double *Y, const int incY, double *A);
 
@@ -366,65 +366,65 @@ void cblas_dspr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
 /*
  * Routines with C and Z prefixes only
  */
-void cblas_chemv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_chemv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                  const int N, const void *alpha, const void *A,
                  const int lda, const void *X, const int incX,
                  const void *beta, void *Y, const int incY);
-void cblas_chbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_chbmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                  const int N, const int K, const void *alpha, const void *A,
                  const int lda, const void *X, const int incX,
                  const void *beta, void *Y, const int incY);
-void cblas_chpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_chpmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                  const int N, const void *alpha, const void *Ap,
                  const void *X, const int incX,
                  const void *beta, void *Y, const int incY);
-void cblas_cgeru(const enum CBLAS_ORDER Order, const int M, const int N,
+void cblas_cgeru(const CBLAS_ORDER Order, const int M, const int N,
                  const void *alpha, const void *X, const int incX,
                  const void *Y, const int incY, void *A, const int lda);
-void cblas_cgerc(const enum CBLAS_ORDER Order, const int M, const int N,
+void cblas_cgerc(const CBLAS_ORDER Order, const int M, const int N,
                  const void *alpha, const void *X, const int incX,
                  const void *Y, const int incY, void *A, const int lda);
-void cblas_cher(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_cher(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                 const int N, const float alpha, const void *X, const int incX,
                 void *A, const int lda);
-void cblas_chpr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_chpr(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                 const int N, const float alpha, const void *X,
                 const int incX, void *A);
-void cblas_cher2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const int N,
+void cblas_cher2(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo, const int N,
                 const void *alpha, const void *X, const int incX,
                 const void *Y, const int incY, void *A, const int lda);
-void cblas_chpr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const int N,
+void cblas_chpr2(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo, const int N,
                 const void *alpha, const void *X, const int incX,
                 const void *Y, const int incY, void *Ap);
 
-void cblas_zhemv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_zhemv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                  const int N, const void *alpha, const void *A,
                  const int lda, const void *X, const int incX,
                  const void *beta, void *Y, const int incY);
-void cblas_zhbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_zhbmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                  const int N, const int K, const void *alpha, const void *A,
                  const int lda, const void *X, const int incX,
                  const void *beta, void *Y, const int incY);
-void cblas_zhpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_zhpmv(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                  const int N, const void *alpha, const void *Ap,
                  const void *X, const int incX,
                  const void *beta, void *Y, const int incY);
-void cblas_zgeru(const enum CBLAS_ORDER Order, const int M, const int N,
+void cblas_zgeru(const CBLAS_ORDER Order, const int M, const int N,
                  const void *alpha, const void *X, const int incX,
                  const void *Y, const int incY, void *A, const int lda);
-void cblas_zgerc(const enum CBLAS_ORDER Order, const int M, const int N,
+void cblas_zgerc(const CBLAS_ORDER Order, const int M, const int N,
                  const void *alpha, const void *X, const int incX,
                  const void *Y, const int incY, void *A, const int lda);
-void cblas_zher(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_zher(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                 const int N, const double alpha, const void *X, const int incX,
                 void *A, const int lda);
-void cblas_zhpr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+void cblas_zhpr(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
                 const int N, const double alpha, const void *X,
                 const int incX, void *A);
-void cblas_zher2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const int N,
+void cblas_zher2(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo, const int N,
                 const void *alpha, const void *X, const int incX,
                 const void *Y, const int incY, void *A, const int lda);
-void cblas_zhpr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const int N,
+void cblas_zhpr2(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo, const int N,
                 const void *alpha, const void *X, const int incX,
                 const void *Y, const int incY, void *Ap);
 
@@ -437,123 +437,123 @@ void cblas_zhpr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const
 /*
  * Routines with standard 4 prefixes (S, D, C, Z)
  */
-void cblas_sgemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_TRANSPOSE TransB, const int M, const int N,
+void cblas_sgemm(const CBLAS_ORDER Order, const CBLAS_TRANSPOSE TransA,
+                 const CBLAS_TRANSPOSE TransB, const int M, const int N,
                  const int K, const float alpha, const float *A,
                  const int lda, const float *B, const int ldb,
                  const float beta, float *C, const int ldc);
-void cblas_ssymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const int M, const int N,
+void cblas_ssymm(const CBLAS_ORDER Order, const CBLAS_SIDE Side,
+                 const CBLAS_UPLO Uplo, const int M, const int N,
                  const float alpha, const float *A, const int lda,
                  const float *B, const int ldb, const float beta,
                  float *C, const int ldc);
-void cblas_ssyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+void cblas_ssyrk(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE Trans, const int N, const int K,
                  const float alpha, const float *A, const int lda,
                  const float beta, float *C, const int ldc);
-void cblas_ssyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+void cblas_ssyr2k(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                  const CBLAS_TRANSPOSE Trans, const int N, const int K,
                   const float alpha, const float *A, const int lda,
                   const float *B, const int ldb, const float beta,
                   float *C, const int ldc);
-void cblas_strmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_DIAG Diag, const int M, const int N,
+void cblas_strmm(const CBLAS_ORDER Order, const CBLAS_SIDE Side,
+                 const CBLAS_UPLO Uplo, const CBLAS_TRANSPOSE TransA,
+                 const CBLAS_DIAG Diag, const int M, const int N,
                  const float alpha, const float *A, const int lda,
                  float *B, const int ldb);
-void cblas_strsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_DIAG Diag, const int M, const int N,
+void cblas_strsm(const CBLAS_ORDER Order, const CBLAS_SIDE Side,
+                 const CBLAS_UPLO Uplo, const CBLAS_TRANSPOSE TransA,
+                 const CBLAS_DIAG Diag, const int M, const int N,
                  const float alpha, const float *A, const int lda,
                  float *B, const int ldb);
 
-void cblas_dgemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_TRANSPOSE TransB, const int M, const int N,
+void cblas_dgemm(const CBLAS_ORDER Order, const CBLAS_TRANSPOSE TransA,
+                 const CBLAS_TRANSPOSE TransB, const int M, const int N,
                  const int K, const double alpha, const double *A,
                  const int lda, const double *B, const int ldb,
                  const double beta, double *C, const int ldc);
-void cblas_dsymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const int M, const int N,
+void cblas_dsymm(const CBLAS_ORDER Order, const CBLAS_SIDE Side,
+                 const CBLAS_UPLO Uplo, const int M, const int N,
                  const double alpha, const double *A, const int lda,
                  const double *B, const int ldb, const double beta,
                  double *C, const int ldc);
-void cblas_dsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+void cblas_dsyrk(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE Trans, const int N, const int K,
                  const double alpha, const double *A, const int lda,
                  const double beta, double *C, const int ldc);
-void cblas_dsyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+void cblas_dsyr2k(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                  const CBLAS_TRANSPOSE Trans, const int N, const int K,
                   const double alpha, const double *A, const int lda,
                   const double *B, const int ldb, const double beta,
                   double *C, const int ldc);
-void cblas_dtrmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_DIAG Diag, const int M, const int N,
+void cblas_dtrmm(const CBLAS_ORDER Order, const CBLAS_SIDE Side,
+                 const CBLAS_UPLO Uplo, const CBLAS_TRANSPOSE TransA,
+                 const CBLAS_DIAG Diag, const int M, const int N,
                  const double alpha, const double *A, const int lda,
                  double *B, const int ldb);
-void cblas_dtrsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_DIAG Diag, const int M, const int N,
+void cblas_dtrsm(const CBLAS_ORDER Order, const CBLAS_SIDE Side,
+                 const CBLAS_UPLO Uplo, const CBLAS_TRANSPOSE TransA,
+                 const CBLAS_DIAG Diag, const int M, const int N,
                  const double alpha, const double *A, const int lda,
                  double *B, const int ldb);
 
-void cblas_cgemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_TRANSPOSE TransB, const int M, const int N,
+void cblas_cgemm(const CBLAS_ORDER Order, const CBLAS_TRANSPOSE TransA,
+                 const CBLAS_TRANSPOSE TransB, const int M, const int N,
                  const int K, const void *alpha, const void *A,
                  const int lda, const void *B, const int ldb,
                  const void *beta, void *C, const int ldc);
-void cblas_csymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const int M, const int N,
+void cblas_csymm(const CBLAS_ORDER Order, const CBLAS_SIDE Side,
+                 const CBLAS_UPLO Uplo, const int M, const int N,
                  const void *alpha, const void *A, const int lda,
                  const void *B, const int ldb, const void *beta,
                  void *C, const int ldc);
-void cblas_csyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+void cblas_csyrk(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE Trans, const int N, const int K,
                  const void *alpha, const void *A, const int lda,
                  const void *beta, void *C, const int ldc);
-void cblas_csyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+void cblas_csyr2k(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                  const CBLAS_TRANSPOSE Trans, const int N, const int K,
                   const void *alpha, const void *A, const int lda,
                   const void *B, const int ldb, const void *beta,
                   void *C, const int ldc);
-void cblas_ctrmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_DIAG Diag, const int M, const int N,
+void cblas_ctrmm(const CBLAS_ORDER Order, const CBLAS_SIDE Side,
+                 const CBLAS_UPLO Uplo, const CBLAS_TRANSPOSE TransA,
+                 const CBLAS_DIAG Diag, const int M, const int N,
                  const void *alpha, const void *A, const int lda,
                  void *B, const int ldb);
-void cblas_ctrsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_DIAG Diag, const int M, const int N,
+void cblas_ctrsm(const CBLAS_ORDER Order, const CBLAS_SIDE Side,
+                 const CBLAS_UPLO Uplo, const CBLAS_TRANSPOSE TransA,
+                 const CBLAS_DIAG Diag, const int M, const int N,
                  const void *alpha, const void *A, const int lda,
                  void *B, const int ldb);
 
-void cblas_zgemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_TRANSPOSE TransB, const int M, const int N,
+void cblas_zgemm(const CBLAS_ORDER Order, const CBLAS_TRANSPOSE TransA,
+                 const CBLAS_TRANSPOSE TransB, const int M, const int N,
                  const int K, const void *alpha, const void *A,
                  const int lda, const void *B, const int ldb,
                  const void *beta, void *C, const int ldc);
-void cblas_zsymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const int M, const int N,
+void cblas_zsymm(const CBLAS_ORDER Order, const CBLAS_SIDE Side,
+                 const CBLAS_UPLO Uplo, const int M, const int N,
                  const void *alpha, const void *A, const int lda,
                  const void *B, const int ldb, const void *beta,
                  void *C, const int ldc);
-void cblas_zsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+void cblas_zsyrk(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE Trans, const int N, const int K,
                  const void *alpha, const void *A, const int lda,
                  const void *beta, void *C, const int ldc);
-void cblas_zsyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+void cblas_zsyr2k(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                  const CBLAS_TRANSPOSE Trans, const int N, const int K,
                   const void *alpha, const void *A, const int lda,
                   const void *B, const int ldb, const void *beta,
                   void *C, const int ldc);
-void cblas_ztrmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_DIAG Diag, const int M, const int N,
+void cblas_ztrmm(const CBLAS_ORDER Order, const CBLAS_SIDE Side,
+                 const CBLAS_UPLO Uplo, const CBLAS_TRANSPOSE TransA,
+                 const CBLAS_DIAG Diag, const int M, const int N,
                  const void *alpha, const void *A, const int lda,
                  void *B, const int ldb);
-void cblas_ztrsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_DIAG Diag, const int M, const int N,
+void cblas_ztrsm(const CBLAS_ORDER Order, const CBLAS_SIDE Side,
+                 const CBLAS_UPLO Uplo, const CBLAS_TRANSPOSE TransA,
+                 const CBLAS_DIAG Diag, const int M, const int N,
                  const void *alpha, const void *A, const int lda,
                  void *B, const int ldb);
 
@@ -561,31 +561,31 @@ void cblas_ztrsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
 /*
  * Routines with prefixes C and Z only
  */
-void cblas_chemm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const int M, const int N,
+void cblas_chemm(const CBLAS_ORDER Order, const CBLAS_SIDE Side,
+                 const CBLAS_UPLO Uplo, const int M, const int N,
                  const void *alpha, const void *A, const int lda,
                  const void *B, const int ldb, const void *beta,
                  void *C, const int ldc);
-void cblas_cherk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+void cblas_cherk(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE Trans, const int N, const int K,
                  const float alpha, const void *A, const int lda,
                  const float beta, void *C, const int ldc);
-void cblas_cher2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+void cblas_cher2k(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                  const CBLAS_TRANSPOSE Trans, const int N, const int K,
                   const void *alpha, const void *A, const int lda,
                   const void *B, const int ldb, const float beta,
                   void *C, const int ldc);
-void cblas_zhemm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const int M, const int N,
+void cblas_zhemm(const CBLAS_ORDER Order, const CBLAS_SIDE Side,
+                 const CBLAS_UPLO Uplo, const int M, const int N,
                  const void *alpha, const void *A, const int lda,
                  const void *B, const int ldb, const void *beta,
                  void *C, const int ldc);
-void cblas_zherk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+void cblas_zherk(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                 const CBLAS_TRANSPOSE Trans, const int N, const int K,
                  const double alpha, const void *A, const int lda,
                  const double beta, void *C, const int ldc);
-void cblas_zher2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+void cblas_zher2k(const CBLAS_ORDER Order, const CBLAS_UPLO Uplo,
+                  const CBLAS_TRANSPOSE Trans, const int N, const int K,
                   const void *alpha, const void *A, const int lda,
                   const void *B, const int ldb, const double beta,
                   void *C, const int ldc);

--- a/sklearn/src/cblas/cblas_dgemv.c
+++ b/sklearn/src/cblas/cblas_dgemv.c
@@ -36,7 +36,7 @@
 #endif
 #include "atlas_level2.h"
 
-void cblas_dgemv(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TA,
+void cblas_dgemv(const CBLAS_ORDER Order, const CBLAS_TRANSPOSE TA,
                  const int M, const int N, const double alpha, const double *A,
                  const int lda, const double *X, const int incX,
                  const double beta, double *Y, const int incY)

--- a/sklearn/src/cblas/cblas_dger.c
+++ b/sklearn/src/cblas/cblas_dger.c
@@ -36,7 +36,7 @@
 #endif
 #include "atlas_level2.h"
 
-void cblas_dger (const enum CBLAS_ORDER Order, const int M, const int N,
+void cblas_dger (const CBLAS_ORDER Order, const int M, const int N,
                  const double alpha, const double *X, const int incX,
                  const double *Y, const int incY, double *A, const int lda)
 {

--- a/sklearn/src/cblas/cblas_sgemv.c
+++ b/sklearn/src/cblas/cblas_sgemv.c
@@ -36,7 +36,7 @@
 #endif
 #include "atlas_level2.h"
 
-void cblas_sgemv(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TA,
+void cblas_sgemv(const CBLAS_ORDER Order, const CBLAS_TRANSPOSE TA,
                  const int M, const int N, const float alpha, const float *A,
                  const int lda, const float *X, const int incX,
                  const float beta, float *Y, const int incY)

--- a/sklearn/src/cblas/cblas_sger.c
+++ b/sklearn/src/cblas/cblas_sger.c
@@ -36,7 +36,7 @@
 #endif
 #include "atlas_level2.h"
 
-void cblas_sger (const enum CBLAS_ORDER Order, const int M, const int N,
+void cblas_sger (const CBLAS_ORDER Order, const int M, const int N,
                  const float alpha, const float *X, const int incX,
                  const float *Y, const int incY, float *A, const int lda)
 {


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #13632

#### What does this implement/fix? Explain your changes.

This fixes incorrect API provided by internal CBLAS library and fixes build error then scikit-learn is being built against another CBLAS implementation (reference one or OpenBLAS).

#### Any other comments?

Actually the only commit required for sklearn being built against OpenBLAS/reference is 
`59fa8eb` that simply `typedef`s used enums (as it should be) in *.pyx. But I've also included another one that changes API of internal CBLAS library to match OpenBLAS/reference one. I strongly want to see at least `59fa8eb` to be accepted into sklearn.