### PR TITLE
MAINT filter deprecation warnings triggered by all_estimators

### DIFF
--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -511,7 +511,9 @@ def all_estimators(include_meta_estimators=None,
         if IS_PYPY and ('_svmlight_format' in modname or
                         'feature_extraction._hashing' in modname):
             continue
-        module = __import__(modname, fromlist="dummy")
+        # Ignore deprecation warnings triggered at import time.
+        with ignore_warnings(category=DeprecationWarning):
+            module = __import__(modname, fromlist="dummy")
         classes = inspect.getmembers(module, inspect.isclass)
         all_classes.extend(classes)
 


### PR DESCRIPTION
`sklearn.testing.all_estimators` can trigger spurious `DeprecationWarnings` when importing the scikit-learn modules to inspect them to collect the list of estimators.

This PRs filter them out but I am not 100% sure if this is the correct way to do it. Shall we filter them in all_estimators itself as done here or in code that reliease on `all_estimators`?