### PR TITLE
Remove the use of assert_raises and assert_raises_regex from the tests 

### DIFF
--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -9,8 +9,8 @@ from scipy.sparse import csr_matrix
 
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils.testing import (
-    assert_array_equal, assert_raises,
-    assert_warns, assert_warns_message, assert_no_warnings)
+    assert_array_equal, assert_warns,
+    assert_warns_message, assert_no_warnings)
 
 from sklearn.cluster.affinity_propagation_ import AffinityPropagation
 from sklearn.cluster.affinity_propagation_ import (
@@ -59,12 +59,16 @@ def test_affinity_propagation():
     assert_array_equal(labels, labels_no_copy)
 
     # Test input validation
-    assert_raises(ValueError, affinity_propagation, S[:, :-1])
-    assert_raises(ValueError, affinity_propagation, S, damping=0)
+    with pytest.raises(ValueError):
+        affinity_propagation(S[:, :-1])
+    with pytest.raises(ValueError):
+        affinity_propagation(S, damping=0)
     af = AffinityPropagation(affinity="unknown")
-    assert_raises(ValueError, af.fit, X)
+    with pytest.raises(ValueError):
+        af.fit(X)
     af_2 = AffinityPropagation(affinity='precomputed')
-    assert_raises(TypeError, af_2.fit, csr_matrix((3, 3)))
+    with pytest.raises(TypeError):
+        af_2.fit(csr_matrix((3, 3)))
 
 def test_affinity_propagation_predict():
     # Test AffinityPropagation.predict
@@ -78,13 +82,15 @@ def test_affinity_propagation_predict_error():
     # Test exception in AffinityPropagation.predict
     # Not fitted.
     af = AffinityPropagation(affinity="euclidean")
-    assert_raises(ValueError, af.predict, X)
+    with pytest.raises(ValueError):
+        af.predict(X)
 
     # Predict not supported when affinity="precomputed".
     S = np.dot(X, X.T)
     af = AffinityPropagation(affinity="precomputed")
     af.fit(S)
-    assert_raises(ValueError, af.predict, X)
+    with pytest.raises(ValueError):
+        af.predict(X)
 
 
 def test_affinity_propagation_fit_non_convergence():

--- a/sklearn/cluster/tests/test_bicluster.py
+++ b/sklearn/cluster/tests/test_bicluster.py
@@ -234,10 +234,14 @@ def test_perfect_checkerboard():
 
 @pytest.mark.parametrize(
     "args",
-    [{'n_clusters': (3, 3, 3)}, {'n_clusters': 'abc'},
-     {'n_clusters': (3, 'abc')}, {'method': 'unknown'},
-     {'n_components': 0}, {'n_best': 0},
-     {'svd_method': 'unknown'}]
+    [{'n_clusters': (3, 3, 3)},
+     {'n_clusters': 'abc'},
+     {'n_clusters': (3, 'abc')},
+     {'method': 'unknown'},
+     {'n_components': 0},
+     {'n_best': 0},
+     {'svd_method': 'unknown'},
+     {'n_components': 3, 'n_best': 4}]
 )
 def test_errors(args):
     data = np.arange(25).reshape((5, 5))
@@ -246,9 +250,6 @@ def test_errors(args):
     with pytest.raises(ValueError):
         model.fit(data)
 
-    model = SpectralBiclustering(n_components=3, n_best=4)
-    with pytest.raises(ValueError):
-        model.fit(data)
 
 def test_wrong_shape():
     model = SpectralBiclustering()

--- a/sklearn/cluster/tests/test_bicluster.py
+++ b/sklearn/cluster/tests/test_bicluster.py
@@ -1,6 +1,7 @@
 """Testing for Spectral Biclustering methods"""
 
 import numpy as np
+import pytest
 from scipy.sparse import csr_matrix, issparse
 
 from sklearn.model_selection import ParameterGrid
@@ -8,7 +9,6 @@ from sklearn.model_selection import ParameterGrid
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import SkipTest
 
 from sklearn.base import BaseEstimator, BiclusterMixin
@@ -114,7 +114,8 @@ def test_spectral_biclustering():
 
                 if issparse(mat) and model.get_params().get('method') == 'log':
                     # cannot take log of sparse matrix
-                    assert_raises(ValueError, model.fit, mat)
+                    with pytest.raises(ValueError):
+                        model.fit(mat)
                     continue
                 else:
                     model.fit(mat)
@@ -235,29 +236,38 @@ def test_errors():
     data = np.arange(25).reshape((5, 5))
 
     model = SpectralBiclustering(n_clusters=(3, 3, 3))
-    assert_raises(ValueError, model.fit, data)
+    with pytest.raises(ValueError):
+        model.fit(data)
 
     model = SpectralBiclustering(n_clusters='abc')
-    assert_raises(ValueError, model.fit, data)
+    with pytest.raises(ValueError):
+        model.fit(data)
 
     model = SpectralBiclustering(n_clusters=(3, 'abc'))
-    assert_raises(ValueError, model.fit, data)
+    with pytest.raises(ValueError):
+        model.fit(data)
 
     model = SpectralBiclustering(method='unknown')
-    assert_raises(ValueError, model.fit, data)
+    with pytest.raises(ValueError):
+        model.fit(data)
 
     model = SpectralBiclustering(svd_method='unknown')
-    assert_raises(ValueError, model.fit, data)
+    with pytest.raises(ValueError):
+        model.fit(data)
 
     model = SpectralBiclustering(n_components=0)
-    assert_raises(ValueError, model.fit, data)
+    with pytest.raises(ValueError):
+        model.fit(data)
 
     model = SpectralBiclustering(n_best=0)
-    assert_raises(ValueError, model.fit, data)
+    with pytest.raises(ValueError):
+        model.fit(data)
 
     model = SpectralBiclustering(n_components=3, n_best=4)
-    assert_raises(ValueError, model.fit, data)
+    with pytest.raises(ValueError):
+        model.fit(data)
 
     model = SpectralBiclustering()
     data = np.arange(27).reshape((3, 3, 3))
-    assert_raises(ValueError, model.fit, data)
+    with pytest.raises(ValueError):
+        model.fit(data)

--- a/sklearn/cluster/tests/test_bicluster.py
+++ b/sklearn/cluster/tests/test_bicluster.py
@@ -250,6 +250,7 @@ def test_errors(args):
     with pytest.raises(ValueError):
         model.fit(data)
 
+def test_wrong_shape():
     model = SpectralBiclustering()
     data = np.arange(27).reshape((3, 3, 3))
     with pytest.raises(ValueError):

--- a/sklearn/cluster/tests/test_bicluster.py
+++ b/sklearn/cluster/tests/test_bicluster.py
@@ -232,34 +232,17 @@ def test_perfect_checkerboard():
                            (rows, cols)) == 1
 
 
-def test_errors():
+@pytest.mark.parametrize(
+    "args",
+    [{'n_clusters': (3, 3, 3)}, {'n_clusters': 'abc'},
+     {'n_clusters': (3, 'abc')}, {'method':'unknown'},
+     {'n_components': 0}, {'n_best': 0},
+     {'svd_method': 'unknown'}]
+)
+def test_errors(args):
     data = np.arange(25).reshape((5, 5))
 
-    model = SpectralBiclustering(n_clusters=(3, 3, 3))
-    with pytest.raises(ValueError):
-        model.fit(data)
-
-    model = SpectralBiclustering(n_clusters='abc')
-    with pytest.raises(ValueError):
-        model.fit(data)
-
-    model = SpectralBiclustering(n_clusters=(3, 'abc'))
-    with pytest.raises(ValueError):
-        model.fit(data)
-
-    model = SpectralBiclustering(method='unknown')
-    with pytest.raises(ValueError):
-        model.fit(data)
-
-    model = SpectralBiclustering(svd_method='unknown')
-    with pytest.raises(ValueError):
-        model.fit(data)
-
-    model = SpectralBiclustering(n_components=0)
-    with pytest.raises(ValueError):
-        model.fit(data)
-
-    model = SpectralBiclustering(n_best=0)
+    model = SpectralBiclustering(**args)
     with pytest.raises(ValueError):
         model.fit(data)
 

--- a/sklearn/cluster/tests/test_bicluster.py
+++ b/sklearn/cluster/tests/test_bicluster.py
@@ -235,7 +235,7 @@ def test_perfect_checkerboard():
 @pytest.mark.parametrize(
     "args",
     [{'n_clusters': (3, 3, 3)}, {'n_clusters': 'abc'},
-     {'n_clusters': (3, 'abc')}, {'method':'unknown'},
+     {'n_clusters': (3, 'abc')}, {'method': 'unknown'},
      {'n_components': 0}, {'n_best': 0},
      {'svd_method': 'unknown'}]
 )

--- a/sklearn/cluster/tests/test_birch.py
+++ b/sklearn/cluster/tests/test_birch.py
@@ -4,6 +4,7 @@ Tests for the birch clustering algorithm.
 
 from scipy import sparse
 import numpy as np
+import pytest
 
 from sklearn.cluster.tests.common import generate_clustered_data
 from sklearn.cluster.birch import Birch
@@ -16,7 +17,6 @@ from sklearn.metrics import pairwise_distances_argmin, v_measure_score
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
 
 
@@ -87,7 +87,8 @@ def test_n_clusters():
     # Test that the wrong global clustering step raises an Error.
     clf = ElasticNet()
     brc3 = Birch(n_clusters=clf)
-    assert_raises(ValueError, brc3.fit, X)
+    with pytest.raises(ValueError):
+        brc3.fit(X)
 
     # Test that a small number of clusters raises a warning.
     brc4 = Birch(threshold=10000.)
@@ -134,7 +135,8 @@ def test_branching_factor():
 
     # Raises error when branching_factor is set to one.
     brc = Birch(n_clusters=None, branching_factor=1, threshold=0.01)
-    assert_raises(ValueError, brc.fit, X)
+    with pytest.raises(ValueError):
+        brc.fit(X)
 
 
 def check_threshold(birch_instance, threshold):

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -12,7 +12,6 @@ from scipy import sparse
 import pytest
 
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raises
 from sklearn.neighbors import NearestNeighbors
 from sklearn.cluster.dbscan_ import DBSCAN
 from sklearn.cluster.dbscan_ import dbscan
@@ -224,21 +223,16 @@ def test_input_validation():
 
 def test_dbscan_badargs():
     # Test bad argument values: these should all raise ValueErrors
-    assert_raises(ValueError,
-                  dbscan,
-                  X, eps=-1.0)
-    assert_raises(ValueError,
-                  dbscan,
-                  X, algorithm='blah')
-    assert_raises(ValueError,
-                  dbscan,
-                  X, metric='blah')
-    assert_raises(ValueError,
-                  dbscan,
-                  X, leaf_size=-1)
-    assert_raises(ValueError,
-                  dbscan,
-                  X, p=-1)
+    with pytest.raises(ValueError):
+        dbscan(X, eps=-1.0)
+    with pytest.raises(ValueError):
+        dbscan(X, algorithm='blah')
+    with pytest.raises(ValueError):
+        dbscan(X, metric='blah')
+    with pytest.raises(ValueError):
+        dbscan(X, leaf_size=-1)
+    with pytest.raises(ValueError):
+        dbscan(X, p=-1)
 
 
 def test_pickle():
@@ -260,8 +254,10 @@ def test_boundaries():
 
 def test_weighted_dbscan():
     # ensure sample_weight is validated
-    assert_raises(ValueError, dbscan, [[0], [1]], sample_weight=[2])
-    assert_raises(ValueError, dbscan, [[0], [1]], sample_weight=[2, 3, 4])
+    with pytest.raises(ValueError):
+        dbscan([[0], [1]], sample_weight=[2])
+    with pytest.raises(ValueError):
+        dbscan([[0], [1]], sample_weight=[2, 3, 4])
 
     # ensure sample_weight has an effect
     assert_array_equal([], dbscan([[0], [1]], sample_weight=None,

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -220,19 +220,15 @@ def test_input_validation():
     X = [[1., 2.], [3., 4.]]
     DBSCAN().fit(X)             # must not raise exception
 
-
-def test_dbscan_badargs():
+@pytest.mark.parametrize(
+    "args",
+    [{'eps': -1.0}, {'algorithm': 'blah'}, {'metric': 'blah'},
+     {'leaf_size': -1}, {'p': -1}]
+)
+def test_dbscan_badargs(args):
     # Test bad argument values: these should all raise ValueErrors
     with pytest.raises(ValueError):
-        dbscan(X, eps=-1.0)
-    with pytest.raises(ValueError):
-        dbscan(X, algorithm='blah')
-    with pytest.raises(ValueError):
-        dbscan(X, metric='blah')
-    with pytest.raises(ValueError):
-        dbscan(X, leaf_size=-1)
-    with pytest.raises(ValueError):
-        dbscan(X, p=-1)
+        dbscan(X, **args)
 
 
 def test_pickle():

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -220,6 +220,7 @@ def test_input_validation():
     X = [[1., 2.], [3., 4.]]
     DBSCAN().fit(X)             # must not raise exception
 
+
 @pytest.mark.parametrize(
     "args",
     [{'eps': -1.0}, {'algorithm': 'blah'}, {'metric': 'blah'},

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -10,8 +10,6 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import assert_almost_equal
-from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import if_safe_multiprocessing_with_blas
@@ -243,7 +241,8 @@ def test_k_means_precompute_distances_flag():
     # check that a warning is raised if the precompute_distances flag is not
     # supported
     km = KMeans(precompute_distances="wrong")
-    assert_raises(ValueError, km.fit, X)
+    with pytest.raises(ValueError):
+        km.fit(X)
 
 
 def test_k_means_plus_plus_init_not_precomputed():
@@ -272,8 +271,10 @@ def test_k_means_n_init():
 
     # two regression tests on bad n_init argument
     # previous bug: n_init <= 0 threw non-informative TypeError (#3858)
-    assert_raises_regex(ValueError, "n_init", KMeans(n_init=0).fit, X)
-    assert_raises_regex(ValueError, "n_init", KMeans(n_init=-1).fit, X)
+    with pytest.raises(ValueError, match="n_init"):
+        KMeans(n_init=0).fit(X)
+    with pytest.raises(ValueError, match="n_init"):
+        KMeans(n_init=-1).fit(X)
 
 
 @pytest.mark.parametrize('Class', [KMeans, MiniBatchKMeans])
@@ -286,21 +287,25 @@ def test_k_means_explicit_init_shape(Class):
     # mismatch of number of features
     km = Class(n_init=1, init=X[:, :2], n_clusters=len(X))
     msg = "does not match the number of features of the data"
-    assert_raises_regex(ValueError, msg, km.fit, X)
+    with pytest.raises(ValueError, match=msg):
+        km.fit(X)
     # for callable init
     km = Class(n_init=1,
                init=lambda X_, k, random_state: X_[:, :2],
                n_clusters=len(X))
-    assert_raises_regex(ValueError, msg, km.fit, X)
+    with pytest.raises(ValueError, match=msg):
+        km.fit(X)
     # mismatch of number of clusters
     msg = "does not match the number of clusters"
     km = Class(n_init=1, init=X[:2, :], n_clusters=3)
-    assert_raises_regex(ValueError, msg, km.fit, X)
+    with pytest.raises(ValueError, match=msg):
+        km.fit(X)
     # for callable init
     km = Class(n_init=1,
                init=lambda X_, k, random_state: X_[:2, :],
                n_clusters=3)
-    assert_raises_regex(ValueError, msg, km.fit, X)
+    with pytest.raises(ValueError, match=msg):
+        km.fit(X)
 
 
 def test_k_means_fortran_aligned_data():
@@ -488,9 +493,8 @@ def test_sparse_mb_k_means_callable_init():
     # Small test to check that giving the wrong number of centers
     # raises a meaningful error
     msg = "does not match the number of clusters"
-    assert_raises_regex(ValueError, msg, MiniBatchKMeans(init=test_init,
-                                                         random_state=42).fit,
-                        X_csr)
+    with pytest.raises(ValueError, match=msg):
+        MiniBatchKMeans(init=test_init, random_state=42).fit(X_csr)
 
     # Now check that the fit actually works
     mb_k_means = MiniBatchKMeans(n_clusters=3, init=test_init,
@@ -536,7 +540,8 @@ def test_minibatch_set_init_size():
 @pytest.mark.parametrize("Estimator", [KMeans, MiniBatchKMeans])
 def test_k_means_invalid_init(Estimator):
     km = Estimator(init="invalid", n_init=1, n_clusters=n_clusters)
-    assert_raises(ValueError, km.fit, X)
+    with pytest.raises(ValueError):
+        km.fit(X)
 
 
 def test_k_means_copyx():
@@ -718,8 +723,8 @@ def test_k_means_function():
                  sample_weight=None, init=centers)
 
     # to many clusters desired
-    assert_raises(ValueError, k_means, X, n_clusters=X.shape[0] + 1,
-                  sample_weight=None)
+    with pytest.raises(ValueError):
+        k_means(X, n_clusters=X.shape[0] + 1, sample_weight=None)
 
     # kmeans for algorithm='elkan' raises TypeError on sparse matrix
     assert_raise_message(TypeError, "algorithm='elkan' not supported for "
@@ -827,7 +832,8 @@ def test_sparse_validate_centers():
 
     msg = r"The shape of the initial centers \(\(4L?, 4L?\)\) " \
           "does not match the number of clusters 3"
-    assert_raises_regex(ValueError, msg, classifier.fit, X)
+    with pytest.raises(ValueError, match=msg):
+        classifier.fit(X)
 
 
 def test_less_centers_than_unique_points():

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -9,7 +9,6 @@ import pickle
 
 from sklearn.utils import check_random_state
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns_message
 
 from sklearn.cluster import SpectralClustering, spectral_clustering
@@ -68,8 +67,9 @@ def test_spectral_unknown_mode():
     D = pairwise_distances(X)  # Distance matrix
     S = np.max(D) - D  # Similarity matrix
     S = sparse.coo_matrix(S)
-    assert_raises(ValueError, spectral_clustering, S, n_clusters=2,
-                  random_state=0, eigen_solver="<unknown>")
+    with pytest.raises(ValueError):
+        spectral_clustering(S, n_clusters=2, random_state=0,
+                            eigen_solver="<unknown>")
 
 
 def test_spectral_unknown_assign_labels():
@@ -84,8 +84,9 @@ def test_spectral_unknown_assign_labels():
     D = pairwise_distances(X)  # Distance matrix
     S = np.max(D) - D  # Similarity matrix
     S = sparse.coo_matrix(S)
-    assert_raises(ValueError, spectral_clustering, S, n_clusters=2,
-                  random_state=0, assign_labels="<unknown>")
+    with pytest.raises(ValueError):
+        spectral_clustering(S, n_clusters=2, random_state=0,
+                            assign_labels="<unknown>")
 
 
 def test_spectral_clustering_sparse():
@@ -145,7 +146,8 @@ def test_affinities():
 
     # raise error on unknown affinity
     sp = SpectralClustering(n_clusters=2, affinity='<unknown>')
-    assert_raises(ValueError, sp.fit, X)
+    with pytest.raises(ValueError):
+        sp.fit(X)
 
 
 @pytest.mark.parametrize('n_samples', [50, 100, 150, 500])
@@ -199,9 +201,9 @@ def test_spectral_clustering_with_arpack_amg_solvers():
             graph, n_clusters=2, eigen_solver='amg', random_state=0)
         assert adjusted_rand_score(labels_arpack, labels_amg) == 1
     else:
-        assert_raises(
-            ValueError, spectral_clustering,
-            graph, n_clusters=2, eigen_solver='amg', random_state=0)
+        with pytest.raises(ValueError):
+            spectral_clustering(graph, n_clusters=2, eigen_solver='amg',
+                                random_state=0)
 
 
 def test_n_components():


### PR DESCRIPTION
This is a follow up on my PR https://github.com/scikit-learn/scikit-learn/pull/14645
This completes the replacement of `assert_raises` and `assert_raises_regex` with 
the `with pytest.raises` context manager.


related to #14216 