### PR TITLE
[MRG] DOC Increases search results for API object results

### DIFF
--- a/doc/themes/scikit-learn-modern/static/js/searchtools.js
+++ b/doc/themes/scikit-learn-modern/static/js/searchtools.js
@@ -65,7 +65,7 @@ var Search = {
     _index: null,
     _queued_query: null,
     _pulse_status: -1,
-    _total_non_object_results: 5,
+    _total_non_object_results: 10,
 
     htmlToText: function (htmlString) {
         var htmlString = htmlString.replace(/<img[\s\S]+?>/g, "");

--- a/doc/themes/scikit-learn-modern/static/js/searchtools.js
+++ b/doc/themes/scikit-learn-modern/static/js/searchtools.js
@@ -65,7 +65,7 @@ var Search = {
     _index: null,
     _queued_query: null,
     _pulse_status: -1,
-    _total_non_object_results: 10,
+    _total_non_object_results: 5,
 
     htmlToText: function (htmlString) {
         var htmlString = htmlString.replace(/<img[\s\S]+?>/g, "");


### PR DESCRIPTION
This PR adds includes all the API results in the search results and caps the number of results from other sources (such as the user guide) to 5. The results from the other sources will make another HTTP request to get the context. On the other hand, the API results do not make these request, so there is no reason to cap them. As a result of this PR, all the matching classes and functions from the API will be displayed in search.

CC @lesteve @jnothman 