### PR TITLE
MNT: datasets tests

### DIFF
--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -29,7 +29,6 @@ from sklearn.datasets.tests.test_common import check_return_X_y
 
 from sklearn.externals._pilutil import pillow_installed
 
-from sklearn.utils.testing import assert_raises
 from sklearn.utils import IS_PYPY
 
 
@@ -169,8 +168,8 @@ def test_load_sample_image():
 
 def test_load_missing_sample_image_error():
     if pillow_installed:
-        assert_raises(AttributeError, load_sample_image,
-                      'blop.jpg')
+        with pytest.raises(AttributeError):
+            load_sample_image('blop.jpg')
     else:
         warnings.warn("Could not load sample images, PIL is not available.")
 

--- a/sklearn/datasets/tests/test_lfw.py
+++ b/sklearn/datasets/tests/test_lfw.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import tempfile
 import numpy as np
+import pytest
 from functools import partial
 from sklearn.externals._pilutil import pillow_installed, imsave
 from sklearn.datasets import fetch_lfw_pairs
@@ -20,7 +21,6 @@ from sklearn.datasets import fetch_lfw_people
 
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import SkipTest
-from sklearn.utils.testing import assert_raises
 from sklearn.datasets.tests.test_common import check_return_X_y
 
 
@@ -105,8 +105,9 @@ def teardown_module():
 
 
 def test_load_empty_lfw_people():
-    assert_raises(IOError, fetch_lfw_people, data_home=SCIKIT_LEARN_EMPTY_DATA,
-                  download_if_missing=False)
+    with pytest.raises(IOError):
+        fetch_lfw_people(data_home=SCIKIT_LEARN_EMPTY_DATA,
+                         download_if_missing=False)
 
 
 def test_load_fake_lfw_people():
@@ -149,14 +150,15 @@ def test_load_fake_lfw_people():
 
 
 def test_load_fake_lfw_people_too_restrictive():
-    assert_raises(ValueError, fetch_lfw_people, data_home=SCIKIT_LEARN_DATA,
-                  min_faces_per_person=100, download_if_missing=False)
+    with pytest.raises(ValueError):
+        fetch_lfw_people(data_home=SCIKIT_LEARN_DATA, min_faces_per_person=100,
+                         download_if_missing=False)
 
 
 def test_load_empty_lfw_pairs():
-    assert_raises(IOError, fetch_lfw_pairs,
-                  data_home=SCIKIT_LEARN_EMPTY_DATA,
-                  download_if_missing=False)
+    with pytest.raises(IOError):
+        fetch_lfw_pairs(data_home=SCIKIT_LEARN_EMPTY_DATA,
+                        download_if_missing=False)
 
 
 def test_load_fake_lfw_pairs():

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -469,6 +469,6 @@ def test_make_circles():
             "Samples not correctly distributed across circles.")
 
     with pytest.raises(ValueError):
-       make_circles(factor=-0.01)
+        make_circles(factor=-0.01)
     with pytest.raises(ValueError):
         make_circles(factor=1.)

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -9,7 +9,6 @@ import scipy.sparse as sp
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raise_message
 
 from sklearn.datasets import make_classification
@@ -130,18 +129,21 @@ def test_make_classification_informative_features():
                                                       "centered on hypercube "
                                                       "vertices")
                 else:
-                    assert_raises(AssertionError,
-                                  assert_array_almost_equal,
-                                  np.abs(centroid) / class_sep,
-                                  np.ones(n_informative),
-                                  decimal=5,
-                                  err_msg="Clusters should not be centered "
-                                          "on hypercube vertices")
+                    with pytest.raises(AssertionError):
+                        assert_array_almost_equal(np.abs(centroid) / class_sep,
+                                                  np.ones(n_informative),
+                                                  decimal=5,
+                                                  err_msg="Clusters should "
+                                                          "not be centered "
+                                                          "on hypercube "
+                                                          "vertices")
 
-    assert_raises(ValueError, make, n_features=2, n_informative=2, n_classes=5,
-                  n_clusters_per_class=1)
-    assert_raises(ValueError, make, n_features=2, n_informative=2, n_classes=3,
-                  n_clusters_per_class=2)
+    with pytest.raises(ValueError):
+        make(n_features=2, n_informative=2, n_classes=5,
+             n_clusters_per_class=1)
+    with pytest.raises(ValueError):
+        make(n_features=2, n_informative=2, n_classes=3,
+             n_clusters_per_class=2)
 
 
 def test_make_multilabel_classification_return_sequences():
@@ -466,5 +468,7 @@ def test_make_circles():
         assert X[y == 1].shape == (n_inner, 2), (
             "Samples not correctly distributed across circles.")
 
-    assert_raises(ValueError, make_circles, factor=-0.01)
-    assert_raises(ValueError, make_circles, factor=1.)
+    with pytest.raises(ValueError):
+       make_circles(factor=-0.01)
+    with pytest.raises(ValueError):
+        make_circles(factor=1.)

--- a/sklearn/datasets/tests/test_svmlight_format.py
+++ b/sklearn/datasets/tests/test_svmlight_format.py
@@ -11,8 +11,6 @@ import pytest
 
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.testing import fails_if_pypy
 
 import sklearn
@@ -107,7 +105,8 @@ def test_load_svmlight_file_n_features():
         assert X[i, j] == val
 
     # 21 features in file
-    assert_raises(ValueError, load_svmlight_file, datafile, n_features=20)
+    with pytest.raises(ValueError):
+        load_svmlight_file(datafile, n_features=20)
 
 
 def test_load_compressed():
@@ -139,16 +138,19 @@ def test_load_compressed():
 
 
 def test_load_invalid_file():
-    assert_raises(ValueError, load_svmlight_file, invalidfile)
+    with pytest.raises(ValueError):
+        load_svmlight_file(invalidfile)
 
 
 def test_load_invalid_order_file():
-    assert_raises(ValueError, load_svmlight_file, invalidfile2)
+    with pytest.raises(ValueError):
+        load_svmlight_file(invalidfile2)
 
 
 def test_load_zero_based():
     f = BytesIO(b"-1 4:1.\n1 0:1\n")
-    assert_raises(ValueError, load_svmlight_file, f, zero_based=False)
+    with pytest.raises(ValueError):
+        load_svmlight_file(f, zero_based=False)
 
 
 def test_load_zero_based_auto():
@@ -197,18 +199,20 @@ def test_load_large_qid():
 
 
 def test_load_invalid_file2():
-    assert_raises(ValueError, load_svmlight_files,
-                  [datafile, invalidfile, datafile])
+    with pytest.raises(ValueError):
+        load_svmlight_files([datafile, invalidfile, datafile])
 
 
 def test_not_a_filename():
     # in python 3 integers are valid file opening arguments (taken as unix
     # file descriptors)
-    assert_raises(TypeError, load_svmlight_file, .42)
+    with pytest.raises(TypeError):
+        load_svmlight_file(.42)
 
 
 def test_invalid_filename():
-    assert_raises(IOError, load_svmlight_file, "trou pic nic douille")
+    with pytest.raises(IOError):
+        load_svmlight_file("trou pic nic douille")
 
 
 def test_dump():
@@ -342,8 +346,8 @@ def test_dump_comment():
     # XXX we have to update this to support Python 3.x
     utf8_comment = b"It is true that\n\xc2\xbd\xc2\xb2 = \xc2\xbc"
     f = BytesIO()
-    assert_raises(UnicodeDecodeError,
-                  dump_svmlight_file, X, y, f, comment=utf8_comment)
+    with pytest.raises(UnicodeDecodeError):
+        dump_svmlight_file(X, y, f, comment=utf8_comment)
 
     unicode_comment = utf8_comment.decode("utf-8")
     f = BytesIO()
@@ -355,8 +359,8 @@ def test_dump_comment():
     assert_array_almost_equal(y, y2)
 
     f = BytesIO()
-    assert_raises(ValueError,
-                  dump_svmlight_file, X, y, f, comment="I've got a \0.")
+    with pytest.raises(ValueError):
+        dump_svmlight_file(X, y, f, comment="I've got a \0.")
 
 
 def test_dump_invalid():
@@ -364,10 +368,12 @@ def test_dump_invalid():
 
     f = BytesIO()
     y2d = [y]
-    assert_raises(ValueError, dump_svmlight_file, X, y2d, f)
+    with pytest.raises(ValueError):
+        dump_svmlight_file(X, y2d, f)
 
     f = BytesIO()
-    assert_raises(ValueError, dump_svmlight_file, X, y[:-1], f)
+    with pytest.raises(ValueError):
+       dump_svmlight_file(X, y[:-1], f)
 
 
 def test_dump_query_id():
@@ -511,5 +517,5 @@ def test_load_offset_exhaustive_splits():
 
 
 def test_load_with_offsets_error():
-    assert_raises_regex(ValueError, "n_features is required",
-                        load_svmlight_file, datafile, offset=3, length=3)
+    with pytest.raises(ValueError, match="n_features is required"):
+        load_svmlight_file(datafile, offset=3, length=3)

--- a/sklearn/datasets/tests/test_svmlight_format.py
+++ b/sklearn/datasets/tests/test_svmlight_format.py
@@ -373,7 +373,7 @@ def test_dump_invalid():
 
     f = BytesIO()
     with pytest.raises(ValueError):
-       dump_svmlight_file(X, y[:-1], f)
+        dump_svmlight_file(X, y[:-1], f)
 
 
 def test_dump_query_id():


### PR DESCRIPTION
 fix `assert_raises` and `assert_raises_regex` in ` sklearn/datasets/tests/`.

replaced them with `with pytest.raises(TheException)` context manager

related to #14216
