### PR TITLE
[MRG] Fix OverflowError on DictVectorizer

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -308,6 +308,10 @@ Changelog
   removes accents from strings that are in NFKD normalized form. :pr:`15100` by
   :user:`Daniel Grady <DGrady>`.
 
+- |Fix| Fixed a bug that caused :class:`feature_extraction.DictVectorizer` to raise
+  an `OverflowError` during the `transform` operation when producing a `scipy.sparse`
+  matrix on large input data. :pr:`` by :user:`Norvan Sahiner <norvan>`.
+
 :mod:`sklearn.feature_selection`
 ................................
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -310,7 +310,7 @@ Changelog
 
 - |Fix| Fixed a bug that caused :class:`feature_extraction.DictVectorizer` to raise
   an `OverflowError` during the `transform` operation when producing a `scipy.sparse`
-  matrix on large input data. :pr:`` by :user:`Norvan Sahiner <norvan>`.
+  matrix on large input data. :pr:`15463` by :user:`Norvan Sahiner <norvan>`.
 
 :mod:`sklearn.feature_selection`
 ................................

--- a/sklearn/feature_extraction/_dict_vectorizer.py
+++ b/sklearn/feature_extraction/_dict_vectorizer.py
@@ -154,7 +154,7 @@ class DictVectorizer(TransformerMixin, BaseEstimator):
         X = [X] if isinstance(X, Mapping) else X
 
         indices = array("i")
-        indptr = array("i", [0])
+        indptr = [0]
         # XXX we could change values to an array.array as well, but it
         # would require (heuristic) conversion of dtype to typecode...
         values = []
@@ -182,7 +182,6 @@ class DictVectorizer(TransformerMixin, BaseEstimator):
             raise ValueError("Sample sequence X is empty.")
 
         indices = np.frombuffer(indices, dtype=np.intc)
-        indptr = np.frombuffer(indptr, dtype=np.intc)
         shape = (len(indptr) - 1, len(vocab))
 
         result_matrix = sp.csr_matrix((values, indices, indptr),


### PR DESCRIPTION
Fixes #13045 

DictVectorizer's transform step raises an OverflowError if the input data has too many samples.
Replacing indptr to a list resolves this issue without impairing performance.

Similar solution has been proposed by @rth on #9147

Checks on performance was run locally to confirm there was no increase in the duration of the transform step:

Duration was:
* `2.79 s ± 16.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)` before the change
* `2.83 s ± 25.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)` after the change

Code:

```python
from sklearn.feature_extraction import DictVectorizer
from sklearn.feature_selection import GenericUnivariateSelect, chi2
from numpy.random import random

n_samples = 1000000

data = [{"alpha": i, "beta": int(random()*100)} for i in range(n_samples)]

vectorizer = DictVectorizer(sparse=True, dtype=np.uint16).fit(data)

%timeit vectorized_data = vectorizer.transform(data)
```
