### PR TITLE
MNT deprecating presort

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -320,17 +320,6 @@ largest reduction in entropy.  This has a cost of
 total cost over the entire trees (by summing the cost at each node) of
 :math:`O(n_{features}n_{samples}^{2}\log(n_{samples}))`.
 
-Scikit-learn offers a more efficient implementation for the construction of
-decision trees.  A naive implementation (as above) would recompute the class
-label histograms (for classification) or the means (for regression) at for each
-new split point along a given feature. Presorting the feature over all
-relevant samples, and retaining a running label count, will reduce the complexity
-at each node to :math:`O(n_{features}\log(n_{samples}))`, which results in a
-total cost of :math:`O(n_{features}n_{samples}\log(n_{samples}))`. This is an option
-for all tree based algorithms. By default it is turned on for gradient boosting,
-where in general it makes training faster, but turned off for all other algorithms as
-it tends to slow down training when training deep trees.
-
 
 Tips on practical use
 =====================

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -179,6 +179,8 @@ Changelog
 - |API| ``presort`` is now deprecated in
   :class:`ensemble.GradientBoostingClassifier` and
   :class:`ensemble.GradientBoostingRegressor`, and the parameter has no effect.
+  Users are recommended to use :class:`ensemble.HistGradientBoostingClassifier`
+  and :class:`ensemble.HistGradientBoostingRegressor` instead.
   :pr:`14907` by `Adrin Jalali`_.
 
 :mod:`sklearn.feature_extraction`

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -161,6 +161,11 @@ Changelog
   `predict_proba` give consistent results.
   :pr:`14114` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- |API| ``presort`` is now deprecated in
+  :class:`ensemble.GradientBoostingClassifier` and
+  :class:`ensemble.GradientBoostingRegressor`, and the parameter has no effect.
+  :pr:`14907` by `Adrin Jalali`_.
+
 :mod:`sklearn.feature_extraction`
 .................................
 
@@ -358,6 +363,11 @@ Changelog
   :class:`ensemble.GradientBoostingClassifier`, 
   and :class:`ensemble.GradientBoostingRegressor`.
   :pr:`12887` by `Thomas Fan`_.
+
+- |API| ``presort`` is now deprecated in
+  :class:`tree.DecisionTreeClassifier` and
+  :class:`tree.DecisionTreeRegressor`, and the parameter has no effect.
+  :pr:`14907` by `Adrin Jalali`_.
 
 :mod:`sklearn.preprocessing`
 ............................

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1172,7 +1172,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                  max_depth, min_impurity_decrease, min_impurity_split,
                  init, subsample, max_features, ccp_alpha,
                  random_state, alpha=0.9, verbose=0, max_leaf_nodes=None,
-                 warm_start=False, presort='auto',
+                 warm_start=False, presort='deprecated',
                  validation_fraction=0.1, n_iter_no_change=None,
                  tol=1e-4):
 
@@ -1234,7 +1234,6 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                 max_features=self.max_features,
                 max_leaf_nodes=self.max_leaf_nodes,
                 random_state=random_state,
-                presort=self.presort,
                 ccp_alpha=self.ccp_alpha)
 
             if self.subsample < 1.0:
@@ -1334,10 +1333,11 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                              "integer. %r was passed"
                              % self.n_iter_no_change)
 
-        allowed_presort = ('auto', True, False)
-        if self.presort not in allowed_presort:
-            raise ValueError("'presort' should be in {}. Got {!r} instead."
-                             .format(allowed_presort, self.presort))
+        if self.presort != 'deprecated':
+            warnings.warn("The parameter 'presort' is deprecated and has no "
+                          "effect. It will be removed in v0.24. You can "
+                          "suppress this warning by not passing any value "
+                          "to the 'presort' parameter.", UserWarning)
 
     def _init_state(self):
         """Initialize model state and allocate model state data structures. """
@@ -1527,20 +1527,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             raw_predictions = self._raw_predict(X)
             self._resize_state()
 
-        if self.presort is True and issparse(X):
-            raise ValueError(
-                "Presorting is not supported for sparse matrices.")
-
-        presort = self.presort
-        # Allow presort to be 'auto', which means True if the dataset is dense,
-        # otherwise it will be False.
-        if presort == 'auto':
-            presort = not issparse(X)
-
         X_idx_sorted = None
-        if presort:
-            X_idx_sorted = np.asfortranarray(np.argsort(X, axis=0),
-                                             dtype=np.int32)
 
         # fit the boosting stages
         n_stages = self._fit_stages(
@@ -1967,14 +1954,8 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         and add more estimators to the ensemble, otherwise, just erase the
         previous solution. See :term:`the Glossary <warm_start>`.
 
-    presort : bool or 'auto', optional (default='auto')
-        Whether to presort the data to speed up the finding of best splits in
-        fitting. Auto mode by default will use presorting on dense data and
-        default to normal sorting on sparse data. Setting presort to true on
-        sparse data will raise an error.
-
-        .. versionadded:: 0.17
-           *presort* parameter.
+    presort : deprecated, default='deprecated'
+        This parameter is deprecated and will be removed in v0.24.
 
     validation_fraction : float, optional, default 0.1
         The proportion of training data to set aside as validation set for
@@ -2082,7 +2063,7 @@ shape (n_estimators, ``loss_.K``)
                  min_impurity_split=None, init=None,
                  random_state=None, max_features=None, verbose=0,
                  max_leaf_nodes=None, warm_start=False,
-                 presort='auto', validation_fraction=0.1,
+                 presort='deprecated', validation_fraction=0.1,
                  n_iter_no_change=None, tol=1e-4, ccp_alpha=0.0):
 
         super().__init__(
@@ -2447,14 +2428,8 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         and add more estimators to the ensemble, otherwise, just erase the
         previous solution. See :term:`the Glossary <warm_start>`.
 
-    presort : bool or 'auto', optional (default='auto')
-        Whether to presort the data to speed up the finding of best splits in
-        fitting. Auto mode by default will use presorting on dense data and
-        default to normal sorting on sparse data. Setting presort to true on
-        sparse data will raise an error.
-
-        .. versionadded:: 0.17
-           optional parameter *presort*.
+    presort : deprecated, default='deprecated'
+        This parameter is deprecated and will be removed in v0.24.
 
     validation_fraction : float, optional, default 0.1
         The proportion of training data to set aside as validation set for
@@ -2548,7 +2523,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
                  max_depth=3, min_impurity_decrease=0.,
                  min_impurity_split=None, init=None, random_state=None,
                  max_features=None, alpha=0.9, verbose=0, max_leaf_nodes=None,
-                 warm_start=False, presort='auto', validation_fraction=0.1,
+                 warm_start=False, presort='deprecated', validation_fraction=0.1,
                  n_iter_no_change=None, tol=1e-4, ccp_alpha=0.0):
 
         super().__init__(

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1337,7 +1337,9 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             warnings.warn("The parameter 'presort' is deprecated and has no "
                           "effect. It will be removed in v0.24. You can "
                           "suppress this warning by not passing any value "
-                          "to the 'presort' parameter.", DeprecationWarning)
+                          "to the 'presort' parameter. We also recommend "
+                          "using HistGradientBoosting models instead.",
+                          DeprecationWarning)
 
     def _init_state(self):
         """Initialize model state and allocate model state data structures. """

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1337,7 +1337,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             warnings.warn("The parameter 'presort' is deprecated and has no "
                           "effect. It will be removed in v0.24. You can "
                           "suppress this warning by not passing any value "
-                          "to the 'presort' parameter.", UserWarning)
+                          "to the 'presort' parameter.", DeprecationWarning)
 
     def _init_state(self):
         """Initialize model state and allocate model state data structures. """
@@ -1957,6 +1957,8 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
     presort : deprecated, default='deprecated'
         This parameter is deprecated and will be removed in v0.24.
 
+        .. deprecated :: 0.22
+
     validation_fraction : float, optional, default 0.1
         The proportion of training data to set aside as validation set for
         early stopping. Must be between 0 and 1.
@@ -2430,6 +2432,8 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
 
     presort : deprecated, default='deprecated'
         This parameter is deprecated and will be removed in v0.24.
+
+        .. deprecated :: 0.22
 
     validation_fraction : float, optional, default 0.1
         The proportion of training data to set aside as validation set for

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -2523,7 +2523,8 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
                  max_depth=3, min_impurity_decrease=0.,
                  min_impurity_split=None, init=None, random_state=None,
                  max_features=None, alpha=0.9, verbose=0, max_leaf_nodes=None,
-                 warm_start=False, presort='deprecated', validation_fraction=0.1,
+                 warm_start=False, presort='deprecated',
+                 validation_fraction=0.1,
                  n_iter_no_change=None, tol=1e-4, ccp_alpha=0.0):
 
         super().__init__(

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1413,6 +1413,6 @@ def test_presort_deprecated(Cls, presort):
     X = np.zeros((10, 10))
     y = np.r_[[0] * 5, [1] * 5]
     gb = Cls(presort=presort)
-    with pytest.warns(UserWarning,
+    with pytest.warns(DeprecationWarning,
                       match="The parameter 'presort' is deprecated "):
         gb.fit(X, y)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1406,11 +1406,12 @@ def test_gbr_degenerate_feature_importances():
     assert_array_equal(gbr.feature_importances_,
                        np.zeros(10, dtype=np.float64))
 
+
 @pytest.mark.parametrize('Cls', GRADIENT_BOOSTING_ESTIMATORS)
 @pytest.mark.parametrize('presort', ['auto', True, False])
 def test_presort_deprecated(Cls, presort):
     X = np.zeros((10, 10))
-    y = np.r_[[0] * 5, [1] * 5]    
+    y = np.r_[[0] * 5, [1] * 5]
     gb = Cls(presort=presort)
     with pytest.warns(UserWarning,
                       match="The parameter 'presort' is deprecated "):

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -65,10 +65,10 @@ iris.data = iris.data[perm]
 iris.target = iris.target[perm]
 
 
-def check_classification_toy(presort, loss):
+def check_classification_toy(loss):
     # Check classification on a toy dataset.
     clf = GradientBoostingClassifier(loss=loss, n_estimators=10,
-                                     random_state=1, presort=presort)
+                                     random_state=1)
 
     assert_raises(ValueError, clf.predict, T)
 
@@ -83,10 +83,9 @@ def check_classification_toy(presort, loss):
     assert leaves.shape == (6, 10, 1)
 
 
-@pytest.mark.parametrize('presort', ('auto', True, False))
 @pytest.mark.parametrize('loss', ('deviance', 'exponential'))
-def test_classification_toy(presort, loss):
-    check_classification_toy(presort, loss)
+def test_classification_toy(loss):
+    check_classification_toy(loss)
 
 
 def test_classifier_parameter_checks():
@@ -148,13 +147,6 @@ def test_classifier_parameter_checks():
                       loss='deviance').fit(X, y),
                   X, [0, 0, 0, 0])
 
-    allowed_presort = ('auto', True, False)
-    assert_raise_message(ValueError,
-                         "'presort' should be in {}. "
-                         "Got 'invalid' instead.".format(allowed_presort),
-                         GradientBoostingClassifier(presort='invalid')
-                         .fit, X, y)
-
 
 def test_regressor_parameter_checks():
     # Check input parameter validation for GradientBoostingRegressor
@@ -173,12 +165,6 @@ def test_regressor_parameter_checks():
                          " or an integer. 'invalid' was passed",
                          GradientBoostingRegressor(n_iter_no_change='invalid')
                          .fit, X, y)
-    allowed_presort = ('auto', True, False)
-    assert_raise_message(ValueError,
-                         "'presort' should be in {}. "
-                         "Got 'invalid' instead.".format(allowed_presort),
-                         GradientBoostingRegressor(presort='invalid')
-                         .fit, X, y)
 
 
 def test_loss_function():
@@ -196,7 +182,7 @@ def test_loss_function():
                   GradientBoostingRegressor(loss='exponential').fit, X, y)
 
 
-def check_classification_synthetic(presort, loss):
+def check_classification_synthetic(loss):
     # Test GradientBoostingClassifier on synthetic dataset used by
     # Hastie et al. in ESLII Example 12.7.
     X, y = datasets.make_hastie_10_2(n_samples=12000, random_state=1)
@@ -214,20 +200,18 @@ def check_classification_synthetic(presort, loss):
     gbrt = GradientBoostingClassifier(n_estimators=200, min_samples_split=2,
                                       max_depth=1, loss=loss,
                                       learning_rate=1.0, subsample=0.5,
-                                      random_state=0,
-                                      presort=presort)
+                                      random_state=0)
     gbrt.fit(X_train, y_train)
     error_rate = (1.0 - gbrt.score(X_test, y_test))
     assert error_rate < 0.08
 
 
-@pytest.mark.parametrize('presort', ('auto', True, False))
 @pytest.mark.parametrize('loss', ('deviance', 'exponential'))
-def test_classification_synthetic(presort, loss):
-    check_classification_synthetic(presort, loss)
+def test_classification_synthetic(loss):
+    check_classification_synthetic(loss)
 
 
-def check_boston(presort, loss, subsample):
+def check_boston(loss, subsample):
     # Check consistency on dataset boston house prices with least squares
     # and least absolute deviation.
     ones = np.ones(len(boston.target))
@@ -238,8 +222,7 @@ def check_boston(presort, loss, subsample):
                                         max_depth=4,
                                         subsample=subsample,
                                         min_samples_split=2,
-                                        random_state=1,
-                                        presort=presort)
+                                        random_state=1)
 
         assert_raises(ValueError, clf.predict, boston.data)
         clf.fit(boston.data, boston.target,
@@ -257,20 +240,18 @@ def check_boston(presort, loss, subsample):
         last_y_pred = y_pred
 
 
-@pytest.mark.parametrize('presort', ('auto', True, False))
 @pytest.mark.parametrize('loss', ('ls', 'lad', 'huber'))
 @pytest.mark.parametrize('subsample', (1.0, 0.5))
-def test_boston(presort, loss, subsample):
-    check_boston(presort, loss, subsample)
+def test_boston(loss, subsample):
+    check_boston(loss, subsample)
 
 
-def check_iris(presort, subsample, sample_weight):
+def check_iris(subsample, sample_weight):
     # Check consistency on dataset iris.
     clf = GradientBoostingClassifier(n_estimators=100,
                                      loss='deviance',
                                      random_state=1,
-                                     subsample=subsample,
-                                     presort=presort)
+                                     subsample=subsample)
     clf.fit(iris.data, iris.target, sample_weight=sample_weight)
     score = clf.score(iris.data, iris.target)
     assert score > 0.9
@@ -279,13 +260,12 @@ def check_iris(presort, subsample, sample_weight):
     assert leaves.shape == (150, 100, 3)
 
 
-@pytest.mark.parametrize('presort', ('auto', True, False))
 @pytest.mark.parametrize('subsample', (1.0, 0.5))
 @pytest.mark.parametrize('sample_weight', (None, 1))
-def test_iris(presort, subsample, sample_weight):
+def test_iris(subsample, sample_weight):
     if sample_weight == 1:
         sample_weight = np.ones(len(iris.target))
-    check_iris(presort, subsample, sample_weight)
+    check_iris(subsample, sample_weight)
 
 
 def test_regression_synthetic():
@@ -303,47 +283,40 @@ def test_regression_synthetic():
     X_train, y_train = X[:200], y[:200]
     X_test, y_test = X[200:], y[200:]
 
-    for presort in True, False:
-        clf = GradientBoostingRegressor(presort=presort)
-        clf.fit(X_train, y_train)
-        mse = mean_squared_error(y_test, clf.predict(X_test))
-        assert mse < 5.0
+    clf = GradientBoostingRegressor()
+    clf.fit(X_train, y_train)
+    mse = mean_squared_error(y_test, clf.predict(X_test))
+    assert mse < 5.0
 
     # Friedman2
     X, y = datasets.make_friedman2(n_samples=1200, random_state=random_state)
     X_train, y_train = X[:200], y[:200]
     X_test, y_test = X[200:], y[200:]
 
-    for presort in True, False:
-        regression_params['presort'] = presort
-        clf = GradientBoostingRegressor(**regression_params)
-        clf.fit(X_train, y_train)
-        mse = mean_squared_error(y_test, clf.predict(X_test))
-        assert mse < 1700.0
+    clf = GradientBoostingRegressor(**regression_params)
+    clf.fit(X_train, y_train)
+    mse = mean_squared_error(y_test, clf.predict(X_test))
+    assert mse < 1700.0
 
     # Friedman3
     X, y = datasets.make_friedman3(n_samples=1200, random_state=random_state)
     X_train, y_train = X[:200], y[:200]
     X_test, y_test = X[200:], y[200:]
 
-    for presort in True, False:
-        regression_params['presort'] = presort
-        clf = GradientBoostingRegressor(**regression_params)
-        clf.fit(X_train, y_train)
-        mse = mean_squared_error(y_test, clf.predict(X_test))
-        assert mse < 0.015
+    clf = GradientBoostingRegressor(**regression_params)
+    clf.fit(X_train, y_train)
+    mse = mean_squared_error(y_test, clf.predict(X_test))
+    assert mse < 0.015
 
 
 def test_feature_importances():
     X = np.array(boston.data, dtype=np.float32)
     y = np.array(boston.target, dtype=np.float32)
 
-    for presort in True, False:
-        clf = GradientBoostingRegressor(n_estimators=100, max_depth=5,
-                                        min_samples_split=2, random_state=1,
-                                        presort=presort)
-        clf.fit(X, y)
-        assert hasattr(clf, 'feature_importances_')
+    clf = GradientBoostingRegressor(n_estimators=100, max_depth=5,
+                                    min_samples_split=2, random_state=1)
+    clf.fit(X, y)
+    assert hasattr(clf, 'feature_importances_')
 
 
 def test_probability_log():
@@ -1195,20 +1168,13 @@ def test_non_uniform_weights_toy_edge_case_clf():
 def check_sparse_input(EstimatorClass, X, X_sparse, y):
     dense = EstimatorClass(n_estimators=10, random_state=0,
                            max_depth=2).fit(X, y)
-    sparse = EstimatorClass(n_estimators=10, random_state=0, max_depth=2,
-                            presort=False).fit(X_sparse, y)
-    auto = EstimatorClass(n_estimators=10, random_state=0, max_depth=2,
-                          presort='auto').fit(X_sparse, y)
+    sparse = EstimatorClass(n_estimators=10, random_state=0,
+                            max_depth=2).fit(X_sparse, y)
 
     assert_array_almost_equal(sparse.apply(X), dense.apply(X))
     assert_array_almost_equal(sparse.predict(X), dense.predict(X))
     assert_array_almost_equal(sparse.feature_importances_,
                               dense.feature_importances_)
-
-    assert_array_almost_equal(sparse.apply(X), auto.apply(X))
-    assert_array_almost_equal(sparse.predict(X), auto.predict(X))
-    assert_array_almost_equal(sparse.feature_importances_,
-                              auto.feature_importances_)
 
     assert_array_almost_equal(sparse.predict(X_sparse), dense.predict(X))
     assert_array_almost_equal(dense.predict(X_sparse), sparse.predict(X))
@@ -1218,11 +1184,6 @@ def check_sparse_input(EstimatorClass, X, X_sparse, y):
                                   dense.predict_proba(X))
         assert_array_almost_equal(sparse.predict_log_proba(X),
                                   dense.predict_log_proba(X))
-
-        assert_array_almost_equal(sparse.predict_proba(X),
-                                  auto.predict_proba(X))
-        assert_array_almost_equal(sparse.predict_log_proba(X),
-                                  auto.predict_log_proba(X))
 
         assert_array_almost_equal(sparse.decision_function(X_sparse),
                                   sparse.decision_function(X))
@@ -1444,3 +1405,13 @@ def test_gbr_degenerate_feature_importances():
     gbr = GradientBoostingRegressor().fit(X, y)
     assert_array_equal(gbr.feature_importances_,
                        np.zeros(10, dtype=np.float64))
+
+@pytest.mark.parametrize('Cls', GRADIENT_BOOSTING_ESTIMATORS)
+@pytest.mark.parametrize('presort', ['auto', True, False])
+def test_presort_deprecated(Cls, presort):
+    X = np.zeros((10, 10))
+    y = np.r_[[0] * 5, [1] * 5]    
+    gb = Cls(presort=presort)
+    with pytest.warns(UserWarning,
+                      match="The parameter 'presort' is deprecated "):
+        gb.fit(X, y)

--- a/sklearn/tree/_splitter.pxd
+++ b/sklearn/tree/_splitter.pxd
@@ -57,9 +57,6 @@ cdef class Splitter:
     cdef SIZE_t start                    # Start position for the current node
     cdef SIZE_t end                      # End position for the current node
 
-    cdef bint presort                    # Whether to use presorting, only
-                                         # allowed on dense data
-
     cdef const DOUBLE_t[:, ::1] y
     cdef DOUBLE_t* sample_weight
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1619,6 +1619,7 @@ def test_public_apply_sparse_trees(name):
                          (DecisionTreeRegressor, DecisionTreeClassifier))
 @pytest.mark.parametrize('presort', ['auto', True, False])
 def test_presort_deprecated(Cls, presort):
+    # TODO: remove in v0.24
     X = np.zeros((10, 10))
     y = np.r_[[0] * 5, [1] * 5]
     tree = Cls(presort=presort)

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -49,15 +49,11 @@ REG_CRITERIONS = ("mse", "mae", "friedman_mse")
 
 CLF_TREES = {
     "DecisionTreeClassifier": DecisionTreeClassifier,
-    "Presort-DecisionTreeClassifier": partial(DecisionTreeClassifier,
-                                              presort=True),
     "ExtraTreeClassifier": ExtraTreeClassifier,
 }
 
 REG_TREES = {
     "DecisionTreeRegressor": DecisionTreeRegressor,
-    "Presort-DecisionTreeRegressor": partial(DecisionTreeRegressor,
-                                             presort=True),
     "ExtraTreeRegressor": ExtraTreeRegressor,
 }
 
@@ -1045,16 +1041,15 @@ def test_memory_layout():
         y = iris.target
         assert_array_equal(est.fit(X, y).predict(X), y)
 
-        if not est.presort:
-            # csr matrix
-            X = csr_matrix(iris.data, dtype=dtype)
-            y = iris.target
-            assert_array_equal(est.fit(X, y).predict(X), y)
+        # csr matrix
+        X = csr_matrix(iris.data, dtype=dtype)
+        y = iris.target
+        assert_array_equal(est.fit(X, y).predict(X), y)
 
-            # csc_matrix
-            X = csc_matrix(iris.data, dtype=dtype)
-            y = iris.target
-            assert_array_equal(est.fit(X, y).predict(X), y)
+        # csc_matrix
+        X = csc_matrix(iris.data, dtype=dtype)
+        y = iris.target
+        assert_array_equal(est.fit(X, y).predict(X), y)
 
         # Strided
         X = np.asarray(iris.data[::3], dtype=dtype)
@@ -1583,9 +1578,8 @@ def check_min_weight_leaf_split_level(name):
     sample_weight = [0.2, 0.2, 0.2, 0.2, 0.2]
     _check_min_weight_leaf_split_level(TreeEstimator, X, y, sample_weight)
 
-    if not TreeEstimator().presort:
-        _check_min_weight_leaf_split_level(TreeEstimator, csc_matrix(X), y,
-                                           sample_weight)
+    _check_min_weight_leaf_split_level(TreeEstimator, csc_matrix(X), y,
+                                       sample_weight)
 
 
 @pytest.mark.parametrize("name", ALL_TREES)
@@ -1621,37 +1615,16 @@ def test_public_apply_sparse_trees(name):
     check_public_apply_sparse(name)
 
 
-def check_presort_sparse(est, X, y):
-    with pytest.raises(ValueError):
-        est.fit(X, y)
-
-
-def test_presort_sparse():
-    ests = (DecisionTreeClassifier(presort=True),
-            DecisionTreeRegressor(presort=True))
-    sparse_matrices = (csr_matrix, csc_matrix, coo_matrix)
-
-    y, X = datasets.make_multilabel_classification(random_state=0,
-                                                   n_samples=50,
-                                                   n_features=1,
-                                                   n_classes=20)
-    y = y[:, 0]
-
-    for est, sparse_matrix in product(ests, sparse_matrices):
-        check_presort_sparse(est, sparse_matrix(X), y)
-
-
-@pytest.mark.parametrize('cls',
+@pytest.mark.parametrize('Cls',
                          (DecisionTreeRegressor, DecisionTreeClassifier))
-def test_invalid_presort(cls):
-    allowed_presort = ('auto', True, False)
-    invalid_presort = 'invalid'
-    msg = ("'presort' should be in {}. "
-           "Got {!r} instead.".format(allowed_presort, invalid_presort))
-    est = cls(presort=invalid_presort)
-    with pytest.raises(ValueError,
-                       match=msg.replace('(', r'\(').replace(')', r'\)')):
-        est.fit(X, y)
+@pytest.mark.parametrize('presort', ['auto', True, False])
+def test_presort_deprecated(Cls, presort):
+    X = np.zeros((10, 10))
+    y = np.r_[[0] * 5, [1] * 5]    
+    tree = Cls(presort=presort)
+    with pytest.warns(UserWarning,
+                      match="The parameter 'presort' is deprecated "):
+        tree.fit(X, y)
 
 
 def test_decision_path_hardcoded():

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1622,7 +1622,7 @@ def test_presort_deprecated(Cls, presort):
     X = np.zeros((10, 10))
     y = np.r_[[0] * 5, [1] * 5]
     tree = Cls(presort=presort)
-    with pytest.warns(UserWarning,
+    with pytest.warns(DeprecationWarning,
                       match="The parameter 'presort' is deprecated "):
         tree.fit(X, y)
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1620,7 +1620,7 @@ def test_public_apply_sparse_trees(name):
 @pytest.mark.parametrize('presort', ['auto', True, False])
 def test_presort_deprecated(Cls, presort):
     X = np.zeros((10, 10))
-    y = np.r_[[0] * 5, [1] * 5]    
+    y = np.r_[[0] * 5, [1] * 5]
     tree = Cls(presort=presort)
     with pytest.warns(UserWarning,
                       match="The parameter 'presort' is deprecated "):

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -94,7 +94,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
                  min_impurity_decrease,
                  min_impurity_split,
                  class_weight=None,
-                 presort=False,
+                 presort='deprecated',
                  ccp_alpha=0.0):
         self.criterion = criterion
         self.splitter = splitter
@@ -315,35 +315,11 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             raise ValueError("min_impurity_decrease must be greater than "
                              "or equal to 0")
 
-        allowed_presort = ('auto', True, False)
-        if self.presort not in allowed_presort:
-            raise ValueError("'presort' should be in {}. Got {!r} instead."
-                             .format(allowed_presort, self.presort))
-
-        if self.presort is True and issparse(X):
-            raise ValueError("Presorting is not supported for sparse "
-                             "matrices.")
-
-        presort = self.presort
-        # Allow presort to be 'auto', which means True if the dataset is dense,
-        # otherwise it will be False.
-        if self.presort == 'auto':
-            presort = not issparse(X)
-
-        # If multiple trees are built on the same dataset, we only want to
-        # presort once. Splitters now can accept presorted indices if desired,
-        # but do not handle any presorting themselves. Ensemble algorithms
-        # which desire presorting must do presorting themselves and pass that
-        # matrix into each tree.
-        if X_idx_sorted is None and presort:
-            X_idx_sorted = np.asfortranarray(np.argsort(X, axis=0),
-                                             dtype=np.int32)
-
-        if presort and X_idx_sorted.shape != X.shape:
-            raise ValueError("The shape of X (X.shape = {}) doesn't match "
-                             "the shape of X_idx_sorted (X_idx_sorted"
-                             ".shape = {})".format(X.shape,
-                                                   X_idx_sorted.shape))
+        if self.presort != 'deprecated':
+            warnings.warn("The parameter 'presort' is deprecated and has no "
+                          "effect. It will be removed in v0.24. You can "
+                          "suppress this warning by not passing any value "
+                          "to the 'presort' parameter.", UserWarning)
 
         # Build tree
         criterion = self.criterion
@@ -363,8 +339,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
                                                 self.max_features_,
                                                 min_samples_leaf,
                                                 min_weight_leaf,
-                                                random_state,
-                                                self.presort)
+                                                random_state)
 
         self.tree_ = Tree(self.n_features_, self.n_classes_, self.n_outputs_)
 
@@ -725,12 +700,8 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
         Note that these weights will be multiplied with sample_weight (passed
         through the fit method) if sample_weight is specified.
 
-    presort : bool, optional (default=False)
-        Whether to presort the data to speed up the finding of best splits in
-        fitting. For the default settings of a decision tree on large
-        datasets, setting this to true may slow down the training process.
-        When using either a smaller dataset or a restricted depth, this may
-        speed up the training.
+    presort : deprecated, default='deprecated'
+        This parameter is deprecated and will be removed in v0.24.
 
     ccp_alpha : non-negative float, optional (default=0.0)
         Complexity parameter used for Minimal Cost-Complexity Pruning. The
@@ -831,7 +802,7 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
                  min_impurity_decrease=0.,
                  min_impurity_split=None,
                  class_weight=None,
-                 presort=False,
+                 presort='deprecated',
                  ccp_alpha=0.0):
         super().__init__(
             criterion=criterion,
@@ -1087,12 +1058,8 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
            ``min_impurity_split`` will change from 1e-7 to 0 in 0.23 and it
            will be removed in 0.25. Use ``min_impurity_decrease`` instead.
 
-    presort : bool, optional (default=False)
-        Whether to presort the data to speed up the finding of best splits in
-        fitting. For the default settings of a decision tree on large
-        datasets, setting this to true may slow down the training process.
-        When using either a smaller dataset or a restricted depth, this may
-        speed up the training.
+    presort : deprecated, default='deprecated'
+        This parameter is deprecated and will be removed in v0.24.
 
     ccp_alpha : non-negative float, optional (default=0.0)
         Complexity parameter used for Minimal Cost-Complexity Pruning. The
@@ -1184,7 +1151,7 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
                  max_leaf_nodes=None,
                  min_impurity_decrease=0.,
                  min_impurity_split=None,
-                 presort=False,
+                 presort='deprecated',
                  ccp_alpha=0.0):
         super().__init__(
             criterion=criterion,

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -319,7 +319,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             warnings.warn("The parameter 'presort' is deprecated and has no "
                           "effect. It will be removed in v0.24. You can "
                           "suppress this warning by not passing any value "
-                          "to the 'presort' parameter.", UserWarning)
+                          "to the 'presort' parameter.", DeprecationWarning)
 
         # Build tree
         criterion = self.criterion
@@ -703,6 +703,8 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
     presort : deprecated, default='deprecated'
         This parameter is deprecated and will be removed in v0.24.
 
+        .. deprecated :: 0.22
+
     ccp_alpha : non-negative float, optional (default=0.0)
         Complexity parameter used for Minimal Cost-Complexity Pruning. The
         subtree with the largest cost complexity that is smaller than
@@ -1060,6 +1062,8 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
 
     presort : deprecated, default='deprecated'
         This parameter is deprecated and will be removed in v0.24.
+
+        .. deprecated :: 0.22
 
     ccp_alpha : non-negative float, optional (default=0.0)
         Complexity parameter used for Minimal Cost-Complexity Pruning. The


### PR DESCRIPTION
Related to #14711. 

This PR removes `presort` from the tree codebase and deprecates wherever public facing.

It is a first step towards simplifying the tree codebase, and we can do it since presort is only used in the `GradientBoosting*` classes, which are superseded by `HistGradientBoost*`.

@glemaitre is working on benchmarks.

Also ping @ogrisel , @NicolasHug 