### PR TITLE
DOC disable GL01 check in numpydoc test_docstring

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -49,8 +49,11 @@ def filter_errors(errors, method):
         #    should contain only the type, ..
         #   (as we may need refer to the name of the returned
         #    object)
+        #  - GL01: Docstring text (summary) should start in the line
+        #  immediately after the opening quotes (not in the same line,
+        #  or leaving a blank line in between)
 
-        if code in ["RT02"]:
+        if code in ["RT02", "GL01"]:
             continue
 
         # Following codes are only taken into account for the


### PR DESCRIPTION
Make it acceptable to start docstring on either the same line or the following line, after the opening triple quote. This follows PEP 257 for multi-line docstrings.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
