### PR TITLE
Add environment variable to skip OpenMP support check

### DIFF
--- a/sklearn/_build_utils/openmp_helpers.py
+++ b/sklearn/_build_utils/openmp_helpers.py
@@ -62,6 +62,10 @@ def check_openmp_support():
     ccompiler = new_compiler()
     customize_compiler(ccompiler)
 
+    if os.getenv('SKLEARN_SKIP_OPENMP_CHECK'):
+        # Skip check and try building with OpenMP support
+        return True
+
     if os.getenv('SKLEARN_NO_OPENMP'):
         # Build explicitly without OpenMP support
         return False


### PR DESCRIPTION
#### Reference Issues/PRs
no

#### What does this implement/fix? Explain your changes.
In some situations, build environment is not fully configurable. Reading LDFLAGS environment variable might cause issue. For example, if LDFLAGS contains `-shared`, then the OpenMP test program will fail as the built "executable" is not really an executable, but having `-shared` is actually fine when building the scikit-learn.
It is definitely a good idea to have this explicit message printed when OpenMP is not supported, and let people notice the option to build without OpenMP support, I think it is also a good idea to give people option to try building with OpenMP support regardless of potential failures.

#### Any other comments?
I don't think we need to promote this specific environment variable in documentation/error message, as the use case is probably not very common. However, I am open to add this to documentation/error message, probably something like "if you are very sure that your compiler supports OpenMP, please set the environment variable `SKLEARN_SKIP_OPENMP_CHECK`"
