### PR TITLE
MNT CI switch to pypi for the 'latest' env

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
       # Linux environment to test the latest available dependencies and MKL.
       # It runs tests requiring pandas and PyAMG.
       pylatest_pip_openblas_pandas:
-        DISTRIB: 'latest'
+        DISTRIB: 'conda-latest'
         PYTHON_VERSION: '*'
         COVERAGE: 'true'
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,18 +31,8 @@ jobs:
       # Linux environment to test the latest available dependencies and MKL.
       # It runs tests requiring pandas and PyAMG.
       pylatest_conda_mkl_pandas:
-        DISTRIB: 'conda'
+        DISTRIB: 'latest'
         PYTHON_VERSION: '*'
-        INSTALL_MKL: 'true'
-        NUMPY_VERSION: '*'
-        SCIPY_VERSION: '*'
-        PANDAS_VERSION: '*'
-        CYTHON_VERSION: '*'
-        PYAMG_VERSION: '*'
-        PILLOW_VERSION: '*'
-        JOBLIB_VERSION: '*'
-        PYTEST_VERSION: '4.6.2'
-        MATPLOTLIB_VERSION: '*'
         COVERAGE: 'true'
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
         TEST_DOCSTRINGS: 'true'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
         COVERAGE: 'true'
       # Linux environment to test the latest available dependencies and MKL.
       # It runs tests requiring pandas and PyAMG.
-      pylatest_conda_mkl_pandas:
+      pylatest_pip_openblas_pandas:
         DISTRIB: 'latest'
         PYTHON_VERSION: '*'
         COVERAGE: 'true'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,7 @@ jobs:
       pylatest_pip_openblas_pandas:
         DISTRIB: 'conda-latest'
         PYTHON_VERSION: '*'
+        PYTEST_VERSION: '4.6.2'
         COVERAGE: 'true'
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
         TEST_DOCSTRINGS: 'true'

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -22,6 +22,7 @@ conda_version=$(conda -V | awk '{print $2}')
 
 make_conda() {
     TO_INSTALL="$@"
+    conda init
     conda create -n $VIRTUALENV --yes $TO_INSTALL
     if version_ge "$conda_version" "4.6.0"; then
         conda activate $VIRTUALENV

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -88,10 +88,10 @@ elif [[ "$DISTRIB" == "ubuntu-32" ]]; then
     python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
     source $VIRTUALENV/bin/activate
     python -m pip install pytest==$PYTEST_VERSION pytest-cov cython joblib==$JOBLIB_VERSION
-elif [[ "$DISTRIB" == "latest" ]]; then
+elif [[ "$DISTRIB" == "conda-latest" ]]; then
     # since conda main channel usually lacks behind on the latest releases,
     # we use pypi to test against the latest releases of the dependencies.
-    make_conda "python=$PYTHON_VERSION pip"
+    make_conda "python=$PYTHON_VERSION"
     python -m pip install numpy scipy joblib cython
     python -m pip install pytest==$PYTEST_VERSION pytest-cov pytest-xdist
     python -m pip install pandas matplotlib pyamg pillow

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -86,7 +86,7 @@ elif [[ "$DISTRIB" == "ubuntu-32" ]]; then
     python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
     source $VIRTUALENV/bin/activate
     python -m pip install pytest==$PYTEST_VERSION pytest-cov cython joblib==$JOBLIB_VERSION
-elif [[ "$DISTRIB" == "latest"]]; then
+elif [[ "$DISTRIB" == "latest" ]]; then
     # since conda main channel usually lacks behind on the latest releases,
     # we use pypi to test against the latest releases of the dependencies.
     make_conda("python=$PYTHON_VERSION")

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -91,7 +91,8 @@ elif [[ "$DISTRIB" == "ubuntu-32" ]]; then
 elif [[ "$DISTRIB" == "latest" ]]; then
     # since conda main channel usually lacks behind on the latest releases,
     # we use pypi to test against the latest releases of the dependencies.
-    make_conda "python=$PYTHON_VERSION pip"
+    TO_INSTALL="python=$PYTHON_VERSION pip"
+    make_conda $TO_INSTALL
     python -m pip install numpy scipy joblib cython
     python -m pip install pytest==$PYTEST_VERSION pytest-cov pytest-xdist
     python -m pip install pandas matplotlib pyamg pillow

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -22,7 +22,7 @@ conda_version=$(conda -V | awk '{print $2}')
 
 make_conda() {
     TO_INSTALL="$@"
-    conda init
+    conda init "bash"
     conda create -n $VIRTUALENV --yes $TO_INSTALL
     if version_ge "$conda_version" "4.6.0"; then
         conda activate $VIRTUALENV

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -x
 
 UNAMESTR=`uname`
 
@@ -90,7 +91,7 @@ elif [[ "$DISTRIB" == "ubuntu-32" ]]; then
 elif [[ "$DISTRIB" == "latest" ]]; then
     # since conda main channel usually lacks behind on the latest releases,
     # we use pypi to test against the latest releases of the dependencies.
-    make_conda "python=$PYTHON_VERSION"
+    make_conda "python=$PYTHON_VERSION pip"
     python -m pip install numpy scipy joblib cython
     python -m pip install pytest==$PYTEST_VERSION pytest-cov pytest-xdist
     python -m pip install pandas matplotlib pyamg pillow

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -89,7 +89,7 @@ elif [[ "$DISTRIB" == "ubuntu-32" ]]; then
 elif [[ "$DISTRIB" == "latest" ]]; then
     # since conda main channel usually lacks behind on the latest releases,
     # we use pypi to test against the latest releases of the dependencies.
-    make_conda("python=$PYTHON_VERSION")
+    make_conda "python=$PYTHON_VERSION"
     python -m pip install numpy scipy joblib cython
     python -m pip install pytest==$PYTEST_VERSION pytest-cov pytest-xdist
     python -m pip install mkl pandas matplotlib pyamg pillow

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -21,7 +21,7 @@ fi
 make_conda() {
     TO_INSTALL="$@"
     conda create -n $VIRTUALENV --yes $TO_INSTALL
-    source activate $VIRTUALENV
+    conda activate $VIRTUALENV
 }
 
 version_ge() {

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -18,10 +18,16 @@ if [[ "$UNAMESTR" == "Darwin" ]]; then
     export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
 fi
 
+conda_version=$(conda -V | awk '{print $2}')
+
 make_conda() {
     TO_INSTALL="$@"
     conda create -n $VIRTUALENV --yes $TO_INSTALL
-    conda activate $VIRTUALENV
+    if version_ge "$conda_version" "4.6.0"; then
+        conda activate $VIRTUALENV
+    else
+        source activate $VIRTUALENV
+    fi
 }
 
 version_ge() {
@@ -64,7 +70,6 @@ if [[ "$DISTRIB" == "conda" ]]; then
     # we are using them for testing Python 3.5. See
     # https://www.anaconda.com/why-we-removed-the-free-channel-in-conda-4-7/
     # for more details. restore_free_channel is defined starting from conda 4.7
-    conda_version=$(conda -V | awk '{print $2}')
     if version_ge "$conda_version" "4.7.0" && [[ "$PYTHON_VERSION" == "3.5" ]]; then
         conda config --set restore_free_channel true
     fi

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -86,6 +86,13 @@ elif [[ "$DISTRIB" == "ubuntu-32" ]]; then
     python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
     source $VIRTUALENV/bin/activate
     python -m pip install pytest==$PYTEST_VERSION pytest-cov cython joblib==$JOBLIB_VERSION
+elif [[ "$DISTRIB" == "latest"]]
+    # since conda main channel usually lacks behind on the latest releases,
+    # we use pypi to test against the latest releases of the dependencies.
+    make_conda("python=$PYTHON_VERSION")
+    python -m pip install numpy scipy joblib cython
+    python -m pip install pytest==$PYTEST_VERSION pytest-cov pytest-xdist
+    python -m pip install mkl pandas matplotlib pyamg pillow
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -97,7 +97,7 @@ elif [[ "$DISTRIB" == "latest" ]]; then
     make_conda "python=$PYTHON_VERSION"
     python -m pip install numpy scipy joblib cython
     python -m pip install pytest==$PYTEST_VERSION pytest-cov pytest-xdist
-    python -m pip install mkl pandas matplotlib pyamg pillow
+    python -m pip install pandas matplotlib pyamg pillow
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-set -x
 
 UNAMESTR=`uname`
 
@@ -18,8 +17,6 @@ if [[ "$UNAMESTR" == "Darwin" ]]; then
     export LDFLAGS="$LDFLAGS -L/usr/local/opt/libomp/lib -lomp"
     export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
 fi
-
-conda_version=$(conda -V | awk '{print $2}')
 
 make_conda() {
     TO_INSTALL="$@"
@@ -67,6 +64,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
     # we are using them for testing Python 3.5. See
     # https://www.anaconda.com/why-we-removed-the-free-channel-in-conda-4-7/
     # for more details. restore_free_channel is defined starting from conda 4.7
+    conda_version=$(conda -V | awk '{print $2}')
     if version_ge "$conda_version" "4.7.0" && [[ "$PYTHON_VERSION" == "3.5" ]]; then
         conda config --set restore_free_channel true
     fi

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -22,13 +22,8 @@ conda_version=$(conda -V | awk '{print $2}')
 
 make_conda() {
     TO_INSTALL="$@"
-    conda init "bash"
     conda create -n $VIRTUALENV --yes $TO_INSTALL
-    if version_ge "$conda_version" "4.6.0"; then
-        conda activate $VIRTUALENV
-    else
-        source activate $VIRTUALENV
-    fi
+    source activate $VIRTUALENV
 }
 
 version_ge() {

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -86,7 +86,7 @@ elif [[ "$DISTRIB" == "ubuntu-32" ]]; then
     python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
     source $VIRTUALENV/bin/activate
     python -m pip install pytest==$PYTEST_VERSION pytest-cov cython joblib==$JOBLIB_VERSION
-elif [[ "$DISTRIB" == "latest"]]
+elif [[ "$DISTRIB" == "latest"]]; then
     # since conda main channel usually lacks behind on the latest releases,
     # we use pypi to test against the latest releases of the dependencies.
     make_conda("python=$PYTHON_VERSION")

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -22,10 +22,10 @@ jobs:
   steps:
     - bash: echo "##vso[task.prependpath]$CONDA/bin"
       displayName: Add conda to PATH
-      condition: eq(variables['DISTRIB'], 'conda')
+      condition: startsWith(variables['DISTRIB'], 'conda')
     - bash: sudo chown -R $USER $CONDA
       displayName: Take ownership of conda installation
-      condition: eq(variables['DISTRIB'], 'conda')
+      condition: startsWith(variables['DISTRIB'], 'conda')
     - script: |
         build_tools/azure/install.sh
       displayName: 'Install'

--- a/build_tools/azure/test_docs.sh
+++ b/build_tools/azure/test_docs.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ "$DISTRIB" == "conda" ]]; then
+if [[ "$DISTRIB" =~ ^conda.* ]]; then
     source activate $VIRTUALENV
 elif [[ "$DISTRIB" == "ubuntu" ]]; then
     source $VIRTUALENV/bin/activate

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ "$DISTRIB" == "conda" ]]; then
+if [[ "$DISTRIB" =~ ^conda.* ]]; then
     source activate $VIRTUALENV
 elif [[ "$DISTRIB" == "ubuntu" ]] || [[ "$DISTRIB" == "ubuntu-32" ]]; then
     source $VIRTUALENV/bin/activate


### PR DESCRIPTION
related to https://github.com/scikit-learn/scikit-learn/pull/14702

This PR uses the latest available releases on pypi instead of conda main channel to test against the latest releases.

Ping @amueller, @thomasjpfan 