### PR TITLE
DOC update to attribute from docstring in RidgeClassifierCV class

### DIFF
--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1762,7 +1762,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         ``cv=None``). After ``fit()`` has been called, this attribute will
         contain the mean squared errors (by default) or the values of the
         ``{loss,score}_func`` function (if provided in the constructor). This 
-        attribute exists only when store_cv_values is True. 
+        attribute exists only when ``store_cv_values`` is True.
 
     coef_ : array, shape (1, n_features) or (n_targets, n_features)
         Coefficient of the features in the decision function.

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1757,6 +1757,13 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
     Attributes
     ----------
+    cv_values_ : array, shape = [n_samples, n_targets, n_alphas], optional
+        Cross-validation values for each alpha (if ``store_cv_values=True`` and
+        ``cv=None``). After ``fit()`` has been called, this attribute will
+        contain the mean squared errors (by default) or the values of the
+        ``{loss,score}_func`` function (if provided in the constructor). This 
+        attribute exists only when store_cv_values is True. 
+
     coef_ : array, shape (1, n_features) or (n_targets, n_features)
         Coefficient of the features in the decision function.
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1757,12 +1757,6 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
     Attributes
     ----------
-    cv_values_ : array, shape = [n_samples, n_targets, n_alphas], optional
-        Cross-validation values for each alpha (if ``store_cv_values=True`` and
-        ``cv=None``). After ``fit()`` has been called, this attribute will
-        contain the mean squared errors (by default) or the values of the
-        ``{loss,score}_func`` function (if provided in the constructor).
-
     coef_ : array, shape (1, n_features) or (n_targets, n_features)
         Coefficient of the features in the decision function.
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1761,7 +1761,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         Cross-validation values for each alpha (if ``store_cv_values=True`` and
         ``cv=None``). After ``fit()`` has been called, this attribute will
         contain the mean squared errors (by default) or the values of the
-        ``{loss,score}_func`` function (if provided in the constructor). This 
+        ``{loss,score}_func`` function (if provided in the constructor). This
         attribute exists only when ``store_cv_values`` is True.
 
     coef_ : array, shape (1, n_features) or (n_targets, n_features)


### PR DESCRIPTION
partially addresses #14312 

The cv_values_  attribute in the docstrings of RidgeClassifierCV only exists when store_cv_values is set to True. I tested this by creating a fitted model (using the example here: https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RidgeClassifierCV.html) and checked for this attribute. Therefore the docstring for the cv_values_ attribute has been updated to include that caveat 

