### PR TITLE
MAINT Remove the use of assert_raises* in decomposition

### DIFF
--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -9,7 +9,6 @@ from sklearn.utils import check_array
 
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import TempMemmap
 
@@ -218,7 +217,8 @@ def test_dict_learning_nonzero_coefs():
 def test_dict_learning_unknown_fit_algorithm():
     n_components = 5
     dico = DictionaryLearning(n_components, fit_algorithm='<unknown>')
-    assert_raises(ValueError, dico.fit, X)
+    with pytest.raises(ValueError):
+        dico.fit(X)
 
 
 def test_dict_learning_split():
@@ -466,7 +466,8 @@ def test_unknown_method():
     n_components = 12
     rng = np.random.RandomState(0)
     V = rng.randn(n_components, n_features)  # random init
-    assert_raises(ValueError, sparse_encode, X, V, algorithm="<unknown>")
+    with pytest.raises(ValueError):
+        sparse_encode(X, V, algorithm="<unknown>")
 
 
 def test_sparse_coder_estimator():

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -3,9 +3,9 @@
 # License: BSD3
 
 import numpy as np
+import pytest
 
 from sklearn.utils.testing import assert_warns
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.exceptions import ConvergenceWarning
@@ -32,10 +32,12 @@ def test_factor_analysis():
     # wlog, mean is 0
     X = np.dot(h, W) + noise
 
-    assert_raises(ValueError, FactorAnalysis, svd_method='foo')
+    with pytest.raises(ValueError):
+        FactorAnalysis(svd_method='foo')
     fa_fail = FactorAnalysis()
     fa_fail.svd_method = 'foo'
-    assert_raises(ValueError, fa_fail.fit, X)
+    with pytest.raises(ValueError):
+        fa_fail.fit(X)
     fas = []
     for method in ['randomized', 'lapack']:
         fa = FactorAnalysis(n_components=n_components, svd_method=method)
@@ -60,7 +62,8 @@ def test_factor_analysis():
         assert diff < 0.1, "Mean absolute difference is %f" % diff
         fa = FactorAnalysis(n_components=n_components,
                             noise_variance_init=np.ones(n_features))
-        assert_raises(ValueError, fa.fit, X[:, :2])
+        with pytest.raises(ValueError):
+            fa.fit(X[:, :2])
 
     f = lambda x, y: np.abs(getattr(x, y))  # sign will not be equal
     fa1, fa2 = fas

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -11,8 +11,6 @@ from scipy import stats
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_warns
-from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import assert_raises_regex
 
 from sklearn.decomposition import FastICA, fastica, PCA
 from sklearn.decomposition.fastica_ import _gs_decorrelation
@@ -85,15 +83,15 @@ def test_fastica_simple(add_noise, seed):
         if whiten:
             k_, mixing_, s_ = fastica(m.T, fun=nl, algorithm=algo,
                                       random_state=rng)
-            assert_raises(ValueError, fastica, m.T, fun=np.tanh,
-                          algorithm=algo)
+            with pytest.raises(ValueError):
+                fastica(m.T, fun=np.tanh, algorithm=algo)
         else:
             pca = PCA(n_components=2, whiten=True, random_state=rng)
             X = pca.fit_transform(m.T)
             k_, mixing_, s_ = fastica(X, fun=nl, algorithm=algo, whiten=False,
                                       random_state=rng)
-            assert_raises(ValueError, fastica, X, fun=np.tanh,
-                          algorithm=algo)
+            with pytest.raises(ValueError):
+                fastica(X, fun=np.tanh, algorithm=algo)
         s_ = s_.T
         # Check that the mixing model described in the docstring holds:
         if whiten:
@@ -131,9 +129,11 @@ def test_fastica_simple(add_noise, seed):
 
     for fn in [np.tanh, "exp(-.5(x^2))"]:
         ica = FastICA(fun=fn, algorithm=algo)
-        assert_raises(ValueError, ica.fit, m.T)
+        with pytest.raises(ValueError):
+            ica.fit(m.T)
 
-    assert_raises(TypeError, FastICA(fun=range(10)).fit, m.T)
+    with pytest.raises(TypeError):
+        FastICA(fun=range(10)).fit(m.T)
 
 
 def test_fastica_nowhiten():
@@ -270,13 +270,13 @@ def test_fastica_errors():
     rng = np.random.RandomState(0)
     X = rng.random_sample((n_samples, n_features))
     w_init = rng.randn(n_features + 1, n_features + 1)
-    assert_raises_regex(ValueError, 'max_iter should be greater than 1',
-                        FastICA, max_iter=0)
-    assert_raises_regex(ValueError, r'alpha must be in \[1,2\]',
-                        fastica, X, fun_args={'alpha': 0})
-    assert_raises_regex(ValueError, 'w_init has invalid shape.+'
-                        r'should be \(3L?, 3L?\)',
-                        fastica, X, w_init=w_init)
-    assert_raises_regex(ValueError,
-                        'Invalid algorithm.+must be.+parallel.+or.+deflation',
-                        fastica, X, algorithm='pizza')
+    with pytest.raises(ValueError, match='max_iter should be greater than 1'):
+        FastICA(max_iter=0)
+    with pytest.raises(ValueError, match=r'alpha must be in \[1,2\]'):
+        fastica(X, fun_args={'alpha': 0})
+    with pytest.raises(ValueError, match='w_init has invalid shape.+'
+                       r'should be \(3L?, 3L?\)'):
+        fastica(X, w_init=w_init)
+    with pytest.raises(ValueError, match='Invalid algorithm.+must '
+                       'be.+parallel.+or.+deflation'):
+        fastica(X, algorithm='pizza')

--- a/sklearn/decomposition/tests/test_incremental_pca.py
+++ b/sklearn/decomposition/tests/test_incremental_pca.py
@@ -4,8 +4,6 @@ import pytest
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.testing import assert_allclose_dense_sparse
 
 from sklearn import datasets
@@ -115,20 +113,19 @@ def test_incremental_pca_validation():
     X = np.array([[0, 1, 0], [1, 0, 0]])
     n_samples, n_features = X.shape
     for n_components in [-1, 0, .99, 4]:
-        assert_raises_regex(ValueError,
-                            "n_components={} invalid for n_features={}, need"
-                            " more rows than columns for IncrementalPCA "
-                            "processing".format(n_components, n_features),
-                            IncrementalPCA(n_components, batch_size=10).fit, X)
+        with pytest.raises(ValueError, match="n_components={} invalid"
+                           " for n_features={}, need more rows than"
+                           " columns for IncrementalPCA"
+                           " processing".format(n_components,
+                           n_features)):
+            IncrementalPCA(n_components, batch_size=10).fit(X)
 
     # Tests that n_components is also <= n_samples.
     n_components = 3
-    assert_raises_regex(ValueError,
-                        "n_components={} must be less or equal to "
-                        "the batch number of samples {}".format(
-                            n_components, n_samples),
-                        IncrementalPCA(
-                            n_components=n_components).partial_fit, X)
+    with pytest.raises(ValueError, match="n_components={} must be"
+                       " less or equal to the batch number of"
+                       " samples {}".format( n_components, n_samples)):
+        IncrementalPCA(n_components=n_components).partial_fit(X)
 
 
 def test_n_components_none():
@@ -161,10 +158,12 @@ def test_incremental_pca_set_params():
     ipca.fit(X)
     # Decreasing number of components
     ipca.set_params(n_components=10)
-    assert_raises(ValueError, ipca.partial_fit, X2)
+    with pytest.raises(ValueError):
+        ipca.partial_fit(X2)
     # Increasing number of components
     ipca.set_params(n_components=15)
-    assert_raises(ValueError, ipca.partial_fit, X3)
+    with pytest.raises(ValueError):
+       ipca.partial_fit(X3)
     # Returning to original setting
     ipca.set_params(n_components=20)
     ipca.partial_fit(X)
@@ -178,7 +177,8 @@ def test_incremental_pca_num_features_change():
     X2 = rng.randn(n_samples, 50)
     ipca = IncrementalPCA(n_components=None)
     ipca.fit(X)
-    assert_raises(ValueError, ipca.partial_fit, X2)
+    with pytest.raises(ValueError):
+        ipca.partial_fit(X2)
 
 
 def test_incremental_pca_batch_signs():

--- a/sklearn/decomposition/tests/test_incremental_pca.py
+++ b/sklearn/decomposition/tests/test_incremental_pca.py
@@ -117,14 +117,14 @@ def test_incremental_pca_validation():
                            " for n_features={}, need more rows than"
                            " columns for IncrementalPCA"
                            " processing".format(n_components,
-                           n_features)):
+                                                n_features)):
             IncrementalPCA(n_components, batch_size=10).fit(X)
 
     # Tests that n_components is also <= n_samples.
     n_components = 3
     with pytest.raises(ValueError, match="n_components={} must be"
                        " less or equal to the batch number of"
-                       " samples {}".format( n_components, n_samples)):
+                       " samples {}".format(n_components, n_samples)):
         IncrementalPCA(n_components=n_components).partial_fit(X)
 
 
@@ -163,7 +163,7 @@ def test_incremental_pca_set_params():
     # Increasing number of components
     ipca.set_params(n_components=15)
     with pytest.raises(ValueError):
-       ipca.partial_fit(X3)
+        ipca.partial_fit(X3)
     # Returning to original setting
     ipca.set_params(n_components=20)
     ipca.partial_fit(X)

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -3,7 +3,7 @@ import scipy.sparse as sp
 import pytest
 
 from sklearn.utils.testing import (assert_array_almost_equal,
-                                   assert_raises, assert_allclose)
+                                   assert_allclose)
 
 from sklearn.decomposition import PCA, KernelPCA
 from sklearn.datasets import make_circles
@@ -53,8 +53,8 @@ def test_kernel_pca():
 
 
 def test_kernel_pca_invalid_parameters():
-    assert_raises(ValueError, KernelPCA, 10, fit_inverse_transform=True,
-                  kernel='precomputed')
+    with pytest.raises(ValueError):
+        KernelPCA(10, fit_inverse_transform=True, kernel='precomputed')
 
 
 def test_kernel_pca_consistent_transform():
@@ -210,7 +210,8 @@ def test_kernel_pca_invalid_kernel():
     rng = np.random.RandomState(0)
     X_fit = rng.random_sample((2, 4))
     kpca = KernelPCA(kernel="tototiti")
-    assert_raises(ValueError, kpca.fit, X_fit)
+    with pytest.raises(ValueError):
+        kpca.fit(X_fit)
 
 
 # 0.23. warning about tol not having its correct default value.

--- a/sklearn/decomposition/tests/test_online_lda.py
+++ b/sklearn/decomposition/tests/test_online_lda.py
@@ -14,7 +14,6 @@ from sklearn.decomposition._online_lda import (_dirichlet_expectation_1d,
 from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_almost_equal
-from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils.testing import if_safe_multiprocessing_with_blas
 
 from sklearn.exceptions import NotFittedError
@@ -149,8 +148,8 @@ def test_lda_partial_fit_dim_mismatch():
                                     learning_offset=5., total_samples=20,
                                     random_state=rng)
     lda.partial_fit(X_1)
-    assert_raises_regexp(ValueError, r"^The provided data has",
-                         lda.partial_fit, X_2)
+    with pytest.raises(ValueError, match=r"^The provided data has"):
+        lda.partial_fit(X_2)
 
 
 def test_invalid_params():
@@ -166,7 +165,8 @@ def test_invalid_params():
     )
     for param, model in invalid_models:
         regex = r"^Invalid %r parameter" % param
-        assert_raises_regexp(ValueError, regex, model.fit, X)
+        with pytest.raises(ValueError, match=regex):
+            model.fit(X)
 
 
 def test_lda_negative_input():
@@ -174,7 +174,8 @@ def test_lda_negative_input():
     X = np.full((5, 10), -1.)
     lda = LatentDirichletAllocation()
     regex = r"^Negative values in data passed"
-    assert_raises_regexp(ValueError, regex, lda.fit, X)
+    with pytest.raises(ValueError, match=regex):
+        lda.fit(X)
 
 
 def test_lda_no_component_error():
@@ -184,7 +185,8 @@ def test_lda_no_component_error():
     lda = LatentDirichletAllocation()
     regex = ("This LatentDirichletAllocation instance is not fitted yet. "
              "Call 'fit' with appropriate arguments before using this method.")
-    assert_raises_regexp(NotFittedError, regex, lda.perplexity, X)
+    with pytest.raises(NotFittedError, match=regex):
+        lda.perplexity(X)
 
 
 def test_lda_transform_mismatch():
@@ -197,8 +199,8 @@ def test_lda_transform_mismatch():
     lda = LatentDirichletAllocation(n_components=n_components,
                                     random_state=rng)
     lda.partial_fit(X)
-    assert_raises_regexp(ValueError, r"^The provided data has",
-                         lda.partial_fit, X_2)
+    with pytest.raises(ValueError, match=r"^The provided data has"):
+        lda.partial_fit(X_2)
 
 
 @if_safe_multiprocessing_with_blas
@@ -247,13 +249,12 @@ def test_lda_preplexity_mismatch():
     lda.fit(X)
     # invalid samples
     invalid_n_samples = rng.randint(4, size=(n_samples + 1, n_components))
-    assert_raises_regexp(ValueError, r'Number of samples',
-                         lda._perplexity_precomp_distr, X, invalid_n_samples)
+    with pytest.raises(ValueError, match=r'Number of samples'):
+        lda._perplexity_precomp_distr(X, invalid_n_samples)
     # invalid topic number
     invalid_n_components = rng.randint(4, size=(n_samples, n_components + 1))
-    assert_raises_regexp(ValueError, r'Number of topics',
-                         lda._perplexity_precomp_distr, X,
-                         invalid_n_components)
+    with pytest.raises(ValueError, match=r'Number of topics'):
+        lda._perplexity_precomp_distr(X, invalid_n_components)
 
 
 @pytest.mark.parametrize('method', ('online', 'batch'))


### PR DESCRIPTION
Replaced `assert_raises` and `assert_raises_regex` with
the `with pytest.raises` context manager.

related to #14216