### PR TITLE
DOC clarified documentation on flip_y for make_classification

### DIFF
--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -100,7 +100,7 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
         ``weights`` exceeds 1.
 
     flip_y : float, optional (default=0.01)
-        The fraction of samples whose class are randomly exchanged. Larger
+        The fraction of samples whose class is assigned randomly. Larger
         values introduce noise in the labels and make the classification
         task harder.
 


### PR DESCRIPTION
The current description is: "The fraction of samples whose class are randomly exchanged. Larger
values introduce noise in the labels and make the classification
task harder."

We are suggesting: "The fraction of samples whose class **is assigned randomly**. Larger
values introduce noise in the labels and make the classification
task harder."

Pair programming wimlds sklearn sprint with @akeshavan

#### Reference Issues/PRs
Fixes #14088