### PR TITLE
Use correct n_components in case n_components is passed as a float between 0 and 1

### DIFF
--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -464,7 +464,7 @@ class PCA(_BasePCA):
             # number of components for which the cumulated explained
             # variance percentage is superior to the desired threshold
             ratio_cumsum = stable_cumsum(explained_variance_ratio_)
-            n_components = np.searchsorted(ratio_cumsum, n_components) + 1
+            n_components = np.nonzero(ratio_cumsum > n_components)[0][0]
 
         # Compute noise covariance using Probabilistic PCA model
         # The sigma2 maximum likelihood (cf. eq. 12.46)

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -464,7 +464,7 @@ class PCA(_BasePCA):
             # number of components for which the cumulated explained
             # variance percentage is superior to the desired threshold
             ratio_cumsum = stable_cumsum(explained_variance_ratio_)
-            n_components = np.nonzero(ratio_cumsum > n_components)[0][0]
+            n_components = np.argmax(ratio_cumsum > n_components)
 
         # Compute noise covariance using Probabilistic PCA model
         # The sigma2 maximum likelihood (cf. eq. 12.46)


### PR DESCRIPTION
`n_components` is the total number of principal components. When n_components is passed as a float between 0 and 1, n_components is converted into integer something like this:
`n_components = np.searchsorted(ratio_cumsum, n_components) + 1`
There is a catch in numpy's searchsorted function. It returns index i where `a[i-1] < v <= a[i]`. So here `i` can be returned such that `v < a[i]` which is exactly what is mentioned in the documentation: 

If `0 < n_components < 1` and `svd_solver == 'full'`, select the number of components such that the amount of variance that needs to be explained is greater than the percentage specified by n_components. [[Link](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html)]

Here v is percentage specified by n_components, which comes as input from the user something like `PCA(n_components=0.99, svd_solver='full')` and a[i] is the amount of the variance that needs to be explained. So adding 1 here is redundant as v is ALREADY less than a[i] which is exactly what's required according to the above-mentioned documentation.

But if `v = a[i]` then 1 should be added as v is NOT less than a[i].

Hence I feel using np.searchsorted for this task isn't correct and it should be replaced by alternatives like:
`n_components = np.nonzero(ratio_cumsum > n_components)[0][0]`

Now, n_components is just the exact total number of principal components required.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
It fixes the variable `n_components` which was calculated to be a bit higher before due to the addition of 1. This pull request aims to address that issue by changing that one line of code responsible for it. After this change, the number of principal components will be exactly how much is required.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
