### PR TITLE
[MRG] Deprecate utils.fixes.parallel_helper

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -59,7 +59,7 @@ from ..tree._tree import DTYPE, DOUBLE
 from ..utils import check_random_state, check_array, compute_sample_weight
 from ..exceptions import DataConversionWarning
 from .base import BaseEnsemble, _partition_estimators
-from ..utils.fixes import parallel_helper, _joblib_parallel_args
+from ..utils.fixes import _joblib_parallel_args
 from ..utils.multiclass import check_classification_targets
 from ..utils.validation import check_is_fitted
 
@@ -218,7 +218,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         X = self._validate_X_predict(X)
         results = Parallel(n_jobs=self.n_jobs, verbose=self.verbose,
                            **_joblib_parallel_args(prefer="threads"))(
-            delayed(parallel_helper)(tree, 'apply', X, check_input=False)
+            delayed(tree.apply)(X, check_input=False)
             for tree in self.estimators_)
 
         return np.array(results).T
@@ -249,8 +249,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         X = self._validate_X_predict(X)
         indicators = Parallel(n_jobs=self.n_jobs, verbose=self.verbose,
                               **_joblib_parallel_args(prefer='threads'))(
-            delayed(parallel_helper)(tree, 'decision_path', X,
-                                     check_input=False)
+            delayed(tree.decision_path)(X, check_input=False)
             for tree in self.estimators_)
 
         n_nodes = [0]

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -23,7 +23,6 @@ from .base import BaseEstimator, clone, MetaEstimatorMixin
 from .base import RegressorMixin, ClassifierMixin, is_classifier
 from .model_selection import cross_val_predict
 from .utils import check_array, check_X_y, check_random_state
-from .utils.fixes import parallel_helper
 from .utils.metaestimators import if_delegate_has_method
 from .utils.validation import check_is_fitted, has_fit_parameter
 from .utils.multiclass import check_classification_targets
@@ -193,7 +192,7 @@ class MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
         X = check_array(X, accept_sparse=True)
 
         y = Parallel(n_jobs=self.n_jobs)(
-            delayed(parallel_helper)(e, 'predict', X)
+            delayed(e.predict)(X)
             for e in self.estimators_)
 
         return np.asarray(y).T

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -18,6 +18,8 @@ import scipy
 import scipy.stats
 from scipy.sparse.linalg import lsqr as sparse_lsqr  # noqa
 
+from . import deprecated
+
 
 def _parse_version(version_string):
     version = []
@@ -155,7 +157,14 @@ else:
             return arr_or_matrix.argmax(axis=axis)
 
 
+# TODO: remove in 0.24
+@deprecated("parallel_helper is deprecated in version "
+            "0.22 and will be removed in version 0.24.")
 def parallel_helper(obj, methodname, *args, **kwargs):
+    return _parallel_helper(obj, methodname, *args, **kwargs)
+
+
+def _parallel_helper(obj, methodname, *args, **kwargs):
     """Workaround for Python 2 limitations of pickling instance methods
 
     Parameters

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -164,6 +164,7 @@ def parallel_helper(obj, methodname, *args, **kwargs):
     return _parallel_helper(obj, methodname, *args, **kwargs)
 
 
+# TODO: remove in 0.24. It isn't used anywhere
 def _parallel_helper(obj, methodname, *args, **kwargs):
     """Workaround for Python 2 limitations of pickling instance methods
 

--- a/sklearn/utils/tests/test_deprecated_utils.py
+++ b/sklearn/utils/tests/test_deprecated_utils.py
@@ -11,6 +11,7 @@ from sklearn.utils.estimator_checks import set_checking_parameters
 from sklearn.utils.optimize import newton_cg
 from sklearn.utils.random import random_choice_csc
 from sklearn.utils import safe_indexing
+from sklearn.utils.fixes import parallel_helper
 
 
 # This file tests the utils that are deprecated
@@ -85,3 +86,9 @@ def test_random_choice_csc():
 def test_safe_indexing():
     with pytest.warns(DeprecationWarning, match="removed in version 0.24"):
         safe_indexing([1, 2], 0)
+
+
+# TODO: remove in 0.24
+def test_parallel_helper():
+    with pytest.warns(DeprecationWarning, match="removed in version 0.24"):
+        parallel_helper(list(), 'append', 2)


### PR DESCRIPTION
Towards #6616 (comment)

That thing was a Python 2 workaround so we don't need it anymore.