### PR TITLE
WIP: adds missing Attribute documentation for `BernoulliRBM`

### DIFF
--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -73,6 +73,10 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         Weight matrix, where n_features in the number of
         visible units and n_components is the number of hidden units.
 
+    h_samples : array-like, shape (batch_size, n_components)
+        Weight matrix, where batch_size in the number of examples per minibatch
+        and n_components is the number of hidden units.
+
     Examples
     --------
 

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -73,8 +73,8 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         Weight matrix, where n_features in the number of
         visible units and n_components is the number of hidden units.
 
-    h_samples : array-like, shape (batch_size, n_components)
-        Weight matrix, where batch_size in the number of examples per minibatch
+    h_samples_ : array-like, shape (batch_size, n_components)
+        Model matrix, where batch_size in the number of examples per minibatch
         and n_components is the number of hidden units.
 
     Examples

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -74,8 +74,9 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         visible units and n_components is the number of hidden units.
 
     h_samples_ : array-like, shape (batch_size, n_components)
-        Model matrix, where batch_size in the number of examples per minibatch
-        and n_components is the number of hidden units.
+        Hidden Activation sampled from the model distribution,
+        where batch_size in the number of examples per minibatch and
+        n_components is the number of hidden units.
 
     Examples
     --------


### PR DESCRIPTION
partially addresses #14312
The `h_samples_` attribute is missing in the docstrings of `BernoulliRBM` 