### PR TITLE
[MRG] Change default dataset for `plot_johnson_lindenstrauss_bound.py`

### DIFF
--- a/examples/plot_johnson_lindenstrauss_bound.py
+++ b/examples/plot_johnson_lindenstrauss_bound.py
@@ -105,7 +105,7 @@ plt.show()
 # Empirical validation
 # ====================
 #
-# We validate the above bounds on the 20 newsgroups text document 
+# We validate the above bounds on the 20 newsgroups text document
 # (TF-IDF word frequencies) dataset or on the digits dataset:
 #
 # - for the 20 newsgroups dataset some 500 documents with 100k

--- a/examples/plot_johnson_lindenstrauss_bound.py
+++ b/examples/plot_johnson_lindenstrauss_bound.py
@@ -115,7 +115,7 @@ plt.show()
 #   larger number of dimensions ``n_components``.
 #
 # The default dataset is the 20 newsgroups dataset. To run the example on the
-# digits dataset, pass the ---use-digits-dataset command line argument to this
+# digits dataset, pass the ``--use-digits-dataset`` command line argument to this
 # script.
 
 if '--use-digits-dataset' in sys.argv:

--- a/examples/plot_johnson_lindenstrauss_bound.py
+++ b/examples/plot_johnson_lindenstrauss_bound.py
@@ -146,9 +146,9 @@ plt.xlabel("Distortion eps")
 plt.ylabel("Minimum number of dimensions")
 plt.title("Johnson-Lindenstrauss bounds:\nn_components vs eps")
 
-# Part 2: perform sparse random projection of some documents of the 20 newsgroups 
-# dataset which is both high dimensional and sparse or some digits images which are
-# quite low dimensional and dense
+# Part 2: perform sparse random projection of some documents of the 20
+# newsgroups dataset which is both high dimensional and sparse or some
+# digits images which are quite low dimensional and dense
 
 if '---use-digits-dataset' in sys.argv:
     data = load_digits().data[:500]

--- a/examples/plot_johnson_lindenstrauss_bound.py
+++ b/examples/plot_johnson_lindenstrauss_bound.py
@@ -157,7 +157,7 @@ for n_components in n_components_range:
         projected_data, squared=True).ravel()[nonzero]
 
     plt.figure()
-    min_dist = min(projected_dists.max(), dists.min())
+    min_dist = min(projected_dists.min(), dists.min())
     max_dist = max(projected_dists.max(), dists.max())
     plt.hexbin(dists, projected_dists, gridsize=100, cmap=plt.cm.PuBu,
                extent=[min_dist, max_dist, min_dist, max_dist])

--- a/examples/plot_johnson_lindenstrauss_bound.py
+++ b/examples/plot_johnson_lindenstrauss_bound.py
@@ -118,7 +118,7 @@ plt.show()
 # digits dataset, pass the ---use-digits-dataset command line argument to this
 # script.
 
-if '---use-digits-dataset' in sys.argv:
+if '--use-digits-dataset' in sys.argv:
     data = load_digits().data[:500]
 else:
     data = fetch_20newsgroups_vectorized().data[:500]

--- a/examples/plot_johnson_lindenstrauss_bound.py
+++ b/examples/plot_johnson_lindenstrauss_bound.py
@@ -115,8 +115,8 @@ plt.show()
 #   larger number of dimensions ``n_components``.
 #
 # The default dataset is the 20 newsgroups dataset. To run the example on the
-# digits dataset, pass the ``--use-digits-dataset`` command line argument to this
-# script.
+# digits dataset, pass the ``--use-digits-dataset`` command line argument to
+# this script.
 
 if '--use-digits-dataset' in sys.argv:
     data = load_digits().data[:500]

--- a/examples/plot_johnson_lindenstrauss_bound.py
+++ b/examples/plot_johnson_lindenstrauss_bound.py
@@ -9,9 +9,6 @@ dataset can be randomly projected into a lower dimensional Euclidean
 space while controlling the distortion in the pairwise distances.
 
 .. _`Johnson-Lindenstrauss lemma`: https://en.wikipedia.org/wiki/Johnson%E2%80%93Lindenstrauss_lemma
-
-
-Theoretical bounds
 """
 
 print(__doc__)

--- a/examples/plot_johnson_lindenstrauss_bound.py
+++ b/examples/plot_johnson_lindenstrauss_bound.py
@@ -56,8 +56,8 @@ text document (TF-IDF word frequencies) dataset:
   euclidean spaces with various values for the target number of dimensions
   ``n_components``.
 
-The default dataset is the digits dataset. To run the example on the twenty
-newsgroups dataset, pass the --twenty-newsgroups command line argument to this
+The default dataset is the 20 newsgroups dataset. To run the example on the
+digits dataset, pass the ---use-digits-dataset command line argument to this
 script.
 
 For each value of ``n_components``, we plot:
@@ -146,15 +146,14 @@ plt.xlabel("Distortion eps")
 plt.ylabel("Minimum number of dimensions")
 plt.title("Johnson-Lindenstrauss bounds:\nn_components vs eps")
 
-# Part 2: perform sparse random projection of some digits images which are
-# quite low dimensional and dense or documents of the 20 newsgroups dataset
-# which is both high dimensional and sparse
+# Part 2: perform sparse random projection of some documents of the 20 newsgroups 
+# dataset which is both high dimensional and sparse or some digits images which are
+# quite low dimensional and dense
 
-if '--twenty-newsgroups' in sys.argv:
-    # Need an internet connection hence not enabled by default
-    data = fetch_20newsgroups_vectorized().data[:500]
-else:
+if '---use-digits-dataset' in sys.argv:
     data = load_digits().data[:500]
+else:
+    data = fetch_20newsgroups_vectorized().data[:500]
 
 n_samples, n_features = data.shape
 print("Embedding %d samples with dim %d using various random projections"
@@ -182,7 +181,10 @@ for n_components in n_components_range:
         projected_data, squared=True).ravel()[nonzero]
 
     plt.figure()
-    plt.hexbin(dists, projected_dists, gridsize=100, cmap=plt.cm.PuBu)
+    min_dist = min(projected_dists.max(), dists.min())
+    max_dist = max(projected_dists.max(), dists.max())
+    plt.hexbin(dists, projected_dists, gridsize=100, cmap=plt.cm.PuBu,
+               extent=[min_dist, max_dist, min_dist, max_dist])
     plt.xlabel("Pairwise squared distances in original space")
     plt.ylabel("Pairwise squared distances in projected space")
     plt.title("Pairwise distances distribution for n_components=%d" %


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

Closes #12649 


#### What does this implement/fix? Explain your changes.

Change the default dataset used in the `examples/plot_johnson_lindenstrauss_bound.py`  to the  twenty news groups. Use the digits dataset only if the flag `---use-digits-dataset` is specified. 

Also, changed the hexbin plots to have square heatmaps.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
