### PR TITLE
Rename p to power parameter in mean_tweedie_deviance

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -2028,14 +2028,14 @@ Mean Poisson, Gamma, and Tweedie deviances
 The :func:`mean_tweedie_deviance` function computes the `mean Tweedie
 deviance error
 <https://en.wikipedia.org/wiki/Tweedie_distribution#The_Tweedie_deviance>`_
-with power parameter `p`. This is a metric that elicits predicted expectation
+with a ``power`` parameter. This is a metric that elicits predicted expectation
 values of regression targets.
 
 Following special cases exist,
 
-- when `p=0` it is equivalent to :func:`mean_squared_error`.
-- when `p=1` it is equivalent to :func:`mean_poisson_deviance`.
-- when `p=2` it is equivalent to :func:`mean_gamma_deviance`.
+- when ``power=0`` it is equivalent to :func:`mean_squared_error`.
+- when ``power=1`` it is equivalent to :func:`mean_poisson_deviance`.
+- when ``power=2`` it is equivalent to :func:`mean_gamma_deviance`.
 
 If :math:`\hat{y}_i` is the predicted value of the :math:`i`-th sample,
 and :math:`y_i` is the corresponding true value, then the mean Tweedie
@@ -2046,48 +2046,49 @@ deviance error (D) estimated over :math:`n_{\text{samples}}` is defined as
   \text{D}(y, \hat{y}) = \frac{1}{n_\text{samples}}
   \sum_{i=0}^{n_\text{samples} - 1}
   \begin{cases}
-  (y_i-\hat{y}_i)^2, & \text{for }p=0\text{ (Normal)}\\
-  2(y_i \log(y/\hat{y}_i) + \hat{y}_i - y_i),  & \text{for }p=1\text{ (Poisson)}\\
-  2(\log(\hat{y}_i/y_i) + y_i/\hat{y}_i - 1),  & \text{for }p=2\text{ (Gamma)}\\
+  (y_i-\hat{y}_i)^2, & \text{for }\text{power}=0\text{ (Normal)}\\
+  2(y_i \log(y/\hat{y}_i) + \hat{y}_i - y_i),  & \text{for power}=1\text{ (Poisson)}\\
+  2(\log(\hat{y}_i/y_i) + y_i/\hat{y}_i - 1),  & \text{for power}=2\text{ (Gamma)}\\
   2\left(\frac{\max(y_i,0)^{2-p}}{(1-p)(2-p)}-
   \frac{y\,\hat{y}^{1-p}_i}{1-p}+\frac{\hat{y}^{2-p}_i}{2-p}\right),
   & \text{otherwise}
   \end{cases}
 
-Tweedie deviance is a homogeneous function of degree ``2-p``.
-Thus, Gamma distribution with `p=2` means that simultaneously scaling `y_true`
-and `y_pred` has no effect on the deviance. For Poisson distribution `p=1`
-the deviance scales linearly, and for Normal distribution (`p=0`),
-quadratically.  In general, the higher `p` the less weight is given to extreme
-deviations between true and predicted targets.
+Tweedie deviance is a homogeneous function of degree ``2-power``.
+Thus, Gamma distribution with ``power=2`` means that simultaneously scaling
+``y_true`` and ``y_pred`` has no effect on the deviance. For Poisson
+distribution ``power=1`` the deviance scales linearly, and for Normal
+distribution (``power=0``), quadratically.  In general, the higher
+``power`` the less weight is given to extreme deviations between true
+and predicted targets.
 
 For instance, let's compare the two predictions 1.0 and 100 that are both
 50% of their corresponding true value.
 
-The mean squared error (``p=0``) is very sensitive to the
+The mean squared error (``power=0``) is very sensitive to the
 prediction difference of the second point,::
 
     >>> from sklearn.metrics import mean_tweedie_deviance
-    >>> mean_tweedie_deviance([1.0], [1.5], p=0)
+    >>> mean_tweedie_deviance([1.0], [1.5], power=0)
     0.25
-    >>> mean_tweedie_deviance([100.], [150.], p=0)
+    >>> mean_tweedie_deviance([100.], [150.], power=0)
     2500.0
 
 If we increase ``p`` to 1,::
 
-    >>> mean_tweedie_deviance([1.0], [1.5], p=1)
+    >>> mean_tweedie_deviance([1.0], [1.5], power=1)
     0.18...
-    >>> mean_tweedie_deviance([100.], [150.], p=1)
+    >>> mean_tweedie_deviance([100.], [150.], power=1)
     18.9...
 
-the difference in errors decreases. Finally, by setting, ``p=2``::
+the difference in errors decreases. Finally, by setting, ``power=2``::
 
-    >>> mean_tweedie_deviance([1.0], [1.5], p=2)
+    >>> mean_tweedie_deviance([1.0], [1.5], power=2)
     0.14...
-    >>> mean_tweedie_deviance([100.], [150.], p=2)
+    >>> mean_tweedie_deviance([100.], [150.], power=2)
     0.14...
 
-we would get identical errors. The deviance when `p=2` is thus only
+we would get identical errors. The deviance when ``power=2`` is thus only
 sensitive to relative errors.
 
 .. _clustering_metrics:

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -2028,8 +2028,8 @@ Mean Poisson, Gamma, and Tweedie deviances
 The :func:`mean_tweedie_deviance` function computes the `mean Tweedie
 deviance error
 <https://en.wikipedia.org/wiki/Tweedie_distribution#The_Tweedie_deviance>`_
-with a ``power`` parameter. This is a metric that elicits predicted expectation
-values of regression targets.
+with a ``power`` parameter (:math:`p`). This is a metric that elicits
+predicted expectation values of regression targets.
 
 Following special cases exist,
 
@@ -2039,16 +2039,17 @@ Following special cases exist,
 
 If :math:`\hat{y}_i` is the predicted value of the :math:`i`-th sample,
 and :math:`y_i` is the corresponding true value, then the mean Tweedie
-deviance error (D) estimated over :math:`n_{\text{samples}}` is defined as
+deviance error (D) for power :math:`p`, estimated over :math:`n_{\text{samples}}`
+is defined as
 
 .. math::
 
   \text{D}(y, \hat{y}) = \frac{1}{n_\text{samples}}
   \sum_{i=0}^{n_\text{samples} - 1}
   \begin{cases}
-  (y_i-\hat{y}_i)^2, & \text{for }\text{power}=0\text{ (Normal)}\\
-  2(y_i \log(y/\hat{y}_i) + \hat{y}_i - y_i),  & \text{for power}=1\text{ (Poisson)}\\
-  2(\log(\hat{y}_i/y_i) + y_i/\hat{y}_i - 1),  & \text{for power}=2\text{ (Gamma)}\\
+  (y_i-\hat{y}_i)^2, & \text{for }p=0\text{ (Normal)}\\
+  2(y_i \log(y/\hat{y}_i) + \hat{y}_i - y_i),  & \text{for}p=1\text{ (Poisson)}\\
+  2(\log(\hat{y}_i/y_i) + y_i/\hat{y}_i - 1),  & \text{for}p=2\text{ (Gamma)}\\
   2\left(\frac{\max(y_i,0)^{2-p}}{(1-p)(2-p)}-
   \frac{y\,\hat{y}^{1-p}_i}{1-p}+\frac{\hat{y}^{2-p}_i}{2-p}\right),
   & \text{otherwise}
@@ -2074,7 +2075,7 @@ prediction difference of the second point,::
     >>> mean_tweedie_deviance([100.], [150.], power=0)
     2500.0
 
-If we increase ``p`` to 1,::
+If we increase ``power`` to 1,::
 
     >>> mean_tweedie_deviance([1.0], [1.5], power=1)
     0.18...

--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -626,7 +626,7 @@ def max_error(y_true, y_pred):
     return np.max(np.abs(y_true - y_pred))
 
 
-def mean_tweedie_deviance(y_true, y_pred, sample_weight=None, p=0):
+def mean_tweedie_deviance(y_true, y_pred, sample_weight=None, power=0):
     """Mean Tweedie deviance regression loss.
 
     Read more in the :ref:`User Guide <mean_tweedie_deviance>`.
@@ -642,20 +642,21 @@ def mean_tweedie_deviance(y_true, y_pred, sample_weight=None, p=0):
     sample_weight : array-like, shape (n_samples,), optional
         Sample weights.
 
-    p : float, optional
-        Tweedie power parameter. Either p <= 0 or p >= 1.
+    power : float, default=0
+        Tweedie power parameter. Either power <= 0 or power >= 1.
 
         The higher `p` the less weight is given to extreme
         deviations between true and predicted targets.
 
-        - p < 0: Extreme stable distribution. Requires: y_pred > 0.
-        - p = 0 : Normal distribution, output corresponds to
+        - power < 0: Extreme stable distribution. Requires: y_pred > 0.
+        - power = 0 : Normal distribution, output corresponds to
           mean_squared_error. y_true and y_pred can be any real numbers.
-        - p = 1 : Poisson distribution. Requires: y_true >= 0 and y_pred > 0.
+        - power = 1 : Poisson distribution. Requires: y_true >= 0 and
+          y_pred > 0.
         - 1 < p < 2 : Compound Poisson distribution. Requires: y_true >= 0
           and y_pred > 0.
-        - p = 2 : Gamma distribution. Requires: y_true > 0 and y_pred > 0.
-        - p = 3 : Inverse Gaussian distribution. Requires: y_true > 0
+        - power = 2 : Gamma distribution. Requires: y_true > 0 and y_pred > 0.
+        - power = 3 : Inverse Gaussian distribution. Requires: y_true > 0
           and y_pred > 0.
         - otherwise : Positive stable distribution. Requires: y_true > 0
           and y_pred > 0.
@@ -670,7 +671,7 @@ def mean_tweedie_deviance(y_true, y_pred, sample_weight=None, p=0):
     >>> from sklearn.metrics import mean_tweedie_deviance
     >>> y_true = [2, 0, 1, 4]
     >>> y_pred = [0.5, 0.5, 2., 2.]
-    >>> mean_tweedie_deviance(y_true, y_pred, p=1)
+    >>> mean_tweedie_deviance(y_true, y_pred, power=1)
     1.4260...
     """
     y_type, y_true, y_pred, _ = _check_reg_targets(
@@ -683,34 +684,35 @@ def mean_tweedie_deviance(y_true, y_pred, sample_weight=None, p=0):
         sample_weight = column_or_1d(sample_weight)
         sample_weight = sample_weight[:, np.newaxis]
 
-    message = ("Mean Tweedie deviance error with p={} can only be used on "
-               .format(p))
-    if p < 0:
+    message = ("Mean Tweedie deviance error with power={} can only be used on "
+               .format(power))
+    if power < 0:
         # 'Extreme stable', y_true any realy number, y_pred > 0
         if (y_pred <= 0).any():
             raise ValueError(message + "strictly positive y_pred.")
-        dev = 2 * (np.power(np.maximum(y_true, 0), 2-p)/((1-p) * (2-p)) -
-                   y_true * np.power(y_pred, 1-p)/(1-p) +
-                   np.power(y_pred, 2-p)/(2-p))
-    elif p == 0:
+        dev = 2 * (np.power(np.maximum(y_true, 0), 2 - power)
+                   / ((1 - power) * (2 - power))
+                   - y_true * np.power(y_pred, 1 - power)/(1 - power)
+                   + np.power(y_pred, 2 - power)/(2 - power))
+    elif power == 0:
         # Normal distribution, y_true and y_pred any real number
         dev = (y_true - y_pred)**2
-    elif p < 1:
-        raise ValueError("Tweedie deviance is only defined for p<=0 and "
-                         "p>=1.")
-    elif p == 1:
+    elif power < 1:
+        raise ValueError("Tweedie deviance is only defined for power<=0 and "
+                         "power>=1.")
+    elif power == 1:
         # Poisson distribution, y_true >= 0, y_pred > 0
         if (y_true < 0).any() or (y_pred <= 0).any():
             raise ValueError(message + "non-negative y_true and strictly "
                              "positive y_pred.")
         dev = 2 * (xlogy(y_true, y_true/y_pred) - y_true + y_pred)
-    elif p == 2:
+    elif power == 2:
         # Gamma distribution, y_true and y_pred > 0
         if (y_true <= 0).any() or (y_pred <= 0).any():
             raise ValueError(message + "strictly positive y_true and y_pred.")
         dev = 2 * (np.log(y_pred/y_true) + y_true/y_pred - 1)
     else:
-        if p < 2:
+        if power < 2:
             # 1 < p < 2 is Compound Poisson, y_true >= 0, y_pred > 0
             if (y_true < 0).any() or (y_pred <= 0).any():
                 raise ValueError(message + "non-negative y_true and strictly "
@@ -720,9 +722,9 @@ def mean_tweedie_deviance(y_true, y_pred, sample_weight=None, p=0):
                 raise ValueError(message + "strictly positive y_true and "
                                            "y_pred.")
 
-        dev = 2 * (np.power(y_true, 2-p)/((1-p) * (2-p)) -
-                   y_true * np.power(y_pred, 1-p)/(1-p) +
-                   np.power(y_pred, 2-p)/(2-p))
+        dev = 2 * (np.power(y_true, 2 - power)/((1 - power) * (2 - power))
+                   - y_true * np.power(y_pred, 1 - power)/(1 - power)
+                   + np.power(y_pred, 2 - power)/(2 - power))
 
     return np.average(dev, weights=sample_weight)
 
@@ -760,7 +762,7 @@ def mean_poisson_deviance(y_true, y_pred, sample_weight=None):
     1.4260...
     """
     return mean_tweedie_deviance(
-        y_true, y_pred, sample_weight=sample_weight, p=1
+        y_true, y_pred, sample_weight=sample_weight, power=1
     )
 
 
@@ -798,5 +800,5 @@ def mean_gamma_deviance(y_true, y_pred, sample_weight=None):
     1.0568...
     """
     return mean_tweedie_deviance(
-        y_true, y_pred, sample_weight=sample_weight, p=2
+        y_true, y_pred, sample_weight=sample_weight, power=2
     )

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -25,7 +25,7 @@ import numpy as np
 
 from . import (r2_score, median_absolute_error, max_error, mean_absolute_error,
                mean_squared_error, mean_squared_log_error,
-               mean_tweedie_deviance, accuracy_score,
+               mean_poisson_deviance, mean_gamma_deviance, accuracy_score,
                f1_score, roc_auc_score, average_precision_score,
                precision_score, recall_score, log_loss,
                balanced_accuracy_score, explained_variance_score,
@@ -499,11 +499,11 @@ neg_root_mean_squared_error_scorer = make_scorer(mean_squared_error,
                                                  greater_is_better=False,
                                                  squared=False)
 neg_mean_poisson_deviance_scorer = make_scorer(
-    mean_tweedie_deviance, p=1., greater_is_better=False
+    mean_poisson_deviance, greater_is_better=False
 )
 
 neg_mean_gamma_deviance_scorer = make_scorer(
-    mean_tweedie_deviance, p=2., greater_is_better=False
+    mean_gamma_deviance, greater_is_better=False
 )
 
 # Standard Classification Scores

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -102,11 +102,11 @@ REGRESSION_METRICS = {
     "median_absolute_error": median_absolute_error,
     "explained_variance_score": explained_variance_score,
     "r2_score": partial(r2_score, multioutput='variance_weighted'),
-    "mean_normal_deviance": partial(mean_tweedie_deviance, p=0),
+    "mean_normal_deviance": partial(mean_tweedie_deviance, power=0),
     "mean_poisson_deviance": mean_poisson_deviance,
     "mean_gamma_deviance": mean_gamma_deviance,
     "mean_compound_poisson_deviance":
-    partial(mean_tweedie_deviance, p=1.4),
+    partial(mean_tweedie_deviance, power=1.4),
 }
 
 CLASSIFICATION_METRICS = {

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -36,7 +36,7 @@ def test_regression_metrics(n_samples=50):
     assert_almost_equal(max_error(y_true, y_pred), 1.)
     assert_almost_equal(r2_score(y_true, y_pred),  0.995, 2)
     assert_almost_equal(explained_variance_score(y_true, y_pred), 1.)
-    assert_almost_equal(mean_tweedie_deviance(y_true, y_pred, p=0),
+    assert_almost_equal(mean_tweedie_deviance(y_true, y_pred, power=0),
                         mean_squared_error(y_true, y_pred))
 
     # Tweedie deviance needs positive y_pred, except for p=0,
@@ -45,15 +45,15 @@ def test_regression_metrics(n_samples=50):
     y_true = np.arange(1, 1 + n_samples)
     y_pred = 2 * y_true
     n = n_samples
-    assert_almost_equal(mean_tweedie_deviance(y_true, y_pred, p=-1),
+    assert_almost_equal(mean_tweedie_deviance(y_true, y_pred, power=-1),
                         5/12 * n * (n**2 + 2 * n + 1))
-    assert_almost_equal(mean_tweedie_deviance(y_true, y_pred, p=1),
+    assert_almost_equal(mean_tweedie_deviance(y_true, y_pred, power=1),
                         (n + 1) * (1 - np.log(2)))
-    assert_almost_equal(mean_tweedie_deviance(y_true, y_pred, p=2),
+    assert_almost_equal(mean_tweedie_deviance(y_true, y_pred, power=2),
                         2 * np.log(2) - 1)
-    assert_almost_equal(mean_tweedie_deviance(y_true, y_pred, p=3/2),
+    assert_almost_equal(mean_tweedie_deviance(y_true, y_pred, power=3/2),
                         ((6 * np.sqrt(2) - 8) / n) * np.sqrt(y_true).sum())
-    assert_almost_equal(mean_tweedie_deviance(y_true, y_pred, p=3),
+    assert_almost_equal(mean_tweedie_deviance(y_true, y_pred, power=3),
                         np.sum(1 / y_true) / (4 * n))
 
 
@@ -101,40 +101,41 @@ def test_regression_metrics_at_limits():
                         mean_squared_log_error, [1., -2., 3.], [1., 2., 3.])
 
     # Tweedie deviance error
-    p = -1.2
-    assert_allclose(mean_tweedie_deviance([0], [1.], p=p),
-                    2./(2.-p), rtol=1e-3)
+    power = -1.2
+    assert_allclose(mean_tweedie_deviance([0], [1.], power=power),
+                    2 / (2 - power), rtol=1e-3)
     with pytest.raises(ValueError,
                        match="can only be used on strictly positive y_pred."):
-        mean_tweedie_deviance([0.], [0.], p=p)
-    assert_almost_equal(mean_tweedie_deviance([0.], [0.], p=0), 0.00, 2)
+        mean_tweedie_deviance([0.], [0.], power=power)
+    assert_almost_equal(mean_tweedie_deviance([0.], [0.], power=0), 0.00, 2)
 
     msg = "only be used on non-negative y_true and strictly positive y_pred."
     with pytest.raises(ValueError, match=msg):
-        mean_tweedie_deviance([0.], [0.], p=1.0)
+        mean_tweedie_deviance([0.], [0.], power=1.0)
 
-    p = 1.5
-    assert_allclose(mean_tweedie_deviance([0.], [1.], p=p), 2./(2.-p))
+    power = 1.5
+    assert_allclose(mean_tweedie_deviance([0.], [1.], power=power),
+                    2 / (2 - power))
     msg = "only be used on non-negative y_true and strictly positive y_pred."
     with pytest.raises(ValueError, match=msg):
-        mean_tweedie_deviance([0.], [0.], p=p)
-    p = 2.
-    assert_allclose(mean_tweedie_deviance([1.], [1.], p=p), 0.00,
+        mean_tweedie_deviance([0.], [0.], power=power)
+    power = 2.
+    assert_allclose(mean_tweedie_deviance([1.], [1.], power=power), 0.00,
                     atol=1e-8)
     msg = "can only be used on strictly positive y_true and y_pred."
     with pytest.raises(ValueError, match=msg):
-        mean_tweedie_deviance([0.], [0.], p=p)
-    p = 3.
-    assert_allclose(mean_tweedie_deviance([1.], [1.], p=p),
+        mean_tweedie_deviance([0.], [0.], power=power)
+    power = 3.
+    assert_allclose(mean_tweedie_deviance([1.], [1.], power=power),
                     0.00, atol=1e-8)
 
     msg = "can only be used on strictly positive y_true and y_pred."
     with pytest.raises(ValueError, match=msg):
-        mean_tweedie_deviance([0.], [0.], p=p)
+        mean_tweedie_deviance([0.], [0.], power=power)
 
     with pytest.raises(ValueError,
-                       match="deviance is only defined for p<=0 and p>=1."):
-        mean_tweedie_deviance([0.], [0.], p=0.5)
+                       match="is only defined for power<=0 and power>=1"):
+        mean_tweedie_deviance([0.], [0.], power=0.5)
 
 
 def test__check_reg_targets():
@@ -274,21 +275,21 @@ def test_tweedie_deviance_continuity():
     y_true = np.random.RandomState(0).rand(n_samples) + 0.1
     y_pred = np.random.RandomState(1).rand(n_samples) + 0.1
 
-    assert_allclose(mean_tweedie_deviance(y_true, y_pred, p=0 - 1e-10),
-                    mean_tweedie_deviance(y_true, y_pred, p=0))
+    assert_allclose(mean_tweedie_deviance(y_true, y_pred, power=0 - 1e-10),
+                    mean_tweedie_deviance(y_true, y_pred, power=0))
 
     # Ws we get closer to the limit, with 1e-12 difference the absolute
     # tolerance to pass the below check increases. There are likely
     # numerical precision issues on the edges of different definition
     # regions.
-    assert_allclose(mean_tweedie_deviance(y_true, y_pred, p=1 + 1e-10),
-                    mean_tweedie_deviance(y_true, y_pred, p=1),
+    assert_allclose(mean_tweedie_deviance(y_true, y_pred, power=1 + 1e-10),
+                    mean_tweedie_deviance(y_true, y_pred, power=1),
                     atol=1e-6)
 
-    assert_allclose(mean_tweedie_deviance(y_true, y_pred, p=2 - 1e-10),
-                    mean_tweedie_deviance(y_true, y_pred, p=2),
+    assert_allclose(mean_tweedie_deviance(y_true, y_pred, power=2 - 1e-10),
+                    mean_tweedie_deviance(y_true, y_pred, power=2),
                     atol=1e-6)
 
-    assert_allclose(mean_tweedie_deviance(y_true, y_pred, p=2 + 1e-10),
-                    mean_tweedie_deviance(y_true, y_pred, p=2),
+    assert_allclose(mean_tweedie_deviance(y_true, y_pred, power=2 + 1e-10),
+                    mean_tweedie_deviance(y_true, y_pred, power=2),
                     atol=1e-6)


### PR DESCRIPTION
Rename p to power parameter in mean_tweedie_deviance to be consistent with `TweedieRegressor(power=0)` in https://github.com/scikit-learn/scikit-learn/pull/14300 following @NicolasHug and @ogrisel suggestion in (https://github.com/scikit-learn/scikit-learn/pull/14300#issuecomment-525746539)

This will help reducing the diff in https://github.com/scikit-learn/scikit-learn/pull/14300 a bit. We can do this without a deprecation cycle since `mean_tweedie_deviance` was introduced only recently.

~~Marking as WIP for now as I need to check the rendered docs on the use of `\textrm` vs `\text` in Latex.~~ Edit: Nevermind, that was for a different PR.