### PR TITLE
DOC remove extra colon from doc string

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1656,9 +1656,9 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
     If Y is given (default is None), then the returned matrix is the pairwise
     kernel between the arrays from both X and Y.
 
-    Valid values for metric are::
+    Valid values for metric are:
         ['additive_chi2', 'chi2', 'linear', 'poly', 'polynomial', 'rbf',
-         'laplacian', 'sigmoid', 'cosine']
+        'laplacian', 'sigmoid', 'cosine']
 
     Read more in the :ref:`User Guide <metrics>`.
 


### PR DESCRIPTION
Fixes #14741 -- this seems simple. After removing the second colon the doc string renders like
<img width="841" alt="Screen Shot 2019-09-09 at 11 52 06 PM" src="https://user-images.githubusercontent.com/4280843/64582860-e7262700-d35c-11e9-81c8-448a6c1a83a8.png">

