### PR TITLE
[MRG] Write consistent descriptions of the data attribute C in LinearSVC, LinearSVR, SVC and SVR 

### DIFF
--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -44,9 +44,9 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         Tolerance for stopping criteria.
 
     C : float, optional (default=1.0)
-        Penalty or regularization parameter (strictly positive) that is
-        inversely proportional to the regularization strength and is multiplied
-        to the loss term of the cost function.
+        Strictly positive parameter that is inversely proportional to the
+        regularization strength and is multiplied with the loss term of the
+        in the cost function.
 
     multi_class : string, 'ovr' or 'crammer_singer' (default='ovr')
         Determines the multi-class strategy if `y` contains more than
@@ -275,9 +275,9 @@ class LinearSVR(LinearModel, RegressorMixin):
         Tolerance for stopping criteria.
 
     C : float, optional (default=1.0)
-        Penalty or regularization parameter (strictly positive) that is
-        inversely proportional to the regularization strength and is multiplied
-        to the loss term of the cost function.
+        Strictly positive parameter that is inversely proportional to the
+        regularization strength and is multiplied with the loss term of the
+        in the cost function.
 
     loss : string, optional (default='epsilon_insensitive')
         Specifies the loss function. The epsilon-insensitive loss
@@ -457,9 +457,8 @@ class SVC(BaseSVC):
     Parameters
     ----------
     C : float, optional (default=1.0)
-        Penalty or regularization parameter (strictly positive) that is
-        inversely proportional to the regularization strength and is multiplied
-        to the loss term of the cost function.
+        Strictly positive parameter that is inversely proportional to the
+        regularization strength. The penalty is a squared l2 penalty.
 
     kernel : string, optional (default='rbf')
         Specifies the kernel type to be used in the algorithm.
@@ -871,9 +870,8 @@ class SVR(BaseLibSVM, RegressorMixin):
         Tolerance for stopping criterion.
 
     C : float, optional (default=1.0)
-        Penalty or regularization parameter (strictly positive) that is
-        inversely proportional to the regularization strength and is multiplied
-        to the loss term of the cost function.
+        Strictly positive parameter that is inversely proportional to the
+        regularization strength. The penalty is a squared l2 penalty.
 
     epsilon : float, optional (default=0.1)
          Epsilon in the epsilon-SVR model. It specifies the epsilon-tube

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -44,9 +44,9 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         Tolerance for stopping criteria.
 
     C : float, optional (default=1.0)
-        Penalty parameter (strictly positive) that is inversely proportional to the 
-        regularization strength and is multiplied to the loss term of the 
-        cost function.
+        Penalty or regularization parameter (strictly positive) that is inversely 
+        proportional to the regularization strength and is multiplied to the 
+        loss term of the cost function.
 
     multi_class : string, 'ovr' or 'crammer_singer' (default='ovr')
         Determines the multi-class strategy if `y` contains more than
@@ -275,9 +275,9 @@ class LinearSVR(LinearModel, RegressorMixin):
         Tolerance for stopping criteria.
 
     C : float, optional (default=1.0)
-        Penalty parameter (strictly positive) that is inversely proportional to the 
-        regularization strength and is multiplied to the loss term of the 
-        cost function.
+        Penalty or regularization parameter (strictly positive) that is inversely 
+        proportional to the regularization strength and is multiplied to the 
+        loss term of the cost function.
 
     loss : string, optional (default='epsilon_insensitive')
         Specifies the loss function. The epsilon-insensitive loss
@@ -457,7 +457,9 @@ class SVC(BaseSVC):
     Parameters
     ----------
     C : float, optional (default=1.0)
-        Penalty parameter C applied to the loss term of the cost function. The bigger this parameter, the less regularization is used.
+        Penalty or regularization parameter (strictly positive) that is inversely 
+        proportional to the regularization strength and is multiplied to the 
+        loss term of the cost function.
 
     kernel : string, optional (default='rbf')
         Specifies the kernel type to be used in the algorithm.
@@ -869,8 +871,10 @@ class SVR(BaseLibSVM, RegressorMixin):
         Tolerance for stopping criterion.
 
     C : float, optional (default=1.0)
-        Penalty parameter C applied to the loss term of the cost function. The bigger this parameter, the less regularization is used.
-
+        Penalty or regularization parameter (strictly positive) that is inversely 
+        proportional to the regularization strength and is multiplied to the 
+        loss term of the cost function.
+        
     epsilon : float, optional (default=0.1)
          Epsilon in the epsilon-SVR model. It specifies the epsilon-tube
          within which no penalty is associated in the training loss function

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -44,9 +44,9 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         Tolerance for stopping criteria.
 
     C : float, optional (default=1.0)
-        Penalty or regularization parameter (strictly positive) that is inversely 
-        proportional to the regularization strength and is multiplied to the 
-        loss term of the cost function.
+        Penalty or regularization parameter (strictly positive) that is
+        inversely proportional to the regularization strength and is multiplied
+        to the loss term of the cost function.
 
     multi_class : string, 'ovr' or 'crammer_singer' (default='ovr')
         Determines the multi-class strategy if `y` contains more than
@@ -275,9 +275,9 @@ class LinearSVR(LinearModel, RegressorMixin):
         Tolerance for stopping criteria.
 
     C : float, optional (default=1.0)
-        Penalty or regularization parameter (strictly positive) that is inversely 
-        proportional to the regularization strength and is multiplied to the 
-        loss term of the cost function.
+        Penalty or regularization parameter (strictly positive) that is
+        inversely proportional to the regularization strength and is multiplied
+        to the loss term of the cost function.
 
     loss : string, optional (default='epsilon_insensitive')
         Specifies the loss function. The epsilon-insensitive loss
@@ -457,9 +457,9 @@ class SVC(BaseSVC):
     Parameters
     ----------
     C : float, optional (default=1.0)
-        Penalty or regularization parameter (strictly positive) that is inversely 
-        proportional to the regularization strength and is multiplied to the 
-        loss term of the cost function.
+        Penalty or regularization parameter (strictly positive) that is
+        inversely proportional to the regularization strength and is multiplied
+        to the loss term of the cost function.
 
     kernel : string, optional (default='rbf')
         Specifies the kernel type to be used in the algorithm.
@@ -871,9 +871,9 @@ class SVR(BaseLibSVM, RegressorMixin):
         Tolerance for stopping criterion.
 
     C : float, optional (default=1.0)
-        Penalty or regularization parameter (strictly positive) that is inversely 
-        proportional to the regularization strength and is multiplied to the 
-        loss term of the cost function.
+        Penalty or regularization parameter (strictly positive) that is
+        inversely proportional to the regularization strength and is multiplied
+        to the loss term of the cost function.
 
     epsilon : float, optional (default=0.1)
          Epsilon in the epsilon-SVR model. It specifies the epsilon-tube

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -977,7 +977,7 @@ class NuSVR(BaseLibSVM, RegressorMixin):
         default 0.5 will be taken.
 
     C : float, optional (default=1.0)
-         Penalty parameter C of the error term.
+        Penalty parameter C of the error term.
 
     kernel : string, optional (default='rbf')
          Specifies the kernel type to be used in the algorithm.

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -866,7 +866,7 @@ class SVR(BaseLibSVM, RegressorMixin):
         Tolerance for stopping criterion.
 
     C : float, optional (default=1.0)
-        Penalty parameter C of the error term.
+        Penalty parameter C of the error term. The bigger this parameter, the less regularization is used.
 
     epsilon : float, optional (default=0.1)
          Epsilon in the epsilon-SVR model. It specifies the epsilon-tube

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -874,7 +874,7 @@ class SVR(BaseLibSVM, RegressorMixin):
         Penalty or regularization parameter (strictly positive) that is inversely 
         proportional to the regularization strength and is multiplied to the 
         loss term of the cost function.
-        
+
     epsilon : float, optional (default=0.1)
          Epsilon in the epsilon-SVR model. It specifies the epsilon-tube
          within which no penalty is associated in the training loss function
@@ -977,7 +977,7 @@ class NuSVR(BaseLibSVM, RegressorMixin):
         default 0.5 will be taken.
 
     C : float, optional (default=1.0)
-        Penalty parameter C applied to the loss term of the cost function. The bigger this parameter, the less regularization is used.
+         Penalty parameter C of the error term.
 
     kernel : string, optional (default='rbf')
          Specifies the kernel type to be used in the algorithm.

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -44,9 +44,8 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         Tolerance for stopping criteria.
 
     C : float, optional (default=1.0)
-        Strictly positive parameter that is inversely proportional to the
-        regularization strength and is multiplied with the loss term of the
-        in the cost function.
+        Regularization parameter. The strength of the regularization is
+        inversely proportional to C. Must be strictly positive.
 
     multi_class : string, 'ovr' or 'crammer_singer' (default='ovr')
         Determines the multi-class strategy if `y` contains more than
@@ -275,9 +274,8 @@ class LinearSVR(LinearModel, RegressorMixin):
         Tolerance for stopping criteria.
 
     C : float, optional (default=1.0)
-        Strictly positive parameter that is inversely proportional to the
-        regularization strength and is multiplied with the loss term of the
-        in the cost function.
+        Regularization parameter. The strength of the regularization is
+        inversely proportional to C. Must be strictly positive.
 
     loss : string, optional (default='epsilon_insensitive')
         Specifies the loss function. The epsilon-insensitive loss
@@ -457,8 +455,9 @@ class SVC(BaseSVC):
     Parameters
     ----------
     C : float, optional (default=1.0)
-        Strictly positive parameter that is inversely proportional to the
-        regularization strength. The penalty is a squared l2 penalty.
+        Regularization parameter. The strength of the regularization is
+        inversely proportional to C. Must be strictly positive. The penalty
+        is a squared l2 penalty.
 
     kernel : string, optional (default='rbf')
         Specifies the kernel type to be used in the algorithm.
@@ -870,8 +869,9 @@ class SVR(BaseLibSVM, RegressorMixin):
         Tolerance for stopping criterion.
 
     C : float, optional (default=1.0)
-        Strictly positive parameter that is inversely proportional to the
-        regularization strength. The penalty is a squared l2 penalty.
+        Regularization parameter. The strength of the regularization is
+        inversely proportional to C. Must be strictly positive.
+        The penalty is a squared l2 penalty.
 
     epsilon : float, optional (default=0.1)
          Epsilon in the epsilon-SVR model. It specifies the epsilon-tube

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -44,7 +44,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         Tolerance for stopping criteria.
 
     C : float, optional (default=1.0)
-        Penalty parameter C of the error term.
+        Penalty parameter C of the error term. The bigger this parameter, the less regularization is used.
 
     multi_class : string, 'ovr' or 'crammer_singer' (default='ovr')
         Determines the multi-class strategy if `y` contains more than
@@ -454,7 +454,7 @@ class SVC(BaseSVC):
     Parameters
     ----------
     C : float, optional (default=1.0)
-        Penalty parameter C of the error term.
+        Penalty parameter C of the error term. The bigger this parameter, the less regularization is used.
 
     kernel : string, optional (default='rbf')
         Specifies the kernel type to be used in the algorithm.
@@ -866,7 +866,7 @@ class SVR(BaseLibSVM, RegressorMixin):
         Tolerance for stopping criterion.
 
     C : float, optional (default=1.0)
-        Penalty parameter C of the error term.
+        Penalty parameter C of the error term. The bigger this parameter, the less regularization is used.
 
     epsilon : float, optional (default=0.1)
          Epsilon in the epsilon-SVR model. It specifies the epsilon-tube
@@ -970,7 +970,7 @@ class NuSVR(BaseLibSVM, RegressorMixin):
         default 0.5 will be taken.
 
     C : float, optional (default=1.0)
-        Penalty parameter C of the error term.
+        Penalty parameter C of the error term. The bigger this parameter, the less regularization is used.
 
     kernel : string, optional (default='rbf')
          Specifies the kernel type to be used in the algorithm.

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -44,7 +44,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         Tolerance for stopping criteria.
 
     C : float, optional (default=1.0)
-        Penalty parameter C of the error term. The bigger this parameter, the less regularization is used.
+        Penalty parameter C applied to the loss term of the cost function. The bigger this parameter, the less regularization is used.
 
     multi_class : string, 'ovr' or 'crammer_singer' (default='ovr')
         Determines the multi-class strategy if `y` contains more than
@@ -273,7 +273,7 @@ class LinearSVR(LinearModel, RegressorMixin):
         Tolerance for stopping criteria.
 
     C : float, optional (default=1.0)
-        Penalty parameter C of the error term. The penalty is a squared
+        Penalty parameter C applied to the loss term of the cost function. The penalty is a squared
         l2 penalty. The bigger this parameter, the less regularization is used.
 
     loss : string, optional (default='epsilon_insensitive')
@@ -454,7 +454,7 @@ class SVC(BaseSVC):
     Parameters
     ----------
     C : float, optional (default=1.0)
-        Penalty parameter C of the error term. The bigger this parameter, the less regularization is used.
+        Penalty parameter C applied to the loss term of the cost function. The bigger this parameter, the less regularization is used.
 
     kernel : string, optional (default='rbf')
         Specifies the kernel type to be used in the algorithm.
@@ -866,7 +866,7 @@ class SVR(BaseLibSVM, RegressorMixin):
         Tolerance for stopping criterion.
 
     C : float, optional (default=1.0)
-        Penalty parameter C of the error term. The bigger this parameter, the less regularization is used.
+        Penalty parameter C applied to the loss term of the cost function. The bigger this parameter, the less regularization is used.
 
     epsilon : float, optional (default=0.1)
          Epsilon in the epsilon-SVR model. It specifies the epsilon-tube
@@ -970,7 +970,7 @@ class NuSVR(BaseLibSVM, RegressorMixin):
         default 0.5 will be taken.
 
     C : float, optional (default=1.0)
-        Penalty parameter C of the error term. The bigger this parameter, the less regularization is used.
+        Penalty parameter C applied to the loss term of the cost function. The bigger this parameter, the less regularization is used.
 
     kernel : string, optional (default='rbf')
          Specifies the kernel type to be used in the algorithm.

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -44,7 +44,9 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         Tolerance for stopping criteria.
 
     C : float, optional (default=1.0)
-        Penalty parameter C applied to the loss term of the cost function. The bigger this parameter, the less regularization is used.
+        Penalty parameter (strictly positive) that is inversely proportional to the 
+        regularization strength and is multiplied to the loss term of the 
+        cost function.
 
     multi_class : string, 'ovr' or 'crammer_singer' (default='ovr')
         Determines the multi-class strategy if `y` contains more than
@@ -273,8 +275,9 @@ class LinearSVR(LinearModel, RegressorMixin):
         Tolerance for stopping criteria.
 
     C : float, optional (default=1.0)
-        Penalty parameter C applied to the loss term of the cost function. The penalty is a squared
-        l2 penalty. The bigger this parameter, the less regularization is used.
+        Penalty parameter (strictly positive) that is inversely proportional to the 
+        regularization strength and is multiplied to the loss term of the 
+        cost function.
 
     loss : string, optional (default='epsilon_insensitive')
         Specifies the loss function. The epsilon-insensitive loss


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->


#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #11772 

#### What does this implement/fix? Explain your changes.
In the module `sklearn.svm`, in classes `LinearSVC, LinearSVR, SVC, SVR`, the definitions for the `C` data attribute were inconsistent. The goal was to come up with a definition that would be in line with the two papers from which these 4 classes have been implemented. While `LinearSVC, LinearSVR` use [Liblinear](https://www.csie.ntu.edu.tw/~cjlin/liblinear/) which calls `C` a _penalty parameter_, `SVC, SVR` use [Libsvm](https://www.csie.ntu.edu.tw/~cjlin/libsvm/) which labels `C` as a _regularization parameter_. I have tried to come up with a definition that is consistent with both of these papers mainly
```
        Penalty or regularization parameter (strictly positive) that is inversely 
        proportional to the regularization strength and is multiplied to the 
        loss term of the cost function.
```
 



#### Any other comments?
Issue #11772 also talks about editing the User Guide to clarify the different losses versus the different regularization norms being used. I feel that this discussion is beyond the scope of this issue and could be addressed with the creation of another more specific issue.  
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->


####  Acknowledgements
Thanks to [WiMLDS](https://github.com/WiMLDS/nyc-2019-scikit-sprint) for holding the Sprint event and @neginkrahbar.
