### PR TITLE
MNT remove inheriting from object

### DIFF
--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -925,7 +925,7 @@ Some tips and tricks:
 
         >>> from nltk import word_tokenize          # doctest: +SKIP
         >>> from nltk.stem import WordNetLemmatizer # doctest: +SKIP
-        >>> class LemmaTokenizer(object):
+        >>> class LemmaTokenizer:
         ...     def __init__(self):
         ...         self.wnl = WordNetLemmatizer()
         ...     def __call__(self, doc):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -605,13 +605,13 @@ class MetaEstimatorMixin:
     """Mixin class for all meta estimators in scikit-learn."""
 
 
-class MultiOutputMixin(object):
+class MultiOutputMixin:
     """Mixin to mark estimators that support multioutput."""
     def _more_tags(self):
         return {'multioutput': True}
 
 
-class _UnstableArchMixin(object):
+class _UnstableArchMixin:
     """Mark estimators that are non-determinstic on 32bit or PowerPC"""
     def _more_tags(self):
         return {'non_deterministic': (

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1088,7 +1088,7 @@ class ExponentialLoss(ClassificationLossFunction):
         return (score.ravel() >= 0.0).astype(np.int)
 
 
-class VerboseReporter(object):
+class VerboseReporter:
     """Reports verbose output to stdout.
 
     Parameters

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -70,7 +70,7 @@ from sklearn.model_selection.tests.common import OneTimeSplitter
 
 # Neither of the following two estimators inherit from BaseEstimator,
 # to test hyperparameter search on user-defined classifiers.
-class MockClassifier(object):
+class MockClassifier:
     """Dummy classifier to test the parameter search algorithms"""
     def __init__(self, foo_param=0):
         self.foo_param = foo_param

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -67,7 +67,7 @@ def _color_brew(n):
     return color_list
 
 
-class Sentinel(object):
+class Sentinel:
     def __repr__(self):
         return '"tree.dot"'
 
@@ -176,7 +176,7 @@ def plot_tree(decision_tree, max_depth=None, feature_names=None,
     return exporter.export(decision_tree, ax=ax)
 
 
-class _BaseTreeExporter(object):
+class _BaseTreeExporter:
     def __init__(self, max_depth=None, feature_names=None,
                  class_names=None, label='all', filled=False,
                  impurity=True, node_ids=False,


### PR DESCRIPTION
Some cleanup.

There are still some left in Cython files:
```
sklearn/cluster/_hierarchical.pyx:cdef class UnionFind(object):
sklearn/utils/weight_vector.pxd:cdef class WeightVector(object):
sklearn/utils/weight_vector.pyx:cdef class WeightVector(object):
```
wasn't sure if it was worth fixing these as well? or leave for another PR?