### PR TITLE
ENH reduce memory consumption in nan_euclidean_distances

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -406,6 +406,11 @@ def nan_euclidean_distances(X, Y=None, squared=False,
     distances -= np.dot(XX, missing_Y.T)
     distances -= np.dot(missing_X, YY.T)
 
+    if X is Y:
+        # Ensure that distances between vectors and themselves are set to 0.0.
+        # This may not be the case due to floating point rounding errors.
+        np.fill_diagonal(distances, 0.0)
+
     present_X = 1 - missing_X
     present_Y = present_X if Y is X else ~missing_Y
     present_count = np.dot(present_X, present_Y.T)
@@ -414,11 +419,6 @@ def nan_euclidean_distances(X, Y=None, squared=False,
     np.maximum(1, present_count, out=present_count)
     distances /= present_count
     distances *= X.shape[1]
-
-    if X is Y:
-        # Ensure that distances between vectors and themselves are set to 0.0.
-        # This may not be the case due to floating point rounding errors.
-        np.fill_diagonal(distances, 0.0)
 
     if not squared:
         np.sqrt(distances, out=distances)


### PR DESCRIPTION
This goes towards fixing #15604

Basic benchmark: 

```py
import numpy as np
from sklearn.datasets import fetch_california_housing
from sklearn.metrics.pairwise import nan_euclidean_distances

calhousing = fetch_california_housing()

X = pd.DataFrame(calhousing.data, columns=calhousing.feature_names)
y = pd.Series(calhousing.target, name='house_value')

rng = np.random.RandomState(42)

density = 4  # one in 10 values will be NaN

mask = rng.randint(density, size=X.shape) == 0
X_na = X.copy()
X_na.values[mask] = np.nan

%time nan_euclidean_distances(X_na)
```

At master:
```
CPU times: user 33 s, sys: 9.42 s, total: 42.4 s
Wall time: 24 s
```
This branch:
```
CPU times: user 27.3 s, sys: 3.71 s, total: 31 s
Wall time: 14.8 s
```


Faster times could possibly be achieved with chunking.