### PR TITLE
STY Fixes whitespace for code in headers

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -588,6 +588,13 @@ div.sk-page-content h4 {
   word-wrap: break-word;
 }
 
+div.sk-page-content h1 code,
+div.sk-page-content h2 code,
+div.sk-page-content h3 code,
+div.sk-page-content h4 code {
+  white-space: normal;
+}
+
 /* longtables */
 
 table.longtable p {


### PR DESCRIPTION
On small screens the header would be cut off:

![Screen Shot 2019-09-25 at 1 20 19 PM](https://user-images.githubusercontent.com/5402633/65624144-3db77600-df97-11e9-8c68-0d864138b910.png)


This PR adjusts it so it wraps:

![Screen Shot 2019-09-25 at 1 19 50 PM](https://user-images.githubusercontent.com/5402633/65624104-2bd5d300-df97-11e9-8feb-3385c4d9a215.png)
