### PR TITLE
Fix buffer dtype mismatch in isotonic regression

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -452,6 +452,14 @@ Changelog
   with a target matrix `Y` in which the first column was constant.
   :issue:`13609` by :user:`Camila Williamson <camilaagw>`.
 
+:mod:`sklearn.isotonic`
+..................................
+
+- |Fix| Fixed a bug where :class:`isotonic.IsotonicRegression.fit` raised error
+  when `X.dtype == 'float32'` and `X.dtype != y.dtype`.
+  :pr:`14902` by :user:`Lucas <lostcoaster>`.
+
+
 Miscellaneous
 .............
 

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -324,10 +324,9 @@ class IsotonicRegression(RegressorMixin, TransformerMixin, BaseEstimator):
         X is stored for future use, as :meth:`transform` needs X to interpolate
         new input data.
         """
-        check_params = dict(accept_sparse=False, ensure_2d=False,
-                            dtype=[np.float64])
-        X = check_array(X, **check_params)
-        y = check_array(y, **check_params)
+        check_params = dict(accept_sparse=False, ensure_2d=False)
+        X = check_array(X, dtype=[np.float64, np.float32], **check_params)
+        y = check_array(y, dtype=X.dtype, **check_params)
         check_consistent_length(X, y, sample_weight)
 
         # Transform y by running the isotonic regression algorithm and

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -325,7 +325,7 @@ class IsotonicRegression(RegressorMixin, TransformerMixin, BaseEstimator):
         new input data.
         """
         check_params = dict(accept_sparse=False, ensure_2d=False,
-                            dtype=[np.float64, np.float32])
+                            dtype=[np.float64])
         X = check_array(X, **check_params)
         y = check_array(y, **check_params)
         check_consistent_length(X, y, sample_weight)

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -3,6 +3,8 @@ import numpy as np
 import pickle
 import copy
 
+import pytest
+
 from sklearn.isotonic import (check_increasing, isotonic_regression,
                               IsotonicRegression, _make_unique)
 
@@ -485,14 +487,17 @@ def test_isotonic_dtype():
             assert res.dtype == expected_dtype
 
 
-def test_isotonic_mismatched_dtype():
+@pytest.mark.parametrize(
+    "y_dtype", [np.int32, np.int64, np.float32, np.float64]
+)
+def test_isotonic_mismatched_dtype(y_dtype):
+    # regression test for #15004
+    # check that data are converted when X and y dtype differ
     reg = IsotonicRegression()
-    y = [2, 1, 4, 3, 5]
-    for dtype in (np.int32, np.int64, np.float64):
-        y_np = np.array(y, dtype=dtype)
-        X = np.arange(len(y), dtype=np.float32)
-        reg.fit(X, y_np)
-        assert reg.predict(X).dtype == X.dtype
+    y = np.array([2, 1, 4, 3, 5], dtype=y_dtype)
+    X = np.arange(len(y), dtype=np.float32)
+    reg.fit(X, y)
+    assert reg.predict(X).dtype == X.dtype
 
 
 def test_make_unique_dtype():

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -385,19 +385,19 @@ def test_isotonic_ymin_ymax():
                   -0.896, -0.377, -1.327, 0.180])
     y = isotonic_regression(x, y_min=0., y_max=0.1)
 
-    assert (np.all(y >= 0))
-    assert (np.all(y <= 0.1))
+    assert np.all(y >= 0)
+    assert np.all(y <= 0.1)
 
     # Also test decreasing case since the logic there is different
     y = isotonic_regression(x, y_min=0., y_max=0.1, increasing=False)
 
-    assert (np.all(y >= 0))
-    assert (np.all(y <= 0.1))
+    assert np.all(y >= 0)
+    assert np.all(y <= 0.1)
 
     # Finally, test with only one bound
     y = isotonic_regression(x, y_min=0., increasing=False)
 
-    assert (np.all(y >= 0))
+    assert np.all(y >= 0)
 
 
 def test_isotonic_zero_weight_loop():
@@ -490,7 +490,7 @@ def test_isotonic_mismatched_dtype():
     y = [2, 1, 4, 3, 5]
     for dtype in (np.int32, np.int64, np.float64):
         y_np = np.array(y, dtype=dtype)
-        X = np.arange(len(y), dtype=np.float32).reshape((-1, 1))
+        X = np.arange(len(y), dtype=np.float32)
         reg.fit(X, y_np)
         assert reg.predict(X).dtype == X.dtype
 

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -385,19 +385,19 @@ def test_isotonic_ymin_ymax():
                   -0.896, -0.377, -1.327, 0.180])
     y = isotonic_regression(x, y_min=0., y_max=0.1)
 
-    assert(np.all(y >= 0))
-    assert(np.all(y <= 0.1))
+    assert (np.all(y >= 0))
+    assert (np.all(y <= 0.1))
 
     # Also test decreasing case since the logic there is different
     y = isotonic_regression(x, y_min=0., y_max=0.1, increasing=False)
 
-    assert(np.all(y >= 0))
-    assert(np.all(y <= 0.1))
+    assert (np.all(y >= 0))
+    assert (np.all(y <= 0.1))
 
     # Finally, test with only one bound
     y = isotonic_regression(x, y_min=0., increasing=False)
 
-    assert(np.all(y >= 0))
+    assert (np.all(y >= 0))
 
 
 def test_isotonic_zero_weight_loop():
@@ -483,6 +483,16 @@ def test_isotonic_dtype():
             reg.fit(X, y_np, sample_weight=sample_weight)
             res = reg.predict(X)
             assert res.dtype == expected_dtype
+
+
+def test_isotonic_mismatched_dtype():
+    reg = IsotonicRegression()
+    y = [2, 1, 4, 3, 5]
+    for dtype in (np.int32, np.int64, np.float64):
+        y_np = np.array(y, dtype=dtype)
+        X = np.arange(len(y)).astype(np.float32)
+        reg.fit(X, y_np)
+        assert reg.predict(X).dtype == X.dtype
 
 
 def test_make_unique_dtype():

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -490,7 +490,7 @@ def test_isotonic_mismatched_dtype():
     y = [2, 1, 4, 3, 5]
     for dtype in (np.int32, np.int64, np.float64):
         y_np = np.array(y, dtype=dtype)
-        X = np.arange(len(y)).astype(np.float32)
+        X = np.arange(len(y), dtype=np.float32).reshape((-1, 1))
         reg.fit(X, y_np)
         assert reg.predict(X).dtype == X.dtype
 


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/15004

Error replay:
```
from sklearn import isotonic
import numpy as np
m = isotonic.IsotonicRegression()
m.fit(np.zeros((10,),dtype='float32'), np.zeros((10,),dtype='int64'))
```
Gives
```
File "sklearn/_isotonic.pyx", line 66, in sklearn._isotonic._make_unique
ValueError: Buffer dtype mismatch, expected 'float' but got 'double'
```
Tested under : `scikit-learn==0.21.3` `numpy==0.17.0`.

A more realistic scenario is creating an XGBClassifier model (with `xgboost==0.90`), and run `sklearn.calibration.CalibratedClassifierCV` on it. The same error happens.

I am not good at Cython but I think the reason is by using `check_array`, `X` and `y` get converted to different types. Here is a simple fix that make the code work, I think there should be a better way to fix it in Cython code.