### PR TITLE
DOC Typo in the error message of _binary_clf_curve

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -539,7 +539,7 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
         classes_repr = ", ".join(repr(c) for c in classes)
         raise ValueError("y_true takes value in {{{classes_repr}}} and "
                          "pos_label is not specified: either make y_true "
-                         "take integer value in {{0, 1}} or {{-1, 1}} or "
+                         "take value in {{0, 1}} or {{-1, 1}} or "
                          "pass pos_label explicitly.".format(
                              classes_repr=classes_repr))
     elif pos_label is None:

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -683,7 +683,7 @@ def test_binary_clf_curve_implicit_pos_label(curve_func):
     # Check that using string class labels raises an informative
     # error for any supported string dtype:
     msg = ("y_true takes value in {'a', 'b'} and pos_label is "
-           "not specified: either make y_true take integer "
+           "not specified: either make y_true take "
            "value in {0, 1} or {-1, 1} or pass pos_label "
            "explicitly.")
     with pytest.raises(ValueError, match=msg):
@@ -695,7 +695,7 @@ def test_binary_clf_curve_implicit_pos_label(curve_func):
     # The error message is slightly different for bytes-encoded
     # class labels, but otherwise the behavior is the same:
     msg = ("y_true takes value in {b'a', b'b'} and pos_label is "
-           "not specified: either make y_true take integer "
+           "not specified: either make y_true take "
            "value in {0, 1} or {-1, 1} or pass pos_label "
            "explicitly.")
     with pytest.raises(ValueError, match=msg):


### PR DESCRIPTION
Typo in #15562, we support float y_true and it's tested.
ping @ogrisel @thomasjpfan 