### PR TITLE
Less verbose estimator tags mechanism

### DIFF
--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -537,14 +537,19 @@ X_types
     of the ``'sparse'`` tag.
 
 
-To override the tags of a child class, one must define the `_more_tags()`
-method and return a dict with the desired tags, e.g::
+To override the tags in a child class, one must define `_more_tags`
+as an attribute or a property returning a dict with the desired tags, e.g::
 
     class MyMultiOutputEstimator(BaseEstimator):
 
-        def _more_tags(self):
-            return {'multioutput_only': True,
-                    'non_deterministic': True}
+        _more_tags = {'multioutput_only': True, 'non_deterministic': True}
+
+
+Estimator tags are assembled from parent classes in the standard Python
+`Method Resolution Order (MRO)
+<https://www.python.org/download/releases/2.3/mro/>`_ order. Duplicate tags
+are overwritten by child classes.
+
 
 In addition to the tags, estimators also need to declare any non-optional
 parameters to ``__init__`` in the ``_required_parameters`` class attribute,

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -321,9 +321,10 @@ class BaseEstimator:
                 if hasattr(base_class._more_tags, "__call__"):
                     more_tags = base_class._more_tags(self)
                     warnings.warn(
-                        "class {}: callable _more_tags are deprecated!"
-                        "_more_tags should either be a dict, or a property "
-                        "returning a dict".format(base_class.__name__),
+                        "class {}: callable _more_tags are deprecated in 0.22 "
+                        "and will be removed in 0.23! _more_tags should either"
+                        " be a dict, or a property returning a dict"
+                        .format(base_class.__name__),
                         category=DeprecationWarning)
                 elif isinstance(base_class._more_tags, property):
                     more_tags = base_class._more_tags.fget(self)

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -234,5 +234,4 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
 
         return pred_trans
 
-    def _more_tags(self):
-        return {'poor_score': True, 'no_validation': True}
+    _more_tags = {'poor_score': True, 'no_validation': True}

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -464,8 +464,7 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
         """
         return self.fit(X, y).transform(X, y)
 
-    def _more_tags(self):
-        return {'poor_score': True}
+    _more_tags = {'poor_score': True}
 
 
 class PLSRegression(_PLS):

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -1240,8 +1240,7 @@ class NMF(TransformerMixin, BaseEstimator):
         self.verbose = verbose
         self.shuffle = shuffle
 
-    def _more_tags(self):
-        return {'requires_positive_X': True}
+    _more_tags = {'requires_positive_X': True}
 
     def fit_transform(self, X, y=None, W=None, H=None):
         """Learn a NMF model for the data X and returns the transformed data.

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -466,8 +466,7 @@ class LatentDirichletAllocation(TransformerMixin, BaseEstimator):
         self.n_batch_iter_ += 1
         return
 
-    def _more_tags(self):
-        return {'requires_positive_X': True}
+    _more_tags = {'requires_positive_X': True}
 
     def _check_non_neg_array(self, X, whom):
         """check X format

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -318,8 +318,7 @@ class DummyClassifier(MultiOutputMixin, ClassifierMixin, BaseEstimator):
         else:
             return [np.log(p) for p in proba]
 
-    def _more_tags(self):
-        return {'poor_score': True, 'no_validation': True}
+    _more_tags = {'poor_score': True, 'no_validation': True}
 
     def score(self, X, y, sample_weight=None):
         """Returns the mean accuracy on the given test data and labels.
@@ -511,8 +510,7 @@ class DummyRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
         return (y, y_std) if return_std else y
 
-    def _more_tags(self):
-        return {'poor_score': True, 'no_validation': True}
+    _more_tags = {'poor_score': True, 'no_validation': True}
 
     def score(self, X, y, sample_weight=None):
         """Returns the coefficient of determination R^2 of the prediction.

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -622,8 +622,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
 
         return averaged_predictions
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    _more_tags = {'allow_nan': True}
 
     @abstractmethod
     def _get_loss(self):

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -361,5 +361,4 @@ class DictVectorizer(TransformerMixin, BaseEstimator):
 
         return self
 
-    def _more_tags(self):
-        return {'X_types': ["dict"]}
+    _more_tags = {'X_types': ["dict"]}

--- a/sklearn/feature_extraction/hashing.py
+++ b/sklearn/feature_extraction/hashing.py
@@ -162,5 +162,6 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
 
         return X
 
+    @property
     def _more_tags(self):
         return {'X_types': [self.input_type]}

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -535,5 +535,4 @@ class PatchExtractor(BaseEstimator):
                 image, patch_size, self.max_patches, self.random_state)
         return patches
 
-    def _more_tags(self):
-        return {'X_types': ['3darray']}
+    _more_tags = {'X_types': ['3darray']}

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -741,8 +741,7 @@ class HashingVectorizer(TransformerMixin, VectorizerMixin, BaseEstimator):
                              input_type='string', dtype=self.dtype,
                              alternate_sign=self.alternate_sign)
 
-    def _more_tags(self):
-        return {'X_types': ['string']}
+    _more_tags = {'X_types': ['string']}
 
 
 def _document_frequency(X):
@@ -1220,8 +1219,7 @@ class CountVectorizer(VectorizerMixin, BaseEstimator):
         return [t for t, i in sorted(self.vocabulary_.items(),
                                      key=itemgetter(1))]
 
-    def _more_tags(self):
-        return {'X_types': ['string']}
+    _more_tags = {'X_types': ['string']}
 
 
 def _make_int_array():
@@ -1404,8 +1402,7 @@ class TfidfTransformer(TransformerMixin, BaseEstimator):
         self._idf_diag = sp.spdiags(value, diags=0, m=n_features,
                                     n=n_features, format='csr')
 
-    def _more_tags(self):
-        return {'X_types': 'sparse'}
+    _more_tags = {'X_types': 'sparse'}
 
 
 class TfidfVectorizer(CountVectorizer):
@@ -1761,5 +1758,4 @@ class TfidfVectorizer(CountVectorizer):
         X = super().transform(raw_documents)
         return self._tfidf.transform(X, copy=False)
 
-    def _more_tags(self):
-        return {'X_types': ['string'], '_skip_test': True}
+    _more_tags = {'X_types': ['string'], '_skip_test': True}

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -325,8 +325,7 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         check_is_fitted(self)
         return self.estimator_.predict_log_proba(self.transform(X))
 
-    def _more_tags(self):
-        return {'poor_score': True}
+    _more_tags = {'poor_score': True}
 
 
 class RFECV(RFE):

--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -485,5 +485,4 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         return theta_opt, func_min
 
-    def _more_tags(self):
-        return {'requires_fit': False}
+    _more_tags = {'requires_fit': False}

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -412,8 +412,7 @@ class SimpleImputer(TransformerMixin, BaseEstimator):
 
         return X
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    _more_tags = {'allow_nan': True}
 
 
 class MissingIndicator(TransformerMixin, BaseEstimator):
@@ -679,6 +678,4 @@ class MissingIndicator(TransformerMixin, BaseEstimator):
 
         return imputer_mask
 
-    def _more_tags(self):
-        return {'allow_nan': True,
-                'X_types': ['2darray', 'string']}
+    _more_tags = {'allow_nan': True, 'X_types': ['2darray', 'string']}

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -685,5 +685,4 @@ class IterativeImputer(TransformerMixin, BaseEstimator):
         self.fit_transform(X)
         return self
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    _more_tags = {'allow_nan': True}

--- a/sklearn/impute/_knn.py
+++ b/sklearn/impute/_knn.py
@@ -264,5 +264,6 @@ class KNNImputer(TransformerMixin, BaseEstimator):
 
         return X[:, valid_idx]
 
+    @property
     def _more_tags(self):
         return {'allow_nan': is_scalar_nan(self.missing_values)}

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -415,5 +415,4 @@ class IsotonicRegression(RegressorMixin, TransformerMixin, BaseEstimator):
         if hasattr(self, '_necessary_X_') and hasattr(self, '_necessary_y_'):
             self._build_f(self._necessary_X_, self._necessary_y_)
 
-    def _more_tags(self):
-        return {'X_types': ['1darray']}
+    _more_tags = {'X_types': ['1darray']}

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -425,8 +425,7 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
 
         return sp.hstack(X_new)
 
-    def _more_tags(self):
-        return {'stateless': True}
+    _more_tags = {'stateless': True}
 
 
 class Nystroem(TransformerMixin, BaseEstimator):

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1796,8 +1796,7 @@ class MultiTaskElasticNet(Lasso):
         # return self for chaining fit and predict calls
         return self
 
-    def _more_tags(self):
-        return {'multioutput_only': True}
+    _more_tags = {'multioutput_only': True}
 
 
 class MultiTaskLasso(MultiTaskElasticNet):
@@ -2101,8 +2100,7 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         self.random_state = random_state
         self.selection = selection
 
-    def _more_tags(self):
-        return {'multioutput_only': True}
+    _more_tags = {'multioutput_only': True}
 
 
 class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
@@ -2263,5 +2261,4 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
             cv=cv, verbose=verbose, n_jobs=n_jobs, random_state=random_state,
             selection=selection)
 
-    def _more_tags(self):
-        return {'multioutput_only': True}
+    _more_tags = {'multioutput_only': True}

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -198,8 +198,7 @@ class MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
 
         return np.asarray(y).T
 
-    def _more_tags(self):
-        return {'multioutput_only': True}
+    _more_tags = {'multioutput_only': True}
 
 
 class MultiOutputRegressor(RegressorMixin, MultiOutputEstimator):
@@ -405,9 +404,8 @@ class MultiOutputClassifier(ClassifierMixin, MultiOutputEstimator):
         y_pred = self.predict(X)
         return np.mean(np.all(y == y_pred, axis=1))
 
-    def _more_tags(self):
-        # FIXME
-        return {'_skip_test': True}
+    # FIXME
+    _more_tags = {'_skip_test': True}
 
 
 class _BaseChain(BaseEstimator, metaclass=ABCMeta):
@@ -671,9 +669,7 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
 
         return Y_decision
 
-    def _more_tags(self):
-        return {'_skip_test': True,
-                'multioutput_only': True}
+    _more_tags = {'_skip_test': True, 'multioutput_only': True}
 
 
 class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
@@ -758,5 +754,4 @@ class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
         super().fit(X, Y)
         return self
 
-    def _more_tags(self):
-        return {'multioutput_only': True}
+    _more_tags = {'multioutput_only': True}

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -635,8 +635,7 @@ class BaseDiscreteNB(BaseNB):
     coef_ = property(_get_coef)
     intercept_ = property(_get_intercept)
 
-    def _more_tags(self):
-        return {'poor_score': True}
+    _more_tags = {'poor_score': True}
 
 
 class MultinomialNB(BaseDiscreteNB):
@@ -726,8 +725,7 @@ class MultinomialNB(BaseDiscreteNB):
         self.fit_prior = fit_prior
         self.class_prior = class_prior
 
-    def _more_tags(self):
-        return {'requires_positive_X': True}
+    _more_tags = {'requires_positive_X': True}
 
     def _count(self, X, Y):
         """Count and smooth feature occurrences."""
@@ -832,8 +830,7 @@ class ComplementNB(BaseDiscreteNB):
         self.class_prior = class_prior
         self.norm = norm
 
-    def _more_tags(self):
-        return {'requires_positive_X': True}
+    _more_tags = {'requires_positive_X': True}
 
     def _count(self, X, Y):
         """Count feature occurrences."""

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -144,8 +144,7 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
 
         return X_int, X_mask
 
-    def _more_tags(self):
-        return {'X_types': ['categorical']}
+    _more_tags = {'X_types': ['categorical']}
 
 
 class OneHotEncoder(_BaseEncoder):

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -155,6 +155,4 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
 
         return func(X, **(kw_args if kw_args else {}))
 
-    def _more_tags(self):
-        return {'no_validation': True,
-                'stateless': True}
+    _more_tags = {'no_validation': True, 'stateless': True}

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -413,8 +413,7 @@ class MinMaxScaler(TransformerMixin, BaseEstimator):
         X /= self.scale_
         return X
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    _more_tags = {'allow_nan': True}
 
 
 def minmax_scale(X, feature_range=(0, 1), axis=0, copy=True):
@@ -817,8 +816,7 @@ class StandardScaler(TransformerMixin, BaseEstimator):
                 X += self.mean_
         return X
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    _more_tags = {'allow_nan': True}
 
 
 class MaxAbsScaler(TransformerMixin, BaseEstimator):
@@ -987,8 +985,7 @@ class MaxAbsScaler(TransformerMixin, BaseEstimator):
             X *= self.scale_
         return X
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    _more_tags = {'allow_nan': True}
 
 
 def maxabs_scale(X, axis=0, copy=True):
@@ -1244,8 +1241,7 @@ class RobustScaler(TransformerMixin, BaseEstimator):
                 X += self.center_
         return X
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    _more_tags = {'allow_nan': True}
 
 
 def robust_scale(X, axis=0, with_centering=True, with_scaling=True,
@@ -1791,8 +1787,7 @@ class Normalizer(TransformerMixin, BaseEstimator):
         X = check_array(X, accept_sparse='csr')
         return normalize(X, norm=self.norm, axis=1, copy=copy)
 
-    def _more_tags(self):
-        return {'stateless': True}
+    _more_tags = {'stateless': True}
 
 
 def binarize(X, threshold=0.0, copy=True):
@@ -1926,8 +1921,7 @@ class Binarizer(TransformerMixin, BaseEstimator):
         copy = copy if copy is not None else self.copy
         return binarize(X, threshold=self.threshold, copy=copy)
 
-    def _more_tags(self):
-        return {'stateless': True}
+    _more_tags = {'stateless': True}
 
 
 class KernelCenterer(TransformerMixin, BaseEstimator):
@@ -2494,8 +2488,7 @@ class QuantileTransformer(TransformerMixin, BaseEstimator):
 
         return self._transform(X, inverse=True)
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    _more_tags = {'allow_nan': True}
 
 
 def quantile_transform(X, axis=0, n_quantiles=1000,
@@ -2980,8 +2973,7 @@ class PowerTransformer(TransformerMixin, BaseEstimator):
 
         return X
 
-    def _more_tags(self):
-        return {'allow_nan': True}
+    _more_tags = {'allow_nan': True}
 
 
 def power_transform(X, method='warn', standardize=True, copy=True):

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -296,8 +296,7 @@ class LabelEncoder(TransformerMixin, BaseEstimator):
         y = np.asarray(y)
         return self.classes_[y]
 
-    def _more_tags(self):
-        return {'X_types': ['1dlabels']}
+    _more_tags = {'X_types': ['1dlabels']}
 
 
 class LabelBinarizer(TransformerMixin, BaseEstimator):
@@ -532,8 +531,7 @@ class LabelBinarizer(TransformerMixin, BaseEstimator):
 
         return y_inv
 
-    def _more_tags(self):
-        return {'X_types': ['1dlabels']}
+    _more_tags = {'X_types': ['1dlabels']}
 
 
 def label_binarize(y, classes, neg_label=0, pos_label=1, sparse_output=False):
@@ -1019,5 +1017,4 @@ class MultiLabelBinarizer(TransformerMixin, BaseEstimator):
             return [tuple(self.classes_.compress(indicators)) for indicators
                     in yt]
 
-    def _more_tags(self):
-        return {'X_types': ['2dlabels']}
+    _more_tags = {'X_types': ['2dlabels']}

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -48,27 +48,28 @@ class T(BaseEstimator):
 
 
 class NaNTag(BaseEstimator):
-    def _more_tags(self):
-        return {'allow_nan': True}
+    _more_tags = {'allow_nan': True}
 
 
 class NoNaNTag(BaseEstimator):
-    def _more_tags(self):
-        return {'allow_nan': False}
+    _more_tags = {'allow_nan': False}
 
 
 class OverrideTag(NaNTag):
-    def _more_tags(self):
-        return {'allow_nan': False}
+    _more_tags = {'allow_nan': False}
 
 
 class DiamondOverwriteTag(NaNTag, NoNaNTag):
-    def _more_tags(self):
-        return dict()
+    _more_tags = {}
 
 
 class InheritDiamondOverwriteTag(DiamondOverwriteTag):
     pass
+
+
+class DeprecatedTag(BaseEstimator):
+    def _more_tags(self):
+        return {'allow_nan': True}
 
 
 class ModifyInitParams(BaseEstimator):
@@ -488,6 +489,13 @@ def test_tag_inheritance():
 
     inherit_diamond_tag_est = InheritDiamondOverwriteTag()
     assert inherit_diamond_tag_est._get_tags()['allow_nan']
+
+
+def test_tag_deprecated():
+    estimator = DeprecatedTag()
+    msg = "class DeprecatedTag: callable _more_tags are deprecated"
+    with pytest.warns(DeprecationWarning, match=msg):
+        assert estimator._get_tags()['allow_nan']
 
 
 # XXX: Remove in 0.23

--- a/sklearn/utils/mocking.py
+++ b/sklearn/utils/mocking.py
@@ -133,5 +133,4 @@ class CheckingClassifier(ClassifierMixin, BaseEstimator):
             score = 0.
         return score
 
-    def _more_tags(self):
-        return {'_skip_test': True, 'X_types': ['1dlabel']}
+    _more_tags = {'_skip_test': True, 'X_types': ['1dlabel']}

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -289,8 +289,7 @@ class UntaggedBinaryClassifier(DecisionTreeClassifier):
 
 class TaggedBinaryClassifier(UntaggedBinaryClassifier):
     # Toy classifier that only supports binary classification.
-    def _more_tags(self):
-        return {'binary_only': True}
+    _more_tags = {'binary_only': True}
 
 
 class RequiresPositiveYRegressor(LinearRegression):
@@ -301,8 +300,7 @@ class RequiresPositiveYRegressor(LinearRegression):
             raise ValueError('negative y values not supported!')
         return super().fit(X, y)
 
-    def _more_tags(self):
-        return {"requires_positive_y": True}
+    _more_tags = {"requires_positive_y": True}
 
 
 def test_check_fit_score_takes_y_works_on_deprecated_fit():


### PR DESCRIPTION
Alternative to https://github.com/scikit-learn/scikit-learn/pull/14644

We should pick one of these two PRs.

This uses the current tag estimator mechanism but changes it from,
```py
class Estimator(BaseEstimator):
    def _more_tags(self):
        return {'allow_nan': True}
```   
to a less verbose,
```py
class Estimator(BaseEstimator):
    _more_tags = {'allow_nan': True}
```
`_more_tags` can also be a property.

The previous behavior still works with a deprecation warning.

Tried to also address @thomasjpfan's comment  from https://github.com/scikit-learn/scikit-learn/pull/14884#issuecomment-528336441
> In a follow up, we should document how the order of the inheritance matters now when using tags.

but the description can certainly be improved.

cc @amueller 