### PR TITLE
add dcg_score and ndcg_score to api reference

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -879,6 +879,7 @@ details.
    metrics.classification_report
    metrics.cohen_kappa_score
    metrics.confusion_matrix
+   metrics.dcg_score
    metrics.f1_score
    metrics.fbeta_score
    metrics.hamming_loss
@@ -887,6 +888,7 @@ details.
    metrics.log_loss
    metrics.matthews_corrcoef
    metrics.multilabel_confusion_matrix
+   metrics.ndcg_score
    metrics.precision_recall_curve
    metrics.precision_recall_fscore_support
    metrics.precision_score


### PR DESCRIPTION
makes sure that the docs get actually rendered as well