### PR TITLE
MRG Add dtype parameter in KBinsDiscretizer

### DIFF
--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -118,7 +118,11 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
            [ 0.5,  3.5, -1.5,  1.5]])
     """
 
-    def __init__(self, n_bins=5, encode='onehot', strategy='quantile', dtype='float64'):
+    def __init__(self, 
+                 n_bins=5, 
+                 encode='onehot', 
+                 strategy='quantile', 
+                 dtype='float64'):
         self.n_bins = n_bins
         self.encode = encode
         self.strategy = strategy

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -53,6 +53,9 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         kmeans
             Values in each bin have the same nearest center of a 1D k-means
             cluster.
+    
+    dtype : {'float32', 'float64'}, (default='float64')
+        The dtype of transformed array.
 
     Attributes
     ----------
@@ -115,10 +118,11 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
            [ 0.5,  3.5, -1.5,  1.5]])
     """
 
-    def __init__(self, n_bins=5, encode='onehot', strategy='quantile'):
+    def __init__(self, n_bins=5, encode='onehot', strategy='quantile', dtype='float64'):
         self.n_bins = n_bins
         self.encode = encode
         self.strategy = strategy
+        self.dtype = dtype
 
     def fit(self, X, y=None):
         """
@@ -149,6 +153,11 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             raise ValueError("Valid options for 'strategy' are {}. "
                              "Got strategy={!r} instead."
                              .format(valid_strategy, self.strategy))
+        valid_dtype = ('float32', 'float64')
+        if self.dtype not in valid_dtype:
+            raise ValueError("Valid options for 'dtype' are {}."
+                             "Got dtype={!r} instead."
+                             .format(valid_dtype, self.dtype))
 
         n_features = X.shape[1]
         n_bins = self._validate_n_bins(n_features)
@@ -281,7 +290,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         if self.encode == 'ordinal':
             return Xt
 
-        return self._encoder.transform(Xt)
+        return self._encoder.transform(Xt).astype(self.dtype)
 
     def inverse_transform(self, Xt):
         """

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -292,7 +292,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         np.clip(Xt, 0, self.n_bins_ - 1, out=Xt)
 
         if self.encode == 'ordinal':
-            return Xt
+            return Xt.astype(self.dtype)
 
         return self._encoder.transform(Xt).astype(self.dtype)
 

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -54,7 +54,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             Values in each bin have the same nearest center of a 1D k-means
             cluster.
 
-    dtype : {np.float32, np.float64}, (default=np.float64)
+    dtype : {np.float32, np.float64}, default=np.float64
         The dtype of the transformed array.
 
     Attributes
@@ -158,7 +158,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
                              "Got strategy={!r} instead."
                              .format(valid_strategy, self.strategy))
         valid_dtype = (np.float32, np.float64)
-        if self.dtype not in valid_dtype:
+        if np.dtype(self.dtype) not in valid_dtype:
             raise ValueError("Valid options for 'dtype' are {}. "
                              "Got dtype={!r} instead."
                              .format(valid_dtype, self.dtype))

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -53,7 +53,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         kmeans
             Values in each bin have the same nearest center of a 1D k-means
             cluster.
-    
+
     dtype : {'float32', 'float64'}, (default='float64')
         The dtype of transformed array.
 

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -118,10 +118,10 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
            [ 0.5,  3.5, -1.5,  1.5]])
     """
 
-    def __init__(self, 
-                 n_bins=5, 
-                 encode='onehot', 
-                 strategy='quantile', 
+    def __init__(self,
+                 n_bins=5,
+                 encode='onehot',
+                 strategy='quantile',
                  dtype='float64'):
         self.n_bins = n_bins
         self.encode = encode

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -54,8 +54,8 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             Values in each bin have the same nearest center of a 1D k-means
             cluster.
 
-    dtype : {'float32', 'float64'}, (default='float64')
-        The dtype of transformed array.
+    dtype : {np.float32, np.float64}, (default=np.float64)
+        The dtype of the transformed array.
 
     Attributes
     ----------
@@ -122,7 +122,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
                  n_bins=5,
                  encode='onehot',
                  strategy='quantile',
-                 dtype='float64'):
+                 dtype=np.float64):
         self.n_bins = n_bins
         self.encode = encode
         self.strategy = strategy
@@ -157,7 +157,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             raise ValueError("Valid options for 'strategy' are {}. "
                              "Got strategy={!r} instead."
                              .format(valid_strategy, self.strategy))
-        valid_dtype = ('float32', 'float64')
+        valid_dtype = (np.float32, np.float64)
         if self.dtype not in valid_dtype:
             raise ValueError("Valid options for 'dtype' are {}. "
                              "Got dtype={!r} instead."
@@ -216,7 +216,8 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         if 'onehot' in self.encode:
             self._encoder = OneHotEncoder(
                 categories=[np.arange(i) for i in self.n_bins_],
-                sparse=self.encode == 'onehot')
+                sparse=self.encode == 'onehot',
+                dtype=self.dtype)
             # Fit the OneHotEncoder with toy datasets
             # so that it's ready for use after the KBinsDiscretizer is fitted
             self._encoder.fit(np.zeros((1, len(self.n_bins_)), dtype=int))
@@ -294,7 +295,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         if self.encode == 'ordinal':
             return Xt.astype(self.dtype)
 
-        return self._encoder.transform(Xt).astype(self.dtype)
+        return self._encoder.transform(Xt)
 
     def inverse_transform(self, Xt):
         """

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -159,7 +159,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
                              .format(valid_strategy, self.strategy))
         valid_dtype = ('float32', 'float64')
         if self.dtype not in valid_dtype:
-            raise ValueError("Valid options for 'dtype' are {}."
+            raise ValueError("Valid options for 'dtype' are {}. "
                              "Got dtype={!r} instead."
                              .format(valid_dtype, self.dtype))
 

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -188,6 +188,13 @@ def test_invalid_strategy_option():
     with pytest.raises(ValueError, match=err_msg):
         est.fit(X)
 
+def test_invalid_dtype_option():
+    est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], dtype='invalid-dtype')
+    err_msg = (r"Valid options for 'dtype' are "
+               r"\('float32', 'float64'\). "
+               r"Got dtype='invalid-dtype' instead.")
+    with pytest.raises(ValueError, match=err_msg):
+        est.fit(X)
 
 @pytest.mark.parametrize(
     'strategy, expected_2bins, expected_3bins, expected_5bins',
@@ -242,6 +249,12 @@ def test_transform_outside_fit_range(strategy):
     X2t = kbd.transform(X2)
     assert_array_equal(X2t.max(axis=0) + 1, kbd.n_bins_)
     assert_array_equal(X2t.min(axis=0), [0])
+
+@pytest.mark.parametrize('data_type', ['float32', 'float64'])
+def test_dtype_float32_float64(data_type):
+    kbd = KBinsDiscretizer(n_bins=3, strategy='uniform', encode='ordinal', dtype=data_type)
+    Xt = kbd.fit_transform(X)
+    assert Xt.dtype == data_type
 
 
 def test_overwrite():

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -192,7 +192,7 @@ def test_invalid_strategy_option():
 def test_invalid_dtype_option():
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], dtype='invalid-dtype')
     err_msg = (r"Valid options for 'dtype' are "
-               r"\('float32', 'float64'\). "
+               r"\(<class 'numpy.float32'>, <class 'numpy.float64'>\). "
                r"Got dtype='invalid-dtype' instead.")
     with pytest.raises(ValueError, match=err_msg):
         est.fit(X)
@@ -253,7 +253,7 @@ def test_transform_outside_fit_range(strategy):
     assert_array_equal(X2t.min(axis=0), [0])
 
 
-@pytest.mark.parametrize('data_type', ['float32', 'float64'])
+@pytest.mark.parametrize('data_type', [np.float32, np.float64])
 def test_dtype_float32_float64(data_type):
     kbd = KBinsDiscretizer(n_bins=3, strategy='uniform', encode='ordinal',
                            dtype=data_type)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -255,7 +255,7 @@ def test_transform_outside_fit_range(strategy):
 
 @pytest.mark.parametrize('data_type', ['float32', 'float64'])
 def test_dtype_float32_float64(data_type):
-    kbd = KBinsDiscretizer(n_bins=3, strategy='uniform', encode='ordinal', 
+    kbd = KBinsDiscretizer(n_bins=3, strategy='uniform', encode='ordinal',
                            dtype=data_type)
     Xt = kbd.fit_transform(X)
     assert Xt.dtype == data_type

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -258,7 +258,7 @@ def test_dtype_float32_float64(data_type):
     kbd = KBinsDiscretizer(n_bins=3, strategy='uniform', encode='ordinal',
                            dtype=data_type)
     Xt = kbd.fit_transform(X)
-    assert data_type == Xt.dtype
+    assert Xt.dtype == data_type
 
 
 def test_overwrite():

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -258,7 +258,7 @@ def test_dtype_float32_float64(data_type):
     kbd = KBinsDiscretizer(n_bins=3, strategy='uniform', encode='ordinal',
                            dtype=data_type)
     Xt = kbd.fit_transform(X)
-    assert Xt.dtype == data_type
+    assert data_type == Xt.dtype
 
 
 def test_overwrite():

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -190,10 +190,10 @@ def test_invalid_strategy_option():
 
 
 def test_invalid_dtype_option():
-    est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], dtype='invalid-dtype')
+    est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], dtype='int32')
     err_msg = (r"Valid options for 'dtype' are "
                r"\(<class 'numpy.float32'>, <class 'numpy.float64'>\). "
-               r"Got dtype='invalid-dtype' instead.")
+               r"Got dtype='int32' instead.")
     with pytest.raises(ValueError, match=err_msg):
         est.fit(X)
 

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -188,6 +188,7 @@ def test_invalid_strategy_option():
     with pytest.raises(ValueError, match=err_msg):
         est.fit(X)
 
+
 def test_invalid_dtype_option():
     est = KBinsDiscretizer(n_bins=[2, 3, 3, 3], dtype='invalid-dtype')
     err_msg = (r"Valid options for 'dtype' are "
@@ -195,6 +196,7 @@ def test_invalid_dtype_option():
                r"Got dtype='invalid-dtype' instead.")
     with pytest.raises(ValueError, match=err_msg):
         est.fit(X)
+
 
 @pytest.mark.parametrize(
     'strategy, expected_2bins, expected_3bins, expected_5bins',
@@ -250,9 +252,11 @@ def test_transform_outside_fit_range(strategy):
     assert_array_equal(X2t.max(axis=0) + 1, kbd.n_bins_)
     assert_array_equal(X2t.min(axis=0), [0])
 
+
 @pytest.mark.parametrize('data_type', ['float32', 'float64'])
 def test_dtype_float32_float64(data_type):
-    kbd = KBinsDiscretizer(n_bins=3, strategy='uniform', encode='ordinal', dtype=data_type)
+    kbd = KBinsDiscretizer(n_bins=3, strategy='uniform', encode='ordinal', 
+                           dtype=data_type)
     Xt = kbd.fit_transform(X)
     assert Xt.dtype == data_type
 


### PR DESCRIPTION
Fixes #15409

Add dtype parameter in KBinsDiscretizer. Returns transformed array with data_type as dtype.
Add tests to assert the returned data type.