### PR TITLE
[MRG] ENH add normalize parameter to confusion_matrix

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -583,6 +583,17 @@ example, which creates the following figure:
    :scale: 75
    :align: center
 
+The parameter ``normalize`` allows to report ratios instead of counts. The
+confusion matrix can be normalized in 3 different ways: ``'pred'``, ``'true'``,
+and ``'all'`` which will divide the counts by the sum of each columns, rows, or
+the entire matrix, respectively.
+
+  >>> y_true = [0, 0, 0, 1, 1, 1, 1, 1]
+  >>> y_pred = [0, 1, 0, 1, 0, 1, 0, 1]
+  >>> confusion_matrix(y_true, y_pred, normalize='all')
+  array([[0.25 , 0.125],
+         [0.25 , 0.375]])
+
 For binary problems, we can get counts of true negatives, false positives,
 false negatives and true positives as follows::
 
@@ -591,18 +602,6 @@ false negatives and true positives as follows::
   >>> tn, fp, fn, tp = confusion_matrix(y_true, y_pred).ravel()
   >>> tn, fp, fn, tp
   (2, 1, 2, 3)
-
-The parameter ``normalize`` allows to report ratios instead of counts. The
-confusion matrix can be normalized in 3 different ways: ``'pred'``, ``'true'``,
-and ``'all'`` which will divide the counts by the sum of each columns, rows, or
-the entire matrix, respectively.
-
-  >>> y_true = [0, 0, 0, 1, 1, 1, 1, 1]
-  >>> y_pred = [0, 1, 0, 1, 0, 1, 0, 1]
-  >>> tn, fp, fn, tp = confusion_matrix(
-  ...     y_true, y_pred, normalize='all').ravel()
-  >>> tn, fp, fn, tp
-  (0.25, 0.125, 0.25, 0.375)
 
 .. topic:: Example:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -574,7 +574,7 @@ predicted to be in group :math:`j`. Here is an example::
          [1, 0, 2]])
 
 :func:`plot_confusion_matrix` can be used to visually represent a confusion
-matrix as shown in the 
+matrix as shown in the
 :ref:`sphx_glr_auto_examples_model_selection_plot_confusion_matrix.py`
 example, which creates the following figure:
 
@@ -591,6 +591,18 @@ false negatives and true positives as follows::
   >>> tn, fp, fn, tp = confusion_matrix(y_true, y_pred).ravel()
   >>> tn, fp, fn, tp
   (2, 1, 2, 3)
+
+The parameter ``normalize`` allows to report ratios instead of counts. The
+confusion matrix can be normalized in 3 different ways: ``'pred'``, ``'true'``,
+and ``'all'`` which will divide the counts by the sum of each columns, rows, or
+the entire matrix, respectively.
+
+  >>> y_true = [0, 0, 0, 1, 1, 1, 1, 1]
+  >>> y_pred = [0, 1, 0, 1, 0, 1, 0, 1]
+  >>> tn, fp, fn, tp = confusion_matrix(
+  ...     y_true, y_pred, normalize='all').ravel()
+  >>> tn, fp, fn, tp
+  (0.25, 0.125, 0.25, 0.375)
 
 .. topic:: Example:
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -627,7 +627,7 @@ Changelog
 - |Enhancement| :func:`metrics.confusion_matrix` accepts a parameters
   `normalize` allowing to normalize the confusion matrix by column, rows, or
   overall.
-  :pr:`xxx` by `Guillaume Lemaitre <glemaitre>`.
+  :pr:`15625` by `Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.model_selection`
 ..............................

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -624,6 +624,11 @@ Changelog
   used as the :term:`scoring` parameter of model-selection tools.
   :pr:`14417` by `Thomas Fan`_.
 
+- |Enhancement| :func:`metrics.confusion_matrix` accepts a parameters
+  `normalize` allowing to normalize the confusion matrix by column, rows, or
+  overall.
+  :pr:`xxx` by `Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.model_selection`
 ..............................
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -313,7 +313,7 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
             cm = cm / cm.sum(axis=0, keepdims=True)
         elif normalize == 'all':
             cm = cm / cm.sum()
-        cm = np.nan_to_num(cm, copy=False)
+        cm = np.nan_to_num(cm)
 
     return cm
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -193,8 +193,9 @@ def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
     return _weighted_sum(score, sample_weight, normalize)
 
 
-def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
-    """Compute confusion matrix to evaluate the accuracy of a classification
+def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
+                     normalize=None):
+    """Compute confusion matrix to evaluate the accuracy of a classification.
 
     By definition a confusion matrix :math:`C` is such that :math:`C_{i, j}`
     is equal to the number of observations known to be in group :math:`i` and
@@ -208,25 +209,30 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
 
     Parameters
     ----------
-    y_true : array, shape = [n_samples]
+    y_true : array-like of shape (n_samples,)
         Ground truth (correct) target values.
 
-    y_pred : array, shape = [n_samples]
+    y_pred : array-like of shape (n_samples,)
         Estimated targets as returned by a classifier.
 
-    labels : array, shape = [n_classes], optional
+    labels : array-like of shape (n_classes), default=None
         List of labels to index the matrix. This may be used to reorder
         or select a subset of labels.
-        If none is given, those that appear at least once
+        If ``None`` is given, those that appear at least once
         in ``y_true`` or ``y_pred`` are used in sorted order.
 
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights.
 
+    normalize : {'true', 'pred', 'all'}, default=None
+        Normalizes confusion matrix over the true (rows), predicted (columns)
+        conditions or all the population. If None, confusion matrix will not be
+        normalized.
+
     Returns
     -------
     C : ndarray of shape (n_classes, n_classes)
-        Confusion matrix
+        Confusion matrix.
 
     References
     ----------
@@ -296,11 +302,20 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
     else:
         dtype = np.float64
 
-    CM = coo_matrix((sample_weight, (y_true, y_pred)),
+    cm = coo_matrix((sample_weight, (y_true, y_pred)),
                     shape=(n_labels, n_labels), dtype=dtype,
                     ).toarray()
 
-    return CM
+    with np.errstate(all='ignore'):
+        if normalize == 'true':
+            cm = cm / cm.sum(axis=1, keepdims=True)
+        elif normalize == 'pred':
+            cm = cm / cm.sum(axis=0, keepdims=True)
+        elif normalize == 'all':
+            cm = cm / cm.sum()
+        cm = np.nan_to_num(cm, copy=False)
+
+    return cm
 
 
 def multilabel_confusion_matrix(y_true, y_pred, sample_weight=None,

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -155,7 +155,7 @@ def plot_confusion_matrix(estimator, X, y_true, sample_weight=None,
         Includes values in confusion matrix.
 
     normalize : {'true', 'pred', 'all'}, default=None
-        Normalizes confusion matrix over the true (rows), predicited (columns)
+        Normalizes confusion matrix over the true (rows), predicted (columns)
         conditions or all the population. If None, confusion matrix will not be
         normalized.
 
@@ -190,14 +190,7 @@ def plot_confusion_matrix(estimator, X, y_true, sample_weight=None,
 
     y_pred = estimator.predict(X)
     cm = confusion_matrix(y_true, y_pred, sample_weight=sample_weight,
-                          labels=labels)
-
-    if normalize == 'true':
-        cm = cm / cm.sum(axis=1, keepdims=True)
-    elif normalize == 'pred':
-        cm = cm / cm.sum(axis=0, keepdims=True)
-    elif normalize == 'all':
-        cm = cm / cm.sum()
+                          labels=labels, normalize=normalize)
 
     if display_labels is None:
         if labels is None:

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -537,12 +537,12 @@ def test_confusion_matrix_normalize_single_class():
     # additionally check that no warnings are raised due to a division by zero
     with pytest.warns(None) as rec:
         cm_pred = confusion_matrix(y_test, y_pred, normalize='pred')
-    assert not len(rec)
+    assert not rec
     assert cm_pred.sum() == pytest.approx(1.0)
 
     with pytest.warns(None) as rec:
         cm_pred = confusion_matrix(y_pred, y_test, normalize='true')
-    assert not len(rec)
+    assert not rec
 
 
 def test_cohen_kappa():

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -514,17 +514,17 @@ def test_multilabel_confusion_matrix_errors():
 
 @pytest.mark.parametrize(
     "normalize, cm_dtype, expected_results",
-    [('true', float, 0.333333333),
-     ('pred', float, 0.333333333),
-     ('all', float, 0.1111111111),
-     (None, int, 2)]
+    [('true', 'f', 0.333333333),
+     ('pred', 'f', 0.333333333),
+     ('all', 'f', 0.1111111111),
+     (None, 'i', 2)]
 )
 def test_confusion_matrix_normalize(normalize, cm_dtype, expected_results):
     y_test = [0, 1, 2] * 6
     y_pred = list(chain(*permutations([0, 1, 2])))
     cm = confusion_matrix(y_test, y_pred, normalize=normalize)
     assert_allclose(cm, expected_results)
-    assert cm.dtype == cm_dtype
+    assert cm.dtype.kind == cm_dtype
 
 
 def test_confusion_matrix_normalize_single_class():

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -534,7 +534,7 @@ def test_confusion_matrix_normalize_single_class():
     cm_true = confusion_matrix(y_test, y_pred, normalize='true')
     assert cm_true.sum() == pytest.approx(2.0)
 
-    # additionally check that not warning is raised due to a division by zero
+    # additionally check that no warnings are raised due to a division by zero
     with pytest.warns(None) as rec:
         cm_pred = confusion_matrix(y_test, y_pred, normalize='pred')
     assert not len(rec)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

closes #14478


#### What does this implement/fix? Explain your changes.

Move the normalization `normalize` from `plot_confusion_matrix` to `confusion_matrix`.
I added a couple of test and handle division by zeros without raising warning.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
