### PR TITLE
mean_absolute_error multioutput test fix

### DIFF
--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -73,7 +73,7 @@ def test_multioutput_regression():
     # mean_absolute_error and mean_squared_error are equal because
     # it is a binary problem.
     error = mean_absolute_error(y_true, y_pred)
-    assert_almost_equal(error, (1. / 3 + 2. / 3 + 2. / 3) / 4.)
+    assert_almost_equal(error, (1. + 2. / 3) / 4.)
 
     error = r2_score(y_true, y_pred, multioutput='variance_weighted')
     assert_almost_equal(error, 1. - 5. / 2)


### PR DESCRIPTION
This was picked up while I was working on another PR (#14732) but was not related so I am submitting a new PR.

The `test_multioutput_regression` test for `mean_absolute_error` had an error in calculating the expected value but, coincidentally, it yielded a correct result. This has now been fixed to avoid confusion in the future.  