### PR TITLE
FIX accept pandas Index for feature_names in PDP

### DIFF
--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -623,7 +623,8 @@ def plot_partial_dependence(estimator, X, features, feature_names=None,
         else:
             # define a list of numbered indices for a numpy array
             feature_names = [str(i) for i in range(n_features)]
-    elif isinstance(feature_names, np.ndarray):
+    elif hasattr(feature_names, "tolist"):
+        # convert numpy array or pandas index to a list
         feature_names = feature_names.tolist()
     if len(set(feature_names)) != len(feature_names):
         raise ValueError('feature_names should not contain duplicates.')

--- a/sklearn/inspection/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/tests/test_plot_partial_dependence.py
@@ -10,6 +10,8 @@ from sklearn.datasets import make_classification, make_regression
 from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.linear_model import LinearRegression
+from sklearn.utils._testing import _convert_container
+
 from sklearn.inspection import plot_partial_dependence
 
 
@@ -86,12 +88,15 @@ def test_plot_partial_dependence(grid_resolution, pyplot, clf_boston, boston):
 
 
 @pytest.mark.parametrize(
-    "input_type, use_feature_names",
-    [('dataframe', False), ('dataframe', True),
-     ('list', True), ('array', True)]
+    "input_type, feature_names_type",
+    [('dataframe', None),
+     ('dataframe', 'list'), ('list', 'list'), ('array', 'list'),
+     ('dataframe', 'array'), ('list', 'array'), ('array', 'array'),
+     ('dataframe', 'series'), ('list', 'series'), ('array', 'series'),
+     ('dataframe', 'index'), ('list', 'index'), ('array', 'index')]
 )
 def test_plot_partial_dependence_str_features(pyplot, clf_boston, boston,
-                                              input_type, use_feature_names):
+                                              input_type, feature_names_type):
     if input_type == 'dataframe':
         pd = pytest.importorskip("pandas")
         X = pd.DataFrame(boston.data, columns=boston.feature_names)
@@ -99,7 +104,12 @@ def test_plot_partial_dependence_str_features(pyplot, clf_boston, boston,
         X = boston.data.tolist()
     else:
         X = boston.data
-    feature_names = boston.feature_names if use_feature_names else None
+
+    if feature_names_type is None:
+        feature_names = None
+    else:
+        feature_names = _convert_container(boston.feature_names,
+                                           feature_names_type)
 
     grid_resolution = 25
     # check with str features and array feature names and single column

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -912,3 +912,25 @@ def assert_run_python_script(source_code, timeout=60):
                                % e.output.decode('utf-8'))
     finally:
         os.unlink(source_file)
+
+
+def _convert_container(container, constructor_name, columns_name=None):
+    if constructor_name == 'list':
+        return list(container)
+    elif constructor_name == 'tuple':
+        return tuple(container)
+    elif constructor_name == 'array':
+        return np.asarray(container)
+    elif constructor_name == 'sparse':
+        return sp.sparse.csr_matrix(container)
+    elif constructor_name == 'dataframe':
+        pd = pytest.importorskip('pandas')
+        return pd.DataFrame(container, columns=columns_name)
+    elif constructor_name == 'series':
+        pd = pytest.importorskip('pandas')
+        return pd.Series(container)
+    elif constructor_name == 'index':
+        pd = pytest.importorskip('pandas')
+        return pd.Index(container)
+    elif constructor_name == 'slice':
+        return slice(container[0], container[1])

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -32,7 +32,8 @@ from sklearn.utils._testing import (
     assert_raises_regex,
     TempMemmap,
     create_memmap_backed_data,
-    _delete_folder)
+    _delete_folder,
+    _convert_container)
 
 from sklearn.utils._testing import SkipTest
 from sklearn.tree import DecisionTreeClassifier
@@ -674,3 +675,20 @@ def test_deprecated_helpers(callable, args):
            '0.24. Please use "assert" instead')
     with pytest.warns(FutureWarning, match=msg):
         callable(*args)
+
+
+@pytest.mark.parametrize(
+    "constructor_name, container_type",
+    [('list', list),
+     ('tuple', tuple),
+     ('array', np.ndarray),
+     ('sparse', sparse.csr_matrix),
+     ('dataframe', pytest.importorskip('pandas').DataFrame),
+     ('series', pytest.importorskip('pandas').Series),
+     ('index', pytest.importorskip('pandas').Index),
+     ('slice', slice)]
+)
+def test_convert_container(constructor_name, container_type):
+    container = [0, 1]
+    assert isinstance(_convert_container(container, constructor_name),
+                      container_type)

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -9,10 +9,12 @@ import numpy as np
 import scipy.sparse as sp
 
 from sklearn.utils._testing import (assert_raises,
-                                   assert_array_equal,
-                                   assert_allclose_dense_sparse,
-                                   assert_raises_regex,
-                                   assert_warns_message, assert_no_warnings)
+                                    assert_array_equal,
+                                    assert_allclose_dense_sparse,
+                                    assert_raises_regex,
+                                    assert_warns_message,
+                                    assert_no_warnings,
+                                    _convert_container)
 from sklearn.utils import check_random_state
 from sklearn.utils import _determine_key_type
 from sklearn.utils import deprecated
@@ -234,25 +236,6 @@ def test_determine_key_type_error():
 def test_determine_key_type_slice_error():
     with pytest.raises(TypeError, match="Only array-like or scalar are"):
         _determine_key_type(slice(0, 2, 1), accept_slice=False)
-
-
-def _convert_container(container, constructor_name, columns_name=None):
-    if constructor_name == 'list':
-        return list(container)
-    elif constructor_name == 'tuple':
-        return tuple(container)
-    elif constructor_name == 'array':
-        return np.asarray(container)
-    elif constructor_name == 'sparse':
-        return sp.csr_matrix(container)
-    elif constructor_name == 'dataframe':
-        pd = pytest.importorskip('pandas')
-        return pd.DataFrame(container, columns=columns_name)
-    elif constructor_name == 'series':
-        pd = pytest.importorskip('pandas')
-        return pd.Series(container)
-    elif constructor_name == 'slice':
-        return slice(container[0], container[1])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
closes #15638 

#### What does this implement/fix? Explain your changes.
Implicitly convert pandas index into a list if one is passing `feature_names=X.columns`.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
