### PR TITLE
[WIP] Allowing optional list of Parallel keyworded parameters within estimators

### DIFF
--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -698,7 +698,9 @@ def _get_args(function, varargs=False):
         # Error on builtin C function
         return []
     args = [key for key, param in params.items()
-            if param.kind not in (param.VAR_POSITIONAL, param.VAR_KEYWORD)]
+            if (key == 'parallel_params' and
+                param.kind == param.VAR_KEYWORD) or
+            param.kind not in (param.VAR_POSITIONAL, param.VAR_KEYWORD)]
     if varargs:
         varargs = [param.name for param in params.values()
                    if param.kind == param.VAR_POSITIONAL]


### PR DESCRIPTION
Changing `OneVsRestClassifier`, `OneVsOneClassifier` and `OutputCodeClassifier` multiclass learning algorithms within *multiclass.py*, by replacing `n_jobs` parameter with keyworded, variable-length argument list, in order to allow any `Parallel` parameter to be passed, as well as support `parallel_backend` context manager.

`n_jobs` remains one of the possible parameters, but other ones can be added, including `max_nbytes`, which might be useful in order to avoid *ValueError* when dealing with a large training set processed by concurrently running jobs defined by `n_jobs > 0` or by `n_jobs = -1`.

More specifically, in parallel computing of large arrays with "loky" backend, [Parallel](https://joblib.readthedocs.io/en/latest/parallel.html#parallel-reference-documentation) sets a default 1-megabyte [threshold](https://joblib.readthedocs.io/en/latest/parallel.html#automated-array-to-memmap-conversion) on the size of arrays passed to the workers. Such parameter may not be enough for large arrays and could break jobs with exception **ValueError: UPDATEIFCOPY base is read-only**.
`Parallel` uses `max_nbytes` to control this threshold.

Through this fix, the multiclass classifiers will offer the optional possibility to customize the max size of arrays.

Fixes #6614

See also #4597

------------
Edited text and title, to reflect the support of `parallel_backend` context manager