### PR TITLE
[MRG] cache get_params to improve clone performance

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -156,7 +156,7 @@ class BaseEstimator:
     def _get_param_names(cls):
         params = cls._param_names_cache.get(cls, None)
         if params is not None:
-            return copy.copy(params)
+            return [*params]
 
         """Get parameter names for the estimator"""
         # fetch the constructor or the original constructor before
@@ -184,7 +184,7 @@ class BaseEstimator:
         sorted_parameters = sorted([p.name for p in parameters])
         cls._param_names_cache[cls] = sorted_parameters
 
-        return copy.copy(sorted_parameters)
+        return [*sorted_parameters]
 
     def get_params(self, deep=True):
         """Get parameters for this estimator.

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -149,15 +149,15 @@ class BaseEstimator:
     at the class level in their ``__init__`` as explicit keyword
     arguments (no ``*args`` or ``**kwargs``).
     """
-	
-	_param_names_cache = dict()
+
+    _param_names_cache = dict()
 
     @classmethod
     def _get_param_names(cls):
-	    params = _param_names_cache.get(cls, None)
+        params = _param_names_cache.get(cls, None)
         if params is not None:
-            return params		
-	
+            return params
+
         """Get parameter names for the estimator"""
         # fetch the constructor or the original constructor before
         # deprecation wrapping if any
@@ -182,9 +182,9 @@ class BaseEstimator:
                                    % (cls, init_signature))
         # Extract and sort argument names excluding 'self'
         sorted_parameters = sorted([p.name for p in parameters])
-		_param_names_cache[cls] = sorted_parameters
-		
-		return sorted_parameters
+        _param_names_cache[cls] = sorted_parameters
+
+        return sorted_parameters
 
     def get_params(self, deep=True):
         """Get parameters for this estimator.

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -149,9 +149,15 @@ class BaseEstimator:
     at the class level in their ``__init__`` as explicit keyword
     arguments (no ``*args`` or ``**kwargs``).
     """
+	
+	_param_names_cache = dict()
 
     @classmethod
     def _get_param_names(cls):
+	    params = _param_names_cache.get(cls, None)
+        if params is not None:
+            return params		
+	
         """Get parameter names for the estimator"""
         # fetch the constructor or the original constructor before
         # deprecation wrapping if any
@@ -175,7 +181,10 @@ class BaseEstimator:
                                    " follow this convention."
                                    % (cls, init_signature))
         # Extract and sort argument names excluding 'self'
-        return sorted([p.name for p in parameters])
+        sorted_parameters = sorted([p.name for p in parameters])
+		_param_names_cache[cls] = sorted_parameters
+		
+		return sorted_parameters
 
     def get_params(self, deep=True):
         """Get parameters for this estimator.

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -154,7 +154,7 @@ class BaseEstimator:
 
     @classmethod
     def _get_param_names(cls):
-        params = _param_names_cache.get(cls, None)
+        params = cls._param_names_cache.get(cls, None)
         if params is not None:
             return params
 
@@ -182,7 +182,7 @@ class BaseEstimator:
                                    % (cls, init_signature))
         # Extract and sort argument names excluding 'self'
         sorted_parameters = sorted([p.name for p in parameters])
-        _param_names_cache[cls] = sorted_parameters
+        cls._param_names_cache[cls] = sorted_parameters
 
         return sorted_parameters
 

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -150,7 +150,7 @@ class BaseEstimator:
     arguments (no ``*args`` or ``**kwargs``).
     """
 
-    _param_names_cache = dict()
+    _param_names_cache = {}
 
     @classmethod
     def _get_param_names(cls):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -156,7 +156,7 @@ class BaseEstimator:
     def _get_param_names(cls):
         params = cls._param_names_cache.get(cls, None)
         if params is not None:
-            return params
+            return copy.copy(params)
 
         """Get parameter names for the estimator"""
         # fetch the constructor or the original constructor before
@@ -184,7 +184,7 @@ class BaseEstimator:
         sorted_parameters = sorted([p.name for p in parameters])
         cls._param_names_cache[cls] = sorted_parameters
 
-        return sorted_parameters
+        return copy.copy(sorted_parameters)
 
     def get_params(self, deep=True):
         """Get parameters for this estimator.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

In our use case (Bayesian optimization) - "get_params" takes about 30% of the total time of the run. From a quick look it seems like it's using signature which can be very heavy when run multiple times. Since signature is class based and not object based (obviously) this can be cached (not too many classes around so no worries about memory implications). for us it improved our runtime by 30%.
Let me know what you think! 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
