### PR TITLE
[WIP] CLN Encoder refactor

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -564,12 +564,11 @@ class _SingleOneHotEncoder(TransformerMixin, BaseEstimator):
             X_encoded[X_encoded > self.drop_idx_] -= 1
 
         n_samples = X.shape[0]
-        X_mask_non_zero = np.flatnonzero(X_mask)
-
-        out = sparse.csr_matrix((n_samples, self.n_features_out_),
-                                dtype=self.dtype)
-        out[X_mask_non_zero, X_encoded[X_mask]] = 1
-
+        row = np.arange(0, n_samples)[X_mask]
+        col = X_encoded[X_mask]
+        data = np.ones(np.sum(X_mask), dtype=self.dtype)
+        out = sparse.csr_matrix((data, (row, col)),
+                                shape=(n_samples, self.n_features_out_))
         if self.sparse:
             return out
         else:

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -564,10 +564,10 @@ class _SingleOneHotEncoder(TransformerMixin, BaseEstimator):
             X_encoded[X_encoded > self.drop_idx_] -= 1
 
         n_samples = X.shape[0]
-        row = np.arange(0, n_samples)[X_mask]
+        row = np.flatnonzero(X_mask)
         col = X_encoded[X_mask]
         data = np.ones(np.sum(X_mask), dtype=self.dtype)
-        out = sparse.csr_matrix((data, (row, col)),
+        out = sparse.csc_matrix((data, (row, col)),
                                 shape=(n_samples, self.n_features_out_))
         if self.sparse:
             return out

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -293,7 +293,8 @@ class OneHotEncoder(_EncoderUnion):
 
     @property
     def drop_idx_(self):
-        return np.array([encoder.drop_idx_ for encoder in self._encoders])
+        return np.array([encoder.drop_idx_ for encoder in self._encoders],
+                        dtype=np.int_)
 
     def _fit(self, X):
         """Validate keywords and fit `X` and return `X_list`."""
@@ -407,11 +408,11 @@ class OneHotEncoder(_EncoderUnion):
                                                len(input_features)))
 
         feature_names = []
-        for i in range(len(cats)):
-            names = [
-                input_features[i] + '_' + str(t) for t in cats[i]]
+        for input_feat, cat, encoder in zip(input_features, cats,
+                                            self._encoders):
+            names = [input_feat + '_' + str(t) for t in cat]
             if self.drop is not None:
-                names.pop(self.drop_idx_[i])
+                names.pop(encoder.drop_idx_)
             feature_names.extend(names)
 
         return np.array(feature_names, dtype=object)

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -61,10 +61,9 @@ class _EncoderUnion(TransformerMixin, BaseEstimator):
             # to keep the dtype information to be used in the encoder.
             needs_validation = True
 
-        n_features = X.shape[1]
         X_columns = []
 
-        for i in range(n_features):
+        for i in range(X.shape[1]):
             Xi = safe_indexing(X, i, axis=1)
             Xi = check_array(Xi, ensure_2d=False, dtype=None,
                              force_all_finite=needs_validation)
@@ -90,12 +89,10 @@ class _EncoderUnion(TransformerMixin, BaseEstimator):
 
     def _fit_list(self, X_list, encoders):
         """Fit encoders on X_list"""
-        assert len(X_list) == len(encoders)
-
         for X_col, encoder in zip(X_list, encoders):
             encoder.fit(X_col)
 
-        # map from X_trans indicies to indicies from the original X
+        # map from X_trans indices to indices from the original X
         X_trans_to_orig_idx = []
         X_trans_idx = 0
         for encoder in encoders:
@@ -115,7 +112,8 @@ class _EncoderUnion(TransformerMixin, BaseEstimator):
                 "The number of features in X is different to the number of "
                 "features of the fitted data. The fitted data had {} features "
                 "and the X has {} features."
-                .format(len(self.categories_,), n_features))
+                .format(len(self.categories_,), n_features)
+            )
 
         X_trs = []
         for encoder, X_col in zip(self._encoders, X_list):

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -811,7 +811,7 @@ class _SingleOrdinalEncoder(TransformerMixin, BaseEstimator):
 
         _, encoded = _encode(X, self.categories_, encode=True,
                              check_unknown=False)
-        return encoded[:, None].astype(self.dtype)
+        return encoded[:, None].astype(self.dtype, copy=False)
 
     def inverse_transform(self, X):
         """Convert the data back into the original representation.

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -119,7 +119,8 @@ class _EncoderUnion(TransformerMixin, BaseEstimator):
 
         X_trs = []
         for encoder, X_col in zip(self._encoders, X_list):
-            X_trs.append(encoder.transform(X_col))
+            if encoder.n_features_out_ != 0:
+                X_trs.append(encoder.transform(X_col))
         return self._hstack(X_trs)
 
     def _hstack(self, Xs):

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -455,7 +455,12 @@ class OneHotEncoder(_EncoderUnion):
 
 
 class _SingleOneHotEncoder(TransformerMixin, BaseEstimator):
-    """One hot encoder for a single categorical feature."""
+    """One hot encoder for a single categorical feature.
+
+    When calling `fit`, the attribute `drop_idx_` will be set to 'missing'
+    when the drop category is not found in the dataset or given by
+    categories. `drop_idx_` should be checked be the caller to make sure
+    the encoder is valid."""
     def __init__(self, categories='auto', drop=None, drop_first=False,
                  dtype=np.float64, handle_unknown='error',
                  sparse=True, feature_idx=0):
@@ -502,6 +507,8 @@ class _SingleOneHotEncoder(TransformerMixin, BaseEstimator):
         elif self.drop is None:
             self.drop_idx_ = None
         elif self.drop not in self.categories_:
+            # This is an error state. Caller should check this value and
+            # handle according.
             self.drop_idx_ = 'missing'
         else:
             self.drop_idx_ = np.where(self.categories_ == self.drop)[0][0]


### PR DESCRIPTION
This PR refactors `_encoders.py` as follows:

1. Introduces `_SingleOneHotEncoder` and `_SingleOrdinalEncoder` to encode a single categorical feature. They implement, `fit`, `transform` and `inverse_transform`. `transform` and `fit` operates on `X` of shape `(n_samples,)`.
2. Introduces `_EncoderUnion` that provides utilities for child classes to call, which will distribute the features to the encoders:

- `_check_X` does validation checks and returns a list of features, `X_list`
- `_fit_list` takes a list of encoders and sends the elements of `X_list` to their respected encoders to be fitted.
- `_transform_list` takes a list of `X_list` and sends the elements of `X_list` to their respected encoders to be transformed.
- `inverse_transform` is defined for all encoders.

3. `OneHotEncoder` and `OrdinalEncoder` does input validation and uses the utilities provided by `_EncoderUnion`.

The motivation of this design is to separate the handling of distributing feature columns and encoding. When we introduce more encoders in the future, we would need to implement a child class of `_EncoderUnion` and a `_Single***Encoder`. This refactor should also make it easier to implement more features into our encoders such as https://github.com/scikit-learn/scikit-learn/issues/14954.

CC: @NicolasHug 