### PR TITLE
[MRG] BUG Clip distances below 0 in nan_euclidean_distances

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -406,6 +406,8 @@ def nan_euclidean_distances(X, Y=None, squared=False,
     distances -= np.dot(XX, missing_Y.T)
     distances -= np.dot(missing_X, YY.T)
 
+    np.clip(distances, 0, None, out=distances)
+
     if X is Y:
         # Ensure that distances between vectors and themselves are set to 0.0.
         # This may not be the case due to floating point rounding errors.

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -871,6 +871,23 @@ def test_nan_euclidean_distances_not_trival(missing_value):
     assert_allclose(D6, D7)
 
 
+@pytest.mark.parametrize("missing_value", [np.nan, -1])
+def test_nan_euclidean_distances_one_feature_match_positive(missing_value):
+    # First feature is the only feature that is non-nan and in both
+    # samples. The result of `nan_euclidean_distances` with squared=True
+    # should be non-negative. The non-squared version should all be close to 0.
+    X = np.array([[-122.27, 648., missing_value, 37.85],
+                  [-122.27, missing_value, 2.34701493, missing_value]])
+
+    dist_squared = nan_euclidean_distances(X, missing_values=missing_value,
+                                           squared=True)
+    assert np.all(dist_squared >= 0)
+
+    dist = nan_euclidean_distances(X, missing_values=missing_value,
+                                   squared=False)
+    assert_allclose(dist, 0.0)
+
+
 def test_cosine_distances():
     # Check the pairwise Cosine distances computation
     rng = np.random.RandomState(1337)


### PR DESCRIPTION
Clips distances below 0 in `nan_euclidean_distances`. There can be precision errors when doing `distances -=` with floats which may cause some of the distances to be `<0`.

CC: @jnothman @glemaitre 