### PR TITLE
[MRG] Improve error message with implicit pos_label in _binary_clf_curve

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -31,7 +31,6 @@ from ..utils import column_or_1d, check_array
 from ..utils.multiclass import type_of_target
 from ..utils.extmath import stable_cumsum
 from ..utils.sparsefuncs import count_nonzero
-from ..utils import _determine_key_type
 from ..exceptions import UndefinedMetricWarning
 from ..preprocessing import label_binarize
 from ..preprocessing._label import _encode

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -528,7 +528,7 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     # ensure binary classification if pos_label is not specified
     # _determine_key_type(classes) == 'str' is required to avoid
     # triggering a FutureWarning by calling np.array_equal(a, b)
-    # where a has string values and b has integer values.
+    # when elements in the two arrays are not comparable.
     classes = np.unique(y_true)
     if (pos_label is None and (
             _determine_key_type(classes) == 'str' or

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -531,16 +531,17 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     # when elements in the two arrays are not comparable.
     classes = np.unique(y_true)
     if (pos_label is None and (
-            _determine_key_type(classes) == 'str' or
+            classes.dtype.kind in ('O', 'U', 'S') or
             not (np.array_equal(classes, [0, 1]) or
                  np.array_equal(classes, [-1, 1]) or
                  np.array_equal(classes, [0]) or
                  np.array_equal(classes, [-1]) or
                  np.array_equal(classes, [1])))):
-        raise ValueError("y_true takes value in {classes} and pos_label is "
+        classes_repr = ", ".join(repr(c) for c in classes)
+        raise ValueError("y_true takes value in {{{classes_repr}}} and pos_label is "
                          "not specified: either make y_true take integer "
                          "value in {{0, 1}} or {{-1, 1}} or pass pos_label "
-                         "explicitly.".format(classes=set(classes)))
+                         "explicitly.".format(classes_repr=classes_repr))
     elif pos_label is None:
         pos_label = 1.
 

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -31,6 +31,7 @@ from ..utils import column_or_1d, check_array
 from ..utils.multiclass import type_of_target
 from ..utils.extmath import stable_cumsum
 from ..utils.sparsefuncs import count_nonzero
+from ..utils import _determine_key_type
 from ..exceptions import UndefinedMetricWarning
 from ..preprocessing import label_binarize
 from ..preprocessing._label import _encode
@@ -525,14 +526,21 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
         sample_weight = column_or_1d(sample_weight)
 
     # ensure binary classification if pos_label is not specified
+    # _determine_key_type(classes) == 'str' is required to avoid
+    # triggering a FutureWarning by calling np.array_equal(a, b)
+    # where a has string values and b has integer values.
     classes = np.unique(y_true)
-    if (pos_label is None and
-        not (np.array_equal(classes, [0, 1]) or
-             np.array_equal(classes, [-1, 1]) or
-             np.array_equal(classes, [0]) or
-             np.array_equal(classes, [-1]) or
-             np.array_equal(classes, [1]))):
-        raise ValueError("Data is not binary and pos_label is not specified")
+    if (pos_label is None and (
+            _determine_key_type(classes) == 'str' or
+            not (np.array_equal(classes, [0, 1]) or
+                 np.array_equal(classes, [-1, 1]) or
+                 np.array_equal(classes, [0]) or
+                 np.array_equal(classes, [-1]) or
+                 np.array_equal(classes, [1])))):
+        raise ValueError("y_true takes value in {classes} and pos_label is "
+                         "not specified: either make y_true take integer "
+                         "value in {{0, 1}} or {{-1, 1}} or pass pos_label "
+                         "explicitly.".format(classes=set(classes)))
     elif pos_label is None:
         pos_label = 1.
 

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -538,10 +538,11 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
                  np.array_equal(classes, [-1]) or
                  np.array_equal(classes, [1])))):
         classes_repr = ", ".join(repr(c) for c in classes)
-        raise ValueError("y_true takes value in {{{classes_repr}}} and pos_label is "
-                         "not specified: either make y_true take integer "
-                         "value in {{0, 1}} or {{-1, 1}} or pass pos_label "
-                         "explicitly.".format(classes_repr=classes_repr))
+        raise ValueError("y_true takes value in {{{classes_repr}}} and "
+                         "pos_label is not specified: either make y_true "
+                         "take integer value in {{0, 1}} or {{-1, 1}} or "
+                         "pass pos_label explicitly.".format(
+                             classes_repr=classes_repr))
     elif pos_label is None:
         pos_label = 1.
 

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -525,7 +525,7 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
         sample_weight = column_or_1d(sample_weight)
 
     # ensure binary classification if pos_label is not specified
-    # _determine_key_type(classes) == 'str' is required to avoid
+    # classes.dtype.kind in ('O', 'U', 'S') is required to avoid
     # triggering a FutureWarning by calling np.array_equal(a, b)
     # when elements in the two arrays are not comparable.
     classes = np.unique(y_true)

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1086,8 +1086,8 @@ def check_alternative_lrap_implementation(lrap_score, n_classes=5,
 
     # Score with ties
     y_score = _sparse_random_matrix(n_components=y_true.shape[0],
-                                   n_features=y_true.shape[1],
-                                   random_state=random_state)
+                                    n_features=y_true.shape[1],
+                                    random_state=random_state)
 
     if hasattr(y_score, "toarray"):
         y_score = y_score.toarray()

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -662,11 +662,20 @@ def test_auc_score_non_binary_class():
             roc_auc_score(y_true, y_pred)
 
 
-def test_binary_clf_curve():
+def test_binary_clf_curve_multiclass_error():
     rng = check_random_state(404)
     y_true = rng.randint(0, 3, size=10)
     y_pred = rng.rand(10)
     msg = "multiclass format is not supported"
+    with pytest.raises(ValueError, match=msg):
+        precision_recall_curve(y_true, y_pred)
+
+
+def test_binary_clf_curve_implicit_pos_label():
+    y_true = ["a", "b"]
+    y_pred = [0., 1.]
+    msg = ("make y_true take integer value in {0, 1} or {-1, 1}"
+           " or pass pos_label explicitly.")
     with pytest.raises(ValueError, match=msg):
         precision_recall_curve(y_true, y_pred)
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -667,8 +667,12 @@ def test_binary_clf_curve_multiclass_error():
     y_true = rng.randint(0, 3, size=10)
     y_pred = rng.rand(10)
     msg = "multiclass format is not supported"
+
     with pytest.raises(ValueError, match=msg):
         precision_recall_curve(y_true, y_pred)
+
+    with pytest.raises(ValueError, match=msg):
+        roc_curve(y_true, y_pred)
 
 
 def test_binary_clf_curve_implicit_pos_label():
@@ -676,8 +680,12 @@ def test_binary_clf_curve_implicit_pos_label():
     y_pred = [0., 1.]
     msg = ("make y_true take integer value in {0, 1} or {-1, 1}"
            " or pass pos_label explicitly.")
+
     with pytest.raises(ValueError, match=msg):
         precision_recall_curve(y_true, y_pred)
+
+    with pytest.raises(ValueError, match=msg):
+        roc_curve(y_true, y_pred)
 
 
 def test_precision_recall_curve():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -701,7 +701,6 @@ def test_binary_clf_curve_implicit_pos_label(curve_func):
     with pytest.raises(ValueError, match=msg):
         roc_curve(np.array([b"a", b"b"], dtype='<S1'), [0., 1.])
 
-
     # Check that it is possible to use floating point class labels
     # that are interpreted similarly to integer class labels:
     y_pred = [0., 1., 0.2, 0.42]


### PR DESCRIPTION
This takes the good part of #15405 that was closed when we decided to drop the pos_label argument of plot_roc_curve.

However this improvement in the error message was still useful for other functions such as `precision_recall_curve` as shown in the test.