### PR TITLE
[MRG] Example for multioutput.RegressorChain

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -734,6 +734,18 @@ class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
     order_ : list
         The order of labels in the classifier chain.
 
+    Examples
+    --------
+    >>> from sklearn.multioutput import RegressorChain
+    >>> from sklearn.linear_model import LogisticRegression
+    >>> logreg = LogisticRegression(solver='lbfgs',multi_class='multinomial')
+    >>> X, Y = [[1,0],[0,1],[1,1]], [[0,2],[1,1],[2,0]]
+    >>> chain = RegressorChain(base_estimator=logreg,order=[0,1]).fit(X,Y)
+    >>> chain.predict(X)
+    array([[0., 2.],
+           [1., 1.],
+           [2., 0.]])
+
     See also
     --------
     ClassifierChain: Equivalent for classification


### PR DESCRIPTION
#### Reference Issues/PRs

Issue #3846

#### What does this implement/fix? Explain your changes.

Example for `multioutput.RegressorChain`

#### Any other comments?

The naming of this class is wrong, it should be `MultiLabelClassifierChain`, it is not a regression but a multi-label classification