### PR TITLE
ENH Minor update to error message from check_is_fitted

### DIFF
--- a/sklearn/decomposition/tests/test_online_lda.py
+++ b/sklearn/decomposition/tests/test_online_lda.py
@@ -184,7 +184,8 @@ def test_lda_no_component_error():
     X = rng.randint(4, size=(20, 10))
     lda = LatentDirichletAllocation()
     regex = ("This LatentDirichletAllocation instance is not fitted yet. "
-             "Call 'fit' with appropriate arguments before using this method.")
+             "Call 'fit' with appropriate arguments before using this "
+             "estimator.")
     with pytest.raises(NotFittedError, match=regex):
         lda.perplexity(X)
 

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -367,7 +367,8 @@ def test_importances_asymptotic():
 @pytest.mark.parametrize('name', FOREST_ESTIMATORS)
 def test_unfitted_feature_importances(name):
     err_msg = ("This {} instance is not fitted yet. Call 'fit' with "
-               "appropriate arguments before using this method.".format(name))
+               "appropriate arguments before using this estimator."
+               .format(name))
     with pytest.raises(NotFittedError, match=err_msg):
         getattr(FOREST_ESTIMATORS[name](), 'feature_importances_')
 

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -85,7 +85,7 @@ def test_notfitted():
                             voting='soft')
     ereg = VotingRegressor([('dr', DummyRegressor())])
     msg = ("This %s instance is not fitted yet. Call \'fit\'"
-           " with appropriate arguments before using this method.")
+           " with appropriate arguments before using this estimator.")
     assert_raise_message(NotFittedError, msg % 'VotingClassifier',
                          eclf.predict, X)
     assert_raise_message(NotFittedError, msg % 'VotingClassifier',

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -30,7 +30,7 @@ class NotFittedError(ValueError, AttributeError):
     ... except NotFittedError as e:
     ...     print(repr(e))
     NotFittedError("This LinearSVC instance is not fitted yet. Call 'fit' with
-    appropriate arguments before using this method."...)
+    appropriate arguments before using this estimator."...)
 
     .. versionchanged:: 0.18
        Moved from sklearn.utils.validation.

--- a/sklearn/mixture/tests/test_bayesian_mixture.py
+++ b/sklearn/mixture/tests/test_bayesian_mixture.py
@@ -479,7 +479,7 @@ def test_bayesian_mixture_predict_predict_proba():
                                  "This BayesianGaussianMixture instance"
                                  " is not fitted yet. Call 'fit' with "
                                  "appropriate arguments before using "
-                                 "this method.", bgmm.predict, X)
+                                 "this estimator.", bgmm.predict, X)
 
             bgmm.fit(X)
             Y_pred = bgmm.predict(X)

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -559,7 +559,7 @@ def test_gaussian_mixture_predict_predict_proba():
         assert_raise_message(NotFittedError,
                              "This GaussianMixture instance is not fitted "
                              "yet. Call 'fit' with appropriate arguments "
-                             "before using this method.", g.predict, X)
+                             "before using this estimator.", g.predict, X)
 
         g.fit(X)
         Y_pred = g.predict(X)
@@ -858,7 +858,7 @@ def test_score():
     assert_raise_message(NotFittedError,
                          "This GaussianMixture instance is not fitted "
                          "yet. Call 'fit' with appropriate arguments "
-                         "before using this method.", gmm1.score, X)
+                         "before using this estimator.", gmm1.score, X)
 
     # Check score value
     with warnings.catch_warnings():
@@ -888,7 +888,7 @@ def test_score_samples():
     assert_raise_message(NotFittedError,
                          "This GaussianMixture instance is not fitted "
                          "yet. Call 'fit' with appropriate arguments "
-                         "before using this method.", gmm.score_samples, X)
+                         "before using this estimator.", gmm.score_samples, X)
 
     gmm_score_samples = gmm.fit(X).score_samples(X)
     assert gmm_score_samples.shape[0] == rand_data.n_samples

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -84,7 +84,8 @@ def test_one_hot_encoder_not_fitted():
     X = np.array([['a'], ['b']])
     enc = OneHotEncoder(categories=['a', 'b'])
     msg = ("This OneHotEncoder instance is not fitted yet. "
-           "Call 'fit' with appropriate arguments before using this method.")
+           "Call 'fit' with appropriate arguments before using this "
+           "estimator.")
     with pytest.raises(NotFittedError, match=msg):
         enc.transform(X)
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -903,7 +903,8 @@ def check_is_fitted(estimator, attributes='deprecated', msg=None,
 
     msg : string
         The default error message is, "This %(name)s instance is not fitted
-        yet. Call 'fit' with appropriate arguments before using this method."
+        yet. Call 'fit' with appropriate arguments before using this
+        estimator."
 
         For custom messages if "%(name)s" is present in the message string,
         it is substituted for the estimator name.
@@ -936,7 +937,7 @@ def check_is_fitted(estimator, attributes='deprecated', msg=None,
         raise TypeError("{} is a class, not an instance.".format(estimator))
     if msg is None:
         msg = ("This %(name)s instance is not fitted yet. Call 'fit' with "
-               "appropriate arguments before using this method.")
+               "appropriate arguments before using this estimator.")
 
     if not hasattr(estimator, 'fit'):
         raise TypeError("%s is not an estimator instance." % (estimator))


### PR DESCRIPTION
That's a nit...

Current message says "call fit before using this method"

which is now changed to "call fit before using this estimator"

since not just methods rely on `check_is_fitted`, e.g. `partial_dependence()`