### PR TITLE
[MRG] ENH: Add scaling to convergence warning for LBFGS

### DIFF
--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -385,13 +385,18 @@ def test_consistency_path():
                                   err_msg="with solver = %s" % solver)
 
 
-def test_logistic_regression_path_convergence_fail():
+def test_logistic_regression_path_convergence_fail(capsys):
     rng = np.random.RandomState(0)
     X = np.concatenate((rng.randn(100, 2) + [1, 1], rng.randn(100, 2)))
     y = [1] * 100 + [-1] * 100
     Cs = [1e3]
-    assert_warns(ConvergenceWarning, _logistic_regression_path,
-                 X, y, Cs=Cs, tol=0., max_iter=1, random_state=0, verbose=1)
+
+    msg = (r"lbfgs failed to converge.+Increase the number of iterations or "
+           r"scale the data")
+
+    with pytest.warns(ConvergenceWarning, match=msg):
+        _logistic_regression_path(
+            X, y, Cs=Cs, tol=0., max_iter=1, random_state=0, verbose=0)
 
 
 def test_liblinear_dual_random_state():

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -385,7 +385,7 @@ def test_consistency_path():
                                   err_msg="with solver = %s" % solver)
 
 
-def test_logistic_regression_path_convergence_fail(capsys):
+def test_logistic_regression_path_convergence_fail():
     rng = np.random.RandomState(0)
     X = np.concatenate((rng.randn(100, 2) + [1, 1], rng.randn(100, 2)))
     y = [1] * 100 + [-1] * 100

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -234,7 +234,7 @@ def _check_optimize_result(solver, result, max_iter=None):
     if solver == "lbfgs":
         if result.status != 0:
             warnings.warn("{} failed to converge (status={}): {}. "
-                          "Increase the number of iterations."
+                          "Increase the number of iterations or scale the data"
                           .format(solver, result.status, result.message),
                           ConvergenceWarning, stacklevel=2)
         if max_iter is not None:

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -234,7 +234,9 @@ def _check_optimize_result(solver, result, max_iter=None):
     if solver == "lbfgs":
         if result.status != 0:
             warnings.warn("{} failed to converge (status={}): {}. "
-                          "Increase the number of iterations or scale the data"
+                          "Increase the number of iterations or scale the "
+                          "data as shown in https://scikit-learn.org/stable/"
+                          "modules/preprocessing.html"
                           .format(solver, result.status, result.message),
                           ConvergenceWarning, stacklevel=2)
         if max_iter is not None:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Partially addresses https://github.com/scikit-learn/scikit-learn/issues/15556


#### What does this implement/fix? Explain your changes.
Adds "scale the data" to the `ConvergenceWarning` for lbfgs.

#### Any other comments?
My whiteboard tells me it is possible to make the optimization more stable with some proper care for sparse matrices, regularization, and zero variance features. (I still need to work out the multinomial case to be sure)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
