### PR TITLE
ENH Do not pass random_state to estimator in IterativeImputer

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -489,6 +489,14 @@ Changelog
   :class:`tree.DecisionTreeRegressor`. :pr:`15864` by
   `Nicolas Hug`_.
 
+:mod:`sklearn.impute`
+...............................
+
+- |Enhancement| :class:`impute.IterativeImputer` Will set the estimator's
+  `random_state` to the same `random_state` that was passed to the imputer
+  instead of a `RandomState`, allowing to use it with more external classes.
+  :pr:`15636` by :user:`David Cortes <david-cortes>`.
+
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -489,14 +489,6 @@ Changelog
   :class:`tree.DecisionTreeRegressor`. :pr:`15864` by
   `Nicolas Hug`_.
 
-:mod:`sklearn.impute`
-...............................
-
-- |Enhancement| :class:`impute.IterativeImputer` Will set the estimator's
-  `random_state` to the same `random_state` that was passed to the imputer
-  instead of a `RandomState`, allowing to use it with more external classes.
-  :pr:`15636` by :user:`David Cortes <david-cortes>`.
-
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -215,7 +215,7 @@ Changelog
   with `add_indicator=True`.
   :pr:`17612` by :user:`Srimukh Sripada <d3b0unce>`
 
-- |Enhancement| :class:`impute.IterativeImputer` will not attempt to set the
+- |Fix| :class:`impute.IterativeImputer` will not attempt to set the
   estimator's `random_state` attribute, allowing to use it with more external classes.
   :pr:`15636` by :user:`David Cortes <david-cortes>`.
 

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -215,9 +215,8 @@ Changelog
   with `add_indicator=True`.
   :pr:`17612` by :user:`Srimukh Sripada <d3b0unce>`
 
-- |Enhancement| :class:`impute.IterativeImputer` will set the estimator's
-  `random_state` to the same `random_state` that was passed to the imputer
-  instead of a `RandomState`, allowing to use it with more external classes.
+- |Enhancement| :class:`impute.IterativeImputer` will not attempt to set the
+  estimator's `random_state` attribute, allowing to use it with more external classes.
   :pr:`15636` by :user:`David Cortes <david-cortes>`.
 
 :mod:`sklearn.inspection`

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -228,6 +228,14 @@ Changelog
   :func:`inspection.permutation_importance`. :pr:`16906` by
   :user:`Roei Kahny <RoeiKa>`.
 
+:mod:`sklearn.impute`
+...............................
+
+- |Enhancement| :class:`impute.IterativeImputer` Will set the estimator's
+  `random_state` to the same `random_state` that was passed to the imputer
+  instead of a `RandomState`, allowing to use it with more external classes.
+  :pr:`15636` by :user:`David Cortes <david-cortes>`.
+
 :mod:`sklearn.isotonic`
 .......................
 

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -215,6 +215,11 @@ Changelog
   with `add_indicator=True`.
   :pr:`17612` by :user:`Srimukh Sripada <d3b0unce>`
 
+- |Enhancement| :class:`impute.IterativeImputer` will set the estimator's
+  `random_state` to the same `random_state` that was passed to the imputer
+  instead of a `RandomState`, allowing to use it with more external classes.
+  :pr:`15636` by :user:`David Cortes <david-cortes>`.
+
 :mod:`sklearn.inspection`
 .........................
 
@@ -227,14 +232,6 @@ Changelog
 - |Feature| Add `sample_weight` parameter to
   :func:`inspection.permutation_importance`. :pr:`16906` by
   :user:`Roei Kahny <RoeiKa>`.
-
-:mod:`sklearn.impute`
-...............................
-
-- |Enhancement| :class:`impute.IterativeImputer` Will set the estimator's
-  `random_state` to the same `random_state` that was passed to the imputer
-  instead of a `RandomState`, allowing to use it with more external classes.
-  :pr:`15636` by :user:`David Cortes <david-cortes>`.
 
 :mod:`sklearn.isotonic`
 .......................

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -589,9 +589,7 @@ class IterativeImputer(_BaseImputer):
             and self._estimator.random_state is None
             and self.random_state is not None
         ):
-            random_state = self.random_state_.randint(
-                np.iinfo(np.int32).max)
-            self._estimator.set_params(random_state=random_state)
+            self._estimator.set_params(random_state=self.random_state)
 
         self.imputation_sequence_ = []
 

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -130,7 +130,9 @@ class IterativeImputer(_BaseImputer):
         The seed of the pseudo random number generator to use. Randomizes
         selection of estimator features if n_nearest_features is not None, the
         ``imputation_order`` if ``random``, and the sampling from posterior if
-        ``sample_posterior`` is True. Use an integer for determinism.
+        ``sample_posterior`` is True. If the estimator has a `random_state`,
+        but it's set to None, will set it to this value too. Use an integer
+        for determinism.
         See :term:`the Glossary <random_state>`.
 
     add_indicator : boolean, default=False

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -584,8 +584,14 @@ class IterativeImputer(_BaseImputer):
         else:
             self._estimator = clone(self.estimator)
 
-        if hasattr(self._estimator, 'random_state'):
-            self._estimator.random_state = self.random_state_
+        if (
+            hasattr(self._estimator, "random_state")
+            and self._estimator.random_state is None
+            and self.random_state is not None
+        ):
+            random_state = self.random_state_.randint(
+                np.iinfo(np.int32).max)
+            self._estimator.set_params(random_state=random_state)
 
         self.imputation_sequence_ = []
 

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -130,9 +130,7 @@ class IterativeImputer(_BaseImputer):
         The seed of the pseudo random number generator to use. Randomizes
         selection of estimator features if n_nearest_features is not None, the
         ``imputation_order`` if ``random``, and the sampling from posterior if
-        ``sample_posterior`` is True. If the estimator has a `random_state`,
-        and it's set to None, will set it to this value too. Use an integer
-        for determinism.
+        ``sample_posterior`` is True. Use an integer for determinism.
         See :term:`the Glossary <random_state>`.
 
     add_indicator : boolean, default=False
@@ -585,13 +583,6 @@ class IterativeImputer(_BaseImputer):
             self._estimator = BayesianRidge()
         else:
             self._estimator = clone(self.estimator)
-
-        if (
-            hasattr(self._estimator, "random_state")
-            and self._estimator.random_state is None
-            and self.random_state is not None
-        ):
-            self._estimator.set_params(random_state=self.random_state)
 
         self.imputation_sequence_ = []
 

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -131,7 +131,7 @@ class IterativeImputer(_BaseImputer):
         selection of estimator features if n_nearest_features is not None, the
         ``imputation_order`` if ``random``, and the sampling from posterior if
         ``sample_posterior`` is True. If the estimator has a `random_state`,
-        but it's set to None, will set it to this value too. Use an integer
+        and it's set to None, will set it to this value too. Use an integer
         for determinism.
         See :term:`the Glossary <random_state>`.
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1094,7 +1094,7 @@ def test_iterative_imputer_set_estimator_random_state(
 
         def predict(self, X):
             return np.zeros(X.shape[0])
-    
+
     X = np.ones((10, 3), dtype=float)
     X[[1, 2, 3], 0] = np.nan
     X[[4, 5, 6], 1] = np.nan

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1070,7 +1070,7 @@ def test_iterative_imputer_skip_non_missing(skip_complete):
 
 
 @pytest.mark.parametrize(
-    "rs_imputer, rs_estimator, expect_in_fit",
+    "rs_imputer, rs_estimator, rs_expect",
     [(None, None, None),
      (401, None, 401),
      (np.random.RandomState(seed=402), None, "RandomState"),
@@ -1082,25 +1082,25 @@ def test_iterative_imputer_skip_non_missing(skip_complete):
      (np.random.RandomState(seed=409), "string", "string")]
 )
 def test_iterative_imputer_set_estimator_random_state(
-    rs_imputer, rs_estimator, expect_in_fit
+    rs_imputer, rs_estimator, rs_expect
 ):
     # Check that the estimator's random_state is set to the imputer's
     # random_state if a value is passed to the imputer's but not to
     # the estimator's random_state
     class ZeroPredictor(BaseEstimator):
-        def __init__(self, random_state=None, expect_in_fit=None):
-            self.expect_in_fit = expect_in_fit
+        def __init__(self, random_state=None, rs_expect=None):
+            self.rs_expect = rs_expect
             self.random_state = random_state
 
         def fit(self, X, y):
-            if self.expect_in_fit == "RandomState":
+            if self.rs_expect == "RandomState":
                 rng_state_est = self.random_state.get_state()
                 rng_state_imp = rs_imputer.get_state()
                 assert rng_state_est[0] == rng_state_imp[0]
                 assert_array_equal(rng_state_est[1], rng_state_imp[1])
                 assert_array_equal(rng_state_est[2:], rng_state_imp[2:])
             else:
-                assert self.random_state == self.expect_in_fit
+                assert self.random_state == self.rs_expect
 
         def predict(self, X):
             return np.zeros(X.shape[0])
@@ -1108,7 +1108,7 @@ def test_iterative_imputer_set_estimator_random_state(
     X = np.ones((10, 3), dtype=float)
     X[[1, 2, 3], 0] = np.nan
     X[[4, 5, 6], 1] = np.nan
-    estimator = ZeroPredictor(rs_estimator, expect_in_fit)
+    estimator = ZeroPredictor(rs_estimator, rs_expect)
     imputer = IterativeImputer(estimator=estimator, random_state=rs_imputer)
     imputer.fit_transform(X)
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1070,50 +1070,6 @@ def test_iterative_imputer_skip_non_missing(skip_complete):
 
 
 @pytest.mark.parametrize(
-    "rs_imputer, rs_estimator, rs_expect",
-    [(None, None, None),
-     (401, None, 401),
-     (np.random.RandomState(seed=402), None, "RandomState"),
-     (None, 403, 403),
-     (404, 405, 405),
-     (np.random.RandomState(seed=406), 407, 407),
-     (None, "string", "string"),
-     (408, "string", "string"),
-     (np.random.RandomState(seed=409), "string", "string")]
-)
-def test_iterative_imputer_set_estimator_random_state(
-    rs_imputer, rs_estimator, rs_expect
-):
-    # Check that the estimator's random_state is set to the imputer's
-    # random_state if a value is passed to the imputer's but not to
-    # the estimator's random_state
-    class ZeroPredictor(BaseEstimator):
-        def __init__(self, random_state=None, rs_expect=None):
-            self.rs_expect = rs_expect
-            self.random_state = random_state
-
-        def fit(self, X, y):
-            if self.rs_expect == "RandomState":
-                rng_state_est = self.random_state.get_state()
-                rng_state_imp = rs_imputer.get_state()
-                assert rng_state_est[0] == rng_state_imp[0]
-                assert_array_equal(rng_state_est[1], rng_state_imp[1])
-                assert_array_equal(rng_state_est[2:], rng_state_imp[2:])
-            else:
-                assert self.random_state == self.rs_expect
-
-        def predict(self, X):
-            return np.zeros(X.shape[0])
-
-    X = np.ones((10, 3), dtype=float)
-    X[[1, 2, 3], 0] = np.nan
-    X[[4, 5, 6], 1] = np.nan
-    estimator = ZeroPredictor(rs_estimator, rs_expect)
-    imputer = IterativeImputer(estimator=estimator, random_state=rs_imputer)
-    imputer.fit_transform(X)
-
-
-@pytest.mark.parametrize(
     "X_fit, X_trans, params, msg_err",
     [(np.array([[-1, 1], [1, 2]]), np.array([[-1, 1], [1, -1]]),
       {'features': 'missing-only', 'sparse': 'auto'},

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1094,7 +1094,11 @@ def test_iterative_imputer_set_estimator_random_state(
 
         def fit(self, X, y):
             if self.expect_in_fit == "RandomState":
-                assert isinstance(self.random_state, np.random.RandomState)
+                rng_state_est = self.random_state.get_state()
+                rng_state_imp = rs_imputer.get_state()
+                assert rng_state_est[0] == rng_state_imp[0]
+                assert_array_equal(rng_state_est[1], rng_state_imp[1])
+                assert_array_equal(rng_state_est[2:], rng_state_imp[2:])
             else:
                 assert self.random_state == self.expect_in_fit
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1094,6 +1094,7 @@ def test_iterative_imputer_set_estimator_random_state(
 
         def predict(self, X):
             return np.zeros(X.shape[0])
+    
     X = np.ones((10, 3), dtype=float)
     X[[1, 2, 3], 0] = np.nan
     X[[4, 5, 6], 1] = np.nan

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -17,7 +17,6 @@ from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.experimental import enable_iterative_imputer  # noqa
 
 from sklearn.datasets import load_diabetes
-from sklearn.base import BaseEstimator
 from sklearn.impute import MissingIndicator
 from sklearn.impute import SimpleImputer, IterativeImputer
 from sklearn.dummy import DummyRegressor

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1069,6 +1069,38 @@ def test_iterative_imputer_skip_non_missing(skip_complete):
 
 
 @pytest.mark.parametrize(
+    "rs_imputer, rs_estimator",
+    [
+        (None, None),
+        (1, None),
+        (np.random.RandomState(seed=1), None),
+        (None, 1),
+        (1, 1),
+        (np.random.RandomState(seed=1), 1),
+        (None, np.random.RandomState(seed=1)),
+        (1, np.random.RandomState(seed=1)),
+        (np.random.RandomState(seed=1), np.random.RandomState(seed=1))
+    ]
+)
+def test_iterative_imputer_dont_set_random_state(rs_imputer, rs_estimator):
+    class ZeroEstimator:
+        def __init__(self, random_state):
+            self.random_state = random_state
+
+        def fit(self, *args, **kgards):
+            return self
+
+        def predict(self, X):
+            return np.zeros(X.shape[0])
+
+    estimator = ZeroEstimator(random_state=rs_estimator)
+    imputer = IterativeImputer(random_state=rs_imputer)
+    X_train = np.zeros((10, 3))
+    imputer.fit(X_train)
+    assert estimator.random_state == rs_estimator
+
+
+@pytest.mark.parametrize(
     "X_fit, X_trans, params, msg_err",
     [(np.array([[-1, 1], [1, 2]]), np.array([[-1, 1], [1, -1]]),
       {'features': 'missing-only', 'sparse': 'auto'},

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1070,27 +1070,30 @@ def test_iterative_imputer_skip_non_missing(skip_complete):
 
 
 @pytest.mark.parametrize(
-    "rs_imputer, rs_estimator, rs_expect",
-    [(None, None, None), (401, None, 401),
+    "rs_imputer, rs_estimator, expect_in_fit",
+    [(None, None, None),
+     (401, None, 401),
      (np.random.RandomState(seed=402), None, "RandomState"),
-     (None, 403, 403), (404, 405, 405),
+     (None, 403, 403),
+     (404, 405, 405),
      (np.random.RandomState(seed=406), 407, 407),
-     (None, "string", "string"), (408, "string", "string"),
+     (None, "string", "string"),
+     (408, "string", "string"),
      (np.random.RandomState(seed=409), "string", "string")]
 )
 def test_iterative_imputer_set_estimator_random_state(
-    rs_imputer, rs_estimator, rs_expect
+    rs_imputer, rs_estimator, expect_in_fit
 ):
     class ZeroPredictor(BaseEstimator):
-        def __init__(self, random_state=None, rs_expect="None"):
-            self.rs_expect = rs_expect
+        def __init__(self, random_state=None, expect_in_fit=None):
+            self.expect_in_fit = expect_in_fit
             self.random_state = random_state
 
         def fit(self, X, y):
-            if self.rs_expect == "RandomState":
+            if self.expect_in_fit == "RandomState":
                 assert isinstance(self.random_state, np.random.RandomState)
             else:
-                assert self.random_state == self.rs_expect
+                assert self.random_state == self.expect_in_fit
 
         def predict(self, X):
             return np.zeros(X.shape[0])
@@ -1098,7 +1101,7 @@ def test_iterative_imputer_set_estimator_random_state(
     X = np.ones((10, 3), dtype=float)
     X[[1, 2, 3], 0] = np.nan
     X[[4, 5, 6], 1] = np.nan
-    estimator = ZeroPredictor(random_state=rs_estimator, rs_expect=rs_expect)
+    estimator = ZeroPredictor(rs_estimator, expect_in_fit)
     imputer = IterativeImputer(estimator=estimator, random_state=rs_imputer)
     imputer.fit_transform(X)
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1071,8 +1071,8 @@ def test_iterative_imputer_skip_non_missing(skip_complete):
 
 @pytest.mark.parametrize(
     "rs_imputer, rs_estimator, rs_expect",
-    [(None, None, "None"), (401, None, "int"),
-     (np.random.RandomState(seed=402), None, "int"),
+    [(None, None, None), (401, None, 401),
+     (np.random.RandomState(seed=402), None, "RandomState"),
      (None, 403, 403), (404, 405, 405),
      (np.random.RandomState(seed=406), 407, 407),
      (None, "string", "string"), (408, "string", "string"),
@@ -1087,10 +1087,8 @@ def test_iterative_imputer_set_estimator_random_state(
             self.random_state = random_state
 
         def fit(self, X, y):
-            if self.rs_expect == "None":
-                assert self.random_state is None
-            elif self.rs_expect == "int":
-                assert isinstance(self.random_state, int)
+            if self.rs_expect == "RandomState":
+                assert isinstance(self.random_state, np.random.RandomState)
             else:
                 assert self.random_state == self.rs_expect
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1069,18 +1069,12 @@ def test_iterative_imputer_skip_non_missing(skip_complete):
 
 
 @pytest.mark.parametrize(
-    "rs_imputer, rs_estimator",
-    [
-        (None, None),
-        (1, None),
-        (np.random.RandomState(seed=1), None),
-        (None, 1),
-        (1, 1),
-        (np.random.RandomState(seed=1), 1),
-        (None, np.random.RandomState(seed=1)),
-        (1, np.random.RandomState(seed=1)),
-        (np.random.RandomState(seed=1), np.random.RandomState(seed=1))
-    ]
+    "rs_imputer",
+    [None, 1, np.random.RandomState(seed=1)]
+)
+@pytest.mark.parametrize(
+    "rs_estimator",
+    [None, 1, np.random.RandomState(seed=1)]
 )
 def test_iterative_imputer_dont_set_random_state(rs_imputer, rs_estimator):
     class ZeroEstimator:

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1084,6 +1084,9 @@ def test_iterative_imputer_skip_non_missing(skip_complete):
 def test_iterative_imputer_set_estimator_random_state(
     rs_imputer, rs_estimator, expect_in_fit
 ):
+    # Check that the estimator's random_state is set to the imputer's
+    # random_state if a value is passed to the imputer's but not to
+    # the estimator's random_state
     class ZeroPredictor(BaseEstimator):
         def __init__(self, random_state=None, expect_in_fit=None):
             self.expect_in_fit = expect_in_fit


### PR DESCRIPTION
Trying to fix issue: https://github.com/scikit-learn/scikit-learn/issues/15611

Lots of algorithms that rely on randomization offer an argument `random_state` through which it's possible to pass them RNG seeds that would ensure reproducible results. The `IterativeImputer` class will take some regressor/classifier and set their attribute `random_state` to a NumPy MT19937 object class if the object has such attribute, in such a way that this object is modified implicitly once the regressor/classifier to which it was assigned produces some random number.

This is fine for SciKit-Learn’s own classes, but other libraries which provide different regressors/classifiers which are SciKit-Learn-compatible might not be able to use such `RandomState` objects (e.g. if they generate random numbers in C++ with some method other than MT19937).

This PR addresses the issue by setting the `random_state` of the estimator to ~~a random integer, which is drawn from the imputer's `RandomState` object~~ the same value that was passed to the imputer, but does so only if it's not already set in the estimator. This way:
* It doesn't override the `random_state` which is passed to the constructor of the estimator used for imputation (if it was passed).
* Allows to use a wider array of SciKit-Learn-compatible objects from external libraries as estimators for `IterativeImputer`. Example:
```python
import numpy as np
from lightgbm import LGBMRegressor
from sklearn.experimental import enable_iterative_imputer
from sklearn.impute import IterativeImputer

np.random.seed(123)
X = np.random.normal(size = (100, 5))
X[np.random.randint(100, size = 10),
  np.random.randint(5,   size = 10)] = np.nan

imputer = IterativeImputer(LGBMRegressor(), random_state = 456)
X_full = imputer.fit_transform(X)
```