### PR TITLE
CI Use new conda syntax to select blas

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
       pylatest_conda_mkl:
         DISTRIB: 'conda'
         PYTHON_VERSION: '*'
-        INSTALL_MKL: 'true'
+        BLAS: 'mkl'
         NUMPY_VERSION: '*'
         SCIPY_VERSION: '*'
         CYTHON_VERSION: '*'
@@ -52,7 +52,7 @@ jobs:
       py35_conda_openblas:
         DISTRIB: 'conda'
         PYTHON_VERSION: '3.5'
-        INSTALL_MKL: 'false'
+        BLAS: 'openblas'
         NUMPY_VERSION: '1.11.0'
         SCIPY_VERSION: '0.17.0'
         PANDAS_VERSION: '*'
@@ -96,7 +96,7 @@ jobs:
       pylatest_conda_mkl:
         DISTRIB: 'conda'
         PYTHON_VERSION: '*'
-        INSTALL_MKL: 'true'
+        BLAS: 'mkl'
         NUMPY_VERSION: '*'
         SCIPY_VERSION: '*'
         CYTHON_VERSION: '*'
@@ -107,7 +107,7 @@ jobs:
       pylatest_conda_mkl_no_openmp:
         DISTRIB: 'conda'
         PYTHON_VERSION: '*'
-        INSTALL_MKL: 'true'
+        BLAS: 'mkl'
         NUMPY_VERSION: '*'
         SCIPY_VERSION: '*'
         CYTHON_VERSION: '*'

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -22,13 +22,8 @@ if [[ "$DISTRIB" == "conda" ]]; then
 
     TO_INSTALL="python=$PYTHON_VERSION pip \
                 numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
-                cython=$CYTHON_VERSION joblib=$JOBLIB_VERSION"
-
-    if [[ "$INSTALL_MKL" == "true" ]]; then
-        TO_INSTALL="$TO_INSTALL mkl"
-    else
-        TO_INSTALL="$TO_INSTALL nomkl"
-    fi
+                cython=$CYTHON_VERSION joblib=$JOBLIB_VERSION\
+                blas[build=$BLAS]"
 
     if [[ -n "$PANDAS_VERSION" ]]; then
         TO_INSTALL="$TO_INSTALL pandas=$PANDAS_VERSION"


### PR DESCRIPTION
conda install numpy is less predictable than it used to be w.r.t blas.
in python < 3.8 it will install mkl; in python 3.8 it's openblas (for now ?)

So currently our pylatest_conda_mkl job actually uses openblas :/

We can be sure of which implementation of blas we will get with the following syntax
`conda install numpy blas[build=mkl]`
(An alternative syntax is `blas=*=mkl` but I prefer the first one.)