### PR TITLE
[MRG] Fixed pytest ignoring generated deprecation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,9 @@ sklearn/ensemble/weight_boosting.py
 sklearn/tree/export.py
 sklearn/tree/tree.py
 
+sklearn/neural_network/rbm.py
+sklearn/neural_network/multilayer_perceptron.py
+
 sklearn/utils/weight_vector.py
 sklearn/utils/seq_dataset.py
 sklearn/utils/fast_dict.py

--- a/conftest.py
+++ b/conftest.py
@@ -96,3 +96,43 @@ def pytest_runtest_setup(item):
 def pytest_runtest_teardown(item, nextitem):
     if isinstance(item, DoctestItem):
         set_config(print_changed_only=False)
+
+
+# We don't want pytest to run these files during test discovery since they
+# immediately raise a DeprecationWarning.
+# TODO: remove all of these in 0.24
+collect_ignore_glob = [
+    "sklearn/utils/mocking.py", # 0.24
+
+    "sklearn/ensemble/bagging.py", # 0.24
+    "sklearn/ensemble/base.py", # 0.24
+    "sklearn/ensemble/forest.py", # 0.24
+    "sklearn/ensemble/gradient_boosting.py", # 0.24
+    "sklearn/ensemble/iforest.py", # 0.24
+    "sklearn/ensemble/stacking.py", # 0.24
+    "sklearn/ensemble/voting.py", # 0.24
+    "sklearn/ensemble/weight_boosting.py", # 0.24
+    "sklearn/tree/export.py", # 0.24
+    "sklearn/tree/tree.py", # 0.24
+
+    "sklearn/neural_network/rbm.py", # 0.24
+    "sklearn/neural_network/multilayer_perceptron.py", # 0.24
+
+    "sklearn/utils/weight_vector.py", # 0.24
+    "sklearn/utils/seq_dataset.py", # 0.24
+    "sklearn/utils/fast_dict.py", # 0.24
+
+    "sklearn/cluster/affinity_propagation_.py", # 0.24
+    "sklearn/cluster/bicluster.py", # 0.24
+    "sklearn/cluster/birch.py", # 0.24
+    "sklearn/cluster/dbscan_.py", # 0.24
+    "sklearn/cluster/hierarchical.py", # 0.24
+    "sklearn/cluster/k_means_.py", # 0.24
+    "sklearn/cluster/mean_shift_.py", # 0.24
+    "sklearn/cluster/optics_.py", # 0.24
+    "sklearn/cluster/spectral.py", # 0.24
+
+    "sklearn/mixture/base.py", # 0.24
+    "sklearn/mixture/gaussian_mixture.py", # 0.24
+    "sklearn/mixture/bayesian_mixture.py", # 0.24
+]

--- a/conftest.py
+++ b/conftest.py
@@ -102,37 +102,37 @@ def pytest_runtest_teardown(item, nextitem):
 # immediately raise a DeprecationWarning.
 # TODO: remove all of these in 0.24
 collect_ignore_glob = [
-    "sklearn/utils/mocking.py", # 0.24
+    "sklearn/utils/mocking.py",  # 0.24
 
-    "sklearn/ensemble/bagging.py", # 0.24
-    "sklearn/ensemble/base.py", # 0.24
-    "sklearn/ensemble/forest.py", # 0.24
-    "sklearn/ensemble/gradient_boosting.py", # 0.24
-    "sklearn/ensemble/iforest.py", # 0.24
-    "sklearn/ensemble/stacking.py", # 0.24
-    "sklearn/ensemble/voting.py", # 0.24
-    "sklearn/ensemble/weight_boosting.py", # 0.24
-    "sklearn/tree/export.py", # 0.24
-    "sklearn/tree/tree.py", # 0.24
+    "sklearn/ensemble/bagging.py",  # 0.24
+    "sklearn/ensemble/base.py",  # 0.24
+    "sklearn/ensemble/forest.py",  # 0.24
+    "sklearn/ensemble/gradient_boosting.py",  # 0.24
+    "sklearn/ensemble/iforest.py",  # 0.24
+    "sklearn/ensemble/stacking.py",  # 0.24
+    "sklearn/ensemble/voting.py",  # 0.24
+    "sklearn/ensemble/weight_boosting.py",  # 0.24
+    "sklearn/tree/export.py",  # 0.24
+    "sklearn/tree/tree.py",  # 0.24
 
-    "sklearn/neural_network/rbm.py", # 0.24
-    "sklearn/neural_network/multilayer_perceptron.py", # 0.24
+    "sklearn/neural_network/rbm.py",  # 0.24
+    "sklearn/neural_network/multilayer_perceptron.py",  # 0.24
 
-    "sklearn/utils/weight_vector.py", # 0.24
-    "sklearn/utils/seq_dataset.py", # 0.24
-    "sklearn/utils/fast_dict.py", # 0.24
+    "sklearn/utils/weight_vector.py",  # 0.24
+    "sklearn/utils/seq_dataset.py",  # 0.24
+    "sklearn/utils/fast_dict.py",  # 0.24
 
-    "sklearn/cluster/affinity_propagation_.py", # 0.24
-    "sklearn/cluster/bicluster.py", # 0.24
-    "sklearn/cluster/birch.py", # 0.24
-    "sklearn/cluster/dbscan_.py", # 0.24
-    "sklearn/cluster/hierarchical.py", # 0.24
-    "sklearn/cluster/k_means_.py", # 0.24
-    "sklearn/cluster/mean_shift_.py", # 0.24
-    "sklearn/cluster/optics_.py", # 0.24
-    "sklearn/cluster/spectral.py", # 0.24
+    "sklearn/cluster/affinity_propagation_.py",  # 0.24
+    "sklearn/cluster/bicluster.py",  # 0.24
+    "sklearn/cluster/birch.py",  # 0.24
+    "sklearn/cluster/dbscan_.py",  # 0.24
+    "sklearn/cluster/hierarchical.py",  # 0.24
+    "sklearn/cluster/k_means_.py",  # 0.24
+    "sklearn/cluster/mean_shift_.py",  # 0.24
+    "sklearn/cluster/optics_.py",  # 0.24
+    "sklearn/cluster/spectral.py",  # 0.24
 
-    "sklearn/mixture/base.py", # 0.24
-    "sklearn/mixture/gaussian_mixture.py", # 0.24
-    "sklearn/mixture/bayesian_mixture.py", # 0.24
+    "sklearn/mixture/base.py",  # 0.24
+    "sklearn/mixture/gaussian_mixture.py",  # 0.24
+    "sklearn/mixture/bayesian_mixture.py",  # 0.24
 ]

--- a/sklearn/_build_utils/deprecated_modules.py
+++ b/sklearn/_build_utils/deprecated_modules.py
@@ -20,6 +20,10 @@ _DEPRECATED_MODULES = {
     ('_classes', 'sklearn.tree.tree', 'sklearn.tree'),
     ('_export', 'sklearn.tree.export', 'sklearn.tree'),
 
+    ('_rbm', 'sklearn.neural_network.rbm', 'sklearn.neural_network'),
+    ('_multilayer_perceptron',
+     'sklearn.neural_network.multilayer_perceptron', 'sklearn.neural_network'),
+
     ('_weight_vector', 'sklearn.utils.weight_vector', 'sklearn.utils'),
     ('_seq_dataset', 'sklearn.utils.seq_dataset', 'sklearn.utils'),
     ('_fast_dict', 'sklearn.utils.fast_dict', 'sklearn.utils'),

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -24,7 +24,7 @@ from sklearn.cluster import ward_tree
 from sklearn.cluster import AgglomerativeClustering, FeatureAgglomeration
 from sklearn.cluster._hierarchical import (_hc_cut, _TREE_BUILDERS,
                                            _fix_connectivity)
-from sklearn.cluster.hierarchical import linkage_tree
+from sklearn.cluster._hierarchical import linkage_tree
 from sklearn.feature_extraction.image import grid_to_graph
 from sklearn.metrics.pairwise import PAIRED_DISTANCES, cosine_distances,\
     manhattan_distances, pairwise_distances

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -1,9 +1,0 @@
-from ._multilayer_perceptron import *  # noqa
-from ..utils.deprecation import _raise_dep_warning_if_not_pytest
-
-
-# TODO: remove entire file in 0.24
-deprecated_path = 'sklearn.neural_network.multilayer_perceptron'
-correct_path = 'sklearn.neural_network'
-
-_raise_dep_warning_if_not_pytest(deprecated_path, correct_path)

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -1,9 +1,0 @@
-from ._rbm import *  # noqa
-from ..utils.deprecation import _raise_dep_warning_if_not_pytest
-
-
-# TODO: remove entire file in 0.24
-deprecated_path = 'sklearn.neural_network.rbm'
-correct_path = 'sklearn.neural_network'
-
-_raise_dep_warning_if_not_pytest(deprecated_path, correct_path)

--- a/sklearn/tests/test_import_deprecations.py
+++ b/sklearn/tests/test_import_deprecations.py
@@ -43,6 +43,7 @@ from sklearn.utils.testing import assert_run_python_script
     ('sklearn.mixture.base', 'BaseMixture'),
     ('sklearn.mixture.bayesian_mixture', 'BayesianGaussianMixture'),
     ('sklearn.mixture.gaussian_mixture', 'GaussianMixture'),
+
 ))
 def test_import_is_deprecated(deprecated_path, importee):
     # Make sure that "from deprecated_path import importee" is still possible

--- a/sklearn/utils/deprecation.py
+++ b/sklearn/utils/deprecation.py
@@ -128,9 +128,6 @@ def _raise_dep_warning_if_not_pytest(deprecated_path, correct_path):
     # Raise a deprecation warning with standardized deprecation message.
     # Useful because we are now deprecating # anything that isn't explicitly
     # in an __init__ file.
-    # We don't want to raise a dep warning if we are in a pytest session else
-    # the CIs with -Werror::DeprecationWarning would fail. The deprecations are
-    # still properly tested in sklearn/tests/test_import_deprecations.py
 
     # TODO: remove in 0.24 since this shouldn't be needed anymore.
 
@@ -143,5 +140,4 @@ def _raise_dep_warning_if_not_pytest(deprecated_path, correct_path):
         "part of the private API."
     ).format(deprecated_path=deprecated_path, correct_path=correct_path)
 
-    if not getattr(sys, '_is_pytest_session', False):
-        warnings.warn(message, DeprecationWarning)
+    warnings.warn(message, DeprecationWarning)


### PR DESCRIPTION
We're deprecating a lot of paths by renaming `file.py` into `_file.py` and automatically generating a new `_file.py` to raise a warning.

We don't want pytest to run `_file.py` because now the file raises a deprecation warning and that makes the CI fail.

The current solution on master is to not raise the warning if we're in a pytest session, **but that results in warnings being completely ignored by pytest**. This leads us to missing some bad imports, c.f. https://github.com/scikit-learn/scikit-learn/pull/15276 and https://github.com/scikit-learn/scikit-learn/pull/15278.

This PR fixes this by telling pytest to simply ignore the `_file.py` during test discovery. Now the warnings from these files are still properly raised in the test.

(I updated the `sklearn.neural_network` to use the automatically generated files for consistency, instead of relying on manually created files. It's unrelated to the "fix").

Ping @adrinjalali @thomasjpfan 
Also @rth, I know you're not a fan of `collect_ignore_glob` but I don't see a better solution here