### PR TITLE
DOC change model evaluation section title

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -3,7 +3,7 @@
 .. _model_evaluation:
 
 ===========================================================
-Metrics and scorers: quantifying the quality of predictions
+Metrics and scoring: quantifying the quality of predictions
 ===========================================================
 
 There are 3 different APIs for evaluating the quality of a model's

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -2,9 +2,9 @@
 
 .. _model_evaluation:
 
-========================================================
-Model evaluation: quantifying the quality of predictions
-========================================================
+===========================================================
+Metrics and scorers: quantifying the quality of predictions
+===========================================================
 
 There are 3 different APIs for evaluating the quality of a model's
 predictions:


### PR DESCRIPTION
This PR changes the section title

> Model evaluation: quantifying the quality of predictions

to 

> Metrics and scoring: quantifying the quality of predictions

Reasons:

- This section is about metrics and scorers
- Model evaluation is actually covered before in the "Cross-validation: evaluating estimator performance" section.