### PR TITLE
Fix LassoLars copy_X comment format

### DIFF
--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -1021,7 +1021,7 @@ class LassoLars(Lars):
         the tolerance of the optimization.
         By default, ``np.finfo(np.float).eps`` is used.
 
-    copy_X : bool default=True
+    copy_X : bool, default=True
         If True, X will be copied; else, it may be overwritten.
 
     fit_path : bool, default=True


### PR DESCRIPTION
#### Reference Issues/PRs

Add missing comma in comment in PR #14512.

#### What does this implement/fix? Explain your changes.

Comma is missing in comment regressing documentation parsing.

@amueller, @NicolasHug