### PR TITLE
[MRG] MAINT/CI pin sphinx version until release of jinja2

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -102,7 +102,8 @@ fi
 
 if [[ "$TEST_DOCSTRINGS" == "true" ]]; then
     # numpydoc requires sphinx
-    # pin sphinx until jinja2 (>2.10.1) is not released
+    # FIXME: until jinja2 2.10.2 is released with a fix the import station for
+    # collections.abc so as to not raise a spurious deprecation warning
     python -m pip install sphinx==2.1.2
     python -m pip install numpydoc
 fi

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -101,7 +101,10 @@ if [[ "$COVERAGE" == "true" ]]; then
 fi
 
 if [[ "$TEST_DOCSTRINGS" == "true" ]]; then
-    python -m pip install sphinx numpydoc  # numpydoc requires sphinx
+    # numpydoc requires sphinx
+    # pin sphinx until jinja2 (>2.10.1) is not released
+    python -m pip install sphinx==2.1.2
+    python -m pip install numpydoc
 fi
 
 python --version


### PR DESCRIPTION
CI started to break because Sphinx 2.2.0 has been released.
It calls something from Jinja2 which import from `collections` instead of `collections.abc`.
The fix is already in master. We can remove the pinning once Jinja2 (> 2.10.1) is released.