### PR TITLE
[MRG] API Exposes trustworthiness in top level module

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -882,7 +882,7 @@ Miscellaneous
     manifold.locally_linear_embedding
     manifold.smacof
     manifold.spectral_embedding
-    manifold.t_sne.trustworthiness
+    manifold.trustworthiness
 	
 
 .. _metrics_ref:

--- a/sklearn/manifold/__init__.py
+++ b/sklearn/manifold/__init__.py
@@ -6,7 +6,8 @@ from ._locally_linear import locally_linear_embedding, LocallyLinearEmbedding
 from ._isomap import Isomap
 from ._mds import MDS, smacof
 from ._spectral_embedding_ import SpectralEmbedding, spectral_embedding
-from ._t_sne import TSNE
+from ._t_sne import TSNE, trustworthiness
 
 __all__ = ['locally_linear_embedding', 'LocallyLinearEmbedding', 'Isomap',
-           'MDS', 'smacof', 'SpectralEmbedding', 'spectral_embedding', "TSNE"]
+           'MDS', 'smacof', 'SpectralEmbedding', 'spectral_embedding', "TSNE",
+           'trustworthiness']


### PR DESCRIPTION
This PR exposes `trustworthiness`  in `sklearn.manifold`.