### PR TITLE
[MRG] Use return_X_y=True with load_boston where appropriate

### DIFF
--- a/doc/modules/compose.rst
+++ b/doc/modules/compose.rst
@@ -256,9 +256,7 @@ variable::
   >>> from sklearn.preprocessing import QuantileTransformer
   >>> from sklearn.linear_model import LinearRegression
   >>> from sklearn.model_selection import train_test_split
-  >>> boston = load_boston()
-  >>> X = boston.data
-  >>> y = boston.target
+  >>> X, y = load_boston(return_X_y=True)
   >>> transformer = QuantileTransformer(output_distribution='normal')
   >>> regressor = LinearRegression()
   >>> regr = TransformedTargetRegressor(regressor=regressor,

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -1132,17 +1132,15 @@ Usage
 
 The following example shows how to fit the VotingRegressor::
 
-   >>> from sklearn import datasets
+   >>> from sklearn.datasets import load_boston
    >>> from sklearn.ensemble import GradientBoostingRegressor
    >>> from sklearn.ensemble import RandomForestRegressor
    >>> from sklearn.linear_model import LinearRegression
    >>> from sklearn.ensemble import VotingRegressor
 
    >>> # Loading some example data
-   >>> boston = datasets.load_boston()
-   >>> X = boston.data
-   >>> y = boston.target
-
+   >>> X, y = load_boston(return_X_y=True)
+   
    >>> # Training classifiers
    >>> reg1 = GradientBoostingRegressor(random_state=1, n_estimators=10)
    >>> reg2 = RandomForestRegressor(random_state=1, n_estimators=10)

--- a/examples/applications/plot_model_complexity_influence.py
+++ b/examples/applications/plot_model_complexity_influence.py
@@ -44,12 +44,12 @@ np.random.seed(0)
 
 def generate_data(case, sparse=False):
     """Generate regression/classification data."""
-    bunch = None
     if case == 'regression':
-        bunch = datasets.load_boston()
+        X, y = datasets.load_boston(return_X_y=True)
     elif case == 'classification':
-        bunch = datasets.fetch_20newsgroups_vectorized(subset='all')
-    X, y = shuffle(bunch.data, bunch.target)
+        X, y = datasets.fetch_20newsgroups_vectorized(subset='all',
+                                                      return_X_y=True)
+    X, y = shuffle(X, y)
     offset = int(X.shape[0] * 0.8)
     X_train, y_train = X[:offset], y[:offset]
     X_test, y_test = X[offset:], y[offset:]

--- a/examples/ensemble/plot_voting_regressor.py
+++ b/examples/ensemble/plot_voting_regressor.py
@@ -23,9 +23,7 @@ from sklearn.linear_model import LinearRegression
 from sklearn.ensemble import VotingRegressor
 
 # Loading some example data
-boston = datasets.load_boston()
-X = boston.data
-y = boston.target
+X, y = datasets.load_boston(return_X_y=True)
 
 # Training classifiers
 reg1 = GradientBoostingRegressor(random_state=1, n_estimators=10)

--- a/examples/feature_selection/plot_select_from_model_boston.py
+++ b/examples/feature_selection/plot_select_from_model_boston.py
@@ -19,8 +19,7 @@ from sklearn.feature_selection import SelectFromModel
 from sklearn.linear_model import LassoCV
 
 # Load the boston dataset.
-boston = load_boston()
-X, y = boston['data'], boston['target']
+X, y = load_boston(return_X_y=True)
 
 # We use the base estimator LassoCV since the L1 norm promotes sparsity of features.
 clf = LassoCV()

--- a/examples/model_selection/plot_cv_predict.py
+++ b/examples/model_selection/plot_cv_predict.py
@@ -13,12 +13,11 @@ from sklearn import linear_model
 import matplotlib.pyplot as plt
 
 lr = linear_model.LinearRegression()
-boston = datasets.load_boston()
-y = boston.target
+X, y = datasets.load_boston(return_X_y=True)
 
 # cross_val_predict returns an array of the same size as `y` where each entry
 # is a prediction obtained by cross validation:
-predicted = cross_val_predict(lr, boston.data, y, cv=10)
+predicted = cross_val_predict(lr, X, y, cv=10)
 
 fig, ax = plt.subplots()
 ax.scatter(y, predicted, edgecolors=(0, 0, 0))

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -724,8 +724,8 @@ def load_boston(return_X_y=False):
     Examples
     --------
     >>> from sklearn.datasets import load_boston
-    >>> boston = load_boston()
-    >>> print(boston.data.shape)
+    >>> X, y = load_boston(return_X_y=True)
+    >>> print(X.shape)
     (506, 13)
     """
     module_path = dirname(__file__)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
@@ -13,9 +13,9 @@ from sklearn.ensemble._hist_gradient_boosting.types import (
 
 @pytest.mark.parametrize('max_bins', [200, 256])
 def test_boston_dataset(max_bins):
-    boston = load_boston()
+    X, y = load_boston(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(
-        boston.data, boston.target, random_state=42)
+        X, y, random_state=42)
 
     mapper = _BinMapper(max_bins=max_bins, random_state=42)
     X_train_binned = mapper.fit_transform(X_train)

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -32,8 +32,7 @@ from sklearn.dummy import DummyRegressor
 iris = datasets.load_iris()
 X, y = iris.data[:, 1:3], iris.target
 
-boston = datasets.load_boston()
-X_r, y_r = boston.data, boston.target
+X_r, y_r = datasets.load_boston(return_X_y=True)
 
 
 def test_estimator_init():

--- a/sklearn/inspection/tests/test_permutation_importance.py
+++ b/sklearn/inspection/tests/test_permutation_importance.py
@@ -26,8 +26,7 @@ def test_permutation_importance_correlated_feature_regression(n_jobs):
     rng = np.random.RandomState(42)
     n_repeats = 5
 
-    dataset = load_boston()
-    X, y = dataset.data, dataset.target
+    X, y = load_boston(return_X_y=True)
     y_with_little_noise = (
         y + rng.normal(scale=0.001, size=y.shape[0])).reshape(-1, 1)
 

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -555,8 +555,7 @@ def test_warm_start_convergence():
 
 
 def test_warm_start_convergence_with_regularizer_decrement():
-    boston = load_boston()
-    X, y = boston.data, boston.target
+    X, y = load_boston(return_X_y=True)
 
     # Train a model to converge on a lightly regularized problem
     final_alpha = 1e-5

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -765,8 +765,7 @@ def test_cross_val_score_multilabel():
 
 
 def test_cross_val_predict():
-    boston = load_boston()
-    X, y = boston.data, boston.target
+    X, y = load_boston(return_X_y=True)
     cv = KFold()
 
     est = Ridge()

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -1078,9 +1078,9 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
     >>> from sklearn.datasets import load_boston
     >>> from sklearn.model_selection import cross_val_score
     >>> from sklearn.tree import DecisionTreeRegressor
-    >>> boston = load_boston()
+    >>> X, y = load_boston(return_X_y=True)
     >>> regressor = DecisionTreeRegressor(random_state=0)
-    >>> cross_val_score(regressor, boston.data, boston.target, cv=10)
+    >>> cross_val_score(regressor, X, y, cv=10)
     ...                    # doctest: +SKIP
     ...
     array([ 0.61..., 0.57..., -0.34..., 0.41..., 0.75...,

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -328,8 +328,7 @@ def check_estimator(Estimator):
 def _boston_subset(n_samples=200):
     global BOSTON
     if BOSTON is None:
-        boston = load_boston()
-        X, y = boston.data, boston.target
+        X, y = load_boston(return_X_y=True)
         X, y = shuffle(X, y, random_state=0)
         X, y = X[:n_samples], y[:n_samples]
         X = StandardScaler().fit_transform(X)
@@ -2408,8 +2407,7 @@ def check_set_params(name, estimator_orig):
 def check_classifiers_regression_target(name, estimator_orig):
     # Check if classifier throws an exception when fed regression targets
 
-    boston = load_boston()
-    X, y = boston.data, boston.target
+    X, y = load_boston(return_X_y=True)
     e = clone(estimator_orig)
     msg = 'Unknown label type: '
     if not _safe_tags(e, "no_validation"):


### PR DESCRIPTION
#### Reference Issues/PRs
Partially addresses #14347 (Use return_X_y=True when applicable in examples)

#### What does this implement/fix? Explain your changes.
Changes how `load_boston` is used in examples and tests where applicable.

#### Any other comments?
*

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
