### PR TITLE
allow object dtype arrays in clustering metrics

### DIFF
--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -43,10 +43,10 @@ def check_clusterings(labels_true, labels_pred):
         The predicted labels.
     """
     labels_true = check_array(
-        labels_true, ensure_2d=False, ensure_min_samples=0
+        labels_true, ensure_2d=False, ensure_min_samples=0, dtype=None,
     )
     labels_pred = check_array(
-        labels_pred, ensure_2d=False, ensure_min_samples=0
+        labels_pred, ensure_2d=False, ensure_min_samples=0, dtype=None,
     )
 
     # input checks

--- a/sklearn/metrics/cluster/tests/test_common.py
+++ b/sklearn/metrics/cluster/tests/test_common.py
@@ -162,8 +162,8 @@ def test_format_invariance(metric_name):
         yield y, 'array of ints'
         yield y.tolist(), 'list of ints'
         yield [str(x) + "-a" for x in y.tolist()], 'list of strs'
-        yield (np.array([str(x) + "-a" for x in y.tolist()], dtype=object)
-               , 'array of strs')
+        yield (np.array([str(x) + "-a" for x in y.tolist()], dtype=object),
+               'array of strs')
         yield y - 1, 'including negative ints'
         yield y + 1, 'strictly positive ints'
 

--- a/sklearn/metrics/cluster/tests/test_common.py
+++ b/sklearn/metrics/cluster/tests/test_common.py
@@ -161,7 +161,9 @@ def test_format_invariance(metric_name):
         y = np.array(y)
         yield y, 'array of ints'
         yield y.tolist(), 'list of ints'
-        yield [str(x) for x in y.tolist()], 'list of strs'
+        yield [str(x) + "-a" for x in y.tolist()], 'list of strs'
+        yield (np.array([str(x) + "-a" for x in y.tolist()], dtype=object)
+               , 'array of strs')
         yield y - 1, 'including negative ints'
         yield y + 1, 'strictly positive ints'
 


### PR DESCRIPTION
Fixes #15534.

Btw, the current test only passes because ``@pytest.mark.filterwarnings('ignore::FutureWarning')`` is very broad and actually catches the string type handling warning, which would otherwise cause the test to fail (I think).