### PR TITLE
[MRG] STY Fixes citation style for some references

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -492,8 +492,12 @@ div.sk-navbar-collapse {
   text-align: center;
 }
 
-dl.citation dd li {
+dl.citation > dd > ol > li {
   display: inline;
+}
+
+dl.citation > dd > ol {
+  margin-bottom: 0;
 }
 
 /* docs index */

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -492,6 +492,9 @@ div.sk-navbar-collapse {
   text-align: center;
 }
 
+dl.citation dd li {
+  display: inline;
+}
 
 /* docs index */
 


### PR DESCRIPTION
For some citations the html structure is different which leads to this on master:

<img width="575" alt="Screen Shot 2019-10-19 at 1 39 02 PM" src="https://user-images.githubusercontent.com/5402633/67149153-dc24b780-f275-11e9-9322-74f123387910.png">

This PR addresses this by:

<img width="580" alt="Screen Shot 2019-10-19 at 1 39 13 PM" src="https://user-images.githubusercontent.com/5402633/67149157-e3e45c00-f275-11e9-9743-ec3df3f583fb.png">