### PR TITLE
MAINT Standardize sample weights validation in KernelDensity

### DIFF
--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -7,7 +7,8 @@ Kernel Density Estimation
 import numpy as np
 from scipy.special import gammainc
 from ..base import BaseEstimator
-from ..utils import check_array, check_random_state, check_consistent_length
+from ..utils import check_array, check_random_state
+from ..utils.validation import _check_sample_weight
 
 from ..utils.extmath import row_norms
 from ._ball_tree import BallTree, DTYPE
@@ -154,13 +155,7 @@ class KernelDensity(BaseEstimator):
         X = check_array(X, order='C', dtype=DTYPE)
 
         if sample_weight is not None:
-            sample_weight = check_array(sample_weight, order='C', dtype=DTYPE,
-                                        ensure_2d=False)
-            if sample_weight.ndim != 1:
-                raise ValueError("the shape of sample_weight must be ({0},),"
-                                 " but was {1}".format(X.shape[0],
-                                                       sample_weight.shape))
-            check_consistent_length(X, sample_weight)
+            sample_weight = _check_sample_weight(sample_weight, X, DTYPE)
             if sample_weight.min() <= 0:
                 raise ValueError("sample_weight must have positive values")
 

--- a/sklearn/neighbors/tests/test_kde.py
+++ b/sklearn/neighbors/tests/test_kde.py
@@ -204,6 +204,21 @@ def test_kde_sample_weights():
                     assert_allclose(scores_scaled_weight, scores_weight)
 
 
+def test_sample_weight_invalid():
+    # Check sample weighting raises errors.
+    kde = KernelDensity()
+    data = np.reshape([1., 2., 3.], (-1, 1))
+
+    sample_weight = [0.1, 0.2]
+    with pytest.raises(ValueError):
+        kde.fit(data, sample_weight=sample_weight)
+
+    sample_weight = [0.1, -0.2, 0.3]
+    expected_err = "sample_weight must have positive values"
+    with pytest.raises(ValueError, match=expected_err):
+        kde.fit(data, sample_weight=sample_weight)
+
+
 @pytest.mark.parametrize('sample_weight', [None, [0.1, 0.2, 0.3]])
 def test_pickling(tmpdir, sample_weight):
     # Make sure that predictions are the same before and after pickling. Used


### PR DESCRIPTION
#### Reference Issues/PRs
Partially addresses #15358 for KernelDensity

#### What does this implement/fix? Explain your changes.
Replaces custom validation logic with standardized method `utils.validation._check_sample_weight` (relatively newly introduced).

#### Any other comments?
1. We saw that there was custom logic to test weights were not less than zero, which would not be covered with the new util function.  We left that code alone, but maybe the util function should be refactored to include that case as well.

2. We noticed though all these PRs for this refactor that we are adding tests that test the validation transitively through the estimator.  We still want tests to make sure the validation is there. However, maybe this should be done in common tests if possible, or at least use something like `unittest.mock`  to verify the `check_sample_weight` is called instead of asserting on the exceptions thrown...