### PR TITLE
DOC add missing attributes to _PLS

### DIFF
--- a/sklearn/cross_decomposition/_pls_.py
+++ b/sklearn/cross_decomposition/_pls_.py
@@ -196,6 +196,18 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
     y_rotations_ : array, [q, n_components]
         Y block to latents rotations.
 
+    x_mean_ : array, [p]
+        X mean for each predictor.
+
+    y_mean_ : array, [q]
+        Y mean for each response variable.
+
+    x_std_ : array, [p]
+        X standard deviation for each predictor.
+
+    y_std_ : array, [q]
+        Y standard deviation for each response variable.
+
     coef_ : array, [p, q]
         The coefficients of the linear model: ``Y = X coef_ + Err``
 


### PR DESCRIPTION
#### Reference Issues/PRs
Partially addresses #14312

#### What does this implement/fix? Explain your changes.
Adds description for:
- x_mean_
- y_mean_
- x_std_
- y_std_

in _PLS class. These attributes are derived in public PLSCanonical, PLSRegression and PLSSVD classes. Tried to fit into \_pls\_.py doc conventions.
