### PR TITLE
[MRG] Using one single random seed for warm start in HGBDT

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -157,11 +157,9 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         n_bins = self.max_bins + 1  # + 1 for missing values
         self.bin_mapper_ = _BinMapper(n_bins=n_bins,
                                       random_state=self._random_seed)
-        X_binned_train = self._bin_data(X_train, self._random_seed,
-                                        is_training_data=True)
+        X_binned_train = self._bin_data(X_train, is_training_data=True)
         if X_val is not None:
-            X_binned_val = self._bin_data(X_val, self._random_seed,
-                                          is_training_data=False)
+            X_binned_val = self._bin_data(X_val, is_training_data=False)
         else:
             X_binned_val = None
 
@@ -484,7 +482,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                                for score in recent_scores]
         return not any(recent_improvements)
 
-    def _bin_data(self, X, rng, is_training_data):
+    def _bin_data(self, X, is_training_data):
         """Bin data X.
 
         If is_training_data, then set the bin_mapper_ attribute.

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -104,8 +104,11 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         X, y = check_X_y(X, y, dtype=[X_DTYPE], force_all_finite=False)
         y = self._encode_y(y)
 
-        # The rng state must be preserved if warm_start is True
         rng = check_random_state(self.random_state)
+
+        # When warm starting, we want to re-use the same seed that was used
+        # the first time fit was called (e.g. for subsampling or for the
+        # train/val split).
         if not (self.warm_start and self._is_fitted()):
             self._random_seed = rng.randint(np.iinfo(np.uint32).max,
                                             dtype='u8')

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -107,7 +107,8 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         # The rng state must be preserved if warm_start is True
         rng = check_random_state(self.random_state)
         if not (self.warm_start and self._is_fitted()):
-            self._random_seed = rng.randint(np.iinfo(np.uint32).max)
+            self._random_seed = rng.randint(np.iinfo(np.uint32).max,
+                                            dtype='u8')
 
         self._validate_parameters()
         self.n_features_ = X.shape[1]  # used for validation in predict()

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_warm_start.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_warm_start.py
@@ -169,22 +169,16 @@ def test_random_seeds_warm_start(GradientBoosting, X, y, rng_type):
     gb_1 = GradientBoosting(n_iter_no_change=5, max_iter=2,
                             random_state=random_state)
     gb_1.fit(X, y)
-    train_val_seed_1 = gb_1._train_val_split_seed
-    small_trainset_seed_1 = gb_1._small_trainset_seed
+    random_seed_1 = gb_1._random_seed
 
     random_state = _get_rng(rng_type)
     gb_2 = GradientBoosting(n_iter_no_change=5, max_iter=2,
                             random_state=random_state, warm_start=True)
     gb_2.fit(X, y)  # inits state
-    train_val_seed_2 = gb_2._train_val_split_seed
-    small_trainset_seed_2 = gb_2._small_trainset_seed
+    random_seed_2 = gb_2._random_seed
     gb_2.fit(X, y)  # clears old state and equals est
-    train_val_seed_3 = gb_2._train_val_split_seed
-    small_trainset_seed_3 = gb_2._small_trainset_seed
+    random_seed_3 = gb_2._random_seed
 
     # Check that all seeds are equal
-    assert train_val_seed_1 == train_val_seed_2
-    assert small_trainset_seed_1 == small_trainset_seed_2
-
-    assert train_val_seed_2 == train_val_seed_3
-    assert small_trainset_seed_2 == small_trainset_seed_3
+    assert random_seed_1 == random_seed_2
+    assert random_seed_2 == random_seed_3

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_warm_start.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_warm_start.py
@@ -154,13 +154,15 @@ def test_warm_start_clear(GradientBoosting, X, y):
     (HistGradientBoostingClassifier, X_classification, y_classification),
     (HistGradientBoostingRegressor, X_regression, y_regression)
 ])
-@pytest.mark.parametrize('rng_type', ('int', 'instance'))
+@pytest.mark.parametrize('rng_type', ('none', 'int', 'instance'))
 def test_random_seeds_warm_start(GradientBoosting, X, y, rng_type):
     # Make sure the seeds for train/val split and small trainset subsampling
     # are correctly set in a warm start context.
     def _get_rng(rng_type):
         # Helper to avoid consuming rngs
-        if rng_type == 'int':
+        if rng_type == 'none':
+            return None
+        elif rng_type == 'int':
             return 42
         else:
             return np.random.RandomState(0)
@@ -169,16 +171,30 @@ def test_random_seeds_warm_start(GradientBoosting, X, y, rng_type):
     gb_1 = GradientBoosting(n_iter_no_change=5, max_iter=2,
                             random_state=random_state)
     gb_1.fit(X, y)
-    random_seed_1 = gb_1._random_seed
+    random_seed_1_1 = gb_1._random_seed
+
+    gb_1.fit(X, y)
+    random_seed_1_2 = gb_1._random_seed  # clear the old state, different seed
 
     random_state = _get_rng(rng_type)
     gb_2 = GradientBoosting(n_iter_no_change=5, max_iter=2,
                             random_state=random_state, warm_start=True)
     gb_2.fit(X, y)  # inits state
-    random_seed_2 = gb_2._random_seed
+    random_seed_2_1 = gb_2._random_seed
     gb_2.fit(X, y)  # clears old state and equals est
-    random_seed_3 = gb_2._random_seed
+    random_seed_2_2 = gb_2._random_seed
 
-    # Check that all seeds are equal
-    assert random_seed_1 == random_seed_2
-    assert random_seed_2 == random_seed_3
+    # Without warm starting, the seeds should be
+    # * all different if random state is None
+    # * all equal if random state is an integer
+    # * different when refitting and equal with a new estimator (because
+    #   the random state is mutated)
+    if rng_type == 'none':
+        assert random_seed_1_1 != random_seed_1_2 != random_seed_2_1
+    elif rng_type == 'int':
+        assert random_seed_1_1 == random_seed_1_2 == random_seed_2_1
+    else:
+        assert random_seed_1_1 == random_seed_2_1 != random_seed_1_2
+
+    # With warm starting, the seeds must be equal
+    assert random_seed_2_1 == random_seed_2_2


### PR DESCRIPTION
#### Reference Issues/PRs

Discussion from #14034. **This PR is for the histogram-based version of GBDT.**

#### What does this implement/fix? Explain your changes.

One single random seed is used instead of several ones. It is needed to save it for warm starting, so that every time there is some sort of RNG, the same seed is used.

* `self._small_trainset_seed = rng.randint(1024)` and `self._train_val_split_seed = rng.randint(1024)` have been replaced with `self._random_seed = rng.randint(np.iinfo(np.uint32).max)` ([@ogrisel  comment](https://github.com/scikit-learn/scikit-learn/issues/14034#issuecomment-531150174))

* The random seed is passed to the bin mapper ([@NicolasHug comment](https://github.com/scikit-learn/scikit-learn/issues/14034#issuecomment-531563182)). The `rng` parameter in the [_bin_data](https://github.com/scikit-learn/scikit-learn/blob/d2476fb679f05e80c56e8b151ff0f6d7a470e4ae/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py#L491-L513) is removed since it is not used, and we pass the `rng` parameter to `BinMapper` [two lines above](https://github.com/johannfaouzi/scikit-learn/blob/9b83c211a46a05821ffb825f255a9a525b074e89/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py#L158-L159).

#### Any other comments?

When we have a version of warm starting that is good enough for HGBDT, I will try to do the same for GBDT (i.e. fix #14034).

Possible reviewers: @NicolasHug @ogrisel 