### PR TITLE
don't set upstream remote and branch!!!

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -228,7 +228,7 @@ then submit a "pull request" (PR):
    changes::
 
        $ git fetch upstream
-       $ git checkout -b my-feature upstream/master
+       $ git checkout -b my-feature
 
    and start making changes. Always use a ``feature`` branch. It's good
    practice to never work on the ``master`` branch!


### PR DESCRIPTION
@NicolasHug just pointed this out to me. Apparently @adrinjalali and @jnothman like it.
I'm quite sure this is wrong. This sets the upstream remote for the feature branch to "upstream", i.e. the scikit-learn main repo, and the upstream branch to "master".
Both of these are bad things and wrong, imho.
The upstream should be ``origin/<branchname>`` which is the same feature branch on their own fork.

Using the current docs will result in users failing to push (because they can't write to upstream), and if it's done by a contributor, it means they push to master directly from their feature branch without a PR.

Also, if it fails, git gives a confusing error message that can result in you pushing a feature branch to upstream (as @NicolasHug just did).

Either way, think the current command is doubly wrong, unless I completely misunderstand it.