### PR TITLE
ENH Adds target names to fetch_openml

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -124,6 +124,9 @@ Changelog
 - |Feature| :func:`datasets.fetch_openml` now supports heterogeneous data using
   pandas by setting `as_frame=True`. :pr:`13902` by `Thomas Fan`_.
 
+- |Feature| :func:`datasets.fetch_openml` now includes the `target_names` in
+  the returned Bunch. :pr:`15160` by `Thomas Fan`_.
+
 - |Enhancement| The parameter `return_X_y` was added to
   :func:`datasets.fetch_20newsgroups` and :func:`datasets.fetch_olivetti_faces`
   . :pr:`14259` by :user:`Sourav Singh <souravsingh>`.

--- a/sklearn/datasets/openml.py
+++ b/sklearn/datasets/openml.py
@@ -594,6 +594,9 @@ def fetch_openml(name=None, version='active', data_id=None, data_home=None,
             The names of the dataset columns
         target_names: list
             The names of the target columns
+
+        .. versionadded:: 0.22
+
         categories : dict or None
             Maps each categorical feature name to a list of values, such
             that the value encoded as i is ith in the list. If ``as_frame``

--- a/sklearn/datasets/openml.py
+++ b/sklearn/datasets/openml.py
@@ -592,6 +592,8 @@ def fetch_openml(name=None, version='active', data_id=None, data_home=None,
             The full description of the dataset
         feature_names : list
             The names of the dataset columns
+        target_names: list
+            The names of the target columns
         categories : dict or None
             Maps each categorical feature name to a list of values, such
             that the value encoded as i is ith in the list. If ``as_frame``
@@ -784,6 +786,7 @@ def fetch_openml(name=None, version='active', data_id=None, data_home=None,
 
     bunch = Bunch(
         data=X, target=y, frame=frame, feature_names=data_columns,
+        target_names=target_columns,
         DESCR=description, details=data_description,
         categories=nominal_attributes,
         url="https://www.openml.org/d/{}".format(data_id))

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -96,10 +96,12 @@ def _fetch_dataset_from_openml(data_id, data_name, data_version,
     if isinstance(target_column, str):
         # single target, so target is vector
         assert data_by_id.target.shape == (expected_observations, )
+        assert data_by_id.target_names == [target_column]
     elif isinstance(target_column, list):
         # multi target, so target is array
         assert data_by_id.target.shape == (expected_observations,
                                            len(target_column))
+        assert data_by_id.target_names == target_column
     assert data_by_id.data.dtype == np.float64
     assert data_by_id.target.dtype == expected_target_dtype
     assert len(data_by_id.feature_names) == expected_features
@@ -310,6 +312,7 @@ def test_fetch_openml_iris_pandas(monkeypatch):
     assert data.shape == data_shape
     assert np.all(data.columns == data_names)
     assert np.all(bunch.feature_names == data_names)
+    assert bunch.target_names == [target_name]
 
     assert isinstance(target, pd.Series)
     assert target.dtype == target_dtype
@@ -372,6 +375,7 @@ def test_fetch_openml_iris_multitarget_pandas(monkeypatch):
     assert data.shape == data_shape
     assert np.all(data.columns == data_names)
     assert np.all(bunch.feature_names == data_names)
+    assert bunch.target_names == target_names
 
     assert isinstance(target, pd.DataFrame)
     assert np.all(target.dtypes == target_dtypes)
@@ -453,6 +457,7 @@ def test_fetch_openml_cpu_pandas(monkeypatch):
     assert np.all(data.dtypes == data_dtypes)
     assert np.all(data.columns == feature_names)
     assert np.all(bunch.feature_names == feature_names)
+    assert bunch.target_names == [target_name]
 
     assert isinstance(target, pd.Series)
     assert target.shape == target_shape
@@ -671,6 +676,7 @@ def test_fetch_openml_titanic_pandas(monkeypatch):
     assert isinstance(data, pd.DataFrame)
     assert data.shape == data_shape
     assert np.all(data.columns == feature_names)
+    assert bunch.target_names == [target_name]
 
     assert isinstance(target, pd.Series)
     assert target.shape == target_shape


### PR DESCRIPTION
Adds `target_names` into bunch returned by `fetch_openml`. The target name when `target='default-target'` is useful to have.