### PR TITLE
EXA Fix order of arguments in classification_report

### DIFF
--- a/examples/compose/plot_column_transformer.py
+++ b/examples/compose/plot_column_transformer.py
@@ -132,4 +132,4 @@ X_test, y_test = fetch_20newsgroups(random_state=1,
 
 pipeline.fit(X_train, y_train)
 y_pred = pipeline.predict(X_test)
-print(classification_report(y_pred, y_test))
+print(classification_report(y_test, y_pred))


### PR DESCRIPTION
The function classification_report is called with wrong parameters (ordering).

For classification_report the first parameter should be the ground truth and the second parameters is the predictions. However the arguments are swapped.

#### Reference Issues/PRs
Fixes #15269 