### PR TITLE
TST: Fix assert_raises in tests_neural_networks.py

### DIFF
--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -437,53 +437,37 @@ def test_partial_fit_errors():
     assert not hasattr(MLPClassifier(solver='lbfgs'), 'partial_fit')
 
 
-def test_params_errors():
+@pytest.mark.parametrize(
+        "args",
+        [{'hidden_layer_sizes': -1},
+         {'max_iter': -1},
+         {'shuffle': 'true'},
+         {'alpha': -1},
+         {'learning_rate_init': -1},
+         {'momentum': 2},
+         {'momentum': -0.5},
+         {'nesterovs_momentum': 'invalid'},
+         {'early_stopping': 'invalid'},
+         {'validation_fraction': 1},
+         {'validation_fraction': -0.5},
+         {'beta_1': 1},
+         {'beta_1': -0.5},
+         {'beta_2': 1},
+         {'beta_2': -0.5},
+         {'epsilon': -0.5},
+         {'n_iter_no_change': -1},
+         {'solver': 'hadoken'},
+         {'learning_rate': 'converge'},
+         {'activation': 'cloak'}]
+)
+def test_params_errors(args):
     # Test that invalid parameters raise value error
     X = [[3, 2], [1, 6]]
     y = [1, 0]
     clf = MLPClassifier
 
     with pytest.raises(ValueError):
-        clf(hidden_layer_sizes=-1).fit(X, y)
-    with pytest.raises(ValueError):
-        clf(max_iter=-1).fit(X, y)
-    with pytest.raises(ValueError):
-        clf(shuffle='true').fit(X, y)
-    with pytest.raises(ValueError):
-        clf(alpha=-1).fit(X, y)
-    with pytest.raises(ValueError):
-        clf(learning_rate_init=-1).fit(X, y)
-    with pytest.raises(ValueError):
-        clf(momentum=2).fit(X, y)
-    with pytest.raises(ValueError):
-        clf(momentum=-0.5).fit(X, y)
-    with pytest.raises(ValueError):
-        clf(nesterovs_momentum='invalid').fit(X, y)
-    with pytest.raises(ValueError):
-        clf(early_stopping='invalid').fit(X, y)
-    with pytest.raises(ValueError):
-        clf(validation_fraction=1).fit(X, y)
-    with pytest.raises(ValueError):
-        clf(validation_fraction=-0.5).fit(X, y)
-    with pytest.raises(ValueError):
-        clf(beta_1=1).fit(X, y)
-    with pytest.raises(ValueError):
-        clf(beta_1=-0.5).fit(X, y)
-    with pytest.raises(ValueError):
-        clf(beta_2=1).fit(X, y)
-    with pytest.raises(ValueError):
-        clf(beta_2=-0.5).fit(X, y)
-    with pytest.raises(ValueError):
-        clf(epsilon=-0.5).fit(X, y)
-    with pytest.raises(ValueError):
-        clf(n_iter_no_change=-1).fit(X, y)
-
-    with pytest.raises(ValueError):
-        clf(solver='hadoken').fit(X, y)
-    with pytest.raises(ValueError):
-        clf(learning_rate='converge').fit(X, y)
-    with pytest.raises(ValueError):
-        clf(activation='cloak').fit(X, y)
+        clf(**args).fit(X, y)
 
 
 def test_predict_proba_binary():

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -24,7 +24,6 @@ from sklearn.preprocessing import LabelBinarizer
 from sklearn.preprocessing import StandardScaler, MinMaxScaler
 from scipy.sparse import csr_matrix
 from sklearn.utils.testing import ignore_warnings
-from sklearn.utils.testing import assert_raise_message
 
 
 ACTIVATION_TYPES = ["identity", "logistic", "tanh", "relu"]
@@ -659,7 +658,8 @@ def test_warm_start():
         message = ('warm_start can only be used where `y` has the same '
                    'classes as in the previous call to fit.'
                    ' Previously got [0 1 2], `y` has %s' % np.unique(y_i))
-        assert_raise_message(ValueError, message, clf.fit, X, y_i)
+        with pytest.raises(ValueError, match=message):
+            clf.fit(X, y_i)
 
 
 def test_n_iter_no_change():

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -23,7 +23,7 @@ from sklearn.neural_network import MLPRegressor
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.preprocessing import StandardScaler, MinMaxScaler
 from scipy.sparse import csr_matrix
-from sklearn.utils.testing import assert_raises, ignore_warnings
+from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_raise_message
 
 
@@ -295,7 +295,8 @@ def test_lbfgs_regression_maxfun(X, y):
             assert max_fun >= mlp.n_iter_
 
     mlp.max_fun = -1
-    assert_raises(ValueError, mlp.fit, X, y)
+    with pytest.raises(ValueError):
+        mlp.fit(X, y)
 
 
 def test_learning_rate_warmstart():
@@ -360,7 +361,8 @@ def test_partial_fit_classes_error():
     y = [0]
     clf = MLPClassifier(solver='sgd')
     clf.partial_fit(X, y, classes=[0, 1])
-    assert_raises(ValueError, clf.partial_fit, X, y, classes=[1, 2])
+    with pytest.raises(ValueError):
+        clf.partial_fit(X, y, classes=[1, 2])
 
 
 def test_partial_fit_classification():
@@ -428,8 +430,8 @@ def test_partial_fit_errors():
     y = [1, 0]
 
     # no classes passed
-    assert_raises(ValueError,
-                  MLPClassifier(solver='sgd').partial_fit, X, y, classes=[2])
+    with pytest.raises(ValueError):
+        MLPClassifier(solver='sgd').partial_fit(X, y, classes=[2])
 
     # lbfgs doesn't support partial_fit
     assert not hasattr(MLPClassifier(solver='lbfgs'), 'partial_fit')
@@ -441,27 +443,47 @@ def test_params_errors():
     y = [1, 0]
     clf = MLPClassifier
 
-    assert_raises(ValueError, clf(hidden_layer_sizes=-1).fit, X, y)
-    assert_raises(ValueError, clf(max_iter=-1).fit, X, y)
-    assert_raises(ValueError, clf(shuffle='true').fit, X, y)
-    assert_raises(ValueError, clf(alpha=-1).fit, X, y)
-    assert_raises(ValueError, clf(learning_rate_init=-1).fit, X, y)
-    assert_raises(ValueError, clf(momentum=2).fit, X, y)
-    assert_raises(ValueError, clf(momentum=-0.5).fit, X, y)
-    assert_raises(ValueError, clf(nesterovs_momentum='invalid').fit, X, y)
-    assert_raises(ValueError, clf(early_stopping='invalid').fit, X, y)
-    assert_raises(ValueError, clf(validation_fraction=1).fit, X, y)
-    assert_raises(ValueError, clf(validation_fraction=-0.5).fit, X, y)
-    assert_raises(ValueError, clf(beta_1=1).fit, X, y)
-    assert_raises(ValueError, clf(beta_1=-0.5).fit, X, y)
-    assert_raises(ValueError, clf(beta_2=1).fit, X, y)
-    assert_raises(ValueError, clf(beta_2=-0.5).fit, X, y)
-    assert_raises(ValueError, clf(epsilon=-0.5).fit, X, y)
-    assert_raises(ValueError, clf(n_iter_no_change=-1).fit, X, y)
+    with pytest.raises(ValueError):
+        clf(hidden_layer_sizes=-1).fit(X, y)
+    with pytest.raises(ValueError):
+        clf(max_iter=-1).fit(X, y)
+    with pytest.raises(ValueError):
+        clf(shuffle='true').fit(X, y)
+    with pytest.raises(ValueError):
+        clf(alpha=-1).fit(X, y)
+    with pytest.raises(ValueError):
+        clf(learning_rate_init=-1).fit(X, y)
+    with pytest.raises(ValueError):
+        clf(momentum=2).fit(X, y)
+    with pytest.raises(ValueError):
+        clf(momentum=-0.5).fit(X, y)
+    with pytest.raises(ValueError):
+        clf(nesterovs_momentum='invalid').fit(X, y)
+    with pytest.raises(ValueError):
+        clf(early_stopping='invalid').fit(X, y)
+    with pytest.raises(ValueError):
+        clf(validation_fraction=1).fit(X, y)
+    with pytest.raises(ValueError):
+        clf(validation_fraction=-0.5).fit(X, y)
+    with pytest.raises(ValueError):
+        clf(beta_1=1).fit(X, y)
+    with pytest.raises(ValueError):
+        clf(beta_1=-0.5).fit(X, y)
+    with pytest.raises(ValueError):
+        clf(beta_2=1).fit(X, y)
+    with pytest.raises(ValueError):
+        clf(beta_2=-0.5).fit(X, y)
+    with pytest.raises(ValueError):
+        clf(epsilon=-0.5).fit(X, y)
+    with pytest.raises(ValueError):
+        clf(n_iter_no_change=-1).fit(X, y)
 
-    assert_raises(ValueError, clf(solver='hadoken').fit, X, y)
-    assert_raises(ValueError, clf(learning_rate='converge').fit, X, y)
-    assert_raises(ValueError, clf(activation='cloak').fit, X, y)
+    with pytest.raises(ValueError):
+        clf(solver='hadoken').fit(X, y)
+    with pytest.raises(ValueError):
+        clf(learning_rate='converge').fit(X, y)
+    with pytest.raises(ValueError):
+        clf(activation='cloak').fit(X, y)
 
 
 def test_predict_proba_binary():

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -8,6 +8,7 @@ Testing for Multi-layer Perceptron module (sklearn.neural_network)
 import pytest
 import sys
 import warnings
+import re
 
 import numpy as np
 
@@ -658,7 +659,7 @@ def test_warm_start():
         message = ('warm_start can only be used where `y` has the same '
                    'classes as in the previous call to fit.'
                    ' Previously got [0 1 2], `y` has %s' % np.unique(y_i))
-        with pytest.raises(ValueError, match=message):
+        with pytest.raises(ValueError, match=re.escape(message)):
             clf.fit(X, y_i)
 
 


### PR DESCRIPTION
replaced `assert_raises` and `assert_raises_regex` with `pytest.raises` context manager.

related to #14216
