### PR TITLE
[MRG] FIX Nystroem with precomputed kernel

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -9,7 +9,7 @@ Version 0.22.0
 
 **In Development**
 
-Changed models 
+Changed models
 --------------
 
 The following estimators and functions, when fit with the same data and
@@ -197,10 +197,10 @@ Changelog
   `Nicolas Hug`_.
 
 :mod:`sklearn.kernel_approximation`
-...........................
+...................................
 
 -|FIX| Fixed a bug where :class:`kernel_approximation.Nystroem` raised a
- KeyError when using `kernel="precomputed"`.
+ `KeyError` when using `kernel="precomputed"`.
  :pr:`14706` by :user:`Venkatachalam N <venkyyuvy>`. 
 
 :mod:`sklearn.linear_model`

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -9,7 +9,7 @@ Version 0.22.0
 
 **In Development**
 
-Changed models
+Changed models 
 --------------
 
 The following estimators and functions, when fit with the same data and
@@ -195,6 +195,13 @@ Changelog
   method for :class:`ensemble.HistGradientBoostingClassifier` and
   :class:`ensemble.HistGradientBoostingRegressor`. :pr:`13769` by
   `Nicolas Hug`_.
+
+:mod:`sklearn.kernel_approximation`
+...........................
+
+-|FIX| Fixed a bug where :class:`kernel_approximation.Nystroem` raised a
+ KeyError when using `kernel="precomputed"`.
+ :pr:`14706` by :user:`Venkatachalam N <venkyyuvy>`. 
 
 :mod:`sklearn.linear_model`
 ...........................

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -512,6 +512,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
 
     sklearn.metrics.pairwise.kernel_metrics : List of built-in kernels.
     """
+
     def __init__(self, kernel="rbf", gamma=None, coef0=None, degree=None,
                  kernel_params=None, n_components=100, random_state=None):
         self.kernel = kernel
@@ -594,7 +595,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
         params = self.kernel_params
         if params is None:
             params = {}
-        if not callable(self.kernel):
+        if not (callable(self.kernel) or self.kernel == 'precomputed'):
             for param in (KERNEL_PARAMS[self.kernel]):
                 if getattr(self, param) is not None:
                     params[param] = getattr(self, param)
@@ -603,6 +604,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
                     self.coef0 is not None or
                     self.degree is not None):
                 raise ValueError("Don't pass gamma, coef0 or degree to "
-                                 "Nystroem if using a callable kernel.")
+                                 "Nystroem if using a callable "
+                                 "or precomputed kernel")
 
         return params

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -595,7 +595,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
         params = self.kernel_params
         if params is None:
             params = {}
-        if callable(self.kernel) and self.kernel != 'precomputed':
+        if not callable(self.kernel) and self.kernel != 'precomputed':
             for param in (KERNEL_PARAMS[self.kernel]):
                 if getattr(self, param) is not None:
                     params[param] = getattr(self, param)

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -595,7 +595,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
         params = self.kernel_params
         if params is None:
             params = {}
-        if not (callable(self.kernel) or self.kernel == 'precomputed'):
+        if callable(self.kernel) and self.kernel != 'precomputed':
             for param in (KERNEL_PARAMS[self.kernel]):
                 if getattr(self, param) is not None:
                     params[param] = getattr(self, param)

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1629,7 +1629,6 @@ def kernel_metrics():
 
 
 KERNEL_PARAMS = {
-    "precomputed": (),
     "additive_chi2": (),
     "chi2": frozenset(["gamma"]),
     "cosine": (),

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1629,6 +1629,7 @@ def kernel_metrics():
 
 
 KERNEL_PARAMS = {
+    "precomputed": (),
     "additive_chi2": (),
     "chi2": frozenset(["gamma"]),
     "cosine": (),

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -258,6 +258,7 @@ def test_nystroem_callable():
 
 def test_nystroem_precomputed_kernel():
     # Non-regression: test Nystroem on precomputed kernel.
+    # PR - 14706
     rnd = np.random.RandomState(12)
     X = rnd.uniform(size=(10, 4))
 
@@ -265,3 +266,12 @@ def test_nystroem_precomputed_kernel():
     nystroem = Nystroem(kernel='precomputed', n_components=X.shape[0])
     X_transformed = nystroem.fit_transform(K)
     assert_array_almost_equal(np.dot(X_transformed, X_transformed.T), K)
+
+    # if degree, gamma or coef0 is passed, we raise a ValueError
+    msg = "Don't pass gamma, coef0 or degree to Nystroem"
+    params = ({'gamma': 1}, {'coef0': 1}, {'degree': 2})
+    for param in params:
+        ny = Nystroem(kernel='precomputed', n_components=X.shape[0],
+                      **param)
+        with pytest.raises(ValueError, match=msg):
+            ny.fit(K)

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -254,3 +254,13 @@ def test_nystroem_callable():
         ny = Nystroem(kernel=linear_kernel, **param)
         with pytest.raises(ValueError, match=msg):
             ny.fit(X)
+
+def test_nystroem_precomputed_kernel():
+    # Non-regression: test Nystroem on precomputed kernel.
+    rnd = np.random.RandomState(12)
+    X = rnd.uniform(size=(10, 4))
+
+    K = polynomial_kernel(X, degree=2, coef0=.1)
+    nystroem = Nystroem(kernel='precomputed', n_components=X.shape[0])
+    X_transformed = nystroem.fit_transform(K)
+    assert_array_equal(np.dot(X_transformed, X_transformed.T), K)

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -255,6 +255,7 @@ def test_nystroem_callable():
         with pytest.raises(ValueError, match=msg):
             ny.fit(X)
 
+
 def test_nystroem_precomputed_kernel():
     # Non-regression: test Nystroem on precomputed kernel.
     rnd = np.random.RandomState(12)
@@ -264,3 +265,4 @@ def test_nystroem_precomputed_kernel():
     nystroem = Nystroem(kernel='precomputed', n_components=X.shape[0])
     X_transformed = nystroem.fit_transform(K)
     assert_array_equal(np.dot(X_transformed, X_transformed.T), K)
+    

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -264,4 +264,4 @@ def test_nystroem_precomputed_kernel():
     K = polynomial_kernel(X, degree=2, coef0=.1)
     nystroem = Nystroem(kernel='precomputed', n_components=X.shape[0])
     X_transformed = nystroem.fit_transform(K)
-    assert_array_equal(np.dot(X_transformed, X_transformed.T), K)
+    assert_array_almost_equal(np.dot(X_transformed, X_transformed.T), K)

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -265,4 +265,3 @@ def test_nystroem_precomputed_kernel():
     nystroem = Nystroem(kernel='precomputed', n_components=X.shape[0])
     X_transformed = nystroem.fit_transform(K)
     assert_array_equal(np.dot(X_transformed, X_transformed.T), K)
-    


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #14641
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Added 
- key `precomputed` in `KERNEL_PARAMS`
- non-regression test to validate `Nystroem` with `precomputed` kernel using `polynomial_kernel`
#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
