### PR TITLE
[MRG] Standardize sample weights validation in DummyClassifier

### DIFF
--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -13,7 +13,8 @@ from .utils import check_random_state
 from .utils.validation import _num_samples
 from .utils.validation import check_array
 from .utils.validation import check_consistent_length
-from .utils.validation import check_is_fitted, _check_sample_weight
+from .utils.validation import check_is_fitted
+from .utils.validation import _check_sample_weight
 from .utils.random import _random_choice_csc
 from .utils.stats import _weighted_percentile
 from .utils.multiclass import class_distribution
@@ -156,7 +157,10 @@ class DummyClassifier(MultiOutputMixin, ClassifierMixin, BaseEstimator):
 
         self.n_outputs_ = y.shape[1]
 
-        check_consistent_length(X, y, sample_weight)
+        check_consistent_length(X, y)
+
+        if sample_weight is not None:
+            sample_weight = _check_sample_weight(sample_weight, X)
 
         if sample_weight is not None:
             sample_weight = _check_sample_weight(sample_weight, X)
@@ -245,7 +249,7 @@ class DummyClassifier(MultiOutputMixin, ClassifierMixin, BaseEstimator):
                 classes_ = [np.array([c]) for c in constant]
 
             y = _random_choice_csc(n_samples, classes_, class_prob,
-                                  self.random_state)
+                                   self.random_state)
         else:
             if self._strategy in ("most_frequent", "prior"):
                 y = np.tile([classes_[k][class_prior_[k].argmax()] for

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -13,8 +13,7 @@ from .utils import check_random_state
 from .utils.validation import _num_samples
 from .utils.validation import check_array
 from .utils.validation import check_consistent_length
-from .utils.validation import check_is_fitted
-from .utils.validation import _check_sample_weight
+from .utils.validation import check_is_fitted, _check_sample_weight
 from .utils.random import _random_choice_csc
 from .utils.stats import _weighted_percentile
 from .utils.multiclass import class_distribution
@@ -158,9 +157,6 @@ class DummyClassifier(MultiOutputMixin, ClassifierMixin, BaseEstimator):
         self.n_outputs_ = y.shape[1]
 
         check_consistent_length(X, y)
-
-        if sample_weight is not None:
-            sample_weight = _check_sample_weight(sample_weight, X)
 
         if sample_weight is not None:
             sample_weight = _check_sample_weight(sample_weight, X)

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -580,23 +580,6 @@ def test_sample_weight_invalid():
     clf = DummyClassifier().fit(X, y, sample_weight)
     assert_array_almost_equal(clf.class_prior_, [0.2 / 1.2, 1. / 1.2])
 
-    sample_weight = np.random.rand(3, 1)
-    with pytest.raises(ValueError):
-        clf.fit(X, y, sample_weight=sample_weight)
-
-    sample_weight = np.array(0)
-    expected_err = r"Singleton.* cannot be considered a valid collection"
-    with pytest.raises(TypeError, match=expected_err):
-        clf.fit(X, y, sample_weight=sample_weight)
-
-    sample_weight = np.ones(4)
-    with pytest.raises(ValueError):
-        clf.fit(X, y, sample_weight=sample_weight)
-
-    sample_weight = np.ones(2)
-    with pytest.raises(ValueError):
-        clf.fit(X, y, sample_weight=sample_weight)
-
 
 def test_constant_strategy_sparse_target():
     X = [[0]] * 5  # ignored

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -571,16 +571,6 @@ def test_classification_sample_weight():
     assert_array_almost_equal(clf.class_prior_, [0.2 / 1.2, 1. / 1.2])
 
 
-def test_sample_weight_invalid():
-    # Check sample weighting raises errors.
-    X = [[0], [0], [1]]
-    y = [0, 1, 0]
-    sample_weight = [0.1, 1., 0.1]
-
-    clf = DummyClassifier().fit(X, y, sample_weight)
-    assert_array_almost_equal(clf.class_prior_, [0.2 / 1.2, 1. / 1.2])
-
-
 def test_constant_strategy_sparse_target():
     X = [[0]] * 5  # ignored
     y = sp.csc_matrix(np.array([[0, 1],

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -571,6 +571,33 @@ def test_classification_sample_weight():
     assert_array_almost_equal(clf.class_prior_, [0.2 / 1.2, 1. / 1.2])
 
 
+def test_sample_weight_invalid():
+    # Check sample weighting raises errors.
+    X = [[0], [0], [1]]
+    y = [0, 1, 0]
+    sample_weight = [0.1, 1., 0.1]
+
+    clf = DummyClassifier().fit(X, y, sample_weight)
+    assert_array_almost_equal(clf.class_prior_, [0.2 / 1.2, 1. / 1.2])
+
+    sample_weight = np.random.rand(3, 1)
+    with pytest.raises(ValueError):
+        clf.fit(X, y, sample_weight=sample_weight)
+
+    sample_weight = np.array(0)
+    expected_err = r"Singleton.* cannot be considered a valid collection"
+    with pytest.raises(TypeError, match=expected_err):
+        clf.fit(X, y, sample_weight=sample_weight)
+
+    sample_weight = np.ones(4)
+    with pytest.raises(ValueError):
+        clf.fit(X, y, sample_weight=sample_weight)
+
+    sample_weight = np.ones(2)
+    with pytest.raises(ValueError):
+        clf.fit(X, y, sample_weight=sample_weight)
+
+
 def test_constant_strategy_sparse_target():
     X = [[0]] * 5  # ignored
     y = sp.csc_matrix(np.array([[0, 1],


### PR DESCRIPTION
#### Reference Issues/PRs
Partially addresses #15358 for DummyClassifier

#### What does this implement/fix? Explain your changes.
Replaces custom validation logic with standardized method `utils.validation._check_sample_weight` (relatively newly introduced).

#### Any other comments?  
