### PR TITLE
TST Remove redundant py2 test in test_forest

### DIFF
--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1003,12 +1003,6 @@ def check_class_weights(name):
     clf2.fit(iris.data, iris.target, sample_weight)
     assert_almost_equal(clf1.feature_importances_, clf2.feature_importances_)
 
-    # Using a Python 2.x list as the sample_weight parameter used to raise
-    # an exception. This test makes sure such code will now run correctly.
-    clf = ForestClassifier()
-    sample_weight = [1.] * len(iris.data)
-    clf.fit(iris.data, iris.target, sample_weight=sample_weight)
-
 
 @pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
 def test_class_weights(name):


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Contributes to #11991 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

An extra test with a list raised an exception in Python2.
Since Python2 is deprecated we do not need this extra test any more.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
