### PR TITLE
MAINT: Remove redundant code in MLP

### DIFF
--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -414,11 +414,10 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
                              % self.n_iter_no_change)
 
         # raise ValueError if not registered
-        supported_activations = ('identity', 'logistic', 'tanh', 'relu')
-        if self.activation not in supported_activations:
+        if self.activation not in ACTIVATIONS:
             raise ValueError("The activation '%s' is not supported. Supported "
-                             "activations are %s." % (self.activation,
-                                                      supported_activations))
+                             "activations are %s."
+                             % (self.activation, list(sorted(ACTIVATIONS))))
         if self.learning_rate not in ["constant", "invscaling", "adaptive"]:
             raise ValueError("learning rate %s is not supported. " %
                              self.learning_rate)

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -15,7 +15,7 @@ import scipy.optimize
 
 from ..base import BaseEstimator, ClassifierMixin, RegressorMixin
 from ..base import is_classifier
-from ._base import ACTIVATIONS, DERIVATIVES, LOSS_FUNCTIONS
+from ._base import LOSS_FUNCTIONS
 from ._stochastic_optimizers import SGDOptimizer, AdamOptimizer
 from ..model_selection import train_test_split
 from ..preprocessing import LabelBinarizer
@@ -97,6 +97,10 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         activations : list, length = n_layers - 1
             The ith element of the list holds the values of the ith layer.
         """
+        # local import to allow custom activations set via this
+        # private variable in _base
+        from ._base import ACTIVATIONS
+
         hidden_activation = ACTIVATIONS[self.activation]
         # Iterate over the hidden layers
         for i in range(self.n_layers_ - 1):
@@ -215,6 +219,10 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         coef_grads : list, length = n_layers - 1
         intercept_grads : list, length = n_layers - 1
         """
+        # local import to allow custom activations set via this
+        # private variable in _base
+        from ._base import DERIVATIVES
+
         n_samples = X.shape[0]
 
         # Forward propagate
@@ -376,6 +384,10 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         return self
 
     def _validate_hyperparameters(self):
+        # local import to allow custom activations set via this
+        # private variable in _base
+        from ._base import ACTIVATIONS
+
         if not isinstance(self.shuffle, bool):
             raise ValueError("shuffle must be either True or False, got %s." %
                              self.shuffle)

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -97,6 +97,8 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         activations : list, length = n_layers - 1
             The ith element of the list holds the values of the ith layer.
         """
+        # local import to allow custom activations set via this
+        # private variable in _base
         from ._base import ACTIVATIONS
 
         hidden_activation = ACTIVATIONS[self.activation]
@@ -217,6 +219,8 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         coef_grads : list, length = n_layers - 1
         intercept_grads : list, length = n_layers - 1
         """
+        # local import to allow custom activations set via this
+        # private variable in _base
         from ._base import DERIVATIVES
 
         n_samples = X.shape[0]
@@ -380,6 +384,8 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         return self
 
     def _validate_hyperparameters(self):
+        # local import to allow custom activations set via this
+        # private variable in _base
         from ._base import ACTIVATIONS
 
         if not isinstance(self.shuffle, bool):

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -97,8 +97,6 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         activations : list, length = n_layers - 1
             The ith element of the list holds the values of the ith layer.
         """
-        # local import to allow custom activations set via this
-        # private variable in _base
         from ._base import ACTIVATIONS
 
         hidden_activation = ACTIVATIONS[self.activation]
@@ -219,8 +217,6 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         coef_grads : list, length = n_layers - 1
         intercept_grads : list, length = n_layers - 1
         """
-        # local import to allow custom activations set via this
-        # private variable in _base
         from ._base import DERIVATIVES
 
         n_samples = X.shape[0]
@@ -384,8 +380,6 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         return self
 
     def _validate_hyperparameters(self):
-        # local import to allow custom activations set via this
-        # private variable in _base
         from ._base import ACTIVATIONS
 
         if not isinstance(self.shuffle, bool):

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -15,7 +15,7 @@ import scipy.optimize
 
 from ..base import BaseEstimator, ClassifierMixin, RegressorMixin
 from ..base import is_classifier
-from ._base import LOSS_FUNCTIONS
+from ._base import ACTIVATIONS, DERIVATIVES, LOSS_FUNCTIONS
 from ._stochastic_optimizers import SGDOptimizer, AdamOptimizer
 from ..model_selection import train_test_split
 from ..preprocessing import LabelBinarizer
@@ -97,10 +97,6 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         activations : list, length = n_layers - 1
             The ith element of the list holds the values of the ith layer.
         """
-        # local import to allow custom activations set via this
-        # private variable in _base
-        from ._base import ACTIVATIONS
-
         hidden_activation = ACTIVATIONS[self.activation]
         # Iterate over the hidden layers
         for i in range(self.n_layers_ - 1):
@@ -219,10 +215,6 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         coef_grads : list, length = n_layers - 1
         intercept_grads : list, length = n_layers - 1
         """
-        # local import to allow custom activations set via this
-        # private variable in _base
-        from ._base import DERIVATIVES
-
         n_samples = X.shape[0]
 
         # Forward propagate
@@ -384,10 +376,6 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         return self
 
     def _validate_hyperparameters(self):
-        # local import to allow custom activations set via this
-        # private variable in _base
-        from ._base import ACTIVATIONS
-
         if not isinstance(self.shuffle, bool):
             raise ValueError("shuffle must be either True or False, got %s." %
                              self.shuffle)

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -710,35 +710,3 @@ def test_early_stopping_stratified():
             ValueError,
             match='The least populated class in y has only 1 member'):
         mlp.fit(X, y)
-
-
-def test_custom_activation(monkeypatch):
-    from sklearn.neural_network import multilayer_perceptron
-
-    X = X_digits_binary[:100]
-    y = y_digits_binary[:100]
-
-    monkeypatch.setattr(multilayer_perceptron, "ACTIVATIONS", {})
-
-    mlp = MLPClassifier()
-    # check that monkeypatching works as expected.
-    msg = r"activation 'relu' is not supported. Supported activations are \[\]"
-    with pytest.raises(ValueError, match=msg):
-        mlp.fit(X, y)
-
-    monkeypatch.setattr(
-        multilayer_perceptron,
-        "ACTIVATIONS",
-        # logistic is necessary for the last layer in any case
-        {'identity2': lambda x: x, 'logistic': lambda x: x}
-    )
-
-    monkeypatch.setattr(
-        multilayer_perceptron,
-        "DERIVATIVES",
-        # logistic is necessary for the last layer in any case
-        {'identity2': lambda x, _: 1.0, 'logistic': lambda x, _: 1.0}
-    )
-
-    mlp = MLPClassifier(activation='identity2')
-    mlp.fit(X, y)

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -727,16 +727,18 @@ def test_custom_activation(monkeypatch):
         mlp.fit(X, y)
 
     monkeypatch.setattr(
-            multilayer_perceptron,
-            "ACTIVATIONS",
-            # logistic is necessary for the last layer in any case
-            {'identity2': lambda x: x, 'logistic': lambda x: x})
+        multilayer_perceptron,
+        "ACTIVATIONS",
+        # logistic is necessary for the last layer in any case
+        {'identity2': lambda x: x, 'logistic': lambda x: x}
+    )
 
     monkeypatch.setattr(
-            multilayer_perceptron,
-            "DERIVATIVES",
-            # logistic is necessary for the last layer in any case
-            {'identity2': lambda x, _: 1.0, 'logistic': lambda x, _: 1.0})
+        multilayer_perceptron,
+        "DERIVATIVES",
+        # logistic is necessary for the last layer in any case
+        {'identity2': lambda x, _: 1.0, 'logistic': lambda x, _: 1.0}
+    )
 
     mlp = MLPClassifier(activation='identity2')
     mlp.fit(X, y)

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -713,12 +713,12 @@ def test_early_stopping_stratified():
 
 
 def test_custom_activation(monkeypatch):
-    import sklearn.neural_network._base
+    from sklearn.neural_network import multilayer_perceptron
 
     X = X_digits_binary[:100]
     y = y_digits_binary[:100]
 
-    monkeypatch.setattr(sklearn.neural_network._base, "ACTIVATIONS", {})
+    monkeypatch.setattr(multilayer_perceptron, "ACTIVATIONS", {})
 
     mlp = MLPClassifier()
     # check that monkeypatching works as expected.
@@ -727,14 +727,14 @@ def test_custom_activation(monkeypatch):
         mlp.fit(X, y)
 
     monkeypatch.setattr(
-        sklearn.neural_network._base,
+        multilayer_perceptron,
         "ACTIVATIONS",
         # logistic is necessary for the last layer in any case
         {'identity2': lambda x: x, 'logistic': lambda x: x}
     )
 
     monkeypatch.setattr(
-        sklearn.neural_network._base,
+        multilayer_perceptron,
         "DERIVATIVES",
         # logistic is necessary for the last layer in any case
         {'identity2': lambda x, _: 1.0, 'logistic': lambda x, _: 1.0}

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -713,12 +713,12 @@ def test_early_stopping_stratified():
 
 
 def test_custom_activation(monkeypatch):
-    from sklearn.neural_network import multilayer_perceptron
+    import sklearn.neural_network._base
 
     X = X_digits_binary[:100]
     y = y_digits_binary[:100]
 
-    monkeypatch.setattr(multilayer_perceptron, "ACTIVATIONS", {})
+    monkeypatch.setattr(sklearn.neural_network._base, "ACTIVATIONS", {})
 
     mlp = MLPClassifier()
     # check that monkeypatching works as expected.
@@ -727,14 +727,14 @@ def test_custom_activation(monkeypatch):
         mlp.fit(X, y)
 
     monkeypatch.setattr(
-        multilayer_perceptron,
+        sklearn.neural_network._base,
         "ACTIVATIONS",
         # logistic is necessary for the last layer in any case
         {'identity2': lambda x: x, 'logistic': lambda x: x}
     )
 
     monkeypatch.setattr(
-        multilayer_perceptron,
+        sklearn.neural_network._base,
         "DERIVATIVES",
         # logistic is necessary for the last layer in any case
         {'identity2': lambda x, _: 1.0, 'logistic': lambda x, _: 1.0}

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -710,3 +710,33 @@ def test_early_stopping_stratified():
             ValueError,
             match='The least populated class in y has only 1 member'):
         mlp.fit(X, y)
+
+
+def test_custom_activation(monkeypatch):
+    from sklearn.neural_network import multilayer_perceptron
+
+    X = X_digits_binary[:100]
+    y = y_digits_binary[:100]
+
+    monkeypatch.setattr(multilayer_perceptron, "ACTIVATIONS", {})
+
+    mlp = MLPClassifier()
+    # check that monkeypatching works as expected.
+    msg = r"activation 'relu' is not supported. Supported activations are \[\]"
+    with pytest.raises(ValueError, match=msg):
+        mlp.fit(X, y)
+
+    monkeypatch.setattr(
+            multilayer_perceptron,
+            "ACTIVATIONS",
+            # logistic is necessary for the last layer in any case
+            {'identity2': lambda x: x, 'logistic': lambda x: x})
+
+    monkeypatch.setattr(
+            multilayer_perceptron,
+            "DERIVATIVES",
+            # logistic is necessary for the last layer in any case
+            {'identity2': lambda x, _: 1.0, 'logistic': lambda x, _: 1.0})
+
+    mlp = MLPClassifier(activation='identity2')
+    mlp.fit(X, y)


### PR DESCRIPTION
Closes https://github.com/scikit-learn/scikit-learn/issues/14807
Closes https://github.com/scikit-learn/scikit-learn/issues/11952

Alternative to https://github.com/scikit-learn/scikit-learn/pull/10665


This makes sure that it's possible to use a custom activation function registering new ones in `sklearn.neural_network.multilayer_perceptron.{ACTIVATIONS,DERIVATIVES}`.

It was almost working before, except for a manual check of supported activation (instead of using the `ACTIVATIONS` variable), so this mostly adds a test.

Not sure if we want to document it (and if so where).  