### PR TITLE
MAINT Add _distributor_init.py

### DIFF
--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -91,7 +91,7 @@ else:
                'show_versions']
 
     # Allow distributors to run custom init code
-    from . import _distributor_init # noqa: F401
+    from . import _distributor_init  # noqa: F401
 
 
 def setup_module(module):

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -91,7 +91,7 @@ else:
                'show_versions']
 
     # Allow distributors to run custom init code
-    from . import _distributor_init
+    from . import _distributor_init # noqa: F401
 
 
 def setup_module(module):

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -90,6 +90,9 @@ else:
                'clone', 'get_config', 'set_config', 'config_context',
                'show_versions']
 
+    # Allow distributors to run custom init code
+    from . import _distributor_init
+
 
 def setup_module(module):
     """Fixture for the tests to assure globally controllable seeding of RNGs"""

--- a/sklearn/_distributor_init.py
+++ b/sklearn/_distributor_init.py
@@ -5,6 +5,6 @@ of scikit-learn.
 
 For example, this is a good place to put any checks for hardware requirements.
 
-The numpy standard source distribution will not put code in this file, so you
-can safely replace this file with your own version.
+The scikit-learn standard source distribution will not put code in this file, 
+so you can safely replace this file with your own version.
 """

--- a/sklearn/_distributor_init.py
+++ b/sklearn/_distributor_init.py
@@ -1,0 +1,10 @@
+""" Distributor init file
+
+Distributors: you can add custom code here to support particular distributions
+of scikit-learn.
+
+For example, this is a good place to put any checks for hardware requirements.
+
+The numpy standard source distribution will not put code in this file, so you
+can safely replace this file with your own version.
+"""

--- a/sklearn/_distributor_init.py
+++ b/sklearn/_distributor_init.py
@@ -5,6 +5,6 @@ of scikit-learn.
 
 For example, this is a good place to put any checks for hardware requirements.
 
-The scikit-learn standard source distribution will not put code in this file, 
+The scikit-learn standard source distribution will not put code in this file,
 so you can safely replace this file with your own version.
 """


### PR DESCRIPTION
NumPy has `_distributor_init.py`:

https://github.com/numpy/numpy/blob/master/numpy/_distributor_init.py

This PR adds one for scikit-learn. The intent is to create a place
to add distributor specific logic, e.g. to implement behavior like in

https://github.com/scikit-learn/scikit-learn/pull/14247#issuecomment-551264093

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
