### PR TITLE
[MRG] Make OPTICS support sparse input

### DIFF
--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -194,7 +194,7 @@ class OPTICS(BaseEstimator, ClusterMixin):
        the Conference "Lernen, Wissen, Daten, Analysen" (LWDA) (2018): 318-329.
     """
 
-    def __init__(self, min_samples=5, max_eps=np.inf, metric='minkowski', p=2,
+    def __init__(self, min_samples=5, max_eps=np.inf, metric='euclidean', p=2,
                  metric_params=None, cluster_method='xi', eps=None, xi=0.05,
                  predecessor_correction=True, min_cluster_size=None,
                  algorithm='auto', leaf_size=30, n_jobs=None):
@@ -517,7 +517,7 @@ def _set_reach_dist(core_distances_, reachability_, predecessor_,
             # the same logic as neighbors, p is ignored if explicitly set
             # in the dict params
             _params['p'] = p
-        dists = pairwise_distances(P, np.take(X, unproc, axis=0),
+        dists = pairwise_distances(P, X[unproc],
                                    metric, n_jobs=None,
                                    **_params).ravel()
 

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -19,6 +19,7 @@ from ..utils import gen_batches, get_chunk_n_rows
 from ..neighbors import NearestNeighbors
 from ..base import BaseEstimator, ClusterMixin
 from ..metrics import pairwise_distances
+from ..metrics.pairwise import PAIRWISE_DISTANCE_FUNCTIONS
 
 
 class OPTICS(BaseEstimator, ClusterMixin):
@@ -194,7 +195,7 @@ class OPTICS(BaseEstimator, ClusterMixin):
        the Conference "Lernen, Wissen, Daten, Analysen" (LWDA) (2018): 318-329.
     """
 
-    def __init__(self, min_samples=5, max_eps=np.inf, metric='euclidean', p=2,
+    def __init__(self, min_samples=5, max_eps=np.inf, metric='minkowski', p=2,
                  metric_params=None, cluster_method='xi', eps=None, xi=0.05,
                  predecessor_correction=True, min_cluster_size=None,
                  algorithm='auto', leaf_size=30, n_jobs=None):
@@ -222,7 +223,8 @@ class OPTICS(BaseEstimator, ClusterMixin):
         Parameters
         ----------
         X : array, shape (n_samples, n_features), or (n_samples, n_samples)  \
-if metric=’precomputed’.
+if metric=’precomputed’, or sparse matrix  \
+            if metric in ['cityblock', 'cosine', 'euclidean', 'haversine', 'l2', 'l1', 'manhattan'].
             A feature array, or array of distances between samples if
             metric='precomputed'.
 
@@ -233,7 +235,10 @@ if metric=’precomputed’.
         self : instance of OPTICS
             The instance.
         """
-        X = check_array(X, accept_sparse='csr')
+        if self.metric in PAIRWISE_DISTANCE_FUNCTIONS:
+            X = check_array(X, accept_sparse='csr')
+        else:
+            X = check_array(X)
 
         if self.cluster_method not in ['dbscan', 'xi']:
             raise ValueError("cluster_method should be one of"

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -223,8 +223,9 @@ class OPTICS(BaseEstimator, ClusterMixin):
         Parameters
         ----------
         X : array, shape (n_samples, n_features), or (n_samples, n_samples)  \
-if metric=’precomputed’, or sparse matrix  \
-            if metric in ['cityblock', 'cosine', 'euclidean', 'haversine', 'l2', 'l1', 'manhattan'].
+if metric=’precomputed’, or sparse matrix (n_samples, n_features) if metric
+            in ['cityblock', 'cosine', 'euclidean', 'haversine', 'l2', 'l1',
+            'manhattan'].
             A feature array, or array of distances between samples if
             metric='precomputed'.
 

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -233,7 +233,7 @@ if metric=’precomputed’.
         self : instance of OPTICS
             The instance.
         """
-        X = check_array(X, dtype=np.float)
+        X = check_array(X, accept_sparse='csr')
 
         if self.cluster_method not in ['dbscan', 'xi']:
             raise ValueError("cluster_method should be one of"

--- a/sklearn/cluster/optics_.py
+++ b/sklearn/cluster/optics_.py
@@ -236,7 +236,9 @@ if metric=’precomputed’, or sparse matrix (n_samples, n_features) if metric
         self : instance of OPTICS
             The instance.
         """
-        if self.metric in PAIRWISE_DISTANCE_FUNCTIONS:
+        # TODO: Support the sparse input for metric = 'precopmuted'.
+        if self.metric != 'precomputed' \
+                and self.metric in PAIRWISE_DISTANCE_FUNCTIONS:
             X = check_array(X, accept_sparse='csr')
         else:
             X = check_array(X)

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -352,7 +352,7 @@ def test_compare_to_ELKI():
     # Tests against known extraction array
     # Does NOT work with metric='euclidean', because sklearn euclidean has
     # worse numeric precision. 'minkowski' is slower but more accurate.
-    clust1 = OPTICS(min_samples=5).fit(X)
+    clust1 = OPTICS(metric='minkowski', min_samples=5).fit(X)
 
     assert_array_equal(clust1.ordering_, np.array(o1))
     assert_array_equal(clust1.predecessor_[clust1.ordering_], np.array(p1))
@@ -386,7 +386,7 @@ def test_compare_to_ELKI():
           11, 19, 15, 10, 47, -1, 20, 22, 25, 25, 25, 25, 22, 22, 23, -1, 30,
           30, 34, 34, 34, 32, 32, 37, 38, -1, -1, -1, -1, -1, -1, -1, -1, -1,
           -1, -1, -1, -1, -1, -1, -1, -1, -1]
-    clust2 = OPTICS(min_samples=5, max_eps=0.5).fit(X)
+    clust2 = OPTICS(metric='minkowski', min_samples=5, max_eps=0.5).fit(X)
 
     assert_array_equal(clust2.ordering_, np.array(o2))
     assert_array_equal(clust2.predecessor_[clust2.ordering_], np.array(p2))

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -352,7 +352,7 @@ def test_compare_to_ELKI():
     # Tests against known extraction array
     # Does NOT work with metric='euclidean', because sklearn euclidean has
     # worse numeric precision. 'minkowski' is slower but more accurate.
-    clust1 = OPTICS(metric='minkowski', min_samples=5).fit(X)
+    clust1 = OPTICS(min_samples=5).fit(X)
 
     assert_array_equal(clust1.ordering_, np.array(o1))
     assert_array_equal(clust1.predecessor_[clust1.ordering_], np.array(p1))
@@ -386,7 +386,7 @@ def test_compare_to_ELKI():
           11, 19, 15, 10, 47, -1, 20, 22, 25, 25, 25, 25, 22, 22, 23, -1, 30,
           30, 34, 34, 34, 32, 32, 37, 38, -1, -1, -1, -1, -1, -1, -1, -1, -1,
           -1, -1, -1, -1, -1, -1, -1, -1, -1]
-    clust2 = OPTICS(metric='minkowski', min_samples=5, max_eps=0.5).fit(X)
+    clust2 = OPTICS(min_samples=5, max_eps=0.5).fit(X)
 
     assert_array_equal(clust2.ordering_, np.array(o2))
     assert_array_equal(clust2.predecessor_[clust2.ordering_], np.array(p2))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

See https://github.com/scikit-learn/scikit-learn/pull/12028#issuecomment-523813165, #11982

#### What does this implement/fix? Explain your changes.

Make `OPTICS.fit(self, X, y=None)` support the sparse matrix `X`.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->