### PR TITLE
property for predict_proba in MultiOutput Classifier

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -547,6 +547,10 @@ Changelog
 - |Fix| :class:`multioutput.MultiOutputClassifier` now has attribute
   ``classes_``. :pr:`14629` by :user:`Agamemnon Krasoulis <agamemnonc>`.
 
+- |Fix| :class:`multioutput.MultiOutputClassifier` now has `predict_proba`
+  as property and can be checked with `hasattr`.
+  :issue:`15488` :pr:`15490` by :user:`Rebekah Kim <rebekahkim>`
+
 :mod:`sklearn.naive_bayes`
 ...............................
 

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -362,8 +362,8 @@ class MultiOutputClassifier(ClassifierMixin, MultiOutputEstimator):
     def _check_proba(self):
         if not all([hasattr(estimator, "predict_proba")
                     for estimator in self.estimators_]):
-            raise AttributeError("The base estimator should implement "
-                             "predict_proba method")
+            raise AttributeError("The base estimator should "
+                                 "implement predict_proba method")
 
     @property
     def predict_proba(self):

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -359,12 +359,6 @@ class MultiOutputClassifier(ClassifierMixin, MultiOutputEstimator):
         self.classes_ = [estimator.classes_ for estimator in self.estimators_]
         return self
 
-    def _check_proba(self):
-        if not all([hasattr(estimator, "predict_proba")
-                    for estimator in self.estimators_]):
-            raise AttributeError("The base estimator should "
-                                 "implement predict_proba method")
-
     @property
     def predict_proba(self):
         """Probability estimates.
@@ -386,7 +380,10 @@ class MultiOutputClassifier(ClassifierMixin, MultiOutputEstimator):
             classes corresponds to that in the attribute :term:`classes_`.
         """
         check_is_fitted(self)
-        self._check_proba()
+        if not all([hasattr(estimator, "predict_proba")
+                    for estimator in self.estimators_]):
+            raise AttributeError("The base estimator should "
+                                 "implement predict_proba method")
         return self._predict_proba
 
     def _predict_proba(self, X):

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -359,7 +359,14 @@ class MultiOutputClassifier(ClassifierMixin, MultiOutputEstimator):
         self.classes_ = [estimator.classes_ for estimator in self.estimators_]
         return self
 
-    def predict_proba(self, X):
+    def _check_proba(self):
+        if not all([hasattr(estimator, "predict_proba")
+                    for estimator in self.estimators_]):
+            raise ValueError("The base estimator should implement "
+                             "predict_proba method")
+
+    @property
+    def predict_proba(self):
         """Probability estimates.
         Returns prediction probabilities for each class of each output.
 
@@ -379,11 +386,10 @@ class MultiOutputClassifier(ClassifierMixin, MultiOutputEstimator):
             classes corresponds to that in the attribute :term:`classes_`.
         """
         check_is_fitted(self)
-        if not all([hasattr(estimator, "predict_proba")
-                    for estimator in self.estimators_]):
-            raise ValueError("The base estimator should implement "
-                             "predict_proba method")
+        self._check_proba()
+        return self._predict_proba
 
+    def _predict_proba(self, X):
         results = [estimator.predict_proba(X) for estimator in
                    self.estimators_]
         return results

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -362,7 +362,7 @@ class MultiOutputClassifier(ClassifierMixin, MultiOutputEstimator):
     def _check_proba(self):
         if not all([hasattr(estimator, "predict_proba")
                     for estimator in self.estimators_]):
-            raise ValueError("The base estimator should implement "
+            raise AttributeError("The base estimator should implement "
                              "predict_proba method")
 
     @property

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -174,6 +174,19 @@ def test_multi_output_classification_partial_fit_parallelism():
         assert est1 is not est2
 
 
+# check multioutput has predict_proba
+def test_hasattr_multi_output_predict_proba():
+    # default SGDClassifier has loss='hinge'
+    # which does not expose a predict_proba method
+    sgd_linear_clf = SGDClassifier(random_state=1, max_iter=5)
+    multi_target_linear = MultiOutputClassifier(sgd_linear_clf)
+    assert hasattr(multi_target_linear, "predict_proba") is False
+    multi_target_linear.fit(X, y)
+    err_msg = "The base estimator should implement predict_proba method"
+    with pytest.raises(ValueError, match=err_msg):
+        hasattr(multi_target_linear, "predict_proba")
+
+
 # check predict_proba passes
 def test_multi_output_predict_proba():
     sgd_linear_clf = SGDClassifier(random_state=1, max_iter=5)
@@ -377,7 +390,8 @@ def test_multi_output_exceptions():
     # and predict_proba are called
     moc = MultiOutputClassifier(LinearSVC(random_state=0))
     assert_raises(NotFittedError, moc.predict, y)
-    assert_raises(NotFittedError, moc.predict_proba, y)
+    with pytest.raises(NotFittedError):
+        moc.predict_proba
     assert_raises(NotFittedError, moc.score, X, y)
     # ValueError when number of outputs is different
     # for fit and score

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -181,13 +181,13 @@ def test_hasattr_multi_output_predict_proba():
     sgd_linear_clf = SGDClassifier(random_state=1, max_iter=5)
     multi_target_linear = MultiOutputClassifier(sgd_linear_clf)
     multi_target_linear.fit(X, y)
-    assert hasattr(multi_target_linear, "predict_proba") is False
+    assert not hasattr(multi_target_linear, "predict_proba")
 
     # case where predict_proba attribute exists
     sgd_linear_clf = SGDClassifier(loss='log', random_state=1, max_iter=5)
     multi_target_linear = MultiOutputClassifier(sgd_linear_clf)
     multi_target_linear.fit(X, y)
-    assert hasattr(multi_target_linear, "predict_proba") is True
+    assert hasattr(multi_target_linear, "predict_proba")
 
 
 # check predict_proba passes

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -180,11 +180,14 @@ def test_hasattr_multi_output_predict_proba():
     # which does not expose a predict_proba method
     sgd_linear_clf = SGDClassifier(random_state=1, max_iter=5)
     multi_target_linear = MultiOutputClassifier(sgd_linear_clf)
-    assert hasattr(multi_target_linear, "predict_proba") is False
     multi_target_linear.fit(X, y)
-    err_msg = "The base estimator should implement predict_proba method"
-    with pytest.raises(ValueError, match=err_msg):
-        hasattr(multi_target_linear, "predict_proba")
+    assert hasattr(multi_target_linear, "predict_proba") is False
+
+    # case where predict_proba attribute exists
+    sgd_linear_clf = SGDClassifier(loss='log', random_state=1, max_iter=5)
+    multi_target_linear = MultiOutputClassifier(sgd_linear_clf)
+    multi_target_linear.fit(X, y)
+    assert hasattr(multi_target_linear, "predict_proba") is True
 
 
 # check predict_proba passes
@@ -211,7 +214,7 @@ def test_multi_output_predict_proba():
     multi_target_linear = MultiOutputClassifier(sgd_linear_clf)
     multi_target_linear.fit(X, y)
     err_msg = "The base estimator should implement predict_proba method"
-    with pytest.raises(ValueError, match=err_msg):
+    with pytest.raises(AttributeError, match=err_msg):
         multi_target_linear.predict_proba(X)
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #15488. See also #12222.

#### What does this implement/fix? Explain your changes.
Have `predict_proba` as a property of `MultiOutputClassifier`.
