### PR TITLE
[WIP] Modified the gaussian kernel latex function in doc

### DIFF
--- a/doc/modules/density.rst
+++ b/doc/modules/density.rst
@@ -113,7 +113,7 @@ The form of these kernels is as follows:
 
 * Gaussian kernel (``kernel = 'gaussian'``)
 
-  :math:`K(x; h) \propto \exp(- \frac{x^2}{2h^2} )`
+  :math:`K(x; h) \propto \exp(- \frac{x^2}{2} )`
 
 * Tophat kernel (``kernel = 'tophat'``)
 


### PR DESCRIPTION
Reference Issues/PRs

See #13659 
What does this implement/fix? Explain your changes.

User @kurmukovai believes that the function for gaussian kernel in document 2.8. Density Estimation was incorrect. He gave an example of what he believed should be the correct function. I have implemented his correction but cannot confirm if it is mathematically correct.
Any other comments?

The purpose of this change is to make the change easier for someone else to check, so that issue #13659 can be accepted or rejected. Please don't assume that it is mathematically correct.