### PR TITLE
Updated confusion matrix metric docstring

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -188,7 +188,7 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
     """Compute confusion matrix to evaluate the accuracy of a classification
 
     By definition a confusion matrix :math:`C` is such that :math:`C_{i, j}`
-    is equal to the number of observations known to be in group :math:`i` but
+    is equal to the number of observations known to be in group :math:`i` and/but
     predicted to be in group :math:`j`.
 
     Thus in binary classification, the count of true negatives is

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -188,7 +188,7 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
     """Compute confusion matrix to evaluate the accuracy of a classification
 
     By definition a confusion matrix :math:`C` is such that :math:`C_{i, j}`
-    is equal to the number of observations known to be in group :math:`i` and/but
+    is equal to the number of observations known to be in group :math:`i` while
     predicted to be in group :math:`j`.
 
     Thus in binary classification, the count of true negatives is

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -188,7 +188,7 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
     """Compute confusion matrix to evaluate the accuracy of a classification
 
     By definition a confusion matrix :math:`C` is such that :math:`C_{i, j}`
-    is equal to the number of observations known to be in group :math:`i` while
+    is equal to the number of observations known to be in group :math:`i` and
     predicted to be in group :math:`j`.
 
     Thus in binary classification, the count of true negatives is


### PR DESCRIPTION
Using `but` implies misclassified entries, which is only true on the diagonal.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
