### PR TITLE
return_X_y for load_diabetes

### DIFF
--- a/doc/tutorial/statistical_inference/model_selection.rst
+++ b/doc/tutorial/statistical_inference/model_selection.rst
@@ -262,9 +262,7 @@ parameter automatically by cross-validation::
 
     >>> from sklearn import linear_model, datasets
     >>> lasso = linear_model.LassoCV()
-    >>> diabetes = datasets.load_diabetes()
-    >>> X_diabetes = diabetes.data
-    >>> y_diabetes = diabetes.target
+    >>> X_diabetes, y_diabetes = datasets.load_diabetes(return_X_y=True)
     >>> lasso.fit(X_diabetes, y_diabetes)
     LassoCV()
     >>> # The estimator chose automatically its lambda:

--- a/doc/tutorial/statistical_inference/supervised_learning.rst
+++ b/doc/tutorial/statistical_inference/supervised_learning.rst
@@ -138,11 +138,11 @@ Linear model: from regression to sparsity
     sex, weight, blood pressure) measure on 442 patients, and an
     indication of disease progression after one year::
 
-        >>> diabetes = datasets.load_diabetes()
-        >>> diabetes_X_train = diabetes.data[:-20]
-        >>> diabetes_X_test  = diabetes.data[-20:]
-        >>> diabetes_y_train = diabetes.target[:-20]
-        >>> diabetes_y_test  = diabetes.target[-20:]
+        >>> diabetes_X, diabetes_y = datasets.load_diabetes(return_X_y=True)
+        >>> diabetes_X_train = diabetes_X[:-20]
+        >>> diabetes_X_test  = diabetes_X[-20:]
+        >>> diabetes_y_train = diabetes_y[:-20]
+        >>> diabetes_y_test  = diabetes_y[-20:]
 
     The task at hand is to predict disease progression from physiological
     variables.

--- a/examples/exercises/plot_cv_diabetes.py
+++ b/examples/exercises/plot_cv_diabetes.py
@@ -20,9 +20,9 @@ from sklearn.linear_model import Lasso
 from sklearn.model_selection import KFold
 from sklearn.model_selection import GridSearchCV
 
-diabetes = datasets.load_diabetes()
-X = diabetes.data[:150]
-y = diabetes.target[:150]
+X, y = datasets.load_diabetes(return_X_y=True)
+X = X[:150]
+y = y[:150]
 
 lasso = Lasso(random_state=0, max_iter=10000)
 alphas = np.logspace(-4, -0.5, 30)

--- a/examples/linear_model/plot_lasso_coordinate_descent_path.py
+++ b/examples/linear_model/plot_lasso_coordinate_descent_path.py
@@ -20,9 +20,9 @@ import matplotlib.pyplot as plt
 from sklearn.linear_model import lasso_path, enet_path
 from sklearn import datasets
 
-diabetes = datasets.load_diabetes()
-X = diabetes.data
-y = diabetes.target
+
+X, y = datasets.load_diabetes(return_X_y=True)
+
 
 X /= X.std(axis=0)  # Standardize data (easier to set the l1_ratio parameter)
 

--- a/examples/linear_model/plot_lasso_lars.py
+++ b/examples/linear_model/plot_lasso_lars.py
@@ -22,9 +22,7 @@ import matplotlib.pyplot as plt
 from sklearn import linear_model
 from sklearn import datasets
 
-diabetes = datasets.load_diabetes()
-X = diabetes.data
-y = diabetes.target
+X, y = datasets.load_diabetes(return_X_y=True)
 
 print("Computing regularization path using the LARS ...")
 _, _, coefs = linear_model.lars_path(X, y, method='lasso', verbose=True)

--- a/examples/linear_model/plot_lasso_model_selection.py
+++ b/examples/linear_model/plot_lasso_model_selection.py
@@ -57,9 +57,7 @@ from sklearn import datasets
 # This is to avoid division by zero while doing np.log10
 EPSILON = 1e-4
 
-diabetes = datasets.load_diabetes()
-X = diabetes.data
-y = diabetes.target
+X, y = datasets.load_diabetes(return_X_y=True)
 
 rng = np.random.RandomState(42)
 X = np.c_[X, rng.randn(X.shape[0], 14)]  # add some bad features
@@ -91,6 +89,7 @@ def plot_ic_criterion(model, name, color):
                 label='alpha: %s estimate' % name)
     plt.xlabel('-log(alpha)')
     plt.ylabel('criterion')
+
 
 plt.figure()
 plot_ic_criterion(model_aic, 'AIC', 'b')

--- a/examples/linear_model/plot_ols.py
+++ b/examples/linear_model/plot_ols.py
@@ -29,19 +29,18 @@ from sklearn import datasets, linear_model
 from sklearn.metrics import mean_squared_error, r2_score
 
 # Load the diabetes dataset
-diabetes = datasets.load_diabetes()
-
+diabetes_X, diabetes_y = datasets.load_diabetes(return_X_y=True)
 
 # Use only one feature
-diabetes_X = diabetes.data[:, np.newaxis, 2]
+diabetes_X = diabetes_X[:, np.newaxis, 2]
 
 # Split the data into training/testing sets
 diabetes_X_train = diabetes_X[:-20]
 diabetes_X_test = diabetes_X[-20:]
 
 # Split the targets into training/testing sets
-diabetes_y_train = diabetes.target[:-20]
-diabetes_y_test = diabetes.target[-20:]
+diabetes_y_train = diabetes_y[:-20]
+diabetes_y_test = diabetes_y[-20:]
 
 # Create linear regression object
 regr = linear_model.LinearRegression()

--- a/examples/linear_model/plot_ols_3d.py
+++ b/examples/linear_model/plot_ols_3d.py
@@ -25,13 +25,13 @@ from mpl_toolkits.mplot3d import Axes3D
 
 from sklearn import datasets, linear_model
 
-diabetes = datasets.load_diabetes()
+X, y = datasets.load_diabetes(return_X_y=True)
 indices = (0, 1)
 
-X_train = diabetes.data[:-20, indices]
-X_test = diabetes.data[-20:, indices]
-y_train = diabetes.target[:-20]
-y_test = diabetes.target[-20:]
+X_train = X[:-20, indices]
+X_test = X[-20:, indices]
+y_train = y[:-20]
+y_test = y[-20:]
 
 ols = linear_model.LinearRegression()
 ols.fit(X_train, y_train)
@@ -58,7 +58,8 @@ def plot_figs(fig_num, elev, azim, X_train, clf):
     ax.w_yaxis.set_ticklabels([])
     ax.w_zaxis.set_ticklabels([])
 
-#Generate the three different figures from different views
+
+# Generate the three different figures from different views
 elev = 43.5
 azim = -110
 plot_figs(1, elev, azim, X_train, ols)

--- a/sklearn/covariance/tests/test_covariance.py
+++ b/sklearn/covariance/tests/test_covariance.py
@@ -17,7 +17,7 @@ from sklearn.covariance import empirical_covariance, EmpiricalCovariance, \
     ShrunkCovariance, shrunk_covariance, \
     LedoitWolf, ledoit_wolf, ledoit_wolf_shrinkage, OAS, oas
 
-X = datasets.load_diabetes().data
+X, _ = datasets.load_diabetes(return_X_y=True)
 X_1d = X[:, 0]
 n_samples, n_features = X.shape
 


### PR DESCRIPTION
Reference Issues/PRs
Partially addresses #14347 (Use return_X_y=True when applicable in examples)

What does this implement/fix? Explain your changes.
Changes how load_diabetes is used in examples where applicable.

Any other comments?