### PR TITLE
MNT use x.y.z (no rc/beta/etc) for version in sphinx config

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -125,12 +125,13 @@ if [[ "$CIRCLE_JOB" == "doc-min-dependencies" ]]; then
     conda config --set restore_free_channel true
 fi
 
+# packaging won't be needed once setuptools starts shipping packaging>=17.0
 conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
   numpy="${NUMPY_VERSION:-*}" scipy="${SCIPY_VERSION:-*}" \
   cython="${CYTHON_VERSION:-*}" pytest coverage \
   matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=2.1.2 pillow \
   scikit-image="${SCIKIT_IMAGE_VERSION:-*}" pandas="${PANDAS_VERSION:-*}" \
-  joblib memory_profiler
+  joblib memory_profiler packaging
 
 source activate testenv
 pip install sphinx-gallery==0.3.1

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,7 +16,7 @@ import sys
 import os
 import warnings
 import re
-from pkg_resources import parse_version
+from packaging.version import parse
 
 # If extensions (or modules to document with autodoc) are in another
 # directory, add these directories to sys.path here. If the directory
@@ -86,7 +86,7 @@ copyright = '2007 - 2019, scikit-learn developers (BSD License)'
 #
 # The short X.Y version.
 import sklearn
-version = parse_version(sklearn.__version__).base_version
+version = parse(sklearn.__version__).base_version
 # The full version, including alpha/beta/rc tags.
 release = sklearn.__version__
 
@@ -246,7 +246,7 @@ intersphinx_mapping = {
     'joblib': ('https://joblib.readthedocs.io/en/latest/', None),
 }
 
-v = parse_version(release)
+v = parse(release)
 if v.release is None:
     raise ValueError(
         'Ill-formed version: {!r}. Version should follow '

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,7 +16,7 @@ import sys
 import os
 import warnings
 import re
-from distutils.version import StrictVersion
+from pkg_resources import parse_version
 
 # If extensions (or modules to document with autodoc) are in another
 # directory, add these directories to sys.path here. If the directory
@@ -86,8 +86,7 @@ copyright = '2007 - 2019, scikit-learn developers (BSD License)'
 #
 # The short X.Y version.
 import sklearn
-version = '.'.join([str(x) for x in
-                    StrictVersion(sklearn.__version__).version])
+version = parse_version(sklearn.__version__).base_version
 # The full version, including alpha/beta/rc tags.
 release = sklearn.__version__
 
@@ -247,17 +246,16 @@ intersphinx_mapping = {
     'joblib': ('https://joblib.readthedocs.io/en/latest/', None),
 }
 
-if 'dev' in version:
+v = parse_version(release)
+if v.release is None:
+    raise ValueError(
+        'Ill-formed version: {!r}. Version should follow '
+        'PEP440'.format(version))
+
+if v.is_devrelease:
     binder_branch = 'master'
 else:
-    match = re.match(r'^(\d+)\.(\d+)(?:\.\d+)?$', version)
-    if match is None:
-        raise ValueError(
-            'Ill-formed version: {!r}. Expected either '
-            "a version containing 'dev' "
-            'or a version like X.Y or X.Y.Z.'.format(version))
-
-    major, minor = match.groups()
+    major, minor = v.release[:2]
     binder_branch = '{}.{}.X'.format(major, minor)
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,6 +16,7 @@ import sys
 import os
 import warnings
 import re
+from distutils.version import StrictVersion
 
 # If extensions (or modules to document with autodoc) are in another
 # directory, add these directories to sys.path here. If the directory
@@ -85,7 +86,8 @@ copyright = '2007 - 2019, scikit-learn developers (BSD License)'
 #
 # The short X.Y version.
 import sklearn
-version = sklearn.__version__
+version = '.'.join([str(x) for x in
+                    StrictVersion(sklearn.__version__).version])
 # The full version, including alpha/beta/rc tags.
 release = sklearn.__version__
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -537,9 +537,12 @@ Building the documentation
 First, make sure you have :ref:`properly installed <install_bleeding_edge>`
 the development version.
 
+..
+    packaging is not needed once setuptools starts shipping packaging>=17.0
+
 Building the documentation requires installing some additional packages::
 
-    pip install sphinx sphinx-gallery numpydoc matplotlib Pillow pandas scikit-image
+    pip install sphinx sphinx-gallery numpydoc matplotlib Pillow pandas scikit-image packaging
 
 To build the documentation, you need to be in the ``doc`` folder::
 


### PR DESCRIPTION
We expect the `version` to be `x.y.z` (no rc/beta/etc), and `release` to include the beta/rc/etc info. This PR takes the base part of the `__version__` for `version` variable in sphinx config.

Note that the regexp checkng for this had been introduced in https://github.com/scikit-learn/scikit-learn/pull/11221

Alternatively we can fix that regexp.