### PR TITLE
clarify that sklearn.metric.pairwise doesn't provide callables for pairwise_kernel

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1678,8 +1678,8 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
         If metric is "precomputed", X is assumed to be a kernel matrix.
         Alternatively, if metric is a callable function, it is called on each
         pair of instances (rows) and the resulting value recorded. The callable
-        should take two rows from X as input and return the corresponding kernel
-        value as a single number. This means that callables from
+        should take two rows from X as input and return the corresponding
+        kernel value as a single number. This means that callables from
         `sklearn.metrics.pairwise` are not allowed, as they operate on
         matrices, not single samples. Use the string identifying the kernel
         instead.

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1678,8 +1678,8 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
         If metric is "precomputed", X is assumed to be a kernel matrix.
         Alternatively, if metric is a callable function, it is called on each
         pair of instances (rows) and the resulting value recorded. The callable
-        should take two rows from X as input and return a value indicating
-        the distance between them. This means that callables from
+        should take two rows from X as input and return the corresponding kernel
+        value as a single number. This means that callables from
         ``sklearn.metrics.pairwise`` are not allowed, as they operate on
         matrices, not single samples. Use the string identifying the kernel
         instead.

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1678,8 +1678,10 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
         If metric is "precomputed", X is assumed to be a kernel matrix.
         Alternatively, if metric is a callable function, it is called on each
         pair of instances (rows) and the resulting value recorded. The callable
-        should take two arrays from X as input and return a value indicating
-        the distance between them.
+        should take two rows from X as input and return a value indicating
+        the distance between them. This means that callables from
+        sklearn.metrics.pairwise are not allowed, as they operate on matrices,
+        not single samples. Use the string identifying this metric instead.
 
     filter_params : boolean
         Whether to filter invalid parameters or not.

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1681,7 +1681,7 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
         should take two rows from X as input and return a value indicating
         the distance between them. This means that callables from
         ``sklearn.metrics.pairwise`` are not allowed, as they operate on
-        matrices, not single samples. Use the string identifying this metric
+        matrices, not single samples. Use the string identifying the kernel
         instead.
 
     filter_params : boolean

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1680,7 +1680,7 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
         pair of instances (rows) and the resulting value recorded. The callable
         should take two rows from X as input and return the corresponding kernel
         value as a single number. This means that callables from
-        ``sklearn.metrics.pairwise`` are not allowed, as they operate on
+        `sklearn.metrics.pairwise` are not allowed, as they operate on
         matrices, not single samples. Use the string identifying the kernel
         instead.
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1680,8 +1680,9 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
         pair of instances (rows) and the resulting value recorded. The callable
         should take two rows from X as input and return a value indicating
         the distance between them. This means that callables from
-        sklearn.metrics.pairwise are not allowed, as they operate on matrices,
-        not single samples. Use the string identifying this metric instead.
+        ``sklearn.metrics.pairwise`` are not allowed, as they operate on
+        matrices, not single samples. Use the string identifying this metric
+        instead.
 
     filter_params : boolean
         Whether to filter invalid parameters or not.


### PR DESCRIPTION
Fixes #10890. Closes #13111.

Changing the current behavior in the suggested way just means that computations are unnecessarily slower because the user didn't read the docstring carefully. 