### PR TITLE
[MRG] Adaboost numpytest docstrings

### DIFF
--- a/sklearn/cluster/_k_means.py
+++ b/sklearn/cluster/_k_means.py
@@ -647,7 +647,7 @@ def _init_centroids(X, k, init, random_state=None, x_squared_norms=None,
 
 
 class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
-    """K-Means clustering
+    """K-Means clustering.
 
     Read more in the :ref:`User Guide <k_means>`.
 
@@ -681,7 +681,7 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
         single run.
 
     tol : float, default: 1e-4
-        Relative tolerance with regards to inertia to declare convergence
+        Relative tolerance with regards to inertia to declare convergence.
 
     precompute_distances : {'auto', True, False}
         Precompute distances (faster but takes more memory).
@@ -690,9 +690,9 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
         million. This corresponds to about 100MB overhead per job using
         double precision.
 
-        True : always precompute distances
+        True : always precompute distances.
 
-        False : never precompute distances
+        False : never precompute distances.
 
     verbose : int, default 0
         Verbosity mode.
@@ -702,7 +702,7 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
         an int to make the randomness deterministic.
         See :term:`Glossary <random_state>`.
 
-    copy_x : boolean, optional
+    copy_x : bool, optional
         When pre-computing distances it is more numerically accurate to center
         the data first.  If copy_x is True (default), then the original data is
         not modified, ensuring X is C-contiguous.  If False, the original data
@@ -741,23 +741,7 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
     n_iter_ : int
         Number of iterations run.
 
-    Examples
-    --------
-
-    >>> from sklearn.cluster import KMeans
-    >>> import numpy as np
-    >>> X = np.array([[1, 2], [1, 4], [1, 0],
-    ...               [10, 2], [10, 4], [10, 0]])
-    >>> kmeans = KMeans(n_clusters=2, random_state=0).fit(X)
-    >>> kmeans.labels_
-    array([1, 1, 1, 0, 0, 0], dtype=int32)
-    >>> kmeans.predict([[0, 0], [12, 3]])
-    array([1, 0], dtype=int32)
-    >>> kmeans.cluster_centers_
-    array([[10.,  2.],
-           [ 1.,  2.]])
-
-    See also
+    See Also
     --------
 
     MiniBatchKMeans
@@ -788,6 +772,21 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
     iteration to make ``labels_`` consistent with ``predict`` on the training
     set.
 
+    Examples
+    --------
+
+    >>> from sklearn.cluster import KMeans
+    >>> import numpy as np
+    >>> X = np.array([[1, 2], [1, 4], [1, 0],
+    ...               [10, 2], [10, 4], [10, 0]])
+    >>> kmeans = KMeans(n_clusters=2, random_state=0).fit(X)
+    >>> kmeans.labels_
+    array([1, 1, 1, 0, 0, 0], dtype=int32)
+    >>> kmeans.predict([[0, 0], [12, 3]])
+    array([1, 0], dtype=int32)
+    >>> kmeans.cluster_centers_
+    array([[10.,  2.],
+           [ 1.,  2.]])
     """
 
     def __init__(self, n_clusters=8, init='k-means++', n_init=10,
@@ -834,6 +833,11 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
         sample_weight : array-like, shape (n_samples,), optional
             The weights for each observation in X. If None, all observations
             are assigned equal weight (default: None).
+
+        Returns
+        -------
+        self
+            Fitted estimator.
         """
         random_state = check_random_state(self.random_state)
 

--- a/sklearn/cluster/_k_means.py
+++ b/sklearn/cluster/_k_means.py
@@ -244,7 +244,7 @@ def k_means(X, n_clusters, sample_weight=None, init='k-means++',
         an int to make the randomness deterministic.
         See :term:`Glossary <random_state>`.
 
-    copy_x : boolean, optional
+    copy_x : bool, optional
         When pre-computing distances it is more numerically accurate to center
         the data first.  If copy_x is True (default), then the original data is
         not modified, ensuring X is C-contiguous.  If False, the original data
@@ -286,7 +286,6 @@ def k_means(X, n_clusters, sample_weight=None, init='k-means++',
     best_n_iter : int
         Number of iterations corresponding to the best results.
         Returned only if `return_n_iter` is set to True.
-
     """
 
     est = KMeans(

--- a/sklearn/cluster/_k_means.py
+++ b/sklearn/cluster/_k_means.py
@@ -1070,7 +1070,7 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
 
         sample_weight : array-like, shape (n_samples,), optional
             The weights for each observation in X. If None, all observations
-            are assigned equal weight (default: None)
+            are assigned equal weight (default: None).
 
         Returns
         -------
@@ -1093,11 +1093,11 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
             New data.
 
         y : Ignored
-            not used, present here for API consistency by convention.
+            Not used, present here for API consistency by convention.
 
         sample_weight : array-like, shape (n_samples,), optional
             The weights for each observation in X. If None, all observations
-            are assigned equal weight (default: None)
+            are assigned equal weight (default: None).
 
         Returns
         -------

--- a/sklearn/cluster/_k_means.py
+++ b/sklearn/cluster/_k_means.py
@@ -1013,11 +1013,11 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
             New data to transform.
 
         y : Ignored
-            not used, present here for API consistency by convention.
+            Not used, present here for API consistency by convention.
 
         sample_weight : array-like, shape (n_samples,), optional
             The weights for each observation in X. If None, all observations
-            are assigned equal weight (default: None)
+            are assigned equal weight (default: None).
 
         Returns
         -------

--- a/sklearn/cluster/_k_means.py
+++ b/sklearn/cluster/_k_means.py
@@ -989,11 +989,11 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
             New data to transform.
 
         y : Ignored
-            not used, present here for API consistency by convention.
+            Not used, present here for API consistency by convention.
 
         sample_weight : array-like, shape (n_samples,), optional
             The weights for each observation in X. If None, all observations
-            are assigned equal weight (default: None)
+            are assigned equal weight (default: None).
 
         Returns
         -------

--- a/sklearn/cluster/_k_means.py
+++ b/sklearn/cluster/_k_means.py
@@ -829,12 +829,11 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
             copy if the given data is not C-contiguous.
 
         y : Ignored
-            not used, present here for API consistency by convention.
+            Not used, present here for API consistency by convention.
 
         sample_weight : array-like, shape (n_samples,), optional
             The weights for each observation in X. If None, all observations
-            are assigned equal weight (default: None)
-
+            are assigned equal weight (default: None).
         """
         random_state = check_random_state(self.random_state)
 

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -300,9 +300,9 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
         The base estimator from which the boosted ensemble is built.
         Support for sample weighting is required, as well as proper
         ``classes_`` and ``n_classes_`` attributes. If ``None``, then
-        the base estimator is ``DecisionTreeClassifier(max_depth=1)``
+        the base estimator is ``DecisionTreeClassifier(max_depth=1)``.
 
-    n_estimators : integer, optional (default=50)
+    n_estimators : int, optional (default=50)
         The maximum number of estimators at which boosting is terminated.
         In case of perfect fit, the learning procedure is stopped early.
 
@@ -348,6 +348,31 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
     feature_importances_ : ndarray of shape (n_features,)
         The feature importances if supported by the ``base_estimator``.
 
+    See Also
+    --------
+    AdaBoostRegressor
+        An AdaBoost regressor that begins by fitting a regressor on the original
+        dataset and then fits additional copies of the regressor on the same
+        dataset but where the weights of instances are adjusted according to the
+        error of the current prediction.
+
+    GradientBoostingClassifier
+        GB builds an additive model in a forward stage-wise fashion. Regression
+        trees are fit on the negative gradient of the binomial or multinomial deviance loss function.
+        Binary classification is a special case where only a single regression tree is induced.
+
+    sklearn.tree.DecisionTreeClassifier
+        A non-parametric supervised learning method used for classification.
+        Creates a model that predicts the value of a target variable by learning
+        simple decision rules inferred from the data features.
+
+    References
+    ----------
+    .. [1] Y. Freund, R. Schapire, "A Decision-Theoretic Generalization of
+           on-Line Learning and an Application to Boosting", 1995.
+
+    .. [2] J. Zhu, H. Zou, S. Rosset, T. Hastie, "Multi-class AdaBoost", 2009.
+
     Examples
     --------
     >>> from sklearn.ensemble import AdaBoostClassifier
@@ -364,19 +389,6 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
     array([1])
     >>> clf.score(X, y)
     0.983...
-
-    See also
-    --------
-    AdaBoostRegressor, GradientBoostingClassifier,
-    sklearn.tree.DecisionTreeClassifier
-
-    References
-    ----------
-    .. [1] Y. Freund, R. Schapire, "A Decision-Theoretic Generalization of
-           on-Line Learning and an Application to Boosting", 1995.
-
-    .. [2] J. Zhu, H. Zou, S. Rosset, T. Hastie, "Multi-class AdaBoost", 2009.
-
     """
     def __init__(self,
                  base_estimator=None,

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -223,7 +223,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         sample_weight : array-like of shape (n_samples,), default=None
             Sample weights.
 
-        Returns
+        Yields
         -------
         z : float
         """
@@ -242,7 +242,8 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
 
         Returns
         -------
-        feature_importances_ : array, shape = [n_features]
+        feature_importances_ : ndarray of shape (n_features,)
+            The feature importances.
         """
         if self.estimators_ is None or len(self.estimators_) == 0:
             raise ValueError("Estimator not fitted, "
@@ -424,6 +425,7 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
         Returns
         -------
         self : object
+            A fitted estimator.
         """
         # Check that algorithm is supported
         if self.algorithm not in ('SAMME', 'SAMME.R'):
@@ -642,7 +644,7 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
             The input samples. Sparse matrix can be CSC, CSR, COO,
             DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
-        Returns
+        Yields
         -------
         y : generator of array, shape = [n_samples]
             The predicted classes.
@@ -713,7 +715,7 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
             The training input samples. Sparse matrix can be CSC, CSR, COO,
             DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
-        Returns
+        Yields
         -------
         score : generator of array, shape = [n_samples, k]
             The decision function of the input samples. The order of
@@ -821,7 +823,7 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
             The training input samples. Sparse matrix can be CSC, CSR, COO,
             DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
-        Returns
+        Yields
         -------
         p : generator of array, shape = [n_samples]
             The class probabilities of the input samples. The order of
@@ -1138,7 +1140,7 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
             The training input samples.
 
-        Returns
+        Yields
         -------
         y : generator of array, shape = [n_samples]
             The predicted regression values.

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -352,20 +352,21 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
     See Also
     --------
     AdaBoostRegressor
-        An AdaBoost regressor that begins by fitting a regressor on the original
-        dataset and then fits additional copies of the regressor on the same
-        dataset but where the weights of instances are adjusted according to the
-        error of the current prediction.
+        An AdaBoost regressor that begins by fitting a regressor on the
+        original dataset and then fits additional copies of the regressor
+        on the same dataset but where the weights of instances are
+        adjusted according to the error of the current prediction.
 
     GradientBoostingClassifier
         GB builds an additive model in a forward stage-wise fashion. Regression
-        trees are fit on the negative gradient of the binomial or multinomial deviance loss function.
-        Binary classification is a special case where only a single regression tree is induced.
+        trees are fit on the negative gradient of the binomial or multinomial
+        deviance loss function. Binary classification is a special case where
+        only a single regression tree is induced.
 
     sklearn.tree.DecisionTreeClassifier
         A non-parametric supervised learning method used for classification.
-        Creates a model that predicts the value of a target variable by learning
-        simple decision rules inferred from the data features.
+        Creates a model that predicts the value of a target variable by
+        learning simple decision rules inferred from the data features.
 
     References
     ----------


### PR DESCRIPTION
Reference Issues/PRs
Addresses #15440 (Apply numpydoc validation to docstrings) for sklearn.ensemble.AdaBoostClassifier

What does this implement/fix? Explain your changes.
Applies numpydoc validation to sklearn.ensemble.AdaBoostClassifier docstrings

Any other comments?
