### PR TITLE
[MRG] Remove GraphViz mention in plot_tree docstring.

### DIFF
--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -96,7 +96,7 @@ def plot_tree(decision_tree, max_depth=None, feature_names=None,
     Parameters
     ----------
     decision_tree : decision tree regressor or classifier
-        The decision tree to be exported to GraphViz.
+        The decision tree to be plotted.
 
     max_depth : int, optional (default=None)
         The maximum depth of the representation. If None, the tree is fully


### PR DESCRIPTION
`plot_tree` is not using or related to GraphViz.

Probably from a copy and paste from `export_graphviz` in the original `plot_tree` PR https://github.com/scikit-learn/scikit-learn/pull/9251.