### PR TITLE
MAINT revert unecessary deprecation for permutation_importance module

### DIFF
--- a/sklearn/_build_utils/deprecated_modules.py
+++ b/sklearn/_build_utils/deprecated_modules.py
@@ -143,8 +143,6 @@ _DEPRECATED_MODULES = [
 
     ('_partial_dependence', 'sklearn.inspection.partial_dependence',
      'sklearn.inspection', 'partial_dependence'),
-    ('_permutation_importance', 'sklearn.inspection.permutation_importance',
-     'sklearn.inspection', 'permutation_importance'),
 
     ('_ball_tree', 'sklearn.neighbors.ball_tree', 'sklearn.neighbors',
      'BallTree'),


### PR DESCRIPTION
In #14028, we face a `pytest` bug which confusing `permutation_importance` as a module and a function after the collection of the tests.

`permutation_importance.py` has been renamed to `_permutation_importance.py` during the module privatization. However, we are raising a deprecation warning and creating a `permutation_importance.py` module for that. This is unnecessary since `permutation_importance.py` module is not existing in scikit-learn 0.21 and his only present in the master branch. Therefore, we can safely rename the module with the leading underscore without breaking people code and work around the `pytest` bug.

Note that it would be nice to get a minimal example to report to pytest regarding this issue.