### PR TITLE
EXA Show how to clean-up joblib cache in examples

### DIFF
--- a/examples/neighbors/plot_caching_nearest_neighbors.py
+++ b/examples/neighbors/plot_caching_nearest_neighbors.py
@@ -19,6 +19,7 @@ larger, or when the grid of parameter to search is large.
 # Author: Tom Dupre la Tour
 #
 # License: BSD 3 clause
+from tempfile import TemporaryDirectory
 import matplotlib.pyplot as plt
 
 from sklearn.neighbors import KNeighborsTransformer, KNeighborsClassifier
@@ -38,14 +39,17 @@ graph_model = KNeighborsTransformer(n_neighbors=max(n_neighbors_list),
                                     mode='distance')
 classifier_model = KNeighborsClassifier(metric='precomputed')
 
-# Note that we give `memory` a directory to cache the graph computation.
-full_model = Pipeline(
-    steps=[('graph', graph_model), ('classifier', classifier_model)],
-    memory='./cache')
+# Note that we give `memory` a directory to cache the graph computation
+# that will be used several times when tuning the hyperparameters of the
+# classifier.
+with TemporaryDirectory(prefix="sklearn_graph_cache_") as tmpdir:
+    full_model = Pipeline(
+        steps=[('graph', graph_model), ('classifier', classifier_model)],
+        memory=tmpdir)
 
-param_grid = {'classifier__n_neighbors': n_neighbors_list}
-grid_model = GridSearchCV(full_model, param_grid)
-grid_model.fit(X, y)
+    param_grid = {'classifier__n_neighbors': n_neighbors_list}
+    grid_model = GridSearchCV(full_model, param_grid)
+    grid_model.fit(X, y)
 
 # Plot the results of the grid search.
 fig, axes = plt.subplots(1, 2, figsize=(8, 4))

--- a/examples/release_highlights/plot_release_highlights_0_22_0.py
+++ b/examples/release_highlights/plot_release_highlights_0_22_0.py
@@ -133,16 +133,19 @@ print(titanic.data.head()[['pclass', 'embarked']])
 # implementations, such as approximate nearest neighbors methods.
 # See more details in the :ref:`User Guide <neighbors_transformer>`.
 
+from tempfile import TemporaryDirectory
 from sklearn.neighbors import KNeighborsTransformer
 from sklearn.manifold import Isomap
 from sklearn.pipeline import make_pipeline
 
-estimator = make_pipeline(
-    KNeighborsTransformer(n_neighbors=10, mode='distance'),
-    Isomap(n_neighbors=10, metric='precomputed'),
-    memory='.')
-estimator.fit(X)
+with TemporaryDirectory(prefix="sklearn_cache_") as tmpdir:
+    estimator = make_pipeline(
+        KNeighborsTransformer(n_neighbors=10, mode='distance'),
+        Isomap(n_neighbors=10, metric='precomputed'),
+        memory=tmpdir)
+    estimator.fit(X)
 
-# We can decrease the number of neighbors and the graph will not be recomputed.
-estimator.set_params(isomap__n_neighbors=5)
-estimator.fit(X)
+    # We can decrease the number of neighbors and the graph will not be
+    # recomputed.
+    estimator.set_params(isomap__n_neighbors=5)
+    estimator.fit(X)


### PR DESCRIPTION
This is an alternative fix for #15360.

I think it's important to show to our users how to use the `tempfile.TemporyDirectory` context manager from the standard library (since Python 3.2) if they need to setup temporary cache folders.
