### PR TITLE
[MRG] Fix whats new link

### DIFF
--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -8,7 +8,7 @@
         <h1 class="sk-landing-header text-white text-monospace">scikit-learn</h1>
         <h4 class="sk-landing-subheader text-white font-italic mb-3">Machine Learning in Python</h4>
         <a class="btn sk-landing-btn mb-1" href="{{ pathto('getting_started') }}" role="button">Getting Started</a>
-        <a class="btn sk-landing-btn mb-1" href="whats_new.html" role="button">Whats New in {{ version }}</a>
+        <a class="btn sk-landing-btn mb-1" href="whats_new/v{{ version }}}.html" role="button">What's New in {{ version }}</a>
         <a class="btn sk-landing-btn mb-1" href="https://github.com/scikit-learn/scikit-learn" role="button">GitHub</a>
       </div>
       <div class="col-md-6 d-flex">

--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -8,7 +8,7 @@
         <h1 class="sk-landing-header text-white text-monospace">scikit-learn</h1>
         <h4 class="sk-landing-subheader text-white font-italic mb-3">Machine Learning in Python</h4>
         <a class="btn sk-landing-btn mb-1" href="{{ pathto('getting_started') }}" role="button">Getting Started</a>
-        <a class="btn sk-landing-btn mb-1" href="whats_new/v{{ version }}}.html" role="button">What's New in {{ version }}</a>
+        <a class="btn sk-landing-btn mb-1" href="whats_new/v{{ version }}.html" role="button">What's New in {{ version }}</a>
         <a class="btn sk-landing-btn mb-1" href="https://github.com/scikit-learn/scikit-learn" role="button">GitHub</a>
       </div>
       <div class="col-md-6 d-flex">


### PR DESCRIPTION
The current "What's new in 0.22" button in the index page links to the list of what's news instead of  the 0.22's whatsnew

Also fix spelling

@thomasjpfan @adrinjalali @glemaitre 