### PR TITLE
put back the donate button

### DIFF
--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -182,6 +182,11 @@
         <li><strong>Gitter:</strong> <a href="https://gitter.im/scikit-learn/scikit-learn">gitter.im/scikit-learn</a></li>
         </ul>
 
+        <form target="_top" id="paypal-form" method="post" action="https://www.paypal.com/cgi-bin/webscr">
+          <input type="hidden" value="_s-xclick" name="cmd">
+          <input type="hidden" value="74EYUMF3FTSW8" name="hosted_button_id">
+        </form>
+        <a class="btn btn-warning btn-big sk-donate-btn mb-1" onclick="document.getElementById('paypal-form').submit(); ">Help us, <strong>donate!</strong></a>
         <a class="btn btn-warning btn-big mb-1" href="about.html#citing-scikit-learn"><strong>Cite us!</strong></a>
       </div>
       <div class="col-md-4">

--- a/doc/themes/scikit-learn/static/nature.css_t
+++ b/doc/themes/scikit-learn/static/nature.css_t
@@ -967,6 +967,11 @@ div.container.index-lower ul li em {
     font-weight: bold;
 }
 
+#paypal-form {
+    margin: 30px 0;
+    padding: 0;
+}
+
 div.container.index-lower a.cite-us {
     margin-left: 60px;
     padding-right: 20px;


### PR DESCRIPTION
The button was removed by mistake in https://github.com/scikit-learn/scikit-learn/commit/e0b90ef19b7231f499fbd868e131b044b014faee during https://github.com/scikit-learn/scikit-learn/pull/15324

This PR puts it back.

ping @glemaitre 