### PR TITLE
fix: replaced check_consistent_length with _check_sample_weight in DBSCAN

### DIFF
--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -14,7 +14,8 @@ import warnings
 from scipy import sparse
 
 from ..base import BaseEstimator, ClusterMixin
-from ..utils import check_array, check_consistent_length
+from ..utils import check_array
+from ..utils.validation import _check_sample_weight
 from ..neighbors import NearestNeighbors
 
 from ._dbscan_inner import dbscan_inner
@@ -312,8 +313,7 @@ class DBSCAN(ClusterMixin, BaseEstimator):
             raise ValueError("eps must be positive.")
 
         if sample_weight is not None:
-            sample_weight = np.asarray(sample_weight)
-            check_consistent_length(X, sample_weight)
+            sample_weight = _check_sample_weight(sample_weight, X)
 
         # Calculate neighborhood for all samples. This leaves the original
         # point in, which needs to be considered later (i.e. point i is in the


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes the DBSCAN part of https://github.com/scikit-learn/scikit-learn/issues/15358


#### What does this implement/fix? Explain your changes.

Using the newly introduced `utils.validation._check_sample_weight` which returns a validated sample_weight array for the DBSCAN fit method.

pair programmed with @kesshijordan for the wimlds SF sprint


