### PR TITLE
FIX encode target for scoring when using early stopping in HistGradientBoostinClassifier

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -132,8 +132,7 @@ Changelog
     method for both estimators. :pr:`13769` by `Nicolas Hug`_.
   - |Fix| Estimators now bin the training and validation data separately to
     avoid any data leak. :pr:`13933` by `Nicolas Hug`_.
-  - |Fix| Targets are encoded before to compute score when using early stopping
-    to avoid inconsistent target data types.
+  - |Fix| Fixed a bug where early stopping would break with string targets.
     :pr:`14710` by :user:`Guillaume Lemaitre <glemaitre>`.
 
   Note that pickles from 0.21 will not work in 0.22.

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -132,6 +132,9 @@ Changelog
     method for both estimators. :pr:`13769` by `Nicolas Hug`_.
   - |Fix| Estimators now bin the training and validation data separately to
     avoid any data leak. :pr:`13933` by `Nicolas Hug`_.
+  - |Fix| Targets are encoded before to compute score when using early stopping
+    to avoid inconsistent target data types.
+    :pr:`14710` by :user:`Guillaume Lemaitre <glemaitre>`.
 
   Note that pickles from 0.21 will not work in 0.22.
 

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -248,7 +248,6 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                     (X_binned_small_train,
                      y_small_train) = self._get_small_trainset(
                         X_binned_train, y_train, self._small_trainset_seed)
-
                     self._check_early_stopping_scorer(
                         X_binned_small_train, y_small_train,
                         X_binned_val, y_val,
@@ -426,11 +425,15 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
 
         Scores are computed on validation data or on training data.
         """
+        if hasattr(self, 'classes_'):
+            y_small_train = self.classes_[y_small_train.astype(int)]
         self.train_score_.append(
             self.scorer_(self, X_binned_small_train, y_small_train)
         )
 
         if self._use_validation_data:
+            if hasattr(self, 'classes_'):
+                y_val = self.classes_[y_val.astype(int)]
             self.validation_score_.append(
                 self.scorer_(self, X_binned_val, y_val)
             )

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -426,14 +426,14 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
 
         Scores are computed on validation data or on training data.
         """
-        if hasattr(self, 'classes_'):
+        if is_classifier(self):
             y_small_train = self.classes_[y_small_train.astype(int)]
         self.train_score_.append(
             self.scorer_(self, X_binned_small_train, y_small_train)
         )
 
         if self._use_validation_data:
-            if hasattr(self, 'classes_'):
+            if is_classifier(self):
                 y_val = self.classes_[y_val.astype(int)]
             self.validation_score_.append(
                 self.scorer_(self, X_binned_val, y_val)

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -248,6 +248,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                     (X_binned_small_train,
                      y_small_train) = self._get_small_trainset(
                         X_binned_train, y_train, self._small_trainset_seed)
+
                     self._check_early_stopping_scorer(
                         X_binned_small_train, y_small_train,
                         X_binned_val, y_val,

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -417,10 +417,12 @@ def test_infinite_values_missing_values():
     assert stump_clf.fit(X, y_isnan).score(X, y_isnan) == 1
 
 
-def test_string_target_early_stopping():
+@pytest.mark.parametrize("scoring", [None, 'loss'])
+def test_string_target_early_stopping(scoring):
     # Regression tests for #14709 where the targets need to be encoded before
     # to compute the score
-    X = np.random.randn(100, 10)
+    rng = np.random.RandomState(42)
+    X = rng.randn(100, 10)
     y = np.array(['x'] * 50 + ['y'] * 50, dtype=object)
-    gbrt = HistGradientBoostingClassifier(n_iter_no_change=10)
+    gbrt = HistGradientBoostingClassifier(n_iter_no_change=10, scoring=scoring)
     gbrt.fit(X, y)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -415,3 +415,12 @@ def test_infinite_values_missing_values():
 
     assert stump_clf.fit(X, y_isinf).score(X, y_isinf) == 1
     assert stump_clf.fit(X, y_isnan).score(X, y_isnan) == 1
+
+
+def test_string_target_early_stopping():
+    # Regression tests for #14709 where the targets need to be encoded before
+    # to compute the score
+    X = np.random.randn(100, 10)
+    y = np.array(['x'] * 50 + ['y'] * 50, dtype=object)
+    gbrt = HistGradientBoostingClassifier(n_iter_no_change=10)
+    gbrt.fit(X, y)


### PR DESCRIPTION
fixes #14709 
