### PR TITLE
[MRG] BUG Releases memory in linear.cpp

### DIFF
--- a/sklearn/svm/src/liblinear/linear.cpp
+++ b/sklearn/svm/src/liblinear/linear.cpp
@@ -515,6 +515,7 @@ Solver_MCSVM_CS::~Solver_MCSVM_CS()
 {
 	delete[] B;
 	delete[] G;
+	delete[] C;
 }
 
 int compare_double(const void *a, const void *b)


### PR DESCRIPTION
Releases memory in the destructor of `Solver_MCSVM_CS` in linear.cpp.