### PR TITLE
[MRG+2] Allowing Gaussian process kernels on structured data - updated

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -405,6 +405,16 @@ Changelog
   estimator's constructor but not stored as attributes on the instance.
   :pr:`14464` by `Joel Nothman`_.
 
+- |Feature| The Gaussian process models, i.e. :class:`gaussian_process.GaussianProcessRegressor`
+  and :class:`gaussian_process.GaussianProcessClassifier` can now accept a list
+  of generic objects (e.g. strings, trees, graphs, etc.) as the ``X`` argument
+  of their training/prediction methods.
+  A user-defined kernel should be provided for computing the kernel matrix among
+  the objects, and should inherit from :class:`gaussian_process.kernels.GenericKernelMixin`
+  to notify the GPR/GPC model about its capability in handling non-vectorial
+  samples.
+  :pr:`15557` by :user:`Yu-Hang Tang <yhtang>`.
+
 :mod:`sklearn.impute`
 .....................
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -405,14 +405,13 @@ Changelog
   estimator's constructor but not stored as attributes on the instance.
   :pr:`14464` by `Joel Nothman`_.
 
-- |Feature| The Gaussian process models, i.e. :class:`gaussian_process.GaussianProcessRegressor`
+- |Feature| Gaussian process models on structured data: :class:`gaussian_process.GaussianProcessRegressor`
   and :class:`gaussian_process.GaussianProcessClassifier` can now accept a list
   of generic objects (e.g. strings, trees, graphs, etc.) as the ``X`` argument
-  of their training/prediction methods.
+  to their training/prediction methods.
   A user-defined kernel should be provided for computing the kernel matrix among
-  the objects, and should inherit from :class:`gaussian_process.kernels.GenericKernelMixin`
-  to notify the GPR/GPC model about its capability in handling non-vectorial
-  samples.
+  the generic objects, and should inherit from :class:`gaussian_process.kernels.GenericKernelMixin`
+  to notify the GPR/GPC model that it handles non-vectorial samples.
   :pr:`15557` by :user:`Yu-Hang Tang <yhtang>`.
 
 :mod:`sklearn.impute`

--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -126,7 +126,7 @@ Regression
 '''
 
 training_idx = [0, 1, 3, 4]
-gp = GaussianProcessRegressor(kernel)
+gp = GaussianProcessRegressor(kernel=kernel)
 gp.fit(X[training_idx], y[training_idx])
 
 plt.figure(figsize=(8, 5))

--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -13,7 +13,7 @@ variable-length strings consisting of letters 'A', 'T', 'C', and 'G',
 while the output variables are floating point numbers and True/False labels
 in the regression and classification tasks, respectively.
 
-A kernel between the gene sequences is defined using R-convolution [1] by
+A kernel between the gene sequences is defined using R-convolution [1]_ by
 integrating a binary letter-wise kernel over all pairs of letters among a pair
 of strings.
 
@@ -32,7 +32,7 @@ sequences and make predictions on another 5 sequences. The ground truth here is
 simply  whether there is at least one 'A' in the sequence. Here the model makes
 four correct classifications and fails on one.
 
-[1] Haussler, D. (1999). Convolution kernels on discrete structures (Vol. 646).
+.. [1] Haussler, D. (1999). Convolution kernels on discrete structures (Vol. 646).
 Technical report, Department of Computer Science, University of California at
 Santa Cruz.
 """

--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -116,10 +116,8 @@ D = kernel.diag(X)
 
 plt.figure(figsize=(8, 5))
 plt.imshow(np.diag(D**-0.5).dot(K).dot(np.diag(D**-0.5)))
-plt.gca().set_xticks(np.arange(len(X)))
-plt.gca().set_xticklabels(X)
-plt.gca().set_yticks(np.arange(len(X)))
-plt.gca().set_yticklabels(X)
+plt.xticks(ticks=np.arange(len(X)), labels=X)
+plt.yticks(ticks=np.arange(len(X)), labels=X)
 plt.title('Sequence similarity under the kernel')
 
 '''
@@ -135,8 +133,7 @@ plt.figure(figsize=(8, 5))
 plt.bar(np.arange(len(X)), gp.predict(X), color='b', label='prediction')
 plt.bar(training_idx, y[training_idx], width=0.2, color='r',
         alpha=0.5, label='training')
-plt.gca().set_xticks(np.arange(len(X)))
-plt.gca().set_xticklabels(X)
+plt.xticks(ticks=np.arange(len(X)), labels=X)
 plt.title('Regression on sequences')
 plt.legend()
 
@@ -166,10 +163,9 @@ plt.scatter(len(X) + np.arange(len(seqs_test)),
             [1.0 if c else -1.0 for c in gp.predict(seqs_test)],
             s=100, marker='x', edgecolor=(0, 1.0, 0.3), linewidth=2,
             label='prediction')
-plt.gca().set_xticks(np.arange(len(X) + len(seqs_test)))
-plt.gca().set_xticklabels(np.concatenate((X, seqs_test)))
-plt.gca().set_yticks([-1, 1])
-plt.gca().set_yticklabels([False, True])
+plt.xticks(ticks=np.arange(len(X) + len(seqs_test)),
+           labels=np.concatenate((X, seqs_test)))
+plt.yticks(ticks=[-1, 1], labels=[False, True])
 plt.title('Classification on sequences')
 plt.legend()
 

--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -32,9 +32,9 @@ sequences and make predictions on another 5 sequences. The ground truth here is
 simply  whether there is at least one 'A' in the sequence. Here the model makes
 four correct classifications and fails on one.
 
-.. [1] Haussler, D. (1999). Convolution kernels on discrete structures (Vol. 646).
-Technical report, Department of Computer Science, University of California at
-Santa Cruz.
+.. [1] Haussler, D. (1999). Convolution kernels on discrete structures
+(Vol. 646). Technical report, Department of Computer Science, University of
+California at Santa Cruz.
 """
 print(__doc__)
 
@@ -49,8 +49,8 @@ from sklearn.base import clone
 
 class SequenceKernel(GenericKernelMixin, Kernel):
     '''
-    A minimal (but valid) convolutional kernel for sequences of variable length.
-    '''
+    A minimal (but valid) convolutional kernel for sequences of variable
+    lengths.'''
     def __init__(self,
                  baseline_similarity=0.5,
                  baseline_similarity_bounds=(1e-5, 1)):

--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -107,7 +107,8 @@ X = np.array(['AGCT', 'AGC', 'AACT', 'TAA', 'AAA', 'GAACA'])
 y = np.array([1.0, 1.0, 2.0, 2.0, 3.0, 3.0])
 
 '''
-Visualize sequence similarity matrix under the kernel
+Sequence similarity matrix under the kernel
+===========================================
 '''
 
 K = kernel(X)
@@ -123,6 +124,7 @@ plt.title('Sequence similarity under the kernel')
 
 '''
 Regression
+==========
 '''
 
 training_idx = [0, 1, 3, 4]
@@ -140,6 +142,7 @@ plt.legend()
 
 '''
 Classification
+==============
 '''
 
 X = np.array(['AGCT', 'CGA', 'TAAC', 'TCG', 'CTTT', 'TGCT'])

--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -103,13 +103,12 @@ class SequenceKernel(GenericKernelMixin, Kernel):
 
 kernel = SequenceKernel()
 
-X = np.array(['AGCT', 'AGC', 'AACT', 'TAA', 'AAA', 'GAACA'])
-y = np.array([1.0, 1.0, 2.0, 2.0, 3.0, 3.0])
-
 '''
 Sequence similarity matrix under the kernel
 ===========================================
 '''
+
+X = np.array(['AGCT', 'AGC', 'AACT', 'TAA', 'AAA', 'GAACA'])
 
 K = kernel(X)
 D = kernel.diag(X)
@@ -125,13 +124,16 @@ Regression
 ==========
 '''
 
+X = np.array(['AGCT', 'AGC', 'AACT', 'TAA', 'AAA', 'GAACA'])
+Y = np.array([1.0, 1.0, 2.0, 2.0, 3.0, 3.0])
+
 training_idx = [0, 1, 3, 4]
 gp = GaussianProcessRegressor(kernel=kernel)
-gp.fit(X[training_idx], y[training_idx])
+gp.fit(X[training_idx], Y[training_idx])
 
 plt.figure(figsize=(8, 5))
 plt.bar(np.arange(len(X)), gp.predict(X), color='b', label='prediction')
-plt.bar(training_idx, y[training_idx], width=0.2, color='r',
+plt.bar(training_idx, Y[training_idx], width=0.2, color='r',
         alpha=1, label='training')
 plt.xticks(np.arange(len(X)), X)
 plt.title('Regression on sequences')
@@ -142,29 +144,29 @@ Classification
 ==============
 '''
 
-X = np.array(['AGCT', 'CGA', 'TAAC', 'TCG', 'CTTT', 'TGCT'])
+X_train = np.array(['AGCT', 'CGA', 'TAAC', 'TCG', 'CTTT', 'TGCT'])
 # whether there are 'A's in the sequence
-t = np.array([True, True, True, False, False, False])
+Y_train = np.array([True, True, True, False, False, False])
 
 gp = GaussianProcessClassifier(kernel)
-gp.fit(X, t)
+gp.fit(X_train, Y_train)
 
-seqs_test = ['AAA', 'ATAG', 'CTC', 'CT', 'C']
-clss_test = [True, True, False, False, False]
+X_test = ['AAA', 'ATAG', 'CTC', 'CT', 'C']
+Y_test = [True, True, False, False, False]
 
 plt.figure(figsize=(8, 5))
-plt.scatter(np.arange(len(X)), [1.0 if c else -1.0 for c in t],
+plt.scatter(np.arange(len(X_train)), [1.0 if c else -1.0 for c in Y_train],
             s=100, marker='o', edgecolor='none', facecolor=(1, 0.75, 0),
             label='training')
-plt.scatter(len(X) + np.arange(len(seqs_test)),
-            [1.0 if c else -1.0 for c in clss_test],
+plt.scatter(len(X_train) + np.arange(len(X_test)),
+            [1.0 if c else -1.0 for c in Y_test],
             s=100, marker='o', edgecolor='none', facecolor='r', label='truth')
-plt.scatter(len(X) + np.arange(len(seqs_test)),
-            [1.0 if c else -1.0 for c in gp.predict(seqs_test)],
+plt.scatter(len(X_train) + np.arange(len(X_test)),
+            [1.0 if c else -1.0 for c in gp.predict(X_test)],
             s=100, marker='x', edgecolor=(0, 1.0, 0.3), linewidth=2,
             label='prediction')
-plt.xticks(np.arange(len(X) + len(seqs_test)),
-           np.concatenate((X, seqs_test)))
+plt.xticks(np.arange(len(X_train) + len(X_test)),
+           np.concatenate((X_train, X_test)))
 plt.yticks([-1, 1], [False, True])
 plt.title('Classification on sequences')
 plt.legend()

--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -1,0 +1,173 @@
+"""
+==========================================================================
+Gaussian processes on discrete data structures
+==========================================================================
+
+This example illustrates the use of Gaussian processes for regression and
+classification tasks on data that are not in fixed-length feature vector form.
+This is achieved through the use of kernel functions that operates directly
+on discrete structures such as variable-length sequences, trees, and graphs.
+
+Specifically, here the input variables are some gene sequences stored as
+variable-length strings consisting of letters 'A', 'T', 'C', and 'G',
+while the output variables are floating point numbers and True/False labels
+in the regression and classification tasks, respectively.
+
+A kernel between the gene sequences is defined using R-convolution [1] by
+integrating a binary letter-wise kernel over all pairs of letters among a pair
+of strings.
+
+This example will generate three figures.
+
+In the first figure, we visualize the value of the kernel, i.e. the similarity
+of the sequences, using a colormap. Brighter color here indicates higher
+similarity.
+
+In the second figure, we show some regression result on a dataset of 6
+sequences. Here we use the 1st, 2nd, 4th, and 5th sequences as the training set
+to make predictions on the 3rd and 6th sequences.
+
+In the third figure, we demonstrate a classification model by training on 6
+sequences and make predictions on another 5 sequences. The ground truth here is
+simply  whether there is at least one 'A' in the sequence. Here the model makes
+four correct classifications and fails on one.
+
+[1] Haussler, D. (1999). Convolution kernels on discrete structures (Vol. 646).
+Technical report, Department of Computer Science, University of California at
+Santa Cruz.
+"""
+print(__doc__)
+
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.gaussian_process.kernels import Kernel, Hyperparameter
+from sklearn.gaussian_process.kernels import GenericKernelMixin
+from sklearn.gaussian_process import GaussianProcessRegressor
+from sklearn.gaussian_process import GaussianProcessClassifier
+from sklearn.base import clone
+
+
+class SequenceKernel(GenericKernelMixin, Kernel):
+    '''
+    a mimimal (but valid) convolutional kernel for sequences of variable length
+    '''
+    def __init__(self,
+                 baseline_similarity=0.5,
+                 baseline_similarity_bounds=(1e-5, 1)):
+        self.baseline_similarity = baseline_similarity
+        self.baseline_similarity_bounds = baseline_similarity_bounds
+
+    @property
+    def hyperparameter_baseline_similarity(self):
+        return Hyperparameter("baseline_similarity",
+                              "numeric",
+                              self.baseline_similarity_bounds)
+
+    def _f(self, s1, s2):
+        '''
+        kernel value between a pair of sequences
+        '''
+        return sum([1.0 if c1 == c2 else self.baseline_similarity
+                   for c1 in s1
+                   for c2 in s2])
+
+    def _g(self, s1, s2):
+        '''
+        kernel derivative between a pair of sequences
+        '''
+        return sum([0.0 if c1 == c2 else 1.0
+                    for c1 in s1
+                    for c2 in s2])
+
+    def __call__(self, X, Y=None, eval_gradient=False):
+        if Y is None:
+            Y = X
+
+        if eval_gradient:
+            return (np.array([[self._f(x, y) for y in Y] for x in X]),
+                    np.array([[[self._g(x, y)] for y in Y] for x in X]))
+        else:
+            return np.array([[self._f(x, y) for y in Y] for x in X])
+
+    def diag(self, X):
+        return np.array([self._f(x, x) for x in X])
+
+    def is_stationary(self):
+        return False
+
+    def clone_with_theta(self, theta):
+        cloned = clone(self)
+        cloned.theta = theta
+        return cloned
+
+
+kernel = SequenceKernel()
+
+X = np.array(['AGCT', 'AGC', 'AACT', 'TAA', 'AAA', 'GAACA'])
+y = np.array([1.0, 1.0, 2.0, 2.0, 3.0, 3.0])
+
+'''
+Visualize sequence similarity matrix under the kernel
+'''
+
+K = kernel(X)
+D = kernel.diag(X)
+
+plt.figure(figsize=(8, 5))
+plt.imshow(np.diag(D**-0.5).dot(K).dot(np.diag(D**-0.5)))
+plt.gca().set_xticks(np.arange(len(X)))
+plt.gca().set_xticklabels(X)
+plt.gca().set_yticks(np.arange(len(X)))
+plt.gca().set_yticklabels(X)
+plt.title('Sequence similarity under the kernel')
+
+'''
+Regression
+'''
+
+training_idx = [0, 1, 3, 4]
+gp = GaussianProcessRegressor(kernel)
+gp.fit(X[training_idx], y[training_idx])
+
+plt.figure(figsize=(8, 5))
+plt.bar(np.arange(len(X)), gp.predict(X), color='b', label='prediction')
+plt.bar(training_idx, y[training_idx], width=0.2, color='r',
+        alpha=0.5, label='training')
+plt.gca().set_xticks(np.arange(len(X)))
+plt.gca().set_xticklabels(X)
+plt.title('Regression on sequences')
+plt.legend()
+
+'''
+Classification
+'''
+
+X = np.array(['AGCT', 'CGA', 'TAAC', 'TCG', 'CTTT', 'TGCT'])
+# whether there are 'A's in the sequence
+t = np.array([True, True, True, False, False, False])
+
+gp = GaussianProcessClassifier(kernel)
+gp.fit(X, t)
+
+seqs_test = ['AAA', 'ATAG', 'CTC', 'CT', 'C']
+clss_test = [True, True, False, False, False]
+
+plt.figure(figsize=(8, 5))
+plt.scatter(np.arange(len(X)), [1.0 if c else -1.0 for c in t],
+            s=100, marker='o', edgecolor='none', facecolor=(1, 0.75, 0),
+            label='training')
+plt.scatter(len(X) + np.arange(len(seqs_test)),
+            [1.0 if c else -1.0 for c in clss_test],
+            s=100, marker='o', edgecolor='none', facecolor='r', label='truth')
+plt.scatter(len(X) + np.arange(len(seqs_test)),
+            [1.0 if c else -1.0 for c in gp.predict(seqs_test)],
+            s=100, marker='x', edgecolor=(0, 1.0, 0.3), linewidth=2,
+            label='prediction')
+plt.gca().set_xticks(np.arange(len(X) + len(seqs_test)))
+plt.gca().set_xticklabels(np.concatenate((X, seqs_test)))
+plt.gca().set_yticks([-1, 1])
+plt.gca().set_yticklabels([False, True])
+plt.title('Classification on sequences')
+plt.legend()
+
+plt.show()

--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -132,7 +132,7 @@ gp.fit(X[training_idx], y[training_idx])
 plt.figure(figsize=(8, 5))
 plt.bar(np.arange(len(X)), gp.predict(X), color='b', label='prediction')
 plt.bar(training_idx, y[training_idx], width=0.2, color='r',
-        alpha=0.5, label='training')
+        alpha=1, label='training')
 plt.xticks(np.arange(len(X)), X)
 plt.title('Regression on sequences')
 plt.legend()

--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -116,8 +116,8 @@ D = kernel.diag(X)
 
 plt.figure(figsize=(8, 5))
 plt.imshow(np.diag(D**-0.5).dot(K).dot(np.diag(D**-0.5)))
-plt.xticks(ticks=np.arange(len(X)), labels=X)
-plt.yticks(ticks=np.arange(len(X)), labels=X)
+plt.xticks(np.arange(len(X)), X)
+plt.yticks(np.arange(len(X)), X)
 plt.title('Sequence similarity under the kernel')
 
 '''
@@ -133,7 +133,7 @@ plt.figure(figsize=(8, 5))
 plt.bar(np.arange(len(X)), gp.predict(X), color='b', label='prediction')
 plt.bar(training_idx, y[training_idx], width=0.2, color='r',
         alpha=0.5, label='training')
-plt.xticks(ticks=np.arange(len(X)), labels=X)
+plt.xticks(np.arange(len(X)), X)
 plt.title('Regression on sequences')
 plt.legend()
 
@@ -163,9 +163,9 @@ plt.scatter(len(X) + np.arange(len(seqs_test)),
             [1.0 if c else -1.0 for c in gp.predict(seqs_test)],
             s=100, marker='x', edgecolor=(0, 1.0, 0.3), linewidth=2,
             label='prediction')
-plt.xticks(ticks=np.arange(len(X) + len(seqs_test)),
-           labels=np.concatenate((X, seqs_test)))
-plt.yticks(ticks=[-1, 1], labels=[False, True])
+plt.xticks(np.arange(len(X) + len(seqs_test)),
+           np.concatenate((X, seqs_test)))
+plt.yticks([-1, 1], [False, True])
 plt.title('Classification on sequences')
 plt.legend()
 

--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -49,7 +49,7 @@ from sklearn.base import clone
 
 class SequenceKernel(GenericKernelMixin, Kernel):
     '''
-    a mimimal (but valid) convolutional kernel for sequences of variable length
+    A minimal (but valid) convolutional kernel for sequences of variable length.
     '''
     def __init__(self,
                  baseline_similarity=0.5,

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -383,8 +383,9 @@ class RegressorMixin:
         ----------
         X : array-like of shape (n_samples, n_features)
             Test samples. For some estimators this may be a
-            precomputed kernel matrix instead, shape = (n_samples,
-            n_samples_fitted], where n_samples_fitted is the number of
+            precomputed kernel matrix or a list of generic objects instead,
+            shape = (n_samples, n_samples_fitted],
+            where n_samples_fitted is the number of
             samples used in the fitting for the estimator.
 
         y : array-like of shape (n_samples,) or (n_samples, n_outputs)

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -384,7 +384,7 @@ class RegressorMixin:
         X : array-like of shape (n_samples, n_features)
             Test samples. For some estimators this may be a
             precomputed kernel matrix or a list of generic objects instead,
-            shape = (n_samples, n_samples_fitted],
+            shape = (n_samples, n_samples_fitted),
             where n_samples_fitted is the number of
             samples used in the fitting for the estimator.
 

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -118,7 +118,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
     X_train_ : sequence of length n_samples
         Feature vectors or other representations of training data (also
         required for prediction). Could either be array-like with shape =
-        (n_samples, n_features) or a list of objects
+        (n_samples, n_features) or a list of objects.
 
     y_train_ : array-like of shape (n_samples,)
         Target values in training data (also required for prediction)

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -115,8 +115,10 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
     Attributes
     ----------
-    X_train_ : array-like of shape (n_samples, n_features)
-        Feature values in training data (also required for prediction)
+    X_train_ : sequence of length n_samples
+        Feature vectors or other representations of training data (also
+        required for prediction). Could either be array-like with shape =
+        (n_samples, n_features) or a list of objects
 
     y_train_ : array-like of shape (n_samples,)
         Target values in training data (also required for prediction)
@@ -160,8 +162,10 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-            Training data
+        X : sequence of length n_samples
+            Feature vectors or other representations of training data.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         y : array-like of shape (n_samples,)
             Target values, must be binary
@@ -248,7 +252,10 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : sequence of length n_samples
+            Query points where the GP is evaluated for classification.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         Returns
         -------
@@ -270,7 +277,10 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : sequence of length n_samples
+            Query points where the GP is evaluated for classification.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         Returns
         -------
@@ -602,8 +612,10 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-            Training data
+        X : sequence of length n_samples
+            Feature vectors or other representations of training data.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         y : array-like of shape (n_samples,)
             Target values, must be binary
@@ -612,7 +624,12 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         -------
         self : returns an instance of self.
         """
-        X, y = check_X_y(X, y, multi_output=False)
+        if self.kernel is None or self.kernel.requires_vector_input():
+            X, y = check_X_y(X, y, multi_output=False,
+                             ensure_2d=True, dtype="numeric")
+        else:
+            X, y = check_X_y(X, y, multi_output=False,
+                             ensure_2d=False, dtype=None)
 
         self.base_estimator_ = _BinaryGaussianProcessClassifierLaplace(
             self.kernel, self.optimizer, self.n_restarts_optimizer,
@@ -656,7 +673,10 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : sequence of length n_samples
+            Query points where the GP is evaluated for classification.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         Returns
         -------
@@ -664,7 +684,12 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
             Predicted target values for X, values are from ``classes_``
         """
         check_is_fitted(self)
-        X = check_array(X)
+
+        if self.kernel is None or self.kernel.requires_vector_input():
+            X = check_array(X, ensure_2d=True, dtype="numeric")
+        else:
+            X = check_array(X, ensure_2d=False, dtype=None)
+
         return self.base_estimator_.predict(X)
 
     def predict_proba(self, X):
@@ -672,7 +697,10 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : sequence of length n_samples
+            Query points where the GP is evaluated for classification.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         Returns
         -------
@@ -686,7 +714,12 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
             raise ValueError("one_vs_one multi-class mode does not support "
                              "predicting probability estimates. Use "
                              "one_vs_rest mode instead.")
-        X = check_array(X)
+
+        if self.kernel is None or self.kernel.requires_vector_input():
+            X = check_array(X, ensure_2d=True, dtype="numeric")
+        else:
+            X = check_array(X, ensure_2d=False, dtype=None)
+
         return self.base_estimator_.predict_proba(X)
 
     @property

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -624,7 +624,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         -------
         self : returns an instance of self.
         """
-        if self.kernel is None or self.kernel.requires_vector_input():
+        if self.kernel is None or self.kernel.requires_vector_input:
             X, y = check_X_y(X, y, multi_output=False,
                              ensure_2d=True, dtype="numeric")
         else:
@@ -685,7 +685,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         """
         check_is_fitted(self)
 
-        if self.kernel is None or self.kernel.requires_vector_input():
+        if self.kernel is None or self.kernel.requires_vector_input:
             X = check_array(X, ensure_2d=True, dtype="numeric")
         else:
             X = check_array(X, ensure_2d=False, dtype=None)
@@ -715,7 +715,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
                              "predicting probability estimates. Use "
                              "one_vs_rest mode instead.")
 
-        if self.kernel is None or self.kernel.requires_vector_input():
+        if self.kernel is None or self.kernel.requires_vector_input:
             X = check_array(X, ensure_2d=True, dtype="numeric")
         else:
             X = check_array(X, ensure_2d=False, dtype=None)

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -117,7 +117,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
     X_train_ : sequence of length n_samples
         Feature vectors or other representations of training data (also
         required for prediction). Could either be array-like with shape =
-        (n_samples, n_features) or a list of objects
+        (n_samples, n_features) or a list of objects.
 
     y_train_ : array-like of shape (n_samples,) or (n_samples, n_targets)
         Target values in training data (also required for prediction)

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -186,7 +186,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         self._rng = check_random_state(self.random_state)
 
-        if self.kernel_.requires_vector_input():
+        if self.kernel_.requires_vector_input:
             X, y = check_X_y(X, y, multi_output=True, y_numeric=True,
                              ensure_2d=True, dtype="numeric")
         else:
@@ -313,7 +313,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
                 "Not returning standard deviation of predictions when "
                 "returning full covariance.")
 
-        if self.kernel is None or self.kernel.requires_vector_input():
+        if self.kernel is None or self.kernel.requires_vector_input:
             X = check_array(X, ensure_2d=True, dtype="numeric")
         else:
             X = check_array(X, ensure_2d=False, dtype=None)

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -164,7 +164,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : array-like of shape (n_samples, n_features) 
             Training data
 
         y : array-like of shape (n_samples,) or (n_samples, n_targets)

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -114,8 +114,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
     Attributes
     ----------
-    X_train_ : array-like of shape (n_samples, n_features)
-        Feature values in training data (also required for prediction)
+    X_train_ : sequence of length n_samples
+        Feature vectors or other representations of training data (also
+        required for prediction). Could either be array-like with shape =
+        (n_samples, n_features) or a list of objects
 
     y_train_ : array-like of shape (n_samples,) or (n_samples, n_targets)
         Target values in training data (also required for prediction)
@@ -164,8 +166,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Parameters
         ----------
-        X : array-like of  shape (n_samples, n_features)
-            Training data
+        X : sequence of length n_samples
+            Feature vectors or other representations of training data.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         y : array-like of shape (n_samples,) or (n_samples, n_targets)
             Target values
@@ -182,7 +186,12 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         self._rng = check_random_state(self.random_state)
 
-        X, y = check_X_y(X, y, multi_output=True, y_numeric=True)
+        if self.kernel_.requires_vector_input():
+            X, y = check_X_y(X, y, multi_output=True, y_numeric=True,
+                             ensure_2d=True, dtype="numeric")
+        else:
+            X, y = check_X_y(X, y, multi_output=True, y_numeric=True,
+                             ensure_2d=False, dtype=None)
 
         # Normalize target value
         if self.normalize_y:
@@ -273,8 +282,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-            Query points where the GP is evaluated
+        X : sequence of length n_samples
+            Query points where the GP is evaluated.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         return_std : bool, default: False
             If True, the standard-deviation of the predictive distribution at
@@ -302,7 +313,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
                 "Not returning standard deviation of predictions when "
                 "returning full covariance.")
 
-        X = check_array(X)
+        if self.kernel is None or self.kernel.requires_vector_input():
+            X = check_array(X, ensure_2d=True, dtype="numeric")
+        else:
+            X = check_array(X, ensure_2d=False, dtype=None)
 
         if not hasattr(self, "X_train_"):  # Unfitted;predict based on GP prior
             if self.kernel is None:
@@ -357,8 +371,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Parameters
         ----------
-        X : array-like of shape (n_samples_X, n_features)
-            Query points where the GP samples are evaluated
+        X : sequence of length n_samples
+            Query points where the GP is evaluated.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         n_samples : int, default: 1
             The number of samples drawn from the Gaussian process

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -164,7 +164,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features) 
+        X : array-like of  shape (n_samples, n_features)
             Training data
 
         y : array-like of shape (n_samples,) or (n_samples, n_targets)

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -366,6 +366,7 @@ class Kernel(metaclass=ABCMeta):
     def is_stationary(self):
         """Returns whether the kernel is stationary. """
 
+    @property
     def requires_vector_input(self):
         """Returns whether the kernel is defined on fixed-length feature
         vectors or generic objects. Defaults to True for backward
@@ -416,6 +417,7 @@ class GenericKernelMixin:
 
     .. versionadded:: TBD
     """
+    @property
     def requires_vector_input(self):
         """whether the kernel works only on fixed-length feature vectors."""
         return False
@@ -545,9 +547,10 @@ class CompoundKernel(Kernel):
         """Returns whether the kernel is stationary. """
         return np.all([kernel.is_stationary() for kernel in self.kernels])
 
+    @property
     def requires_vector_input(self):
         """Returns whether the kernel is defined on discrete structures. """
-        return np.any([kernel.requires_vector_input()
+        return np.any([kernel.requires_vector_input
                        for kernel in self.kernels])
 
     def diag(self, X):
@@ -673,10 +676,11 @@ class KernelOperator(Kernel):
         """Returns whether the kernel is stationary. """
         return self.k1.is_stationary() and self.k2.is_stationary()
 
+    @property
     def requires_vector_input(self):
         """Returns whether the kernel is stationary. """
-        return (self.k1.requires_vector_input() or
-                self.k2.requires_vector_input())
+        return (self.k1.requires_vector_input or
+                self.k2.requires_vector_input)
 
 
 class Sum(KernelOperator):
@@ -996,9 +1000,10 @@ class Exponentiation(Kernel):
         """Returns whether the kernel is stationary. """
         return self.kernel.is_stationary()
 
+    @property
     def requires_vector_input(self):
         """Returns whether the kernel is defined on discrete structures. """
-        return self.kernel.requires_vector_input()
+        return self.kernel.requires_vector_input
 
 
 class ConstantKernel(StationaryKernelMixin, GenericKernelMixin,

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -420,7 +420,7 @@ class GenericKernelMixin:
 
     @property
     def requires_vector_input(self):
-        """whether the kernel works only on fixed-length feature vectors."""
+        """Whether the kernel works only on fixed-length feature vectors."""
         return False
 
 

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -366,10 +366,11 @@ class Kernel(metaclass=ABCMeta):
     def is_stationary(self):
         """Returns whether the kernel is stationary. """
 
-    @abstractmethod
     def requires_vector_input(self):
         """Returns whether the kernel is defined on fixed-length feature
-        vectors or generic objects."""
+        vectors or generic objects. Defaults to True for backward
+        compatibility."""
+        return True
 
 
 class NormalizedKernelMixin:
@@ -406,16 +407,6 @@ class StationaryKernelMixin:
 
     def is_stationary(self):
         """Returns whether the kernel is stationary. """
-        return True
-
-
-class VectorKernelMixin:
-    """Mixin for kernels which operate on fixed-length feature vectors.
-
-    .. versionadded:: TBD
-    """
-    def requires_vector_input(self):
-        """whether the kernel works only on fixed-length feature vectors."""
         return True
 
 
@@ -1213,8 +1204,7 @@ class WhiteKernel(StationaryKernelMixin, GenericKernelMixin,
                                                  self.noise_level)
 
 
-class RBF(StationaryKernelMixin, NormalizedKernelMixin, VectorKernelMixin,
-          Kernel):
+class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
     """Radial-basis function kernel (aka squared-exponential kernel).
 
     The RBF kernel is a stationary kernel. It is also known as the
@@ -1478,8 +1468,7 @@ class Matern(RBF):
                 self.nu)
 
 
-class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin,
-                        VectorKernelMixin, Kernel):
+class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
     """Rational Quadratic kernel.
 
     The RationalQuadratic kernel can be seen as a scale mixture (an infinite
@@ -1595,8 +1584,7 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin,
             self.__class__.__name__, self.alpha, self.length_scale)
 
 
-class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin,
-                     VectorKernelMixin, Kernel):
+class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
     r"""Exp-Sine-Squared kernel.
 
     The ExpSineSquared kernel allows modeling periodic functions. It is
@@ -1709,7 +1697,7 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin,
             self.__class__.__name__, self.length_scale, self.periodicity)
 
 
-class DotProduct(VectorKernelMixin, Kernel):
+class DotProduct(Kernel):
     r"""Dot-Product kernel.
 
     The DotProduct kernel is non-stationary and can be obtained from linear
@@ -1831,7 +1819,7 @@ def _approx_fprime(xk, f, epsilon, args=()):
     return grad
 
 
-class PairwiseKernel(VectorKernelMixin, Kernel):
+class PairwiseKernel(Kernel):
     """Wrapper for kernels in sklearn.metrics.pairwise.
 
     A thin wrapper around the functionality of the kernels in

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -368,7 +368,8 @@ class Kernel(metaclass=ABCMeta):
 
     @abstractmethod
     def requires_vector_input(self):
-        """Returns whether the kernel is defined on discrete structures. """
+        """Returns whether the kernel is defined on fixed-length feature
+        vectors or generic objects."""
 
 
 class NormalizedKernelMixin:
@@ -409,7 +410,7 @@ class StationaryKernelMixin:
 
 
 class VectorKernelMixin:
-    """Mixin for kernels which operate on fixed-length feature vectors
+    """Mixin for kernels which operate on fixed-length feature vectors.
 
     .. versionadded:: TBD
     """
@@ -418,9 +419,9 @@ class VectorKernelMixin:
         return True
 
 
-class StructuredKernelMixin:
-    """Mixin for kernels which operate on discrete structures
-       such as sequences, trees, and graphs
+class GenericKernelMixin:
+    """Mixin for kernels which operate on generic objects such as variable-
+    length sequences, trees, and graphs.
 
     .. versionadded:: TBD
     """
@@ -1009,7 +1010,7 @@ class Exponentiation(Kernel):
         return self.kernel.requires_vector_input()
 
 
-class ConstantKernel(StationaryKernelMixin, StructuredKernelMixin,
+class ConstantKernel(StationaryKernelMixin, GenericKernelMixin,
                      Kernel):
     """Constant kernel.
 
@@ -1111,7 +1112,7 @@ class ConstantKernel(StationaryKernelMixin, StructuredKernelMixin,
         return "{0:.3g}**2".format(np.sqrt(self.constant_value))
 
 
-class WhiteKernel(StationaryKernelMixin, StructuredKernelMixin,
+class WhiteKernel(StationaryKernelMixin, GenericKernelMixin,
                   Kernel):
     """White kernel.
 

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -415,7 +415,7 @@ class GenericKernelMixin:
     """Mixin for kernels which operate on generic objects such as variable-
     length sequences, trees, and graphs.
 
-    .. versionadded:: TBD
+    .. versionadded:: 0.22
     """
     @property
     def requires_vector_input(self):

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -675,8 +675,8 @@ class KernelOperator(Kernel):
 
     def requires_vector_input(self):
         """Returns whether the kernel is stationary. """
-        return np.any([self.k1.requires_vector_input(),
-                       self.k2.requires_vector_input()])
+        return (self.k1.requires_vector_input() or
+                self.k2.requires_vector_input())
 
 
 class Sum(KernelOperator):

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -417,6 +417,7 @@ class GenericKernelMixin:
 
     .. versionadded:: 0.22
     """
+
     @property
     def requires_vector_input(self):
         """whether the kernel works only on fixed-length feature vectors."""

--- a/sklearn/gaussian_process/tests/_mini_sequence_kernel.py
+++ b/sklearn/gaussian_process/tests/_mini_sequence_kernel.py
@@ -9,7 +9,7 @@ class MiniSeqKernel(GenericKernelMixin,
                     StationaryKernelMixin,
                     Kernel):
     '''
-    a mimimal (but valid) convolutional kernel for sequences of variable length
+    A mimimal (but valid) convolutional kernel for sequences of variable length.
     '''
     def __init__(self,
                  baseline_similarity=0.5,

--- a/sklearn/gaussian_process/tests/_mini_sequence_kernel.py
+++ b/sklearn/gaussian_process/tests/_mini_sequence_kernel.py
@@ -9,7 +9,7 @@ class MiniSeqKernel(GenericKernelMixin,
                     StationaryKernelMixin,
                     Kernel):
     '''
-    A mimimal (but valid) convolutional kernel for sequences of variable
+    A minimal (but valid) convolutional kernel for sequences of variable
     length.
     '''
     def __init__(self,

--- a/sklearn/gaussian_process/tests/_mini_sequence_kernel.py
+++ b/sklearn/gaussian_process/tests/_mini_sequence_kernel.py
@@ -1,0 +1,50 @@
+from sklearn.gaussian_process.kernels import Kernel, Hyperparameter
+from sklearn.gaussian_process.kernels import GenericKernelMixin
+from sklearn.gaussian_process.kernels import StationaryKernelMixin
+import numpy as np
+from sklearn.base import clone
+
+
+class MiniSeqKernel(GenericKernelMixin,
+                    StationaryKernelMixin,
+                    Kernel):
+    '''
+    a mimimal (but valid) convolutional kernel for sequences of variable length
+    '''
+    def __init__(self,
+                 baseline_similarity=0.5,
+                 baseline_similarity_bounds=(1e-5, 1)):
+        self.baseline_similarity = baseline_similarity
+        self.baseline_similarity_bounds = baseline_similarity_bounds
+
+    @property
+    def hyperparameter_baseline_similarity(self):
+        return Hyperparameter("baseline_similarity",
+                              "numeric",
+                              self.baseline_similarity_bounds)
+
+    def _f(self, s1, s2):
+        return sum([1.0 if c1 == c2 else self.baseline_similarity
+                   for c1 in s1
+                   for c2 in s2])
+
+    def _g(self, s1, s2):
+        return sum([0.0 if c1 == c2 else 1.0 for c1 in s1 for c2 in s2])
+
+    def __call__(self, X, Y=None, eval_gradient=False):
+        if Y is None:
+            Y = X
+
+        if eval_gradient:
+            return (np.array([[self._f(x, y) for y in Y] for x in X]),
+                    np.array([[[self._g(x, y)] for y in Y] for x in X]))
+        else:
+            return np.array([[self._f(x, y) for y in Y] for x in X])
+
+    def diag(self, X):
+        return np.array([self._f(x, x) for x in X])
+
+    def clone_with_theta(self, theta):
+        cloned = clone(self)
+        cloned.theta = theta
+        return cloned

--- a/sklearn/gaussian_process/tests/_mini_sequence_kernel.py
+++ b/sklearn/gaussian_process/tests/_mini_sequence_kernel.py
@@ -9,7 +9,8 @@ class MiniSeqKernel(GenericKernelMixin,
                     StationaryKernelMixin,
                     Kernel):
     '''
-    A mimimal (but valid) convolutional kernel for sequences of variable length.
+    A mimimal (but valid) convolutional kernel for sequences of variable
+    length.
     '''
     def __init__(self,
                  baseline_similarity=0.5,

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -18,6 +18,8 @@ from sklearn.utils._testing import assert_almost_equal, assert_array_equal
 
 def f(x):
     return np.sin(x)
+
+
 X = np.atleast_2d(np.linspace(0, 10, 30)).T
 X2 = np.atleast_2d([2., 4., 5.5, 6.5, 7.5]).T
 y = np.array(f(X).ravel() > 0, dtype=int)
@@ -60,7 +62,7 @@ def test_lml_improving(kernel):
     # Test that hyperparameter-tuning improves log-marginal likelihood.
     gpc = GaussianProcessClassifier(kernel=kernel).fit(X, y)
     assert (gpc.log_marginal_likelihood(gpc.kernel_.theta) >
-                   gpc.log_marginal_likelihood(kernel.theta))
+            gpc.log_marginal_likelihood(kernel.theta))
 
 
 @pytest.mark.parametrize('kernel', kernels)
@@ -150,7 +152,7 @@ def test_custom_optimizer(kernel):
     gpc.fit(X, y_mc)
     # Checks that optimizer improved marginal likelihood
     assert (gpc.log_marginal_likelihood(gpc.kernel_.theta) >
-                   gpc.log_marginal_likelihood(kernel.theta))
+            gpc.log_marginal_likelihood(kernel.theta))
 
 
 @pytest.mark.parametrize('kernel', kernels)

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -11,6 +11,7 @@ import pytest
 
 from sklearn.gaussian_process import GaussianProcessClassifier
 from sklearn.gaussian_process.kernels import RBF, ConstantKernel as C
+from sklearn.gaussian_process.tests._mini_sequence_kernel import MiniSeqKernel
 
 from sklearn.utils._testing import assert_almost_equal, assert_array_equal
 
@@ -39,6 +40,16 @@ non_fixed_kernels = [kernel for kernel in kernels
 @pytest.mark.parametrize('kernel', kernels)
 def test_predict_consistent(kernel):
     # Check binary predict decision has also predicted probability above 0.5.
+    gpc = GaussianProcessClassifier(kernel=kernel).fit(X, y)
+    assert_array_equal(gpc.predict(X),
+                       gpc.predict_proba(X)[:, 1] >= 0.5)
+
+
+def test_predict_consistent_structured():
+    # Check binary predict decision has also predicted probability above 0.5.
+    X = ['A', 'AB', 'B']
+    y = np.array([True, False, True])
+    kernel = MiniSeqKernel(baseline_similarity_bounds='fixed')
     gpc = GaussianProcessClassifier(kernel=kernel).fit(X, y)
     assert_array_equal(gpc.predict(X),
                        gpc.predict_proba(X)[:, 1] >= 0.5)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -13,6 +13,7 @@ from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels \
     import RBF, ConstantKernel as C, WhiteKernel
 from sklearn.gaussian_process.kernels import DotProduct
+from sklearn.gaussian_process.tests._mini_sequence_kernel import MiniSeqKernel
 
 from sklearn.utils._testing \
     import (assert_array_less,
@@ -49,6 +50,20 @@ def test_gpr_interpolation(kernel):
     gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
     y_pred, y_cov = gpr.predict(X, return_cov=True)
 
+    assert_almost_equal(y_pred, y)
+    assert_almost_equal(np.diag(y_cov), 0.)
+
+
+def test_gpr_interpolation_structured():
+    # Test the interpolating property for different kernels.
+    kernel = MiniSeqKernel(baseline_similarity_bounds='fixed')
+    X = ['A', 'B', 'C']
+    y = np.array([1, 2, 3])
+    gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
+    y_pred, y_cov = gpr.predict(X, return_cov=True)
+
+    assert_almost_equal(kernel(X, eval_gradient=True)[1].ravel(),
+                        (1 - np.eye(len(X))).ravel())
     assert_almost_equal(y_pred, y)
     assert_almost_equal(np.diag(y_cov), 0.)
 

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -73,7 +73,7 @@ def test_lml_improving(kernel):
     # Test that hyperparameter-tuning improves log-marginal likelihood.
     gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
     assert (gpr.log_marginal_likelihood(gpr.kernel_.theta) >
-                   gpr.log_marginal_likelihood(kernel.theta))
+            gpr.log_marginal_likelihood(kernel.theta))
 
 
 @pytest.mark.parametrize('kernel', kernels)
@@ -81,7 +81,7 @@ def test_lml_precomputed(kernel):
     # Test that lml of optimized kernel is stored correctly.
     gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
     assert (gpr.log_marginal_likelihood(gpr.kernel_.theta) ==
-                 gpr.log_marginal_likelihood())
+            gpr.log_marginal_likelihood())
 
 
 @pytest.mark.parametrize('kernel', kernels)
@@ -194,7 +194,7 @@ def test_anisotropic_kernel():
     kernel = RBF([1.0, 1.0])
     gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
     assert (np.exp(gpr.kernel_.theta[1]) >
-                   np.exp(gpr.kernel_.theta[0]) * 5)
+            np.exp(gpr.kernel_.theta[0]) * 5)
 
 
 def test_random_starts():
@@ -312,7 +312,7 @@ def test_custom_optimizer(kernel):
     gpr.fit(X, y)
     # Checks that optimizer improved marginal likelihood
     assert (gpr.log_marginal_likelihood(gpr.kernel_.theta) >
-                   gpr.log_marginal_likelihood(gpr.kernel.theta))
+            gpr.log_marginal_likelihood(gpr.kernel.theta))
 
 
 def test_gpr_correct_error_message():

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -189,21 +189,21 @@ def test_kernel_stationary(kernel):
 def test_kernel_input_type(kernel):
     # Test whether kernels is for vectors or structured data
     if isinstance(kernel, Exponentiation):
-        assert(kernel.requires_vector_input() ==
-               kernel.kernel.requires_vector_input())
+        assert(kernel.requires_vector_input ==
+               kernel.kernel.requires_vector_input)
     if isinstance(kernel, KernelOperator):
-        assert(kernel.requires_vector_input() ==
-               (kernel.k1.requires_vector_input() or
-                kernel.k2.requires_vector_input()))
+        assert(kernel.requires_vector_input ==
+               (kernel.k1.requires_vector_input or
+                kernel.k2.requires_vector_input))
 
 
 def test_compound_kernel_input_type():
     kernel = CompoundKernel([WhiteKernel(noise_level=3.0)])
-    assert(kernel.requires_vector_input() is not True)
+    assert(kernel.requires_vector_input is not True)
 
     kernel = CompoundKernel([WhiteKernel(noise_level=3.0),
                              RBF(length_scale=2.0)])
-    assert(kernel.requires_vector_input())
+    assert(kernel.requires_vector_input)
 
 
 def check_hyperparameters_equal(kernel1, kernel2):

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -199,11 +199,11 @@ def test_kernel_input_type(kernel):
 
 def test_compound_kernel_input_type():
     kernel = CompoundKernel([WhiteKernel(noise_level=3.0)])
-    assert(kernel.requires_vector_input is not True)
+    assert not kernel.requires_vector_input
 
     kernel = CompoundKernel([WhiteKernel(noise_level=3.0),
                              RBF(length_scale=2.0)])
-    assert(kernel.requires_vector_input)
+    assert kernel.requires_vector_input
 
 
 def check_hyperparameters_equal(kernel1, kernel2):

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -358,9 +358,6 @@ def test_warns_on_get_params_non_attribute():
         def is_stationary(self):
             return False
 
-        def requires_vector_input(self):
-            return True
-
     est = MyKernel()
     with pytest.warns(FutureWarning, match='AttributeError'):
         params = est.get_params()


### PR DESCRIPTION
Fixes #13936.

This PR is a from-scratch refresh of #13954 (with all previous modifications incorporated) based on the latest master branch.

Made the Gaussian process regressor and classifier compatible with generic kernels on arbitrary data. Specifically:
1. Added a `requires_vector_input` property to all the built-in GP kernels in `gaussian_process/kernels.py`.
2. Added a `GenericKernelMixin` base classes to overload the `requires_vector_input` property for kernels that can work on structured and/or generic data.
3. Let the GP regressor and classifier use different `check_array` and `check_X_y` parameters for vector/generic input. I.e., do not force the X and Y array to be at least 2D and numeric if the kernel can operate on generic input. Updated docstrings accordingly.
4. Provided a minimal example of GP regression and classification using a sequence kernel on variable-length strings in `plot_gpr_on_structured_data.py`.
