### PR TITLE
[MRG] Add return_centers parameter to make_blobs

### DIFF
--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -702,7 +702,7 @@ def make_moons(n_samples=100, shuffle=True, noise=None, random_state=None):
 
 
 def make_blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
-               center_box=(-10.0, 10.0), shuffle=True, random_state=None):
+               center_box=(-10.0, 10.0), shuffle=True, random_state=None, return_centers=False):
     """Generate isotropic Gaussian blobs for clustering.
 
     Read more in the :ref:`User Guide <sample_generators>`.
@@ -839,7 +839,8 @@ def make_blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
         generator.shuffle(indices)
         X = X[indices]
         y = y[indices]
-
+    if return_centers:
+        return X, y, centers
     return X, y
 
 

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -702,7 +702,8 @@ def make_moons(n_samples=100, shuffle=True, noise=None, random_state=None):
 
 
 def make_blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
-               center_box=(-10.0, 10.0), shuffle=True, random_state=None, return_centers=False):
+               center_box=(-10.0, 10.0), shuffle=True, random_state=None,
+               return_centers=False):
     """Generate isotropic Gaussian blobs for clustering.
 
     Read more in the :ref:`User Guide <sample_generators>`.

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -741,6 +741,9 @@ def make_blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
         for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
+    return_centers : boolean, optional (default=False)
+        Return cluster centers array
+
     Returns
     -------
     X : array of shape [n_samples, n_features]

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -840,8 +840,10 @@ def make_blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
         generator.shuffle(indices)
         X = X[indices]
         y = y[indices]
+
     if return_centers:
         return X, y, centers
+
     return X, y
 
 

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -283,6 +283,16 @@ def test_make_blobs_n_samples_list():
         "Incorrect number of samples per blob"
 
 
+def test_make_blobs_n_samples_with_centers_list():
+    n_samples = [50, 30, 20]
+    X, y, centers = make_blobs(n_samples=n_samples, n_features=2,
+                               random_state=0, return_centers=True)
+
+    assert len(n_samples) == len(centers), "Mismatch in length of " \
+                                           "n_sanmpes and number " \
+                                           "of centers"
+
+
 def test_make_blobs_n_samples_list_with_centers():
     n_samples = [20, 20, 20]
     centers = np.array([[0.0, 0.0], [1.0, 1.0], [0.0, 1.0]])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
####Reference Issues/PRs
FIxes #15684 


#### What does this implement/fix? Explain your changes.
Add return_centers parameter to make_blobs. 

#### Any other comments?
This can be useful for comparing with e.g. GaussianMixture.means_ or KMeans.cluster_centers_, when the centers are randomly generated by make_blobs

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->