### PR TITLE
MAINT: simpler binder requirements.txt

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,7 +1,8 @@
 --find-links https://sklearn-nightly.scdn8.secure.raxcdn.com scikit-learn
+--pre
 matplotlib
 scikit-image
 pandas
 sphinx-gallery
-scikit-learn>=0.22.dev0
+scikit-learn
 


### PR DESCRIPTION
Mentioned by @ogrisel in https://github.com/scikit-learn/scikit-learn/pull/14719#discussion_r318516578.

I tested this by doing:
`pip install -r .binder/requirements.txt` which does install scikit-learn dev version.

The advantages:
* simpler
* no need to remember to update `.binder/requirements.txt` after a new release. 