### PR TITLE
MNT Remove utils.fixes.parallel_helper

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -59,7 +59,7 @@ from ..tree._tree import DTYPE, DOUBLE
 from ..utils import check_random_state, check_array, compute_sample_weight
 from ..exceptions import DataConversionWarning
 from .base import BaseEnsemble, _partition_estimators
-from ..utils.fixes import parallel_helper, _joblib_parallel_args
+from ..utils.fixes import _joblib_parallel_args
 from ..utils.multiclass import check_classification_targets
 from ..utils.validation import check_is_fitted
 
@@ -218,7 +218,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         X = self._validate_X_predict(X)
         results = Parallel(n_jobs=self.n_jobs, verbose=self.verbose,
                            **_joblib_parallel_args(prefer="threads"))(
-            delayed(parallel_helper)(tree, 'apply', X, check_input=False)
+            delayed(tree.apply)(X, check_input=False)
             for tree in self.estimators_)
 
         return np.array(results).T
@@ -249,7 +249,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         X = self._validate_X_predict(X)
         indicators = Parallel(n_jobs=self.n_jobs, verbose=self.verbose,
                               **_joblib_parallel_args(prefer='threads'))(
-            delayed(parallel_helper)(tree, 'decision_path', X,
+            delayed(tree.decision_path)(X,
                                      check_input=False)
             for tree in self.estimators_)
 

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -23,7 +23,6 @@ from .base import BaseEstimator, clone, MetaEstimatorMixin
 from .base import RegressorMixin, ClassifierMixin, is_classifier
 from .model_selection import cross_val_predict
 from .utils import check_array, check_X_y, check_random_state
-from .utils.fixes import parallel_helper
 from .utils.metaestimators import if_delegate_has_method
 from .utils.validation import check_is_fitted, has_fit_parameter
 from .utils.multiclass import check_classification_targets
@@ -193,7 +192,7 @@ class MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
         X = check_array(X, accept_sparse=True)
 
         y = Parallel(n_jobs=self.n_jobs)(
-            delayed(parallel_helper)(e, 'predict', X)
+            delayed(e.predict)(X)
             for e in self.estimators_)
 
         return np.asarray(y).T

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -155,20 +155,6 @@ else:
             return arr_or_matrix.argmax(axis=axis)
 
 
-def parallel_helper(obj, methodname, *args, **kwargs):
-    """Workaround for Python 2 limitations of pickling instance methods
-
-    Parameters
-    ----------
-    obj
-    methodname
-    *args
-    **kwargs
-
-    """
-    return getattr(obj, methodname)(*args, **kwargs)
-
-
 if np_version < (1, 12):
     class MaskedArray(np.ma.MaskedArray):
         # Before numpy 1.12, np.ma.MaskedArray object is not picklable


### PR DESCRIPTION
#### Reference Issues/PRs
Contributes to #11991 

#### What does this implement/fix? Explain your changes.
Removes the function parallel_helper which was only needed for Python 2 compatibility

#### Any other comments?
