### PR TITLE
DOC Add pytest-cov installation in contributing guide

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -210,7 +210,7 @@ how to set up your git repository:
 
 4. Install the development dependencies::
 
-       $ pip install cython pytest flake8
+       $ pip install cython pytest pytest-cov flake8
 
 5. Install scikit-learn in editable mode::
 


### PR DESCRIPTION
Running ```make test-coverage``` I got the follow error:
```
  rm -rf coverage .coverage
  pytest sklearn --showlocals -v --cov=sklearn --cov-report=html:coverage
  ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
  pytest: error: unrecognized arguments: --cov=sklearn --cov-report=html:coverage
    inifile: Pydata2019/Sprint/scikit-learn/setup.cfg
    rootdir: Pydata2019/Sprint/scikit-learn

  Makefile:40: recipe for target 'test-coverage' failed
  make: *** [test-coverage] Error 4
```
This happen because the `pytest-cov` package is not installed. I suggest to add it in the contribution guide where all the other base requirements are written.