### PR TITLE
Fix the equation in FriedmanMSE splitting criterion

### DIFF
--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1273,7 +1273,7 @@ cdef class FriedmanMSE(MSE):
     Uses the formula (35) in Friedman's original Gradient Boosting paper:
 
         diff = mean_left - mean_right
-        improvement = n_left * n_right * diff^2 / (n_left + n_right)
+        improvement = diff^2 / (n_left * n_right * (n_left + n_right))
     """
 
     cdef double proxy_impurity_improvement(self) nogil:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

The equation in the doc doesn't reflect the implementation, this pr changes the equation follow the way we implement it

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
