### PR TITLE
MAINT less misleading distrib name in azure ci

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
       # Linux environment to test the latest available dependencies and MKL.
       # It runs tests requiring pandas and PyAMG.
       pylatest_pip_openblas_pandas:
-        DISTRIB: 'conda-latest'
+        DISTRIB: 'conda-pip-latest'
         PYTHON_VERSION: '*'
         PYTEST_VERSION: '4.6.2'
         COVERAGE: 'true'

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -86,9 +86,10 @@ elif [[ "$DISTRIB" == "ubuntu-32" ]]; then
     python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
     source $VIRTUALENV/bin/activate
     python -m pip install pytest==$PYTEST_VERSION pytest-cov cython joblib==$JOBLIB_VERSION
-elif [[ "$DISTRIB" == "conda-latest" ]]; then
-    # since conda main channel usually lacks behind on the latest releases,
+elif [[ "$DISTRIB" == "conda-pip-latest" ]]; then
+    # Since conda main channel usually lacks behind on the latest releases,
     # we use pypi to test against the latest releases of the dependencies.
+    # conda is still used as a convenient way to install Python and pip.
     make_conda "python=$PYTHON_VERSION"
     python -m pip install numpy scipy joblib cython
     python -m pip install pytest==$PYTEST_VERSION pytest-cov pytest-xdist


### PR DESCRIPTION
Just a tiny renaming:

```yaml
DISTRIB: 'conda-latest'
```

to

```yaml
DISTRIB: 'conda-pip-latest'
```

Otherwise one might think that numpy / scipy / blas are installed with conda while in fact they are installed with pip from PyPI and only Python is installed with conda.