### PR TITLE
Added option to use standard idf term for TfidfTransformer and TfidfVectorizer

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -395,6 +395,13 @@ def test_sublinear_tf():
     assert tfidf[1] < 2
     assert tfidf[2] < 3
 
+def test_standard_idf():
+    X = [[1, 1, 1],
+         [1, 1, 0],
+         [1, 0, 0]]
+    tr = TfidfTransformer(standard_idf=True)
+    tfidf = tr.fit_transform(X).toarray()
+    assert np.allclose(np.array([0, 0, 0]), tfidf[:, 0])
 
 def test_vectorizer():
     # raw documents as an iterator

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -395,6 +395,7 @@ def test_sublinear_tf():
     assert tfidf[1] < 2
     assert tfidf[2] < 3
 
+
 def test_standard_idf():
     X = [[1, 1, 1],
          [1, 1, 0],
@@ -402,6 +403,7 @@ def test_standard_idf():
     tr = TfidfTransformer(standard_idf=True)
     tfidf = tr.fit_transform(X).toarray()
     assert np.allclose(np.array([0, 0, 0]), tfidf[:, 0])
+
 
 def test_vectorizer():
     # raw documents as an iterator

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -520,7 +520,7 @@ def test_vectorizer():
 
 def test_tfidf_vectorizer_setters():
     tv = TfidfVectorizer(norm='l2', use_idf=False, smooth_idf=False,
-                         sublinear_tf=False)
+                         sublinear_tf=False, standard_idf=False)
     tv.norm = 'l1'
     assert tv._tfidf.norm == 'l1'
     tv.use_idf = True
@@ -529,6 +529,8 @@ def test_tfidf_vectorizer_setters():
     assert tv._tfidf.smooth_idf
     tv.sublinear_tf = True
     assert tv._tfidf.sublinear_tf
+    tv.standard_idf = True
+    assert tv._tfidf.standard_idf
 
 
 # FIXME Remove copy parameter support in 0.24

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1242,15 +1242,15 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
     informative than features that occur in a small fraction of the training
     corpus.
 
-    The formula that is used to compute the tf-idf for a term t of a document d 
-    in a document set is tf-idf(t, d) = tf(t, d) * idf(t). The idf term is 
-    computed as idf(t) = log [n / df(t)] + 1 if ``standard_idf=False``, 
-    otherwise it is computed as idf(t) = log [n / df(t)], where n is the total 
-    number number of documents and df(t) is the document frequency of t; the 
-    document frequency is the number of documents in the document set that 
-    contain the term t. The effect of adding "1" to the idf term in the 
+    The formula that is used to compute the tf-idf for a term t of a document d
+    in a document set is tf-idf(t, d) = tf(t, d) * idf(t). The idf term is
+    computed as idf(t) = log [n / df(t)] + 1 if ``standard_idf=False``,
+    otherwise it is computed as idf(t) = log [n / df(t)], where n is the total
+    number number of documents and df(t) is the document frequency of t; the
+    document frequency is the number of documents in the document set that
+    contain the term t. The effect of adding "1" to the idf term in the
     equation above results in terms with zero idf, i.e., terms that occur in
-    all documents in a training set, will not be entirely ignored. If 
+    all documents in a training set, will not be entirely ignored. If
     ``standard_idf=True`` the standard textbook definition of the idf term
     will be used, which ignores terms with a zero idf.
 
@@ -1677,7 +1677,6 @@ class TfidfVectorizer(CountVectorizer):
     @standard_idf.setter
     def standard_idf(self, value):
         self._tfidf.standard_idf = value
-    
 
     @property
     def idf_(self):

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1674,9 +1674,9 @@ class TfidfVectorizer(CountVectorizer):
     def standard_idf(self):
     	return self._standard_idf
 
-	@standard_idf.setter
-	def standard_idf(self, value):
-		self._tfidf.standard_idf = value
+    @standard_idf.setter
+    def standard_idf(self, value):
+    	self._tfidf.standard_idf = value
     
 
     @property

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1292,7 +1292,7 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
     sublinear_tf : boolean (default=False)
         Apply sublinear tf scaling, i.e. replace tf with 1 + log(tf).
 
-    standard_idf: boolean (default=False)
+    standard_idf : boolean (default=False)
         Use standard idf term, log(n/df(t)). If false idf is log(n/df(t)) + 1.
 
     Attributes
@@ -1557,7 +1557,7 @@ class TfidfVectorizer(CountVectorizer):
     sublinear_tf : boolean (default=False)
         Apply sublinear tf scaling, i.e. replace tf with 1 + log(tf).
 
-    standard_idf: boolean (default=False)
+    standard_idf : boolean (default=False)
         Use standard idf term, log(n/df(t)). If false idf is log(n/df(t)) + 1.
 
     Attributes

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1293,7 +1293,7 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
         Apply sublinear tf scaling, i.e. replace tf with 1 + log(tf).
 
     standard_idf: boolean (default=False)
-    	Use standard idf term, log(n/df(t)). If false idf is log(n/df(t)) + 1.
+        Use standard idf term, log(n/df(t)). If false idf is log(n/df(t)) + 1.
 
     Attributes
     ----------
@@ -1558,7 +1558,7 @@ class TfidfVectorizer(CountVectorizer):
         Apply sublinear tf scaling, i.e. replace tf with 1 + log(tf).
 
     standard_idf: boolean (default=False)
-    	Use standard idf term, log(n/df(t)). If false idf is log(n/df(t)) + 1.
+        Use standard idf term, log(n/df(t)). If false idf is log(n/df(t)) + 1.
 
     Attributes
     ----------
@@ -1672,11 +1672,11 @@ class TfidfVectorizer(CountVectorizer):
 
     @property
     def standard_idf(self):
-    	return self._standard_idf
+        return self._tfidf.standard_idf
 
     @standard_idf.setter
     def standard_idf(self, value):
-    	self._tfidf.standard_idf = value
+        self._tfidf.standard_idf = value
     
 
     @property


### PR DESCRIPTION
The TfidfTransformer and TfidfVectorizer use an idf that is not the standard textbook definition. I added a parameter to both as an option to use the standard definition, while leaving the previously defined idf term as the default. I created some test cases to make sure it works but I didn't include them in tests/test_text.py. Should I include them there?