### PR TITLE
[MRG] Proper error message instead of wrong results in PowerTransformer

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2927,7 +2927,16 @@ class PowerTransformer(TransformerMixin, BaseEstimator):
             x_trans = self._yeo_johnson_transform(x, lmbda)
             n_samples = x.shape[0]
 
-            loglike = -n_samples / 2 * np.log(x_trans.var())
+            var = x_trans.var()
+            if var < np.finfo(x_trans.dtype).eps * 10:
+                raise RuntimeError(
+                    "The variance of the transformed data is too small. "
+                    "This might be because your input values are too large. "
+                    "You can try to rescale your data. Note that if your "
+                    "data is strictly positive, you can use box-cox instead."
+                )
+
+            loglike = -n_samples / 2 * np.log(var)
             loglike += (lmbda - 1) * (np.sign(x) * np.log1p(np.abs(x))).sum()
 
             return -loglike

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2484,3 +2484,20 @@ def test_power_transform_default_method():
 
     X_trans_boxcox = power_transform(X, method='box-cox')
     assert_array_equal(X_trans_boxcox, X_trans_default)
+
+
+def test_yeo_johnson_degenerate_case():
+    # When values are too high the variance of the transformed output may be
+    # too small in the log-likelihood computation. We error in these cases for
+    # now since there is no clean or easy fix. See issue 14959 or scipy issue
+    # 10821. (note that this is properly fixed for boxcox in scipy).
+
+    a = np.array([3251637.22, 620695.44]).reshape(-1, 1)
+
+    with pytest.raises(RuntimeError,
+                       match="variance of the transformed data is too small"):
+        PowerTransformer().fit_transform(a)
+
+    # error message suggests to scale the data, make sure that's OK then
+    a = StandardScaler().fit_transform(a)
+    PowerTransformer().fit_transform(a)


### PR DESCRIPTION
Temporary fix for https://github.com/scikit-learn/scikit-learn/issues/14959

We "gracefully" error instead of providing wrong results when the variance of the transformed data is too small in the YeoJohnson transformer.

Not sure that needs a whatsnew?