### PR TITLE
[WIP] Add support for Histogram-Like Multi-Labeled Encodings with Associated Values

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1376,6 +1376,7 @@ Model validation
    preprocessing.LabelBinarizer
    preprocessing.LabelEncoder
    preprocessing.MultiLabelBinarizer
+   preprocessing.MultiLabelHistogram
    preprocessing.MaxAbsScaler
    preprocessing.MinMaxScaler
    preprocessing.Normalizer

--- a/sklearn/preprocessing/__init__.py
+++ b/sklearn/preprocessing/__init__.py
@@ -32,6 +32,7 @@ from ._label import label_binarize
 from ._label import LabelBinarizer
 from ._label import LabelEncoder
 from ._label import MultiLabelBinarizer
+from ._label import MultiLabelHistogram
 
 from ._discretization import KBinsDiscretizer
 
@@ -44,6 +45,7 @@ __all__ = [
     'LabelBinarizer',
     'LabelEncoder',
     'MultiLabelBinarizer',
+    'MultiLabelHistogram',
     'MinMaxScaler',
     'MaxAbsScaler',
     'QuantileTransformer',

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -1058,14 +1058,14 @@ class MultiLabelHistogram(TransformerMixin, BaseEstimator):
     >>> from sklearn.preprocessing import MultiLabelHistogram
     >>> mlh = MultiLabelHistogram()
     >>> mlh.fit_transform([{1: 5.5, 2: -3.0}, {3: 999}])
-    array([[  5.5  -3.    0. ],
-           [  0.    0.  999. ]])
+    array([[  5.5,  -3. ,   0. ],
+           [  0. ,   0. , 999. ]], dtype=float32)
     >>> mlh.classes_
     array([1, 2, 3])
 
     >>> mlh.fit_transform([{'sci-fi': -2.0, 'thriller': 5.0}, {'comedy': 0.1}])
-    array([[ 0.  -2.   5. ],
-           [ 0.1  0.   0. ]])
+    array([[ 0. , -2. ,  5. ],
+           [ 0.1,  0. ,  0. ]], dtype=float32)
     >>> list(mlh.classes_)
     ['comedy', 'sci-fi', 'thriller']
 

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -1245,11 +1245,15 @@ class MultiLabelHistogram(TransformerMixin, BaseEstimator):
 
         if sp.issparse(yt):
             yt = yt.tocsr()
-            return [dict(zip(self.classes_.take(yt.indices[start:end]), yt.data[start:end]))
+            return [dict(zip(
+                      self.classes_.take(yt.indices[start:end]),
+                      yt.data[start:end]))
                     for start, end in zip(yt.indptr[:-1], yt.indptr[1:])]
         else:
             print([ind for ind in yt])
-            return [dict(zip(self.classes_.compress(indicators), filter(None, indicators)))
+            return [dict(zip(
+                      self.classes_.compress(indicators),
+                      filter(None, indicators)))
                     for indicators in yt]
 
     def _more_tags(self):

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -661,12 +661,12 @@ def test_encode_check_unknown():
 def test_multilabel_histogram():
     mlh = MultiLabelHistogram()
     y = [{1: 5.5, 2: -3.0}, {3: 999}]
-    Y = np.array([[  5.5,  -3.,    0. ],
-                  [  0.,    0.,  999. ]])
+    Y = np.array([[  5.5,  -3. ,   0. ],
+                  [  0. ,   0. , 999. ]], dtype=np.float32)
     assert_allclose(mlh.fit_transform(y), Y)
 
     mlh = MultiLabelHistogram()
     y = [{'sci-fi': -2.0, 'thriller': 5.0}, {'comedy': 0.1}]
-    Y = np.array([[ 0.,  -2.,   5. ],
-                  [ 0.1,  0.,   0. ]])
+    Y = np.array([[ 0. , -2. ,  5. ],
+                  [ 0.1,  0. ,  0. ]], dtype=np.float32)
     assert_allclose(mlh.fit_transform(y), Y)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -661,12 +661,12 @@ def test_encode_check_unknown():
 def test_multilabel_histogram():
     mlh = MultiLabelHistogram()
     y = [{1: 5.5, 2: -3.0}, {3: 999}]
-    Y = np.array([[  5.5,  -3. ,   0. ],
-                  [  0. ,   0. , 999. ]], dtype=np.float32)
+    Y = np.array([[5.5, -3., 0.],
+                  [0., 0., 999.]], dtype=np.float32)
     assert_allclose(mlh.fit_transform(y), Y)
 
     mlh = MultiLabelHistogram()
     y = [{'sci-fi': -2.0, 'thriller': 5.0}, {'comedy': 0.1}]
-    Y = np.array([[ 0. , -2. ,  5. ],
-                  [ 0.1,  0. ,  0. ]], dtype=np.float32)
+    Y = np.array([[0., -2., 5.],
+                  [0.1, 0., 0.]], dtype=np.float32)
     assert_allclose(mlh.fit_transform(y), Y)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -11,12 +11,14 @@ from scipy.sparse import lil_matrix
 
 from sklearn.utils.multiclass import type_of_target
 
+from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import ignore_warnings
 
 from sklearn.preprocessing._label import LabelBinarizer
 from sklearn.preprocessing._label import MultiLabelBinarizer
+from sklearn.preprocessing._label import MultiLabelHistogram
 from sklearn.preprocessing._label import LabelEncoder
 from sklearn.preprocessing._label import label_binarize
 
@@ -654,3 +656,17 @@ def test_encode_check_unknown():
     with pytest.raises(ValueError,
                        match='y contains previously unseen labels'):
         _encode(values, uniques, encode=True, check_unknown=False)
+
+
+def test_multilabel_histogram():
+    mlh = MultiLabelHistogram()
+    y = [{1: 5.5, 2: -3.0}, {3: 999}]
+    Y = np.array([[  5.5,  -3.,    0. ],
+                  [  0.,    0.,  999. ]])
+    assert_allclose(mlh.fit_transform(y), Y)
+
+    mlh = MultiLabelHistogram()
+    y = [{'sci-fi': -2.0, 'thriller': 5.0}, {'comedy': 0.1}]
+    Y = np.array([[ 0.,  -2.,   5. ],
+                  [ 0.1,  0.,   0. ]])
+    assert_allclose(mlh.fit_transform(y), Y)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This allows the user to create multi-labeled encodings for dict-like objects with classes and associated values. My use-case is encoding a histogram with string-like keys. MultiLabelBinarizer does not support dictionaries with fuzzy values, only discrete `{0,1}` sets. 

Examples:
```
    mlh = MultiLabelHistogram()
    y = [{1: 5.5, 2: -3.0}, {3: 999}]
    Y = np.array([[5.5, -3., 0.],
                  [0., 0., 999.]], dtype=np.float32)
    assert_allclose(mlh.fit_transform(y), Y)
```
```
    mlh = MultiLabelHistogram()
    y = [{'sci-fi': -2.0, 'thriller': 5.0}, {'comedy': 0.1}]
    Y = np.array([[0., -2., 5.],
                  [0.1, 0., 0.]], dtype=np.float32)
    assert_allclose(mlh.fit_transform(y), Y)
```

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
