### PR TITLE
MAINT Fix assert raises in sklearn/ensemble/tests/

### DIFF
--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -7,15 +7,14 @@ Testing for the bagging ensemble module (sklearn.ensemble.bagging).
 
 import numpy as np
 import joblib
+import pytest
 
 from sklearn.base import BaseEstimator
 
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
-from sklearn.utils.testing import assert_raise_message
 
 from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.model_selection import GridSearchCV, ParameterGrid
@@ -401,28 +400,28 @@ def test_error():
     base = DecisionTreeClassifier()
 
     # Test max_samples
-    assert_raises(ValueError,
-                  BaggingClassifier(base, max_samples=-1).fit, X, y)
-    assert_raises(ValueError,
-                  BaggingClassifier(base, max_samples=0.0).fit, X, y)
-    assert_raises(ValueError,
-                  BaggingClassifier(base, max_samples=2.0).fit, X, y)
-    assert_raises(ValueError,
-                  BaggingClassifier(base, max_samples=1000).fit, X, y)
-    assert_raises(ValueError,
-                  BaggingClassifier(base, max_samples="foobar").fit, X, y)
+    with pytest.raises(ValueError):
+        BaggingClassifier(base, max_samples=-1).fit(X, y)
+    with pytest.raises(ValueError):
+        BaggingClassifier(base, max_samples=0.0).fit(X, y)
+    with pytest.raises(ValueError):
+        BaggingClassifier(base, max_samples=2.0).fit(X, y)
+    with pytest.raises(ValueError):
+        BaggingClassifier(base, max_samples=1000).fit(X, y)
+    with pytest.raises(ValueError):
+        BaggingClassifier(base, max_samples="foobar").fit(X, y)
 
     # Test max_features
-    assert_raises(ValueError,
-                  BaggingClassifier(base, max_features=-1).fit, X, y)
-    assert_raises(ValueError,
-                  BaggingClassifier(base, max_features=0.0).fit, X, y)
-    assert_raises(ValueError,
-                  BaggingClassifier(base, max_features=2.0).fit, X, y)
-    assert_raises(ValueError,
-                  BaggingClassifier(base, max_features=5).fit, X, y)
-    assert_raises(ValueError,
-                  BaggingClassifier(base, max_features="foobar").fit, X, y)
+    with pytest.raises(ValueError):
+        BaggingClassifier(base, max_features=-1).fit(X, y)
+    with pytest.raises(ValueError):
+        BaggingClassifier(base, max_features=0.0).fit(X, y)
+    with pytest.raises(ValueError):
+        BaggingClassifier(base, max_features=2.0).fit(X, y)
+    with pytest.raises(ValueError):
+        BaggingClassifier(base, max_features=5).fit(X, y)
+    with pytest.raises(ValueError):
+        BaggingClassifier(base, max_features="foobar").fit(X, y)
 
     # Test support of decision_function
     assert not hasattr(BaggingClassifier(base).fit(X, y), 'decision_function')
@@ -467,11 +466,12 @@ def test_parallel_classification():
     assert_array_almost_equal(decisions1, decisions2)
 
     X_err = np.hstack((X_test, np.zeros((X_test.shape[0], 1))))
-    assert_raise_message(ValueError, "Number of features of the model "
-                         "must match the input. Model n_features is {0} "
-                         "and input n_features is {1} "
-                         "".format(X_test.shape[1], X_err.shape[1]),
-                         ensemble.decision_function, X_err)
+    err_msg = ("Number of features of the model "
+               "must match the input. Model n_features is {0} "
+               "and input n_features is {1} "
+               "".format(X_test.shape[1], X_err.shape[1]))
+    with pytest.raises(ValueError, match=err_msg):
+        ensemble.decision_function(X_err)
 
     ensemble = BaggingClassifier(SVC(decision_function_shape='ovr'),
                                  n_jobs=1,
@@ -595,8 +595,9 @@ def test_bagging_sample_weight_unsupported_but_passed():
     rng = check_random_state(0)
 
     estimator.fit(iris.data, iris.target).predict(iris.data)
-    assert_raises(ValueError, estimator.fit, iris.data, iris.target,
-                  sample_weight=rng.randint(10, size=(iris.data.shape[0])))
+    with pytest.raises(ValueError):
+        estimator.fit(iris.data, iris.target, sample_weight=rng.randint(10,
+                      size=(iris.data.shape[0])))
 
 
 def test_warm_start(random_state=42):
@@ -629,7 +630,8 @@ def test_warm_start_smaller_n_estimators():
     clf = BaggingClassifier(n_estimators=5, warm_start=True)
     clf.fit(X, y)
     clf.set_params(n_estimators=4)
-    assert_raises(ValueError, clf.fit, X, y)
+    with pytest.raises(ValueError):
+        clf.fit(X, y)
 
 
 def test_warm_start_equal_n_estimators():
@@ -675,7 +677,8 @@ def test_warm_start_with_oob_score_fails():
     # Check using oob_score and warm_start simultaneously fails
     X, y = make_hastie_10_2(n_samples=20, random_state=1)
     clf = BaggingClassifier(n_estimators=5, warm_start=True, oob_score=True)
-    assert_raises(ValueError, clf.fit, X, y)
+    with pytest.raises(ValueError):
+        clf.fit(X, y)
 
 
 def test_oob_score_removed_on_warm_start():
@@ -687,7 +690,8 @@ def test_oob_score_removed_on_warm_start():
     clf.set_params(warm_start=True, oob_score=False, n_estimators=100)
     clf.fit(X, y)
 
-    assert_raises(AttributeError, getattr, clf, "oob_score_")
+    with pytest.raises(AttributeError):
+        getattr(clf, "oob_score_")
 
 
 def test_oob_score_consistency():
@@ -831,9 +835,11 @@ def test_bagging_regressor_with_missing_inputs():
         # Verify that exceptions can be raised by wrapper regressor
         regressor = DecisionTreeRegressor()
         pipeline = make_pipeline(regressor)
-        assert_raises(ValueError, pipeline.fit, X, y)
+        with pytest.raises(ValueError):
+            pipeline.fit(X, y)
         bagging_regressor = BaggingRegressor(pipeline)
-        assert_raises(ValueError, bagging_regressor.fit, X, y)
+        with pytest.raises(ValueError):
+            bagging_regressor.fit(X, y)
 
 
 def test_bagging_classifier_with_missing_inputs():
@@ -861,9 +867,11 @@ def test_bagging_classifier_with_missing_inputs():
     # Verify that exceptions can be raised by wrapper classifier
     classifier = DecisionTreeClassifier()
     pipeline = make_pipeline(classifier)
-    assert_raises(ValueError, pipeline.fit, X, y)
+    with pytest.raises(ValueError):
+        pipeline.fit(X, y)
     bagging_classifier = BaggingClassifier(pipeline)
-    assert_raises(ValueError, bagging_classifier.fit, X, y)
+    with pytest.raises(ValueError):
+        bagging_classifier.fit(X, y)
 
 
 def test_bagging_small_max_features():

--- a/sklearn/ensemble/tests/test_base.py
+++ b/sklearn/ensemble/tests/test_base.py
@@ -6,8 +6,8 @@ Testing for the base module (sklearn.ensemble.base).
 # License: BSD 3 clause
 
 import numpy as np
+import pytest
 
-from sklearn.utils.testing import assert_raise_message
 
 from sklearn.datasets import load_iris
 from sklearn.ensemble import BaggingClassifier
@@ -54,9 +54,9 @@ def test_base_zero_n_estimators():
     ensemble = BaggingClassifier(base_estimator=Perceptron(),
                                  n_estimators=0)
     iris = load_iris()
-    assert_raise_message(ValueError,
-                         "n_estimators must be greater than zero, got 0.",
-                         ensemble.fit, iris.data, iris.target)
+    with pytest.raises(ValueError, match="n_estimators must be greater than"
+                                         " zero, got 0."):
+        ensemble.fit(iris.data, iris.target)
 
 
 def test_base_not_int_n_estimators():
@@ -65,14 +65,12 @@ def test_base_not_int_n_estimators():
     string_ensemble = BaggingClassifier(base_estimator=Perceptron(),
                                         n_estimators='3')
     iris = load_iris()
-    assert_raise_message(ValueError,
-                         "n_estimators must be an integer",
-                         string_ensemble.fit, iris.data, iris.target)
+    with pytest.raises(ValueError, match="n_estimators must be an integer"):
+        string_ensemble.fit(iris.data, iris.target)
     float_ensemble = BaggingClassifier(base_estimator=Perceptron(),
                                        n_estimators=3.0)
-    assert_raise_message(ValueError,
-                         "n_estimators must be an integer",
-                         float_ensemble.fit, iris.data, iris.target)
+    with pytest.raises(ValueError, match="n_estimators must be an integer"):
+        float_ensemble.fit(iris.data, iris.target)
 
 
 def test_set_random_states():

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -28,7 +28,6 @@ import joblib
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import ignore_warnings
@@ -420,10 +419,11 @@ def check_oob_score_raise_error(name):
 
     if name in FOREST_TRANSFORMERS:
         for oob_score in [True, False]:
-            assert_raises(TypeError, ForestEstimator, oob_score=oob_score)
+            with pytest.raises(TypeError):
+                ForestEstimator(oob_score=oob_score)
 
-        assert_raises(NotImplementedError, ForestEstimator()._set_oob_score,
-                      X, y)
+        with pytest.raises(NotImplementedError):
+            ForestEstimator()._set_oob_score(X, y)
 
     else:
         # Unfitted /  no bootstrap / no oob_score
@@ -434,8 +434,8 @@ def check_oob_score_raise_error(name):
             assert not hasattr(est, "oob_score_")
 
         # No bootstrap
-        assert_raises(ValueError, ForestEstimator(oob_score=True,
-                                                  bootstrap=False).fit, X, y)
+        with pytest.raises(ValueError):
+            ForestEstimator(oob_score=True, bootstrap=False).fit(X, y)
 
 
 @pytest.mark.parametrize('name', FOREST_ESTIMATORS)
@@ -749,12 +749,12 @@ def check_min_samples_split(name):
     ForestEstimator = FOREST_ESTIMATORS[name]
 
     # test boundary value
-    assert_raises(ValueError,
-                  ForestEstimator(min_samples_split=-1).fit, X, y)
-    assert_raises(ValueError,
-                  ForestEstimator(min_samples_split=0).fit, X, y)
-    assert_raises(ValueError,
-                  ForestEstimator(min_samples_split=1.1).fit, X, y)
+    with pytest.raises(ValueError):
+        ForestEstimator(min_samples_split=-1).fit(X, y)
+    with pytest.raises(ValueError):
+        ForestEstimator(min_samples_split=0).fit(X, y)
+    with pytest.raises(ValueError):
+        ForestEstimator(min_samples_split=1.1).fit(X, y)
 
     est = ForestEstimator(min_samples_split=10, n_estimators=1, random_state=0)
     est.fit(X, y)
@@ -786,10 +786,10 @@ def check_min_samples_leaf(name):
     ForestEstimator = FOREST_ESTIMATORS[name]
 
     # test boundary value
-    assert_raises(ValueError,
-                  ForestEstimator(min_samples_leaf=-1).fit, X, y)
-    assert_raises(ValueError,
-                  ForestEstimator(min_samples_leaf=0).fit, X, y)
+    with pytest.raises(ValueError):
+        ForestEstimator(min_samples_leaf=-1).fit(X, y)
+    with pytest.raises(ValueError):
+        ForestEstimator(min_samples_leaf=0).fit(X, y)
 
     est = ForestEstimator(min_samples_leaf=5, n_estimators=1, random_state=0)
     est.fit(X, y)
@@ -941,14 +941,15 @@ def test_memory_layout(name, dtype):
 @ignore_warnings
 def check_1d_input(name, X, X_2d, y):
     ForestEstimator = FOREST_ESTIMATORS[name]
-    assert_raises(ValueError, ForestEstimator(n_estimators=1,
-                                              random_state=0).fit, X, y)
+    with pytest.raises(ValueError):
+        ForestEstimator(n_estimators=1, random_state=0).fit(X, y)
 
     est = ForestEstimator(random_state=0)
     est.fit(X_2d, y)
 
     if name in FOREST_CLASSIFIERS or name in FOREST_REGRESSORS:
-        assert_raises(ValueError, est.predict, X)
+        with pytest.raises(ValueError):
+            est.predict(X)
 
 
 @pytest.mark.parametrize('name', FOREST_ESTIMATORS)
@@ -1041,8 +1042,10 @@ def check_class_weight_errors(name):
 
     # Invalid preset string
     clf = ForestClassifier(class_weight='the larch', random_state=0)
-    assert_raises(ValueError, clf.fit, X, y)
-    assert_raises(ValueError, clf.fit, X, _y)
+    with pytest.raises(ValueError):
+        clf.fit(X, y)
+    with pytest.raises(ValueError):
+        clf.fit(X, _y)
 
     # Warning warm_start with preset
     clf = ForestClassifier(class_weight='balanced', warm_start=True,
@@ -1052,11 +1055,13 @@ def check_class_weight_errors(name):
 
     # Not a list or preset for multi-output
     clf = ForestClassifier(class_weight=1, random_state=0)
-    assert_raises(ValueError, clf.fit, X, _y)
+    with pytest.raises(ValueError):
+        clf.fit(X, _y)
 
     # Incorrect length list for multi-output
     clf = ForestClassifier(class_weight=[{-1: 0.5, 1: 1.}], random_state=0)
-    assert_raises(ValueError, clf.fit, X, _y)
+    with pytest.raises(ValueError):
+        clf.fit(X, _y)
 
 
 @pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
@@ -1125,7 +1130,8 @@ def check_warm_start_smaller_n_estimators(name):
     clf = ForestEstimator(n_estimators=5, max_depth=1, warm_start=True)
     clf.fit(X, y)
     clf.set_params(n_estimators=4)
-    assert_raises(ValueError, clf.fit, X, y)
+    with pytest.raises(ValueError):
+        clf.fit(X, y)
 
 
 @pytest.mark.parametrize('name', FOREST_ESTIMATORS)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -3,7 +3,6 @@ Testing for the gradient boosting module (sklearn.ensemble.gradient_boosting).
 """
 import warnings
 import numpy as np
-import re
 
 from scipy.sparse import csr_matrix
 from scipy.sparse import csc_matrix
@@ -145,12 +144,6 @@ def test_classifier_parameter_checks():
         (lambda X, y: GradientBoostingClassifier(loss='deviance').
          fit(X, y))(X, [0, 0, 0, 0])
 
-    allowed_presort = ('auto', True, False)
-    err_msg = ("'presort' should be in {}. "
-               "Got 'invalid' instead.".format(allowed_presort))
-    with pytest.raises(ValueError, match=re.escape(err_msg)):
-        GradientBoostingClassifier(presort='invalid').fit(X, y)
-
 
 def test_regressor_parameter_checks():
     # Check input parameter validation for GradientBoostingRegressor
@@ -169,11 +162,6 @@ def test_regressor_parameter_checks():
                " or an integer. 'invalid' was passed")
     with pytest.raises(ValueError, match=err_msg):
         GradientBoostingRegressor(n_iter_no_change='invalid').fit(X, y)
-    allowed_presort = ('auto', True, False)
-    err_msg = ("'presort' should be in {}. "
-               "Got 'invalid' instead.".format(allowed_presort))
-    with pytest.raises(ValueError, match=re.escape(err_msg)):
-        GradientBoostingRegressor(presort='invalid').fit(X, y)
 
 
 def test_loss_function():

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -12,7 +12,6 @@ import numpy as np
 
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_allclose
@@ -92,12 +91,12 @@ def test_iforest_error():
     X = iris.data
 
     # Test max_samples
-    assert_raises(ValueError,
-                  IsolationForest(max_samples=-1).fit, X)
-    assert_raises(ValueError,
-                  IsolationForest(max_samples=0.0).fit, X)
-    assert_raises(ValueError,
-                  IsolationForest(max_samples=2.0).fit, X)
+    with pytest.raises(ValueError):
+        IsolationForest(max_samples=-1).fit(X)
+    with pytest.raises(ValueError):
+        IsolationForest(max_samples=0.0).fit(X)
+    with pytest.raises(ValueError):
+        IsolationForest(max_samples=2.0).fit(X)
     # The dataset has less than 256 samples, explicitly setting
     # max_samples > n_samples should result in a warning. If not set
     # explicitly there should be no warning
@@ -118,11 +117,14 @@ def test_iforest_error():
                      if issubclass(each.category, UserWarning)]
     assert len(user_warnings) == 0
 
-    assert_raises(ValueError, IsolationForest(max_samples='foobar').fit, X)
-    assert_raises(ValueError, IsolationForest(max_samples=1.5).fit, X)
+    with pytest.raises(ValueError):
+        IsolationForest(max_samples='foobar').fit(X)
+    with pytest.raises(ValueError):
+        IsolationForest(max_samples=1.5).fit(X)
 
     # test X_test n_features match X_train one:
-    assert_raises(ValueError, IsolationForest().fit(X).predict, X[:, 1:])
+    with pytest.raises(ValueError):
+        IsolationForest().fit(X).predict(X[:, 1:])
 
     # test that behaviour='old' will raise an error
     msg = "The old behaviour of IsolationForest is not implemented anymore."

--- a/sklearn/ensemble/tests/test_partial_dependence.py
+++ b/sklearn/ensemble/tests/test_partial_dependence.py
@@ -6,7 +6,6 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 
-from sklearn.utils.testing import assert_raises
 from sklearn.ensemble.partial_dependence import partial_dependence
 from sklearn.ensemble.partial_dependence import plot_partial_dependence
 from sklearn.ensemble import GradientBoostingClassifier
@@ -128,27 +127,30 @@ def test_partial_dependecy_input():
     clf = GradientBoostingClassifier(n_estimators=10, random_state=1)
     clf.fit(X, y)
 
-    assert_raises(ValueError, partial_dependence,
-                  clf, [0], grid=None, X=None)
+    with pytest.raises(ValueError):
+        partial_dependence(clf, [0], grid=None, X=None)
 
-    assert_raises(ValueError, partial_dependence,
-                  clf, [0], grid=[0, 1], X=X)
+    with pytest.raises(ValueError):
+        partial_dependence(clf, [0], grid=[0, 1], X=X)
 
     # first argument must be an instance of BaseGradientBoosting
-    assert_raises(ValueError, partial_dependence,
-                  {}, [0], X=X)
+    with pytest.raises(ValueError):
+        partial_dependence({}, [0], X=X)
 
     # Gradient boosting estimator must be fit
-    assert_raises(ValueError, partial_dependence,
-                  GradientBoostingClassifier(), [0], X=X)
+    with pytest.raises(ValueError):
+        partial_dependence(GradientBoostingClassifier(), [0], X=X)
 
-    assert_raises(ValueError, partial_dependence, clf, [-1], X=X)
+    with pytest.raises(ValueError):
+        partial_dependence(clf, [-1], X=X)
 
-    assert_raises(ValueError, partial_dependence, clf, [100], X=X)
+    with pytest.raises(ValueError):
+        partial_dependence(clf, [100], X=X)
 
     # wrong ndim for grid
     grid = np.random.rand(10, 2, 1)
-    assert_raises(ValueError, partial_dependence, clf, [0], grid=grid)
+    with pytest.raises(ValueError):
+        partial_dependence(clf, [0], grid=grid)
 
 
 @ignore_warnings(category=DeprecationWarning)
@@ -193,33 +195,33 @@ def test_plot_partial_dependence_input(pyplot):
     clf = GradientBoostingClassifier(n_estimators=10, random_state=1)
 
     # not fitted yet
-    assert_raises(ValueError, plot_partial_dependence,
-                  clf, X, [0])
+    with pytest.raises(ValueError):
+        plot_partial_dependence(clf, X, [0])
 
     clf.fit(X, y)
 
-    assert_raises(ValueError, plot_partial_dependence,
-                  clf, np.array(X)[:, :0], [0])
+    with pytest.raises(ValueError):
+        plot_partial_dependence(clf, np.array(X)[:, :0], [0])
 
     # first argument must be an instance of BaseGradientBoosting
-    assert_raises(ValueError, plot_partial_dependence,
-                  {}, X, [0])
+    with pytest.raises(ValueError):
+        plot_partial_dependence({}, X, [0])
 
     # must be larger than -1
-    assert_raises(ValueError, plot_partial_dependence,
-                  clf, X, [-1])
+    with pytest.raises(ValueError):
+        plot_partial_dependence(clf, X, [-1])
 
     # too large feature value
-    assert_raises(ValueError, plot_partial_dependence,
-                  clf, X, [100])
+    with pytest.raises(ValueError):
+        plot_partial_dependence(clf, X, [100])
 
     # str feature but no feature_names
-    assert_raises(ValueError, plot_partial_dependence,
-                  clf, X, ['foobar'])
+    with pytest.raises(ValueError):
+        plot_partial_dependence(clf, X, ['foobar'])
 
     # not valid features value
-    assert_raises(ValueError, plot_partial_dependence,
-                  clf, X, [{'foo': 'bar'}])
+    with pytest.raises(ValueError):
+        plot_partial_dependence(clf, X, [{'foo': 'bar'}])
 
 
 @pytest.mark.filterwarnings('ignore: Using or importing the ABCs from')
@@ -250,14 +252,14 @@ def test_plot_partial_dependence_multiclass(pyplot):
     assert all(ax.has_data for ax in axs)
 
     # label not in gbrt.classes_
-    assert_raises(ValueError, plot_partial_dependence,
-                  clf, iris.data, [0, 1], label='foobar',
-                  grid_resolution=grid_resolution)
+    with pytest.raises(ValueError):
+        plot_partial_dependence(clf, iris.data, [0, 1], label='foobar',
+                                grid_resolution=grid_resolution)
 
     # label not provided
-    assert_raises(ValueError, plot_partial_dependence,
-                  clf, iris.data, [0, 1],
-                  grid_resolution=grid_resolution)
+    with pytest.raises(ValueError):
+        plot_partial_dependence(clf, iris.data, [0, 1],
+                                grid_resolution=grid_resolution)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -5,7 +5,6 @@ import pytest
 
 from sklearn.utils.testing import assert_array_equal, assert_array_less
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_raises, assert_raises_regexp
 
 from sklearn.base import BaseEstimator
 from sklearn.model_selection import train_test_split
@@ -263,17 +262,14 @@ def test_importances():
 
 def test_error():
     # Test that it gives proper exception on deficient input.
-    assert_raises(ValueError,
-                  AdaBoostClassifier(learning_rate=-1).fit,
-                  X, y_class)
+    with pytest.raises(ValueError):
+        AdaBoostClassifier(learning_rate=-1).fit(X, y_class)
 
-    assert_raises(ValueError,
-                  AdaBoostClassifier(algorithm="foo").fit,
-                  X, y_class)
+    with pytest.raises(ValueError):
+        AdaBoostClassifier(algorithm="foo").fit(X, y_class)
 
-    assert_raises(ValueError,
-                  AdaBoostClassifier().fit,
-                  X, y_class, sample_weight=np.asarray([-1]))
+    with pytest.raises(ValueError):
+        AdaBoostClassifier().fit(X, y_class, sample_weight=np.asarray([-1]))
 
 
 def test_base_estimator():
@@ -300,18 +296,20 @@ def test_base_estimator():
     X_fail = [[1, 1], [1, 1], [1, 1], [1, 1]]
     y_fail = ["foo", "bar", 1, 2]
     clf = AdaBoostClassifier(SVC(), algorithm="SAMME")
-    assert_raises_regexp(ValueError, "worse than random",
-                         clf.fit, X_fail, y_fail)
+    with pytest.raises(ValueError, match="worse than random"):
+        clf.fit(X_fail, y_fail)
 
 
 def test_sample_weight_missing():
     from sklearn.cluster import KMeans
 
     clf = AdaBoostClassifier(KMeans(), algorithm="SAMME")
-    assert_raises(ValueError, clf.fit, X, y_regr)
+    with pytest.raises(ValueError):
+        clf.fit(X, y_regr)
 
     clf = AdaBoostRegressor(KMeans())
-    assert_raises(ValueError, clf.fit, X, y_regr)
+    with pytest.raises(ValueError):
+        clf.fit(X, y_regr)
 
 
 def test_sparse_classification():


### PR DESCRIPTION
replaced the use of `assert_raises`, `assert_raises_regex` , and `assert_raise_message` with `pytest.raises` context manager.

related to #14216

