### PR TITLE
[MRG] Solve part of 'Remove fixes/compat for Python 2' #11991

### DIFF
--- a/doc/conftest.py
+++ b/doc/conftest.py
@@ -9,7 +9,6 @@ from sklearn.utils import IS_PYPY
 from sklearn.utils.testing import SkipTest
 from sklearn.utils.testing import check_skip_network
 from sklearn.datasets import get_data_home
-from sklearn.datasets.base import _pkl_filepath
 from sklearn.datasets.twenty_newsgroups import CACHE_NAME
 
 
@@ -29,7 +28,7 @@ def setup_rcv1():
 
 def setup_twenty_newsgroups():
     data_home = get_data_home()
-    cache_path = _pkl_filepath(get_data_home(), CACHE_NAME)
+    cache_path = join(get_data_home(), CACHE_NAME)
     if not exists(cache_path):
         raise SkipTest("Skipping dataset loading doctests")
 
@@ -38,7 +37,7 @@ def setup_working_with_text_data():
     if IS_PYPY and os.environ.get('CI', None):
         raise SkipTest('Skipping too slow test with PyPy on CI')
     check_skip_network()
-    cache_path = _pkl_filepath(get_data_home(), CACHE_NAME)
+    cache_path = join(get_data_home(), CACHE_NAME)
     if not exists(cache_path):
         raise SkipTest("Skipping dataset loading doctests")
 

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -846,35 +846,6 @@ def load_sample_image(image_name):
     return images.images[index]
 
 
-def _pkl_filepath(*args, **kwargs):
-    """Ensure different filenames for Python 2 and Python 3 pickles
-
-    An object pickled under Python 3 cannot be loaded under Python 2. An object
-    pickled under Python 2 can sometimes not be loaded correctly under Python 3
-    because some Python 2 strings are decoded as Python 3 strings which can be
-    problematic for objects that use Python 2 strings as byte buffers for
-    numerical data instead of "real" strings.
-
-    Therefore, dataset loaders in scikit-learn use different files for pickles
-    manages by Python 2 and Python 3 in the same SCIKIT_LEARN_DATA folder so as
-    to avoid conflicts.
-
-    args[-1] is expected to be the ".pkl" filename. Under Python 3, a suffix is
-    inserted before the extension to s
-
-    _pkl_filepath('/path/to/folder', 'filename.pkl') returns:
-      - /path/to/folder/filename.pkl under Python 2
-      - /path/to/folder/filename_py3.pkl under Python 3+
-
-    """
-    py3_suffix = kwargs.get("py3_suffix", "_py3")
-    basename, ext = splitext(args[-1])
-    if sys.version_info[0] >= 3:
-        basename += py3_suffix
-    new_args = args[:-1] + (basename + ext,)
-    return join(*new_args)
-
-
 def _sha256(path):
     """Calculate the sha256 hash of the file at path."""
     sha256hash = hashlib.sha256()

--- a/sklearn/datasets/california_housing.py
+++ b/sklearn/datasets/california_housing.py
@@ -32,7 +32,6 @@ import joblib
 
 from .base import get_data_home
 from .base import _fetch_remote
-from .base import _pkl_filepath
 from .base import RemoteFileMetadata
 from .base import _refresh_cache
 from ..utils import Bunch
@@ -107,7 +106,7 @@ def fetch_california_housing(data_home=None, download_if_missing=True,
     if not exists(data_home):
         makedirs(data_home)
 
-    filepath = _pkl_filepath(data_home, 'cal_housing.pkz')
+    filepath = join(data_home, 'cal_housing.pkz')
     if not exists(filepath):
         if not download_if_missing:
             raise IOError("Data not found and `download_if_missing` is False")

--- a/sklearn/datasets/covtype.py
+++ b/sklearn/datasets/covtype.py
@@ -27,7 +27,6 @@ from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from .base import _refresh_cache
 from ..utils import Bunch
-from .base import _pkl_filepath
 from ..utils import check_random_state
 
 # The original data can be found in:
@@ -101,8 +100,8 @@ def fetch_covtype(data_home=None, download_if_missing=True,
 
     data_home = get_data_home(data_home=data_home)
     covtype_dir = join(data_home, "covertype")
-    samples_path = _pkl_filepath(covtype_dir, "samples")
-    targets_path = _pkl_filepath(covtype_dir, "targets")
+    samples_path = join(covtype_dir, "samples")
+    targets_path = join(covtype_dir, "targets")
     available = exists(samples_path)
 
     if download_if_missing and not available:

--- a/sklearn/datasets/olivetti_faces.py
+++ b/sklearn/datasets/olivetti_faces.py
@@ -23,7 +23,6 @@ import joblib
 from .base import get_data_home
 from .base import _fetch_remote
 from .base import RemoteFileMetadata
-from .base import _pkl_filepath
 from .base import _refresh_cache
 from ..utils import check_random_state, Bunch
 
@@ -94,7 +93,7 @@ def fetch_olivetti_faces(data_home=None, shuffle=False, random_state=0,
     data_home = get_data_home(data_home=data_home)
     if not exists(data_home):
         makedirs(data_home)
-    filepath = _pkl_filepath(data_home, 'olivetti.pkz')
+    filepath = join(data_home, 'olivetti.pkz')
     if not exists(filepath):
         if not download_if_missing:
             raise IOError("Data not found and `download_if_missing` is False")

--- a/sklearn/datasets/rcv1.py
+++ b/sklearn/datasets/rcv1.py
@@ -19,7 +19,6 @@ import scipy.sparse as sp
 import joblib
 
 from .base import get_data_home
-from .base import _pkl_filepath
 from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from .base import _refresh_cache
@@ -161,10 +160,10 @@ def fetch_rcv1(data_home=None, subset='all', download_if_missing=True,
         if not exists(rcv1_dir):
             makedirs(rcv1_dir)
 
-    samples_path = _pkl_filepath(rcv1_dir, "samples.pkl")
-    sample_id_path = _pkl_filepath(rcv1_dir, "sample_id.pkl")
-    sample_topics_path = _pkl_filepath(rcv1_dir, "sample_topics.pkl")
-    topics_path = _pkl_filepath(rcv1_dir, "topics_names.pkl")
+    samples_path = join(rcv1_dir, "samples.pkl")
+    sample_id_path = join(rcv1_dir, "sample_id.pkl")
+    sample_topics_path = join(rcv1_dir, "sample_topics.pkl")
+    topics_path = join(rcv1_dir, "topics_names.pkl")
 
     # load data (X) and sample_id
     if download_if_missing and (not exists(samples_path) or

--- a/sklearn/datasets/species_distributions.py
+++ b/sklearn/datasets/species_distributions.py
@@ -39,7 +39,7 @@ For an example of using this dataset, see
 
 from io import BytesIO
 from os import makedirs, remove
-from os.path import exists
+from os.path import exists, join
 
 import logging
 import numpy as np
@@ -50,7 +50,6 @@ from .base import get_data_home
 from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from ..utils import Bunch
-from .base import _pkl_filepath
 from .base import _refresh_cache
 
 # The original data can be found at:
@@ -225,7 +224,7 @@ def fetch_species_distributions(data_home=None,
                         grid_size=0.05)
     dtype = np.int16
 
-    archive_path = _pkl_filepath(data_home, DATA_ARCHIVE_NAME)
+    archive_path = join(data_home, DATA_ARCHIVE_NAME)
 
     if not exists(archive_path):
         if not download_if_missing:

--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -39,7 +39,6 @@ import joblib
 
 from .base import get_data_home
 from .base import load_files
-from .base import _pkl_filepath
 from .base import _fetch_remote
 from .base import RemoteFileMetadata
 from ..feature_extraction.text import CountVectorizer
@@ -227,7 +226,7 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
     """
 
     data_home = get_data_home(data_home=data_home)
-    cache_path = _pkl_filepath(data_home, CACHE_NAME)
+    cache_path = join(data_home, CACHE_NAME)
     twenty_home = os.path.join(data_home, "20news_home")
     cache = None
     if os.path.exists(cache_path):
@@ -389,7 +388,7 @@ def fetch_20newsgroups_vectorized(subset="train", remove=(), data_home=None,
     filebase = '20newsgroup_vectorized'
     if remove:
         filebase += 'remove-' + ('-'.join(remove))
-    target_file = _pkl_filepath(data_home, filebase + ".pkl")
+    target_file = join(data_home, filebase + ".pkl")
 
     # we shuffle but use a fixed seed for the memoization
     data_train = fetch_20newsgroups(data_home=data_home,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Solves part of #11991
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
The function
sklearn.datasets.base._pkl_filepath
is a compatibility function for Python 2 support.

The function expects path components as *args and constructs and returns the path to a pickel from it.

It modifies the last path component as follows:
- For Python 3, it adds a suffix ('_py3' by default, or the value of the kwarg 'py3_suffix' if specified).
- For Python 2, it does nothing .
It then concatenates its arguments using os.path.join and returns the
result.

If Python 2 support is to be deprecated, we can
- remove the function _pkl_filepath and
- replace all calls to it by direct calls to os.path.join,
as done in this MR.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
