### PR TITLE
update definitions for oob_ attributes for BaggingClassifier, BaggingRegressor, ExtraTreesClassifier, ExtraTreesRegressor, RandomForestClassifier, RandomForestRegressor

### DIFF
--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -532,12 +532,14 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
 
     oob_score_ : float
         Score of the training dataset obtained using an out-of-bag estimate.
+        This attribute exists only when ``oob_score`` is True.
 
     oob_decision_function_ : array of shape = [n_samples, n_classes]
         Decision function computed with out-of-bag estimate on the training
         set. If n_estimators is small it might be possible that a data point
         was never left out during the bootstrap. In this case,
-        `oob_decision_function_` might contain NaN.
+        `oob_decision_function_` might contain NaN. This attribute exists 
+        only when ``oob_score`` is True.
 
     References
     ----------
@@ -908,12 +910,14 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
 
     oob_score_ : float
         Score of the training dataset obtained using an out-of-bag estimate.
+        This attribute exists only when ``oob_score`` is True.
 
     oob_prediction_ : array of shape = [n_samples]
         Prediction computed with out-of-bag estimate on the training
         set. If n_estimators is small it might be possible that a data point
         was never left out during the bootstrap. In this case,
-        `oob_prediction_` might contain NaN.
+        `oob_prediction_` might contain NaN. This attribute exists only 
+        when ``oob_score`` is True.
 
     References
     ----------

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -951,12 +951,14 @@ class RandomForestClassifier(ForestClassifier):
 
     oob_score_ : float
         Score of the training dataset obtained using an out-of-bag estimate.
+        This attribute exists only when ``oob_score`` is True.
 
     oob_decision_function_ : array of shape = [n_samples, n_classes]
         Decision function computed with out-of-bag estimate on the training
         set. If n_estimators is small it might be possible that a data point
         was never left out during the bootstrap. In this case,
-        `oob_decision_function_` might contain NaN.
+        `oob_decision_function_` might contain NaN. This attribute exists 
+        only when ``oob_score`` is True.
 
     Examples
     --------
@@ -1218,9 +1220,11 @@ class RandomForestRegressor(ForestRegressor):
 
     oob_score_ : float
         Score of the training dataset obtained using an out-of-bag estimate.
+        This attribute exists only when ``oob_score`` is True.
 
     oob_prediction_ : array of shape = [n_samples]
         Prediction computed with out-of-bag estimate on the training set.
+        This attribute exists only when ``oob_score`` is True.
 
     Examples
     --------
@@ -1512,12 +1516,14 @@ class ExtraTreesClassifier(ForestClassifier):
 
     oob_score_ : float
         Score of the training dataset obtained using an out-of-bag estimate.
+        This attribute exists only when ``oob_score`` is True.
 
     oob_decision_function_ : array of shape = [n_samples, n_classes]
         Decision function computed with out-of-bag estimate on the training
         set. If n_estimators is small it might be possible that a data point
         was never left out during the bootstrap. In this case,
-        `oob_decision_function_` might contain NaN.
+        `oob_decision_function_` might contain NaN. This attribute exists 
+        only when ``oob_score`` is True.
 
     Notes
     -----
@@ -1756,9 +1762,11 @@ class ExtraTreesRegressor(ForestRegressor):
 
     oob_score_ : float
         Score of the training dataset obtained using an out-of-bag estimate.
+        This attribute exists only when ``oob_score`` is True.
 
     oob_prediction_ : array of shape = [n_samples]
         Prediction computed with out-of-bag estimate on the training set.
+        This attribute exists only when ``oob_score`` is True.
 
     Notes
     -----


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
partially addresses #14312

#### What does this implement/fix? Explain your changes.

oob_ attributes below are false positives, they only exist when oob_score is True. Added comments.

BaggingClassifier, [ oob_decision_function_, oob_score_]
BaggingRegressor, [ oob_prediction_, oob_score_]
ExtraTreesClassifier, [ oob_decision_function_, oob_score_]
ExtraTreesRegressor, [ oob_prediction_, oob_score_]
RandomForestClassifier, [oob_decision_function_, oob_score_]
RandomForestRegressor, [oob_prediction_, oob_score_]

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
