### PR TITLE
[MRG] BUILD: avoid displaying OpenMP error message when irrelevant

### DIFF
--- a/sklearn/_build_utils/openmp_helpers.py
+++ b/sklearn/_build_utils/openmp_helpers.py
@@ -152,9 +152,15 @@ def check_openmp_support():
             nthreads = int(output[0].strip().split('=')[1])
             openmp_supported = (len(output) == nthreads)
         else:
+            print("########################")
+            print("output error")
+            print("########################")
             openmp_supported = False
 
     except (CompileError, LinkError, subprocess.CalledProcessError):
+        print("########################")
+        print("compile error")
+        print("########################")
         openmp_supported = False
 
     err_message = textwrap.dedent(

--- a/sklearn/_build_utils/openmp_helpers.py
+++ b/sklearn/_build_utils/openmp_helpers.py
@@ -38,7 +38,7 @@ CCODE_OPENMP = textwrap.dedent(
     """)
 
 
-def compile_test_program(CCODE, extra_preargs=[], extra_postargs=[]):
+def compile_test_program(code, extra_preargs=[], extra_postargs=[]):
     """Check that some C code can be compiled and run"""
     ccompiler = new_compiler()
     customize_compiler(ccompiler)

--- a/sklearn/_build_utils/openmp_helpers.py
+++ b/sklearn/_build_utils/openmp_helpers.py
@@ -57,7 +57,7 @@ def compile_test_program(code, extra_preargs=[], extra_postargs=[]):
 
         # Write test program
         with open('test_program.c', 'w') as f:
-            f.write(CCODE)
+            f.write(code)
 
         os.mkdir('objects')
 
@@ -88,7 +88,7 @@ def basic_check_build():
     """Check basic compilation and linking of C code"""
     try:
         output = compile_test_program(CCODE)
-        if 'success' in output[0]:
+        if "success" in output[0]:
             compiler_ok = True
         else:
             compiler_ok = False

--- a/sklearn/_build_utils/openmp_helpers.py
+++ b/sklearn/_build_utils/openmp_helpers.py
@@ -75,9 +75,6 @@ def compile_test_program(code, extra_preargs=[], extra_postargs=[]):
         # Run test program
         output = subprocess.check_output('./test_program')
         output = output.decode(sys.stdout.encoding or 'utf-8').splitlines()
-        print("###################")
-        print(output)
-        print("##################")
 
         os.chdir(start_dir)
 
@@ -155,15 +152,9 @@ def check_openmp_support():
             nthreads = int(output[0].strip().split('=')[1])
             openmp_supported = (len(output) == nthreads)
         else:
-            print("########################")
-            print("output error")
-            print("########################")
             openmp_supported = False
 
     except (CompileError, LinkError, subprocess.CalledProcessError):
-        print("########################")
-        print("compile error")
-        print("########################")
         openmp_supported = False
 
     err_message = textwrap.dedent(

--- a/sklearn/_build_utils/openmp_helpers.py
+++ b/sklearn/_build_utils/openmp_helpers.py
@@ -75,6 +75,9 @@ def compile_test_program(code, extra_preargs=[], extra_postargs=[]):
         # Run test program
         output = subprocess.check_output('./test_program')
         output = output.decode(sys.stdout.encoding or 'utf-8').splitlines()
+        print("###################")
+        print(output)
+        print("##################")
 
         os.chdir(start_dir)
 


### PR DESCRIPTION
If the build fails for some reason not related to openmp, we don't want to check the build with openmp
and we don't want to display the openmp error message. see #15129