### PR TITLE
DOC added missing attributes in SkewedChi2Sampler

### DIFF
--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -146,6 +146,16 @@ class SkewedChi2Sampler(TransformerMixin, BaseEstimator):
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
+    Attributes
+    ----------
+    random_weights_ : array-like, shape (n_features, n_components)
+        Weight array, sampled from a secant hyperbolic distribution, which will
+        be used to linearly transform the log of the data.
+
+    random_offset_ : array-like, shape (n_features, n_components)
+        Bias term, which will be added to the data. It is uniformly distributed
+        between 0 and 2*pi.
+
     Examples
     --------
     >>> from sklearn.kernel_approximation import SkewedChi2Sampler

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -148,11 +148,11 @@ class SkewedChi2Sampler(TransformerMixin, BaseEstimator):
 
     Attributes
     ----------
-    random_weights_ : array-like, shape (n_features, n_components)
+    random_weights_ : ndarray of shape (n_features, n_components)
         Weight array, sampled from a secant hyperbolic distribution, which will
         be used to linearly transform the log of the data.
 
-    random_offset_ : array-like, shape (n_features, n_components)
+    random_offset_ : ndarray of shape (n_features, n_components)
         Bias term, which will be added to the data. It is uniformly distributed
         between 0 and 2*pi.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
#14312
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
I added documentation for the attributes, random_weights_ and random_offset_ to the doc-string for SkewedChi2Sampler. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
