### PR TITLE
DOC Add note in BinaryTree about callables in metric

### DIFF
--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -141,7 +141,7 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             if self.algorithm == 'kd_tree':
                 # callable metric is only valid for brute force and ball_tree
                 raise ValueError(
-                    "kd_tree algorithm does not support callable metric. Function call overhead will result in very poor performance.'%s'"
+                    "kd_tree does not support callable metrics. Results in poor performance.'%s'"
                     % self.metric)
         elif self.metric not in VALID_METRICS[alg_check]:
             raise ValueError("Metric '%s' not valid. Use "

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -141,7 +141,7 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             if self.algorithm == 'kd_tree':
                 # callable metric is only valid for brute force and ball_tree
                 raise ValueError(
-                    "kd_tree does not support callable metrics.'%s'"
+                    "kd_tree does not support callable metric '%s'"
                     "Function call overhead will result"
                     "in very poor performance."
                     % self.metric)

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -141,7 +141,9 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             if self.algorithm == 'kd_tree':
                 # callable metric is only valid for brute force and ball_tree
                 raise ValueError(
-                    "kd_tree does not support callable metrics - poor performance'%s'"
+                    "kd_tree does not support callable metrics.'%s'"
+                    "Function call overhead will result"
+                    "in very poor performance."
                     % self.metric)
         elif self.metric not in VALID_METRICS[alg_check]:
             raise ValueError("Metric '%s' not valid. Use "

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -141,7 +141,7 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             if self.algorithm == 'kd_tree':
                 # callable metric is only valid for brute force and ball_tree
                 raise ValueError(
-                    "kd_tree does not support callable metrics. Results in poor performance.'%s'"
+                    "kd_tree does not support callable metrics - poor performance'%s'"
                     % self.metric)
         elif self.metric not in VALID_METRICS[alg_check]:
             raise ValueError("Metric '%s' not valid. Use "

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -141,7 +141,7 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             if self.algorithm == 'kd_tree':
                 # callable metric is only valid for brute force and ball_tree
                 raise ValueError(
-                    "kd_tree algorithm does not support callable metric '%s'"
+                    "kd_tree algorithm does not support callable metric. Function call overhead will result in very poor performance.'%s'"
                     % self.metric)
         elif self.metric not in VALID_METRICS[alg_check]:
             raise ValueError("Metric '%s' not valid. Use "

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -289,7 +289,7 @@ metric : string or DistanceMetric object
     are valid for {BinaryTree}.
 
 Additional keywords are passed to the distance metric class.
-Note: Callable functions in the metric parameter is NOT supported for KDTree
+Note: Callable functions in the metric parameter are NOT supported for KDTree
 and Ball Tree. Function call overhead will result in very poor performance.
 
 Attributes

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -289,6 +289,8 @@ metric : string or DistanceMetric object
     are valid for {BinaryTree}.
 
 Additional keywords are passed to the distance metric class.
+Note: Callable functions in the metric parameter is NOT supported for KDTree
+and Ball Tree. Function call overhead will result in very poor performance.
 
 Attributes
 ----------


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This doc addition is in relation to #14131 KDTree and BallTree both inherit their docstring from Binary tree so I added a notice warning about the unsupported use of callables in metric.

#### Any other comments?
This is one of my first times contributing. I'm open to alternative methods of making this doc clear to users. I decided to give it a go since there was not much activity going on for this issue.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
