### PR TITLE
DOC clarify StratifiedShuffleSplit supports 2d y

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1713,7 +1713,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
             hence ``np.zeros(n_samples)`` may be used as a placeholder for
             ``X`` instead of actual training data.
 
-        y : array-like, shape (n_samples,)
+        y : array-like, shape (n_samples,) or (n_samples, n_labels)
             The target variable for supervised learning problems.
             Stratification is done based on the y labels.
 


### PR DESCRIPTION
#### Reference Issues/PRs
See also #9044

#### What does this implement/fix? Explain your changes.
Added optional y shape in doc, to make it clear that 2d y is supported.

