### PR TITLE
DOC Fix 'Title underline too short' sphinx warning.

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -744,7 +744,7 @@ Changelog
   :pr:`14336` by :user:`Gregory Dexter <gdex1>`.
 
 :mod:`sklearn.model_selection`
-..................
+..............................
 
 - |Fix| :class:`model_selection.GridSearchCV` and
   `model_selection.RandomizedSearchCV` now supports the


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Fix a 'Title underline too short' sphinx warning in what's new 0.22