### PR TITLE
MNT Typo in governance.rst

### DIFF
--- a/doc/governance.rst
+++ b/doc/governance.rst
@@ -30,7 +30,7 @@ Core developers
 ---------------
 Core developers are community members who have shown that they are dedicated to
 the continued development of the project through ongoing engagement with the
-community. They have shown they can be trusted to maintain Scikit-learn with
+community. They have shown they can be trusted to maintain scikit-learn with
 care. Being a core developer allows contributors to more easily carry on
 with their project related activities by giving them direct access to the
 project’s repository and is represented as being an organization member on the


### PR DESCRIPTION
Removed captalisation to preserve consistency.
