### PR TITLE
[MRG] Verbose flag for `VotingClassifier` and `VotingRegressor`

### DIFF
--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -1360,6 +1360,14 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
     n_iter_ : int
         Number of iterations run.
 
+    iter_offset_ : int
+        The number of iteration on data batches that has been
+        performed before.
+
+    random_state_ : RandomState 
+        RandomState instance that is generated either from a seed, the random
+        number generattor or by `np.random`. 
+
     Notes
     -----
     **References:**

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -1364,9 +1364,9 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
         The number of iteration on data batches that has been
         performed before.
 
-    random_state_ : RandomState 
+    random_state_ : RandomState
         RandomState instance that is generated either from a seed, the random
-        number generattor or by `np.random`. 
+        number generattor or by `np.random`.
 
     Notes
     -----

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -1360,14 +1360,6 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
     n_iter_ : int
         Number of iterations run.
 
-    iter_offset_ : int
-        The number of iteration on data batches that has been
-        performed before.
-
-    random_state_ : RandomState
-        RandomState instance that is generated either from a seed, the random
-        number generattor or by `np.random`.
-
     Notes
     -----
     **References:**

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -530,10 +530,14 @@ def test_check_estimators_voting_estimator(estimator):
     check_estimator(estimator)
     check_no_attributes_set_in_init(estimator.__class__.__name__, estimator)
 
+
 @pytest.mark.parametrize('pattern',
-            [r'\[Voting\].*\(classifier 1 of 3\) Processing lr, total=.*\n'
-            r'\[Voting\].*\(classifier 2 of 3\) Processing rf, total=.*\n'
-            r'\[Voting\].*\(classifier 3 of 3\) Processing gnb, total=.*\n$'])
+                         [r'\[Voting\].*\(classifier 1 of 3\)'
+                          ' Processing lr, total=.*\n'
+                          r'\[Voting\].*\(classifier 2 of 3\)'
+                          ' Processing rf, total=.*\n'
+                          r'\[Voting\].*\(classifier 3 of 3\)'
+                          ' Processing gnb, total=.*\n$'])
 def test_voting_verbose(pattern, capsys):
     clf1 = LogisticRegression(random_state=123)
     clf2 = RandomForestClassifier(random_state=123)

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -387,7 +387,7 @@ def test_set_params():
     assert eclf1.estimators[0][1].get_params()['C'] == 10.0
     assert eclf2.estimators[1][1].get_params()['max_depth'] == 5
     assert (eclf1.get_params()["lr__C"] ==
-                 eclf1.get_params()["lr"].get_params()['C'])
+            eclf1.get_params()["lr"].get_params()['C'])
 
 
 @pytest.mark.parametrize("drop", [None, 'drop'])
@@ -531,10 +531,10 @@ def test_check_estimators_voting_estimator(estimator):
     check_no_attributes_set_in_init(estimator.__class__.__name__, estimator)
 
 @pytest.mark.parametrize('pattern',
-                         [r'\[Voting\].*\(classifier 1 of 3\) Processing lr, total=.*\n'
-                         r'\[Voting\].*\(classifier 2 of 3\) Processing rf, total=.*\n'
-                         r'\[Voting\].*\(classifier 3 of 3\) Processing gnb, total=.*\n$'])
-def test_voting_verbose(pattern,capsys):
+            [r'\[Voting\].*\(classifier 1 of 3\) Processing lr, total=.*\n'
+            r'\[Voting\].*\(classifier 2 of 3\) Processing rf, total=.*\n'
+            r'\[Voting\].*\(classifier 3 of 3\) Processing gnb, total=.*\n$'])
+def test_voting_verbose(pattern, capsys):
     clf1 = LogisticRegression(random_state=123)
     clf2 = RandomForestClassifier(random_state=123)
     clf3 = GaussianNB()
@@ -554,4 +554,4 @@ def test_voting_verbose(pattern,capsys):
     VotingClassifier(estimators=[
        ('lr', clf1), ('rf', clf2), ('gnb', clf3)],
        voting='soft', verbose=True).fit(X, y)
-    assert re.match(pattern, capsys.readouterr()[0]) 
+    assert re.match(pattern, capsys.readouterr()[0])

--- a/sklearn/ensemble/voting.py
+++ b/sklearn/ensemble/voting.py
@@ -41,8 +41,8 @@ def _parallel_fit_estimator(estimator, X, y, sample_weight=None,
             except TypeError as exc:
                 if "unexpected keyword argument 'sample_weight'" in str(exc):
                     raise ValueError(
-                        "Underlying estimator {} does not support sample weights."
-                        .format(estimator.__class__.__name__)
+                     "Underlying estimator {} does not support sample weights."
+                     .format(estimator.__class__.__name__)
                     ) from exc
                 raise
         else:
@@ -105,8 +105,8 @@ class _BaseVoting(_BaseComposition, TransformerMixin):
                 delayed(_parallel_fit_estimator)(clone(clf), X, y,
                                                  sample_weight=sample_weight,
                                                  message_clsname='Voting',
-                                                 message=self._log_message(names[idx],
-                                                 idx,len(clfs)))
+                                                 message=self._log_message(
+                                                 names[idx], idx, len(clfs)))
                 for idx, clf in enumerate(clfs) if clf not in (None, 'drop')
             )
 

--- a/sklearn/ensemble/voting.py
+++ b/sklearn/ensemble/voting.py
@@ -99,7 +99,7 @@ class _BaseVoting(_BaseComposition, TransformerMixin):
                 'All estimators are None or "drop". At least one is required!'
             )
 
-        self.estimators_ = Parallel(n_jobs=self.n_jobs)(
+        self.estimators_ = Parallel(n_jobs=self.n_jobs,verbose=self.verbose)(
                 delayed(_parallel_fit_estimator)(clone(clf), X, y,
                                                  sample_weight=sample_weight)
                 for clf in clfs if clf not in (None, 'drop')
@@ -165,6 +165,12 @@ class VotingClassifier(_BaseVoting, ClassifierMixin):
         Else if 'soft', predicts the class label based on the argmax of
         the sums of the predicted probabilities, which is recommended for
         an ensemble of well-calibrated classifiers.
+
+    verbose : int, optional (default=0)
+        Verbosity level, with more frequent messages the higher the number.
+        If it is non-zero, progress messages are printed.
+        If > 50, the output is sent to stdout.
+        If > 10, all iterations are reported.
 
     weights : array-like, shape (n_classifiers,), optional (default=`None`)
         Sequence of weights (`float` or `int`) to weight the occurrences of
@@ -238,10 +244,11 @@ class VotingClassifier(_BaseVoting, ClassifierMixin):
     VotingRegressor: Prediction voting regressor.
     """
 
-    def __init__(self, estimators, voting='hard', weights=None, n_jobs=None,
-                 flatten_transform=True):
+    def __init__(self, estimators, voting='hard', verbose=0, weights=None,
+                 n_jobs=None, flatten_transform=True):
         self.estimators = estimators
         self.voting = voting
+        self.verbose = verbose
         self.weights = weights
         self.n_jobs = n_jobs
         self.flatten_transform = flatten_transform
@@ -394,6 +401,12 @@ class VotingRegressor(_BaseVoting, RegressorMixin):
         ``self.estimators_``. An estimator can be set to ``None`` or ``'drop'``
         using ``set_params``.
 
+    verbose : int, optional (default=0)
+        Verbosity level, with more frequent messages the higher the number.
+        If it is non-zero, progress messages are printed.
+        If > 50, the output is sent to stdout.
+        If > 10, all iterations are reported.
+
     weights : array-like, shape (n_regressors,), optional (default=`None`)
         Sequence of weights (`float` or `int`) to weight the occurrences of
         predicted values before averaging. Uses uniform weights if `None`.
@@ -432,8 +445,9 @@ class VotingRegressor(_BaseVoting, RegressorMixin):
     VotingClassifier: Soft Voting/Majority Rule classifier.
     """
 
-    def __init__(self, estimators, weights=None, n_jobs=None):
+    def __init__(self, estimators, verbose=0, weights=None, n_jobs=None):
         self.estimators = estimators
+        self.verbose = verbose
         self.weights = weights
         self.n_jobs = n_jobs
 

--- a/sklearn/ensemble/voting.py
+++ b/sklearn/ensemble/voting.py
@@ -24,28 +24,30 @@ from ..base import RegressorMixin
 from ..base import TransformerMixin
 from ..base import clone
 from ..preprocessing import LabelEncoder
-from ..utils import Bunch
+from ..utils import Bunch, _print_elapsed_time
 from ..utils.validation import check_is_fitted
 from ..utils.metaestimators import _BaseComposition
 from ..utils.multiclass import check_classification_targets
 from ..utils.validation import column_or_1d
 
 
-def _parallel_fit_estimator(estimator, X, y, sample_weight=None):
+def _parallel_fit_estimator(estimator, X, y, sample_weight=None,
+                            message_clsname='', message=None):
     """Private function used to fit an estimator within a job."""
-    if sample_weight is not None:
-        try:
-            estimator.fit(X, y, sample_weight=sample_weight)
-        except TypeError as exc:
-            if "unexpected keyword argument 'sample_weight'" in str(exc):
-                raise ValueError(
-                    "Underlying estimator {} does not support sample weights."
-                    .format(estimator.__class__.__name__)
-                ) from exc
-            raise
-    else:
-        estimator.fit(X, y)
-    return estimator
+    with _print_elapsed_time(message_clsname, message):
+        if sample_weight is not None:
+            try:
+                estimator.fit(X, y, sample_weight=sample_weight)
+            except TypeError as exc:
+                if "unexpected keyword argument 'sample_weight'" in str(exc):
+                    raise ValueError(
+                        "Underlying estimator {} does not support sample weights."
+                        .format(estimator.__class__.__name__)
+                    ) from exc
+                raise
+        else:
+            estimator.fit(X, y)
+        return estimator
 
 
 class _BaseVoting(_BaseComposition, TransformerMixin):
@@ -116,7 +118,7 @@ class _BaseVoting(_BaseComposition, TransformerMixin):
     def _log_message(self, name, idx, total):
         if not self.verbose:
             return None
-        return '(classifier %d of %d) Processing %s' % (idx, total, name)
+        return '(classifier %d of %d) Processing %s' % (idx+1, total, name)
 
     def set_params(self, **params):
         """ Setting the parameters for the ensemble estimator


### PR DESCRIPTION
@spbail 

This PR adds a boolean verbose flag for the classes in `voting.py`. Adds function `_log_message` to `_BaseVoting` and uses code format as in #11364.

Verbose messages looks like:

> [Voting] ............ (classifier 1 of 3) Processing lr, total=   0.0s
[Voting] ............ (classifier 2 of 3) Processing rf, total=   0.0s
[Voting] ........... (classifier 3 of 3) Processing gnb, total=   0.0s
