### PR TITLE
TST Improve error message in DummyClassifier

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -115,7 +115,7 @@ Changelog
 :mod:`sklearn.dummy`
 ............................
 
-- |Fix| :class:`dummy.DummyClassifiers()` now handles checking the existence
+- |Fix| :class:`dummy.DummyClassifier` now handles checking the existence
   of the provided constant in multiouput cases.
   :pr:`14908` by :user:`Martina G. Vilas <martinagvilas>`.
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -116,7 +116,7 @@ Changelog
 ............................
 
 - |Fix| :class:`dummy.DummyClassifiers()` now handles checking the existence
-  of the provided constant in multiouput cases
+  of the provided constant in multiouput cases.
   :pr:`14908` by `Martina G. Vilas`_.
 
 :mod:`sklearn.ensemble`
@@ -204,8 +204,8 @@ Changelog
 :mod:`sklearn.impute`
 .....................
 
-- |MajorFeature| Added :class:`impute.KNNImputer`, to impute missing values using
-  k-Nearest Neighbors. :issue:`12852` by :user:`Ashim Bhattarai <ashimb9>` and
+- |MajorFeature| Added :class:`impute.KNNImputer`, to impute missing values using 
+  k-Nearest Neighbors. :issue:`12852` by :user:`Ashim Bhattarai <ashimb9>` and 
   `Thomas Fan`_.
 
 :mod:`sklearn.inspection`
@@ -226,7 +226,7 @@ Changelog
 
 -|FIX| Fixed a bug where :class:`kernel_approximation.Nystroem` raised a
  `KeyError` when using `kernel="precomputed"`.
- :pr:`14706` by :user:`Venkatachalam N <venkyyuvy>`.
+ :pr:`14706` by :user:`Venkatachalam N <venkyyuvy>`. 
 
 :mod:`sklearn.linear_model`
 ...........................
@@ -271,7 +271,7 @@ Changelog
 
 - |Feature| Added the :func:`metrics.nan_euclidean_distances` metric, which
   calculates euclidean distances in the presence of missing values.
-  :issue:`12852` by :user:`Ashim Bhattarai <ashimb9>` and
+  :issue:`12852` by :user:`Ashim Bhattarai <ashimb9>` and 
   `Thomas Fan`_.
 
 - |Feature| New ranking metrics :func:`metrics.ndcg_score` and
@@ -350,19 +350,19 @@ Changelog
 - |Enhancement| SVM now throws more specific error when fit on non-square data
   and kernel = precomputed.  :class:`svm.BaseLibSVM`
   :pr:`14336` by :user:`Gregory Dexter <gdex1>`.
-
+  
 :mod:`sklearn.tree`
 ...................
 
 - |Feature| Adds minimal cost complexity pruning, controlled by ``ccp_alpha``,
   to :class:`tree.DecisionTreeClassifier`, :class:`tree.DecisionTreeRegressor`,
   :class:`tree.ExtraTreeClassifier`, :class:`tree.ExtraTreeRegressor`,
-  :class:`ensemble.RandomForestClassifier`,
+  :class:`ensemble.RandomForestClassifier`, 
   :class:`ensemble.RandomForestRegressor`,
-  :class:`ensemble.ExtraTreesClassifier`,
+  :class:`ensemble.ExtraTreesClassifier`, 
   :class:`ensemble.ExtraTreesRegressor`,
-  :class:`ensemble.RandomTreesEmbedding`,
-  :class:`ensemble.GradientBoostingClassifier`,
+  :class:`ensemble.RandomTreesEmbedding`, 
+  :class:`ensemble.GradientBoostingClassifier`, 
   and :class:`ensemble.GradientBoostingRegressor`.
   :pr:`12887` by `Thomas Fan`_.
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -117,7 +117,7 @@ Changelog
 
 - |Fix| :class:`dummy.DummyClassifiers()` now handles checking the existence
   of the provided constant in multiouput cases.
-  :pr:`14908` by `Martina G. Vilas`_.
+  :pr:`14908` by :user:`Martina G. Vilas <martinagvilas>`.
 
 :mod:`sklearn.ensemble`
 .......................

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -112,6 +112,13 @@ Changelog
   need to store the entire dense matrix at once.
   :pr:`13960` by :user:`Scott Gigante <scottgigante>`.
 
+:mod:`sklearn.dummy`
+............................
+
+- |Fix| :class:`dummy.DummyClassifiers()` now handles checking the existence
+  of the provided constant in multiouput cases
+  :pr:`14908` by `Martina G. Vilas`_.
+
 :mod:`sklearn.ensemble`
 .......................
 
@@ -197,8 +204,8 @@ Changelog
 :mod:`sklearn.impute`
 .....................
 
-- |MajorFeature| Added :class:`impute.KNNImputer`, to impute missing values using 
-  k-Nearest Neighbors. :issue:`12852` by :user:`Ashim Bhattarai <ashimb9>` and 
+- |MajorFeature| Added :class:`impute.KNNImputer`, to impute missing values using
+  k-Nearest Neighbors. :issue:`12852` by :user:`Ashim Bhattarai <ashimb9>` and
   `Thomas Fan`_.
 
 :mod:`sklearn.inspection`
@@ -219,7 +226,7 @@ Changelog
 
 -|FIX| Fixed a bug where :class:`kernel_approximation.Nystroem` raised a
  `KeyError` when using `kernel="precomputed"`.
- :pr:`14706` by :user:`Venkatachalam N <venkyyuvy>`. 
+ :pr:`14706` by :user:`Venkatachalam N <venkyyuvy>`.
 
 :mod:`sklearn.linear_model`
 ...........................
@@ -264,7 +271,7 @@ Changelog
 
 - |Feature| Added the :func:`metrics.nan_euclidean_distances` metric, which
   calculates euclidean distances in the presence of missing values.
-  :issue:`12852` by :user:`Ashim Bhattarai <ashimb9>` and 
+  :issue:`12852` by :user:`Ashim Bhattarai <ashimb9>` and
   `Thomas Fan`_.
 
 - |Feature| New ranking metrics :func:`metrics.ndcg_score` and
@@ -343,19 +350,19 @@ Changelog
 - |Enhancement| SVM now throws more specific error when fit on non-square data
   and kernel = precomputed.  :class:`svm.BaseLibSVM`
   :pr:`14336` by :user:`Gregory Dexter <gdex1>`.
-  
+
 :mod:`sklearn.tree`
 ...................
 
 - |Feature| Adds minimal cost complexity pruning, controlled by ``ccp_alpha``,
   to :class:`tree.DecisionTreeClassifier`, :class:`tree.DecisionTreeRegressor`,
   :class:`tree.ExtraTreeClassifier`, :class:`tree.ExtraTreeRegressor`,
-  :class:`ensemble.RandomForestClassifier`, 
+  :class:`ensemble.RandomForestClassifier`,
   :class:`ensemble.RandomForestRegressor`,
-  :class:`ensemble.ExtraTreesClassifier`, 
+  :class:`ensemble.ExtraTreesClassifier`,
   :class:`ensemble.ExtraTreesRegressor`,
-  :class:`ensemble.RandomTreesEmbedding`, 
-  :class:`ensemble.GradientBoostingClassifier`, 
+  :class:`ensemble.RandomTreesEmbedding`,
+  :class:`ensemble.GradientBoostingClassifier`,
   and :class:`ensemble.GradientBoostingRegressor`.
   :pr:`12887` by `Thomas Fan`_.
 

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -143,13 +143,17 @@ class DummyClassifier(MultiOutputMixin, ClassifierMixin, BaseEstimator):
          self.n_classes_,
          self.class_prior_) = class_distribution(y, sample_weight)
 
-        if (self.strategy == "constant" and
-                any(constant[k] not in self.classes_[k]
-                    for k in range(self.n_outputs_))):
-            # Checking in case of constant strategy if the constant
-            # provided by the user is in y.
-            raise ValueError("The constant target value must be "
-                             "present in training data")
+        if self.strategy == "constant":
+            for k in range(self.n_outputs_):
+                if constant[k] not in self.classes_[k]:
+                    # Checking in case of constant strategy if the constant
+                    # provided by the user is in y.
+                    raise ValueError(
+                        "The constant target value must be present "
+                        "in the training data. "
+                        "You provided constant=%r. "
+                        "Possible values are: %r." % (self.constant,
+                                                      list(self.classes_[k])))
 
         if self.n_outputs_ == 1 and not self.output_2d_:
             self.n_classes_ = self.n_classes_[0]

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -151,7 +151,7 @@ class DummyClassifier(MultiOutputMixin, ClassifierMixin, BaseEstimator):
                     err_msg = ("The constant target value must be present in "
                                "the training data. You provided constant={}. "
                                "Possible values are: {}."
-                               .format(self.constant,list(self.classes_[k])))
+                               .format(self.constant, list(self.classes_[k])))
                     raise ValueError(err_msg)
 
         if self.n_outputs_ == 1 and not self.output_2d_:

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -145,15 +145,14 @@ class DummyClassifier(MultiOutputMixin, ClassifierMixin, BaseEstimator):
 
         if self.strategy == "constant":
             for k in range(self.n_outputs_):
-                if constant[k] not in self.classes_[k]:
+                if not any(constant[k][0] == c for c in self.classes_[k]):
                     # Checking in case of constant strategy if the constant
                     # provided by the user is in y.
-                    raise ValueError(
-                        "The constant target value must be present "
-                        "in the training data. "
-                        "You provided constant=%r. "
-                        "Possible values are: %r." % (self.constant,
-                                                      list(self.classes_[k])))
+                    err_msg = ("The constant target value must be present in "
+                               "the training data. You provided constant={}. "
+                               "Possible values are: {}."
+                               .format(self.constant,list(self.classes_[k])))
+                    raise ValueError(err_msg)
 
         if self.n_outputs_ == 1 and not self.output_2d_:
             self.n_classes_ = self.n_classes_[0]

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -546,9 +546,15 @@ def test_constant_strategy_multioutput():
      "Constant.*should have shape"),
     ([2, 1, 2, 2],
      {'constant': 'my-constant'},
-     "constant=my-constant.*Possible values.*[2, 1, 2, 2]")])
+     "constant=my-constant.*Possible values.*\\[1, 2]"),
+    (np.transpose([[2, 1, 2, 2], [2, 1, 2, 2]]),
+     {'constant': [2, 'unknown']},
+     "constant=\\[2, 'unknown'].*Possible values.*\\[1, 2]")],
+    ids=["no-constant", "too-many-constant", "not-enough-output",
+         "single-output", "multi-output"]
+)
 def test_constant_strategy_exceptions(y, params, err_msg):
-    X = [[0], [0], [0], [0]]  # ignored
+    X = [[0], [0], [0], [0]]
 
     clf = DummyClassifier(strategy="constant", **params)
 

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -534,20 +534,27 @@ def test_constant_strategy_multioutput():
     _check_predict_proba(clf, X, y)
 
 
-def test_constant_strategy_exceptions():
+@pytest.mark.parametrize('y, params, err_msg', [
+    ([2, 1, 2, 2],
+     {'random_state': 0},
+     "Constant.*has to be specified"),
+    ([2, 1, 2, 2],
+     {'constant': [2, 0]},
+     "Constant.*should have shape"),
+    (np.transpose([[2, 1, 2, 2], [2, 1, 2, 2]]),
+     {'constant': 2},
+     "Constant.*should have shape"),
+    ([2, 1, 2, 2],
+     {'constant': 'my-constant'},
+     "constant=my-constant.*Possible values.*[2, 1, 2, 2]")])
+def test_constant_strategy_exceptions(y, params, err_msg):
     X = [[0], [0], [0], [0]]  # ignored
-    y = [2, 1, 2, 2]
-    clf = DummyClassifier(strategy="constant", random_state=0)
-    assert_raises(ValueError, clf.fit, X, y)
-    clf = DummyClassifier(strategy="constant", random_state=0,
-                          constant=[2, 0])
-    assert_raises(ValueError, clf.fit, X, y)
 
-    clf = DummyClassifier(strategy='constant', constant='not-in-dataset')
-    with pytest.raises(ValueError,
-                       match="constant='not-in-dataset'.+"
-                       "Possible values.+['class1', 'class2']"):
-        clf.fit([[1., 2.], [2., 3.]], ['class1', 'class2'])
+    clf = DummyClassifier(strategy="constant", **params)
+
+    with pytest.raises(ValueError, match=err_msg):
+        clf.fit(X, y)
+
 
 def test_classification_sample_weight():
     X = [[0], [0], [1]]

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -543,6 +543,11 @@ def test_constant_strategy_exceptions():
                           constant=[2, 0])
     assert_raises(ValueError, clf.fit, X, y)
 
+    clf = DummyClassifier(strategy='constant', constant='not-in-dataset')
+    with pytest.raises(ValueError,
+        match="constant='not-in-dataset'.+"
+              "Possible values.+['class1', 'class2']"):
+        clf.fit([[1., 2.], [2., 3.]], ['class1', 'class2'])
 
 def test_classification_sample_weight():
     X = [[0], [0], [1]]

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -545,8 +545,8 @@ def test_constant_strategy_exceptions():
 
     clf = DummyClassifier(strategy='constant', constant='not-in-dataset')
     with pytest.raises(ValueError,
-        match="constant='not-in-dataset'.+"
-              "Possible values.+['class1', 'class2']"):
+                       match="constant='not-in-dataset'.+"
+                       "Possible values.+['class1', 'class2']"):
         clf.fit([[1., 2.], [2., 3.]], ['class1', 'class2'])
 
 def test_classification_sample_weight():


### PR DESCRIPTION
Fix #14903 

Add to the error message the constant value passed and the real possible values in the data when the constant value is not in the training data.
