### PR TITLE
[NOMRG] deprecate support of coef_ and intercept_ attributes in OneVsRestClassifier

### DIFF
--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -381,24 +381,24 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin,
     def n_classes_(self):
         return len(self.classes_)
 
-    @property
-    def coef_(self):
-        check_is_fitted(self)
-        if not hasattr(self.estimators_[0], "coef_"):
-            raise AttributeError(
-                "Base estimator doesn't have a coef_ attribute.")
-        coefs = [e.coef_ for e in self.estimators_]
-        if sp.issparse(coefs[0]):
-            return sp.vstack(coefs)
-        return np.vstack(coefs)
+    # @property
+    # def coef_(self):
+    #     check_is_fitted(self)
+    #     if not hasattr(self.estimators_[0], "coef_"):
+    #         raise AttributeError(
+    #             "Base estimator doesn't have a coef_ attribute.")
+    #     coefs = [e.coef_ for e in self.estimators_]
+    #     if sp.issparse(coefs[0]):
+    #         return sp.vstack(coefs)
+    #     return np.vstack(coefs)
 
-    @property
-    def intercept_(self):
-        check_is_fitted(self)
-        if not hasattr(self.estimators_[0], "intercept_"):
-            raise AttributeError(
-                "Base estimator doesn't have an intercept_ attribute.")
-        return np.array([e.intercept_.ravel() for e in self.estimators_])
+    # @property
+    # def intercept_(self):
+    #     check_is_fitted(self)
+    #     if not hasattr(self.estimators_[0], "intercept_"):
+    #         raise AttributeError(
+    #             "Base estimator doesn't have an intercept_ attribute.")
+    #     return np.array([e.intercept_.ravel() for e in self.estimators_])
 
     @property
     def _pairwise(self):

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -438,33 +438,33 @@ def test_ovr_pipeline():
     assert_array_equal(ovr.predict(iris.data), ovr_pipe.predict(iris.data))
 
 
-def test_ovr_coef_():
-    for base_classifier in [SVC(kernel='linear', random_state=0),
-                            LinearSVC(random_state=0)]:
-        # SVC has sparse coef with sparse input data
+# def test_ovr_coef_():
+#     for base_classifier in [SVC(kernel='linear', random_state=0),
+#                             LinearSVC(random_state=0)]:
+#         # SVC has sparse coef with sparse input data
 
-        ovr = OneVsRestClassifier(base_classifier)
-        for X in [iris.data, sp.csr_matrix(iris.data)]:
-            # test with dense and sparse coef
-            ovr.fit(X, iris.target)
-            shape = ovr.coef_.shape
-            assert shape[0] == n_classes
-            assert shape[1] == iris.data.shape[1]
-            # don't densify sparse coefficients
-            assert (sp.issparse(ovr.estimators_[0].coef_) ==
-                         sp.issparse(ovr.coef_))
+#         ovr = OneVsRestClassifier(base_classifier)
+#         for X in [iris.data, sp.csr_matrix(iris.data)]:
+#             # test with dense and sparse coef
+#             ovr.fit(X, iris.target)
+#             shape = ovr.coef_.shape
+#             assert shape[0] == n_classes
+#             assert shape[1] == iris.data.shape[1]
+#             # don't densify sparse coefficients
+#             assert (sp.issparse(ovr.estimators_[0].coef_) ==
+#                          sp.issparse(ovr.coef_))
 
 
-def test_ovr_coef_exceptions():
-    # Not fitted exception!
-    ovr = OneVsRestClassifier(LinearSVC(random_state=0))
-    # lambda is needed because we don't want coef_ to be evaluated right away
-    assert_raises(ValueError, lambda x: ovr.coef_, None)
+# def test_ovr_coef_exceptions():
+#     # Not fitted exception!
+#     ovr = OneVsRestClassifier(LinearSVC(random_state=0))
+#     # lambda is needed because we don't want coef_ to be evaluated right away
+#     assert_raises(ValueError, lambda x: ovr.coef_, None)
 
-    # Doesn't have coef_ exception!
-    ovr = OneVsRestClassifier(DecisionTreeClassifier())
-    ovr.fit(iris.data, iris.target)
-    assert_raises(AttributeError, lambda x: ovr.coef_, None)
+#     # Doesn't have coef_ exception!
+#     ovr = OneVsRestClassifier(DecisionTreeClassifier())
+#     ovr.fit(iris.data, iris.target)
+#     assert_raises(AttributeError, lambda x: ovr.coef_, None)
 
 
 def test_ovo_exceptions():


### PR DESCRIPTION
WIP for now, I just want to see where the CI fails if we remove the attributes