### PR TITLE
[MRG] ENH Add absolute error rate criterion for DecisionTreeClassifier (#15578)

### DIFF
--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -59,7 +59,9 @@ __all__ = ["DecisionTreeClassifier",
 DTYPE = _tree.DTYPE
 DOUBLE = _tree.DOUBLE
 
-CRITERIA_CLF = {"gini": _criterion.Gini, "entropy": _criterion.Entropy}
+CRITERIA_CLF = {"gini": _criterion.Gini, "entropy": _criterion.Entropy,
+                "absolute_error": _criterion.AbsoluteErrorRate}
+
 CRITERIA_REG = {"mse": _criterion.MSE, "friedman_mse": _criterion.FriedmanMSE,
                 "mae": _criterion.MAE}
 

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -449,6 +449,7 @@ def test_plot_tree_gini(pyplot):
     assert nodes[1].get_text() == "gini = 0.0\nsamples = 3\nvalue = [3, 0]"
     assert nodes[2].get_text() == "gini = 0.0\nsamples = 3\nvalue = [0, 3]"
 
+
 def test_plot_tree_abolute_error(pyplot):
     # mostly smoke tests
     # Check correctness of export_graphviz for criterion = absolute_error
@@ -464,5 +465,7 @@ def test_plot_tree_abolute_error(pyplot):
     assert len(nodes) == 3
     assert nodes[0].get_text() == ("first feat <= 0.0\nabsolute_error = 3.0\n"
                                    "samples = 6\nvalue = [3, 3]")
-    assert nodes[1].get_text() == "absolute_error = 0.0\nsamples = 3\nvalue = [3, 0]"
-    assert nodes[2].get_text() == "absolute_error = 0.0\nsamples = 3\nvalue = [0, 3]"
+    assert nodes[1].get_text() == ("absolute_error = 0.0\nsamples = 3\n"
+                                   "value = [3, 0]")
+    assert nodes[2].get_text() == ("absolute_error = 0.0\nsamples = 3\n"
+                                   "value = [0, 3]")

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -448,3 +448,21 @@ def test_plot_tree_gini(pyplot):
                                    "samples = 6\nvalue = [3, 3]")
     assert nodes[1].get_text() == "gini = 0.0\nsamples = 3\nvalue = [3, 0]"
     assert nodes[2].get_text() == "gini = 0.0\nsamples = 3\nvalue = [0, 3]"
+
+def test_plot_tree_abolute_error(pyplot):
+    # mostly smoke tests
+    # Check correctness of export_graphviz for criterion = absolute_error
+    clf = DecisionTreeClassifier(max_depth=3,
+                                 min_samples_split=2,
+                                 criterion="absolute_error",
+                                 random_state=2)
+    clf.fit(X, y)
+
+    # Test export code
+    feature_names = ['first feat', 'sepal_width']
+    nodes = plot_tree(clf, feature_names=feature_names)
+    assert len(nodes) == 3
+    assert nodes[0].get_text() == ("first feat <= 0.0\nabsolute_error = 3.0\n"
+                                   "samples = 6\nvalue = [3, 3]")
+    assert nodes[1].get_text() == "absolute_error = 0.0\nsamples = 3\nvalue = [3, 0]"
+    assert nodes[2].get_text() == "absolute_error = 0.0\nsamples = 3\nvalue = [0, 3]"

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -43,7 +43,7 @@ from sklearn import datasets
 
 from sklearn.utils import compute_sample_weight
 
-CLF_CRITERIONS = ("gini", "entropy")
+CLF_CRITERIONS = ("gini", "entropy", "absolute_error")
 REG_CRITERIONS = ("mse", "mae", "friedman_mse")
 
 CLF_TREES = {
@@ -1163,16 +1163,16 @@ def check_class_weights(name):
     sample_weight[iris.target == 1] *= 100
     class_weight = {0: 1., 1: 100., 2: 1.}
     clf1 = TreeClassifier(random_state=0)
-    clf1.fit(iris.data, iris.target, sample_weight)
+    clf1.fit(iris.data, iris.target, sample_weight=sample_weight)
     clf2 = TreeClassifier(class_weight=class_weight, random_state=0)
     clf2.fit(iris.data, iris.target)
     assert_almost_equal(clf1.feature_importances_, clf2.feature_importances_)
 
     # Check that sample_weight and class_weight are multiplicative
     clf1 = TreeClassifier(random_state=0)
-    clf1.fit(iris.data, iris.target, sample_weight ** 2)
+    clf1.fit(iris.data, iris.target, sample_weight=sample_weight ** 2)
     clf2 = TreeClassifier(class_weight=class_weight, random_state=0)
-    clf2.fit(iris.data, iris.target, sample_weight)
+    clf2.fit(iris.data, iris.target, sample_weight=sample_weight)
     assert_almost_equal(clf1.feature_importances_, clf2.feature_importances_)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

Implements #15578

#### What does this implement?
Implements a new criterion for the `DecisionTreeClassifier` model. This criterion is called `absolute_error` and represents the absolute error rate of a node as defined in #15578.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
