### PR TITLE
Multithreaded kneighbors_graph in TSNE

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -347,6 +347,11 @@ Changelog
   neighbors graph as input. :issue:`10482` by `Tom Dupre la Tour`_ and
   :user:`Kumar Ashutosh <thechargedneutron>`.
 
+- |Feature| Exposed the ``n_jobs`` parameter in :class:`manifold.TSNE` for
+  multi-core calculation of the neighbors graph. This parameter has no
+  impact when ``metric="precomputed"`` or (``metric="euclidean"`` and
+  ``method="exact"``). :issue:`15082` by `Roman Yurchak`_.
+
 - |API| Deprecate ``training_data_`` unused attribute in
   :class:`manifold.Isomap`. :issue:`10482` by `Tom Dupre la Tour`_.
 

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -578,7 +578,9 @@ class TSNE(BaseEstimator):
         computation time and angle greater 0.8 has quickly increasing error.
 
     n_jobs : int or None, optional (default=None)
-        The number of parallel jobs to run for neighbors search.
+        The number of parallel jobs to run for neighbors search. This parameter
+        has no impact when ``metric="precomputed"`` or
+        (``metric="euclidean"`` and ``method="exact"``).
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -702,8 +702,7 @@ class TSNE(BaseEstimator):
 
                 if self.metric == "euclidean":
                     distances = pairwise_distances(X, metric=self.metric,
-                                                   squared=True,
-                                                   n_jobs=self.n_jobs)
+                                                   squared=True)
                 else:
                     distances = pairwise_distances(X, metric=self.metric,
                                                    n_jobs=self.n_jobs)

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -627,7 +627,8 @@ class TSNE(BaseEstimator):
                  early_exaggeration=12.0, learning_rate=200.0, n_iter=1000,
                  n_iter_without_progress=300, min_grad_norm=1e-7,
                  metric="euclidean", init="random", verbose=0,
-                 random_state=None, method='barnes_hut', angle=0.5, n_jobs=None):
+                 random_state=None, method='barnes_hut', angle=0.5,
+                 n_jobs=None):
         self.n_components = n_components
         self.perplexity = perplexity
         self.early_exaggeration = early_exaggeration

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -577,6 +577,12 @@ class TSNE(BaseEstimator):
         in the range of 0.2 - 0.8. Angle less than 0.2 has quickly increasing
         computation time and angle greater 0.8 has quickly increasing error.
 
+    n_jobs : int or None, optional (default=None)
+        The number of parallel jobs to run for neighbors search.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
+        for more details.
+
     Attributes
     ----------
     embedding_ : array-like, shape (n_samples, n_components)
@@ -621,7 +627,7 @@ class TSNE(BaseEstimator):
                  early_exaggeration=12.0, learning_rate=200.0, n_iter=1000,
                  n_iter_without_progress=300, min_grad_norm=1e-7,
                  metric="euclidean", init="random", verbose=0,
-                 random_state=None, method='barnes_hut', angle=0.5):
+                 random_state=None, method='barnes_hut', angle=0.5, n_jobs=None):
         self.n_components = n_components
         self.perplexity = perplexity
         self.early_exaggeration = early_exaggeration
@@ -635,6 +641,7 @@ class TSNE(BaseEstimator):
         self.random_state = random_state
         self.method = method
         self.angle = angle
+        self.n_jobs = n_jobs
 
     def _fit(self, X, skip_num_points=0):
         """Private function to fit the model using X as training data."""
@@ -692,9 +699,11 @@ class TSNE(BaseEstimator):
 
                 if self.metric == "euclidean":
                     distances = pairwise_distances(X, metric=self.metric,
-                                                   squared=True)
+                                                   squared=True,
+                                                   n_jobs=self.n_jobs)
                 else:
-                    distances = pairwise_distances(X, metric=self.metric)
+                    distances = pairwise_distances(X, metric=self.metric,
+                                                   n_jobs=self.n_jobs)
 
                 if np.any(distances < 0):
                     raise ValueError("All distances should be positive, the "
@@ -720,6 +729,7 @@ class TSNE(BaseEstimator):
 
             # Find the nearest neighbors for every point
             knn = NearestNeighbors(algorithm='auto',
+                                   n_jobs=self.n_jobs,
                                    n_neighbors=n_neighbors,
                                    metric=self.metric)
             t0 = time()

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -585,6 +585,8 @@ class TSNE(BaseEstimator):
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
+        .. versionadded:: 0.22
+
     Attributes
     ----------
     embedding_ : array-like, shape (n_samples, n_components)

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -845,3 +845,17 @@ def test_tsne_with_different_distance_metrics():
             metric='precomputed', n_components=n_components_embedding,
             random_state=0, n_iter=300).fit_transform(dist_func(X))
         assert_array_equal(X_transformed_tsne, X_transformed_tsne_precomputed)
+
+
+@pytest.mark.parametrize('method', ['exact', 'barnes_hut'])
+def test_tsne_n_jobs(method):
+    """Make sure that the n_jobs parameter doesn't impact the output"""
+    random_state = check_random_state(0)
+    n_features = 10
+    X = random_state.randn(30, n_features)
+    X_tr_ref = TSNE(n_components=2, method=method, perplexity=30.0,
+                    angle=0, n_jobs=1, random_state=0).fit_transform(X)
+    X_tr = TSNE(n_components=2, method=method, perplexity=30.0,
+                angle=0, n_jobs=2, random_state=0).fit_transform(X)
+
+    assert_allclose(X_tr_ref, X_tr)


### PR DESCRIPTION
Partially addresses https://github.com/scikit-learn/scikit-learn/issues/10044
Partially addresses https://github.com/scikit-learn/scikit-learn/issues/10023

Computing the `kneighbors_graph` is one of the bottlenecks in TSNE. Actually we computing it in parallel, including for kd_tree and ball_tree has been supported for a while. This adds the `n_jobs` parameter to TSNE, which will pass it to `NearestNeighbours`.

On the first 20k samples of MNIST
<details>

```py
import numpy as np
from sklearn.manifold import TSNE
from sklearn.datasets import fetch_openml
from joblib import Memory


memory = Memory('/tmp/joblib_cache')

mnist = memory.cache(fetch_openml)(data_id=41063)

TSNE(verbose=5, n_jobs=8).fit_transform(mnist.data[:20000])
```

</details>

we can get up to a 2.5x run time speedup when running with `n_jobs=8`,

| MNIST n_samples=20k / `n_jobs` | 1    | 4    | 8    | 12  |
|--------------------------------|------|------|------|-----|
| kneighbors_graph (s)           | 340  | 130  | 86   | 80  |
| total run time (s)             | 462  | 246  | 189  | 184 |

The strong scaling limit seem to be around 10 CPU cores in this example.

For the full MNIST (60k samples), k-neighbours search takes proportionally even longer, and therefore multi-core scalability is better, with a x3.0 speed up at `n_jobs=8` (and x3.7 at `n_jobs=12`) ,

| MNIST n_samples=60k / `n_jobs` | 1   | 8    | 12   |
|--------------------------------|-----|------|------|
| kneighbors_graph (min)         | 61  | 15   | 10   |
| total run time (min)           | 68 | 22.4 | 18.5 | 

https://github.com/scikit-learn/scikit-learn/issues/10044#issuecomment-361735807 proposed smarter improvements that are still worth investigating, but in any case NN search is a bottleneck and we can't use `annoy` or similar unlike other TSNE libraries.

Not sure if this needs additional tests given that `n_jobs` in` NearesNeigbours` is already extensively tested.