### PR TITLE
MAINT Use C99 functions from Cython

### DIFF
--- a/sklearn/cluster/_hierarchical.pyx
+++ b/sklearn/cluster/_hierarchical.pyx
@@ -18,16 +18,13 @@ from ..utils.fast_dict cimport IntFloatDict
 # C++
 from cython.operator cimport dereference as deref, preincrement as inc
 from libcpp.map cimport map as cpp_map
+from libc.math cimport fmax
 
 DTYPE = np.float64
 ctypedef np.float64_t DTYPE_t
 
 ITYPE = np.intp
 ctypedef np.intp_t ITYPE_t
-
-# Reimplementation for MSVC support
-cdef inline double fmax(double a, double b):
-    return max(a, b)
 
 ###############################################################################
 # Utilities for computing the ward momentum

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -145,6 +145,7 @@
 cimport cython
 cimport numpy as np
 from libc.math cimport fabs, sqrt, exp, cos, pow, log, lgamma
+from libc.math cimport fmin, fmax
 from libc.stdlib cimport calloc, malloc, free
 from libc.string cimport memcpy
 
@@ -2610,12 +2611,6 @@ def nodeheap_sort(DTYPE_t[::1] vals):
 
     return np.asarray(vals_sorted), np.asarray(indices)
 
-# Reimplementation for MSVC support
-cdef inline double fmin(double a, double b):
-    return min(a, b)
-
-cdef inline double fmax(double a, double b) nogil:
-    return max(a, b)
 
 cdef inline DTYPE_t _total_node_weight(NodeData_t* node_data,
                                        DTYPE_t* sample_weight,

--- a/sklearn/neighbors/quad_tree.pyx
+++ b/sklearn/neighbors/quad_tree.pyx
@@ -11,6 +11,7 @@ from cpython cimport Py_INCREF, PyObject, PyTypeObject
 from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy
 from libc.stdio cimport printf
+from libc.math import fabs
 
 from ..tree._utils cimport safe_realloc, sizet_ptr_to_ndarray
 from ..utils import check_array
@@ -19,9 +20,6 @@ import numpy as np
 cimport numpy as np
 np.import_array()
 
-cdef extern from "math.h":
-    float fabsf(float x) nogil
-
 cdef extern from "numpy/arrayobject.h":
     object PyArray_NewFromDescr(PyTypeObject* subtype, np.dtype descr,
                                 int nd, np.npy_intp* dims,
@@ -29,9 +27,7 @@ cdef extern from "numpy/arrayobject.h":
                                 void* data, int flags, object obj)
 
 
-# XXX using (size_t)(-1) is ugly, but SIZE_MAX is not available in C89
-# (i.e., older MSVC).
-cdef SIZE_t DEFAULT = <SIZE_t>(-1)
+cdef SIZE_t DEFAULT = SIZE_MAX
 
 
 # Repeat struct definition for numpy
@@ -279,7 +275,7 @@ cdef class _QuadTree:
         cdef bint res = True
         for i in range(self.n_dimensions):
             # Use EPSILON to avoid numerical error that would overgrow the tree
-            res &= fabsf(point1[i] - point2[i]) <= EPSILON
+            res &= fabs(point1[i] - point2[i]) <= EPSILON
         return res
 
 
@@ -443,7 +439,7 @@ cdef class _QuadTree:
         for i in range(self.n_dimensions):
             results[idx + i] = point[i] - cell.barycenter[i]
             results[idx_d] += results[idx + i] * results[idx + i]
-            duplicate &= fabsf(results[idx + i]) <= EPSILON
+            duplicate &= fabs(results[idx + i]) <= EPSILON
 
         # Do not compute self interactions
         if duplicate and cell.is_leaf:

--- a/sklearn/neighbors/quad_tree.pyx
+++ b/sklearn/neighbors/quad_tree.pyx
@@ -11,7 +11,7 @@ from cpython cimport Py_INCREF, PyObject, PyTypeObject
 from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy
 from libc.stdio cimport printf
-from libc.math import fabs
+from libc.stdint cimport SIZE_MAX
 
 from ..tree._utils cimport safe_realloc, sizet_ptr_to_ndarray
 from ..utils import check_array
@@ -19,6 +19,9 @@ from ..utils import check_array
 import numpy as np
 cimport numpy as np
 np.import_array()
+
+cdef extern from "math.h":
+    float fabsf(float x) nogil
 
 cdef extern from "numpy/arrayobject.h":
     object PyArray_NewFromDescr(PyTypeObject* subtype, np.dtype descr,
@@ -275,7 +278,7 @@ cdef class _QuadTree:
         cdef bint res = True
         for i in range(self.n_dimensions):
             # Use EPSILON to avoid numerical error that would overgrow the tree
-            res &= fabs(point1[i] - point2[i]) <= EPSILON
+            res &= fabsf(point1[i] - point2[i]) <= EPSILON
         return res
 
 
@@ -439,7 +442,7 @@ cdef class _QuadTree:
         for i in range(self.n_dimensions):
             results[idx + i] = point[i] - cell.barycenter[i]
             results[idx_d] += results[idx + i] * results[idx + i]
-            duplicate &= fabs(results[idx + i]) <= EPSILON
+            duplicate &= fabsf(results[idx + i]) <= EPSILON
 
         # Do not compute self interactions
         if duplicate and cell.is_leaf:

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -22,6 +22,7 @@ from libc.stdlib cimport free
 from libc.math cimport fabs
 from libc.string cimport memcpy
 from libc.string cimport memset
+from libc.stdint cimport SIZE_MAX
 
 import numpy as np
 cimport numpy as np
@@ -244,7 +245,7 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
                                          split.threshold, impurity, n_node_samples,
                                          weighted_n_node_samples)
 
-                if node_id == <SIZE_t>(-1):
+                if node_id == SIZE_MAX:
                     rc = -1
                     break
 
@@ -468,7 +469,7 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
                                  is_left, is_leaf,
                                  split.feature, split.threshold, impurity, n_node_samples,
                                  weighted_n_node_samples)
-        if node_id == <SIZE_t>(-1):
+        if node_id == SIZE_MAX:
             return -1
 
         # compute values also for split nodes (might become leafs later).
@@ -691,9 +692,7 @@ cdef class Tree:
             with gil:
                 raise MemoryError()
 
-    # XXX using (size_t)(-1) is ugly, but SIZE_MAX is not available in C89
-    # (i.e., older MSVC).
-    cdef int _resize_c(self, SIZE_t capacity=<SIZE_t>(-1)) nogil except -1:
+    cdef int _resize_c(self, SIZE_t capacity=SIZE_MAX) nogil except -1:
         """Guts of _resize
 
         Returns -1 in case of failure to allocate memory (and raise MemoryError)
@@ -702,7 +701,7 @@ cdef class Tree:
         if capacity == self.capacity and self.nodes != NULL:
             return 0
 
-        if capacity == <SIZE_t>(-1):
+        if capacity == SIZE_MAX:
             if self.capacity == 0:
                 capacity = 3  # default initial value
             else:
@@ -738,7 +737,7 @@ cdef class Tree:
 
         if node_id >= self.capacity:
             if self._resize_c() != 0:
-                return <SIZE_t>(-1)
+                return SIZE_MAX
 
         cdef Node* node = &self.nodes[node_id]
         node.impurity = impurity
@@ -1619,7 +1618,7 @@ cdef _build_pruned_tree(
                 node.impurity, node.n_node_samples,
                 node.weighted_n_node_samples)
 
-            if new_node_id == <SIZE_t>(-1):
+            if new_node_id == SIZE_MAX:
                 rc = -1
                 break
 


### PR DESCRIPTION
Removes some hacks and re-implementations for older MSVC compilers than should no longer be necessary since we dropped Python <3.5