### PR TITLE
MAINT:Remove the use of assert_raises and assert_raises_regex

### DIFF
--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -15,7 +15,6 @@ from scipy import sparse
 from scipy.cluster import hierarchy
 
 from sklearn.metrics.cluster.supervised import adjusted_rand_score
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_raise_message
@@ -41,9 +40,14 @@ def test_linkage_misc():
     # Misc tests on linkage
     rng = np.random.RandomState(42)
     X = rng.normal(size=(5, 5))
-    assert_raises(ValueError, AgglomerativeClustering(linkage='foo').fit, X)
-    assert_raises(ValueError, linkage_tree, X, linkage='foo')
-    assert_raises(ValueError, linkage_tree, X, connectivity=np.ones((4, 4)))
+    with pytest.raises(ValueError):
+        AgglomerativeClustering(linkage='foo').fit(X)
+
+    with pytest.raises(ValueError):
+        linkage_tree(X, linkage='foo')
+
+    with pytest.raises(ValueError):
+        linkage_tree(X, connectivity=np.ones((4, 4)))
 
     # Smoke test FeatureAgglomeration
     FeatureAgglomeration().fit(X)
@@ -74,11 +78,11 @@ def test_structured_linkage_tree():
         assert len(children) + n_leaves == n_nodes
         # Check that ward_tree raises a ValueError with a connectivity matrix
         # of the wrong shape
-        assert_raises(ValueError,
-                      tree_builder, X.T, np.ones((4, 4)))
+        with pytest.raises(ValueError):
+            tree_builder(X.T, np.ones((4, 4)))
         # Check that fitting with no samples raises an error
-        assert_raises(ValueError,
-                      tree_builder, X.T[:0], connectivity)
+        with pytest.raises(ValueError):
+            tree_builder(X.T[:0], connectivity)
 
 
 def test_unstructured_linkage_tree():
@@ -124,7 +128,8 @@ def test_agglomerative_clustering_wrong_arg_memory():
     X = rng.randn(n_samples, 50)
     memory = 5
     clustering = AgglomerativeClustering(memory=memory)
-    assert_raises(ValueError, clustering.fit, X)
+    with pytest.raises(ValueError):
+        clustering.fit(X)
 
 
 def test_zero_cosine_linkage_tree():
@@ -179,7 +184,8 @@ def test_agglomerative_clustering():
             connectivity=sparse.lil_matrix(
                 connectivity.toarray()[:10, :10]),
             linkage=linkage)
-        assert_raises(ValueError, clustering.fit, X)
+        with pytest.raises(ValueError):
+            clustering.fit(X)
 
     # Test that using ward with another metric than euclidean raises an
     # exception
@@ -188,7 +194,8 @@ def test_agglomerative_clustering():
         connectivity=connectivity.toarray(),
         affinity="manhattan",
         linkage="ward")
-    assert_raises(ValueError, clustering.fit, X)
+    with pytest.raises(ValueError):
+        clustering.fit(X)
 
     # Test using another metric than euclidean works with linkage complete
     for affinity in PAIRED_DISTANCES.keys():
@@ -241,7 +248,8 @@ def test_ward_agglomeration():
     assert_array_almost_equal(agglo.transform(X_full), X_red)
 
     # Check that fitting with no samples raises a ValueError
-    assert_raises(ValueError, agglo.fit, X[:0])
+    with pytest.raises(ValueError):
+        agglo.fit(X[:0])
 
 
 def test_single_linkage_clustering():
@@ -302,7 +310,8 @@ def test_scikit_vs_scipy():
             assess_same_labelling(cut, cut_)
 
     # Test error management in _hc_cut
-    assert_raises(ValueError, _hc_cut, n_leaves + 1, children, n_leaves)
+    with pytest.raises(ValueError):
+        _hc_cut(n_leaves + 1, children, n_leaves)
 
 
 def test_identical_points():


### PR DESCRIPTION
removed the use of assert_raises and assert_raises_regex
from `sklearn/cluster/tests/test_hierarchical.py`

changed `assert_raises` to `with pytest.raises` context manager

fixes #14216 

I still have to complete the whole `sklearn/cluster/tests/` folder. I just wanted to get a review if any other changes are required.
Thanks!