### PR TITLE
[MGR] Fix RepeatedKFold and RepeatedStratifiedKFold __repr__ string

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2161,6 +2161,8 @@ def _build_repr(self):
         try:
             with warnings.catch_warnings(record=True) as w:
                 value = getattr(self, key, None)
+                if value is None and hasattr(self, 'cvargs'):
+                    value = self.cvargs.get(key, None)
             if len(w) and w[0].category == DeprecationWarning:
                 # if the parameter is deprecated, don't show it
                 continue

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1163,6 +1163,9 @@ class _RepeatedSplits(metaclass=ABCMeta):
                      **self.cvargs)
         return cv.get_n_splits(X, y, groups) * self.n_repeats
 
+    def __repr__(self):
+        return _build_repr(self)
+
 
 class RepeatedKFold(_RepeatedSplits):
     """Repeated K-Fold cross validator.

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -980,16 +980,15 @@ def test_repeated_cv_value_errors():
         assert_raises(ValueError, cv, n_repeats=1.5)
 
 
-def test_repeated_cv_repr():
-    n_splits = 2
-    n_repeats = 6
-    rkf = RepeatedKFold(n_splits, n_repeats)
-    rskf = RepeatedStratifiedKFold(n_splits, n_repeats)
-    rkf_repr = 'RepeatedKFold(n_repeats=6, n_splits=2, random_state=None)'
-    rskf_repr = \
-        'RepeatedStratifiedKFold(n_repeats=6, n_splits=2, random_state=None)'
-    for cv, cv_repr in zip([rkf, rskf], [rkf_repr, rskf_repr]):
-        assert cv_repr == repr(cv)
+@pytest.mark.parametrize(
+    "RepeatedCV", [RepeatedKFold, RepeatedStratifiedKFold]
+)
+def test_repeated_cv_repr(RepeatedCV):
+    n_splits, n_repeats = 2, 6
+    repeated_cv = RepeatedCV(n_splits=n_splits, n_repeats=n_repeats)
+    repeated_cv_repr = ('{}(n_repeats=6, n_splits=2, random_state=None)'
+                        .format(repeated_cv.__class__.__name__))
+    assert repeated_cv_repr == repr(repeated_cv)
 
 
 def test_repeated_kfold_determinstic_split():

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -979,6 +979,7 @@ def test_repeated_cv_value_errors():
         assert_raises(ValueError, cv, n_repeats=0)
         assert_raises(ValueError, cv, n_repeats=1.5)
 
+
 def test_repeated_cv_repr():
     n_splits = 2
     n_repeats = 6
@@ -989,6 +990,7 @@ def test_repeated_cv_repr():
         'RepeatedStratifiedKFold(n_repeats=6, n_splits=2, random_state=None)'
     for cv, cv_repr in zip([rkf, rskf], [rkf_repr, rskf_repr]):
         assert cv_repr == repr(cv)
+
 
 def test_repeated_kfold_determinstic_split():
     X = [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -979,6 +979,16 @@ def test_repeated_cv_value_errors():
         assert_raises(ValueError, cv, n_repeats=0)
         assert_raises(ValueError, cv, n_repeats=1.5)
 
+def test_repeated_cv_repr():
+    n_splits = 2
+    n_repeats = 6
+    rkf = RepeatedKFold(n_splits, n_repeats)
+    rskf = RepeatedStratifiedKFold(n_splits, n_repeats)
+    rkf_repr = 'RepeatedKFold(n_repeats=6, n_splits=2, random_state=None)'
+    rskf_repr = \
+        'RepeatedStratifiedKFold(n_repeats=6, n_splits=2, random_state=None)'
+    for cv, cv_repr in zip([rkf, rskf], [rkf_repr, rskf_repr]):
+        assert cv_repr == repr(cv)
 
 def test_repeated_kfold_determinstic_split():
     X = [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #14970.


#### What does this implement/fix? Explain your changes.

Implements the `__repr__` method in the `_RepeatedSplit` class from which `RepeatedKFold` and `RepeatedStratifiedKFold` inherit.

Unit testing of the `__repr__` method for both `RepeatedKFold` and `RepeatedStratifiedKFold` has also been added.

#### Any other comments?

The change required the modification of the `_build_repr` function to show the value of the `n_splits` parameter which is stored in the `cvargs` class attribute. Without this modification, the `__repr__` method returns `None` for the `n_splits` parameter.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
