### PR TITLE
[MRG] Deprecate None in VotingClassifer and VotingRegressor

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -234,6 +234,10 @@ Changelog
   :user:`Matt Hancock <notmatthancock>` and
   :pr:`5963` by :user:`Pablo Duboue <DrDub>`.
 
+- |API| `None` as a estimators is now deprecated in
+  :class:`ensemble.VotingClassifier` and  :class:`ensemble.VotingRegressor`.
+  Please use `'drop'` instead. :pr:`15090` by `Thomas Fan`_.
+
 :mod:`sklearn.feature_extraction`
 .................................
 

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -390,7 +390,7 @@ def test_set_params():
                  eclf1.get_params()["lr"].get_params()['C'])
 
 
-# TODO: Remove in 0.24 when None is removed in Voting*
+# TODO: Remove parametrization in 0.24 when None is removed in Voting*
 @pytest.mark.parametrize("drop", [None, 'drop'])
 def test_set_estimator_none(drop):
     """VotingClassifier set_params should be able to set estimators as None or
@@ -505,7 +505,7 @@ def test_transform():
     )
 
 
-# TODO: Remove in 0.24 when None is removed in Voting*
+# TODO: Remove drop=None in 0.24 when None is removed in Voting*
 @pytest.mark.parametrize(
     "X, y, voter",
     [(X, y, VotingClassifier(
@@ -558,7 +558,7 @@ def test_deprecate_none_transformer():
             estimators=[('lr', None),
                         ('tree', DecisionTreeClassifier(random_state=0))])]
 
-    msg = ("Using None as a estimator is deprecated in version 0.22 and will "
+    msg = ("Using None as an estimator is deprecated in version 0.22 and will "
            "be removed in version 0.24. Please use 'drop' instead.")
     for est in ests:
         with pytest.warns(DeprecationWarning, match=msg):

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -535,6 +535,7 @@ def test_check_estimators_voting_estimator(estimator):
     check_no_attributes_set_in_init(estimator.__class__.__name__, estimator)
 
 
+# TODO: Remove in 0.24 when 'drop' is removed in Voting*
 def test_deprecate_none_transformer():
     ests = [
         VotingRegressor(

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -6,7 +6,6 @@ import numpy as np
 from sklearn.utils.testing import assert_almost_equal, assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_raise_message
-from sklearn.utils.testing import ignore_warnings
 from sklearn.base import clone
 from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.estimator_checks import check_no_attributes_set_in_init

--- a/sklearn/ensemble/voting.py
+++ b/sklearn/ensemble/voting.py
@@ -76,14 +76,6 @@ class _BaseVoting(TransformerMixin, _BaseComposition):
         names, clfs = zip(*self.estimators)
         self._validate_names(names)
 
-        # TODO: Remove in 0.24 when 'drop' is removed in Voting*
-        for _, clf in self.estimators:
-            if clf is None:
-                warnings.warn("Using None as a estimator is deprecated "
-                              "in version 0.22 and will be removed in "
-                              "version 0.24. Please use 'drop' instead.",
-                              DeprecationWarning)
-
         n_isnone = np.sum(
             [clf in (None, 'drop') for _, clf in self.estimators]
         )
@@ -91,6 +83,14 @@ class _BaseVoting(TransformerMixin, _BaseComposition):
             raise ValueError(
                 'All estimators are None or "drop". At least one is required!'
             )
+
+        # TODO: Remove in 0.24 when None is removed in Voting*
+        for _, clf in self.estimators:
+            if clf is None:
+                warnings.warn("Using None as a estimator is deprecated "
+                              "in version 0.22 and will be removed in "
+                              "version 0.24. Please use 'drop' instead.",
+                              DeprecationWarning)
 
         self.estimators_ = Parallel(n_jobs=self.n_jobs)(
                 delayed(_parallel_fit_estimator)(clone(clf), X, y,

--- a/sklearn/ensemble/voting.py
+++ b/sklearn/ensemble/voting.py
@@ -14,6 +14,7 @@ This module contains:
 # License: BSD 3 clause
 
 from abc import abstractmethod
+import warnings
 
 import numpy as np
 
@@ -74,6 +75,14 @@ class _BaseVoting(TransformerMixin, _BaseComposition):
 
         names, clfs = zip(*self.estimators)
         self._validate_names(names)
+
+        # TODO: Remove in 0.24 when 'drop' is removed in Voting*
+        for _, clf in self.estimators:
+            if clf is None:
+                warnings.warn("Using None as a estimator is deprecated "
+                              "in version 0.22 and will be removed in "
+                              "version 0.24. Please use 'drop' instead.",
+                              DeprecationWarning)
 
         n_isnone = np.sum(
             [clf in (None, 'drop') for _, clf in self.estimators]

--- a/sklearn/ensemble/voting.py
+++ b/sklearn/ensemble/voting.py
@@ -150,8 +150,11 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
     estimators : list of (string, estimator) tuples
         Invoking the ``fit`` method on the ``VotingClassifier`` will fit clones
         of those original estimators that will be stored in the class attribute
-        ``self.estimators_``. An estimator can be set to ``None`` or ``'drop'``
-        using ``set_params``.
+        ``self.estimators_``. An estimator can be set to ``'drop'`` using
+        ``set_params``.
+
+        .. versionchanged:: 0.22
+           Deprecated `None` as a estimators in favor of `'drop'`.
 
     voting : str, {'hard', 'soft'} (default='hard')
         If 'hard', uses predicted class labels for majority rule voting.
@@ -384,8 +387,11 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
     estimators : list of (string, estimator) tuples
         Invoking the ``fit`` method on the ``VotingRegressor`` will fit clones
         of those original estimators that will be stored in the class attribute
-        ``self.estimators_``. An estimator can be set to ``None`` or ``'drop'``
-        using ``set_params``.
+        ``self.estimators_``. An estimator can be set to ``'drop'`` using
+        ``set_params``.
+
+        .. versionchanged:: 0.22
+           Deprecated `None` as a estimators in favor of `'drop'`.
 
     weights : array-like, shape (n_regressors,), optional (default=`None`)
         Sequence of weights (`float` or `int`) to weight the occurrences of

--- a/sklearn/ensemble/voting.py
+++ b/sklearn/ensemble/voting.py
@@ -87,7 +87,7 @@ class _BaseVoting(TransformerMixin, _BaseComposition):
         # TODO: Remove in 0.24 when None is removed in Voting*
         for _, clf in self.estimators:
             if clf is None:
-                warnings.warn("Using None as a estimator is deprecated "
+                warnings.warn("Using None as an estimator is deprecated "
                               "in version 0.22 and will be removed in "
                               "version 0.24. Please use 'drop' instead.",
                               DeprecationWarning)
@@ -154,7 +154,7 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         ``set_params``.
 
         .. versionchanged:: 0.22
-           Deprecated `None` as a estimators in favor of `'drop'`.
+           Deprecated `None` as an estimators in favor of `'drop'`.
 
     voting : str, {'hard', 'soft'} (default='hard')
         If 'hard', uses predicted class labels for majority rule voting.
@@ -391,7 +391,7 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
         ``set_params``.
 
         .. versionchanged:: 0.22
-           Deprecated `None` as a estimators in favor of `'drop'`.
+           Deprecated `None` as an estimators in favor of `'drop'`.
 
     weights : array-like, shape (n_regressors,), optional (default=`None`)
         Sequence of weights (`float` or `int`) to weight the occurrences of


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Resolves https://github.com/scikit-learn/scikit-learn/issues/14813


#### What does this implement/fix? Explain your changes.
Deprecates `None` in `VotingClassifer` and `VotingRegressor`.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->