### PR TITLE
[MRG] Changed Cross Validate Return Section Doc

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -149,13 +149,13 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv=None,
 
             ``test_score``
                 The score array for test scores on each cv split.
-                Suffix ``_score`` in ``test_score`` changes to a specific metric 
-                like ``test_r2`` or ``test_auc`` if there are
+                Suffix ``_score`` in ``test_score`` changes to a specific
+                metric like ``test_r2`` or ``test_auc`` if there are
                 multiple scoring metrics in the scoring parameter.
             ``train_score``
                 The score array for train scores on each cv split.
-                Suffix ``_score`` in ``train_score`` changes to a specific metric 
-                like ``train_r2`` or ``train_auc`` if there are
+                Suffix ``_score`` in ``train_score`` changes to a specific
+                metric like ``train_r2`` or ``train_auc`` if there are
                 multiple scoring metrics in the scoring parameter.
                 This is available only if ``return_train_score`` parameter
                 is ``True``.

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -149,8 +149,14 @@ def cross_validate(estimator, X, y=None, groups=None, scoring=None, cv=None,
 
             ``test_score``
                 The score array for test scores on each cv split.
+                Suffix ``_score`` in ``test_score`` changes to a specific metric 
+                like ``test_r2`` or ``test_auc`` if there are
+                multiple scoring metrics in the scoring parameter.
             ``train_score``
                 The score array for train scores on each cv split.
+                Suffix ``_score`` in ``train_score`` changes to a specific metric 
+                like ``train_r2`` or ``train_auc`` if there are
+                multiple scoring metrics in the scoring parameter.
                 This is available only if ``return_train_score`` parameter
                 is ``True``.
             ``fit_time``


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #14831 
<!--
Example: Fixes #14831 . See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
In the Returns section of sklearn.model_selection.cross_validate (https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_validate.html) , the names test_score, and train_score for keys in return dict, changes to test_r2, train_r2 or test_auc , train_auc, if there are multiple scoring metrics in the scoring parameter for the cross_validate method. This information was not there in the docstring, so added it. 




<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
