### PR TITLE
FIX switch to binary_crossentropy if a binary problem

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -136,9 +136,9 @@ Changelog
     avoid any data leak. :pr:`13933` by `Nicolas Hug`_.
   - |Fix| Fixed a bug where early stopping would break with string targets.
     :pr:`14710` by :user:`Guillaume Lemaitre <glemaitre>`.
-  - |Fix| :class:`ensemble.HistGradientBoostingClassifier` now switches to
-    ``binary_crossentropy`` loss if ``categorical_crossentropy`` is given for
-    a binary classification problem. :pr:`14869` by `Adrin Jalali`_.
+  - |Fix| :class:`ensemble.HistGradientBoostingClassifier` now raises an error
+    if ``categorical_crossentropy`` loss is given for a binary classification
+    problem. :pr:`14869` by `Adrin Jalali`_.
 
   Note that pickles from 0.21 will not work in 0.22.
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -136,6 +136,9 @@ Changelog
     avoid any data leak. :pr:`13933` by `Nicolas Hug`_.
   - |Fix| Fixed a bug where early stopping would break with string targets.
     :pr:`14710` by :user:`Guillaume Lemaitre <glemaitre>`.
+  - |Fix| :class:`ensemble.HistGradientBoostingClassifier` now switches to
+    ``binary_crossentropy`` loss if ``categorical_crossentropy`` is given for
+    a binary classification problem. :pr:`14869` by `Adrin Jalali`_.
 
   Note that pickles from 0.21 will not work in 0.22.
 

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1039,16 +1039,16 @@ class HistGradientBoostingClassifier(BaseHistGradientBoosting,
         return encoded_y
 
     def _get_loss(self):
-        if self.loss == 'auto':
-            if self.n_trees_per_iteration_ == 1:
-                return _LOSSES['binary_crossentropy']()
-            else:
-                return _LOSSES['categorical_crossentropy']()
-
         if (self.loss == 'categorical_crossentropy' and
                 self.n_trees_per_iteration_ == 1):
             raise ValueError("'categorical_crossentropy' is not suitable for "
                              "a binary classification problem. Please use "
                              "'auto' or 'binary_crossentropy' instead.")
+
+        if self.loss == 'auto':
+            if self.n_trees_per_iteration_ == 1:
+                return _LOSSES['binary_crossentropy']()
+            else:
+                return _LOSSES['categorical_crossentropy']()
 
         return _LOSSES[self.loss]()

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -3,7 +3,6 @@
 
 from abc import ABC, abstractmethod
 from functools import partial
-import warnings
 
 import numpy as np
 from timeit import default_timer as time
@@ -1048,9 +1047,8 @@ class HistGradientBoostingClassifier(BaseHistGradientBoosting,
 
         if (self.loss == 'categorical_crossentropy' and
                 self.n_trees_per_iteration_ == 1):
-            warnings.warn("Switching to 'binary_crossentropy' loss since "
-                          "'categorical_crossentropy' is not suitable for a "
-                          "binary classification problem.", UserWarning)
-            return _LOSSES['binary_crossentropy']()
+            raise ValueError("'categorical_crossentropy' is not suitable for "
+                             "a binary classification problem. Please use "
+                             "'auto' or 'binary_crossentropy' instead.")
 
         return _LOSSES[self.loss]()

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -3,6 +3,7 @@
 
 from abc import ABC, abstractmethod
 from functools import partial
+import warnings
 
 import numpy as np
 from timeit import default_timer as time
@@ -1044,5 +1045,12 @@ class HistGradientBoostingClassifier(BaseHistGradientBoosting,
                 return _LOSSES['binary_crossentropy']()
             else:
                 return _LOSSES['categorical_crossentropy']()
+
+        if (self.loss == 'categorical_crossentropy' and
+                self.n_trees_per_iteration_ == 1):
+            warnings.warn("Switching to 'binary_crossentropy' loss since "
+                          "'categorical_crossentropy' is not suitable for a "
+                          "binary classification problem.", UserWarning)
+            return _LOSSES['binary_crossentropy']()
 
         return _LOSSES[self.loss]()

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -423,8 +423,8 @@ def test_crossentropy_binary_problem():
     X = [[1], [0]]
     y = [0, 1]
     gbrt = HistGradientBoostingClassifier(loss='categorical_crossentropy')
-    with pytest.warns(UserWarning,
-                      match="Switching to 'binary_crossentropy' loss since"):
+    with pytest.raises(ValueError,
+                       match="'categorical_crossentropy' is not suitable for"):
         gbrt.fit(X, y)
 
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -417,6 +417,17 @@ def test_infinite_values_missing_values():
     assert stump_clf.fit(X, y_isnan).score(X, y_isnan) == 1
 
 
+def test_crossentropy_binary_problem():
+    # categorical_crossentropy should only be used if there are more than two
+    # classes present.
+    X = [[1], [0]]
+    y = [0, 1]
+    gbrt = HistGradientBoostingClassifier(loss='categorical_crossentropy')
+    with pytest.warns(UserWarning,
+                      match="Switching to 'binary_crossentropy' loss since"):
+        gbrt.fit(X, y)
+
+
 @pytest.mark.parametrize("scoring", [None, 'loss'])
 def test_string_target_early_stopping(scoring):
     # Regression tests for #14709 where the targets need to be encoded before

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -419,7 +419,7 @@ def test_infinite_values_missing_values():
 
 def test_crossentropy_binary_problem():
     # categorical_crossentropy should only be used if there are more than two
-    # classes present.
+    # classes present. PR #14869
     X = [[1], [0]]
     y = [0, 1]
     gbrt = HistGradientBoostingClassifier(loss='categorical_crossentropy')


### PR DESCRIPTION
Fixes #14858.

Raise a warning and switch to `binary_crossentropy` if it's a binary classification problem and `categorical_crossentropy` is given.