### PR TITLE
FIX SparseCoder set_params works correctly

### DIFF
--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -1018,12 +1018,18 @@ class SparseCoder(SparseCodingMixin, BaseEstimator):
                  transform_n_nonzero_coefs=None, transform_alpha=None,
                  split_sign=False, n_jobs=None, positive_code=False,
                  transform_max_iter=1000):
-        self._set_sparse_coding_params(dictionary.shape[0],
-                                       transform_algorithm,
-                                       transform_n_nonzero_coefs,
-                                       transform_alpha, split_sign, n_jobs,
-                                       positive_code, transform_max_iter)
-        self.components_ = dictionary
+        self.dictionary = dictionary
+        self.transform_algorithm = transform_algorithm
+        self.transform_n_nonzero_coefs = transform_n_nonzero_coefs
+        self.transform_alpha = transform_alpha
+        self.transform_max_iter = transform_max_iter
+        self.split_sign = split_sign
+        self.n_jobs = n_jobs
+        self.positive_code = positive_code
+
+    @property
+    def n_components(self):
+        return self.dictionary.shape[0]
 
     def fit(self, X, y=None):
         """Do nothing and return the estimator unchanged
@@ -1042,6 +1048,7 @@ class SparseCoder(SparseCodingMixin, BaseEstimator):
         self : object
             Returns the object itself
         """
+        self.components_ = self.dictionary
         return self
 
 

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -500,6 +500,17 @@ def test_sparse_coder_set_params_works():
     assert np.sqrt(np.sum((np.dot(code, correct_V) - X) ** 2)) < 0.1
 
 
+@pytest.mark.parametrize('dictionary, n_components', [
+    (np.zeros((1, 1)), 1),
+    (np.zeros((1, 3)), 1),
+    (np.zeros((3, 1)), 3),
+    (np.zeros((5, 4)), 5),
+])
+def test_sparse_coder_n_components(dictionary, n_components):
+    coder = SparseCoder(dictionary=dictionary)
+    assert coder.n_components == n_components
+
+
 def test_sparse_coder_parallel_mmap():
     # Non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/5956


### PR DESCRIPTION
Fixes a bug with `SparseCoder.set_params`. One of the consequences
of this bug is that, for instance, grid searching on the dictionary has no effect.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklistThe way that SparseCoder was initialized led to a bug so that
set_params on the dictionary had actually no effect. I added a test
that breaks on the current master, and the fix to make the test pass.

-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

The way that `SparseCoder` was initialized led to a bug so that
`set_params` on the dictionary had actually no effect. I added a test
that breaks on the current master, and the fix to make the test pass.

#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
