### PR TITLE
MAINT:Fix assert raises in `sklearn/feature_extraction/tests/`

### DIFF
--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -1,9 +1,10 @@
 
 import numpy as np
 from numpy.testing import assert_array_equal
+import pytest
 
 from sklearn.feature_extraction import FeatureHasher
-from sklearn.utils.testing import (assert_raises, ignore_warnings,
+from sklearn.utils.testing import (ignore_warnings,
                                    fails_if_pypy)
 
 pytestmark = fails_if_pypy
@@ -86,22 +87,30 @@ def test_hash_empty_input():
 
 
 def test_hasher_invalid_input():
-    assert_raises(ValueError, FeatureHasher, input_type="gobbledygook")
-    assert_raises(ValueError, FeatureHasher, n_features=-1)
-    assert_raises(ValueError, FeatureHasher, n_features=0)
-    assert_raises(TypeError, FeatureHasher, n_features='ham')
+    with pytest.raises(ValueError):
+        FeatureHasher(input_type="gobbledygook")
+    with pytest.raises(ValueError):
+        FeatureHasher(n_features=-1)
+    with pytest.raises(ValueError):
+        FeatureHasher(n_features=0)
+    with pytest.raises(TypeError):
+        FeatureHasher(n_features='ham')
 
     h = FeatureHasher(n_features=np.uint16(2 ** 6))
-    assert_raises(ValueError, h.transform, [])
-    assert_raises(Exception, h.transform, [[5.5]])
-    assert_raises(Exception, h.transform, [[None]])
+    with pytest.raises(ValueError):
+        h.transform([])
+    with pytest.raises(Exception):
+        h.transform([[5.5]])
+    with pytest.raises(Exception):
+        h.transform([[None]])
 
 
 def test_hasher_set_params():
     # Test delayed input validation in fit (useful for grid search).
     hasher = FeatureHasher()
     hasher.set_params(n_features=np.inf)
-    assert_raises(TypeError, hasher.fit)
+    with pytest.raises(TypeError):
+        hasher.fit()
 
 
 def test_hasher_zeros():

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -6,11 +6,12 @@ import numpy as np
 import scipy as sp
 from scipy import ndimage
 from scipy.sparse.csgraph import connected_components
+import pytest
 
 from sklearn.feature_extraction.image import (
     img_to_graph, grid_to_graph, extract_patches_2d,
     reconstruct_from_patches_2d, PatchExtractor, extract_patches)
-from sklearn.utils.testing import assert_raises, ignore_warnings
+from sklearn.utils.testing import ignore_warnings
 
 
 def test_img_to_graph():
@@ -172,10 +173,10 @@ def test_extract_patches_max_patches():
     patches = extract_patches_2d(face, (p_h, p_w), max_patches=0.5)
     assert patches.shape == (expected_n_patches, p_h, p_w)
 
-    assert_raises(ValueError, extract_patches_2d, face, (p_h, p_w),
-                  max_patches=2.0)
-    assert_raises(ValueError, extract_patches_2d, face, (p_h, p_w),
-                  max_patches=-1.0)
+    with pytest.raises(ValueError):
+        extract_patches_2d(face, (p_h, p_w), max_patches=2.0)
+    with pytest.raises(ValueError):
+        extract_patches_2d(face, (p_h, p_w), max_patches=-1.0)
 
 
 def test_extract_patch_same_size_image():
@@ -328,5 +329,7 @@ def test_extract_patches_square():
 def test_width_patch():
     # width and height of the patch should be less than the image
     x = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    assert_raises(ValueError, extract_patches_2d, x, (4, 1))
-    assert_raises(ValueError, extract_patches_2d, x, (1, 4))
+    with pytest.raises(ValueError):
+        extract_patches_2d(x, (4, 1))
+    with pytest.raises(ValueError):
+        extract_patches_2d(x, (1, 4))

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -305,7 +305,7 @@ def test_countvectorizer_stop_words():
         cv.get_stop_words()
     cv.set_params(stop_words='_bad_unicode_stop_')
     with pytest.raises(ValueError):
-       cv.get_stop_words()
+        cv.get_stop_words()
     stoplist = ['some', 'other', 'words']
     cv.set_params(stop_words=stoplist)
     assert cv.get_stop_words() == set(stoplist)

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -33,7 +33,7 @@ from sklearn.exceptions import ChangedBehaviorWarning
 from sklearn.utils.testing import (assert_almost_equal,
                                    assert_warns_message, assert_raise_message,
                                    clean_warning_registry,
-                                   SkipTest, assert_raises, assert_no_warnings,
+                                   SkipTest, assert_no_warnings,
                                    fails_if_pypy, assert_allclose_dense_sparse,
                                    skip_if_32bit)
 from collections import defaultdict
@@ -178,11 +178,13 @@ def test_unicode_decode_error():
     # Then let the Analyzer try to decode it as ascii. It should fail,
     # because we have given it an incorrect encoding.
     wa = CountVectorizer(ngram_range=(1, 2), encoding='ascii').build_analyzer()
-    assert_raises(UnicodeDecodeError, wa, text_bytes)
+    with pytest.raises(UnicodeDecodeError):
+        wa(text_bytes)
 
     ca = CountVectorizer(analyzer='char', ngram_range=(3, 6),
                          encoding='ascii').build_analyzer()
-    assert_raises(UnicodeDecodeError, ca, text_bytes)
+    with pytest.raises(UnicodeDecodeError):
+        ca(text_bytes)
 
 
 def test_char_ngram_analyzer():
@@ -299,9 +301,11 @@ def test_countvectorizer_stop_words():
     cv.set_params(stop_words='english')
     assert cv.get_stop_words() == ENGLISH_STOP_WORDS
     cv.set_params(stop_words='_bad_str_stop_')
-    assert_raises(ValueError, cv.get_stop_words)
+    with pytest.raises(ValueError):
+        cv.get_stop_words()
     cv.set_params(stop_words='_bad_unicode_stop_')
-    assert_raises(ValueError, cv.get_stop_words)
+    with pytest.raises(ValueError):
+       cv.get_stop_words()
     stoplist = ['some', 'other', 'words']
     cv.set_params(stop_words=stoplist)
     assert cv.get_stop_words() == set(stoplist)
@@ -451,7 +455,8 @@ def test_vectorizer():
 
     # test idf transform with unlearned idf vector
     t3 = TfidfTransformer(use_idf=True)
-    assert_raises(ValueError, t3.transform, counts_train)
+    with pytest.raises(ValueError):
+        t3.transform(counts_train)
 
     # test idf transform with incompatible n_features
     X = [[1, 1, 5],
@@ -459,7 +464,8 @@ def test_vectorizer():
     t3.fit(X)
     X_incompt = [[1, 3],
                  [1, 3]]
-    assert_raises(ValueError, t3.transform, X_incompt)
+    with pytest.raises(ValueError):
+        t3.transform(X_incompt)
 
     # L1-normalized term frequencies sum to one
     assert_array_almost_equal(np.sum(tf, axis=1), [1.0] * n_train)
@@ -480,7 +486,8 @@ def test_vectorizer():
 
     # test transform on unfitted vectorizer with empty vocabulary
     v3 = CountVectorizer(vocabulary=None)
-    assert_raises(ValueError, v3.transform, train_data)
+    with pytest.raises(ValueError):
+        v3.transform(train_data)
 
     # ascii preprocessor?
     v3.set_params(strip_accents='ascii', lowercase=False)
@@ -493,11 +500,13 @@ def test_vectorizer():
 
     # error on bad strip_accents param
     v3.set_params(strip_accents='_gabbledegook_', preprocessor=None)
-    assert_raises(ValueError, v3.build_preprocessor)
+    with pytest.raises(ValueError):
+        v3.build_preprocessor()
 
     # error with bad analyzer type
     v3.set_params = '_invalid_analyzer_type_'
-    assert_raises(ValueError, v3.build_analyzer)
+    with pytest.raises(ValueError):
+        v3.build_analyzer()
 
 
 def test_tfidf_vectorizer_setters():
@@ -568,7 +577,8 @@ def test_feature_names():
     cv = CountVectorizer(max_df=0.5)
 
     # test for Value error on unfitted/empty vocabulary
-    assert_raises(ValueError, cv.get_feature_names)
+    with pytest.raises(ValueError):
+        cv.get_feature_names()
     assert not cv.fixed_vocabulary_
 
     # test for vocabulary learned from data
@@ -1014,13 +1024,15 @@ def test_tfidfvectorizer_invalid_idf_attr():
     copy = TfidfVectorizer(vocabulary=vect.vocabulary_, use_idf=True)
     expected_idf_len = len(vect.idf_)
     invalid_idf = [1.0] * (expected_idf_len + 1)
-    assert_raises(ValueError, setattr, copy, 'idf_', invalid_idf)
+    with pytest.raises(ValueError):
+        setattr(copy, 'idf_', invalid_idf)
 
 
 def test_non_unique_vocab():
     vocab = ['a', 'b', 'c', 'a', 'a']
     vect = CountVectorizer(vocabulary=vocab)
-    assert_raises(ValueError, vect.fit, [])
+    with pytest.raises(ValueError):
+        vect.fit([])
 
 
 @fails_if_pypy


### PR DESCRIPTION
replaced `assert_raises` and `assert_raises_regex`with `pytest.raises` context manager.

related to #14216