### PR TITLE
sed executed in regexp mode.

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -79,7 +79,7 @@ get_build_type() {
         auto_example_files="$(echo "$img_fig_lines" | grep auto_examples | awk -F "/" '{print $NF}')"
 
         # remove "sphx_glr_" from path and accept replace _(\d\d\d|thumb).png with .py
-        scripts_names="$(echo "$auto_example_files" | sed 's/sphx_glr_//' | sed -e 's/_([[:digit:]][[:digit:]][[:digit:]]|thumb).png/.py/')"
+        scripts_names="$(echo "$auto_example_files" | sed 's/sphx_glr_//' | sed -E 's/_([[:digit:]][[:digit:]][[:digit:]]|thumb).png/.py/')"
 
         # get unique values
         examples_in_rst="$(echo "$scripts_names" | uniq )"


### PR DESCRIPTION
#### Reference Issues/PRs
Should fix false positives in sphinx warning detection (see #15633 #13227)
#### What does this implement/fix? Explain your changes.
`sed` uses extended regular expressions in the script (`-E` option)

Note that `thumb` files are linked in `whats_new/older_version.rst` also, so it is indeed useful to look for them.