### PR TITLE
[MGR] TransformedTargetRegressor passes fit_params to regressor 

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -75,6 +75,10 @@ Changelog
   1.12.
   :pr:`14510` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- |Fix| Fixed a bug in :class:`compose.TransformedTargetRegrssor` which did not
+  pass `**fit_params` to the underlying regressor.
+  :pr:`14890` by :user:`Miguel Cabrera <mfcabrera>`.
+
 :mod:`sklearn.datasets`
 .......................
 
@@ -205,7 +209,7 @@ Changelog
 
 -|FIX| Fixed a bug where :class:`kernel_approximation.Nystroem` raised a
  `KeyError` when using `kernel="precomputed"`.
- :pr:`14706` by :user:`Venkatachalam N <venkyyuvy>`. 
+ :pr:`14706` by :user:`Venkatachalam N <venkyyuvy>`.
 
 :mod:`sklearn.linear_model`
 ...........................
@@ -324,19 +328,19 @@ Changelog
 - |Enhancement| SVM now throws more specific error when fit on non-square data
   and kernel = precomputed.  :class:`svm.BaseLibSVM`
   :pr:`14336` by :user:`Gregory Dexter <gdex1>`.
-  
+
 :mod:`sklearn.tree`
 ...................
 
 - |Feature| Adds minimal cost complexity pruning, controlled by ``ccp_alpha``,
   to :class:`tree.DecisionTreeClassifier`, :class:`tree.DecisionTreeRegressor`,
   :class:`tree.ExtraTreeClassifier`, :class:`tree.ExtraTreeRegressor`,
-  :class:`ensemble.RandomForestClassifier`, 
+  :class:`ensemble.RandomForestClassifier`,
   :class:`ensemble.RandomForestRegressor`,
-  :class:`ensemble.ExtraTreesClassifier`, 
+  :class:`ensemble.ExtraTreesClassifier`,
   :class:`ensemble.ExtraTreesRegressor`,
-  :class:`ensemble.RandomTreesEmbedding`, 
-  :class:`ensemble.GradientBoostingClassifier`, 
+  :class:`ensemble.RandomTreesEmbedding`,
+  :class:`ensemble.GradientBoostingClassifier`,
   and :class:`ensemble.GradientBoostingRegressor`.
   :pr:`12887` by `Thomas Fan`_.
 

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -148,7 +148,7 @@ class TransformedTargetRegressor(BaseEstimator, RegressorMixin):
                               " you are sure you want to proceed regardless"
                               ", set 'check_inverse=False'", UserWarning)
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, **fit_params):
         """Fit the model according to the given training data.
 
         Parameters
@@ -160,9 +160,9 @@ class TransformedTargetRegressor(BaseEstimator, RegressorMixin):
         y : array-like, shape (n_samples,)
             Target values.
 
-        sample_weight : array-like, shape (n_samples,) optional
-            Array of weights that are assigned to individual samples.
-            If not provided, then each sample is given unit weight.
+        **fit_params : dict of string -> object
+            Parameters passed to the ``fit`` method of the underlying regressor.
+
 
         Returns
         -------
@@ -197,10 +197,7 @@ class TransformedTargetRegressor(BaseEstimator, RegressorMixin):
         else:
             self.regressor_ = clone(self.regressor)
 
-        if sample_weight is None:
-            self.regressor_.fit(X, y_trans)
-        else:
-            self.regressor_.fit(X, y_trans, sample_weight=sample_weight)
+        self.regressor_.fit(X, y_trans, **fit_params)
 
         return self
 

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -161,7 +161,8 @@ class TransformedTargetRegressor(BaseEstimator, RegressorMixin):
             Target values.
 
         **fit_params : dict of string -> object
-            Parameters passed to the ``fit`` method of the underlying regressor.
+            Parameters passed to the ``fit`` method of the underlying
+            regressor.
 
 
         Returns

--- a/sklearn/compose/tests/test_target.py
+++ b/sklearn/compose/tests/test_target.py
@@ -294,3 +294,21 @@ def test_transform_target_regressor_count_fit(check_inverse):
     )
     ttr.fit(X, y)
     assert ttr.transformer_.fit_counter == 1
+
+
+class DummyRegressorWithExtraFitParams(DummyRegressor):
+    def fit(self, X, y, sample_weight=None, check_input=True):
+        # on the test below we force this to false, we make sure this actually passed
+        # to the regressor
+        assert not check_input
+        return super().fit(X, y, sample_weight)
+
+
+def test_transform_target_regressor_pass_fit_parameters():
+    X, y = friedman
+    # provide a transformer and functions at the same time
+    regr = TransformedTargetRegressor(regressor=DummyRegressorWithExtraFitParams(),
+                                      transformer=DummyTransformer())
+
+    regr.fit(X, y, check_input=False)
+    assert regr.transformer_.fit_counter == 1

--- a/sklearn/compose/tests/test_target.py
+++ b/sklearn/compose/tests/test_target.py
@@ -298,17 +298,18 @@ def test_transform_target_regressor_count_fit(check_inverse):
 
 class DummyRegressorWithExtraFitParams(DummyRegressor):
     def fit(self, X, y, sample_weight=None, check_input=True):
-        # on the test below we force this to false, we make sure this actually passed
-        # to the regressor
+        # on the test below we force this to false, we make sure this is
+        # actually passed to the regressor
         assert not check_input
         return super().fit(X, y, sample_weight)
 
 
 def test_transform_target_regressor_pass_fit_parameters():
     X, y = friedman
-    # provide a transformer and functions at the same time
-    regr = TransformedTargetRegressor(regressor=DummyRegressorWithExtraFitParams(),
-                                      transformer=DummyTransformer())
+    regr = TransformedTargetRegressor(
+        regressor=DummyRegressorWithExtraFitParams(),
+        transformer=DummyTransformer()
+    )
 
     regr.fit(X, y, check_input=False)
     assert regr.transformer_.fit_counter == 1

--- a/sklearn/compose/tests/test_target.py
+++ b/sklearn/compose/tests/test_target.py
@@ -14,6 +14,8 @@ from sklearn.utils.testing import assert_no_warnings
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.preprocessing import StandardScaler
 
+from sklearn.pipeline import Pipeline
+
 from sklearn.linear_model import LinearRegression, Lasso
 
 from sklearn import datasets
@@ -312,4 +314,21 @@ def test_transform_target_regressor_pass_fit_parameters():
     )
 
     regr.fit(X, y, check_input=False)
+    assert regr.transformer_.fit_counter == 1
+
+
+def test_transform_target_regressor_route_pipeline():
+    X, y = friedman
+
+    regr = TransformedTargetRegressor(
+        regressor=DummyRegressorWithExtraFitParams(),
+        transformer=DummyTransformer()
+    )
+    estimators = [
+        ('normalize', StandardScaler()), ('est', regr)
+    ]
+
+    pip = Pipeline(estimators)
+    pip.fit(X, y, **{'est__check_input': False})
+
     assert regr.transformer_.fit_counter == 1


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #13349 

#### What does this implement/fix? Explain your changes.

Originally TransformedTargetRegressor  only passed `sample_weight` to the  `fit` method of the underlying regressor. However This regressor might have other parameters and could theoretically even be a pipeline.  With this change you can pass arbitrary paramter to it. 
