### PR TITLE
[DOC] fix syntax error for reference in plot_cost_complexity_pruning.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 build
 sklearn/datasets/__config__.py
 sklearn/**/*.html
-env/
+
 dist/
 MANIFEST
 doc/_build/

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 build
 sklearn/datasets/__config__.py
 sklearn/**/*.html
-
+env/
 dist/
 MANIFEST
 doc/_build/

--- a/examples/tree/plot_cost_complexity_pruning.py
+++ b/examples/tree/plot_cost_complexity_pruning.py
@@ -14,7 +14,7 @@ increase the number of nodes pruned. Here we only show the effect of
 ``ccp_alpha`` on regularizing the trees and how to choose a ``ccp_alpha``
 based on validation scores.
 
-See also `ref`:_minimal_cost_complexity_pruning` for details on pruning.
+See also :ref:`_minimal_cost_complexity_pruning` for details on pruning.
 """
 
 print(__doc__)

--- a/examples/tree/plot_cost_complexity_pruning.py
+++ b/examples/tree/plot_cost_complexity_pruning.py
@@ -14,7 +14,7 @@ increase the number of nodes pruned. Here we only show the effect of
 ``ccp_alpha`` on regularizing the trees and how to choose a ``ccp_alpha``
 based on validation scores.
 
-See also :ref:`_minimal_cost_complexity_pruning` for details on pruning.
+See also :ref:`minimal_cost_complexity_pruning` for details on pruning.
 """
 
 print(__doc__)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #15421 


#### What does this implement/fix? Explain your changes.
Fixes the syntax error for reference in [plot_cost_complexity_pruning.py](https://github.com/scikit-learn/scikit-learn/blob/master/examples/tree/plot_cost_complexity_pruning.py)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
