### PR TITLE
MAINT Improve method detection in numpydoc validation script

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -113,9 +113,7 @@ def repr_errors(res, estimator=None, method: Optional[str] = None) -> str:
         try:
             obj_signature = signature(obj)
         except TypeError:
-            # In particular we can't parse the signature
-            # for properties that are still callable such as
-            # predict_proba
+            # In particular we can't parse the signature of properties
             obj_signature = (
                     "\nParsing of the method signature failed, "
                     "possibly because this is a property."


### PR DESCRIPTION
This improves estimator method detection in the `test_docstrings.py`. Previously all objects in the estimator class namespace were considered as methods (which kind of worked in most cases).

This restricts method search only to callable objects, and also applies a fix for properties as `inspect.signature` doesn't work for those. This previously producing errors in the validator (see e.g. https://github.com/scikit-learn/scikit-learn/pull/15509)