### PR TITLE
fix UserWarning on GUI backend

### DIFF
--- a/examples/gaussian_process/plot_gpr_prior_posterior.py
+++ b/examples/gaussian_process/plot_gpr_prior_posterior.py
@@ -15,7 +15,9 @@ print(__doc__)
 
 import numpy as np
 
+import matplotlib
 from matplotlib import pyplot as plt
+matplotlib.use('tkagg')
 
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import (RBF, Matern, RationalQuadratic,


### PR DESCRIPTION
#### Reference Issues

Partially Fixes #14117 


#### What does this fix?

This implementation fixes the error
> UserWarning: Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure. plt.show() 

Changed the GUI backend to TKAGG to be able to plot.
