### PR TITLE
[MRG] Reorganize document classification example into subsections

### DIFF
--- a/examples/text/plot_document_classification_20newsgroups.py
+++ b/examples/text/plot_document_classification_20newsgroups.py
@@ -96,9 +96,9 @@ print()
 ##############################################################################
 # Load data from the training set
 # ------------------------------------
-# Let's load data from the newsgroups dataset which comprises around 18000 newsgroups
-# posts on 20 topics split in two subsets: one for training (or development)
-# and the other one for testing (or for performance evaluation).
+# Let's load data from the newsgroups dataset which comprises around 18000
+# newsgroups posts on 20 topics split in two subsets: one for training (or
+# development) and the other one for testing (or for performance evaluation).
 if opts.all_categories:
     categories = None
 else:

--- a/examples/text/plot_document_classification_20newsgroups.py
+++ b/examples/text/plot_document_classification_20newsgroups.py
@@ -13,9 +13,6 @@ automatically downloaded, then cached.
 
 """
 
-##############################################################################
-# Setting up commond line parser and data loading
-# ------------------------------------
 # Author: Peter Prettenhofer <peter.prettenhofer@gmail.com>
 #         Olivier Grisel <olivier.grisel@ensta.org>
 #         Mathieu Blondel <mathieu@mblondel.org>
@@ -96,8 +93,8 @@ op.print_help()
 print()
 
 
-# #############################################################################
-# Load some categories from the training set
+##############################################################################
+# Load data from the training set
 # ------------------------------------
 if opts.all_categories:
     categories = None
@@ -199,10 +196,9 @@ def trim(s):
     return s if len(s) <= 80 else s[:77] + "..."
 
 
-# #############################################################################
+##############################################################################
 # Benchmark classifiers
 # ------------------------------------
-
 def benchmark(clf):
     print('_' * 80)
     print("Training: ")
@@ -295,8 +291,9 @@ results.append(benchmark(Pipeline([
                                                   tol=1e-3))),
   ('classification', LinearSVC(penalty="l2"))])))
 
-# #############################################################################
-# Adding plots
+
+##############################################################################
+# Add plots
 # ------------------------------------
 # The bar plot indicates the accuracy, training time (normalized) and test time
 # (normalized) of each classifier.

--- a/examples/text/plot_document_classification_20newsgroups.py
+++ b/examples/text/plot_document_classification_20newsgroups.py
@@ -11,11 +11,11 @@ efficiently handle sparse matrices.
 The dataset used in this example is the 20 newsgroups dataset. It will be
 automatically downloaded, then cached.
 
-The bar plot indicates the accuracy, training time (normalized) and test time
-(normalized) of each classifier.
-
 """
 
+##############################################################################
+# Setting up commond line parser and data loading
+# ------------------------------------
 # Author: Peter Prettenhofer <peter.prettenhofer@gmail.com>
 #         Olivier Grisel <olivier.grisel@ensta.org>
 #         Mathieu Blondel <mathieu@mblondel.org>
@@ -51,8 +51,6 @@ from sklearn import metrics
 logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s %(levelname)s %(message)s')
 
-
-# parse commandline arguments
 op = OptionParser()
 op.add_option("--report",
               action="store_true", dest="print_report",
@@ -100,6 +98,7 @@ print()
 
 # #############################################################################
 # Load some categories from the training set
+# ------------------------------------
 if opts.all_categories:
     categories = None
 else:
@@ -202,6 +201,8 @@ def trim(s):
 
 # #############################################################################
 # Benchmark classifiers
+# ------------------------------------
+
 def benchmark(clf):
     print('_' * 80)
     print("Training: ")
@@ -294,8 +295,11 @@ results.append(benchmark(Pipeline([
                                                   tol=1e-3))),
   ('classification', LinearSVC(penalty="l2"))])))
 
-# make some plots
-
+# #############################################################################
+# Adding plots
+# ------------------------------------
+# The bar plot indicates the accuracy, training time (normalized) and test time
+# (normalized) of each classifier.
 indices = np.arange(len(results))
 
 results = [[x[i] for x in results] for i in range(4)]

--- a/examples/text/plot_document_classification_20newsgroups.py
+++ b/examples/text/plot_document_classification_20newsgroups.py
@@ -96,6 +96,9 @@ print()
 ##############################################################################
 # Load data from the training set
 # ------------------------------------
+# Let's load data from the newsgroups dataset which comprises around 18000 newsgroups
+# posts on 20 topics split in two subsets: one for training (or development)
+# and the other one for testing (or for performance evaluation).
 if opts.all_categories:
     categories = None
 else:
@@ -199,6 +202,8 @@ def trim(s):
 ##############################################################################
 # Benchmark classifiers
 # ------------------------------------
+# We train and test the datasets with 15 different classification models
+# and get performance results for each model.
 def benchmark(clf):
     print('_' * 80)
     print("Training: ")


### PR DESCRIPTION
#### Reference Issues/PRs 
Partial fixes #14703.

#### What does this implement/fix? Explain your changes.
Reorganize document classification example into subsections for examples/text/plot_document_classification_20newsgroups.py

#### Any other comments?
Working with @ruchitagarde