### PR TITLE
MRG clone parameters in gridsearch etc

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -730,8 +730,10 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             self.best_params_ = results["params"][self.best_index_]
 
         if self.refit:
-            self.best_estimator_ = clone(base_estimator).set_params(
-                **self.best_params_)
+            # we clone again after setting params in case some
+            # of the params are estimators as well.
+            self.best_estimator_ = clone(clone(base_estimator).set_params(
+                **self.best_params_))
             refit_start_time = time.time()
             if y is not None:
                 self.best_estimator_.fit(X, y, **fit_params)

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -491,7 +491,11 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         # clone after setting parameters in case any parameters
         # are estimators (like pipeline steps)
         # because pipeline doesn't clone steps in fit
-        estimator = clone(estimator.set_params(**parameters))
+        cloned_parameters = {}
+        for k, v in parameters.items():
+            cloned_parameters[k] = clone(v, safe=False)
+
+        estimator = estimator.set_params(**cloned_parameters)
 
     start_time = time.time()
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -488,7 +488,7 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
 
     train_scores = {}
     if parameters is not None:
-        estimator.set_params(**parameters)
+        estimator = clone(estimator.set_params(**parameters))
 
     start_time = time.time()
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -488,6 +488,9 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
 
     train_scores = {}
     if parameters is not None:
+        # clone after setting parameters in case any parameters
+        # are estimators (like pipeline steps)
+        # because pipeline doesn't clone steps in fit
         estimator = clone(estimator.set_params(**parameters))
 
     start_time = time.time()

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -63,7 +63,7 @@ from sklearn.metrics import make_scorer
 from sklearn.metrics import roc_auc_score
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
-from sklearn.linear_model import Ridge, SGDClassifier
+from sklearn.linear_model import Ridge, SGDClassifier, LinearRegression
 
 from sklearn.model_selection.tests.common import OneTimeSplitter
 
@@ -196,6 +196,18 @@ def test_grid_search():
     # Test exception handling on scoring
     grid_search.scoring = 'sklearn'
     assert_raises(ValueError, grid_search.fit, X, y)
+
+
+def test_grid_search_pipeline_steps():
+    pipe = Pipeline([('regressor', LinearRegression())])
+    param_grid = {'regressor': [LinearRegression(), Ridge()]}
+    grid_search = GridSearchCV(pipe, param_grid, cv=2)
+    grid_search.fit(X, y)
+    regressor_results = grid_search.cv_results_['param_regressor']
+    assert isinstance(regressor_results[0], LinearRegression)
+    assert isinstance(regressor_results[1], Ridge)
+    assert not hasattr(regressor_results[0], 'coef_')
+    assert not hasattr(regressor_results[1], 'coef_')
 
 
 def check_hyperparameter_searcher_with_fit_params(klass, **klass_kwargs):

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -199,6 +199,7 @@ def test_grid_search():
 
 
 def test_grid_search_pipeline_steps():
+    # check that parameters that are estimators are cloned before fitting
     pipe = Pipeline([('regressor', LinearRegression())])
     param_grid = {'regressor': [LinearRegression(), Ridge()]}
     grid_search = GridSearchCV(pipe, param_grid, cv=2)

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -208,6 +208,9 @@ def test_grid_search_pipeline_steps():
     assert isinstance(regressor_results[1], Ridge)
     assert not hasattr(regressor_results[0], 'coef_')
     assert not hasattr(regressor_results[1], 'coef_')
+    # check that we didn't modify the parameter grid that was passed
+    assert not hasattr(param_grid['regressor'][0], 'coef_')
+    assert not hasattr(param_grid['regressor'][1], 'coef_')
 
 
 def check_hyperparameter_searcher_with_fit_params(klass, **klass_kwargs):

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -209,6 +209,8 @@ def test_grid_search_pipeline_steps():
     assert isinstance(regressor_results[1], Ridge)
     assert not hasattr(regressor_results[0], 'coef_')
     assert not hasattr(regressor_results[1], 'coef_')
+    assert regressor_results[0] is not grid_search.best_estimator_
+    assert regressor_results[1] is not grid_search.best_estimator_
     # check that we didn't modify the parameter grid that was passed
     assert not hasattr(param_grid['regressor'][0], 'coef_')
     assert not hasattr(param_grid['regressor'][1], 'coef_')


### PR DESCRIPTION
Fixed #10063 without going through the pain of #8350.

I don't see a case where this could change behavior, as we immediately call ``fit`` after setting the steps, but maybe I'm missing something.

This not only removes possible confusion of users (see #8350 on how the stored estimators are quite hard to interpret), it also saves us potentially *a lot* of memory (imagine grid-searching a neural net and storing the weights for each parameter setting).