### PR TITLE
DOC Improved the docstring of TransformedTargetRegressor

### DIFF
--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -17,10 +17,10 @@ __all__ = ['TransformedTargetRegressor']
 class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
     """Meta-estimator to regress on a transformed target.
 
-    Useful for applying a non-linear transformation to the target ``y`` in regression
-    problems. This transformation can be given as a Transformer such as the
-    QuantileTransformer or as a function and its inverse such as ``log`` and
-    ``exp``.
+    Useful for applying a non-linear transformation to the target ``y`` in
+    regression problems. This transformation can be given as a Transformer
+    such as the QuantileTransformer or as a function and its inverse such as
+    ``log`` and ``exp``.
 
     The computation during ``fit`` is::
 
@@ -38,7 +38,7 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
 
         transformer.inverse_transform(regressor.predict(X))
 
-    Read more in the :ref:`User Guide <preprocessing_targets>`.
+    Read more in the :ref:`User Guide <transformed_target_regressor>`.
 
     Parameters
     ----------
@@ -101,9 +101,7 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
     output will be reshaped to a have the same number of dimensions as ``y``.
 
     See :ref:`examples/compose/plot_transformed_target.py
-    <sphx_glr_auto_examples_compose_plot_transformed_target.py>` and
-    `Transforming target in regression
-    <https://scikit-learn.org/stable/modules/compose.html#transformed-target-regressor>`_.
+    <sphx_glr_auto_examples_compose_plot_transformed_target.py>`.
 
     """
     def __init__(self, regressor=None, transformer=None,

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -17,7 +17,7 @@ __all__ = ['TransformedTargetRegressor']
 class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
     """Meta-estimator to regress on a transformed target.
 
-    Useful for applying a non-linear transformation in regression
+    Useful for applying a non-linear transformation to the target ``y`` in regression
     problems. This transformation can be given as a Transformer such as the
     QuantileTransformer or as a function and its inverse such as ``log`` and
     ``exp``.
@@ -101,7 +101,9 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
     output will be reshaped to a have the same number of dimensions as ``y``.
 
     See :ref:`examples/compose/plot_transformed_target.py
-    <sphx_glr_auto_examples_compose_plot_transformed_target.py>`.
+    <sphx_glr_auto_examples_compose_plot_transformed_target.py>` and
+    `Transforming target in regression
+    <https://scikit-learn.org/stable/modules/compose.html#transformed-target-regressor>`_.
 
     """
     def __init__(self, regressor=None, transformer=None,


### PR DESCRIPTION
Added link to section on "Transforming target in regression" in user guide and added to the docstring explanation a little bit.