### PR TITLE
DOC Typo in path on example, contributing

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -319,7 +319,7 @@ complies with the following rules before marking a PR as ``[MRG]``. The
      specific to the file
    - `pytest sklearn/linear_model` to test the whole
      :mod:`~sklearn.linear_model` module
-   - `pytest sklearn/doc/linear_model.rst` to make sure the user guide
+   - `pytest doc/modules/linear_model.rst` to make sure the user guide
      examples are correct.
    - `pytest sklearn/tests/test_common.py -k LogisticRegression` to run all our
      estimator checks (specifically for `LogisticRegression`, if that's the


### PR DESCRIPTION
#### Reference Issues/PRs
This does not address any specific issue; it's a very small typo I ran into as I was working on a different branch.


#### What does this implement/fix? Explain your changes.
The `contribruting.rst` docs referred to `pytest sklearn/doc/linear_model.rst` for testing out the user guide. That path was out of date; it looks like the updated path is `doc/modules/linear_model.rst`. 
