### PR TITLE
[MRG] BUG Fixes partial dependence bug by setting axes to be invisible

### DIFF
--- a/examples/plot_partial_dependence_visualization_api.py
+++ b/examples/plot_partial_dependence_visualization_api.py
@@ -93,16 +93,6 @@ mlp_disp.plot(ax=ax2, line_kw={"c": "red"})
 ax2.set_title("Multi-layer Perceptron")
 plt.show()
 
-fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 10))
-ax1.set_title("Decision Tree")
-tree_disp.plot(ax=ax1)
-ax2.set_title("Multi-layer Perceptron")
-mlp_disp.plot(ax=ax2, line_kw={"c": "red"})
-
-plt.show()
-import sys
-sys.exit(1)
-
 ##############################################################################
 # Another way to compare the curves is to plot them on top of each other. Here,
 # we create a figure with one row and two columns. The axes are passed into the

--- a/examples/plot_partial_dependence_visualization_api.py
+++ b/examples/plot_partial_dependence_visualization_api.py
@@ -91,6 +91,17 @@ tree_disp.plot(ax=ax1)
 ax1.set_title("Decision Tree")
 mlp_disp.plot(ax=ax2, line_kw={"c": "red"})
 ax2.set_title("Multi-layer Perceptron")
+plt.show()
+
+fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 10))
+ax1.set_title("Decision Tree")
+tree_disp.plot(ax=ax1)
+ax2.set_title("Multi-layer Perceptron")
+mlp_disp.plot(ax=ax2, line_kw={"c": "red"})
+
+plt.show()
+import sys
+sys.exit(1)
 
 ##############################################################################
 # Another way to compare the curves is to plot them on top of each other. Here,

--- a/examples/plot_partial_dependence_visualization_api.py
+++ b/examples/plot_partial_dependence_visualization_api.py
@@ -91,7 +91,6 @@ tree_disp.plot(ax=ax1)
 ax1.set_title("Decision Tree")
 mlp_disp.plot(ax=ax2, line_kw={"c": "red"})
 ax2.set_title("Multi-layer Perceptron")
-plt.show()
 
 ##############################################################################
 # Another way to compare the curves is to plot them on top of each other. Here,

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -843,15 +843,14 @@ class PartialDependenceDisplay:
         n_features = len(self.features)
 
         if isinstance(ax, plt.Axes):
-            # If ax has visible==False, it has most likely been set to False
+            # If ax was set off, it has most likely been set to off
             # by a previous call to plot.
-            if not ax.get_visible():
+            if not ax.axison:
                 raise ValueError("The ax was already used in another plot "
                                  "function, please set ax=display.axes_ "
                                  "instead")
 
             ax.set_axis_off()
-            ax.set_visible(False)
             self.bounding_ax_ = ax
             self.figure_ = ax.figure
 

--- a/sklearn/inspection/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/tests/test_plot_partial_dependence.py
@@ -229,7 +229,16 @@ def test_plot_partial_dependence_incorrent_num_axes(pyplot, clf_boston,
 
 
 def test_plot_partial_dependence_with_same_axes(pyplot, clf_boston, boston):
-    # The first call to `plot_*` will plot the axes
+    # The first call to plot_partial_dependence will create two new axes to
+    # place in the space of the passed in axes, which results in a total of
+    # three axes in the figure.
+    # Currently the API does not allow for the second call to
+    # plot_partial_dependence to use the same axes again, because it will
+    # create two new axes in the space resulting in five axes. To get the
+    # expected behavior one needs to pass the generated axes into the second
+    # call:
+    # disp1 = plot_partial_dependence(...)
+    # disp2 = plot_partial_dependence(..., ax=disp1.axes_)
 
     grid_resolution = 25
     fig, ax = pyplot.subplots()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes bug with the title not displaying in `examples/plot_partial_dependence_visualization_api.py`

Instead of making the axes not visible, this checks if the axes is off to see if the axes was used twice.

#### What does this implement/fix? Explain your changes.
To see why this check was needed, please look at `test_plot_partial_dependence_with_same_axes`.

#### Any other comments?
CC @NicolasHug @amueller @glemaitre 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
