### PR TITLE
MAINT:Fix assert raises in `sklearn/feature_selection/tests/`

### DIFF
--- a/sklearn/feature_selection/tests/test_base.py
+++ b/sklearn/feature_selection/tests/test_base.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from scipy import sparse as sp
 
 from numpy.testing import assert_array_equal
@@ -6,7 +7,6 @@ from numpy.testing import assert_array_equal
 from sklearn.base import BaseEstimator
 from sklearn.feature_selection.base import SelectorMixin
 from sklearn.utils import check_array
-from sklearn.utils.testing import assert_raises
 
 
 class StepSelector(SelectorMixin, BaseEstimator):
@@ -54,7 +54,8 @@ def test_transform_dense():
     assert_array_equal(feature_names_t, names_t_actual.ravel())
 
     # Check wrong shape raises error
-    assert_raises(ValueError, sel.transform, np.array([[1], [2]]))
+    with pytest.raises(ValueError):
+        sel.transform(np.array([[1], [2]]))
 
 
 def test_transform_sparse():
@@ -70,7 +71,8 @@ def test_transform_sparse():
     assert np.float32 == sel.transform(sparse(X).astype(np.float32)).dtype
 
     # Check wrong shape raises error
-    assert_raises(ValueError, sel.transform, np.array([[1], [2]]))
+    with pytest.raises(ValueError):
+        sel.transform(np.array([[1], [2]]))
 
 
 def test_inverse_transform_dense():
@@ -89,7 +91,8 @@ def test_inverse_transform_dense():
     assert_array_equal(feature_names_inv, names_inv_actual.ravel())
 
     # Check wrong shape raises error
-    assert_raises(ValueError, sel.inverse_transform, np.array([[1], [2]]))
+    with pytest.raises(ValueError):
+        sel.inverse_transform(np.array([[1], [2]]))
 
 
 def test_inverse_transform_sparse():
@@ -105,7 +108,8 @@ def test_inverse_transform_sparse():
                  sel.inverse_transform(sparse(Xt).astype(np.float32)).dtype)
 
     # Check wrong shape raises error
-    assert_raises(ValueError, sel.inverse_transform, np.array([[1], [2]]))
+    with pytest.raises(ValueError):
+        sel.inverse_transform(np.array([[1], [2]]))
 
 
 def test_get_support():

--- a/sklearn/feature_selection/tests/test_chi2.py
+++ b/sklearn/feature_selection/tests/test_chi2.py
@@ -6,12 +6,12 @@ specifically to work with sparse matrices.
 import warnings
 
 import numpy as np
+import pytest
 from scipy.sparse import coo_matrix, csr_matrix
 import scipy.stats
 
 from sklearn.feature_selection import SelectKBest, chi2
 from sklearn.feature_selection.univariate_selection import _chisquare
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 
@@ -65,7 +65,8 @@ def test_chi2_negative():
     # Check for proper error on negative numbers in the input X.
     X, y = [[0, 1], [-1e-20, 1]], [0, 1]
     for X in (X, np.array(X), csr_matrix(X)):
-        assert_raises(ValueError, chi2, X, y)
+        with pytest.raises(ValueError):
+            chi2(X, y)
 
 
 def test_chi2_unused_feature():

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -328,7 +328,7 @@ def test_invalid_percentile():
     with pytest.raises(ValueError):
         SelectPercentile(percentile=101).fit(X, y)
     with pytest.raises(ValueError):
-       GenericUnivariateSelect(mode='percentile', param=-1).fit(X, y)
+        GenericUnivariateSelect(mode='percentile', param=-1).fit(X, y)
     with pytest.raises(ValueError):
         GenericUnivariateSelect(mode='percentile', param=101).fit(X, y)
 

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -9,7 +9,6 @@ from scipy import stats, sparse
 import pytest
 
 from sklearn.utils.testing import assert_almost_equal
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_warns
@@ -324,12 +323,14 @@ def test_invalid_percentile():
     X, y = make_regression(n_samples=10, n_features=20,
                            n_informative=2, shuffle=False, random_state=0)
 
-    assert_raises(ValueError, SelectPercentile(percentile=-1).fit, X, y)
-    assert_raises(ValueError, SelectPercentile(percentile=101).fit, X, y)
-    assert_raises(ValueError, GenericUnivariateSelect(mode='percentile',
-                                                      param=-1).fit, X, y)
-    assert_raises(ValueError, GenericUnivariateSelect(mode='percentile',
-                                                      param=101).fit, X, y)
+    with pytest.raises(ValueError):
+        SelectPercentile(percentile=-1).fit(X, y)
+    with pytest.raises(ValueError):
+        SelectPercentile(percentile=101).fit(X, y)
+    with pytest.raises(ValueError):
+       GenericUnivariateSelect(mode='percentile', param=-1).fit(X, y)
+    with pytest.raises(ValueError):
+        GenericUnivariateSelect(mode='percentile', param=101).fit(X, y)
 
 
 def test_select_kbest_regression():
@@ -564,19 +565,22 @@ def test_score_func_error():
 
     for SelectFeatures in [SelectKBest, SelectPercentile, SelectFwe,
                            SelectFdr, SelectFpr, GenericUnivariateSelect]:
-        assert_raises(TypeError, SelectFeatures(score_func=10).fit, X, y)
+        with pytest.raises(TypeError):
+            SelectFeatures(score_func=10).fit(X, y)
 
 
 def test_invalid_k():
     X = [[0, 1, 0], [0, -1, -1], [0, .5, .5]]
     y = [1, 0, 1]
 
-    assert_raises(ValueError, SelectKBest(k=-1).fit, X, y)
-    assert_raises(ValueError, SelectKBest(k=4).fit, X, y)
-    assert_raises(ValueError,
-                  GenericUnivariateSelect(mode='k_best', param=-1).fit, X, y)
-    assert_raises(ValueError,
-                  GenericUnivariateSelect(mode='k_best', param=4).fit, X, y)
+    with pytest.raises(ValueError):
+        SelectKBest(k=-1).fit(X, y)
+    with pytest.raises(ValueError):
+        SelectKBest(k=4).fit(X, y)
+    with pytest.raises(ValueError):
+        GenericUnivariateSelect(mode='k_best', param=-1).fit(X, y)
+    with pytest.raises(ValueError):
+        GenericUnivariateSelect(mode='k_best', param=4).fit(X, y)
 
 
 def test_f_classif_constant_feature():

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -4,7 +4,6 @@ import numpy as np
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_allclose
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import skip_if_32bit
 
 from sklearn import datasets
@@ -28,7 +27,8 @@ def test_invalid_input():
     for threshold in ["gobbledigook", ".5 * gobbledigook"]:
         model = SelectFromModel(clf, threshold=threshold)
         model.fit(data, y)
-        assert_raises(ValueError, model.transform, data)
+        with pytest.raises(ValueError):
+            model.transform(data)
 
 
 def test_input_estimator_unchanged():
@@ -290,7 +290,8 @@ def test_prefit():
 
     # Check that prefit=True and calling fit raises a ValueError
     model = SelectFromModel(clf, prefit=True)
-    assert_raises(ValueError, model.fit, data, y)
+    with pytest.raises(ValueError):
+        model.fit(data, y)
 
 
 def test_threshold_string():

--- a/sklearn/feature_selection/tests/test_mutual_info.py
+++ b/sklearn/feature_selection/tests/test_mutual_info.py
@@ -1,10 +1,10 @@
 
 import numpy as np
+import pytest
 from scipy.sparse import csr_matrix
 
 from sklearn.utils import check_random_state
-from sklearn.utils.testing import (assert_array_equal, assert_almost_equal,
-                                   assert_raises)
+from sklearn.utils.testing import assert_array_equal, assert_almost_equal
 from sklearn.feature_selection.mutual_info_ import (
     mutual_info_regression, mutual_info_classif, _compute_mi)
 
@@ -182,15 +182,16 @@ def test_mutual_info_options():
     X_csr = csr_matrix(X)
 
     for mutual_info in (mutual_info_regression, mutual_info_classif):
-        assert_raises(ValueError, mutual_info, X_csr, y,
-                      discrete_features=False)
-        assert_raises(ValueError, mutual_info, X, y,
-                      discrete_features='manual')
-        assert_raises(ValueError, mutual_info, X_csr, y,
-                      discrete_features=[True, False, True])
-        assert_raises(IndexError, mutual_info, X, y,
-                      discrete_features=[True, False, True, False])
-        assert_raises(IndexError, mutual_info, X, y, discrete_features=[1, 4])
+        with pytest.raises(ValueError):
+            mutual_info(X_csr, y, discrete_features=False)
+        with pytest.raises(ValueError):
+            mutual_info(X, y, discrete_features='manual')
+        with pytest.raises(ValueError):
+            mutual_info(X_csr, y, discrete_features=[True, False, True])
+        with pytest.raises(IndexError):
+            mutual_info(X, y, discrete_features=[True, False, True, False])
+        with pytest.raises(IndexError):
+            mutual_info(X, y, discrete_features=[1, 4])
 
         mi_1 = mutual_info(X, y, discrete_features='auto', random_state=0)
         mi_2 = mutual_info(X, y, discrete_features=False, random_state=0)

--- a/sklearn/feature_selection/tests/test_variance_threshold.py
+++ b/sklearn/feature_selection/tests/test_variance_threshold.py
@@ -12,10 +12,6 @@ data = [[0, 1, 2, 3, 4],
         [1, 1, 2, 4, 0]]
 
 
-@pytest.mark.parametrize(
-    "args",
-    [[[0, 1, 2, 3]],
-     [[0, 1], [0, 1]]])
 def test_zero_variance(args):
     # Test VarianceThreshold with default setting, zero variance.
 
@@ -24,8 +20,9 @@ def test_zero_variance(args):
         assert_array_equal([0, 1, 3, 4], sel.get_support(indices=True))
 
     with pytest.raises(ValueError):
-        VarianceThreshold().fit(*args)
-
+        VarianceThreshold().fit([[0, 1, 2, 3]])
+    with pytest.raises(ValueError):
+        VarianceThreshold().fit([[0, 1], [0, 1]])
 
 def test_variance_threshold():
     # Test VarianceThreshold with custom variance.

--- a/sklearn/feature_selection/tests/test_variance_threshold.py
+++ b/sklearn/feature_selection/tests/test_variance_threshold.py
@@ -24,6 +24,7 @@ def test_zero_variance(args):
     with pytest.raises(ValueError):
         VarianceThreshold().fit([[0, 1], [0, 1]])
 
+
 def test_variance_threshold():
     # Test VarianceThreshold with custom variance.
     for X in [data, csr_matrix(data)]:

--- a/sklearn/feature_selection/tests/test_variance_threshold.py
+++ b/sklearn/feature_selection/tests/test_variance_threshold.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from sklearn.utils.testing import assert_array_equal, assert_raises
+from sklearn.utils.testing import assert_array_equal
 
 from scipy.sparse import bsr_matrix, csc_matrix, csr_matrix
 
@@ -12,15 +12,19 @@ data = [[0, 1, 2, 3, 4],
         [1, 1, 2, 4, 0]]
 
 
-def test_zero_variance():
+@pytest.mark.parametrize(
+    "args",
+    [[[0, 1, 2, 3]],
+     [[0, 1], [0, 1]]])
+def test_zero_variance(args):
     # Test VarianceThreshold with default setting, zero variance.
 
     for X in [data, csr_matrix(data), csc_matrix(data), bsr_matrix(data)]:
         sel = VarianceThreshold().fit(X)
         assert_array_equal([0, 1, 3, 4], sel.get_support(indices=True))
 
-    assert_raises(ValueError, VarianceThreshold().fit, [[0, 1, 2, 3]])
-    assert_raises(ValueError, VarianceThreshold().fit, [[0, 1], [0, 1]])
+    with pytest.raises(ValueError):
+        VarianceThreshold().fit(*args)
 
 
 def test_variance_threshold():

--- a/sklearn/feature_selection/tests/test_variance_threshold.py
+++ b/sklearn/feature_selection/tests/test_variance_threshold.py
@@ -12,7 +12,7 @@ data = [[0, 1, 2, 3, 4],
         [1, 1, 2, 4, 0]]
 
 
-def test_zero_variance(args):
+def test_zero_variance():
     # Test VarianceThreshold with default setting, zero variance.
 
     for X in [data, csr_matrix(data), csc_matrix(data), bsr_matrix(data)]:


### PR DESCRIPTION
replaced `assert_raises` and `assert_raises_regex` with `pytest.raises` context manager.

related to #14216