### PR TITLE
ENH: adds support for list of list for multilabel_indicator target types

### DIFF
--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -915,7 +915,7 @@ def test_multilabel_representation_invariance():
 def test_raise_value_error_multilabel_sequences(name):
     # make sure the multilabel-sequence format raises ValueError
     multilabel_sequences = [
-        [[0, 1], [1]],
+        [[0, 1], [1]], # the initial value was a valid multi_label.
         [[1], [2], [0, 1]],
         [(), (2), (0, 1)],
         [[]],

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -914,8 +914,8 @@ def test_multilabel_representation_invariance():
 @pytest.mark.parametrize('name', sorted(MULTILABELS_METRICS))
 def test_raise_value_error_multilabel_sequences(name):
     # make sure the multilabel-sequence format raises ValueError
+    # [[1, 2]] is a valid multi-label object
     multilabel_sequences = [
-        [[0, 1]],
         [[1], [2], [0, 1]],
         [(), (2), (0, 1)],
         [[]],

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -915,7 +915,7 @@ def test_multilabel_representation_invariance():
 def test_raise_value_error_multilabel_sequences(name):
     # make sure the multilabel-sequence format raises ValueError
     multilabel_sequences = [
-        [[0, 1], [1]], # the initial value was a valid multi_label.
+        [[0, 1], [1]],
         [[1], [2], [0, 1]],
         [(), (2), (0, 1)],
         [[]],

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -914,8 +914,8 @@ def test_multilabel_representation_invariance():
 @pytest.mark.parametrize('name', sorted(MULTILABELS_METRICS))
 def test_raise_value_error_multilabel_sequences(name):
     # make sure the multilabel-sequence format raises ValueError
-    # [[1, 2]] is a valid multi-label object
     multilabel_sequences = [
+        [[0, 1], [1]],
         [[1], [2], [0, 1]],
         [(), (2), (0, 1)],
         [[]],

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -422,3 +422,15 @@ def test_ovr_decision_function():
                                              n_classes)[0] for i in range(4)]
 
     assert_allclose(dec_values, dec_values_one, atol=1e-6)
+
+
+def type_of_target_is_consistent_for_array_like_entities():
+    y_list = [[1, 1], [0, 1]]
+    y_np_ndarray = np.asarray(y_list)
+
+    expected_type_of_target = "multilable_indicator"
+    type_of_target_list = type_of_target(y_list)
+    type_of_target_nd_array = type_of_target(y_np_ndarray)
+
+    assert type_of_target_list == expected_type_of_target
+    assert type_of_target_list == type_of_target_nd_array


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

Fixes [#14671](https://github.com/scikit-learn/scikit-learn/issues/14671)
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This PR fixes the bug referenced above. 
Initially, 
```
from sklearn.utils.multiclass import type_of_targets
import numpy as np
x = [[1, 2]]
assert type_of_targets(x) == assert type_of_targets(np.array(x)) 
```
results in an error, although it shouldn't. My changes fixes this. 

I fixed the bug my refactoring the function `multiclass.is_multilabel` (which type_of_tagets depends on)  to accept numpy arrays  as well as lists. I also added tests to verify that the bug is fixed. 



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->