### PR TITLE
DOC Improve summary in KernelDensity.score_samples docstring

### DIFF
--- a/doc/modules/density.rst
+++ b/doc/modules/density.rst
@@ -113,7 +113,7 @@ The form of these kernels is as follows:
 
 * Gaussian kernel (``kernel = 'gaussian'``)
 
-  :math:`K(x; h) \propto \exp(- \frac{x^2}{2h^2} )`
+  :math:`K(x; h) \propto \exp(- \frac{x^2}{2} )`
 
 * Tophat kernel (``kernel = 'tophat'``)
 

--- a/doc/modules/density.rst
+++ b/doc/modules/density.rst
@@ -113,7 +113,7 @@ The form of these kernels is as follows:
 
 * Gaussian kernel (``kernel = 'gaussian'``)
 
-  :math:`K(x; h) \propto \exp(- \frac{x^2}{2} )`
+  :math:`K(x; h) \propto \exp(- \frac{x^2}{2h^2} )`
 
 * Tophat kernel (``kernel = 'tophat'``)
 

--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -148,7 +148,7 @@ class KernelDensity(BaseEstimator):
         return self
 
     def score_samples(self, X):
-        """Evaluate the density model on the data.
+        """Evaluate the log density model on the data.
 
         Parameters
         ----------


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #12035 

#### What does this implement/fix?

Clarifies the 1 line description for the method 'score_samples'; notifies the user that the log density is returned.  Modifies the comment with 1 word 'log' as requested by user @bangdasun .

From: "Evaluate the density model on the data"
To:       "Evaluate the **log** density model on the data"