### PR TITLE
TST Fix assert raises in sklearn/neighbors/tests/ 

### DIFF
--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -12,7 +12,6 @@ from scipy.spatial.distance import cdist
 from sklearn.neighbors.dist_metrics import DistanceMetric
 from sklearn.neighbors import BallTree
 from sklearn.utils import check_random_state
-from sklearn.utils.testing import assert_raises_regex
 
 
 def dist_func(x1, x2, p):
@@ -184,9 +183,9 @@ def test_bad_pyfunc_metric():
         return "1"
 
     X = np.ones((5, 2))
-    assert_raises_regex(TypeError,
-                        "Custom distance function must accept two vectors",
-                        BallTree, X, metric=wrong_distance)
+    err_msg = "Custom distance function must accept two vectors"
+    with pytest.raises(TypeError, match=err_msg):
+        BallTree(X, metric=wrong_distance)
 
 
 def test_input_data_size():

--- a/sklearn/neighbors/tests/test_kde.py
+++ b/sklearn/neighbors/tests/test_kde.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import pytest
 
-from sklearn.utils.testing import assert_allclose, assert_raises
+from sklearn.utils.testing import assert_allclose
 from sklearn.neighbors import KernelDensity, KDTree, NearestNeighbors
 from sklearn.neighbors.ball_tree import kernel_norm
 from sklearn.pipeline import make_pipeline
@@ -90,7 +90,8 @@ def test_kernel_density_sampling(n_samples=100, n_features=3):
     # check unsupported kernels
     for kernel in ['epanechnikov', 'exponential', 'linear', 'cosine']:
         kde = KernelDensity(bandwidth, kernel=kernel).fit(X)
-        assert_raises(NotImplementedError, kde.sample, 100)
+        with pytest.raises(NotImplementedError):
+            kde.sample(100)
 
     # non-regression test: used to return a scalar
     X = rng.randn(4, 1)
@@ -109,8 +110,8 @@ def test_kde_algorithm_metric_choice(algorithm, metric):
     Y = rng.randn(10, 2)
 
     if algorithm == 'kd_tree' and metric not in KDTree.valid_metrics:
-        assert_raises(ValueError, KernelDensity,
-                      algorithm=algorithm, metric=metric)
+        with pytest.raises(ValueError):
+            KernelDensity(algorithm=algorithm, metric=metric)
     else:
         kde = KernelDensity(algorithm=algorithm, metric=metric)
         kde.fit(X)
@@ -127,21 +128,21 @@ def test_kde_score(n_samples=100, n_features=3):
 
 
 def test_kde_badargs():
-    assert_raises(ValueError, KernelDensity,
-                  algorithm='blah')
-    assert_raises(ValueError, KernelDensity,
-                  bandwidth=0)
-    assert_raises(ValueError, KernelDensity,
-                  kernel='blah')
-    assert_raises(ValueError, KernelDensity,
-                  metric='blah')
-    assert_raises(ValueError, KernelDensity,
-                  algorithm='kd_tree', metric='blah')
+    with pytest.raises(ValueError):
+        KernelDensity(algorithm='blah')
+    with pytest.raises(ValueError):
+        KernelDensity(bandwidth=0)
+    with pytest.raises(ValueError):
+        KernelDensity(kernel='blah')
+    with pytest.raises(ValueError):
+        KernelDensity(metric='blah')
+    with pytest.raises(ValueError):
+        KernelDensity(algorithm='kd_tree', metric='blah')
     kde = KernelDensity()
-    assert_raises(ValueError, kde.fit, np.random.random((200, 10)),
-                  sample_weight=np.random.random((200, 10)))
-    assert_raises(ValueError, kde.fit, np.random.random((200, 10)),
-                  sample_weight=-np.random.random(200))
+    with pytest.raises(ValueError):
+        kde.fit(np.random.random((200, 10)), sample_weight=np.random.random((200, 10)))
+    with pytest.raises(ValueError):
+        kde.fit(np.random.random((200, 10)), sample_weight=-np.random.random(200))
 
 
 def test_kde_pipeline_gridsearch():

--- a/sklearn/neighbors/tests/test_lof.py
+++ b/sklearn/neighbors/tests/test_lof.py
@@ -3,6 +3,7 @@
 # License: BSD 3 clause
 
 from math import sqrt
+import pytest
 
 import numpy as np
 from sklearn import neighbors
@@ -15,8 +16,6 @@ from sklearn.metrics import roc_auc_score
 from sklearn.utils import check_random_state
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_warns_message
-from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.estimator_checks import check_outlier_corruption
 
@@ -148,7 +147,8 @@ def test_score_samples():
 def test_contamination():
     X = [[1, 1], [1, 0]]
     clf = neighbors.LocalOutlierFactor(contamination=0.6)
-    assert_raises(ValueError, clf.fit, X)
+    with pytest.raises(ValueError):
+        clf.fit(X)
 
 
 def test_novelty_errors():
@@ -160,12 +160,14 @@ def test_novelty_errors():
     # predict, decision_function and score_samples raise ValueError
     for method in ['predict', 'decision_function', 'score_samples']:
         msg = ('{} is not available when novelty=False'.format(method))
-        assert_raises_regex(AttributeError, msg, getattr, clf, method)
+        with pytest.raises(AttributeError, match=msg):
+            getattr(clf, method)
 
     # check errors for novelty=True
     clf = neighbors.LocalOutlierFactor(novelty=True)
     msg = 'fit_predict is not available when novelty=True'
-    assert_raises_regex(AttributeError, msg, getattr, clf, 'fit_predict')
+    with pytest.raises(AttributeError, match=msg):
+        getattr(clf, 'fit_predict')
 
 
 def test_novelty_training_scores():

--- a/sklearn/neighbors/tests/test_nca.py
+++ b/sklearn/neighbors/tests/test_nca.py
@@ -15,7 +15,7 @@ from scipy.optimize import check_grad
 from sklearn import clone
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils import check_random_state
-from sklearn.utils.testing import (assert_raise_message, assert_warns_message)
+from sklearn.utils.testing import assert_warns_message
 from sklearn.datasets import load_iris, make_classification, make_blobs
 from sklearn.neighbors.nca import NeighborhoodComponentsAnalysis
 from sklearn.metrics import pairwise_distances
@@ -137,32 +137,31 @@ def test_params_validation():
     with pytest.raises(TypeError):
         NCA(warm_start=1).fit(X, y)
 
+    err_msg = (r"`init` must be 'auto', 'pca', 'lda', 'identity', "
+               r"'random' or a numpy array of shape "
+               r"\(n_components, n_features\).")
     # ValueError
-    assert_raise_message(ValueError,
-                         "`init` must be 'auto', 'pca', 'lda', 'identity', "
-                         "'random' or a numpy array of shape "
-                         "(n_components, n_features).",
-                         NCA(init=1).fit, X, y)
-    assert_raise_message(ValueError,
-                         '`max_iter`= -1, must be >= 1.',
-                         NCA(max_iter=-1).fit, X, y)
+    with pytest.raises(ValueError, match=err_msg):
+        NCA(init=1).fit(X, y)
+    with pytest.raises(ValueError, match='`max_iter`= -1, must be >= 1.'):
+        NCA(max_iter=-1).fit(X, y)
 
     init = rng.rand(5, 3)
-    assert_raise_message(ValueError,
-                         'The output dimensionality ({}) of the given linear '
-                         'transformation `init` cannot be greater than its '
-                         'input dimensionality ({}).'
-                         .format(init.shape[0], init.shape[1]),
-                         NCA(init=init).fit, X, y)
+    err_msg = (r'The output dimensionality \({}\) of the given linear '
+               r'transformation `init` cannot be greater than its '
+               r'input dimensionality \({}\).')
+    with pytest.raises(ValueError, match=err_msg.format(init.shape[0],
+                                                        init.shape[1])):
+        NCA(init=init).fit(X, y)
 
     n_components = 10
-    assert_raise_message(ValueError,
-                         'The preferred dimensionality of the '
-                         'projected space `n_components` ({}) cannot '
-                         'be greater than the given data '
-                         'dimensionality ({})!'
-                         .format(n_components, X.shape[1]),
-                         NCA(n_components=n_components).fit, X, y)
+    err_msg = (r'The preferred dimensionality of the '
+               r'projected space `n_components` \({}\) cannot '
+               r'be greater than the given data '
+               r'dimensionality \({}\)!')
+    with pytest.raises(ValueError, match=err_msg.format(n_components,
+                                                        X.shape[1])):
+        NCA(n_components=n_components).fit(X, y)
 
 
 def test_transformation_dimensions():
@@ -196,24 +195,24 @@ def test_n_components():
     # n_components = X.shape[1] != transformation.shape[0]
     n_components = X.shape[1]
     nca = NeighborhoodComponentsAnalysis(init=init, n_components=n_components)
-    assert_raise_message(ValueError,
-                         'The preferred dimensionality of the '
-                         'projected space `n_components` ({}) does not match '
-                         'the output dimensionality of the given '
-                         'linear transformation `init` ({})!'
-                         .format(n_components, init.shape[0]),
-                         nca.fit, X, y)
+    err_msg = (r'The preferred dimensionality of the '
+               r'projected space `n_components` \({}\) does not match '
+               r'the output dimensionality of the given '
+               r'linear transformation `init` \({}\)!')
+    with pytest.raises(ValueError, match=err_msg.format(n_components,
+                                                        init.shape[0])):
+        nca.fit(X, y)
 
     # n_components > X.shape[1]
     n_components = X.shape[1] + 2
     nca = NeighborhoodComponentsAnalysis(init=init, n_components=n_components)
-    assert_raise_message(ValueError,
-                         'The preferred dimensionality of the '
-                         'projected space `n_components` ({}) cannot '
-                         'be greater than the given data '
-                         'dimensionality ({})!'
-                         .format(n_components, X.shape[1]),
-                         nca.fit, X, y)
+    err_msg = (r'The preferred dimensionality of the '
+               r'projected space `n_components` \({}\) cannot '
+               r'be greater than the given data '
+               r'dimensionality \({}\)!')
+    with pytest.raises(ValueError, match=err_msg.format(n_components,
+                                                        X.shape[1])):
+        nca.fit(X, y)
 
     # n_components < X.shape[1]
     nca = NeighborhoodComponentsAnalysis(n_components=2, init='identity')
@@ -251,34 +250,34 @@ def test_init_transformation():
     # init.shape[1] must match X.shape[1]
     init = rng.rand(X.shape[1], X.shape[1] + 1)
     nca = NeighborhoodComponentsAnalysis(init=init)
-    assert_raise_message(ValueError,
-                         'The input dimensionality ({}) of the given '
-                         'linear transformation `init` must match the '
-                         'dimensionality of the given inputs `X` ({}).'
-                         .format(init.shape[1], X.shape[1]),
-                         nca.fit, X, y)
+    err_msg = (r'The input dimensionality \({}\) of the given '
+               r'linear transformation `init` must match the '
+               r'dimensionality of the given inputs `X` \({}\).')
+    with pytest.raises(ValueError, match=err_msg.format(init.shape[1],
+                                                        X.shape[1])):
+        nca.fit(X, y)
 
     # init.shape[0] must be <= init.shape[1]
     init = rng.rand(X.shape[1] + 1, X.shape[1])
     nca = NeighborhoodComponentsAnalysis(init=init)
-    assert_raise_message(ValueError,
-                         'The output dimensionality ({}) of the given '
-                         'linear transformation `init` cannot be '
-                         'greater than its input dimensionality ({}).'
-                         .format(init.shape[0], init.shape[1]),
-                         nca.fit, X, y)
+    err_msg = (r'The output dimensionality \({}\) of the given '
+               r'linear transformation `init` cannot be '
+               r'greater than its input dimensionality \({}\).')
+    with pytest.raises(ValueError, match=err_msg.format(init.shape[0],
+                                                        init.shape[1])):
+        nca.fit(X, y)
 
     # init.shape[0] must match n_components
     init = rng.rand(X.shape[1], X.shape[1])
     n_components = X.shape[1] - 2
     nca = NeighborhoodComponentsAnalysis(init=init, n_components=n_components)
-    assert_raise_message(ValueError,
-                         'The preferred dimensionality of the '
-                         'projected space `n_components` ({}) does not match '
-                         'the output dimensionality of the given '
-                         'linear transformation `init` ({})!'
-                         .format(n_components, init.shape[0]),
-                         nca.fit, X, y)
+    err_msg = (r'The preferred dimensionality of the '
+               r'projected space `n_components` \({}\) does not match '
+               r'the output dimensionality of the given '
+               r'linear transformation `init` \({}\)!')
+    with pytest.raises(ValueError, match=err_msg.format(n_components,
+                                                        init.shape[0])):
+        nca.fit(X, y)
 
 
 @pytest.mark.parametrize('n_samples', [3, 5, 7, 11])
@@ -327,13 +326,13 @@ def test_warm_start_validation():
     X_less_features, y = make_classification(n_samples=30, n_features=4,
                                              n_classes=4, n_redundant=0,
                                              n_informative=4, random_state=0)
-    assert_raise_message(ValueError,
-                         'The new inputs dimensionality ({}) does not '
-                         'match the input dimensionality of the '
-                         'previously learned transformation ({}).'
-                         .format(X_less_features.shape[1],
-                                 nca.components_.shape[1]),
-                         nca.fit, X_less_features, y)
+    err_msg = (r'The new inputs dimensionality \({}\) does not '
+               r'match the input dimensionality of the '
+               r'previously learned transformation \({}\).')
+    with pytest.raises(ValueError,
+                       match=err_msg.format(X_less_features.shape[1],
+                                            nca.components_.shape[1])):
+        nca.fit(X_less_features, y)
 
 
 def test_warm_start_effectiveness():

--- a/sklearn/neighbors/tests/test_nca.py
+++ b/sklearn/neighbors/tests/test_nca.py
@@ -15,8 +15,7 @@ from scipy.optimize import check_grad
 from sklearn import clone
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils import check_random_state
-from sklearn.utils.testing import (assert_raises,
-                                   assert_raise_message, assert_warns_message)
+from sklearn.utils.testing import (assert_raise_message, assert_warns_message)
 from sklearn.datasets import load_iris, make_classification, make_blobs
 from sklearn.neighbors.nca import NeighborhoodComponentsAnalysis
 from sklearn.metrics import pairwise_distances
@@ -127,11 +126,16 @@ def test_params_validation():
     rng = np.random.RandomState(42)
 
     # TypeError
-    assert_raises(TypeError, NCA(max_iter='21').fit, X, y)
-    assert_raises(TypeError, NCA(verbose='true').fit, X, y)
-    assert_raises(TypeError, NCA(tol='1').fit, X, y)
-    assert_raises(TypeError, NCA(n_components='invalid').fit, X, y)
-    assert_raises(TypeError, NCA(warm_start=1).fit, X, y)
+    with pytest.raises(TypeError):
+        NCA(max_iter='21').fit(X, y)
+    with pytest.raises(TypeError):
+        NCA(verbose='true').fit(X, y)
+    with pytest.raises(TypeError):
+        NCA(tol='1').fit(X, y)
+    with pytest.raises(TypeError):
+        NCA(n_components='invalid').fit(X, y)
+    with pytest.raises(TypeError):
+        NCA(warm_start=1).fit(X, y)
 
     # ValueError
     assert_raise_message(ValueError,
@@ -167,17 +171,15 @@ def test_transformation_dimensions():
 
     # Fail if transformation input dimension does not match inputs dimensions
     transformation = np.array([[1, 2], [3, 4]])
-    assert_raises(ValueError,
-                  NeighborhoodComponentsAnalysis(init=transformation).fit,
-                  X, y)
+    with pytest.raises(ValueError):
+        NeighborhoodComponentsAnalysis(init=transformation).fit(X, y)
 
     # Fail if transformation output dimension is larger than
     # transformation input dimension
     transformation = np.array([[1, 2], [3, 4], [5, 6]])
     # len(transformation) > len(transformation[0])
-    assert_raises(ValueError,
-                  NeighborhoodComponentsAnalysis(init=transformation).fit,
-                  X, y)
+    with pytest.raises(ValueError):
+        NeighborhoodComponentsAnalysis(init=transformation).fit(X, y)
 
     # Pass otherwise
     transformation = np.arange(9).reshape(3, 3)
@@ -466,7 +468,8 @@ def test_callback(capsys):
     y = iris_target
 
     nca = NeighborhoodComponentsAnalysis(callback='my_cb')
-    assert_raises(ValueError, nca.fit, X, y)
+    with pytest.raises(ValueError):
+        nca.fit(X, y)
 
     max_iter = 10
 

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -3,12 +3,12 @@ Testing for the nearest centroid module.
 """
 
 import numpy as np
+import pytest
 from scipy import sparse as sp
 from numpy.testing import assert_array_equal
 
 from sklearn.neighbors import NearestCentroid
 from sklearn import datasets
-from sklearn.utils.testing import assert_raises
 
 # toy sample
 X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]
@@ -56,7 +56,7 @@ def test_classification_toy():
 
 def test_precomputed():
     clf = NearestCentroid(metric='precomputed')
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         clf.fit(X, y)
 
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -18,7 +18,6 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
-from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.validation import check_random_state
 
@@ -1025,10 +1024,9 @@ def test_neighbors_badargs():
 
         nbrs = cls(metric='haversine', algorithm='brute')
         nbrs.fit(X3, y)
-        assert_raise_message(ValueError,
-                             "Haversine distance only valid in 2 dimensions",
-                             nbrs.predict,
-                             X3)
+        err_msg = "Haversine distance only valid in 2 dimensions"
+        with pytest.raises(ValueError, match=err_msg):
+            nbrs.predict(X3)
 
         nbrs = cls()
         with pytest.raises(ValueError):


### PR DESCRIPTION
replaced the use of `assert_raises`, `assert_raises_regex`, and `assert_raise_message` with `pytest.raises` context manager.

related to #14216