### PR TITLE
**predict_params added to predict method

### DIFF
--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -212,11 +212,11 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
         ----------
         X : {array-like, sparse matrix}, shape = (n_samples, n_features)
             Samples.
-        
+
         **predict_params : dict of string -> object
             Parameters passed to the ``predict`` method of the underlying
             regressor.
-            
+
         Returns
         -------
         y_hat : array, shape = (n_samples,)

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -202,7 +202,7 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
 
         return self
 
-    def predict(self, X):
+    def predict(self, X, **predict_params):
         """Predict using the base regressor, applying inverse.
 
         The regressor is used to predict and the ``inverse_func`` or
@@ -212,7 +212,11 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
         ----------
         X : {array-like, sparse matrix}, shape = (n_samples, n_features)
             Samples.
-
+        
+        **predict_params : dict of string -> object
+            Parameters passed to the ``predict`` method of the underlying
+            regressor.
+            
         Returns
         -------
         y_hat : array, shape = (n_samples,)
@@ -220,7 +224,7 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
 
         """
         check_is_fitted(self)
-        pred = self.regressor_.predict(X)
+        pred = self.regressor_.predict(X, **predict_params)
         if pred.ndim == 1:
             pred_trans = self.transformer_.inverse_transform(
                 pred.reshape(-1, 1))

--- a/sklearn/compose/tests/test_target.py
+++ b/sklearn/compose/tests/test_target.py
@@ -332,3 +332,39 @@ def test_transform_target_regressor_route_pipeline():
     pip.fit(X, y, **{'est__check_input': False})
 
     assert regr.transformer_.fit_counter == 1
+
+class DummyRegressorWithExtraPredictParams(DummyRegressor):
+    def predict(self, X, return_std=False, check_input=True):
+        # on the test below we force this to false, we make sure this is
+        # actually passed to the regressor
+        assert not check_input
+        return super().predict(X, return_std)
+
+
+def test_transform_target_regressor_pass_predict_parameters():
+    X, y = friedman
+    regr = TransformedTargetRegressor(
+        regressor=DummyRegressorWithExtraPredictParams(),
+        transformer=DummyTransformer()
+    )
+
+    regr.fit(X, y)
+    regr.predict(X, check_input=False)
+
+
+def test_transform_target_regressor_route_pipeline_with_predict_parameters():
+    X, y = friedman
+
+    regr = TransformedTargetRegressor(
+        regressor=DummyRegressorWithExtraPredictParams(),
+        transformer=DummyTransformer()
+    )
+    estimators = [
+        ('normalize', StandardScaler()), ('est', regr)
+    ]
+
+    pip = Pipeline(estimators)
+    pip.fit(X, y)
+    # Unlike **fit_params in fit Pipeline method, **predict_params in predict
+    # Pipeline method are given directly to the last step of the Pipeline.
+    pip.predict(X, check_input=False)

--- a/sklearn/compose/tests/test_target.py
+++ b/sklearn/compose/tests/test_target.py
@@ -335,11 +335,11 @@ def test_transform_target_regressor_route_pipeline():
 
 
 class DummyRegressorWithExtraPredictParams(DummyRegressor):
-    def predict(self, X, return_std=False, check_input=True):
+    def predict(self, X, check_input=True):
         # on the test below we force this to false, we make sure this is
         # actually passed to the regressor
         assert not check_input
-        return super().predict(X, return_std)
+        return super().predict(X)
 
 
 def test_transform_target_regressor_pass_predict_parameters():
@@ -351,21 +351,3 @@ def test_transform_target_regressor_pass_predict_parameters():
 
     regr.fit(X, y)
     regr.predict(X, check_input=False)
-
-
-def test_transform_target_regressor_route_pipeline_with_predict_parameters():
-    X, y = friedman
-
-    regr = TransformedTargetRegressor(
-        regressor=DummyRegressorWithExtraPredictParams(),
-        transformer=DummyTransformer()
-    )
-    estimators = [
-        ('normalize', StandardScaler()), ('est', regr)
-    ]
-
-    pip = Pipeline(estimators)
-    pip.fit(X, y)
-    # Unlike **fit_params in fit Pipeline method, **predict_params in predict
-    # Pipeline method are given directly to the last step of the Pipeline.
-    pip.predict(X, check_input=False)

--- a/sklearn/compose/tests/test_target.py
+++ b/sklearn/compose/tests/test_target.py
@@ -333,6 +333,7 @@ def test_transform_target_regressor_route_pipeline():
 
     assert regr.transformer_.fit_counter == 1
 
+
 class DummyRegressorWithExtraPredictParams(DummyRegressor):
     def predict(self, X, return_std=False, check_input=True):
         # on the test below we force this to false, we make sure this is


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Add **predict_params to the predict method to pass them to the predict of the underlying regressor , see discussion  #14890

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
