### PR TITLE
DOC macOS instructions: mention xcode-select --install

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -221,6 +221,10 @@ If you use the conda package manager, you can install the ``compilers``
 meta-package from the conda-forge channel, which provides OpenMP-enabled C/C++
 compilers based on the llvm toolchain.
 
+First install the macOS command line tools::
+
+    xcode-select --install
+
 It is recommended to use a dedicated `conda environment`_ to build
 scikit-learn from source::
 
@@ -264,11 +268,17 @@ macOS compilers from Homebrew
 Another solution is to enable OpenMP support for the clang compiler shipped
 by default on macOS.
 
-You first need to install the OpenMP library using Homebrew_::
+First install the macOS command line tools::
+
+    xcode-select --install
+
+Install the Homebrew_ package manager for macOS.
+
+Install the LLVM OpenMP library::
 
     brew install libomp
 
-Then you need to set the following environment variables::
+Set the following environment variables::
 
     export CC=/usr/bin/clang
     export CXX=/usr/bin/clang++


### PR DESCRIPTION
While investigating the issue reported in #15443 we found out that we could further improve our macOS build instructions even though this was not the cause of #15443.