### PR TITLE
[DOC] Adds to the current list of attributes for Bayes ARDRegression class

### DIFF
--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -456,7 +456,7 @@ class ARDRegression(RegressorMixin, LinearModel):
     intercept_ : float
         Independent term in decision function. Set to 0.0 if
         ``fit_intercept = False``.
-        
+
     Examples
     --------
     >>> from sklearn import linear_model

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -454,7 +454,8 @@ class ARDRegression(RegressorMixin, LinearModel):
         if computed, value of the objective function (to be maximized)
 
     intercept_ : float
-        Independent term in decision function. Set to 0.0 if ``fit_intercept = False``
+        Independent term in decision function. Set to 0.0 if
+        ``fit_intercept = False``.
         
     Examples
     --------

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -453,6 +453,9 @@ class ARDRegression(RegressorMixin, LinearModel):
     scores_ : float
         if computed, value of the objective function (to be maximized)
 
+    intercept_ : float
+        Independent term in decision function. Set to 0.0 if ``fit_intercept = False``
+        
     Examples
     --------
     >>> from sklearn import linear_model


### PR DESCRIPTION
#### Reference Issues/PRs
Resolves #14868 

#### What does this implement/fix? Explain your changes.

Adds `intercept_ `  to the list of attributes for Bayes Regression class: ARDRegression.

- [ARDRegression docs](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ARDRegression.html#sklearn.linear_model.ARDRegression).
