### PR TITLE
MAINT Fix assert raises in sklearn/semi_supervised/tests/

### DIFF
--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -1,9 +1,9 @@
 """ test the label propagation module """
 
 import numpy as np
+import pytest
 
 from sklearn.utils.testing import assert_warns
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_no_warnings
 from sklearn.semi_supervised import label_propagation
 from sklearn.metrics.pairwise import rbf_kernel
@@ -119,10 +119,10 @@ def test_valid_alpha():
     X, y = make_classification(n_classes=n_classes, n_samples=200,
                                random_state=0)
     for alpha in [-0.1, 0, 1, 1.1, None]:
-        assert_raises(ValueError,
-                      lambda **kwargs:
-                      label_propagation.LabelSpreading(**kwargs).fit(X, y),
-                      alpha=alpha)
+        with pytest.raises(ValueError):
+            (lambda **kwargs:
+             label_propagation.LabelSpreading(**kwargs).
+             fit(X, y))(alpha=alpha)
 
 
 def test_convergence_speed():

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -120,9 +120,7 @@ def test_valid_alpha():
                                random_state=0)
     for alpha in [-0.1, 0, 1, 1.1, None]:
         with pytest.raises(ValueError):
-            (lambda **kwargs:
-             label_propagation.LabelSpreading(**kwargs).
-             fit(X, y))(alpha=alpha)
+            label_propagation.LabelSpreading(alpha=alpha).fit(X, y)
 
 
 def test_convergence_speed():


### PR DESCRIPTION
replaced `assert_raises` and `assert_raises_regex` with `pytest.raises` context manager.

related to #14216