### PR TITLE
[MRG+1] Batching in nmf/sparse_dot to prevent MemoryError

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -160,6 +160,10 @@ Changelog
   underlying :class:`linear_model.LassoLars` when `algorithm='lasso_lars'`.
   :issue:`12650` by `Adrin Jalali`_.
 
+- |Fix| :func:`decomposition.nmf._special_sparse_dot()` now uses batching to avoid
+  briefly allocating an array with size (#non-zero elements, n_components).
+  :issue:`15242` by `Mart Willocx <Maocx>`_.
+
 :mod:`sklearn.dummy`
 ....................
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -160,9 +160,9 @@ Changelog
   underlying :class:`linear_model.LassoLars` when `algorithm='lasso_lars'`.
   :issue:`12650` by `Adrin Jalali`_.
 
-- |Fix| :func:`decomposition.nmf._special_sparse_dot()` now uses batching to avoid
-  briefly allocating an array with size (#non-zero elements, n_components).
-  :issue:`15242` by `Mart Willocx <Maocx>`_.
+- |Efficiency| :class:`decomposition.NMF(solver='mu')` fitted on sparse input
+  matrices now uses batching to avoid briefly allocating an array with size
+  (#non-zero elements, n_components). :pr:`15257` by `Mart Willocx <Maocx>`_.
 
 :mod:`sklearn.dummy`
 ....................

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -6,13 +6,12 @@
 #         Tom Dupre la Tour
 # License: BSD 3 clause
 
-import math
 import numbers
 import numpy as np
 import scipy.sparse as sp
 import time
 import warnings
-from math import sqrt
+from math import sqrt, floor
 
 from .cdnmf_fast import _update_cdnmf_fast
 from ..base import BaseEstimator, TransformerMixin
@@ -174,9 +173,11 @@ def _special_sparse_dot(W, H, X):
         dot_vals = np.empty(n_vals)
         i = 0
         rank = W.shape[1]
-        batch_size = math.floor(n_vals / rank)
+        batch_size = floor(n_vals / rank)
         while i < n_vals:
-            s = i + batch_size if i + batch_size <= n_vals else n_vals
+            s = i + batch_size
+            if s > n_vals:
+                s = n_vals
             dot_vals[i:s] = np.multiply(W[ii[i:s], :],
                                         H.T[jj[i:s], :]).sum(axis=1)
             i = s

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -176,9 +176,7 @@ def _special_sparse_dot(W, H, X):
         rank = W.shape[1]
         batch_size = math.floor(n_vals / rank)
         while i < n_vals:
-            s = i + batch_size
-            if s > n_vals:
-                i = n_vals
+            s = i + batch_size if i + batch_size <= n_vals else n_vals
             dot_vals[i:s] = np.multiply(W[ii[i:s], :],
                                         H.T[jj[i:s], :]).sum(axis=1)
             i = s

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -176,7 +176,8 @@ def _special_sparse_dot(W, H, X):
         batch_size = max(n_components, n_vals // n_components)
         for start in range(0, n_vals, batch_size):
             batch = slice(start, start + batch_size)
-            dot_vals[batch] = np.multiply(W[ii[batch], :], H.T[jj[batch], :]).sum(axis=1)
+            dot_vals[batch] = np.multiply(W[ii[batch], :],
+                                          H.T[jj[batch], :]).sum(axis=1)
 
         WH = sp.coo_matrix((dot_vals, (ii, jj)), shape=X.shape)
         return WH.tocsr()

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -8,6 +8,7 @@
 
 from math import sqrt
 import warnings
+import math
 import numbers
 import time
 
@@ -170,7 +171,16 @@ def _special_sparse_dot(W, H, X):
     """Computes np.dot(W, H), only where X is non zero."""
     if sp.issparse(X):
         ii, jj = X.nonzero()
-        dot_vals = np.multiply(W[ii, :], H.T[jj, :]).sum(axis=1)
+        n_vals = ii.shape[0]
+        dot_vals = np.empty(n_vals)
+        index = 0
+        rank = W.shape[1]
+        batch_size = math.floor(n_vals / rank)
+        while index < n_vals:
+            selector = index + batch_size if index + batch_size <= n_vals else n_vals
+            dot_vals[index:selector] = np.multiply(W[ii[index:selector], :], H.T[jj[index:selector], :]).sum(axis=1)
+            index = selector
+
         WH = sp.coo_matrix((dot_vals, (ii, jj)), shape=X.shape)
         return WH.tocsr()
     else:


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes https://github.com/scikit-learn/scikit-learn/issues/15242 .


#### What does this implement/fix? Explain your changes.
Batching whilst calculating the sparse dot prevents the allocation of an array with shape (#non-zero elements, rank). I propose to do the batching such that we limit the allocation to an array with shape (#non-zero elements / rank, rank).

#### Any other comments?
Benchmark code to compare the difference in time:
```python
import time

import math
import numpy as np
import scipy.sparse as sp


def batched_simple(W, H, X):
    """Computes np.dot(W, H), only where X is non zero."""
    if sp.issparse(X):
        ii, jj = X.nonzero()
        n_vals = ii.shape[0]
        dot_vals = np.empty(n_vals)
        index = 0
        rank = W.shape[1]
        batch_size = math.floor(n_vals / rank)
        while index < n_vals:
            selector = index + batch_size if index + batch_size <= n_vals else n_vals
            dot_vals[index:selector] = np.multiply(W[ii[index:selector], :], H.T[jj[index:selector], :]).sum(axis=1)
            index = selector

        WH = sp.coo_matrix((dot_vals, (ii, jj)), shape=X.shape)
        return WH.tocsr()
    else:
        return np.dot(W, H)


def original_sparse_dot(W, H, X):
    """Computes np.dot(W, H), only where X is non zero."""
    if sp.issparse(X):
        ii, jj = X.nonzero()
        dot_vals = np.multiply(W[ii, :], H.T[jj, :]).sum(axis=1)
        WH = sp.coo_matrix((dot_vals, (ii, jj)), shape=X.shape)
        return WH.tocsr()
    else:
        return np.dot(W, H)


def generate_values():
    # From the unittests
    n_samples = 1000
    n_features = 50
    n_components = 30
    rng = np.random.mtrand.RandomState(42)
    X = rng.randn(n_samples, n_features)
    np.clip(X, 0, None, out=X)
    X_csr = sp.csr_matrix(X)

    W = np.abs(rng.randn(n_samples, n_components))
    H = np.abs(rng.randn(n_components, n_features))
    return W, H, X_csr


def benchmark():
    W, H, X_csr = generate_values()
    rounds = 100

    def test_func(func, name, rounds, W, H, X_csr):
        start_time = time.clock()
        for i in range(rounds):
            WH = func(W, H, X_csr)
        end_time = time.clock()
        print(name + ": " + str((end_time - start_time) / rounds * 1000) + "ms per loop.")

    test_func(original_sparse_dot, "original version", rounds, W, H, X_csr)
    test_func(batched_simple, "batched_simple", rounds, W, H, X_csr)


if __name__ == '__main__':
    benchmark()
```
Output:
```
original version: 11.216264ms per loop.
batched_simple: 4.231038999999999ms per loop.
```
I think this to be a strange result: I would have expected one big batch to be better. Discussion welcome :-)
