### PR TITLE
MNT:Remove the use of assert_raises and assert_raises_regex 

### DIFF
--- a/sklearn/covariance/tests/test_covariance.py
+++ b/sklearn/covariance/tests/test_covariance.py
@@ -5,11 +5,11 @@
 # License: BSD 3 clause
 
 import numpy as np
+import pytest
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
 
 from sklearn import datasets
@@ -38,8 +38,8 @@ def test_covariance():
         cov.error_norm(emp_cov, scaling=False), 0)
     assert_almost_equal(
         cov.error_norm(emp_cov, squared=False), 0)
-    assert_raises(NotImplementedError,
-                  cov.error_norm, emp_cov, norm='foo')
+    with pytest.raises(NotImplementedError):
+        cov.error_norm(emp_cov, norm='foo')
     # Mahalanobis distances computation test
     mahal_dist = cov.mahalanobis(X)
     assert np.amin(mahal_dist) > 0

--- a/sklearn/covariance/tests/test_elliptic_envelope.py
+++ b/sklearn/covariance/tests/test_elliptic_envelope.py
@@ -3,8 +3,9 @@ Testing for Elliptic Envelope algorithm (sklearn.covariance.elliptic_envelope).
 """
 
 import numpy as np
+import pytest
+
 from sklearn.covariance import EllipticEnvelope
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
@@ -15,8 +16,10 @@ def test_elliptic_envelope():
     rnd = np.random.RandomState(0)
     X = rnd.randn(100, 10)
     clf = EllipticEnvelope(contamination=0.1)
-    assert_raises(NotFittedError, clf.predict, X)
-    assert_raises(NotFittedError, clf.decision_function, X)
+    with pytest.raises(NotFittedError):
+        clf.predict(X)
+    with pytest.raises(NotFittedError):
+        clf.decision_function(X)
     clf.fit(X)
     y_pred = clf.predict(X)
     scores = clf.score_samples(X)


### PR DESCRIPTION
from `sklearn/covariance/tests/`

Replaced `assert_raises` and `assert_raises_regex` with
the `with pytest.raises` context manager

related to #14216
