### PR TITLE
CI: Add direct CircleCI artifact link

### DIFF
--- a/.circleci/artifact_path
+++ b/.circleci/artifact_path
@@ -1,0 +1,1 @@
+0/doc/_changed.html


### PR DESCRIPTION
I wrote a little [GitHub app](https://github.com/apps/circleci-artifacts-redirector/) to add direct linking to CircleCI artifacts for some repos. It cuts down on number-of-clicks and waiting on CircleCI Artifacts tab to render when reviewing PRs.

See CI status over in https://github.com/scipy/scipy/pull/10707 for an example. 

If you do want this (or want to try it at least), you'll need to add the  app to `sklearn/sklearn`, then I can push-force here and you can see what it looks like. The app is not very configurable (see [the GitHub page](https://github.com/larsoner/circleci-artifacts-redirector) for known limitations) but I suspect it would be useful for `sklearn`.

cc @jnothman esp. since you posted this a while ago https://discuss.circleci.com/t/easily-get-artifact-url/10394/2