### PR TITLE
DOC adds a random seed to plot_permutation_importance example

### DIFF
--- a/examples/inspection/plot_permutation_importance.py
+++ b/examples/inspection/plot_permutation_importance.py
@@ -51,8 +51,9 @@ from sklearn.preprocessing import OneHotEncoder
 # - ``random_cat`` is a low cardinality categorical variable (3 possible
 #   values).
 X, y = fetch_openml("titanic", version=1, as_frame=True, return_X_y=True)
-X['random_cat'] = np.random.randint(3, size=X.shape[0])
-X['random_num'] = np.random.randn(X.shape[0])
+rng = np.random.RandomState(seed=42)
+X['random_cat'] = rng.randint(3, size=X.shape[0])
+X['random_num'] = rng.randn(X.shape[0])
 
 categorical_columns = ['pclass', 'sex', 'embarked', 'random_cat']
 numerical_columns = ['age', 'sibsp', 'parch', 'fare', 'random_num']


### PR DESCRIPTION
The example was missing a random seed, hence the user would get a different result from the plots generated in the example.