### PR TITLE
DOC Fix Title level inconsistency and orphaned page.

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -1175,7 +1175,7 @@ Such a regressor can be useful for a set of equally well performing models
 in order to balance out their individual weaknesses.
 
 Usage
-.....
+-----
 
 The following example shows how to fit the VotingRegressor::
 

--- a/doc/other_distributions.rst
+++ b/doc/other_distributions.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _install_by_distribution:
 
 Third party distributions of scikit-learn

--- a/doc/other_distributions.rst
+++ b/doc/other_distributions.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _install_by_distribution:
 
 Third party distributions of scikit-learn


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR fix the last two "easy" sphinx warnings.

- Title level inconsistent
- document isn't included in any toctree