### PR TITLE
DOC Remove 'cholesky_delete' from toc (fix sphinx autodoc warning).

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1551,7 +1551,6 @@ Plotting
    :toctree: generated/
    :template: function.rst
 
-   utils.arrayfuncs.cholesky_delete
    utils.arrayfuncs.min_pos
    utils.as_float_array
    utils.assert_all_finite


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #13380 and closes #15331.

#### What does this implement/fix? Explain your changes.
Considering that `cholesky_delete` is already undocumented and a reorganisation of `utils` is ongoing making private a number of public functions (#6616, #15223, #15225), this PR removes `cholesky_delete` from the documentation fixing the corresponding sphinx autodoc warning.
