### PR TITLE
Avoid deprecation warning for cluster module

### DIFF
--- a/sklearn/cluster/_birch.py
+++ b/sklearn/cluster/_birch.py
@@ -14,7 +14,7 @@ from ..utils import check_array
 from ..utils.extmath import row_norms, safe_sparse_dot
 from ..utils.validation import check_is_fitted
 from ..exceptions import ConvergenceWarning
-from .hierarchical import AgglomerativeClustering
+from ._hierarchical import AgglomerativeClustering
 
 
 def _iterate_sparse_X(X):


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

After https://github.com/scikit-learn/scikit-learn/pull/14948, there's an unavoidable warning on import, because the birch module is using the deprecated path (added the assert to make the culprit clearer).

```
In [2]: import sklearn.cluster
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-2-c8a0f0fed13e> in <module>
----> 1 import sklearn.cluster

~/sandbox/scikit-learn/sklearn/cluster/__init__.py in <module>
     15                       cluster_optics_xi)
     16 from ._bicluster import SpectralBiclustering, SpectralCoclustering
---> 17 from ._birch import Birch
     18
     19 __all__ = ['AffinityPropagation',

~/sandbox/scikit-learn/sklearn/cluster/_birch.py in <module>
     15 from ..utils.validation import check_is_fitted
     16 from ..exceptions import ConvergenceWarning
---> 17 from .hierarchical import AgglomerativeClustering
     18
     19

~/sandbox/scikit-learn/sklearn/cluster/hierarchical.py in <module>
      2 # THIS FILE WAS AUTOMATICALLY GENERATED BY deprecated_modules.py
      3
----> 4 assert 0
      5 from ._hierarchical import *  # noqa
      6 from ..utils.deprecation import _raise_dep_warning_if_not_pytest
```
