### PR TITLE
Moved the text around to different subsections for documentation of "…

### DIFF
--- a/examples/applications/plot_out_of_core_classification.py
+++ b/examples/applications/plot_out_of_core_classification.py
@@ -47,8 +47,8 @@ def _not_in_sphinx():
 # Reuters Dataset related routines
 # --------------------------------
 #
-#The dataset used in this example is Reuters-21578 as provided by the UCI ML
-#repository. It will be automatically downloaded and uncompressed on first run.
+# The dataset used in this example is Reuters-21578 as provided by the UCI ML
+# repository. It will be automatically downloaded and uncompressed on first run.
 
 
 
@@ -314,12 +314,12 @@ for i, (X_train_text, y_train) in enumerate(minibatch_iterators):
 # Plot results
 # ------------
 #
-#The plot represents the learning curve of the classifier: the evolution
-#of classification accuracy over the course of the mini-batches. Accuracy is
-#measured on the first 1000 samples, held out as a validation set.
+# The plot represents the learning curve of the classifier: the evolution
+# of classification accuracy over the course of the mini-batches. Accuracy is
+# measured on the first 1000 samples, held out as a validation set.
 #
-#To limit the memory consumption, we queue examples up to a fixed amount before
-#feeding them to the learner.
+# To limit the memory consumption, we queue examples up to a fixed amount before
+# feeding them to the learner.
 
 
 def plot_accuracy(x, y, x_legend):

--- a/examples/applications/plot_out_of_core_classification.py
+++ b/examples/applications/plot_out_of_core_classification.py
@@ -11,16 +11,6 @@ that the features space remains the same over time we leverage a
 HashingVectorizer that will project each example into the same feature space.
 This is especially useful in the case of text classification where new
 features (words) may appear in each batch.
-
-The dataset used in this example is Reuters-21578 as provided by the UCI ML
-repository. It will be automatically downloaded and uncompressed on first run.
-
-The plot represents the learning curve of the classifier: the evolution
-of classification accuracy over the course of the mini-batches. Accuracy is
-measured on the first 1000 samples, held out as a validation set.
-
-To limit the memory consumption, we queue examples up to a fixed amount before
-feeding them to the learner.
 """
 
 # Authors: Eustache Diemert <eustache@diemert.fr>
@@ -57,6 +47,9 @@ def _not_in_sphinx():
 # Reuters Dataset related routines
 # --------------------------------
 #
+#The dataset used in this example is Reuters-21578 as provided by the UCI ML
+#repository. It will be automatically downloaded and uncompressed on first run.
+
 
 
 class ReutersParser(HTMLParser):
@@ -320,6 +313,13 @@ for i, (X_train_text, y_train) in enumerate(minibatch_iterators):
 ###############################################################################
 # Plot results
 # ------------
+#
+#The plot represents the learning curve of the classifier: the evolution
+#of classification accuracy over the course of the mini-batches. Accuracy is
+#measured on the first 1000 samples, held out as a validation set.
+#
+#To limit the memory consumption, we queue examples up to a fixed amount before
+#feeding them to the learner.
 
 
 def plot_accuracy(x, y, x_legend):

--- a/examples/applications/plot_out_of_core_classification.py
+++ b/examples/applications/plot_out_of_core_classification.py
@@ -48,7 +48,8 @@ def _not_in_sphinx():
 # --------------------------------
 #
 # The dataset used in this example is Reuters-21578 as provided by the UCI ML
-# repository. It will be automatically downloaded and uncompressed on first run.
+# repository. It will be automatically downloaded and uncompressed on first
+# run.
 
 
 
@@ -318,8 +319,8 @@ for i, (X_train_text, y_train) in enumerate(minibatch_iterators):
 # of classification accuracy over the course of the mini-batches. Accuracy is
 # measured on the first 1000 samples, held out as a validation set.
 #
-# To limit the memory consumption, we queue examples up to a fixed amount before
-# feeding them to the learner.
+# To limit the memory consumption, we queue examples up to a fixed amount 
+# before feeding them to the learner.
 
 
 def plot_accuracy(x, y, x_legend):

--- a/examples/applications/plot_out_of_core_classification.py
+++ b/examples/applications/plot_out_of_core_classification.py
@@ -319,7 +319,7 @@ for i, (X_train_text, y_train) in enumerate(minibatch_iterators):
 # of classification accuracy over the course of the mini-batches. Accuracy is
 # measured on the first 1000 samples, held out as a validation set.
 #
-# To limit the memory consumption, we queue examples up to a fixed amount 
+# To limit the memory consumption, we queue examples up to a fixed amount
 # before feeding them to the learner.
 
 


### PR DESCRIPTION
[MRG] …Out-of-core classification of text documents"

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--Fixes Reorganize examples into different subsections #14703 "Out-of-core classification of text documents"
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
-Fixes Reorganize examples into different subsections #14703 "Out-of-core classification of text documents"

#### What does this implement/fix? Explain your changes.
Moves some text around from the top to other document subheadings to break up documentation  and make it clearer

#### Any other comments?
Begun as part of NYC WiMLDS sprint


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
