### PR TITLE
DOC typo in installation guide: cython -> Cython

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -140,7 +140,7 @@ the conda-forge channel, which provides OpenMP-enabled C compilers.
 It is recommended to use a dedicated conda environment to build scikit-learn
 from source::
 
-    conda create -n sklearn-dev python numpy scipy cython joblib pytest \
+    conda create -n sklearn-dev python numpy scipy Cython joblib pytest \
         conda-forge::compilers conda-forge::llvm-openmp
     conda activate sklearn-dev
     pip install --verbose --editable .


### PR DESCRIPTION
I tried the new installation guide, it works except that it should be `Cython`.

Ping @jeremiedbb @thomasjpfan 