### PR TITLE
TST: Fix assert raises in `sklearn/metrics/cluster/tests/`

### DIFF
--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import re
 
 from sklearn.metrics.cluster import adjusted_mutual_info_score
 from sklearn.metrics.cluster import adjusted_rand_score
@@ -17,7 +18,7 @@ from sklearn.metrics.cluster.supervised import _generalized_average
 
 from sklearn.utils import assert_all_finite
 from sklearn.utils.testing import (
-        assert_almost_equal, assert_raise_message, ignore_warnings)
+        assert_almost_equal, ignore_warnings)
 from numpy.testing import assert_array_almost_equal
 
 
@@ -40,11 +41,11 @@ def test_error_messages_on_wrong_input():
             score_func([0, 1], [1, 1, 1])
 
         expected = "labels_true must be 1D: shape is (2"
-        with pytest.raises(ValueError, match=expected):
+        with pytest.raises(ValueError, match=re.escape(expected)):
             score_func([[0, 1], [1, 0]], [1, 1, 1])
 
         expected = "labels_pred must be 1D: shape is (2"
-        with pytest.raises(ValueError, match=expected):
+        with pytest.raises(ValueError, match=re.escape(expected)):
             score_func([0, 1, 0], [[1, 1], [0, 0]])
 
 
@@ -262,10 +263,8 @@ def test_contingency_matrix_sparse():
     C = contingency_matrix(labels_a, labels_b)
     C_sparse = contingency_matrix(labels_a, labels_b, sparse=True).toarray()
     assert_array_almost_equal(C, C_sparse)
-    C_sparse = assert_raise_message(ValueError,
-                                    "Cannot set 'eps' when sparse=True",
-                                    contingency_matrix, labels_a, labels_b,
-                                    eps=1e-10, sparse=True)
+    with pytest.raises(ValueError, match="Cannot set 'eps' when sparse=True"):
+        contingency_matrix(labels_a, labels_b, eps=1e-10, sparse=True)
 
 
 @ignore_warnings(category=FutureWarning)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-import re
 
 from sklearn.metrics.cluster import adjusted_mutual_info_score
 from sklearn.metrics.cluster import adjusted_rand_score
@@ -40,12 +39,12 @@ def test_error_messages_on_wrong_input():
         with pytest.raises(ValueError, match=expected):
             score_func([0, 1], [1, 1, 1])
 
-        expected = "labels_true must be 1D: shape is (2"
-        with pytest.raises(ValueError, match=re.escape(expected)):
+        expected = r"labels_true must be 1D: shape is \(2"
+        with pytest.raises(ValueError, match=expected):
             score_func([[0, 1], [1, 0]], [1, 1, 1])
 
-        expected = "labels_pred must be 1D: shape is (2"
-        with pytest.raises(ValueError, match=re.escape(expected)):
+        expected = r"labels_pred must be 1D: shape is \(2"
+        with pytest.raises(ValueError, match=expected):
             score_func([0, 1, 0], [[1, 1], [0, 0]])
 
 

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -35,16 +35,16 @@ def test_error_messages_on_wrong_input():
     for score_func in score_funcs:
         expected = ('labels_true and labels_pred must have same size,'
                     ' got 2 and 3')
-        assert_raise_message(ValueError, expected, score_func,
-                             [0, 1], [1, 1, 1])
+        with pytest.raises(ValueError, match=expected):
+            score_func([0, 1], [1, 1, 1])
 
         expected = "labels_true must be 1D: shape is (2"
-        assert_raise_message(ValueError, expected, score_func,
-                             [[0, 1], [1, 0]], [1, 1, 1])
+        with pytest.raises(ValueError, match=expected):
+            score_func([[0, 1], [1, 0]], [1, 1, 1])
 
         expected = "labels_pred must be 1D: shape is (2"
-        assert_raise_message(ValueError, expected, score_func,
-                             [0, 1, 0], [[1, 1], [0, 0]])
+        with pytest.raises(ValueError, match=expected):
+            score_func([0, 1, 0], [[1, 1], [0, 0]])
 
 
 def test_generalized_average():

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from sklearn.metrics.cluster import adjusted_mutual_info_score
 from sklearn.metrics.cluster import adjusted_rand_score

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -135,16 +135,16 @@ def test_correct_labelsize():
 
     # n_labels = n_samples
     y = np.arange(X.shape[0])
-    with pytest.raises(ValueError,
-                       match=r'Number of labels is %d\. Valid values are 2 '
-                       r'to n_samples - 1 \(inclusive\)' % len(np.unique(y))):
+    err_msg = (r'Number of labels is %d\. Valid values are 2 '
+               r'to n_samples - 1 \(inclusive\)' % len(np.unique(y)))
+    with pytest.raises(ValueError, match=err_msg):
         silhouette_score(X, y)
 
     # n_labels = 1
     y = np.zeros(X.shape[0])
-    with pytest.raises(ValueError,
-                       match=r'Number of labels is %d\. Valid values are 2 '
-                       r'to n_samples - 1 \(inclusive\)' % len(np.unique(y))):
+    err_msg = (r'Number of labels is %d\. Valid values are 2 '
+               r'to n_samples - 1 \(inclusive\)' % len(np.unique(y)))
+    with pytest.raises(ValueError, match=err_msg):
         silhouette_score(X, y)
 
 

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -5,7 +5,6 @@ from scipy.sparse import csr_matrix
 
 from sklearn import datasets
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_warns_message
 from sklearn.metrics.cluster import silhouette_score
 from sklearn.metrics.cluster import silhouette_samples
@@ -190,17 +189,15 @@ def test_silhouette_nonzero_diag(dtype):
 def assert_raises_on_only_one_label(func):
     """Assert message when there is only one label"""
     rng = np.random.RandomState(seed=0)
-    assert_raise_message(ValueError, "Number of labels is",
-                         func,
-                         rng.rand(10, 2), np.zeros(10))
+    with pytest.raises(ValueError, match="Number of labels is"):
+        func(rng.rand(10, 2), np.zeros(10))
 
 
 def assert_raises_on_all_points_same_cluster(func):
     """Assert message when all point are in different clusters"""
     rng = np.random.RandomState(seed=0)
-    assert_raise_message(ValueError, "Number of labels is",
-                         func,
-                         rng.rand(10, 2), np.arange(10))
+    with pytest.raises(ValueError, match="Number of labels is"):
+        func(rng.rand(10, 2), np.arange(10))
 
 
 def test_calinski_harabasz_score():

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -5,7 +5,6 @@ from scipy.sparse import csr_matrix
 
 from sklearn import datasets
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_warns_message
 from sklearn.metrics.cluster import silhouette_score
@@ -137,17 +136,17 @@ def test_correct_labelsize():
 
     # n_labels = n_samples
     y = np.arange(X.shape[0])
-    assert_raises_regexp(ValueError,
-                         r'Number of labels is %d\. Valid values are 2 '
-                         r'to n_samples - 1 \(inclusive\)' % len(np.unique(y)),
-                         silhouette_score, X, y)
+    with pytest.raises(ValueError,
+                       match=r'Number of labels is %d\. Valid values are 2 '
+                       r'to n_samples - 1 \(inclusive\)' % len(np.unique(y))):
+        silhouette_score(X, y)
 
     # n_labels = 1
     y = np.zeros(X.shape[0])
-    assert_raises_regexp(ValueError,
-                         r'Number of labels is %d\. Valid values are 2 '
-                         r'to n_samples - 1 \(inclusive\)' % len(np.unique(y)),
-                         silhouette_score, X, y)
+    with pytest.raises(ValueError,
+                       match=r'Number of labels is %d\. Valid values are 2 '
+                       r'to n_samples - 1 \(inclusive\)' % len(np.unique(y))):
+        silhouette_score(X, y)
 
 
 def test_non_encoded_labels():


### PR DESCRIPTION
replaced `assert_raises` and `assert_raises_regex` with `pytest.raises` context manager.

related to #14216