### PR TITLE
Add CI config to test scikit-learn with latest numpy / scipy / mkl from conda defaults channel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,6 +38,17 @@ jobs:
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
         TEST_DOCSTRINGS: 'true'
         CHECK_WARNINGS: 'true'
+      pylatest_conda_mkl:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '*'
+        INSTALL_MKL: 'true'
+        NUMPY_VERSION: '*'
+        SCIPY_VERSION: '*'
+        CYTHON_VERSION: '*'
+        PILLOW_VERSION: '*'
+        PYTEST_VERSION: '*'
+        JOBLIB_VERSION: '*'
+        COVERAGE: 'true'
 
 - template: build_tools/azure/posix-32.yml
   parameters:

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -36,9 +36,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
 
     TO_INSTALL="python=$PYTHON_VERSION pip pytest=$PYTEST_VERSION \
                 pytest-cov numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
-                cython=$CYTHON_VERSION joblib=$JOBLIB_VERSION \
-                intel-openmp=2019.4"  # FIXME: pin openmp since there is a bug
-                # https://github.com/scikit-learn/scikit-learn/pull/15020
+                cython=$CYTHON_VERSION joblib=$JOBLIB_VERSION
 
     if [[ "$INSTALL_MKL" == "true" ]]; then
         TO_INSTALL="$TO_INSTALL mkl"

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -36,7 +36,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
 
     TO_INSTALL="python=$PYTHON_VERSION pip pytest=$PYTEST_VERSION \
                 pytest-cov numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
-                cython=$CYTHON_VERSION joblib=$JOBLIB_VERSION
+                cython=$CYTHON_VERSION joblib=$JOBLIB_VERSION"
 
     if [[ "$INSTALL_MKL" == "true" ]]; then
         TO_INSTALL="$TO_INSTALL mkl"

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -36,7 +36,9 @@ if [[ "$DISTRIB" == "conda" ]]; then
 
     TO_INSTALL="python=$PYTHON_VERSION pip pytest=$PYTEST_VERSION \
                 pytest-cov numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
-                cython=$CYTHON_VERSION joblib=$JOBLIB_VERSION"
+                cython=$CYTHON_VERSION joblib=$JOBLIB_VERSION \
+                intel-openmp=2019.4"  # FIXME: pin openmp since there is a bug
+                # https://github.com/scikit-learn/scikit-learn/pull/15020
 
     if [[ "$INSTALL_MKL" == "true" ]]; then
         TO_INSTALL="$TO_INSTALL mkl"

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -58,6 +58,9 @@ __version__ = '0.22.dev0'
 # the outer OpenMP parallel section.
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "True")
 
+# Workaround issue discovered in intel-openmp 2019.5:
+# https://github.com/ContinuumIO/anaconda-issues/issues/11294
+os.environ.setdefault("KMP_INIT_AT_FORK", "FALSE")
 
 try:
     # This variable is injected in the __builtins__ by the build

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -18,12 +18,6 @@ import warnings
 import logging
 import os
 
-# work around to link against OpenMP
-try:
-    import numpy
-except ImportError:
-    pass
-
 from ._config import get_config, set_config, config_context
 
 logger = logging.getLogger(__name__)

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -18,6 +18,12 @@ import warnings
 import logging
 import os
 
+# work around to link against OpenMP
+try:
+    import numpy
+except ImportError:
+    pass
+
 from ._config import get_config, set_config, config_context
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes #15030 

By testing locally in a conda env with mkl we recently observed the following crash in tests that use both `n_jobs>=2` and numpy.

```
OMP: Error #13: Assertion failure at z_Linux_util.cpp(2361)
```

The issue is caused by a regression introduced in `intel-opemp=2015.5` recently published by Anaconda.

We realized that this environment was not covered in our CI.