### PR TITLE
[WIP] Add top_k_accuracy

### DIFF
--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -31,6 +31,7 @@ from ._classification import matthews_corrcoef
 from ._classification import precision_recall_fscore_support
 from ._classification import precision_score
 from ._classification import recall_score
+from ._classification import top_k_accuracy_score
 from ._classification import zero_one_loss
 from ._classification import brier_score_loss
 from ._classification import multilabel_confusion_matrix
@@ -147,6 +148,7 @@ __all__ = [
     'SCORERS',
     'silhouette_samples',
     'silhouette_score',
+    'top_k_accuracy_score',
     'v_measure_score',
     'zero_one_loss',
     'brier_score_loss',

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -193,35 +193,34 @@ def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
     return _weighted_sum(score, sample_weight, normalize)
 
 
-def top_k_accuracy_score(y_true, y_pred, k=5, normalize=True):
-    """Top k Accuracy classification score.
+def top_k_accuracy_score(y_true, y_score, k=5, normalize=True):
+    """Top-k Accuracy classification score.
     For multiclass classification tasks, this metric returns the
-    number of times that the correct class was among the top k classes
+    number of times that the correct class was among the top-k classes
     predicted.
 
     Parameters
     ----------
-    y_true : 1d array-like, or class indicator array / sparse matrix
-        shape num_samples or [num_samples, num_classes]
+    y_true : 1d array-like, or class indicator array / sparse matrix,
+        shape num_samples or [n_samples, n_classes]
         Ground truth (correct) classes.
 
-    y_pred : array-like, shape [num_samples, num_classes]
-        For each sample, each row represents the
-        likelihood of each possible class.
-        The number of columns must be at least as large as the set of possible
-        classes.
-    k : int, optional (default=5) predictions are counted as correct if
-        probability of correct class is in the top k classes.
+    y_score : 2d array-like, shape [n_samples, n_classes]
+        For each sample, each row represents the likelihood of each possible class.
+        The number of columns must be equal to number of classes.
+    k : int, optional (default=5)
+        Predictions are counted as correct if probability of correct class is in the
+        top-k classes.
 
     normalize : bool, optional (default=True)
-        If ``False``, return the number of top k correctly classified samples.
-        Otherwise, return the fraction of top k correctly classified samples.
+        If ``False``, return the number of top-k correctly classified samples.
+        Otherwise, return the fraction of top-k correctly classified samples.
 
     Returns
     -------
     score : float
-        If ``normalize == True``, return the proportion of top k correctly
-        classified samples, (float), else it returns the number of top k
+        If ``normalize == True``, return the proportion of top-k correctly
+        classified samples, (float), else it returns the number of top-k
         correctly classified samples (int.)
 
         The best performance is 1 with ``normalize == True`` and the number
@@ -246,32 +245,32 @@ def top_k_accuracy_score(y_true, y_pred, k=5, normalize=True):
     --------
     >>> import numpy as np
     >>> from sklearn.metrics import top_k_accuracy_score
-    >>> y_pred = np.array([[0.1, 0.3, 0.4, 0.2],
+    >>> y_scores = np.array([[0.1, 0.3, 0.4, 0.2],
     ...                    [0.4, 0.3, 0.2, 0.1],
     ...                    [0.2, 0.3, 0.4, 0.1],
     ...                    [0.8, 0.1, 0.025, 0.075]])
     >>> y_true = np.array([2, 2, 2, 1])
-    >>> top_k_accuracy_score(y_true, y_pred, k=1)
+    >>> top_k_accuracy_score(y_true, y_scores, k=1)
     0.5
-    >>> top_k_accuracy_score(y_true, y_pred, k=2)
+    >>> top_k_accuracy_score(y_true, y_scores, k=2)
     0.75
-    >>> top_k_accuracy_score(y_true, y_pred, k=3)
+    >>> top_k_accuracy_score(y_true, y_scores, k=3)
     1.0
-    >>> top_k_accuracy_score(y_true, y_pred, k=2, normalize=False)
+    >>> top_k_accuracy_score(y_true, y_scores, k=2, normalize=False)
     3
     """
     if len(y_true.shape) == 2:
         y_true = np.argmax(y_true, axis=1)
 
-    num_obs, num_labels = y_pred.shape
-    idx = num_labels - k - 1
+    n_samples, n_labels = y_score.shape
+    idx = n_labels - k - 1
     counter = 0
-    argsorted = np.argsort(y_pred, axis=1)
-    for i in range(num_obs):
+    argsorted = np.argsort(y_score, axis=1)
+    for i in range(n_samples):
         if y_true[i] in argsorted[i, idx+1:]:
             counter += 1
     if normalize:
-        return counter / num_obs
+        return counter / n_samples
     else:
         return counter
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -246,9 +246,9 @@ def top_k_accuracy_score(y_true, y_score, k=5, normalize=True):
     >>> import numpy as np
     >>> from sklearn.metrics import top_k_accuracy_score
     >>> y_scores = np.array([[0.1, 0.3, 0.4, 0.2],
-    ...                    [0.4, 0.3, 0.2, 0.1],
-    ...                    [0.2, 0.3, 0.4, 0.1],
-    ...                    [0.8, 0.1, 0.025, 0.075]])
+    ...                      [0.4, 0.3, 0.2, 0.1],
+    ...                      [0.2, 0.3, 0.4, 0.1],
+    ...                      [0.8, 0.1, 0.025, 0.075]])
     >>> y_true = np.array([2, 2, 2, 1])
     >>> top_k_accuracy_score(y_true, y_scores, k=1)
     0.5

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -193,6 +193,89 @@ def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
     return _weighted_sum(score, sample_weight, normalize)
 
 
+def top_k_accuracy_score(y_true, y_pred, k=5, normalize=True):
+    """Top k Accuracy classification score.
+    For multiclass classification tasks, this metric returns the
+    number of times that the correct class was among the top k classes
+    predicted.
+
+    Parameters
+    ----------
+    y_true : 1d array-like, or class indicator array / sparse matrix
+        shape num_samples or [num_samples, num_classes]
+        Ground truth (correct) classes.
+
+    y_pred : array-like, shape [num_samples, num_classes]
+        For each sample, each row represents the
+        likelihood of each possible class.
+        The number of columns must be at least as large as the set of possible
+        classes.
+    k : int, optional (default=5) predictions are counted as correct if
+        probability of correct class is in the top k classes.
+
+    normalize : bool, optional (default=True)
+        If ``False``, return the number of top k correctly classified samples.
+        Otherwise, return the fraction of top k correctly classified samples.
+
+    Returns
+    -------
+    score : float
+        If ``normalize == True``, return the proportion of top k correctly
+        classified samples, (float), else it returns the number of top k
+        correctly classified samples (int.)
+
+        The best performance is 1 with ``normalize == True`` and the number
+        of samples with ``normalize == False``.
+
+    See also
+    --------
+    accuracy_score
+
+    Notes
+    -----
+    If k = 1, the result will be the same as the accuracy_score (though see
+    note below). If k is the same as the number of classes, this score will be
+    perfect and meaningless.
+
+    In cases where two or more classes are assigned equal likelihood, the
+    result may be incorrect if one of those classes falls at the threshold, as
+    one class must be chosen to be the nth class and the class chosen may not
+    be the correct one.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.metrics import top_k_accuracy_score
+    >>> y_pred = np.array([[0.1, 0.3, 0.4, 0.2],
+    ...                    [0.4, 0.3, 0.2, 0.1],
+    ...                    [0.2, 0.3, 0.4, 0.1],
+    ...                    [0.8, 0.1, 0.025, 0.075]])
+    >>> y_true = np.array([2, 2, 2, 1])
+    >>> top_k_accuracy_score(y_true, y_pred, k=1)
+    0.5
+    >>> top_k_accuracy_score(y_true, y_pred, k=2)
+    0.75
+    >>> top_k_accuracy_score(y_true, y_pred, k=3)
+    1.0
+    >>> top_k_accuracy_score(y_true, y_pred, k=2, normalize=False)
+    3
+    """
+    if len(y_true.shape) == 2:
+        y_true = np.argmax(y_true, axis=1)
+
+    num_obs, num_labels = y_pred.shape
+    idx = num_labels - k - 1
+    counter = 0
+    argsorted = np.argsort(y_pred, axis=1)
+    for i in range(num_obs):
+        if y_true[i] in argsorted[i, idx+1:]:
+            counter += 1
+    if normalize:
+        return counter / num_obs
+    else:
+        return counter
+
+
 def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
     """Compute confusion matrix to evaluate the accuracy of a classification
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -206,11 +206,11 @@ def top_k_accuracy_score(y_true, y_score, k=5, normalize=True):
         Ground truth (correct) classes.
 
     y_score : 2d array-like, shape [n_samples, n_classes]
-        For each sample, each row represents the likelihood of each possible class.
-        The number of columns must be equal to number of classes.
+        For each sample, each row represents the likelihood of each possible
+        class. The number of columns must be equal to number of classes.
     k : int, optional (default=5)
-        Predictions are counted as correct if probability of correct class is in the
-        top-k classes.
+        Predictions are counted as correct if probability of correct class is
+        in the top-k classes.
 
     normalize : bool, optional (default=True)
         If ``False``, return the number of top-k correctly classified samples.

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -157,19 +157,19 @@ def test_top_k_accuracy_score():
     # Test top_k_accuracy_score on synthetic five-class prediction task
     y_true = np.array([2, 1, 2, 3])
     # Correct classes in pred_proba are at ranks 2, 4, 3, 4
-    pred_proba = np.array([[0.3, 0.2, 0.25, 0.15, 0.1],
+    y_scores = np.array([[0.3, 0.2, 0.25, 0.15, 0.1],
                            [0.2, 0.06, 0.1, 0.04, 0.6],
                            [0.1, 0.15, 0.2, 0.3, 0.25],
                            [0.4, 0.05, 0.25, 0.1, 0.2]])
 
     # edge case, perfect accuracy
-    assert_equal(top_k_accuracy_score(y_true, pred_proba, k=5), 1.0)
+    assert top_k_accuracy_score(y_true, y_scores, k=5) == 1.0
 
-    assert_equal(top_k_accuracy_score(y_true, pred_proba, k=1),
-                 accuracy_score(y_true, np.argmax(pred_proba, axis=1)))
-    assert_equal(top_k_accuracy_score(y_true, pred_proba, k=2), 0.25)
-    assert_equal(top_k_accuracy_score(y_true, pred_proba, k=3), 0.5)
-    assert_equal(top_k_accuracy_score(y_true, pred_proba, k=4), 1.0)
+    assert top_k_accuracy_score(y_true, y_scores, k=1) == \
+                 accuracy_score(y_true, np.argmax(y_scores, axis=1))
+    assert top_k_accuracy_score(y_true, y_scores, k=2) == 0.25
+    assert top_k_accuracy_score(y_true, y_scores, k=3) == 0.5
+    assert top_k_accuracy_score(y_true, y_scores, k=4) == 1.0
 
 
 def test_multilabel_accuracy_score_subset_accuracy():

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -166,7 +166,7 @@ def test_top_k_accuracy_score():
     assert top_k_accuracy_score(y_true, y_scores, k=5) == 1.0
 
     assert top_k_accuracy_score(y_true, y_scores, k=1) == \
-                 accuracy_score(y_true, np.argmax(y_scores, axis=1))
+        accuracy_score(y_true, np.argmax(y_scores, axis=1))
     assert top_k_accuracy_score(y_true, y_scores, k=2) == 0.25
     assert top_k_accuracy_score(y_true, y_scores, k=3) == 0.5
     assert top_k_accuracy_score(y_true, y_scores, k=4) == 1.0

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -158,9 +158,9 @@ def test_top_k_accuracy_score():
     y_true = np.array([2, 1, 2, 3])
     # Correct classes in pred_proba are at ranks 2, 4, 3, 4
     y_scores = np.array([[0.3, 0.2, 0.25, 0.15, 0.1],
-                           [0.2, 0.06, 0.1, 0.04, 0.6],
-                           [0.1, 0.15, 0.2, 0.3, 0.25],
-                           [0.4, 0.05, 0.25, 0.1, 0.2]])
+                         [0.2, 0.06, 0.1, 0.04, 0.6],
+                         [0.1, 0.15, 0.2, 0.3, 0.25],
+                         [0.4, 0.05, 0.25, 0.1, 0.2]])
 
     # edge case, perfect accuracy
     assert top_k_accuracy_score(y_true, y_scores, k=5) == 1.0

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -41,6 +41,7 @@ from sklearn.metrics import matthews_corrcoef
 from sklearn.metrics import precision_recall_fscore_support
 from sklearn.metrics import precision_score
 from sklearn.metrics import recall_score
+from sklearn.metrics import top_k_accuracy_score
 from sklearn.metrics import zero_one_loss
 from sklearn.metrics import brier_score_loss
 from sklearn.metrics import multilabel_confusion_matrix
@@ -150,6 +151,25 @@ def test_classification_report_dictionary_output():
     assert type(expected_report['macro avg']['precision']) == float
     assert type(expected_report['setosa']['support']) == int
     assert type(expected_report['macro avg']['support']) == int
+
+
+def test_top_k_accuracy_score():
+    # Test top_k_accuracy_score on synthetic five-class prediction task
+    y_true = np.array([2, 1, 2, 3])
+    # Correct classes in pred_proba are at ranks 2, 4, 3, 4
+    pred_proba = np.array([[0.3, 0.2, 0.25, 0.15, 0.1],
+                           [0.2, 0.06, 0.1, 0.04, 0.6],
+                           [0.1, 0.15, 0.2, 0.3, 0.25],
+                           [0.4, 0.05, 0.25, 0.1, 0.2]])
+
+    # edge case, perfect accuracy
+    assert_equal(top_k_accuracy_score(y_true, pred_proba, k=5), 1.0)
+
+    assert_equal(top_k_accuracy_score(y_true, pred_proba, k=1),
+                 accuracy_score(y_true, np.argmax(pred_proba, axis=1)))
+    assert_equal(top_k_accuracy_score(y_true, pred_proba, k=2), 0.25)
+    assert_equal(top_k_accuracy_score(y_true, pred_proba, k=3), 0.5)
+    assert_equal(top_k_accuracy_score(y_true, pred_proba, k=4), 1.0)
 
 
 def test_multilabel_accuracy_score_subset_accuracy():


### PR DESCRIPTION
This is a continuation of #10488. 

> Reference Issues
> Fixes #10144
> Fixes #8234
>
> What does this implement/fix? Explain your changes.
>
> This implements a top-k accuracy classification metric, for use with probabilistic class predictions in multiclass classification settings. A prediction is considered top-k accurate if the correct class is one of the k classes with the highest predicted probabilities. Probability maybe is too strong a term here, as all that is really required is a ranking of the predicted classes.

This is currently a work in progress. I'll be addressing the concerns that were raised in the review of #10488.