### PR TITLE
TST/CI Fixes import for hashing test for PyPy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,20 +135,20 @@ workflows:
   build-doc-and-deploy:
     jobs:
       - lint
-      # - doc:
-      #     requires:
-      #       - lint
-      # - doc-min-dependencies:
-      #     requires:
-      #       - lint
-      - pypy3
-          # filters:
-          #   branches:
-          #     only:
-          #       - 0.20.X
-      # - deploy:
-      #     requires:
-      #       - doc
+      - doc:
+          requires:
+            - lint
+      - doc-min-dependencies:
+          requires:
+            - lint
+      - pypy3:
+          filters:
+            branches:
+              only:
+                - 0.20.X
+      - deploy:
+          requires:
+            - doc
   pypy:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,20 +135,20 @@ workflows:
   build-doc-and-deploy:
     jobs:
       - lint
-      # - doc:
-      #     requires:
-      #       - lint
-      # - doc-min-dependencies:
-      #     requires:
-      #       - lint
-      - pypy3
-      #     filters:
-      #       branches:
-      #         only:
-      #           - 0.20.X
-      # - deploy:
-      #     requires:
-      #       - doc
+      - doc:
+          requires:
+            - lint
+      - doc-min-dependencies:
+          requires:
+            - lint
+      - pypy3:
+          filters:
+            branches:
+              only:
+                - 0.20.X
+      - deploy:
+          requires:
+            - doc
   pypy:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,20 +135,20 @@ workflows:
   build-doc-and-deploy:
     jobs:
       - lint
-      - doc:
-          requires:
-            - lint
-      - doc-min-dependencies:
-          requires:
-            - lint
-      - pypy3:
-          filters:
-            branches:
-              only:
-                - 0.20.X
-      - deploy:
-          requires:
-            - doc
+      # - doc:
+      #     requires:
+      #       - lint
+      # - doc-min-dependencies:
+      #     requires:
+      #       - lint
+      - pypy3
+          # filters:
+          #   branches:
+          #     only:
+          #       - 0.20.X
+      # - deploy:
+      #     requires:
+      #       - doc
   pypy:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,20 +135,20 @@ workflows:
   build-doc-and-deploy:
     jobs:
       - lint
-      - doc:
-          requires:
-            - lint
-      - doc-min-dependencies:
-          requires:
-            - lint
-      - pypy3:
-          filters:
-            branches:
-              only:
-                - 0.20.X
-      - deploy:
-          requires:
-            - doc
+      # - doc:
+      #     requires:
+      #       - lint
+      # - doc-min-dependencies:
+      #     requires:
+      #       - lint
+      - pypy3
+      #     filters:
+      #       branches:
+      #         only:
+      #           - 0.20.X
+      # - deploy:
+      #     requires:
+      #       - doc
   pypy:
     triggers:
       - schedule:

--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -4,7 +4,6 @@ from numpy.testing import assert_array_equal
 import pytest
 
 from sklearn.feature_extraction import FeatureHasher
-from sklearn.feature_extraction._hashing import transform as _hashing_transform
 from sklearn.utils.testing import (ignore_warnings,
                                    fails_if_pypy)
 
@@ -48,6 +47,9 @@ def test_feature_hasher_strings():
 
 def test_hashing_transform_seed():
     # check the influence of the seed when computing the hashes
+    # import is here because _hashing is not build on pypy
+    from sklearn.feature_extraction._hashing import transform as \
+            _hashing_transform
     raw_X = [["foo", "bar", "baz", "foo".encode("ascii")],
              ["bar".encode("ascii"), "baz", "quux"]]
 

--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -1,5 +1,4 @@
 
-from contextlib import suppress
 import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
@@ -50,9 +49,11 @@ def test_feature_hasher_strings():
 def test_hashing_transform_seed():
     # check the influence of the seed when computing the hashes
     # import is here to avoid importing on pypy
-    with suppress(ImportError):
+    try:
         from sklearn.feature_extraction._hashing import (
                 transform as _hashing_transform)
+    except ImportError:
+        return
 
     raw_X = [["foo", "bar", "baz", "foo".encode("ascii")],
              ["bar".encode("ascii"), "baz", "quux"]]

--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -1,4 +1,4 @@
-from contextlib import suppress
+
 import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
@@ -6,10 +6,6 @@ import pytest
 from sklearn.feature_extraction import FeatureHasher
 from sklearn.utils.testing import (ignore_warnings,
                                    fails_if_pypy)
-# suppress error because module is not built on pypy
-with suppress(ModuleNotFoundError):
-    from sklearn.feature_extraction._hashing import transform as \
-            _hashing_transform
 
 pytestmark = fails_if_pypy
 
@@ -49,8 +45,12 @@ def test_feature_hasher_strings():
         assert X.nnz == 6
 
 
+@fails_if_pypy
 def test_hashing_transform_seed():
     # check the influence of the seed when computing the hashes
+    # import is here to avoid importing on pypy
+    from sklearn.feature_extraction._hashing import transform as \
+            _hashing_transform
     raw_X = [["foo", "bar", "baz", "foo".encode("ascii")],
              ["bar".encode("ascii"), "baz", "quux"]]
 

--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -50,7 +50,6 @@ def test_hashing_transform_seed():
     # import is here to avoid importing on pypy
     from sklearn.feature_extraction._hashing import (
             transform as _hashing_transform)
-
     raw_X = [["foo", "bar", "baz", "foo".encode("ascii")],
              ["bar".encode("ascii"), "baz", "quux"]]
 

--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -45,15 +45,11 @@ def test_feature_hasher_strings():
         assert X.nnz == 6
 
 
-@fails_if_pypy
 def test_hashing_transform_seed():
     # check the influence of the seed when computing the hashes
     # import is here to avoid importing on pypy
-    try:
-        from sklearn.feature_extraction._hashing import (
-                transform as _hashing_transform)
-    except ImportError:  # pragma: no cover
-        return
+    from sklearn.feature_extraction._hashing import (
+            transform as _hashing_transform)
 
     raw_X = [["foo", "bar", "baz", "foo".encode("ascii")],
              ["bar".encode("ascii"), "baz", "quux"]]

--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -52,7 +52,7 @@ def test_hashing_transform_seed():
     try:
         from sklearn.feature_extraction._hashing import (
                 transform as _hashing_transform)
-    except ImportError:
+    except ImportError:  # pragma: no cover
         return
 
     raw_X = [["foo", "bar", "baz", "foo".encode("ascii")],

--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -1,4 +1,4 @@
-
+from contextlib import suppress
 import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
@@ -6,6 +6,10 @@ import pytest
 from sklearn.feature_extraction import FeatureHasher
 from sklearn.utils.testing import (ignore_warnings,
                                    fails_if_pypy)
+# suppress error because module is not built on pypy
+with suppress(ModuleNotFoundError):
+    from sklearn.feature_extraction._hashing import transform as \
+            _hashing_transform
 
 pytestmark = fails_if_pypy
 
@@ -47,9 +51,6 @@ def test_feature_hasher_strings():
 
 def test_hashing_transform_seed():
     # check the influence of the seed when computing the hashes
-    # import is here because _hashing is not build on pypy
-    from sklearn.feature_extraction._hashing import transform as \
-            _hashing_transform
     raw_X = [["foo", "bar", "baz", "foo".encode("ascii")],
              ["bar".encode("ascii"), "baz", "quux"]]
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -580,7 +580,7 @@ try:
                                        reason='skipped on 32bit platforms')
     skip_travis = pytest.mark.skipif(os.environ.get('TRAVIS') == 'true',
                                      reason='skip on travis')
-    fails_if_pypy = pytest.mark.xfail(IS_PYPY, raises=NotImplementedError,
+    fails_if_pypy = pytest.mark.xfail(IS_PYPY,
                                       reason='not compatible with PyPy')
     skip_if_no_parallel = pytest.mark.skipif(not joblib.parallel.mp,
                                              reason="joblib is in serial mode")


### PR DESCRIPTION
Fixes error on master when running on pypy.

This is set to NOMRG, because the circleci config must be adjusted to run the pypy test on this PR.