### PR TITLE
MNT fix deprecation warning in test_mds

### DIFF
--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 import pytest
 
-from sklearn.manifold import mds
+from sklearn.manifold import _mds as mds
 
 
 def test_smacof():


### PR DESCRIPTION
No idea why master isn't failing right now, but this makes some PRs break.