### PR TITLE
Make non-convergence output match documentation

### DIFF
--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -410,6 +410,7 @@ class AffinityPropagation(ClusterMixin, BaseEstimator):
             Cluster labels.
         """
         check_is_fitted(self)
+        X = check_array(X)
         if not hasattr(self, "cluster_centers_"):
             raise ValueError("Predict method is not supported when "
                              "affinity='precomputed'.")

--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -194,17 +194,19 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
             unconverged = (np.sum((se == convergence_iter) + (se == 0))
                            != n_samples)
             if (not unconverged and (K > 0)) or (it == max_iter):
+                never_converged = False
                 if verbose:
                     print("Converged after %d iterations." % it)
                 break
     else:
+        never_converged = True
         if verbose:
             print("Did not converge")
 
     I = np.flatnonzero(E)
     K = I.size  # Identify exemplars
 
-    if K > 0:
+    if K > 0 and not never_converged:
         c = np.argmax(S[:, I], axis=1)
         c[I] = np.arange(K)  # Identify clusters
         # Refine the final set of exemplars and clusters and return results

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -152,6 +152,14 @@ def test_affinity_propagation_predict_non_convergence():
     assert_array_equal(np.array([-1, -1, -1]), y)
 
 
+def test_affinity_propagation_non_convergence_regressiontest():
+    X = np.array([[1, 0, 0, 0, 0, 0],
+                  [0, 1, 1, 1, 0, 0],
+                  [0, 0, 1, 0, 0, 1]])
+    af = AffinityPropagation(affinity='euclidean', max_iter=2).fit(X)
+    assert_array_equal(np.array([-1, -1, -1]), af.labels_)
+
+
 def test_equal_similarities_and_preferences():
     # Unequal distances
     X = np.array([[0, 0], [1, 1], [-2, -2]])


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #14472

#### What does this implement/fix? Explain your changes.
the warning and output for a non-convergent condition did not explicitly depend on convergence. That meant that if a cluster was identified (K>0) but there was no convergence, it did not behave in the way the documentation stated ("When the algorithm does not converge, it returns an empty array as cluster_center_indices and -1 as label for each training sample."). This behavior is demonstrated in #14472. We added a boolean that reflected the convergence state, and checked that in addition to K>0 for the non-convergence warning logic.

pair programmed with @akeshavan for the wimlds SF sprint