### PR TITLE
CI/DOC Use sphinx-gallery 0.3.1

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -118,7 +118,7 @@ export PATH="$MINICONDA_PATH/bin:$PATH"
 # provided versions
 conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
   numpy="${NUMPY_VERSION:-*}" scipy="${SCIPY_VERSION:-*}" cython \
-  pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=1.6.2 pillow \
+  pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=1.6.3 pillow \
   scikit-image="${SCIKIT_IMAGE_VERSION:-*}" pandas="${PANDAS_VERSION:-*}" \
   joblib
 

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -123,7 +123,7 @@ conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
   joblib
 
 source activate testenv
-pip install "sphinx-gallery>=0.2,<0.3"
+pip install sphinx-gallery==0.3.1
 pip install numpydoc==0.9
 
 # Build and install scikit-learn in dev mode


### PR DESCRIPTION
This PR target the `0.21.X` branch. I cherry-picked the commit from #14507 (merged 4 weeks ago in master).

My goal behind this is to add binder links to the stable doc (very similar to #11221 which added binder links to the dev doc). The work done in master needs sphinx-gallery 0.3.1.

I am not expecting any issues, but once the doc is built in this PR I will double-check whether I don't see any obvious problems in the generated doc.

Also what is the preferred way of changing things in a relase branch:
* should this PR be merged (similar workflow as master)?
* should someone push the commit directly in the `0.21.X` branch (more obvious that it is a cherry-pick of a commit in master)? This seems to be the approach for bug-fixes in `0.21.X` as far as I can see. 