### PR TITLE
TST Skip some doctests if pillow not installed

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -93,7 +93,7 @@ elif [[ "$DISTRIB" == "conda-pip-latest" ]]; then
     make_conda "python=$PYTHON_VERSION"
     python -m pip install numpy scipy joblib cython
     python -m pip install pytest==$PYTEST_VERSION pytest-cov pytest-xdist
-    python -m pip install pandas matplotlib pyamg pillow
+    python -m pip install pandas matplotlib pyamg
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then

--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,7 @@ from _pytest.doctest import DoctestItem
 
 from sklearn import set_config
 from sklearn.utils import _IS_32BIT
+from sklearn.externals import _pilutil
 
 PYTEST_MIN_VERSION = '3.3.0'
 
@@ -67,6 +68,13 @@ def pytest_collection_modifyitems(config, items):
 
         for item in items:
             if isinstance(item, DoctestItem):
+                item.add_marker(skip_marker)
+    elif not _pilutil.pillow_installed:
+        skip_marker = pytest.mark.skip(reason="pillow (or PIL) not installed!")
+        for item in items:
+            if item.name in [
+                    "sklearn.feature_extraction.image.PatchExtractor",
+                    "sklearn.feature_extraction.image.extract_patches_2d"]:
                 item.add_marker(skip_marker)
 
 


### PR DESCRIPTION
Currently if pillow (or PIL) is not installed some doctests in `sklearn.feature_extraction.image` would fails.

I kept running into this while running the test suite in a new environment. Failing because pillow is not installed is not ideal.

This PR skips those 2 doctests in that case with an appropriate message.