### PR TITLE
fix log_likelihood function in covariance module

### DIFF
--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -40,7 +40,8 @@ def log_likelihood(emp_cov, precision):
     sample mean of the log-likelihood
     """
     p = precision.shape[0]
-    log_likelihood_ = - np.sum(emp_cov * precision) + fast_logdet(precision)
+    log_likelihood_ = fast_logdet(precision)
+    log_likelihood_ -= np.sum(np.dot(emp_cov, precision))
     log_likelihood_ -= p * np.log(2 * np.pi)
     log_likelihood_ /= 2.
     return log_likelihood_


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

<!--#### Reference Issues/PRs-->
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
The logarithmic likelihood formula for graphical LASSO is:
![image](https://user-images.githubusercontent.com/40843206/68269377-f72c5f80-009c-11ea-924a-8a425322214b.png)
(quoted from expression (2.1) in [“Sparse inverse covariance estimation with the graphical lasso”](https://academic.oup.com/biostatistics/article/9/3/432/224260).)

However, in the source code, matrix multiplication between S and Phi is incorrectly replaced with element-wise multiplication.
#### Any other comments?
This modification also affects score of EmpiricalCovariance, but I can't determine if the modification is correct also for EmpiricalCovariance because there was no appropriate reference.
Could you give me some advice?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
