### PR TITLE
[MRG] Standardize sample weights validation in BaseDecisionTree

### DIFF
--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -32,6 +32,7 @@ from ..base import MultiOutputMixin
 from ..utils import Bunch
 from ..utils import check_array
 from ..utils import check_random_state
+from ..utils.validation import _check_sample_weight
 from ..utils import compute_sample_weight
 from ..utils.multiclass import check_classification_targets
 from ..utils.validation import check_is_fitted
@@ -266,18 +267,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
                               "or larger than 1").format(max_leaf_nodes))
 
         if sample_weight is not None:
-            if (getattr(sample_weight, "dtype", None) != DOUBLE or
-                    not sample_weight.flags.contiguous):
-                sample_weight = np.ascontiguousarray(
-                    sample_weight, dtype=DOUBLE)
-            if len(sample_weight.shape) > 1:
-                raise ValueError("Sample weights array has more "
-                                 "than one dimension: %d" %
-                                 len(sample_weight.shape))
-            if len(sample_weight) != n_samples:
-                raise ValueError("Number of weights=%d does not match "
-                                 "number of samples=%d" %
-                                 (len(sample_weight), n_samples))
+            sample_weight = _check_sample_weight(sample_weight, X, np.float64)
 
         if expanded_class_weight is not None:
             if sample_weight is not None:

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -267,7 +267,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
                               "or larger than 1").format(max_leaf_nodes))
 
         if sample_weight is not None:
-            sample_weight = _check_sample_weight(sample_weight, X, np.float64)
+            sample_weight = _check_sample_weight(sample_weight, X, DOUBLE)
 
         if expanded_class_weight is not None:
             if sample_weight is not None:

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1121,7 +1121,7 @@ def test_sample_weight_invalid():
         clf.fit(X, y, sample_weight=sample_weight)
 
     sample_weight = np.array(0)
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         clf.fit(X, y, sample_weight=sample_weight)
 
     sample_weight = np.ones(101)

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -3,7 +3,6 @@ Testing for the tree module (sklearn.tree).
 """
 import copy
 import pickle
-from functools import partial
 from itertools import product
 import struct
 
@@ -1121,7 +1120,8 @@ def test_sample_weight_invalid():
         clf.fit(X, y, sample_weight=sample_weight)
 
     sample_weight = np.array(0)
-    with pytest.raises(TypeError):
+    expected_err = r"Singleton.* cannot be considered a valid collection"
+    with pytest.raises(TypeError, match=expected_err):
         clf.fit(X, y, sample_weight=sample_weight)
 
     sample_weight = np.ones(101)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #15358 for BaseDecisionTree

#### What does this implement/fix? Explain your changes.
Replaces custom validation logic with standardized method `utils.validation._check_sample_weight` (relatively newly introduced).

#### Any other comments?
Two things to check:

1. the new validation method only accepts `float32` and `float64`, but the class is using `._tree.DOUBLE` which we think is the same 
2. In the case of an empty array, we now get a TypeError instead of a ValueError due to shared implementation.

We think these are both ok changes.
