### PR TITLE
Add int dtype to labels_pred in mutual_info_score()

### DIFF
--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -592,7 +592,7 @@ def mutual_info_score(labels_true, labels_pred, contingency=None):
     labels_true : int array, shape = [n_samples]
         A clustering of the data into disjoint subsets.
 
-    labels_pred : array-like of shape (n_samples,)
+    labels_pred : int array-like of shape (n_samples,)
         A clustering of the data into disjoint subsets.
 
     contingency : {None, array, sparse matrix}, \
@@ -679,7 +679,7 @@ def adjusted_mutual_info_score(labels_true, labels_pred,
     labels_true : int array, shape = [n_samples]
         A clustering of the data into disjoint subsets.
 
-    labels_pred : array-like of shape (n_samples,)
+    labels_pred : int array-like of shape (n_samples,)
         A clustering of the data into disjoint subsets.
 
     average_method : string, optional (default: 'arithmetic')
@@ -798,7 +798,7 @@ def normalized_mutual_info_score(labels_true, labels_pred,
     labels_true : int array, shape = [n_samples]
         A clustering of the data into disjoint subsets.
 
-    labels_pred : array-like of shape (n_samples,)
+    labels_pred : int array-like of shape (n_samples,)
         A clustering of the data into disjoint subsets.
 
     average_method : string, optional (default: 'arithmetic')


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

This PR specifies the dtypes of arguments in `sklearn.metrics.mutual_info_score`, `sklearn.metrics.adjusted_mutual_info_score` and `sklearn.metrics.normalized_mutual_info_score`. In the current documentation, the dtype of `labels_true` is specified to be `int` but the dtype of `labels_pred` is not specified. Since our goal is to compare the two clusterings and the metrics are symmetric the two arguments should have the same dtypes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
