### PR TITLE
[MRG] DOC Remove baloo quote

### DIFF
--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -7,19 +7,6 @@
 Manifold learning
 =================
 
-.. rst-class:: quote
-
-                 | Look for the bare necessities
-                 | The simple bare necessities
-                 | Forget about your worries and your strife
-                 | I mean the bare necessities
-                 | Old Mother Nature's recipes
-                 | That bring the bare necessities of life
-                 |
-                 |             -- Baloo's song [The Jungle Book]
-
-
-
 .. figure:: ../auto_examples/manifold/images/sphx_glr_plot_compare_methods_001.png
    :target: ../auto_examples/manifold/plot_compare_methods.html
    :align: center


### PR DESCRIPTION
As much as I love the song... it doesn't [render properly](https://scikit-learn.org/dev/modules/manifold.html#manifold) with the new theme

This is the only occurrence of a `.. rst-class:: quote`. We could fix it but the lazy solution is to just remove it.