### PR TITLE
[MRG] Fix ZeroDivisionError when using sparse data in SVM in case where support_vectors_ is empty

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -572,6 +572,9 @@ Changelog
   :class:`svm.OneClassSVM` was previously non-initialized, and had size 2. It
   has now size 1 with the correct value. :pr:`15099` by `Nicolas Hug`_.
 
+- |Fix| fixed a bug in :class:`BaseLibSVM._sparse_fit` where n_SV=0 raised a
+  ZeroDivisionError. :pr:`14894` by :user:`Danna Naser <danna-naser>`.
+
 :mod:`sklearn.tree`
 ...................
 

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -287,7 +287,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
         n_SV = self.support_vectors_.shape[0]
 
         dual_coef_indices = np.tile(np.arange(n_SV), n_class)
-        if dual_coef_indices.size == 0:
+        if not n_SV:
             self.dual_coef_ = sp.csr_matrix([])
         else:
             dual_coef_indptr = np.arange(0, dual_coef_indices.size + 1,

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -287,11 +287,14 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
         n_SV = self.support_vectors_.shape[0]
 
         dual_coef_indices = np.tile(np.arange(n_SV), n_class)
-        dual_coef_indptr = np.arange(0, dual_coef_indices.size + 1,
-                                     dual_coef_indices.size / n_class)
-        self.dual_coef_ = sp.csr_matrix(
-            (dual_coef_data, dual_coef_indices, dual_coef_indptr),
-            (n_class, n_SV))
+        if dual_coef_indices.size == 0:
+            self.dual_coef_ = sp.csr_matrix([])
+        else:
+            dual_coef_indptr = np.arange(0, dual_coef_indices.size + 1,
+                                         dual_coef_indices.size / n_class)
+            self.dual_coef_ = sp.csr_matrix(
+                (dual_coef_data, dual_coef_indices, dual_coef_indptr),
+                (n_class, n_SV))
 
     def predict(self, X):
         """Perform regression on samples in X.

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -691,6 +691,7 @@ def test_sparse_precomputed():
 
 
 def test_sparse_fit_support_vectors_empty():
+    # Regression test for #14893
     X_train = sparse.csr_matrix([[0, 1, 0, 0],
                                  [0, 0, 0, 1],
                                  [0, 0, 1, 0],

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -697,7 +697,7 @@ def test_sparse_fit_support_vectors_empty():
                                  [0, 0, 0, 1]])
     y_train = np.array([0.04, 0.04, 0.10, 0.16])
     model = svm.SVR(C=316.227766017, cache_size=200, coef0=0.0, degree=3,
-		    epsilon=0.1, gamma=1.0, kernel='linear', max_iter=15000,
+                    epsilon=0.1, gamma=1.0, kernel='linear', max_iter=15000,
                     shrinking=True, tol=0.001, verbose=False)
     model.fit(x_train, y_train)
     assert model.support_vectors_.data.size == 0

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -696,8 +696,8 @@ def test_sparse_fit_support_vectors_empty():
                                  [0, 0, 1, 0],
                                  [0, 0, 0, 1]])
     y_train = np.array([0.04, 0.04, 0.10, 0.16])
-    model = svm.SVR(C=316.227766017, cache_size=200, coef0=0.0, degree=3, epsilon=0.1,
-                    gamma=1.0, kernel='linear', max_iter=15000,
+    model = svm.SVR(C=316.227766017, cache_size=200, coef0=0.0, degree=3,
+		    epsilon=0.1, gamma=1.0, kernel='linear', max_iter=15000,
                     shrinking=True, tol=0.001, verbose=False)
     model.fit(x_train, y_train)
     assert model.support_vectors_.data.size == 0

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -691,15 +691,13 @@ def test_sparse_precomputed():
 
 
 def test_sparse_fit_support_vectors_empty():
-    x_train = sparse.csr_matrix([[0, 1, 0, 0],
+    X_train = sparse.csr_matrix([[0, 1, 0, 0],
                                  [0, 0, 0, 1],
                                  [0, 0, 1, 0],
                                  [0, 0, 0, 1]])
     y_train = np.array([0.04, 0.04, 0.10, 0.16])
-    model = svm.SVR(C=316.227766017, cache_size=200, coef0=0.0, degree=3,
-                    epsilon=0.1, gamma=1.0, kernel='linear', max_iter=15000,
-                    shrinking=True, tol=0.001, verbose=False)
-    model.fit(x_train, y_train)
+    model = svm.SVR(kernel='linear')
+    model.fit(X_train, y_train)
     assert model.support_vectors_.data.size == 0
     assert model.dual_coef_.data.size == 0
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -690,7 +690,7 @@ def test_sparse_precomputed():
         assert "Sparse precomputed" in str(e)
 
 
-def test_sparse_fit_no_support_vectors():
+def test_sparse_fit_support_vectors_empty():
     x_train = sparse.csr_matrix([[0, 1, 0, 0],
                                  [0, 0, 0, 1],
                                  [0, 0, 1, 0],

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -700,8 +700,8 @@ def test_sparse_fit_no_support_vectors():
                     gamma=1.0, kernel='linear', max_iter=15000,
                     shrinking=True, tol=0.001, verbose=False)
     model.fit(x_train, y_train)
-    assert not model.support_vectors_
-    assert model.dual_coef_ == sparse.csr_matrix([])
+    assert not model.support_vectors_.data
+    assert not model.dual_coef_.data
 
 
 def test_linearsvc_parameters():

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -690,6 +690,20 @@ def test_sparse_precomputed():
         assert "Sparse precomputed" in str(e)
 
 
+def test_sparse_fit_no_support_vectors():
+    x_train = sparse.csr_matrix([[0, 1, 0, 0],
+                                 [0, 0, 0, 1],
+                                 [0, 0, 1, 0],
+                                 [0, 0, 0, 1]])
+    y_train = np.array([0.04, 0.04, 0.10, 0.16])
+    model = svm.SVR(C=316.227766017, cache_size=200, coef0=0.0, degree=3, epsilon=0.1,
+                    gamma=1.0, kernel='linear', max_iter=15000,
+                    shrinking=True, tol=0.001, verbose=False)
+    model.fit(x_train, y_train)
+    assert not model.support_vectors_
+    assert model.dual_coef_ == sparse.csr_matrix([])
+
+
 def test_linearsvc_parameters():
     # Test possible parameter combinations in LinearSVC
     # Generate list of possible parameter combinations

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -700,8 +700,8 @@ def test_sparse_fit_support_vectors_empty():
                     gamma=1.0, kernel='linear', max_iter=15000,
                     shrinking=True, tol=0.001, verbose=False)
     model.fit(x_train, y_train)
-    assert not model.support_vectors_.data
-    assert not model.dual_coef_.data
+    assert model.support_vectors_.data.size == 0
+    assert model.dual_coef_.data.size == 0
 
 
 def test_linearsvc_parameters():

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -699,8 +699,8 @@ def test_sparse_fit_support_vectors_empty():
     y_train = np.array([0.04, 0.04, 0.10, 0.16])
     model = svm.SVR(kernel='linear')
     model.fit(X_train, y_train)
-    assert model.support_vectors_.data.size == 0
-    assert model.dual_coef_.data.size == 0
+    assert not model.support_vectors_.data.size
+    assert not model.dual_coef_.data.size
 
 
 def test_linearsvc_parameters():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #14893 #14893
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
When model.support_vectors_ is an empty sparse matrix, to calculate model.dual_coef_, we use
```
dual_coef_indptr = np.arange(0, dual_coef_indices.size + 1,
                                         dual_coef_indices.size / n_class)
```
which results in ZeroDivisionError.
This change skips this calculation in this case and makes the model.dual_coef_ consistent in dense vs sparse data
#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
