### PR TITLE
DOC Wrong statement in release highlight

### DIFF
--- a/examples/release_highlights/plot_release_highlights_0_22_0.py
+++ b/examples/release_highlights/plot_release_highlights_0_22_0.py
@@ -246,10 +246,10 @@ def test_sklearn_compatible_estimator(estimator, check):
 # classification. Two averaging strategies are currently supported: the
 # one-vs-one algorithm computes the average of the pairwise ROC AUC scores, and
 # the one-vs-rest algorithm computes the average of the ROC AUC scores for each
-# class against all other classes. In both cases, the scores correspond to the
-# probability estimates that a sample belongs to a particular
-# class. The OvO and OvR algorithms supports weighting uniformly
-# (``average='macro'``) and weighting by the prevalence
+# class against all other classes. In both cases, the multiclass ROC AUC scores
+# are computed from the probability estimates that a sample belongs to a
+# particular class according to the model. The OvO and OvR algorithms supports
+# weighting uniformly (``average='macro'``) and weighting by the prevalence
 # (``average='weighted'``).
 #
 # Read more in the :ref:`User Guide <roc_metrics>`.

--- a/examples/release_highlights/plot_release_highlights_0_22_0.py
+++ b/examples/release_highlights/plot_release_highlights_0_22_0.py
@@ -248,7 +248,7 @@ def test_sklearn_compatible_estimator(estimator, check):
 # the one-vs-rest algorithm computes the average of the ROC AUC scores for each
 # class against all other classes. In both cases, the multiclass ROC AUC scores
 # are computed from the probability estimates that a sample belongs to a
-# particular class according to the model. The OvO and OvR algorithms supports
+# particular class according to the model. The OvO and OvR algorithms support
 # weighting uniformly (``average='macro'``) and weighting by the prevalence
 # (``average='weighted'``).
 #

--- a/examples/release_highlights/plot_release_highlights_0_22_0.py
+++ b/examples/release_highlights/plot_release_highlights_0_22_0.py
@@ -246,9 +246,8 @@ def test_sklearn_compatible_estimator(estimator, check):
 # classification. Two averaging strategies are currently supported: the
 # one-vs-one algorithm computes the average of the pairwise ROC AUC scores, and
 # the one-vs-rest algorithm computes the average of the ROC AUC scores for each
-# class against all other classes. In both cases, the predicted labels are
-# provided in an array with values from 0 to ``n_classes``, and the scores
-# correspond to the probability estimates that a sample belongs to a particular
+# class against all other classes. In both cases, the scores correspond to the
+# probability estimates that a sample belongs to a particular
 # class. The OvO and OvR algorithms supports weighting uniformly
 # (``average='macro'``) and weighting by the prevalence
 # (``average='weighted'``).


### PR DESCRIPTION
y_true don't need to be integers between 0 and ``n_classes - 1``.
See https://scikit-learn.org/dev/modules/generated/sklearn.metrics.roc_auc_score.html
labels array, shape = [n_classes] or None, optional (default=None)
List of labels to index y_score used for multiclass. If None, the lexicon order of y_true is used to index y_score

ping @adrinjalali 