### PR TITLE
Remove positional arguments in SGDClassifier.set_params()

### DIFF
--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -98,8 +98,8 @@ class BaseSGD(SparseCoefMixin, BaseEstimator, metaclass=ABCMeta):
         # but we are not allowed to set attributes
         self._validate_params()
 
-    def set_params(self, *args, **kwargs):
-        super().set_params(*args, **kwargs)
+    def set_params(self, **kwargs):
+        super().set_params(**kwargs)
         self._validate_params()
         return self
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

https://github.com/scikit-learn/scikit-learn/pull/15470

#### What does this implement/fix? Explain your changes.

Currently, `SGDClassifier.set_params()` accepts positional and keyword arguments, and then calls `BaseEstimator.set_params()` with those arguments. However, `BaseEstimator.set_params()` does not accept positional arguments, so if you actually try to call `SGDClassifier.set_params()` with positional arguments, it fails like so:

```
>>> import sklearn.linear_model
>>> sgd_clf = sklearn.linear_model.SGDClassifier()
>>> sgd_clf.set_params(0.01, alpha=0.0002)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "scikit-learn/sklearn/linear_model/_stochastic_gradient.py", line 102, in set_params
    super().set_params(*args, **kwargs)
TypeError: set_params() takes 1 positional argument but 2 were given
```

After this PR, the error message changes slightly:

```
>>> import sklearn.linear_model
>>> sgd_clf = sklearn.linear_model.SGDClassifier()
>>> sgd_clf.set_params(0.01, alpha=0.0002)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: set_params() takes 1 positional argument but 2 were given
```

#### Any other comments?

Context for this PR: While trying to improve docstrings of `SGDClassifier` (in https://github.com/scikit-learn/scikit-learn/pull/15470) as part of today's WIMLDS `scikit-learn` sprint, stumbled upon `SGDClassifier.set_params()` which did not have a docstring at all. 

Couldn't write a valid docstring for `SGDClassifier.set_params()` since `*args` was an invalid argument; merging this PR will unblock me on writing a valid docstring. 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
