### PR TITLE
[MRG] DOC clarify LabelEncoder's docstring

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -149,7 +149,7 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
 
 
 class OneHotEncoder(_BaseEncoder):
-    """Encode categorical integer features as a one-hot numeric array.
+    """Encode categorical features as a one-hot numeric array.
 
     The input to this transformer should be an array-like of integers or
     strings, denoting the values taken on by categorical (discrete) features.

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -211,10 +211,10 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    sklearn.preprocessing.OrdinalEncoder : Encode categorical input features
+    sklearn.preprocessing.OrdinalEncoder : Encode categorical features
         using an ordinal encoding scheme.
 
-    sklearn.preprocessing.OneHotEncoder : Encode categorical integer features
+    sklearn.preprocessing.OneHotEncoder : Encode categorical features
         as a one-hot numeric array.
     """
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -210,8 +210,11 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    sklearn.preprocessing.OrdinalEncoder : encode categorical input features
+    sklearn.preprocessing.OrdinalEncoder : Encode categorical input features
         using an ordinal encoding scheme.
+
+    sklearn.preprocessing.OneHotEncoder : Encode categorical integer features
+        as a one-hot numeric array.
     """
 
     def fit(self, y):

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -169,9 +169,10 @@ def _encode_check_unknown(values, uniques, return_mask=False):
 
 
 class LabelEncoder(BaseEstimator, TransformerMixin):
-    """Encode target labels with value between 0 and n_classes-1. This
-    transformer should be used to encode target values, *i.e.* ``y``, and not
-    the input ``X``.
+    """Encode target labels with value between 0 and n_classes-1.
+
+    This transformer should be used to encode target values, *i.e.* `y`, and
+    not the input `X`.
 
     Read more in the :ref:`User Guide <preprocessing_targets>`.
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -169,7 +169,9 @@ def _encode_check_unknown(values, uniques, return_mask=False):
 
 
 class LabelEncoder(BaseEstimator, TransformerMixin):
-    """Encode labels with value between 0 and n_classes-1.
+    """Encode target labels with value between 0 and n_classes-1. This
+    transformer should be used to encode target values, *i.e.* ``y``, and not
+    the input ``X``.
 
     Read more in the :ref:`User Guide <preprocessing_targets>`.
 
@@ -208,7 +210,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    sklearn.preprocessing.OrdinalEncoder : encode categorical features
+    sklearn.preprocessing.OrdinalEncoder : encode categorical input features
         using an ordinal encoding scheme.
     """
 


### PR DESCRIPTION
This PR is an effort to emphasize that `LabelEncoder` should not be used to encode input features. I was reminded of this when I went back to check https://github.com/scikit-learn/scikit-learn/issues/12086 . I remember I did the same mistake back in the day.