### PR TITLE
TST: Fix assert raises in `sklearn/metrics/tests/`

### DIFF
--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -491,11 +491,11 @@ def test_multilabel_confusion_matrix_errors():
                                                    [3, 4, 5]])
 
     # Bad labels
-    err_msg = "All labels must be in [0, n labels)"
-    with pytest.raises(ValueError, match=re.escape(err_msg)):
+    err_msg = r"All labels must be in \[0, n labels\)"
+    with pytest.raises(ValueError, match=err_msg):
         multilabel_confusion_matrix(y_true, y_pred, labels=[-1])
-    err_msg = "All labels must be in [0, n labels)"
-    with pytest.raises(ValueError, match=re.escape(err_msg)):
+    err_msg = r"All labels must be in \[0, n labels\)"
+    with pytest.raises(ValueError, match=err_msg):
         multilabel_confusion_matrix(y_true, y_pred, labels=[3])
 
     # Using samplewise outside multilabel
@@ -1151,24 +1151,24 @@ def test_multilabel_hamming_loss():
 def test_jaccard_score_validation():
     y_true = np.array([0, 1, 0, 1, 1])
     y_pred = np.array([0, 1, 0, 1, 1])
-    err_msg = "pos_label=2 is not a valid label: array([0, 1])"
-    with pytest.raises(ValueError, match=re.escape(err_msg)):
+    err_msg = r"pos_label=2 is not a valid label: array\(\[0, 1\]\)"
+    with pytest.raises(ValueError, match=err_msg):
         jaccard_score(y_true, y_pred, average='binary', pos_label=2)
 
     y_true = np.array([[0, 1, 1], [1, 0, 0]])
     y_pred = np.array([[1, 1, 1], [1, 0, 1]])
-    msg1 = ("Target is multilabel-indicator but average='binary'. "
-            "Please choose another average setting, one of [None, "
-            "'micro', 'macro', 'weighted', 'samples'].")
-    with pytest.raises(ValueError, match=re.escape(msg1)):
+    msg1 = (r"Target is multilabel-indicator but average='binary'. "
+            r"Please choose another average setting, one of \[None, "
+            r"'micro', 'macro', 'weighted', 'samples'\].")
+    with pytest.raises(ValueError, match=msg1):
         jaccard_score(y_true, y_pred, average='binary', pos_label=-1)
 
     y_true = np.array([0, 1, 1, 0, 2])
     y_pred = np.array([1, 1, 1, 1, 0])
-    msg2 = ("Target is multiclass but average='binary'. Please choose "
-            "another average setting, one of [None, 'micro', 'macro', "
-            "'weighted'].")
-    with pytest.raises(ValueError, match=re.escape(msg2)):
+    msg2 = (r"Target is multiclass but average='binary'. Please choose "
+            r"another average setting, one of \[None, 'micro', 'macro', "
+            r"'weighted'\].")
+    with pytest.raises(ValueError, match=msg2):
         jaccard_score(y_true, y_pred, average='binary')
     msg3 = ("Samplewise metrics are not available outside of multilabel "
             "classification.")
@@ -1685,14 +1685,14 @@ def test_prf_average_binary_data_non_binary():
     # Error if user does not explicitly set non-binary average mode
     y_true_mc = [1, 2, 3, 3]
     y_pred_mc = [1, 2, 3, 1]
-    msg_mc = ("Target is multiclass but average='binary'. Please "
-              "choose another average setting, one of ["
-              "None, 'micro', 'macro', 'weighted'].")
+    msg_mc = (r"Target is multiclass but average='binary'. Please "
+              r"choose another average setting, one of \["
+              r"None, 'micro', 'macro', 'weighted'\].")
     y_true_ind = np.array([[0, 1, 1], [1, 0, 0], [0, 0, 1]])
     y_pred_ind = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
-    msg_ind = ("Target is multilabel-indicator but average='binary'. Please "
-               "choose another average setting, one of ["
-               "None, 'micro', 'macro', 'weighted', 'samples'].")
+    msg_ind = (r"Target is multilabel-indicator but average='binary'. Please "
+               r"choose another average setting, one of \["
+               r"None, 'micro', 'macro', 'weighted', 'samples'\].")
 
     for y_true, y_pred, msg in [
         (y_true_mc, y_pred_mc, msg_mc),
@@ -1700,7 +1700,7 @@ def test_prf_average_binary_data_non_binary():
     ]:
         for metric in [precision_score, recall_score, f1_score,
                        partial(fbeta_score, beta=2)]:
-            with pytest.raises(ValueError, match=re.escape(msg)):
+            with pytest.raises(ValueError, match=msg):
                 metric(y_true, y_pred)
 
 
@@ -1948,9 +1948,9 @@ def test_log_loss():
     y_true = [2, 2]
     y_pred = [[0.2, 0.7], [0.6, 0.5]]
     y_score = np.array([[0.1, 0.9], [0.1, 0.9]])
-    error_str = ('y_true contains only one label (2). Please provide '
-                 'the true labels explicitly through the labels argument.')
-    with pytest.raises(ValueError, match=re.escape(error_str)):
+    error_str = (r'y_true contains only one label \(2\). Please provide '
+                 r'the true labels explicitly through the labels argument.')
+    with pytest.raises(ValueError, match=error_str):
         log_loss(y_true, y_pred)
 
     y_pred = [[0.2, 0.7], [0.6, 0.5], [0.2, 0.3]]

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1151,9 +1151,10 @@ def check_sample_weight_invariance(name, metric, y1, y2):
     # use context manager to supply custom error message
     with pytest.raises(AssertionError):
         assert_allclose(unweighted_score, weighted_score)
-        raise ValueError("Unweighted and weighted scores are unexpectedly almost "
-                  "equal (%s) and (%s) for %s" % (unweighted_score,
-                                                  weighted_score, name))
+        raise ValueError("Unweighted and weighted scores are unexpectedly "
+                         "almost equal (%s) and (%s) "
+                         "for %s" % (unweighted_score,
+                                     weighted_score, name))
 
     # check that sample_weight can be a list
     weighted_score_list = metric(y1, y2,

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -21,7 +21,6 @@ from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_less
 from sklearn.utils.testing import assert_raise_message
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import ignore_warnings
 
 from sklearn.metrics import accuracy_score
@@ -556,7 +555,7 @@ def test_not_symmetric_metric(name):
     metric = ALL_METRICS[name]
 
     # use context manager to supply custom error message
-    with assert_raises(AssertionError) as cm:
+    with pytest.raises(AssertionError) as cm:
         assert_array_equal(metric(y_true, y_pred), metric(y_pred, y_true))
         cm.msg = ("%s seems to be symmetric" % name)
 
@@ -681,18 +680,25 @@ def test_format_invariance_with_1d_vectors(name):
                                 "list and np-array-column" % name)
 
         # These mix representations aren't allowed
-        assert_raises(ValueError, metric, y1_1d, y2_row)
-        assert_raises(ValueError, metric, y1_row, y2_1d)
-        assert_raises(ValueError, metric, y1_list, y2_row)
-        assert_raises(ValueError, metric, y1_row, y2_list)
-        assert_raises(ValueError, metric, y1_column, y2_row)
-        assert_raises(ValueError, metric, y1_row, y2_column)
+        with pytest.raises(ValueError):
+            metric(y1_1d, y2_row)
+        with pytest.raises(ValueError):
+            metric(y1_row, y2_1d)
+        with pytest.raises(ValueError):
+            metric(y1_list, y2_row)
+        with pytest.raises(ValueError):
+            metric(y1_row, y2_list)
+        with pytest.raises(ValueError):
+            metric(y1_column, y2_row)
+        with pytest.raises(ValueError):
+            metric(y1_row, y2_column)
 
         # NB: We do not test for y1_row, y2_row as these may be
         # interpreted as multilabel or multioutput data.
         if (name not in (MULTIOUTPUT_METRICS | THRESHOLDED_MULTILABEL_METRICS |
                          MULTILABELS_METRICS)):
-            assert_raises(ValueError, metric, y1_row, y2_row)
+            with pytest.raises(ValueError):
+                metric(y1_row, y2_row)
 
 
 @pytest.mark.parametrize(
@@ -776,8 +782,10 @@ def test_thresholded_invariance_string_vs_numbers_labels(name):
                                        "invariance test".format(name))
         else:
             # TODO those metrics doesn't support string label yet
-            assert_raises(ValueError, metric, y1_str, y2)
-            assert_raises(ValueError, metric, y1_str.astype('O'), y2)
+            with pytest.raises(ValueError):
+                metric(y1_str, y2)
+            with pytest.raises(ValueError):
+                metric(y1_str.astype('O'), y2)
 
 
 invalids = [([0, 1], [np.inf, np.inf]),
@@ -853,7 +861,8 @@ def test_multioutput_number_of_output_differ(name):
     y_pred = np.array([[0, 0], [1, 0], [0, 0]])
 
     metric = ALL_METRICS[name]
-    assert_raises(ValueError, metric, y_true, y_pred)
+    with pytest.raises(ValueError):
+        metric(y_true, y_pred)
 
 
 @pytest.mark.parametrize('name', sorted(MULTIOUTPUT_METRICS))
@@ -924,7 +933,8 @@ def test_raise_value_error_multilabel_sequences(name):
 
     metric = ALL_METRICS[name]
     for seq in multilabel_sequences:
-        assert_raises(ValueError, metric, seq, seq)
+        with pytest.raises(ValueError):
+            metric(seq, seq)
 
 
 @pytest.mark.parametrize('name', sorted(METRICS_WITH_NORMALIZE_OPTION))
@@ -1031,8 +1041,10 @@ def _check_averaging(metric, y_true, y_pred, y_true_binarize, y_pred_binarize,
                         np.mean([metric(y_true_binarize[i], y_pred_binarize[i])
                                  for i in range(n_samples)]))
 
-    assert_raises(ValueError, metric, y_true, y_pred, average="unknown")
-    assert_raises(ValueError, metric, y_true, y_pred, average="garbage")
+    with pytest.raises(ValueError):
+        metric(y_true, y_pred, average="unknown")
+    with pytest.raises(ValueError):
+        metric(y_true, y_pred, average="garbage")
 
 
 def check_averaging(name, y_true, y_true_binarize, y_pred, y_pred_binarize,
@@ -1140,7 +1152,7 @@ def check_sample_weight_invariance(name, metric, y1, y2):
     weighted_score = metric(y1, y2, sample_weight=sample_weight)
 
     # use context manager to supply custom error message
-    with assert_raises(AssertionError) as cm:
+    with pytest.raises(AssertionError) as cm:
         assert_allclose(unweighted_score, weighted_score)
         cm.msg = ("Unweighted and weighted scores are unexpectedly almost "
                   "equal (%s) and (%s) for %s" % (unweighted_score,

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -555,9 +555,9 @@ def test_not_symmetric_metric(name):
     metric = ALL_METRICS[name]
 
     # use context manager to supply custom error message
-    with pytest.raises(AssertionError) as cm:
+    with pytest.raises(AssertionError):
         assert_array_equal(metric(y_true, y_pred), metric(y_pred, y_true))
-        cm.msg = ("%s seems to be symmetric" % name)
+        raise ValueError("%s seems to be symmetric" % name)
 
 
 @pytest.mark.parametrize(
@@ -1152,9 +1152,9 @@ def check_sample_weight_invariance(name, metric, y1, y2):
     weighted_score = metric(y1, y2, sample_weight=sample_weight)
 
     # use context manager to supply custom error message
-    with pytest.raises(AssertionError) as cm:
+    with pytest.raises(AssertionError):
         assert_allclose(unweighted_score, weighted_score)
-        cm.msg = ("Unweighted and weighted scores are unexpectedly almost "
+        raise ValueError("Unweighted and weighted scores are unexpectedly almost "
                   "equal (%s) and (%s) for %s" % (unweighted_score,
                                                   weighted_score, name))
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -20,7 +20,6 @@ from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_less
-from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import ignore_warnings
 
 from sklearn.metrics import accuracy_score
@@ -799,19 +798,17 @@ invalids = [([0, 1], [np.inf, np.inf]),
 def test_regression_thresholded_inf_nan_input(metric):
 
     for y_true, y_score in invalids:
-        assert_raise_message(ValueError,
-                             "contains NaN, infinity",
-                             metric, y_true, y_score)
+        with pytest.raises(ValueError, match="contains NaN, infinity"):
+            metric(y_true, y_score)
 
 
 @pytest.mark.parametrize('metric', CLASSIFICATION_METRICS.values())
 def test_classification_inf_nan_input(metric):
     # Classification metrics all raise a mixed input exception
     for y_true, y_score in invalids:
-        assert_raise_message(ValueError,
-                             "Input contains NaN, infinity or a "
-                             "value too large",
-                             metric, y_true, y_score)
+        err_msg = "Input contains NaN, infinity or a value too large"
+        with pytest.raises(ValueError, match=err_msg):
+            metric(y_true, y_score)
 
 
 @ignore_warnings
@@ -1204,13 +1201,13 @@ def check_sample_weight_invariance(name, metric, y1, y2):
 
     # Check that if number of samples in y_true and sample_weight are not
     # equal, meaningful error is raised.
-    error_message = ("Found input variables with inconsistent numbers of "
-                     "samples: [{}, {}, {}]".format(
+    error_message = (r"Found input variables with inconsistent numbers of "
+                     r"samples: \[{}, {}, {}\]".format(
                          _num_samples(y1), _num_samples(y2),
                          _num_samples(sample_weight) * 2))
-    assert_raise_message(ValueError, error_message, metric, y1, y2,
-                         sample_weight=np.hstack([sample_weight,
-                                                  sample_weight]))
+    with pytest.raises(ValueError, match=error_message):
+        metric(y1, y2, sample_weight=np.hstack([sample_weight,
+                                                sample_weight]))
 
 
 @pytest.mark.parametrize(

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -16,7 +16,6 @@ from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import ignore_warnings
-from sklearn.utils.testing import assert_raise_message
 
 from sklearn.metrics.pairwise import euclidean_distances
 from sklearn.metrics.pairwise import manhattan_distances
@@ -800,9 +799,9 @@ def test_haversine_distances():
     assert_array_almost_equal(D1, D2)
     # Test haversine distance does not accept X where n_feature != 2
     X = rng.random_sample((10, 3))
-    assert_raise_message(ValueError,
-                         "Haversine distance only valid in 2 dimensions",
-                         haversine_distances, X)
+    err_msg = "Haversine distance only valid in 2 dimensions"
+    with pytest.raises(ValueError, match=err_msg):
+        haversine_distances(X)
 
 
 # Paired distances

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -15,8 +15,6 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_allclose
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_raise_message
 
@@ -142,12 +140,14 @@ def test_pairwise_distances():
     assert_array_almost_equal(S, S2)
 
     # Test that scipy distance metrics throw an error if sparse matrix given
-    assert_raises(TypeError, pairwise_distances, X_sparse, metric="minkowski")
-    assert_raises(TypeError, pairwise_distances, X, Y_sparse,
-                  metric="minkowski")
+    with pytest.raises(TypeError):
+        pairwise_distances(X_sparse, metric="minkowski")
+    with pytest.raises(TypeError):
+        pairwise_distances(X, Y_sparse, metric="minkowski")
 
     # Test that a value error is raised if the metric is unknown
-    assert_raises(ValueError, pairwise_distances, X, Y, metric="blah")
+    with pytest.raises(ValueError):
+        pairwise_distances(X, Y, metric="blah")
 
 
 @pytest.mark.parametrize('metric', PAIRWISE_BOOLEAN_FUNCTIONS)
@@ -193,16 +193,14 @@ def test_no_data_conversion_warning():
 @pytest.mark.parametrize('func', [pairwise_distances, pairwise_kernels])
 def test_pairwise_precomputed(func):
     # Test correct shape
-    assert_raises_regexp(ValueError, '.* shape .*',
-                         func, np.zeros((5, 3)), metric='precomputed')
+    with pytest.raises(ValueError, match='.* shape .*'):
+        func(np.zeros((5, 3)), metric='precomputed')
     # with two args
-    assert_raises_regexp(ValueError, '.* shape .*',
-                         func, np.zeros((5, 3)), np.zeros((4, 4)),
-                         metric='precomputed')
+    with pytest.raises(ValueError, match='.* shape .*'):
+        func(np.zeros((5, 3)), np.zeros((4, 4)), metric='precomputed')
     # even if shape[1] agrees (although thus second arg is spurious)
-    assert_raises_regexp(ValueError, '.* shape .*',
-                         func, np.zeros((5, 3)), np.zeros((4, 3)),
-                         metric='precomputed')
+    with pytest.raises(ValueError, match='.* shape .*'):
+        func(np.zeros((5, 3)), np.zeros((4, 3)), metric='precomputed')
 
     # Test not copied (if appropriate dtype)
     S = np.zeros((5, 5))
@@ -224,9 +222,8 @@ def test_pairwise_precomputed(func):
 
 def test_pairwise_precomputed_non_negative():
     # Test non-negative values
-    assert_raises_regexp(ValueError, '.* non-negative values.*',
-                         pairwise_distances, np.full((5, 5), -1),
-                         metric='precomputed')
+    with pytest.raises(ValueError, match='.* non-negative values.*'):
+        pairwise_distances(np.full((5, 5), -1), metric='precomputed')
 
 
 _wminkowski_kwds = {'w': np.arange(1, 5).astype('double', copy=False), 'p': 1}
@@ -309,8 +306,9 @@ def test_pairwise_kernels(metric):
     Y_sparse = csr_matrix(Y)
     if metric in ["chi2", "additive_chi2"]:
         # these don't support sparse matrices yet
-        assert_raises(ValueError, pairwise_kernels,
-                      X_sparse, Y=Y_sparse, metric=metric)
+        with pytest.raises(ValueError):
+            pairwise_kernels(X_sparse, Y=Y_sparse,
+                             metric=metric)
         return
     K1 = pairwise_kernels(X_sparse, Y=Y_sparse, metric=metric)
     assert_array_almost_equal(K1, K2)
@@ -344,7 +342,8 @@ def test_pairwise_kernels_filter_param():
     K2 = pairwise_kernels(X, Y, metric="rbf", filter_params=True, **params)
     assert_array_almost_equal(K, K2)
 
-    assert_raises(TypeError, pairwise_kernels, X, Y, "rbf", **params)
+    with pytest.raises(TypeError):
+        pairwise_kernels(X, Y, "rbf", **params)
 
 
 @pytest.mark.parametrize('metric, func', PAIRED_DISTANCES.items())
@@ -385,7 +384,8 @@ def test_paired_distances_callable():
     # Test that a value error is raised when the lengths of X and Y should not
     # differ
     Y = rng.random_sample((3, 4))
-    assert_raises(ValueError, paired_distances, X, Y)
+    with pytest.raises(ValueError):
+        paired_distances(X, Y)
 
 
 def test_pairwise_distances_argmin_min():
@@ -509,7 +509,8 @@ def test_pairwise_distances_chunked_reduce_invalid(bad_reduce, err_type,
     X = np.arange(10).reshape(-1, 1)
     S_chunks = pairwise_distances_chunked(X, None, reduce_func=bad_reduce,
                                           working_memory=64)
-    assert_raises_regexp(err_type, message, next, S_chunks)
+    with pytest.raises(err_type, match=message):
+        next(S_chunks)
 
 
 def check_pairwise_distances_chunked(X, Y, working_memory, metric='euclidean'):
@@ -580,8 +581,8 @@ def test_pairwise_distances_chunked():
     check_pairwise_distances_chunked(X, Y, working_memory=1,
                                      metric='cityblock')
     # Test that a value error is raised if the metric is unknown
-    assert_raises(ValueError, next,
-                  pairwise_distances_chunked(X, Y, metric="blah"))
+    with pytest.raises(ValueError):
+        next(pairwise_distances_chunked(X, Y, metric="blah"))
 
     # Test precomputed returns all at once
     D = pairwise_distances(X)
@@ -590,7 +591,8 @@ def test_pairwise_distances_chunked():
                                      metric='precomputed')
     assert isinstance(gen, GeneratorType)
     assert next(gen) is D
-    assert_raises(StopIteration, next, gen)
+    with pytest.raises(StopIteration):
+        next(gen)
 
 
 @pytest.mark.parametrize("x_array_constr", [np.array, csr_matrix],
@@ -863,17 +865,22 @@ def test_chi_square_kernel():
     assert K[1, 1] > K[1, 0]
 
     # test negative input
-    assert_raises(ValueError, chi2_kernel, [[0, -1]])
-    assert_raises(ValueError, chi2_kernel, [[0, -1]], [[-1, -1]])
-    assert_raises(ValueError, chi2_kernel, [[0, 1]], [[-1, -1]])
+    with pytest.raises(ValueError):
+        chi2_kernel([[0, -1]])
+    with pytest.raises(ValueError):
+        chi2_kernel([[0, -1]], [[-1, -1]])
+    with pytest.raises(ValueError):
+        chi2_kernel([[0, 1]], [[-1, -1]])
 
     # different n_features in X and Y
-    assert_raises(ValueError, chi2_kernel, [[0, 1]], [[.2, .2, .6]])
+    with pytest.raises(ValueError):
+        chi2_kernel([[0, 1]], [[.2, .2, .6]])
 
     # sparse matrices
-    assert_raises(ValueError, chi2_kernel, csr_matrix(X), csr_matrix(Y))
-    assert_raises(ValueError, additive_chi2_kernel,
-                  csr_matrix(X), csr_matrix(Y))
+    with pytest.raises(ValueError):
+        chi2_kernel(csr_matrix(X), csr_matrix(Y))
+    with pytest.raises(ValueError):
+        additive_chi2_kernel(csr_matrix(X), csr_matrix(Y))
 
 
 @pytest.mark.parametrize(
@@ -1003,10 +1010,12 @@ def test_check_different_dimensions():
     # Ensure an error is raised if the dimensions are different.
     XA = np.resize(np.arange(45), (5, 9))
     XB = np.resize(np.arange(32), (4, 8))
-    assert_raises(ValueError, check_pairwise_arrays, XA, XB)
+    with pytest.raises(ValueError):
+        check_pairwise_arrays(XA, XB)
 
     XB = np.resize(np.arange(4 * 9), (4, 9))
-    assert_raises(ValueError, check_paired_arrays, XA, XB)
+    with pytest.raises(ValueError):
+        check_paired_arrays(XA, XB)
 
 
 def test_check_invalid_dimensions():
@@ -1015,10 +1024,12 @@ def test_check_invalid_dimensions():
     # converted to 2D anyways
     XA = np.arange(45).reshape(9, 5)
     XB = np.arange(32).reshape(4, 8)
-    assert_raises(ValueError, check_pairwise_arrays, XA, XB)
+    with pytest.raises(ValueError):
+        check_pairwise_arrays(XA, XB)
     XA = np.arange(45).reshape(9, 5)
     XB = np.arange(32).reshape(4, 8)
-    assert_raises(ValueError, check_pairwise_arrays, XA, XB)
+    with pytest.raises(ValueError):
+        check_pairwise_arrays(XA, XB)
 
 
 def test_check_sparse_arrays():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1,3 +1,4 @@
+import re
 import pytest
 import numpy as np
 import warnings
@@ -12,7 +13,6 @@ from sklearn.random_projection import sparse_random_matrix
 from sklearn.utils.validation import check_array, check_consistent_length
 from sklearn.utils.validation import check_random_state
 
-from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
@@ -447,7 +447,8 @@ def test_auc_errors():
     y = [5, 6, 7, 8]
     error_message = ("x is neither increasing nor decreasing : "
                      "{}".format(np.array(x)))
-    assert_raise_message(ValueError, error_message, auc, x, y)
+    with pytest.raises(ValueError, match=re.escape(error_message)):
+        auc(x, y)
 
 
 @pytest.mark.parametrize(
@@ -636,28 +637,29 @@ def test_auc_score_non_binary_class():
     y_pred = rng.rand(10)
     # y_true contains only one class value
     y_true = np.zeros(10, dtype="int")
-    assert_raise_message(ValueError, "ROC AUC score is not defined",
-                         roc_auc_score, y_true, y_pred)
+    err_msg = "ROC AUC score is not defined"
+    with pytest.raises(ValueError, match=err_msg):
+        roc_auc_score(y_true, y_pred)
     y_true = np.ones(10, dtype="int")
-    assert_raise_message(ValueError, "ROC AUC score is not defined",
-                         roc_auc_score, y_true, y_pred)
+    with pytest.raises(ValueError, match=err_msg):
+        roc_auc_score(y_true, y_pred)
     y_true = np.full(10, -1, dtype="int")
-    assert_raise_message(ValueError, "ROC AUC score is not defined",
-                         roc_auc_score, y_true, y_pred)
+    with pytest.raises(ValueError, match=err_msg):
+        roc_auc_score(y_true, y_pred)
 
     with warnings.catch_warnings(record=True):
         rng = check_random_state(404)
         y_pred = rng.rand(10)
         # y_true contains only one class value
         y_true = np.zeros(10, dtype="int")
-        assert_raise_message(ValueError, "ROC AUC score is not defined",
-                             roc_auc_score, y_true, y_pred)
+        with pytest.raises(ValueError, match=err_msg):
+            roc_auc_score(y_true, y_pred)
         y_true = np.ones(10, dtype="int")
-        assert_raise_message(ValueError, "ROC AUC score is not defined",
-                             roc_auc_score, y_true, y_pred)
+        with pytest.raises(ValueError, match=err_msg):
+            roc_auc_score(y_true, y_pred)
         y_true = np.full(10, -1, dtype="int")
-        assert_raise_message(ValueError, "ROC AUC score is not defined",
-                             roc_auc_score, y_true, y_pred)
+        with pytest.raises(ValueError, match=err_msg):
+            roc_auc_score(y_true, y_pred)
 
 
 def test_binary_clf_curve():
@@ -665,8 +667,8 @@ def test_binary_clf_curve():
     y_true = rng.randint(0, 3, size=10)
     y_pred = rng.rand(10)
     msg = "multiclass format is not supported"
-    assert_raise_message(ValueError, msg, precision_recall_curve,
-                         y_true, y_pred)
+    with pytest.raises(ValueError, match=msg):
+        precision_recall_curve(y_true, y_pred)
 
 
 def test_precision_recall_curve():
@@ -845,8 +847,8 @@ def test_average_precision_score_pos_label_errors():
     y_true = np.array([0, 1])
     y_pred = np.array([0, 1])
     error_message = ("pos_label=2 is invalid. Set it to a label in y_true.")
-    assert_raise_message(ValueError, error_message, average_precision_score,
-                         y_true, y_pred, pos_label=2)
+    with pytest.raises(ValueError, match=error_message):
+        average_precision_score(y_true, y_pred, pos_label=2)
     # Raise an error for multilabel-indicator y_true with
     # pos_label other than 1
     y_true = np.array([[1, 0], [0, 1], [0, 1], [1, 0]])
@@ -854,8 +856,8 @@ def test_average_precision_score_pos_label_errors():
     error_message = ("Parameter pos_label is fixed to 1 for multilabel"
                      "-indicator y_true. Do not set pos_label or set "
                      "pos_label to 1.")
-    assert_raise_message(ValueError, error_message, average_precision_score,
-                         y_true, y_pred, pos_label=0)
+    with pytest.raises(ValueError, match=error_message):
+        average_precision_score(y_true, y_pred, pos_label=0)
 
 
 def test_score_scale_invariance():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -12,7 +12,6 @@ from sklearn.random_projection import sparse_random_matrix
 from sklearn.utils.validation import check_array, check_consistent_length
 from sklearn.utils.validation import check_random_state
 
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
@@ -226,7 +225,8 @@ def test_roc_curve_multi():
     # roc_curve not applicable for multi-class problems
     y_true, _, probas_pred = make_prediction(binary=False)
 
-    assert_raises(ValueError, roc_curve, y_true, probas_pred)
+    with pytest.raises(ValueError):
+        roc_curve(y_true, probas_pred)
 
 
 def test_roc_curve_confidence():
@@ -336,7 +336,8 @@ def test_roc_curve_toydata():
     # assert UndefinedMetricWarning because of no positive sample in y_true
     tpr, fpr, _ = assert_warns(UndefinedMetricWarning, roc_curve, y_true,
                                y_score)
-    assert_raises(ValueError, roc_auc_score, y_true, y_score)
+    with pytest.raises(ValueError):
+        roc_auc_score(y_true, y_score)
     assert_array_almost_equal(tpr, [0., 0.5, 1.])
     assert_array_almost_equal(fpr, [np.nan, np.nan, np.nan])
 
@@ -345,24 +346,27 @@ def test_roc_curve_toydata():
     # assert UndefinedMetricWarning because of no negative sample in y_true
     tpr, fpr, _ = assert_warns(UndefinedMetricWarning, roc_curve, y_true,
                                y_score)
-    assert_raises(ValueError, roc_auc_score, y_true, y_score)
+    with pytest.raises(ValueError):
+        roc_auc_score(y_true, y_score)
     assert_array_almost_equal(tpr, [np.nan, np.nan, np.nan])
     assert_array_almost_equal(fpr, [0., 0.5, 1.])
 
     # Multi-label classification task
     y_true = np.array([[0, 1], [0, 1]])
     y_score = np.array([[0, 1], [0, 1]])
-    assert_raises(ValueError, roc_auc_score, y_true, y_score, average="macro")
-    assert_raises(ValueError, roc_auc_score, y_true, y_score,
-                  average="weighted")
+    with pytest.raises(ValueError):
+        roc_auc_score(y_true, y_score, average="macro")
+    with pytest.raises(ValueError):
+        roc_auc_score(y_true, y_score, average="weighted")
     assert_almost_equal(roc_auc_score(y_true, y_score, average="samples"), 1.)
     assert_almost_equal(roc_auc_score(y_true, y_score, average="micro"), 1.)
 
     y_true = np.array([[0, 1], [0, 1]])
     y_score = np.array([[0, 1], [1, 0]])
-    assert_raises(ValueError, roc_auc_score, y_true, y_score, average="macro")
-    assert_raises(ValueError, roc_auc_score, y_true, y_score,
-                  average="weighted")
+    with pytest.raises(ValueError):
+        roc_auc_score(y_true, y_score, average="macro")
+    with pytest.raises(ValueError):
+        roc_auc_score(y_true, y_score, average="weighted")
     assert_almost_equal(roc_auc_score(y_true, y_score, average="samples"), 0.5)
     assert_almost_equal(roc_auc_score(y_true, y_score, average="micro"), 0.5)
 
@@ -431,10 +435,12 @@ def test_auc():
 
 def test_auc_errors():
     # Incompatible shapes
-    assert_raises(ValueError, auc, [0.0, 0.5, 1.0], [0.1, 0.2])
+    with pytest.raises(ValueError):
+        auc([0.0, 0.5, 1.0], [0.1, 0.2])
 
     # Too few x values
-    assert_raises(ValueError, auc, [0.0], [0.1])
+    with pytest.raises(ValueError):
+        auc([0.0], [0.1])
 
     # x is not in order
     x = [2, 1, 3, 4]
@@ -703,8 +709,8 @@ def _test_precision_recall_curve(y_true, probas_pred):
 
 def test_precision_recall_curve_errors():
     # Contains non-binary labels
-    assert_raises(ValueError, precision_recall_curve,
-                  [0, 1, 2], [[0.0], [1.0], [1.0]])
+    with pytest.raises(ValueError):
+        precision_recall_curve([0, 1, 2], [[0.0], [1.0], [1.0]])
 
 
 def test_precision_recall_curve_toydata():
@@ -755,8 +761,10 @@ def test_precision_recall_curve_toydata():
 
         y_true = [0, 0]
         y_score = [0.25, 0.75]
-        assert_raises(Exception, precision_recall_curve, y_true, y_score)
-        assert_raises(Exception, average_precision_score, y_true, y_score)
+        with pytest.raises(Exception):
+            precision_recall_curve(y_true, y_score)
+        with pytest.raises(Exception):
+            average_precision_score(y_true, y_score)
 
         y_true = [1, 1]
         y_score = [0.25, 0.75]
@@ -768,10 +776,10 @@ def test_precision_recall_curve_toydata():
         # Multi-label classification task
         y_true = np.array([[0, 1], [0, 1]])
         y_score = np.array([[0, 1], [0, 1]])
-        assert_raises(Exception, average_precision_score, y_true, y_score,
-                      average="macro")
-        assert_raises(Exception, average_precision_score, y_true, y_score,
-                      average="weighted")
+        with pytest.raises(Exception):
+            average_precision_score(y_true, y_score, average="macro")
+        with pytest.raises(Exception):
+            average_precision_score(y_true, y_score, average="weighted")
         assert_almost_equal(average_precision_score(y_true, y_score,
                             average="samples"), 1.)
         assert_almost_equal(average_precision_score(y_true, y_score,
@@ -779,10 +787,10 @@ def test_precision_recall_curve_toydata():
 
         y_true = np.array([[0, 1], [0, 1]])
         y_score = np.array([[0, 1], [1, 0]])
-        assert_raises(Exception, average_precision_score, y_true, y_score,
-                      average="macro")
-        assert_raises(Exception, average_precision_score, y_true, y_score,
-                      average="weighted")
+        with pytest.raises(Exception):
+            average_precision_score(y_true, y_score, average="macro")
+        with pytest.raises(Exception):
+            average_precision_score(y_true, y_score, average="weighted")
         assert_almost_equal(average_precision_score(y_true, y_score,
                             average="samples"), 0.75)
         assert_almost_equal(average_precision_score(y_true, y_score,
@@ -955,20 +963,28 @@ def check_zero_or_all_relevant_labels(lrap_score):
 
 def check_lrap_error_raised(lrap_score):
     # Raise value error if not appropriate format
-    assert_raises(ValueError, lrap_score,
-                  [0, 1, 0], [0.25, 0.3, 0.2])
-    assert_raises(ValueError, lrap_score, [0, 1, 2],
-                  [[0.25, 0.75, 0.0], [0.7, 0.3, 0.0], [0.8, 0.2, 0.0]])
-    assert_raises(ValueError, lrap_score, [(0), (1), (2)],
-                  [[0.25, 0.75, 0.0], [0.7, 0.3, 0.0], [0.8, 0.2, 0.0]])
+    with pytest.raises(ValueError):
+        lrap_score([0, 1, 0], [0.25, 0.3, 0.2])
+    with pytest.raises(ValueError):
+        lrap_score([0, 1, 2],
+                   [[0.25, 0.75, 0.0], [0.7, 0.3, 0.0], [0.8, 0.2, 0.0]])
+    with pytest.raises(ValueError):
+        lrap_score([(0), (1), (2)],
+                   [[0.25, 0.75, 0.0], [0.7, 0.3, 0.0], [0.8, 0.2, 0.0]])
 
     # Check that y_true.shape != y_score.shape raise the proper exception
-    assert_raises(ValueError, lrap_score, [[0, 1], [0, 1]], [0, 1])
-    assert_raises(ValueError, lrap_score, [[0, 1], [0, 1]], [[0, 1]])
-    assert_raises(ValueError, lrap_score, [[0, 1], [0, 1]], [[0], [1]])
-    assert_raises(ValueError, lrap_score, [[0, 1]], [[0, 1], [0, 1]])
-    assert_raises(ValueError, lrap_score, [[0], [1]], [[0, 1], [0, 1]])
-    assert_raises(ValueError, lrap_score, [[0, 1], [0, 1]], [[0], [1]])
+    with pytest.raises(ValueError):
+        lrap_score([[0, 1], [0, 1]], [0, 1])
+    with pytest.raises(ValueError):
+        lrap_score([[0, 1], [0, 1]], [[0, 1]])
+    with pytest.raises(ValueError):
+        lrap_score([[0, 1], [0, 1]], [[0], [1]])
+    with pytest.raises(ValueError):
+        lrap_score([[0, 1]], [[0, 1], [0, 1]])
+    with pytest.raises(ValueError):
+        lrap_score([[0], [1]], [[0, 1], [0, 1]])
+    with pytest.raises(ValueError):
+        lrap_score([[0, 1], [0, 1]], [[0], [1]])
 
 
 def check_lrap_only_ties(lrap_score):
@@ -1241,15 +1257,18 @@ def test_label_ranking_loss():
 
 def test_ranking_appropriate_input_shape():
     # Check that y_true.shape != y_score.shape raise the proper exception
-    assert_raises(ValueError, label_ranking_loss, [[0, 1], [0, 1]], [0, 1])
-    assert_raises(ValueError, label_ranking_loss, [[0, 1], [0, 1]], [[0, 1]])
-    assert_raises(ValueError, label_ranking_loss,
-                  [[0, 1], [0, 1]], [[0], [1]])
-
-    assert_raises(ValueError, label_ranking_loss, [[0, 1]], [[0, 1], [0, 1]])
-    assert_raises(ValueError, label_ranking_loss,
-                  [[0], [1]], [[0, 1], [0, 1]])
-    assert_raises(ValueError, label_ranking_loss, [[0, 1], [0, 1]], [[0], [1]])
+    with pytest.raises(ValueError):
+        label_ranking_loss([[0, 1], [0, 1]], [0, 1])
+    with pytest.raises(ValueError):
+        label_ranking_loss([[0, 1], [0, 1]], [[0, 1]])
+    with pytest.raises(ValueError):
+        label_ranking_loss([[0, 1], [0, 1]], [[0], [1]])
+    with pytest.raises(ValueError):
+        label_ranking_loss([[0, 1]], [[0, 1], [0, 1]])
+    with pytest.raises(ValueError):
+        label_ranking_loss([[0], [1]], [[0, 1], [0, 1]])
+    with pytest.raises(ValueError):
+        label_ranking_loss([[0, 1], [0, 1]], [[0], [1]])
 
 
 def test_ranking_loss_ties_handling():

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -4,7 +4,6 @@ from numpy.testing import assert_allclose
 from itertools import product
 import pytest
 
-from sklearn.utils.testing import assert_raises, assert_raises_regex
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
@@ -90,15 +89,15 @@ def test_regression_metrics_at_limits():
     assert_almost_equal(max_error([0.], [0.]), 0.00, 2)
     assert_almost_equal(explained_variance_score([0.], [0.]), 1.00, 2)
     assert_almost_equal(r2_score([0., 1], [0., 1]), 1.00, 2)
-    assert_raises_regex(ValueError, "Mean Squared Logarithmic Error cannot be "
-                        "used when targets contain negative values.",
-                        mean_squared_log_error, [-1.], [-1.])
-    assert_raises_regex(ValueError, "Mean Squared Logarithmic Error cannot be "
-                        "used when targets contain negative values.",
-                        mean_squared_log_error, [1., 2., 3.], [1., -2., 3.])
-    assert_raises_regex(ValueError, "Mean Squared Logarithmic Error cannot be "
-                        "used when targets contain negative values.",
-                        mean_squared_log_error, [1., -2., 3.], [1., 2., 3.])
+    with pytest.raises(ValueError, match="Mean Squared Logarithmic Error "
+                       "cannot be used when targets contain negative values."):
+        mean_squared_log_error([-1.], [-1.])
+    with pytest.raises(ValueError, match="Mean Squared Logarithmic Error "
+                       "cannot be used when targets contain negative values."):
+        mean_squared_log_error([1., 2., 3.], [1., -2., 3.])
+    with pytest.raises(ValueError, match="Mean Squared Logarithmic Error "
+                       "cannot be used when targets contain negative values."):
+        mean_squared_log_error([1., -2., 3.], [1., 2., 3.])
 
     # Tweedie deviance error
     p = -1.2
@@ -161,7 +160,8 @@ def test__check_reg_targets():
                 assert_array_equal(y_check1, y1)
                 assert_array_equal(y_check2, y2)
         else:
-            assert_raises(ValueError, _check_reg_targets, y1, y2, None)
+            with pytest.raises(ValueError):
+                _check_reg_targets(y1, y2, None)
 
 
 def test__check_reg_targets_exception():
@@ -169,11 +169,8 @@ def test__check_reg_targets_exception():
     expected_message = ("Allowed 'multioutput' string values are.+"
                         "You provided multioutput={!r}".format(
                             invalid_multioutput))
-    assert_raises_regex(ValueError, expected_message,
-                        _check_reg_targets,
-                        [1, 2, 3],
-                        [[1], [2], [3]],
-                        invalid_multioutput)
+    with pytest.raises(ValueError, match=expected_message):
+        _check_reg_targets([1, 2, 3], [[1], [2], [3]], invalid_multioutput)
 
 
 def test_regression_multioutput_array():

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -89,14 +89,17 @@ def test_regression_metrics_at_limits():
     assert_almost_equal(max_error([0.], [0.]), 0.00, 2)
     assert_almost_equal(explained_variance_score([0.], [0.]), 1.00, 2)
     assert_almost_equal(r2_score([0., 1], [0., 1]), 1.00, 2)
-    with pytest.raises(ValueError, match="Mean Squared Logarithmic Error "
-                       "cannot be used when targets contain negative values."):
+    err_msg = ("Mean Squared Logarithmic Error cannot be used when targets "
+               "contain negative values.")
+    with pytest.raises(ValueError, match=err_msg):
         mean_squared_log_error([-1.], [-1.])
-    with pytest.raises(ValueError, match="Mean Squared Logarithmic Error "
-                       "cannot be used when targets contain negative values."):
+    err_msg = ("Mean Squared Logarithmic Error cannot be used when targets "
+               "contain negative values.")
+    with pytest.raises(ValueError, match=err_msg):
         mean_squared_log_error([1., 2., 3.], [1., -2., 3.])
-    with pytest.raises(ValueError, match="Mean Squared Logarithmic Error "
-                       "cannot be used when targets contain negative values."):
+    err_msg = ("Mean Squared Logarithmic Error cannot be used when targets "
+               "contain negative values.")
+    with pytest.raises(ValueError, match=err_msg):
         mean_squared_log_error([1., -2., 3.], [1., 2., 3.])
 
     # Tweedie deviance error

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -10,8 +10,6 @@ import joblib
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils.testing import ignore_warnings
 
 from sklearn.base import BaseEstimator
@@ -170,7 +168,8 @@ def check_scoring_validator_for_single_metric_usecases(scoring_validator):
     estimator = EstimatorWithoutFit()
     pattern = (r"estimator should be an estimator implementing 'fit' method,"
                r" .* was passed")
-    assert_raises_regexp(TypeError, pattern, scoring_validator, estimator)
+    with pytest.raises(TypeError, match=pattern):
+        scoring_validator(estimator)
 
     estimator = EstimatorWithFitAndScore()
     estimator.fit([[1]], [1])
@@ -182,7 +181,8 @@ def check_scoring_validator_for_single_metric_usecases(scoring_validator):
     estimator.fit([[1]], [1])
     pattern = (r"If no scoring is specified, the estimator passed should have"
                r" a 'score' method\. The estimator .* does not\.")
-    assert_raises_regexp(TypeError, pattern, scoring_validator, estimator)
+    with pytest.raises(TypeError, match=pattern):
+        scoring_validator(estimator)
 
     scorer = scoring_validator(estimator, "accuracy")
     assert_almost_equal(scorer(estimator, [[1]], [1]), 1.0)
@@ -259,9 +259,8 @@ def test_check_scoring_and_check_multimetric_scoring():
     for scoring in ((make_scorer(precision_score),  # Tuple of callables
                      make_scorer(accuracy_score)), [5],
                     (make_scorer(precision_score),), (), ('f1', 'f1')):
-        assert_raises_regexp(ValueError, error_message_regexp,
-                             _check_multimetric_scoring, estimator,
-                             scoring=scoring)
+        with pytest.raises(ValueError, match=error_message_regexp):
+            _check_multimetric_scoring(estimator, scoring=scoring)
 
 
 def test_check_scoring_gridsearchcv():
@@ -287,8 +286,8 @@ def test_check_scoring_gridsearchcv():
 def test_make_scorer():
     # Sanity check on the make_scorer factory function.
     f = lambda *args: 0
-    assert_raises(ValueError, make_scorer, f, needs_threshold=True,
-                  needs_proba=True)
+    with pytest.raises(ValueError):
+        make_scorer(f, needs_threshold=True, needs_proba=True)
 
 
 def test_classification_scores():
@@ -460,11 +459,12 @@ def test_raises_on_score_list():
     X, y = make_blobs(random_state=0)
     f1_scorer_no_average = make_scorer(f1_score, average=None)
     clf = DecisionTreeClassifier()
-    assert_raises(ValueError, cross_val_score, clf, X, y,
-                  scoring=f1_scorer_no_average)
+    with pytest.raises(ValueError):
+        cross_val_score(clf, X, y, scoring=f1_scorer_no_average)
     grid_search = GridSearchCV(clf, scoring=f1_scorer_no_average,
                                param_grid={'max_depth': [1, 2]})
-    assert_raises(ValueError, grid_search.fit, X, y)
+    with pytest.raises(ValueError):
+        grid_search.fit(X, y)
 
 
 @ignore_warnings
@@ -537,11 +537,11 @@ def test_scorer_memmap_input(name):
 
 
 def test_scoring_is_not_metric():
-    assert_raises_regexp(ValueError, 'make_scorer', check_scoring,
-                         LogisticRegression(), f1_score)
-    assert_raises_regexp(ValueError, 'make_scorer', check_scoring,
-                         LogisticRegression(), roc_auc_score)
-    assert_raises_regexp(ValueError, 'make_scorer', check_scoring,
-                         Ridge(), r2_score)
-    assert_raises_regexp(ValueError, 'make_scorer', check_scoring,
-                         KMeans(), cluster_module.adjusted_rand_score)
+    with pytest.raises(ValueError, match='make_scorer'):
+        check_scoring(LogisticRegression(), f1_score)
+    with pytest.raises(ValueError, match='make_scorer'):
+        check_scoring(LogisticRegression(), roc_auc_score)
+    with pytest.raises(ValueError, match='make_scorer'):
+        check_scoring(Ridge(), r2_score)
+    with pytest.raises(ValueError, match='make_scorer'):
+        check_scoring(KMeans(), cluster_module.adjusted_rand_score)


### PR DESCRIPTION
replaced `assert_raises` and `assert_raises_regex` with `pytest.raises` context manager.

related to #14216