### PR TITLE
TST Removes deprecated imports from cluster tests

### DIFF
--- a/sklearn/cluster/tests/test_birch.py
+++ b/sklearn/cluster/tests/test_birch.py
@@ -7,8 +7,8 @@ import numpy as np
 import pytest
 
 from sklearn.cluster.tests.common import generate_clustered_data
-from sklearn.cluster.birch import Birch
-from sklearn.cluster.hierarchical import AgglomerativeClustering
+from sklearn.cluster import Birch
+from sklearn.cluster import AgglomerativeClustering
 from sklearn.datasets import make_blobs
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import ElasticNet

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -23,7 +23,8 @@ from sklearn.utils.testing import ignore_warnings
 from sklearn.cluster import ward_tree
 from sklearn.cluster import AgglomerativeClustering, FeatureAgglomeration
 from sklearn.cluster._hierarchical import (_hc_cut, _TREE_BUILDERS,
-                                           linkage_tree, _fix_connectivity)
+                                           _fix_connectivity)
+from sklearn.cluster.hierarchical import linkage_tree
 from sklearn.feature_extraction.image import grid_to_graph
 from sklearn.metrics.pairwise import PAIRED_DISTANCES, cosine_distances,\
     manhattan_distances, pairwise_distances

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -10,7 +10,7 @@ from sklearn.cluster import OPTICS
 from sklearn.cluster._optics import _extend_region, _extract_xi_labels
 from sklearn.metrics.cluster import contingency_matrix
 from sklearn.metrics.pairwise import pairwise_distances
-from sklearn.cluster.dbscan_ import DBSCAN
+from sklearn.cluster import DBSCAN
 from sklearn.utils import shuffle
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raise_message

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -12,7 +12,7 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_warns_message
 
 from sklearn.cluster import SpectralClustering, spectral_clustering
-from sklearn.cluster.spectral import discretize
+from sklearn.cluster._spectral import discretize
 from sklearn.feature_extraction import img_to_graph
 from sklearn.metrics import pairwise_distances
 from sklearn.metrics import adjusted_rand_score


### PR DESCRIPTION
Replaces deprecate imports in the cluster tests and prefer importing from the public module if available.