### PR TITLE
[MRG] BUG: Passes sample_weight to roc_auc_curve

### DIFF
--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -150,6 +150,7 @@ def plot_roc_curve(estimator, X, y, pos_label=None, sample_weight=None,
                              "binary classification problem")
         y_pred = y_pred[:, 1]
     fpr, tpr, _ = roc_curve(y, y_pred, pos_label=pos_label,
+                            sample_weight=sample_weight,
                             drop_intermediate=drop_intermediate)
     roc_auc = auc(fpr, tpr)
     viz = RocCurveDisplay(fpr, tpr, roc_auc, estimator.__class__.__name__)

--- a/sklearn/metrics/_plot/tests/test_plot_roc_curve.py
+++ b/sklearn/metrics/_plot/tests/test_plot_roc_curve.py
@@ -58,7 +58,8 @@ def test_plot_roc_curve(pyplot, response_method, data_binary,
                         with_sample_weight, drop_intermediate):
     X, y = data_binary
     if with_sample_weight:
-        sample_weight = np.random.randint(1, 4, size=(X.shape[0]))
+        rng = np.random.RandomState(42)
+        sample_weight = rng.randint(1, 4, size=(X.shape[0]))
     else:
         sample_weight = None
 


### PR DESCRIPTION
This PR correctly fixes a bug by passing `sample_weight` to `roc_auc_curve` in `plot_roc_auc_curve`.