### PR TITLE
[MRG] Apply numpydoc validation to VotingRegressor methods

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -22,6 +22,11 @@ DOCSTRING_WHITELIST = [
     "RidgeClassifier.decision_function",
     "RidgeClassifierCV.decision_function",
     "SGDClassifier.decision_function",
+    "VotingRegressor$",
+    "VotingRegressor.fit",
+    "VotingRegressor.transform",
+    "VotingRegressor.predict",
+    "VotingRegressor.score",
 ]
 
 

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -369,7 +369,7 @@ class RegressorMixin:
     _estimator_type = "regressor"
 
     def score(self, X, y, sample_weight=None):
-        """Returns the coefficient of determination R^2 of the prediction.
+        """Return the coefficient of determination R^2 of the prediction.
 
         The coefficient R^2 is defined as (1 - u/v), where u is the residual
         sum of squares ((y_true - y_pred) ** 2).sum() and v is the total
@@ -548,11 +548,13 @@ class TransformerMixin:
         y : numpy array of shape [n_samples]
             Target values.
 
+        **fit_params : Any number of parameters
+            Fit parameters.
+
         Returns
         -------
         X_new : numpy array of shape [n_samples, n_features_new]
             Transformed array.
-
         """
         # non-optimized default implementation; override when a better
         # method is possible for a given clustering algorithm

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -328,7 +328,7 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
 
     Parameters
     ----------
-    estimators : list of (string, estimator) tuples
+    estimators : list of (str, estimator) tuples
         Invoking the ``fit`` method on the ``VotingRegressor`` will fit clones
         of those original estimators that will be stored in the class attribute
         ``self.estimators_``. An estimator can be set to ``'drop'`` using
@@ -359,6 +359,10 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
 
         .. versionadded:: 0.20
 
+    See Also
+    --------
+    VotingClassifier: Soft Voting/Majority Rule classifier.
+
     Examples
     --------
     >>> import numpy as np
@@ -372,10 +376,6 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
     >>> er = VotingRegressor([('lr', r1), ('rf', r2)])
     >>> print(er.fit(X, y).predict(X))
     [ 3.3  5.7 11.8 19.7 28.  40.3]
-
-    See also
-    --------
-    VotingClassifier: Soft Voting/Majority Rule classifier.
     """
 
     def __init__(self, estimators, weights=None, n_jobs=None):
@@ -384,7 +384,7 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
         self.n_jobs = n_jobs
 
     def fit(self, X, y, sample_weight=None):
-        """ Fit the estimators.
+        """Fit the estimators.
 
         Parameters
         ----------
@@ -403,6 +403,7 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
         Returns
         -------
         self : object
+            Returns self.
         """
         y = column_or_1d(y, warn=True)
         return super().fit(X, y, sample_weight)
@@ -438,7 +439,7 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
         Returns
         -------
         predictions
-            array-like of shape (n_samples, n_classifiers), being
+            Array-like of shape (n_samples, n_classifiers), being
             values predicted by each regressor.
         """
         check_is_fitted(self)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Addresses #https://github.com/scikit-learn/scikit-learn/issues/15440. 


#### What does this implement/fix? Explain your changes.
Applied numpydoc validation to the estimator VotingRegressor and a some of the methods and added them to the docstring test whitelist
- fit
- transform
- predict
- score

Specifically, changes included:
- adding missing return doc
- properly capitalizing section names
- removing whitespaces surrounding docstring text
- starting summary with infinitive verb (as opposed to third person)
- documenting undocumented parameters
- properly ordering sections
- eliminating blank lines at the end of docstring

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
