### PR TITLE
[MRG] Fixed n_support_ attr for OneClassSVM and SVR

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -532,6 +532,10 @@ Changelog
   Now in these cases, fit() will fail with an Exception.
   :pr:`14286` by :user:`Alex Shacked <alexshacked>`.
 
+- |Fix| The `n_support_` attribute of :class:`svm.SVR` and
+  :class:`svm.OneClassSVM` was previously non-initialized, and had size 2. It
+  has now size 1 with the correct value. :pr:`15099` by `Nicolas Hug`_.
+
 :mod:`sklearn.tree`
 ...................
 

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -486,6 +486,11 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
 
     @property
     def n_support_(self):
+        try:
+            check_is_fitted(self)
+        except NotFittedError:
+            raise AttributeError
+
         svm_type = LIBSVM_IMPL.index(self._impl)
         if svm_type in (0, 1):
             return self._n_support

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -486,7 +486,6 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
 
     @property
     def n_support_(self):
-        check_is_fitted(self)
         svm_type = LIBSVM_IMPL.index(self._impl)
         if svm_type in (0, 1):
             return self._n_support

--- a/sklearn/svm/libsvm.pyx
+++ b/sklearn/svm/libsvm.pyx
@@ -217,7 +217,6 @@ def fit(
         support_vectors = np.empty((SV_len, X.shape[1]), dtype=np.float64)
         copy_SV(support_vectors.data, model, support_vectors.shape)
 
-    # TODO: do only in classification
     cdef np.ndarray[np.int32_t, ndim=1, mode='c'] n_class_SV
     if (svm_type == 0 or svm_type == 1):
         n_class_SV = np.empty(n_class, dtype=np.int32)

--- a/sklearn/svm/libsvm.pyx
+++ b/sklearn/svm/libsvm.pyx
@@ -218,7 +218,7 @@ def fit(
         copy_SV(support_vectors.data, model, support_vectors.shape)
 
     cdef np.ndarray[np.int32_t, ndim=1, mode='c'] n_class_SV
-    if (svm_type == 0 or svm_type == 1):
+    if svm_type == 0 or svm_type == 1:
         n_class_SV = np.empty(n_class, dtype=np.int32)
         copy_nSV(n_class_SV.data, model)
     else:

--- a/sklearn/svm/libsvm.pyx
+++ b/sklearn/svm/libsvm.pyx
@@ -222,6 +222,7 @@ def fit(
         n_class_SV = np.empty(n_class, dtype=np.int32)
         copy_nSV(n_class_SV.data, model)
     else:
+        # OneClass and SVR are considered to have 2 classes
         n_class_SV = np.array([SV_len, SV_len], dtype=np.int32)
 
     cdef np.ndarray[np.float64_t, ndim=1, mode='c'] probA

--- a/sklearn/svm/libsvm.pyx
+++ b/sklearn/svm/libsvm.pyx
@@ -219,8 +219,11 @@ def fit(
 
     # TODO: do only in classification
     cdef np.ndarray[np.int32_t, ndim=1, mode='c'] n_class_SV
-    n_class_SV = np.empty(n_class, dtype=np.int32)
-    copy_nSV(n_class_SV.data, model)
+    if (svm_type == 0 or svm_type == 1):
+        n_class_SV = np.empty(n_class, dtype=np.int32)
+        copy_nSV(n_class_SV.data, model)
+    else:
+        n_class_SV = np.array([SV_len, SV_len], dtype=np.int32)
 
     cdef np.ndarray[np.float64_t, ndim=1, mode='c'] probA
     cdef np.ndarray[np.float64_t, ndim=1, mode='c'] probB

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -1188,3 +1188,17 @@ def test_gamma_scale():
     # gamma is not explicitly set.
     X, y = [[1, 2], [3, 2 * np.sqrt(6) / 3 + 2]], [0, 1]
     assert_no_warnings(clf.fit, X, y)
+
+
+def test_n_support_oneclass_svr():
+    # Make sure n_support is not zero for oneclass and SVR
+    # non regression test for issue #14774
+    X = np.array([[0], [0.44], [0.45], [0.46], [1]])
+    clf = svm.OneClassSVM().fit(X)
+    assert np.all(clf.n_support_ == clf.support_vectors_.shape[0])
+    assert np.all(clf.n_support_ == 3)
+
+    y = np.arange(X.shape[0])
+    reg = svm.SVR().fit(X, y)
+    assert np.all(reg.n_support_ == reg.support_vectors_.shape[0])
+    assert np.all(reg.n_support_ == 4)

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -1194,7 +1194,9 @@ def test_n_support_oneclass_svr():
     # Make sure n_support is not zero for oneclass and SVR
     # non regression test for issue #14774
     X = np.array([[0], [0.44], [0.45], [0.46], [1]])
-    clf = svm.OneClassSVM().fit(X)
+    clf = svm.OneClassSVM()
+    assert not hasattr(clf, 'n_support_')
+    clf.fit(X)
     assert clf.n_support_ == clf.support_vectors_.shape[0]
     assert clf.n_support_.size == 1
     assert clf.n_support_ == 3

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -1191,8 +1191,9 @@ def test_gamma_scale():
 
 
 def test_n_support_oneclass_svr():
-    # Make sure n_support is not zero for oneclass and SVR
-    # non regression test for issue #14774
+    # Make n_support is correct for oneclass and SVR (used to be
+    # non-initialized)
+    # this is a non regression test for issue #14774
     X = np.array([[0], [0.44], [0.45], [0.46], [1]])
     clf = svm.OneClassSVM()
     assert not hasattr(clf, 'n_support_')

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -1195,10 +1195,12 @@ def test_n_support_oneclass_svr():
     # non regression test for issue #14774
     X = np.array([[0], [0.44], [0.45], [0.46], [1]])
     clf = svm.OneClassSVM().fit(X)
-    assert np.all(clf.n_support_ == clf.support_vectors_.shape[0])
-    assert np.all(clf.n_support_ == 3)
+    assert clf.n_support_ == clf.support_vectors_.shape[0]
+    assert clf.n_support_.size == 1
+    assert clf.n_support_ == 3
 
     y = np.arange(X.shape[0])
     reg = svm.SVR().fit(X, y)
-    assert np.all(reg.n_support_ == reg.support_vectors_.shape[0])
-    assert np.all(reg.n_support_ == 4)
+    assert reg.n_support_ == reg.support_vectors_.shape[0]
+    assert reg.n_support_.size == 1
+    assert reg.n_support_ == 4


### PR DESCRIPTION
Closes https://github.com/scikit-learn/scikit-learn/pull/14799
Closes https://github.com/scikit-learn/scikit-learn/pull/15034

Fixes https://github.com/scikit-learn/scikit-learn/issues/14774

@amueller I think this is enough?

~~(That doesn't fix the nonsense that the attribute has size 2 (i.e. 2 classes) for OneClass and SVR but that's a different issue)~~  It does now