### PR TITLE
[MRG] CLN Fix uncaught deprecation imports

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1480,20 +1480,6 @@ Estimators
 
    svm.l1_min_c
 
-Low-level methods
------------------
-
-.. autosummary::
-   :toctree: generated
-   :template: function.rst
-
-   svm.libsvm.cross_validation
-   svm.libsvm.decision_function
-   svm.libsvm.fit
-   svm.libsvm.predict
-   svm.libsvm.predict_proba
-
-
 .. _tree_ref:
 
 :mod:`sklearn.tree`: Decision Trees

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -64,7 +64,7 @@ from scipy.sparse import csgraph
 
 from ..base import BaseEstimator, ClassifierMixin
 from ..metrics.pairwise import rbf_kernel
-from ..neighbors.unsupervised import NearestNeighbors
+from ..neighbors import NearestNeighbors
 from ..utils.extmath import safe_sparse_dot
 from ..utils.multiclass import check_classification_targets
 from ..utils.validation import check_X_y, check_is_fitted, check_array


### PR DESCRIPTION
Removes documentation for low level libsvm methods and cleans up deprecation import.

CC @NicolasHug @adrinjalali 