### PR TITLE
OneSE: the One-Standard-Error Rule

### DIFF
--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -322,3 +322,37 @@ def test_iforest_deprecation():
     warn_msg = "'behaviour' is deprecated in 0.22 and will be removed in 0.24"
     with pytest.warns(DeprecationWarning, match=warn_msg):
         iforest.fit(iris.data)
+
+
+def test_iforest_with_uniform_data():
+    """Test whether iforest predicts inliers when using uniform data"""
+
+    # 2-d array of all 1s
+    X = np.ones((100, 10))
+    iforest = IsolationForest()
+    iforest.fit(X)
+
+    rng = np.random.RandomState(0)
+
+    assert all(iforest.predict(X) == 1)
+    assert all(iforest.predict(rng.randn(100, 10)) == 1)
+    assert all(iforest.predict(X + 1) == 1)
+    assert all(iforest.predict(X - 1) == 1)
+
+    # 2-d array where columns contain the same value across rows
+    X = np.repeat(rng.randn(1, 10), 100, 0)
+    iforest = IsolationForest()
+    iforest.fit(X)
+
+    assert all(iforest.predict(X) == 1)
+    assert all(iforest.predict(rng.randn(100, 10)) == 1)
+    assert all(iforest.predict(np.ones((100, 10))) == 1)
+
+    # Single row
+    X = rng.randn(1, 10)
+    iforest = IsolationForest()
+    iforest.fit(X)
+
+    assert all(iforest.predict(X) == 1)
+    assert all(iforest.predict(rng.randn(100, 10)) == 1)
+    assert all(iforest.predict(np.ones((100, 10))) == 1)


### PR DESCRIPTION
#### Reference Issues/PRs
https://github.com/scikit-learn/scikit-learn/blob/master/examples/model_selection/plot_grid_search_refit_callable.py
See also #11269. See also #11354. See also #12865. See also #9499.

#### What does this implement/fix? Explain your changes.
As discussed briefly with @amueller and @NicolasHug last week, this is an enhancement to the latest implementation of sklearn's refit callable functionality. The aim is to provide a more generic set of methods for balancing model complexity with CV performance via model selection 'smoothing'.  In the context of a highly versatile package such as sklearn, where it becomes possible to fit the vast majority of model types using an extensive set of parameters and scorers, the risk of overfitting may be more pressing. To ameliorate this, OneSE might be especially valuable for final model estimation in CV.

#### Any other comments?
The challenge with implementing such a tool has always been with generalizing its functionality to all types of models, parameters, and scoring methods. In particular, defining model 'complexity' is also relatively context-dependent.  This PR lays out a prototype that allows these definitions to be user-determined, rather than hard-coded defaults. Currently, both _error and _score type scorers are supported, along with multi-metric scoring. Either 1 SD bounds can be used, or a percentile tolerance can be specified. Feel free to revise, rewrite, and discuss!

Expanding upon the excellent example recently created by @jiaowoshabi :
```py
import numpy as np
import matplotlib.pyplot as plt
from sklearn.datasets import load_digits
from sklearn.decomposition import PCA
from sklearn.model_selection import GridSearchCV
from sklearn.model_selection._search import OneSE
from sklearn.pipeline import Pipeline
from sklearn.svm import LinearSVC

pipe = Pipeline([
        ('reduce_dim', PCA(random_state=42)),
        ('classify', LinearSVC(random_state=42)),
])

param_grid = {
    'reduce_dim__n_components': [2, 4, 6, 8]
}

# Here, we set our OneSE parameters, though ideally, we would make them explicit arguments for the actual OneSE callable below:
param='n_components'
greater_is_complex=True
refit_scoring = 'accuracy'
tol = None

grid = GridSearchCV(pipe, cv=10, n_jobs=1, param_grid=param_grid,
                    scoring=['accuracy', 'neg_mean_squared_log_error'], refit=OneSE)
digits = load_digits()
grid.fit(digits.data, digits.target)

n_components = grid.cv_results_['param_reduce_dim__n_components']
test_scores = grid.cv_results_['mean_test_accuracy']

plt.figure()
plt.bar(n_components, test_scores, width=1.3, color='b')

plt.axhline(np.max(test_scores), linestyle='--', color='y', label='Best score')

plt.title("Balance model complexity and cross-validated score")
plt.xlabel('Number of PCA components used')
plt.ylabel('Digit classification accuracy')
plt.xticks(n_components.tolist())
plt.ylim((0, 1.0))
plt.legend(loc='upper left')

best_index_ = grid.best_index_

print("The best_index_ is %d" % best_index_)
print("The n_components selected is %d" % n_components[best_index_])
print("The corresponding accuracy score is %.2f"
      % grid.cv_results_['mean_test_accuracy'][best_index_])
plt.show()
```

Let me know what you think
@dPys