### PR TITLE
STY Adjust CSS for pre output

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -943,8 +943,7 @@ div.sphx-glr-thumbcontainer {
 }
 
 .sphx-glr-script-out .highlight pre {
-  padding-top: 1ex;
-  padding-right: 1ex;
+  padding: 1ex;
 }
 
 .sphx-glr-script-out div.highlight {


### PR DESCRIPTION
Really small tweak to make the `Out` code block nicer in sphinx gallery.