### PR TITLE
[DOC] fixed typos in mean_precision_prior in _bayesian_mixture

### DIFF
--- a/sklearn/mixture/_bayesian_mixture.py
+++ b/sklearn/mixture/_bayesian_mixture.py
@@ -140,14 +140,14 @@ class BayesianGaussianMixture(BaseMixture):
 
     mean_precision_prior : float | None, optional.
         The precision prior on the mean distribution (Gaussian).
-        Controls the extend to where means can be placed. Larger
-        values concentrate the means of each clusters around `mean_prior`.
+        Controls the extent of where means can be placed. Larger
+        values concentrate the cluster means around `mean_prior`.
         The value of the parameter must be greater than 0.
-        If it is None, it's set to 1.
+        If it is None, it is set to 1.
 
     mean_prior : array-like, shape (n_features,), optional
         The prior on the mean distribution (Gaussian).
-        If it is None, it's set to the mean of X.
+        If it is None, it is set to the mean of X.
 
     degrees_of_freedom_prior : float | None, optional.
         The prior of the number of degrees of freedom on the covariance
@@ -257,11 +257,12 @@ class BayesianGaussianMixture(BaseMixture):
         The dirichlet concentration of each component on the weight
         distribution (Dirichlet).
 
-    mean_precision_prior : float
+    mean_precision_prior_ : float
         The precision prior on the mean distribution (Gaussian).
-        Controls the extend to where means can be placed.
-        Larger values concentrate the means of each clusters around
-        `mean_prior`.
+        Controls the extent of where means can be placed.
+        Larger values concentrate the cluster means around `mean_prior`.
+        If mean_precision_prior is set to None, mean_precision_prior_ is set to
+        1.
 
     mean_precision_ : array-like, shape (n_components,)
         The precision of each components on the mean distribution (Gaussian).


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
#14312 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
I fixed a number of typos in the documentation of the parameter, `mean_precision_prior`, and attribute, `mean_precision_prior_`, in `_bayesian_mixture`.

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
