### PR TITLE
Update .gitignore :  files from build in examples directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ nips2010_pdf/
 *.tgz
 
 examples/cluster/joblib
+examples/release_highlights/joblib
+examples/neighbors/cache
 reuters/
 benchmarks/bench_covertype_data/
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR update `.gitignore` for two directories probably produced by new examples... I couldn't trace the origin of   `examples/neighbors/cache`, while I suppose that `examples/release_highlights/joblib` has something to do with the introduction of release highlights (see  #14743)