### PR TITLE
MAINT:Fix assert raises in `sklearn/preprocessing/tests/`

### DIFF
--- a/sklearn/preprocessing/tests/test_base.py
+++ b/sklearn/preprocessing/tests/test_base.py
@@ -3,7 +3,6 @@ import pytest
 from scipy import sparse
 
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raise_message
 from sklearn.preprocessing.base import _transform_selected
 from sklearn.preprocessing.data import Binarizer
 
@@ -61,22 +60,21 @@ def test_transform_selected_copy_arg(output_dtype, input_dtype):
 def test_transform_selected_retain_order():
     X = [[-1, 1], [2, -2]]
 
-    assert_raise_message(ValueError,
-                         "The retain_order option can only be set to True "
-                         "for dense matrices.",
-                         _transform_selected, sparse.csr_matrix(X),
-                         Binarizer().transform, dtype=np.int, selected=[0],
-                         retain_order=True)
+    err_msg = ("The retain_order option can only be set to True "
+               "for dense matrices.")
+    with pytest.raises(ValueError, match=err_msg):
+        _transform_selected(sparse.csr_matrix(X), Binarizer().transform,
+                            dtype=np.int, selected=[0], retain_order=True)
 
     def transform(X):
         return np.hstack((X, [[0], [0]]))
 
-    assert_raise_message(ValueError,
-                         "The retain_order option can only be set to True "
-                         "if the dimensions of the input array match the "
-                         "dimensions of the transformed array.",
-                         _transform_selected, X, transform, dtype=np.int,
-                         selected=[0], retain_order=True)
+    err_msg = ("The retain_order option can only be set to True "
+               "if the dimensions of the input array match the "
+               "dimensions of the transformed array.")
+    with pytest.raises(ValueError, match=err_msg):
+        _transform_selected(X, transform, dtype=np.int,
+                            selected=[0], retain_order=True)
 
     X_expected = [[-1, 1], [2, 0]]
     Xtr = _transform_selected(X, Binarizer().transform, dtype=np.int,

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -21,8 +21,6 @@ from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_less
-from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import assert_allclose
@@ -693,7 +691,8 @@ def test_min_max_scaler_iris():
 
     # raises on invalid range
     scaler = MinMaxScaler(feature_range=(2, 1))
-    assert_raises(ValueError, scaler.fit, X)
+    with pytest.raises(ValueError):
+        scaler.fit(X)
 
 
 def test_min_max_scaler_zero_variance_features():
@@ -791,8 +790,10 @@ def test_scaler_without_centering():
     X_csr = sparse.csr_matrix(X)
     X_csc = sparse.csc_matrix(X)
 
-    assert_raises(ValueError, StandardScaler().fit, X_csr)
-    assert_raises(ValueError, StandardScaler().fit, X_csc)
+    with pytest.raises(ValueError):
+        StandardScaler().fit(X_csr)
+    with pytest.raises(ValueError):
+        StandardScaler().fit(X_csc)
 
     null_transform = StandardScaler(with_mean=False, with_std=False, copy=True)
     X_null = null_transform.fit_transform(X_csr)
@@ -1024,30 +1025,38 @@ def test_scale_sparse_with_mean_raise_exception():
     X_csc = sparse.csc_matrix(X)
 
     # check scaling and fit with direct calls on sparse data
-    assert_raises(ValueError, scale, X_csr, with_mean=True)
-    assert_raises(ValueError, StandardScaler(with_mean=True).fit, X_csr)
+    with pytest.raises(ValueError):
+        scale(X_csr, with_mean=True)
+    with pytest.raises(ValueError):
+        StandardScaler(with_mean=True).fit(X_csr)
 
-    assert_raises(ValueError, scale, X_csc, with_mean=True)
-    assert_raises(ValueError, StandardScaler(with_mean=True).fit, X_csc)
+    with pytest.raises(ValueError):
+        scale(X_csc, with_mean=True)
+    with pytest.raises(ValueError):
+        StandardScaler(with_mean=True).fit(X_csc)
 
     # check transform and inverse_transform after a fit on a dense array
     scaler = StandardScaler(with_mean=True).fit(X)
-    assert_raises(ValueError, scaler.transform, X_csr)
-    assert_raises(ValueError, scaler.transform, X_csc)
+    with pytest.raises(ValueError):
+        scaler.transform(X_csr)
+    with pytest.raises(ValueError):
+        scaler.transform(X_csc)
 
     X_transformed_csr = sparse.csr_matrix(scaler.transform(X))
-    assert_raises(ValueError, scaler.inverse_transform, X_transformed_csr)
+    with pytest.raises(ValueError):
+        scaler.inverse_transform(X_transformed_csr)
 
     X_transformed_csc = sparse.csc_matrix(scaler.transform(X))
-    assert_raises(ValueError, scaler.inverse_transform, X_transformed_csc)
+    with pytest.raises(ValueError):
+        scaler.inverse_transform(X_transformed_csc)
 
 
 def test_scale_input_finiteness_validation():
     # Check if non finite inputs raise ValueError
     X = [[np.inf, 5, 6, 7, 8]]
-    assert_raises_regex(ValueError,
-                        "Input contains infinity or a value too large",
-                        scale, X)
+    with pytest.raises(ValueError, match="Input contains infinity "
+                       "or a value too large"):
+        scale(X)
 
 
 def test_robust_scaler_error_sparse():
@@ -1201,53 +1210,59 @@ def test_quantile_transform_check_error():
                           [0, 0, 2.6, 4.1, 0, 0, 2.3, 0, 9.5, 0.1]])
     X_neg = sparse.csc_matrix(X_neg)
 
-    assert_raises_regex(ValueError, "Invalid value for 'n_quantiles': 0.",
-                        QuantileTransformer(n_quantiles=0).fit, X)
-    assert_raises_regex(ValueError, "Invalid value for 'subsample': 0.",
-                        QuantileTransformer(subsample=0).fit, X)
-    assert_raises_regex(ValueError, "The number of quantiles cannot be"
-                        " greater than the number of samples used. Got"
-                        " 1000 quantiles and 10 samples.",
-                        QuantileTransformer(subsample=10).fit, X)
+    with pytest.raises(ValueError, match="Invalid value for "
+                                         "'n_quantiles': 0."):
+        QuantileTransformer(n_quantiles=0).fit(X)
+    with pytest.raises(ValueError, match="Invalid value for "
+                                         "'subsample': 0."):
+        QuantileTransformer(subsample=0).fit(X)
+    with pytest.raises(ValueError, match="The number of quantiles "
+                                         "cannot be greater than "
+                                         "the number of samples "
+                                         "used. Got 1000 quantiles "
+                                         "and 10 samples."):
+        QuantileTransformer(subsample=10).fit(X)
 
     transformer = QuantileTransformer(n_quantiles=10)
-    assert_raises_regex(ValueError, "QuantileTransformer only accepts "
-                        "non-negative sparse matrices.",
-                        transformer.fit, X_neg)
+    with pytest.raises(ValueError, match="QuantileTransformer only accepts "
+                                         "non-negative sparse matrices."):
+        transformer.fit(X_neg)
     transformer.fit(X)
-    assert_raises_regex(ValueError, "QuantileTransformer only accepts "
-                        "non-negative sparse matrices.",
-                        transformer.transform, X_neg)
+    with pytest.raises(ValueError, match="QuantileTransformer only accepts "
+                                         "non-negative sparse matrices."):
+        transformer.transform(X_neg)
 
     X_bad_feat = np.transpose([[0, 25, 50, 0, 0, 0, 75, 0, 0, 100],
                                [0, 0, 2.6, 4.1, 0, 0, 2.3, 0, 9.5, 0.1]])
-    assert_raises_regex(ValueError, "X does not have the same number of "
-                        "features as the previously fitted data. Got 2"
-                        " instead of 3.",
-                        transformer.transform, X_bad_feat)
-    assert_raises_regex(ValueError, "X does not have the same number of "
-                        "features as the previously fitted data. Got 2"
-                        " instead of 3.",
-                        transformer.inverse_transform, X_bad_feat)
+    with pytest.raises(ValueError, match="X does not have the same number of "
+                                         "features as the previously fitted "
+                                         "data. Got 2 instead of 3."):
+        transformer.transform(X_bad_feat)
+    with pytest.raises(ValueError, match="X does not have the same number of "
+                                         "features as the previously fitted "
+                                         "data. Got 2 instead of 3."):
+        transformer.inverse_transform(X_bad_feat)
 
     transformer = QuantileTransformer(n_quantiles=10,
                                       output_distribution='rnd')
     # check that an error is raised at fit time
-    assert_raises_regex(ValueError, "'output_distribution' has to be either"
-                        " 'normal' or 'uniform'. Got 'rnd' instead.",
-                        transformer.fit, X)
+    with pytest.raises(ValueError, match="'output_distribution' has to "
+                       "be either 'normal' or 'uniform'. Got 'rnd' instead."):
+        transformer.fit(X)
     # check that an error is raised at transform time
     transformer.output_distribution = 'uniform'
     transformer.fit(X)
     X_tran = transformer.transform(X)
     transformer.output_distribution = 'rnd'
-    assert_raises_regex(ValueError, "'output_distribution' has to be either"
-                        " 'normal' or 'uniform'. Got 'rnd' instead.",
-                        transformer.transform, X)
+    with pytest.raises(ValueError, match="'output_distribution' has to "
+                                         "be either 'normal' or 'uniform'. "
+                                         "Got 'rnd' instead."):
+        transformer.transform(X)
     # check that an error is raised at inverse_transform time
-    assert_raises_regex(ValueError, "'output_distribution' has to be either"
-                        " 'normal' or 'uniform'. Got 'rnd' instead.",
-                        transformer.inverse_transform, X_tran)
+    with pytest.raises(ValueError, match="'output_distribution' has to "
+                                         "be either 'normal' or 'uniform'. "
+                                         "Got 'rnd' instead."):
+        transformer.inverse_transform(X_tran)
     # check that an error is raised if input is scalar
     assert_raise_message(ValueError,
                          'Expected 2D array, got scalar array instead',
@@ -1541,8 +1556,8 @@ def test_robust_scaler_invalid_range():
     ]:
         scaler = RobustScaler(quantile_range=range_)
 
-        assert_raises_regex(ValueError, r'Invalid quantile range: \(',
-                            scaler.fit, iris.data)
+        with pytest.raises(ValueError, match=r'Invalid quantile range: \('):
+            scaler.fit(iris.data)
 
 
 def test_scale_function_without_centering():
@@ -1562,7 +1577,8 @@ def test_scale_function_without_centering():
     assert_array_almost_equal(X_scaled, X_csc_scaled.toarray())
 
     # raises value error on axis != 0
-    assert_raises(ValueError, scale, X_csr, with_mean=False, axis=1)
+    with pytest.raises(ValueError):
+        scale(X_csr, with_mean=False, axis=1)
 
     assert_array_almost_equal(X_scaled.mean(axis=0),
                               [0., -0.01, 2.24, -0.35, -0.78], 2)
@@ -1951,8 +1967,10 @@ def test_normalize():
     X = np.random.RandomState(37).randn(3, 2)
     assert_array_equal(normalize(X, copy=False),
                        normalize(X.T, axis=0, copy=False).T)
-    assert_raises(ValueError, normalize, [[0]], axis=2)
-    assert_raises(ValueError, normalize, [[0]], norm='l3')
+    with pytest.raises(ValueError):
+        normalize([[0]], axis=2)
+    with pytest.raises(ValueError):
+        normalize([[0]], norm='l3')
 
     rs = np.random.RandomState(0)
     X_dense = rs.randn(10, 5)
@@ -1987,8 +2005,8 @@ def test_normalize():
 
     X_sparse = sparse.csr_matrix(X_dense)
     for norm in ('l1', 'l2'):
-        assert_raises(NotImplementedError, normalize, X_sparse,
-                      norm=norm, return_norm=True)
+        with pytest.raises(NotImplementedError):
+            normalize(X_sparse, norm=norm, return_norm=True)
     _, norms = normalize(X_sparse, norm='max', return_norm=True)
     assert_array_almost_equal(norms, np.array([4.0, 1.0, 3.0]))
 
@@ -2045,7 +2063,8 @@ def test_binarizer():
         X_bin = binarizer.transform(X)
 
     # Cannot use threshold < 0 for sparse
-    assert_raises(ValueError, binarizer.transform, sparse.csc_matrix(X))
+    with pytest.raises(ValueError):
+        binarizer.transform(sparse.csc_matrix(X))
 
 
 def test_center_kernel():
@@ -2151,16 +2170,19 @@ def test_quantile_transform_valid_axis():
                   [2, 4, 6, 8, 10],
                   [2.6, 4.1, 2.3, 9.5, 0.1]])
 
-    assert_raises_regex(ValueError, "axis should be either equal to 0 or 1"
-                        ". Got axis=2", quantile_transform, X.T, axis=2)
+    with pytest.raises(ValueError, match="axis should be either equal "
+                                         "to 0 or 1. Got axis=2"):
+        quantile_transform(X.T, axis=2)
 
 
 @pytest.mark.parametrize("method", ['box-cox', 'yeo-johnson'])
 def test_power_transformer_notfitted(method):
     pt = PowerTransformer(method=method)
     X = np.abs(X_1col)
-    assert_raises(NotFittedError, pt.transform, X)
-    assert_raises(NotFittedError, pt.inverse_transform, X)
+    with pytest.raises(NotFittedError):
+        pt.transform(X)
+    with pytest.raises(NotFittedError):
+        pt.inverse_transform(X)
 
 
 @pytest.mark.parametrize('method', ['box-cox', 'yeo-johnson'])

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -16,7 +16,6 @@ import pytest
 
 from sklearn.utils import gen_batches
 
-from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
@@ -1264,9 +1263,9 @@ def test_quantile_transform_check_error():
                                          "Got 'rnd' instead."):
         transformer.inverse_transform(X_tran)
     # check that an error is raised if input is scalar
-    assert_raise_message(ValueError,
-                         'Expected 2D array, got scalar array instead',
-                         transformer.transform, 10)
+    with pytest.raises(ValueError,
+                       match='Expected 2D array, got scalar array instead'):
+        transformer.transform(10)
     # check that a warning is raised is n_quantiles > n_samples
     transformer = QuantileTransformer(n_quantiles=100)
     warn_msg = "n_quantiles is set to n_samples"
@@ -2263,23 +2262,23 @@ def test_power_transformer_boxcox_strictly_positive_exception():
     X_with_negatives = X_2d
     not_positive_message = 'strictly positive'
 
-    assert_raise_message(ValueError, not_positive_message,
-                         pt.transform, X_with_negatives)
+    with pytest.raises(ValueError, match=not_positive_message):
+        pt.transform(X_with_negatives)
 
-    assert_raise_message(ValueError, not_positive_message,
-                         pt.fit, X_with_negatives)
+    with pytest.raises(ValueError, match=not_positive_message):
+        pt.fit(X_with_negatives)
 
-    assert_raise_message(ValueError, not_positive_message,
-                         power_transform, X_with_negatives, 'box-cox')
+    with pytest.raises(ValueError, match=not_positive_message):
+        power_transform(X_with_negatives, 'box-cox')
 
-    assert_raise_message(ValueError, not_positive_message,
-                         pt.transform, np.zeros(X_2d.shape))
+    with pytest.raises(ValueError, match=not_positive_message):
+        pt.transform(np.zeros(X_2d.shape))
 
-    assert_raise_message(ValueError, not_positive_message,
-                         pt.fit, np.zeros(X_2d.shape))
+    with pytest.raises(ValueError, match=not_positive_message):
+        pt.fit(np.zeros(X_2d.shape))
 
-    assert_raise_message(ValueError, not_positive_message,
-                         power_transform, np.zeros(X_2d.shape), 'box-cox')
+    with pytest.raises(ValueError, match=not_positive_message):
+        power_transform(np.zeros(X_2d.shape), 'box-cox')
 
 
 @pytest.mark.parametrize('X', [X_2d, np.abs(X_2d), -np.abs(X_2d),
@@ -2299,11 +2298,11 @@ def test_power_transformer_shape_exception(method):
     # than during fitting
     wrong_shape_message = 'Input data has a different number of features'
 
-    assert_raise_message(ValueError, wrong_shape_message,
-                         pt.transform, X[:, 0:1])
+    with pytest.raises(ValueError, match=wrong_shape_message):
+        pt.transform(X[:, 0:1])
 
-    assert_raise_message(ValueError, wrong_shape_message,
-                         pt.inverse_transform, X[:, 0:1])
+    with pytest.raises(ValueError, match=wrong_shape_message):
+        pt.inverse_transform(X[:, 0:1])
 
 
 def test_power_transformer_method_exception():
@@ -2312,8 +2311,8 @@ def test_power_transformer_method_exception():
 
     # An exception should be raised if PowerTransformer.method isn't valid
     bad_method_message = "'method' must be one of"
-    assert_raise_message(ValueError, bad_method_message,
-                         pt.fit, X)
+    with pytest.raises(ValueError, match=bad_method_message):
+        pt.fit(X)
 
 
 def test_power_transformer_lambda_zero():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1209,58 +1209,58 @@ def test_quantile_transform_check_error():
                           [0, 0, 2.6, 4.1, 0, 0, 2.3, 0, 9.5, 0.1]])
     X_neg = sparse.csc_matrix(X_neg)
 
-    with pytest.raises(ValueError, match="Invalid value for "
-                                         "'n_quantiles': 0."):
+    err_msg = "Invalid value for 'n_quantiles': 0."
+    with pytest.raises(ValueError, match=err_msg):
         QuantileTransformer(n_quantiles=0).fit(X)
-    with pytest.raises(ValueError, match="Invalid value for "
-                                         "'subsample': 0."):
+    err_msg = "Invalid value for 'subsample': 0."
+    with pytest.raises(ValueError, match=err_msg):
         QuantileTransformer(subsample=0).fit(X)
-    with pytest.raises(ValueError, match="The number of quantiles "
-                                         "cannot be greater than "
-                                         "the number of samples "
-                                         "used. Got 1000 quantiles "
-                                         "and 10 samples."):
+    err_msg = ("The number of quantiles cannot be greater than "
+               "the number of samples used. Got 1000 quantiles "
+               "and 10 samples.")
+    with pytest.raises(ValueError, match=err_msg):
         QuantileTransformer(subsample=10).fit(X)
 
     transformer = QuantileTransformer(n_quantiles=10)
-    with pytest.raises(ValueError, match="QuantileTransformer only accepts "
-                                         "non-negative sparse matrices."):
+    err_msg = "QuantileTransformer only accepts non-negative sparse matrices."
+    with pytest.raises(ValueError, match=err_msg):
         transformer.fit(X_neg)
     transformer.fit(X)
-    with pytest.raises(ValueError, match="QuantileTransformer only accepts "
-                                         "non-negative sparse matrices."):
+    err_msg = "QuantileTransformer only accepts non-negative sparse matrices."
+    with pytest.raises(ValueError, match=err_msg):
         transformer.transform(X_neg)
 
     X_bad_feat = np.transpose([[0, 25, 50, 0, 0, 0, 75, 0, 0, 100],
                                [0, 0, 2.6, 4.1, 0, 0, 2.3, 0, 9.5, 0.1]])
-    with pytest.raises(ValueError, match="X does not have the same number of "
-                                         "features as the previously fitted "
-                                         "data. Got 2 instead of 3."):
+    err_msg = ("X does not have the same number of features as the previously"
+               " fitted " "data. Got 2 instead of 3.")
+    with pytest.raises(ValueError, match=err_msg):
         transformer.transform(X_bad_feat)
-    with pytest.raises(ValueError, match="X does not have the same number of "
-                                         "features as the previously fitted "
-                                         "data. Got 2 instead of 3."):
+    err_msg = ("X does not have the same number of features "
+               "as the previously fitted data. Got 2 instead of 3.")
+    with pytest.raises(ValueError, match=err_msg):
         transformer.inverse_transform(X_bad_feat)
 
     transformer = QuantileTransformer(n_quantiles=10,
                                       output_distribution='rnd')
     # check that an error is raised at fit time
-    with pytest.raises(ValueError, match="'output_distribution' has to "
-                       "be either 'normal' or 'uniform'. Got 'rnd' instead."):
+    err_msg = ("'output_distribution' has to be either 'normal' or "
+               "'uniform'. Got 'rnd' instead.")
+    with pytest.raises(ValueError, match=err_msg):
         transformer.fit(X)
     # check that an error is raised at transform time
     transformer.output_distribution = 'uniform'
     transformer.fit(X)
     X_tran = transformer.transform(X)
     transformer.output_distribution = 'rnd'
-    with pytest.raises(ValueError, match="'output_distribution' has to "
-                                         "be either 'normal' or 'uniform'. "
-                                         "Got 'rnd' instead."):
+    err_msg = ("'output_distribution' has to be either 'normal' or 'uniform'."
+               " Got 'rnd' instead.")
+    with pytest.raises(ValueError, match=err_msg):
         transformer.transform(X)
     # check that an error is raised at inverse_transform time
-    with pytest.raises(ValueError, match="'output_distribution' has to "
-                                         "be either 'normal' or 'uniform'. "
-                                         "Got 'rnd' instead."):
+    err_msg = ("'output_distribution' has to be either 'normal' or 'uniform'."
+               " Got 'rnd' instead.")
+    with pytest.raises(ValueError, match=err_msg):
         transformer.inverse_transform(X_tran)
     # check that an error is raised if input is scalar
     with pytest.raises(ValueError,

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -9,7 +9,6 @@ from sklearn.preprocessing import OneHotEncoder
 from sklearn.utils.testing import (
     assert_array_almost_equal,
     assert_array_equal,
-    assert_raises,
     assert_raise_message,
     assert_warns_message
 )
@@ -128,11 +127,13 @@ def test_same_min_max(strategy):
 def test_transform_1d_behavior():
     X = np.arange(4)
     est = KBinsDiscretizer(n_bins=2)
-    assert_raises(ValueError, est.fit, X)
+    with pytest.raises(ValueError):
+        est.fit(X)
 
     est = KBinsDiscretizer(n_bins=2)
     est.fit(X.reshape(-1, 1))
-    assert_raises(ValueError, est.transform, X)
+    with pytest.raises(ValueError):
+        est.transform(X)
 
 
 @pytest.mark.parametrize('i', range(1, 9))

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -45,7 +45,7 @@ def test_invalid_n_bins():
     est = KBinsDiscretizer(n_bins=1.1)
     err_msg = ("KBinsDiscretizer received an invalid "
                "n_bins type. Received float, expected int.")
-    with pytest.raises(ValueError, match=err_msg): 
+    with pytest.raises(ValueError, match=err_msg):
         est.fit_transform(X)
 
 
@@ -55,7 +55,7 @@ def test_invalid_n_bins_array():
     est = KBinsDiscretizer(n_bins=n_bins)
     err_msg = "n_bins must be a scalar or array of shape (n_features,)."
     with pytest.raises(ValueError,
-                       match=err_msg.replace('(', '\(').replace(')', '\)')):
+                       match=err_msg.replace('(', r'\(').replace(')', r'\)')):
         est.fit_transform(X)
 
     # Incorrect number of features
@@ -63,7 +63,7 @@ def test_invalid_n_bins_array():
     est = KBinsDiscretizer(n_bins=n_bins)
     err_msg = "n_bins must be a scalar or array of shape (n_features,)."
     with pytest.raises(ValueError,
-                       match=err_msg.replace('(', '\(').replace(')', '\)')):
+                       match=err_msg.replace('(', r'\(').replace(')', r'\)')):
         est.fit_transform(X)
 
     # Bad bin values
@@ -156,7 +156,7 @@ def test_invalid_encode_option():
                "('onehot', 'onehot-dense', 'ordinal'). "
                "Got encode='invalid-encode' instead.")
     with pytest.raises(ValueError,
-                       match=err_msg.replace('(', '\(').replace(')', '\)')):
+                       match=err_msg.replace('(', r'\(').replace(')', r'\)')):
         est.fit(X)
 
 
@@ -189,7 +189,7 @@ def test_invalid_strategy_option():
                "('uniform', 'quantile', 'kmeans'). "
                "Got strategy='invalid-strategy' instead.")
     with pytest.raises(ValueError,
-                       match=err_msg.replace('(', '\(').replace(')', '\)')):
+                       match=err_msg.replace('(', r'\(').replace(')', r'\)')):
         est.fit(X)
 
 

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -9,7 +9,6 @@ from sklearn.preprocessing import OneHotEncoder
 from sklearn.utils.testing import (
     assert_array_almost_equal,
     assert_array_equal,
-    assert_raise_message,
     assert_warns_message
 )
 
@@ -38,48 +37,52 @@ def test_valid_n_bins():
 
 def test_invalid_n_bins():
     est = KBinsDiscretizer(n_bins=1)
-    assert_raise_message(ValueError, "KBinsDiscretizer received an invalid "
-                         "number of bins. Received 1, expected at least 2.",
-                         est.fit_transform, X)
+    err_msg = ("KBinsDiscretizer received an invalid "
+               "number of bins. Received 1, expected at least 2.")
+    with pytest.raises(ValueError, match=err_msg):
+        est.fit_transform(X)
 
     est = KBinsDiscretizer(n_bins=1.1)
-    assert_raise_message(ValueError, "KBinsDiscretizer received an invalid "
-                         "n_bins type. Received float, expected int.",
-                         est.fit_transform, X)
+    err_msg = ("KBinsDiscretizer received an invalid "
+               "n_bins type. Received float, expected int.")
+    with pytest.raises(ValueError, match=err_msg): 
+        est.fit_transform(X)
 
 
 def test_invalid_n_bins_array():
     # Bad shape
     n_bins = np.full((2, 4), 2.)
     est = KBinsDiscretizer(n_bins=n_bins)
-    assert_raise_message(ValueError,
-                         "n_bins must be a scalar or array of shape "
-                         "(n_features,).", est.fit_transform, X)
+    err_msg = "n_bins must be a scalar or array of shape (n_features,)."
+    with pytest.raises(ValueError,
+                       match=err_msg.replace('(', '\(').replace(')', '\)')):
+        est.fit_transform(X)
 
     # Incorrect number of features
     n_bins = [1, 2, 2]
     est = KBinsDiscretizer(n_bins=n_bins)
-    assert_raise_message(ValueError,
-                         "n_bins must be a scalar or array of shape "
-                         "(n_features,).", est.fit_transform, X)
+    err_msg = "n_bins must be a scalar or array of shape (n_features,)."
+    with pytest.raises(ValueError,
+                       match=err_msg.replace('(', '\(').replace(')', '\)')):
+        est.fit_transform(X)
 
     # Bad bin values
     n_bins = [1, 2, 2, 1]
     est = KBinsDiscretizer(n_bins=n_bins)
-    assert_raise_message(ValueError,
-                         "KBinsDiscretizer received an invalid number of bins "
-                         "at indices 0, 3. Number of bins must be at least 2, "
-                         "and must be an int.",
-                         est.fit_transform, X)
+    err_msg = ("KBinsDiscretizer received an invalid number of bins "
+               "at indices 0, 3. Number of bins must be at least 2, "
+               "and must be an int.")
+    with pytest.raises(ValueError, match=err_msg):
+        est.fit_transform(X)
 
     # Float bin values
     n_bins = [2.1, 2, 2.1, 2]
     est = KBinsDiscretizer(n_bins=n_bins)
-    assert_raise_message(ValueError,
-                         "KBinsDiscretizer received an invalid number of bins "
-                         "at indices 0, 2. Number of bins must be at least 2, "
-                         "and must be an int.",
-                         est.fit_transform, X)
+    err_msg = ("KBinsDiscretizer received an invalid number of bins "
+               "at indices 0, 2. Number of bins must be at least 2, "
+               "and must be an int.")
+    with pytest.raises(ValueError, match=err_msg):
+        est.fit_transform(X)
 
 
 @pytest.mark.parametrize(
@@ -102,9 +105,9 @@ def test_fit_transform_n_bins_array(strategy, expected):
 def test_invalid_n_features():
     est = KBinsDiscretizer(n_bins=3).fit(X)
     bad_X = np.arange(25).reshape(5, -1)
-    assert_raise_message(ValueError,
-                         "Incorrect number of features. Expecting 4, "
-                         "received 5", est.transform, bad_X)
+    err_msg = "Incorrect number of features. Expecting 4, received 5"
+    with pytest.raises(ValueError, match=err_msg):
+        est.transform(bad_X)
 
 
 @pytest.mark.parametrize('strategy', ['uniform', 'kmeans', 'quantile'])
@@ -149,10 +152,12 @@ def test_numeric_stability(i):
 
 def test_invalid_encode_option():
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], encode='invalid-encode')
-    assert_raise_message(ValueError, "Valid options for 'encode' are "
-                         "('onehot', 'onehot-dense', 'ordinal'). "
-                         "Got encode='invalid-encode' instead.",
-                         est.fit, X)
+    err_msg = ("Valid options for 'encode' are "
+               "('onehot', 'onehot-dense', 'ordinal'). "
+               "Got encode='invalid-encode' instead.")
+    with pytest.raises(ValueError,
+                       match=err_msg.replace('(', '\(').replace(')', '\)')):
+        est.fit(X)
 
 
 def test_encode_options():
@@ -180,10 +185,12 @@ def test_encode_options():
 
 def test_invalid_strategy_option():
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], strategy='invalid-strategy')
-    assert_raise_message(ValueError, "Valid options for 'strategy' are "
-                         "('uniform', 'quantile', 'kmeans'). "
-                         "Got strategy='invalid-strategy' instead.",
-                         est.fit, X)
+    err_msg = ("Valid options for 'strategy' are "
+               "('uniform', 'quantile', 'kmeans'). "
+               "Got strategy='invalid-strategy' instead.")
+    with pytest.raises(ValueError,
+                       match=err_msg.replace('(', '\(').replace(')', '\)')):
+        est.fit(X)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -53,17 +53,15 @@ def test_invalid_n_bins_array():
     # Bad shape
     n_bins = np.full((2, 4), 2.)
     est = KBinsDiscretizer(n_bins=n_bins)
-    err_msg = "n_bins must be a scalar or array of shape (n_features,)."
-    with pytest.raises(ValueError,
-                       match=err_msg.replace('(', r'\(').replace(')', r'\)')):
+    err_msg = r"n_bins must be a scalar or array of shape \(n_features,\)."
+    with pytest.raises(ValueError, match=err_msg):
         est.fit_transform(X)
 
     # Incorrect number of features
     n_bins = [1, 2, 2]
     est = KBinsDiscretizer(n_bins=n_bins)
-    err_msg = "n_bins must be a scalar or array of shape (n_features,)."
-    with pytest.raises(ValueError,
-                       match=err_msg.replace('(', r'\(').replace(')', r'\)')):
+    err_msg = r"n_bins must be a scalar or array of shape \(n_features,\)."
+    with pytest.raises(ValueError, match=err_msg):
         est.fit_transform(X)
 
     # Bad bin values
@@ -152,11 +150,10 @@ def test_numeric_stability(i):
 
 def test_invalid_encode_option():
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], encode='invalid-encode')
-    err_msg = ("Valid options for 'encode' are "
-               "('onehot', 'onehot-dense', 'ordinal'). "
+    err_msg = (r"Valid options for 'encode' are "
+               "\('onehot', 'onehot-dense', 'ordinal'\). "
                "Got encode='invalid-encode' instead.")
-    with pytest.raises(ValueError,
-                       match=err_msg.replace('(', r'\(').replace(')', r'\)')):
+    with pytest.raises(ValueError, match=err_msg):
         est.fit(X)
 
 
@@ -185,11 +182,10 @@ def test_encode_options():
 
 def test_invalid_strategy_option():
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], strategy='invalid-strategy')
-    err_msg = ("Valid options for 'strategy' are "
-               "('uniform', 'quantile', 'kmeans'). "
+    err_msg = (r"Valid options for 'strategy' are "
+               "\('uniform', 'quantile', 'kmeans'\). "
                "Got strategy='invalid-strategy' instead.")
-    with pytest.raises(ValueError,
-                       match=err_msg.replace('(', r'\(').replace(')', r'\)')):
+    with pytest.raises(ValueError, match=err_msg):
         est.fit(X)
 
 

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -151,8 +151,8 @@ def test_numeric_stability(i):
 def test_invalid_encode_option():
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], encode='invalid-encode')
     err_msg = (r"Valid options for 'encode' are "
-               "\('onehot', 'onehot-dense', 'ordinal'\). "
-               "Got encode='invalid-encode' instead.")
+               r"\('onehot', 'onehot-dense', 'ordinal'\). "
+               r"Got encode='invalid-encode' instead.")
     with pytest.raises(ValueError, match=err_msg):
         est.fit(X)
 
@@ -183,8 +183,8 @@ def test_encode_options():
 def test_invalid_strategy_option():
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], strategy='invalid-strategy')
     err_msg = (r"Valid options for 'strategy' are "
-               "\('uniform', 'quantile', 'kmeans'\). "
-               "Got strategy='invalid-strategy' instead.")
+               r"\('uniform', 'quantile', 'kmeans'\). "
+               r"Got strategy='invalid-strategy' instead.")
     with pytest.raises(ValueError, match=err_msg):
         est.fit(X)
 

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -645,9 +645,8 @@ def test_one_hot_encoder_invalid_params(X_fit, params, err_msg):
 @pytest.mark.parametrize('drop', [['abc', 3], ['abc', 3, 41, 'a']])
 def test_invalid_drop_length(drop):
     enc = OneHotEncoder(drop=drop)
-    with pytest.raises(ValueError,
-                       match="`drop` should have length "
-                       "equal to the number"):
+    err_msg = "`drop` should have length equal to the number"
+    with pytest.raises(ValueError, match=err_msg):
         enc.fit([['abc', 2, 55], ['def', 1, 55], ['def', 3, 59]])
 
 

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -8,7 +8,6 @@ import pytest
 
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.testing import assert_allclose
 
 from sklearn.preprocessing import OneHotEncoder
@@ -261,7 +260,8 @@ def test_one_hot_encoder_inverse(sparse_, drop):
     # incorrect shape raises
     X_tr = np.array([[0, 1, 1], [1, 0, 1]])
     msg = re.escape('Shape of the passed X data is not correct')
-    assert_raises_regex(ValueError, msg, enc.inverse_transform, X_tr)
+    with pytest.raises(ValueError, match=msg):
+        enc.inverse_transform(X_tr)
 
 
 @pytest.mark.parametrize("method", ['fit', 'fit_transform'])
@@ -520,7 +520,8 @@ def test_ordinal_encoder_inverse():
     # incorrect shape raises
     X_tr = np.array([[0, 1, 1, 2], [1, 0, 1, 0]])
     msg = re.escape('Shape of the passed X data is not correct')
-    assert_raises_regex(ValueError, msg, enc.inverse_transform, X_tr)
+    with pytest.raises(ValueError, match=msg):
+        enc.inverse_transform(X_tr)
 
 
 @pytest.mark.parametrize("X", [np.array([[1, np.nan]]).T,
@@ -550,6 +551,7 @@ def test_ordinal_encoder_raise_categories_shape():
 
     with pytest.raises(ValueError, match=msg):
         enc.fit(X)
+
 
 def test_encoder_dtypes():
     # check that dtypes are preserved when determining categories
@@ -643,10 +645,10 @@ def test_one_hot_encoder_invalid_params(X_fit, params, err_msg):
 @pytest.mark.parametrize('drop', [['abc', 3], ['abc', 3, 41, 'a']])
 def test_invalid_drop_length(drop):
     enc = OneHotEncoder(drop=drop)
-    assert_raises_regex(
-        ValueError,
-        "`drop` should have length equal to the number",
-        enc.fit, [['abc', 2, 55], ['def', 1, 55], ['def', 3, 59]])
+    with pytest.raises(ValueError,
+                       match="`drop` should have length "
+                       "equal to the number"):
+        enc.fit([['abc', 2, 55], ['def', 1, 55], ['def', 3, 59]])
 
 
 @pytest.mark.parametrize("density", [True, False],

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -12,7 +12,6 @@ from scipy.sparse import lil_matrix
 from sklearn.utils.multiclass import type_of_target
 
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import ignore_warnings
@@ -133,41 +132,53 @@ def test_label_binarizer_errors():
     lb = LabelBinarizer().fit(one_class)
 
     multi_label = [(2, 3), (0,), (0, 2)]
-    assert_raises(ValueError, lb.transform, multi_label)
+    with pytest.raises(ValueError):
+        lb.transform(multi_label)
 
     lb = LabelBinarizer()
-    assert_raises(ValueError, lb.transform, [])
-    assert_raises(ValueError, lb.inverse_transform, [])
+    with pytest.raises(ValueError):
+        lb.transform([])
+    with pytest.raises(ValueError):
+        lb.inverse_transform([])
 
-    assert_raises(ValueError, LabelBinarizer, neg_label=2, pos_label=1)
-    assert_raises(ValueError, LabelBinarizer, neg_label=2, pos_label=2)
+    with pytest.raises(ValueError):
+        LabelBinarizer(neg_label=2, pos_label=1)
+    with pytest.raises(ValueError):
+        LabelBinarizer(neg_label=2, pos_label=2)
 
-    assert_raises(ValueError, LabelBinarizer, neg_label=1, pos_label=2,
-                  sparse_output=True)
+    with pytest.raises(ValueError):
+        LabelBinarizer(neg_label=1, pos_label=2, sparse_output=True)
 
     # Fail on y_type
-    assert_raises(ValueError, _inverse_binarize_thresholding,
-                  y=csr_matrix([[1, 2], [2, 1]]), output_type="foo",
-                  classes=[1, 2], threshold=0)
+    with pytest.raises(ValueError):
+        _inverse_binarize_thresholding(y=csr_matrix([[1, 2], [2, 1]]),
+                                       output_type="foo", classes=[1, 2],
+                                       threshold=0)
 
     # Sequence of seq type should raise ValueError
     y_seq_of_seqs = [[], [1, 2], [3], [0, 1, 3], [2]]
-    assert_raises(ValueError, LabelBinarizer().fit_transform, y_seq_of_seqs)
+    with pytest.raises(ValueError):
+        LabelBinarizer().fit_transform(y_seq_of_seqs)
 
     # Fail on the number of classes
-    assert_raises(ValueError, _inverse_binarize_thresholding,
-                  y=csr_matrix([[1, 2], [2, 1]]), output_type="foo",
-                  classes=[1, 2, 3], threshold=0)
+    with pytest.raises(ValueError):
+        _inverse_binarize_thresholding(y=csr_matrix([[1, 2], [2, 1]]),
+                                       output_type="foo",
+                                       classes=[1, 2, 3],
+                                       threshold=0)
 
     # Fail on the dimension of 'binary'
-    assert_raises(ValueError, _inverse_binarize_thresholding,
-                  y=np.array([[1, 2, 3], [2, 1, 3]]), output_type="binary",
-                  classes=[1, 2, 3], threshold=0)
+    with pytest.raises(ValueError):
+        _inverse_binarize_thresholding(y=np.array([[1, 2, 3], [2, 1, 3]]),
+                                       output_type="binary",
+                                       classes=[1, 2, 3],
+                                       threshold=0)
 
     # Fail on multioutput data
-    assert_raises(ValueError, LabelBinarizer().fit, np.array([[1, 3], [2, 1]]))
-    assert_raises(ValueError, label_binarize, np.array([[1, 3], [2, 1]]),
-                  [1, 2, 3])
+    with pytest.raises(ValueError):
+        LabelBinarizer().fit(np.array([[1, 3], [2, 1]]))
+    with pytest.raises(ValueError):
+        label_binarize(np.array([[1, 3], [2, 1]]), [1, 2, 3])
 
 
 @pytest.mark.parametrize(
@@ -204,7 +215,8 @@ def test_label_encoder_negative_ints():
                        [1, 2, 3, 3, 4, 0, 0])
     assert_array_equal(le.inverse_transform([1, 2, 3, 3, 4, 0, 0]),
                        [0, 1, 4, 4, 5, -1, -1])
-    assert_raises(ValueError, le.transform, [0, 6])
+    with pytest.raises(ValueError):
+        le.transform([0, 6])
 
 
 @pytest.mark.parametrize("dtype", ['str', 'object'])
@@ -218,8 +230,10 @@ def test_label_encoder_str_bad_shape(dtype):
 def test_label_encoder_errors():
     # Check that invalid arguments yield ValueError
     le = LabelEncoder()
-    assert_raises(ValueError, le.transform, [])
-    assert_raises(ValueError, le.inverse_transform, [])
+    with pytest.raises(ValueError):
+        le.transform([])
+    with pytest.raises(ValueError):
+        le.inverse_transform([])
 
     # Fail on unseen labels
     le = LabelEncoder()
@@ -288,10 +302,10 @@ def test_sparse_output_multilabel_binarizer():
             assert_array_equal([1, 2, 3], mlb.classes_)
             assert mlb.inverse_transform(got) == inverse
 
-    assert_raises(ValueError, mlb.inverse_transform,
-                  csr_matrix(np.array([[0, 1, 1],
-                                       [2, 0, 0],
-                                       [1, 1, 0]])))
+    with pytest.raises(ValueError):
+        mlb.inverse_transform(csr_matrix(np.array([[0, 1, 1],
+                                                   [2, 0, 0],
+                                                   [1, 1, 0]])))
 
 
 def test_multilabel_binarizer():
@@ -439,7 +453,8 @@ def test_multilabel_binarizer_non_integer_labels():
         assert_array_equal(mlb.inverse_transform(indicator_mat), inp)
 
     mlb = MultiLabelBinarizer()
-    assert_raises(TypeError, mlb.fit_transform, [({}), ({}, {'a': 'b'})])
+    with pytest.raises(TypeError):
+        mlb.fit_transform([({}), ({}, {'a': 'b'})])
 
 
 def test_multilabel_binarizer_non_unique():
@@ -454,15 +469,18 @@ def test_multilabel_binarizer_inverse_validation():
     mlb = MultiLabelBinarizer()
     mlb.fit_transform(inp)
     # Not binary
-    assert_raises(ValueError, mlb.inverse_transform, np.array([[1, 3]]))
+    with pytest.raises(ValueError):
+        mlb.inverse_transform(np.array([[1, 3]]))
     # The following binary cases are fine, however
     mlb.inverse_transform(np.array([[0, 0]]))
     mlb.inverse_transform(np.array([[1, 1]]))
     mlb.inverse_transform(np.array([[1, 0]]))
 
     # Wrong shape
-    assert_raises(ValueError, mlb.inverse_transform, np.array([[1]]))
-    assert_raises(ValueError, mlb.inverse_transform, np.array([[1, 1, 1]]))
+    with pytest.raises(ValueError):
+        mlb.inverse_transform(np.array([[1]]))
+    with pytest.raises(ValueError):
+        mlb.inverse_transform(np.array([[1, 1, 1]]))
 
 
 def test_label_binarize_with_class_order():
@@ -486,9 +504,10 @@ def test_label_binarize_with_class_order():
 def check_binarized_results(y, classes, pos_label, neg_label, expected):
     for sparse_output in [True, False]:
         if ((pos_label == 0 or neg_label != 0) and sparse_output):
-            assert_raises(ValueError, label_binarize, y, classes,
-                          neg_label=neg_label, pos_label=pos_label,
-                          sparse_output=sparse_output)
+            with pytest.raises(ValueError):
+                label_binarize(y, classes, neg_label=neg_label,
+                               pos_label=pos_label,
+                               sparse_output=sparse_output)
             continue
 
         # check label_binarize
@@ -552,8 +571,9 @@ def test_label_binarize_multiclass():
 
     check_binarized_results(y, classes, pos_label, neg_label, expected)
 
-    assert_raises(ValueError, label_binarize, y, classes, neg_label=-1,
-                  pos_label=pos_label, sparse_output=True)
+    with pytest.raises(ValueError):
+        label_binarize(y, classes, neg_label=-1, pos_label=pos_label,
+                       sparse_output=True)
 
 
 def test_label_binarize_multilabel():
@@ -570,13 +590,14 @@ def test_label_binarize_multilabel():
         check_binarized_results(y, classes, pos_label, neg_label,
                                 expected)
 
-    assert_raises(ValueError, label_binarize, y, classes, neg_label=-1,
-                  pos_label=pos_label, sparse_output=True)
+    with pytest.raises(ValueError):
+        label_binarize(y, classes, neg_label=-1, pos_label=pos_label,
+                       sparse_output=True)
 
 
 def test_invalid_input_label_binarize():
-    assert_raises(ValueError, label_binarize, [0, 2], classes=[0, 2],
-                  pos_label=0, neg_label=1)
+    with pytest.raises(ValueError):
+        label_binarize([0, 2], classes=[0, 2], pos_label=0, neg_label=1)
 
 
 def test_inverse_binarize_multiclass():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -12,7 +12,6 @@ from scipy.sparse import lil_matrix
 from sklearn.utils.multiclass import type_of_target
 
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import ignore_warnings
 
@@ -224,7 +223,8 @@ def test_label_encoder_str_bad_shape(dtype):
     le = LabelEncoder()
     le.fit(np.array(["apple", "orange"], dtype=dtype))
     msg = "bad input shape"
-    assert_raise_message(ValueError, msg, le.transform, "apple")
+    with pytest.raises(ValueError, match=msg):
+        le.transform("apple")
 
 
 def test_label_encoder_errors():
@@ -239,12 +239,15 @@ def test_label_encoder_errors():
     le = LabelEncoder()
     le.fit([1, 2, 3, -1, 1])
     msg = "contains previously unseen labels"
-    assert_raise_message(ValueError, msg, le.inverse_transform, [-2])
-    assert_raise_message(ValueError, msg, le.inverse_transform, [-2, -3, -4])
+    with pytest.raises(ValueError, match=msg):
+        le.inverse_transform([-2])
+    with pytest.raises(ValueError, match=msg):
+        le.inverse_transform([-2, -3, -4])
 
     # Fail on inverse_transform("")
     msg = "bad input shape ()"
-    assert_raise_message(ValueError, msg, le.inverse_transform, "")
+    with pytest.raises(ValueError, match=msg):
+        le.inverse_transform("")
 
 
 @pytest.mark.parametrize(
@@ -390,7 +393,8 @@ def test_multilabel_binarizer_given_classes():
     err_msg = "The classes argument contains duplicate classes. Remove " \
               "these duplicates before passing them to MultiLabelBinarizer."
     mlb = MultiLabelBinarizer(classes=[1, 3, 2, 3])
-    assert_raise_message(ValueError, err_msg, mlb.fit, inp)
+    with pytest.raises(ValueError, match=err_msg):
+        mlb.fit(inp)
 
 
 def test_multilabel_binarizer_multiple_calls():


### PR DESCRIPTION
replaced `assert_raises` and `assert_raises_regex` with `pytest.raises` context manager.

related to #14216