### PR TITLE
TST Fix leak in tmp folders in LFW test when pillow is missing

### DIFF
--- a/sklearn/datasets/tests/test_lfw.py
+++ b/sklearn/datasets/tests/test_lfw.py
@@ -24,10 +24,10 @@ from sklearn.utils._testing import SkipTest
 from sklearn.datasets.tests.test_common import check_return_X_y
 
 
-SCIKIT_LEARN_DATA = tempfile.mkdtemp(prefix="scikit_learn_lfw_test_")
-SCIKIT_LEARN_EMPTY_DATA = tempfile.mkdtemp(prefix="scikit_learn_empty_test_")
+SCIKIT_LEARN_DATA = None
+SCIKIT_LEARN_EMPTY_DATA = None
+LFW_HOME = None
 
-LFW_HOME = os.path.join(SCIKIT_LEARN_DATA, 'lfw_home')
 FAKE_NAMES = [
     'Abdelatif_Smith',
     'Abhati_Kepler',
@@ -43,6 +43,14 @@ def setup_module():
     """Test fixture run once and common to all tests of this module"""
     if not pillow_installed:
         raise SkipTest("PIL not installed.")
+
+    global SCIKIT_LEARN_DATA, SCIKIT_LEARN_EMPTY_DATA, LFW_HOME
+
+    SCIKIT_LEARN_DATA = tempfile.mkdtemp(prefix="scikit_learn_lfw_test_")
+    LFW_HOME = os.path.join(SCIKIT_LEARN_DATA, 'lfw_home')
+
+    SCIKIT_LEARN_EMPTY_DATA = tempfile.mkdtemp(
+        prefix="scikit_learn_empty_test_")
 
     if not os.path.exists(LFW_HOME):
         os.makedirs(LFW_HOME)


### PR DESCRIPTION
I just noticed that  `sklearn/datasets/tests/test_lfw.py` creates temporary folders that are not collected when the pillow/PIL package is not installed: this is because the `teardown_module` function is not called when `SkipTest` is raised in the `setup_module` function.

This PR fixes that by not creating the temp folders before we check for the presence of PIL.