### PR TITLE
MNT pin pytest in failing job on azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,8 @@ jobs:
         SCIPY_VERSION: '0.17.0'
         PANDAS_VERSION: '*'
         CYTHON_VERSION: '*'
-        PYTEST_VERSION: '*'
+        # temporary pin pytest due to unknown failure with pytest 5.3
+        PYTEST_VERSION: '5.2'
         PILLOW_VERSION: '4.0.0'
         MATPLOTLIB_VERSION: '1.5.1'
         # later version of joblib are not packaged in conda for Python 3.5


### PR DESCRIPTION
Trying to solve the failing job in Azure. Pytest 3.5.0 has been available since the job is failing.