### PR TITLE
DOC Fix typo in Yeo-Johnson formula

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -559,8 +559,8 @@ parameter allows the user to specify a category for each feature to be dropped.
 This is useful to avoid co-linearity in the input matrix in some classifiers.
 Such functionality is useful, for example, when using non-regularized
 regression (:class:`LinearRegression <sklearn.linear_model.LinearRegression>`),
-since co-linearity would cause the covariance matrix to be non-invertible.
-When this paramenter is not None, ``handle_unknown`` must be set to
+since co-linearity would cause the covariance matrix to be non-invertible. 
+When this paramenter is not None, ``handle_unknown`` must be set to 
 ``error``::
 
     >>> X = [['male', 'from US', 'uses Safari'], ['female', 'from Europe', 'uses Firefox']]

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -332,7 +332,7 @@ The Yeo-Johnson transform is given by:
     x_i^{(\lambda)} =
     \begin{cases}
      [(x_i + 1)^\lambda - 1] / \lambda & \text{if } \lambda \neq 0, x_i \geq 0, \\[8pt]
-    \ln{(x_i) + 1} & \text{if } \lambda = 0, x_i \geq 0 \\[8pt]
+    \ln{(x_i + 1)} & \text{if } \lambda = 0, x_i \geq 0 \\[8pt]
     -[(-x_i + 1)^{2 - \lambda} - 1] / (2 - \lambda) & \text{if } \lambda \neq 2, x_i < 0, \\[8pt]
      - \ln (- x_i + 1) & \text{if } \lambda = 2, x_i < 0
     \end{cases}
@@ -559,8 +559,8 @@ parameter allows the user to specify a category for each feature to be dropped.
 This is useful to avoid co-linearity in the input matrix in some classifiers.
 Such functionality is useful, for example, when using non-regularized
 regression (:class:`LinearRegression <sklearn.linear_model.LinearRegression>`),
-since co-linearity would cause the covariance matrix to be non-invertible. 
-When this paramenter is not None, ``handle_unknown`` must be set to 
+since co-linearity would cause the covariance matrix to be non-invertible.
+When this paramenter is not None, ``handle_unknown`` must be set to
 ``error``::
 
     >>> X = [['male', 'from US', 'uses Safari'], ['female', 'from Europe', 'uses Firefox']]


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

There is a typo in the formula for the Yeo-Johnson transformation in the documentation.
For `lambda = 0` and a non-negative `x`, the formula is `ln(x + 1)`.

Source:
* [Wikipedia](https://en.wikipedia.org/wiki/Power_transform#Yeo–Johnson_transformation)
* [SciPy documentation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.yeojohnson.html)