### PR TITLE
[MRG] DOC: min version for conda on macos (install with compilers package)

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -225,9 +225,9 @@ to enable OpenMP support:
 macOS compilers from conda-forge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you use the conda package manager, you can install the ``compilers``
-meta-package from the conda-forge channel, which provides OpenMP-enabled C/C++
-compilers based on the llvm toolchain.
+If you use the conda package manager (version >= 4.7), you can install the
+``compilers`` meta-package from the conda-forge channel, which provides
+OpenMP-enabled C/C++ compilers based on the llvm toolchain.
 
 First install the macOS command line tools::
 
@@ -264,7 +264,8 @@ variables::
     echo $LDFLAGS
 
 They point to files and folders from your ``sklearn-dev`` conda environment
-(in particular in the bin/, include/ and lib/ subfolders).
+(in particular in the bin/, include/ and lib/ subfolders). For instance
+``-L/path/to/conda/envs/sklearn-dev/lib`` should appear in ``LDFLAGS``.
 
 In the log, you should see the compiled extension being built with the clang
 and clang++ compilers installed by conda with the ``-fopenmp`` command line


### PR DESCRIPTION
closes #15443

with conda < 4.7, the build of scikit-learn fails because it installs a version of the `compilers` package too old, which does not set the appropriate flags.

I also added an example of what kind of flags one should expect to see when installing compilers.