### PR TITLE
BUG: do not filter searchindex for pdf doc generation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -338,13 +338,15 @@ def make_carousel_thumbs(app, exception):
 def filter_search_index(app, exception):
     if exception is not None:
         return
-    searchindex_path = os.path.join(app.builder.outdir, 'searchindex.js')
 
-    # searchindex.js does not exist when generating latex
-    if not os.path.exists(searchindex_path):
+    # searchindex only exist when generating html
+    if app.builder.name != 'html':
         return
 
     print('Removing methods from search index')
+
+    searchindex_path = os.path.join(app.builder.outdir, 'searchindex.js')
+
     with open(searchindex_path, 'r') as f:
         searchindex_text = f.read()
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -340,6 +340,7 @@ def filter_search_index(app, exception):
         return
     searchindex_path = os.path.join(app.builder.outdir, 'searchindex.js')
 
+    # searchindex.js does not exist when generating latex
     if not os.path.exists(searchindex_path):
         return
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -338,9 +338,12 @@ def make_carousel_thumbs(app, exception):
 def filter_search_index(app, exception):
     if exception is not None:
         return
-    print('Removing methods from search index')
-
     searchindex_path = os.path.join(app.builder.outdir, 'searchindex.js')
+
+    if not os.path.exists(searchindex_path):
+        return
+
+    print('Removing methods from search index')
     with open(searchindex_path, 'r') as f:
         searchindex_text = f.read()
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -346,7 +346,6 @@ def filter_search_index(app, exception):
     print('Removing methods from search index')
 
     searchindex_path = os.path.join(app.builder.outdir, 'searchindex.js')
-
     with open(searchindex_path, 'r') as f:
         searchindex_text = f.read()
 


### PR DESCRIPTION
Fixes bug on master where `filter_search_index` tries to run when `searchindex.js` does not exist. `searchindex.js` does not exist when we are building a pdf.

CC @lesteve @jnothman @rth 