### PR TITLE
Deprecate classes attribute in DecisionTreeRegressor

### DIFF
--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1954,3 +1954,18 @@ def test_prune_tree_raises_negative_ccp_alpha():
     with pytest.raises(ValueError, match=msg):
         clf.set_params(ccp_alpha=-1.0)
         clf._prune_tree()
+
+def test_classes_deprecated():
+    X = [[0, 0], [2, 2], [4, 6], [10, 11]]
+    y = [0.5, 2.5, 3.5, 5.5]
+    clf = DecisionTreeRegressor()
+    
+    clf = clf.fit(X,y)
+    
+    match = ("'classes_'is to be deprecated from version 0.20 and "
+             "will be removed in 0.22.")
+    
+    with pytest.warns(DeprecationWarning, match=match):
+        n = clf.classes_
+    assert n == clf.classes_
+        

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1966,5 +1966,5 @@ def test_classes_deprecated():
              "will be removed in 0.22.")
 
     with pytest.warns(DeprecationWarning, match=match):
-        n=clf.classes_
-        assert n==clf._classes
+        n = clf.classes_
+        assert n == clf._classes

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -438,12 +438,12 @@ def test_max_features():
         est = TreeEstimator(max_features="sqrt")
         est.fit(iris.data, iris.target)
         assert (est.max_features_ ==
-                     int(np.sqrt(iris.data.shape[1])))
+                int(np.sqrt(iris.data.shape[1])))
 
         est = TreeEstimator(max_features="log2")
         est.fit(iris.data, iris.target)
         assert (est.max_features_ ==
-                     int(np.log2(iris.data.shape[1])))
+                int(np.log2(iris.data.shape[1])))
 
         est = TreeEstimator(max_features=1)
         est.fit(iris.data, iris.target)
@@ -460,7 +460,7 @@ def test_max_features():
         est = TreeEstimator(max_features=0.5)
         est.fit(iris.data, iris.target)
         assert (est.max_features_ ==
-                     int(0.5 * iris.data.shape[1]))
+                int(0.5 * iris.data.shape[1]))
 
         est = TreeEstimator(max_features=1.0)
         est.fit(iris.data, iris.target)
@@ -1954,13 +1954,3 @@ def test_prune_tree_raises_negative_ccp_alpha():
     with pytest.raises(ValueError, match=msg):
         clf.set_params(ccp_alpha=-1.0)
         clf._prune_tree()
-
-def test_classes_deprecated():
-    X = [[0, 0], [2, 2], [4, 6], [10, 11]]
-    y = [0.5, 2.5, 3.5, 5.5]
-    clf = DecisionTreeRegressor()
-    
-    clf = clf.fit(X,y)
-    
-    match = ("'classes_'is to be deprecated from version 0.20 and "
-             "will be removed in 0.22.")

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1954,3 +1954,17 @@ def test_prune_tree_raises_negative_ccp_alpha():
     with pytest.raises(ValueError, match=msg):
         clf.set_params(ccp_alpha=-1.0)
         clf._prune_tree()
+
+
+def test_classes_deprecated():
+    X = [[0, 0], [2, 2], [4, 6], [10, 11]]
+    y = [0.5, 2.5, 3.5, 5.5]
+    clf = DecisionTreeRegressor()
+    clf = clf.fit(X, y)
+
+    match = ("'classes_' is to be deprecated from version 0.20 and "
+             "will be removed in 0.22.")
+
+    with pytest.warns(DeprecationWarning, match=match):
+        n=clf.classes_
+        assert n==clf._classes

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1964,8 +1964,3 @@ def test_classes_deprecated():
     
     match = ("'classes_'is to be deprecated from version 0.20 and "
              "will be removed in 0.22.")
-    
-    with pytest.warns(DeprecationWarning, match=match):
-        n = clf.classes_
-    assert n == clf.classes_
-        

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -162,7 +162,7 @@ class BaseDecisionTree(BaseEstimator, MultiOutputMixin, metaclass=ABCMeta):
             check_classification_targets(y)
             y = np.copy(y)
 
-            self.classes_ = []
+            self._classes = []
             self.n_classes_ = []
 
             if self.class_weight is not None:
@@ -172,7 +172,7 @@ class BaseDecisionTree(BaseEstimator, MultiOutputMixin, metaclass=ABCMeta):
             for k in range(self.n_outputs_):
                 classes_k, y_encoded[:, k] = np.unique(y[:, k],
                                                        return_inverse=True)
-                self.classes_.append(classes_k)
+                self._classes.append(classes_k)
                 self.n_classes_.append(classes_k.shape[0])
             y = y_encoded
 
@@ -181,7 +181,7 @@ class BaseDecisionTree(BaseEstimator, MultiOutputMixin, metaclass=ABCMeta):
                     self.class_weight, y_original)
 
         else:
-            self.classes_ = [None] * self.n_outputs_
+            self._classes = [None] * self.n_outputs_
             self.n_classes_ = [1] * self.n_outputs_
 
         self.n_classes_ = np.array(self.n_classes_, dtype=np.intp)
@@ -389,11 +389,20 @@ class BaseDecisionTree(BaseEstimator, MultiOutputMixin, metaclass=ABCMeta):
 
         if self.n_outputs_ == 1:
             self.n_classes_ = self.n_classes_[0]
-            self.classes_ = self.classes_[0]
+            self._classes = self._classes[0]
 
         self._prune_tree()
 
         return self
+
+    @property
+    def classes_(self):
+        if is_classifier(self):
+            return self._classes
+        
+        warnings.warn("'classes_'is to be deprecated from version 0.20 and "
+                      "will be removed in 0.22.", DeprecationWarning)
+        return self._classes
 
     def _validate_X_predict(self, X, check_input):
         """Validate X whenever one tries to predict, apply, predict_proba"""

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -399,10 +399,9 @@ class BaseDecisionTree(BaseEstimator, MultiOutputMixin, metaclass=ABCMeta):
     def classes_(self):
         if is_classifier(self):
             return self._classes
-        
         else:
-            warnings.warn("'classes_' is to be deprecated from version 0.20 and "
-                      "will be removed in 0.22.", DeprecationWarning)
+            warnings.warn("'classes_' is to be deprecated from version 0.20 "
+                          "and will be removed in 0.22.", DeprecationWarning)
             return self._classes
 
     def _validate_X_predict(self, X, check_input):
@@ -1123,7 +1122,7 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
 
     max_features_ : int,
         The inferred value of max_features.
-        
+
     n_features_ : int
         The number of features when ``fit`` is performed.
 

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -395,15 +395,6 @@ class BaseDecisionTree(BaseEstimator, MultiOutputMixin, metaclass=ABCMeta):
 
         return self
 
-    @property
-    def classes_(self):
-        if is_classifier(self):
-            return self._classes
-        else:
-            warnings.warn("'classes_' is to be deprecated from version 0.20 "
-                          "and will be removed in 0.22.", DeprecationWarning)
-            return self._classes
-
     def _validate_X_predict(self, X, check_input):
         """Validate X whenever one tries to predict, apply, predict_proba"""
         if check_input:
@@ -980,6 +971,10 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
 
             return proba
 
+    @property
+    def classes_(self):
+        return self._classes
+
 
 class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
     """A decision tree regressor.
@@ -1251,6 +1246,12 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
             check_input=check_input,
             X_idx_sorted=X_idx_sorted)
         return self
+
+    @property
+    def classes_(self):
+        warnings.warn("'classes_' is to be deprecated from version 0.20 "
+                      "and will be removed in 0.22.", DeprecationWarning)
+        return self._classes
 
 
 class ExtraTreeClassifier(DecisionTreeClassifier):

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -1104,9 +1104,7 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
 
     Attributes
     ----------
-    classes_ : array of shape = [n_classes] or a list of such arrays
-        The classes labels (single output problem),
-        or a list of arrays of class labels (multi-output problem).
+    classes_ : None
         
     feature_importances_ : array of shape = [n_features]
         The feature importances.
@@ -1118,10 +1116,7 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
     max_features_ : int,
         The inferred value of max_features.
         
-    n_classes_ : int or list
-        The number of classes (for single output problems),
-        or a list containing the number of classes for each
-        output (for multi-output problems).
+    n_classes_ : None
 
     n_features_ : int
         The number of features when ``fit`` is performed.

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -1104,6 +1104,10 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
 
     Attributes
     ----------
+    classes_ : array of shape = [n_classes] or a list of such arrays
+        The classes labels (single output problem),
+        or a list of arrays of class labels (multi-output problem).
+        
     feature_importances_ : array of shape = [n_features]
         The feature importances.
         The higher, the more important the feature.
@@ -1113,6 +1117,11 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
 
     max_features_ : int,
         The inferred value of max_features.
+        
+    n_classes_ : int or list
+        The number of classes (for single output problems),
+        or a list containing the number of classes for each
+        output (for multi-output problems).
 
     n_features_ : int
         The number of features when ``fit`` is performed.

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -400,9 +400,10 @@ class BaseDecisionTree(BaseEstimator, MultiOutputMixin, metaclass=ABCMeta):
         if is_classifier(self):
             return self._classes
         
-        warnings.warn("'classes_'is to be deprecated from version 0.20 and "
+        else:
+            warnings.warn("'classes_' is to be deprecated from version 0.20 and "
                       "will be removed in 0.22.", DeprecationWarning)
-        return self._classes
+            return self._classes
 
     def _validate_X_predict(self, X, check_input):
         """Validate X whenever one tries to predict, apply, predict_proba"""
@@ -1113,8 +1114,6 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
 
     Attributes
     ----------
-    classes_ : None
-        
     feature_importances_ : array of shape = [n_features]
         The feature importances.
         The higher, the more important the feature.
@@ -1125,8 +1124,6 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
     max_features_ : int,
         The inferred value of max_features.
         
-    n_classes_ : None
-
     n_features_ : int
         The number of features when ``fit`` is performed.
 


### PR DESCRIPTION
This partially relates to issue #14766 

Currently, if you fit a decision tree regressor, and call the attribute `classes_` , it will return none. This attribute does not appear on the doc string and shouldn't. This was surfaced from an issue related to mismatch attributes (#14312 ) 

Reviewed the [contributions guide](https://scikit-learn.org/dev/developers/contributing.html#deprecation) and worked with @thomasjpfan on different options including using a decorator on a property but it triggered the deprecation message when calling fit which was bad. 

In this PR, the `classes_` was changed to `_classes` in the parent. And a test was added to the test_tree.py 