### PR TITLE
Allow overwriting tags by rewriting the mechanism to use inheritance

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1596,14 +1596,16 @@ X_types
     of the ``'sparse'`` tag.
 
 
-To override the tags of a child class, one must define the `_more_tags()`
+To override the tags of a child class, one must define the `_get_tags()`
 method and return a dict with the desired tags, e.g::
 
     class MyMultiOutputEstimator(BaseEstimator):
 
-        def _more_tags(self):
-            return {'multioutput_only': True,
-                    'non_deterministic': True}
+        def _get_tags(self):
+            tags = super()._get_tags()
+            tags.update({'multioutput_only': True,
+                         'non_deterministic': True})
+            return tags
 
 In addition to the tags, estimators also need to declare any non-optional
 parameters to ``__init__`` in the ``_required_parameters`` class attribute,
@@ -1719,7 +1721,7 @@ attributes:
                       drop_intermediate=True, response_method="auto",
                       name=None, ax=None, **kwargs):
        # do computation
-       viz = RocCurveDisplay(fpr, tpr, roc_auc, 
+       viz = RocCurveDisplay(fpr, tpr, roc_auc,
                                 estimator.__class__.__name__)
        return viz.plot(ax=ax, name=name, **kwargs)
 ```

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -129,17 +129,6 @@ def _pprint(params, offset=0, printer=repr):
     return lines
 
 
-def _update_if_consistent(dict1, dict2):
-    common_keys = set(dict1.keys()).intersection(dict2.keys())
-    for key in common_keys:
-        if dict1[key] != dict2[key]:
-            raise TypeError("Inconsistent values for tag {}: {} != {}".format(
-                key, dict1[key], dict2[key]
-            ))
-    dict1.update(dict2)
-    return dict1
-
-
 class BaseEstimator:
     """Base class for all estimators in scikit-learn
 
@@ -321,18 +310,12 @@ class BaseEstimator:
             self.__dict__.update(state)
 
     def _get_tags(self):
-        collected_tags = {}
-        for base_class in inspect.getmro(self.__class__):
-            if (hasattr(base_class, '_more_tags')
-                    and base_class != self.__class__):
-                more_tags = base_class._more_tags(self)
-                collected_tags = _update_if_consistent(collected_tags,
-                                                       more_tags)
-        if hasattr(self, '_more_tags'):
-            more_tags = self._more_tags()
-            collected_tags = _update_if_consistent(collected_tags, more_tags)
         tags = _DEFAULT_TAGS.copy()
-        tags.update(collected_tags)
+        if hasattr(super(), '_get_tags'):
+            tags.update(super()._get_tags())
+        if hasattr(self, '_more_tags'):
+            tags.update(self._more_tags())
+
         return tags
 
 

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -129,7 +129,15 @@ def _pprint(params, offset=0, printer=repr):
     return lines
 
 
-class BaseEstimator:
+class TagsBase:
+    def _get_tags(self):
+        tags = _DEFAULT_TAGS.copy()
+        if hasattr(super(), '_get_tags'):
+            tags.update(super()._get_tags())
+        return tags
+
+
+class BaseEstimator(TagsBase):
     """Base class for all estimators in scikit-learn
 
     Notes
@@ -309,17 +317,8 @@ class BaseEstimator:
         except AttributeError:
             self.__dict__.update(state)
 
-    def _get_tags(self):
-        tags = _DEFAULT_TAGS.copy()
-        if hasattr(super(), '_get_tags'):
-            tags.update(super()._get_tags())
-        if hasattr(self, '_more_tags'):
-            tags.update(self._more_tags())
 
-        return tags
-
-
-class ClassifierMixin:
+class ClassifierMixin(TagsBase):
     """Mixin class for all classifiers in scikit-learn."""
     _estimator_type = "classifier"
 
@@ -351,7 +350,7 @@ class ClassifierMixin:
         return accuracy_score(y, self.predict(X), sample_weight=sample_weight)
 
 
-class RegressorMixin:
+class RegressorMixin(TagsBase):
     """Mixin class for all regression estimators in scikit-learn."""
     _estimator_type = "regressor"
 
@@ -416,7 +415,7 @@ class RegressorMixin:
                         multioutput='variance_weighted')
 
 
-class ClusterMixin:
+class ClusterMixin(TagsBase):
     """Mixin class for all cluster estimators in scikit-learn."""
     _estimator_type = "clusterer"
 
@@ -442,7 +441,7 @@ class ClusterMixin:
         return self.labels_
 
 
-class BiclusterMixin:
+class BiclusterMixin(TagsBase):
     """Mixin class for all bicluster estimators in scikit-learn"""
 
     @property
@@ -517,7 +516,7 @@ class BiclusterMixin:
         return data[row_ind[:, np.newaxis], col_ind]
 
 
-class TransformerMixin:
+class TransformerMixin(TagsBase):
     """Mixin class for all transformers in scikit-learn."""
 
     def fit_transform(self, X, y=None, **fit_params):
@@ -550,7 +549,7 @@ class TransformerMixin:
             return self.fit(X, y, **fit_params).transform(X)
 
 
-class DensityMixin:
+class DensityMixin(TagsBase):
     """Mixin class for all density estimators in scikit-learn."""
     _estimator_type = "DensityEstimator"
 
@@ -568,7 +567,7 @@ class DensityMixin:
         pass
 
 
-class OutlierMixin:
+class OutlierMixin(TagsBase):
     """Mixin class for all outlier detection estimators in scikit-learn."""
     _estimator_type = "outlier_detector"
 
@@ -594,22 +593,26 @@ class OutlierMixin:
         return self.fit(X).predict(X)
 
 
-class MetaEstimatorMixin:
+class MetaEstimatorMixin(TagsBase):
     _required_parameters = ["estimator"]
     """Mixin class for all meta estimators in scikit-learn."""
 
 
-class MultiOutputMixin(object):
+class MultiOutputMixin(TagsBase):
     """Mixin to mark estimators that support multioutput."""
-    def _more_tags(self):
-        return {'multioutput': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'multioutput': True})
+        return tags
 
 
-class _UnstableArchMixin(object):
+class _UnstableArchMixin(TagsBase):
     """Mark estimators that are non-determinstic on 32bit or PowerPC"""
-    def _more_tags(self):
-        return {'non_deterministic': (
-            _IS_32BIT or platform.machine().startswith(('ppc', 'powerpc')))}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'non_deterministic': (
+            _IS_32BIT or platform.machine().startswith(('ppc', 'powerpc')))})
+        return tags
 
 
 def is_classifier(estimator):

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -234,5 +234,7 @@ class TransformedTargetRegressor(BaseEstimator, RegressorMixin):
 
         return pred_trans
 
-    def _more_tags(self):
-        return {'poor_score': True, 'no_validation': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'poor_score': True, 'no_validation': True})
+        return tags

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -460,8 +460,10 @@ class _PLS(BaseEstimator, TransformerMixin, RegressorMixin, MultiOutputMixin,
         """
         return self.fit(X, y).transform(X, y)
 
-    def _more_tags(self):
-        return {'poor_score': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'poor_score': True})
+        return tags
 
 
 class PLSRegression(_PLS):

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -318,8 +318,10 @@ class DummyClassifier(BaseEstimator, ClassifierMixin, MultiOutputMixin):
         else:
             return [np.log(p) for p in proba]
 
-    def _more_tags(self):
-        return {'poor_score': True, 'no_validation': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'poor_score': True, 'no_validation': True})
+        return tags
 
     def score(self, X, y, sample_weight=None):
         """Returns the mean accuracy on the given test data and labels.
@@ -511,8 +513,10 @@ class DummyRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
 
         return (y, y_std) if return_std else y
 
-    def _more_tags(self):
-        return {'poor_score': True, 'no_validation': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'poor_score': True, 'no_validation': True})
+        return tags
 
     def score(self, X, y, sample_weight=None):
         """Returns the coefficient of determination R^2 of the prediction.

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -606,12 +606,14 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         check_is_fitted(self, '_predictors')
         return len(self._predictors)
 
-    def _more_tags(self):
+    def _get_tags(self):
+        tags = super()._get_tags()
         # This is not strictly True, but it's needed since
         # force_all_finite=False means accept both nans and infinite values.
         # Without the tag, common checks would fail.
         # This comment must be removed once we merge PR 13911
-        return {'allow_nan': True}
+        tags.update({'allow_nan': True})
+        return tags
 
 
 class HistGradientBoostingRegressor(BaseHistGradientBoosting, RegressorMixin):

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -361,5 +361,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
 
         return self
 
-    def _more_tags(self):
-        return {'X_types': ["dict"]}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'X_types': ["dict"]})
+        return tags

--- a/sklearn/feature_extraction/hashing.py
+++ b/sklearn/feature_extraction/hashing.py
@@ -162,5 +162,7 @@ class FeatureHasher(BaseEstimator, TransformerMixin):
 
         return X
 
-    def _more_tags(self):
-        return {'X_types': [self.input_type]}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'X_types': [self.input_type]})
+        return tags

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -535,5 +535,7 @@ class PatchExtractor(BaseEstimator):
                 image, patch_size, self.max_patches, self.random_state)
         return patches
 
-    def _more_tags(self):
-        return {'X_types': ['3darray']}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'X_types': ['3darray']})
+        return tags

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -25,7 +25,7 @@ import warnings
 import numpy as np
 import scipy.sparse as sp
 
-from ..base import BaseEstimator, TransformerMixin
+from ..base import BaseEstimator, TransformerMixin, TagsBase
 from ..preprocessing import normalize
 from .hashing import FeatureHasher
 from .stop_words import ENGLISH_STOP_WORDS
@@ -181,7 +181,7 @@ def _check_stop_list(stop):
         return frozenset(stop)
 
 
-class VectorizerMixin:
+class VectorizerMixin(TagsBase):
     """Provides common code for text vectorizers (tokenization logic)."""
 
     _white_spaces = re.compile(r"\s\s+")
@@ -739,8 +739,10 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin, TransformerMixin):
                              input_type='string', dtype=self.dtype,
                              alternate_sign=self.alternate_sign)
 
-    def _more_tags(self):
-        return {'X_types': ['string']}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'X_types': ['string']})
+        return tags
 
 
 def _document_frequency(X):
@@ -1224,8 +1226,10 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         return [t for t, i in sorted(self.vocabulary_.items(),
                                      key=itemgetter(1))]
 
-    def _more_tags(self):
-        return {'X_types': ['string']}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'X_types': ['string']})
+        return tags
 
 
 def _make_int_array():
@@ -1408,8 +1412,10 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
         self._idf_diag = sp.spdiags(value, diags=0, m=n_features,
                                     n=n_features, format='csr')
 
-    def _more_tags(self):
-        return {'X_types': 'sparse'}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'X_types': 'sparse'})
+        return tags
 
 
 class TfidfVectorizer(CountVectorizer):
@@ -1765,5 +1771,7 @@ class TfidfVectorizer(CountVectorizer):
         X = super().transform(raw_documents)
         return self._tfidf.transform(X, copy=False)
 
-    def _more_tags(self):
-        return {'X_types': ['string'], '_skip_test': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'X_types': ['string'], '_skip_test': True})
+        return tags

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -325,8 +325,10 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         check_is_fitted(self, 'estimator_')
         return self.estimator_.predict_log_proba(self.transform(X))
 
-    def _more_tags(self):
-        return {'poor_score': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'poor_score': True})
+        return tags
 
 
 class RFECV(RFE):

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -19,7 +19,8 @@ from ..utils.validation import check_X_y, check_array
 from ..utils.optimize import _check_optimize_result
 
 
-class GaussianProcessRegressor(BaseEstimator, MultiOutputMixin, RegressorMixin):
+class GaussianProcessRegressor(BaseEstimator, MultiOutputMixin,
+                               RegressorMixin):
     """Gaussian process regression (GPR).
 
     The implementation is based on Algorithm 2.1 of Gaussian Processes

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -19,8 +19,7 @@ from ..utils.validation import check_X_y, check_array
 from ..utils.optimize import _check_optimize_result
 
 
-class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
-                               MultiOutputMixin):
+class GaussianProcessRegressor(BaseEstimator, MultiOutputMixin, RegressorMixin):
     """Gaussian process regression (GPR).
 
     The implementation is based on Algorithm 2.1 of Gaussian Processes
@@ -485,5 +484,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin,
 
         return theta_opt, func_min
 
-    def _more_tags(self):
-        return {'requires_fit': False}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'requires_fit': False})
+        return tags

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -30,7 +30,7 @@ from scipy.special import kv, gamma
 from scipy.spatial.distance import pdist, cdist, squareform
 
 from ..metrics.pairwise import pairwise_kernels
-from ..base import clone
+from ..base import clone, TagsBase
 
 
 def _check_length_scale(X, length_scale):
@@ -366,7 +366,7 @@ class Kernel(metaclass=ABCMeta):
         """Returns whether the kernel is stationary. """
 
 
-class NormalizedKernelMixin:
+class NormalizedKernelMixin(TagsBase):
     """Mixin for kernels which are normalized: k(X, X)=1.
 
     .. versionadded:: 0.18
@@ -392,7 +392,7 @@ class NormalizedKernelMixin:
         return np.ones(X.shape[0])
 
 
-class StationaryKernelMixin:
+class StationaryKernelMixin(TagsBase):
     """Mixin for kernels which are stationary: k(X, Y)= f(X-Y).
 
     .. versionadded:: 0.18

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -430,8 +430,10 @@ class SimpleImputer(BaseEstimator, TransformerMixin):
 
         return X
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'allow_nan': True})
+        return tags
 
 
 class MissingIndicator(BaseEstimator, TransformerMixin):
@@ -697,6 +699,8 @@ class MissingIndicator(BaseEstimator, TransformerMixin):
 
         return imputer_mask
 
-    def _more_tags(self):
-        return {'allow_nan': True,
-                'X_types': ['2darray', 'string']}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'allow_nan': True,
+                     'X_types': ['2darray', 'string']})
+        return tags

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -684,5 +684,7 @@ class IterativeImputer(BaseEstimator, TransformerMixin):
         self.fit_transform(X)
         return self
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'allow_nan': True})
+        return tags

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -415,5 +415,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         if hasattr(self, '_necessary_X_') and hasattr(self, '_necessary_y_'):
             self._build_f(self._necessary_X_, self._necessary_y_)
 
-    def _more_tags(self):
-        return {'X_types': ['1darray']}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'X_types': ['1darray']})
+        return tags

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -419,8 +419,10 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
 
         return sp.hstack(X_new)
 
-    def _more_tags(self):
-        return {'stateless': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'stateless': True})
+        return tags
 
 
 class Nystroem(BaseEstimator, TransformerMixin):

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -25,7 +25,7 @@ from scipy.special import expit
 from joblib import Parallel, delayed
 
 from ..base import (BaseEstimator, ClassifierMixin, RegressorMixin,
-                    MultiOutputMixin)
+                    MultiOutputMixin, TagsBase)
 from ..utils import check_array, check_X_y
 from ..utils.validation import FLOAT_DTYPES
 from ..utils import check_random_state
@@ -308,7 +308,7 @@ class LinearClassifierMixin(ClassifierMixin):
             return prob
 
 
-class SparseCoefMixin:
+class SparseCoefMixin(TagsBase):
     """Mixin for converting coef_ to and from CSR format.
 
     L1-regularizing estimators should inherit this.

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1794,8 +1794,10 @@ class MultiTaskElasticNet(Lasso):
         # return self for chaining fit and predict calls
         return self
 
-    def _more_tags(self):
-        return {'multioutput_only': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'multioutput_only': True})
+        return tags
 
 
 class MultiTaskLasso(MultiTaskElasticNet):
@@ -2099,8 +2101,10 @@ class MultiTaskElasticNetCV(LinearModelCV, RegressorMixin):
         self.random_state = random_state
         self.selection = selection
 
-    def _more_tags(self):
-        return {'multioutput_only': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'multioutput_only': True})
+        return tags
 
 
 class MultiTaskLassoCV(LinearModelCV, RegressorMixin):
@@ -2261,5 +2265,7 @@ class MultiTaskLassoCV(LinearModelCV, RegressorMixin):
             cv=cv, verbose=verbose, n_jobs=n_jobs, random_state=random_state,
             selection=selection)
 
-    def _more_tags(self):
-        return {'multioutput_only': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'multioutput_only': True})
+        return tags

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -198,8 +198,10 @@ class MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
 
         return np.asarray(y).T
 
-    def _more_tags(self):
-        return {'multioutput_only': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'multioutput_only': True})
+        return tags
 
 
 class MultiOutputRegressor(MultiOutputEstimator, RegressorMixin):
@@ -382,9 +384,11 @@ class MultiOutputClassifier(MultiOutputEstimator, ClassifierMixin):
         y_pred = self.predict(X)
         return np.mean(np.all(y == y_pred, axis=1))
 
-    def _more_tags(self):
+    def _get_tags(self):
         # FIXME
-        return {'_skip_test': True}
+        tags = super()._get_tags()
+        tags.update({'_skip_test': True})
+        return tags
 
 
 class _BaseChain(BaseEstimator, metaclass=ABCMeta):
@@ -648,9 +652,11 @@ class ClassifierChain(_BaseChain, ClassifierMixin, MetaEstimatorMixin):
 
         return Y_decision
 
-    def _more_tags(self):
-        return {'_skip_test': True,
-                'multioutput_only': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'_skip_test': True,
+                     'multioutput_only': True})
+        return tags
 
 
 class RegressorChain(_BaseChain, RegressorMixin, MetaEstimatorMixin):
@@ -735,5 +741,7 @@ class RegressorChain(_BaseChain, RegressorMixin, MetaEstimatorMixin):
         super().fit(X, Y)
         return self
 
-    def _more_tags(self):
-        return {'multioutput_only': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'multioutput_only': True})
+        return tags

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -635,8 +635,10 @@ class BaseDiscreteNB(BaseNB):
     coef_ = property(_get_coef)
     intercept_ = property(_get_intercept)
 
-    def _more_tags(self):
-        return {'poor_score': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'poor_score': True})
+        return tags
 
 
 class MultinomialNB(BaseDiscreteNB):

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -20,7 +20,7 @@ from joblib import Parallel, delayed, effective_n_jobs
 
 from .ball_tree import BallTree
 from .kd_tree import KDTree
-from ..base import BaseEstimator, MultiOutputMixin
+from ..base import BaseEstimator, MultiOutputMixin, TagsBase
 from ..metrics import pairwise_distances_chunked
 from ..metrics.pairwise import PAIRWISE_DISTANCE_FUNCTIONS
 from ..utils import check_X_y, check_array, gen_even_slices
@@ -298,7 +298,7 @@ def _tree_query_parallel_helper(tree, data, n_neighbors, return_distance):
     return tree.query(data, n_neighbors, return_distance)
 
 
-class KNeighborsMixin:
+class KNeighborsMixin(TagsBase):
     """Mixin for k-neighbors searches"""
 
     def _kneighbors_reduce_func(self, dist, start,
@@ -588,7 +588,7 @@ def _tree_query_radius_parallel_helper(tree, data, radius, return_distance):
     return tree.query_radius(data, radius, return_distance)
 
 
-class RadiusNeighborsMixin:
+class RadiusNeighborsMixin(TagsBase):
     """Mixin for radius-based neighbors searches"""
 
     def _radius_neighbors_reduce_func(self, dist, start,
@@ -862,7 +862,7 @@ class RadiusNeighborsMixin:
                           shape=(n_samples1, n_samples2))
 
 
-class SupervisedFloatMixin:
+class SupervisedFloatMixin(TagsBase):
     def fit(self, X, y):
         """Fit the model using X as training data and y as target values
 
@@ -882,7 +882,7 @@ class SupervisedFloatMixin:
         return self._fit(X)
 
 
-class SupervisedIntegerMixin:
+class SupervisedIntegerMixin(TagsBase):
     def fit(self, X, y):
         """Fit the model using X as training data and y as target values
 
@@ -925,7 +925,7 @@ class SupervisedIntegerMixin:
         return self._fit(X)
 
 
-class UnsupervisedMixin:
+class UnsupervisedMixin(TagsBase):
     def fit(self, X, y=None):
         """Fit the model using X as training data
 

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -144,8 +144,10 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
 
         return X_int, X_mask
 
-    def _more_tags(self):
-        return {'X_types': ['categorical']}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'X_types': ['categorical']})
+        return tags
 
 
 class OneHotEncoder(_BaseEncoder):

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -158,6 +158,8 @@ class FunctionTransformer(BaseEstimator, TransformerMixin):
 
         return func(X, **(kw_args if kw_args else {}))
 
-    def _more_tags(self):
-        return {'no_validation': True,
-                'stateless': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'no_validation': True,
+                     'stateless': True})
+        return tags

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -413,8 +413,10 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         X /= self.scale_
         return X
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'allow_nan': True})
+        return tags
 
 
 def minmax_scale(X, feature_range=(0, 1), axis=0, copy=True):
@@ -817,8 +819,10 @@ class StandardScaler(BaseEstimator, TransformerMixin):
                 X += self.mean_
         return X
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'allow_nan': True})
+        return tags
 
 
 class MaxAbsScaler(BaseEstimator, TransformerMixin):
@@ -987,8 +991,10 @@ class MaxAbsScaler(BaseEstimator, TransformerMixin):
             X *= self.scale_
         return X
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'allow_nan': True})
+        return tags
 
 
 def maxabs_scale(X, axis=0, copy=True):
@@ -1244,8 +1250,10 @@ class RobustScaler(BaseEstimator, TransformerMixin):
                 X += self.center_
         return X
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'allow_nan': True})
+        return tags
 
 
 def robust_scale(X, axis=0, with_centering=True, with_scaling=True,
@@ -1791,8 +1799,10 @@ class Normalizer(BaseEstimator, TransformerMixin):
         X = check_array(X, accept_sparse='csr')
         return normalize(X, norm=self.norm, axis=1, copy=copy)
 
-    def _more_tags(self):
-        return {'stateless': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'stateless': True})
+        return tags
 
 
 def binarize(X, threshold=0.0, copy=True):
@@ -1926,8 +1936,10 @@ class Binarizer(BaseEstimator, TransformerMixin):
         copy = copy if copy is not None else self.copy
         return binarize(X, threshold=self.threshold, copy=copy)
 
-    def _more_tags(self):
-        return {'stateless': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'stateless': True})
+        return tags
 
 
 class KernelCenterer(BaseEstimator, TransformerMixin):
@@ -2494,8 +2506,10 @@ class QuantileTransformer(BaseEstimator, TransformerMixin):
 
         return self._transform(X, inverse=True)
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'allow_nan': True})
+        return tags
 
 
 def quantile_transform(X, axis=0, n_quantiles=1000,
@@ -2980,8 +2994,10 @@ class PowerTransformer(BaseEstimator, TransformerMixin):
 
         return X
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'allow_nan': True})
+        return tags
 
 
 def power_transform(X, method='warn', standardize=True, copy=True):

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -290,8 +290,10 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y = np.asarray(y)
         return self.classes_[y]
 
-    def _more_tags(self):
-        return {'X_types': ['1dlabels']}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'X_types': ['1dlabels']})
+        return tags
 
 
 class LabelBinarizer(BaseEstimator, TransformerMixin):
@@ -526,8 +528,10 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
 
         return y_inv
 
-    def _more_tags(self):
-        return {'X_types': ['1dlabels']}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'X_types': ['1dlabels']})
+        return tags
 
 
 def label_binarize(y, classes, neg_label=0, pos_label=1, sparse_output=False):
@@ -996,5 +1000,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
             return [tuple(self.classes_.compress(indicators)) for indicators
                     in yt]
 
-    def _more_tags(self):
-        return {'X_types': ['2dlabels']}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'X_types': ['2dlabels']})
+        return tags

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -21,7 +21,7 @@ from sklearn.tree import DecisionTreeClassifier
 from sklearn.tree import DecisionTreeRegressor
 from sklearn import datasets
 
-from sklearn.base import TransformerMixin
+from sklearn.base import TransformerMixin, TagsBase
 from sklearn.utils.mocking import MockDataFrame
 import pickle
 
@@ -48,18 +48,24 @@ class T(BaseEstimator):
 
 
 class NaNTag(BaseEstimator):
-    def _more_tags(self):
-        return {'allow_nan': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'allow_nan': True})
+        return tags
 
 
 class NoNaNTag(BaseEstimator):
-    def _more_tags(self):
-        return {'allow_nan': False}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'allow_nan': False})
+        return tags
 
 
 class OverrideTag(NaNTag):
-    def _more_tags(self):
-        return {'allow_nan': False}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'allow_nan': False})
+        return tags
 
 
 class DiamondOverwriteTag(NaNTag, NoNaNTag):
@@ -397,7 +403,7 @@ def test_pickle_version_no_warning_is_issued_with_non_sklearn_estimator():
         TreeNoVersion.__module__ = module_backup
 
 
-class DontPickleAttributeMixin:
+class DontPickleAttributeMixin(TagsBase):
     def __getstate__(self):
         data = self.__dict__.copy()
         data["_attribute_not_pickled"] = None

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -475,13 +475,11 @@ def test_tag_inheritance():
     assert nan_tag_est._get_tags()['allow_nan']
     assert not no_nan_tag_est._get_tags()['allow_nan']
 
-    invalid_tags_est = OverrideTag()
-    with pytest.raises(TypeError, match="Inconsistent values for tag"):
-        invalid_tags_est._get_tags()
+    redefine_tags_est = OverrideTag()
+    assert not redefine_tags_est._get_tags()['allow_nan']
 
     diamond_tag_est = DiamondOverwriteTag()
-    with pytest.raises(TypeError, match="Inconsistent values for tag"):
-        diamond_tag_est._get_tags()
+    assert diamond_tag_est._get_tags()
 
 
 # XXX: Remove in 0.23

--- a/sklearn/utils/mocking.py
+++ b/sklearn/utils/mocking.py
@@ -133,5 +133,7 @@ class CheckingClassifier(BaseEstimator, ClassifierMixin):
             score = 0.
         return score
 
-    def _more_tags(self):
-        return {'_skip_test': True, 'X_types': ['1dlabel']}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'_skip_test': True, 'X_types': ['1dlabel']})
+        return tags

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -289,8 +289,10 @@ class UntaggedBinaryClassifier(DecisionTreeClassifier):
 
 class TaggedBinaryClassifier(UntaggedBinaryClassifier):
     # Toy classifier that only supports binary classification.
-    def _more_tags(self):
-        return {'binary_only': True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update({'binary_only': True})
+        return tags
 
 
 class RequiresPositiveYRegressor(LinearRegression):
@@ -301,8 +303,10 @@ class RequiresPositiveYRegressor(LinearRegression):
             raise ValueError('negative y values not supported!')
         return super().fit(X, y)
 
-    def _more_tags(self):
-        return {"requires_positive_y": True}
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags.update("requires_positive_y": True)
+        return tags
 
 
 def test_check_fit_score_takes_y_works_on_deprecated_fit():

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -305,7 +305,7 @@ class RequiresPositiveYRegressor(LinearRegression):
 
     def _get_tags(self):
         tags = super()._get_tags()
-        tags.update("requires_positive_y": True)
+        tags.update({"requires_positive_y": True})
         return tags
 
 


### PR DESCRIPTION
Fixes #14044.

This should work but might be considered slightly hacky.
It avoids reordering mixins and base estimator by creating a common base class.
I would argue it would be nicer to not use mixins and use inheritance instead and make the mixins ABCs.

This is semi-backward-incompatible for third-party authors. If they had a hierarchy of classes that added (different) tags in each class using ``_more_tags``, this will now break as ``_more_tags`` is only called on ``self`` and not on the full MRO.
If they only have one class which defines ``_more_tags`` I think this should work.

This rewrite basically gets rid of ``_more_tags`` which could be deprecated.
