### PR TITLE
Deprecate TfidfVectorizer

### DIFF
--- a/examples/applications/plot_topics_extraction_with_nmf_lda.py
+++ b/examples/applications/plot_topics_extraction_with_nmf_lda.py
@@ -28,7 +28,7 @@ proportional to (n_samples * iterations).
 
 from time import time
 
-from sklearn.feature_extraction.text import TfidfVectorizer, CountVectorizer
+from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
 from sklearn.decomposition import NMF, LatentDirichletAllocation
 from sklearn.datasets import fetch_20newsgroups
 
@@ -60,17 +60,9 @@ data, _ = fetch_20newsgroups(shuffle=True, random_state=1,
 data_samples = data[:n_samples]
 print("done in %0.3fs." % (time() - t0))
 
-# Use tf-idf features for NMF.
-print("Extracting tf-idf features for NMF...")
-tfidf_vectorizer = TfidfVectorizer(max_df=0.95, min_df=2,
-                                   max_features=n_features,
-                                   stop_words='english')
-t0 = time()
-tfidf = tfidf_vectorizer.fit_transform(data_samples)
-print("done in %0.3fs." % (time() - t0))
 
 # Use tf (raw term count) features for LDA.
-print("Extracting tf features for LDA...")
+print("Extracting tf features...")
 tf_vectorizer = CountVectorizer(max_df=0.95, min_df=2,
                                 max_features=n_features,
                                 stop_words='english')
@@ -78,6 +70,13 @@ t0 = time()
 tf = tf_vectorizer.fit_transform(data_samples)
 print("done in %0.3fs." % (time() - t0))
 print()
+
+# Use tf-idf features for NMF.
+print("Extracting tf-idf features for NMF...")
+tfidf_transformer = TfidfTransformer()
+t0 = time()
+tfidf = tfidf_transformer.fit_transform(tf)
+print("done in %0.3fs." % (time() - t0))
 
 # Fit the NMF model
 print("Fitting the NMF model (Frobenius norm) with tf-idf features, "
@@ -89,7 +88,7 @@ nmf = NMF(n_components=n_components, random_state=1,
 print("done in %0.3fs." % (time() - t0))
 
 print("\nTopics in NMF model (Frobenius norm):")
-tfidf_feature_names = tfidf_vectorizer.get_feature_names()
+tfidf_feature_names = tf_vectorizer.get_feature_names()
 print_top_words(nmf, tfidf_feature_names, n_top_words)
 
 # Fit the NMF model
@@ -103,7 +102,7 @@ nmf = NMF(n_components=n_components, random_state=1,
 print("done in %0.3fs." % (time() - t0))
 
 print("\nTopics in NMF model (generalized Kullback-Leibler divergence):")
-tfidf_feature_names = tfidf_vectorizer.get_feature_names()
+tfidf_feature_names = tf_vectorizer.get_feature_names()
 print_top_words(nmf, tfidf_feature_names, n_top_words)
 
 print("Fitting LDA models with tf features, "

--- a/examples/compose/plot_column_transformer.py
+++ b/examples/compose/plot_column_transformer.py
@@ -35,7 +35,7 @@ from sklearn.datasets.twenty_newsgroups import strip_newsgroup_footer
 from sklearn.datasets.twenty_newsgroups import strip_newsgroup_quoting
 from sklearn.decomposition import TruncatedSVD
 from sklearn.feature_extraction import DictVectorizer
-from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
 from sklearn.metrics import classification_report
 from sklearn.pipeline import Pipeline
 from sklearn.compose import ColumnTransformer
@@ -92,11 +92,15 @@ pipeline = Pipeline([
     ('union', ColumnTransformer(
         [
             # Pulling features from the post's subject line (first column)
-            ('subject', TfidfVectorizer(min_df=50), 0),
+            ('subject', Pipeline([
+                ('vect', CountVectorizer(min_df=50)),
+                ('tfidf', TfidfTransformer()),
+            ]), 0),
 
             # Pipeline for standard bag-of-words model for body (second column)
             ('body_bow', Pipeline([
-                ('tfidf', TfidfVectorizer()),
+                ('vect', CountVectorizer()),
+                ('tfidf', TfidfTransformer()),
                 ('best', TruncatedSVD(n_components=50)),
             ]), 1),
 

--- a/examples/text/plot_document_classification_20newsgroups.py
+++ b/examples/text/plot_document_classification_20newsgroups.py
@@ -69,8 +69,8 @@ op.add_option("--use_hashing",
               action="store_true",
               help="Use a hashing vectorizer.")
 op.add_option("--no-idf",
-                action="store_false", dest="use_idf", default=True,
-                help="Disable Inverse Document Frequency feature weighting.")
+              action="store_false", dest="use_idf", default=True,
+              help="Disable Inverse Document Frequency feature weighting.")
 op.add_option("--n_features",
               action="store", type=int, default=2 ** 16,
               help="n_features when using the hashing vectorizer.")

--- a/examples/text/plot_document_clustering.py
+++ b/examples/text/plot_document_clustering.py
@@ -11,7 +11,7 @@ Two feature extraction methods can be used in this example:
 
   - CountVectorizer uses a in-memory vocabulary (a python dict) to map the most
     frequent words to features indices and hence compute a word occurrence
-    frequency (sparse) matrix. 
+    frequency (sparse) matrix.
   - HashingVectorizer hashes word occurrences to a fixed dimensional space,
     possibly with collisions. The word count vectors are then normalized to
     each have l2-norm equal to one (projected to the euclidean unit-ball) which

--- a/examples/text/plot_hashing_vs_dict_vectorizer.py
+++ b/examples/text/plot_hashing_vs_dict_vectorizer.py
@@ -37,7 +37,7 @@ def tokens(doc):
     """Extract tokens from doc.
 
     This uses a simple regex to break strings into tokens. For a more
-    principled approach, see CountVectorizer or TfidfVectorizer.
+    principled approach, see CountVectorizer.
     """
     return (tok.lower() for tok in re.findall(r"\w+", doc))
 

--- a/sklearn/datasets/descr/twenty_newsgroups.rst
+++ b/sklearn/datasets/descr/twenty_newsgroups.rst
@@ -99,12 +99,15 @@ for statistical analysis. This can be achieved with the utilities of the
 example that extract `TF-IDF`_ vectors of unigram tokens
 from a subset of 20news::
 
-  >>> from sklearn.feature_extraction.text import TfidfVectorizer
+  >>> from sklearn.feature_extraction.text import (
+  ...     CountVectorizer, TfidfTransformer
+  ... )
+  >>> from sklearn.pipeline import make_pipeline
   >>> categories = ['alt.atheism', 'talk.religion.misc',
   ...               'comp.graphics', 'sci.space']
   >>> newsgroups_train = fetch_20newsgroups(subset='train',
   ...                                       categories=categories)
-  >>> vectorizer = TfidfVectorizer()
+  >>> vectorizer = make_pipeline(CountVectorizer(), TfidfTransformer())
   >>> vectors = vectorizer.fit_transform(newsgroups_train.data)
   >>> vectors.shape
   (2034, 34118)

--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -330,8 +330,7 @@ def fetch_20newsgroups_vectorized(subset="train", remove=(), data_home=None,
     fetch_20newsgroups with a custom
     :class:`sklearn.feature_extraction.text.CountVectorizer`,
     :class:`sklearn.feature_extraction.text.HashingVectorizer`,
-    :class:`sklearn.feature_extraction.text.TfidfTransformer` or
-    :class:`sklearn.feature_extraction.text.TfidfVectorizer`.
+    :class:`sklearn.feature_extraction.text.TfidfTransformer`
 
     =================   ==========
     Classes                     20

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -35,7 +35,7 @@ from sklearn.utils.testing import (assert_almost_equal,
                                    clean_warning_registry,
                                    SkipTest, assert_no_warnings,
                                    fails_if_pypy, assert_allclose_dense_sparse,
-                                   skip_if_32bit)
+                                   skip_if_32bit, ignore_warnings)
 from collections import defaultdict
 from functools import partial
 import pickle
@@ -269,6 +269,8 @@ def test_countvectorizer_custom_vocabulary():
         assert len(inv) == X.shape[0]
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 def test_countvectorizer_custom_vocabulary_pipeline():
     what_we_like = ["pizza", "beer"]
     pipe = Pipeline([
@@ -335,6 +337,8 @@ def test_fit_countvectorizer_twice():
     assert X1.shape[1] != X2.shape[1]
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 def test_tf_idf_smoothing():
     X = [[1, 1, 1],
          [1, 1, 0],
@@ -355,6 +359,8 @@ def test_tf_idf_smoothing():
     assert (tfidf >= 0).all()
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 def test_tfidf_no_smoothing():
     X = [[1, 1, 1],
          [1, 1, 0],
@@ -396,6 +402,8 @@ def test_sublinear_tf():
     assert tfidf[2] < 3
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 def test_vectorizer():
     # raw documents as an iterator
     train_data = iter(ALL_FOOD_DOCS[:-1])
@@ -509,6 +517,8 @@ def test_vectorizer():
         v3.build_analyzer()
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 def test_tfidf_vectorizer_setters():
     tv = TfidfVectorizer(norm='l2', use_idf=False, smooth_idf=False,
                          sublinear_tf=False)
@@ -609,6 +619,8 @@ def test_feature_names():
         assert idx == cv.vocabulary_.get(name)
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 @pytest.mark.parametrize('Vectorizer', (CountVectorizer, TfidfVectorizer))
 def test_vectorizer_max_features(Vectorizer):
     expected_vocabulary = {'burger', 'beer', 'salad', 'pizza'}
@@ -742,6 +754,8 @@ def test_hashed_binary_occurrences():
     assert X.dtype == np.float64
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 @pytest.mark.parametrize('Vectorizer', (CountVectorizer, TfidfVectorizer))
 def test_vectorizer_inverse_transform(Vectorizer):
     # raw documents
@@ -762,6 +776,8 @@ def test_vectorizer_inverse_transform(Vectorizer):
         assert_array_equal(np.sort(terms), np.sort(terms2))
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 def test_count_vectorizer_pipeline_grid_selection():
     # raw documents
     data = JUNK_FOOD_DOCS + NOTJUNK_FOOD_DOCS
@@ -798,6 +814,8 @@ def test_count_vectorizer_pipeline_grid_selection():
     assert best_vectorizer.ngram_range == (1, 1)
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 def test_vectorizer_pipeline_grid_selection():
     # raw documents
     data = JUNK_FOOD_DOCS + NOTJUNK_FOOD_DOCS
@@ -837,6 +855,8 @@ def test_vectorizer_pipeline_grid_selection():
     assert not best_vectorizer.fixed_vocabulary_
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 def test_vectorizer_pipeline_cross_validation():
     # raw documents
     data = JUNK_FOOD_DOCS + NOTJUNK_FOOD_DOCS
@@ -876,6 +896,8 @@ def test_vectorizer_unicode():
     assert_array_equal(np.sort(X_counted.data), np.sort(X_hashed.data))
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 def test_tfidf_vectorizer_with_fixed_vocabulary():
     # non regression smoke test for inheritance issues
     vocabulary = ['pizza', 'celeri']
@@ -886,6 +908,8 @@ def test_tfidf_vectorizer_with_fixed_vocabulary():
     assert vect.fixed_vocabulary_
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 def test_pickling_vectorizer():
     instances = [
         HashingVectorizer(),
@@ -965,6 +989,8 @@ def test_countvectorizer_vocab_dicts_when_pickling():
         assert cv.get_feature_names() == unpickled_cv.get_feature_names()
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 def test_stop_words_removal():
     # Ensure that deleting the stop_words_ attribute doesn't affect transform
 
@@ -1008,6 +1034,8 @@ def test_transformer_idf_setter():
         orig.transform(X).toarray())
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 def test_tfidf_vectorizer_setter():
     orig = TfidfVectorizer(use_idf=True)
     orig.fit(JUNK_FOOD_DOCS)
@@ -1018,6 +1046,8 @@ def test_tfidf_vectorizer_setter():
         orig.transform(JUNK_FOOD_DOCS).toarray())
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 def test_tfidfvectorizer_invalid_idf_attr():
     vect = TfidfVectorizer(use_idf=True)
     vect.fit(JUNK_FOOD_DOCS)
@@ -1049,6 +1079,8 @@ def test_hashingvectorizer_nan_in_docs():
     assert_raise_message(exception, message, func)
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 def test_tfidfvectorizer_binary():
     # Non-regression test: TfidfVectorizer used to ignore its "binary" param.
     v = TfidfVectorizer(binary=True, use_idf=False, norm=None)
@@ -1060,12 +1092,16 @@ def test_tfidfvectorizer_binary():
     assert_array_equal(X2.ravel(), [1, 1, 1, 0])
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 def test_tfidfvectorizer_export_idf():
     vect = TfidfVectorizer(use_idf=True)
     vect.fit(JUNK_FOOD_DOCS)
     assert_array_almost_equal(vect.idf_, vect._tfidf.idf_)
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 def test_vectorizer_vocab_clone():
     vect_vocab = TfidfVectorizer(vocabulary=["the"])
     vect_vocab_clone = clone(vect_vocab)
@@ -1074,6 +1110,8 @@ def test_vectorizer_vocab_clone():
     assert vect_vocab_clone.vocabulary_ == vect_vocab.vocabulary_
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 @pytest.mark.parametrize('Vectorizer',
                          (CountVectorizer, TfidfVectorizer, HashingVectorizer))
 def test_vectorizer_string_object_as_input(Vectorizer):
@@ -1104,6 +1142,8 @@ def test_tfidf_transformer_sparse():
     assert X_trans_csc.format == X_trans_csr.format
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 @pytest.mark.parametrize(
     "vectorizer_dtype, output_dtype, warning_expected",
     [(np.int32, np.float64, True),
@@ -1129,15 +1169,18 @@ def test_tfidf_vectorizer_type(vectorizer_dtype, output_dtype,
     assert X_idf.dtype == output_dtype
 
 
-@pytest.mark.parametrize("vec", [
-        HashingVectorizer(ngram_range=(2, 1)),
-        CountVectorizer(ngram_range=(2, 1)),
-        TfidfVectorizer(ngram_range=(2, 1))
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
+@pytest.mark.parametrize("Estimator, ngram_range", [
+        (HashingVectorizer, (2, 1)),
+        (CountVectorizer, (2, 1)),
+        (TfidfVectorizer, (2, 1))
     ])
-def test_vectorizers_invalid_ngram_range(vec):
+def test_vectorizers_invalid_ngram_range(Estimator, ngram_range):
     # vectorizers could be initialized with invalid ngram range
     # test for raising error message
-    invalid_range = vec.ngram_range
+    vec = Estimator(ngram_range=ngram_range)
+    invalid_range = ngram_range
     message = ("Invalid value for ngram_range=%s "
                "lower boundary larger than the upper boundary."
                % str(invalid_range))
@@ -1162,6 +1205,8 @@ def _check_stop_words_consistency(estimator):
                                                    tokenize)
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 @fails_if_pypy
 def test_vectorizer_stop_words_inconsistent():
     lstr = "['and', 'll', 've']"
@@ -1216,6 +1261,8 @@ def test_countvectorizer_sort_features_64bit_sparse_indices():
     assert INDICES_DTYPE == Xs.indices.dtype
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 @fails_if_pypy
 @pytest.mark.parametrize('Estimator',
                          [CountVectorizer, TfidfVectorizer, HashingVectorizer])
@@ -1245,6 +1292,8 @@ def test_stop_word_validation_custom_preprocessor(Estimator):
     assert _check_stop_words_consistency(vec) is True
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 @pytest.mark.parametrize(
     'Estimator',
     [CountVectorizer,
@@ -1265,6 +1314,8 @@ def test_callable_analyzer_error(Estimator, input_type, err_type, err_msg):
                   input=input_type).fit_transform(data)
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 @pytest.mark.parametrize(
     'Estimator',
     [CountVectorizer,
@@ -1288,6 +1339,8 @@ def test_callable_analyzer_change_behavior(Estimator, analyzer, input_type):
     assert warn_msg in ' '.join([str(el) for el in records])
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 @pytest.mark.parametrize(
     'Estimator',
     [CountVectorizer,
@@ -1309,6 +1362,8 @@ def test_callable_analyzer_reraise_error(tmpdir, Estimator):
         Estimator(analyzer=analyzer, input='file').fit_transform([f])
 
 
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
 @pytest.mark.parametrize(
     'Vectorizer',
     [CountVectorizer, HashingVectorizer, TfidfVectorizer]
@@ -1346,3 +1401,14 @@ def test_unused_parameters_warn(Vectorizer, stop_words,
            )
     with pytest.warns(UserWarning, match=msg):
         vect.fit(train_data)
+
+
+# TODO: TfidfVectorizer is deprecated in 0.22 and will be removed in 0.24
+@ignore_warnings(category=DeprecationWarning)
+def test_deprecation_tfidfvectorizer():
+    msg = (r"TfidfTransformer is deprecated in version 0.22 "
+           r"and will be removed in version 0.24. Use "
+           r"make_pipeline\(CountVectorizer\(\), TfidfTransformer\(\)\) "
+           r"instead.")
+    with pytest.warns(DeprecationWarning, match=msg):
+        TfidfVectorizer().fit(['a document'])

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1278,11 +1278,14 @@ def test_callable_analyzer_error(Estimator, input_type, err_type, err_msg):
 def test_callable_analyzer_change_behavior(Estimator, analyzer, input_type):
     data = ['this is text, not file or filename']
     warn_msg = 'Since v0.21, vectorizer'
+    warns_expected = [ChangedBehaviorWarning]
+    if issubclass(Estimator, TfidfVectorizer):
+        warns_expected.append(DeprecationWarning)
     with pytest.raises((FileNotFoundError, AttributeError)):
-        with pytest.warns(ChangedBehaviorWarning, match=warn_msg) as records:
+        with pytest.warns(tuple(warns_expected)) as records:
             Estimator(analyzer=analyzer, input=input_type).fit_transform(data)
-    assert len(records) == 1
-    assert warn_msg in str(records[0])
+    assert len(records) == len(warns_expected)
+    assert warn_msg in ' '.join([str(el) for el in records])
 
 
 @pytest.mark.parametrize(

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1263,10 +1263,6 @@ def _make_int_array():
     return array.array(str("i"))
 
 
-@deprecated("TfidfTransformer is deprecated in version 0.22 "
-            "and will be removed in version 0.24. Use "
-            "make_pipeline(CountVectorizer(), TfidfTransformer()) "
-            "instead.")
 class TfidfTransformer(TransformerMixin, BaseEstimator):
     """Transform a count matrix to a normalized tf or tf-idf representation
 
@@ -1446,6 +1442,10 @@ class TfidfTransformer(TransformerMixin, BaseEstimator):
         return {'X_types': 'sparse'}
 
 
+@deprecated("TfidfTransformer is deprecated in version 0.22 "
+            "and will be removed in version 0.24. Use "
+            "make_pipeline(CountVectorizer(), TfidfTransformer()) "
+            "instead.")
 class TfidfVectorizer(CountVectorizer):
     """Convert a collection of raw documents to a matrix of TF-IDF features.
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -30,7 +30,7 @@ from ..preprocessing import normalize
 from .hashing import FeatureHasher
 from .stop_words import ENGLISH_STOP_WORDS
 from ..utils.validation import check_is_fitted, check_array, FLOAT_DTYPES
-from ..utils import _IS_32BIT
+from ..utils import _IS_32BIT, deprecated
 from ..utils.fixes import _astype_copy_false
 from ..exceptions import ChangedBehaviorWarning, NotFittedError
 
@@ -957,7 +957,7 @@ class CountVectorizer(VectorizerMixin, BaseEstimator):
 
     See also
     --------
-    HashingVectorizer, TfidfVectorizer
+    HashingVectorizer
 
     Notes
     -----
@@ -1263,6 +1263,10 @@ def _make_int_array():
     return array.array(str("i"))
 
 
+@deprecated("TfidfTransformer is deprecated in version 0.22 "
+            "and will be removed in version 0.24. Use "
+            "make_pipeline(CountVectorizer(), TfidfTransformer()) "
+            "instead.")
 class TfidfTransformer(TransformerMixin, BaseEstimator):
     """Transform a count matrix to a normalized tf or tf-idf representation
 


### PR DESCRIPTION
Partially addresses https://github.com/scikit-learn/scikit-learn/issues/14951

Tentatively deprecates `TfidfVectorizer` in favor of using `CountVectorizer` in a pipeline with `TfidfTransformer`. The main argument in favour of the deprecation is the complexity of the API and the number of parameters in the `TfidfVectorizer` class. That would also make the use of `CountVectorizer` and `HashingVectorizer` more symetric.

This will affect a lot of uses as `TfidfVectorizer` is frequently used. At least 3 approvals would probably be good as this is potentially controversial.

TODO:
 - [ ] make sure the documentation is fully consistent. I can do it once we are sure we want to deprecate it.