### PR TITLE
Pass through non-ndarray object that support nep13 and nep18: vaex+sklearn out of core

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -431,6 +431,13 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
             "removed in 0.23. Don't set `warn_on_dtype` to remove this "
             "warning.",
             DeprecationWarning, stacklevel=2)
+    # If a non-ndarray object supporting nep13 and nep18, we pass it through
+    # see https://numpy.org/neps/nep-0013-ufunc-overrides.html
+    # and https://numpy.org/neps/nep-0018-array-function-protocol.html
+    if not isinstance(array, np.ndarray) and\
+            hasattr(array, '__array_function__') and\
+            hasattr(array, '__array_ufunc__'):
+        return array
 
     # store reference to original array to check if copy is needed when
     # function returns


### PR DESCRIPTION
# Intro

At EuroScipy we (@ogrisel, @adrinjalali @JovanVeljanoski and me) discussed the options of 'dataframe in (same) dataframe out' for sklearn. Also, this was a popular topic at the dataframe summit (https://datapythonista.github.io/blog/dataframe-summit-at-euroscipy.html cc @datapythonista). 

The idea was, to experiment first with some transformers, so see if we can get that to work with a vaex dataframe. The proof of concept is in this PR: https://github.com/vaexio/vaex/pull/415 

The result is that we/vaex can reuse sklearn without any modification and it works out of core (works on a billion rows for instance).

# How does it work?

## fit
By monkey patching (or using this PR), we pass through objects in check_array that are non-ndarray, but follow [NEP13](https://numpy.org/neps/nep-0013-ufunc-overrides.html) and [NEP18](https://numpy.org/neps/nep-0018-array-function-protocol.html). The idea being that if you want to behave like numpy, we will not try to convert you.

Vaex implements NEP13 and NEP18 in the referenced PR, and for instance will intercept np.sum/np.std/np.var/np.isnan etc. During for instance StandardScalar.fit, it will use vaex for the computations.

## transform
Executing StandardScalar.transform, the dataframe gets modified by building up virtual columns (we track what operations are being performed, we don't compute). The result is a dataframe with virtual columns that will be computed on the fly when needed.

# What do we get out of this?

During the fit, no memory copies are being made (at least for the examples in the vaex PR) and we get multithreading for free. The standard scalar is 5x faster out of the box and will take virtually no memory (memory-mapped data).

After the transform, we don't have just the numerical result, we have the expressions that will lead to the numerical result. These expressions can be jitted using Numba, Pythran, of by using CuPy for extra performance or GPU acceleration. Also, since we don't compute the result, we don't take up any memory.

Also, instead of having a 'nameless' ndarray, we now have a dataframe with meaningful column names.

# Conclusion / Question

Should sklearn pass through object following NEP13/NEP18? If yes, there probably needs to be a way to explicitly say 'now i need a real in memory c/fortran-contiguous array'. 

I doubt that this PR will be the final step in getting for instance vaex and sklearn or other dataframe/numpy like libraries to work together*, I hope that at least it gives food for thought. I can also imagine having an even stricter opt-int than just NEP13 and NEP18 (another magic dunder?).


*) One issue I see is in the PCA, which is using scipy.linalg.svd, which vaex cannot intercept. If numpy.linalg.svd was used, vaex could intercept that and pass it on to for instance dask. 

# Demo notebook screenshot
![image](https://user-images.githubusercontent.com/1765949/64768010-0aadc500-d549-11e9-8c9b-a501d66c5e99.png)
