### PR TITLE
[WIP] Add inverse_transform method to _PLS base object

### DIFF
--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -420,6 +420,36 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
 
         return x_scores
 
+    def inverse_transform(self, X, copy=True):
+        """Transform data back to its original space.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_components)
+            New data, where n_samples is the number of samples
+            and n_components is the number of pls components.
+
+        copy : boolean, default True
+            Whether to copy X, or perform in-place normalization.
+
+        Returns
+        -------
+        X_original array-like, shape (n_samples, n_features)
+
+        Notes
+        This transformation will only be exact if n_components=n_features
+        -----
+        """
+        check_is_fitted(self)
+        X = check_array(X, copy=copy, dtype=FLOAT_DTYPES)
+        # From pls space to original space
+        X_original = np.matmul(X, self.x_loadings_.T)
+
+        # Denormalize
+        X_original *= self.x_std_
+        X_original += self.x_mean_
+        return X_original
+
     def predict(self, X, copy=True):
         """Apply the dimension reduction learned on the train data.
 

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -420,6 +420,31 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
 
         return x_scores
 
+    def inverse_transform(self,X,copy=True):
+        """Transform data back to its original space.
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_components)
+            New data, where n_samples is the number of samples
+            and n_components is the number of pls components.
+        Returns
+        -------
+        X_original array-like, shape (n_samples, n_features)
+        Notes
+        This transformation will only be exact if n_components=n_features
+        -----
+        """
+        check_is_fitted(self)
+        X = check_array(X, copy=copy, dtype=FLOAT_DTYPES)
+        #From pls space to original space
+        X_original = np.matmul(X, self.x_loadings_.T)
+
+        # Denormalize
+        X_original *= self.x_std_
+        X_original += self.x_mean_
+        
+        return X_original
+    
     def predict(self, X, copy=True):
         """Apply the dimension reduction learned on the train data.
 

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -420,7 +420,7 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
 
         return x_scores
 
-    def inverse_transform(self,X,copy=True):
+    def inverse_transform(self, X, copy=True):
         """Transform data back to its original space.
         Parameters
         ----------
@@ -436,13 +436,12 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
         """
         check_is_fitted(self)
         X = check_array(X, copy=copy, dtype=FLOAT_DTYPES)
-        #From pls space to original space
+        # From pls space to original space
         X_original = np.matmul(X, self.x_loadings_.T)
 
         # Denormalize
         X_original *= self.x_std_
         X_original += self.x_mean_
-        
         return X_original
     
     def predict(self, X, copy=True):

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -422,6 +422,7 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
 
     def inverse_transform(self, X, copy=True):
         """Transform data back to its original space.
+
         Parameters
         ----------
         X : array-like, shape (n_samples, n_components)
@@ -434,7 +435,7 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
         Returns
         -------
         X_original array-like, shape (n_samples, n_features)
-        
+
         Notes
         This transformation will only be exact if n_components=n_features
         -----

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -443,7 +443,7 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
         X_original *= self.x_std_
         X_original += self.x_mean_
         return X_original
-    
+
     def predict(self, X, copy=True):
         """Apply the dimension reduction learned on the train data.
 

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -427,9 +427,14 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
         X : array-like, shape (n_samples, n_components)
             New data, where n_samples is the number of samples
             and n_components is the number of pls components.
+
+        copy : boolean, default True
+            Whether to copy X, or perform in-place normalization.
+
         Returns
         -------
         X_original array-like, shape (n_samples, n_features)
+        
         Notes
         This transformation will only be exact if n_components=n_features
         -----

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -79,6 +79,12 @@ def test_pls():
     assert_array_almost_equal(Yr, plsca.y_scores_,
                               err_msg="rotation on Y failed")
 
+    # Check that inverse_transform works
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Xreconstructed = plsca.inverse_transform(Xr)
+    assert_array_almost_equal(Xreconstructed, X,
+                              err_msg="inverse_transform failed")
+
     # "Non regression test" on canonical PLS
     # --------------------------------------
     # The results were checked against the R-package plspm

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -78,6 +78,12 @@ def test_pls():
                               err_msg="rotation on X failed")
     assert_array_almost_equal(Yr, plsca.y_scores_,
                               err_msg="rotation on Y failed")
+    
+    # Check that inverse_transform works
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Xreconstructed = plsca.inverse_transform(Xr)
+    assert_array_almost_equal(Xreconstructed, X,
+                              err_msg="inverse_transform failed")
 
     # "Non regression test" on canonical PLS
     # --------------------------------------

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -78,7 +78,7 @@ def test_pls():
                               err_msg="rotation on X failed")
     assert_array_almost_equal(Yr, plsca.y_scores_,
                               err_msg="rotation on Y failed")
-    
+
     # Check that inverse_transform works
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Xreconstructed = plsca.inverse_transform(Xr)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
With this PR I'm adding a function `inverse_transform` to the base _PLS object and the consecuent test. This function is already implemented in other decomposition methods like PCA [here](https://github.com/scikit-learn/scikit-learn/blob/1495f6924/sklearn/decomposition/base.py#L135).

The function transforms back to the original space by multiplying the transformed data with the x_loadings as `X_original = np.matmul(X, self.x_loadings_.T)` and denormalizes the result with the model std and mean.

This function allows you to transform back data to the original space (this transformation will only be exact if n_components=n_features). This transformation is widely used to compute the _**Squared Prediction Error**_ of our _PLS model. This metric is famous for its use in industry scenarios where PLS acts as a statistical model to control processes where time takes a big act (papers on this: [1](https://arxiv.org/pdf/0901.2880.pdf), [2](https://mpra.ub.uni-muenchen.de/6399/1/MPRA) ) 

Following Sklearn _PLS example this is how the function should be used:
```python
from sklearn.cross_decomposition import PLSRegression
X = [[0., 0., 1.], [1.,0.,0.], [2.,2.,2.], [2.,5.,4.]]
Y = [[0.1, -0.2], [0.9, 1.1], [6.2, 5.9], [11.9, 12.3]]
pls2 = PLSRegression(n_components=2)
pls2.fit(X, Y)


t = [0., 0., 1.]
Y_pred = pls2.transform([t])
X_reconstructed = pls2.inverse_transform(Y_pred) # Value will be [0.02257852, 0.11391906, 0.87805722]
```

And a example to showcase the correctness of the function with n_components==n_features
```python
from sklearn.cross_decomposition import PLSRegression
X = [[0., 0., 1.], [1.,0.,0.], [2.,2.,2.], [2.,5.,4.]]
Y = [[0.1, -0.2], [0.9, 1.1], [6.2, 5.9], [11.9, 12.3]]
pls2 = PLSRegression(n_components=3)
pls2.fit(X, Y)


t = [0., 0., 1.]
Y_pred = pls2.transform([t])
X_reconstructed = pls2.inverse_transform(Y_pred) # Value will be [0, 0, 1]
```


#### Any other comments?


I have been developing software for multivariate statistical process control for some time now and Sklearn implementation of PLS has been widely used in this field. I always thought the _PLS was lacking from this method while PCA had it and decided to make a contribution for it :) 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
